### PR TITLE
chore: tighten S3 signing scope

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -71,6 +71,7 @@ jobs:
           allow-dependencies-licenses: >-
             pkg:npm/@ai-sdk/provider,
             pkg:npm/@ai-sdk/provider-utils,
+            pkg:npm/@aws-sdk/client-sts,
             pkg:npm/@hocuspocus/provider,
             pkg:npm/@hocuspocus/server,
             pkg:npm/@stll/ai-catalog,

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -65,6 +65,9 @@ SMTP_PASSWORD=""
 S3_ENDPOINT="http://localhost:9000"
 S3_BUCKET="stella"
 S3_REGION="us-east-1"
+# Optional in AWS deployments. When set, presigned S3 URLs are generated
+# with STS credentials scoped to the requested organization/workspace prefix.
+S3_SCOPED_SIGNING_ROLE_ARN=""
 # Credential source: "auto" prefers IAM roles for AWS S3 endpoints and env
 # credentials for S3-compatible endpoints. Use "env", "aws-runtime", or "none"
 # to force a specific mode.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
     "@ai-sdk/valibot": "^2.0.28",
     "@aws-sdk/client-s3": "^3.1057.0",
     "@aws-sdk/client-sesv2": "^3.1057.0",
+    "@aws-sdk/client-sts": "^3.1057.0",
     "@aws-sdk/s3-request-presigner": "^3.1057.0",
     "@better-auth/oauth-provider": "catalog:",
     "@elysiajs/cors": "^1.4.2",

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -45,6 +45,7 @@ export const envBase = createEnv({
     S3_ACCESS_KEY_ID: v.optional(v.string()),
     S3_SECRET_ACCESS_KEY: v.optional(v.string()),
     S3_REGION: v.string(),
+    S3_SCOPED_SIGNING_ROLE_ARN: v.optional(v.string()),
     POSTHOG_KEY: v.optional(v.string()),
     POSTHOG_HOST: v.optional(v.string()),
     POSTHOG_LOCAL_DEBUG: v.optional(

--- a/apps/api/src/handlers/entities/desktop-edit-session-utils.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-utils.ts
@@ -5,7 +5,7 @@ import { fields } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import { createFileKey } from "@/api/handlers/files/utils";
 import type { SafeId } from "@/api/lib/branded-types";
-import { presignDownloadUrl } from "@/api/lib/s3";
+import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 type DatabaseTransaction = Transaction;
@@ -160,7 +160,7 @@ export const readVersionDocxTarget = async ({
   return asDocxFieldContent(row.content);
 };
 
-export const presignDocxFieldDownload = ({
+export const presignDocxFieldDownload = async ({
   fileContent,
   organizationId,
   workspaceId,
@@ -169,7 +169,7 @@ export const presignDocxFieldDownload = ({
   organizationId: SafeId<"organization">;
   workspaceId: SafeId<"workspace">;
 }) =>
-  presignDownloadUrl(
+  await presignDownloadUrl(
     createFileKey({
       fileId: fileContent.id,
       mimeType: fileContent.mimeType,
@@ -179,10 +179,11 @@ export const presignDocxFieldDownload = ({
     {
       expiresIn: 900,
       fileName: fileContent.fileName,
+      scope: { organizationId, workspaceId },
     },
   );
 
-export const presignDocxDownloadFromFileId = ({
+export const presignDocxDownloadFromFileId = async ({
   fileId,
   fileName,
   organizationId,
@@ -193,7 +194,7 @@ export const presignDocxDownloadFromFileId = ({
   organizationId: SafeId<"organization">;
   workspaceId: SafeId<"workspace">;
 }) =>
-  presignDownloadUrl(
+  await presignDownloadUrl(
     createFileKey({
       fileId,
       mimeType: DOCX_MIME_TYPE,
@@ -203,5 +204,6 @@ export const presignDocxDownloadFromFileId = ({
     {
       expiresIn: 900,
       fileName,
+      scope: { organizationId, workspaceId },
     },
   );

--- a/apps/api/src/handlers/entities/open-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/open-desktop-edit-session.ts
@@ -233,7 +233,7 @@ const buildExistingOpenDesktopEditSessionResponse = async ({
   if (existingSession.checkpointUpdatedAt) {
     return {
       baseVersionNumber: baseVersion.versionNumber,
-      downloadUrl: presignDocxDownloadFromFileId({
+      downloadUrl: await presignDocxDownloadFromFileId({
         fileId: existingSession.checkpointFileId,
         fileName: existingSession.fileName,
         organizationId,
@@ -266,7 +266,7 @@ const buildExistingOpenDesktopEditSessionResponse = async ({
 
   return {
     baseVersionNumber: baseVersion.versionNumber,
-    downloadUrl: presignDocxFieldDownload({
+    downloadUrl: await presignDocxFieldDownload({
       fileContent: baseVersionContent,
       organizationId,
       workspaceId,
@@ -471,7 +471,7 @@ export const openDesktopEditSessionHandler = async function* ({
 
       return {
         baseVersionNumber: currentTarget.baseVersionNumber,
-        downloadUrl: presignDocxFieldDownload({
+        downloadUrl: await presignDocxFieldDownload({
           fileContent: currentTarget.fileContent,
           organizationId,
           workspaceId,

--- a/apps/api/src/handlers/entities/open-folio-collab-session.ts
+++ b/apps/api/src/handlers/entities/open-folio-collab-session.ts
@@ -168,7 +168,7 @@ const openFolioCollabSessionHandler = async function* ({
             baseVersionId: existingSession.baseVersionId,
             collabSessionId: existingSession.id,
             fileName: existingSession.fileName,
-            seedDownloadUrl: presignDocxFieldDownload({
+            seedDownloadUrl: await presignDocxFieldDownload({
               fileContent: baseContent,
               organizationId,
               workspaceId,
@@ -238,7 +238,7 @@ const openFolioCollabSessionHandler = async function* ({
         baseVersionId: currentTarget.baseVersionId,
         collabSessionId,
         fileName: currentTarget.fileContent.fileName,
-        seedDownloadUrl: presignDocxFieldDownload({
+        seedDownloadUrl: await presignDocxFieldDownload({
           fileContent: currentTarget.fileContent,
           organizationId,
           workspaceId,

--- a/apps/api/src/handlers/files/read-by-id.ts
+++ b/apps/api/src/handlers/files/read-by-id.ts
@@ -19,6 +19,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { contentDisposition } from "@/api/lib/content-disposition";
 import { injectStamp, isStampableDocx } from "@/api/lib/docx-stamp";
 import { getS3 } from "@/api/lib/s3";
+import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 type FilePurpose = "download" | "display" | "native-display";
@@ -98,6 +99,8 @@ export const readFileHandler = async ({
           s3Key: fileKey,
           expiresInSeconds: 900,
           fileName: content.fileName,
+          organizationId,
+          workspaceId,
           metadata: {
             fieldId,
             mimeType: content.mimeType,
@@ -126,21 +129,23 @@ export const readFileHandler = async ({
       return status(400);
     }
 
+    const nativeFileKey = createFileKey({
+      organizationId,
+      workspaceId,
+      fileId: content.id,
+      mimeType: content.mimeType,
+    });
+
     return {
       fileId: content.id,
       mimeType: content.mimeType,
       originalMimeType: content.mimeType,
       fileName: content.fileName,
       encrypted: content.encrypted,
-      presignedUrl: getS3().presign(
-        createFileKey({
-          organizationId,
-          workspaceId,
-          fileId: content.id,
-          mimeType: content.mimeType,
-        }),
-        { expiresIn: 900 },
-      ),
+      presignedUrl: await presignDownloadUrl(nativeFileKey, {
+        expiresIn: 900,
+        scope: { organizationId, workspaceId },
+      }),
       stampable: false,
     };
   }
@@ -150,21 +155,23 @@ export const readFileHandler = async ({
   // Gotenberg. PDFs serve themselves. Anything else needs a
   // PDF derivative on the field.
   if (isNativelyRenderableMimeType(content.mimeType)) {
+    const nativeFileKey = createFileKey({
+      organizationId,
+      workspaceId,
+      fileId: content.id,
+      mimeType: content.mimeType,
+    });
+
     return {
       fileId: content.id,
       mimeType: content.mimeType,
       originalMimeType: content.mimeType,
       fileName: content.fileName,
       encrypted: content.encrypted,
-      presignedUrl: getS3().presign(
-        createFileKey({
-          organizationId,
-          workspaceId,
-          fileId: content.id,
-          mimeType: content.mimeType,
-        }),
-        { expiresIn: 900 },
-      ),
+      presignedUrl: await presignDownloadUrl(nativeFileKey, {
+        expiresIn: 900,
+        scope: { organizationId, workspaceId },
+      }),
       stampable: false,
     };
   }
@@ -175,21 +182,23 @@ export const readFileHandler = async ({
 
   const displayFileId = content.pdfFileId ?? content.id;
 
+  const displayFileKey = createFileKey({
+    organizationId,
+    workspaceId,
+    fileId: displayFileId,
+    mimeType: PDF_MIME_TYPE,
+  });
+
   return {
     fileId: displayFileId,
     mimeType: PDF_MIME_TYPE,
     originalMimeType: content.mimeType,
     fileName: content.fileName,
     encrypted: content.encrypted,
-    presignedUrl: getS3().presign(
-      createFileKey({
-        organizationId,
-        workspaceId,
-        fileId: displayFileId,
-        mimeType: PDF_MIME_TYPE,
-      }),
-      { expiresIn: 900 },
-    ),
+    presignedUrl: await presignDownloadUrl(displayFileKey, {
+      expiresIn: 900,
+      scope: { organizationId, workspaceId },
+    }),
     stampable: false,
   };
 };

--- a/apps/api/src/handlers/templates/get.ts
+++ b/apps/api/src/handlers/templates/get.ts
@@ -59,6 +59,7 @@ const getTemplate = createSafeRootHandler(
           s3Key: template.s3Key,
           expiresInSeconds: PRESIGN_EXPIRES_IN,
           fileName: template.fileName,
+          organizationId,
           metadata: { sizeBytes: template.sizeBytes },
         });
 

--- a/apps/api/src/handlers/templates/versions.ts
+++ b/apps/api/src/handlers/templates/versions.ts
@@ -5,7 +5,7 @@ import type { ScopedDb } from "@/api/db";
 import { templateVersions } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
-import { presignDownloadUrl } from "@/api/lib/s3";
+import { presignDownloadUrl } from "@/api/lib/s3-presign";
 
 /** Presigned download URLs expire after 15 minutes, matching every
  *  other read path (`templates/get.ts`, `files/read-by-id.ts`). */
@@ -117,9 +117,10 @@ export const getTemplateVersionHandler = async ({
     });
   }
 
-  const downloadUrl = presignDownloadUrl(version.s3Key, {
+  const downloadUrl = await presignDownloadUrl(version.s3Key, {
     expiresIn: PRESIGN_EXPIRES_IN,
     fileName: template.fileName,
+    scope: { organizationId },
   });
 
   return {

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -15,7 +15,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
 
 import { pendingUploads } from "@/api/db/schema";
-import { tmpUploadKey } from "@/api/handlers/uploads/lib";
+import { tmpUploadKeys } from "@/api/handlers/uploads/lib";
 import {
   authorizeUploadPurpose,
   uploadRoutePermission,
@@ -39,7 +39,7 @@ const config = {
 
 const abortUpload = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, user, memberRole, params }) {
+  async function* ({ safeDb, session, workspaceId, user, memberRole, params }) {
     const uploadId = params.uploadId;
 
     const existing = yield* Result.await(
@@ -136,11 +136,21 @@ const abortUpload = createSafeHandler(
     // Best-effort tmp cleanup. The client may have never actually
     // PUT (so the object never existed) — `delete` on a missing key
     // is a no-op on S3 / MinIO.
-    await getS3()
-      .delete(tmpUploadKey(uploadId))
-      .catch((error: unknown) =>
-        captureError(error, { uploadId, stage: "tmp-cleanup-after-abort" }),
-      );
+    for (const key of tmpUploadKeys({
+      organizationId: session.activeOrganizationId,
+      uploadId,
+      workspaceId,
+    })) {
+      await getS3()
+        .delete(key)
+        .catch((error: unknown) =>
+          captureError(error, {
+            key,
+            uploadId,
+            stage: "tmp-cleanup-after-abort",
+          }),
+        );
+    }
 
     return Result.ok({ ok: true as const });
   },

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -30,8 +30,10 @@ import { finalizeEntityCreate } from "@/api/handlers/uploads/entity-create";
 import { finalizeEntityVersion } from "@/api/handlers/uploads/entity-version";
 import {
   FINALIZE_CLAIM_TIMEOUT_MS,
+  legacyTmpUploadKey,
   sha256Base64ToHex,
   tmpUploadKey,
+  tmpUploadKeys,
   UploadFinalizeError,
 } from "@/api/handlers/uploads/lib";
 import {
@@ -47,6 +49,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { scanFile } from "@/api/lib/file-scan/scan";
 import { getS3 } from "@/api/lib/s3";
+import type { HeadObjectResult, S3PresignError } from "@/api/lib/s3-presign";
 import { copyObject, headObject } from "@/api/lib/s3-presign";
 
 const finalizeParamsSchema = t.Object({
@@ -255,14 +258,12 @@ const finalizeUpload = createSafeHandler(
       if (terminalStatus === "rejected") {
         // Best-effort tmp cleanup only for terminal rejections.
         // Transient failures keep tmp bytes so finalize can retry.
-        await getS3()
-          .delete(tmpUploadKey(uploadId))
-          .catch((deleteError: unknown) =>
-            captureError(deleteError, {
-              uploadId,
-              stage: "tmp-cleanup-after-reject",
-            }),
-          );
+        await deleteStagedUploadObjects({
+          organizationId: session.activeOrganizationId,
+          uploadId,
+          workspaceId,
+          stage: "tmp-cleanup-after-reject",
+        });
       }
       return Result.err(
         new HandlerError({ status: error.status, message: error.message }),
@@ -289,6 +290,54 @@ type RunFinalizeOk = {
   finalizedResult: PendingUploadFinalizedResult;
 };
 
+type StagedUploadKeyProps = {
+  organizationId: SafeId<"organization">;
+  uploadId: SafeId<"pendingUpload">;
+  workspaceId: SafeId<"workspace">;
+};
+
+type StagedUploadObject = {
+  head: HeadObjectResult;
+  tmpKey: string;
+};
+
+const resolveStagedUploadObject = async ({
+  organizationId,
+  uploadId,
+  workspaceId,
+}: StagedUploadKeyProps): Promise<
+  Result<StagedUploadObject, S3PresignError>
+> => {
+  const scopedTmpKey = tmpUploadKey({ organizationId, uploadId, workspaceId });
+  const scopedHead = await headObject(scopedTmpKey);
+  if (Result.isOk(scopedHead)) {
+    return Result.ok({ head: scopedHead.value, tmpKey: scopedTmpKey });
+  }
+
+  const legacyTmpKey = legacyTmpUploadKey(uploadId);
+  const legacyHead = await headObject(legacyTmpKey);
+  if (Result.isOk(legacyHead)) {
+    return Result.ok({ head: legacyHead.value, tmpKey: legacyTmpKey });
+  }
+
+  return Result.err(scopedHead.error);
+};
+
+const deleteStagedUploadObjects = async ({
+  organizationId,
+  stage,
+  uploadId,
+  workspaceId,
+}: StagedUploadKeyProps & { stage: string }) => {
+  for (const key of tmpUploadKeys({ organizationId, uploadId, workspaceId })) {
+    await getS3()
+      .delete(key)
+      .catch((deleteError: unknown) =>
+        captureError(deleteError, { key, stage, uploadId }),
+      );
+  }
+};
+
 /**
  * Generic finalize body. Verifies what S3 has against what the
  * pending row says, scans the bytes, dispatches into the
@@ -313,11 +362,13 @@ const runFinalize = async function* ({
   Result<RunFinalizeOk, UploadFinalizeError>,
   unknown
 > {
-  const tmpKey = tmpUploadKey(claimed.id);
-
   // 2. S3 HEAD — exists? size matches? checksum matches?
-  const head = await headObject(tmpKey);
-  if (Result.isError(head)) {
+  const stagedObject = await resolveStagedUploadObject({
+    organizationId,
+    uploadId: claimed.id,
+    workspaceId,
+  });
+  if (Result.isError(stagedObject)) {
     return Result.err(
       new UploadFinalizeError({
         status: 404,
@@ -326,18 +377,19 @@ const runFinalize = async function* ({
       }),
     );
   }
-  if (head.value.contentLength !== claimed.declaredSize) {
+  const { head, tmpKey } = stagedObject.value;
+  if (head.contentLength !== claimed.declaredSize) {
     return Result.err(
       new UploadFinalizeError({
         status: 422,
-        message: `Uploaded size ${head.value.contentLength} does not match declared ${claimed.declaredSize}`,
+        message: `Uploaded size ${head.contentLength} does not match declared ${claimed.declaredSize}`,
         rejectReason: "size-mismatch",
       }),
     );
   }
   if (
-    head.value.checksumSHA256 &&
-    sha256Base64ToHex(head.value.checksumSHA256) !== claimed.declaredSha256
+    head.checksumSHA256 &&
+    sha256Base64ToHex(head.checksumSHA256) !== claimed.declaredSha256
   ) {
     return Result.err(
       new UploadFinalizeError({
@@ -350,7 +402,7 @@ const runFinalize = async function* ({
 
   // 3. Download for scan.
   const fileBuffer = await getS3().file(tmpKey).arrayBuffer();
-  if (!head.value.checksumSHA256) {
+  if (!head.checksumSHA256) {
     const uploadedSha256 = new Bun.CryptoHasher("sha256")
       .update(fileBuffer)
       .digest("hex");

--- a/apps/api/src/handlers/uploads/lib.test.ts
+++ b/apps/api/src/handlers/uploads/lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  legacyTmpUploadKey,
+  tmpUploadKey,
+  tmpUploadKeys,
+} from "@/api/handlers/uploads/lib";
+import { toSafeId } from "@/api/lib/branded-types";
+
+const organizationId = toSafeId<"organization">("org_1");
+const workspaceId = toSafeId<"workspace">("ws_1");
+const uploadId = toSafeId<"pendingUpload">("upload_1");
+
+describe("tmp upload keys", () => {
+  test("stages new uploads under the organization/workspace prefix", () => {
+    expect(tmpUploadKey({ organizationId, uploadId, workspaceId })).toBe(
+      "org_1/ws_1/tmp/upload_1",
+    );
+  });
+
+  test("keeps legacy tmp key fallback for pending upload migration", () => {
+    expect(legacyTmpUploadKey(uploadId)).toBe("tmp/upload_1");
+    expect(tmpUploadKeys({ organizationId, uploadId, workspaceId })).toEqual([
+      "org_1/ws_1/tmp/upload_1",
+      "tmp/upload_1",
+    ]);
+  });
+});

--- a/apps/api/src/handlers/uploads/lib.ts
+++ b/apps/api/src/handlers/uploads/lib.ts
@@ -28,9 +28,31 @@ export const PRESIGN_URL_EXPIRY_SECONDS = 5 * 60;
  */
 export const FINALIZE_CLAIM_TIMEOUT_MS = 60_000;
 
-/** `tmp/{uploadId}` is the staging-area key the bucket lifecycle covers. */
-export const tmpUploadKey = (uploadId: SafeId<"pendingUpload">): string =>
+type TmpUploadKeyProps = {
+  organizationId: SafeId<"organization">;
+  uploadId: SafeId<"pendingUpload">;
+  workspaceId: SafeId<"workspace">;
+};
+
+/**
+ * New presigned uploads stage under the same organization/workspace prefix
+ * as durable file objects, so scoped STS credentials can sign the URL.
+ */
+export const tmpUploadKey = ({
+  organizationId,
+  uploadId,
+  workspaceId,
+}: TmpUploadKeyProps): string =>
+  `${organizationId}/${workspaceId}/tmp/${uploadId}`;
+
+/** Pre-scoped-signing staging key. Kept only for pending upload migration. */
+export const legacyTmpUploadKey = (uploadId: SafeId<"pendingUpload">): string =>
   `tmp/${uploadId}`;
+
+export const tmpUploadKeys = (props: TmpUploadKeyProps): string[] => [
+  tmpUploadKey(props),
+  legacyTmpUploadKey(props.uploadId),
+];
 
 /** Convert lowercase hex SHA-256 to base64 (S3's checksum API expects base64). */
 export const sha256HexToBase64 = (hex: string): string =>

--- a/apps/api/src/handlers/uploads/presign.ts
+++ b/apps/api/src/handlers/uploads/presign.ts
@@ -156,17 +156,27 @@ const presignUpload = createSafeHandler(
     }
 
     const uploadId = createSafeId<"pendingUpload">();
+    const tmpKey = tmpUploadKey({
+      organizationId: session.activeOrganizationId,
+      uploadId,
+      workspaceId,
+    });
     const now = new Date();
     const expiresAt = new Date(
       now.getTime() + PRESIGN_URL_EXPIRY_SECONDS * 1000,
     );
 
     const presign = await presignUploadUrl({
-      key: tmpUploadKey(uploadId),
+      key: tmpKey,
       expiresIn: PRESIGN_URL_EXPIRY_SECONDS,
       contentType: purposeBody.mimeType,
       contentLength: purposeBody.size,
       sha256Base64: sha256HexToBase64(purposeBody.sha256Hex),
+      scope: {
+        organizationId: session.activeOrganizationId,
+        workspaceId,
+      },
+      tagAsTemporaryUpload: true,
     });
     if (Result.isError(presign)) {
       return Result.err(

--- a/apps/api/src/lib/audited-download.ts
+++ b/apps/api/src/lib/audited-download.ts
@@ -2,7 +2,7 @@ import type { Transaction } from "@/api/db";
 import type { AuditRecorder, AuditResourceType } from "@/api/lib/audit-log";
 import { AUDIT_ACTION } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
-import { getS3, presignDownloadUrl } from "@/api/lib/s3";
+import { presignDownloadUrl } from "@/api/lib/s3-presign";
 
 type AuditedPresignDownloadOptions = {
   tx: Transaction;
@@ -22,6 +22,7 @@ type AuditedPresignDownloadOptions = {
   fileName?: string;
   /** Additional audit metadata (e.g., sizeBytes, contentType). */
   metadata?: Record<string, unknown>;
+  organizationId?: SafeId<"organization"> | null;
   workspaceId?: SafeId<"workspace"> | null;
 };
 
@@ -45,6 +46,7 @@ export const auditedPresignDownload = async ({
   expiresInSeconds,
   fileName,
   metadata,
+  organizationId,
   workspaceId,
 }: AuditedPresignDownloadOptions): Promise<string> => {
   await recordAuditEvent(tx, {
@@ -61,12 +63,11 @@ export const auditedPresignDownload = async ({
     },
   });
 
-  if (fileName) {
-    return presignDownloadUrl(s3Key, {
-      expiresIn: expiresInSeconds,
-      fileName,
-    });
-  }
-
-  return getS3().presign(s3Key, { expiresIn: expiresInSeconds });
+  return await presignDownloadUrl(s3Key, {
+    expiresIn: expiresInSeconds,
+    ...(fileName ? { fileName } : {}),
+    ...(organizationId
+      ? { scope: { organizationId, workspaceId: workspaceId ?? null } }
+      : {}),
+  });
 };

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -5,6 +5,7 @@ import { getS3 } from "@/api/lib/s3";
 import {
   copyObject,
   headObject,
+  isS3KeyInSigningScope,
   presignUploadUrl,
   resetAwsS3ClientForTesting,
 } from "@/api/lib/s3-presign";
@@ -24,6 +25,51 @@ const parseSignedHeaders = (url: string): Set<string> => {
 const HELLO_BODY = "hello";
 const HELLO_SHA256_BASE64 = sha256Base64(HELLO_BODY);
 const HELLO_BYTES = new TextEncoder().encode(HELLO_BODY);
+
+describe("isS3KeyInSigningScope", () => {
+  test("accepts document keys under the requested workspace prefix", () => {
+    expect(
+      isS3KeyInSigningScope("org_1/ws_1/file_1.pdf", {
+        organizationId: "org_1",
+        workspaceId: "ws_1",
+      }),
+    ).toBe(true);
+    expect(
+      isS3KeyInSigningScope("org_1/ws_1/tmp/upload_1", {
+        organizationId: "org_1",
+        workspaceId: "ws_1",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects sibling organizations and workspaces", () => {
+    expect(
+      isS3KeyInSigningScope("org_2/ws_1/file_1.pdf", {
+        organizationId: "org_1",
+        workspaceId: "ws_1",
+      }),
+    ).toBe(false);
+    expect(
+      isS3KeyInSigningScope("org_1/ws_10/file_1.pdf", {
+        organizationId: "org_1",
+        workspaceId: "ws_1",
+      }),
+    ).toBe(false);
+  });
+
+  test("accepts organization-level template keys without workspace scope", () => {
+    expect(
+      isS3KeyInSigningScope("org_1/templates/template_1.docx", {
+        organizationId: "org_1",
+      }),
+    ).toBe(true);
+    expect(
+      isS3KeyInSigningScope("org_10/templates/template_1.docx", {
+        organizationId: "org_1",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("presignUploadUrl", () => {
   beforeAll(() => {

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -138,6 +138,31 @@ describe("presignUploadUrl", () => {
       "presign-method-probe",
     );
   });
+
+  test("binds temporary upload tagging into a request header", async () => {
+    const result = await presignUploadUrl({
+      key: "org_1/ws_1/tmp/presign-tagging-probe",
+      expiresIn: 60,
+      contentType: "application/octet-stream",
+      contentLength: HELLO_BYTES.byteLength,
+      sha256Base64: HELLO_SHA256_BASE64,
+      tagAsTemporaryUpload: true,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (!Result.isOk(result)) {
+      return;
+    }
+
+    const parsed = new URL(result.value.url);
+    const signed = parseSignedHeaders(result.value.url);
+
+    expect(signed.has("x-amz-tagging")).toBe(true);
+    expect(parsed.searchParams.has("x-amz-tagging")).toBe(false);
+    expect(result.value.headers["x-amz-tagging"]).toBe(
+      "stella-upload-stage=tmp",
+    );
+  });
 });
 
 // -----------------------------------------------------------------

--- a/apps/api/src/lib/s3-presign.test.ts
+++ b/apps/api/src/lib/s3-presign.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { getS3 } from "@/api/lib/s3";
 import {
   copyObject,
+  hasScopedSessionTimeForPresign,
   headObject,
   isS3KeyInSigningScope,
   presignUploadUrl,
@@ -162,6 +163,25 @@ describe("presignUploadUrl", () => {
     expect(result.value.headers["x-amz-tagging"]).toBe(
       "stella-upload-stage=tmp",
     );
+  });
+});
+
+describe("hasScopedSessionTimeForPresign", () => {
+  test("requires scoped credentials to outlive the presigned URL plus refresh skew", () => {
+    expect(
+      hasScopedSessionTimeForPresign({
+        expiresAt: 961_000,
+        expiresIn: 900,
+        now: 0,
+      }),
+    ).toBe(true);
+    expect(
+      hasScopedSessionTimeForPresign({
+        expiresAt: 960_000,
+        expiresIn: 900,
+        now: 0,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -111,7 +111,7 @@ let _clientPromise: Promise<CachedClient> | null = null;
 let _stsClientPromise: Promise<STSClient> | null = null;
 let _scopedClientPromises = new Map<string, Promise<CachedScopedClient>>();
 const CLIENT_MAX_AGE_MS = 50 * 60 * 1000;
-const SCOPED_SESSION_SECONDS = 900;
+const SCOPED_SESSION_SECONDS = 3600;
 const SCOPED_CLIENT_REFRESH_SKEW_MS = 60 * 1000;
 const TEMP_UPLOAD_TAG_KEY = "stella-upload-stage";
 const TEMP_UPLOAD_TAG_VALUE = "tmp";
@@ -248,6 +248,17 @@ const scopedClientCacheKey = (
   actions: readonly S3SigningAction[],
 ): string => `${s3SigningScopePrefix(scope)}|${[...actions].sort().join(",")}`;
 
+export const hasScopedSessionTimeForPresign = ({
+  expiresAt,
+  expiresIn,
+  now = Date.now(),
+}: {
+  expiresAt: number;
+  expiresIn: number;
+  now?: number;
+}): boolean =>
+  expiresAt - now > expiresIn * 1000 + SCOPED_CLIENT_REFRESH_SKEW_MS;
+
 const buildScopedAwsS3Client = async (
   scope: S3SigningScope,
   actions: readonly S3SigningAction[],
@@ -301,6 +312,7 @@ const buildScopedAwsS3Client = async (
 const getScopedAwsS3Client = async (
   scope: S3SigningScope,
   actions: readonly S3SigningAction[],
+  expiresIn: number,
 ): Promise<AwsS3Client> => {
   const cacheKey = scopedClientCacheKey(scope, actions);
   const existingPromise = _scopedClientPromises.get(cacheKey);
@@ -314,7 +326,9 @@ const getScopedAwsS3Client = async (
       }
       throw error;
     }
-    if (cached.expiresAt - Date.now() > SCOPED_CLIENT_REFRESH_SKEW_MS) {
+    if (
+      hasScopedSessionTimeForPresign({ expiresAt: cached.expiresAt, expiresIn })
+    ) {
       return cached.client;
     }
   }
@@ -334,10 +348,12 @@ const getScopedAwsS3Client = async (
 
 const getPresignClient = async ({
   actions,
+  expiresIn,
   key,
   scope,
 }: {
   actions: readonly S3SigningAction[];
+  expiresIn: number;
   key: string;
   scope: S3SigningScope | undefined;
 }): Promise<AwsS3Client> => {
@@ -355,7 +371,7 @@ const getPresignClient = async ({
     });
   }
 
-  return await getScopedAwsS3Client(scope, actions);
+  return await getScopedAwsS3Client(scope, actions, expiresIn);
 };
 
 /** Reset the cached client. Test seam; not used in prod. */
@@ -385,6 +401,7 @@ export const presignUploadUrl = async ({
   await Result.tryPromise({
     try: async () => {
       const client = await getPresignClient({
+        expiresIn,
         key,
         scope,
         actions: tagAsTemporaryUpload
@@ -464,6 +481,7 @@ export const presignDownloadUrl = async (
   const result = await Result.tryPromise({
     try: async () => {
       const client = await getPresignClient({
+        expiresIn,
         key,
         scope,
         actions: ["s3:GetObject"],
@@ -556,6 +574,7 @@ export const copyObject = async (
           Key: destKey,
           // Staged uploads carry a lifecycle tag; durable objects must not.
           TaggingDirective: "REPLACE",
+          Tagging: "",
         }),
       );
     },

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -51,6 +51,7 @@ export type PresignedUploadHeaders = {
   "content-length": string;
   "x-amz-checksum-sha256": string;
   "x-amz-sdk-checksum-algorithm": "SHA256";
+  "x-amz-tagging"?: string;
 };
 
 export type PresignUploadOptions = {
@@ -304,13 +305,28 @@ const getScopedAwsS3Client = async (
   const cacheKey = scopedClientCacheKey(scope, actions);
   const existingPromise = _scopedClientPromises.get(cacheKey);
   if (existingPromise) {
-    const cached = await existingPromise;
+    let cached: CachedScopedClient;
+    try {
+      cached = await existingPromise;
+    } catch (error) {
+      if (_scopedClientPromises.get(cacheKey) === existingPromise) {
+        _scopedClientPromises.delete(cacheKey);
+      }
+      throw error;
+    }
     if (cached.expiresAt - Date.now() > SCOPED_CLIENT_REFRESH_SKEW_MS) {
       return cached.client;
     }
   }
 
-  const nextPromise = buildScopedAwsS3Client(scope, actions);
+  const nextPromise = buildScopedAwsS3Client(scope, actions).catch(
+    (error: unknown) => {
+      if (_scopedClientPromises.get(cacheKey) === nextPromise) {
+        _scopedClientPromises.delete(cacheKey);
+      }
+      throw error;
+    },
+  );
   _scopedClientPromises.set(cacheKey, nextPromise);
   const built = await nextPromise;
   return built.client;
@@ -407,10 +423,12 @@ export const presignUploadUrl = async ({
           "content-length",
           "x-amz-checksum-sha256",
           "x-amz-sdk-checksum-algorithm",
+          ...(tagAsTemporaryUpload ? ["x-amz-tagging"] : []),
         ]),
         unhoistableHeaders: new Set([
           "x-amz-checksum-sha256",
           "x-amz-sdk-checksum-algorithm",
+          ...(tagAsTemporaryUpload ? ["x-amz-tagging"] : []),
         ]),
       });
 
@@ -419,6 +437,9 @@ export const presignUploadUrl = async ({
         "content-length": String(contentLength),
         "x-amz-checksum-sha256": sha256Base64,
         "x-amz-sdk-checksum-algorithm": "SHA256",
+        ...(tagAsTemporaryUpload
+          ? { "x-amz-tagging": TEMP_UPLOAD_TAGGING }
+          : {}),
       };
 
       return { url, headers };

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -99,6 +99,7 @@ const isAwsS3Endpoint = (endpoint: string): boolean => {
 };
 
 type CachedClient = { client: AwsS3Client; createdAt: number };
+type CachedStsClient = { client: STSClient; createdAt: number };
 type CachedScopedClient = { client: AwsS3Client; expiresAt: number };
 export type S3SigningScope = {
   organizationId: string;
@@ -108,7 +109,7 @@ type S3SigningAction = "s3:GetObject" | "s3:PutObject" | "s3:PutObjectTagging";
 type KmsSigningAction = "kms:Decrypt" | "kms:GenerateDataKey";
 
 let _clientPromise: Promise<CachedClient> | null = null;
-let _stsClientPromise: Promise<STSClient> | null = null;
+let _stsClientPromise: Promise<CachedStsClient> | null = null;
 let _scopedClientPromises = new Map<string, Promise<CachedScopedClient>>();
 const CLIENT_MAX_AGE_MS = 50 * 60 * 1000;
 const SCOPED_SESSION_SECONDS = 3600;
@@ -136,9 +137,9 @@ const buildAwsS3Client = async (): Promise<CachedClient> => {
   return { client, createdAt: Date.now() };
 };
 
-const buildStsClient = async (): Promise<STSClient> => {
+const buildStsClient = async (): Promise<CachedStsClient> => {
   const creds = await resolveS3Credentials();
-  return new STSClient({
+  const client = new STSClient({
     region: envBase.S3_REGION,
     ...(creds
       ? {
@@ -150,6 +151,7 @@ const buildStsClient = async (): Promise<STSClient> => {
         }
       : {}),
   });
+  return { client, createdAt: Date.now() };
 };
 
 /**
@@ -173,8 +175,19 @@ const getAwsS3Client = async (): Promise<AwsS3Client> => {
 };
 
 const getStsClient = async (): Promise<STSClient> => {
-  _stsClientPromise ??= buildStsClient();
-  return await _stsClientPromise;
+  if (_stsClientPromise) {
+    const cached = await _stsClientPromise;
+    if (Date.now() - cached.createdAt < CLIENT_MAX_AGE_MS) {
+      return cached.client;
+    }
+  }
+
+  _stsClientPromise = buildStsClient().catch((error: unknown) => {
+    _stsClientPromise = null;
+    throw error;
+  });
+  const built = await _stsClientPromise;
+  return built.client;
 };
 
 const shouldUseScopedSigning = (): boolean =>

--- a/apps/api/src/lib/s3-presign.ts
+++ b/apps/api/src/lib/s3-presign.ts
@@ -13,21 +13,26 @@
  * 5-minute expiry window cannot be reused to upload a different
  * payload or a different size.
  *
- * Credential resolution is shared with the Bun client — both
+ * Base credential resolution is shared with the Bun client — both
  * routes call `resolveS3Credentials()`, so static env credentials,
  * ECS container credentials, and IMDSv2 fallback all behave
- * identically across the two SDKs.
+ * identically across the two SDKs. In AWS prod, client-visible
+ * presigned URLs can then be issued through an STS session policy
+ * scoped to one organization/workspace key prefix.
  */
 import {
   CopyObjectCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
   S3Client as AwsS3Client,
 } from "@aws-sdk/client-s3";
+import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { Result, TaggedError } from "better-result";
 
 import { envBase } from "@/api/env-base";
+import { contentDisposition } from "@/api/lib/content-disposition";
 import { resolveS3Credentials } from "@/api/lib/s3";
 
 export class S3PresignError extends TaggedError("S3PresignError")<{
@@ -49,7 +54,7 @@ export type PresignedUploadHeaders = {
 };
 
 export type PresignUploadOptions = {
-  /** Final S3 key the client will write to (caller chooses; usually `tmp/{uploadId}`). */
+  /** Final S3 key the client will write to. */
   key: string;
   /** Lifetime of the signed URL in seconds. Keep short — finalize is fast. */
   expiresIn: number;
@@ -59,6 +64,8 @@ export type PresignUploadOptions = {
   contentLength: number;
   /** SHA-256 of the bytes. Base64-encoded per the `x-amz-checksum-sha256` API. */
   sha256Base64: string;
+  scope?: S3SigningScope;
+  tagAsTemporaryUpload?: boolean;
 };
 
 export type PresignUploadResult = {
@@ -81,10 +88,33 @@ const isPathStyleRequired = (endpoint: string): boolean => {
   }
 };
 
+const isAwsS3Endpoint = (endpoint: string): boolean => {
+  try {
+    const host = new URL(endpoint).hostname.toLowerCase();
+    return host.includes("s3") && host.endsWith(".amazonaws.com");
+  } catch {
+    return false;
+  }
+};
+
 type CachedClient = { client: AwsS3Client; createdAt: number };
+type CachedScopedClient = { client: AwsS3Client; expiresAt: number };
+export type S3SigningScope = {
+  organizationId: string;
+  workspaceId?: string | null;
+};
+type S3SigningAction = "s3:GetObject" | "s3:PutObject" | "s3:PutObjectTagging";
+type KmsSigningAction = "kms:Decrypt" | "kms:GenerateDataKey";
 
 let _clientPromise: Promise<CachedClient> | null = null;
+let _stsClientPromise: Promise<STSClient> | null = null;
+let _scopedClientPromises = new Map<string, Promise<CachedScopedClient>>();
 const CLIENT_MAX_AGE_MS = 50 * 60 * 1000;
+const SCOPED_SESSION_SECONDS = 900;
+const SCOPED_CLIENT_REFRESH_SKEW_MS = 60 * 1000;
+const TEMP_UPLOAD_TAG_KEY = "stella-upload-stage";
+const TEMP_UPLOAD_TAG_VALUE = "tmp";
+const TEMP_UPLOAD_TAGGING = `${TEMP_UPLOAD_TAG_KEY}=${TEMP_UPLOAD_TAG_VALUE}`;
 
 const buildAwsS3Client = async (): Promise<CachedClient> => {
   const creds = await resolveS3Credentials();
@@ -103,6 +133,22 @@ const buildAwsS3Client = async (): Promise<CachedClient> => {
       : {}),
   });
   return { client, createdAt: Date.now() };
+};
+
+const buildStsClient = async (): Promise<STSClient> => {
+  const creds = await resolveS3Credentials();
+  return new STSClient({
+    region: envBase.S3_REGION,
+    ...(creds
+      ? {
+          credentials: {
+            accessKeyId: creds.accessKeyId,
+            secretAccessKey: creds.secretAccessKey,
+            ...(creds.sessionToken ? { sessionToken: creds.sessionToken } : {}),
+          },
+        }
+      : {}),
+  });
 };
 
 /**
@@ -125,9 +171,182 @@ const getAwsS3Client = async (): Promise<AwsS3Client> => {
   return built.client;
 };
 
+const getStsClient = async (): Promise<STSClient> => {
+  _stsClientPromise ??= buildStsClient();
+  return await _stsClientPromise;
+};
+
+const shouldUseScopedSigning = (): boolean =>
+  !!envBase.S3_SCOPED_SIGNING_ROLE_ARN && isAwsS3Endpoint(envBase.S3_ENDPOINT);
+
+const s3SigningScopePrefix = ({
+  organizationId,
+  workspaceId,
+}: S3SigningScope): string =>
+  workspaceId ? `${organizationId}/${workspaceId}/` : `${organizationId}/`;
+
+export const isS3KeyInSigningScope = (
+  key: string,
+  scope: S3SigningScope,
+): boolean => key.startsWith(s3SigningScopePrefix(scope));
+
+const roleSessionName = (scope: S3SigningScope): string => {
+  const scopeHash = new Bun.CryptoHasher("sha256")
+    .update(s3SigningScopePrefix(scope))
+    .digest("hex")
+    .slice(0, 24);
+  return `s3-scope-${scopeHash}`;
+};
+
+const scopedSessionPolicy = (
+  scope: S3SigningScope,
+  actions: readonly S3SigningAction[],
+): string => {
+  const kmsActions = kmsSigningActionsForS3Actions(actions);
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: actions,
+        Resource: `arn:aws:s3:::${envBase.S3_BUCKET}/${s3SigningScopePrefix(scope)}*`,
+      },
+      ...(kmsActions.length > 0
+        ? [
+            {
+              Effect: "Allow",
+              Action: kmsActions,
+              Resource: "*",
+              Condition: {
+                StringEquals: {
+                  "kms:ViaService": `s3.${envBase.S3_REGION}.amazonaws.com`,
+                },
+              },
+            },
+          ]
+        : []),
+    ],
+  });
+};
+
+const kmsSigningActionsForS3Actions = (
+  actions: readonly S3SigningAction[],
+): KmsSigningAction[] => {
+  const kmsActions: KmsSigningAction[] = [];
+  if (actions.includes("s3:GetObject")) {
+    kmsActions.push("kms:Decrypt");
+  }
+  if (actions.includes("s3:PutObject")) {
+    kmsActions.push("kms:GenerateDataKey");
+  }
+  return kmsActions;
+};
+
+const scopedClientCacheKey = (
+  scope: S3SigningScope,
+  actions: readonly S3SigningAction[],
+): string => `${s3SigningScopePrefix(scope)}|${[...actions].sort().join(",")}`;
+
+const buildScopedAwsS3Client = async (
+  scope: S3SigningScope,
+  actions: readonly S3SigningAction[],
+): Promise<CachedScopedClient> => {
+  const roleArn = envBase.S3_SCOPED_SIGNING_ROLE_ARN;
+  if (!roleArn) {
+    throw new S3PresignError({
+      message: "Scoped S3 signing role ARN is not configured",
+    });
+  }
+
+  const sts = await getStsClient();
+  const assumed = await sts.send(
+    new AssumeRoleCommand({
+      RoleArn: roleArn,
+      RoleSessionName: roleSessionName(scope),
+      DurationSeconds: SCOPED_SESSION_SECONDS,
+      Policy: scopedSessionPolicy(scope, actions),
+    }),
+  );
+  const credentials = assumed.Credentials;
+  if (
+    !credentials?.AccessKeyId ||
+    !credentials.SecretAccessKey ||
+    !credentials.SessionToken
+  ) {
+    throw new S3PresignError({
+      message: "STS returned incomplete scoped S3 credentials",
+    });
+  }
+
+  const client = new AwsS3Client({
+    region: envBase.S3_REGION,
+    endpoint: envBase.S3_ENDPOINT,
+    forcePathStyle: isPathStyleRequired(envBase.S3_ENDPOINT),
+    credentials: {
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken,
+    },
+  });
+
+  return {
+    client,
+    expiresAt:
+      credentials.Expiration?.getTime() ??
+      Date.now() + SCOPED_SESSION_SECONDS * 1000,
+  };
+};
+
+const getScopedAwsS3Client = async (
+  scope: S3SigningScope,
+  actions: readonly S3SigningAction[],
+): Promise<AwsS3Client> => {
+  const cacheKey = scopedClientCacheKey(scope, actions);
+  const existingPromise = _scopedClientPromises.get(cacheKey);
+  if (existingPromise) {
+    const cached = await existingPromise;
+    if (cached.expiresAt - Date.now() > SCOPED_CLIENT_REFRESH_SKEW_MS) {
+      return cached.client;
+    }
+  }
+
+  const nextPromise = buildScopedAwsS3Client(scope, actions);
+  _scopedClientPromises.set(cacheKey, nextPromise);
+  const built = await nextPromise;
+  return built.client;
+};
+
+const getPresignClient = async ({
+  actions,
+  key,
+  scope,
+}: {
+  actions: readonly S3SigningAction[];
+  key: string;
+  scope: S3SigningScope | undefined;
+}): Promise<AwsS3Client> => {
+  if (!shouldUseScopedSigning()) {
+    return await getAwsS3Client();
+  }
+
+  if (!scope) {
+    return await getAwsS3Client();
+  }
+
+  if (!isS3KeyInSigningScope(key, scope)) {
+    throw new S3PresignError({
+      message: "S3 key is outside the requested signing scope",
+    });
+  }
+
+  return await getScopedAwsS3Client(scope, actions);
+};
+
 /** Reset the cached client. Test seam; not used in prod. */
 export const resetAwsS3ClientForTesting = (): void => {
   _clientPromise = null;
+  _stsClientPromise = null;
+  _scopedClientPromises = new Map();
 };
 
 /**
@@ -142,12 +361,20 @@ export const presignUploadUrl = async ({
   contentType,
   contentLength,
   sha256Base64,
+  scope,
+  tagAsTemporaryUpload = false,
 }: PresignUploadOptions): Promise<
   Result<PresignUploadResult, S3PresignError>
 > =>
   await Result.tryPromise({
     try: async () => {
-      const client = await getAwsS3Client();
+      const client = await getPresignClient({
+        key,
+        scope,
+        actions: tagAsTemporaryUpload
+          ? ["s3:PutObject", "s3:PutObjectTagging"]
+          : ["s3:PutObject"],
+      });
       const command = new PutObjectCommand({
         Bucket: envBase.S3_BUCKET,
         Key: key,
@@ -155,6 +382,7 @@ export const presignUploadUrl = async ({
         ContentLength: contentLength,
         ChecksumSHA256: sha256Base64,
         ChecksumAlgorithm: "SHA256",
+        ...(tagAsTemporaryUpload ? { Tagging: TEMP_UPLOAD_TAGGING } : {}),
       });
 
       // SDK v3 hoists `x-amz-*` headers into the query string by
@@ -202,6 +430,49 @@ export const presignUploadUrl = async ({
       }),
   });
 
+export type PresignDownloadOptions = {
+  expiresIn: number;
+  fileName?: string;
+  scope?: S3SigningScope;
+};
+
+export const presignDownloadUrl = async (
+  key: string,
+  { expiresIn, fileName, scope }: PresignDownloadOptions,
+): Promise<string> => {
+  const result = await Result.tryPromise({
+    try: async () => {
+      const client = await getPresignClient({
+        key,
+        scope,
+        actions: ["s3:GetObject"],
+      });
+      return await getSignedUrl(
+        client,
+        new GetObjectCommand({
+          Bucket: envBase.S3_BUCKET,
+          Key: key,
+          ...(fileName
+            ? { ResponseContentDisposition: contentDisposition(fileName) }
+            : {}),
+        }),
+        { expiresIn },
+      );
+    },
+    catch: (cause) =>
+      new S3PresignError({
+        message: "Failed to generate presigned download URL",
+        cause,
+      }),
+  });
+
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+
+  return result.value;
+};
+
 export type HeadObjectResult = {
   /** Size in bytes as reported by S3 (after the upload completed). */
   contentLength: number;
@@ -243,7 +514,7 @@ export const headObject = async (
 
 /**
  * Server-side CopyObject. Used by finalize to promote a scanned
- * `tmp/{uploadId}` object to its final workspace key without
+ * staged upload object to its final workspace key without
  * pulling bytes through the API task. We prefer this over Bun's
  * `write(target, file(source))` for promotion specifically
  * because the SDK v3 path is documented as a server-side copy;
@@ -262,6 +533,8 @@ export const copyObject = async (
           // CopySource needs the bucket prefix and URL-encoded key.
           CopySource: `${envBase.S3_BUCKET}/${encodeURIComponent(sourceKey)}`,
           Key: destKey,
+          // Staged uploads carry a lifecycle tag; durable objects must not.
+          TaggingDirective: "REPLACE",
         }),
       );
     },

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@ai-sdk/valibot": "^2.0.28",
         "@aws-sdk/client-s3": "^3.1057.0",
         "@aws-sdk/client-sesv2": "^3.1057.0",
+        "@aws-sdk/client-sts": "^3.1057.0",
         "@aws-sdk/s3-request-presigner": "^3.1057.0",
         "@better-auth/oauth-provider": "catalog:",
         "@elysiajs/cors": "^1.4.2",
@@ -728,6 +729,8 @@
     "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1057.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-node": "^3.972.47", "@aws-sdk/middleware-bucket-endpoint": "^3.972.17", "@aws-sdk/middleware-expect-continue": "^3.972.14", "@aws-sdk/middleware-flexible-checksums": "^3.974.23", "@aws-sdk/middleware-location-constraint": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.44", "@aws-sdk/middleware-ssec": "^3.972.11", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-4MV5+ph7WSLEqStKYdWf2EIHIvLpPzV8xN98jWSVJfUpp5j7T8dyN3AROPPsKWvCme8hbx1ybCjtK76ALCZUYg=="],
 
     "@aws-sdk/client-sesv2": ["@aws-sdk/client-sesv2@3.1057.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-node": "^3.972.47", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-ChXHkr2DIkJIwyRZJvUSjE/jfc/2Vr/srWgInUSztz5C0ImQJs0XWijdMApUKZVfuOPFS2fG37i/3R7WI4CwJw=="],
+
+    "@aws-sdk/client-sts": ["@aws-sdk/client-sts@3.1057.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-node": "^3.972.47", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-67Qi3j1Np/y8QAiTQn3SlYIDg6j3gUbwbjYqPzL0S0pDTYoNtnHjABrvarg21txotlQn9ZkbgBawEL3+f3A/Qg=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 


### PR DESCRIPTION
## Summary
- add optional scoped S3 signing for client-visible document and template URLs on AWS S3 endpoints
- stage presigned uploads under organization/workspace temp keys with legacy temp-key fallback
- keep S3-compatible self-hosting behavior when scoped signing is not configured

## Validation
- bun test --preload ./src/tests/setup-env.ts src/lib/s3-presign.test.ts src/handlers/uploads/lib.test.ts
- bun run typecheck (apps/api)
- bun run lint (apps/api)
- pre-commit format/lint/secrets