### PR TITLE
feat(folio): pin page-anchored topAndBottom text boxes to the page top (eigenpal #694)

### DIFF
--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -9,6 +9,10 @@
  */
 
 import {
+  measuredLineAdvance,
+  measuredLineContentOffset,
+} from "../layout-engine/lineFlow";
+import {
   measureRun,
   findCharacterAtX as findCharAtX,
 } from "../layout-engine/measure/measureContainer";
@@ -220,13 +224,13 @@ function findLineAtY(
   ) {
     // SAFETY: lineIndex < measure.lines.length in for loop
     const line = measure.lines[lineIndex]!;
-    const lineHeight = line.lineHeight;
+    const lineAdvance = measuredLineAdvance(line);
 
-    if (localY >= y && localY < y + lineHeight) {
+    if (localY >= y && localY < y + lineAdvance) {
       return lineIndex;
     }
 
-    y += lineHeight;
+    y += lineAdvance;
   }
 
   // If Y is beyond all lines, return the last line
@@ -429,12 +433,6 @@ export function clickToPositionInParagraph(
   const line = paragraphMeasure.lines[lineIndex];
   if (!line) {
     return null;
-  }
-
-  // Calculate Y offset from line top
-  let _lineY = 0;
-  for (let i = paragraphFragment.fromLine; i < lineIndex; i++) {
-    _lineY += paragraphMeasure.lines[i]?.lineHeight ?? 0;
   }
 
   // Calculate available width (accounting for indentation)
@@ -682,11 +680,11 @@ export function getPositionRect(
     alignmentOffset = Math.max(0, availableWidth - line.width);
   }
 
-  // Calculate Y position of the line
-  let lineY = 0;
-  for (let i = fromLine; i < result.lineIndex; i++) {
-    lineY += measure.lines[i]?.lineHeight ?? 0;
-  }
+  const lineY = measuredLineContentOffset(
+    measure.lines,
+    fromLine,
+    result.lineIndex,
+  );
 
   return {
     x: fragmentX + indentLeft + alignmentOffset + result.x,

--- a/packages/folio/src/core/layout-bridge/hitTest.ts
+++ b/packages/folio/src/core/layout-bridge/hitTest.ts
@@ -6,6 +6,7 @@
  */
 
 import { getHeaderRowsHeight } from "../layout-engine/index";
+import { measuredLineRangeHeight } from "../layout-engine/lineFlow";
 import type {
   Layout,
   Page,
@@ -198,16 +199,11 @@ function calculateParagraphFragmentHeight(
   fragment: ParagraphFragment,
   measure: ParagraphMeasure,
 ): number {
-  let height = 0;
-  for (
-    let i = fragment.fromLine;
-    i < fragment.toLine && i < measure.lines.length;
-    i++
-  ) {
-    // SAFETY: i is bounded by measure.lines.length in loop condition
-    height += measure.lines[i]!.lineHeight;
-  }
-  return height;
+  return measuredLineRangeHeight(
+    measure.lines,
+    fragment.fromLine,
+    fragment.toLine,
+  );
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/measuring/index.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/index.ts
@@ -38,6 +38,8 @@ export {
   measureParagraphs,
   getRunCharWidths,
   clampFloatingWrapMargins,
+  findClearLineY,
+  MIN_WRAP_SEGMENT_WIDTH,
   type FloatingImageZone,
   type MeasureParagraphOptions,
 } from "../../layout-engine/measure/measureParagraph";

--- a/packages/folio/src/core/layout-bridge/selectionRects.test.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.test.ts
@@ -319,6 +319,80 @@ describe("selection rect geometry", () => {
     expect(caret?.x).toBe(14);
   });
 
+  test("caret Y includes float skip before the target line", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      pmStart: 0,
+      pmEnd: 4,
+      runs: [
+        {
+          kind: "text",
+          text: "ab",
+          fontFamily: "Calibri",
+          fontSize: 11,
+          pmStart: 1,
+          pmEnd: 3,
+        },
+      ],
+    };
+    const measures: Measure[] = [
+      {
+        kind: "paragraph",
+        lines: [
+          {
+            fromRun: 0,
+            toRun: 0,
+            fromChar: 0,
+            toChar: 1,
+            width: 7,
+            lineHeight: 16,
+            ascent: 12,
+            descent: 4,
+          },
+          {
+            fromRun: 0,
+            toRun: 0,
+            fromChar: 1,
+            toChar: 2,
+            width: 7,
+            lineHeight: 16,
+            ascent: 12,
+            descent: 4,
+            floatSkipBefore: 40,
+          },
+        ],
+        totalHeight: 72,
+      },
+    ];
+    const layout: Layout = {
+      pageGap: 0,
+      pages: [
+        {
+          number: 1,
+          size: { w: 600, h: 800 },
+          margins: { top: 0, right: 0, bottom: 0, left: 0 },
+          fragments: [
+            {
+              kind: "paragraph",
+              blockId: "p1",
+              x: 0,
+              y: 0,
+              width: 500,
+              height: 72,
+              fromLine: 0,
+              toLine: 2,
+            },
+          ],
+        },
+      ],
+    };
+
+    const caret = getCaretPosition(layout, [block], measures, 3);
+
+    expect(caret?.y).toBe(56);
+  });
+
   test("selection rects only include visible lines from clipped table rows", () => {
     const { layout, block, measure } = clippedTableFixture();
 

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -9,6 +9,7 @@
  */
 
 import { getHeaderRowsHeight } from "../layout-engine/index";
+import { measuredLineContentOffset } from "../layout-engine/lineFlow";
 import { measureParagraph } from "../layout-engine/measure";
 import { measureRun } from "../layout-engine/measure/measureContainer";
 import type { FontStyle } from "../layout-engine/measure/measureContainer";
@@ -374,23 +375,6 @@ function charOffsetToX(
   return x;
 }
 
-/**
- * Calculate the rendered top of a line, including float-driven vertical skips.
- */
-function lineHeightBefore(
-  measure: ParagraphMeasure,
-  lineIndex: number,
-): number {
-  let height = 0;
-  for (let i = 0; i < lineIndex && i < measure.lines.length; i++) {
-    // SAFETY: i < measure.lines.length in for loop
-    const line = measure.lines[i]!;
-    height += (line.floatSkipBefore ?? 0) + line.lineHeight;
-  }
-  height += measure.lines[lineIndex]?.floatSkipBefore ?? 0;
-  return height;
-}
-
 // =============================================================================
 // MAIN FUNCTIONS
 // =============================================================================
@@ -520,9 +504,11 @@ export function selectionToRects(
           }
 
           // Calculate line Y offset within fragment
-          const lineOffset =
-            lineHeightBefore(paragraphMeasure, index) -
-            lineHeightBefore(paragraphMeasure, paragraphFragment.fromLine);
+          const lineOffset = measuredLineContentOffset(
+            paragraphMeasure.lines,
+            paragraphFragment.fromLine,
+            index,
+          );
 
           // Create selection rectangle
           const rectX =
@@ -679,7 +665,11 @@ export function selectionToRects(
                   contentWidth,
                 );
 
-                const lineY = lineHeightBefore(paragraphMeasure, index);
+                const lineY = measuredLineContentOffset(
+                  paragraphMeasure.lines,
+                  0,
+                  index,
+                );
                 const clippedLineY = contentOffsetY + blockY + lineY;
                 if (
                   clippedLineY + line.lineHeight <= clipTop ||
@@ -832,9 +822,11 @@ export function getCaretPosition(
             }
 
             // Calculate Y offset
-            const lineOffset =
-              lineHeightBefore(paragraphMeasure, lineIndex) -
-              lineHeightBefore(paragraphMeasure, paragraphFragment.fromLine);
+            const lineOffset = measuredLineContentOffset(
+              paragraphMeasure.lines,
+              paragraphFragment.fromLine,
+              lineIndex,
+            );
 
             return {
               x: fragment.x + indentLeft + alignmentOffset + x,

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -744,6 +744,36 @@ describe("toFlowBlocks list numbering", () => {
     expect(textBox.content.at(0)?.attrs?.listMarker).toBe("2.");
   });
 
+  test("carries anchored text-box position into flow blocks", () => {
+    const textBoxNode = schema.nodes.textBox;
+    if (!textBoxNode) {
+      throw new Error("Expected textBox node in schema");
+    }
+
+    const position = {
+      horizontal: { relativeTo: "margin", align: "center" },
+      vertical: { relativeTo: "page", posOffset: 123_456 },
+    } as const;
+    const doc = schema.node("doc", null, [
+      textBoxNode.create(
+        {
+          wrapType: "topAndBottom",
+          position,
+        },
+        [schema.node("paragraph", null, [schema.text("Inside")])],
+      ),
+    ]);
+
+    const textBox = toFlowBlocks(doc).at(0);
+
+    expect(textBox?.kind).toBe("textBox");
+    if (textBox?.kind !== "textBox") {
+      throw new Error("Expected textBox block");
+    }
+    expect(textBox.wrapType).toBe("topAndBottom");
+    expect(textBox.position).toEqual(position);
+  });
+
   test("substitutes style-inherited marker templates without paragraph numPr", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2265,6 +2265,9 @@ function convertTextBoxNode(
   if (attrs.distRight !== undefined) {
     textBox.distRight = attrs.distRight;
   }
+  if (attrs.position !== undefined) {
+    textBox.position = attrs.position;
+  }
   return textBox;
 }
 

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -15,7 +15,11 @@ import {
 import { measuredLineAdvance } from "./lineFlow";
 import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
 import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
-import { bandTopContentY, floatingTextBoxReservesBand } from "./textBoxFlow";
+import {
+  bandFragmentX,
+  bandTopContentY,
+  floatingTextBoxReservesBand,
+} from "./textBoxFlow";
 import type {
   FlowBlock,
   Measure,
@@ -1108,10 +1112,22 @@ function layoutTextBox(
     // inside the resolver instead would desync the box from its band on a
     // title page whose first-page top margin differs from the section margin.
     const bandTop = bandTopContentY(block.position?.vertical, sectionMarginTop);
+    // Honor the box's horizontal anchor (align center/right, page-relative
+    // offset) instead of always pinning to the column's left edge. The band is
+    // full-width regardless, so this only moves where the box paints.
+    const horizontal = block.position?.horizontal;
+    const x = horizontal
+      ? bandFragmentX(horizontal, {
+          pageWidth: state.page.size.w,
+          marginLeft: state.page.margins.left,
+          marginRight: state.page.margins.right,
+          boxWidth: measure.width,
+        })
+      : paginator.getColumnX(state.columnIndex);
     const fragment: TextBoxFragment = {
       kind: "textBox",
       blockId: block.id,
-      x: paginator.getColumnX(state.columnIndex),
+      x,
       y: state.topMargin + bandTop,
       width: measure.width,
       height: measure.height,

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./keep-together";
 import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
 import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
+import { floatingTextBoxReservesBand } from "./textBoxFlow";
 import type {
   FlowBlock,
   Measure,
@@ -1085,6 +1086,27 @@ function layoutTextBox(
   measure: TextBoxMeasure,
   paginator: ReturnType<typeof createPaginator>,
 ): void {
+  // A page/margin-pinned topAndBottom band (e.g. a title banner) floats to the
+  // top of its page; the reserved band in the measure pass pushes body text
+  // below it (see extractFloatingZones in PagedEditor). It must not also consume
+  // flow at its anchor, or the box height would be reserved twice. Place it at
+  // the page content top without advancing the cursor. eigenpal #694.
+  if (isPagePinnedBandTextBox(block)) {
+    const state = paginator.getCurrentState();
+    const fragment: TextBoxFragment = {
+      kind: "textBox",
+      blockId: block.id,
+      x: paginator.getColumnX(state.columnIndex),
+      y: state.topMargin,
+      width: measure.width,
+      height: measure.height,
+      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+    };
+    state.page.fragments.push(fragment);
+    return;
+  }
+
   const state = paginator.ensureFits(measure.height);
 
   const fragment: TextBoxFragment = {
@@ -1100,6 +1122,18 @@ function layoutTextBox(
 
   const result = paginator.addFragment(fragment, measure.height, 0, 0);
   fragment.y = result.y;
+}
+
+/**
+ * A topAndBottom text box whose vertical anchor is page/margin-relative — it
+ * floats to the page top rather than flowing in document order.
+ */
+function isPagePinnedBandTextBox(block: TextBoxBlock): boolean {
+  if (!floatingTextBoxReservesBand(block)) {
+    return false;
+  }
+  const relativeTo = block.position?.vertical?.relativeTo;
+  return relativeTo === "page" || relativeTo === "margin";
 }
 
 /**

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -19,6 +19,7 @@ import {
   bandFragmentX,
   bandTopContentY,
   floatingTextBoxReservesBand,
+  isPageFrameRelativeAnchor,
 } from "./textBoxFlow";
 import type {
   FlowBlock,
@@ -284,7 +285,13 @@ export function layoutDocument(
 
   // Process each block, tracking section break index with a counter (O(1) per break)
   let sectionIdx = 0;
+  // Section page geometry for resolving page/margin-pinned topAndBottom bands.
+  // The measure pass (extractFloatingZones) uses the section config, not the
+  // page's possibly-different first-page margins, so layout must too or the
+  // reserved band and painted box desync. eigenpal #694.
   let activeSectionMarginTop = initialConfig.margins.top;
+  let activeSectionPageHeight = initialConfig.pageSize.h;
+  let activeSectionMarginBottom = initialConfig.margins.bottom;
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
@@ -344,12 +351,12 @@ export function layoutDocument(
         break;
 
       case "textBox":
-        layoutTextBox(
-          block as TextBoxBlock,
-          measure as TextBoxMeasure,
+        layoutTextBox(block as TextBoxBlock, measure as TextBoxMeasure, {
           paginator,
-          activeSectionMarginTop,
-        );
+          sectionMarginTop: activeSectionMarginTop,
+          sectionPageHeight: activeSectionPageHeight,
+          sectionMarginBottom: activeSectionMarginBottom,
+        });
         break;
 
       case "pageBreak":
@@ -375,6 +382,8 @@ export function layoutDocument(
           sectionIdx + 1,
         );
         activeSectionMarginTop = nextSectionConfig.margins.top;
+        activeSectionPageHeight = nextSectionConfig.pageSize.h;
+        activeSectionMarginBottom = nextSectionConfig.margins.bottom;
         sectionIdx++;
         break;
       }
@@ -1088,14 +1097,25 @@ function layoutAnchoredImage(
   state.page.fragments.push(fragment);
 }
 
+type LayoutTextBoxOptions = {
+  paginator: ReturnType<typeof createPaginator>;
+  sectionMarginTop: number;
+  sectionPageHeight: number;
+  sectionMarginBottom: number;
+};
+
 /**
  * Layout a text box block onto pages.
  */
 function layoutTextBox(
   block: TextBoxBlock,
   measure: TextBoxMeasure,
-  paginator: ReturnType<typeof createPaginator>,
-  sectionMarginTop: number,
+  {
+    paginator,
+    sectionMarginTop,
+    sectionPageHeight,
+    sectionMarginBottom,
+  }: LayoutTextBoxOptions,
 ): void {
   // A page/margin-pinned topAndBottom band (e.g. a title banner) floats to the
   // top of its page; the reserved band in the measure pass pushes body text
@@ -1111,7 +1131,12 @@ function layoutTextBox(
     // own top margin (`state.topMargin`) to convert. Using `state.topMargin`
     // inside the resolver instead would desync the box from its band on a
     // title page whose first-page top margin differs from the section margin.
-    const bandTop = bandTopContentY(block.position?.vertical, sectionMarginTop);
+    const bandTop = bandTopContentY(block.position?.vertical, {
+      pageHeight: sectionPageHeight,
+      marginTop: sectionMarginTop,
+      marginBottom: sectionMarginBottom,
+      boxHeight: measure.height,
+    });
     // Honor the box's horizontal anchor (align center/right, page-relative
     // offset) instead of always pinning to the column's left edge. The band is
     // full-width regardless, so this only moves where the box paints.
@@ -1156,15 +1181,16 @@ function layoutTextBox(
 }
 
 /**
- * A topAndBottom text box whose vertical anchor is page/margin-relative — it
- * floats to the page top rather than flowing in document order.
+ * A topAndBottom text box whose vertical anchor pins it to the page frame
+ * (page/margin/margin-strip) — it floats to a fixed page position rather than
+ * flowing in document order. Must agree with the measure pass's band extraction
+ * (extractFloatingZones), which uses the same predicate. eigenpal #694.
  */
 function isPagePinnedBandTextBox(block: TextBoxBlock): boolean {
   if (!floatingTextBoxReservesBand(block)) {
     return false;
   }
-  const relativeTo = block.position?.vertical?.relativeTo;
-  return relativeTo === "page" || relativeTo === "margin";
+  return isPageFrameRelativeAnchor(block.position?.vertical?.relativeTo);
 }
 
 /**

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./keep-together";
 import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
 import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
-import { floatingTextBoxReservesBand } from "./textBoxFlow";
+import { bandTopContentY, floatingTextBoxReservesBand } from "./textBoxFlow";
 import type {
   FlowBlock,
   Measure,
@@ -1093,11 +1093,16 @@ function layoutTextBox(
   // the page content top without advancing the cursor. eigenpal #694.
   if (isPagePinnedBandTextBox(block)) {
     const state = paginator.getCurrentState();
+    // Position the box at the same Y the measure pass reserved its band at
+    // (bandTopContentY is content-relative; fragment.y is page-absolute, so add
+    // the top margin). Honors the anchor's vertical offset instead of always
+    // pinning to the content top.
+    const bandTop = bandTopContentY(block.position?.vertical, state.topMargin);
     const fragment: TextBoxFragment = {
       kind: "textBox",
       blockId: block.id,
       x: paginator.getColumnX(state.columnIndex),
-      y: state.topMargin,
+      y: state.topMargin + bandTop,
       width: measure.width,
       height: measure.height,
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -12,6 +12,7 @@ import {
   getMidChainIndices,
   hasPageBreakBefore,
 } from "./keep-together";
+import { measuredLineAdvance } from "./lineFlow";
 import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
 import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
 import { bandTopContentY, floatingTextBoxReservesBand } from "./textBoxFlow";
@@ -499,14 +500,14 @@ function layoutParagraph(
 
     for (let j = currentLineIndex; j < lines.length; j++) {
       const line = lines[j]!; // SAFETY: j < lines.length
-      const lineHeight = line.lineHeight;
+      const lineAdvance = measuredLineAdvance(line);
       const lineRefs = getLineFootnoteRefs(
         block,
         line.fromRun,
         line.toRun,
         footnoteHeightById,
       );
-      const totalWithLine = linesHeight + lineHeight;
+      const totalWithLine = linesHeight + lineAdvance;
       const withSpacing =
         totalWithLine +
         firstFragmentSpaceBefore +
@@ -604,7 +605,7 @@ function layoutParagraph(
 
     // If more lines remain, advance to next column/page
     if (currentLineIndex < lines.length) {
-      paginator.ensureFits(lines[currentLineIndex]!.lineHeight); // SAFETY: guarded by length check
+      paginator.ensureFits(measuredLineAdvance(lines[currentLineIndex]!)); // SAFETY: guarded by length check
     }
   }
 }

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -834,11 +834,16 @@ function layoutTable(
     const rawAvailableHeight = paginator.getAvailableHeight();
     const isFirstFragment = currentRowIndex === 0;
 
-    // Account for trailing spacing from previous block that addFragment will consume.
-    // addFragment computes effectiveSpaceBefore = max(spaceBefore, trailingSpacing)
-    // and adds it to the fragment height before calling ensureFits.
-    // We pass spaceBefore=0 for tables, so the overhead is just trailingSpacing.
-    const pendingSpacing = isFirstFragment ? state.trailingSpacing : 0;
+    // Leading skip past a page-pinned band, applied only to the table's first
+    // fragment (a band sits on one page). eigenpal #694.
+    const bandSkip = isFirstFragment ? (measure.bandSkipBefore ?? 0) : 0;
+
+    // Account for the space addFragment will consume before the fragment, which
+    // is max(spaceBefore, trailingSpacing). We pass bandSkip as spaceBefore, so
+    // the overhead is the larger of that and the previous block's trailing space.
+    const pendingSpacing = isFirstFragment
+      ? Math.max(bandSkip, state.trailingSpacing)
+      : 0;
     const availableHeight = rawAvailableHeight - pendingSpacing;
 
     const repeatHeaderRowsForNormalFragment = shouldRepeatHeaderRows(
@@ -894,7 +899,7 @@ function layoutTable(
       ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
     };
 
-    const result = paginator.addFragment(fragment, fragmentHeight, 0, 0);
+    const result = paginator.addFragment(fragment, fragmentHeight, bandSkip, 0);
     fragment.y = result.y;
     fragment.x = desiredX;
 
@@ -1044,8 +1049,9 @@ function layoutImage(
     return;
   }
 
-  // Inline image - ensure it fits
-  const state = paginator.ensureFits(measure.height);
+  // Inline image - ensure it fits (plus any leading skip past a page band)
+  const bandSkip = measure.bandSkipBefore ?? 0;
+  const state = paginator.ensureFits(bandSkip + measure.height);
 
   const fragment: ImageFragment = {
     kind: "image",
@@ -1058,7 +1064,7 @@ function layoutImage(
     ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
   };
 
-  const result = paginator.addFragment(fragment, measure.height, 0, 0);
+  const result = paginator.addFragment(fragment, measure.height, bandSkip, 0);
   fragment.y = result.y;
 }
 

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -280,6 +280,7 @@ export function layoutDocument(
 
   // Process each block, tracking section break index with a counter (O(1) per break)
   let sectionIdx = 0;
+  let activeSectionMarginTop = initialConfig.margins.top;
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]!; // SAFETY: i < blocks.length
     const measure = measures[i]!; // SAFETY: measures.length === blocks.length (validated above)
@@ -343,7 +344,7 @@ export function layoutDocument(
           block as TextBoxBlock,
           measure as TextBoxMeasure,
           paginator,
-          margins.top,
+          activeSectionMarginTop,
         );
         break;
 
@@ -358,15 +359,18 @@ export function layoutDocument(
       case "sectionBreak": {
         // Use the NEXT section's columns; for break type, prefer next section's
         // type but fall back to current break's type (preserves explicit 'continuous')
+        const nextSectionConfig =
+          sectionConfigs[sectionIdx + 1] ?? initialConfig;
         const nextType =
           sectionBreakTypes[sectionIdx + 1] ?? sectionBreakTypes[sectionIdx];
         handleSectionBreak(
           block as SectionBreakBlock,
           paginator,
-          sectionConfigs[sectionIdx + 1] ?? initialConfig,
+          nextSectionConfig,
           nextType,
           sectionIdx + 1,
         );
+        activeSectionMarginTop = nextSectionConfig.margins.top;
         sectionIdx++;
         break;
       }

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -342,6 +342,7 @@ export function layoutDocument(
           block as TextBoxBlock,
           measure as TextBoxMeasure,
           paginator,
+          margins.top,
         );
         break;
 
@@ -1085,6 +1086,7 @@ function layoutTextBox(
   block: TextBoxBlock,
   measure: TextBoxMeasure,
   paginator: ReturnType<typeof createPaginator>,
+  sectionMarginTop: number,
 ): void {
   // A page/margin-pinned topAndBottom band (e.g. a title banner) floats to the
   // top of its page; the reserved band in the measure pass pushes body text
@@ -1093,11 +1095,14 @@ function layoutTextBox(
   // the page content top without advancing the cursor. eigenpal #694.
   if (isPagePinnedBandTextBox(block)) {
     const state = paginator.getCurrentState();
-    // Position the box at the same Y the measure pass reserved its band at
-    // (bandTopContentY is content-relative; fragment.y is page-absolute, so add
-    // the top margin). Honors the anchor's vertical offset instead of always
-    // pinning to the content top.
-    const bandTop = bandTopContentY(block.position?.vertical, state.topMargin);
+    // Position the box at the same content-Y the measure pass reserved its band
+    // at. The measure pass uses the section top margin (not a page's
+    // first-page margin), so use the same value here; `bandTopContentY` is
+    // content-relative, and `fragment.y` is page-absolute, so add the page's
+    // own top margin (`state.topMargin`) to convert. Using `state.topMargin`
+    // inside the resolver instead would desync the box from its band on a
+    // title page whose first-page top margin differs from the section margin.
+    const bandTop = bandTopContentY(block.position?.vertical, sectionMarginTop);
     const fragment: TextBoxFragment = {
       kind: "textBox",
       blockId: block.id,

--- a/packages/folio/src/core/layout-engine/lineFlow.ts
+++ b/packages/folio/src/core/layout-engine/lineFlow.ts
@@ -1,0 +1,33 @@
+import type { MeasuredLine } from "./types";
+
+export function measuredLineAdvance(line: MeasuredLine): number {
+  return line.lineHeight + (line.floatSkipBefore ?? 0);
+}
+
+export function measuredLineRangeHeight(
+  lines: readonly MeasuredLine[],
+  fromLine: number,
+  toLine: number,
+): number {
+  let height = 0;
+  const start = Math.max(0, fromLine);
+  const end = Math.min(toLine, lines.length);
+
+  for (let index = start; index < end; index++) {
+    height += measuredLineAdvance(lines[index]!); // SAFETY: index < end <= lines.length
+  }
+
+  return height;
+}
+
+export function measuredLineContentOffset(
+  lines: readonly MeasuredLine[],
+  fromLine: number,
+  lineIndex: number,
+): number {
+  const line = lines.at(lineIndex);
+  return (
+    measuredLineRangeHeight(lines, fromLine, lineIndex) +
+    (line?.floatSkipBefore ?? 0)
+  );
+}

--- a/packages/folio/src/core/layout-engine/measure/floatingZones.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/floatingZones.test.ts
@@ -4,7 +4,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { rectsToFloatingZones } from "./floatingZones";
+import {
+  getFloatingMargins,
+  rectsToFloatingZones,
+  type FloatingImageZone,
+} from "./floatingZones";
+import { findClearLineY } from "./measureParagraph";
 
 describe("rectsToFloatingZones", () => {
   test("centered both-sides object falls back to the wider side (split rendering is not yet supported)", () => {
@@ -152,5 +157,79 @@ describe("rectsToFloatingZones", () => {
 
     expect(zone?.leftMargin).toBe(0);
     expect(zone?.rightMargin).toBe(0);
+  });
+});
+
+describe("topAndBottom full-width band (eigenpal #694)", () => {
+  test("rectsToFloatingZones builds a full-width band, no side wrap", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "left",
+          x: 0,
+          y: -10,
+          width: 500,
+          height: 200,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 0,
+          distRight: 0,
+          wrapType: "topAndBottom",
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.fullWidthBlock).toBe(true);
+    expect(zone?.leftMargin).toBe(0);
+    expect(zone?.rightMargin).toBe(0);
+    expect(zone?.topY).toBe(-10);
+    expect(zone?.bottomY).toBe(190);
+  });
+
+  test("getFloatingMargins gives a line overlapping the band zero width", () => {
+    const band: FloatingImageZone[] = [
+      {
+        leftMargin: 0,
+        rightMargin: 0,
+        topY: 0,
+        bottomY: 102,
+        fullWidthBlock: true,
+      },
+    ];
+    const margins = getFloatingMargins(10, 16, band, 0);
+    expect(margins.segments).toEqual([{ leftOffset: 0, availableWidth: 0 }]);
+  });
+
+  test("getFloatingMargins leaves a line clear of the band unobstructed", () => {
+    const band: FloatingImageZone[] = [
+      {
+        leftMargin: 0,
+        rightMargin: 0,
+        topY: 0,
+        bottomY: 102,
+        fullWidthBlock: true,
+      },
+    ];
+    expect(getFloatingMargins(120, 16, band, 0)).toEqual({
+      leftMargin: 0,
+      rightMargin: 0,
+    });
+  });
+
+  test("findClearLineY pushes a line below the band", () => {
+    const band: FloatingImageZone[] = [
+      {
+        leftMargin: 0,
+        rightMargin: 0,
+        topY: 0,
+        bottomY: 102,
+        fullWidthBlock: true,
+      },
+    ];
+    // No text fits in the band → the line hops to its bottom.
+    expect(findClearLineY(0, 16, band, 500, 24)).toBe(102);
+    // Below the band there is full width again.
+    expect(findClearLineY(110, 16, band, 500, 24)).toBe(110);
   });
 });

--- a/packages/folio/src/core/layout-engine/measure/floatingZones.ts
+++ b/packages/folio/src/core/layout-engine/measure/floatingZones.ts
@@ -51,6 +51,12 @@ export type FloatingImageZone = {
   bottomY: number;
   /** Optional split segments for centered both-sides wrapping. */
   segments?: FloatingLineSegmentZone[];
+  /**
+   * Full-width vertical band (OOXML `topAndBottom` wrap): no text fits beside
+   * it, so any line overlapping `[topY, bottomY]` is pushed below the band
+   * (via `findClearLineY`). Ported from eigenpal docx-editor #694.
+   */
+  fullWidthBlock?: boolean;
 };
 
 export type FloatingLineSegmentZone = {
@@ -88,6 +94,18 @@ export function rectsToFloatingZones(
     const rectRight = rect.x + rect.width + rect.distRight;
     const rectTop = rect.y - rect.distTop;
     const rectBottom = rect.y + rect.height + rect.distBottom;
+
+    // topAndBottom: full-width band, no side wrap. Lines overlapping the band
+    // flow above/below it (handled in getFloatingMargins / findClearLineY).
+    if (rect.wrapType === "topAndBottom") {
+      return {
+        leftMargin: 0,
+        rightMargin: 0,
+        topY: rectTop,
+        bottomY: rectBottom,
+        fullWidthBlock: true,
+      };
+    }
 
     let leftMargin = 0;
     let rightMargin = 0;
@@ -192,6 +210,15 @@ export function getFloatingMargins(
   for (const zone of zones) {
     if (absoluteLineBottom <= zone.topY || absoluteLineTop >= zone.bottomY) {
       continue;
+    }
+    if (zone.fullWidthBlock) {
+      // No room beside a full-width band: a zero-width segment forces the
+      // available width to 0, which findClearLineY uses to push the line below.
+      return {
+        leftMargin: 0,
+        rightMargin: 0,
+        segments: [{ leftOffset: 0, availableWidth: 0 }],
+      };
     }
     if (zone.segments?.length) {
       segments = segments

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -12,6 +12,7 @@ import {
 import type { TabContext } from "../../prosemirror/utils/tabCalculator";
 import { DEFAULT_SINGLE_LINE_RATIO } from "../../utils/fontResolver";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
+import { measuredLineAdvance } from "../lineFlow";
 import type {
   ParagraphBlock,
   ParagraphMeasure,
@@ -1208,7 +1209,7 @@ export function measureParagraph(
   // Calculate total height — include floatSkipBefore from lines bumped past
   // floats so containers stay sized correctly.
   const totalHeight = lines.reduce(
-    (sum, line) => sum + line.lineHeight + (line.floatSkipBefore ?? 0),
+    (sum, line) => sum + measuredLineAdvance(line),
     0,
   );
 

--- a/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  bandFragmentX,
   floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
   isFloatingTextBoxBlock,
@@ -72,5 +73,74 @@ describe("floatingTextBoxReservesBand", () => {
     expect(floatingTextBoxReservesBand({ wrapType: "behind" })).toBe(false);
     expect(floatingTextBoxReservesBand({ displayMode: "float" })).toBe(false);
     expect(floatingTextBoxReservesBand({})).toBe(false);
+  });
+});
+
+describe("bandFragmentX (eigenpal #694)", () => {
+  // 816px page, 96px side margins → 624px content box; 600px banner.
+  const geometry = {
+    pageWidth: 816,
+    marginLeft: 96,
+    marginRight: 96,
+    boxWidth: 600,
+  };
+  const EMU_PER_INCH = 914_400; // 1in = 96px at 96 DPI = marginLeft.
+
+  test("no horizontal anchor → content left edge", () => {
+    expect(bandFragmentX(undefined, geometry)).toBe(96);
+  });
+
+  test("margin-relative align=center centers within the content box", () => {
+    // 96 + (624 - 600) / 2
+    expect(
+      bandFragmentX({ relativeTo: "margin", align: "center" }, geometry),
+    ).toBe(108);
+  });
+
+  test("margin-relative align=right pins to the content right edge", () => {
+    // (816 - 96) - 600
+    expect(
+      bandFragmentX({ relativeTo: "margin", align: "right" }, geometry),
+    ).toBe(120);
+  });
+
+  test("page-relative align=center centers within the full page", () => {
+    // (816 - 600) / 2
+    expect(
+      bandFragmentX({ relativeTo: "page", align: "center" }, geometry),
+    ).toBe(108);
+  });
+
+  test("page-relative align=right pins to the page right edge", () => {
+    // 816 - 600
+    expect(
+      bandFragmentX({ relativeTo: "page", align: "right" }, geometry),
+    ).toBe(216);
+  });
+
+  test("align=outside aliases right, align=inside aliases left", () => {
+    expect(
+      bandFragmentX({ relativeTo: "margin", align: "outside" }, geometry),
+    ).toBe(120);
+    expect(
+      bandFragmentX({ relativeTo: "margin", align: "inside" }, geometry),
+    ).toBe(96);
+  });
+
+  test("explicit posOffset wins over align and is frame-relative", () => {
+    // page frame: 0 + 96
+    expect(
+      bandFragmentX(
+        { relativeTo: "page", posOffset: EMU_PER_INCH, align: "center" },
+        geometry,
+      ),
+    ).toBe(96);
+    // margin frame: 96 + 96
+    expect(
+      bandFragmentX(
+        { relativeTo: "margin", posOffset: EMU_PER_INCH },
+        geometry,
+      ),
+    ).toBe(192);
   });
 });

--- a/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
@@ -6,9 +6,11 @@ import { describe, expect, test } from "bun:test";
 
 import {
   bandFragmentX,
+  bandTopContentY,
   floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
   isFloatingTextBoxBlock,
+  isPageFrameRelativeAnchor,
 } from "./textBoxFlow";
 
 describe("isFloatingTextBoxBlock", () => {
@@ -142,5 +144,94 @@ describe("bandFragmentX (eigenpal #694)", () => {
         geometry,
       ),
     ).toBe(192);
+  });
+});
+
+describe("isPageFrameRelativeAnchor (eigenpal #694)", () => {
+  test("page, text margin, and margin strips pin to the page frame", () => {
+    expect(isPageFrameRelativeAnchor("page")).toBe(true);
+    expect(isPageFrameRelativeAnchor("margin")).toBe(true);
+    expect(isPageFrameRelativeAnchor("topMargin")).toBe(true);
+    expect(isPageFrameRelativeAnchor("bottomMargin")).toBe(true);
+    expect(isPageFrameRelativeAnchor("insideMargin")).toBe(true);
+    expect(isPageFrameRelativeAnchor("outsideMargin")).toBe(true);
+  });
+
+  test("flow-relative and absent anchors are not page-pinned", () => {
+    expect(isPageFrameRelativeAnchor("paragraph")).toBe(false);
+    expect(isPageFrameRelativeAnchor("line")).toBe(false);
+    expect(isPageFrameRelativeAnchor(undefined)).toBe(false);
+  });
+});
+
+describe("bandTopContentY (eigenpal #694)", () => {
+  // 1056px page, 96px top / 48px bottom margin → content frame [96, 1008];
+  // 100px band box. Returned Y is content-relative (0 = content top).
+  const geometry = {
+    pageHeight: 1056,
+    marginTop: 96,
+    marginBottom: 48,
+    boxHeight: 100,
+  };
+  const EMU_PER_INCH = 914_400; // 1in = 96px at 96 DPI = marginTop.
+
+  test("page/margin offset-0 anchors keep their content-relative origin", () => {
+    // page frame top 0 → content-relative -marginTop; margin frame top → 0.
+    expect(bandTopContentY({ relativeTo: "page" }, geometry)).toBe(-96);
+    expect(bandTopContentY({ relativeTo: "margin" }, geometry)).toBe(0);
+    expect(bandTopContentY(undefined, geometry)).toBe(0);
+  });
+
+  test("center align resolves to the middle of the anchor frame", () => {
+    // margin frame [96, 1008]: 96 + (912 - 100) / 2 = 502 → content 406.
+    expect(
+      bandTopContentY({ relativeTo: "margin", align: "center" }, geometry),
+    ).toBe(406);
+    // page frame [0, 1056]: (1056 - 100) / 2 = 478 → content 382.
+    expect(
+      bandTopContentY({ relativeTo: "page", align: "center" }, geometry),
+    ).toBe(382);
+  });
+
+  test("bottom/outside align pins the box to the frame bottom", () => {
+    // margin frame bottom 1008 - 100 = 908 → content 812.
+    expect(
+      bandTopContentY({ relativeTo: "margin", align: "bottom" }, geometry),
+    ).toBe(812);
+    expect(
+      bandTopContentY({ relativeTo: "margin", align: "outside" }, geometry),
+    ).toBe(812);
+    // inside aliases top: margin frame top 96 → content 0.
+    expect(
+      bandTopContentY({ relativeTo: "margin", align: "inside" }, geometry),
+    ).toBe(0);
+  });
+
+  test("margin-strip anchors resolve to their strip", () => {
+    // topMargin/insideMargin → [0, 96] strip top → content -96.
+    expect(bandTopContentY({ relativeTo: "topMargin" }, geometry)).toBe(-96);
+    expect(bandTopContentY({ relativeTo: "insideMargin" }, geometry)).toBe(-96);
+    // bottomMargin/outsideMargin → [1008, 1056] strip top → content 912.
+    expect(bandTopContentY({ relativeTo: "bottomMargin" }, geometry)).toBe(912);
+    expect(bandTopContentY({ relativeTo: "outsideMargin" }, geometry)).toBe(
+      912,
+    );
+    // bottom-aligned within the bottom strip: 1056 - 100 = 956 → content 860.
+    expect(
+      bandTopContentY(
+        { relativeTo: "bottomMargin", align: "bottom" },
+        geometry,
+      ),
+    ).toBe(860);
+  });
+
+  test("explicit posOffset wins over align and is frame-relative", () => {
+    // margin frame top 96 + 96 = 192 → content 96 (align ignored).
+    expect(
+      bandTopContentY(
+        { relativeTo: "margin", posOffset: EMU_PER_INCH, align: "center" },
+        geometry,
+      ),
+    ).toBe(96);
   });
 });

--- a/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
   isFloatingTextBoxBlock,
 } from "./textBoxFlow";
@@ -55,5 +56,21 @@ describe("floatingTextBoxWrapsText", () => {
   test("does not wrap text for non-floating blocks", () => {
     expect(floatingTextBoxWrapsText({ displayMode: "inline" })).toBe(false);
     expect(floatingTextBoxWrapsText({})).toBe(false);
+  });
+});
+
+describe("floatingTextBoxReservesBand", () => {
+  test("topAndBottom reserves a full-width band, no side wrap (eigenpal #694)", () => {
+    const box = { wrapType: "topAndBottom" } as const;
+    expect(floatingTextBoxReservesBand(box)).toBe(true);
+    expect(floatingTextBoxWrapsText(box)).toBe(false);
+    expect(isFloatingTextBoxBlock(box)).toBe(true);
+  });
+
+  test("side-wrap and wrapNone types do not reserve a band", () => {
+    expect(floatingTextBoxReservesBand({ wrapType: "square" })).toBe(false);
+    expect(floatingTextBoxReservesBand({ wrapType: "behind" })).toBe(false);
+    expect(floatingTextBoxReservesBand({ displayMode: "float" })).toBe(false);
+    expect(floatingTextBoxReservesBand({})).toBe(false);
   });
 });

--- a/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
@@ -145,6 +145,22 @@ describe("bandFragmentX (eigenpal #694)", () => {
       ),
     ).toBe(192);
   });
+
+  test("resolves left/right margin-strip frames", () => {
+    // leftMargin/insideMargin → left strip [0, 96]; rightMargin/outsideMargin →
+    // right strip [720, 816]. The box's left edge sits at the strip's left.
+    expect(bandFragmentX({ relativeTo: "leftMargin" }, geometry)).toBe(0);
+    expect(bandFragmentX({ relativeTo: "insideMargin" }, geometry)).toBe(0);
+    expect(bandFragmentX({ relativeTo: "rightMargin" }, geometry)).toBe(720);
+    expect(bandFragmentX({ relativeTo: "outsideMargin" }, geometry)).toBe(720);
+    // posOffset is measured from the strip's left edge, not the content box.
+    expect(
+      bandFragmentX(
+        { relativeTo: "leftMargin", posOffset: EMU_PER_INCH },
+        geometry,
+      ),
+    ).toBe(96);
+  });
 });
 
 describe("isPageFrameRelativeAnchor (eigenpal #694)", () => {

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -40,21 +40,122 @@ export function floatingTextBoxReservesBand(block: TextBoxFlowAttrs): boolean {
   return isFloatingTextBoxBlock(block) && block.wrapType === "topAndBottom";
 }
 
+type VerticalRelativeTo = NonNullable<
+  ImageRunPosition["vertical"]
+>["relativeTo"];
+type VerticalAlign = NonNullable<ImageRunPosition["vertical"]>["align"];
+
+/**
+ * `true` when a vertical anchor pins the box to a fixed position on the page
+ * (page body, text margin, or a margin strip) rather than to the surrounding
+ * text flow. A `topAndBottom` box with such an anchor reserves a full-width
+ * band; `paragraph`/`line` anchors keep folio's in-flow handling. Exhaustive
+ * over the OOXML `ST_RelFromV` set so a new relativeFrom value forces a decision
+ * here instead of silently falling through. eigenpal #694.
+ */
+export function isPageFrameRelativeAnchor(
+  relativeTo: VerticalRelativeTo,
+): boolean {
+  switch (relativeTo) {
+    case "page":
+    case "margin":
+    case "topMargin":
+    case "bottomMargin":
+    case "insideMargin":
+    case "outsideMargin":
+      return true;
+    case "paragraph":
+    case "line":
+    case undefined:
+      return false;
+    default:
+      relativeTo satisfies never;
+      return false;
+  }
+}
+
+/** Page geometry needed to resolve a band box's vertical anchor. */
+export type BandVerticalGeometry = {
+  pageHeight: number;
+  marginTop: number;
+  marginBottom: number;
+  boxHeight: number;
+};
+
+/**
+ * Page-absolute `[top, bottom]` (px) of the frame a vertical anchor positions
+ * within. `insideMargin`/`outsideMargin` map to the top/bottom margin strips
+ * (vertical page parity is not modelled); flow-relative anchors fall back to the
+ * content box, which is also where a page-pinned band with no usable anchor
+ * sits. eigenpal #694.
+ */
+function bandVerticalFrame(
+  relativeTo: VerticalRelativeTo,
+  geometry: BandVerticalGeometry,
+): { top: number; bottom: number } {
+  const { pageHeight, marginTop, marginBottom } = geometry;
+  switch (relativeTo) {
+    case "page":
+      return { top: 0, bottom: pageHeight };
+    case "topMargin":
+    case "insideMargin":
+      return { top: 0, bottom: marginTop };
+    case "bottomMargin":
+    case "outsideMargin":
+      return { top: pageHeight - marginBottom, bottom: pageHeight };
+    case "margin":
+    case "paragraph":
+    case "line":
+    case undefined:
+      return { top: marginTop, bottom: pageHeight - marginBottom };
+    default:
+      relativeTo satisfies never;
+      return { top: marginTop, bottom: pageHeight - marginBottom };
+  }
+}
+
+/** Page-absolute top Y (px) of the box within its frame for a bare `align`. */
+function alignedFrameTop(
+  align: VerticalAlign,
+  frame: { top: number; bottom: number },
+  boxHeight: number,
+): number {
+  switch (align) {
+    case "center":
+      return frame.top + (frame.bottom - frame.top - boxHeight) / 2;
+    case "bottom":
+    case "outside":
+      return frame.bottom - boxHeight;
+    case "top":
+    case "inside":
+    case undefined:
+      return frame.top;
+    default:
+      align satisfies never;
+      return frame.top;
+  }
+}
+
 /**
  * Content-area top Y (px) of a `topAndBottom` band box's reserved band, resolved
  * from its OOXML vertical anchor. Shared by the measure pass
  * (`extractFloatingZones`) and the layout pass (`layoutTextBox`) so the reserved
- * band and the painted box land at the same Y — a page-relative offset is
- * measured from the page edge (subtract the top margin); a margin-relative
- * offset (or no offset) is already content-relative. Ported from eigenpal #694.
+ * band and the painted box land at the same Y. Within the anchor's frame an
+ * explicit `posOffset` wins, then `align` (top/center/bottom/inside/outside);
+ * otherwise the box sits at the frame top. The result is content-relative
+ * (0 = content top), so a page/margin-strip frame is converted by subtracting
+ * the top margin. Ported from eigenpal #694.
  */
 export function bandTopContentY(
   vertical: ImageRunPosition["vertical"],
-  marginTop: number,
+  geometry: BandVerticalGeometry,
 ): number {
-  const offset =
-    vertical?.posOffset !== undefined ? emuToPixels(vertical.posOffset) : 0;
-  return vertical?.relativeTo === "page" ? offset - marginTop : offset;
+  const frame = bandVerticalFrame(vertical?.relativeTo, geometry);
+  const pageTop =
+    vertical?.posOffset !== undefined
+      ? frame.top + emuToPixels(vertical.posOffset)
+      : alignedFrameTop(vertical?.align, frame, geometry.boxHeight);
+  return pageTop - geometry.marginTop;
 }
 
 /** Page geometry needed to resolve a band box's horizontal anchor. */

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -56,3 +56,41 @@ export function bandTopContentY(
     vertical?.posOffset !== undefined ? emuToPixels(vertical.posOffset) : 0;
   return vertical?.relativeTo === "page" ? offset - marginTop : offset;
 }
+
+/** Page geometry needed to resolve a band box's horizontal anchor. */
+export type BandHorizontalGeometry = {
+  pageWidth: number;
+  marginLeft: number;
+  marginRight: number;
+  boxWidth: number;
+};
+
+/**
+ * Page-absolute left X (px) of a `topAndBottom` band box, resolved from its
+ * OOXML horizontal anchor. A page-relative anchor measures from the page edge;
+ * a margin/column anchor measures from the content box. Within that frame an
+ * explicit `posOffset` wins, then `align` (center/right); otherwise the box sits
+ * at the frame's left edge. The band itself is always full-width, so this only
+ * shifts where the box paints, not the reserved vertical space. Ported from
+ * eigenpal #694.
+ */
+export function bandFragmentX(
+  horizontal: ImageRunPosition["horizontal"],
+  geometry: BandHorizontalGeometry,
+): number {
+  const { pageWidth, marginLeft, marginRight, boxWidth } = geometry;
+  const usesPageFrame = horizontal?.relativeTo === "page";
+  const frameLeft = usesPageFrame ? 0 : marginLeft;
+  const frameRight = usesPageFrame ? pageWidth : pageWidth - marginRight;
+
+  if (horizontal?.posOffset !== undefined) {
+    return frameLeft + emuToPixels(horizontal.posOffset);
+  }
+  if (horizontal?.align === "center") {
+    return frameLeft + (frameRight - frameLeft - boxWidth) / 2;
+  }
+  if (horizontal?.align === "right" || horizontal?.align === "outside") {
+    return frameRight - boxWidth;
+  }
+  return frameLeft;
+}

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -3,7 +3,8 @@
  */
 
 import { isFloatingWrapType, isWrapNone } from "../docx/wrapTypes";
-import type { TextBoxBlock } from "./types";
+import { emuToPixels } from "../utils/units";
+import type { ImageRunPosition, TextBoxBlock } from "./types";
 
 export type TextBoxFlowAttrs = Pick<TextBoxBlock, "displayMode" | "wrapType">;
 
@@ -37,4 +38,21 @@ export function floatingTextBoxWrapsText(block: TextBoxFlowAttrs): boolean {
  */
 export function floatingTextBoxReservesBand(block: TextBoxFlowAttrs): boolean {
   return isFloatingTextBoxBlock(block) && block.wrapType === "topAndBottom";
+}
+
+/**
+ * Content-area top Y (px) of a `topAndBottom` band box's reserved band, resolved
+ * from its OOXML vertical anchor. Shared by the measure pass
+ * (`extractFloatingZones`) and the layout pass (`layoutTextBox`) so the reserved
+ * band and the painted box land at the same Y — a page-relative offset is
+ * measured from the page edge (subtract the top margin); a margin-relative
+ * offset (or no offset) is already content-relative. Ported from eigenpal #694.
+ */
+export function bandTopContentY(
+  vertical: ImageRunPosition["vertical"],
+  marginTop: number,
+): number {
+  const offset =
+    vertical?.posOffset !== undefined ? emuToPixels(vertical.posOffset) : 0;
+  return vertical?.relativeTo === "page" ? offset - marginTop : offset;
 }

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -166,32 +166,80 @@ export type BandHorizontalGeometry = {
   boxWidth: number;
 };
 
+type HorizontalRelativeTo = NonNullable<
+  ImageRunPosition["horizontal"]
+>["relativeTo"];
+type HorizontalAlign = NonNullable<ImageRunPosition["horizontal"]>["align"];
+
+/**
+ * Page-absolute `[left, right]` (px) of the frame a horizontal anchor positions
+ * within. `inside`/`outsideMargin` map to the left/right margin strips (page
+ * parity is not modelled); `column`/`character` fall back to the content box
+ * (folio has no per-column/character X here). eigenpal #694.
+ */
+function bandHorizontalFrame(
+  relativeTo: HorizontalRelativeTo,
+  geometry: BandHorizontalGeometry,
+): { left: number; right: number } {
+  const { pageWidth, marginLeft, marginRight } = geometry;
+  switch (relativeTo) {
+    case "page":
+      return { left: 0, right: pageWidth };
+    case "leftMargin":
+    case "insideMargin":
+      return { left: 0, right: marginLeft };
+    case "rightMargin":
+    case "outsideMargin":
+      return { left: pageWidth - marginRight, right: pageWidth };
+    case "margin":
+    case "column":
+    case "character":
+    case undefined:
+      return { left: marginLeft, right: pageWidth - marginRight };
+    default:
+      relativeTo satisfies never;
+      return { left: marginLeft, right: pageWidth - marginRight };
+  }
+}
+
+/** Page-absolute left X (px) of the box within its frame for a bare `align`. */
+function alignedFrameLeft(
+  align: HorizontalAlign,
+  frame: { left: number; right: number },
+  boxWidth: number,
+): number {
+  switch (align) {
+    case "center":
+      return frame.left + (frame.right - frame.left - boxWidth) / 2;
+    case "right":
+    case "outside":
+      return frame.right - boxWidth;
+    case "left":
+    case "inside":
+    case undefined:
+      return frame.left;
+    default:
+      align satisfies never;
+      return frame.left;
+  }
+}
+
 /**
  * Page-absolute left X (px) of a `topAndBottom` band box, resolved from its
- * OOXML horizontal anchor. A page-relative anchor measures from the page edge;
- * a margin/column anchor measures from the content box. Within that frame an
- * explicit `posOffset` wins, then `align` (center/right); otherwise the box sits
- * at the frame's left edge. The band itself is always full-width, so this only
- * shifts where the box paints, not the reserved vertical space. Ported from
- * eigenpal #694.
+ * OOXML horizontal anchor. Picks the anchor's frame (page, content box, or a
+ * left/right margin strip), then within it an explicit `posOffset` wins, else
+ * `align` (left/center/right/inside/outside); otherwise the box sits at the
+ * frame's left edge. The band itself is always full-width, so this only shifts
+ * where the box paints, not the reserved vertical space. Ported from eigenpal
+ * #694.
  */
 export function bandFragmentX(
   horizontal: ImageRunPosition["horizontal"],
   geometry: BandHorizontalGeometry,
 ): number {
-  const { pageWidth, marginLeft, marginRight, boxWidth } = geometry;
-  const usesPageFrame = horizontal?.relativeTo === "page";
-  const frameLeft = usesPageFrame ? 0 : marginLeft;
-  const frameRight = usesPageFrame ? pageWidth : pageWidth - marginRight;
-
+  const frame = bandHorizontalFrame(horizontal?.relativeTo, geometry);
   if (horizontal?.posOffset !== undefined) {
-    return frameLeft + emuToPixels(horizontal.posOffset);
+    return frame.left + emuToPixels(horizontal.posOffset);
   }
-  if (horizontal?.align === "center") {
-    return frameLeft + (frameRight - frameLeft - boxWidth) / 2;
-  }
-  if (horizontal?.align === "right" || horizontal?.align === "outside") {
-    return frameRight - boxWidth;
-  }
-  return frameLeft;
+  return alignedFrameLeft(horizontal?.align, frame, geometry.boxWidth);
 }

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -9,7 +9,8 @@ export type TextBoxFlowAttrs = Pick<TextBoxBlock, "displayMode" | "wrapType">;
 
 /**
  * `true` when the text box is anchored outside normal block flow — either
- * via the `float` display mode or via an OOXML floating wrap type.
+ * via the `float` display mode or via an OOXML floating wrap type (which
+ * includes `topAndBottom`; see {@link floatingTextBoxReservesBand}).
  */
 export function isFloatingTextBoxBlock(block: TextBoxFlowAttrs): boolean {
   return block.displayMode === "float" || isFloatingWrapType(block.wrapType);
@@ -26,4 +27,14 @@ export function floatingTextBoxWrapsText(block: TextBoxFlowAttrs): boolean {
     !isWrapNone(block.wrapType) &&
     block.wrapType !== "topAndBottom"
   );
+}
+
+/**
+ * `true` when a floating text box reserves a full-width vertical band rather
+ * than a side exclusion. `topAndBottom` boxes break the text above and below
+ * the box (no text beside it), so surrounding lines flow past the band.
+ * Ported from eigenpal #694.
+ */
+export function floatingTextBoxReservesBand(block: TextBoxFlowAttrs): boolean {
+  return isFloatingTextBoxBlock(block) && block.wrapType === "topAndBottom";
 }

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -1,0 +1,115 @@
+/**
+ * A page/margin-pinned topAndBottom text box (e.g. a "For Internal Use" banner)
+ * floats to the page top instead of dropping into the flow at its anchor, and it
+ * does not consume flow height (the reserved band in the measure pass — see
+ * extractFloatingZones in PagedEditor — pushes body text below it). A
+ * paragraph-anchored topAndBottom box keeps the in-flow handling.
+ * Regression for eigenpal/docx-editor#694.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { layoutDocument } from "./index";
+import type {
+  FlowBlock,
+  LayoutOptions,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  PageMargins,
+  TextBoxBlock,
+  TextBoxFragment,
+  TextBoxMeasure,
+} from "./types";
+
+const MARGINS: PageMargins = { top: 96, right: 96, bottom: 96, left: 96 };
+const OPTIONS: LayoutOptions = {
+  pageSize: { w: 816, h: 1056 },
+  margins: MARGINS,
+  pageGap: 20,
+};
+
+const BOX_HEIGHT = 100;
+
+function banner(relativeTo: "page" | undefined): TextBoxBlock {
+  return {
+    kind: "textBox",
+    id: "banner",
+    width: 600,
+    height: BOX_HEIGHT,
+    content: [],
+    wrapType: "topAndBottom",
+    ...(relativeTo
+      ? { position: { vertical: { relativeTo, posOffset: 0 } } }
+      : {}),
+  };
+}
+
+const boxMeasure: TextBoxMeasure = {
+  kind: "textBox",
+  width: 600,
+  height: BOX_HEIGHT,
+  innerMeasures: [],
+};
+
+function para(id: string): ParagraphBlock {
+  return { kind: "paragraph", id, runs: [{ kind: "text", text: id }] };
+}
+
+const paraMeasure: ParagraphMeasure = {
+  kind: "paragraph",
+  lines: [
+    {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 4,
+      width: 40,
+      ascent: 16,
+      descent: 4,
+      lineHeight: 20,
+    },
+  ],
+  totalHeight: 20,
+};
+
+function textBoxFragments(blocks: FlowBlock[], measures: Measure[]) {
+  const layout = layoutDocument(blocks, measures, OPTIONS);
+  return layout.pages[0]!.fragments;
+}
+
+describe("topAndBottom band text box layout", () => {
+  test("page-pinned banner sits at the page top and does not consume flow", () => {
+    const frags = textBoxFragments(
+      [banner("page"), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    const paragraph = frags.find((f) => f.kind === "paragraph");
+
+    // Banner pinned flush to the page content top.
+    expect(box?.y).toBe(MARGINS.top);
+    // Flow not advanced by the banner: the paragraph still starts at the top
+    // (the measure pass, not layout, reserves the band that pushes text down).
+    expect(paragraph?.y).toBe(MARGINS.top);
+  });
+
+  test("paragraph-anchored topAndBottom box stays in flow (unchanged)", () => {
+    const frags = textBoxFragments(
+      [banner(undefined), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    const paragraph = frags.find((f) => f.kind === "paragraph");
+
+    // In-flow box at the top, paragraph pushed below it by the box height.
+    expect(box?.y).toBe(MARGINS.top);
+    expect(paragraph?.y).toBe(MARGINS.top + BOX_HEIGHT);
+  });
+});

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -31,7 +31,13 @@ const OPTIONS: LayoutOptions = {
 
 const BOX_HEIGHT = 100;
 
-function banner(relativeTo: "page" | undefined): TextBoxBlock {
+// 1 inch in EMU = 96px at 96 DPI; equals MARGINS.top, so offsets read cleanly.
+const EMU_PER_INCH = 914_400;
+
+function banner(
+  relativeTo: "page" | "margin" | undefined,
+  posOffset = 0,
+): TextBoxBlock {
   return {
     kind: "textBox",
     id: "banner",
@@ -40,7 +46,7 @@ function banner(relativeTo: "page" | undefined): TextBoxBlock {
     content: [],
     wrapType: "topAndBottom",
     ...(relativeTo
-      ? { position: { vertical: { relativeTo, posOffset: 0 } } }
+      ? { position: { vertical: { relativeTo, posOffset } } }
       : {}),
   };
 }
@@ -79,7 +85,7 @@ function textBoxFragments(blocks: FlowBlock[], measures: Measure[]) {
 }
 
 describe("topAndBottom band text box layout", () => {
-  test("page-pinned banner sits at the page top and does not consume flow", () => {
+  test("page-relative banner sits at the page top edge and does not consume flow", () => {
     const frags = textBoxFragments(
       [banner("page"), para("p")],
       [boxMeasure, paraMeasure],
@@ -90,11 +96,35 @@ describe("topAndBottom band text box layout", () => {
       | undefined;
     const paragraph = frags.find((f) => f.kind === "paragraph");
 
-    // Banner pinned flush to the page content top.
-    expect(box?.y).toBe(MARGINS.top);
+    // relativeTo=page, offset 0 → the very top of the page (y=0, in the margin).
+    expect(box?.y).toBe(0);
     // Flow not advanced by the banner: the paragraph still starts at the top
     // (the measure pass, not layout, reserves the band that pushes text down).
     expect(paragraph?.y).toBe(MARGINS.top);
+  });
+
+  test("margin-relative banner sits at the content top", () => {
+    const frags = textBoxFragments(
+      [banner("margin"), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    expect(box?.y).toBe(MARGINS.top);
+  });
+
+  test("honors a non-zero vertical offset (layout matches the measure band)", () => {
+    // page-relative offset of 1 inch (= MARGINS.top px) → page Y = 96.
+    const frags = textBoxFragments(
+      [banner("page", EMU_PER_INCH), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // y = topMargin + (emuToPixels(offset) - topMargin) = emuToPixels(offset) = 96
+    expect(box?.y).toBe(96);
   });
 
   test("paragraph-anchored topAndBottom box stays in flow (unchanged)", () => {

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -58,6 +58,12 @@ function withHorizontal(
   return { ...block, position: { ...block.position, horizontal } };
 }
 
+function verticalBanner(
+  vertical: NonNullable<NonNullable<TextBoxBlock["position"]>["vertical"]>,
+): TextBoxBlock {
+  return { ...banner(undefined), position: { vertical } };
+}
+
 const boxMeasure: TextBoxMeasure = {
   kind: "textBox",
   width: 600,
@@ -154,6 +160,42 @@ describe("topAndBottom band text box layout", () => {
       | undefined;
     // y = topMargin + (emuToPixels(offset) - topMargin) = emuToPixels(offset) = 96
     expect(box?.y).toBe(96);
+  });
+
+  test("centers a page-aligned banner within the page frame", () => {
+    const frags = textBoxFragments(
+      [verticalBanner({ relativeTo: "page", align: "center" }), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // page frame [0, 1056], 100px box → (1056 - 100) / 2 = 478.
+    expect(box?.y).toBe(478);
+  });
+
+  test("pins a bottom-aligned margin banner to the content bottom", () => {
+    const frags = textBoxFragments(
+      [verticalBanner({ relativeTo: "margin", align: "bottom" }), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // content frame [96, 960], 100px box → 960 - 100 = 860.
+    expect(box?.y).toBe(860);
+  });
+
+  test("places a bottomMargin banner in the bottom margin strip", () => {
+    const frags = textBoxFragments(
+      [verticalBanner({ relativeTo: "bottomMargin" }), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // bottom margin strip [960, 1056] top → 960.
+    expect(box?.y).toBe(960);
   });
 
   test("paragraph-anchored topAndBottom box stays in flow (unchanged)", () => {

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -189,4 +189,35 @@ describe("topAndBottom band text box layout", () => {
     expect(box?.y).toBe(FIRST_PAGE_TOP - MARGINS.top);
     expect((box?.y ?? 0) - page.margins.top).toBe(-MARGINS.top);
   });
+
+  test("band uses the current section top margin after a section break", () => {
+    const nextSectionMargins: PageMargins = { ...MARGINS, top: 144 };
+    const sectionBreak: FlowBlock = {
+      kind: "sectionBreak",
+      id: "section-one",
+      type: "nextPage",
+      pageSize: OPTIONS.pageSize,
+      margins: MARGINS,
+    };
+    const layout = layoutDocument(
+      [sectionBreak, banner("page"), para("p")],
+      [{ kind: "sectionBreak" }, boxMeasure, paraMeasure],
+      {
+        ...OPTIONS,
+        finalMargins: nextSectionMargins,
+      },
+    );
+    const page = layout.pages.find((candidate) =>
+      candidate.fragments.some((fragment) => fragment.kind === "textBox"),
+    );
+    if (!page) {
+      throw new Error("Expected a page with the section text box");
+    }
+    const box = page.fragments.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+
+    expect(page.margins.top).toBe(nextSectionMargins.top);
+    expect(box?.y).toBe(0);
+  });
 });

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -103,6 +103,28 @@ describe("topAndBottom band text box layout", () => {
     expect(paragraph?.y).toBe(MARGINS.top);
   });
 
+  test("paragraph layout reserves measured float-skip height", () => {
+    const baseLine = paraMeasure.lines[0]!;
+    const skippedMeasure: ParagraphMeasure = {
+      kind: "paragraph",
+      lines: [{ ...baseLine, floatSkipBefore: BOX_HEIGHT }],
+      totalHeight: BOX_HEIGHT + baseLine.lineHeight,
+    };
+
+    const layout = layoutDocument(
+      [para("p1"), para("p2")],
+      [skippedMeasure, paraMeasure],
+      OPTIONS,
+    );
+    const first = layout.pages[0]?.fragments[0];
+    const second = layout.pages[0]?.fragments[1];
+
+    expect(first?.kind).toBe("paragraph");
+    expect(first?.height).toBe(BOX_HEIGHT + baseLine.lineHeight);
+    expect(second?.kind).toBe("paragraph");
+    expect(second?.y).toBe(MARGINS.top + BOX_HEIGHT + baseLine.lineHeight);
+  });
+
   test("margin-relative banner sits at the content top", () => {
     const frags = textBoxFragments(
       [banner("margin"), para("p")],

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, test } from "bun:test";
 import { layoutDocument } from "./index";
 import type {
   FlowBlock,
+  ImageBlock,
+  ImageMeasure,
   LayoutOptions,
   Measure,
   ParagraphBlock,
@@ -326,5 +328,30 @@ describe("topAndBottom band text box layout", () => {
       | undefined;
     // page frame left 0 + 96px offset = 96.
     expect(box?.x).toBe(96);
+  });
+
+  test("a non-paragraph block reserves its measured band skip before layout", () => {
+    // The measure pass records `bandSkipBefore` on tables/images that follow a
+    // page band; layout applies it as leading space so the block lands below the
+    // band. eigenpal #694.
+    const imageBlock: ImageBlock = {
+      kind: "image",
+      id: "img",
+      src: "data:,",
+      width: 80,
+      height: 40,
+    };
+    const imageMeasure: ImageMeasure = {
+      kind: "image",
+      width: 80,
+      height: 40,
+      bandSkipBefore: BOX_HEIGHT,
+    };
+
+    const layout = layoutDocument([imageBlock], [imageMeasure], OPTIONS);
+    const imgFrag = layout.pages[0]?.fragments.find((f) => f.kind === "image");
+
+    // Content top is MARGINS.top; the band skip pushes the image down by it.
+    expect(imgFrag?.y).toBe(MARGINS.top + BOX_HEIGHT);
   });
 });

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -142,4 +142,29 @@ describe("topAndBottom band text box layout", () => {
     expect(box?.y).toBe(MARGINS.top);
     expect(paragraph?.y).toBe(MARGINS.top + BOX_HEIGHT);
   });
+
+  test("band uses the section top margin, not a page's first-page margin", () => {
+    // On a title page the first-page top margin can differ from the section
+    // margin. The measure pass reserves the band using the section margin, so
+    // the box must too — otherwise box and band desync. The box's
+    // content-relative top (fragment.y - page top margin) must equal the band's
+    // content top (= -section margin for a page-relative offset-0 banner).
+    const FIRST_PAGE_TOP = 200;
+    const layout = layoutDocument(
+      [banner("page"), para("p")],
+      [boxMeasure, paraMeasure],
+      {
+        ...OPTIONS,
+        firstPageMargins: { ...MARGINS, top: FIRST_PAGE_TOP },
+      },
+    );
+    const page = layout.pages[0]!;
+    const box = page.fragments.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // y = firstPageTop + (0 - sectionMarginTop) = 200 - 96 = 104, so the
+    // content-relative top is 104 - 200 = -96 = -section margin (band-aligned).
+    expect(box?.y).toBe(FIRST_PAGE_TOP - MARGINS.top);
+    expect((box?.y ?? 0) - page.margins.top).toBe(-MARGINS.top);
+  });
 });

--- a/packages/folio/src/core/layout-engine/textbox-band.test.ts
+++ b/packages/folio/src/core/layout-engine/textbox-band.test.ts
@@ -51,6 +51,13 @@ function banner(
   };
 }
 
+function withHorizontal(
+  block: TextBoxBlock,
+  horizontal: NonNullable<NonNullable<TextBoxBlock["position"]>["horizontal"]>,
+): TextBoxBlock {
+  return { ...block, position: { ...block.position, horizontal } };
+}
+
 const boxMeasure: TextBoxMeasure = {
   kind: "textBox",
   width: 600,
@@ -219,5 +226,63 @@ describe("topAndBottom band text box layout", () => {
 
     expect(page.margins.top).toBe(nextSectionMargins.top);
     expect(box?.y).toBe(0);
+  });
+
+  test("defaults to the content left edge without a horizontal anchor", () => {
+    const frags = textBoxFragments(
+      [banner("page"), para("p")],
+      [boxMeasure, paraMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // Unchanged behavior: pinned to the column/content left edge.
+    expect(box?.x).toBe(MARGINS.left);
+  });
+
+  test("honors a margin-relative center horizontal anchor", () => {
+    const frags = textBoxFragments(
+      [
+        withHorizontal(banner("page"), {
+          relativeTo: "margin",
+          align: "center",
+        }),
+      ],
+      [boxMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // content box 624px, 600px banner → 96 + (624 - 600) / 2 = 108.
+    expect(box?.x).toBe(108);
+  });
+
+  test("honors a page-relative right horizontal anchor", () => {
+    const frags = textBoxFragments(
+      [withHorizontal(banner("page"), { relativeTo: "page", align: "right" })],
+      [boxMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // page 816px, 600px banner → 816 - 600 = 216.
+    expect(box?.x).toBe(216);
+  });
+
+  test("honors a page-relative horizontal posOffset", () => {
+    const frags = textBoxFragments(
+      [
+        withHorizontal(banner("page"), {
+          relativeTo: "page",
+          posOffset: EMU_PER_INCH,
+        }),
+      ],
+      [boxMeasure],
+    );
+    const box = frags.find((f) => f.kind === "textBox") as
+      | TextBoxFragment
+      | undefined;
+    // page frame left 0 + 96px offset = 96.
+    expect(box?.x).toBe(96);
   });
 });

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -636,7 +636,7 @@ export type TextBoxBlock = {
   wrapType?: string;
   /** OOXML wrapText direction for anchored text boxes. */
   wrapText?: "bothSides" | "left" | "right" | "largest";
-  /** Position for floating/anchored text boxes (pixel-converted EMU). */
+  /** Position for floating/anchored text boxes (OOXML EMU offsets). */
   position?: ImageRunPosition;
   /** Wrap distances in pixels. */
   distTop?: number;

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -5,6 +5,8 @@
  * Converts document blocks + measurements into positioned fragments on pages.
  */
 
+import type { ImagePosition } from "@stll/docx-core/model";
+
 /**
  * Unique identifier for a block in the document.
  * Format: typically `${index}-${type}` or just the block index.
@@ -135,16 +137,21 @@ export type TabRun = RunFormatting & {
 /**
  * Position data for floating/anchored images.
  */
+// OOXML drawing anchors (`ST_RelFromH`/`ST_RelFromV`, `ST_AlignH`/`ST_AlignV`).
+// Mirrors the typed `ImagePositionAttrs` (schema/nodes.ts) rather than widening
+// to `string`, so band/anchor resolution can switch exhaustively over the
+// finite value set. The DOCX parser already narrows raw XML to these unions via
+// `narrowEnum`, so no runtime validation is needed here.
 export type ImageRunPosition = {
   horizontal?: {
-    relativeTo?: string;
+    relativeTo?: NonNullable<ImagePosition["horizontal"]["relativeTo"]>;
     posOffset?: number;
-    align?: string;
+    align?: NonNullable<ImagePosition["horizontal"]["alignment"]>;
   };
   vertical?: {
-    relativeTo?: string;
+    relativeTo?: NonNullable<ImagePosition["vertical"]["relativeTo"]>;
     posOffset?: number;
-    align?: string;
+    align?: NonNullable<ImagePosition["vertical"]["alignment"]>;
   };
 };
 

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -1263,4 +1263,5 @@ export type { TextBoxFlowAttrs } from "./textBoxFlow";
 export {
   isFloatingTextBoxBlock,
   floatingTextBoxWrapsText,
+  floatingTextBoxReservesBand,
 } from "./textBoxFlow";

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -763,6 +763,12 @@ export type ImageMeasure = {
   kind: "image";
   width: number;
   height: number;
+  /**
+   * Leading space (px) layout inserts before the block to clear a page-pinned
+   * topAndBottom band on the same page. Paragraphs absorb this per line via
+   * `floatSkipBefore`; non-paragraph blocks reserve it here. eigenpal #694.
+   */
+  bandSkipBefore?: number;
 };
 
 /**
@@ -793,6 +799,9 @@ export type TableMeasure = {
   columnWidths: number[];
   totalWidth: number;
   totalHeight: number;
+  /** Leading space (px) before the table to clear a page-pinned band on the
+   * same page; applied to the table's first fragment. See {@link ImageMeasure}. */
+  bandSkipBefore?: number;
 };
 
 /**

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import { clearAllCaches } from "../layout-engine/measure/cache";
+import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import type {
   Page,
   HeaderFooterContent,
@@ -78,8 +80,17 @@ class FakeElement {
     }
   }
 
-  getContext(): null {
-    return null;
+  getContext() {
+    return {
+      font: "",
+      measureText(text: string) {
+        return {
+          width: text.length * 5,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        };
+      },
+    };
   }
 
   querySelectorAll<T = FakeElement>(selector: string): T[] {
@@ -211,6 +222,27 @@ function collectByClass(
   }
 
   return matches;
+}
+
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  clearAllCaches();
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    clearAllCaches();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
 }
 
 const page: Page = {
@@ -380,6 +412,111 @@ describe("page font fallback", () => {
     expect(getDefaultPageFontFamily()).toBe(
       "Calibri, Carlito, Arial, Helvetica, sans-serif",
     );
+  });
+});
+
+describe("floating text box render zones", () => {
+  test("does not apply a page-pinned band to earlier fragments", () => {
+    withFakeTextMeasure(() => {
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "before" }],
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 80,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const paragraphMeasure: ParagraphMeasure = {
+        kind: "paragraph",
+        lines: [
+          {
+            fromRun: 0,
+            fromChar: 0,
+            toRun: 0,
+            toChar: 6,
+            width: 30,
+            ascent: 8,
+            descent: 2,
+            lineHeight: 10,
+          },
+        ],
+        totalHeight: 10,
+      };
+      const bandMeasure: TextBoxMeasure = {
+        kind: "textBox",
+        width: 300,
+        height: 80,
+        innerMeasures: [],
+      };
+      const rendered = renderPage(
+        {
+          ...page,
+          fragments: [
+            {
+              kind: "paragraph",
+              blockId: "before",
+              x: 72,
+              y: 72,
+              width: 672,
+              height: 10,
+              fromLine: 0,
+              toLine: 1,
+            },
+            {
+              kind: "textBox",
+              blockId: "band",
+              x: 72,
+              y: 72,
+              width: 300,
+              height: 80,
+            },
+            {
+              kind: "paragraph",
+              blockId: "after",
+              x: 72,
+              y: 72,
+              width: 672,
+              height: 10,
+              fromLine: 0,
+              toLine: 1,
+            },
+          ],
+        },
+        { pageNumber: 1, totalPages: 1, section: "body" },
+        {
+          document: fakeDocument,
+          blockLookup: new Map([
+            ["before", { block: before, measure: paragraphMeasure }],
+            ["band", { block: band, measure: bandMeasure }],
+            ["after", { block: after, measure: paragraphMeasure }],
+          ]),
+        },
+      ) as unknown as FakeElement;
+
+      const paragraphs = collectByClass(rendered, "layout-paragraph");
+      const beforeLine = findByClass(
+        paragraphs.find((el) => el.dataset["blockId"] === "before")!,
+        "layout-line",
+      );
+      const afterLine = findByClass(
+        paragraphs.find((el) => el.dataset["blockId"] === "after")!,
+        "layout-line",
+      );
+
+      expect(beforeLine?.style.marginTop).toBeUndefined();
+      expect(afterLine?.style.marginTop).toBe("80px");
+    });
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -19,6 +19,7 @@ import {
   FOOTNOTE_ENTRY_MARGIN_BOTTOM,
   FOOTNOTE_FALLBACK_LINE_HEIGHT,
   FOOTNOTE_SEPARATOR_HEIGHT,
+  floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
   isFloatingTextBoxBlock,
 } from "../layout-engine/types";
@@ -1871,7 +1872,11 @@ export function renderPage(
       if (!isFloatingTextBoxBlock(textBoxBlock)) {
         continue;
       }
-      if (!floatingTextBoxWrapsText(textBoxBlock)) {
+      // topAndBottom reserves a full-width band (text flows above/below);
+      // side-wrap types reserve a side exclusion. Both push a rect — the band
+      // is distinguished by `wrapType` in rectsToFloatingZones. eigenpal #694.
+      const reservesBand = floatingTextBoxReservesBand(textBoxBlock);
+      if (!reservesBand && !floatingTextBoxWrapsText(textBoxBlock)) {
         continue;
       }
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -117,6 +117,16 @@ export type PageFloatingImage = {
   behindDoc: boolean;
 };
 
+type ScopedFloatingRect = {
+  startsAtFragmentIndex: number;
+  rect: FloatingExclusionRect;
+};
+
+type ScopedFloatingZone = {
+  startsAtFragmentIndex: number;
+  zone: FloatingImageZone;
+};
+
 /**
  * CSS class names for page elements
  */
@@ -464,6 +474,27 @@ function syncPageWatermarkOverlay(
   }
 
   pageEl.append(overlay);
+}
+
+function floatingZonesForFragment(
+  pageWideZones: FloatingImageZone[],
+  scopedZones: ScopedFloatingZone[],
+  fragmentIndex: number,
+): FloatingImageZone[] {
+  if (scopedZones.length === 0) {
+    return pageWideZones;
+  }
+
+  let activeZones: FloatingImageZone[] | undefined;
+  for (const scopedZone of scopedZones) {
+    if (scopedZone.startsAtFragmentIndex > fragmentIndex) {
+      continue;
+    }
+    activeZones ??= [...pageWideZones];
+    activeZones.push(scopedZone.zone);
+  }
+
+  return activeZones ?? pageWideZones;
 }
 
 /**
@@ -1761,6 +1792,7 @@ export function renderPage(
   // PHASE 1: Extract all floating images from paragraphs on this page
   const allFloatingImages: PageFloatingImage[] = [];
   const floatingRects: FloatingExclusionRect[] = [];
+  const scopedFloatingRects: ScopedFloatingRect[] = [];
   const pageGeometry: PageGeometry = {
     pageWidth: page.size.w,
     pageHeight: page.size.h,
@@ -1860,7 +1892,12 @@ export function renderPage(
   // contribution so body text wraps around anchored boxes instead of
   // running underneath them.
   if (options.blockLookup) {
-    for (const fragment of page.fragments) {
+    for (
+      let fragmentIndex = 0;
+      fragmentIndex < page.fragments.length;
+      fragmentIndex++
+    ) {
+      const fragment = page.fragments[fragmentIndex]!; // SAFETY: fragmentIndex < page.fragments.length
       if (fragment.kind !== "textBox") {
         continue;
       }
@@ -1916,7 +1953,14 @@ export function renderPage(
       if (textBoxBlock.wrapType !== undefined) {
         rect.wrapType = textBoxBlock.wrapType;
       }
-      floatingRects.push(rect);
+      if (reservesBand) {
+        scopedFloatingRects.push({
+          startsAtFragmentIndex: fragmentIndex,
+          rect,
+        });
+      } else {
+        floatingRects.push(rect);
+      }
     }
   }
 
@@ -1925,6 +1969,13 @@ export function renderPage(
     floatingRects.length > 0
       ? rectsToFloatingZones(floatingRects, contentWidth)
       : [];
+  const scopedFloatingZones: ScopedFloatingZone[] = scopedFloatingRects.flatMap(
+    ({ startsAtFragmentIndex, rect }) =>
+      rectsToFloatingZones([rect], contentWidth).map((zone) => ({
+        startsAtFragmentIndex,
+        zone,
+      })),
+  );
 
   // PHASE 3a: Render behindDoc images first so they paint below body text.
   // Front-layer images (everything else) are appended after fragments below
@@ -1993,9 +2044,14 @@ export function renderPage(
 
         // Re-measure paragraph with floating zones for text wrapping
         let paragraphMeasure = blockData.measure as ParagraphMeasure;
-        if (floatingZones.length > 0) {
+        const fragmentFloatingZones = floatingZonesForFragment(
+          floatingZones,
+          scopedFloatingZones,
+          i,
+        );
+        if (fragmentFloatingZones.length > 0) {
           paragraphMeasure = measureParagraph(paragraphBlock, contentWidth, {
-            floatingZones,
+            floatingZones: fragmentFloatingZones,
             paragraphYOffset: fragmentContentY,
           });
         }

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -382,6 +382,8 @@ describe("ProseMirror attr readers", () => {
     const textBox = schema.nodes.textBox.create({
       width: "wide",
       cssFloat: "center",
+      wrapType: "sideways",
+      position: { vertical: { relativeTo: "ceiling" } },
     });
 
     const shapeResult = readShapeAttrs(shape);
@@ -412,6 +414,12 @@ describe("ProseMirror attr readers", () => {
       );
       expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
         "textBox.attrs.cssFloat",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs.wrapType",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs.position.vertical.relativeTo",
       );
     }
   });

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -976,7 +976,13 @@ export const readTextBoxAttrs = (
     issues,
     IMAGE_CSS_FLOATS,
   );
-  optionalString(attrs, "wrapType", "textBox.attrs.wrapType", issues);
+  optionalOneOf(
+    attrs,
+    "wrapType",
+    "textBox.attrs.wrapType",
+    issues,
+    IMAGE_WRAP_TYPE_VALUES,
+  );
   optionalOneOf(
     attrs,
     "wrapText",
@@ -988,6 +994,7 @@ export const readTextBoxAttrs = (
   optionalNumber(attrs, "distBottom", "textBox.attrs.distBottom", issues);
   optionalNumber(attrs, "distLeft", "textBox.attrs.distLeft", issues);
   optionalNumber(attrs, "distRight", "textBox.attrs.distRight", issues);
+  optionalImagePosition(attrs, "position", "textBox.attrs.position", issues);
   optionalOneOf(
     attrs,
     "_docxPlacement",

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -8,6 +8,7 @@ import type {
   Table,
   TableCell,
 } from "../../types/document";
+import { pixelsToEmu } from "../../utils/units";
 import { expectHardBreakAttrs, expectParagraphAttrs } from "../attrs";
 import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
@@ -733,6 +734,45 @@ describe("fromProseDoc", () => {
     }
     expect(firstRunContent.shape.shapeType).toBe("textBox");
     expect(firstRunContent.shape.textBody?.content).toHaveLength(1);
+  });
+
+  test("preserves textBox wrap and position attrs on save", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node(
+        "textBox",
+        {
+          width: 120,
+          height: 60,
+          wrapType: "topAndBottom",
+          distTop: 3,
+          distBottom: 4,
+          position: {
+            horizontal: { relativeTo: "margin", align: "center" },
+            vertical: { relativeTo: "page", posOffset: 123_456 },
+          },
+        },
+        [schema.node("paragraph", null, [schema.text("Inside")])],
+      ),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const block = document.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    const shape = firstShapeContent(block)?.shape;
+    expect(shape?.shapeType).toBe("textBox");
+    expect(shape?.wrap).toEqual({
+      type: "topAndBottom",
+      distT: pixelsToEmu(3),
+      distB: pixelsToEmu(4),
+    });
+    expect(shape?.position).toEqual({
+      horizontal: { relativeTo: "margin", alignment: "center" },
+      vertical: { relativeTo: "page", posOffset: 123_456 },
+    });
   });
 
   test("preserves OOXML outline dash tokens on shape nodes", () => {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -92,6 +92,8 @@ import type {
   TableAttrs,
   TableRowAttrs,
   TableCellAttrs,
+  ImagePositionAttrs,
+  TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
 
@@ -137,6 +139,69 @@ function parseTransformAttr(
     return undefined;
   }
   return transform;
+}
+
+function imagePositionFromAttrs(
+  attrs: ImagePositionAttrs | undefined,
+): ImagePosition | undefined {
+  const horizontalPosition = attrs?.horizontal;
+  const verticalPosition = attrs?.vertical;
+  if (!horizontalPosition || !verticalPosition) {
+    return undefined;
+  }
+
+  const horizontal: ImagePosition["horizontal"] = {
+    relativeTo: horizontalPosition.relativeTo || "column",
+  };
+  if (horizontalPosition.align) {
+    horizontal.alignment = horizontalPosition.align;
+  }
+  if (horizontalPosition.posOffset !== undefined) {
+    horizontal.posOffset = horizontalPosition.posOffset;
+  }
+
+  const vertical: ImagePosition["vertical"] = {
+    relativeTo: verticalPosition.relativeTo || "paragraph",
+  };
+  if (verticalPosition.align) {
+    vertical.alignment = verticalPosition.align;
+  }
+  if (verticalPosition.posOffset !== undefined) {
+    vertical.posOffset = verticalPosition.posOffset;
+  }
+
+  return { horizontal, vertical };
+}
+
+function textBoxWrapFromAttrs(attrs: TextBoxAttrs): ImageWrap | undefined {
+  const hasWrapData =
+    (attrs.wrapType !== undefined && attrs.wrapType !== "inline") ||
+    attrs.wrapText !== undefined ||
+    attrs.distTop !== undefined ||
+    attrs.distBottom !== undefined ||
+    attrs.distLeft !== undefined ||
+    attrs.distRight !== undefined;
+  if (!hasWrapData) {
+    return undefined;
+  }
+
+  const wrap: ImageWrap = { type: attrs.wrapType ?? "inline" };
+  if (attrs.wrapText !== undefined) {
+    wrap.wrapText = attrs.wrapText;
+  }
+  if (attrs.distTop !== undefined) {
+    wrap.distT = pixelsToEmu(attrs.distTop);
+  }
+  if (attrs.distBottom !== undefined) {
+    wrap.distB = pixelsToEmu(attrs.distBottom);
+  }
+  if (attrs.distLeft !== undefined) {
+    wrap.distL = pixelsToEmu(attrs.distLeft);
+  }
+  if (attrs.distRight !== undefined) {
+    wrap.distR = pixelsToEmu(attrs.distRight);
+  }
+  return wrap;
 }
 
 /**
@@ -1483,32 +1548,9 @@ function createImageRun(node: PMNode): Run {
     image.opacity = attrs.opacity;
   }
 
-  // Round-trip floating image position (ImagePositionAttrs uses loose strings;
-  // cast to the strict OOXML union types for the Document model)
-  const horizontalPosition = attrs.position?.horizontal;
-  const verticalPosition = attrs.position?.vertical;
-  if (horizontalPosition && verticalPosition) {
-    const horizontal: ImagePosition["horizontal"] = {
-      relativeTo: horizontalPosition.relativeTo || "column",
-    };
-    if (horizontalPosition.align) {
-      horizontal.alignment = horizontalPosition.align;
-    }
-    if (horizontalPosition.posOffset !== undefined) {
-      horizontal.posOffset = horizontalPosition.posOffset;
-    }
-
-    const vertical: ImagePosition["vertical"] = {
-      relativeTo: verticalPosition.relativeTo || "paragraph",
-    };
-    if (verticalPosition.align) {
-      vertical.alignment = verticalPosition.align;
-    }
-    if (verticalPosition.posOffset !== undefined) {
-      vertical.posOffset = verticalPosition.posOffset;
-    }
-
-    image.position = { horizontal, vertical };
+  const imagePosition = imagePositionFromAttrs(attrs.position);
+  if (imagePosition) {
+    image.position = imagePosition;
   }
 
   // Round-trip border/outline
@@ -1632,30 +1674,9 @@ function createShapeRun(node: PMNode): Run {
   }
   shape.wrap = wrap;
 
-  const horizontalPosition = attrs.position?.horizontal;
-  const verticalPosition = attrs.position?.vertical;
-  if (horizontalPosition && verticalPosition) {
-    const horizontal: ImagePosition["horizontal"] = {
-      relativeTo: horizontalPosition.relativeTo || "column",
-    };
-    if (horizontalPosition.align) {
-      horizontal.alignment = horizontalPosition.align;
-    }
-    if (horizontalPosition.posOffset !== undefined) {
-      horizontal.posOffset = horizontalPosition.posOffset;
-    }
-
-    const vertical: ImagePosition["vertical"] = {
-      relativeTo: verticalPosition.relativeTo || "paragraph",
-    };
-    if (verticalPosition.align) {
-      vertical.alignment = verticalPosition.align;
-    }
-    if (verticalPosition.posOffset !== undefined) {
-      vertical.posOffset = verticalPosition.posOffset;
-    }
-
-    shape.position = { horizontal, vertical };
+  const shapePosition = imagePositionFromAttrs(attrs.position);
+  if (shapePosition) {
+    shape.position = shapePosition;
   }
 
   // Fill
@@ -2565,6 +2586,15 @@ function convertPMTextBox(node: PMNode): Paragraph {
       tbOutline.color = { rgb: attrs.outlineColor.replace("#", "") };
     }
     shape.outline = tbOutline;
+  }
+
+  const wrap = textBoxWrapFromAttrs(attrs);
+  if (wrap) {
+    shape.wrap = wrap;
+  }
+  const position = imagePositionFromAttrs(attrs.position);
+  if (position) {
+    shape.position = position;
   }
 
   // Wrap the shape in a paragraph with a run containing ShapeContent

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
@@ -24,6 +24,10 @@ function textBoxAttrsFromImport(args: {
     | "inFront";
   wrapText?: "bothSides" | "left" | "right" | "largest";
   hAlign?: "left" | "right" | "center";
+  hRelativeTo?: "column" | "margin" | "page";
+  hPosOffsetEmu?: number;
+  vRelativeTo?: "paragraph" | "margin" | "page";
+  vPosOffsetEmu?: number;
   distTEmu?: number;
   distBEmu?: number;
   distLEmu?: number;
@@ -47,10 +51,18 @@ function textBoxAttrsFromImport(args: {
                       size: { width: 914_400, height: 457_200 },
                       position: {
                         horizontal: {
-                          relativeTo: "column",
+                          relativeTo: args.hRelativeTo ?? "column",
+                          ...(args.hPosOffsetEmu !== undefined
+                            ? { posOffset: args.hPosOffsetEmu }
+                            : {}),
                           ...(args.hAlign ? { alignment: args.hAlign } : {}),
                         },
-                        vertical: { relativeTo: "paragraph" },
+                        vertical: {
+                          relativeTo: args.vRelativeTo ?? "paragraph",
+                          ...(args.vPosOffsetEmu !== undefined
+                            ? { posOffset: args.vPosOffsetEmu }
+                            : {}),
+                        },
                       },
                       wrap: {
                         type: args.wrapType,
@@ -139,6 +151,21 @@ describe("toProseDoc propagates text-box wrap attributes", () => {
     expect(attrs["wrapType"]).toBe("topAndBottom");
     expect(attrs["displayMode"]).toBe("block");
     expect(attrs["cssFloat"]).toBe("none");
+  });
+
+  test("preserves anchored position for imported topAndBottom text boxes", () => {
+    const attrs = textBoxAttrsFromImport({
+      wrapType: "topAndBottom",
+      hRelativeTo: "margin",
+      hAlign: "center",
+      vRelativeTo: "page",
+      vPosOffsetEmu: 123_456,
+    });
+
+    expect(attrs["position"]).toEqual({
+      horizontal: { relativeTo: "margin", align: "center" },
+      vertical: { relativeTo: "page", posOffset: 123_456 },
+    });
   });
 
   test("wrap='behind' becomes a float (anchored, paints over text)", () => {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2813,6 +2813,29 @@ function convertTextBox(
   const wrapType = textBox.wrap?.type;
   const wrapText = textBox.wrap?.wrapText;
   const hAlign = textBox.position?.horizontal.alignment;
+  let position: ImagePositionAttrs | undefined;
+  if (textBox.position) {
+    position = {
+      horizontal: {
+        relativeTo: textBox.position.horizontal.relativeTo,
+        ...(textBox.position.horizontal.posOffset !== undefined
+          ? { posOffset: textBox.position.horizontal.posOffset }
+          : {}),
+        ...(textBox.position.horizontal.alignment
+          ? { align: textBox.position.horizontal.alignment }
+          : {}),
+      },
+      vertical: {
+        relativeTo: textBox.position.vertical.relativeTo,
+        ...(textBox.position.vertical.posOffset !== undefined
+          ? { posOffset: textBox.position.vertical.posOffset }
+          : {}),
+        ...(textBox.position.vertical.alignment
+          ? { align: textBox.position.vertical.alignment }
+          : {}),
+      },
+    };
+  }
 
   let cssFloat: "left" | "right" | "none" | undefined;
   if (wrapType === undefined || wrapType === "inline") {
@@ -2887,6 +2910,7 @@ function convertTextBox(
       distBottom,
       distLeft,
       distRight,
+      position,
       _docxPlacement: options.placement,
       _docxGroupId: options.groupId,
     },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -6,7 +6,10 @@
  * Supports inline and floating positioning.
  */
 
+import type { ImageWrap } from "../../../types/document";
+import { IMAGE_WRAP_TYPE_VALUES } from "../../../types/documentEnumValues";
 import { expectTextBoxAttrs } from "../../attrs";
+import type { ImagePositionAttrs } from "../../schema/nodes";
 import { createNodeExtension } from "../create";
 
 export type TextBoxAttrs = {
@@ -39,7 +42,7 @@ export type TextBoxAttrs = {
   /** CSS float direction */
   cssFloat?: "left" | "right" | "none";
   /** Wrap type */
-  wrapType?: string;
+  wrapType?: ImageWrap["type"];
   /** OOXML wrapText direction for anchored text boxes (eigenpal #474). */
   wrapText?: "bothSides" | "left" | "right" | "largest";
   /** Wrap distance from top edge, in pixels (OOXML distT, EMU-converted). */
@@ -50,11 +53,41 @@ export type TextBoxAttrs = {
   distLeft?: number;
   /** Wrap distance from right edge, in pixels. */
   distRight?: number;
+  /** Position for floating/anchored text boxes. */
+  position?: ImagePositionAttrs;
   /** Original DOCX placement hint for save-path reconstruction. */
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */
   _docxGroupId?: string;
 };
+
+function parseTextBoxPosition(
+  raw: string | undefined,
+): ImagePositionAttrs | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return undefined;
+    }
+    return parsed as ImagePositionAttrs;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseTextBoxWrapType(
+  raw: string | undefined,
+): ImageWrap["type"] | undefined {
+  for (const value of IMAGE_WRAP_TYPE_VALUES) {
+    if (value === raw) {
+      return value;
+    }
+  }
+  return undefined;
+}
 
 export const TextBoxExtension = createNodeExtension({
   name: "textBox",
@@ -85,6 +118,7 @@ export const TextBoxExtension = createNodeExtension({
       distBottom: { default: null },
       distLeft: { default: null },
       distRight: { default: null },
+      position: { default: null },
       _docxPlacement: { default: null },
       _docxGroupId: { default: null },
     },
@@ -97,6 +131,8 @@ export const TextBoxExtension = createNodeExtension({
           }
           const el = dom;
           const d = el.dataset;
+          const position = parseTextBoxPosition(d["position"]);
+          const wrapType = parseTextBoxWrapType(d["wrapType"]);
           return {
             ...(d["width"] ? { width: Number(d["width"]) } : {}),
             ...(d["height"] ? { height: Number(d["height"]) } : {}),
@@ -132,7 +168,7 @@ export const TextBoxExtension = createNodeExtension({
                   >,
                 }
               : {}),
-            ...(d["wrapType"] ? { wrapType: d["wrapType"] } : {}),
+            ...(wrapType ? { wrapType } : {}),
             ...(d["wrapText"]
               ? {
                   wrapText: d["wrapText"] as NonNullable<
@@ -144,6 +180,7 @@ export const TextBoxExtension = createNodeExtension({
             ...(d["distBottom"] ? { distBottom: Number(d["distBottom"]) } : {}),
             ...(d["distLeft"] ? { distLeft: Number(d["distLeft"]) } : {}),
             ...(d["distRight"] ? { distRight: Number(d["distRight"]) } : {}),
+            ...(position ? { position } : {}),
           };
         },
       },
@@ -214,6 +251,9 @@ export const TextBoxExtension = createNodeExtension({
       }
       if (typeof attrs.distRight === "number") {
         domAttrs["data-dist-right"] = String(attrs.distRight);
+      }
+      if (attrs.position) {
+        domAttrs["data-position"] = JSON.stringify(attrs.position);
       }
 
       // Build inline styles

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -468,7 +468,7 @@ export type TextBoxAttrs = {
   /** CSS float direction */
   cssFloat?: "left" | "right" | "none";
   /** Wrap type */
-  wrapType?: string;
+  wrapType?: ImageWrap["type"];
   /** OOXML wrapText direction for anchored text boxes (eigenpal #474). */
   wrapText?: "bothSides" | "left" | "right" | "largest";
   /** Wrap distance from top edge, in pixels (OOXML distT, EMU-converted). */
@@ -479,6 +479,8 @@ export type TextBoxAttrs = {
   distLeft?: number;
   /** Wrap distance from right edge, in pixels. */
   distRight?: number;
+  /** Position for floating/anchored text boxes */
+  position?: ImagePositionAttrs;
   /** Original DOCX placement hint for save-path reconstruction. */
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -403,6 +403,59 @@ describe("measureBlocks floating text-box bands", () => {
       expect(skip + beforeMeasure.totalHeight).toBeCloseTo(56, 5);
     });
   });
+
+  test("two bands sharing a topY each anchor to their own text box", () => {
+    withFakeTextMeasure(() => {
+      // Both bands are margin-pinned at offset 0 (same topY), but they pin to
+      // different text boxes. The second band must not be regrouped onto the
+      // first band's anchor, or `mid` (between them) would reserve the taller
+      // second band that is painted later. eigenpal #694.
+      const bandA: TextBoxBlock = {
+        kind: "textBox",
+        id: "band-a",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const mid: ParagraphBlock = {
+        kind: "paragraph",
+        id: "mid",
+        runs: [{ kind: "text", text: "mid" }],
+      };
+      const bandB: TextBoxBlock = {
+        kind: "textBox",
+        id: "band-b",
+        width: 300,
+        height: 200,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks([bandA, mid, bandB, after], 500, 96);
+      const midMeasure = measures.at(1);
+      const afterMeasure = measures.at(3);
+
+      if (
+        midMeasure?.kind !== "paragraph" ||
+        afterMeasure?.kind !== "paragraph"
+      ) {
+        throw new Error("Expected paragraph measures around the bands");
+      }
+      // `mid` clears only the first band (60), not the second band's 200; the
+      // bug regrouped both onto bandA's anchor and reserved ~200 here.
+      expect(midMeasure.lines.at(0)?.floatSkipBefore).toBeCloseTo(60, 5);
+      // The second band still reserves space at its own anchor.
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBeGreaterThan(0);
+    });
+  });
 });
 
 describe("measureTableBlock", () => {

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -456,6 +456,138 @@ describe("measureBlocks floating text-box bands", () => {
       expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBeGreaterThan(0);
     });
   });
+
+  test("a hard page break before the band restarts the page frame", () => {
+    withFakeTextMeasure(() => {
+      // `before` fills the prior page past the band height, but a page break
+      // resets the cursor: layout paints the band at the new page top, so the
+      // measure pass must reserve the full band again from Y 0 — otherwise the
+      // band's prior-page Y skips the reservation and body text overlaps it.
+      // eigenpal #694.
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "tall ".repeat(400).trim() }],
+      };
+      const pageBreak: FlowBlock = { kind: "pageBreak", id: "pb" };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks([before, pageBreak, band, after], 200, 96);
+      const beforeMeasure = measures.at(0);
+      const afterMeasure = measures.at(3);
+
+      if (
+        beforeMeasure?.kind !== "paragraph" ||
+        afterMeasure?.kind !== "paragraph"
+      ) {
+        throw new Error("Expected paragraph measures around the band");
+      }
+      expect(beforeMeasure.totalHeight).toBeGreaterThan(60);
+      // Full band reserved from the fresh page top despite the tall prior page.
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBeCloseTo(60, 5);
+    });
+  });
+
+  test("a next-page section break before the band restarts the page frame", () => {
+    withFakeTextMeasure(() => {
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "tall ".repeat(400).trim() }],
+      };
+      const sectionBreak: FlowBlock = {
+        kind: "sectionBreak",
+        id: "sb",
+        type: "nextPage",
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks(
+        [before, sectionBreak, band, after],
+        200,
+        96,
+      );
+      const afterMeasure = measures.at(3);
+      if (afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure after the band");
+      }
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBeCloseTo(60, 5);
+    });
+  });
+
+  test("a continuous section break does not restart the page frame", () => {
+    withFakeTextMeasure(() => {
+      // A continuous break stays on the same page, so the tall `before` still
+      // sits above the band: the cursor is already past it and `after` gets no
+      // skip, exactly as with no break. Guards `isNextPageSectionBreak`.
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "tall ".repeat(400).trim() }],
+      };
+      const sectionBreak: FlowBlock = {
+        kind: "sectionBreak",
+        id: "sb",
+        type: "continuous",
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks(
+        [before, sectionBreak, band, after],
+        200,
+        96,
+      );
+      const beforeMeasure = measures.at(0);
+      const afterMeasure = measures.at(3);
+      if (
+        beforeMeasure?.kind !== "paragraph" ||
+        afterMeasure?.kind !== "paragraph"
+      ) {
+        throw new Error("Expected paragraph measures around the band");
+      }
+      expect(beforeMeasure.totalHeight).toBeGreaterThan(60);
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
+    });
+  });
 });
 
 describe("measureTableBlock", () => {

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -260,8 +260,55 @@ describe("measureBlocks floating text-box bands", () => {
       if (afterMeasure?.kind !== "paragraph") {
         throw new Error("Expected second paragraph measure");
       }
+      // The band activates at its real anchor: `before` (above the anchor) is
+      // not pushed down.
       expect(beforeMeasure.totalHeight).toBeLessThan(50);
-      expect(afterMeasure.totalHeight).toBeGreaterThanOrEqual(120);
+      // `after` clears the band from the real cursor, not from the page top: it
+      // is pushed only by the band remaining below `before`, landing exactly at
+      // the band bottom (floatSkipBefore + before height = band height = 120).
+      // A full-band skip here would open a blank gap. eigenpal #694.
+      const skip = afterMeasure.lines.at(0)?.floatSkipBefore ?? 0;
+      expect(skip).toBeGreaterThan(0);
+      expect(skip + beforeMeasure.totalHeight).toBeCloseTo(120, 5);
+    });
+  });
+
+  test("a tall block before the anchor leaves no band skip (no blank gap)", () => {
+    withFakeTextMeasure(() => {
+      // `before` is taller than the band bottom, so the cursor is already below
+      // the band when `after` is reached: it must not be pushed down again.
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "tall ".repeat(400).trim() }],
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks([before, band, after], 200, 96);
+      const beforeMeasure = measures.at(0);
+      const afterMeasure = measures.at(2);
+
+      if (
+        beforeMeasure?.kind !== "paragraph" ||
+        afterMeasure?.kind !== "paragraph"
+      ) {
+        throw new Error("Expected paragraph measures around the band");
+      }
+      expect(beforeMeasure.totalHeight).toBeGreaterThan(60);
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
     });
   });
 
@@ -334,13 +381,26 @@ describe("measureBlocks floating text-box bands", () => {
         [500, 500, 500],
         [96, 144, 144],
       );
+      const beforeMeasure = measures.at(0);
       const afterMeasure = measures.at(2);
 
+      expect(beforeMeasure?.kind).toBe("paragraph");
       expect(afterMeasure?.kind).toBe("paragraph");
+      if (beforeMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure before band");
+      }
       if (afterMeasure?.kind !== "paragraph") {
         throw new Error("Expected paragraph measure after band");
       }
-      expect(afterMeasure.lines.at(0)?.floatSkipBefore).toBe(56);
+      // The band bottom sits at 56 in content coords: page-relative offset 0
+      // resolves to `bandHeight - sectionMarginTop = 200 - 144`. The 96px first
+      // section margin must not leak in (that would yield 200 - 96 = 104).
+      // `before` already occupies the top of the page, so `after` is pushed down
+      // only by the remaining band below the cursor and lands exactly at the band
+      // bottom: floatSkipBefore + before height = 56. eigenpal #694.
+      const skip = afterMeasure.lines.at(0)?.floatSkipBefore ?? 0;
+      expect(skip).toBeGreaterThan(0);
+      expect(skip + beforeMeasure.totalHeight).toBeCloseTo(56, 5);
     });
   });
 });

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -7,8 +7,10 @@ import type {
   Measure,
   ParagraphBlock,
   ParagraphMeasure,
+  TextBoxBlock,
 } from "../core/layout-engine/types";
 import {
+  measureBlocks,
   measureTableBlock,
   measureTableCellBlockVisualHeight,
 } from "./PagedEditor";
@@ -220,6 +222,47 @@ describe("measureTableCellBlockVisualHeight", () => {
     };
 
     expect(measureTableCellBlockVisualHeight(block, measure)).toBe(22);
+  });
+});
+
+describe("measureBlocks floating text-box bands", () => {
+  test("activates a margin-pinned band at its real text-box anchor", () => {
+    withFakeTextMeasure(() => {
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "before" }],
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 120,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks([before, band, after], 500, 96);
+      const beforeMeasure = measures.at(0);
+      const afterMeasure = measures.at(2);
+
+      expect(beforeMeasure?.kind).toBe("paragraph");
+      expect(afterMeasure?.kind).toBe("paragraph");
+      if (beforeMeasure?.kind !== "paragraph") {
+        throw new Error("Expected first paragraph measure");
+      }
+      if (afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected second paragraph measure");
+      }
+      expect(beforeMeasure.totalHeight).toBeLessThan(50);
+      expect(afterMeasure.totalHeight).toBeGreaterThanOrEqual(120);
+    });
   });
 });
 

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -588,6 +588,38 @@ describe("measureBlocks floating text-box bands", () => {
       expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
     });
   });
+
+  test("a hard break after a band clears it for the next page", () => {
+    withFakeTextMeasure(() => {
+      // band, then a page break, then a paragraph with no new anchor: the band
+      // belongs to the previous page, so `after` must NOT inherit its
+      // float-skip (layout paints no band on the new page). Without clearing the
+      // active zones at the break, `after` would get a phantom ~60px skip.
+      // eigenpal #694.
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const pageBreak: FlowBlock = { kind: "pageBreak", id: "pb" };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks([band, pageBreak, after], 200, 96);
+      const afterMeasure = measures.at(2);
+      if (afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure after the break");
+      }
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
+    });
+  });
 });
 
 describe("measureTableBlock", () => {

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -306,6 +306,43 @@ describe("measureBlocks floating text-box bands", () => {
       );
     });
   });
+
+  test("uses the current section top margin for page-pinned bands", () => {
+    withFakeTextMeasure(() => {
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "before" }],
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 200,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "page", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks(
+        [before, band, after],
+        [500, 500, 500],
+        [96, 144, 144],
+      );
+      const afterMeasure = measures.at(2);
+
+      expect(afterMeasure?.kind).toBe("paragraph");
+      if (afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure after band");
+      }
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore).toBe(56);
+    });
+  });
 });
 
 describe("measureTableBlock", () => {

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -264,6 +264,48 @@ describe("measureBlocks floating text-box bands", () => {
       expect(afterMeasure.totalHeight).toBeGreaterThanOrEqual(120);
     });
   });
+
+  test("reserves measured height for auto-height bands", () => {
+    withFakeTextMeasure(() => {
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        content: [
+          {
+            kind: "paragraph",
+            id: "band-content",
+            runs: [{ kind: "text", text: "banner" }],
+          },
+        ],
+        margins: { top: 0, right: 0, bottom: 0, left: 0 },
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks([band, after], 500, 96);
+      const bandMeasure = measures.at(0);
+      const afterMeasure = measures.at(1);
+
+      expect(bandMeasure?.kind).toBe("textBox");
+      expect(afterMeasure?.kind).toBe("paragraph");
+      if (bandMeasure?.kind !== "textBox") {
+        throw new Error("Expected text box measure");
+      }
+      if (afterMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure");
+      }
+      expect(bandMeasure.height).toBeGreaterThan(0);
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore).toBeGreaterThanOrEqual(
+        bandMeasure.height,
+      );
+    });
+  });
 });
 
 describe("measureTableBlock", () => {

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -620,6 +620,70 @@ describe("measureBlocks floating text-box bands", () => {
       expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
     });
   });
+
+  test("a band after a float anchor reserves from the page cursor, not the float frame", () => {
+    withFakeTextMeasure(() => {
+      // A floating image earlier on the page resets the local float cursor to 0;
+      // the page-pinned band must still measure from the real page position
+      // (below the tall `before`), so `after` — already past the band — gets no
+      // skip. Measuring from the float frame would add a phantom one. eigenpal #694.
+      const before: ParagraphBlock = {
+        kind: "paragraph",
+        id: "before",
+        runs: [{ kind: "text", text: "tall ".repeat(400).trim() }],
+      };
+      const floatImagePara: ParagraphBlock = {
+        kind: "paragraph",
+        id: "float",
+        runs: [
+          { kind: "text", text: "x" },
+          {
+            kind: "image",
+            src: "data:,",
+            width: 40,
+            height: 40,
+            wrapType: "square",
+            position: {
+              horizontal: { align: "left" },
+              vertical: { relativeTo: "margin" },
+            },
+          },
+        ],
+      };
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const after: ParagraphBlock = {
+        kind: "paragraph",
+        id: "after",
+        runs: [{ kind: "text", text: "after" }],
+      };
+
+      const measures = measureBlocks(
+        [before, floatImagePara, band, after],
+        200,
+        96,
+      );
+      const beforeMeasure = measures.at(0);
+      const afterMeasure = measures.at(3);
+      if (
+        beforeMeasure?.kind !== "paragraph" ||
+        afterMeasure?.kind !== "paragraph"
+      ) {
+        throw new Error("Expected paragraph measures");
+      }
+      // `before` alone already exceeds the 60px band, so the band sits entirely
+      // above the cursor and `after` is not pushed down.
+      expect(beforeMeasure.totalHeight).toBeGreaterThan(60);
+      expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
+    });
+  });
 });
 
 describe("measureTableBlock", () => {

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -4,9 +4,11 @@ import { clearAllCaches } from "../core/layout-engine/measure/cache";
 import { resetCanvasContext } from "../core/layout-engine/measure/measureContainer";
 import type {
   FlowBlock,
+  ImageBlock,
   Measure,
   ParagraphBlock,
   ParagraphMeasure,
+  TableBlock,
   TextBoxBlock,
 } from "../core/layout-engine/types";
 import {
@@ -682,6 +684,66 @@ describe("measureBlocks floating text-box bands", () => {
       // above the cursor and `after` is not pushed down.
       expect(beforeMeasure.totalHeight).toBeGreaterThan(60);
       expect(afterMeasure.lines.at(0)?.floatSkipBefore ?? 0).toBe(0);
+    });
+  });
+
+  test("reserves a leading skip for a table or image following a band", () => {
+    withFakeTextMeasure(() => {
+      // A table or inline image right after a page-pinned band has no per-line
+      // skip mechanism, so the measure pass records a block-level skip that
+      // pushes it below the band instead of under it. eigenpal #694.
+      const band: TextBoxBlock = {
+        kind: "textBox",
+        id: "band",
+        width: 300,
+        height: 60,
+        content: [],
+        wrapType: "topAndBottom",
+        position: { vertical: { relativeTo: "margin", posOffset: 0 } },
+      };
+      const table: TableBlock = {
+        kind: "table",
+        id: "tbl",
+        rows: [
+          {
+            id: "r",
+            cells: [
+              {
+                id: "c",
+                blocks: [
+                  {
+                    kind: "paragraph",
+                    id: "tp",
+                    runs: [{ kind: "text", text: "cell" }],
+                  },
+                ],
+                padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              },
+            ],
+          },
+        ],
+      };
+      const image: ImageBlock = {
+        kind: "image",
+        id: "img",
+        src: "data:,",
+        width: 80,
+        height: 40,
+      };
+
+      const tableMeasure = measureBlocks([band, table], 200, 96).at(1);
+      const imageMeasure = measureBlocks([band, image], 200, 96).at(1);
+
+      // The band bottom sits at 60 (margin-relative offset 0, height 60), so the
+      // follower is pushed down by the full band height.
+      expect(tableMeasure?.kind).toBe("table");
+      if (tableMeasure?.kind === "table") {
+        expect(tableMeasure.bandSkipBefore).toBeCloseTo(60, 5);
+      }
+      expect(imageMeasure?.kind).toBe("image");
+      if (imageMeasure?.kind === "image") {
+        expect(imageMeasure.bandSkipBefore).toBeCloseTo(60, 5);
+      }
     });
   });
 });

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -87,6 +87,7 @@ import type { ToFlowBlocksOptions } from "../core/layout-bridge/toFlowBlocks";
 // Layout engine
 import { layoutDocument } from "../core/layout-engine";
 import type { ColumnLayout, SectionLayoutConfig } from "../core/layout-engine";
+import { floatingTextBoxReservesBand } from "../core/layout-engine/textBoxFlow";
 import type {
   Layout,
   FlowBlock,
@@ -2069,6 +2070,7 @@ type FloatingZoneWithAnchor = {
 function extractFloatingZones(
   blocks: FlowBlock[],
   contentWidth: number,
+  marginTop = 0,
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
 
@@ -2218,6 +2220,54 @@ function extractFloatingZones(
     });
   }
 
+  // Page/margin-anchored topAndBottom text boxes (e.g. a banner pinned to the
+  // page top) reserve a full-width band so body text flows above and below the
+  // box instead of the box dropping into the flow at its anchor paragraph.
+  // Paragraph-anchored topAndBottom boxes keep folio's in-flow handling (they
+  // already render on their own line at the anchor). eigenpal docx-editor #694.
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+    const block = blocks[blockIndex]!; // SAFETY: blockIndex < blocks.length
+    if (block.kind !== "textBox") {
+      continue;
+    }
+    const tb = block as TextBoxBlock;
+    if (!floatingTextBoxReservesBand(tb)) {
+      continue;
+    }
+    const v = tb.position?.vertical;
+    const pagePinned = v?.relativeTo === "page" || v?.relativeTo === "margin";
+    if (!pagePinned) {
+      continue;
+    }
+
+    const height = tb.height ?? 0;
+    const distTop = tb.distTop ?? 0;
+    const distBottom = tb.distBottom ?? 0;
+    // Resolve the band top in content coordinates. A page-relative offset is
+    // measured from the page edge, so subtract the top margin; a margin-relative
+    // offset (or a top/align with no offset) sits at the content top (0).
+    let rawTop = 0;
+    if (v.posOffset !== undefined) {
+      rawTop =
+        v.relativeTo === "page"
+          ? emuToPixels(v.posOffset) - marginTop
+          : emuToPixels(v.posOffset);
+    }
+    const bottomY = rawTop + height + distBottom;
+    if (bottomY <= 0) {
+      continue;
+    }
+    zones.push({
+      leftMargin: 0,
+      rightMargin: 0,
+      topY: Math.max(0, rawTop - distTop),
+      bottomY,
+      anchorBlockIndex: blockIndex,
+      isMarginRelative: true,
+      fullWidthBlock: true,
+    });
+  }
+
   return zones;
 }
 
@@ -2324,12 +2374,17 @@ function measureBlock(
 function measureBlocks(
   blocks: FlowBlock[],
   contentWidth: number | number[],
+  marginTop = 0,
 ): Measure[] {
   const defaultWidth = Array.isArray(contentWidth)
     ? (contentWidth[0] ?? 0)
     : contentWidth;
   // Pre-extract floating image exclusion zones with anchor block indices
-  const floatingZonesWithAnchors = extractFloatingZones(blocks, defaultWidth);
+  const floatingZonesWithAnchors = extractFloatingZones(
+    blocks,
+    defaultWidth,
+    marginTop,
+  );
 
   // Margin-relative zones (positioned relative to page/margin) on the same vertical
   // position are likely on the same page. Group them and activate all from the earliest
@@ -2362,17 +2417,30 @@ function measureBlocks(
   // Group zones by effective anchor block index
   const zonesByAnchor = new Map<number, FloatingImageZone[]>();
   for (const z of adjustedZones) {
-    const existing = zonesByAnchor.get(z.anchorBlockIndex) ?? [];
-    existing.push({
-      leftMargin: z.leftMargin,
-      rightMargin: z.rightMargin,
-      topY: z.topY,
-      bottomY: z.bottomY,
-    });
-    zonesByAnchor.set(z.anchorBlockIndex, existing);
+    // A page/margin-pinned full-width band (e.g. a title banner at the top of
+    // the page) reserves space from the top of content, so it must reach the
+    // blocks that precede its own anchor paragraph. Anchor it at block 0 and
+    // keep its content-relative topY/bottomY. Exact for the common case (a
+    // banner near the document start); a band whose anchor lands on a later
+    // page can over-reach — matches upstream's documented caveat.
+    const anchor =
+      z.fullWidthBlock && z.isMarginRelative ? 0 : z.anchorBlockIndex;
+    const existing = zonesByAnchor.get(anchor) ?? [];
+    // Strip the anchor-tracking fields; the rest IS a FloatingImageZone. Spread
+    // (rather than copying each field) so fullWidthBlock/segments can't be
+    // dropped here.
+    const {
+      anchorBlockIndex: _anchorBlockIndex,
+      isMarginRelative: _isMarginRelative,
+      ...zone
+    } = z;
+    existing.push(zone);
+    zonesByAnchor.set(anchor, existing);
   }
 
-  const anchorIndices = new Set(adjustedZones.map((z) => z.anchorBlockIndex));
+  // Derive from the map keys, not the raw zones — full-width bands are
+  // re-anchored to block 0 above, and the activation set must match.
+  const anchorIndices = new Set(zonesByAnchor.keys());
 
   // Track cumulative Y position for floating zone overlap calculation
   // Resets when we reach a block with floating images (establishing local page coords)
@@ -3024,7 +3092,8 @@ export function PagedEditor(
               })
             : null;
         const newMeasures =
-          incrementalResult?.measures ?? measureBlocks(newBlocks, blockWidths);
+          incrementalResult?.measures ??
+          measureBlocks(newBlocks, blockWidths, margins.top);
         layoutArtifactsRef.current = {
           blocks: newBlocks,
           blockWidths,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2366,7 +2366,7 @@ function measureBlock(
  * Then measures each block, passing the zones so paragraphs can calculate
  * per-line widths based on vertical overlap with floating images.
  */
-function measureBlocks(
+export function measureBlocks(
   blocks: FlowBlock[],
   contentWidth: number | number[],
   marginTop = 0,
@@ -2412,15 +2412,7 @@ function measureBlocks(
   // Group zones by effective anchor block index
   const zonesByAnchor = new Map<number, FloatingImageZone[]>();
   for (const z of adjustedZones) {
-    // A page/margin-pinned full-width band (e.g. a title banner at the top of
-    // the page) reserves space from the top of content, so it must reach the
-    // blocks that precede its own anchor paragraph. Anchor it at block 0 and
-    // keep its content-relative topY/bottomY. Exact for the common case (a
-    // banner near the document start); a band whose anchor lands on a later
-    // page can over-reach — matches upstream's documented caveat.
-    const anchor =
-      z.fullWidthBlock && z.isMarginRelative ? 0 : z.anchorBlockIndex;
-    const existing = zonesByAnchor.get(anchor) ?? [];
+    const existing = zonesByAnchor.get(z.anchorBlockIndex) ?? [];
     // Strip the anchor-tracking fields; the rest IS a FloatingImageZone. Spread
     // (rather than copying each field) so fullWidthBlock/segments can't be
     // dropped here.
@@ -2430,11 +2422,9 @@ function measureBlocks(
       ...zone
     } = z;
     existing.push(zone);
-    zonesByAnchor.set(anchor, existing);
+    zonesByAnchor.set(z.anchorBlockIndex, existing);
   }
 
-  // Derive from the map keys, not the raw zones — full-width bands are
-  // re-anchored to block 0 above, and the activation set must match.
   const anchorIndices = new Set(zonesByAnchor.keys());
 
   // Track cumulative Y position for floating zone overlap calculation

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2494,9 +2494,15 @@ export function measureBlocks(
 
   const anchorIndices = new Set(zonesByAnchor.keys());
 
-  // Track cumulative Y position for floating zone overlap calculation
-  // Resets when we reach a block with floating images (establishing local page coords)
+  // Two running Y cursors for floating-zone overlap:
+  //  - cumulativeY resets to 0 at each floating-image/table anchor, giving that
+  //    object a local frame for its side-wrap zone.
+  //  - pageRelativeY is the real page cursor; it resets only at hard page breaks
+  //    (never at a float anchor), so a page-pinned topAndBottom band always
+  //    measures from a true page-relative position even when a float was
+  //    anchored earlier on the same page. eigenpal #694.
   let cumulativeY = 0;
+  let pageRelativeY = 0;
   let activeZones: FloatingImageZone[] = [];
 
   return blocks.map((block, blockIndex) => {
@@ -2504,15 +2510,15 @@ export function measureBlocks(
 
     // A hard page/section break starts a fresh page. Any active zone — including
     // a page-pinned topAndBottom band — belongs to the page it was anchored on,
-    // so drop the active zones and restart the running Y at the new page top. A
+    // so drop the active zones and restart both cursors at the new page top. A
     // band anchor on the new page re-establishes its own zone below; without
     // this, the first block after the break would be measured against a stale
     // band (a phantom float-skip) while layout paints no band there, opening a
-    // gap. This also resets the running Y so a band anchor that opens the new
-    // page reserves from content-Y 0, not the prior page's cursor. eigenpal #694.
+    // gap. eigenpal #694.
     if (block.kind === "pageBreak" || isNextPageSectionBreak(block)) {
       activeZones = [];
       cumulativeY = 0;
+      pageRelativeY = 0;
     }
 
     // Check if this block is an anchor for floating images
@@ -2520,20 +2526,16 @@ export function measureBlocks(
     // after a Y reset since their topY/bottomY are in the old coordinate system).
     if (anchorIndices.has(blockIndex)) {
       activeZones = zonesByAnchor.get(blockIndex) ?? [];
-      // Floating-image anchors establish a fresh local page frame, so the
-      // running Y resets to 0. Page/margin-pinned topAndBottom bands are
-      // different: they pin to the page top regardless of where their anchor
-      // sits in the flow, so resetting here would measure the following block as
-      // if it began at the page top and reserve the whole band even when in-flow
-      // content already precedes the anchor on the page, opening a blank gap.
-      // Keep the running Y for pure band anchors so the band is reserved from the
-      // real cursor down. (A band anchor that opens a fresh page already had its
-      // running Y reset to 0 by the hard-break handling above.) eigenpal #694.
+      // Floating-image anchors open a fresh local frame (cumulativeY → 0). A
+      // page/margin-pinned band instead reserves against the page, so it
+      // measures from pageRelativeY — the real page cursor, which a prior float
+      // anchor has not reset. This is a no-op when no float precedes the band on
+      // the page (the two cursors agree) and 0 right after a hard break, so the
+      // band still reserves from the real cursor down rather than re-reserving
+      // the whole band over content that already precedes its anchor. eigenpal #694.
       const bandOnlyAnchor =
         activeZones.length > 0 && activeZones.every((z) => z.fullWidthBlock);
-      if (!bandOnlyAnchor) {
-        cumulativeY = 0;
-      }
+      cumulativeY = bandOnlyAnchor ? pageRelativeY : 0;
     }
 
     const zones = activeZones.length > 0 ? activeZones : undefined;
@@ -2544,12 +2546,13 @@ export function measureBlocks(
         : contentWidth;
       const measure = measureBlock(block, blockWidth, zones, cumulativeY);
 
-      // Update cumulative Y for next block
+      // Advance both cursors for the next block.
       if (
         "totalHeight" in measure &&
         !(block.kind === "table" && (block as TableBlock).floating)
       ) {
         cumulativeY += measure.totalHeight;
+        pageRelativeY += measure.totalHeight;
       }
 
       return measure;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -106,6 +106,7 @@ import type {
   PageMargins,
   SectionBreakBlock,
   TextBoxBlock,
+  TextBoxMeasure,
   FootnoteContent,
   PageHeaderFooterRefs,
 } from "../core/layout-engine/types";
@@ -2243,7 +2244,7 @@ function extractFloatingZones(
       continue;
     }
 
-    const height = tb.height ?? 0;
+    const height = measureTextBoxBlock(tb).height;
     const distTop = tb.distTop ?? 0;
     const distBottom = tb.distBottom ?? 0;
     // Shared with layoutTextBox so the reserved band and the painted box agree.
@@ -2320,24 +2321,7 @@ function measureBlock(
     }
 
     case "textBox": {
-      const tb = block as TextBoxBlock;
-      const margins = tb.margins ?? DEFAULT_TEXTBOX_MARGINS;
-      const innerWidth = tb.width - margins.left - margins.right;
-      const innerMeasures = tb.content.map((p) =>
-        measureParagraph(p, innerWidth),
-      );
-      const contentHeight = innerMeasures.reduce(
-        (sum, m) => sum + m.totalHeight,
-        0,
-      );
-      const totalHeight =
-        tb.height ?? contentHeight + margins.top + margins.bottom;
-      return {
-        kind: "textBox" as const,
-        width: tb.width,
-        height: totalHeight,
-        innerMeasures,
-      };
+      return measureTextBoxBlock(block as TextBoxBlock);
     }
 
     case "pageBreak":
@@ -2357,6 +2341,23 @@ function measureBlock(
         totalHeight: 0,
       };
   }
+}
+
+function measureTextBoxBlock(tb: TextBoxBlock): TextBoxMeasure {
+  const margins = tb.margins ?? DEFAULT_TEXTBOX_MARGINS;
+  const innerWidth = tb.width - margins.left - margins.right;
+  const innerMeasures = tb.content.map((p) => measureParagraph(p, innerWidth));
+  const contentHeight = innerMeasures.reduce(
+    (sum, m) => sum + m.totalHeight,
+    0,
+  );
+  const totalHeight = tb.height ?? contentHeight + margins.top + margins.bottom;
+  return {
+    kind: "textBox",
+    width: tb.width,
+    height: totalHeight,
+    innerMeasures,
+  };
 }
 
 /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2380,6 +2380,17 @@ function measureTextBoxBlock(tb: TextBoxBlock): TextBoxMeasure {
 }
 
 /**
+ * `true` for a section break that starts a new page (`nextPage`/`evenPage`/
+ * `oddPage`, or an unspecified type, which the layout treats as `nextPage`).
+ * A `continuous` break stays on the current page, so it does not open a fresh
+ * page frame. Used by `measureBlocks` to reset the running Y for a page-pinned
+ * band that lands right after the break. eigenpal #694.
+ */
+function isNextPageSectionBreak(block: FlowBlock): boolean {
+  return block.kind === "sectionBreak" && block.type !== "continuous";
+}
+
+/**
  * Measure all blocks with floating image support.
  *
  * Pre-scans all blocks to find floating images and creates exclusion zones.
@@ -2455,9 +2466,17 @@ export function measureBlocks(
   // Resets when we reach a block with floating images (establishing local page coords)
   let cumulativeY = 0;
   let activeZones: FloatingImageZone[] = [];
+  // Set by a hard page/section break; cleared once height-consuming flow lands
+  // or any anchor claims the frame. While set, the next page-pinned band anchor
+  // opens a fresh page at content-Y 0 (see the band reset below). eigenpal #694.
+  let freshPageFramePending = false;
 
   return blocks.map((block, blockIndex) => {
     recordMeasureBlock(blockIndex, block);
+
+    if (block.kind === "pageBreak" || isNextPageSectionBreak(block)) {
+      freshPageFramePending = true;
+    }
 
     // Check if this block is an anchor for floating images
     // If so, replace active zones (old zones from previous anchors are invalid
@@ -2471,12 +2490,17 @@ export function measureBlocks(
       // if it began at the page top and reserve the whole band even when in-flow
       // content already precedes the anchor on the page, opening a blank gap.
       // Keep the running Y for pure band anchors so the band is reserved from the
-      // real cursor down. eigenpal #694.
+      // real cursor down — unless the band anchor opens a fresh page (directly
+      // after a hard page/section break). There the new page restarts at Y 0 and
+      // layout paints the band at that page top, so keeping the prior page's Y
+      // would skip the reservation and let body text overlap the band. eigenpal
+      // #694.
       const bandOnlyAnchor =
         activeZones.length > 0 && activeZones.every((z) => z.fullWidthBlock);
-      if (!bandOnlyAnchor) {
+      if (!bandOnlyAnchor || freshPageFramePending) {
         cumulativeY = 0;
       }
+      freshPageFramePending = false;
     }
 
     const zones = activeZones.length > 0 ? activeZones : undefined;
@@ -2493,6 +2517,12 @@ export function measureBlocks(
         !(block.kind === "table" && (block as TableBlock).floating)
       ) {
         cumulativeY += measure.totalHeight;
+        // Real flow content on the new page means a later band no longer sits at
+        // the fresh page top; a zero-height (suppressed) block leaves Y at 0, so
+        // the frame is still fresh and the flag must persist.
+        if (measure.totalHeight > 0) {
+          freshPageFramePending = false;
+        }
       }
 
       return measure;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2456,12 +2456,23 @@ export function measureBlocks(
     recordMeasureBlock(blockIndex, block);
 
     // Check if this block is an anchor for floating images
-    // If so, reset cumulative Y and replace active zones (old zones from previous
-    // anchors are invalid after the Y reset since their topY/bottomY are in the old
-    // coordinate system)
+    // If so, replace active zones (old zones from previous anchors are invalid
+    // after a Y reset since their topY/bottomY are in the old coordinate system).
     if (anchorIndices.has(blockIndex)) {
-      cumulativeY = 0;
       activeZones = zonesByAnchor.get(blockIndex) ?? [];
+      // Floating-image anchors establish a fresh local page frame, so the
+      // running Y resets to 0. Page/margin-pinned topAndBottom bands are
+      // different: they pin to the page top regardless of where their anchor
+      // sits in the flow, so resetting here would measure the following block as
+      // if it began at the page top and reserve the whole band even when in-flow
+      // content already precedes the anchor on the page, opening a blank gap.
+      // Keep the running Y for pure band anchors so the band is reserved from the
+      // real cursor down. eigenpal #694.
+      const bandOnlyAnchor =
+        activeZones.length > 0 && activeZones.every((z) => z.fullWidthBlock);
+      if (!bandOnlyAnchor) {
+        cumulativeY = 0;
+      }
     }
 
     const zones = activeZones.length > 0 ? activeZones : undefined;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3147,47 +3147,6 @@ export function PagedEditor(
         setBlocks(newBlocks);
         recordPhaseDuration("flow-blocks", phaseStartedAt);
 
-        // Compute per-block widths accounting for section breaks with different column configs
-        phaseStartedAt = performance.now();
-        const bodyLayoutConfig: SectionLayoutConfig = {
-          pageSize,
-          margins,
-        };
-        if (columns !== undefined) {
-          bodyLayoutConfig.columns = columns;
-        }
-        const blockMeasureInputs = computePerBlockMeasureInputs({
-          blocks: newBlocks,
-          bodyConfig: bodyLayoutConfig,
-          finalConfig: bodyLayoutConfig,
-        });
-        const blockWidths = blockMeasureInputs.widths;
-        const incrementalResult =
-          options.dirtyRange && !options.forceFull && layoutArtifactsRef.current
-            ? tryBuildIncrementalMeasures({
-                previousBlocks: layoutArtifactsRef.current.blocks,
-                previousMeasures: layoutArtifactsRef.current.measures,
-                previousBlockWidths: layoutArtifactsRef.current.blockWidths,
-                nextBlocks: newBlocks,
-                nextBlockWidths: blockWidths,
-                dirtyRange: options.dirtyRange,
-                measureBlock: measureSingleBlockWithoutFloatingZones,
-              })
-            : null;
-        const newMeasures =
-          incrementalResult?.measures ??
-          measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
-            pageHeight: blockMeasureInputs.pageHeights,
-            marginBottom: blockMeasureInputs.marginBottoms,
-          });
-        layoutArtifactsRef.current = {
-          blocks: newBlocks,
-          blockWidths,
-          measures: newMeasures,
-        };
-        setMeasures(newMeasures);
-        recordPhaseDuration("measure-blocks", phaseStartedAt);
-
         // Step 2.5: Collect footnote references from blocks
         phaseStartedAt = performance.now();
         const footnoteRefs = collectFootnoteRefs(newBlocks);
@@ -3304,6 +3263,52 @@ export function PagedEditor(
           }
         }
         recordPhaseDuration("header-footer", phaseStartedAt);
+
+        // Compute per-block widths + band geometry from the EFFECTIVE margins
+        // layout uses (header/footer overflow extension + section-break margin
+        // extension applied above), so a page/margin-pinned topAndBottom band
+        // reserves its band at the same Y the box is painted. Measuring with the
+        // raw margins would mis-place the reserved band when a tall header/footer
+        // extends the margins. eigenpal #694.
+        phaseStartedAt = performance.now();
+        const bodyLayoutConfig: SectionLayoutConfig = {
+          pageSize,
+          margins: effectiveMargins,
+        };
+        if (columns !== undefined) {
+          bodyLayoutConfig.columns = columns;
+        }
+        const blockMeasureInputs = computePerBlockMeasureInputs({
+          blocks: newBlocks,
+          bodyConfig: bodyLayoutConfig,
+          finalConfig: bodyLayoutConfig,
+        });
+        const blockWidths = blockMeasureInputs.widths;
+        const incrementalResult =
+          options.dirtyRange && !options.forceFull && layoutArtifactsRef.current
+            ? tryBuildIncrementalMeasures({
+                previousBlocks: layoutArtifactsRef.current.blocks,
+                previousMeasures: layoutArtifactsRef.current.measures,
+                previousBlockWidths: layoutArtifactsRef.current.blockWidths,
+                nextBlocks: newBlocks,
+                nextBlockWidths: blockWidths,
+                dirtyRange: options.dirtyRange,
+                measureBlock: measureSingleBlockWithoutFloatingZones,
+              })
+            : null;
+        const newMeasures =
+          incrementalResult?.measures ??
+          measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
+            pageHeight: blockMeasureInputs.pageHeights,
+            marginBottom: blockMeasureInputs.marginBottoms,
+          });
+        layoutArtifactsRef.current = {
+          blocks: newBlocks,
+          blockWidths,
+          measures: newMeasures,
+        };
+        setMeasures(newMeasures);
+        recordPhaseDuration("measure-blocks", phaseStartedAt);
 
         // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
         phaseStartedAt = performance.now();

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -74,6 +74,8 @@ import {
   clearAllCaches,
   getCachedParagraphMeasure,
   setCachedParagraphMeasure,
+  findClearLineY,
+  MIN_WRAP_SEGMENT_WIDTH,
 } from "../core/layout-bridge/measuring";
 import type { FloatingImageZone } from "../core/layout-bridge/measuring";
 import type {
@@ -2545,6 +2547,33 @@ export function measureBlocks(
         ? (contentWidth[blockIndex] ?? defaultWidth)
         : contentWidth;
       const measure = measureBlock(block, blockWidth, zones, cumulativeY);
+
+      // Paragraphs clear a full-width band internally (findClearLineY inside
+      // measureParagraph). An in-flow table or inline image does not, so reserve
+      // a leading skip here that layout applies before the block, pushing it
+      // below the band rather than under it. eigenpal #694.
+      const bandZones = zones?.filter((zone) => zone.fullWidthBlock);
+      if (
+        bandZones?.length &&
+        (measure.kind === "image" ||
+          (measure.kind === "table" && !(block as TableBlock).floating))
+      ) {
+        const blockHeight =
+          measure.kind === "image" ? measure.height : measure.totalHeight;
+        const skip =
+          findClearLineY(
+            cumulativeY,
+            blockHeight,
+            bandZones,
+            blockWidth,
+            MIN_WRAP_SEGMENT_WIDTH,
+          ) - cumulativeY;
+        if (skip > 0) {
+          measure.bandSkipBefore = skip;
+          cumulativeY += skip;
+          pageRelativeY += skip;
+        }
+      }
 
       // Advance both cursors for the next block.
       if (

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -87,7 +87,10 @@ import type { ToFlowBlocksOptions } from "../core/layout-bridge/toFlowBlocks";
 // Layout engine
 import { layoutDocument } from "../core/layout-engine";
 import type { ColumnLayout, SectionLayoutConfig } from "../core/layout-engine";
-import { floatingTextBoxReservesBand } from "../core/layout-engine/textBoxFlow";
+import {
+  bandTopContentY,
+  floatingTextBoxReservesBand,
+} from "../core/layout-engine/textBoxFlow";
 import type {
   Layout,
   FlowBlock,
@@ -2243,16 +2246,8 @@ function extractFloatingZones(
     const height = tb.height ?? 0;
     const distTop = tb.distTop ?? 0;
     const distBottom = tb.distBottom ?? 0;
-    // Resolve the band top in content coordinates. A page-relative offset is
-    // measured from the page edge, so subtract the top margin; a margin-relative
-    // offset (or a top/align with no offset) sits at the content top (0).
-    let rawTop = 0;
-    if (v.posOffset !== undefined) {
-      rawTop =
-        v.relativeTo === "page"
-          ? emuToPixels(v.posOffset) - marginTop
-          : emuToPixels(v.posOffset);
-    }
+    // Shared with layoutTextBox so the reserved band and the painted box agree.
+    const rawTop = bandTopContentY(v, marginTop);
     const bottomY = rawTop + height + distBottom;
     if (bottomY <= 0) {
       continue;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -90,6 +90,7 @@ import type { ColumnLayout, SectionLayoutConfig } from "../core/layout-engine";
 import {
   bandTopContentY,
   floatingTextBoxReservesBand,
+  isPageFrameRelativeAnchor,
 } from "../core/layout-engine/textBoxFlow";
 import type {
   Layout,
@@ -2082,15 +2083,30 @@ function perBlockNumberValue(
   return value;
 }
 
+// Page geometry the band extraction needs to resolve page/margin-pinned
+// topAndBottom anchors (bottom-strip frames, centered/bottom align). Per-block
+// because sections can vary page size and margins. eigenpal #694.
+type BandPageGeometry = {
+  pageHeight: number | number[];
+  marginBottom: number | number[];
+};
+
 function extractFloatingZones(
   blocks: FlowBlock[],
   contentWidth: number,
   marginTop: number | number[] = 0,
+  pageGeometry: BandPageGeometry = { pageHeight: 0, marginBottom: 0 },
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
   const defaultMarginTop = Array.isArray(marginTop)
     ? (marginTop[0] ?? 0)
     : marginTop;
+  const defaultPageHeight = Array.isArray(pageGeometry.pageHeight)
+    ? (pageGeometry.pageHeight[0] ?? 0)
+    : pageGeometry.pageHeight;
+  const defaultMarginBottom = Array.isArray(pageGeometry.marginBottom)
+    ? (pageGeometry.marginBottom[0] ?? 0)
+    : pageGeometry.marginBottom;
 
   for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
     const block = blocks[blockIndex]!; // SAFETY: blockIndex < blocks.length
@@ -2253,8 +2269,7 @@ function extractFloatingZones(
       continue;
     }
     const v = tb.position?.vertical;
-    const pagePinned = v?.relativeTo === "page" || v?.relativeTo === "margin";
-    if (!pagePinned) {
+    if (!isPageFrameRelativeAnchor(v?.relativeTo)) {
       continue;
     }
 
@@ -2267,7 +2282,20 @@ function extractFloatingZones(
       defaultMarginTop,
     );
     // Shared with layoutTextBox so the reserved band and the painted box agree.
-    const rawTop = bandTopContentY(v, blockMarginTop);
+    const rawTop = bandTopContentY(v, {
+      pageHeight: perBlockNumberValue(
+        pageGeometry.pageHeight,
+        blockIndex,
+        defaultPageHeight,
+      ),
+      marginTop: blockMarginTop,
+      marginBottom: perBlockNumberValue(
+        pageGeometry.marginBottom,
+        blockIndex,
+        defaultMarginBottom,
+      ),
+      boxHeight: height,
+    });
     const bottomY = rawTop + height + distBottom;
     if (bottomY <= 0) {
       continue;
@@ -2401,6 +2429,7 @@ export function measureBlocks(
   blocks: FlowBlock[],
   contentWidth: number | number[],
   marginTop: number | number[] = 0,
+  pageGeometry: BandPageGeometry = { pageHeight: 0, marginBottom: 0 },
 ): Measure[] {
   const defaultWidth = Array.isArray(contentWidth)
     ? (contentWidth[0] ?? 0)
@@ -2410,6 +2439,7 @@ export function measureBlocks(
     blocks,
     defaultWidth,
     marginTop,
+    pageGeometry,
   );
 
   // Margin-relative zones (positioned relative to page/margin) on the same vertical
@@ -3144,7 +3174,10 @@ export function PagedEditor(
             : null;
         const newMeasures =
           incrementalResult?.measures ??
-          measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops);
+          measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
+            pageHeight: blockMeasureInputs.pageHeights,
+            marginBottom: blockMeasureInputs.marginBottoms,
+          });
         layoutArtifactsRef.current = {
           blocks: newBlocks,
           blockWidths,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2095,18 +2095,20 @@ function extractFloatingZones(
   blocks: FlowBlock[],
   contentWidth: number,
   marginTop: number | number[] = 0,
-  pageGeometry: BandPageGeometry = { pageHeight: 0, marginBottom: 0 },
+  pageGeometry?: BandPageGeometry,
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
   const defaultMarginTop = Array.isArray(marginTop)
     ? (marginTop[0] ?? 0)
     : marginTop;
-  const defaultPageHeight = Array.isArray(pageGeometry.pageHeight)
-    ? (pageGeometry.pageHeight[0] ?? 0)
-    : pageGeometry.pageHeight;
-  const defaultMarginBottom = Array.isArray(pageGeometry.marginBottom)
-    ? (pageGeometry.marginBottom[0] ?? 0)
-    : pageGeometry.marginBottom;
+  const pageHeightInput = pageGeometry?.pageHeight ?? 0;
+  const marginBottomInput = pageGeometry?.marginBottom ?? 0;
+  const defaultPageHeight = Array.isArray(pageHeightInput)
+    ? (pageHeightInput[0] ?? 0)
+    : pageHeightInput;
+  const defaultMarginBottom = Array.isArray(marginBottomInput)
+    ? (marginBottomInput[0] ?? 0)
+    : marginBottomInput;
 
   for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
     const block = blocks[blockIndex]!; // SAFETY: blockIndex < blocks.length
@@ -2284,13 +2286,13 @@ function extractFloatingZones(
     // Shared with layoutTextBox so the reserved band and the painted box agree.
     const rawTop = bandTopContentY(v, {
       pageHeight: perBlockNumberValue(
-        pageGeometry.pageHeight,
+        pageHeightInput,
         blockIndex,
         defaultPageHeight,
       ),
       marginTop: blockMarginTop,
       marginBottom: perBlockNumberValue(
-        pageGeometry.marginBottom,
+        marginBottomInput,
         blockIndex,
         defaultMarginBottom,
       ),
@@ -2429,7 +2431,7 @@ export function measureBlocks(
   blocks: FlowBlock[],
   contentWidth: number | number[],
   marginTop: number | number[] = 0,
-  pageGeometry: BandPageGeometry = { pageHeight: 0, marginBottom: 0 },
+  pageGeometry?: BandPageGeometry,
 ): Measure[] {
   const defaultWidth = Array.isArray(contentWidth)
     ? (contentWidth[0] ?? 0)

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2406,11 +2406,15 @@ export function measureBlocks(
   // anchor so text wraps around ALL images from the first paragraph onward.
   // e.g. left-aligned and right-aligned images at margin top should both affect text
   // starting from the first anchor paragraph, not just the one containing each image.
+  // Full-width topAndBottom bands are excluded: each pins to its own text box, so a
+  // second band sharing the same topY (e.g. body banners in different sections) must
+  // not be rewritten to the earliest anchor, or earlier pages would reserve a band
+  // that is painted elsewhere. They keep their own anchor below. eigenpal #694.
   const marginRelative = floatingZonesWithAnchors.filter(
-    (z) => z.isMarginRelative,
+    (z) => z.isMarginRelative && !z.fullWidthBlock,
   );
-  const paragraphRelative = floatingZonesWithAnchors.filter(
-    (z) => !z.isMarginRelative,
+  const ownAnchorZones = floatingZonesWithAnchors.filter(
+    (z) => !z.isMarginRelative || z.fullWidthBlock,
   );
 
   // Group margin-relative zones by topY and move all to earliest anchor in group
@@ -2421,7 +2425,7 @@ export function measureBlocks(
     marginByTopY.set(z.topY, group);
   }
 
-  const adjustedZones: FloatingZoneWithAnchor[] = [...paragraphRelative];
+  const adjustedZones: FloatingZoneWithAnchor[] = [...ownAnchorZones];
   for (const group of marginByTopY.values()) {
     const minAnchor = Math.min(...group.map((z) => z.anchorBlockIndex));
     for (const z of group) {

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -199,7 +199,7 @@ import {
   isValidPmScrollPosition,
   prefersReducedMotionBehavior,
 } from "./scrollNavigation";
-import { computePerBlockWidths } from "./sectionBlockWidths";
+import { computePerBlockMeasureInputs } from "./sectionBlockWidths";
 import { SelectionOverlay } from "./SelectionOverlay";
 import { getTransactionDirtyRange } from "./transactionDirtyRange";
 import { useDragAutoScroll } from "./useDragAutoScroll";
@@ -2071,12 +2071,26 @@ type FloatingZoneWithAnchor = {
   isMarginRelative?: boolean;
 } & FloatingImageZone;
 
+function perBlockNumberValue(
+  value: number | number[],
+  blockIndex: number,
+  fallback: number,
+): number {
+  if (Array.isArray(value)) {
+    return value[blockIndex] ?? fallback;
+  }
+  return value;
+}
+
 function extractFloatingZones(
   blocks: FlowBlock[],
   contentWidth: number,
-  marginTop = 0,
+  marginTop: number | number[] = 0,
 ): FloatingZoneWithAnchor[] {
   const zones: FloatingZoneWithAnchor[] = [];
+  const defaultMarginTop = Array.isArray(marginTop)
+    ? (marginTop[0] ?? 0)
+    : marginTop;
 
   for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
     const block = blocks[blockIndex]!; // SAFETY: blockIndex < blocks.length
@@ -2247,8 +2261,13 @@ function extractFloatingZones(
     const height = measureTextBoxBlock(tb).height;
     const distTop = tb.distTop ?? 0;
     const distBottom = tb.distBottom ?? 0;
+    const blockMarginTop = perBlockNumberValue(
+      marginTop,
+      blockIndex,
+      defaultMarginTop,
+    );
     // Shared with layoutTextBox so the reserved band and the painted box agree.
-    const rawTop = bandTopContentY(v, marginTop);
+    const rawTop = bandTopContentY(v, blockMarginTop);
     const bottomY = rawTop + height + distBottom;
     if (bottomY <= 0) {
       continue;
@@ -2370,7 +2389,7 @@ function measureTextBoxBlock(tb: TextBoxBlock): TextBoxMeasure {
 export function measureBlocks(
   blocks: FlowBlock[],
   contentWidth: number | number[],
-  marginTop = 0,
+  marginTop: number | number[] = 0,
 ): Measure[] {
   const defaultWidth = Array.isArray(contentWidth)
     ? (contentWidth[0] ?? 0)
@@ -3060,11 +3079,12 @@ export function PagedEditor(
         if (columns !== undefined) {
           bodyLayoutConfig.columns = columns;
         }
-        const blockWidths = computePerBlockWidths({
+        const blockMeasureInputs = computePerBlockMeasureInputs({
           blocks: newBlocks,
           bodyConfig: bodyLayoutConfig,
           finalConfig: bodyLayoutConfig,
         });
+        const blockWidths = blockMeasureInputs.widths;
         const incrementalResult =
           options.dirtyRange && !options.forceFull && layoutArtifactsRef.current
             ? tryBuildIncrementalMeasures({
@@ -3079,7 +3099,7 @@ export function PagedEditor(
             : null;
         const newMeasures =
           incrementalResult?.measures ??
-          measureBlocks(newBlocks, blockWidths, margins.top);
+          measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops);
         layoutArtifactsRef.current = {
           blocks: newBlocks,
           blockWidths,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2498,16 +2498,21 @@ export function measureBlocks(
   // Resets when we reach a block with floating images (establishing local page coords)
   let cumulativeY = 0;
   let activeZones: FloatingImageZone[] = [];
-  // Set by a hard page/section break; cleared once height-consuming flow lands
-  // or any anchor claims the frame. While set, the next page-pinned band anchor
-  // opens a fresh page at content-Y 0 (see the band reset below). eigenpal #694.
-  let freshPageFramePending = false;
 
   return blocks.map((block, blockIndex) => {
     recordMeasureBlock(blockIndex, block);
 
+    // A hard page/section break starts a fresh page. Any active zone — including
+    // a page-pinned topAndBottom band — belongs to the page it was anchored on,
+    // so drop the active zones and restart the running Y at the new page top. A
+    // band anchor on the new page re-establishes its own zone below; without
+    // this, the first block after the break would be measured against a stale
+    // band (a phantom float-skip) while layout paints no band there, opening a
+    // gap. This also resets the running Y so a band anchor that opens the new
+    // page reserves from content-Y 0, not the prior page's cursor. eigenpal #694.
     if (block.kind === "pageBreak" || isNextPageSectionBreak(block)) {
-      freshPageFramePending = true;
+      activeZones = [];
+      cumulativeY = 0;
     }
 
     // Check if this block is an anchor for floating images
@@ -2522,17 +2527,13 @@ export function measureBlocks(
       // if it began at the page top and reserve the whole band even when in-flow
       // content already precedes the anchor on the page, opening a blank gap.
       // Keep the running Y for pure band anchors so the band is reserved from the
-      // real cursor down — unless the band anchor opens a fresh page (directly
-      // after a hard page/section break). There the new page restarts at Y 0 and
-      // layout paints the band at that page top, so keeping the prior page's Y
-      // would skip the reservation and let body text overlap the band. eigenpal
-      // #694.
+      // real cursor down. (A band anchor that opens a fresh page already had its
+      // running Y reset to 0 by the hard-break handling above.) eigenpal #694.
       const bandOnlyAnchor =
         activeZones.length > 0 && activeZones.every((z) => z.fullWidthBlock);
-      if (!bandOnlyAnchor || freshPageFramePending) {
+      if (!bandOnlyAnchor) {
         cumulativeY = 0;
       }
-      freshPageFramePending = false;
     }
 
     const zones = activeZones.length > 0 ? activeZones : undefined;
@@ -2549,12 +2550,6 @@ export function measureBlocks(
         !(block.kind === "table" && (block as TableBlock).floating)
       ) {
         cumulativeY += measure.totalHeight;
-        // Real flow content on the new page means a later band no longer sits at
-        // the fresh page top; a zero-height (suppressed) block leaves Y at 0, so
-        // the frame is still fresh and the flag must persist.
-        if (measure.totalHeight > 0) {
-          freshPageFramePending = false;
-        }
       }
 
       return measure;

--- a/packages/folio/src/paged-editor/sectionBlockWidths.test.ts
+++ b/packages/folio/src/paged-editor/sectionBlockWidths.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { FlowBlock, ParagraphBlock } from "../core/layout-engine/types";
-import { computePerBlockWidths } from "./sectionBlockWidths";
+import {
+  computePerBlockMeasureInputs,
+  computePerBlockWidths,
+} from "./sectionBlockWidths";
 
 const BODY_CONFIG = {
   pageSize: { w: 1000, h: 1200 },
@@ -17,7 +20,7 @@ function paragraph(id: string): ParagraphBlock {
   };
 }
 
-describe("computePerBlockWidths", () => {
+describe("section block measurement inputs", () => {
   test("uses each section's page size and margins for measurement width", () => {
     const blocks: FlowBlock[] = [
       paragraph("first-section"),
@@ -37,5 +40,26 @@ describe("computePerBlockWidths", () => {
     });
 
     expect(widths).toEqual([500, 500, 800]);
+  });
+
+  test("returns each block's section top margin for band measurement", () => {
+    const blocks: FlowBlock[] = [
+      paragraph("first-section"),
+      {
+        kind: "sectionBreak",
+        id: "section-one",
+        pageSize: { w: 600, h: 1200 },
+        margins: { top: 64, right: 50, bottom: 50, left: 50 },
+      },
+      paragraph("final-section"),
+    ];
+
+    const inputs = computePerBlockMeasureInputs({
+      blocks,
+      bodyConfig: BODY_CONFIG,
+      finalConfig: BODY_CONFIG,
+    });
+
+    expect(inputs.marginTops).toEqual([64, 64, BODY_CONFIG.margins.top]);
   });
 });

--- a/packages/folio/src/paged-editor/sectionBlockWidths.ts
+++ b/packages/folio/src/paged-editor/sectionBlockWidths.ts
@@ -2,11 +2,18 @@ import { collectSectionConfigs } from "../core/layout-engine";
 import type { SectionLayoutConfig } from "../core/layout-engine";
 import type { ColumnLayout, FlowBlock } from "../core/layout-engine/types";
 
-type ComputePerBlockWidthsInput = {
+type ComputePerBlockMeasureInput = {
   blocks: FlowBlock[];
   bodyConfig: SectionLayoutConfig;
   finalConfig: SectionLayoutConfig;
 };
+
+type PerBlockMeasureInputs = {
+  widths: number[];
+  marginTops: number[];
+};
+
+const SINGLE_COLUMN_LAYOUT: ColumnLayout = { count: 1, gap: 0 };
 
 /**
  * Compute per-block measurement widths by scanning for section breaks.
@@ -20,7 +27,19 @@ export function computePerBlockWidths({
   blocks,
   bodyConfig,
   finalConfig,
-}: ComputePerBlockWidthsInput): number[] {
+}: ComputePerBlockMeasureInput): number[] {
+  return computePerBlockMeasureInputs({
+    blocks,
+    bodyConfig,
+    finalConfig,
+  }).widths;
+}
+
+export function computePerBlockMeasureInputs({
+  blocks,
+  bodyConfig,
+  finalConfig,
+}: ComputePerBlockMeasureInput): PerBlockMeasureInputs {
   function colWidth(cw: number, cols: ColumnLayout): number {
     if (cols.count <= 1) {
       return cw;
@@ -40,17 +59,19 @@ export function computePerBlockWidths({
 
   let sectionIdx = 0;
   const widths: number[] = [];
+  const marginTops: number[] = [];
 
   for (let i = 0; i < blocks.length; i++) {
     const config = sectionConfigs[sectionIdx] ?? finalConfig;
     widths.push(
-      colWidth(contentWidth(config), config.columns ?? { count: 1, gap: 0 }),
+      colWidth(contentWidth(config), config.columns ?? SINGLE_COLUMN_LAYOUT),
     );
+    marginTops.push(config.margins.top);
 
     if (sectionIdx < breakIndices.length && i === breakIndices[sectionIdx]) {
       sectionIdx++;
     }
   }
 
-  return widths;
+  return { widths, marginTops };
 }

--- a/packages/folio/src/paged-editor/sectionBlockWidths.ts
+++ b/packages/folio/src/paged-editor/sectionBlockWidths.ts
@@ -11,6 +11,11 @@ type ComputePerBlockMeasureInput = {
 type PerBlockMeasureInputs = {
   widths: number[];
   marginTops: number[];
+  // Page geometry per block, used to resolve page/margin-pinned topAndBottom
+  // bands (`bandTopContentY`) in the measure pass. Sections can vary page size
+  // and margins, so these are per-block like `widths`/`marginTops`.
+  pageHeights: number[];
+  marginBottoms: number[];
 };
 
 const SINGLE_COLUMN_LAYOUT: ColumnLayout = { count: 1, gap: 0 };
@@ -60,6 +65,8 @@ export function computePerBlockMeasureInputs({
   let sectionIdx = 0;
   const widths: number[] = [];
   const marginTops: number[] = [];
+  const pageHeights: number[] = [];
+  const marginBottoms: number[] = [];
 
   for (let i = 0; i < blocks.length; i++) {
     const config = sectionConfigs[sectionIdx] ?? finalConfig;
@@ -67,11 +74,13 @@ export function computePerBlockMeasureInputs({
       colWidth(contentWidth(config), config.columns ?? SINGLE_COLUMN_LAYOUT),
     );
     marginTops.push(config.margins.top);
+    pageHeights.push(config.pageSize.h);
+    marginBottoms.push(config.margins.bottom);
 
     if (sectionIdx < breakIndices.length && i === breakIndices[sectionIdx]) {
       sectionIdx++;
     }
   }
 
-  return { widths, marginTops };
+  return { widths, marginTops, pageHeights, marginBottoms };
 }


### PR DESCRIPTION
Follow-up to #613 (folio ⇄ eigenpal sync). Faithful port of
eigenpal/docx-editor#694's `topAndBottom` band fix, adapted to folio's measure
pipeline.

## Problem

A `topAndBottom` text box with a page/margin-relative vertical anchor (e.g. a
"For Internal Use" banner pinned to the top of the page) was dropped into the
body flow on its own line at its anchor paragraph, instead of floating to the
page top with body text flowing below it (Word's behaviour).

## Approach

Upstream reserves a full-width band in a `measureBlocksWithFloats` pass. Folio's
equivalent pass lives in `PagedEditor` (`extractFloatingZones` + the
`measureBlocks` walk) and already threads exclusion zones + cumulative Y into
`measureParagraph`, which already hops lines past zero-width obstructions
(`findClearLineY`/`skipObstructingFloats`). The port wires a band through that
machinery:

- **floatingZones**: a `topAndBottom` rect becomes a `fullWidthBlock` zone (no
  side margin); `getFloatingMargins` returns a zero-width segment for any line
  overlapping it, so `findClearLineY` pushes the line below the band.
- **textBoxFlow**: add `floatingTextBoxReservesBand`.
- **measure pass (PagedEditor)**: extract a band zone for page/margin-anchored
  `topAndBottom` boxes, re-anchored to block 0 so it reaches blocks before its
  own anchor paragraph; thread the top margin through for page-relative offsets;
  preserve `fullWidthBlock` when grouping zones by anchor (previously dropped).
- **layout engine**: a page-pinned band box is placed at the page content top
  and does not consume flow (the reserved band reserves the space instead).
- **painter**: reserve the band rect for `topAndBottom` boxes so paint matches
  measure.

Paragraph-anchored `topAndBottom` boxes keep folio's existing in-flow handling
(they already render on their own line at the anchor). Exact for the common case
(a banner near the document start); a band whose anchor lands on a later page can
over-reach — matching upstream's documented caveat.

## Tests

- `textBoxFlow.test.ts` — `floatingTextBoxReservesBand` predicate.
- `floatingZones.test.ts` — `topAndBottom` → `fullWidthBlock`; `getFloatingMargins`
  zero-width over the band; `findClearLineY` hop below the band.
- `textbox-band.test.ts` — `layoutDocument` places a page-pinned banner at the
  page top without consuming flow; a paragraph-anchored box stays in flow.

Full folio suite (1769 tests) passes; `tsc --noEmit` and oxlint clean.

## Remaining sync follow-up
- #698 (+ remainder of #699): mid-row table breaking, vMerge cell continuation
  across pages, cut-edge borders, measure-vs-paint spacing collapse, split-table
  selection clipping. Larger architectural port — separate PR.
