### PR TITLE
feat(web): add Open action to translation-ready toast

### DIFF
--- a/apps/web/src/components/translate-document-dialog.tsx
+++ b/apps/web/src/components/translate-document-dialog.tsx
@@ -123,18 +123,25 @@ export const TranslateDocumentDialog = ({
           fileName: data.fileName,
         }),
         type: "success",
+        // Give the user time to reach the action before it auto-dismisses.
+        timeout: 10_000,
+        action: {
+          label: t("common.open"),
+          onClick: () => {
+            void navigate({
+              to: "/workspaces/$workspaceId/$viewId/document",
+              params: { workspaceId, viewId: data.entityId },
+              // `field` is required by the route guard; without it
+              // `RouteComponent` bounces back to the workspace.
+              search: { entity: data.entityId, field: data.fieldId },
+            });
+          },
+        },
       });
       await queryClient.invalidateQueries({
         queryKey: entitiesKeys.all(workspaceId),
       });
       setOpen(false);
-      void navigate({
-        to: "/workspaces/$workspaceId/$viewId/document",
-        params: { workspaceId, viewId: data.entityId },
-        // `field` is required by the route guard; without it
-        // `RouteComponent` bounces back to the workspace.
-        search: { entity: data.entityId, field: data.fieldId },
-      });
     },
     onError: (error: unknown) => {
       analytics.captureError(error);


### PR DESCRIPTION
Replace the automatic redirect after a DeepL document translation with an explicit **Open** action on the success toast.

Previously the success handler showed a toast *and* immediately navigated to the new translated entity, pulling the user off whatever they were viewing. Now the toast surfaces an Open button (reusing the existing `common.open` key) that navigates to the translated document on click; the toast timeout is extended so the action stays reachable.