### PR TITLE
fix(web): refresh document title after matter rename

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
@@ -29,6 +29,22 @@ describe("workspace update cache invalidation", () => {
     ).toEqual(workspacesKeys.all);
   });
 
+  test("refetches active workspace caches and the inactive loader cache", async () => {
+    const { workspaceUpdateRefetchFilters } =
+      await import("@/routes/_protected.workspaces/-mutations");
+    const { workspacesKeys } =
+      await import("@/routes/_protected.workspaces/-queries");
+
+    expect(workspaceUpdateRefetchFilters("ws_test")).toEqual([
+      { queryKey: workspacesKeys.all, type: "active" },
+      {
+        exact: true,
+        queryKey: workspacesKeys.byId("ws_test"),
+        type: "inactive",
+      },
+    ]);
+  });
+
   test("member mutations invalidate the members query and the matters list", async () => {
     const { workspaceMemberMutationInvalidationKeys } =
       await import("@/routes/_protected.workspaces/$workspaceId/-mutations/workspace-members");

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -75,6 +76,7 @@ export const workspaceUpdateInvalidationKeys = () => [workspacesKeys.all];
 export const useUpdateWorkspace = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: async ({ workspaceId, ...body }: UpdateWorkspaceVars) => {
@@ -101,10 +103,17 @@ export const useUpdateWorkspace = () => {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: () => {
-      for (const queryKey of workspaceUpdateInvalidationKeys()) {
-        void queryClient.invalidateQueries({ queryKey });
-      }
+    onSuccess: async () => {
+      await Promise.all(
+        workspaceUpdateInvalidationKeys().map(async (queryKey) => {
+          await queryClient.invalidateQueries({ queryKey });
+        }),
+      );
+      // Re-run route loaders so the document title (driven by the
+      // route `head` from loaderData) reflects the renamed matter
+      // without waiting for a navigation. Query invalidation alone
+      // refreshes components but not the cached loaderData.
+      await router.invalidate();
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -1,4 +1,8 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  type RefetchQueryFilters,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
@@ -73,6 +77,17 @@ type UpdateWorkspaceVars = {
 
 export const workspaceUpdateInvalidationKeys = () => [workspacesKeys.all];
 
+export const workspaceUpdateRefetchFilters = (
+  workspaceId: string,
+): RefetchQueryFilters[] => [
+  { queryKey: workspacesKeys.all, type: "active" },
+  {
+    exact: true,
+    queryKey: workspacesKeys.byId(workspaceId),
+    type: "inactive",
+  },
+];
+
 export const useUpdateWorkspace = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
@@ -103,11 +118,16 @@ export const useUpdateWorkspace = () => {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: async () => {
+    onSuccess: async (_data, { workspaceId }) => {
       await Promise.all(
-        workspaceUpdateInvalidationKeys().map(async (queryKey) => {
-          await queryClient.invalidateQueries({ queryKey });
-        }),
+        workspaceUpdateInvalidationKeys().map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey, refetchType: "none" }),
+        ),
+      );
+      await Promise.all(
+        workspaceUpdateRefetchFilters(toSafeId<"workspace">(workspaceId)).map(
+          (filters) => queryClient.refetchQueries(filters),
+        ),
       );
       // Re-run route loaders so the document title (driven by the
       // route `head` from loaderData) reflects the renamed matter

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -120,13 +120,18 @@ export const useUpdateWorkspace = () => {
     },
     onSuccess: async (_data, { workspaceId }) => {
       await Promise.all(
-        workspaceUpdateInvalidationKeys().map((queryKey) =>
-          queryClient.invalidateQueries({ queryKey, refetchType: "none" }),
-        ),
+        workspaceUpdateInvalidationKeys().map(async (queryKey) => {
+          await queryClient.invalidateQueries({
+            queryKey,
+            refetchType: "none",
+          });
+        }),
       );
       await Promise.all(
         workspaceUpdateRefetchFilters(toSafeId<"workspace">(workspaceId)).map(
-          (filters) => queryClient.refetchQueries(filters),
+          async (filters) => {
+            await queryClient.refetchQueries(filters);
+          },
         ),
       );
       // Re-run route loaders so the document title (driven by the


### PR DESCRIPTION
## Summary

Renaming a matter did not update the browser tab title until a navigation or reload. The tab title comes from the workspace route's `head`, which reads route `loaderData`; the update mutation only invalidated React Query caches, so the cached `loaderData` (and the title) stayed stale.

`useUpdateWorkspace` now awaits the query invalidation and then calls `router.invalidate()`, so the route loader re-runs and `head` recomputes the title immediately. This mirrors the existing `useInvalidateSession` pattern.