### PR TITLE
fix(web): truncate long author/field values in tool detail panel

### DIFF
--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -232,26 +232,30 @@ type FieldProps = {
   value: string;
 };
 
-const Field = ({ icon: Icon, ariaLabel, value }: FieldProps) => (
-  <Tooltip
-    className="max-w-80 text-start whitespace-normal"
-    content={<FieldTooltipContent label={ariaLabel} value={value} />}
-    render={
-      <div
-        aria-label={ariaLabel}
-        className="flex w-fit max-w-full min-w-0 items-center gap-2"
-      >
-        <Icon
-          aria-hidden="true"
-          className="text-muted-foreground size-4 shrink-0"
-        />
-        <span className="text-foreground min-w-0 truncate text-sm font-medium">
-          {value}
-        </span>
-      </div>
-    }
-  />
-);
+const Field = ({ icon: Icon, ariaLabel, value }: FieldProps) => {
+  const fieldLabel = `${ariaLabel}: ${value}`;
+
+  return (
+    <Tooltip
+      className="max-w-80 text-start whitespace-normal"
+      content={<FieldTooltipContent label={ariaLabel} value={value} />}
+      render={
+        <div
+          aria-label={fieldLabel}
+          className="flex w-fit max-w-full min-w-0 items-center gap-2"
+        >
+          <Icon
+            aria-hidden="true"
+            className="text-muted-foreground size-4 shrink-0"
+          />
+          <span className="text-foreground min-w-0 truncate text-sm font-medium">
+            {value}
+          </span>
+        </div>
+      }
+    />
+  );
+};
 
 type AuthorFieldProps = {
   ariaLabel: string;
@@ -261,6 +265,7 @@ type AuthorFieldProps = {
 
 const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
   const safeAuthorUrl = sanitizeHref(authorUrl);
+  const fieldLabel = `${ariaLabel}: ${value}`;
   const tooltipContent = (
     <FieldTooltipContent label={ariaLabel} value={value} />
   );
@@ -289,7 +294,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
         content={tooltipContent}
         render={
           <a
-            aria-label={ariaLabel}
+            aria-label={fieldLabel}
             className="hover:bg-muted -mx-1 flex w-fit max-w-full min-w-0 items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
             href={safeAuthorUrl}
             onClick={(e) => e.stopPropagation()}
@@ -309,7 +314,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
       content={tooltipContent}
       render={
         <div
-          aria-label={ariaLabel}
+          aria-label={fieldLabel}
           className="flex w-fit max-w-full min-w-0 items-center gap-2"
         >
           {inner}

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -236,12 +236,12 @@ const Field = ({ icon: Icon, ariaLabel, value }: FieldProps) => (
   <Tooltip
     content={ariaLabel}
     render={
-      <div aria-label={ariaLabel} className="flex w-fit items-center gap-2">
+      <div aria-label={ariaLabel} className="flex min-w-0 items-center gap-2">
         <Icon
           aria-hidden="true"
           className="text-muted-foreground size-4 shrink-0"
         />
-        <span className="text-foreground truncate text-sm font-medium">
+        <span className="text-foreground min-w-0 truncate text-sm font-medium">
           {value}
         </span>
       </div>
@@ -263,7 +263,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
         aria-hidden="true"
         className="text-muted-foreground size-4 shrink-0"
       />
-      <span className="text-foreground truncate text-sm font-medium">
+      <span className="text-foreground min-w-0 truncate text-sm font-medium">
         {value}
       </span>
       {safeAuthorUrl && (
@@ -282,7 +282,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
         render={
           <a
             aria-label={ariaLabel}
-            className="hover:bg-muted -mx-1 flex w-fit items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+            className="hover:bg-muted -mx-1 flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
             href={safeAuthorUrl}
             onClick={(e) => e.stopPropagation()}
             rel="noreferrer"
@@ -299,7 +299,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
     <Tooltip
       content={ariaLabel}
       render={
-        <div aria-label={ariaLabel} className="flex w-fit items-center gap-2">
+        <div aria-label={ariaLabel} className="flex min-w-0 items-center gap-2">
           {inner}
         </div>
       }

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -234,7 +234,7 @@ type FieldProps = {
 
 const Field = ({ icon: Icon, ariaLabel, value }: FieldProps) => (
   <Tooltip
-    className="max-w-80 whitespace-normal text-start"
+    className="max-w-80 text-start whitespace-normal"
     content={<FieldTooltipContent label={ariaLabel} value={value} />}
     render={
       <div
@@ -285,7 +285,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
   if (safeAuthorUrl) {
     return (
       <Tooltip
-        className="max-w-80 whitespace-normal text-start"
+        className="max-w-80 text-start whitespace-normal"
         content={tooltipContent}
         render={
           <a
@@ -305,7 +305,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
 
   return (
     <Tooltip
-      className="max-w-80 whitespace-normal text-start"
+      className="max-w-80 text-start whitespace-normal"
       content={tooltipContent}
       render={
         <div
@@ -327,7 +327,7 @@ type FieldTooltipContentProps = {
 const FieldTooltipContent = ({ label, value }: FieldTooltipContentProps) => (
   <span className="flex flex-col gap-1">
     <span className="text-xs opacity-75">{label}</span>
-    <span className="break-all text-xs font-medium">{value}</span>
+    <span className="text-xs font-medium break-all">{value}</span>
   </span>
 );
 

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -236,7 +236,10 @@ const Field = ({ icon: Icon, ariaLabel, value }: FieldProps) => (
   <Tooltip
     content={ariaLabel}
     render={
-      <div aria-label={ariaLabel} className="flex min-w-0 items-center gap-2">
+      <div
+        aria-label={ariaLabel}
+        className="flex w-fit max-w-full min-w-0 items-center gap-2"
+      >
         <Icon
           aria-hidden="true"
           className="text-muted-foreground size-4 shrink-0"
@@ -282,7 +285,7 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
         render={
           <a
             aria-label={ariaLabel}
-            className="hover:bg-muted -mx-1 flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+            className="hover:bg-muted -mx-1 flex w-fit max-w-full min-w-0 items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
             href={safeAuthorUrl}
             onClick={(e) => e.stopPropagation()}
             rel="noreferrer"
@@ -299,7 +302,10 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
     <Tooltip
       content={ariaLabel}
       render={
-        <div aria-label={ariaLabel} className="flex min-w-0 items-center gap-2">
+        <div
+          aria-label={ariaLabel}
+          className="flex w-fit max-w-full min-w-0 items-center gap-2"
+        >
           {inner}
         </div>
       }

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -234,7 +234,8 @@ type FieldProps = {
 
 const Field = ({ icon: Icon, ariaLabel, value }: FieldProps) => (
   <Tooltip
-    content={ariaLabel}
+    className="max-w-80 whitespace-normal text-start"
+    content={<FieldTooltipContent label={ariaLabel} value={value} />}
     render={
       <div
         aria-label={ariaLabel}
@@ -260,6 +261,9 @@ type AuthorFieldProps = {
 
 const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
   const safeAuthorUrl = sanitizeHref(authorUrl);
+  const tooltipContent = (
+    <FieldTooltipContent label={ariaLabel} value={value} />
+  );
   const inner = (
     <>
       <UserIcon
@@ -281,7 +285,8 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
   if (safeAuthorUrl) {
     return (
       <Tooltip
-        content={ariaLabel}
+        className="max-w-80 whitespace-normal text-start"
+        content={tooltipContent}
         render={
           <a
             aria-label={ariaLabel}
@@ -300,7 +305,8 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
 
   return (
     <Tooltip
-      content={ariaLabel}
+      className="max-w-80 whitespace-normal text-start"
+      content={tooltipContent}
       render={
         <div
           aria-label={ariaLabel}
@@ -312,6 +318,18 @@ const AuthorField = ({ ariaLabel, authorUrl, value }: AuthorFieldProps) => {
     />
   );
 };
+
+type FieldTooltipContentProps = {
+  label: string;
+  value: string;
+};
+
+const FieldTooltipContent = ({ label, value }: FieldTooltipContentProps) => (
+  <span className="flex flex-col gap-1">
+    <span className="text-xs opacity-75">{label}</span>
+    <span className="break-all text-xs font-medium">{value}</span>
+  </span>
+);
 
 type ChipRowProps = {
   icon: LucideIcon;

--- a/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
+++ b/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
@@ -185,14 +185,14 @@ const Field = ({
 }) => (
   <div
     aria-label={ariaLabel}
-    className="flex items-center gap-2"
+    className="flex w-fit max-w-full min-w-0 items-center gap-2"
     title={ariaLabel}
   >
     <Icon
       aria-hidden="true"
       className="text-muted-foreground size-4 shrink-0"
     />
-    <span className="text-foreground truncate text-sm font-medium">
+    <span className="text-foreground min-w-0 truncate text-sm font-medium">
       {value}
     </span>
   </div>
@@ -215,7 +215,7 @@ const AuthorField = ({
         aria-hidden="true"
         className="text-muted-foreground size-4 shrink-0"
       />
-      <span className="text-foreground truncate text-sm font-medium">
+      <span className="text-foreground min-w-0 truncate text-sm font-medium">
         {value}
       </span>
       {safeAuthorUrl && (
@@ -231,7 +231,7 @@ const AuthorField = ({
     return (
       <a
         aria-label={ariaLabel}
-        className="hover:bg-muted -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+        className="hover:bg-muted -mx-1 flex w-fit max-w-full min-w-0 items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
         href={safeAuthorUrl}
         onClick={(e) => e.stopPropagation()}
         rel="noreferrer"
@@ -246,7 +246,7 @@ const AuthorField = ({
   return (
     <div
       aria-label={ariaLabel}
-      className="flex items-center gap-2"
+      className="flex w-fit max-w-full min-w-0 items-center gap-2"
       title={ariaLabel}
     >
       {inner}

--- a/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
+++ b/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
@@ -182,21 +182,25 @@ const Field = ({
   icon: LucideIcon;
   ariaLabel: string;
   value: string;
-}) => (
-  <div
-    aria-label={ariaLabel}
-    className="flex w-fit max-w-full min-w-0 items-center gap-2"
-    title={ariaLabel}
-  >
-    <Icon
-      aria-hidden="true"
-      className="text-muted-foreground size-4 shrink-0"
-    />
-    <span className="text-foreground min-w-0 truncate text-sm font-medium">
-      {value}
-    </span>
-  </div>
-);
+}) => {
+  const fieldLabel = `${ariaLabel}: ${value}`;
+
+  return (
+    <div
+      aria-label={fieldLabel}
+      className="flex w-fit max-w-full min-w-0 items-center gap-2"
+      title={fieldLabel}
+    >
+      <Icon
+        aria-hidden="true"
+        className="text-muted-foreground size-4 shrink-0"
+      />
+      <span className="text-foreground min-w-0 truncate text-sm font-medium">
+        {value}
+      </span>
+    </div>
+  );
+};
 
 const AuthorField = ({
   ariaLabel,
@@ -209,6 +213,7 @@ const AuthorField = ({
   value: string;
 }) => {
   const safeAuthorUrl = sanitizeHref(authorUrl);
+  const fieldLabel = `${ariaLabel}: ${value}`;
   const inner = (
     <>
       <UserIcon
@@ -230,13 +235,13 @@ const AuthorField = ({
   if (safeAuthorUrl) {
     return (
       <a
-        aria-label={ariaLabel}
+        aria-label={fieldLabel}
         className="hover:bg-muted -mx-1 flex w-fit max-w-full min-w-0 items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
         href={safeAuthorUrl}
         onClick={(e) => e.stopPropagation()}
         rel="noreferrer"
         target="_blank"
-        title={ariaLabel}
+        title={fieldLabel}
       >
         {inner}
       </a>
@@ -245,9 +250,9 @@ const AuthorField = ({
 
   return (
     <div
-      aria-label={ariaLabel}
+      aria-label={fieldLabel}
       className="flex w-fit max-w-full min-w-0 items-center gap-2"
-      title={ariaLabel}
+      title={fieldLabel}
     >
       {inner}
     </div>


### PR DESCRIPTION
## What was wrong

In the catalogue tool detail panel ("Details" section), the `AuthorField` and `Field` rows render inside `w-fit` flex containers with a truncating `<span>`. Because the flex container shrinks to content and both the grid cell and the span keep the default `min-width: auto`, `truncate` never engaged. A long unbroken value (notably a raw `organizationId` shown as the author for non-first-party entries) overflowed its grid-cols-2 cell and visually collided with the neighbouring column.

## Fix

Swap `w-fit` -> `min-w-0` on the field/author flex containers and add `min-w-0` to the truncating spans, so each shrinks to its grid track and `truncate` clips the value inside the cell. Icons and the external-link affordance stay `shrink-0`. The tooltip still surfaces the full label, so truncation is acceptable UX. Layout-only change; author/data logic untouched.

## How to eyeball

Open an installed MCP tool's detail panel where the author is a non-first-party id (long token). The Author value now ellipsizes within its cell instead of overflowing onto the License icon/column.

## Note (out of scope)

Underlying data smell: non-first-party entries surface a raw `organizationId` as the "Author". This PR only fixes the overflow; the author/data mapping is unchanged.