### PR TITLE
fix(web): align chat scrollbar to the chat region edge

### DIFF
--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -306,7 +306,7 @@ export const ChatThreadPage = ({
           </div>
 
           <Conversation>
-            <ConversationContent className="mx-auto w-full max-w-5xl gap-3">
+            <ConversationContent className="mx-auto w-full max-w-5xl gap-3 px-4">
               {messages.length === 0 && !isGenerating && !error ? (
                 <div className="m-auto w-full max-w-md px-4">
                   <PromptSuggestions

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -268,8 +268,8 @@ export const ChatThreadPage = ({
           handleDeny,
         }}
       >
-        <div className="flex w-full max-w-5xl flex-1 flex-col overflow-hidden">
-          <div className="flex items-center justify-between gap-2 px-4 py-2">
+        <div className="flex w-full flex-1 flex-col overflow-hidden">
+          <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-2 px-4 py-2">
             <div className="flex min-w-0 items-center gap-2">
               <NewChatButton
                 hasMessages={messages.length > 0}
@@ -306,7 +306,7 @@ export const ChatThreadPage = ({
           </div>
 
           <Conversation>
-            <ConversationContent className="gap-3">
+            <ConversationContent className="mx-auto w-full max-w-5xl gap-3">
               {messages.length === 0 && !isGenerating && !error ? (
                 <div className="m-auto w-full max-w-md px-4">
                   <PromptSuggestions
@@ -343,7 +343,7 @@ export const ChatThreadPage = ({
             enabled={anonymized}
             workspaceId={workspaceId ?? threadRef.threadId}
           />
-          <div className="p-4">
+          <div className="mx-auto w-full max-w-5xl p-4">
             <ChatInputSurface
               anonymized={anonymized}
               autoFocus


### PR DESCRIPTION
## What was wrong
On the full-page chat (`/chat`), the content wrapper capped itself at `max-w-5xl` while the parent `ChatLayout` centers it (`items-center`). The scroll viewport (`ConversationContent`, `size-full overflow-y-auto`) filled that centered column, so its vertical scrollbar rendered at the **column's** right edge, floating mid-region on wide viewports — most visibly with the inspector side panel open, where it sat in the middle of the window instead of flush against the inspector's left edge.

## Fix
One file, Tailwind only:
- The page wrapper drops `max-w-5xl` and becomes full-width, so the scroll viewport spans the whole chat region and its scrollbar hugs the region's right edge.
- The `max-w-5xl` readable-column cap moves onto the three content bands (header row, `ConversationContent` message list, input wrapper) via `mx-auto w-full max-w-5xl`, so the readable content stays centered exactly as before.

Net: scrollbar position changes; header/messages/input column width and centering are unchanged.

## How to eyeball
1. Open `/chat` on a wide screen (or open the right inspector panel so the chat region is wider than `max-w-5xl`).
2. Have enough messages to scroll.
3. The vertical scrollbar should sit at the right edge of the chat region (flush to the inspector), not floating mid-region.
4. Verify the header, message column, and input box stay centered/aligned at the same width as before, and the empty-state prompt suggestions still center.

Note: `ConversationContent` still uses `scrollbarGutter: "stable both-edges"` (shared with the inspector chat tab); after this change its left gutter is harmless symmetric space inside the now-full-width viewport. Left as-is to keep the shared component untouched.