### PR TITLE
fix(web): pre-bundle lazily-imported deps to stop dev-server re-optimize reloads (e2e flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,6 +542,22 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun --filter @stll/web test:e2e
 
+      # Flake guard: the dev server's dependency optimizer must finish during
+      # the cold pass. A second pass mid-session prints "optimized dependencies
+      # changed. reloading" and forces a full-page reload that can tear the page
+      # down mid-test (see optimizeDeps.include in apps/web/vite.config.ts).
+      # Fail loudly — even on a lucky pass — so a newly added lazy/runtime dep
+      # that escapes the cold scan is fixed at its source instead of flaking.
+      - name: Guard against mid-test Vite re-optimize
+        if: always() && steps.changed.outputs.run == 'true'
+        run: |
+          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
+            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. A dependency reachable only via a lazy/runtime import is missing from optimizeDeps.include in apps/web/vite.config.ts — add the dep(s) named below."
+            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
+            exit 1
+          fi
+          echo "No mid-session dep re-optimize detected."
+
       - name: Upload Playwright report
         if: failure() && steps.changed.outputs.run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -95,6 +95,48 @@ export default defineConfig(({ mode }) => {
       },
     },
     optimizeDeps: {
+      // Pre-bundle deps that are only reached behind lazy/runtime imports so
+      // Vite's dep optimizer handles them during the cold pass, before any
+      // navigation. Two graphs trip this:
+      //
+      //   1. better-auth: src/lib/auth.ts statically imports the public
+      //      entrypoints, but better-auth reaches these deep subpaths only at
+      //      runtime, so the crawler misses them until a protected route runs.
+      //   2. @stll/folio: the document route lazy-loads it via
+      //      `await import("@stll/folio")` ($viewId.document.tsx), dragging in
+      //      the prosemirror family + jszip + fast-xml-parser, none of which
+      //      apps/web imports statically anywhere else.
+      //
+      // When that discovery happens mid-session, Vite kicks off a second
+      // optimize pass and forces a full-page reload ("optimized dependencies
+      // changed. reloading"), and stalls in-flight module/data requests with
+      // net::ERR_EMPTY_RESPONSE. In the e2e suite the reload/stall lands
+      // mid-test and tears the page down before the viewer paints, producing a
+      // flaky upload-docx failure (api.log is empty on these runs — the API
+      // never crashes; it is purely the dev server re-optimizing). Listing the
+      // deps here makes the optimizer finish them up front. Dev-only:
+      // production uses Rollup and ignores optimizeDeps.
+      include: [
+        "@better-auth/core/env",
+        "@better-auth/core/error",
+        "@better-auth/core/utils/error-codes",
+        "@better-auth/core/utils/string",
+        "@better-fetch/fetch",
+        "defu",
+        "nanostores",
+        "prosemirror-commands",
+        "prosemirror-dropcursor",
+        "prosemirror-gapcursor",
+        "prosemirror-history",
+        "prosemirror-keymap",
+        "prosemirror-model",
+        "prosemirror-state",
+        "prosemirror-tables",
+        "prosemirror-transform",
+        "prosemirror-view",
+        "jszip",
+        "fast-xml-parser",
+      ],
       // @stll/*-wasm packages load their .wasm binaries via
       // `new URL("./foo.wasm32-wasi.wasm", import.meta.url)`. Vite's dep
       // optimizer would rewrite that URL into .vite/deps/, where the .wasm


### PR DESCRIPTION
## Problem

`upload-docx.spec.ts` flakes intermittently (~3% of e2e runs; observed on
unrelated branches, each passing on retry). The failure looks like an API/auth
outage — `401 Unauthorized`, then `net::ERR_EMPTY_RESPONSE`, and the rendered
DOCX text never appears — but the **API is healthy**: the `server-logs` artifact
shows `api.log` is **0 bytes** on every failure.

## Root cause

The failure is entirely the **Vite dev server re-optimizing dependencies
mid-test**. `web.log` on a failing run:

```
[vite] (client) [optimizer] bundling dependencies...        <- cold pass
[vite] (client) [optimizer] bundling dependencies...        <- 2nd pass, mid-test
[vite] (client) ✨ new dependencies optimized: @better-auth/core/env, …,
       prosemirror-*, jszip, fast-xml-parser, …
[vite] (client) ✨ optimized dependencies changed. reloading <- full-page reload
```

The forced reload tears the page down (and stalls in-flight module/data requests
as `ERR_EMPTY_RESPONSE`) before the Folio viewer paints, so the 45s
`.layout-run-text` assertion times out. The `401`/`ERR_EMPTY_RESPONSE` are the
dev server re-bootstrapping, not auth.

These deps are only reached behind lazy/runtime imports, so Vite's cold scan
misses them:
- the document route lazy-loads `@stll/folio` via `await import(...)`
  (`$viewId.document.tsx`), pulling in the prosemirror family + `jszip` +
  `fast-xml-parser` — none statically imported by `apps/web` elsewhere;
- `src/lib/auth.ts` imports better-auth, which reaches `@better-auth/core/*`,
  `@better-fetch/fetch`, `defu`, `nanostores` only at runtime.

`upload-docx.spec.ts` is the only spec that navigates into that graph, which is
why it's the only one that flakes.

## Fix

Add `optimizeDeps.include` to `apps/web/vite.config.ts` listing those deps so
the optimizer finishes them during the cold pass, before any navigation — no
second pass, no reload. **Dev-only**: the production build uses Rollup and
ignores `optimizeDeps`, so there is zero production impact. The existing wasm
`exclude` is preserved. No Playwright retries or timeout bumps — this fixes the
cause, not the symptom.

## Validation

Re-run the e2e job: `web.log` should show a single `[optimizer] bundling`
pass at startup and no `optimized dependencies changed. reloading` during the
test. All listed specifiers resolve in `bun.lock`.
