### PR TITLE
fix(api): reconcile orphaned workflow locks and pending cells

### DIFF
--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';

--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';

--- a/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
+++ b/apps/api/drizzle/20260605143000_workflow_pending_fields_index/migration.sql
@@ -1,1 +1,9 @@
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, build the large-table index without
+-- write-blocking locks, then reopen a transaction for Drizzle's migration row.
+COMMIT;
+--> statement-breakpoint
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "fields_pending_workspace_idx" ON "fields" ("workspace_id") WHERE "content"->>'type' = 'pending';
+--> statement-breakpoint
+BEGIN;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1506,6 +1506,10 @@ export const fields = p.pgTable(
       .index("fields_ws_entity_version_property_idx")
       .on(table.workspaceId, table.entityVersionId, table.propertyId),
     p
+      .index("fields_pending_workspace_idx")
+      .on(table.workspaceId)
+      .where(sql`${table.content}->>'type' = 'pending'`),
+    p
       .foreignKey({
         columns: [table.propertyId, table.workspaceId],
         foreignColumns: [properties.id, properties.workspaceId],

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -78,6 +78,7 @@ const SESSION_ID_HEADER = "x-posthog-session-id";
 const SESSION_ID_MAX_LENGTH = 64;
 const SESSION_ID_PATTERN = /^[\w-]+$/u;
 const S3_REFRESH_CHECK_INTERVAL_MS = 60_000;
+const WORKER_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 const STATUS_BY_ELYSIA_CODE: Partial<Record<string, number>> = {
   VALIDATION: 422,
@@ -396,9 +397,37 @@ await refreshS3();
 startS3RefreshLoop();
 
 // BullMQ worker for asynchronous file derivatives.
-initFileDerivativeWorker();
+const fileDerivativeWorker = initFileDerivativeWorker();
 
 // BullMQ workflow worker for AI extraction.
-initWorkflowWorker();
+const workflowWorker = initWorkflowWorker();
 
 api.listen(getApiPort());
+
+// Graceful shutdown: drain the BullMQ workers on SIGTERM/SIGINT (deploy,
+// container stop, or a local `bun --watch` restart) so an in-flight job
+// is not abandoned mid-write. An abandoned job strands its workflow lock
+// and leaves cells stuck `pending` until the next boot reconciles them;
+// draining first avoids creating that orphan in the common case. Bounded
+// so a slow job can't hang shutdown — anything still in flight past the
+// timeout is reclaimed by the next boot's reconciler.
+let shuttingDown = false;
+const shutdownWorkers = async (signal: string): Promise<void> => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  logger.info("api.shutdown_started", { signal });
+  await Promise.race([
+    Promise.allSettled([workflowWorker.close(), fileDerivativeWorker.close()]),
+    Bun.sleep(WORKER_SHUTDOWN_TIMEOUT_MS),
+  ]);
+  logger.info("api.shutdown_complete", { signal });
+  process.exit(0);
+};
+process.once("SIGTERM", () => {
+  void shutdownWorkers("SIGTERM");
+});
+process.once("SIGINT", () => {
+  void shutdownWorkers("SIGINT");
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -404,13 +404,14 @@ const workflowWorker = initWorkflowWorker();
 
 api.listen(getApiPort());
 
-// Graceful shutdown: drain the BullMQ workers on SIGTERM/SIGINT (deploy,
-// container stop, or a local `bun --watch` restart) so an in-flight job
-// is not abandoned mid-write. An abandoned job strands its workflow lock
-// and leaves cells stuck `pending` until the next boot reconciles them;
-// draining first avoids creating that orphan in the common case. Bounded
-// so a slow job can't hang shutdown — anything still in flight past the
-// timeout is reclaimed by the next boot's reconciler.
+// Graceful shutdown: stop accepting HTTP requests, then drain the BullMQ
+// workers on SIGTERM/SIGINT (deploy, container stop, or a local
+// `bun --watch` restart) so an in-flight job is not abandoned mid-write.
+// An abandoned job strands its workflow lock and leaves cells stuck
+// `pending` until the next boot reconciles them; draining avoids creating
+// that orphan in the common case. Worker draining is bounded so a slow job
+// can't hang shutdown; anything still in flight past the timeout is
+// reclaimed by the next boot's reconciler.
 let shuttingDown = false;
 const shutdownWorkers = async (signal: string): Promise<void> => {
   if (shuttingDown) {
@@ -418,6 +419,11 @@ const shutdownWorkers = async (signal: string): Promise<void> => {
   }
   shuttingDown = true;
   logger.info("api.shutdown_started", { signal });
+  await api.stop().catch((error: unknown) => {
+    logger.error("api.stop_failed", {
+      "error.type": errorTag(error),
+    });
+  });
   await Promise.race([
     Promise.allSettled([workflowWorker.close(), fileDerivativeWorker.close()]),
     Bun.sleep(WORKER_SHUTDOWN_TIMEOUT_MS),

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -52,9 +52,11 @@ import {
   getPropertyExecutionPlan,
 } from "@/api/lib/workflow/get-execution-plan";
 import {
+  isCurrentWorkflowRequestState,
   parseRunningLockWorkspaceId,
   selectOrphanWorkspaceIds,
   selectRecoverableOrphanWorkspaceIds,
+  selectRunningLockReservation,
 } from "@/api/lib/workflow/orphan-recovery";
 import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { prepareBatch } from "@/api/lib/workflow/utils";
@@ -163,10 +165,12 @@ const isCurrentWorkflowRequest = async ({
     redis.get(workflowKey(workspaceId, "request-id")),
     redis.get(workflowKey(workspaceId, "running")),
   ]);
-  return (
-    currentRequestId === requestId &&
-    (runningValue === requestId || runningValue === "1")
-  );
+  return isCurrentWorkflowRequestState({
+    currentRequestId,
+    legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+    requestId,
+    runningValue,
+  });
 };
 
 // Self-heal levers. Tuned conservatively so the happy path is never
@@ -219,6 +223,7 @@ const computeJobTimeoutMs = (executionPlan: ExecutionLevel[]): number => {
 // keeps the TTL fresh regardless of this initial value.
 const RUNNING_LOCK_TTL_SEC = 60 * 60;
 const RECOVERY_LOCK_SETTLE_MS = 100;
+const LEGACY_RUNNING_LOCK_VALUE = "1";
 const RECOVERY_LOCK_VALUE = "recovery";
 const RESERVE_RECOVERY_LOCK_SCRIPT = `
 local current = redis.call("GET", KEYS[1])
@@ -911,16 +916,22 @@ const shouldRecoverWorkflow = async ({
     return false;
   }
 
-  if (runningValue === RECOVERY_LOCK_VALUE) {
-    return reserveExistingRunningLock(redis, runningKey, RECOVERY_LOCK_VALUE);
+  const reservation = selectRunningLockReservation({
+    expectedRequestId,
+    legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+    recoveryLockValue: RECOVERY_LOCK_VALUE,
+    requestId,
+    runningValue,
+  });
+  if (reservation.status === "reserve") {
+    return reserveExistingRunningLock(
+      redis,
+      runningKey,
+      reservation.expectedRunningValue,
+    );
   }
-
-  if (runningValue !== "1") {
-    if (runningValue !== expectedRequestId) {
-      return false;
-    }
-
-    return reserveExistingRunningLock(redis, runningKey, runningValue);
+  if (reservation.status === "skip") {
+    return false;
   }
 
   // Legacy locks used "1" as the running value and wrote request-id
@@ -931,11 +942,18 @@ const shouldRecoverWorkflow = async ({
     redis.get(runningKey),
     redis.get(requestIdKey),
   ]);
-  if (settledRunningValue !== "1" || settledRequestId !== expectedRequestId) {
+  if (
+    settledRunningValue !== LEGACY_RUNNING_LOCK_VALUE ||
+    settledRequestId !== expectedRequestId
+  ) {
     return false;
   }
 
-  return reserveExistingRunningLock(redis, runningKey, "1");
+  return reserveExistingRunningLock(
+    redis,
+    runningKey,
+    LEGACY_RUNNING_LOCK_VALUE,
+  );
 };
 
 type RecoverOrphanedWorkflowOptions = {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -7,6 +7,7 @@ import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
 import { isMockAI } from "@/api/consts";
 import type { ScopedDb } from "@/api/db";
 import { jsonField } from "@/api/db/json-utils";
+import { rootDb } from "@/api/db/root";
 import {
   cellMetadata,
   entities,
@@ -35,6 +36,7 @@ import {
   brandPersistedEntityId,
   brandPersistedPropertyId,
   brandPersistedUserId,
+  brandPersistedWorkspaceId,
   brandValidatedWorkflowActorKey,
 } from "@/api/lib/safe-id-boundaries";
 import { broadcast } from "@/api/lib/sse";
@@ -49,6 +51,10 @@ import {
   getExecutionPlanData,
   getPropertyExecutionPlan,
 } from "@/api/lib/workflow/get-execution-plan";
+import {
+  parseRunningLockWorkspaceId,
+  selectOrphanWorkspaceIds,
+} from "@/api/lib/workflow/orphan-recovery";
 import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { prepareBatch } from "@/api/lib/workflow/utils";
 
@@ -103,7 +109,7 @@ type EntityJobData = {
 
 // ── Public API ─────────────────────────────────────────
 
-let queue: Queue | null = null;
+let queue: Queue<EntityJobData> | null = null;
 let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
 let redisClient: RedisClient | null = null;
 
@@ -117,8 +123,8 @@ const getRedis = (): RedisClient => {
   return redisClient;
 };
 
-const getQueue = (): Queue => {
-  queue ??= new Queue(QUEUE_NAME, {
+const getQueue = (): Queue<EntityJobData> => {
+  queue ??= new Queue<EntityJobData>(QUEUE_NAME, {
     connection: getQueueConnection(),
     defaultJobOptions: {
       removeOnComplete: 100,
@@ -669,6 +675,203 @@ export const startWorkflow = async ({
   }
 };
 
+// ── Orphan reconciliation ──────────────────────────────
+//
+// A workflow's Redis run-state can outlive the worker that owns it when
+// the API process dies mid-job — a `bun --watch` hot-reload on save, an
+// OOM, a `kill -9`, or SIGTERM on deploy. The job is abandoned after its
+// cells were set to `pending` but before `finishWorkflow` clears the
+// lock, and a hard kill emits no BullMQ `failed` event, so neither the
+// `running` lock nor the `pending` cells self-heal: every retry is
+// rejected with a 409 until the hour-long lock TTL lapses, and the cells
+// spin forever. The reconciler closes that gap. Any workspace holding a
+// `running` lock or owning `pending` cells with no in-flight queue job is
+// orphaned; its pending cells are flipped to `error` (still re-runnable)
+// and its run-state cleared. Death-cause-agnostic: the next worker boot
+// heals whatever the previous one left behind.
+
+const RECONCILE_INTERVAL_MS = 60 * 1000;
+// Settle window before acting. A workflow that has just taken its
+// `running` lock but not yet enqueued its first entity batch would look
+// orphaned for a moment; we re-confirm against a fresh job snapshot after
+// this delay so a starting run is never reconciled away.
+const RECONCILE_SETTLE_MS = 5 * 1000;
+// Non-terminal BullMQ states. A job in any of these means the workspace
+// still has reclaimable work in flight, so its run-state is legitimate.
+const LIVE_JOB_STATES = [
+  "active",
+  "waiting",
+  "delayed",
+  "prioritized",
+  "waiting-children",
+  "paused",
+] as const;
+// Upper bound on the live-job snapshot. If the queue holds more in-flight
+// jobs than this, skip the cycle rather than risk treating a busy
+// workspace as orphaned from a truncated scan — a false positive must
+// never clobber a healthy run. A later, quieter cycle reconciles it.
+const LIVE_JOB_SCAN_LIMIT = 10_000;
+const RUNNING_LOCK_SCAN_PATTERN = `${WORKFLOW_KEY_PREFIX}:*:running`;
+const RUNNING_LOCK_SCAN_COUNT = "200";
+
+type LiveWorkspaceSnapshot = {
+  workspaceIds: Set<string>;
+  truncated: boolean;
+};
+
+// `Array.isArray` widens `unknown` to `any[]`; this guard narrows to
+// `unknown[]` instead so the SCAN reply stays type-checked.
+const isUnknownArray = (value: unknown): value is readonly unknown[] =>
+  Array.isArray(value);
+
+const scanRunningLockWorkspaceIds = async (
+  redis: RedisClient,
+): Promise<string[]> => {
+  const workspaceIds: string[] = [];
+  let cursor = "0";
+  do {
+    // Bun's RedisClient exposes raw commands via `send`; SCAN returns
+    // [nextCursor, keys]. Iterating the cursor keeps a large keyspace off
+    // a single blocking pass (unlike KEYS).
+    const reply: unknown = await redis.send("SCAN", [
+      cursor,
+      "MATCH",
+      RUNNING_LOCK_SCAN_PATTERN,
+      "COUNT",
+      RUNNING_LOCK_SCAN_COUNT,
+    ]);
+    if (!isUnknownArray(reply) || reply.length < 2) {
+      break;
+    }
+    const nextCursor = reply[0];
+    const keys = reply[1];
+    if (typeof nextCursor !== "string" || !isUnknownArray(keys)) {
+      break;
+    }
+    for (const key of keys) {
+      if (typeof key !== "string") {
+        continue;
+      }
+      const workspaceId = parseRunningLockWorkspaceId(key);
+      if (workspaceId !== null) {
+        workspaceIds.push(workspaceId);
+      }
+    }
+    cursor = nextCursor;
+  } while (cursor !== "0");
+  return workspaceIds;
+};
+
+const selectWorkspacesWithPendingCells = async (): Promise<string[]> => {
+  const rows = await rootDb
+    .selectDistinct({ workspaceId: fields.workspaceId })
+    .from(fields)
+    .where(sql`${fields.content}->>'type' = 'pending'`);
+  return rows.map((row) => row.workspaceId);
+};
+
+const snapshotLiveWorkspaceIds = async (
+  q: Queue<EntityJobData>,
+): Promise<LiveWorkspaceSnapshot> => {
+  const jobs = await q.getJobs([...LIVE_JOB_STATES], 0, LIVE_JOB_SCAN_LIMIT);
+  const workspaceIds = new Set<string>();
+  for (const job of jobs) {
+    workspaceIds.add(job.data.workspaceId);
+  }
+  return { workspaceIds, truncated: jobs.length > LIVE_JOB_SCAN_LIMIT };
+};
+
+const recoverOrphanedWorkflow = async (
+  workspaceId: SafeId<"workspace">,
+): Promise<void> => {
+  // Error the stuck `pending` cells first, while the orphaned lock still
+  // blocks any new run from re-populating them. `error` cells stay
+  // eligible for re-extraction (see `prepareBatch`), so a retry or the
+  // next full run picks them back up.
+  const erroredFields = await rootDb
+    .update(fields)
+    .set({ content: { type: "error", version: 1 } })
+    .where(
+      and(
+        eq(fields.workspaceId, workspaceId),
+        sql`${fields.content}->>'type' = 'pending'`,
+      ),
+    )
+    .returning({ id: fields.id });
+
+  // Then release the run-state so retries / new runs stop hitting the
+  // "a workflow is already running" 409.
+  await clearWorkflowRunState(getRedis(), workspaceId);
+
+  logger.warn("workflow.orphan_reconciled", {
+    workspaceId,
+    erroredFields: String(erroredFields.length),
+  });
+
+  // Push the cleared status + errored cells to any connected client.
+  broadcastWorkflowStatus(workspaceId, false);
+};
+
+type ReconcileOrphanedWorkflowsOptions = {
+  // Boot passes `true` to also sweep the DB for `pending` cells whose
+  // lock already lapsed via TTL; periodic ticks pass `false` and rely on
+  // the cheap lock scan alone.
+  scanPendingCells: boolean;
+};
+
+/**
+ * Reconcile workflows orphaned by a killed worker. Safe to call
+ * repeatedly; a no-op when nothing is orphaned. Exported for the boot +
+ * interval wiring in `initWorkflowWorker` and for operational scripts.
+ */
+export const reconcileOrphanedWorkflows = async ({
+  scanPendingCells,
+}: ReconcileOrphanedWorkflowsOptions): Promise<void> => {
+  const redis = getRedis();
+  const lockedWorkspaceIds = await scanRunningLockWorkspaceIds(redis);
+  const pendingWorkspaceIds = scanPendingCells
+    ? await selectWorkspacesWithPendingCells()
+    : [];
+
+  const candidateWorkspaceIds = [...lockedWorkspaceIds, ...pendingWorkspaceIds];
+  if (candidateWorkspaceIds.length === 0) {
+    return;
+  }
+
+  const q = getQueue();
+  const live = await snapshotLiveWorkspaceIds(q);
+  if (live.truncated) {
+    logger.warn("workflow.reconcile_skipped_backlog", {
+      candidates: String(candidateWorkspaceIds.length),
+    });
+    return;
+  }
+
+  const orphanCandidates = selectOrphanWorkspaceIds({
+    candidateWorkspaceIds,
+    liveWorkspaceIds: live.workspaceIds,
+  });
+  if (orphanCandidates.length === 0) {
+    return;
+  }
+
+  // Re-confirm after a settle delay so a workflow that is mid-startup
+  // (lock taken, first batch not yet enqueued) is not mistaken for an
+  // orphan.
+  await sleep(RECONCILE_SETTLE_MS);
+  const confirmed = await snapshotLiveWorkspaceIds(q);
+  if (confirmed.truncated) {
+    return;
+  }
+
+  for (const workspaceId of orphanCandidates) {
+    if (confirmed.workspaceIds.has(workspaceId)) {
+      continue;
+    }
+    await recoverOrphanedWorkflow(brandPersistedWorkspaceId(workspaceId));
+  }
+};
+
 // ── Worker ─────────────────────────────────────────────
 
 /**
@@ -792,6 +995,29 @@ export const initWorkflowWorker = () => {
   logger.info("workflow.worker_started", {
     concurrency: String(MAX_CONCURRENT_ENTITIES),
   });
+
+  // Heal whatever a previously-killed worker left orphaned. Boot runs a
+  // thorough pass (also sweeping the DB for pending cells whose lock has
+  // already lapsed); the interval then catches orphans that form at
+  // runtime — e.g. a job exhausts its retries while the lock is held —
+  // without waiting for a restart.
+  const runReconcile = (scanPendingCells: boolean): void => {
+    void reconcileOrphanedWorkflows({ scanPendingCells }).catch(
+      (error: unknown) => {
+        captureError(error);
+        logger.error("workflow.reconcile_failed", {
+          "error.type": errorTag(error),
+        });
+      },
+    );
+  };
+  runReconcile(true);
+  const reconcileTimer = setInterval(
+    () => runReconcile(false),
+    RECONCILE_INTERVAL_MS,
+  );
+  // The reconcile cadence must not keep the process alive at shutdown.
+  reconcileTimer.unref();
 
   return worker;
 };

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -789,9 +789,7 @@ const selectWorkspacesWithPendingCells = async (
     const rows = await rootDb
       .selectDistinct({ workspaceId: fields.workspaceId })
       .from(fields)
-      .where(
-        and(workspaceFilter, sql`${fields.content}->>'type' = 'pending'`),
-      );
+      .where(and(workspaceFilter, sql`${fields.content}->>'type' = 'pending'`));
     for (const row of rows) {
       pendingWorkspaceIds.push(row.workspaceId);
     }
@@ -999,7 +997,10 @@ export const reconcileOrphanedWorkflows = async ({
   }
 
   const pendingWorkspaceIdSet = new Set(pendingWorkspaceIds);
-  const initialRequestIds = await readWorkflowRequestIds(redis, orphanCandidates);
+  const initialRequestIds = await readWorkflowRequestIds(
+    redis,
+    orphanCandidates,
+  );
 
   // Re-confirm after a settle delay so a workflow that is mid-startup
   // (lock taken, first batch not yet enqueued) is not mistaken for an
@@ -1010,7 +1011,10 @@ export const reconcileOrphanedWorkflows = async ({
     return;
   }
 
-  const currentRequestIds = await readWorkflowRequestIds(redis, orphanCandidates);
+  const currentRequestIds = await readWorkflowRequestIds(
+    redis,
+    orphanCandidates,
+  );
   const recoverableOrphans = selectRecoverableOrphanWorkspaceIds({
     candidateWorkspaceIds: orphanCandidates,
     currentRequestIds,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -209,6 +209,8 @@ const computeJobTimeoutMs = (executionPlan: ExecutionLevel[]): number => {
 // extended on each entity completion below, so a long-running workflow
 // keeps the TTL fresh regardless of this initial value.
 const RUNNING_LOCK_TTL_SEC = 60 * 60;
+const RECOVERY_LOCK_SETTLE_MS = 100;
+const RECOVERY_LOCK_VALUE = "recovery";
 
 /**
  * Check if a workflow is currently running for a workspace.
@@ -217,7 +219,7 @@ export const isWorkflowRunning = async (
   workspaceId: SafeId<"workspace">,
 ): Promise<boolean> => {
   const val = await getRedis().get(workflowKey(workspaceId, "running"));
-  return val === "1";
+  return val !== null;
 };
 
 type StartWorkflowArgs = {
@@ -495,13 +497,14 @@ export const startWorkflow = async ({
   propertyIds: inputPropertyIds,
 }: StartWorkflowArgs): Promise<StartWorkflowResult> => {
   const redis = getRedis();
+  const requestId = Bun.randomUUIDv7();
 
   // Check if already running (atomic check-and-set). The TTL is the
   // safety net for an uncleanly-killed worker; tuned tight enough that
   // a recovered workspace doesn't sit blocked for hours.
   const wasSet = await redis.set(
     workflowKey(workspaceId, "running"),
-    "1",
+    requestId,
     "EX",
     String(RUNNING_LOCK_TTL_SEC),
     "NX",
@@ -510,7 +513,6 @@ export const startWorkflow = async ({
     return { status: "already-running" };
   }
 
-  const requestId = Bun.randomUUIDv7();
   await redis.set(
     workflowKey(workspaceId, "request-id"),
     requestId,
@@ -838,9 +840,93 @@ const readWorkflowRequestIds = async (
   return requestIds;
 };
 
-const recoverOrphanedWorkflow = async (
-  workspaceId: SafeId<"workspace">,
-): Promise<void> => {
+const getAndRefreshRunningLock = async (
+  redis: RedisClient,
+  runningKey: string,
+): Promise<string | null> => {
+  const reply: unknown = await redis.send("GETEX", [
+    runningKey,
+    "EX",
+    String(RUNNING_LOCK_TTL_SEC),
+  ]);
+  return typeof reply === "string" ? reply : null;
+};
+
+type ShouldRecoverWorkflowOptions = {
+  expectedRequestId: string | null;
+  redis: RedisClient;
+  workspaceId: SafeId<"workspace">;
+};
+
+const shouldRecoverWorkflow = async ({
+  expectedRequestId,
+  redis,
+  workspaceId,
+}: ShouldRecoverWorkflowOptions): Promise<boolean> => {
+  const runningKey = workflowKey(workspaceId, "running");
+  const requestIdKey = workflowKey(workspaceId, "request-id");
+  const recoveryLockValue = expectedRequestId ?? RECOVERY_LOCK_VALUE;
+  const wasSet = await redis.set(
+    runningKey,
+    recoveryLockValue,
+    "EX",
+    String(RUNNING_LOCK_TTL_SEC),
+    "NX",
+  );
+
+  if (wasSet) {
+    const requestId = await redis.get(requestIdKey);
+    if (requestId === expectedRequestId) {
+      return true;
+    }
+
+    await redis.del(runningKey);
+    return false;
+  }
+
+  const [runningValue, requestId] = await Promise.all([
+    getAndRefreshRunningLock(redis, runningKey),
+    redis.get(requestIdKey),
+  ]);
+
+  if (runningValue === null || requestId !== expectedRequestId) {
+    return false;
+  }
+
+  if (runningValue !== "1") {
+    return runningValue === expectedRequestId;
+  }
+
+  // Legacy locks used "1" as the running value and wrote request-id
+  // separately. Let that startup window settle before treating one as
+  // a stable orphan.
+  await sleep(RECOVERY_LOCK_SETTLE_MS);
+  const [settledRunningValue, settledRequestId] = await Promise.all([
+    getAndRefreshRunningLock(redis, runningKey),
+    redis.get(requestIdKey),
+  ]);
+  return settledRunningValue === "1" && settledRequestId === expectedRequestId;
+};
+
+type RecoverOrphanedWorkflowOptions = {
+  expectedRequestId: string | null;
+  workspaceId: SafeId<"workspace">;
+};
+
+const recoverOrphanedWorkflow = async ({
+  expectedRequestId,
+  workspaceId,
+}: RecoverOrphanedWorkflowOptions): Promise<void> => {
+  const redis = getRedis();
+  const shouldRecover = await shouldRecoverWorkflow({
+    expectedRequestId,
+    redis,
+    workspaceId,
+  });
+  if (!shouldRecover) {
+    return;
+  }
+
   // Error the stuck `pending` cells first, while the orphaned lock still
   // blocks any new run from re-populating them. `error` cells stay
   // eligible for re-extraction (see `prepareBatch`), so a retry or the
@@ -858,7 +944,7 @@ const recoverOrphanedWorkflow = async (
 
   // Then release the run-state so retries / new runs stop hitting the
   // "a workflow is already running" 409.
-  await clearWorkflowRunState(getRedis(), workspaceId);
+  await clearWorkflowRunState(redis, workspaceId);
 
   logger.warn("workflow.orphan_reconciled", {
     workspaceId,
@@ -934,7 +1020,10 @@ export const reconcileOrphanedWorkflows = async ({
   });
 
   for (const workspaceId of recoverableOrphans) {
-    await recoverOrphanedWorkflow(brandPersistedWorkspaceId(workspaceId));
+    await recoverOrphanedWorkflow({
+      expectedRequestId: currentRequestIds.get(workspaceId) ?? null,
+      workspaceId: brandPersistedWorkspaceId(workspaceId),
+    });
   }
 };
 

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -782,9 +782,7 @@ const selectWorkspacesWithPendingCells = async (
         ? undefined
         : inArray(
             fields.workspaceId,
-            workspaceIdBatch.map((workspaceId) =>
-              brandPersistedWorkspaceId(workspaceId),
-            ),
+            workspaceIdBatch.map((id) => brandPersistedWorkspaceId(id)),
           );
     const rows = await rootDb
       .selectDistinct({ workspaceId: fields.workspaceId })
@@ -829,11 +827,11 @@ const readWorkflowRequestIds = async (
     LIMITS.workflowEntityBatchSize,
   )) {
     await Promise.all(
-      workspaceIdBatch.map(async (workspaceId) => {
+      workspaceIdBatch.map(async (id) => {
         const requestId = await redis.get(
-          workflowKey(brandPersistedWorkspaceId(workspaceId), "request-id"),
+          workflowKey(brandPersistedWorkspaceId(id), "request-id"),
         );
-        requestIds.set(workspaceId, requestId);
+        requestIds.set(id, requestId);
       }),
     );
   }

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -860,6 +860,27 @@ const readWorkflowRequestIds = async (
   return requestIds;
 };
 
+const readWorkflowRunningValues = async (
+  redis: RedisClient,
+  workspaceIds: readonly string[],
+): Promise<Map<string, string | null>> => {
+  const runningValues = new Map<string, string | null>();
+  for (const workspaceIdBatch of chunkItems(
+    workspaceIds,
+    LIMITS.workflowEntityBatchSize,
+  )) {
+    await Promise.all(
+      workspaceIdBatch.map(async (id) => {
+        const runningValue = await redis.get(
+          workflowKey(brandPersistedWorkspaceId(id), "running"),
+        );
+        runningValues.set(id, runningValue);
+      }),
+    );
+  }
+  return runningValues;
+};
+
 const reserveExistingRunningLock = async (
   redis: RedisClient,
   runningKey: string,
@@ -1065,12 +1086,23 @@ export const reconcileOrphanedWorkflows = async ({
     redis,
     orphanCandidates,
   );
+  const currentRunningValues = await readWorkflowRunningValues(
+    redis,
+    orphanCandidates,
+  );
+  const recoveryWorkspaceIds = new Set<string>();
+  for (const workspaceId of orphanCandidates) {
+    if (currentRunningValues.get(workspaceId) === RECOVERY_LOCK_VALUE) {
+      recoveryWorkspaceIds.add(workspaceId);
+    }
+  }
   const recoverableOrphans = selectRecoverableOrphanWorkspaceIds({
     candidateWorkspaceIds: orphanCandidates,
     currentRequestIds,
     initialRequestIds,
     liveWorkspaceIds: confirmed.workspaceIds,
     pendingWorkspaceIds: pendingWorkspaceIdSet,
+    recoveryWorkspaceIds,
   });
 
   for (const workspaceId of recoverableOrphans) {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -157,8 +157,17 @@ const isCurrentWorkflowRequest = async ({
 }: {
   requestId: string;
   workspaceId: SafeId<"workspace">;
-}): Promise<boolean> =>
-  (await getRedis().get(workflowKey(workspaceId, "request-id"))) === requestId;
+}): Promise<boolean> => {
+  const redis = getRedis();
+  const [currentRequestId, runningValue] = await Promise.all([
+    redis.get(workflowKey(workspaceId, "request-id")),
+    redis.get(workflowKey(workspaceId, "running")),
+  ]);
+  return (
+    currentRequestId === requestId &&
+    (runningValue === requestId || runningValue === "1")
+  );
+};
 
 // Self-heal levers. Tuned conservatively so the happy path is never
 // disrupted, but a stuck job/worker can't block the workspace.
@@ -211,6 +220,14 @@ const computeJobTimeoutMs = (executionPlan: ExecutionLevel[]): number => {
 const RUNNING_LOCK_TTL_SEC = 60 * 60;
 const RECOVERY_LOCK_SETTLE_MS = 100;
 const RECOVERY_LOCK_VALUE = "recovery";
+const RESERVE_RECOVERY_LOCK_SCRIPT = `
+local current = redis.call("GET", KEYS[1])
+if current == ARGV[1] then
+  redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+  return 1
+end
+return 0
+`;
 
 /**
  * Check if a workflow is currently running for a workspace.
@@ -838,16 +855,20 @@ const readWorkflowRequestIds = async (
   return requestIds;
 };
 
-const getAndRefreshRunningLock = async (
+const reserveExistingRunningLock = async (
   redis: RedisClient,
   runningKey: string,
-): Promise<string | null> => {
-  const reply: unknown = await redis.send("GETEX", [
+  expectedRunningValue: string,
+): Promise<boolean> => {
+  const reply: unknown = await redis.send("EVAL", [
+    RESERVE_RECOVERY_LOCK_SCRIPT,
+    "1",
     runningKey,
-    "EX",
+    expectedRunningValue,
+    RECOVERY_LOCK_VALUE,
     String(RUNNING_LOCK_TTL_SEC),
   ]);
-  return typeof reply === "string" ? reply : null;
+  return Number(reply) === 1;
 };
 
 type ShouldRecoverWorkflowOptions = {
@@ -863,10 +884,9 @@ const shouldRecoverWorkflow = async ({
 }: ShouldRecoverWorkflowOptions): Promise<boolean> => {
   const runningKey = workflowKey(workspaceId, "running");
   const requestIdKey = workflowKey(workspaceId, "request-id");
-  const recoveryLockValue = expectedRequestId ?? RECOVERY_LOCK_VALUE;
   const wasSet = await redis.set(
     runningKey,
-    recoveryLockValue,
+    RECOVERY_LOCK_VALUE,
     "EX",
     String(RUNNING_LOCK_TTL_SEC),
     "NX",
@@ -883,7 +903,7 @@ const shouldRecoverWorkflow = async ({
   }
 
   const [runningValue, requestId] = await Promise.all([
-    getAndRefreshRunningLock(redis, runningKey),
+    redis.get(runningKey),
     redis.get(requestIdKey),
   ]);
 
@@ -891,11 +911,16 @@ const shouldRecoverWorkflow = async ({
     return false;
   }
 
+  if (runningValue === RECOVERY_LOCK_VALUE) {
+    return reserveExistingRunningLock(redis, runningKey, RECOVERY_LOCK_VALUE);
+  }
+
   if (runningValue !== "1") {
-    return (
-      runningValue === expectedRequestId ||
-      (expectedRequestId === null && runningValue === RECOVERY_LOCK_VALUE)
-    );
+    if (runningValue !== expectedRequestId) {
+      return false;
+    }
+
+    return reserveExistingRunningLock(redis, runningKey, runningValue);
   }
 
   // Legacy locks used "1" as the running value and wrote request-id
@@ -903,10 +928,14 @@ const shouldRecoverWorkflow = async ({
   // a stable orphan.
   await sleep(RECOVERY_LOCK_SETTLE_MS);
   const [settledRunningValue, settledRequestId] = await Promise.all([
-    getAndRefreshRunningLock(redis, runningKey),
+    redis.get(runningKey),
     redis.get(requestIdKey),
   ]);
-  return settledRunningValue === "1" && settledRequestId === expectedRequestId;
+  if (settledRunningValue !== "1" || settledRequestId !== expectedRequestId) {
+    return false;
+  }
+
+  return reserveExistingRunningLock(redis, runningKey, "1");
 };
 
 type RecoverOrphanedWorkflowOptions = {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -54,6 +54,7 @@ import {
 import {
   parseRunningLockWorkspaceId,
   selectOrphanWorkspaceIds,
+  selectRecoverableOrphanWorkspaceIds,
 } from "@/api/lib/workflow/orphan-recovery";
 import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { prepareBatch } from "@/api/lib/workflow/utils";
@@ -509,6 +510,14 @@ export const startWorkflow = async ({
     return { status: "already-running" };
   }
 
+  const requestId = Bun.randomUUIDv7();
+  await redis.set(
+    workflowKey(workspaceId, "request-id"),
+    requestId,
+    "EX",
+    RUNNING_LOCK_TTL_SEC,
+  );
+
   try {
     const executionPlanData = await getExecutionPlanData(workspaceId, scopedDb);
 
@@ -582,15 +591,7 @@ export const startWorkflow = async ({
       return { status: "skipped" };
     }
 
-    const requestId = Bun.randomUUIDv7();
-
     // Store entity count for completion tracking
-    await redis.set(
-      workflowKey(workspaceId, "request-id"),
-      requestId,
-      "EX",
-      RUNNING_LOCK_TTL_SEC,
-    );
     await redis.set(workflowKey(workspaceId, "total"), String(targetCount));
     await redis.set(workflowKey(workspaceId, "completed"), "0");
 
@@ -762,23 +763,81 @@ const scanRunningLockWorkspaceIds = async (
   return workspaceIds;
 };
 
-const selectWorkspacesWithPendingCells = async (): Promise<string[]> => {
-  const rows = await rootDb
-    .selectDistinct({ workspaceId: fields.workspaceId })
-    .from(fields)
-    .where(sql`${fields.content}->>'type' = 'pending'`);
-  return rows.map((row) => row.workspaceId);
+const selectWorkspacesWithPendingCells = async (
+  workspaceIds?: readonly string[],
+): Promise<string[]> => {
+  if (workspaceIds?.length === 0) {
+    return [];
+  }
+
+  const pendingWorkspaceIds: string[] = [];
+  const workspaceIdBatches =
+    workspaceIds === undefined
+      ? [null]
+      : chunkItems(workspaceIds, LIMITS.workflowEntityBatchSize);
+
+  for (const workspaceIdBatch of workspaceIdBatches) {
+    const workspaceFilter =
+      workspaceIdBatch === null
+        ? undefined
+        : inArray(
+            fields.workspaceId,
+            workspaceIdBatch.map((workspaceId) =>
+              brandPersistedWorkspaceId(workspaceId),
+            ),
+          );
+    const rows = await rootDb
+      .selectDistinct({ workspaceId: fields.workspaceId })
+      .from(fields)
+      .where(
+        and(workspaceFilter, sql`${fields.content}->>'type' = 'pending'`),
+      );
+    for (const row of rows) {
+      pendingWorkspaceIds.push(row.workspaceId);
+    }
+  }
+
+  return pendingWorkspaceIds;
 };
 
 const snapshotLiveWorkspaceIds = async (
   q: Queue<EntityJobData>,
 ): Promise<LiveWorkspaceSnapshot> => {
-  const jobs = await q.getJobs([...LIVE_JOB_STATES], 0, LIVE_JOB_SCAN_LIMIT);
+  const jobs = await q.getJobs(
+    [...LIVE_JOB_STATES],
+    0,
+    LIVE_JOB_SCAN_LIMIT - 1,
+  );
   const workspaceIds = new Set<string>();
   for (const job of jobs) {
-    workspaceIds.add(job.data.workspaceId);
+    const workspaceId = job.data.workspaceId;
+    if (workspaceId.length === 0) {
+      continue;
+    }
+    workspaceIds.add(workspaceId);
   }
-  return { workspaceIds, truncated: jobs.length > LIVE_JOB_SCAN_LIMIT };
+  return { workspaceIds, truncated: jobs.length >= LIVE_JOB_SCAN_LIMIT };
+};
+
+const readWorkflowRequestIds = async (
+  redis: RedisClient,
+  workspaceIds: readonly string[],
+): Promise<Map<string, string | null>> => {
+  const requestIds = new Map<string, string | null>();
+  for (const workspaceIdBatch of chunkItems(
+    workspaceIds,
+    LIMITS.workflowEntityBatchSize,
+  )) {
+    await Promise.all(
+      workspaceIdBatch.map(async (workspaceId) => {
+        const requestId = await redis.get(
+          workflowKey(brandPersistedWorkspaceId(workspaceId), "request-id"),
+        );
+        requestIds.set(workspaceId, requestId);
+      }),
+    );
+  }
+  return requestIds;
 };
 
 const recoverOrphanedWorkflow = async (
@@ -831,7 +890,7 @@ export const reconcileOrphanedWorkflows = async ({
   const lockedWorkspaceIds = await scanRunningLockWorkspaceIds(redis);
   const pendingWorkspaceIds = scanPendingCells
     ? await selectWorkspacesWithPendingCells()
-    : [];
+    : await selectWorkspacesWithPendingCells(lockedWorkspaceIds);
 
   const candidateWorkspaceIds = [...lockedWorkspaceIds, ...pendingWorkspaceIds];
   if (candidateWorkspaceIds.length === 0) {
@@ -855,6 +914,9 @@ export const reconcileOrphanedWorkflows = async ({
     return;
   }
 
+  const pendingWorkspaceIdSet = new Set(pendingWorkspaceIds);
+  const initialRequestIds = await readWorkflowRequestIds(redis, orphanCandidates);
+
   // Re-confirm after a settle delay so a workflow that is mid-startup
   // (lock taken, first batch not yet enqueued) is not mistaken for an
   // orphan.
@@ -864,10 +926,16 @@ export const reconcileOrphanedWorkflows = async ({
     return;
   }
 
-  for (const workspaceId of orphanCandidates) {
-    if (confirmed.workspaceIds.has(workspaceId)) {
-      continue;
-    }
+  const currentRequestIds = await readWorkflowRequestIds(redis, orphanCandidates);
+  const recoverableOrphans = selectRecoverableOrphanWorkspaceIds({
+    candidateWorkspaceIds: orphanCandidates,
+    currentRequestIds,
+    initialRequestIds,
+    liveWorkspaceIds: confirmed.workspaceIds,
+    pendingWorkspaceIds: pendingWorkspaceIdSet,
+  });
+
+  for (const workspaceId of recoverableOrphans) {
     await recoverOrphanedWorkflow(brandPersistedWorkspaceId(workspaceId));
   }
 };

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -892,7 +892,10 @@ const shouldRecoverWorkflow = async ({
   }
 
   if (runningValue !== "1") {
-    return runningValue === expectedRequestId;
+    return (
+      runningValue === expectedRequestId ||
+      (expectedRequestId === null && runningValue === RECOVERY_LOCK_VALUE)
+    );
   }
 
   // Legacy locks used "1" as the running value and wrote request-id

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -99,7 +99,7 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
     ).toEqual([]);
   });
 
-  test("recovers a bare lock with no request id", () => {
+  test("skips a bare lock with no pending-cell evidence", () => {
     expect(
       selectRecoverableOrphanWorkspaceIds({
         candidateWorkspaceIds: ["a"],
@@ -108,7 +108,7 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
         liveWorkspaceIds: new Set(),
         pendingWorkspaceIds: new Set(),
       }),
-    ).toEqual(["a"]);
+    ).toEqual([]);
   });
 });
 

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -71,6 +71,7 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
         initialRequestIds: new Map([["a", "request-a"]]),
         liveWorkspaceIds: new Set(),
         pendingWorkspaceIds: new Set(["a"]),
+        recoveryWorkspaceIds: new Set(),
       }),
     ).toEqual(["a"]);
   });
@@ -83,6 +84,7 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
         initialRequestIds: new Map([["a", "request-a"]]),
         liveWorkspaceIds: new Set(),
         pendingWorkspaceIds: new Set(["a"]),
+        recoveryWorkspaceIds: new Set(),
       }),
     ).toEqual([]);
   });
@@ -95,6 +97,7 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
         initialRequestIds: new Map([["a", "request-a"]]),
         liveWorkspaceIds: new Set(),
         pendingWorkspaceIds: new Set(),
+        recoveryWorkspaceIds: new Set(),
       }),
     ).toEqual([]);
   });
@@ -107,8 +110,22 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
         initialRequestIds: new Map([["a", null]]),
         liveWorkspaceIds: new Set(),
         pendingWorkspaceIds: new Set(),
+        recoveryWorkspaceIds: new Set(),
       }),
     ).toEqual([]);
+  });
+
+  test("recovers a recovery-owned lock with no pending-cell evidence", () => {
+    expect(
+      selectRecoverableOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a"],
+        currentRequestIds: new Map([["a", "request-a"]]),
+        initialRequestIds: new Map([["a", "request-a"]]),
+        liveWorkspaceIds: new Set(),
+        pendingWorkspaceIds: new Set(),
+        recoveryWorkspaceIds: new Set(["a"]),
+      }),
+    ).toEqual(["a"]);
   });
 });
 

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   parseRunningLockWorkspaceId,
   selectOrphanWorkspaceIds,
+  selectRecoverableOrphanWorkspaceIds,
 } from "@/api/lib/workflow/orphan-recovery";
 
 describe("parseRunningLockWorkspaceId", () => {
@@ -53,5 +54,55 @@ describe("selectOrphanWorkspaceIds", () => {
         liveWorkspaceIds: new Set(),
       }),
     ).toEqual(["a", "b"]);
+  });
+});
+
+describe("selectRecoverableOrphanWorkspaceIds", () => {
+  test("recovers stable candidates with pending cells", () => {
+    expect(
+      selectRecoverableOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a"],
+        currentRequestIds: new Map([["a", "request-a"]]),
+        initialRequestIds: new Map([["a", "request-a"]]),
+        liveWorkspaceIds: new Set(),
+        pendingWorkspaceIds: new Set(["a"]),
+      }),
+    ).toEqual(["a"]);
+  });
+
+  test("skips candidates whose request id changed during the settle window", () => {
+    expect(
+      selectRecoverableOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a"],
+        currentRequestIds: new Map([["a", "request-b"]]),
+        initialRequestIds: new Map([["a", "request-a"]]),
+        liveWorkspaceIds: new Set(),
+        pendingWorkspaceIds: new Set(["a"]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("does not recover a planning workflow with an established request id", () => {
+    expect(
+      selectRecoverableOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a"],
+        currentRequestIds: new Map([["a", "request-a"]]),
+        initialRequestIds: new Map([["a", "request-a"]]),
+        liveWorkspaceIds: new Set(),
+        pendingWorkspaceIds: new Set(),
+      }),
+    ).toEqual([]);
+  });
+
+  test("recovers a bare lock with no request id", () => {
+    expect(
+      selectRecoverableOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a"],
+        currentRequestIds: new Map([["a", null]]),
+        initialRequestIds: new Map([["a", null]]),
+        liveWorkspaceIds: new Set(),
+        pendingWorkspaceIds: new Set(),
+      }),
+    ).toEqual(["a"]);
   });
 });

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseRunningLockWorkspaceId,
+  selectOrphanWorkspaceIds,
+} from "@/api/lib/workflow/orphan-recovery";
+
+describe("parseRunningLockWorkspaceId", () => {
+  test("extracts the workspace id from a running-lock key", () => {
+    expect(parseRunningLockWorkspaceId("workflow:ws-123:running")).toBe(
+      "ws-123",
+    );
+  });
+
+  test("ignores sibling run-state keys so only locks are reconciled", () => {
+    expect(parseRunningLockWorkspaceId("workflow:ws-123:completed")).toBeNull();
+    expect(
+      parseRunningLockWorkspaceId("workflow:ws-123:request-id"),
+    ).toBeNull();
+    expect(parseRunningLockWorkspaceId("workflow:ws-123:total")).toBeNull();
+  });
+
+  test("ignores malformed keys", () => {
+    expect(parseRunningLockWorkspaceId("running")).toBeNull();
+    expect(parseRunningLockWorkspaceId("workflow::running")).toBeNull();
+    expect(parseRunningLockWorkspaceId("other:ws-123:running")).toBeNull();
+  });
+});
+
+describe("selectOrphanWorkspaceIds", () => {
+  test("returns candidates with no live job", () => {
+    expect(
+      selectOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a", "b", "c"],
+        liveWorkspaceIds: new Set(["b"]),
+      }),
+    ).toEqual(["a", "c"]);
+  });
+
+  test("treats a workspace with any live job as healthy", () => {
+    expect(
+      selectOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a"],
+        liveWorkspaceIds: new Set(["a"]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("deduplicates a workspace surfaced by both the lock and pending scans", () => {
+    expect(
+      selectOrphanWorkspaceIds({
+        candidateWorkspaceIds: ["a", "a", "b"],
+        liveWorkspaceIds: new Set(),
+      }),
+    ).toEqual(["a", "b"]);
+  });
+});

--- a/apps/api/src/lib/workflow/orphan-recovery.test.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isCurrentWorkflowRequestState,
   parseRunningLockWorkspaceId,
   selectOrphanWorkspaceIds,
   selectRecoverableOrphanWorkspaceIds,
+  selectRunningLockReservation,
 } from "@/api/lib/workflow/orphan-recovery";
+
+const LEGACY_RUNNING_LOCK_VALUE = "1";
+const RECOVERY_LOCK_VALUE = "recovery";
 
 describe("parseRunningLockWorkspaceId", () => {
   test("extracts the workspace id from a running-lock key", () => {
@@ -104,5 +109,78 @@ describe("selectRecoverableOrphanWorkspaceIds", () => {
         pendingWorkspaceIds: new Set(),
       }),
     ).toEqual(["a"]);
+  });
+});
+
+describe("isCurrentWorkflowRequestState", () => {
+  test("accepts the request-owned running lock", () => {
+    expect(
+      isCurrentWorkflowRequestState({
+        currentRequestId: "request-a",
+        legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+        requestId: "request-a",
+        runningValue: "request-a",
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps legacy locks current for in-flight workers", () => {
+    expect(
+      isCurrentWorkflowRequestState({
+        currentRequestId: "request-a",
+        legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+        requestId: "request-a",
+        runningValue: LEGACY_RUNNING_LOCK_VALUE,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not let a recovery reservation look current", () => {
+    expect(
+      isCurrentWorkflowRequestState({
+        currentRequestId: "request-a",
+        legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+        requestId: "request-a",
+        runningValue: RECOVERY_LOCK_VALUE,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("selectRunningLockReservation", () => {
+  test("reserves request-valued locks for the matching request", () => {
+    expect(
+      selectRunningLockReservation({
+        expectedRequestId: "request-a",
+        legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+        recoveryLockValue: RECOVERY_LOCK_VALUE,
+        requestId: "request-a",
+        runningValue: "request-a",
+      }),
+    ).toEqual({ status: "reserve", expectedRunningValue: "request-a" });
+  });
+
+  test("keeps request-valued locks owned by another request untouched", () => {
+    expect(
+      selectRunningLockReservation({
+        expectedRequestId: "request-a",
+        legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+        recoveryLockValue: RECOVERY_LOCK_VALUE,
+        requestId: "request-a",
+        runningValue: "request-b",
+      }),
+    ).toEqual({ status: "skip" });
+  });
+
+  test("settles legacy locks before reserving them", () => {
+    expect(
+      selectRunningLockReservation({
+        expectedRequestId: "request-a",
+        legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+        recoveryLockValue: RECOVERY_LOCK_VALUE,
+        requestId: "request-a",
+        runningValue: LEGACY_RUNNING_LOCK_VALUE,
+      }),
+    ).toEqual({ status: "settle-legacy" });
   });
 });

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -18,6 +18,12 @@ type OrphanSelectionInput = {
   liveWorkspaceIds: ReadonlySet<string>;
 };
 
+type RecoverableOrphanSelectionInput = OrphanSelectionInput & {
+  currentRequestIds: ReadonlyMap<string, string | null>;
+  initialRequestIds: ReadonlyMap<string, string | null>;
+  pendingWorkspaceIds: ReadonlySet<string>;
+};
+
 /**
  * A candidate workspace (one holding a `running` lock or owning `pending`
  * cells) is orphaned when no in-flight queue job belongs to it: the
@@ -40,4 +46,44 @@ export const selectOrphanWorkspaceIds = ({
     orphans.push(workspaceId);
   }
   return orphans;
+};
+
+/**
+ * Final recovery gate after the settle window. A candidate is recoverable only
+ * when it still has no live job, its request id did not change during the
+ * window, and it is either tied to pending cells or has no request id at all.
+ * The last condition avoids reclaiming a healthy workflow that is still
+ * planning before its first queue job exists.
+ */
+export const selectRecoverableOrphanWorkspaceIds = ({
+  candidateWorkspaceIds,
+  currentRequestIds,
+  initialRequestIds,
+  liveWorkspaceIds,
+  pendingWorkspaceIds,
+}: RecoverableOrphanSelectionInput): string[] => {
+  const recoverable: string[] = [];
+  const seen = new Set<string>();
+
+  for (const workspaceId of candidateWorkspaceIds) {
+    if (seen.has(workspaceId) || liveWorkspaceIds.has(workspaceId)) {
+      continue;
+    }
+
+    const initialRequestId = initialRequestIds.get(workspaceId) ?? null;
+    const currentRequestId = currentRequestIds.get(workspaceId) ?? null;
+    if (currentRequestId !== initialRequestId) {
+      continue;
+    }
+
+    const hasPendingCells = pendingWorkspaceIds.has(workspaceId);
+    if (!hasPendingCells && currentRequestId !== null) {
+      continue;
+    }
+
+    seen.add(workspaceId);
+    recoverable.push(workspaceId);
+  }
+
+  return recoverable;
 };

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -24,6 +24,26 @@ type RecoverableOrphanSelectionInput = OrphanSelectionInput & {
   pendingWorkspaceIds: ReadonlySet<string>;
 };
 
+type CurrentWorkflowRequestStateInput = {
+  currentRequestId: string | null;
+  legacyRunningLockValue: string;
+  requestId: string;
+  runningValue: string | null;
+};
+
+type RunningLockReservationInput = {
+  expectedRequestId: string | null;
+  legacyRunningLockValue: string;
+  recoveryLockValue: string;
+  requestId: string | null;
+  runningValue: string | null;
+};
+
+type RunningLockReservation =
+  | { status: "reserve"; expectedRunningValue: string }
+  | { status: "settle-legacy" }
+  | { status: "skip" };
+
 /**
  * A candidate workspace (one holding a `running` lock or owning `pending`
  * cells) is orphaned when no in-flight queue job belongs to it: the
@@ -86,4 +106,39 @@ export const selectRecoverableOrphanWorkspaceIds = ({
   }
 
   return recoverable;
+};
+
+export const isCurrentWorkflowRequestState = ({
+  currentRequestId,
+  legacyRunningLockValue,
+  requestId,
+  runningValue,
+}: CurrentWorkflowRequestStateInput): boolean =>
+  currentRequestId === requestId &&
+  (runningValue === requestId || runningValue === legacyRunningLockValue);
+
+export const selectRunningLockReservation = ({
+  expectedRequestId,
+  legacyRunningLockValue,
+  recoveryLockValue,
+  requestId,
+  runningValue,
+}: RunningLockReservationInput): RunningLockReservation => {
+  if (runningValue === null || requestId !== expectedRequestId) {
+    return { status: "skip" };
+  }
+
+  if (runningValue === recoveryLockValue) {
+    return { status: "reserve", expectedRunningValue: recoveryLockValue };
+  }
+
+  if (runningValue === legacyRunningLockValue) {
+    return { status: "settle-legacy" };
+  }
+
+  if (expectedRequestId === null || runningValue !== expectedRequestId) {
+    return { status: "skip" };
+  }
+
+  return { status: "reserve", expectedRunningValue: runningValue };
 };

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -71,9 +71,10 @@ export const selectOrphanWorkspaceIds = ({
 /**
  * Final recovery gate after the settle window. A candidate is recoverable only
  * when it still has no live job, its request id did not change during the
- * window, and it is either tied to pending cells or has no request id at all.
- * The last condition avoids reclaiming a healthy workflow that is still
- * planning before its first queue job exists.
+ * window, and it is tied to pending cells. The pending-cell requirement avoids
+ * reclaiming a healthy workflow that is still planning before its first queue
+ * job exists, including legacy starters that set the running lock before the
+ * request id.
  */
 export const selectRecoverableOrphanWorkspaceIds = ({
   candidateWorkspaceIds,
@@ -96,8 +97,7 @@ export const selectRecoverableOrphanWorkspaceIds = ({
       continue;
     }
 
-    const hasPendingCells = pendingWorkspaceIds.has(workspaceId);
-    if (!hasPendingCells && currentRequestId !== null) {
+    if (!pendingWorkspaceIds.has(workspaceId)) {
       continue;
     }
 

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -22,6 +22,7 @@ type RecoverableOrphanSelectionInput = OrphanSelectionInput & {
   currentRequestIds: ReadonlyMap<string, string | null>;
   initialRequestIds: ReadonlyMap<string, string | null>;
   pendingWorkspaceIds: ReadonlySet<string>;
+  recoveryWorkspaceIds: ReadonlySet<string>;
 };
 
 type CurrentWorkflowRequestStateInput = {
@@ -71,10 +72,10 @@ export const selectOrphanWorkspaceIds = ({
 /**
  * Final recovery gate after the settle window. A candidate is recoverable only
  * when it still has no live job, its request id did not change during the
- * window, and it is tied to pending cells. The pending-cell requirement avoids
- * reclaiming a healthy workflow that is still planning before its first queue
- * job exists, including legacy starters that set the running lock before the
- * request id.
+ * window, and it is tied to pending cells or a recovery-owned lock. The
+ * evidence requirement avoids reclaiming a healthy workflow that is still
+ * planning before its first queue job exists, including legacy starters that
+ * set the running lock before the request id.
  */
 export const selectRecoverableOrphanWorkspaceIds = ({
   candidateWorkspaceIds,
@@ -82,6 +83,7 @@ export const selectRecoverableOrphanWorkspaceIds = ({
   initialRequestIds,
   liveWorkspaceIds,
   pendingWorkspaceIds,
+  recoveryWorkspaceIds,
 }: RecoverableOrphanSelectionInput): string[] => {
   const recoverable: string[] = [];
   const seen = new Set<string>();
@@ -97,7 +99,9 @@ export const selectRecoverableOrphanWorkspaceIds = ({
       continue;
     }
 
-    if (!pendingWorkspaceIds.has(workspaceId)) {
+    const hasPendingCells = pendingWorkspaceIds.has(workspaceId);
+    const hasRecoveryLock = recoveryWorkspaceIds.has(workspaceId);
+    if (!hasPendingCells && !hasRecoveryLock) {
       continue;
     }
 

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -1,0 +1,43 @@
+// Pure decision helpers for workflow orphan reconciliation. Kept free of
+// Redis/DB/queue imports so the reconciler's logic is unit-testable and
+// importing it never triggers a connection or worker side effect.
+
+const RUNNING_LOCK_KEY = /^workflow:([^:]+):running$/u;
+
+/**
+ * Extract the workspace id from a `workflow:<workspaceId>:running` lock
+ * key. Returns null for any other workflow key (e.g. `:completed`,
+ * `:request-id`) or a malformed key, so only genuine locks are ever
+ * considered for reconciliation.
+ */
+export const parseRunningLockWorkspaceId = (key: string): string | null =>
+  RUNNING_LOCK_KEY.exec(key)?.[1] ?? null;
+
+type OrphanSelectionInput = {
+  candidateWorkspaceIds: readonly string[];
+  liveWorkspaceIds: ReadonlySet<string>;
+};
+
+/**
+ * A candidate workspace (one holding a `running` lock or owning `pending`
+ * cells) is orphaned when no in-flight queue job belongs to it: the
+ * worker that set its state has died without clearing it. Returns the
+ * deduplicated orphans in input order — the same workspace can surface
+ * from both the lock scan and the pending-cell scan, but must be
+ * recovered exactly once.
+ */
+export const selectOrphanWorkspaceIds = ({
+  candidateWorkspaceIds,
+  liveWorkspaceIds,
+}: OrphanSelectionInput): string[] => {
+  const orphans: string[] = [];
+  const seen = new Set<string>();
+  for (const workspaceId of candidateWorkspaceIds) {
+    if (seen.has(workspaceId) || liveWorkspaceIds.has(workspaceId)) {
+      continue;
+    }
+    seen.add(workspaceId);
+    orphans.push(workspaceId);
+  }
+  return orphans;
+};


### PR DESCRIPTION
## Problem

A workflow worker killed mid-job — a `bun --watch` hot-reload on save, an OOM, `kill -9`, or SIGTERM on deploy — abandons the BullMQ job *after* it set its cells to `pending` but *before* `finishWorkflow` clears the workspace's `running` lock. A hard kill emits no BullMQ `failed` event, so the existing stalled-job / failed-handler recovery never fires:

- the `running` lock survives in Redis and rejects every retry with **409 "A workflow is already running"** until its 1h TTL lapses;
- the `pending` cells spin forever.

This reproduces locally on every `bun --watch` reload mid-extraction, and in production on any deploy/restart that kills the API process mid-workflow.

## Fix

**1. Graceful shutdown** (`index.ts`): drain both BullMQ workers on `SIGTERM`/`SIGINT`, bounded by a 10s timeout so a slow job can't hang shutdown. Clean restarts/deploys finish in-flight jobs (which clear their own lock) instead of orphaning them.

**2. Reconciler** (`workflow-queue.ts`): at worker boot and on a 60s interval, any workspace holding a `running` lock or owning `pending` cells with **no in-flight queue job** is treated as orphaned:
- its `pending` cells are flipped to `error` (still re-runnable via `prepareBatch`, so a retry or the next full run re-extracts them);
- its run-state is cleared, so retries / new runs stop hitting the 409.

Boot additionally sweeps the DB for `pending` cells whose lock already lapsed via TTL. Detection acts **only** when no job is live and re-confirms after a short settle window, so a healthy or just-started run is never reconciled away. A live-job backlog above a safety cap skips the cycle rather than risk a false positive.

Death-cause-agnostic: whatever a killed worker leaves behind, the next worker boot heals it.

## Tests

- Unit tests for the orphan-selection and lock-key parsing helpers (kept in a pure, side-effect-free module).
- Verified end-to-end against live Valkey/Postgres: a seeded orphan `running` lock with no jobs is cleared after the settle window.
- `oxlint` (type-aware), `tsgo`, and the workflow test suite (84 tests) pass.