### PR TITLE
fix(folio): keep page-anchored header letterheads from blanking the document (eigenpal #709)

### DIFF
--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.test.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.test.ts
@@ -17,6 +17,18 @@ const footerSpan = {
   dataset: { pmStart: "11", pmEnd: "14" },
   textContent: "footer",
 };
+const associatedSpan = {
+  dataset: { pmStart: "21", pmEnd: "24" },
+  textContent: "moved",
+};
+const associatedImage = {
+  dataset: {
+    hfSlotKind: "header",
+    hfRid: "rIdH1",
+    pmStart: "31",
+    pmEnd: "32",
+  },
+};
 
 const createContainer = (): ParentNode =>
   ({
@@ -71,6 +83,60 @@ describe("HF slot-scoped PM DOM lookups", () => {
     expect(
       findHfPmAnchor(createContainer(), "header", "rIdH1", Number.NaN),
     ).toBeNull();
+  });
+
+  test("includes spans moved to the page layer with HF slot metadata", () => {
+    const container = {
+      querySelectorAll(selector: string) {
+        if (
+          selector ===
+          '[data-hf-slot-kind="header"][data-hf-rid="rIdH1"] span[data-pm-start][data-pm-end]'
+        ) {
+          return [associatedSpan];
+        }
+        return [];
+      },
+    } as unknown as ParentNode;
+
+    const spans = findHfPmSpans(container, "header", "rIdH1");
+
+    expect(spans).toEqual([associatedSpan]);
+  });
+
+  test("includes moved HF roots as PM anchors", () => {
+    const container = {
+      querySelectorAll(selector: string) {
+        if (
+          selector ===
+          '[data-hf-slot-kind="header"][data-hf-rid="rIdH1"][data-pm-start]'
+        ) {
+          return [associatedImage];
+        }
+        return [];
+      },
+    } as unknown as ParentNode;
+
+    const anchors = findHfPmAnchors(container, "header", "rIdH1");
+
+    expect(anchors).toEqual([associatedImage]);
+  });
+
+  test("findHfPmAnchor resolves a moved HF root by pm-start", () => {
+    const container = {
+      querySelector(selector: string) {
+        if (
+          selector ===
+          '[data-hf-slot-kind="header"][data-hf-rid="rIdH1"][data-pm-start="31"]'
+        ) {
+          return associatedImage;
+        }
+        return null;
+      },
+    } as unknown as ParentNode;
+
+    const anchor = findHfPmAnchor(container, "header", "rIdH1", 31);
+
+    expect(anchor).toBe(associatedImage as unknown as HTMLElement);
   });
 });
 
@@ -204,6 +270,28 @@ describe("findHfSlotForTarget", () => {
       kind: "footer",
       rId: "rIdFooter",
       element: footerEl,
+    });
+  });
+
+  test("resolves a moved page-layer HF element by associated slot metadata", () => {
+    const associatedEl = {
+      dataset: { hfSlotKind: "footer", hfRid: "rIdFooter" },
+    } as unknown as HTMLElement;
+    const target = {
+      closest(selector: string) {
+        if (selector === "[data-hf-slot-kind][data-hf-rid]") {
+          return associatedEl;
+        }
+        return null;
+      },
+    } as unknown as Element;
+
+    const slot = findHfSlotForTarget(target);
+
+    expect(slot).toEqual({
+      kind: "footer",
+      rId: "rIdFooter",
+      element: associatedEl,
     });
   });
 

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
@@ -19,15 +19,60 @@ function slotSelector(kind: HfSlotKind, rId: string): string {
     : `.layout-page-footer[data-rid="${rId}"]`;
 }
 
+function associatedSlotSelector(kind: HfSlotKind, rId: string): string {
+  return `[data-hf-slot-kind="${kind}"][data-hf-rid="${rId}"]`;
+}
+
+function uniqueElements(elements: HTMLElement[]): HTMLElement[] {
+  return Array.from(new Set(elements));
+}
+
+function querySlotDescendants(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+  selector: string,
+): HTMLElement[] {
+  return uniqueElements([
+    ...Array.from(
+      container.querySelectorAll<HTMLElement>(
+        `${slotSelector(kind, rId)} ${selector}`,
+      ),
+    ),
+    ...Array.from(
+      container.querySelectorAll<HTMLElement>(
+        `${associatedSlotSelector(kind, rId)} ${selector}`,
+      ),
+    ),
+  ]);
+}
+
+function querySlotAnchors(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+  selector: string,
+): HTMLElement[] {
+  return uniqueElements([
+    ...querySlotDescendants(container, kind, rId, selector),
+    ...Array.from(
+      container.querySelectorAll<HTMLElement>(
+        `${associatedSlotSelector(kind, rId)}${selector}`,
+      ),
+    ),
+  ]);
+}
+
 export function findHfPmSpans(
   container: ParentNode,
   kind: HfSlotKind,
   rId: string,
 ): HTMLElement[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(
-      `${slotSelector(kind, rId)} span[data-pm-start][data-pm-end]`,
-    ),
+  return querySlotDescendants(
+    container,
+    kind,
+    rId,
+    "span[data-pm-start][data-pm-end]",
   );
 }
 
@@ -36,11 +81,7 @@ export function findHfPmAnchors(
   kind: HfSlotKind,
   rId: string,
 ): HTMLElement[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(
-      `${slotSelector(kind, rId)} [data-pm-start]`,
-    ),
-  );
+  return querySlotAnchors(container, kind, rId, "[data-pm-start]");
 }
 
 export function findHfPmAnchor(
@@ -52,8 +93,16 @@ export function findHfPmAnchor(
   if (!Number.isFinite(pmStart)) {
     return null;
   }
-  return container.querySelector<HTMLElement>(
-    `${slotSelector(kind, rId)} [data-pm-start="${String(pmStart)}"]`,
+  return (
+    container.querySelector<HTMLElement>(
+      `${slotSelector(kind, rId)} [data-pm-start="${String(pmStart)}"]`,
+    ) ??
+    container.querySelector<HTMLElement>(
+      `${associatedSlotSelector(kind, rId)} [data-pm-start="${String(pmStart)}"]`,
+    ) ??
+    container.querySelector<HTMLElement>(
+      `${associatedSlotSelector(kind, rId)}[data-pm-start="${String(pmStart)}"]`,
+    )
   );
 }
 
@@ -81,15 +130,11 @@ export function findHfCaretSpan(
   if (!Number.isFinite(pos)) {
     return null;
   }
-  const exact = container.querySelector<HTMLElement>(
-    `${slotSelector(kind, rId)} [data-pm-start="${String(pos)}"]`,
-  );
+  const exact = findHfPmAnchor(container, kind, rId, pos);
   if (exact) {
     return { element: exact, edge: "left" };
   }
-  const spans = container.querySelectorAll<HTMLElement>(
-    `${slotSelector(kind, rId)} span[data-pm-start][data-pm-end]`,
-  );
+  const spans = findHfPmSpans(container, kind, rId);
   let best: HfCaretSpanHit | null = null;
   for (const span of spans) {
     const startStr = span.dataset["pmStart"];
@@ -156,7 +201,6 @@ export function clickToPositionInHfSlot(
 ): number | null {
   const ownerDoc =
     container instanceof Element ? container.ownerDocument : document;
-  const slotSel = slotSelector(kind, rId);
   const elements = ownerDoc.elementsFromPoint(clientX, clientY);
   for (const el of elements) {
     if (!(el instanceof HTMLElement)) {
@@ -166,7 +210,8 @@ export function clickToPositionInHfSlot(
     // the same header is referenced across pages, so a drag that crosses
     // between paginated instances must accept the hit regardless of which
     // exact slot DOM node it lands in.
-    if (!el.closest(slotSel)) {
+    const slot = findHfSlotForTarget(el);
+    if (!slot || slot.kind !== kind || slot.rId !== rId) {
       continue;
     }
     if (
@@ -201,9 +246,7 @@ function findNearestSpanInHfSlots(
   clientX: number,
   clientY: number,
 ): number | null {
-  const spans = container.querySelectorAll<HTMLElement>(
-    `${slotSelector(kind, rId)} span[data-pm-start][data-pm-end]`,
-  );
+  const spans = findHfPmSpans(container, kind, rId);
   if (spans.length === 0) {
     return null;
   }
@@ -276,6 +319,14 @@ export function findHfSlotForTarget(target: Node | null): {
     const rId = footer.dataset["rid"];
     if (rId) {
       return { kind: "footer", rId, element: footer };
+    }
+  }
+  const associated = target.closest("[data-hf-slot-kind][data-hf-rid]");
+  if (associated) {
+    const kind = associated.dataset["hfSlotKind"];
+    const rId = associated.dataset["hfRid"];
+    if ((kind === "header" || kind === "footer") && rId) {
+      return { kind, rId, element: associated };
     }
   }
   return null;

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -269,6 +269,95 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
 
     expect(bounds).toEqual({ top: 0, bottom: 52 });
   });
+
+  test("excludes a floating text-box letterhead from the body push but keeps it in the visual bounds (eigenpal #709)", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "title",
+        runs: [{ kind: "text", text: "Header" }],
+      },
+      {
+        kind: "textBox",
+        id: "letterhead",
+        width: 560,
+        height: 1100,
+        displayMode: "float",
+        content: [],
+      },
+    ];
+    const measures: Measure[] = [
+      { kind: "paragraph", lines: [], totalHeight: 12 },
+      { kind: "textBox", width: 560, height: 1100, innerMeasures: [] },
+    ];
+
+    // Push: only the in-flow paragraph (12) counts — not the 1100px letterhead,
+    // which would otherwise inflate the top margin past the page and blank the
+    // document.
+    expect(
+      calculateHeaderFooterMarginPushBounds(blocks, measures, 12, metrics),
+    ).toEqual({ top: 0, bottom: 12 });
+    // Visual: the letterhead is still part of the rendered extent.
+    expect(
+      calculateHeaderFooterVisualBounds(blocks, measures, 12, metrics)
+        .visualBottom,
+    ).toBeGreaterThanOrEqual(1100);
+  });
+
+  test("excludes a non-behindDoc anchored image block from the body push (eigenpal #709)", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "image",
+        id: "anchored-logo",
+        src: "logo.png",
+        width: 560,
+        height: 900,
+        anchor: { isAnchored: true },
+      },
+    ];
+
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [{ kind: "image", width: 560, height: 900 }],
+      0,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 0 });
+  });
+
+  test("excludes anchored (non-behindDoc) image runs from the body push (eigenpal #709)", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "p",
+        runs: [
+          { kind: "text", text: "x" },
+          {
+            kind: "image",
+            src: "logo.png",
+            width: 560,
+            height: 900,
+            position: {
+              horizontal: { relativeTo: "page", posOffset: 0 },
+              vertical: { relativeTo: "page", posOffset: 0 },
+            },
+          },
+        ],
+      },
+    ];
+
+    // Only the paragraph's text height (12) pushes; the anchored image run is
+    // positioned on the page and does not.
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 12 });
+  });
 });
 
 describe("header/footer layout conversion", () => {

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -7,6 +7,7 @@ import type {
   TableBlock,
 } from "../layout-engine/types";
 import { headerFooterToProseDoc } from "../prosemirror/conversion/toProseDoc";
+import { schema } from "../prosemirror/schema";
 import type { HeaderFooter } from "../types/document";
 import type { HeaderFooterMetrics } from "./headerFooterLayout";
 import {
@@ -80,6 +81,21 @@ function measureBlocks(blocks: FlowBlock[]): Measure[] {
         totalHeight: 24,
       };
     }
+    if (block.kind === "image") {
+      return {
+        kind: "image",
+        width: block.width,
+        height: block.height,
+      };
+    }
+    if (block.kind === "textBox") {
+      return {
+        kind: "textBox",
+        width: block.width,
+        height: block.height ?? 12,
+        innerMeasures: [],
+      };
+    }
 
     return {
       kind: "paragraph",
@@ -146,6 +162,36 @@ describe("calculateHeaderFooterVisualBounds", () => {
     );
 
     expect(bounds).toEqual({ visualTop: 0, visualBottom: 70 });
+  });
+
+  test("does not advance visual flow for floating text boxes before normal content", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "textBox",
+        id: "letterhead",
+        width: 560,
+        height: 1100,
+        displayMode: "float",
+        content: [],
+      },
+      {
+        kind: "paragraph",
+        id: "title",
+        runs: [{ kind: "text", text: "Header" }],
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [
+        { kind: "textBox", width: 560, height: 1100, innerMeasures: [] },
+        { kind: "paragraph", lines: [], totalHeight: 12 },
+      ],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: 0, visualBottom: 1100 });
   });
 
   test("includes behindDoc images in visualBottom (render+hash signal)", () => {
@@ -291,11 +337,10 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
       { kind: "textBox", width: 560, height: 1100, innerMeasures: [] },
     ];
 
-    // Push: only the in-flow paragraph (12) counts — not the 1100px letterhead,
-    // which would otherwise inflate the top margin past the page and blank the
-    // document.
+    // Simulate the pre-fix conversion path, where flowHeight was seeded with
+    // paragraph + floating box height. Push still derives from in-flow blocks.
     expect(
-      calculateHeaderFooterMarginPushBounds(blocks, measures, 12, metrics),
+      calculateHeaderFooterMarginPushBounds(blocks, measures, 1112, metrics),
     ).toEqual({ top: 0, bottom: 12 });
     // Visual: the letterhead is still part of the rendered extent.
     expect(
@@ -319,7 +364,7 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
     const bounds = calculateHeaderFooterMarginPushBounds(
       blocks,
       [{ kind: "image", width: 560, height: 900 }],
-      0,
+      900,
       metrics,
     );
 
@@ -347,12 +392,12 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
       },
     ];
 
-    // Only the paragraph's text height (12) pushes; the anchored image run is
-    // positioned on the page and does not.
+    // Simulate an inflated flowHeight from a paragraph measure plus anchored
+    // image extent; only the paragraph's text height pushes.
     const bounds = calculateHeaderFooterMarginPushBounds(
       blocks,
       [{ kind: "paragraph", lines: [], totalHeight: 12 }],
-      12,
+      912,
       metrics,
     );
 
@@ -361,6 +406,54 @@ describe("calculateHeaderFooterMarginPushBounds", () => {
 });
 
 describe("header/footer layout conversion", () => {
+  test("derives flow height before margin push so floating text boxes do not seed the body push", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Header")]),
+      schema.node(
+        "textBox",
+        {
+          width: 560,
+          height: 1100,
+          displayMode: "float",
+          wrapType: "behind",
+        },
+        [schema.node("paragraph", null, [])],
+      ),
+    ]);
+
+    const result = convertHeaderFooterPmDocToContent(pmDoc, 600, metrics, {
+      measureBlocks,
+    });
+
+    expect(result?.height).toBe(12);
+    expect(result?.marginPushBottom).toBe(12);
+    expect(result?.visualBottom).toBe(1112);
+  });
+
+  test("keeps topAndBottom text boxes in header/footer flow", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node(
+        "textBox",
+        {
+          width: 560,
+          height: 1100,
+          displayMode: "block",
+          wrapType: "topAndBottom",
+        },
+        [schema.node("paragraph", null, [])],
+      ),
+      schema.node("paragraph", null, [schema.text("Header")]),
+    ]);
+
+    const result = convertHeaderFooterPmDocToContent(pmDoc, 600, metrics, {
+      measureBlocks,
+    });
+
+    expect(result?.height).toBe(1112);
+    expect(result?.marginPushBottom).toBe(1112);
+    expect(result?.visualBottom).toBe(1112);
+  });
+
   test("routes header/footer tables through the body FlowBlock pipeline", () => {
     const header: HeaderFooter = {
       type: "header",

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -454,6 +454,30 @@ describe("header/footer layout conversion", () => {
     expect(result?.visualBottom).toBe(1112);
   });
 
+  test("keeps top-and-bottom block text boxes in header/footer flow", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node(
+        "textBox",
+        {
+          width: 560,
+          height: 40,
+          displayMode: "block",
+          wrapType: "topAndBottom",
+        },
+        [schema.node("paragraph", null, [])],
+      ),
+      schema.node("paragraph", null, [schema.text("After")]),
+    ]);
+
+    const result = convertHeaderFooterPmDocToContent(pmDoc, 600, metrics, {
+      measureBlocks,
+    });
+
+    expect(result?.height).toBe(52);
+    expect(result?.marginPushBottom).toBe(52);
+    expect(result?.visualBottom).toBe(52);
+  });
+
   test("routes header/footer tables through the body FlowBlock pipeline", () => {
     const header: HeaderFooter = {
       type: "header",

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -336,6 +336,17 @@ function isBehindDocImageBlock(block: FlowBlock): boolean {
   return block.kind === "image" && block.anchor?.behindDoc === true;
 }
 
+type HeaderFooterTextBoxBlock = Extract<FlowBlock, { kind: "textBox" }>;
+
+function isPositionedHeaderFooterTextBoxBlock(
+  block: HeaderFooterTextBoxBlock,
+): boolean {
+  if (block.displayMode === "block" || block.displayMode === "inline") {
+    return false;
+  }
+  return isFloatingTextBoxBlock(block);
+}
+
 export function calculateHeaderFooterVisualBounds(
   blocks: FlowBlock[],
   measures: Measure[],
@@ -388,10 +399,10 @@ export function calculateHeaderFooterVisualBounds(
     } else {
       // Tables / images / textBoxes contribute their measured height as a
       // single block (they don't reflow within the HF area). Floating
-      // tables (`<w:tblpPr>`) anchor at (tblpX, tblpY) and don't
-      // participate in the cursorY flow — they're positioned absolutely by
-      // the renderer and can overlap surrounding HF content (Word
-      // semantics for unwrapped floating tables).
+      // tables (`<w:tblpPr>`) and floating text boxes anchor at page-level
+      // positions and don't participate in the cursorY flow — they're
+      // positioned absolutely by the renderer and can overlap surrounding
+      // HF content (Word semantics for unwrapped floating content).
       let blockHeight: number;
       let advancesCursor = true;
       if (block.kind === "table" && measure.kind === "table") {
@@ -403,6 +414,9 @@ export function calculateHeaderFooterVisualBounds(
         blockHeight = measure.height;
       } else if (block.kind === "textBox" && measure.kind === "textBox") {
         blockHeight = measure.height;
+        if (isPositionedHeaderFooterTextBoxBlock(block)) {
+          advancesCursor = false;
+        }
       } else {
         continue;
       }
@@ -425,6 +439,13 @@ export function calculateHeaderFooterVisualBounds(
         );
         visualTop = Math.min(visualTop, blockTop);
         visualBottom = Math.max(visualBottom, blockTop + blockHeight);
+      } else if (
+        block.kind === "textBox" &&
+        isPositionedHeaderFooterTextBoxBlock(block) &&
+        measure.kind === "textBox"
+      ) {
+        visualTop = Math.min(visualTop, cursorY);
+        visualBottom = Math.max(visualBottom, cursorY + measure.height);
       }
     }
   }
@@ -434,12 +455,12 @@ export function calculateHeaderFooterVisualBounds(
 
 /**
  * Compute the header/footer bounds used by `computeHeaderFooterMarginExtender`
- * to push body margins clear of HF overflow. Excludes `behindDoc` images
- * (full-page letterheads, watermarks): the renderer lifts them out of the HF
- * container onto the page root and paints them behind body content, so they
- * must not reserve body push-down. Keeping them in `visualBottom` is still
- * correct for the renderer (and for the page-hash invalidation signal), but
- * the margin extender needs the flow-only extent.
+ * to push body margins clear of HF overflow. Excludes anchored/floating objects
+ * (full-page letterheads, watermarks): Word positions them on the page instead
+ * of in the header/footer flow, so they must not reserve body push-down. Keeping
+ * them in `visualBottom` is still correct for the renderer (and for the
+ * page-hash invalidation signal), but the margin extender needs the flow-only
+ * extent.
  */
 export function calculateHeaderFooterMarginPushBounds(
   blocks: FlowBlock[],
@@ -448,7 +469,7 @@ export function calculateHeaderFooterMarginPushBounds(
   metrics: HeaderFooterMetrics,
 ): { top: number; bottom: number } {
   let top = 0;
-  let bottom = flowHeight;
+  let bottom = 0;
   let cursorY = 0;
 
   for (let i = 0; i < blocks.length; i++) {
@@ -493,7 +514,7 @@ export function calculateHeaderFooterMarginPushBounds(
         // positioned on the page and must not push the body margin, or a tall
         // letterhead inflates the top margin past the page and the paginator
         // throws "no content area" (blank document). eigenpal #709.
-        if (isFloatingTextBoxBlock(block)) {
+        if (isPositionedHeaderFooterTextBoxBlock(block)) {
           continue;
         }
         blockHeight = measure.height;
@@ -645,43 +666,33 @@ function finalizeHeaderFooterContent(
 
   const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks);
   const measures = options.measureBlocks(blocksForMeasure, contentWidth);
-  let totalHeight = 0;
+  let flowHeight = 0;
   for (let i = 0; i < measures.length; i++) {
     const m = measures[i];
     const b = blocks[i];
     if (!m || !b) {
       continue;
     }
-    if (m.kind === "paragraph") {
-      totalHeight += m.totalHeight;
-    } else if (m.kind === "table") {
-      if (!(b.kind === "table" && b.floating)) {
-        totalHeight += m.totalHeight;
-      }
-    } else if (m.kind === "image") {
-      totalHeight += m.height;
-    } else if (m.kind === "textBox") {
-      totalHeight += m.height;
-    }
+    flowHeight += getHeaderFooterFlowMeasureHeight(b, m);
   }
   const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(
     blocks,
     measures,
-    totalHeight,
+    flowHeight,
     metrics,
   );
   const { top: marginPushTop, bottom: marginPushBottom } =
     calculateHeaderFooterMarginPushBounds(
       blocks,
       measures,
-      totalHeight,
+      flowHeight,
       metrics,
     );
 
   return {
     blocks,
     measures,
-    height: totalHeight,
+    height: flowHeight,
     visualTop,
     visualBottom,
     marginPushTop,
@@ -689,6 +700,34 @@ function finalizeHeaderFooterContent(
     textSig: computeHeaderFooterTextSig(blocks),
     ...(options.rId ? { rId: options.rId } : {}),
   };
+}
+
+function getHeaderFooterFlowMeasureHeight(
+  block: FlowBlock,
+  measure: Measure,
+): number {
+  if (block.kind === "paragraph" && measure.kind === "paragraph") {
+    return measure.totalHeight;
+  }
+  if (block.kind === "table" && measure.kind === "table") {
+    if (block.floating) {
+      return 0;
+    }
+    return measure.totalHeight;
+  }
+  if (block.kind === "image" && measure.kind === "image") {
+    if (block.anchor?.isAnchored) {
+      return 0;
+    }
+    return measure.height;
+  }
+  if (block.kind === "textBox" && measure.kind === "textBox") {
+    if (isPositionedHeaderFooterTextBoxBlock(block)) {
+      return 0;
+    }
+    return measure.height;
+  }
+  return 0;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -30,7 +30,10 @@ import type {
   TableBlock,
   TableMeasure,
 } from "../layout-engine/types";
-import { isFloatingImageRun } from "../layout-engine/types";
+import {
+  isFloatingImageRun,
+  isFloatingTextBoxBlock,
+} from "../layout-engine/types";
 import { headerFooterToProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type { HeaderFooter, StyleDefinitions, Theme } from "../types/document";
 import { emuToPixels } from "../utils/units";
@@ -329,15 +332,6 @@ function resolveHeaderFooterFloatingTableVisualTop(
   return sourceY;
 }
 
-/**
- * Image is rendered "behind" body content (full-page letterhead, watermark).
- * The renderer lifts these out of the HF container to the page root, so they
- * must not push body margins down because they paint underneath the body.
- */
-function isBehindDocImageRun(run: Run): boolean {
-  return run.kind === "image" && run.wrapType === "behind";
-}
-
 function isBehindDocImageBlock(block: FlowBlock): boolean {
   return block.kind === "image" && block.anchor?.behindDoc === true;
 }
@@ -465,31 +459,14 @@ export function calculateHeaderFooterMarginPushBounds(
     }
 
     if (block.kind === "paragraph" && measure.kind === "paragraph") {
-      const paragraphStartY = cursorY;
-      const paragraphBottomY = paragraphStartY + measure.totalHeight;
-      top = Math.min(top, paragraphStartY);
+      // Margin push is the in-flow extent only. The paragraph's measured
+      // height already covers its inline content; anchored image runs are
+      // positioned on the page (Word does not let them push the body down),
+      // so they extend only the visual bounds, never the push bounds.
+      // eigenpal/docx-editor#709.
+      const paragraphBottomY = cursorY + measure.totalHeight;
+      top = Math.min(top, cursorY);
       bottom = Math.max(bottom, paragraphBottomY);
-
-      for (const run of block.runs) {
-        if (run.kind !== "image") {
-          continue;
-        }
-        if (!run.position && !isFloatingImageRun(run)) {
-          continue;
-        }
-        if (isBehindDocImageRun(run)) {
-          continue;
-        }
-        const runTop = resolveHeaderFooterVisualTop(
-          run,
-          paragraphStartY,
-          flowHeight,
-          metrics,
-        );
-        top = Math.min(top, runTop);
-        bottom = Math.max(bottom, runTop + run.height);
-      }
-
       cursorY = paragraphBottomY;
     } else if (isBehindDocImageBlock(block)) {
       // ImageBlock with anchor.behindDoc: skip entirely for the same reason
@@ -505,8 +482,20 @@ export function calculateHeaderFooterMarginPushBounds(
           advancesCursor = false;
         }
       } else if (block.kind === "image" && measure.kind === "image") {
+        // Anchored images sit on the page (Word positions them there); they
+        // extend only the visual bounds, not the body push. eigenpal #709.
+        if (block.anchor?.isAnchored) {
+          continue;
+        }
         blockHeight = measure.height;
       } else if (block.kind === "textBox" && measure.kind === "textBox") {
+        // Floating/anchored text boxes — e.g. a page-anchored letterhead — are
+        // positioned on the page and must not push the body margin, or a tall
+        // letterhead inflates the top margin past the page and the paginator
+        // throws "no content area" (blank document). eigenpal #709.
+        if (isFloatingTextBoxBlock(block)) {
+          continue;
+        }
         blockHeight = measure.height;
       } else {
         continue;

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -24,6 +24,7 @@ class FakeElement {
   dataset: Record<string, string> = {};
   style: Record<string, string> = {};
   children: FakeElement[] = [];
+  parent: FakeElement | undefined;
   private ownText = "";
   readonly tagName: string;
 
@@ -43,20 +44,41 @@ class FakeElement {
   }
 
   append(...children: FakeElement[]): void {
-    this.children.push(...children);
+    for (const child of children) {
+      this.appendChild(child);
+    }
   }
 
   appendChild(child: FakeElement): FakeElement {
+    child.removeFromParent();
+    child.parent = this;
     this.children.push(child);
     return child;
+  }
+
+  prepend(...children: FakeElement[]): void {
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      const child = children[index];
+      if (!child) {
+        continue;
+      }
+      child.removeFromParent();
+      child.parent = this;
+      this.children.unshift(child);
+    }
   }
 
   getContext(): null {
     return null;
   }
 
-  querySelectorAll(): FakeElement[] {
-    return [];
+  querySelectorAll<T = FakeElement>(selector: string): T[] {
+    const selectors = selector.split(",").map((value) => value.trim());
+    const matches: FakeElement[] = [];
+    for (const child of this.children) {
+      matches.push(...child.querySelectorAllMatching(selectors));
+    }
+    return matches as T[];
   }
 
   querySelector(selector: string): FakeElement | null {
@@ -73,6 +95,48 @@ class FakeElement {
       }
     }
     return null;
+  }
+
+  private querySelectorAllMatching(selectors: string[]): FakeElement[] {
+    const matches = selectors.some((selector) => this.matches(selector))
+      ? [this]
+      : [];
+    for (const child of this.children) {
+      matches.push(...child.querySelectorAllMatching(selectors));
+    }
+    return matches;
+  }
+
+  private matches(selector: string): boolean {
+    if (selector === 'img[style*="z-index"]') {
+      return (
+        this.tagName.toLowerCase() === "img" &&
+        this.style.zIndex !== undefined &&
+        this.style.zIndex !== ""
+      );
+    }
+    if (selector === '.layout-textbox[style*="z-index"]') {
+      return (
+        this.className.split(" ").includes("layout-textbox") &&
+        this.style.zIndex !== undefined &&
+        this.style.zIndex !== ""
+      );
+    }
+    if (selector.startsWith(".")) {
+      return this.className.split(" ").includes(selector.slice(1));
+    }
+    return this.tagName.toLowerCase() === selector.toLowerCase();
+  }
+
+  private removeFromParent(): void {
+    if (!this.parent) {
+      return;
+    }
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) {
+      this.parent.children.splice(index, 1);
+    }
+    this.parent = undefined;
   }
 }
 
@@ -350,6 +414,48 @@ describe("header and footer rendering", () => {
     );
 
     expect(afterParagraph?.style.top).toBe("40px");
+  });
+
+  test("preserves footer content offset when moving behind images to the page layer", () => {
+    const footerNaturalTop = page.size.h - 48;
+    const footerImageBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "footer-background",
+      runs: [
+        {
+          kind: "image",
+          src: "footer-bg.png",
+          width: 160,
+          height: 40,
+          wrapType: "behind",
+          position: {
+            vertical: { relativeTo: "page", posOffset: 0 },
+          },
+        },
+      ],
+    };
+
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        footerContent: {
+          blocks: [footerImageBlock],
+          measures: [{ kind: "paragraph", lines: [], totalHeight: 0 }],
+          height: 0,
+          visualTop: -footerNaturalTop,
+          visualBottom: -footerNaturalTop + 40,
+        },
+      },
+    );
+
+    const image = (pageElement as unknown as FakeElement).querySelector("img");
+
+    expect(image?.parent).toBe(pageElement);
+    expect(image?.style.top).toBe("0px");
+    expect(image?.style.left).toBe("72px");
+    expect(image?.style.zIndex).toBe("0");
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -25,6 +25,17 @@ class FakeElement {
   style: Record<string, string> = {};
   children: FakeElement[] = [];
   parent: FakeElement | undefined;
+  readonly classList = {
+    add: (...classNames: string[]) => {
+      const current = this.className.split(" ").filter(Boolean);
+      for (const className of classNames) {
+        if (!current.includes(className)) {
+          current.push(className);
+        }
+      }
+      this.className = current.join(" ");
+    },
+  };
   private ownText = "";
   readonly tagName: string;
 
@@ -45,14 +56,12 @@ class FakeElement {
 
   append(...children: FakeElement[]): void {
     for (const child of children) {
-      this.appendChild(child);
+      this.addChild(child);
     }
   }
 
   appendChild(child: FakeElement): FakeElement {
-    child.removeFromParent();
-    child.parent = this;
-    this.children.push(child);
+    this.addChild(child);
     return child;
   }
 
@@ -133,10 +142,16 @@ class FakeElement {
       return;
     }
     const index = this.parent.children.indexOf(this);
-    if (index >= 0) {
+    if (index !== -1) {
       this.parent.children.splice(index, 1);
     }
     this.parent = undefined;
+  }
+
+  private addChild(child: FakeElement): void {
+    child.removeFromParent();
+    child.parent = this;
+    this.children.push(child);
   }
 }
 
@@ -409,8 +424,8 @@ describe("header and footer rendering", () => {
       pageElement as unknown as FakeElement,
       "layout-paragraph",
     );
-    const afterParagraph = paragraphs.find((element) =>
-      element.textContent.includes("After box"),
+    const afterParagraph = paragraphs.find(
+      (element) => element.dataset["blockId"] === "hf-after",
     );
 
     expect(afterParagraph?.style.top).toBe("40px");
@@ -441,6 +456,7 @@ describe("header and footer rendering", () => {
       {
         document: fakeDocument,
         footerContent: {
+          rId: "rIdFooter",
           blocks: [footerImageBlock],
           measures: [{ kind: "paragraph", lines: [], totalHeight: 0 }],
           height: 0,
@@ -456,6 +472,8 @@ describe("header and footer rendering", () => {
     expect(image?.style.top).toBe("0px");
     expect(image?.style.left).toBe("72px");
     expect(image?.style.zIndex).toBe("0");
+    expect(image?.dataset["hfSlotKind"]).toBe("footer");
+    expect(image?.dataset["hfRid"]).toBe("rIdFooter");
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -7,6 +7,8 @@ import type {
   ParagraphMeasure,
   TableBlock,
   TableMeasure,
+  TextBoxBlock,
+  TextBoxMeasure,
 } from "../layout-engine/types";
 import type { BlockLookup } from "./index";
 import {
@@ -56,6 +58,22 @@ class FakeElement {
   querySelectorAll(): FakeElement[] {
     return [];
   }
+
+  querySelector(selector: string): FakeElement | null {
+    if (selector.startsWith(".")) {
+      return findByClass(this, selector.slice(1)) ?? null;
+    }
+    if (this.tagName.toLowerCase() === selector.toLowerCase()) {
+      return this;
+    }
+    for (const child of this.children) {
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
 }
 
 const fakeDocument = {
@@ -98,6 +116,21 @@ function findByClass(
   }
 
   return undefined;
+}
+
+function collectByClass(
+  element: FakeElement,
+  className: string,
+): FakeElement[] {
+  const matches = element.className.split(" ").includes(className)
+    ? [element]
+    : [];
+
+  for (const child of element.children) {
+    matches.push(...collectByClass(child, className));
+  }
+
+  return matches;
 }
 
 const page: Page = {
@@ -172,6 +205,10 @@ function headerFooterTextContent(text: string): HeaderFooterContent {
     measures: [measure],
     height: 12,
   };
+}
+
+function textBoxMeasure(width: number, height: number): TextBoxMeasure {
+  return { kind: "textBox", width, height, innerMeasures: [] };
 }
 
 describe("render page fingerprint", () => {
@@ -266,6 +303,53 @@ describe("header and footer rendering", () => {
     expect(pageOptions).toEqual({
       footerContent: headerFooterTextContent("Default footer"),
     });
+  });
+
+  test("keeps top-and-bottom text boxes in header flow", () => {
+    const textBoxBlock: TextBoxBlock = {
+      kind: "textBox",
+      id: "hf-box",
+      width: 160,
+      height: 40,
+      displayMode: "block",
+      wrapType: "topAndBottom",
+      content: [],
+    };
+    const afterBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "hf-after",
+      runs: [{ kind: "text", text: "After box" }],
+    };
+
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        headerContent: {
+          blocks: [textBoxBlock, afterBlock],
+          measures: [
+            textBoxMeasure(textBoxBlock.width, textBoxBlock.height),
+            {
+              kind: "paragraph",
+              lines: [],
+              totalHeight: 12,
+            },
+          ],
+          height: 52,
+        },
+      },
+    );
+
+    const paragraphs = collectByClass(
+      pageElement as unknown as FakeElement,
+      "layout-paragraph",
+    );
+    const afterParagraph = paragraphs.find((element) =>
+      element.textContent.includes("After box"),
+    );
+
+    expect(afterParagraph?.style.top).toBe("40px");
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2297,6 +2297,11 @@ function moveBehindHeaderFooterElementsToPage(
   contentTop: number,
   contentLeft: number,
 ): void {
+  const slotKind = slotEl.className.split(" ").includes(PAGE_CLASS_NAMES.header)
+    ? "header"
+    : "footer";
+  const slotRId = slotEl.dataset["rid"];
+
   // behindDoc images and behind text boxes (full-page letterhead backgrounds)
   // must live on the page element, not inside the clipped HF container. Move
   // them out so they aren't constrained by HF bounds/overflow and so body
@@ -2315,6 +2320,10 @@ function moveBehindHeaderFooterElementsToPage(
     const currentLeft = Number.parseFloat(element.style.left) || 0;
     element.style.top = `${currentTop + contentTop}px`;
     element.style.left = `${currentLeft + contentLeft}px`;
+    if (slotRId) {
+      element.dataset["hfSlotKind"] = slotKind;
+      element.dataset["hfRid"] = slotRId;
+    }
     // Use z-index 0 instead of -1 so the element sits above the page
     // background but below body text content (which remains later in DOM).
     element.style.zIndex = "0";

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2201,7 +2201,7 @@ export function renderPage(
     moveBehindHeaderFooterElementsToPage(
       headerEl,
       pageEl,
-      headerDistance + headerVisualTop,
+      headerDistance,
       page.margins.left,
     );
   }
@@ -2279,7 +2279,7 @@ export function renderPage(
     moveBehindHeaderFooterElementsToPage(
       footerEl,
       pageEl,
-      footerContainerTop,
+      footerNaturalTop,
       page.margins.left,
     );
   }
@@ -2294,13 +2294,15 @@ export function renderPage(
 function moveBehindHeaderFooterElementsToPage(
   slotEl: HTMLElement,
   pageEl: HTMLElement,
-  slotTop: number,
-  slotLeft: number,
+  contentTop: number,
+  contentLeft: number,
 ): void {
   // behindDoc images and behind text boxes (full-page letterhead backgrounds)
   // must live on the page element, not inside the clipped HF container. Move
   // them out so they aren't constrained by HF bounds/overflow and so body
-  // content paints above them.
+  // content paints above them. Descendant positions are relative to the
+  // shifted content wrapper, so add the natural HF flow origin rather than the
+  // outer slot top.
   for (const element of Array.from(
     slotEl.querySelectorAll<HTMLElement>(
       'img[style*="z-index"], .layout-textbox[style*="z-index"]',
@@ -2311,8 +2313,8 @@ function moveBehindHeaderFooterElementsToPage(
     }
     const currentTop = Number.parseFloat(element.style.top) || 0;
     const currentLeft = Number.parseFloat(element.style.left) || 0;
-    element.style.top = `${currentTop + slotTop}px`;
-    element.style.left = `${currentLeft + slotLeft}px`;
+    element.style.top = `${currentTop + contentTop}px`;
+    element.style.left = `${currentLeft + contentLeft}px`;
     // Use z-index 0 instead of -1 so the element sits above the page
     // background but below body text content (which remains later in DOM).
     element.style.zIndex = "0";

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -1269,7 +1269,7 @@ function renderHeaderFooterContent(
     } else if (block.kind === "textBox" && measure.kind === "textBox") {
       // The unified pipeline extracts top-level text boxes inside H/F as
       // their own block. `renderTextBoxFragment` sets `position: absolute`
-      // internally; we only supply top/left so it stacks at cursorY.
+      // internally; we only supply top/left so it anchors at cursorY.
       // Use the *measured* width (not contentWidth): measureBlocks computed
       // `measure.width` and the cached `innerMeasures` against the authored
       // text box width, so passing contentWidth would cause the outer box
@@ -1302,8 +1302,13 @@ function renderHeaderFooterContent(
         block.position?.horizontal,
         layout,
       );
+      if (block.wrapType === "behind") {
+        fragEl.style.zIndex = "-1";
+      }
       containerEl.append(fragEl);
-      cursorY += measure.height;
+      if (!isPositionedHeaderFooterTextBoxBlock(block)) {
+        cursorY += measure.height;
+      }
     }
   }
 
@@ -1355,6 +1360,13 @@ function renderHeaderFooterContent(
   }
 
   return containerEl;
+}
+
+function isPositionedHeaderFooterTextBoxBlock(block: TextBoxBlock): boolean {
+  if (block.displayMode === "block" || block.displayMode === "inline") {
+    return false;
+  }
+  return isFloatingTextBoxBlock(block);
 }
 
 /**
@@ -2186,29 +2198,12 @@ export function renderPage(
     }
     pageEl.append(headerEl);
 
-    // behindDoc images (full-page letterhead backgrounds) must live on the
-    // page element, not inside the clipped header container.  Move them out
-    // so they aren't constrained by the header's bounds/overflow.
-    // Prepend as first child so they paint below the page background layer;
-    // z-index alone doesn't work because the page's own background covers
-    // negative z-index children.
-    for (const img of Array.from(
-      headerEl.querySelectorAll<HTMLImageElement>('img[style*="z-index"]'),
-    )) {
-      if (img.style.zIndex !== "-1") {
-        continue;
-      }
-      // Adjust position: the image's top/left was relative to the header
-      // container origin.  Shift it so it's relative to the page origin.
-      const currentTop = Number.parseFloat(img.style.top) || 0;
-      const currentLeft = Number.parseFloat(img.style.left) || 0;
-      img.style.top = `${currentTop + headerDistance + headerVisualTop}px`;
-      img.style.left = `${currentLeft + page.margins.left}px`;
-      // Use z-index 0 instead of -1 so the image sits above the page
-      // background but below text content (which has higher stacking).
-      img.style.zIndex = "0";
-      pageEl.prepend(img);
-    }
+    moveBehindHeaderFooterElementsToPage(
+      headerEl,
+      pageEl,
+      headerDistance + headerVisualTop,
+      page.margins.left,
+    );
   }
 
   // Render footer area (always rendered for hover hint / double-click target)
@@ -2281,6 +2276,12 @@ export function renderPage(
       footerEl.style.overflow = "hidden";
     }
     pageEl.append(footerEl);
+    moveBehindHeaderFooterElementsToPage(
+      footerEl,
+      pageEl,
+      footerContainerTop,
+      page.margins.left,
+    );
   }
 
   if (pageBorderEl && options.pageBorders?.zOrder !== "back") {
@@ -2288,6 +2289,35 @@ export function renderPage(
   }
 
   return pageEl;
+}
+
+function moveBehindHeaderFooterElementsToPage(
+  slotEl: HTMLElement,
+  pageEl: HTMLElement,
+  slotTop: number,
+  slotLeft: number,
+): void {
+  // behindDoc images and behind text boxes (full-page letterhead backgrounds)
+  // must live on the page element, not inside the clipped HF container. Move
+  // them out so they aren't constrained by HF bounds/overflow and so body
+  // content paints above them.
+  for (const element of Array.from(
+    slotEl.querySelectorAll<HTMLElement>(
+      'img[style*="z-index"], .layout-textbox[style*="z-index"]',
+    ),
+  )) {
+    if (element.style.zIndex !== "-1") {
+      continue;
+    }
+    const currentTop = Number.parseFloat(element.style.top) || 0;
+    const currentLeft = Number.parseFloat(element.style.left) || 0;
+    element.style.top = `${currentTop + slotTop}px`;
+    element.style.left = `${currentLeft + slotLeft}px`;
+    // Use z-index 0 instead of -1 so the element sits above the page
+    // background but below body text content (which remains later in DOM).
+    element.style.zIndex = "0";
+    pageEl.prepend(element);
+  }
 }
 
 /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -47,6 +47,7 @@ import {
 import {
   clickToPositionInHfSlot,
   findHfCaretSpan,
+  findHfPmSpans,
   findHfSlotForTarget,
 } from "../core/layout-bridge/findHfPmSpans";
 import {
@@ -746,13 +747,7 @@ function HfCaretOverlay({
       // enough for single-line and multi-line highlights without doing
       // glyph-level math (Word's selection model is paragraph-line-based
       // — same convention).
-      const slotSelector =
-        selection.kind === "header"
-          ? `.layout-page-header[data-rid="${selection.rId}"]`
-          : `.layout-page-footer[data-rid="${selection.rId}"]`;
-      const spans = pageScope.querySelectorAll<HTMLElement>(
-        `${slotSelector} span[data-pm-start][data-pm-end]`,
-      );
+      const spans = findHfPmSpans(pageScope, selection.kind, selection.rId);
       const rects: { x: number; y: number; width: number; height: number }[] =
         [];
       for (const span of spans) {
@@ -4724,8 +4719,7 @@ export function PagedEditor(
       // When in HF edit mode, clicks outside header/footer area close the HF editor
       if (!readOnly && hfEditMode && onBodyClick) {
         const isInHfArea =
-          target.closest(".layout-page-header") ||
-          target.closest(".layout-page-footer") ||
+          findHfSlotForTarget(target) !== null ||
           target.closest(".hf-inline-editor");
         if (!isInHfArea) {
           e.preventDefault();
@@ -4850,9 +4844,7 @@ export function PagedEditor(
       // In normal mode, clicks in header/footer area should place cursor at
       // start of body content, not inside header/footer (matches Word/Google Docs)
       if (!readOnly && !hfEditMode) {
-        const isInHfArea =
-          target.closest(".layout-page-header") ||
-          target.closest(".layout-page-footer");
+        const isInHfArea = findHfSlotForTarget(target) !== null;
         if (isInHfArea) {
           e.preventDefault();
           // Place cursor at start of body content
@@ -5838,9 +5830,8 @@ export function PagedEditor(
         e.detail === 2 &&
         onHeaderFooterDoubleClick
       ) {
-        const headerEl = target.closest(".layout-page-header");
-        const footerEl = target.closest(".layout-page-footer");
-        if (headerEl || footerEl) {
+        const slot = findHfSlotForTarget(target);
+        if (slot) {
           const pageEl = closestHtmlElement(target, "[data-page-number]");
           const pageNum = pageEl ? Number(pageEl.dataset["pageNumber"]) : 1;
           // Seed the HF caret overlay's page scope so the very first
@@ -5848,18 +5839,10 @@ export function PagedEditor(
           // user double-clicked, not the first painted instance of the
           // shared rId.
           activeHfPageNumberRef.current = pageNum;
-          if (headerEl) {
-            e.preventDefault();
-            e.stopPropagation();
-            onHeaderFooterDoubleClick("header", pageNum);
-            return;
-          }
-          if (footerEl) {
-            e.preventDefault();
-            e.stopPropagation();
-            onHeaderFooterDoubleClick("footer", pageNum);
-            return;
-          }
+          e.preventDefault();
+          e.stopPropagation();
+          onHeaderFooterDoubleClick(slot.kind, pageNum);
+          return;
         }
       }
 


### PR DESCRIPTION
Periodic eigenpal sync. Port of `eigenpal/docx-editor#709` (fixes their #705),
adapted to folio's architecture.

## Problem

A header containing a **page-anchored letterhead** — a floating/anchored text
box, or a non-`behindDoc` anchored image — rendered the whole document **blank**.

`calculateHeaderFooterMarginPushBounds` computes how far the header pushes the
body's top margin down. It's documented as the *flow-only* extent (and already
excluded `behindDoc` images), but it still counted other anchored content. A
full-page letterhead therefore inflated the effective top margin past the page,
and the paginator hit its `panic("page size and margins yield no content area")`
guard — blank render.

## Fix

Restrict the margin-push to genuinely in-flow content, matching Word (anchored
shapes are positioned *on the page* and don't push body text):

- skip floating/anchored text boxes (`isFloatingTextBoxBlock`) — e.g. the
  letterhead box;
- skip anchored image blocks (`anchor.isAnchored`), not just `behindDoc`;
- drop the anchored image-run contribution inside paragraphs (the paragraph's
  measured text height already covers in-flow content).

Anchored objects remain in the **visual** bounds (`calculateHeaderFooterVisualBounds`,
used for rendering and the page-hash invalidation signal) — only the body push
changes. This mirrors upstream's flow-vs-visual split; folio already had the two
functions separated, so the change is contained to the push calculation. Removes
the now-unused `isBehindDocImageRun` helper.

## Tests

`headerFooterLayout.test.ts`:
- a floating text-box letterhead is excluded from the push but stays in the
  visual bounds;
- a non-`behindDoc` anchored image block is excluded from the push;
- anchored image runs in a paragraph don't push.

Existing `behindDoc` and in-flow-content tests still pass. Full folio suite
(1773 tests), `tsc`, oxlint, oxfmt all green.

## Note / possible follow-up

Upstream also adds a clamp so a pathological *in-flow* header degrades to a thin
content band instead of throwing. This PR fixes the actual #705 cause (anchored
content); the clamp is a separate safety net and can be a follow-up if desired.
