### PR TITLE
feat(web): polish the chat home landing (greeting, recent-matters CTA + icon)

### DIFF
--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -438,7 +438,7 @@ function ChatIndex() {
                       size="sm"
                       variant="outline"
                     >
-                      <PlusIcon />
+                      <PlusIcon className="size-4" />
                       {t("workspaces.createNewWorkspace")}
                     </Button>
                   )}

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -19,6 +19,7 @@ import {
   MessageSquareIcon,
   Minimize2Icon,
   PinIcon,
+  PlusIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -31,6 +32,7 @@ import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { StellaMark } from "@/components/stella-mark";
 import Tooltip from "@/components/tooltip";
+import { usePermissions } from "@/hooks/use-permissions";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { ChatAnonymizationLayer } from "@/lib/anonymize/use-chat-anonymization-layer";
@@ -63,6 +65,7 @@ import {
 } from "@/routes/_protected.chat/-queries";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
+import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 
 export const Route = createFileRoute("/_protected/chat/")({
   component: ChatIndex,
@@ -86,6 +89,8 @@ function ChatIndex() {
   const controller = useChatEditor({ threadRef });
   const prompts = useSavedPrompts();
   const pinnedOrder = usePinnedStore((s) => s.pinnedOrder);
+  const canCreateMatter = usePermissions({ workspace: ["create"] });
+  const openCreateMatter = useCreateMatterStore((s) => s.openDialog);
   const activeOrganizationId = protectedRouteApi.useRouteContext({
     select: (ctx) => ctx.user.activeOrganizationId,
   });
@@ -423,7 +428,21 @@ function ChatIndex() {
                 );
               })
             ) : (
-              <LandingEmpty>{t("chat.landing.noMatters")}</LandingEmpty>
+              <LandingEmpty>
+                <div className="flex flex-col items-start gap-2.5">
+                  {t("chat.landing.noMatters")}
+                  {canCreateMatter && (
+                    <Button
+                      onClick={() => openCreateMatter()}
+                      size="sm"
+                      variant="outline"
+                    >
+                      <PlusIcon />
+                      {t("workspaces.createNewWorkspace")}
+                    </Button>
+                  )}
+                </div>
+              </LandingEmpty>
             )}
           </LandingSection>
           <LandingSection

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -339,7 +339,7 @@ function ChatIndex() {
               <StellaMark className="size-7" />
             </div>
             <p className="text-foreground max-w-md text-center text-lg font-medium">
-              {t("chat.greetingSubtitle")}
+              {t("chat.greeting")}
             </p>
           </div>
           <div className="w-full">

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -261,6 +261,7 @@ function ChatIndex() {
     pinnedMatters.length > 0
       ? t("chat.landing.pinnedMatters")
       : t("chat.landing.lastAccessedMatters");
+  const MattersHeadingIcon = pinnedMatters.length > 0 ? PinIcon : LayersIcon;
 
   const recentChats = useMemo(() => {
     const threads: RecentChat[] = [];
@@ -398,7 +399,7 @@ function ChatIndex() {
                 className="text-muted-foreground hover:text-foreground focus-visible:ring-ring flex items-center gap-2 rounded-md px-1 text-xs font-semibold tracking-widest uppercase transition-colors outline-none focus-visible:ring-2"
                 to="/workspaces"
               >
-                <PinIcon className="size-4" />
+                <MattersHeadingIcon className="size-4" />
                 {mattersHeading}
               </Link>
             }


### PR DESCRIPTION
Three small fixes to the chat home landing (`_protected.chat/index.tsx`).

## 1. Clearer hero greeting
The hero showed only "Start with a matter, document, or plain question." — a prose list mixing a container, a file, and an action, which reads as confusing. Surfaces the existing (previously unused) `chat.greeting` ("What do you want to work on?") instead; the input placeholder already explains how to start. No new i18n key.

## 2. Create-matter action in the empty recent-matters state
The recent-matters panel showed only a "No matters yet" placeholder when empty. Adds a **Create new matter** button that opens the existing `CreateMatterDialog` via `useCreateMatterStore().openDialog()` (same action the sidebar "+" uses). Gated by `usePermissions({ workspace: ["create"] })`, mirroring the sidebar. Reuses the existing `workspaces.createNewWorkspace` label — no new i18n key.

## 3. Correct recent-matters heading icon
The panel heading always rendered a pin icon, even when listing last-accessed (not pinned) matters. Now shows the pin only when actually displaying pinned matters; otherwise the layers icon used for matters everywhere else.

All changes confined to the chat home landing. Reuses the design-system `Button`. Verified in-browser.