### PR TITLE
feat(web): add an "Add MCP server" CTA to the empty MCP tools view

### DIFF
--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -270,11 +270,11 @@ export const CatalogueBrowser = ({
     (entry) => entry.isRecommendedForOrg,
   );
   const otherFiltered = filtered.filter((entry) => !entry.isRecommendedForOrg);
-  // On an empty MCP-only view, replace the generic "no entries" + reset
+  const hasMcpEntries = entries.some((entry) => entry.kind === "mcp");
+  // On a truly empty MCP catalogue, replace the generic "no entries" + reset
   // line with a prominent add-MCP call to action. Gated to admins/owners
   // like the add-custom menu, since members can't create connectors.
-  const showMcpEmptyCta =
-    filter === "mcp" && filtered.length === 0 && canAddCustom;
+  const showMcpEmptyCta = filter === "mcp" && !hasMcpEntries && canAddCustom;
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -270,6 +270,11 @@ export const CatalogueBrowser = ({
     (entry) => entry.isRecommendedForOrg,
   );
   const otherFiltered = filtered.filter((entry) => !entry.isRecommendedForOrg);
+  // On an empty MCP-only view, replace the generic "no entries" + reset
+  // line with a prominent add-MCP call to action. Gated to admins/owners
+  // like the add-custom menu, since members can't create connectors.
+  const showMcpEmptyCta =
+    filter === "mcp" && filtered.length === 0 && canAddCustom;
 
   return (
     <div className="flex flex-col gap-6">
@@ -457,10 +462,19 @@ export const CatalogueBrowser = ({
       </div>
 
       <div className="flex flex-col gap-2">
-        {filtered.length === 0 && (
+        {filtered.length === 0 && !showMcpEmptyCta && (
           <p className="text-muted-foreground text-sm">
             {t("catalogue.empty")}
           </p>
+        )}
+        {showMcpEmptyCta && (
+          <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <McpIcon className="text-muted-foreground size-8" />
+            <Button onClick={() => setAddMcpOpen(true)} type="button">
+              <PlusIcon className="size-4" />
+              {t("catalogue.addCustomMcp")}
+            </Button>
+          </div>
         )}
         {recommendedFiltered.length > 0 && (
           <>
@@ -521,7 +535,7 @@ export const CatalogueBrowser = ({
             filter is hiding entries. Always there, regardless of
             whether the filtered subset is empty or partial — the
             user's question is the same: "where's the rest?". */}
-        {entries.length - filtered.length > 0 && (
+        {entries.length - filtered.length > 0 && !showMcpEmptyCta && (
           <div className="flex justify-center pt-2">
             <Button
               onClick={() => {


### PR DESCRIPTION
## What

On the Tools (Nástroje) catalogue, when the **MCP servers** filter is active and nothing matches, the body showed a generic "No entries match the current filter" line plus a centered "Show all (N)" reset. For an empty MCP view, the relevant action isn't "show all the other tools" — it's "add one." This replaces that with a prominent, centered **Add MCP server** call to action.

## How

- New flag `showMcpEmptyCta = filter === "mcp" && filtered.length === 0 && canAddCustom`.
- When set: render a centered MCP icon + **Add MCP server** button that calls `setAddMcpOpen(true)` — the same `AddMcpServerSheet` the "Přidat vlastní" (Add custom) menu opens — and suppress both the generic empty message and the "Show all" reset.
- Gated to admins/owners via the existing `canAddCustom` check (members can't create connectors; matches the add-custom menu).
- Reuses the existing `catalogue.addCustomMcp` label ("Add MCP server" / "Přidat MCP server") — no new i18n key.

Non-MCP empty states (search-with-no-results, skills) are unchanged.

## Verify

Tools page → **MCP servers** tab with no MCP servers installed → centered "Add MCP server" CTA; clicking it opens the add-MCP sheet.