### PR TITLE
feat(ai): single-source the model catalog with an upstream staleness guard

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -73,6 +73,7 @@ jobs:
             pkg:npm/@ai-sdk/provider-utils,
             pkg:npm/@hocuspocus/provider,
             pkg:npm/@hocuspocus/server,
+            pkg:npm/@stll/ai-catalog,
             pkg:npm/@stll/anonymize-chat,
             pkg:npm/@stll/anonymize-wasm,
             pkg:npm/@stll/docx-core,

--- a/.github/workflows/model-catalog-check.yml
+++ b/.github/workflows/model-catalog-check.yml
@@ -1,0 +1,41 @@
+name: Model Catalog Upstream Check
+
+# Providers retire and rename models on their own schedules. This
+# nightly job validates every model ID stella offers (@stll/ai-catalog)
+# against live, public, keyless listings (OpenRouter + models.dev) and
+# fails when an offered model is deprecated or gone upstream — so a
+# retired model surfaces here instead of 400-ing a user at runtime.
+
+on:
+  schedule:
+    # 04:37 UTC daily (off-minute to avoid the :00 stampede)
+    - cron: "37 4 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  model-catalog-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bun ci --ignore-scripts
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Validate offered model IDs against upstream
+        run: bun run check:model-catalog

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,6 +52,7 @@
     "@opentelemetry/api-logs": "^0.218.0",
     "@react-email/render": "^2.0.8",
     "@sinclair/typebox": "^0.34.49",
+    "@stll/ai-catalog": "workspace:*",
     "@stll/anonymize-chat": "workspace:*",
     "@stll/anonymize-data": "catalog:",
     "@stll/anonymize-wasm": "catalog:",

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -1,7 +1,16 @@
+import { APICallError } from "ai";
 import { describe, expect, test } from "bun:test";
 
 import { classifyAIError } from "@/api/lib/ai-error";
 import { ChatLoopDetectedError } from "@/api/lib/errors/tagged-errors";
+
+const apiCallError = (statusCode: number): APICallError =>
+  new APICallError({
+    message: `provider responded ${statusCode}`,
+    url: "https://provider.example/v1/messages",
+    requestBodyValues: {},
+    statusCode,
+  });
 
 describe("classifyAIError", () => {
   test("maps chat loop stops to a stable stream error kind", () => {
@@ -22,5 +31,30 @@ describe("classifyAIError", () => {
     });
 
     expect(classifyAIError(error)).toBe("loop_detected");
+  });
+
+  test("maps a provider 404 to model_unavailable (retired/renamed model)", () => {
+    expect(classifyAIError(apiCallError(404))).toBe("model_unavailable");
+  });
+
+  test("finds a model-not-found 404 through wrapped causes", () => {
+    const error = new Error("generation failed", {
+      cause: apiCallError(404),
+    });
+
+    expect(classifyAIError(error)).toBe("model_unavailable");
+  });
+
+  test("maps the AI SDK NoSuchModelError to model_unavailable", () => {
+    const error = new Error("no such model: gpt-retired");
+    error.name = "AI_NoSuchModelError";
+
+    expect(classifyAIError(error)).toBe("model_unavailable");
+  });
+
+  test("still maps other status codes to their existing kinds", () => {
+    expect(classifyAIError(apiCallError(429))).toBe("quota_exhausted");
+    expect(classifyAIError(apiCallError(402))).toBe("insufficient_credits");
+    expect(classifyAIError(apiCallError(503))).toBe("provider_unavailable");
   });
 });

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -17,12 +17,22 @@ import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
 export const AI_ERROR_KINDS = [
   "quota_exhausted",
   "insufficient_credits",
+  "model_unavailable",
   "provider_unavailable",
   "loop_detected",
   "unknown",
 ] as const;
 
 export type AIErrorKind = (typeof AI_ERROR_KINDS)[number];
+
+// The AI SDK throws `NoSuchModelError` (name "AI_NoSuchModelError")
+// when a provider rejects an unknown model id without an HTTP call;
+// matched structurally so we don't depend on the symbol being exported.
+const isNoSuchModelError = (error: unknown): boolean =>
+  error !== null &&
+  typeof error === "object" &&
+  "name" in error &&
+  error.name === "AI_NoSuchModelError";
 
 export const classifyAIError = (error: unknown): AIErrorKind => {
   if (RetryError.isInstance(error)) {
@@ -31,12 +41,21 @@ export const classifyAIError = (error: unknown): AIErrorKind => {
   if (ChatLoopDetectedError.is(error)) {
     return "loop_detected";
   }
+  if (isNoSuchModelError(error)) {
+    return "model_unavailable";
+  }
   if (APICallError.isInstance(error)) {
     if (error.statusCode === 429) {
       return "quota_exhausted";
     }
     if (error.statusCode === 402) {
       return "insufficient_credits";
+    }
+    // A 404 on a generate/stream call means the provider no longer
+    // serves the configured model (retired or renamed upstream) — a
+    // config problem, not a transient outage, so retrying won't help.
+    if (error.statusCode === 404) {
+      return "model_unavailable";
     }
     if (error.statusCode !== undefined && error.statusCode >= 500) {
       return "provider_unavailable";
@@ -89,6 +108,13 @@ export const aiHandlerError = (
         status: 402,
         message:
           "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+        cause: error,
+      });
+    case "model_unavailable":
+      return new HandlerError({
+        status: 502,
+        message:
+          "The configured AI model is no longer available from the provider. An administrator should update the model in organization settings.",
         cause: error,
       });
     case "provider_unavailable":

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -78,7 +78,7 @@ describe("isAllowedBYOKModel", () => {
     expect(isAllowedBYOKModel("openai", "gpt-5.4")).toBe(true);
     expect(isAllowedBYOKModel("azure_foundry", "customer-gpt-5")).toBe(true);
     expect(isAllowedBYOKModel("huggingface", "customer-model")).toBe(true);
-    expect(isAllowedBYOKModel("openrouter", "anthropic/claude-opus-4.5")).toBe(
+    expect(isAllowedBYOKModel("openrouter", "anthropic/claude-opus-4.8")).toBe(
       true,
     );
   });
@@ -126,7 +126,7 @@ describe("BYOK model overrides", () => {
       ],
       overrideModels: {
         chat: { provider: "google", modelId: "gemini-3.5-flash" },
-        fast: { provider: "google", modelId: "gemini-3.1-flash-lite-preview" },
+        fast: { provider: "google", modelId: "gemini-3.1-flash-lite" },
         reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
         pdf: { provider: "google", modelId: "gemini-3.5-flash" },
       },
@@ -151,7 +151,7 @@ describe("BYOK model overrides", () => {
       ],
       overrideModels: {
         chat: { provider: "google", modelId: "gemini-3.5-flash" },
-        fast: { provider: "google", modelId: "gemini-3.1-flash-lite-preview" },
+        fast: { provider: "google", modelId: "gemini-3.1-flash-lite" },
         reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
         pdf: { provider: "google", modelId: "gemini-3.5-flash" },
       },
@@ -184,7 +184,7 @@ describe("BYOK model overrides", () => {
       ],
       overrideModels: {
         chat: { provider: "google", modelId: "gemini-3.5-flash" },
-        fast: { provider: "google", modelId: "gemini-3.1-flash-lite-preview" },
+        fast: { provider: "google", modelId: "gemini-3.1-flash-lite" },
         reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
         pdf: { provider: "google", modelId: "gemini-3.5-flash" },
       },
@@ -244,15 +244,15 @@ describe("BYOK model overrides", () => {
       overrideModels: {
         pdf: {
           provider: "google",
-          modelId: "gemini-3.1-flash-lite-preview",
+          modelId: "gemini-3.1-flash-lite",
         },
         chat: {
           provider: "google",
-          modelId: "gemini-3.1-flash-lite-preview",
+          modelId: "gemini-3.1-flash-lite",
         },
         fast: {
           provider: "google",
-          modelId: "gemini-3.1-flash-lite-preview",
+          modelId: "gemini-3.1-flash-lite",
         },
         reasoning: {
           provider: "google",
@@ -279,11 +279,11 @@ describe("BYOK model overrides", () => {
       overrideModels: {
         fast: {
           provider: "openrouter",
-          modelId: "google/gemini-3.1-flash-lite-preview",
+          modelId: "google/gemini-3.1-flash-lite",
         },
         chat: {
           provider: "openrouter",
-          modelId: "anthropic/claude-sonnet-4.5",
+          modelId: "anthropic/claude-sonnet-4.6",
         },
         reasoning: {
           provider: "openrouter",
@@ -291,7 +291,7 @@ describe("BYOK model overrides", () => {
         },
         pdf: {
           provider: "openrouter",
-          modelId: "google/gemini-3.1-flash-lite-preview",
+          modelId: "google/gemini-3.1-flash-lite",
         },
       },
     };

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -35,6 +35,14 @@ import { defaultSettingsMiddleware, wrapLanguageModel } from "ai";
 import type { LanguageModel, LanguageModelMiddleware } from "ai";
 import { panic, Result } from "better-result";
 
+import {
+  AI_PROVIDERS,
+  ANTHROPIC_ADAPTIVE_THINKING_MODELS,
+  BYOK_MODEL_OPTIONS,
+  DEFAULT_MODELS,
+} from "@stll/ai-catalog";
+import type { AIProvider, BYOKProvider, ModelRole } from "@stll/ai-catalog";
+
 import { env } from "@/api/env";
 import {
   AZURE_FOUNDRY_DEFAULT_API_VERSION,
@@ -43,143 +51,21 @@ import {
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
-// -- Types ------------------------------------------------------
+// -- Catalog ----------------------------------------------------
 
-/**
- * Logical model roles. Call sites declare *what* they need,
- * not *which* model to use.
- *
- * - fast: classification, extraction, short generation
- * - chat: conversational with tool use and streaming
- * - reasoning: complex multi-step legal analysis
- * - pdf: native PDF/image understanding
- */
-export type ModelRole = "fast" | "chat" | "reasoning" | "pdf";
-
-export const MODEL_ROLES = [
-  "fast",
-  "chat",
-  "reasoning",
-  "pdf",
-] as const satisfies readonly ModelRole[];
-
-export const AI_PROVIDERS = [
-  "google",
-  "openrouter",
-  "openai",
-  "azure_foundry",
-  "anthropic",
-  "mistral",
-  "openai_compatible",
-  "huggingface",
-] as const;
-
-export type AIProvider = (typeof AI_PROVIDERS)[number];
+// Roles, providers, per-role defaults, BYOK options, and the
+// adaptive-thinking set are the single source of truth in
+// @stll/ai-catalog, shared with the BYOK settings UI in apps/web so the
+// picker can never offer a model the API rejects. Re-exported here so
+// existing `@/api/lib/ai-models` consumers keep their imports.
+export { AI_PROVIDERS, BYOK_MODEL_OPTIONS, DEFAULT_MODELS };
+export { MODEL_ROLES } from "@stll/ai-catalog";
+export type { AIProvider, BYOKProvider, ModelRole };
 
 const AI_PROVIDER_VALUES = new Set<string>(AI_PROVIDERS);
 
 const isAIProvider = (value: string): value is AIProvider =>
   AI_PROVIDER_VALUES.has(value);
-
-// -- Default model IDs per provider -----------------------------
-
-export const DEFAULT_MODELS = {
-  google: {
-    fast: "gemini-3.1-flash-lite-preview",
-    chat: "gemini-3.5-flash",
-    reasoning: "gemini-3.1-pro-preview",
-    pdf: "gemini-3.5-flash",
-  },
-  openrouter: {
-    fast: "google/gemini-3.1-flash-lite-preview",
-    chat: "google/gemini-3.5-flash",
-    reasoning: "google/gemini-3.1-pro-preview",
-    pdf: "google/gemini-3.5-flash",
-  },
-  openai: {
-    fast: "gpt-5.4-nano",
-    chat: "gpt-5.4-mini",
-    reasoning: "gpt-5.4",
-    pdf: "gpt-5.4",
-  },
-  azure_foundry: {
-    fast: "gpt-5.4-nano",
-    chat: "gpt-5.4-mini",
-    reasoning: "gpt-5.4",
-    pdf: "gpt-5.4",
-  },
-  anthropic: {
-    fast: "claude-haiku-4-5-20251001",
-    chat: "claude-sonnet-4-6",
-    reasoning: "claude-sonnet-4-6",
-    pdf: "claude-sonnet-4-6",
-  },
-  mistral: {
-    fast: "mistral-small-latest",
-    chat: "mistral-large-latest",
-    reasoning: "magistral-medium-latest",
-    pdf: "mistral-large-latest",
-  },
-  openai_compatible: {
-    fast: "default",
-    chat: "default",
-    reasoning: "default",
-    pdf: "default",
-  },
-  huggingface: {
-    fast: "speakleash/Bielik-1.5B-v3.0-Instruct",
-    chat: "speakleash/Bielik-11B-v2.3-Instruct",
-    reasoning: "speakleash/Bielik-11B-v2.3-Instruct",
-    pdf: "speakleash/Bielik-11B-v2.3-Instruct",
-  },
-} as const satisfies Record<AIProvider, Record<ModelRole, string>>;
-
-/**
- * BYOK-offered model IDs per provider. Server-side allowlist
- * mirroring the picker catalog in
- * apps/web/src/components/ai-config-role-models.logic.ts —
- * keep the two in sync. The frontend list is not a security
- * boundary; this is what the API will accept.
- *
- * Limited to providers BYOK supports (no openai_compatible).
- */
-export const BYOK_MODEL_OPTIONS = {
-  google: [
-    "gemini-3.1-pro-preview",
-    "gemini-3.5-flash",
-    "gemini-3.1-flash-lite-preview",
-  ],
-  anthropic: [
-    "claude-opus-4-7",
-    "claude-sonnet-4-6",
-    "claude-opus-4-6",
-    "claude-haiku-4-5-20251001",
-  ],
-  mistral: [
-    "mistral-medium-3-5",
-    "mistral-large-latest",
-    "mistral-small-latest",
-    "magistral-medium-latest",
-    "magistral-small-latest",
-  ],
-  openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
-  azure_foundry: [],
-  huggingface: [],
-  openrouter: [
-    "google/gemini-3.1-pro-preview",
-    "google/gemini-3.5-flash",
-    "google/gemini-3.1-flash-lite-preview",
-    "anthropic/claude-opus-4.5",
-    "anthropic/claude-sonnet-4.5",
-    "openai/gpt-5.4",
-    "openai/gpt-5.4-mini",
-  ],
-} as const satisfies Record<
-  Exclude<AIProvider, "openai_compatible">,
-  readonly string[]
->;
-
-export type BYOKProvider = keyof typeof BYOK_MODEL_OPTIONS;
 
 const CUSTOM_BYOK_MODEL_PROVIDERS = new Set<BYOKProvider>([
   "azure_foundry",
@@ -1037,12 +923,6 @@ type AnthropicReasoningSettings = Omit<Settings, "temperature"> & {
 
 const ANTHROPIC_LEGACY_THINKING_BUDGET_TOKENS = 10_000;
 
-const ANTHROPIC_ADAPTIVE_THINKING_MODELS = [
-  "claude-sonnet-4-6",
-  "claude-opus-4-6",
-  "claude-opus-4-7",
-] as const;
-
 const supportsAnthropicAdaptiveThinking = (modelId: string): boolean =>
   ANTHROPIC_ADAPTIVE_THINKING_MODELS.some((supportedModelId) =>
     modelId.includes(supportedModelId),
@@ -1061,8 +941,8 @@ const anthropicReasoningDefaults = (
   modelId: string,
 ): AnthropicReasoningSettings => {
   // AI SDK source: adaptive thinking is supported on Claude
-  // sonnet-4-6, opus-4-6, opus-4-7; earlier 4.5 models use the
-  // budget-based `type: "enabled"` form.
+  // sonnet-4-6, opus-4-6, opus-4-7, opus-4-8; earlier 4.5 models
+  // use the budget-based `type: "enabled"` form.
   const anthropicOptions: JSONObject = {
     ...buildAnthropicMetadata(orgId),
     thinking: anthropicThinkingForModel(modelId),

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ESNext"],
     "module": "ESNext",
     "paths": {
+      "@stll/ai-catalog": ["../../packages/ai-catalog/src/index.ts"],
       "@stll/boe": ["../../packages/boe/src/index.ts"],
       "@stll/business-registries": [
         "../../packages/business-registries/src/index.ts"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@libpdf/core": "catalog:",
     "@posthog/react": "^1.9.1",
     "@pydantic/genai-prices": "^0.0.62",
+    "@stll/ai-catalog": "workspace:*",
     "@stll/anonymize-chat": "workspace:*",
     "@stll/anonymize-data": "catalog:",
     "@stll/anonymize-wasm": "catalog:",

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -282,7 +282,7 @@ describe("BYOK provider and model configuration", () => {
   test("encodes OpenRouter model values without breaking model IDs that contain slashes", () => {
     const selection = {
       provider: "openrouter" as const,
-      modelId: "anthropic/claude-opus-4.5",
+      modelId: "anthropic/claude-opus-4.8",
     };
 
     expect(decodeModelSelection(encodeModelSelection(selection))).toEqual(
@@ -424,7 +424,7 @@ describe("BYOK provider and model configuration", () => {
     expect(
       isKnownModelSelection({
         provider: "openrouter",
-        modelId: "anthropic/claude-opus-4.5",
+        modelId: "anthropic/claude-opus-4.8",
       }),
     ).toBe(true);
     expect(

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -1,3 +1,5 @@
+import { BYOK_DEFAULT_MODELS, BYOK_MODEL_OPTIONS } from "@stll/ai-catalog";
+
 export const PROVIDER_KEYS = [
   "google",
   "anthropic",
@@ -95,71 +97,18 @@ export const ENDPOINT_REQUIRED_PROVIDERS = new Set<ProviderValue>([
   "huggingface",
 ]);
 
-export const DEFAULT_MODELS_BY_PROVIDER = {
-  google: {
-    chat: "gemini-3.5-flash",
-    fast: "gemini-3.1-flash-lite-preview",
-    reasoning: "gemini-3.1-pro-preview",
-    pdf: "gemini-3.5-flash",
-  },
-  anthropic: {
-    chat: "claude-sonnet-4-6",
-    fast: "claude-haiku-4-5-20251001",
-    reasoning: "claude-sonnet-4-6",
-    pdf: "claude-sonnet-4-6",
-  },
-  mistral: {
-    chat: "mistral-large-latest",
-    fast: "mistral-small-latest",
-    reasoning: "magistral-medium-latest",
-    pdf: "mistral-large-latest",
-  },
-  openai: {
-    chat: "gpt-5.4-mini",
-    fast: "gpt-5.4-nano",
-    reasoning: "gpt-5.4",
-    pdf: "gpt-5.4",
-  },
-  openrouter: {
-    chat: "google/gemini-3.5-flash",
-    fast: "google/gemini-3.1-flash-lite-preview",
-    reasoning: "google/gemini-3.1-pro-preview",
-    pdf: "google/gemini-3.5-flash",
-  },
-} as const satisfies Partial<Record<ProviderValue, Record<RoleValue, string>>>;
+// Catalog data is the single source of truth in @stll/ai-catalog,
+// shared with the API runtime. The `satisfies` guards also cross-check
+// that the package's provider/role sets still match the UI's
+// ProviderValue/RoleValue — a divergence fails typecheck here.
+export const DEFAULT_MODELS_BY_PROVIDER = BYOK_DEFAULT_MODELS satisfies Partial<
+  Record<ProviderValue, Record<RoleValue, string>>
+>;
 
-export const MODEL_OPTIONS_BY_PROVIDER = {
-  google: [
-    "gemini-3.1-pro-preview",
-    "gemini-3.5-flash",
-    "gemini-3.1-flash-lite-preview",
-  ],
-  anthropic: [
-    "claude-opus-4-7",
-    "claude-sonnet-4-6",
-    "claude-opus-4-6",
-    "claude-haiku-4-5-20251001",
-  ],
-  mistral: [
-    "mistral-medium-3-5",
-    "mistral-large-latest",
-    "mistral-small-latest",
-    "magistral-medium-latest",
-    "magistral-small-latest",
-  ],
-  openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
-  azure_foundry: [],
-  huggingface: [],
-  openrouter: [
-    "google/gemini-3.1-pro-preview",
-    "google/gemini-3.5-flash",
-    "google/gemini-3.1-flash-lite-preview",
-    "anthropic/claude-opus-4.5",
-    "anthropic/claude-sonnet-4.5",
-    "openai/gpt-5.4",
-    "openai/gpt-5.4-mini",
-  ],
-} as const satisfies Record<ProviderValue, readonly string[]>;
+export const MODEL_OPTIONS_BY_PROVIDER = BYOK_MODEL_OPTIONS satisfies Record<
+  ProviderValue,
+  readonly string[]
+>;
 
 export const isProviderValue = (value: string | null): value is ProviderValue =>
   value !== null && PROVIDER_VALUES.has(value);

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -212,6 +212,28 @@ describe("chat thread messages", () => {
     expect(html).not.toContain("provider details must stay hidden");
   });
 
+  test("maps model-unavailable stream errors to admin-facing copy", () => {
+    const html = renderWithProviders(
+      <ChatThreadMessages
+        approvalPendingMessageId={null}
+        error={new Error("model_unavailable")}
+        messages={[]}
+        onAskUserSubmit={() => {}}
+        onCreateDocumentResolve={() => {}}
+        onOpenCreatedDocument={() => {}}
+        onResend={() => {}}
+        showToolCallDetails={false}
+        streamdownComponents={{
+          a: ({ children, ...props }) => <a {...props}>{children}</a>,
+        }}
+      />,
+    );
+
+    expect(html).toContain("The configured AI model is no longer available");
+    expect(html).toContain("Resend");
+    expect(html).not.toContain("model_unavailable");
+  });
+
   test("offers a raw-send override when anonymization blocks an attachment", () => {
     const html = renderWithProviders(
       <ChatThreadMessages

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -244,6 +244,7 @@ const ThinkingIndicator = () => {
 const CHAT_ERROR_TRANSLATION_KEYS = {
   insufficient_credits: "chat.sendErrorInsufficientCredits",
   loop_detected: "chat.sendErrorLoopDetected",
+  model_unavailable: "chat.sendErrorModelUnavailable",
   provider_unavailable: "chat.sendErrorProviderUnavailable",
   quota_exhausted: "chat.sendErrorQuotaExhausted",
 } as const satisfies Record<string, TranslationKey>;

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella nedokázala anonymizovat jednu přílohu, takže se nic neodeslalo. Odeberte soubor, nebo odešlete zprávu bez anonymizace.",
     "sendErrorInsufficientCredits": "AI poskytovatel potřebuje doplnit kredity. Požádejte správce pracovního prostoru o navýšení zůstatku.",
     "sendErrorLoopDetected": "Odpověď AI se příliš opakovala. Zkuste to znovu s užším požadavkem.",
+    "sendErrorModelUnavailable": "Nastavený AI model už není dostupný. Požádejte správce pracovního prostoru, aby model aktualizoval v nastavení organizace.",
     "sendErrorProviderUnavailable": "AI poskytovatel je dočasně nedostupný. Zkuste to prosím za chvíli znovu.",
     "sendErrorQuotaExhausted": "Kvóta AI poskytovatele je vyčerpaná. Zkuste to za chvíli znovu nebo požádejte správce pracovního prostoru o navýšení plánu.",
     "sendPrompt": "Odeslat zprávu",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella konnte einen Anhang nicht anonymisieren, daher wurde nichts gesendet. Entferne die Datei oder sende diese Nachricht ohne Anonymisierung.",
     "sendErrorInsufficientCredits": "Der KI-Provider benötigt mehr Guthaben. Bitte deinen Workspace-Admin, das Konto aufzuladen.",
     "sendErrorLoopDetected": "Die KI-Antwort hat sich zu oft wiederholt. Versuche es mit einer enger gefassten Anfrage erneut.",
+    "sendErrorModelUnavailable": "Das konfigurierte KI-Modell ist nicht mehr verfügbar. Bitte deinen Workspace-Admin, das Modell in den Organisationseinstellungen zu aktualisieren.",
     "sendErrorProviderUnavailable": "Der KI-Provider ist vorübergehend nicht verfügbar. Bitte versuche es gleich noch einmal.",
     "sendErrorQuotaExhausted": "Das Kontingent des KI-Providers ist aufgebraucht. Versuche es gleich noch einmal oder bitte deinen Workspace-Admin, das Paket zu erweitern.",
     "sendPrompt": "Nachricht senden",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella could not anonymize one attachment, so nothing was sent. Remove the file or send this message without anonymization.",
     "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
     "sendErrorLoopDetected": "The AI response repeated too many times. Try again with a narrower request.",
+    "sendErrorModelUnavailable": "The configured AI model is no longer available. Ask your workspace admin to update the model in organization settings.",
     "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
     "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "sendPrompt": "Send message",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella no pudo anonimizar un archivo adjunto, así que no se envió nada. Quita el archivo o envía este mensaje sin anonimización.",
     "sendErrorInsufficientCredits": "El proveedor de IA necesita más créditos. Pídele al administrador del espacio de trabajo que recargue la cuenta.",
     "sendErrorLoopDetected": "La respuesta de IA se repitió demasiadas veces. Inténtalo de nuevo con una solicitud más concreta.",
+    "sendErrorModelUnavailable": "El modelo de IA configurado ya no está disponible. Pídele al administrador del espacio de trabajo que actualice el modelo en la configuración de la organización.",
     "sendErrorProviderUnavailable": "El proveedor de IA no está disponible temporalmente. Inténtalo de nuevo en un momento.",
     "sendErrorQuotaExhausted": "Se ha agotado la cuota del proveedor de IA. Inténtalo de nuevo en un minuto o pídele al administrador del espacio de trabajo que mejore el plan.",
     "sendPrompt": "Enviar mensaje",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella ei saanud üht manust anonüümida, seega midagi ei saadetud. Eemalda fail või saada see sõnum anonüümimiseta.",
     "sendErrorInsufficientCredits": "AI-teenusepakkujal on vaja rohkem krediiti. Palu töökoha administraatoril kontot täiendada.",
     "sendErrorLoopDetected": "AI vastus kordus liiga palju. Proovi uuesti kitsama päringuga.",
+    "sendErrorModelUnavailable": "Seadistatud AI-mudel pole enam saadaval. Palu töökoha administraatoril mudelit organisatsiooni seadetes uuendada.",
     "sendErrorProviderUnavailable": "AI-teenusepakkuja pole hetkel saadaval. Proovi hetke pärast uuesti.",
     "sendErrorQuotaExhausted": "AI-teenusepakkuja kvoot on otsas. Proovi minuti pärast uuesti või palu töökoha administraatoril paketti uuendada.",
     "sendPrompt": "Saada sõnum",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella n’a pas pu anonymiser une pièce jointe, donc rien n’a été envoyé. Retire le fichier ou envoie ce message sans anonymisation.",
     "sendErrorInsufficientCredits": "Le fournisseur d’IA a besoin de crédits supplémentaires. Demande à l’administrateur de l’espace de travail de recharger le compte.",
     "sendErrorLoopDetected": "La réponse de l’IA s’est trop répétée. Réessaie avec une demande plus ciblée.",
+    "sendErrorModelUnavailable": "Le modèle d’IA configuré n’est plus disponible. Demande à l’administrateur de l’espace de travail de le mettre à jour dans les paramètres de l’organisation.",
     "sendErrorProviderUnavailable": "Le fournisseur d’IA est temporairement indisponible. Réessaie dans un instant.",
     "sendErrorQuotaExhausted": "Le quota du fournisseur d’IA est épuisé. Réessaie dans une minute, ou demande à l’administrateur de l’espace de travail de passer à un plan supérieur.",
     "sendPrompt": "Envoyer le message",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "A stella nem tudta anonimizálni az egyik mellékletet, ezért semmi sem lett elküldve. Távolítsd el a fájlt, vagy küldd el az üzenetet anonimizálás nélkül.",
     "sendErrorInsufficientCredits": "Az AI-szolgáltatónak további kreditre van szüksége. Kérd a munkaterület adminisztrátorát, hogy töltse fel a fiókot.",
     "sendErrorLoopDetected": "Az AI-válasz túl sokszor ismétlődött. Próbáld újra szűkebb kéréssel.",
+    "sendErrorModelUnavailable": "A beállított AI-modell már nem érhető el. Kérd a munkaterület adminisztrátorát, hogy frissítse a modellt a szervezet beállításaiban.",
     "sendErrorProviderUnavailable": "Az AI-szolgáltató átmenetileg nem elérhető. Próbáld újra egy pillanat múlva.",
     "sendErrorQuotaExhausted": "Az AI-szolgáltató kvótája kimerült. Próbáld újra egy perc múlva, vagy kérd a munkaterület adminisztrátorát, hogy bővítse a csomagot.",
     "sendPrompt": "Üzenet küldése",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella nepavyko anonimizuoti vieno priedo, todėl niekas nebuvo išsiųsta. Pašalinkite failą arba siųskite šią žinutę be anonimizavimo.",
     "sendErrorInsufficientCredits": "AI teikėjui reikia daugiau kreditų. Paprašykite darbo srities administratoriaus papildyti sąskaitą.",
     "sendErrorLoopDetected": "AI atsakymas kartojosi per daug kartų. Bandykite dar kartą su siauresne užklausa.",
+    "sendErrorModelUnavailable": "Sukonfigūruotas AI modelis nebepasiekiamas. Paprašykite darbo srities administratoriaus atnaujinti modelį organizacijos nustatymuose.",
     "sendErrorProviderUnavailable": "AI teikėjas laikinai nepasiekiamas. Pabandykite po akimirkos dar kartą.",
     "sendErrorQuotaExhausted": "AI teikėjo kvota išnaudota. Pabandykite po minutės dar kartą arba paprašykite darbo srities administratoriaus atnaujinti planą.",
     "sendPrompt": "Siųsti pranešimą",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella nevarēja anonimizēt vienu pielikumu, tāpēc nekas netika nosūtīts. Noņemiet failu vai nosūtiet šo ziņu bez anonimizācijas.",
     "sendErrorInsufficientCredits": "AI pakalpojumu sniedzējam ir vajadzīgi papildu kredīti. Sazinieties ar darba telpas administratoru, lai papildinātu kontu.",
     "sendErrorLoopDetected": "AI atbilde atkārtojās pārāk daudz reižu. Mēģiniet vēlreiz ar šaurāku pieprasījumu.",
+    "sendErrorModelUnavailable": "Konfigurētais AI modelis vairs nav pieejams. Sazinieties ar darba telpas administratoru, lai atjauninātu modeli organizācijas iestatījumos.",
     "sendErrorProviderUnavailable": "AI pakalpojumu sniedzējs uz laiku nav pieejams. Mēģiniet vēlreiz pēc brīža.",
     "sendErrorQuotaExhausted": "AI pakalpojumu sniedzēja kvota ir izsmelta. Mēģiniet vēlreiz pēc minūtes vai sazinieties ar darba telpas administratoru, lai uzlabotu plānu.",
     "sendPrompt": "Sūtīt ziņojumu",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -477,6 +477,7 @@ type Messages = {
     "sendErrorAnonymizationBlocked": "stella could not anonymize one attachment, so nothing was sent. Remove the file or send this message without anonymization.";
     "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.";
     "sendErrorLoopDetected": "The AI response repeated too many times. Try again with a narrower request.";
+    "sendErrorModelUnavailable": "The configured AI model is no longer available. Ask your workspace admin to update the model in organization settings.";
     "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.";
     "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.";
     "sendPrompt": "Send message";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella nie mogła zanonimizować jednego załącznika, więc nic nie wysłano. Usuń plik albo wyślij tę wiadomość bez anonimizacji.",
     "sendErrorInsufficientCredits": "Dostawca AI potrzebuje więcej środków. Poproś administratora obszaru roboczego o doładowanie konta.",
     "sendErrorLoopDetected": "Odpowiedź AI powtórzyła się zbyt wiele razy. Spróbuj ponownie z węższą prośbą.",
+    "sendErrorModelUnavailable": "Skonfigurowany model AI nie jest już dostępny. Poproś administratora obszaru roboczego o zaktualizowanie modelu w ustawieniach organizacji.",
     "sendErrorProviderUnavailable": "Dostawca AI jest tymczasowo niedostępny. Spróbuj ponownie za chwilę.",
     "sendErrorQuotaExhausted": "Limit dostawcy AI został wyczerpany. Spróbuj za chwilę ponownie lub poproś administratora obszaru roboczego o ulepszenie planu.",
     "sendPrompt": "Wyślij wiadomość",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "A stella não conseguiu anonimizar um anexo, então nada foi enviado. Remova o arquivo ou envie esta mensagem sem anonimização.",
     "sendErrorInsufficientCredits": "O provedor de IA precisa de mais créditos. Peça ao administrador do espaço de trabalho para recarregar a conta.",
     "sendErrorLoopDetected": "A resposta da IA se repetiu muitas vezes. Tente novamente com uma solicitação mais específica.",
+    "sendErrorModelUnavailable": "O modelo de IA configurado não está mais disponível. Peça ao administrador do espaço de trabalho para atualizar o modelo nas configurações da organização.",
     "sendErrorProviderUnavailable": "O provedor de IA está temporariamente indisponível. Tente novamente em instantes.",
     "sendErrorQuotaExhausted": "A cota do provedor de IA foi esgotada. Tente novamente em um minuto ou peça ao administrador do espaço de trabalho para atualizar o plano.",
     "sendPrompt": "Enviar mensagem",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -474,6 +474,7 @@
     "sendErrorAnonymizationBlocked": "stella nedokázala anonymizovať jednu prílohu, takže sa nič neodoslalo. Odstráňte súbor alebo odošlite správu bez anonymizácie.",
     "sendErrorInsufficientCredits": "AI poskytovateľ potrebuje doplniť kredity. Požiadajte správcu pracovného priestoru o navýšenie zostatku.",
     "sendErrorLoopDetected": "Odpoveď AI sa príliš opakovala. Skúste to znova s užšou požiadavkou.",
+    "sendErrorModelUnavailable": "Nastavený AI model už nie je dostupný. Požiadajte správcu pracovného priestoru, aby model aktualizoval v nastaveniach organizácie.",
     "sendErrorProviderUnavailable": "AI poskytovateľ je dočasne nedostupný. Skúste to prosím o chvíľu znova.",
     "sendErrorQuotaExhausted": "Kvóta AI poskytovateľa je vyčerpaná. Skúste to o chvíľu znova alebo požiadajte správcu pracovného priestoru o navýšenie plánu.",
     "sendPrompt": "Odoslať správu",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@/api/*": ["../api/src/*"], // this is for eden to work https://elysiajs.com/eden/installation#path-alias-monorepo
+      "@stll/ai-catalog": ["../../packages/ai-catalog/src/index.ts"],
       "@stll/business-registries": [
         "../../packages/business-registries/src/index.ts"
       ],

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "@opentelemetry/api-logs": "^0.218.0",
         "@react-email/render": "^2.0.8",
         "@sinclair/typebox": "^0.34.49",
+        "@stll/ai-catalog": "workspace:*",
         "@stll/anonymize-chat": "workspace:*",
         "@stll/anonymize-data": "catalog:",
         "@stll/anonymize-wasm": "catalog:",
@@ -224,6 +225,7 @@
         "@libpdf/core": "catalog:",
         "@posthog/react": "^1.9.1",
         "@pydantic/genai-prices": "^0.0.62",
+        "@stll/ai-catalog": "workspace:*",
         "@stll/anonymize-chat": "workspace:*",
         "@stll/anonymize-data": "catalog:",
         "@stll/anonymize-wasm": "catalog:",
@@ -312,6 +314,15 @@
         "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "catalog:",
         "unified": "^11.0.5",
+      },
+    },
+    "packages/ai-catalog": {
+      "name": "@stll/ai-catalog",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@stll/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
       },
     },
     "packages/anonymize-chat": {
@@ -510,6 +521,7 @@
         "i18n-typegen": "src/i18n-typegen.ts",
       },
       "dependencies": {
+        "@stll/ai-catalog": "workspace:*",
         "better-result": "catalog:",
       },
       "devDependencies": {
@@ -1627,6 +1639,8 @@
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@stll/aho-corasick-wasm": ["@stll/aho-corasick-wasm@1.0.3", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-wWRiuk7JfmRd2ZWKBUJvJUDz2sVPl5RaimSRMCqe7XMJGhWJajsi2setkZimusfKAXhMGeK6e13NVHNi8x5hjA=="],
+
+    "@stll/ai-catalog": ["@stll/ai-catalog@workspace:packages/ai-catalog"],
 
     "@stll/anonymize-chat": ["@stll/anonymize-chat@workspace:packages/anonymize-chat"],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:ws": "sherif -r unsync-similar-dependencies && bun packages/scripts/src/workspace-hygiene.ts",
     "i18n:check": "turbo run i18n:check --",
     "i18n:sync": "turbo run i18n:sync --",
+    "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
     "test": "turbo run test",
     "db:push": "bun --filter @stll/api db:push",
     "clean": "turbo run clean && git clean -xdf node_modules",

--- a/packages/ai-catalog/package.json
+++ b/packages/ai-catalog/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@stll/ai-catalog",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Canonical AI provider/model catalog — single source of truth shared by the API runtime and the BYOK settings UI",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo node_modules",
+    "test": "bun test src",
+    "typecheck": "tsgo --noEmit",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/ai-catalog",
+    "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/ai-catalog",
+    "format": "oxfmt ."
+  },
+  "devDependencies": {
+    "@stll/typescript-config": "workspace:*",
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AI_PROVIDERS,
+  ANTHROPIC_ADAPTIVE_THINKING_MODELS,
+  BYOK_DEFAULT_MODELS,
+  BYOK_MODEL_OPTIONS,
+  DEFAULT_MODELS,
+  MODEL_ROLES,
+} from "./index";
+
+const CUSTOM_PROVIDERS = new Set(["azure_foundry", "huggingface"]);
+
+describe("DEFAULT_MODELS", () => {
+  test("covers every provider and role", () => {
+    for (const provider of AI_PROVIDERS) {
+      const roles = DEFAULT_MODELS[provider];
+      expect(roles).toBeDefined();
+      for (const role of MODEL_ROLES) {
+        expect(roles[role].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("shares the BYOK defaults verbatim", () => {
+    const byokProviders = [
+      "google",
+      "openrouter",
+      "openai",
+      "anthropic",
+      "mistral",
+    ] as const;
+    for (const provider of byokProviders) {
+      expect(DEFAULT_MODELS[provider]).toEqual(BYOK_DEFAULT_MODELS[provider]);
+    }
+  });
+});
+
+describe("BYOK_MODEL_OPTIONS", () => {
+  test("excludes openai_compatible and lists curated models for cloud providers", () => {
+    expect("openai_compatible" in BYOK_MODEL_OPTIONS).toBe(false);
+    for (const [provider, models] of Object.entries(BYOK_MODEL_OPTIONS)) {
+      if (CUSTOM_PROVIDERS.has(provider)) {
+        expect(models).toHaveLength(0);
+      } else {
+        expect(models.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("anthropic adaptive thinking", () => {
+  // The reasoning role enables adaptive thinking; newer Claude models
+  // reject the legacy budget form, so the reasoning default — and any
+  // offered Claude model selected for reasoning — must be in the
+  // adaptive set or it 400s at call time.
+  const isAdaptive = (modelId: string): boolean =>
+    ANTHROPIC_ADAPTIVE_THINKING_MODELS.some((m) => modelId.includes(m));
+
+  test("the anthropic reasoning default supports adaptive thinking", () => {
+    expect(isAdaptive(DEFAULT_MODELS.anthropic.reasoning)).toBe(true);
+  });
+
+  test("every adaptive model is actually offered to users", () => {
+    for (const model of ANTHROPIC_ADAPTIVE_THINKING_MODELS) {
+      expect(
+        BYOK_MODEL_OPTIONS.anthropic.some((offered) => offered.includes(model)),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -1,0 +1,170 @@
+/**
+ * Canonical AI provider and model catalog.
+ *
+ * Single source of truth for every provider/model identifier stella
+ * offers. Imported by the API runtime (`apps/api/src/lib/ai-models.ts`)
+ * and the BYOK settings UI (`apps/web`), so the picker can never offer
+ * a model the backend rejects, and vice versa.
+ *
+ * Pure data: no provider SDKs, no env access, no side effects. This is
+ * deliberate so scripts (the nightly upstream-validation check) and
+ * both apps can import it cheaply. Keep it that way.
+ *
+ * Model IDs go stale when providers rename or retire models. The
+ * nightly `model-catalog-upstream` check
+ * (`packages/scripts/src/model-catalog-upstream.ts`) validates every
+ * ID here against live provider/aggregator listings so a retired model
+ * fails CI instead of 400-ing a user at runtime.
+ */
+
+/**
+ * Logical model roles. Call sites declare *what* they need, not
+ * *which* model to use.
+ *
+ * - fast: classification, extraction, short generation
+ * - chat: conversational with tool use and streaming
+ * - reasoning: complex multi-step legal analysis
+ * - pdf: native PDF/image understanding
+ */
+export const MODEL_ROLES = ["fast", "chat", "reasoning", "pdf"] as const;
+
+export type ModelRole = (typeof MODEL_ROLES)[number];
+
+export const AI_PROVIDERS = [
+  "google",
+  "openrouter",
+  "openai",
+  "azure_foundry",
+  "anthropic",
+  "mistral",
+  "openai_compatible",
+  "huggingface",
+] as const;
+
+export type AIProvider = (typeof AI_PROVIDERS)[number];
+
+/**
+ * Per-role default model IDs for the BYOK-capable cloud providers.
+ * Shared between the instance default table (`DEFAULT_MODELS`) and the
+ * settings-UI default selection, so a default is defined exactly once.
+ */
+export const BYOK_DEFAULT_MODELS = {
+  google: {
+    fast: "gemini-3.1-flash-lite",
+    chat: "gemini-3.5-flash",
+    reasoning: "gemini-3.1-pro-preview",
+    pdf: "gemini-3.5-flash",
+  },
+  openrouter: {
+    fast: "google/gemini-3.1-flash-lite",
+    chat: "google/gemini-3.5-flash",
+    reasoning: "google/gemini-3.1-pro-preview",
+    pdf: "google/gemini-3.5-flash",
+  },
+  openai: {
+    fast: "gpt-5.4-nano",
+    chat: "gpt-5.4-mini",
+    reasoning: "gpt-5.4",
+    pdf: "gpt-5.4",
+  },
+  anthropic: {
+    fast: "claude-haiku-4-5-20251001",
+    chat: "claude-sonnet-4-6",
+    reasoning: "claude-sonnet-4-6",
+    pdf: "claude-sonnet-4-6",
+  },
+  mistral: {
+    fast: "mistral-small-latest",
+    chat: "mistral-large-latest",
+    reasoning: "magistral-medium-latest",
+    pdf: "mistral-large-latest",
+  },
+} as const satisfies Partial<Record<AIProvider, Record<ModelRole, string>>>;
+
+/**
+ * Instance-level default model IDs per provider. Extends the BYOK
+ * defaults with the providers that only the instance path uses
+ * (custom deployments and OpenAI-compatible endpoints).
+ */
+export const DEFAULT_MODELS = {
+  ...BYOK_DEFAULT_MODELS,
+  azure_foundry: {
+    fast: "gpt-5.4-nano",
+    chat: "gpt-5.4-mini",
+    reasoning: "gpt-5.4",
+    pdf: "gpt-5.4",
+  },
+  openai_compatible: {
+    fast: "default",
+    chat: "default",
+    reasoning: "default",
+    pdf: "default",
+  },
+  huggingface: {
+    fast: "speakleash/Bielik-1.5B-v3.0-Instruct",
+    chat: "speakleash/Bielik-11B-v2.3-Instruct",
+    reasoning: "speakleash/Bielik-11B-v2.3-Instruct",
+    pdf: "speakleash/Bielik-11B-v2.3-Instruct",
+  },
+} as const satisfies Record<AIProvider, Record<ModelRole, string>>;
+
+/**
+ * BYOK-offered model IDs per provider — the curated catalog users pick
+ * from in org settings, and the server-side allowlist the API enforces.
+ * The frontend list is not a security boundary; this is what the API
+ * accepts.
+ *
+ * Limited to providers BYOK supports (no openai_compatible).
+ * `azure_foundry` and `huggingface` take custom deployment IDs, so they
+ * carry no curated list.
+ */
+export const BYOK_MODEL_OPTIONS = {
+  google: [
+    "gemini-3.1-pro-preview",
+    "gemini-3.5-flash",
+    "gemini-3.1-flash-lite",
+  ],
+  anthropic: [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-haiku-4-5-20251001",
+  ],
+  mistral: [
+    "mistral-medium-3-5",
+    "mistral-large-latest",
+    "mistral-small-latest",
+    "magistral-medium-latest",
+  ],
+  openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
+  azure_foundry: [],
+  huggingface: [],
+  openrouter: [
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3.5-flash",
+    "google/gemini-3.1-flash-lite",
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-sonnet-4.6",
+    "openai/gpt-5.5",
+    "openai/gpt-5.4-mini",
+  ],
+} as const satisfies Record<
+  Exclude<AIProvider, "openai_compatible">,
+  readonly string[]
+>;
+
+export type BYOKProvider = keyof typeof BYOK_MODEL_OPTIONS;
+
+/**
+ * Anthropic models that use the adaptive-thinking request shape
+ * (`thinking: { type: "adaptive" }`). Newer Claude models reject the
+ * legacy budget-based form, so every Opus 4.6+/Sonnet 4.6 entry offered
+ * above must appear here or it will 400 on the reasoning role.
+ */
+export const ANTHROPIC_ADAPTIVE_THINKING_MODELS = [
+  "claude-sonnet-4-6",
+  "claude-opus-4-6",
+  "claude-opus-4-7",
+  "claude-opus-4-8",
+] as const;

--- a/packages/ai-catalog/tsconfig.json
+++ b/packages/ai-catalog/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "lib": ["ESNext"],
     "module": "ESNext",
-    "types": ["bun"],
-    "paths": {
-      "@stll/ai-catalog": ["../ai-catalog/src/index.ts"]
-    }
+    "types": ["bun"]
   },
   "include": ["."],
-  "exclude": ["node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -17,6 +17,7 @@
     "format": "oxfmt ."
   },
   "dependencies": {
+    "@stll/ai-catalog": "workspace:*",
     "better-result": "catalog:"
   },
   "devDependencies": {

--- a/packages/scripts/src/model-catalog-upstream.ts
+++ b/packages/scripts/src/model-catalog-upstream.ts
@@ -8,7 +8,7 @@
  * that silent failure into a loud CI failure, using live, public,
  * keyless listings.
  *
- * Two signals, strongest first:
+ * Two signals:
  *  1. Deprecation — models.dev publishes first-party provider catalogs
  *     (google/openai/anthropic/mistral) keyed by the provider-native ID
  *     with a `status: "deprecated"` marker. A deprecated model still
@@ -16,9 +16,9 @@
  *     time to migrate before the hard shutdown. (This is exactly the
  *     `gemini-3.1-flash-lite-preview` case: still listed everywhere,
  *     but marked deprecated.)
- *  2. Existence — IDs not carried as a first-party models.dev key
- *     (OpenRouter slugs, vendor-dated aliases) are checked for mere
- *     presence against OpenRouter's API and the full models.dev set.
+ *  2. Existence — OpenRouter slugs are checked for presence against
+ *     OpenRouter's routing API; future non-first-party providers can
+ *     fall back to the full upstream model set.
  *
  * Aggregators lag on brand-new models, and a model we offer may be
  * deprecated upstream while we still intend to serve it until shutdown.
@@ -32,15 +32,17 @@ import { BYOK_MODEL_OPTIONS, DEFAULT_MODELS } from "@stll/ai-catalog";
 const FETCH_TIMEOUT_MS = 15_000;
 
 /**
- * Known exceptions the check should not fail on, keyed by `canonical()`
- * form. Use for: (a) a model offered ahead of aggregator indexing, or
- * (b) a model deprecated upstream that we deliberately keep serving
- * until its shutdown date. Always leave a dated note; never park an ID
- * to hide a real removal.
+ * Known exceptions the check should not fail on, keyed by provider and
+ * canonical model form. Use for: (a) a model offered ahead of
+ * aggregator indexing, or (b) a model deprecated upstream that we
+ * deliberately keep serving until its shutdown date. Always leave a
+ * dated note; never park an ID to hide a real removal.
  */
-// Seed with canonical() forms, e.g.
-//   ACKNOWLEDGED.add("gpt56nano"); // added 2026-06-05, not yet indexed
-const ACKNOWLEDGED = new Set<string>();
+type AcknowledgementKey = `${string}:${string}`;
+
+// Seed with acknowledgementKey() forms, e.g.
+//   ACKNOWLEDGED.add("openai:gpt56nano"); // added 2026-06-05, not yet indexed
+const ACKNOWLEDGED = new Set<AcknowledgementKey>();
 
 /**
  * Catalog providers whose IDs map 1:1 to a models.dev first-party
@@ -55,10 +57,9 @@ const MODELS_DEV_PROVIDER: Record<string, string> = {
 };
 const FIRST_PARTY_KEYS = new Set(Object.values(MODELS_DEV_PROVIDER));
 
-/** IDs are customer deployment names or server-resolved alias tags; */
+/** IDs are customer deployment names; */
 /** not checkable against a public model list. */
 const CUSTOM_ID_PROVIDERS = new Set(["azure_foundry", "huggingface"]);
-const isAliasTag = (modelId: string): boolean => modelId.endsWith("-latest");
 
 /** Punctuation/case-insensitive form so `claude-opus-4-8`, */
 /** `claude-opus-4.8`, and `anthropic/claude-opus-4.8` all match. */
@@ -69,6 +70,10 @@ const canonical = (modelId: string): string => {
   return slug.toLowerCase().replace(/[.\-_]/gu, "");
 };
 
+/** OpenRouter route form, keeping the provider prefix significant. */
+const canonicalOpenRouterId = (modelId: string): string =>
+  modelId.toLowerCase().replace(/[.\-_]/gu, "");
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
@@ -77,15 +82,33 @@ const isUnknownArray = (value: unknown): value is unknown[] =>
 
 type CatalogEntry = { provider: string; modelId: string };
 
+const acknowledgementKey = ({
+  provider,
+  modelId,
+}: CatalogEntry): AcknowledgementKey => {
+  const id =
+    provider === "openrouter"
+      ? canonicalOpenRouterId(modelId)
+      : canonical(modelId);
+  return `${provider}:${id}`;
+};
+
+/**
+ * Native provider aliases that models.dev does not expose as exact
+ * catalog keys. Example: Mistral's docs use `mistral-medium-3-5`,
+ * while models.dev currently indexes nearby dated Mistral keys. Keep
+ * this provider-scoped, exact, and dated.
+ */
+const FIRST_PARTY_ALIAS_FALLBACK = new Set<AcknowledgementKey>([
+  "mistral:mistralmedium35", // added 2026-06-05; Mistral Medium 3.5 API alias
+]);
+
 const collectCatalogEntries = (): CatalogEntry[] => {
   const entries: CatalogEntry[] = [];
   const seen = new Set<string>();
 
   const add = (provider: string, modelId: string) => {
     if (CUSTOM_ID_PROVIDERS.has(provider) || provider === "openai_compatible") {
-      return;
-    }
-    if (isAliasTag(modelId)) {
       return;
     }
     const key = `${provider}::${modelId}`;
@@ -133,34 +156,42 @@ const fetchJson = async (url: string): Promise<FetchResult> => {
 type Upstream = {
   /** Exact OpenRouter slugs, lowercased. */
   openrouterSlugs: Set<string>;
+  /** canonical() of OpenRouter slugs only. */
+  openrouterCanon: Set<string>;
   /** canonical() of every id seen anywhere (existence fallback). */
   canonAll: Set<string>;
   /** `${provider}:${nativeId}` present in a first-party models.dev catalog. */
   firstPartyPresent: Set<string>;
   /** `${provider}:${nativeId}` marked `status: "deprecated"` upstream. */
   firstPartyDeprecated: Set<string>;
-  /** Whether any source was reachable at all. */
-  reachable: boolean;
+  /** OpenRouter listing was fetched and parsed. */
+  openrouterReachable: boolean;
+  /** models.dev listing was fetched and parsed. */
+  modelsDevReachable: boolean;
 };
 
 const loadUpstream = async (): Promise<Upstream> => {
   const openrouterSlugs = new Set<string>();
+  const openrouterCanon = new Set<string>();
   const canonAll = new Set<string>();
   const firstPartyPresent = new Set<string>();
   const firstPartyDeprecated = new Set<string>();
-  let reachable = false;
+  let openrouterReachable = false;
+  let modelsDevReachable = false;
 
   const openrouter = await fetchJson("https://openrouter.ai/api/v1/models");
   if (openrouter.ok) {
-    reachable = true;
+    openrouterReachable = true;
     const rawData = isObject(openrouter.body)
       ? openrouter.body["data"]
       : undefined;
     const data = isUnknownArray(rawData) ? rawData : [];
     for (const item of data) {
       if (isObject(item) && typeof item["id"] === "string") {
-        openrouterSlugs.add(item["id"].toLowerCase());
-        canonAll.add(canonical(item["id"]));
+        const id = item["id"].toLowerCase();
+        openrouterSlugs.add(id);
+        openrouterCanon.add(canonicalOpenRouterId(id));
+        canonAll.add(canonical(id));
       }
     }
     console.log(`  OpenRouter: ${openrouterSlugs.size} models`);
@@ -170,7 +201,7 @@ const loadUpstream = async (): Promise<Upstream> => {
 
   const modelsDev = await fetchJson("https://models.dev/api.json");
   if (modelsDev.ok && isObject(modelsDev.body)) {
-    reachable = true;
+    modelsDevReachable = true;
     let count = 0;
     for (const [providerKey, providerVal] of Object.entries(modelsDev.body)) {
       if (!isObject(providerVal) || !isObject(providerVal["models"])) {
@@ -197,17 +228,20 @@ const loadUpstream = async (): Promise<Upstream> => {
 
   return {
     openrouterSlugs,
+    openrouterCanon,
     canonAll,
     firstPartyPresent,
     firstPartyDeprecated,
-    reachable,
+    openrouterReachable,
+    modelsDevReachable,
   };
 };
 
 type Verdict =
   | { kind: "ok" }
   | { kind: "deprecated"; detail: string }
-  | { kind: "missing"; detail: string };
+  | { kind: "missing"; detail: string }
+  | { kind: "unverified"; detail: string };
 
 const classify = (entry: CatalogEntry, upstream: Upstream): Verdict => {
   const { provider, modelId } = entry;
@@ -215,9 +249,12 @@ const classify = (entry: CatalogEntry, upstream: Upstream): Verdict => {
   // OpenRouter slugs: OpenRouter's own API is authoritative for what it
   // still routes (it drops dead routes). Exact match, canonical fallback.
   if (provider === "openrouter") {
+    if (!upstream.openrouterReachable) {
+      return { kind: "unverified", detail: "OpenRouter listing unreachable" };
+    }
     if (
       upstream.openrouterSlugs.has(modelId.toLowerCase()) ||
-      upstream.canonAll.has(canonical(modelId))
+      upstream.openrouterCanon.has(canonicalOpenRouterId(modelId))
     ) {
       return { kind: "ok" };
     }
@@ -228,6 +265,9 @@ const classify = (entry: CatalogEntry, upstream: Upstream): Verdict => {
   // authoritative `status` field.
   const mdProvider = MODELS_DEV_PROVIDER[provider];
   if (mdProvider !== undefined) {
+    if (!upstream.modelsDevReachable) {
+      return { kind: "unverified", detail: "models.dev listing unreachable" };
+    }
     const key = `${mdProvider}:${modelId}`;
     if (upstream.firstPartyDeprecated.has(key)) {
       return { kind: "deprecated", detail: "models.dev status=deprecated" };
@@ -235,10 +275,20 @@ const classify = (entry: CatalogEntry, upstream: Upstream): Verdict => {
     if (upstream.firstPartyPresent.has(key)) {
       return { kind: "ok" };
     }
+    if (
+      FIRST_PARTY_ALIAS_FALLBACK.has(acknowledgementKey(entry)) &&
+      upstream.canonAll.has(canonical(modelId))
+    ) {
+      return { kind: "ok" };
+    }
+    return {
+      kind: "missing",
+      detail: "absent from models.dev first-party catalog",
+    };
   }
 
-  // Not a first-party key (vendor-dated alias like mistral-medium-3-5,
-  // or models.dev simply doesn't carry it): fall back to existence.
+  // Future non-first-party providers can fall back to existence in any
+  // reachable upstream listing.
   if (upstream.canonAll.has(canonical(modelId))) {
     return { kind: "ok" };
   }
@@ -249,28 +299,24 @@ const main = async (): Promise<void> => {
   console.log("Validating offered model IDs against upstream listings…");
   const upstream = await loadUpstream();
 
-  if (!upstream.reachable) {
-    // Every source down: a network problem, not a model removal. Don't
-    // cry wolf — pass with a warning.
-    console.warn(
-      "\n⚠ No upstream source reachable; skipping validation this run.",
-    );
-    return;
-  }
-
   const entries = collectCatalogEntries();
   const failures: { entry: CatalogEntry; verdict: Verdict }[] = [];
+  const unverified: { entry: CatalogEntry; verdict: Verdict }[] = [];
 
   for (const entry of entries) {
     const verdict = classify(entry, upstream);
     if (verdict.kind === "ok") {
       continue;
     }
+    if (verdict.kind === "unverified") {
+      unverified.push({ entry, verdict });
+      continue;
+    }
     // ACKNOWLEDGED is intentionally empty by default — it's the
-    // seam maintainers fill to park a known new/deprecated model, so an
+    // set maintainers use to park a known new/deprecated model, so an
     // empty default is correct, not dead code.
     // eslint-disable-next-line sonarjs/no-empty-collection
-    if (ACKNOWLEDGED.has(canonical(entry.modelId))) {
+    if (ACKNOWLEDGED.has(acknowledgementKey(entry))) {
       console.log(
         `  · acknowledged ${verdict.kind} ${entry.provider} / ${entry.modelId}`,
       );
@@ -280,6 +326,25 @@ const main = async (): Promise<void> => {
   }
 
   console.log(`\nChecked ${entries.length} offered model IDs.`);
+
+  if (unverified.length > 0) {
+    console.warn(
+      `\n⚠ Skipped ${unverified.length} offered model ID(s) because an upstream source was unavailable:`,
+    );
+    for (const { entry, verdict } of unverified) {
+      const detail = "detail" in verdict ? ` — ${verdict.detail}` : "";
+      console.warn(
+        `  ⚠ [UNVERIFIED] ${entry.provider} / ${entry.modelId}${detail}`,
+      );
+    }
+  }
+
+  if (entries.length > 0 && unverified.length === entries.length) {
+    console.error(
+      "\n✗ No offered model IDs were verified because every authoritative source was unavailable.",
+    );
+    process.exit(1);
+  }
 
   if (failures.length > 0) {
     console.error(`\n✗ ${failures.length} offered model ID(s) need attention:`);
@@ -293,9 +358,16 @@ const main = async (): Promise<void> => {
     console.error(
       "\nResolve by updating @stll/ai-catalog (migrate off the model), or,\n" +
         "if the model is real and we deliberately keep serving it, add its\n" +
-        "canonical() form to ACKNOWLEDGED in this script with a dated note.",
+        "provider-scoped acknowledgementKey() form to ACKNOWLEDGED with a dated note.",
     );
     process.exit(1);
+  }
+
+  if (unverified.length > 0) {
+    console.log(
+      "\n✓ Verified all model IDs whose authoritative source was reachable.",
+    );
+    return;
   }
 
   console.log("\n✓ All offered model IDs are present and current upstream.");

--- a/packages/scripts/src/model-catalog-upstream.ts
+++ b/packages/scripts/src/model-catalog-upstream.ts
@@ -1,0 +1,304 @@
+/**
+ * Nightly validation: every model ID stella offers must still exist —
+ * and not be deprecated — upstream.
+ *
+ * Providers retire and rename models on their own schedules. When a
+ * model in `@stll/ai-catalog` is shut down, a user's request 400s at
+ * runtime and nobody finds out until they complain. This check turns
+ * that silent failure into a loud CI failure, using live, public,
+ * keyless listings.
+ *
+ * Two signals, strongest first:
+ *  1. Deprecation — models.dev publishes first-party provider catalogs
+ *     (google/openai/anthropic/mistral) keyed by the provider-native ID
+ *     with a `status: "deprecated"` marker. A deprecated model still
+ *     answers for now but is on its way out; flagging it gives us lead
+ *     time to migrate before the hard shutdown. (This is exactly the
+ *     `gemini-3.1-flash-lite-preview` case: still listed everywhere,
+ *     but marked deprecated.)
+ *  2. Existence — IDs not carried as a first-party models.dev key
+ *     (OpenRouter slugs, vendor-dated aliases) are checked for mere
+ *     presence against OpenRouter's API and the full models.dev set.
+ *
+ * Aggregators lag on brand-new models, and a model we offer may be
+ * deprecated upstream while we still intend to serve it until shutdown.
+ * Either case is parked in ACKNOWLEDGED (with a dated note) so the
+ * check stays green until the real removal — which it then catches.
+ *
+ * Usage: bun packages/scripts/src/model-catalog-upstream.ts
+ */
+import { BYOK_MODEL_OPTIONS, DEFAULT_MODELS } from "@stll/ai-catalog";
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Known exceptions the check should not fail on, keyed by `canonical()`
+ * form. Use for: (a) a model offered ahead of aggregator indexing, or
+ * (b) a model deprecated upstream that we deliberately keep serving
+ * until its shutdown date. Always leave a dated note; never park an ID
+ * to hide a real removal.
+ */
+// Seed with canonical() forms, e.g.
+//   ACKNOWLEDGED.add("gpt56nano"); // added 2026-06-05, not yet indexed
+const ACKNOWLEDGED = new Set<string>();
+
+/**
+ * Catalog providers whose IDs map 1:1 to a models.dev first-party
+ * catalog (same key, same native ID), so we can read its authoritative
+ * `status` field. The values are also the models.dev provider keys.
+ */
+const MODELS_DEV_PROVIDER: Record<string, string> = {
+  google: "google",
+  openai: "openai",
+  anthropic: "anthropic",
+  mistral: "mistral",
+};
+const FIRST_PARTY_KEYS = new Set(Object.values(MODELS_DEV_PROVIDER));
+
+/** IDs are customer deployment names or server-resolved alias tags; */
+/** not checkable against a public model list. */
+const CUSTOM_ID_PROVIDERS = new Set(["azure_foundry", "huggingface"]);
+const isAliasTag = (modelId: string): boolean => modelId.endsWith("-latest");
+
+/** Punctuation/case-insensitive form so `claude-opus-4-8`, */
+/** `claude-opus-4.8`, and `anthropic/claude-opus-4.8` all match. */
+const canonical = (modelId: string): string => {
+  const slug = modelId.includes("/")
+    ? (modelId.split("/").at(-1) ?? modelId)
+    : modelId;
+  return slug.toLowerCase().replace(/[.\-_]/gu, "");
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isUnknownArray = (value: unknown): value is unknown[] =>
+  Array.isArray(value);
+
+type CatalogEntry = { provider: string; modelId: string };
+
+const collectCatalogEntries = (): CatalogEntry[] => {
+  const entries: CatalogEntry[] = [];
+  const seen = new Set<string>();
+
+  const add = (provider: string, modelId: string) => {
+    if (CUSTOM_ID_PROVIDERS.has(provider) || provider === "openai_compatible") {
+      return;
+    }
+    if (isAliasTag(modelId)) {
+      return;
+    }
+    const key = `${provider}::${modelId}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    entries.push({ provider, modelId });
+  };
+
+  for (const [provider, models] of Object.entries(BYOK_MODEL_OPTIONS)) {
+    for (const modelId of models) {
+      add(provider, modelId);
+    }
+  }
+  for (const [provider, roles] of Object.entries(DEFAULT_MODELS)) {
+    for (const modelId of Object.values(roles)) {
+      add(provider, modelId);
+    }
+  }
+
+  return entries;
+};
+
+const asMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+type FetchResult = { ok: true; body: unknown } | { ok: false; reason: string };
+
+const fetchJson = async (url: string): Promise<FetchResult> => {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) {
+      return { ok: false, reason: `responded ${response.status}` };
+    }
+    return { ok: true, body: await response.json() };
+  } catch (error) {
+    return { ok: false, reason: asMessage(error) };
+  }
+};
+
+type Upstream = {
+  /** Exact OpenRouter slugs, lowercased. */
+  openrouterSlugs: Set<string>;
+  /** canonical() of every id seen anywhere (existence fallback). */
+  canonAll: Set<string>;
+  /** `${provider}:${nativeId}` present in a first-party models.dev catalog. */
+  firstPartyPresent: Set<string>;
+  /** `${provider}:${nativeId}` marked `status: "deprecated"` upstream. */
+  firstPartyDeprecated: Set<string>;
+  /** Whether any source was reachable at all. */
+  reachable: boolean;
+};
+
+const loadUpstream = async (): Promise<Upstream> => {
+  const openrouterSlugs = new Set<string>();
+  const canonAll = new Set<string>();
+  const firstPartyPresent = new Set<string>();
+  const firstPartyDeprecated = new Set<string>();
+  let reachable = false;
+
+  const openrouter = await fetchJson("https://openrouter.ai/api/v1/models");
+  if (openrouter.ok) {
+    reachable = true;
+    const rawData = isObject(openrouter.body)
+      ? openrouter.body["data"]
+      : undefined;
+    const data = isUnknownArray(rawData) ? rawData : [];
+    for (const item of data) {
+      if (isObject(item) && typeof item["id"] === "string") {
+        openrouterSlugs.add(item["id"].toLowerCase());
+        canonAll.add(canonical(item["id"]));
+      }
+    }
+    console.log(`  OpenRouter: ${openrouterSlugs.size} models`);
+  } else {
+    console.warn(`  OpenRouter: unreachable (${openrouter.reason})`);
+  }
+
+  const modelsDev = await fetchJson("https://models.dev/api.json");
+  if (modelsDev.ok && isObject(modelsDev.body)) {
+    reachable = true;
+    let count = 0;
+    for (const [providerKey, providerVal] of Object.entries(modelsDev.body)) {
+      if (!isObject(providerVal) || !isObject(providerVal["models"])) {
+        continue;
+      }
+      const isFirstParty = FIRST_PARTY_KEYS.has(providerKey);
+      for (const [modelId, modelVal] of Object.entries(providerVal["models"])) {
+        canonAll.add(canonical(modelId));
+        count += 1;
+        if (!isFirstParty) {
+          continue;
+        }
+        const key = `${providerKey}:${modelId}`;
+        firstPartyPresent.add(key);
+        if (isObject(modelVal) && modelVal["status"] === "deprecated") {
+          firstPartyDeprecated.add(key);
+        }
+      }
+    }
+    console.log(`  models.dev: ${count} models`);
+  } else if (!modelsDev.ok) {
+    console.warn(`  models.dev: unreachable (${modelsDev.reason})`);
+  }
+
+  return {
+    openrouterSlugs,
+    canonAll,
+    firstPartyPresent,
+    firstPartyDeprecated,
+    reachable,
+  };
+};
+
+type Verdict =
+  | { kind: "ok" }
+  | { kind: "deprecated"; detail: string }
+  | { kind: "missing"; detail: string };
+
+const classify = (entry: CatalogEntry, upstream: Upstream): Verdict => {
+  const { provider, modelId } = entry;
+
+  // OpenRouter slugs: OpenRouter's own API is authoritative for what it
+  // still routes (it drops dead routes). Exact match, canonical fallback.
+  if (provider === "openrouter") {
+    if (
+      upstream.openrouterSlugs.has(modelId.toLowerCase()) ||
+      upstream.canonAll.has(canonical(modelId))
+    ) {
+      return { kind: "ok" };
+    }
+    return { kind: "missing", detail: "not routed by OpenRouter" };
+  }
+
+  // Native providers with a first-party models.dev catalog: read the
+  // authoritative `status` field.
+  const mdProvider = MODELS_DEV_PROVIDER[provider];
+  if (mdProvider !== undefined) {
+    const key = `${mdProvider}:${modelId}`;
+    if (upstream.firstPartyDeprecated.has(key)) {
+      return { kind: "deprecated", detail: "models.dev status=deprecated" };
+    }
+    if (upstream.firstPartyPresent.has(key)) {
+      return { kind: "ok" };
+    }
+  }
+
+  // Not a first-party key (vendor-dated alias like mistral-medium-3-5,
+  // or models.dev simply doesn't carry it): fall back to existence.
+  if (upstream.canonAll.has(canonical(modelId))) {
+    return { kind: "ok" };
+  }
+  return { kind: "missing", detail: "absent from every upstream listing" };
+};
+
+const main = async (): Promise<void> => {
+  console.log("Validating offered model IDs against upstream listings…");
+  const upstream = await loadUpstream();
+
+  if (!upstream.reachable) {
+    // Every source down: a network problem, not a model removal. Don't
+    // cry wolf — pass with a warning.
+    console.warn(
+      "\n⚠ No upstream source reachable; skipping validation this run.",
+    );
+    return;
+  }
+
+  const entries = collectCatalogEntries();
+  const failures: { entry: CatalogEntry; verdict: Verdict }[] = [];
+
+  for (const entry of entries) {
+    const verdict = classify(entry, upstream);
+    if (verdict.kind === "ok") {
+      continue;
+    }
+    // ACKNOWLEDGED is intentionally empty by default — it's the
+    // seam maintainers fill to park a known new/deprecated model, so an
+    // empty default is correct, not dead code.
+    // eslint-disable-next-line sonarjs/no-empty-collection
+    if (ACKNOWLEDGED.has(canonical(entry.modelId))) {
+      console.log(
+        `  · acknowledged ${verdict.kind} ${entry.provider} / ${entry.modelId}`,
+      );
+      continue;
+    }
+    failures.push({ entry, verdict });
+  }
+
+  console.log(`\nChecked ${entries.length} offered model IDs.`);
+
+  if (failures.length > 0) {
+    console.error(`\n✗ ${failures.length} offered model ID(s) need attention:`);
+    for (const { entry, verdict } of failures) {
+      const label = verdict.kind === "deprecated" ? "DEPRECATED" : "MISSING";
+      const detail = "detail" in verdict ? ` — ${verdict.detail}` : "";
+      console.error(
+        `  ✗ [${label}] ${entry.provider} / ${entry.modelId}${detail}`,
+      );
+    }
+    console.error(
+      "\nResolve by updating @stll/ai-catalog (migrate off the model), or,\n" +
+        "if the model is real and we deliberately keep serving it, add its\n" +
+        "canonical() form to ACKNOWLEDGED in this script with a dated note.",
+    );
+    process.exit(1);
+  }
+
+  console.log("\n✓ All offered model IDs are present and current upstream.");
+};
+
+await main();


### PR DESCRIPTION
## What

- **Single source of truth.** The AI provider/model catalog moves into a new pure-data package `@stll/ai-catalog`, imported by both the API runtime (`apps/api/src/lib/ai-models.ts`) and the BYOK settings UI (`apps/web/.../ai-config-role-models.logic.ts`). The picker can no longer offer a model the API rejects; the web `satisfies` guards cross-check the provider/role sets at typecheck time.
- **Refreshed offered models** to current provider IDs (Anthropic Opus 4.8, OpenAI GPT-5.5, Google `gemini-3.1-flash-lite` GA, OpenRouter slug updates; dropped a retired Mistral alias). One of these (`gemini-3.1-flash-lite-preview`) was a retired ID still wired as the `fast`-role default.
- **Nightly staleness guard.** `packages/scripts/src/model-catalog-upstream.ts` (`bun run check:model-catalog`, plus a nightly workflow) validates every offered ID against public, keyless listings (OpenRouter API + models.dev) and fails when a model is **deprecated** (via models.dev's `status` field, since aggregators retain removed entries) or absent upstream.
- **Runtime degradation.** A provider 404 / `NoSuchModelError` now classifies as a distinct `model_unavailable` kind with an actionable message instead of an opaque 500.

## Notes for review

- `@stll/ai-catalog` is pure data (no SDKs, no env, no side effects) so scripts and both apps import it cheaply.
- The nightly check parks not-yet-indexed IDs in an `ACKNOWLEDGED` set; a stronger keyed `/v1/models` check is a possible follow-up.