### PR TITLE
fix(web): align inspector rail background with sidebar token

### DIFF
--- a/apps/web/src/components/inspector-side-panel.tsx
+++ b/apps/web/src/components/inspector-side-panel.tsx
@@ -8,8 +8,8 @@ import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
 import { useInspectorStore } from "@/components/inspector/inspector-store";
 import type { InspectorTab } from "@/components/inspector/inspector-store";
 import {
+  SIDE_RAIL_CONTAINER_CLASS,
   SIDE_RAIL_ICON_BUTTON_SIZE,
-  SIDE_RAIL_WIDTH,
   TOOLBAR_ROW_HEIGHT,
 } from "@/lib/consts";
 
@@ -27,9 +27,7 @@ const LazyInspectorPanel = lazy(
 // real panel mounts.
 const InspectorRailFallback = () => (
   <div className="bg-background flex h-full border-s shadow-lg">
-    <div
-      className={`bg-muted/50 flex shrink-0 flex-col border-e ${SIDE_RAIL_WIDTH}`}
-    >
+    <div className={SIDE_RAIL_CONTAINER_CLASS}>
       <div
         aria-hidden="true"
         className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-b ${TOOLBAR_ROW_HEIGHT}`}

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -31,8 +31,8 @@ import { useTabContextMenu } from "@/components/inspector/use-tab-context-menu";
 import { getInspectorView } from "@/components/inspector/view-registry";
 import Tooltip from "@/components/tooltip";
 import {
+  SIDE_RAIL_CONTAINER_CLASS,
   SIDE_RAIL_ICON_BUTTON_SIZE,
-  SIDE_RAIL_WIDTH,
   TOOLBAR_ROW_HEIGHT,
 } from "@/lib/consts";
 import { resolveMatterColor } from "@/lib/matter-colors";
@@ -80,12 +80,7 @@ export const InspectorRail = ({
   };
 
   return (
-    <div
-      className={cn(
-        "bg-muted/50 flex shrink-0 flex-col border-e",
-        SIDE_RAIL_WIDTH,
-      )}
-    >
+    <div className={SIDE_RAIL_CONTAINER_CLASS}>
       <div
         className={cn(
           "flex w-full shrink-0 items-center justify-center border-b",

--- a/apps/web/src/lib/consts.ts
+++ b/apps/web/src/lib/consts.ts
@@ -14,6 +14,11 @@ export const TOOLBAR_ROW_HEIGHT = "h-12" as const;
 export const TOOLBAR_ROW_MIN_HEIGHT = "min-h-12" as const;
 export const TOOLBAR_ROW_HEIGHT_PX = 48 as const;
 export const SIDE_RAIL_WIDTH = "w-12" as const;
+/** Outer container classes for the inspector icon rail. The lazy-load
+ * fallback rail must stay pixel-identical to the real rail, so both
+ * read this single source instead of repeating the string. */
+export const SIDE_RAIL_CONTAINER_CLASS =
+  `bg-sidebar flex shrink-0 flex-col border-e ${SIDE_RAIL_WIDTH}` as const;
 export const SIDE_RAIL_ICON_BUTTON_SIZE = "size-8" as const;
 /** Glyph size inside a rail tab button — matches the `size-3.5`
  * class every built-in rail icon uses. Numeric form is for


### PR DESCRIPTION
The inspector icon rail used `bg-muted/50` while the left menu uses `bg-sidebar`, so the two read as different greys in dark mode.

This points both the real rail and the lazy-load fallback rail at a shared `SIDE_RAIL_CONTAINER_CLASS` constant on `bg-sidebar`, so they stay matched across every theme and cannot drift apart.

The panel body keeps `bg-background` (a content surface for PDFs, chat, and metadata); only the icon strip is unified with the left menu chrome.