### PR TITLE
feat(mcp): enrich custom connector detail and smooth add-server input

### DIFF
--- a/apps/api/drizzle/20260605150000_mcp_connector_server_metadata/migration.sql
+++ b/apps/api/drizzle/20260605150000_mcp_connector_server_metadata/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "mcp_connectors"
+  ADD COLUMN "server_version" text;
+
+ALTER TABLE "mcp_connectors"
+  ADD COLUMN "instructions" text;
+
+ALTER TABLE "mcp_connectors"
+  ADD COLUMN "oauth_issuer" text;

--- a/apps/api/drizzle/20260605150000_mcp_connector_server_metadata/migration.sql
+++ b/apps/api/drizzle/20260605150000_mcp_connector_server_metadata/migration.sql
@@ -1,8 +1,8 @@
 ALTER TABLE "mcp_connectors"
+  ADD COLUMN "oauth_issuer" text;
+
+ALTER TABLE "mcp_user_connections"
   ADD COLUMN "server_version" text;
 
-ALTER TABLE "mcp_connectors"
+ALTER TABLE "mcp_user_connections"
   ADD COLUMN "instructions" text;
-
-ALTER TABLE "mcp_connectors"
-  ADD COLUMN "oauth_issuer" text;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -3003,6 +3003,14 @@ export const mcpConnectors = p.pgTable(
     documentationUrl: p.text("documentation_url"),
     tokenHelpUrl: p.text("token_help_url"),
     iconUrl: p.text("icon_url"),
+    // Metadata the server itself reports during the MCP `initialize`
+    // handshake. Captured when we open an authenticated client; null
+    // until the first successful connect.
+    serverVersion: p.text("server_version"),
+    instructions: p.text(),
+    // OAuth authorization-server issuer, captured at create time for
+    // oauth2 connectors. Surfaced as the connector's vendor.
+    oauthIssuer: p.text("oauth_issuer"),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p
       .timestamp("updated_at")

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -3003,13 +3003,9 @@ export const mcpConnectors = p.pgTable(
     documentationUrl: p.text("documentation_url"),
     tokenHelpUrl: p.text("token_help_url"),
     iconUrl: p.text("icon_url"),
-    // Metadata the server itself reports during the MCP `initialize`
-    // handshake. Captured when we open an authenticated client; null
-    // until the first successful connect.
-    serverVersion: p.text("server_version"),
-    instructions: p.text(),
     // OAuth authorization-server issuer, captured at create time for
-    // oauth2 connectors. Surfaced as the connector's vendor.
+    // oauth2 connectors. Surfaced as the connector's vendor. Server-level
+    // and identical for every member, so it lives on the shared row.
     oauthIssuer: p.text("oauth_issuer"),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p
@@ -3111,6 +3107,11 @@ export const mcpUserConnections = p.pgTable(
     cachedTools:
       jsonb("cached_tools").$type<CachedMcpToolDefinition[] | null>(),
     cachedToolsRefreshedAt: p.timestamp("cached_tools_refreshed_at"),
+    // Metadata the server reports during the MCP `initialize` handshake,
+    // captured with this user's credentials. Stored per-connection (not on
+    // the shared connector) since a server may personalise it per account.
+    serverVersion: p.text("server_version"),
+    instructions: p.text(),
     status: p
       .text("status", { enum: MCP_CONNECTION_STATUSES })
       .notNull()

--- a/apps/api/src/handlers/catalogue/list-catalogue.ts
+++ b/apps/api/src/handlers/catalogue/list-catalogue.ts
@@ -9,7 +9,11 @@ import {
   type LoadedCatalogueEntry,
 } from "@stll/catalogue";
 
-import { agentSkills, mcpConnectors } from "@/api/db/schema";
+import {
+  agentSkills,
+  mcpConnectors,
+  mcpUserConnections,
+} from "@/api/db/schema";
 import {
   computeCatalogueInstallState,
   type CatalogueInstallState,
@@ -212,11 +216,21 @@ const listCatalogue = createSafeRootHandler(
             documentationUrl: mcpConnectors.documentationUrl,
             tokenHelpUrl: mcpConnectors.tokenHelpUrl,
             iconUrl: mcpConnectors.iconUrl,
-            instructions: mcpConnectors.instructions,
-            serverVersion: mcpConnectors.serverVersion,
             oauthIssuer: mcpConnectors.oauthIssuer,
+            // Server-reported metadata is per-user; read the caller's own
+            // connection so one member's account-specific text never leaks
+            // to another.
+            instructions: mcpUserConnections.instructions,
+            serverVersion: mcpUserConnections.serverVersion,
           })
           .from(mcpConnectors)
+          .leftJoin(
+            mcpUserConnections,
+            and(
+              eq(mcpUserConnections.connectorId, mcpConnectors.id),
+              eq(mcpUserConnections.userId, user.id),
+            ),
+          )
           .where(
             and(
               eq(mcpConnectors.organizationId, session.activeOrganizationId),
@@ -396,14 +410,14 @@ const appendCustomMcpEntries = ({
  * Vendor shown as the "author" of a custom MCP connector: the OAuth
  * issuer host for oauth2 servers, otherwise the server URL host. Both
  * the connector URL (normalized at create) and the issuer (an OAuth
- * metadata URL) are absolute, so `URL.parse` returns null only for
- * genuinely malformed data, where we fall back to the raw string.
+ * metadata URL) are absolute, so parsing fails only for genuinely
+ * malformed data, where we fall back to the raw string.
  */
 const connectorVendor = (
   connector: OrgCustomMcpRow,
 ): { label: string; url: string | undefined } => {
   const source = connector.oauthIssuer ?? connector.url;
-  const parsed = URL.parse(source);
+  const parsed = Result.try(() => new URL(source)).unwrapOr(null);
   if (!parsed) {
     return { label: source, url: undefined };
   }

--- a/apps/api/src/handlers/catalogue/list-catalogue.ts
+++ b/apps/api/src/handlers/catalogue/list-catalogue.ts
@@ -5,6 +5,7 @@ import {
   filterCatalogueByKind,
   loadCatalogue,
   recommendedSlugsForJurisdictions,
+  type CatalogueCost,
   type LoadedCatalogueEntry,
 } from "@stll/catalogue";
 
@@ -30,33 +31,55 @@ const config = {
 // custom MCPs could turn `/catalogue` into an unbounded read.
 const ORG_CUSTOM_MCP_LIMIT = 100;
 
-type CatalogueEntryResponse = LoadedCatalogueEntry & {
-  isRecommendedForOrg: boolean;
-  installState: CatalogueInstallState;
-  /**
-   * True when the entry is a system capability the user cannot toggle
-   * (non-toggleable pinned native-tools). UI hides install/uninstall
-   * controls and renders the entry in the "Baseline" section.
-   */
-  isLocked: boolean;
-  /**
-   * Per-installation identifiers used by the uninstall path. Set only
-   * when the entry is installed; `null` otherwise. Native-tools uninstall
-   * via `backendSlug` so they don't need a separate handle here.
-   */
-  installedSkillId: string | null;
-  installedConnectorSlug: string | null;
-  /**
-   * Whether the installed entry is currently enabled (turned on for
-   * use in chat). Only meaningful when `installState === "installed"`.
-   * For skills this mirrors `agentSkills.enabled`; for native-tools it
-   * is always `true` when installed (install-state already encodes the
-   * jurisdiction/override decision); for MCP entries this is `null`
-   * because the user connection lives on a separate row and is
-   * surfaced via the dedicated MCP detail flow.
-   */
-  enabled: boolean | null;
-};
+/**
+ * Distributes over the `LoadedCatalogueEntry` union so the per-member
+ * `Omit` keeps each kind's discriminated fields (url/authType, entryPath,
+ * backendSlug) intact while widening license/cost to nullable.
+ */
+type CatalogueEntryResponse = LoadedCatalogueEntry extends infer Entry
+  ? Entry extends LoadedCatalogueEntry
+    ? Omit<Entry, "license" | "cost"> & {
+        /**
+         * License and cost are unknown for user-added custom MCP
+         * connectors — the MCP spec exposes neither — so we surface null
+         * instead of fabricating a value. Curated entries always set both.
+         */
+        license: string | null;
+        cost: CatalogueCost | null;
+        /**
+         * Version the server reports during the MCP `initialize`
+         * handshake. Only populated for custom MCP entries, once the
+         * connector has been connected at least once.
+         */
+        serverVersion?: string | null;
+        isRecommendedForOrg: boolean;
+        installState: CatalogueInstallState;
+        /**
+         * True when the entry is a system capability the user cannot toggle
+         * (non-toggleable pinned native-tools). UI hides install/uninstall
+         * controls and renders the entry in the "Baseline" section.
+         */
+        isLocked: boolean;
+        /**
+         * Per-installation identifiers used by the uninstall path. Set only
+         * when the entry is installed; `null` otherwise. Native-tools
+         * uninstall via `backendSlug` so they don't need a handle here.
+         */
+        installedSkillId: string | null;
+        installedConnectorSlug: string | null;
+        /**
+         * Whether the installed entry is currently enabled (turned on for
+         * use in chat). Only meaningful when `installState === "installed"`.
+         * For skills this mirrors `agentSkills.enabled`; for native-tools it
+         * is always `true` when installed (install-state already encodes the
+         * jurisdiction/override decision); for MCP entries this is `null`
+         * because the user connection lives on a separate row and is
+         * surfaced via the dedicated MCP detail flow.
+         */
+        enabled: boolean | null;
+      }
+    : never
+  : never;
 
 const listCatalogue = createSafeRootHandler(
   config,
@@ -189,6 +212,9 @@ const listCatalogue = createSafeRootHandler(
             documentationUrl: mcpConnectors.documentationUrl,
             tokenHelpUrl: mcpConnectors.tokenHelpUrl,
             iconUrl: mcpConnectors.iconUrl,
+            instructions: mcpConnectors.instructions,
+            serverVersion: mcpConnectors.serverVersion,
+            oauthIssuer: mcpConnectors.oauthIssuer,
           })
           .from(mcpConnectors)
           .where(
@@ -313,7 +339,6 @@ const listCatalogue = createSafeRootHandler(
       response,
       connectors: orgCustomMcps,
       curatedMcpUrls: curatedMcpUrlSet,
-      organizationId: session.activeOrganizationId,
     });
 
     appendAuthoredSkillEntries({
@@ -343,45 +368,70 @@ type OrgCustomMcpRow = {
   documentationUrl: string | null;
   tokenHelpUrl: string | null;
   iconUrl: string | null;
+  instructions: string | null;
+  serverVersion: string | null;
+  oauthIssuer: string | null;
 };
 
 type AppendCustomMcpArgs = {
   response: CatalogueEntryResponse[];
   connectors: readonly OrgCustomMcpRow[];
   curatedMcpUrls: ReadonlySet<string>;
-  organizationId: SafeId<"organization">;
 };
 
 const appendCustomMcpEntries = ({
   response,
   connectors,
   curatedMcpUrls,
-  organizationId,
 }: AppendCustomMcpArgs): void => {
   for (const connector of connectors) {
     if (curatedMcpUrls.has(connector.url)) {
       continue;
     }
-    response.push(buildCustomMcpCatalogueEntry(connector, organizationId));
+    response.push(buildCustomMcpCatalogueEntry(connector));
   }
+};
+
+/**
+ * Vendor shown as the "author" of a custom MCP connector: the OAuth
+ * issuer host for oauth2 servers, otherwise the server URL host. Both
+ * the connector URL (normalized at create) and the issuer (an OAuth
+ * metadata URL) are absolute, so `URL.parse` returns null only for
+ * genuinely malformed data, where we fall back to the raw string.
+ */
+const connectorVendor = (
+  connector: OrgCustomMcpRow,
+): { label: string; url: string | undefined } => {
+  const source = connector.oauthIssuer ?? connector.url;
+  const parsed = URL.parse(source);
+  if (!parsed) {
+    return { label: source, url: undefined };
+  }
+  return { label: parsed.host, url: parsed.origin };
 };
 
 const buildCustomMcpCatalogueEntry = (
   connector: OrgCustomMcpRow,
-  organizationId: SafeId<"organization">,
 ): CatalogueEntryResponse => {
   // DB stores `oauth2`; the curated catalogue schema uses `oauth`.
   // The auth flow is the same; only the literal differs.
   const catalogueAuthType =
     connector.authType === "oauth2" ? "oauth" : connector.authType;
+  const vendor = connectorVendor(connector);
   return {
     kind: "mcp",
     slug: connector.slug,
     displayName: connector.displayName,
-    description: connector.description,
-    author: organizationId,
-    license: "MIT",
-    cost: "free",
+    // The user's own description wins; otherwise fall back to the
+    // server-reported `instructions` from the initialize handshake.
+    description: connector.description || connector.instructions || "",
+    author: vendor.label,
+    ...(vendor.url !== undefined ? { authorUrl: vendor.url } : {}),
+    // License and cost are not part of the MCP spec; leave them unknown
+    // for custom connectors rather than asserting a value we don't have.
+    license: null,
+    cost: null,
+    serverVersion: connector.serverVersion,
     setup: connector.authType === "none" ? "none" : "api-key",
     tags: [],
     jurisdictions: [],

--- a/apps/api/src/handlers/mcp-connectors/create-connector.ts
+++ b/apps/api/src/handlers/mcp-connectors/create-connector.ts
@@ -83,6 +83,8 @@ const createMcpConnector = createSafeRootHandler(
               probe.authType === "oauth2" && probe.scopes.length > 0
                 ? probe.scopes
                 : null,
+            oauthIssuer:
+              probe.authType === "oauth2" ? probe.authorizationServerUrl : null,
             iconUrl,
           })
           .returning({

--- a/apps/api/src/handlers/mcp-connectors/url-normalization.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/url-normalization.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { mcpConnectorUrlIdentity } from "@/api/handlers/mcp-connectors/url-normalization";
+
+describe("mcpConnectorUrlIdentity scheme handling", () => {
+  test("defaults a bare host to https", () => {
+    expect(mcpConnectorUrlIdentity("mcp.example.com")).toBe(
+      "https://mcp.example.com",
+    );
+  });
+
+  test("preserves an explicit http scheme", () => {
+    expect(mcpConnectorUrlIdentity("http://localhost:3001/mcp")).toBe(
+      "http://localhost:3001/mcp",
+    );
+  });
+
+  test("preserves an explicit https scheme", () => {
+    expect(mcpConnectorUrlIdentity("https://mcp.example.com")).toBe(
+      "https://mcp.example.com",
+    );
+  });
+
+  test("does not double-prefix and normalizes scheme case", () => {
+    expect(mcpConnectorUrlIdentity("HTTPS://mcp.example.com")).toBe(
+      "https://mcp.example.com",
+    );
+  });
+
+  test("trims and strips a trailing slash on a bare host with path", () => {
+    expect(mcpConnectorUrlIdentity("  mcp.example.com/api/  ")).toBe(
+      "https://mcp.example.com/api",
+    );
+  });
+});

--- a/apps/api/src/handlers/mcp-connectors/url-normalization.ts
+++ b/apps/api/src/handlers/mcp-connectors/url-normalization.ts
@@ -30,8 +30,14 @@ export const mcpConnectorUrlVariants = (normalizedUrl: string): string[] => {
   return Array.from(variants);
 };
 
+// MCP servers speak HTTP(S) only. Accept a bare host (e.g.
+// "mcp.example.com") and default it to https so users don't have to type
+// the scheme; an explicit http:// / https:// prefix is preserved.
+const ensureHttpScheme = (rawUrl: string): string =>
+  /^https?:\/\//iu.test(rawUrl) ? rawUrl : `https://${rawUrl}`;
+
 const normalizeUrl = (rawUrl: string): string => {
-  const url = new URL(rawUrl.trim());
+  const url = new URL(ensureHttpScheme(rawUrl.trim()));
   url.hash = "";
   while (url.pathname.length > 1 && url.pathname.endsWith("/")) {
     url.pathname = url.pathname.slice(0, -1);

--- a/apps/api/src/lib/mcp-upstream/connections.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.ts
@@ -6,7 +6,7 @@ import {
   type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Result } from "better-result";
-import { and, asc, eq, or, sql } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
 import type { SafeDb } from "@/api/db";
 import {
@@ -388,41 +388,16 @@ export const refreshCachedMcpToolsForConnection = async ({
         .set({
           cachedTools,
           cachedToolsRefreshedAt: new Date(),
+          // Server-reported metadata, captured with this user's
+          // credentials and kept on their own connection row.
+          serverVersion: server?.version ?? null,
+          instructions: server?.instructions ?? null,
           updatedAt: new Date(),
         })
         .where(eq(mcpUserConnections.id, connectionId));
     });
     if (Result.isError(updated)) {
       captureError(updated.error, { source: "mcp-upstream-cache-refresh" });
-    }
-
-    if (server) {
-      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-      const updatedConnector = await safeDb((tx) => {
-        // audit: skip — server-reported MCP metadata mirrored from the upstream initialize handshake; not a user-facing config change
-        return tx
-          .update(mcpConnectors)
-          .set({
-            serverVersion: server.version,
-            instructions: server.instructions,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(mcpConnectors.id, row.connectorId),
-              // Skip the write (and updatedAt churn) when nothing changed.
-              or(
-                sql`${mcpConnectors.serverVersion} is distinct from ${server.version}`,
-                sql`${mcpConnectors.instructions} is distinct from ${server.instructions}`,
-              ),
-            ),
-          );
-      });
-      if (Result.isError(updatedConnector)) {
-        captureError(updatedConnector.error, {
-          source: "mcp-upstream-server-metadata",
-        });
-      }
     }
   } catch (error) {
     captureError(error, { source: "mcp-upstream-cache-refresh" });

--- a/apps/api/src/lib/mcp-upstream/connections.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.ts
@@ -6,7 +6,7 @@ import {
   type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Result } from "better-result";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, or, sql } from "drizzle-orm";
 
 import type { SafeDb } from "@/api/db";
 import {
@@ -286,6 +286,29 @@ export const createMcpClientForConnection = async ({
   });
 };
 
+const MAX_SERVER_VERSION_LEN = 64;
+const MAX_INSTRUCTIONS_LEN = 4000;
+
+const capServerText = (
+  value: string | undefined,
+  maxLen: number,
+): string | null => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, maxLen) : null;
+};
+
+/** Metadata the upstream server reports during the MCP `initialize`
+ * handshake. `null` when no authenticated client could be opened. */
+type McpServerMetadata = {
+  version: string | null;
+  instructions: string | null;
+};
+
+type DiscoverCachedMcpToolsResult = {
+  tools: CachedMcpToolDefinition[];
+  server: McpServerMetadata | null;
+};
+
 export const discoverCachedMcpTools = async ({
   organizationId,
   row,
@@ -296,7 +319,7 @@ export const discoverCachedMcpTools = async ({
   row: LoadedMcpConnection;
   safeDb: SafeDb;
   userId: SafeId<"user">;
-}): Promise<CachedMcpToolDefinition[]> => {
+}): Promise<DiscoverCachedMcpToolsResult> => {
   const client = await createMcpClientForConnection({
     organizationId,
     row,
@@ -304,15 +327,26 @@ export const discoverCachedMcpTools = async ({
     userId,
   });
   if (!client) {
-    return [];
+    return { tools: [], server: null };
   }
 
   try {
     const tools = await client.listTools();
-    return normalizeDiscoveredMcpTools({
-      connectorSlug: row.slug,
-      tools: tools.tools,
-    });
+    return {
+      tools: normalizeDiscoveredMcpTools({
+        connectorSlug: row.slug,
+        tools: tools.tools,
+      }),
+      // Bound what an upstream server can persist on our connector row and
+      // ship in the catalogue payload; the values are server-controlled.
+      server: {
+        version: capServerText(
+          client.serverInfo.version,
+          MAX_SERVER_VERSION_LEN,
+        ),
+        instructions: capServerText(client.instructions, MAX_INSTRUCTIONS_LEN),
+      },
+    };
   } finally {
     await client.close();
   }
@@ -340,7 +374,7 @@ export const refreshCachedMcpToolsForConnection = async ({
       return;
     }
 
-    const cachedTools = await discoverCachedMcpTools({
+    const { tools: cachedTools, server } = await discoverCachedMcpTools({
       organizationId,
       row,
       safeDb,
@@ -360,6 +394,35 @@ export const refreshCachedMcpToolsForConnection = async ({
     });
     if (Result.isError(updated)) {
       captureError(updated.error, { source: "mcp-upstream-cache-refresh" });
+    }
+
+    if (server) {
+      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+      const updatedConnector = await safeDb((tx) => {
+        // audit: skip — server-reported MCP metadata mirrored from the upstream initialize handshake; not a user-facing config change
+        return tx
+          .update(mcpConnectors)
+          .set({
+            serverVersion: server.version,
+            instructions: server.instructions,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(mcpConnectors.id, row.connectorId),
+              // Skip the write (and updatedAt churn) when nothing changed.
+              or(
+                sql`${mcpConnectors.serverVersion} is distinct from ${server.version}`,
+                sql`${mcpConnectors.instructions} is distinct from ${server.instructions}`,
+              ),
+            ),
+          );
+      });
+      if (Result.isError(updatedConnector)) {
+        captureError(updatedConnector.error, {
+          source: "mcp-upstream-server-metadata",
+        });
+      }
     }
   } catch (error) {
     captureError(error, { source: "mcp-upstream-cache-refresh" });

--- a/apps/web/src/components/catalogue/catalogue-row.tsx
+++ b/apps/web/src/components/catalogue/catalogue-row.tsx
@@ -18,7 +18,7 @@ export type CatalogueRowDisplay = {
   displayName: string;
   description: string;
   author: string;
-  cost: "free" | "paid";
+  cost: "free" | "paid" | null;
   setup: "none" | "account" | "api-key";
   icon: string | null;
   iconUrl?: string | null | undefined;

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -793,6 +793,7 @@
     "sessions": "Sezení",
     "settings": "Nastavení",
     "showAll": "Zobrazit vše",
+    "showLess": "Zobrazit méně",
     "showMore": "Zobrazit více",
     "signOut": "Odhlásit se",
     "somethingWentWrong": "Něco se pokazilo",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -793,6 +793,7 @@
     "sessions": "Sitzungen",
     "settings": "Einstellungen",
     "showAll": "Alle anzeigen",
+    "showLess": "Weniger anzeigen",
     "showMore": "Mehr anzeigen",
     "signOut": "Abmelden",
     "somethingWentWrong": "Etwas ist schiefgelaufen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -793,6 +793,7 @@
     "sessions": "Sessions",
     "settings": "Settings",
     "showAll": "Show all",
+    "showLess": "Show less",
     "showMore": "Show more",
     "signOut": "Sign out",
     "somethingWentWrong": "Something went wrong",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -793,6 +793,7 @@
     "sessions": "Sesiones",
     "settings": "Configuración",
     "showAll": "Mostrar todo",
+    "showLess": "Mostrar menos",
     "showMore": "Mostrar más",
     "signOut": "Cerrar sesión",
     "somethingWentWrong": "Algo salió mal",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -793,6 +793,7 @@
     "sessions": "Seansid",
     "settings": "Seaded",
     "showAll": "Näita kõiki",
+    "showLess": "Näita vähem",
     "showMore": "Näita rohkem",
     "signOut": "Logi välja",
     "somethingWentWrong": "Midagi läks valesti",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -793,6 +793,7 @@
     "sessions": "Sessions",
     "settings": "Paramètres",
     "showAll": "Tout afficher",
+    "showLess": "Afficher moins",
     "showMore": "Afficher plus",
     "signOut": "Se déconnecter",
     "somethingWentWrong": "Une erreur est survenue",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -793,6 +793,7 @@
     "sessions": "Munkamenetek",
     "settings": "Beállítások",
     "showAll": "Az összes megjelenítése",
+    "showLess": "Kevesebb megjelenítése",
     "showMore": "Több megjelenítése",
     "signOut": "Kijelentkezés",
     "somethingWentWrong": "Hiba történt",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -793,6 +793,7 @@
     "sessions": "Sesijos",
     "settings": "Nustatymai",
     "showAll": "Rodyti viską",
+    "showLess": "Rodyti mažiau",
     "showMore": "Rodyti daugiau",
     "signOut": "Atsijungti",
     "somethingWentWrong": "Kažkas nepavyko",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -793,6 +793,7 @@
     "sessions": "Sesijas",
     "settings": "Iestatījumi",
     "showAll": "Rādīt visu",
+    "showLess": "Rādīt mazāk",
     "showMore": "Rādīt vairāk",
     "signOut": "Atslēgties",
     "somethingWentWrong": "Kaut kas nogāja greizi",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -796,6 +796,7 @@ type Messages = {
     "sessions": "Sessions";
     "settings": "Settings";
     "showAll": "Show all";
+    "showLess": "Show less";
     "showMore": "Show more";
     "signOut": "Sign out";
     "somethingWentWrong": "Something went wrong";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -793,6 +793,7 @@
     "sessions": "Sesje",
     "settings": "Ustawienia",
     "showAll": "Pokaż wszystko",
+    "showLess": "Pokaż mniej",
     "showMore": "Pokaż więcej",
     "signOut": "Wyloguj się",
     "somethingWentWrong": "Coś poszło nie tak",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -793,6 +793,7 @@
     "sessions": "Sessões",
     "settings": "Configurações",
     "showAll": "Mostrar tudo",
+    "showLess": "Mostrar menos",
     "showMore": "Mostrar mais",
     "signOut": "Sair",
     "somethingWentWrong": "Algo deu errado",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -793,6 +793,7 @@
     "sessions": "Relácie",
     "settings": "Nastavenia",
     "showAll": "Zobraziť všetko",
+    "showLess": "Zobraziť menej",
     "showMore": "Zobraziť viac",
     "signOut": "Odhlásiť sa",
     "somethingWentWrong": "Niečo sa pokazilo",

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
@@ -212,11 +212,12 @@ export const AddMcpServerSheet = ({
                 autoComplete="url"
                 autoFocus
                 id="mcp-url"
+                inputMode="url"
                 onChange={(event) =>
                   setWizard({ step: "url", url: event.target.value })
                 }
                 placeholder={t("knowledge.mcp.urlPlaceholder")}
-                type="url"
+                type="text"
                 value={wizard.url}
               />
               <p className="text-muted-foreground text-xs">

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-badges.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-badges.tsx
@@ -18,8 +18,11 @@ const SETUP_LABEL_KEY = {
   "api-key": "catalogue.setup.apiKey",
 } as const satisfies Record<Setup, TranslationKey>;
 
-export const CostBadge = ({ cost }: { cost: Cost }) => {
+export const CostBadge = ({ cost }: { cost: Cost | null }) => {
   const t = useTranslations();
+  if (cost === null) {
+    return null;
+  }
   const tone =
     cost === "free"
       ? "bg-success/12 text-success"

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -247,7 +247,9 @@ const ExpandableText = ({ text }: { text: string }) => {
   useEffect(() => {
     const el = ref.current;
     if (expanded || !el) {
-      return;
+      return () => {
+        /* no-op cleanup */
+      };
     }
     const observer = new ResizeObserver(() => {
       setOverflowing(el.scrollHeight > el.clientHeight + 1);

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -242,13 +242,18 @@ const ExpandableText = ({ text }: { text: string }) => {
   }, [text]);
 
   // Measure only while clamped, so overflow is detected against the
-  // line-clamp height rather than the fully expanded text.
+  // line-clamp height. A ResizeObserver keeps it correct across font
+  // loads, panel animation, and width changes.
   useEffect(() => {
     const el = ref.current;
     if (expanded || !el) {
       return;
     }
-    setOverflowing(el.scrollHeight > el.clientHeight + 1);
+    const observer = new ResizeObserver(() => {
+      setOverflowing(el.scrollHeight > el.clientHeight + 1);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [text, expanded]);
 
   return (

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+
 import {
   BanknoteIcon,
   ExternalLinkIcon,
@@ -94,11 +96,11 @@ export const CatalogueDetailPanel = ({
       </header>
 
       <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-3 py-4">
-        <Section title={t("onboarding.catalogueDetailAbout")}>
-          <p className="text-foreground text-sm leading-relaxed text-pretty">
-            {entry.description}
-          </p>
-        </Section>
+        {entry.description && (
+          <Section title={t("onboarding.catalogueDetailAbout")}>
+            <ExpandableText text={entry.description} />
+          </Section>
+        )}
 
         {installed && entry.kind === "mcp" && (
           <Section title={t("catalogue.configuration")}>
@@ -113,6 +115,13 @@ export const CatalogueDetailPanel = ({
                 icon={KeyRoundIcon}
                 value={t(`knowledge.mcp.auth.${authKey(entry.authType)}`)}
               />
+              {entry.serverVersion && (
+                <Field
+                  ariaLabel={t("inspector.metadata.version")}
+                  icon={TagIcon}
+                  value={entry.serverVersion}
+                />
+              )}
             </div>
           </Section>
         )}
@@ -126,16 +135,20 @@ export const CatalogueDetailPanel = ({
                 authorUrl={entry.authorUrl}
                 value={isFirstParty ? "stella" : entry.author}
               />
-              <Field
-                ariaLabel={t("onboarding.catalogueDetailLicense")}
-                icon={ScaleIcon}
-                value={entry.license}
-              />
-              <Field
-                ariaLabel={t("onboarding.catalogueDetailCost")}
-                icon={BanknoteIcon}
-                value={t(`catalogue.cost.${entry.cost}`)}
-              />
+              {entry.license && (
+                <Field
+                  ariaLabel={t("onboarding.catalogueDetailLicense")}
+                  icon={ScaleIcon}
+                  value={entry.license}
+                />
+              )}
+              {entry.cost && (
+                <Field
+                  ariaLabel={t("onboarding.catalogueDetailCost")}
+                  icon={BanknoteIcon}
+                  value={t(`catalogue.cost.${entry.cost}`)}
+                />
+              )}
               <Field
                 ariaLabel={t("onboarding.catalogueDetailSetup")}
                 icon={Settings2Icon}
@@ -207,6 +220,59 @@ export const CatalogueDetailPanel = ({
           </p>
         )}
       </footer>
+    </div>
+  );
+};
+
+/**
+ * About-text block that clamps long copy (e.g. server-reported MCP
+ * `instructions`) to a few lines, with a Show more/less toggle. The
+ * toggle only appears when the text actually overflows the clamp.
+ */
+const ExpandableText = ({ text }: { text: string }) => {
+  const t = useTranslations();
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+
+  // Collapse when switching to a different entry (the panel is not
+  // remounted per selection, so expanded state would otherwise leak).
+  useEffect(() => {
+    setExpanded(false);
+  }, [text]);
+
+  // Measure only while clamped, so overflow is detected against the
+  // line-clamp height rather than the fully expanded text.
+  useEffect(() => {
+    const el = ref.current;
+    if (expanded || !el) {
+      return;
+    }
+    setOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [text, expanded]);
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <p
+        className={cn(
+          "text-foreground text-sm leading-relaxed text-pretty",
+          !expanded && "line-clamp-5",
+        )}
+        ref={ref}
+      >
+        {text}
+      </p>
+      {(overflowing || expanded) && (
+        <Button
+          className="text-muted-foreground h-auto p-0 text-xs"
+          onClick={() => setExpanded((prev) => !prev)}
+          size="sm"
+          type="button"
+          variant="link"
+        >
+          {expanded ? t("common.showLess") : t("common.showMore")}
+        </Button>
+      )}
     </div>
   );
 };

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-types.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-types.ts
@@ -9,8 +9,11 @@ type CommonFields = {
   description: string;
   author: string;
   authorUrl?: string | undefined;
-  license: string;
-  cost: CatalogueCost;
+  // null when unknown — custom MCP connectors expose neither license nor
+  // cost (the MCP spec carries no such metadata), so we omit rather than
+  // fabricate. Curated entries always provide both.
+  license: string | null;
+  cost: CatalogueCost | null;
   setup: CatalogueSetup;
   homepage?: string | undefined;
   iconUrl?: string | undefined;
@@ -53,6 +56,8 @@ export type CatalogueMcp = CommonFields & {
   allowedTools: string[];
   documentationUrl?: string | undefined;
   tokenHelpUrl?: string | undefined;
+  /** Version the server reports during `initialize`; null until connected. */
+  serverVersion?: string | null | undefined;
 };
 
 export type CatalogueNativeTool = CommonFields & {


### PR DESCRIPTION
## Summary

Improves the custom MCP connector detail panel and the add-server flow.

- Capture the server's `serverInfo` version and `instructions` during the authenticated `initialize` handshake (length-bounded); use `instructions` as the description fallback and show the version in the detail panel.
- Show the OAuth issuer / server host as the connector author instead of the raw organization id (linked when available).
- Stop fabricating license/cost for custom MCP connectors; render those rows only when known.
- Clamp long "about" copy with a Show more / Show less toggle.
- Accept schemeless URLs (default `https`) and remove native browser URL validation in the add-server form.

Schema (additive migration): adds `oauth_issuer` to `mcp_connectors` (server-level, org-shared) and `server_version` / `instructions` to `mcp_user_connections` (per-user, since a server may personalise its `initialize` text per account). The catalogue reads the caller's own connection for those fields.