### PR TITLE
fix: correct provenance internal scope to @stll

### DIFF
--- a/.provenance.yml
+++ b/.provenance.yml
@@ -2,7 +2,7 @@ version: 1
 output_dir: provenance
 notice:
   internal_scopes:
-    - "@stella"
+    - "@stll"
 sbom:
   exclude_regexes:
     - '(^|/)dist(/.*)?$'


### PR DESCRIPTION
## What

`.provenance.yml` listed `@stella` as the only internal scope, but every first-party workspace package uses the `@stll` scope (27 packages; no `@stella/*` package exists, and the root package is the unscoped `stella`). The stale entry matched nothing, so first-party `@stll/*` packages were counted and published as third-party dependencies in the generated notices.

## Why

Surfaced by the Codex review on #637: the newly-added `@stll/ai-catalog` entry in `provenance/projects/root/THIRD-PARTY-NOTICES.txt` is a private workspace package, not a third-party dependency, making the generated inventory inaccurate for compliance/distribution.

## Change

Update `notice.internal_scopes` from `@stella` to `@stll`.

## Follow-up

This corrects future runs only. The committed notices/SBOMs still list `@stll/*` until regenerated. After this lands on `main`, re-dispatch `provenance-nightly.yml` so the provenance artifacts regenerate with first-party packages excluded.