### PR TITLE
feat(search): index AI chat history into global search

### DIFF
--- a/apps/api/drizzle/20260606120000_chat-thread-search-documents/migration.sql
+++ b/apps/api/drizzle/20260606120000_chat-thread-search-documents/migration.sql
@@ -1,0 +1,87 @@
+CREATE TABLE "chat_thread_search_documents" (
+	"thread_id" uuid PRIMARY KEY,
+	"title" text DEFAULT '' NOT NULL,
+	"searchable_text" text DEFAULT '' NOT NULL,
+	"tsv" tsvector,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "chat_thread_search_documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE INDEX "chat_thread_search_docs_tsv_idx" ON "chat_thread_search_documents" USING gin ("tsv");--> statement-breakpoint
+ALTER TABLE "chat_thread_search_documents" ADD CONSTRAINT "chat_thread_search_documents_thread_id_chat_threads_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "chat_threads"("id") ON DELETE CASCADE;--> statement-breakpoint
+CREATE POLICY "chat_thread_search_document_select" ON "chat_thread_search_documents" AS PERMISSIVE FOR SELECT TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_search_document_insert" ON "chat_thread_search_documents" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_search_document_update" ON "chat_thread_search_documents" AS PERMISSIVE FOR UPDATE TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_search_document_delete" ON "chat_thread_search_documents" AS PERMISSIVE FOR DELETE TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));

--- a/apps/api/drizzle/20260606120000_chat-thread-search-documents/migration.sql
+++ b/apps/api/drizzle/20260606120000_chat-thread-search-documents/migration.sql
@@ -7,6 +7,7 @@ CREATE TABLE "chat_thread_search_documents" (
 );
 --> statement-breakpoint
 ALTER TABLE "chat_thread_search_documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "chat_thread_search_documents" TO stella;--> statement-breakpoint
 CREATE INDEX "chat_thread_search_docs_tsv_idx" ON "chat_thread_search_documents" USING gin ("tsv");--> statement-breakpoint
 ALTER TABLE "chat_thread_search_documents" ADD CONSTRAINT "chat_thread_search_documents_thread_id_chat_threads_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "chat_threads"("id") ON DELETE CASCADE;--> statement-breakpoint
 CREATE POLICY "chat_thread_search_document_select" ON "chat_thread_search_documents" AS PERMISSIVE FOR SELECT TO "stella" USING (EXISTS (

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "db:seed-test-user": "bun scripts/seed-test-user.ts",
     "db:seed-dev": "bun scripts/seed-dev.ts",
     "db:seed-templates": "bun scripts/seed-templates.ts",
+    "db:backfill-chat-search": "bun scripts/backfill-chat-search.ts",
     "scheduler": "bun src/scheduler/index.ts",
     "dev:scheduler": "bun --watch src/scheduler/index.ts",
     "dev:errors": "tail -F .dev-logs/errors.jsonl"

--- a/apps/api/scripts/backfill-chat-search.ts
+++ b/apps/api/scripts/backfill-chat-search.ts
@@ -1,0 +1,23 @@
+/**
+ * Backfill the chat-thread search index for every existing thread.
+ *
+ * Run once after the `chat-thread-search-documents` migration is
+ * applied. Idempotent and resumable: only threads without a search
+ * document are indexed, so re-running is safe.
+ *
+ * Usage:
+ *   bun apps/api/scripts/backfill-chat-search.ts
+ */
+
+import { backfillChatThreadSearchIndex } from "@/api/lib/search/index-chat";
+
+const main = async () => {
+  const indexed = await backfillChatThreadSearchIndex();
+  console.log(`Chat search backfill complete: ${indexed} thread(s) indexed.`);
+  process.exit(0);
+};
+
+main().catch((error: unknown) => {
+  console.error("Chat search backfill failed:", error);
+  process.exit(1);
+});

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -102,6 +102,30 @@ const fileChatThreadScopeCheck = sql`(
   ${workspaceCheck}
 )`;
 
+// The chat search-document table stores only `thread_id` and derives
+// all tenancy from its owning thread, so RLS joins `chat_threads` and
+// applies the same scope the thread enforces. This is defence in
+// depth: global search reads this table via the RLS-bypassing root
+// connection and filters by user explicitly, but any stella-role
+// reader is still held to the thread's own visibility.
+const chatThreadSearchDocumentScopeCheck = sql`(
+  EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        '${sql.raw(SETTING_USER_ID)}', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        '${sql.raw(SETTING_ORGANIZATION_ID)}', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY(${wsIdsArray}))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ ${wsIdsArray}
+      )
+  )
+)`;
+
 export const wsPolicies = () => [
   p.pgPolicy("workspace_select", {
     for: "select",
@@ -519,6 +543,29 @@ export const chatMessagePolicies = () => [
     for: "delete",
     to: stella,
     using: chatMessageScopeCheck,
+  }),
+];
+
+export const chatThreadSearchDocumentPolicies = () => [
+  p.pgPolicy("chat_thread_search_document_select", {
+    for: "select",
+    to: stella,
+    using: chatThreadSearchDocumentScopeCheck,
+  }),
+  p.pgPolicy("chat_thread_search_document_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: chatThreadSearchDocumentScopeCheck,
+  }),
+  p.pgPolicy("chat_thread_search_document_update", {
+    for: "update",
+    to: stella,
+    using: chatThreadSearchDocumentScopeCheck,
+  }),
+  p.pgPolicy("chat_thread_search_document_delete", {
+    for: "delete",
+    to: stella,
+    using: chatThreadSearchDocumentScopeCheck,
   }),
 ];
 

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -14,6 +14,7 @@ import {
   agentSkillResourcePolicies,
   chatMessagePolicies,
   chatThreadPolicies,
+  chatThreadSearchDocumentPolicies,
   fileChatThreadPolicies,
   globalCaseLawPolicies,
   mcpConnectorPolicies,
@@ -1735,6 +1736,28 @@ export const workspaceSearchDocuments = p.pgTable(
     p.index("workspace_search_docs_org_idx").on(table.organizationId),
     p.index("workspace_search_docs_tsv_idx").using("gin", table.tsv),
     ...wsPolicies(),
+  ],
+);
+
+// One row per chat thread. Tenancy is intentionally not denormalised
+// here: the global-search query joins back to `chat_threads` and
+// filters by the owning thread's user/org/workspace scope, so this
+// table never drifts out of sync with thread ownership. Deletes
+// cascade from the thread.
+export const chatThreadSearchDocuments = p.pgTable(
+  "chat_thread_search_documents",
+  {
+    threadId: safeUuid<"chatThread">("thread_id")
+      .primaryKey()
+      .references(() => chatThreads.id, { onDelete: "cascade" }),
+    title: p.text().notNull().default(""),
+    searchableText: p.text("searchable_text").notNull().default(""),
+    tsv: tsvector(),
+    updatedAt: p.timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p.index("chat_thread_search_docs_tsv_idx").using("gin", table.tsv),
+    ...chatThreadSearchDocumentPolicies(),
   ],
 );
 

--- a/apps/api/src/handlers/chat/generate-thread-title.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.ts
@@ -12,6 +12,7 @@ import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { upsertChatThreadSearchDocument } from "@/api/lib/search/index-chat";
 
 const TITLE_MAX_LENGTH = 60;
 const TITLE_CONTEXT_MAX_LENGTH = 500;
@@ -84,7 +85,7 @@ Assistant: ${assistantText}`,
       });
 
       if (!currentThread || currentThread.titleSource !== "user") {
-        return;
+        return false;
       }
 
       const updatedRows = await tx
@@ -99,7 +100,7 @@ Assistant: ${assistantText}`,
         .returning({ id: chatThreads.id });
 
       if (updatedRows.length === 0) {
-        return;
+        return false;
       }
 
       await recordAuditEvent(tx, {
@@ -112,10 +113,19 @@ Assistant: ${assistantText}`,
           titleSource: { old: currentThread.titleSource, new: "ai" },
         },
       });
+
+      return true;
     });
 
     if (Result.isError(updateResult)) {
       captureError(updateResult.error, { threadId });
+      return;
+    }
+
+    // Re-index so the new AI-generated title is searchable. Fire-and-
+    // forget: title generation is already a best-effort side path.
+    if (updateResult.value) {
+      upsertChatThreadSearchDocument(threadId).catch(captureError);
     }
   } catch (error) {
     aiAnalytics.captureError(error);

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -92,6 +92,7 @@ import { FILE_SIZE_LIMIT_BYTES, FILE_SIZE_LIMITS } from "@/api/lib/limits";
 import { PG_ERROR } from "@/api/lib/pg-error";
 import { getS3 } from "@/api/lib/s3";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
+import { upsertChatThreadSearchDocument } from "@/api/lib/search/index-chat";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const config = {
@@ -1613,7 +1614,18 @@ type PersistMessageProps = {
     | undefined;
 };
 
-const persistMessage = async ({
+const persistMessage = async (props: PersistMessageProps) => {
+  const result = await runPersistMessage(props);
+  // Refresh the thread's global-search document whenever its messages
+  // actually changed. Fire-and-forget: indexing must never block or
+  // fail a chat turn.
+  if (Result.isOk(result) && props.persistencePlan.type !== "none") {
+    upsertChatThreadSearchDocument(props.threadId).catch(captureError);
+  }
+  return result;
+};
+
+const runPersistMessage = async ({
   acceptedSendMode = null,
   recordAuditEvent,
   safeDb,

--- a/apps/api/src/handlers/search/ai.test.ts
+++ b/apps/api/src/handlers/search/ai.test.ts
@@ -30,6 +30,14 @@ mock.module("@/api/db/root", () => ({
   },
 }));
 
+// The fire-and-forget chat reindex hook touches rootDb; stub it so the
+// summary-chat tests do not need a live database for the side effect.
+// eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
+mock.module("@/api/lib/search/index-chat", () => ({
+  upsertChatThreadSearchDocument: mock(async () => undefined),
+  backfillChatThreadSearchIndex: mock(async () => 0),
+}));
+
 // Mock index-global directly to prevent transitive db/root imports that
 // require a live database connection and cause flaky failures in CI.
 // eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration

--- a/apps/api/src/handlers/search/ai.test.ts
+++ b/apps/api/src/handlers/search/ai.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
+import {
+  clearRootDbMocks,
+  rootDbSelectMock,
+} from "@/api/tests/helpers/mock-root-db";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
 process.env["REDIS_URL"] ??= "redis://localhost:6379";
@@ -18,17 +22,6 @@ process.env["GOTENBERG_USERNAME"] ??= "test";
 process.env["GOTENBERG_PASSWORD"] ??= "test";
 
 const searchGlobalMock = mock();
-const dbLimitMock = mock(async () => [{ searchableText: "Document content" }]);
-const dbWhereMock = mock(() => ({ limit: dbLimitMock }));
-const dbFromMock = mock(() => ({ where: dbWhereMock }));
-const dbSelectMock = mock(() => ({ from: dbFromMock }));
-
-// eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
-mock.module("@/api/db/root", () => ({
-  rootDb: {
-    select: dbSelectMock,
-  },
-}));
 
 // The fire-and-forget chat reindex hook touches rootDb; stub it so the
 // summary-chat tests do not need a live database for the side effect.
@@ -54,10 +47,7 @@ mock.module("@/api/lib/search/index-global", () => ({
 
 beforeEach(() => {
   searchGlobalMock.mockReset();
-  dbSelectMock.mockClear();
-  dbFromMock.mockClear();
-  dbWhereMock.mockClear();
-  dbLimitMock.mockClear();
+  clearRootDbMocks();
 });
 
 const emptySearchSummaryFilters = () => ({
@@ -95,7 +85,7 @@ describe("search summary chat", () => {
           insertedValues.push(values);
         }),
       })),
-      select: dbSelectMock,
+      select: rootDbSelectMock,
     };
     const { safeDb, scopedDb } = createScopedDbMock(tx);
 
@@ -170,7 +160,7 @@ describe("search summary chat", () => {
       insert: mock((_table: unknown) => ({
         values: mock(async (_values: unknown) => {}),
       })),
-      select: dbSelectMock,
+      select: rootDbSelectMock,
     };
     const { safeDb, scopedDb } = createScopedDbMock(tx);
 
@@ -232,7 +222,7 @@ describe("search summary chat", () => {
           insertedValues.push(values);
         }),
       })),
-      select: dbSelectMock,
+      select: rootDbSelectMock,
     };
     const { safeDb, scopedDb } = createScopedDbMock(tx);
 
@@ -307,7 +297,7 @@ describe("search summary chat", () => {
     const tx = {
       query: { workspaces: {} },
       insert: insertMock,
-      select: dbSelectMock,
+      select: rootDbSelectMock,
     };
     const { safeDb, scopedDb } = createScopedDbMock(tx);
 
@@ -400,7 +390,7 @@ describe("search summary chat", () => {
           insertedValues.push(values);
         }),
       })),
-      select: dbSelectMock,
+      select: rootDbSelectMock,
     };
     const { safeDb, scopedDb } = createScopedDbMock(tx);
 

--- a/apps/api/src/handlers/search/ai.test.ts
+++ b/apps/api/src/handlers/search/ai.test.ts
@@ -158,6 +158,69 @@ describe("search summary chat", () => {
     );
   });
 
+  test("does not let chat hits consume the summary search limit", async () => {
+    const organizationId = toSafeId<"organization">("org_1");
+    const workspaceId = toSafeId<"workspace">("ws_1");
+    const tx = {
+      query: {
+        workspaces: {
+          findMany: mock(async () => [{ id: workspaceId }]),
+        },
+      },
+      insert: mock((_table: unknown) => ({
+        values: mock(async (_values: unknown) => {}),
+      })),
+      select: dbSelectMock,
+    };
+    const { safeDb, scopedDb } = createScopedDbMock(tx);
+
+    searchGlobalMock.mockResolvedValueOnce({
+      facets: { editor: [], mimeType: [], type: [], workspace: [] },
+      hits: [
+        {
+          entityId: "entity_1",
+          headline: null,
+          id: "entity:entity_1",
+          lastEditedByImage: null,
+          lastEditedByName: null,
+          mimeType: "application/pdf",
+          title: "Motion.pdf",
+          type: "document",
+          updatedAt: "2026-04-30T08:00:00.000Z",
+          workspaceId,
+          workspaceName: "Motion matter",
+        },
+      ],
+      nextCursor: null,
+      totalCount: 1,
+    });
+
+    const { createSearchSummaryChatThread } =
+      await import("@/api/handlers/search/ai");
+    await createSearchSummaryChatThread({
+      accessibleWorkspaceIds: [workspaceId],
+      body: {
+        ...emptySearchSummaryFilters(),
+        citations: [{ number: 1 }],
+        limit: 1,
+        query: "motion",
+        summary: "Relevant document [1].",
+        title: "Search summary",
+        types: ["chat", "document"],
+        workspaceIds: [workspaceId],
+      },
+      organizationId,
+      safeDb,
+      search: searchGlobalMock,
+      scopedDb,
+      userId: toSafeId<"user">("user_1"),
+      recordAuditEvent: noopAuditRecorder,
+    });
+
+    const call = searchGlobalMock.mock.calls.at(0)?.[0];
+    expect(call).toMatchObject({ types: ["document"] });
+  });
+
   test("stores global summary chat thread for unfiltered summary chats", async () => {
     const organizationId = toSafeId<"organization">("org_1");
     const workspaceId = toSafeId<"workspace">("ws_1");

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -12,6 +12,7 @@ import {
   chatMessages,
   chatThreads,
   contactSearchDocuments,
+  ENTITY_KINDS,
   searchDocuments,
   workspaceSearchDocuments,
 } from "@/api/db/schema";
@@ -39,14 +40,23 @@ import {
   buildSearchTsQuery,
   validateStellaSearchQuery,
 } from "@/api/lib/search/query";
-import type { GlobalSearchHit } from "@/api/lib/search/types";
-import { GLOBAL_SEARCH_RESULT_TYPES } from "@/api/lib/search/types";
+import {
+  GLOBAL_SEARCH_RESULT_TYPES,
+  type GlobalSearchHit,
+  type GlobalSearchResultType,
+} from "@/api/lib/search/types";
 
 const SEARCH_SUMMARY_RESULT_LIMIT = 5;
 const SEARCH_CONTEXT_CHARS_PER_RESULT = 3000;
 const SEARCH_CONTEXT_TOTAL_CHARS = 14_000;
 const SEARCH_REFINE_MAX_ATTEMPTS = 3;
 const SEARCH_SUMMARY_CITATION_LIMIT = 5;
+const CITABLE_SEARCH_RESULT_TYPES = [
+  "matter",
+  "contact",
+  "case-law",
+  ...ENTITY_KINDS,
+] as const satisfies readonly GlobalSearchResultType[];
 
 export const refineSearchOutputSchema = v.strictObject({
   query: v.pipe(
@@ -168,6 +178,16 @@ type SearchSummaryCitation = {
   title: string;
   type: string;
   reason: string;
+};
+
+const citableSummaryTypes = (
+  types: readonly GlobalSearchResultType[],
+): readonly GlobalSearchResultType[] => {
+  if (types.length === 0) {
+    return CITABLE_SEARCH_RESULT_TYPES;
+  }
+
+  return types.filter((type) => type !== "chat");
 };
 
 type SearchSummaryChatContext = {
@@ -714,13 +734,18 @@ const loadSummaryContexts = async ({
   selectedWorkspaceIds: readonly SafeId<"workspace">[];
   scopedDb: ScopedDb;
 }) => {
+  const types = citableSummaryTypes(filters.types);
+  if (filters.types.length > 0 && types.length === 0) {
+    return [];
+  }
+
   const searchResult = await search({
     query: filters.query,
     organizationId,
     userId,
     accessibleWorkspaceIds,
     selectedWorkspaceIds,
-    types: filters.types,
+    types,
     editedByUserIds: filters.editedByUserIds,
     mimeTypes: filters.mimeTypes,
     updatedFrom: filters.updatedFrom,

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -33,6 +33,7 @@ import {
   brandPersistedEntityId,
   brandPersistedWorkspaceId,
 } from "@/api/lib/safe-id-boundaries";
+import { upsertChatThreadSearchDocument } from "@/api/lib/search/index-chat";
 import { searchGlobal } from "@/api/lib/search/index-global";
 import {
   buildSearchTsQuery,
@@ -141,7 +142,14 @@ type SearchAIContext = {
 
 type SearchSummaryContext = SearchAIContext & {
   accessibleWorkspaceIds: SafeId<"workspace">[];
+  userId: SafeId<"user">;
 };
+
+// Chat threads are searchable but are not citable summary sources:
+// a conversation is not a document to excerpt. They are dropped from
+// the AI summary context, so everything downstream sees only the
+// citable hit variants.
+type CitableSearchHit = Exclude<GlobalSearchHit, { type: "chat" }>;
 
 type SearchResultContext = {
   id: string;
@@ -150,7 +158,7 @@ type SearchResultContext = {
   type: string;
   headline: string | null;
   content: string;
-  hit: GlobalSearchHit;
+  hit: CitableSearchHit;
 };
 
 type SearchSummaryCitation = {
@@ -357,6 +365,7 @@ export const refineSearchQuery = async ({
 export const summarizeSearchResults = async ({
   body,
   organizationId,
+  userId,
   accessibleWorkspaceIds,
   orgAIConfig,
   promptCachingEnabled,
@@ -383,6 +392,7 @@ export const summarizeSearchResults = async ({
     accessibleWorkspaceIds,
     filters: body,
     organizationId,
+    userId,
     selectedWorkspaceIds: resolved.ids,
     scopedDb,
   });
@@ -541,6 +551,7 @@ export const createSearchSummaryChatThread = async ({
     accessibleWorkspaceIds,
     filters: body,
     organizationId,
+    userId,
     selectedWorkspaceIds: resolved.ids,
     scopedDb,
     search,
@@ -670,6 +681,10 @@ export const createSearchSummaryChatThread = async ({
     return status(500, { message: "Failed to create chat thread" });
   }
 
+  // Index the freshly seeded summary thread so it is findable in
+  // global search. Fire-and-forget: indexing must not fail the create.
+  upsertChatThreadSearchDocument(threadId).catch(captureError);
+
   return { threadId };
 };
 
@@ -677,6 +692,7 @@ const loadSummaryContexts = async ({
   accessibleWorkspaceIds,
   filters,
   organizationId,
+  userId,
   search = searchGlobal,
   selectedWorkspaceIds,
   scopedDb,
@@ -693,6 +709,7 @@ const loadSummaryContexts = async ({
     | "updatedTo"
   >;
   organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
   search?: typeof searchGlobal;
   selectedWorkspaceIds: readonly SafeId<"workspace">[];
   scopedDb: ScopedDb;
@@ -700,6 +717,7 @@ const loadSummaryContexts = async ({
   const searchResult = await search({
     query: filters.query,
     organizationId,
+    userId,
     accessibleWorkspaceIds,
     selectedWorkspaceIds,
     types: filters.types,
@@ -768,7 +786,7 @@ const buildChatSummaryText = ({
 };
 
 const extractHitWorkspaceId = (
-  hit: GlobalSearchHit,
+  hit: CitableSearchHit,
 ): SafeId<"workspace"> | null => {
   if (hit.type === "case-law" || hit.type === "contact") {
     return null;
@@ -826,6 +844,12 @@ const buildSearchResultContexts = async ({
       break;
     }
 
+    // Chat threads are not citable summary sources; skip them so the
+    // remaining work narrows to the citable variants.
+    if (hit.type === "chat") {
+      continue;
+    }
+
     const content = await loadSearchHitContent({
       hit,
       organizationId,
@@ -857,7 +881,7 @@ const buildSearchResultContexts = async ({
 };
 
 type LoadSearchHitContentOptions = {
-  hit: GlobalSearchHit;
+  hit: CitableSearchHit;
   organizationId: SafeId<"organization">;
   accessibleWorkspaceIds: SafeId<"workspace">[];
   scopedDb: ScopedDb;

--- a/apps/api/src/handlers/search/routes.ts
+++ b/apps/api/src/handlers/search/routes.ts
@@ -23,12 +23,13 @@ const searchEndpoint = createSafeRootHandler(
     permissions: { workspace: ["read"] },
     body: searchBodySchema,
   } satisfies HandlerConfig,
-  async function* ({ activeWorkspaceIds, body, scopedDb, session }) {
+  async function* ({ activeWorkspaceIds, body, scopedDb, session, user }) {
     const response = yield* Result.await(
       Result.tryPromise(
         async () =>
           await searchHandler({
             organizationId: session.activeOrganizationId,
+            userId: user.id,
             accessibleWorkspaceIds: activeWorkspaceIds,
             body,
             scopedDb,
@@ -103,12 +104,14 @@ const summarizeSearchEndpoint = createSafeRootHandler(
     promptCachingEnabled,
     scopedDb,
     session,
+    user,
   }) {
     const response = yield* Result.await(
       Result.tryPromise(
         async () =>
           await summarizeSearchResults({
             organizationId: session.activeOrganizationId,
+            userId: user.id,
             accessibleWorkspaceIds: activeWorkspaceIds,
             body,
             orgAIConfig,

--- a/apps/api/src/handlers/search/search.test.ts
+++ b/apps/api/src/handlers/search/search.test.ts
@@ -10,6 +10,7 @@ const searchMock = mock();
 const realDateNow = Date.now;
 
 const organizationId = toSafeId<"organization">("org_1");
+const userId = toSafeId<"user">("user_1");
 const accessibleWorkspaceIds = [
   toSafeId<"workspace">("ws_1"),
   toSafeId<"workspace">("ws_2"),
@@ -65,6 +66,7 @@ describe("search handler workspace scoping", () => {
         query: "closing memo",
       },
       organizationId,
+      userId,
       search: searchMock,
       scopedDb: unusedScopedDb,
     });
@@ -73,6 +75,7 @@ describe("search handler workspace scoping", () => {
       cursor: undefined,
       limit: LIMITS.searchPageSizeDefault,
       organizationId: "org_1",
+      userId: "user_1",
       query: "closing memo",
       types: [],
       editedByUserIds: [],
@@ -96,6 +99,7 @@ describe("search handler workspace scoping", () => {
         workspaceIds: [workspaceId],
       },
       organizationId,
+      userId,
       search: searchMock,
       scopedDb: createWorkspaceLookupScopedDb(findManyMock),
     });
@@ -130,6 +134,7 @@ describe("search handler workspace scoping", () => {
         workspaceIds: [workspaceId, workspaceId, workspaceId],
       },
       organizationId,
+      userId,
       search: searchMock,
       scopedDb: createWorkspaceLookupScopedDb(findManyMock),
     });
@@ -158,6 +163,7 @@ describe("search handler workspace scoping", () => {
         workspaceIds: [toSafeId<"workspace">("ws_other")],
       },
       organizationId,
+      userId,
       search: searchMock,
       scopedDb: unusedScopedDb,
     });
@@ -181,6 +187,7 @@ describe("search handler workspace scoping", () => {
         updatedTo: "2026-04-30T12:00:00.000Z",
       },
       organizationId,
+      userId,
       search: searchMock,
       scopedDb: unusedScopedDb,
     });

--- a/apps/api/src/handlers/search/search.ts
+++ b/apps/api/src/handlers/search/search.ts
@@ -96,6 +96,7 @@ export const resolveSelectedWorkspaceIds = async ({
 type SearchHandlerProps = {
   scopedDb: ScopedDb;
   organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
   accessibleWorkspaceIds: SafeId<"workspace">[];
   body: SearchBodySchema;
   search?: typeof searchGlobal;
@@ -104,6 +105,7 @@ type SearchHandlerProps = {
 export const searchHandler = async ({
   scopedDb,
   organizationId,
+  userId,
   accessibleWorkspaceIds,
   body,
   search = searchGlobal,
@@ -123,6 +125,7 @@ export const searchHandler = async ({
   return await search({
     query: body.query,
     organizationId,
+    userId,
     accessibleWorkspaceIds,
     selectedWorkspaceIds: resolved.ids,
     types,

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -69,6 +69,11 @@ export const LIMITS = {
   searchQueryMaxLength: 500,
   searchPageSizeDefault: 20,
   searchPageSizeMax: 100,
+  /** Cap on the rolled-up message text indexed per chat thread for
+   *  global search. Bounds the stored tsv so a long conversation
+   *  cannot blow up the index; the headline only reads the first
+   *  2000 chars anyway. */
+  chatSearchTextMaxLength: 50_000,
   extractedContentMaxChars: 500_000,
   /** Hard timeout (ms) for the sandboxed extraction subprocess. */
   extractionTimeoutMs: 30_000,

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+const rootDbExecuteMock = mock(async (_query: SQL) => []);
+const rootDbChatThreadFindFirstMock = mock(async () => ({
+  id: toSafeId<"chatThread">("thread_1"),
+  title: "Contract review",
+  updatedAt: new Date("2026-06-06T08:00:00.000Z"),
+  messages: [
+    {
+      content: {
+        version: 1 as const,
+        data: [
+          { type: "text" as const, text: "Review the termination clause." },
+        ],
+      },
+    },
+  ],
+}));
+
+// eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
+mock.module("@/api/db/root", () => ({
+  rootDb: {
+    execute: rootDbExecuteMock,
+    query: {
+      chatThreads: {
+        findFirst: rootDbChatThreadFindFirstMock,
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  rootDbExecuteMock.mockClear();
+  rootDbChatThreadFindFirstMock.mockClear();
+});
+
+describe("chat search indexing", () => {
+  test("does not let stale upserts overwrite a newer search document", async () => {
+    const { upsertChatThreadSearchDocument } = await import("./index-chat");
+
+    await upsertChatThreadSearchDocument(toSafeId<"chatThread">("thread_1"));
+
+    const query = rootDbExecuteMock.mock.calls.at(0)?.[0];
+    expect(query).toBeDefined();
+    if (query === undefined) {
+      return;
+    }
+
+    const compiled = new PgDialect().sqlToQuery(query);
+    expect(compiled.sql).toContain(
+      "WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at",
+    );
+  });
+});

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -1,41 +1,36 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import type { SQL } from "drizzle-orm";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import { toSafeId } from "@/api/lib/branded-types";
-
-const rootDbExecuteMock = mock(async (_query: SQL) => []);
-const rootDbChatThreadFindFirstMock = mock(async () => ({
-  id: toSafeId<"chatThread">("thread_1"),
-  title: "Contract review",
-  updatedAt: new Date("2026-06-06T08:00:00.000Z"),
-  messages: [
-    {
-      content: {
-        version: 1 as const,
-        data: [
-          { type: "text" as const, text: "Review the termination clause." },
-        ],
-      },
-    },
-  ],
-}));
-
-// eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
-mock.module("@/api/db/root", () => ({
-  rootDb: {
-    execute: rootDbExecuteMock,
-    query: {
-      chatThreads: {
-        findFirst: rootDbChatThreadFindFirstMock,
-      },
-    },
-  },
-}));
+import {
+  clearRootDbMocks,
+  rootDbChatThreadFindFirstMock,
+  rootDbExecuteMock,
+} from "@/api/tests/helpers/mock-root-db";
 
 beforeEach(() => {
-  rootDbExecuteMock.mockClear();
-  rootDbChatThreadFindFirstMock.mockClear();
+  clearRootDbMocks();
+  rootDbChatThreadFindFirstMock.mockImplementation(
+    async () =>
+      await Promise.resolve({
+        id: toSafeId<"chatThread">("thread_1"),
+        title: "Contract review",
+        updatedAt: new Date("2026-06-06T08:00:00.000Z"),
+        messages: [
+          {
+            content: {
+              version: 1 as const,
+              data: [
+                {
+                  type: "text" as const,
+                  text: "Review the termination clause.",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+  );
 });
 
 describe("chat search indexing", () => {

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -1,0 +1,117 @@
+import { sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import type { PersistedChatMessageContent } from "@/api/handlers/chat/types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+import { logger } from "@/api/lib/observability/logger";
+
+const BACKFILL_BATCH_SIZE = 200;
+const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
+
+/** The plain searchable text of a thread: the prose of every `text`
+ *  part across all messages, in order, from both the user and the
+ *  assistant. Tool-call, reasoning, and data parts carry no
+ *  user-meaningful prose and are skipped. Capped so a long
+ *  conversation cannot bloat the stored tsv. */
+const extractThreadText = (
+  messages: readonly { content: PersistedChatMessageContent }[],
+): string => {
+  const parts: string[] = [];
+  for (const message of messages) {
+    for (const part of message.content.data) {
+      if (part.type !== "text") {
+        continue;
+      }
+      const trimmed = part.text.trim();
+      if (trimmed) {
+        parts.push(trimmed);
+      }
+    }
+  }
+  return parts.join(" ").slice(0, LIMITS.chatSearchTextMaxLength);
+};
+
+/** Recompute the search document for one thread (title + rolled-up
+ *  message text). Tenancy is not stored here; the global-search query
+ *  derives it by joining back to `chat_threads`. Safe to call after
+ *  any thread mutation; a missing thread is a no-op. */
+export const upsertChatThreadSearchDocument = async (
+  threadId: SafeId<"chatThread">,
+): Promise<void> => {
+  const thread = await rootDb.query.chatThreads.findFirst({
+    where: { id: { eq: threadId } },
+    columns: { id: true, title: true, updatedAt: true },
+    with: {
+      messages: {
+        columns: { content: true },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!thread) {
+    return;
+  }
+
+  const searchableText = extractThreadText(thread.messages);
+
+  await rootDb.execute(sql`
+    INSERT INTO chat_thread_search_documents (
+      thread_id, title, searchable_text, updated_at, tsv
+    ) VALUES (
+      ${thread.id},
+      ${thread.title},
+      ${searchableText},
+      ${thread.updatedAt},
+      to_tsvector(
+        'simple',
+        unaccent(
+          coalesce(${thread.title}, '') || ' ' ||
+          coalesce(${searchableText}, '')
+        )
+      )
+    )
+    ON CONFLICT (thread_id) DO UPDATE SET
+      title = EXCLUDED.title,
+      searchable_text = EXCLUDED.searchable_text,
+      updated_at = EXCLUDED.updated_at,
+      tsv = EXCLUDED.tsv
+  `);
+};
+
+/** One-time backfill: index every thread that has no search document
+ *  yet. Idempotent and resumable. Keyset-paginates by thread id so a
+ *  thread that cannot be indexed (e.g. deleted mid-run) advances the
+ *  cursor instead of looping. */
+export const backfillChatThreadSearchIndex = async (): Promise<number> => {
+  let cursor = ZERO_UUID;
+  let total = 0;
+
+  for (;;) {
+    const batch = await rootDb.execute<{ id: SafeId<"chatThread"> }>(sql`
+      SELECT t.id
+      FROM chat_threads t
+      LEFT JOIN chat_thread_search_documents d ON d.thread_id = t.id
+      WHERE d.thread_id IS NULL
+        AND t.id > ${cursor}::uuid
+      ORDER BY t.id
+      LIMIT ${BACKFILL_BATCH_SIZE}
+    `);
+
+    const last = batch.at(-1);
+    if (!last) {
+      break;
+    }
+
+    for (const row of batch) {
+      await upsertChatThreadSearchDocument(row.id);
+    }
+
+    cursor = String(last.id);
+    total += batch.length;
+    logger.info("chat_search.backfill_progress", { indexed: total });
+  }
+
+  return total;
+};

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
 import type { PersistedChatMessageContent } from "@/api/handlers/chat/types";
+import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
@@ -77,6 +78,7 @@ export const upsertChatThreadSearchDocument = async (
       searchable_text = EXCLUDED.searchable_text,
       updated_at = EXCLUDED.updated_at,
       tsv = EXCLUDED.tsv
+    WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at
   `);
 };
 
@@ -105,7 +107,15 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
     }
 
     for (const row of batch) {
-      await upsertChatThreadSearchDocument(row.id);
+      try {
+        await upsertChatThreadSearchDocument(row.id);
+      } catch (error) {
+        captureError(error, {
+          feature: "chat_search.backfill",
+          threadId: row.id,
+        });
+        logger.error("chat_search.backfill_failed", { threadId: row.id });
+      }
     }
 
     cursor = String(last.id);

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -4,6 +4,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { toSafeId } from "@/api/lib/branded-types";
 import { contactWorkspaceAccessSql } from "@/api/lib/search/contact-workspace-access-sql";
 import { mapEntityHit } from "@/api/lib/search/global-search-mappers";
+import { chatThreadScopeSql } from "@/api/lib/search/index-global";
 import { clearRootDbMocks } from "@/api/tests/helpers/mock-root-db";
 
 process.env["S3_ENDPOINT"] ??= "http://localhost:9000";
@@ -48,6 +49,68 @@ describe("global search SQL scope", () => {
 
     expect(compiled.sql).toContain("w.id = ANY");
     expect(compiled.params).toEqual(["ws_1", "org_1"]);
+  });
+
+  test("scopes chat search to the calling user, org, and data workspaces", () => {
+    const dialect = new PgDialect();
+    const compiled = dialect.sqlToQuery(
+      chatThreadScopeSql({
+        userId: toSafeId<"user">("user_1"),
+        organizationId: toSafeId<"organization">("org_1"),
+        accessibleWorkspaceIds: [
+          toSafeId<"workspace">("ws_1"),
+          toSafeId<"workspace">("ws_2"),
+        ],
+        selectedWorkspaceIds: [],
+      }),
+    );
+
+    // The user filter is the privacy boundary: chat threads are
+    // per-user, and searchGlobal runs on the RLS-bypassing root
+    // connection, so a missing user_id predicate would leak other
+    // users' conversations.
+    expect(compiled.sql).toContain("t.user_id =");
+    expect(compiled.sql).toContain("t.organization_id =");
+    // A workspace-scoped thread must live in an accessible workspace,
+    // and every embedded data workspace must stay within reach.
+    expect(compiled.sql).toContain("t.workspace_id IS NULL");
+    expect(compiled.sql).toContain("data_workspace_ids <@");
+    // Two accessible-workspace arrays (workspace scope + data scope),
+    // no selection clause: six params total.
+    expect(compiled.params).toEqual([
+      "user_1",
+      "org_1",
+      "ws_1",
+      "ws_2",
+      "ws_1",
+      "ws_2",
+    ]);
+  });
+
+  test("narrows chat search to the selected workspaces", () => {
+    const dialect = new PgDialect();
+    const compiled = dialect.sqlToQuery(
+      chatThreadScopeSql({
+        userId: toSafeId<"user">("user_1"),
+        organizationId: toSafeId<"organization">("org_1"),
+        accessibleWorkspaceIds: [
+          toSafeId<"workspace">("ws_1"),
+          toSafeId<"workspace">("ws_2"),
+        ],
+        selectedWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+      }),
+    );
+
+    expect(compiled.sql).toContain("t.workspace_id = ANY");
+    expect(compiled.params).toEqual([
+      "user_1",
+      "org_1",
+      "ws_1",
+      "ws_2",
+      "ws_1",
+      "ws_2",
+      "ws_1",
+    ]);
   });
 
   test("maps the last editor avatar for document hits", () => {

--- a/apps/api/src/lib/search/index-global.test.ts
+++ b/apps/api/src/lib/search/index-global.test.ts
@@ -87,7 +87,7 @@ describe("global search SQL scope", () => {
     ]);
   });
 
-  test("narrows chat search to the selected workspaces", () => {
+  test("narrows chat search to selected thread or data workspaces", () => {
     const dialect = new PgDialect();
     const compiled = dialect.sqlToQuery(
       chatThreadScopeSql({
@@ -102,6 +102,7 @@ describe("global search SQL scope", () => {
     );
 
     expect(compiled.sql).toContain("t.workspace_id = ANY");
+    expect(compiled.sql).toContain("t.data_workspace_ids &&");
     expect(compiled.params).toEqual([
       "user_1",
       "org_1",
@@ -109,6 +110,7 @@ describe("global search SQL scope", () => {
       "ws_2",
       "ws_1",
       "ws_2",
+      "ws_1",
       "ws_1",
     ]);
   });

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -239,9 +239,13 @@ export const chatThreadScopeSql = ({
   selectedWorkspaceIds,
 }: ChatScopeArgs): SQL => {
   const accessArray = typedPgArray(accessibleWorkspaceIds, "uuid");
+  const selectedArray = typedPgArray(selectedWorkspaceIds, "uuid");
   const selectedFilter =
     selectedWorkspaceIds.length > 0
-      ? sql`AND t.workspace_id = ANY(${typedPgArray(selectedWorkspaceIds, "uuid")})`
+      ? sql`AND (
+          t.workspace_id = ANY(${selectedArray})
+          OR t.data_workspace_ids && ${selectedArray}
+        )`
       : sql``;
   return sql`
     t.user_id = ${userId}

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -27,6 +27,7 @@ import {
 import { buildSearchTsQuery } from "@/api/lib/search/query";
 import { typedPgArray } from "@/api/lib/search/sql";
 import type {
+  ChatGlobalSearchHit,
   ContactGlobalSearchHit,
   FacetBucket,
   GlobalSearchHit,
@@ -52,6 +53,9 @@ type SearchPromise = Promise<RawRow[]>;
 export type GlobalSearchQuery = {
   query: string;
   organizationId: SafeId<"organization">;
+  /** The calling user. Chat threads are private per user, so the chat
+   *  source filters on this; the workspace-shared sources ignore it. */
+  userId: SafeId<"user">;
   /** All workspaces the caller is allowed to see. */
   accessibleWorkspaceIds: readonly SafeId<"workspace">[];
   /** User-selected subset to filter by; empty means no extra filter. */
@@ -148,11 +152,16 @@ const shouldSearchType = (
   type: GlobalSearchResultType,
 ) => selected.size === 0 || selected.has(type);
 
+const NON_ENTITY_TYPES: ReadonlySet<GlobalSearchResultType> = new Set([
+  "matter",
+  "contact",
+  "case-law",
+  "chat",
+]);
+
 const hasSelectedEntityType = (selected: ReadonlySet<GlobalSearchResultType>) =>
   selected.size === 0 ||
-  [...selected].some(
-    (type) => type !== "matter" && type !== "contact" && type !== "case-law",
-  );
+  [...selected].some((type) => !NON_ENTITY_TYPES.has(type));
 
 const fileFieldJoin = sql`
   LEFT JOIN LATERAL (
@@ -210,6 +219,42 @@ const workspaceAccessSql = ({
   return sql`AND ${column} = ANY(${typedPgArray(effective, "uuid")})`;
 };
 
+type ChatScopeArgs = {
+  userId: SafeId<"user">;
+  organizationId: SafeId<"organization">;
+  accessibleWorkspaceIds: readonly SafeId<"workspace">[];
+  selectedWorkspaceIds: readonly SafeId<"workspace">[];
+};
+
+// Chat threads are private to the calling user, and `searchGlobal`
+// runs on the RLS-bypassing root connection, so this predicate
+// reproduces the chat-thread RLS scope (db/rls.ts) explicitly. It
+// joins back to `chat_threads t`: the row is visible only to its
+// owner, in its organization, and only while every embedded
+// workspace (`data_workspace_ids`) stays within the caller's access.
+export const chatThreadScopeSql = ({
+  userId,
+  organizationId,
+  accessibleWorkspaceIds,
+  selectedWorkspaceIds,
+}: ChatScopeArgs): SQL => {
+  const accessArray = typedPgArray(accessibleWorkspaceIds, "uuid");
+  const selectedFilter =
+    selectedWorkspaceIds.length > 0
+      ? sql`AND t.workspace_id = ANY(${typedPgArray(selectedWorkspaceIds, "uuid")})`
+      : sql``;
+  return sql`
+    t.user_id = ${userId}
+    AND t.organization_id = ${organizationId}
+    AND (t.workspace_id IS NULL OR t.workspace_id = ANY(${accessArray}))
+    AND (
+      cardinality(t.data_workspace_ids) = 0
+      OR t.data_workspace_ids <@ ${accessArray}
+    )
+    ${selectedFilter}
+  `;
+};
+
 const mapMatterHit = (row: RawRow): ScoredGlobalSearchHit => {
   const workspaceId = String(row["id"]);
   const hit: MatterGlobalSearchHit = {
@@ -253,6 +298,22 @@ const mapCaseLawHit = (row: RawRow): ScoredGlobalSearchHit => {
     country: String(row["country"]),
     decisionDate: toNullableString(row["decision_date"]),
     title: `${String(row["case_number"])} - ${String(row["court"])}`,
+    headline: toHeadline(row["headline"]),
+    updatedAt: toIso(row["updated_at"]),
+  };
+
+  return { hit, score: Number(row["score"]) };
+};
+
+const mapChatHit = (row: RawRow): ScoredGlobalSearchHit => {
+  const threadId = String(row["id"]);
+  const hit: ChatGlobalSearchHit = {
+    id: `chat:${threadId}`,
+    type: "chat",
+    threadId,
+    workspaceId: toNullableString(row["workspace_id"]),
+    workspaceName: toNullableString(row["workspace_name"]),
+    title: String(row["title"]),
     headline: toHeadline(row["headline"]),
     updatedAt: toIso(row["updated_at"]),
   };
@@ -407,7 +468,7 @@ const buildSearchFilterFragments = ({
   });
 
   const entityTypes = [...selected].filter(
-    (type) => type !== "matter" && type !== "contact" && type !== "case-law",
+    (type) => !NON_ENTITY_TYPES.has(type),
   );
   const entityEditorFilter = sqlWhen(
     hasEditorFilter,
@@ -432,6 +493,7 @@ const buildSearchFilterFragments = ({
   const matterUpdatedFilter = updatedRangeFilter(sql`wsd.updated_at`);
   const contactUpdatedFilter = updatedRangeFilter(sql`csd.updated_at`);
   const caseLawUpdatedFilter = updatedRangeFilter(sql`clsd.updated_at`);
+  const chatUpdatedFilter = updatedRangeFilter(sql`cst.updated_at`);
   const entityTypeFilter = sqlWhen(
     selected.size > 0,
     () => sql`AND sd.kind = ANY(${typedPgArray(entityTypes, "text")})`,
@@ -454,6 +516,7 @@ const buildSearchFilterFragments = ({
     matterUpdatedFilter,
     contactUpdatedFilter,
     caseLawUpdatedFilter,
+    chatUpdatedFilter,
     entityTypeFilter,
   };
 };
@@ -461,6 +524,7 @@ const buildSearchFilterFragments = ({
 export const searchGlobal = async ({
   query,
   organizationId,
+  userId,
   accessibleWorkspaceIds,
   selectedWorkspaceIds,
   types,
@@ -492,6 +556,7 @@ export const searchGlobal = async ({
     matterUpdatedFilter,
     contactUpdatedFilter,
     caseLawUpdatedFilter,
+    chatUpdatedFilter,
     entityTypeFilter,
   } = buildSearchFilterFragments({
     query,
@@ -626,6 +691,41 @@ export const searchGlobal = async ({
     `),
   );
 
+  const chatScope = chatThreadScopeSql({
+    userId,
+    organizationId,
+    accessibleWorkspaceIds,
+    selectedWorkspaceIds,
+  });
+
+  const chatPromise = rowsWhen(
+    !restrictToEntities && shouldSearchType(selected, "chat"),
+    () =>
+      rootDb.execute(sql`
+      SELECT
+        t.id AS id,
+        t.workspace_id,
+        w.name AS workspace_name,
+        cst.title,
+        ts_headline(
+          ${headlineRegconfig},
+          cst.title || ' ' || left(cst.searchable_text, 2000),
+          ${tsQuery},
+          ${TS_HEADLINE_CONFIG}
+        ) AS headline,
+        ts_rank(cst.tsv, ${tsQuery})::float8 AS score,
+        cst.updated_at
+      FROM chat_thread_search_documents cst
+      JOIN chat_threads t ON t.id = cst.thread_id
+      LEFT JOIN workspaces w ON w.id = t.workspace_id
+      WHERE ${chatScope}
+        ${chatUpdatedFilter}
+        AND cst.tsv @@ ${tsQuery}
+      ORDER BY score DESC, cst.thread_id DESC
+      LIMIT ${fetchLimit}
+    `),
+  );
+
   const countPromises = [
     countWhen(isFirstPage && hasSelectedEntityType(selected), () =>
       rootDb.execute(sql`
@@ -683,6 +783,18 @@ export const searchGlobal = async ({
         FROM case_law_search_documents clsd
         WHERE clsd.tsv @@ ${tsQuery}
           ${caseLawUpdatedFilter}
+      `),
+    ),
+    countWhen(
+      isFirstPage && !restrictToEntities && shouldSearchType(selected, "chat"),
+      () =>
+        rootDb.execute(sql`
+        SELECT count(*)::int AS total
+        FROM chat_thread_search_documents cst
+        JOIN chat_threads t ON t.id = cst.thread_id
+        WHERE ${chatScope}
+          ${chatUpdatedFilter}
+          AND cst.tsv @@ ${tsQuery}
       `),
     ),
   ] as const;
@@ -743,6 +855,19 @@ export const searchGlobal = async ({
       FROM case_law_search_documents clsd
       WHERE clsd.tsv @@ ${tsQuery}
         ${caseLawUpdatedFilter}
+    `),
+  );
+
+  const chatTypeFacetCountPromise = countWhen(
+    isFirstPage && !restrictToEntities,
+    () =>
+      rootDb.execute(sql`
+      SELECT count(*)::int AS total
+      FROM chat_thread_search_documents cst
+      JOIN chat_threads t ON t.id = cst.thread_id
+      WHERE ${chatScope}
+        ${chatUpdatedFilter}
+        AND cst.tsv @@ ${tsQuery}
     `),
   );
 
@@ -850,14 +975,17 @@ export const searchGlobal = async ({
     matterRows,
     contactRows,
     caseLawRows,
+    chatRows,
     entityCount,
     matterCount,
     contactCount,
     caseLawCount,
+    chatCount,
     entityTypeFacetRows,
     matterTypeFacetCount,
     contactTypeFacetCount,
     caseLawTypeFacetCount,
+    chatTypeFacetCount,
     workspaceFacetRows,
     editorFacetRows,
     mimeTypeFacetRows,
@@ -866,11 +994,13 @@ export const searchGlobal = async ({
     matterPromise,
     contactPromise,
     caseLawPromise,
+    chatPromise,
     ...countPromises,
     entityTypeFacetPromise,
     matterTypeFacetCountPromise,
     contactTypeFacetCountPromise,
     caseLawTypeFacetCountPromise,
+    chatTypeFacetCountPromise,
     workspaceFacetPromise,
     editorFacetPromise,
     mimeTypeFacetPromise,
@@ -881,6 +1011,7 @@ export const searchGlobal = async ({
     ...matterRows.map(mapMatterHit),
     ...contactRows.map(mapContactHit),
     ...caseLawRows.map(mapCaseLawHit),
+    ...chatRows.map(mapChatHit),
   ].sort((a, b) => b.score - a.score || b.hit.id.localeCompare(a.hit.id));
 
   const hits = scoredHits.slice(offset, offset + limit).map(({ hit }) => hit);
@@ -888,8 +1019,9 @@ export const searchGlobal = async ({
   const totalMatters = totalFrom(matterCount);
   const totalContacts = totalFrom(contactCount);
   const totalCaseLaw = totalFrom(caseLawCount);
+  const totalChat = totalFrom(chatCount);
   const totalCount =
-    totalEntities + totalMatters + totalContacts + totalCaseLaw;
+    totalEntities + totalMatters + totalContacts + totalCaseLaw + totalChat;
 
   const typeFacetMap = new Map<string, { count: number }>();
   for (const row of entityTypeFacetRows) {
@@ -898,6 +1030,7 @@ export const searchGlobal = async ({
   const matterFacetCount = totalFrom(matterTypeFacetCount);
   const contactFacetCount = totalFrom(contactTypeFacetCount);
   const caseLawFacetCount = totalFrom(caseLawTypeFacetCount);
+  const chatFacetCount = totalFrom(chatTypeFacetCount);
   if (matterFacetCount > 0) {
     typeFacetMap.set("matter", { count: matterFacetCount });
   }
@@ -906,6 +1039,9 @@ export const searchGlobal = async ({
   }
   if (caseLawFacetCount > 0) {
     typeFacetMap.set("case-law", { count: caseLawFacetCount });
+  }
+  if (chatFacetCount > 0) {
+    typeFacetMap.set("chat", { count: chatFacetCount });
   }
 
   const workspaceFacetMap = toStringFacetMap(workspaceFacetRows);

--- a/apps/api/src/lib/search/types.ts
+++ b/apps/api/src/lib/search/types.ts
@@ -115,6 +115,9 @@ export const GLOBAL_SEARCH_RESULT_TYPES = [
   "contact",
   "case-law",
   ...ENTITY_KINDS,
+  // Appended last on purpose: Elysia coerces an absent optional
+  // UnionEnum to the FIRST element, so new types must never take slot 0.
+  "chat",
 ] as const;
 
 export type GlobalSearchResultType =
@@ -172,11 +175,20 @@ export type CaseLawGlobalSearchHit = GlobalSearchHitBase & {
   decisionDate: string | null;
 };
 
+export type ChatGlobalSearchHit = GlobalSearchHitBase & {
+  type: "chat";
+  threadId: string;
+  /** Null for cross-workspace (global) threads. */
+  workspaceId: string | null;
+  workspaceName: string | null;
+};
+
 export type GlobalSearchHit =
   | EntityGlobalSearchHit
   | MatterGlobalSearchHit
   | ContactGlobalSearchHit
-  | CaseLawGlobalSearchHit;
+  | CaseLawGlobalSearchHit
+  | ChatGlobalSearchHit;
 
 export type GlobalSearchFacets = {
   type: FacetBucket[];

--- a/apps/api/src/tests/helpers/mock-root-db.ts
+++ b/apps/api/src/tests/helpers/mock-root-db.ts
@@ -1,19 +1,35 @@
 import { mock } from "bun:test";
+import type { SQL } from "drizzle-orm";
 
 export const rootDbExecuteMock = mock(
-  async (_query: unknown): Promise<Record<string, unknown>[]> =>
+  async (_query: SQL): Promise<Record<string, unknown>[]> =>
     await Promise.resolve([]),
 );
+export const rootDbLimitMock = mock(
+  async (): Promise<Record<string, unknown>[]> =>
+    await Promise.resolve([{ searchableText: "Document content" }]),
+);
+export const rootDbWhereMock = mock(() => ({ limit: rootDbLimitMock }));
+export const rootDbFromMock = mock(() => ({ where: rootDbWhereMock }));
+export const rootDbSelectMock = mock(() => ({ from: rootDbFromMock }));
 export const rootDbCaseLawDecisionFindFirstMock = mock(
   async () => await Promise.resolve(null),
+);
+export const rootDbChatThreadFindFirstMock = mock(
+  async (): Promise<Record<string, unknown> | null> =>
+    await Promise.resolve(null),
 );
 
 void mock.module("@/api/db/root", () => ({
   rootDb: {
     execute: rootDbExecuteMock,
+    select: rootDbSelectMock,
     query: {
       caseLawDecisions: {
         findFirst: rootDbCaseLawDecisionFindFirstMock,
+      },
+      chatThreads: {
+        findFirst: rootDbChatThreadFindFirstMock,
       },
     },
   },
@@ -21,5 +37,27 @@ void mock.module("@/api/db/root", () => ({
 
 export const clearRootDbMocks = () => {
   rootDbExecuteMock.mockClear();
+  rootDbExecuteMock.mockImplementation(
+    async (_query: SQL): Promise<Record<string, unknown>[]> =>
+      await Promise.resolve([]),
+  );
+  rootDbSelectMock.mockClear();
+  rootDbSelectMock.mockImplementation(() => ({ from: rootDbFromMock }));
+  rootDbFromMock.mockClear();
+  rootDbFromMock.mockImplementation(() => ({ where: rootDbWhereMock }));
+  rootDbWhereMock.mockClear();
+  rootDbWhereMock.mockImplementation(() => ({ limit: rootDbLimitMock }));
+  rootDbLimitMock.mockClear();
+  rootDbLimitMock.mockImplementation(
+    async (): Promise<Record<string, unknown>[]> =>
+      await Promise.resolve([{ searchableText: "Document content" }]),
+  );
   rootDbCaseLawDecisionFindFirstMock.mockClear();
+  rootDbCaseLawDecisionFindFirstMock.mockImplementation(
+    async () => await Promise.resolve(null),
+  );
+  rootDbChatThreadFindFirstMock.mockClear();
+  rootDbChatThreadFindFirstMock.mockImplementation(
+    async () => await Promise.resolve(null),
+  );
 };

--- a/apps/web/src/components/search-dialog.logic.test.ts
+++ b/apps/web/src/components/search-dialog.logic.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import type { GlobalSearchHit } from "@stll/api/types";
+
+import { getChatHitRoute } from "./search-dialog.logic";
+
+type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;
+
+const chatHit = (
+  overrides: Pick<ChatGlobalSearchHit, "threadId" | "workspaceId">,
+): ChatGlobalSearchHit => ({
+  id: `chat:${overrides.threadId}`,
+  type: "chat",
+  title: "Review privilege memo",
+  headline: null,
+  updatedAt: "2026-06-06T10:00:00.000Z",
+  threadId: overrides.threadId,
+  workspaceId: overrides.workspaceId,
+  workspaceName: overrides.workspaceId ? "Matter Alpha" : null,
+});
+
+describe("search chat result routing", () => {
+  test("opens global chat hits on the global chat route", () => {
+    expect(
+      getChatHitRoute(
+        chatHit({ threadId: "thread-global", workspaceId: null }),
+      ),
+    ).toEqual({
+      to: "/chat/$threadId",
+      params: { threadId: "thread-global" },
+    });
+  });
+
+  test("opens workspace chat hits on the workspace-scoped chat route", () => {
+    expect(
+      getChatHitRoute(
+        chatHit({ threadId: "thread-workspace", workspaceId: "workspace-1" }),
+      ),
+    ).toEqual({
+      to: "/chat/workspaces/$workspaceId/$threadId",
+      params: { workspaceId: "workspace-1", threadId: "thread-workspace" },
+    });
+  });
+});

--- a/apps/web/src/components/search-dialog.logic.ts
+++ b/apps/web/src/components/search-dialog.logic.ts
@@ -1,0 +1,27 @@
+import type { GlobalSearchHit } from "@stll/api/types";
+
+type ChatGlobalSearchHit = Extract<GlobalSearchHit, { type: "chat" }>;
+
+export type ChatHitRoute =
+  | {
+      to: "/chat/$threadId";
+      params: { threadId: string };
+    }
+  | {
+      to: "/chat/workspaces/$workspaceId/$threadId";
+      params: { workspaceId: string; threadId: string };
+    };
+
+export const getChatHitRoute = (hit: ChatGlobalSearchHit): ChatHitRoute => {
+  if (hit.workspaceId) {
+    return {
+      to: "/chat/workspaces/$workspaceId/$threadId",
+      params: { workspaceId: hit.workspaceId, threadId: hit.threadId },
+    };
+  }
+
+  return {
+    to: "/chat/$threadId",
+    params: { threadId: hit.threadId },
+  };
+};

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -13,6 +13,7 @@ import {
   LinkIcon,
   LoaderIcon,
   MessageSquareIcon,
+  MessagesSquareIcon,
   SquareCheckIcon,
   UserIcon,
   WandSparklesIcon,
@@ -109,6 +110,7 @@ const KIND_ICONS = {
   task: SquareCheckIcon,
   message: MessageSquareIcon,
   link: LinkIcon,
+  chat: MessagesSquareIcon,
 } as const satisfies Record<GlobalSearchResultType, typeof FileTextIcon>;
 
 const KIND_TRANSLATION_KEYS = {
@@ -120,6 +122,7 @@ const KIND_TRANSLATION_KEYS = {
   task: "search.kinds.task",
   message: "search.kinds.message",
   link: "search.kinds.link",
+  chat: "search.kinds.chat",
 } as const satisfies Record<GlobalSearchResultType, TranslationKey>;
 
 const SEARCH_KIND_TYPES = [
@@ -131,6 +134,7 @@ const SEARCH_KIND_TYPES = [
   "task",
   "message",
   "link",
+  "chat",
 ] as const satisfies readonly GlobalSearchResultType[];
 
 const TIME_PRESET_TRANSLATION_KEYS = {
@@ -152,6 +156,7 @@ const isSearchKindOption = (
     case "task":
     case "message":
     case "link":
+    case "chat":
       return true;
     default:
       return false;
@@ -712,6 +717,14 @@ export const SearchDialog = ({
       await navigate({
         to: "/workspaces/$workspaceId",
         params: { workspaceId: hit.workspaceId },
+      });
+      return;
+    }
+
+    if (hit.type === "chat") {
+      await navigate({
+        to: "/chat/$threadId",
+        params: { threadId: hit.threadId },
       });
       return;
     }
@@ -1649,6 +1662,8 @@ const SearchResultItem = ({
   } else if (hit.type === "case-law") {
     meta = "";
   } else if (hit.type === "matter") {
+    meta = compactMeta([hit.workspaceName, formatted]);
+  } else if (hit.type === "chat") {
     meta = compactMeta([hit.workspaceName, formatted]);
   } else {
     const lastEditedByName =

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -41,6 +41,7 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
+import { getChatHitRoute } from "@/components/search-dialog.logic";
 import { UserAvatar } from "@/components/user-avatar";
 import {
   isPublicLawPreviewEnabled,
@@ -722,10 +723,7 @@ export const SearchDialog = ({
     }
 
     if (hit.type === "chat") {
-      await navigate({
-        to: "/chat/$threadId",
-        params: { threadId: hit.threadId },
-      });
+      await navigate(getChatHitRoute(hit));
       return;
     }
 

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -483,6 +483,13 @@
       "pt-BR",
       "sk"
     ],
+    "search.kinds.chat": [
+      "cs",
+      "de",
+      "es",
+      "fr",
+      "sk"
+    ],
     "search.kinds.contact": [
       "fr"
     ],

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Judikatura",
+      "chat": "Chat",
       "contact": "Kontakt",
       "document": "Dokument",
       "folder": "Složka",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Rechtsprechung",
+      "chat": "Chat",
       "contact": "Kontakt",
       "document": "Dokument",
       "folder": "Ordner",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Case law",
+      "chat": "Chat",
       "contact": "Contact",
       "document": "Document",
       "folder": "Folder",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Jurisprudencia",
+      "chat": "Chat",
       "contact": "Contacto",
       "document": "Documento",
       "folder": "Carpeta",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Kohtupraktika",
+      "chat": "Vestlus",
       "contact": "Kontakt",
       "document": "Dokument",
       "folder": "Kaust",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Jurisprudence",
+      "chat": "Chat",
       "contact": "Contact",
       "document": "Document",
       "folder": "Dossier",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Ítélkezési gyakorlat",
+      "chat": "Csevegés",
       "contact": "Kapcsolat",
       "document": "Dokumentum",
       "folder": "Mappa",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Teismų praktika",
+      "chat": "Pokalbis",
       "contact": "Kontaktas",
       "document": "Dokumentas",
       "folder": "Aplankas",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Judikatūra",
+      "chat": "Tērzēšana",
       "contact": "Kontakts",
       "document": "Dokuments",
       "folder": "Mape",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1746,6 +1746,7 @@ type Messages = {
     "escKey": "ESC";
     "kinds": {
       "caseLaw": "Case law";
+      "chat": "Chat";
       "contact": "Contact";
       "document": "Document";
       "folder": "Folder";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Orzecznictwo",
+      "chat": "Czat",
       "contact": "Kontakt",
       "document": "Dokument",
       "folder": "Folder",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Jurisprudência",
+      "chat": "Bate-papo",
       "contact": "Contato",
       "document": "Documento",
       "folder": "Pasta",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1743,6 +1743,7 @@
     "escKey": "ESC",
     "kinds": {
       "caseLaw": "Judikatúra",
+      "chat": "Chat",
       "contact": "Kontakt",
       "document": "Dokument",
       "folder": "Priečinok",


### PR DESCRIPTION
Adds AI chat threads as a fifth source in global search (Cmd+K), alongside entities, matters, contacts, and case law.

## Changes
- **Schema/migration**: new `chat_thread_search_documents` table — one row per thread (title + rolled-up message text + `tsv`). Tenancy is derived by joining back to `chat_threads`, so the index never drifts from thread ownership; rows cascade on thread delete.
- **Indexing**: `index-chat.ts` (`upsertChatThreadSearchDocument`, `backfillChatThreadSearchIndex`), refreshed fire-and-forget on message persistence, AI title generation, and summary-thread creation.
- **Query**: `searchGlobal` gains a `userId` parameter and a per-user scope predicate (`chatThreadScopeSql`). Chat threads are private per user, and the global query runs on the root connection, so the user/workspace/data-scope filter is applied explicitly and mirrors thread access.
- **Result type**: discriminated `ChatGlobalSearchHit`, hit mapper, type-facet count, and `/chat/$threadId` navigation wired through the search dialog. Chat is excluded from AI summary citations (a conversation is not a citable source).
- **i18n**: `search.kinds.chat` across all locales.

## Follow-up after merge
- `db:migrate` to apply the table, then `db:backfill-chat-search` once to index existing threads.

## Out of scope
Per-message deep-linking; chat in the workspace/editor/mime facets.