### PR TITLE
feat(api): log non-PII connection detail for redis worker and SSE errors

### DIFF
--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  connectionErrorFields,
+  errorSystemFields,
+} from "@/api/lib/errors/utils";
+import { sanitizeLogAttributes } from "@/api/lib/observability/logger";
+
+describe("errorSystemFields", () => {
+  test("extracts the structural type and non-PII system codes", () => {
+    const error = Object.assign(
+      new Error("connect ECONNREFUSED 10.0.0.5:6379"),
+      { code: "ECONNREFUSED", errno: -111, syscall: "connect" },
+    );
+    const fields = errorSystemFields(error);
+    expect(fields["error.type"]).toBe("Error");
+    expect(fields["error.code"]).toBe("ECONNREFUSED");
+    expect(fields["error.errno"]).toBe("-111");
+    expect(fields["error.syscall"]).toBe("connect");
+  });
+
+  // The whole reason errorSystemFields exists separately from
+  // connectionErrorFields: it must stay safe for analytics sinks
+  // that can observe handler/user-data errors. A regression that
+  // folds the message in here would leak PII.
+  test("never includes the raw message (PII boundary)", () => {
+    const error = new Error("privileged: alice uploaded merger-secret.docx");
+    const fields = errorSystemFields(error);
+    expect(fields).not.toHaveProperty("error.message");
+    expect(fields).not.toHaveProperty("error.msg");
+  });
+
+  test("surfaces the cause type and code", () => {
+    const cause = Object.assign(new Error("socket hang up"), {
+      code: "ECONNRESET",
+    });
+    const fields = errorSystemFields(new Error("wrapped", { cause }));
+    expect(fields["error.cause.type"]).toBe("Error");
+    expect(fields["error.cause.code"]).toBe("ECONNRESET");
+  });
+
+  test("handles non-Error values", () => {
+    expect(errorSystemFields("boom")).toEqual({ "error.type": "UnknownError" });
+  });
+});
+
+describe("connectionErrorFields", () => {
+  test("adds the message under error.msg on top of the system fields", () => {
+    const error = Object.assign(new Error("Connection is closed"), {
+      code: "ECONNRESET",
+    });
+    const fields = connectionErrorFields(error);
+    expect(fields["error.msg"]).toBe("Connection is closed");
+    expect(fields["error.code"]).toBe("ECONNRESET");
+    expect(fields["error.type"]).toBe("Error");
+  });
+
+  test("omits an empty message", () => {
+    const error = new Error("placeholder");
+    error.message = "";
+    expect(connectionErrorFields(error)).not.toHaveProperty("error.msg");
+  });
+
+  // Regression guard: the logger's sanitizer drops any key matching
+  // /message/i, so the message must ride on `error.msg` to survive.
+  // If anyone renames it back to `error.message`, this fails.
+  test("error.msg survives the logger attribute sanitizer", () => {
+    const error = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    });
+    const sanitized = sanitizeLogAttributes(connectionErrorFields(error));
+    expect(sanitized?.["error.msg"]).toBe("read ECONNRESET");
+    expect(sanitized?.["error.code"]).toBe("ECONNRESET");
+    // Proves the drop the field name sidesteps is real.
+    expect(sanitizeLogAttributes({ "error.message": "x" })).not.toHaveProperty(
+      "error.message",
+    );
+  });
+});

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -23,6 +23,71 @@ export const errorTag = (error: unknown): string => {
 };
 
 /**
+ * Non-PII connection/system fields for infra observability.
+ *
+ * Network, socket, TLS and DNS failures carry structured fields —
+ * `code` (ECONNRESET, ETIMEDOUT, EAI_AGAIN…), `errno`, `syscall` —
+ * that pinpoint the failure without any client data. Unlike
+ * `error.message`, these are safe to ship to analytics dashboards,
+ * so this extends `errorTag` rather than replacing it.
+ */
+export const errorSystemFields = (error: unknown): Record<string, string> => {
+  const fields: Record<string, string> = { "error.type": errorTag(error) };
+  if (!(error instanceof Error)) {
+    return fields;
+  }
+  if ("code" in error && typeof error.code === "string") {
+    fields["error.code"] = error.code;
+  }
+  if ("errno" in error && typeof error.errno === "number") {
+    fields["error.errno"] = String(error.errno);
+  }
+  if ("syscall" in error && typeof error.syscall === "string") {
+    fields["error.syscall"] = error.syscall;
+  }
+  if (error.cause !== undefined) {
+    fields["error.cause.type"] = errorTag(error.cause);
+    if (
+      error.cause instanceof Error &&
+      "code" in error.cause &&
+      typeof error.cause.code === "string"
+    ) {
+      fields["error.cause.code"] = error.cause.code;
+    }
+  }
+  return fields;
+};
+
+/**
+ * `errorSystemFields` plus the raw error message under `error.msg`.
+ *
+ * ONLY for infra sinks that exclusively observe connection-level
+ * failures — Redis/BullMQ `worker.on("error")` and the SSE pub/sub
+ * subscriber. Those errors are socket/TLS/Redis-protocol messages
+ * ("Connection is closed", "read ECONNRESET"), never document
+ * content or client data, so surfacing the message stays non-PII
+ * while making the failure diagnosable. Do NOT use at sinks that
+ * can observe handler or user-data errors; keep those on `errorTag`
+ * or `errorSystemFields`.
+ *
+ * The key is `error.msg`, not `error.message`: the logger's
+ * `sanitizeLogAttributes` drops any attribute key matching /message/i
+ * as a blanket PII guard, which would silently strip the value.
+ * `msg` sidesteps that drop; the connection-only scope above is what
+ * keeps surfacing the message safe. See utils.test.ts for the
+ * sanitizer-survival guard.
+ */
+export const connectionErrorFields = (
+  error: unknown,
+): Record<string, string> => {
+  const fields = errorSystemFields(error);
+  if (error instanceof Error && error.message) {
+    fields["error.msg"] = error.message;
+  }
+  return fields;
+};
+
+/**
  * Surface an error in dev. Two sinks:
  *  1) `console.error` — the interactive dev terminal sees it now.
  *  2) `apps/api/.dev-logs/errors.jsonl` — headless tools (CI repro

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -11,7 +11,7 @@ import {
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
-import { errorTag } from "@/api/lib/errors/utils";
+import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -169,9 +169,7 @@ export const initFileDerivativeWorker = () => {
   });
 
   worker.on("error", (error) => {
-    logger.error("file_derivative.worker_error", {
-      "error.type": errorTag(error),
-    });
+    logger.error("file_derivative.worker_error", connectionErrorFields(error));
   });
 
   logger.info("file_derivative.worker_started", {

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -1,5 +1,5 @@
 import type { SafeId } from "@/api/lib/branded-types";
-import { errorTag } from "@/api/lib/errors/utils";
+import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createRedisClient } from "@/api/lib/redis-client";
 import {
@@ -170,9 +170,7 @@ const initRedis = async () => {
     });
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
-    logger.error("sse.redis_connection_failed", {
-      "error.type": errorTag(error),
-    });
+    logger.error("sse.redis_connection_failed", connectionErrorFields(error));
   }
 };
 

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -24,7 +24,11 @@ import { captureError } from "@/api/lib/analytics";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { acquireCellLocks } from "@/api/lib/cell-lock";
-import { errorTag } from "@/api/lib/errors/utils";
+import {
+  connectionErrorFields,
+  errorSystemFields,
+  errorTag,
+} from "@/api/lib/errors/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 import {
@@ -1230,7 +1234,7 @@ export const initWorkflowWorker = () => {
   });
 
   worker.on("error", (error) => {
-    logger.error("workflow.worker_error", { "error.type": errorTag(error) });
+    logger.error("workflow.worker_error", connectionErrorFields(error));
   });
 
   logger.info("workflow.worker_started", {
@@ -1246,9 +1250,7 @@ export const initWorkflowWorker = () => {
     void reconcileOrphanedWorkflows({ scanPendingCells }).catch(
       (error: unknown) => {
         captureError(error);
-        logger.error("workflow.reconcile_failed", {
-          "error.type": errorTag(error),
-        });
+        logger.error("workflow.reconcile_failed", errorSystemFields(error));
       },
     );
   };


### PR DESCRIPTION
## What

Infra error sinks only recorded the error constructor name (`"error.type":"Error"`), which is undiagnosable for connection-layer failures:
- BullMQ `worker.on("error")` for the workflow and file-derivative queues
- the SSE Redis pub/sub subscriber

Adds two helpers in `errors/utils.ts`:
- **`errorSystemFields`** — structural type plus non-PII system fields (`code` e.g. `ECONNRESET`/`ETIMEDOUT`, `errno`, `syscall`, and the cause's type/code). Safe for any sink; used for `reconcile_failed` (which also touches the DB).
- **`connectionErrorFields`** — `errorSystemFields` plus the raw `error.message`, scoped to sinks that *only* ever observe connection errors (socket/TLS/Redis-protocol messages, never client data).

## Why

Connection failures need the system `code` and message to diagnose; tag-only logging hid both. The split keeps free-text messages off sinks that can observe handler/user-data errors, preserving the non-PII guarantee `errorTag` was written for.

## Test

`errors/utils.test.ts` locks the PII boundary (`errorSystemFields` never emits `error.message`) and the code/cause extraction. 6/6 pass.