### PR TITLE
refactor(folio): tighten layout-engine enum strings to OOXML unions

### DIFF
--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -10,9 +10,10 @@ import type {
   ImageWrap,
   SdtProperties,
   SdtType,
-  ShapeOutline,
   TableWidthType,
 } from "@stll/docx-core/model";
+
+import type { OutlineStyleAttr } from "../types/documentEnumValues";
 
 /**
  * Unique identifier for a block in the document.
@@ -649,8 +650,8 @@ export type TextBoxBlock = {
   outlineWidth?: number;
   /** Border color */
   outlineColor?: string;
-  /** Border style */
-  outlineStyle?: NonNullable<ShapeOutline["style"]>;
+  /** Outline dash style, or `"none"` for an explicit no-outline. */
+  outlineStyle?: OutlineStyleAttr;
   /** Internal padding */
   margins?: { top: number; bottom: number; left: number; right: number };
   /** Paragraph blocks inside the text box */

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -5,7 +5,14 @@
  * Converts document blocks + measurements into positioned fragments on pages.
  */
 
-import type { ImagePosition } from "@stll/docx-core/model";
+import type {
+  ImagePosition,
+  ImageWrap,
+  SdtProperties,
+  SdtType,
+  ShapeOutline,
+  TableWidthType,
+} from "@stll/docx-core/model";
 
 /**
  * Unique identifier for a block in the document.
@@ -27,6 +34,11 @@ export type RunFormatting = {
   strike?: boolean;
   color?: string;
   textColorSource?: "direct" | "paragraphDefault";
+  // TODO: cannot tighten to NonNullable<TextFormatting["highlight"]> (the OOXML
+  // named-color union). The bridge stores a *resolved CSS* color here via
+  // `resolveHighlightToCss` (named color → hex, or raw `#hex`), so values like
+  // `#FFFF00` are not union members. Either keep a separate CSS field or move
+  // resolution to the painter before this can become the named-color union.
   highlight?: string;
   fontFamily?: string;
   fontSize?: number;
@@ -175,7 +187,7 @@ export type ImageRun = {
   /** Position for floating/anchored images */
   position?: ImageRunPosition;
   /** Wrap type from DOCX (inline, square, tight, through, topAndBottom, etc.) */
-  wrapType?: string;
+  wrapType?: ImageWrap["type"];
   /** Display mode for CSS rendering */
   displayMode?: "inline" | "block" | "float";
   /** CSS float direction */
@@ -308,7 +320,12 @@ export type TabStop = {
  * Border specification for paragraphs.
  */
 export type BorderStyle = {
-  style?: string;
+  // TODO: this holds a *CSS* border-style (solid, double, ridge, groove, …),
+  // mapped from OOXML by `OOXML_TO_CSS_BORDER` in the bridge. It is NOT the
+  // OOXML `KnownBorderStyle` union (single/thinThickSmallGap/…), and includes
+  // CSS-only values (ridge/groove) that have no union member. Move the OOXML→CSS
+  // mapping to the painter to make this the `KnownBorderStyle` union.
+  style?: string; // CSS border-style
   width?: number; // in pixels
   color?: string; // CSS color
   space?: number; // spacing from text in pixels (from w:space, converted from pt)
@@ -440,6 +457,9 @@ export type ParagraphBlock = {
 export type CellBorderSpec = {
   width?: number; // pixels
   color?: string; // CSS color
+  // TODO: CSS border-style mapped from OOXML by the bridge, not the OOXML
+  // `KnownBorderStyle` union (see BorderStyle.style). Includes CSS-only values
+  // (ridge/groove) with no union member.
   style?: string; // CSS border-style (solid, dashed, dotted, double)
 };
 
@@ -513,7 +533,7 @@ export type TableBlock = {
   /** Table width value (twips for dxa, 50ths of percent for pct). */
   width?: number;
   /** Table width type ('auto', 'pct', 'dxa', 'nil'). */
-  widthType?: string;
+  widthType?: TableWidthType;
   /** Table horizontal alignment */
   justification?: "left" | "center" | "right";
   /** Table indent from left margin (in pixels, from w:tblInd) */
@@ -630,7 +650,7 @@ export type TextBoxBlock = {
   /** Border color */
   outlineColor?: string;
   /** Border style */
-  outlineStyle?: string;
+  outlineStyle?: NonNullable<ShapeOutline["style"]>;
   /** Internal padding */
   margins?: { top: number; bottom: number; left: number; right: number };
   /** Paragraph blocks inside the text box */
@@ -640,7 +660,7 @@ export type TextBoxBlock = {
   /** CSS float direction copied from the ProseMirror text box node. */
   cssFloat?: "left" | "right" | "none";
   /** OOXML wrap type for anchored text boxes. */
-  wrapType?: string;
+  wrapType?: ImageWrap["type"];
   /** OOXML wrapText direction for anchored text boxes. */
   wrapText?: "bothSides" | "left" | "right" | "largest";
   /** Position for floating/anchored text boxes (OOXML EMU offsets). */
@@ -671,7 +691,7 @@ export type SdtGroup = {
    * the addressing API uses this to disambiguate SDTs that share a tag.
    */
   pmPos: number;
-  sdtType: string;
+  sdtType: SdtType;
   /** OOXML `w:alias` (friendly display name). */
   alias?: string;
   /** OOXML `w:tag` (developer identifier — anchor for addressing API). */
@@ -679,7 +699,7 @@ export type SdtGroup = {
   /** OOXML numeric `w:id`. */
   sdtId?: number;
   /** OOXML `w:lock` setting. */
-  lock?: string;
+  lock?: NonNullable<SdtProperties["lock"]>;
   /** True if `w:showingPlcHdr` is set. */
   showingPlaceholder?: boolean;
   /** Modeled checkbox state, when the control is `w14:checkbox`. */

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -424,6 +424,26 @@ describe("ProseMirror attr readers", () => {
     }
   });
 
+  test("accepts the explicit 'none' outline style (legacy round-trip)", () => {
+    // "none" is the no-outline sentinel persisted in existing documents (see
+    // OUTLINE_STYLE_ATTR_VALUES). It must validate rather than panic, and stay
+    // unchanged, even though it is not an OOXML dash style. eigenpal #694.
+    const shape = schema.nodes.shape.create({ outlineStyle: "none" });
+    const textBox = schema.nodes.textBox.create({ outlineStyle: "none" });
+
+    const shapeResult = readShapeAttrs(shape);
+    const textBoxResult = readTextBoxAttrs(textBox);
+
+    expect(shapeResult.ok).toBe(true);
+    if (shapeResult.ok) {
+      expect(shapeResult.value.outlineStyle).toBe("none");
+    }
+    expect(textBoxResult.ok).toBe(true);
+    if (textBoxResult.ok) {
+      expect(textBoxResult.value.outlineStyle).toBe("none");
+    }
+  });
+
   test("rejects malformed hyperlink mark attrs", () => {
     const mark = schema.marks.hyperlink.create({ href: 42 });
 

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -424,23 +424,27 @@ describe("ProseMirror attr readers", () => {
     }
   });
 
-  test("accepts the explicit 'none' outline style (legacy round-trip)", () => {
-    // "none" is the no-outline sentinel persisted in existing documents (see
-    // OUTLINE_STYLE_ATTR_VALUES). It must validate rather than panic, and stay
-    // unchanged, even though it is not an OOXML dash style. eigenpal #694.
-    const shape = schema.nodes.shape.create({ outlineStyle: "none" });
-    const textBox = schema.nodes.textBox.create({ outlineStyle: "none" });
+  test("accepts non-OOXML outline styles persisted in existing docs", () => {
+    // The folio attr also holds values outside ST_PresetLineDashVal: the CSS
+    // aliases `dashed`/`dotted` (mapped to OOXML on export) and the `"none"`
+    // no-outline sentinel. All must validate rather than panic, and stay
+    // unchanged. See OUTLINE_STYLE_ATTR_VALUES. eigenpal #694.
+    for (const outlineStyle of ["none", "dashed", "dotted"] as const) {
+      const shapeResult = readShapeAttrs(
+        schema.nodes.shape.create({ outlineStyle }),
+      );
+      const textBoxResult = readTextBoxAttrs(
+        schema.nodes.textBox.create({ outlineStyle }),
+      );
 
-    const shapeResult = readShapeAttrs(shape);
-    const textBoxResult = readTextBoxAttrs(textBox);
-
-    expect(shapeResult.ok).toBe(true);
-    if (shapeResult.ok) {
-      expect(shapeResult.value.outlineStyle).toBe("none");
-    }
-    expect(textBoxResult.ok).toBe(true);
-    if (textBoxResult.ok) {
-      expect(textBoxResult.value.outlineStyle).toBe("none");
+      expect(shapeResult.ok).toBe(true);
+      if (shapeResult.ok) {
+        expect(shapeResult.value.outlineStyle).toBe(outlineStyle);
+      }
+      expect(textBoxResult.ok).toBe(true);
+      if (textBoxResult.ok) {
+        expect(textBoxResult.value.outlineStyle).toBe(outlineStyle);
+      }
     }
   });
 

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -11,11 +11,11 @@ import {
   IMAGE_WRAP_TEXT_VALUES,
   IMAGE_WRAP_TYPE_VALUES,
   LINE_SPACING_RULE_VALUES,
+  OUTLINE_STYLE_ATTR_VALUES,
   PARAGRAPH_ALIGNMENT_VALUES,
   SDT_LOCK_VALUES,
   SDT_TYPE_VALUES,
   SHADING_PATTERN_VALUES,
-  SHAPE_OUTLINE_STYLE_VALUES,
   TABLE_CELL_TEXT_DIRECTION_VALUES,
   TABLE_CELL_VERTICAL_ALIGNMENT_VALUES,
   TABLE_JUSTIFICATION_VALUES,
@@ -882,7 +882,7 @@ export const readShapeAttrs = (
     "outlineStyle",
     "shape.attrs.outlineStyle",
     issues,
-    SHAPE_OUTLINE_STYLE_VALUES,
+    OUTLINE_STYLE_ATTR_VALUES,
   );
   optionalOneOf(
     attrs,
@@ -968,7 +968,7 @@ export const readTextBoxAttrs = (
     "outlineStyle",
     "textBox.attrs.outlineStyle",
     issues,
-    SHAPE_OUTLINE_STYLE_VALUES,
+    OUTLINE_STYLE_ATTR_VALUES,
   );
   optionalNumber(attrs, "marginTop", "textBox.attrs.marginTop", issues);
   optionalNumber(attrs, "marginBottom", "textBox.attrs.marginBottom", issues);

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -15,6 +15,7 @@ import {
   SDT_LOCK_VALUES,
   SDT_TYPE_VALUES,
   SHADING_PATTERN_VALUES,
+  SHAPE_OUTLINE_STYLE_VALUES,
   TABLE_CELL_TEXT_DIRECTION_VALUES,
   TABLE_CELL_VERTICAL_ALIGNMENT_VALUES,
   TABLE_JUSTIFICATION_VALUES,
@@ -876,7 +877,13 @@ export const readShapeAttrs = (
   );
   optionalNumber(attrs, "outlineWidth", "shape.attrs.outlineWidth", issues);
   optionalString(attrs, "outlineColor", "shape.attrs.outlineColor", issues);
-  optionalString(attrs, "outlineStyle", "shape.attrs.outlineStyle", issues);
+  optionalOneOf(
+    attrs,
+    "outlineStyle",
+    "shape.attrs.outlineStyle",
+    issues,
+    SHAPE_OUTLINE_STYLE_VALUES,
+  );
   optionalOneOf(
     attrs,
     "outlineCap",
@@ -956,7 +963,13 @@ export const readTextBoxAttrs = (
   optionalString(attrs, "fillColor", "textBox.attrs.fillColor", issues);
   optionalNumber(attrs, "outlineWidth", "textBox.attrs.outlineWidth", issues);
   optionalString(attrs, "outlineColor", "textBox.attrs.outlineColor", issues);
-  optionalString(attrs, "outlineStyle", "textBox.attrs.outlineStyle", issues);
+  optionalOneOf(
+    attrs,
+    "outlineStyle",
+    "textBox.attrs.outlineStyle",
+    issues,
+    SHAPE_OUTLINE_STYLE_VALUES,
+  );
   optionalNumber(attrs, "marginTop", "textBox.attrs.marginTop", issues);
   optionalNumber(attrs, "marginBottom", "textBox.attrs.marginBottom", issues);
   optionalNumber(attrs, "marginLeft", "textBox.attrs.marginLeft", issues);

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -797,6 +797,28 @@ describe("fromProseDoc", () => {
     expect(firstShapeContent(block)?.shape.outline?.style).toBe("dash");
   });
 
+  test("drops a text-box outline for the 'none' sentinel even with a lingering width", () => {
+    const exportTextBox = (outlineStyle: string) => {
+      const document = fromProseDoc(
+        schema.node("doc", null, [
+          schema.node(
+            "textBox",
+            { width: 120, height: 60, outlineWidth: 2, outlineStyle },
+            [schema.node("paragraph", null, [schema.text("x")])],
+          ),
+        ]),
+      );
+      const block = document.package.document.content.at(0);
+      const run = block?.type === "paragraph" ? block.content.at(0) : undefined;
+      const content = run?.type === "run" ? run.content.at(0) : undefined;
+      return content?.type === "shape" ? content.shape : undefined;
+    };
+
+    // "none" suppresses the outline; a real style with the same width keeps it.
+    expect(exportTextBox("none")?.outline).toBeUndefined();
+    expect(exportTextBox("solid")?.outline?.width).toBeGreaterThan(0);
+  });
+
   test("preserves imported shape transform attrs on save", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", null, [

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1717,14 +1717,18 @@ function createShapeRun(node: PMNode): Run {
     shape.fill = { type: "none" };
   }
 
-  // Outline
+  // Outline. `outlineStyle === "none"` is the explicit "no outline" sentinel
+  // (see OUTLINE_STYLE_ATTR_VALUES): suppress the `<a:ln>` element entirely so a
+  // border-free shape round-trips border-free, even if other outline attrs (a
+  // leftover colour/width) linger on the node.
   if (
-    (attrs.outlineWidth !== undefined && attrs.outlineWidth > 0) ||
-    attrs.outlineColor ||
-    attrs.outlineStyle ||
-    attrs.outlineCap ||
-    attrs.outlineHeadEnd ||
-    attrs.outlineTailEnd
+    attrs.outlineStyle !== "none" &&
+    ((attrs.outlineWidth !== undefined && attrs.outlineWidth > 0) ||
+      attrs.outlineColor ||
+      attrs.outlineStyle ||
+      attrs.outlineCap ||
+      attrs.outlineHeadEnd ||
+      attrs.outlineTailEnd)
   ) {
     const shapeOutline: ShapeOutline = {};
     if (attrs.outlineWidth !== undefined && attrs.outlineWidth > 0) {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -2585,8 +2585,13 @@ function convertPMTextBox(node: PMNode): Paragraph {
     };
   }
 
-  // Convert outline back
-  if (attrs.outlineWidth && attrs.outlineWidth > 0) {
+  // Convert outline back. `outlineStyle === "none"` is the explicit no-outline
+  // sentinel: drop the `<a:ln>` even if a width lingers, matching the shape path.
+  if (
+    attrs.outlineStyle !== "none" &&
+    attrs.outlineWidth &&
+    attrs.outlineWidth > 0
+  ) {
     const tbOutline: ShapeOutline = {
       width: pixelsToEmu(attrs.outlineWidth),
       style: normalizeShapeOutlineStyle(attrs.outlineStyle) ?? "solid",

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -57,6 +57,10 @@ import type {
   ColorValue,
   CellMargins,
 } from "../../types/document";
+import {
+  OUTLINE_STYLE_CSS_ALIASES,
+  type OutlineStyleCssAlias,
+} from "../../types/documentEnumValues";
 import { pixelsToEmu } from "../../utils/units";
 import {
   expectCharacterSpacingMarkAttrs,
@@ -103,12 +107,14 @@ function normalizeShapeOutlineStyle(
   if (!style) {
     return undefined;
   }
-  const cssToOoxml: Record<string, NonNullable<ShapeOutline["style"]>> = {
-    solid: "solid",
-    dotted: "dot",
-    dashed: "dash",
-  };
-  return narrowEnum(cssToOoxml[style] ?? style, ShapeOutlineStyleSchema);
+  // Map a folio CSS alias to its OOXML dash style; OOXML values pass through.
+  // `"none"` is not an OOXML dash style, so it narrows to undefined here — the
+  // serializer's no-outline guard must drop the `<a:ln>` before calling this.
+  if (style in OUTLINE_STYLE_CSS_ALIASES) {
+    // SAFETY: the `in` check narrows `style` to a CSS-alias key.
+    return OUTLINE_STYLE_CSS_ALIASES[style as OutlineStyleCssAlias];
+  }
+  return narrowEnum(style, ShapeOutlineStyleSchema);
 }
 
 function parseTransformAttr(

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1719,13 +1719,12 @@ function createShapeRun(node: PMNode): Run {
 
   // Outline
   if (
-    attrs.outlineStyle !== "none" &&
-    ((attrs.outlineWidth !== undefined && attrs.outlineWidth > 0) ||
-      attrs.outlineColor ||
-      attrs.outlineStyle ||
-      attrs.outlineCap ||
-      attrs.outlineHeadEnd ||
-      attrs.outlineTailEnd)
+    (attrs.outlineWidth !== undefined && attrs.outlineWidth > 0) ||
+    attrs.outlineColor ||
+    attrs.outlineStyle ||
+    attrs.outlineCap ||
+    attrs.outlineHeadEnd ||
+    attrs.outlineTailEnd
   ) {
     const shapeOutline: ShapeOutline = {};
     if (attrs.outlineWidth !== undefined && attrs.outlineWidth > 0) {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -512,7 +512,13 @@ export const ShapeExtension = createNodeExtension({
               ? { outlineWidth: Number(d["outlineWidth"]) }
               : {}),
             ...(d["outlineColor"] ? { outlineColor: d["outlineColor"] } : {}),
-            ...(d["outlineStyle"] ? { outlineStyle: d["outlineStyle"] } : {}),
+            ...(d["outlineStyle"]
+              ? {
+                  outlineStyle: d["outlineStyle"] as NonNullable<
+                    ShapeAttrs["outlineStyle"]
+                  >,
+                }
+              : {}),
             ...(d["outlineCap"]
               ? {
                   outlineCap: d["outlineCap"] as NonNullable<

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -758,9 +758,13 @@ export const ShapeExtension = createNodeExtension({
         fillAttr = attrs.fillType === "none" ? "none" : safeFillColor;
       }
 
+      // `outlineStyle === "none"` is the explicit no-outline sentinel: draw no
+      // stroke even if a width/colour lingers (mirrors `fillType === "none"`).
+      const strokeAttr =
+        attrs.outlineStyle === "none" ? "none" : safeStrokeColor;
       svg.setAttribute(
         "style",
-        `fill:${fillAttr};stroke:${safeStrokeColor};stroke-width:${strokeWidth}`,
+        `fill:${fillAttr};stroke:${strokeAttr};stroke-width:${strokeWidth}`,
       );
 
       if (gradient) {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../schema";
+
+describe("TextBoxExtension toDOM border", () => {
+  const styleOf = (attrs: Record<string, unknown>): string => {
+    const node = schema.node("textBox", attrs, [
+      schema.node("paragraph", null, [schema.text("x")]),
+    ]);
+    const toDOM = node.type.spec.toDOM;
+    if (!toDOM) {
+      throw new Error("Expected textBox node to provide toDOM");
+    }
+    const domSpec = toDOM(node) as [string, Record<string, string>, number];
+    return domSpec[1]["style"] ?? "";
+  };
+
+  test("draws no border for the explicit 'none' outline sentinel", () => {
+    // `box-sizing: border-box` is always present, so assert on the border
+    // shorthand specifically.
+    expect(styleOf({ outlineStyle: "none" })).not.toContain("border:");
+  });
+
+  test("draws the default editor border when no outline is set", () => {
+    expect(styleOf({})).toContain("border: 1px solid");
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -6,8 +6,11 @@
  * Supports inline and floating positioning.
  */
 
-import type { ImageWrap, ShapeOutline } from "../../../types/document";
-import { IMAGE_WRAP_TYPE_VALUES } from "../../../types/documentEnumValues";
+import type { ImageWrap } from "../../../types/document";
+import {
+  IMAGE_WRAP_TYPE_VALUES,
+  type OutlineStyleAttr,
+} from "../../../types/documentEnumValues";
 import { expectTextBoxAttrs } from "../../attrs";
 import type { ImagePositionAttrs } from "../../schema/nodes";
 import { createNodeExtension } from "../create";
@@ -25,8 +28,8 @@ export type TextBoxAttrs = {
   outlineWidth?: number;
   /** Outline color as CSS color */
   outlineColor?: string;
-  /** Outline style */
-  outlineStyle?: NonNullable<ShapeOutline["style"]>;
+  /** Outline dash style, or `"none"` for an explicit no-outline. */
+  outlineStyle?: OutlineStyleAttr;
   /** Internal margin top in pixels */
   marginTop?: number;
   /** Internal margin bottom in pixels */

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -6,7 +6,7 @@
  * Supports inline and floating positioning.
  */
 
-import type { ImageWrap } from "../../../types/document";
+import type { ImageWrap, ShapeOutline } from "../../../types/document";
 import { IMAGE_WRAP_TYPE_VALUES } from "../../../types/documentEnumValues";
 import { expectTextBoxAttrs } from "../../attrs";
 import type { ImagePositionAttrs } from "../../schema/nodes";
@@ -26,7 +26,7 @@ export type TextBoxAttrs = {
   /** Outline color as CSS color */
   outlineColor?: string;
   /** Outline style */
-  outlineStyle?: string;
+  outlineStyle?: NonNullable<ShapeOutline["style"]>;
   /** Internal margin top in pixels */
   marginTop?: number;
   /** Internal margin bottom in pixels */
@@ -142,7 +142,13 @@ export const TextBoxExtension = createNodeExtension({
               ? { outlineWidth: Number(d["outlineWidth"]) }
               : {}),
             ...(d["outlineColor"] ? { outlineColor: d["outlineColor"] } : {}),
-            ...(d["outlineStyle"] ? { outlineStyle: d["outlineStyle"] } : {}),
+            ...(d["outlineStyle"]
+              ? {
+                  outlineStyle: d["outlineStyle"] as NonNullable<
+                    TextBoxAttrs["outlineStyle"]
+                  >,
+                }
+              : {}),
             ...(d["marginTop"] ? { marginTop: Number(d["marginTop"]) } : {}),
             ...(d["marginBottom"]
               ? { marginBottom: Number(d["marginBottom"]) }

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -280,12 +280,14 @@ export const TextBoxExtension = createNodeExtension({
         styles.push(`background-color: ${attrs.fillColor}`);
       }
 
-      // Border/outline
+      // Border/outline. `outlineStyle === "none"` is the explicit no-outline
+      // sentinel: skip even the default editor border so it stays border-free
+      // like its export.
       if (attrs.outlineWidth && attrs.outlineWidth > 0) {
         const style = attrs.outlineStyle || "solid";
         const color = attrs.outlineColor || "#000000";
         styles.push(`border: ${attrs.outlineWidth}px ${style} ${color}`);
-      } else {
+      } else if (attrs.outlineStyle !== "none") {
         // Default thin border for text boxes
         styles.push("border: 1px solid var(--doc-border, #d1d5db)");
       }

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -33,6 +33,7 @@ import type {
   SdtProperties,
   SdtType,
 } from "../../types/document";
+import type { OutlineStyleAttr } from "../../types/documentEnumValues";
 import type { SpacingExplicit } from "../../types/formatting";
 
 export type HardBreakAttrs = {
@@ -393,8 +394,8 @@ export type ShapeAttrs = {
   outlineWidth?: number;
   /** Outline color as CSS color */
   outlineColor?: string;
-  /** Outline style */
-  outlineStyle?: NonNullable<ShapeOutline["style"]>;
+  /** Outline dash style, or `"none"` for an explicit no-outline. */
+  outlineStyle?: OutlineStyleAttr;
   /** Line cap */
   outlineCap?: NonNullable<ShapeOutline["cap"]>;
   /** Head arrow/end marker */
@@ -451,8 +452,8 @@ export type TextBoxAttrs = {
   outlineWidth?: number;
   /** Outline color as CSS color */
   outlineColor?: string;
-  /** Outline style */
-  outlineStyle?: NonNullable<ShapeOutline["style"]>;
+  /** Outline dash style, or `"none"` for an explicit no-outline. */
+  outlineStyle?: OutlineStyleAttr;
   /** Internal margin top in pixels */
   marginTop?: number;
   /** Internal margin bottom in pixels */

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -394,7 +394,7 @@ export type ShapeAttrs = {
   /** Outline color as CSS color */
   outlineColor?: string;
   /** Outline style */
-  outlineStyle?: string;
+  outlineStyle?: NonNullable<ShapeOutline["style"]>;
   /** Line cap */
   outlineCap?: NonNullable<ShapeOutline["cap"]>;
   /** Head arrow/end marker */
@@ -452,7 +452,7 @@ export type TextBoxAttrs = {
   /** Outline color as CSS color */
   outlineColor?: string;
   /** Outline style */
-  outlineStyle?: string;
+  outlineStyle?: NonNullable<ShapeOutline["style"]>;
   /** Internal margin top in pixels */
   marginTop?: number;
   /** Internal margin bottom in pixels */

--- a/packages/folio/src/core/types/documentEnumValues.ts
+++ b/packages/folio/src/core/types/documentEnumValues.ts
@@ -674,6 +674,25 @@ export const SHAPE_OUTLINE_STYLE_VALUES = [
   "sysDashDotDot",
 ] as const satisfies readonly NonNullable<ShapeOutline["style"]>[];
 
+/**
+ * Outline-style values for the shape / text-box ProseMirror attribute. Extends
+ * the OOXML dash styles ({@link SHAPE_OUTLINE_STYLE_VALUES}) with the folio
+ * sentinel `"none"`: an explicit "no outline" the author can choose, distinct
+ * from an unset style (which falls back to the node's default). The DOCX
+ * serializer (`createShapeRun`) suppresses the `<a:ln>` element when the style
+ * is `"none"`, and `data-outline-style="none"` carries that intent through the
+ * editor DOM, so a border-free shape round-trips border-free. Kept as a valid
+ * value (not stripped) so loading a document that persisted `"none"` does not
+ * fail validation. eigenpal #694.
+ */
+export const OUTLINE_STYLE_ATTR_VALUES = [
+  ...SHAPE_OUTLINE_STYLE_VALUES,
+  "none",
+] as const;
+
+/** A shape/text-box outline dash style, or `"none"` for an explicit no-outline. */
+export type OutlineStyleAttr = (typeof OUTLINE_STYLE_ATTR_VALUES)[number];
+
 export const NUMBER_FORMAT_VALUES = [
   "decimal",
   "upperRoman",

--- a/packages/folio/src/core/types/documentEnumValues.ts
+++ b/packages/folio/src/core/types/documentEnumValues.ts
@@ -675,22 +675,54 @@ export const SHAPE_OUTLINE_STYLE_VALUES = [
 ] as const satisfies readonly NonNullable<ShapeOutline["style"]>[];
 
 /**
- * Outline-style values for the shape / text-box ProseMirror attribute. Extends
- * the OOXML dash styles ({@link SHAPE_OUTLINE_STYLE_VALUES}) with the folio
- * sentinel `"none"`: an explicit "no outline" the author can choose, distinct
- * from an unset style (which falls back to the node's default). The DOCX
- * serializer (`createShapeRun`) suppresses the `<a:ln>` element when the style
- * is `"none"`, and `data-outline-style="none"` carries that intent through the
- * editor DOM, so a border-free shape round-trips border-free. Kept as a valid
- * value (not stripped) so loading a document that persisted `"none"` does not
- * fail validation. eigenpal #694.
+ * CSS border-style names folio historically stored on `outlineStyle`. They are
+ * NOT part of OOXML `ST_PresetLineDashVal`; they exist only because the node
+ * kept CSS values. This tuple is the single source of truth for which aliases
+ * are accepted — both the serializer (`normalizeShapeOutlineStyle`) and the
+ * attr allow-list ({@link OUTLINE_STYLE_ATTR_VALUES}) derive from it, so they
+ * cannot drift apart. eigenpal #694.
+ */
+export const OUTLINE_STYLE_CSS_ALIAS_VALUES = ["dashed", "dotted"] as const;
+
+export type OutlineStyleCssAlias =
+  (typeof OUTLINE_STYLE_CSS_ALIAS_VALUES)[number];
+
+/**
+ * Each folio CSS alias and the OOXML dash style it serializes to. The
+ * `satisfies` keeps every alias key (from {@link OUTLINE_STYLE_CSS_ALIAS_VALUES})
+ * present and pointed at a real `ShapeOutline["style"]`, so an alias can never
+ * be listed without a mapping.
+ */
+export const OUTLINE_STYLE_CSS_ALIASES = {
+  dashed: "dash",
+  dotted: "dot",
+} as const satisfies Record<
+  OutlineStyleCssAlias,
+  NonNullable<ShapeOutline["style"]>
+>;
+
+/**
+ * Allowed `outlineStyle` values for the shape / text-box ProseMirror attribute:
+ * the complete OOXML `ST_PresetLineDashVal` set ({@link
+ * SHAPE_OUTLINE_STYLE_VALUES}, single-sourced from the docx-core model), the
+ * folio CSS aliases ({@link OUTLINE_STYLE_CSS_ALIAS_VALUES}), and the `"none"`
+ * sentinel — an explicit "no outline" the author can choose, distinct from an
+ * unset style (which falls back to the node default). The DOCX serializer
+ * suppresses the `<a:ln>` element for `"none"` and maps the aliases to OOXML, so
+ * every accepted value round-trips. All three groups are kept valid (not
+ * stripped) so loading a document that persisted any of them does not fail
+ * validation. eigenpal #694.
  */
 export const OUTLINE_STYLE_ATTR_VALUES = [
   ...SHAPE_OUTLINE_STYLE_VALUES,
+  ...OUTLINE_STYLE_CSS_ALIAS_VALUES,
   "none",
 ] as const;
 
-/** A shape/text-box outline dash style, or `"none"` for an explicit no-outline. */
+/**
+ * A shape/text-box outline dash style, a folio CSS alias, or `"none"` for an
+ * explicit no-outline.
+ */
 export type OutlineStyleAttr = (typeof OUTLINE_STYLE_ATTR_VALUES)[number];
 
 export const NUMBER_FORMAT_VALUES = [


### PR DESCRIPTION
Stacked on #616 (base: `feat/folio-topandbottom-band`).

Finishes the pattern #616 started on `ImageRunPosition` (`relativeTo`/`align`): replaces the remaining `string`-typed domain enums in `layout-engine/types.ts` with the canonical OOXML unions from `@stll/docx-core/model`, indexed via the same type names the folio-local `*_VALUES` arrays already pin in their `satisfies` clauses. Each field becomes a compile-time-checked union instead of an open `string` that silently swallows typos and stale values.

## Fields tightened (`layout-engine/types.ts`)

| Field | Now typed as |
| --- | --- |
| `ImageRun.wrapType`, `TextBoxBlock.wrapType` | `ImageWrap["type"]` |
| `TableBlock.widthType` | `TableWidthType` |
| `TextBoxBlock.outlineStyle` | `NonNullable<ShapeOutline["style"]>` |
| `SdtGroup.sdtType` | `SdtType` |
| `SdtGroup.lock` | `NonNullable<SdtProperties["lock"]>` |

The ~9 `wrapType === "…"` comparison sites (square/tight/through/topAndBottom/behind/inFront/inline) all compile unchanged; the union members cover every compared value, so there are no dead comparisons.

## Source-traced narrowing the tightening surfaced

`outlineStyle` flows from the ProseMirror node attrs, which were still `string` while sibling fields (`outlineCap`, `wrapType`) already used the indexed-union pattern. To keep the type honest at the source rather than casting at the consumer:

- `ShapeAttrs.outlineStyle` and `TextBoxAttrs.outlineStyle` (`schema/nodes.ts`, plus the duplicated `TextBoxAttrs` in `TextBoxExtension.ts`) tightened to `NonNullable<ShapeOutline["style"]>`, matching the adjacent `outlineCap` field.
- The attrs readers in `attrs/index.ts` switched from `optionalString` to `optionalOneOf(..., SHAPE_OUTLINE_STYLE_VALUES)` so runtime validation matches the tightened type.
- The two DOM-parse `getAttrs` reads (`ShapeExtension.ts`, `TextBoxExtension.ts`) narrow `dataset["outlineStyle"]` at the boundary with `as NonNullable<…Attrs["outlineStyle"]>`, exactly mirroring the sibling `outlineCap`/`displayMode`/`cssFloat`/`wrapType` reads in the same objects.
- Removed a now-dead `attrs.outlineStyle !== "none"` guard in `fromProseDoc.ts` — `"none"` is not a member of the outline-style union (`<a:prstDash>` presets), so the comparison was always true; the remaining `||` clauses already gate on outline properties being present.

## Left as `string` (deliberate, with `// TODO:` notes)

Two fields look like enum candidates but actually hold **post-conversion CSS values**, not the OOXML union — tightening them would be incorrect:

- `RunFormatting.highlight`: the bridge assigns `resolveHighlightToCss(...)` (named color → hex, or raw `#hex`), so values like `#FFFF00` are not members of the named-color union. Would need a separate CSS field or moving resolution to the painter.
- `BorderStyle.style` / `CellBorderSpec.style`: CSS border-style mapped from OOXML by `OOXML_TO_CSS_BORDER` in the bridge (`single`→`solid`, etc.), and it includes CSS-only values (`ridge`/`groove`) with no `KnownBorderStyle` member.

## Out of scope (follow-ups)

- Branding EMU / twips / px units.
- Branding `BlockId`.

These are larger lifts and intentionally excluded from this enum-string pass.

## Verification

- `cd packages/folio && bun run typecheck` — clean.
- `cd packages/folio && bun test src` — 1887 pass, 0 fail.