### PR TITLE
chore(money): thread CentsAmount brand across the api/web boundary

### DIFF
--- a/apps/api/src/lib/money.ts
+++ b/apps/api/src/lib/money.ts
@@ -1,59 +1,10 @@
 /**
- * Branded monetary amounts.
+ * Branded monetary amounts for the API.
  *
- * Money values in this codebase are stored and computed in
- * minor units ("cents" — for USD/EUR; halere for CZK; etc.).
- * The `CentsAmount` brand prevents the canonical 100x bug
- * where a major-unit value (e.g., 12.50 dollars) is silently
- * mixed with minor-unit math (1250 cents).
- *
- * The brand is structural: a plain `number` is not assignable
- * to `CentsAmount`. The only way to mint one is via `cents()`
- * (after deliberate construction), Drizzle reads from a column
- * declared with `.$type<CentsAmount>()`, or `unsafeCents()` at
- * a documented boundary.
- *
- * This module is currency-agnostic. The currency code lives
- * alongside the amount in the schema (e.g., invoices.currency)
- * and is not part of the brand — pairing them is the call
- * site's responsibility.
+ * The brand and its constructors live in `@stll/money` so the same
+ * `CentsAmount` threads across the API boundary into the web client
+ * (see that package for the full rationale). This module re-exports them
+ * for API-side consumers and the Drizzle schema (`.$type<CentsAmount>()`).
  */
-
-declare const __cents: unique symbol;
-
-export type CentsAmount = number & {
-  readonly [__cents]: "CentsAmount";
-};
-
-/**
- * Construct a CentsAmount from a value already known to be in
- * minor units. Use at boundaries where the input is validated
- * as an integer minor-unit value (e.g., after Elysia
- * `t.Integer({ minimum: 0 })` or after parsing user input that
- * has been multiplied by 100).
- *
- * Throws on non-finite or non-integer input — money math at the
- * minor-unit level must be exact.
- */
-export const cents = (value: number): CentsAmount => {
-  if (!Number.isInteger(value)) {
-    throw new TypeError(
-      `cents(${value}): money values must be integer minor units`,
-    );
-  }
-  // SAFETY: validated to be an integer; brand is nominal so the
-  // assertion is sound at runtime.
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  return value as CentsAmount;
-};
-
-/**
- * Escape hatch for code paths that genuinely need to attach
- * the brand without a runtime check (test fixtures, generated
- * code). Prefer `cents()` everywhere else; reach for this only
- * with a `// SAFETY:` comment naming why the value is already
- * a valid minor-unit integer.
- */
-export const unsafeCents = (value: number): CentsAmount =>
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  value as CentsAmount;
+export { cents, unsafeCents } from "@stll/money";
+export type { CentsAmount } from "@stll/money";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
@@ -10,6 +10,7 @@ import {
 import { useTranslations } from "use-intl";
 
 import { prorateHourlyCents } from "@stll/money";
+import type { CentsAmount } from "@stll/money";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { cn } from "@stll/ui/lib/utils";
@@ -26,7 +27,7 @@ type TimeEntry = {
   dateWorked: string;
   durationMinutes: number;
   billedMinutes: number;
-  rateAtEntry: number;
+  rateAtEntry: CentsAmount;
   currency: string;
   narrative: string;
   invoiceNarrative: string | null;

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -1,28 +1,32 @@
 import { describe, expect, test } from "bun:test";
 
-import { applyMarkupCents, prorateHourlyCents } from ".";
+import { applyMarkupCents, cents, prorateHourlyCents } from ".";
 
 describe("minor-unit billing arithmetic", () => {
   test("rounds prorated hourly rates without floating point cent drift", () => {
     expect(
-      prorateHourlyCents({ billedMinutes: 11, hourlyRateCents: 150 }),
-    ).toBe(28);
+      prorateHourlyCents({ billedMinutes: 11, hourlyRateCents: cents(150) }),
+    ).toBe(cents(28));
     expect(
-      prorateHourlyCents({ billedMinutes: 11, hourlyRateCents: 330 }),
-    ).toBe(61);
+      prorateHourlyCents({ billedMinutes: 11, hourlyRateCents: cents(330) }),
+    ).toBe(cents(61));
   });
 
   test("rounds expense markup without floating point cent drift", () => {
-    expect(applyMarkupCents({ amountCents: 25, markupPercent: 82 })).toBe(46);
-    expect(applyMarkupCents({ amountCents: 50, markupPercent: 13 })).toBe(57);
+    expect(
+      applyMarkupCents({ amountCents: cents(25), markupPercent: 82 }),
+    ).toBe(cents(46));
+    expect(
+      applyMarkupCents({ amountCents: cents(50), markupPercent: 13 }),
+    ).toBe(cents(57));
   });
 
   test("rejects invalid billing inputs", () => {
     expect(() =>
-      prorateHourlyCents({ billedMinutes: 1.5, hourlyRateCents: 100 }),
+      prorateHourlyCents({ billedMinutes: 1.5, hourlyRateCents: cents(100) }),
     ).toThrow(TypeError);
     expect(() =>
-      applyMarkupCents({ amountCents: 100, markupPercent: -1 }),
+      applyMarkupCents({ amountCents: cents(100), markupPercent: -1 }),
     ).toThrow(TypeError);
   });
 });

--- a/packages/money/src/index.ts
+++ b/packages/money/src/index.ts
@@ -1,37 +1,89 @@
 /**
- * Money values in this codebase are stored and computed in minor units
- * ("cents" for USD/EUR, halere for CZK, etc.). These helpers deliberately
- * return plain numbers so browser previews and backend persistence can share
- * the same integer arithmetic without sharing backend-only brands.
+ * Branded monetary amounts and minor-unit billing arithmetic.
+ *
+ * Money in this codebase is stored and computed in minor units
+ * ("cents" for USD/EUR, halere for CZK, etc.). The `CentsAmount`
+ * brand prevents the canonical 100x bug where a major-unit value
+ * (12.50 dollars) is silently mixed with minor-unit math (1250 cents).
+ *
+ * The brand lives here, in a shared package, so it threads end to end:
+ * the same `CentsAmount` flows from a Drizzle column declared with
+ * `.$type<CentsAmount>()`, across the API boundary (Eden infers the
+ * brand from the handler's return type), into browser previews and back.
+ * A plain `number` is not assignable to `CentsAmount`; mint one with
+ * `cents()` after validating minor-unit input, or `unsafeCents()` at a
+ * documented boundary.
+ *
+ * Currency-agnostic: the currency code lives alongside the amount in the
+ * schema (e.g. invoices.currency); pairing them is the call site's
+ * responsibility.
  */
+
+declare const __cents: unique symbol;
+
+export type CentsAmount = number & {
+  readonly [__cents]: "CentsAmount";
+};
+
+/**
+ * Construct a CentsAmount from a value already known to be in minor
+ * units. Use at boundaries where the input is validated as an integer
+ * minor-unit value (e.g. after Elysia `t.Integer({ minimum: 0 })` or
+ * after parsing user input that has been multiplied by 100).
+ *
+ * Throws on non-integer input — money math at the minor-unit level must
+ * be exact.
+ */
+export const cents = (value: number): CentsAmount => {
+  if (!Number.isInteger(value)) {
+    throw new TypeError(
+      `cents(${value}): money values must be integer minor units`,
+    );
+  }
+  // SAFETY: validated to be an integer; brand is nominal so the
+  // assertion is sound at runtime.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as CentsAmount;
+};
+
+/**
+ * Escape hatch for code paths that genuinely need to attach the brand
+ * without a runtime check (test fixtures, generated code). Prefer
+ * `cents()` everywhere else; reach for this only with a `// SAFETY:`
+ * comment naming why the value is already a valid minor-unit integer.
+ */
+export const unsafeCents = (value: number): CentsAmount =>
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  value as CentsAmount;
+
 export type ProrateHourlyCentsInput = {
   billedMinutes: number;
-  hourlyRateCents: number;
+  hourlyRateCents: CentsAmount;
 };
 
 export const prorateHourlyCents = ({
   billedMinutes,
   hourlyRateCents,
-}: ProrateHourlyCentsInput): number => {
+}: ProrateHourlyCentsInput): CentsAmount => {
   assertNonNegativeInteger("billedMinutes", billedMinutes);
   assertNonNegativeInteger("hourlyRateCents", hourlyRateCents);
 
-  return Math.floor((billedMinutes * hourlyRateCents + 30) / 60);
+  return cents(Math.floor((billedMinutes * hourlyRateCents + 30) / 60));
 };
 
 export type ApplyMarkupCentsInput = {
-  amountCents: number;
+  amountCents: CentsAmount;
   markupPercent: number;
 };
 
 export const applyMarkupCents = ({
   amountCents,
   markupPercent,
-}: ApplyMarkupCentsInput): number => {
+}: ApplyMarkupCentsInput): CentsAmount => {
   assertNonNegativeInteger("amountCents", amountCents);
   assertNonNegativeInteger("markupPercent", markupPercent);
 
-  return Math.floor((amountCents * (100 + markupPercent) + 50) / 100);
+  return cents(Math.floor((amountCents * (100 + markupPercent) + 50) / 100));
 };
 
 function assertNonNegativeInteger(name: string, value: number) {


### PR DESCRIPTION
## What

Move the `CentsAmount` brand, `cents()`, and `unsafeCents()` into `@stll/money` so a single nominal brand is shared by both backend and frontend, then thread it through the minor-unit billing helpers.

- `prorateHourlyCents` / `applyMarkupCents` now take `CentsAmount` inputs and return `CentsAmount`.
- `apps/api/src/lib/money.ts` re-exports from `@stll/money`, so every API-side consumer and the Drizzle schema (`.$type<CentsAmount>()`) stay unchanged.
- `time-entry-row.tsx`'s hand-written local type widened `rateAtEntry` from `number` to `CentsAmount`.

## Why

The brand previously lived in `apps/api`, so the frontend did money math on plain `number`s. The brand already flows to the web through Eden inference (the read handlers return branded columns with no response-schema coercion), so sharing it enforces minor-unit safety end to end — Drizzle column → API boundary → browser preview — and structurally prevents the 100x major/minor-unit mixup.

Defining the brand in `@stll/money` while it still existed in `apps/api` would have created two distinct `unique symbol` brands that don't assign across each other; the API module is now a thin re-export to keep the brand single-sourced.

## Verification

- `@stll/money` typecheck + tests (3 pass)
- `@stll/api` typecheck
- IDE typechecker clean on all web call sites (day/week views, invoice detail, time-entry row)