### PR TITLE
perf(web): tighten pinned-store subscriptions

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -34,6 +34,7 @@ import {
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
+import { useShallow } from "zustand/react/shallow";
 
 import {
   Avatar,
@@ -603,10 +604,14 @@ export function AppSidebar(props: AppSidebarProps) {
   });
 
   const [searchOpen, setSearchOpen] = useState(false);
-  const pinnedOrder = usePinnedStore((s) => s.pinnedOrder);
-  const pinnedIds = usePinnedStore((s) => s.pinnedIds);
-  const togglePin = usePinnedStore((s) => s.togglePin);
-  const reorderPinned = usePinnedStore((s) => s.reorder);
+  const { pinnedOrder, pinnedIds, togglePin, reorderPinned } = usePinnedStore(
+    useShallow((s) => ({
+      pinnedOrder: s.pinnedOrder,
+      pinnedIds: s.pinnedIds,
+      togglePin: s.togglePin,
+      reorderPinned: s.reorder,
+    })),
+  );
   const { data: workspacesData } = useQuery(
     workspacesNavigationOptions(user.activeOrganizationId),
   );

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -187,8 +187,8 @@ export const MatterContextMenu = ({
   children,
 }: MatterContextMenuProps) => {
   const t = useTranslations();
-  const { togglePin, isPinned } = usePinnedStore();
-  const pinned = isPinned(workspaceId);
+  const togglePin = usePinnedStore((s) => s.togglePin);
+  const pinned = usePinnedStore((s) => s.pinnedIds.has(workspaceId));
 
   const queryClient = useQueryClient();
   const updateWorkspace = useUpdateWorkspace();


### PR DESCRIPTION
Two Zustand subscription fixes in the sidebar pinned-matter flow.

- `MatterContextMenu` subscribed to the entire `usePinnedStore` (no selector), re-rendering on every pin/unpin anywhere. Now selects `togglePin` plus the derived `pinnedIds.has(workspaceId)` boolean, so it only re-renders when this matter's pin state changes. Subscribing to the derived value (not the stable `isPinned` fn) keeps the pin/unpin label reactive.
- `AppSidebar` made four separate store subscriptions; consolidated into one `useShallow` selector, matching the multi-slice selector convention.

No behavior change beyond fewer re-renders.