### PR TITLE
chore(folio): extract comment state into useFolioComments hook

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -185,7 +185,6 @@ import {
   createComment,
   findSelectionYPosition,
   getCommentAuthorKey,
-  getCommentParentId,
   getFallbackCommentYPosition,
   pruneOrphanedComments,
   removePendingCommentMarkRange,
@@ -245,6 +244,7 @@ import { getBuiltinTableStyle } from "./ui/table-styles";
 import type { TableStylePreset } from "./ui/table-styles";
 import type { TableAction } from "./ui/table-types";
 import { Tooltip } from "./ui/Tooltip";
+import { useFolioComments } from "./useFolioComments";
 
 const CommentsSidebar = lazy(() =>
   import("./CommentsSidebar").then((m) => ({
@@ -497,28 +497,11 @@ export function DocxEditor({
   showOutlineRef.current = showOutline;
   const [outlineHeadings, setHeadingInfos] = useState<HeadingInfo[]>([]);
 
-  // Comments sidebar state
-  const [showCommentsSidebar, setShowCommentsSidebar] = useState(false);
-  const [visibleCommentAuthors, setVisibleCommentAuthors] =
-    useState<Set<string> | null>(null);
-  const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
-  const [comments, setComments] = useState<Comment[]>([]);
-  const commentsDirtyRef = useRef(false);
-  const commentsRef = useRef<Comment[]>([]);
-  commentsRef.current = comments;
   const [, setTrackedChanges] = useState<TrackedChangeEntry[]>([]);
   const [anchorPositions, setAnchorPositions] = useState<Map<string, number>>(
     EMPTY_ANCHOR_POSITIONS,
   );
 
-  const [isAddingComment, setIsAddingComment] = useState(false);
-  const [commentSelectionRange, setCommentSelectionRange] = useState<{
-    from: number;
-    to: number;
-  } | null>(null);
-  const [addCommentYPosition, setAddCommentYPosition] = useState<number | null>(
-    null,
-  );
   const {
     editingMode,
     readOnly,
@@ -531,14 +514,6 @@ export function DocxEditor({
     onModeChange,
     readOnlyProp,
   });
-
-  // Floating "add comment" button position (relative to scroll container, null = hidden)
-  const [floatingCommentBtn, setFloatingCommentBtn] = useState<{
-    top: number;
-    left: number;
-    from: number;
-    to: number;
-  } | null>(null);
 
   // Debounce timer for extractTrackedChanges (avoid full doc walk on every keystroke)
   const extractTrackedChangesTimerRef = useRef<ReturnType<
@@ -630,89 +605,6 @@ export function DocxEditor({
     groupingInterval: 500,
     enableKeyboardShortcuts: true,
   });
-
-  // Extract comments from document model on initial load
-  const commentsLoadedRef = useRef(false);
-  useEffect(() => {
-    if (commentsLoadedRef.current) {
-      return;
-    }
-    const doc = history.state;
-    if (!doc) {
-      return;
-    }
-    const bodyComments = doc.package.document.comments;
-    if (bodyComments && bodyComments.length > 0) {
-      setComments(bodyComments);
-      setVisibleCommentAuthors(null);
-      setActiveCommentId(null);
-      if (autoOpenReviewSidebar) {
-        setShowCommentsSidebar(true);
-      }
-      commentsLoadedRef.current = true;
-    }
-  }, [autoOpenReviewSidebar, history.state]);
-
-  const commentAuthors = useMemo(() => {
-    const seen = new Set<string>();
-    const authors: string[] = [];
-    for (const comment of comments) {
-      const commentAuthor = getCommentAuthorKey(comment.author);
-      if (!seen.has(commentAuthor)) {
-        seen.add(commentAuthor);
-        authors.push(commentAuthor);
-      }
-    }
-    return authors;
-  }, [comments]);
-
-  const visibleCommentAuthorSet = useMemo(
-    () => visibleCommentAuthors ?? new Set(commentAuthors),
-    [visibleCommentAuthors, commentAuthors],
-  );
-
-  const visibleCommentIds = useMemo(() => {
-    const ids = new Set<number>([PENDING_COMMENT_ID]);
-    for (const comment of comments) {
-      if (visibleCommentAuthorSet.has(getCommentAuthorKey(comment.author))) {
-        ids.add(comment.id);
-      }
-    }
-    return ids;
-  }, [comments, visibleCommentAuthorSet]);
-
-  const visibleComments = useMemo(() => {
-    const visibleRootIds = new Set<number>();
-    for (const comment of comments) {
-      const parentId = getCommentParentId(comment);
-      if (
-        parentId === null ||
-        parentId === undefined ||
-        !visibleCommentIds.has(comment.id)
-      ) {
-        continue;
-      }
-      visibleRootIds.add(parentId);
-    }
-    return comments.filter((comment) => {
-      const parentId = getCommentParentId(comment);
-      if (parentId !== null && parentId !== undefined) {
-        return visibleCommentIds.has(comment.id);
-      }
-      return (
-        visibleCommentIds.has(comment.id) || visibleRootIds.has(comment.id)
-      );
-    });
-  }, [comments, visibleCommentIds]);
-
-  const activeCommentVisible =
-    activeCommentId !== null && visibleCommentIds.has(activeCommentId);
-
-  useEffect(() => {
-    if (!activeCommentVisible) {
-      setActiveCommentId(null);
-    }
-  }, [activeCommentVisible]);
 
   // Extension manager — built once, provides schema + plugins + commands
   const extensionManager = useMemo(() => {
@@ -900,62 +792,35 @@ export function DocxEditor({
     color: { rgb: "000000" },
   });
 
-  const syncCommentHighlightStyles = useCallback(() => {
-    const root = editorContentRef.current;
-    if (!root) {
-      return;
-    }
-
-    const nodes = root.querySelectorAll<HTMLElement>(
-      ".layout-run-text[data-comment-id]",
-    );
-    for (const node of nodes) {
-      const commentId = Number.parseInt(node.dataset["commentId"] ?? "", 10);
-      const isPending = commentId === PENDING_COMMENT_ID;
-      const isVisible = isPending || visibleCommentIds.has(commentId);
-      if (!isVisible) {
-        node.style.backgroundColor = "transparent";
-        node.style.borderBottom = "2px solid transparent";
-        node.style.boxShadow = "none";
-        delete node.dataset["activeComment"];
-        continue;
-      }
-
-      if (activeCommentId === commentId) {
-        node.style.backgroundColor =
-          "var(--doc-comment-active-bg, rgba(255, 212, 0, 0.22))";
-        node.style.borderBottom =
-          "1px solid var(--doc-comment-active-border, rgba(180, 130, 0, 0.62))";
-        node.style.boxShadow = "none";
-        node.dataset["activeComment"] = "true";
-        continue;
-      }
-
-      node.style.backgroundColor =
-        "var(--doc-comment-bg, rgba(255, 212, 0, 0.08))";
-      node.style.borderBottom =
-        "1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24))";
-      node.style.boxShadow = "none";
-      delete node.dataset["activeComment"];
-    }
-  }, [visibleCommentIds, activeCommentId]);
-
-  useLayoutEffect(() => {
-    syncCommentHighlightStyles();
-  }, [syncCommentHighlightStyles, anchorPositions]);
-
-  useEffect(() => {
-    syncCommentHighlightStyles();
-    const firstFrame = requestAnimationFrame(() => {
-      syncCommentHighlightStyles();
-      requestAnimationFrame(syncCommentHighlightStyles);
-    });
-    const timeout = setTimeout(syncCommentHighlightStyles, 120);
-    return () => {
-      cancelAnimationFrame(firstFrame);
-      clearTimeout(timeout);
-    };
-  }, [comments.length, syncCommentHighlightStyles]);
+  const {
+    comments,
+    setComments,
+    commentsRef,
+    commentsDirtyRef,
+    commentsLoadedRef,
+    showCommentsSidebar,
+    setShowCommentsSidebar,
+    setVisibleCommentAuthors,
+    activeCommentId,
+    setActiveCommentId,
+    isAddingComment,
+    setIsAddingComment,
+    commentSelectionRange,
+    setCommentSelectionRange,
+    addCommentYPosition,
+    setAddCommentYPosition,
+    floatingCommentBtn,
+    setFloatingCommentBtn,
+    commentAuthors,
+    visibleCommentAuthorSet,
+    visibleComments,
+    syncCommentHighlightStyles,
+  } = useFolioComments({
+    doc: history.state,
+    autoOpenReviewSidebar,
+    anchorPositions,
+    editorContentRef,
+  });
   // Cache style resolver to avoid recreating on every selection change
   const styleResolverCacheRef = useRef<{
     styles: unknown;

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1037,7 +1037,20 @@ export function DocxEditor({
           clearTimeout(collectHeadingsTimerRef.current);
           collectHeadingsTimerRef.current = null;
         }
-      }, [findReplace, setHfEditPosition]),
+      }, [
+        commentsDirtyRef,
+        commentsLoadedRef,
+        findReplace,
+        setActiveCommentId,
+        setAddCommentYPosition,
+        setCommentSelectionRange,
+        setComments,
+        setFloatingCommentBtn,
+        setHfEditPosition,
+        setIsAddingComment,
+        setShowCommentsSidebar,
+        setVisibleCommentAuthors,
+      ]),
       setDocumentLoadState: useCallback((documentLoad: DocumentLoadState) => {
         setState((prev) => ({ ...prev, documentLoad }));
       }, []),
@@ -1069,6 +1082,7 @@ export function DocxEditor({
     history.state,
     extractTrackedChanges,
     autoOpenReviewSidebar,
+    setShowCommentsSidebar,
   ]);
 
   const initialScrollAppliedRef = useRef(false);
@@ -1165,6 +1179,7 @@ export function DocxEditor({
       pushDocument,
       extractTrackedChanges,
       refreshBodyHistoryAvailability,
+      commentsRef,
     ],
   );
 
@@ -1230,7 +1245,7 @@ export function DocxEditor({
       referencedCommentIds,
     );
     return doc;
-  }, [history.state]);
+  }, [history.state, commentsRef]);
 
   const replaceComments = useCallback(
     (nextComments: Comment[]) => {
@@ -1245,14 +1260,20 @@ export function DocxEditor({
 
       onChange?.(currentDocument);
     },
-    [buildCurrentDocument, onChange],
+    [
+      buildCurrentDocument,
+      commentsDirtyRef,
+      commentsRef,
+      onChange,
+      setComments,
+    ],
   );
 
   const updateComments = useCallback(
     (updater: (comments: Comment[]) => Comment[]) => {
       replaceComments(updater(commentsRef.current));
     },
-    [replaceComments],
+    [commentsRef, replaceComments],
   );
 
   const selectFindMatch = useCallback((match: FindMatch): boolean => {
@@ -1510,8 +1531,15 @@ export function DocxEditor({
       // Notify parent
       onSelectionChange?.(selectionState);
     },
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [onSelectionChange, isAddingComment, readOnly],
+    [
+      getActiveEditorView,
+      getCachedStyleResolver,
+      isAddingComment,
+      onSelectionChange,
+      readOnly,
+      setFloatingCommentBtn,
+      theme,
+    ],
   );
 
   // Table selection hook
@@ -2407,6 +2435,11 @@ export function DocxEditor({
       readOnly,
       contextMenu.selectionRange.from,
       contextMenu.selectionRange.to,
+      setAddCommentYPosition,
+      setCommentSelectionRange,
+      setFloatingCommentBtn,
+      setIsAddingComment,
+      setShowCommentsSidebar,
     ],
   );
 
@@ -2545,6 +2578,7 @@ export function DocxEditor({
       originalBufferRef,
       featureFlags,
       onSelectiveSaveTripwire,
+      commentsDirtyRef,
     ],
   );
 
@@ -2793,6 +2827,7 @@ export function DocxEditor({
       loadParsedDocument,
       loadBuffer,
       updateComments,
+      commentsDirtyRef,
     ],
   );
 

--- a/packages/folio/src/components/useFolioComments.ts
+++ b/packages/folio/src/components/useFolioComments.ts
@@ -7,6 +7,7 @@
  * depend on its document-build pipeline.
  */
 import {
+  type RefObject,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -30,7 +31,7 @@ type UseFolioCommentsOptions = {
   /** Anchor offsets from layout; re-triggers highlight sync when they shift. */
   anchorPositions: Map<string, number>;
   /** Editor content root used to locate comment-marked run nodes. */
-  editorContentRef: { readonly current: HTMLElement | null };
+  editorContentRef: RefObject<HTMLElement | null>;
 };
 
 export function useFolioComments({
@@ -193,16 +194,20 @@ export function useFolioComments({
 
   useEffect(() => {
     syncCommentHighlightStyles();
+    let secondFrame: number | null = null;
     const firstFrame = requestAnimationFrame(() => {
       syncCommentHighlightStyles();
-      requestAnimationFrame(syncCommentHighlightStyles);
+      secondFrame = requestAnimationFrame(syncCommentHighlightStyles);
     });
     const timeout = setTimeout(syncCommentHighlightStyles, 120);
     return () => {
       cancelAnimationFrame(firstFrame);
+      if (secondFrame !== null) {
+        cancelAnimationFrame(secondFrame);
+      }
       clearTimeout(timeout);
     };
-  }, [comments.length, syncCommentHighlightStyles]);
+  }, [comments, syncCommentHighlightStyles]);
 
   return {
     comments,

--- a/packages/folio/src/components/useFolioComments.ts
+++ b/packages/folio/src/components/useFolioComments.ts
@@ -1,0 +1,231 @@
+/**
+ * Comment subsystem state for {@link DocxEditor}: thread storage, author
+ * visibility filtering, the in-progress "add comment" flow, and the DOM
+ * highlight sync. Extracted to keep the comment surface in one named seam
+ * rather than scattered across the editor component. Save-coupled mutators
+ * (`replaceComments`/`updateComments`) stay in the component because they
+ * depend on its document-build pipeline.
+ */
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { Comment } from "../core/types/content";
+import type { Document } from "../core/types/document";
+import {
+  PENDING_COMMENT_ID,
+  getCommentAuthorKey,
+  getCommentParentId,
+} from "./commentsHelpers";
+
+type UseFolioCommentsOptions = {
+  /** Current document (history head); seeds comments on first load. */
+  doc: Document | null;
+  autoOpenReviewSidebar: boolean;
+  /** Anchor offsets from layout; re-triggers highlight sync when they shift. */
+  anchorPositions: Map<string, number>;
+  /** Editor content root used to locate comment-marked run nodes. */
+  editorContentRef: { readonly current: HTMLElement | null };
+};
+
+export function useFolioComments({
+  doc,
+  autoOpenReviewSidebar,
+  anchorPositions,
+  editorContentRef,
+}: UseFolioCommentsOptions) {
+  const [showCommentsSidebar, setShowCommentsSidebar] = useState(false);
+  const [visibleCommentAuthors, setVisibleCommentAuthors] =
+    useState<Set<string> | null>(null);
+  const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const commentsDirtyRef = useRef(false);
+  const commentsRef = useRef<Comment[]>([]);
+  commentsRef.current = comments;
+
+  const [isAddingComment, setIsAddingComment] = useState(false);
+  const [commentSelectionRange, setCommentSelectionRange] = useState<{
+    from: number;
+    to: number;
+  } | null>(null);
+  const [addCommentYPosition, setAddCommentYPosition] = useState<number | null>(
+    null,
+  );
+
+  // Floating "add comment" button position (relative to scroll container, null = hidden)
+  const [floatingCommentBtn, setFloatingCommentBtn] = useState<{
+    top: number;
+    left: number;
+    from: number;
+    to: number;
+  } | null>(null);
+
+  // Extract comments from document model on initial load
+  const commentsLoadedRef = useRef(false);
+  useEffect(() => {
+    if (commentsLoadedRef.current) {
+      return;
+    }
+    if (!doc) {
+      return;
+    }
+    const bodyComments = doc.package.document.comments;
+    if (bodyComments && bodyComments.length > 0) {
+      setComments(bodyComments);
+      setVisibleCommentAuthors(null);
+      setActiveCommentId(null);
+      if (autoOpenReviewSidebar) {
+        setShowCommentsSidebar(true);
+      }
+      commentsLoadedRef.current = true;
+    }
+  }, [autoOpenReviewSidebar, doc]);
+
+  const commentAuthors = useMemo(() => {
+    const seen = new Set<string>();
+    const authors: string[] = [];
+    for (const comment of comments) {
+      const commentAuthor = getCommentAuthorKey(comment.author);
+      if (!seen.has(commentAuthor)) {
+        seen.add(commentAuthor);
+        authors.push(commentAuthor);
+      }
+    }
+    return authors;
+  }, [comments]);
+
+  const visibleCommentAuthorSet = useMemo(
+    () => visibleCommentAuthors ?? new Set(commentAuthors),
+    [visibleCommentAuthors, commentAuthors],
+  );
+
+  const visibleCommentIds = useMemo(() => {
+    const ids = new Set<number>([PENDING_COMMENT_ID]);
+    for (const comment of comments) {
+      if (visibleCommentAuthorSet.has(getCommentAuthorKey(comment.author))) {
+        ids.add(comment.id);
+      }
+    }
+    return ids;
+  }, [comments, visibleCommentAuthorSet]);
+
+  const visibleComments = useMemo(() => {
+    const visibleRootIds = new Set<number>();
+    for (const comment of comments) {
+      const parentId = getCommentParentId(comment);
+      if (
+        parentId === null ||
+        parentId === undefined ||
+        !visibleCommentIds.has(comment.id)
+      ) {
+        continue;
+      }
+      visibleRootIds.add(parentId);
+    }
+    return comments.filter((comment) => {
+      const parentId = getCommentParentId(comment);
+      if (parentId !== null && parentId !== undefined) {
+        return visibleCommentIds.has(comment.id);
+      }
+      return (
+        visibleCommentIds.has(comment.id) || visibleRootIds.has(comment.id)
+      );
+    });
+  }, [comments, visibleCommentIds]);
+
+  const activeCommentVisible =
+    activeCommentId !== null && visibleCommentIds.has(activeCommentId);
+
+  useEffect(() => {
+    if (!activeCommentVisible) {
+      setActiveCommentId(null);
+    }
+  }, [activeCommentVisible]);
+
+  const syncCommentHighlightStyles = useCallback(() => {
+    const root = editorContentRef.current;
+    if (!root) {
+      return;
+    }
+
+    const nodes = root.querySelectorAll<HTMLElement>(
+      ".layout-run-text[data-comment-id]",
+    );
+    for (const node of nodes) {
+      const commentId = Number.parseInt(node.dataset["commentId"] ?? "", 10);
+      const isPending = commentId === PENDING_COMMENT_ID;
+      const isVisible = isPending || visibleCommentIds.has(commentId);
+      if (!isVisible) {
+        node.style.backgroundColor = "transparent";
+        node.style.borderBottom = "2px solid transparent";
+        node.style.boxShadow = "none";
+        delete node.dataset["activeComment"];
+        continue;
+      }
+
+      if (activeCommentId === commentId) {
+        node.style.backgroundColor =
+          "var(--doc-comment-active-bg, rgba(255, 212, 0, 0.22))";
+        node.style.borderBottom =
+          "1px solid var(--doc-comment-active-border, rgba(180, 130, 0, 0.62))";
+        node.style.boxShadow = "none";
+        node.dataset["activeComment"] = "true";
+        continue;
+      }
+
+      node.style.backgroundColor =
+        "var(--doc-comment-bg, rgba(255, 212, 0, 0.08))";
+      node.style.borderBottom =
+        "1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24))";
+      node.style.boxShadow = "none";
+      delete node.dataset["activeComment"];
+    }
+  }, [visibleCommentIds, activeCommentId, editorContentRef]);
+
+  useLayoutEffect(() => {
+    syncCommentHighlightStyles();
+  }, [syncCommentHighlightStyles, anchorPositions]);
+
+  useEffect(() => {
+    syncCommentHighlightStyles();
+    const firstFrame = requestAnimationFrame(() => {
+      syncCommentHighlightStyles();
+      requestAnimationFrame(syncCommentHighlightStyles);
+    });
+    const timeout = setTimeout(syncCommentHighlightStyles, 120);
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      clearTimeout(timeout);
+    };
+  }, [comments.length, syncCommentHighlightStyles]);
+
+  return {
+    comments,
+    setComments,
+    commentsRef,
+    commentsDirtyRef,
+    commentsLoadedRef,
+    showCommentsSidebar,
+    setShowCommentsSidebar,
+    setVisibleCommentAuthors,
+    activeCommentId,
+    setActiveCommentId,
+    isAddingComment,
+    setIsAddingComment,
+    commentSelectionRange,
+    setCommentSelectionRange,
+    addCommentYPosition,
+    setAddCommentYPosition,
+    floatingCommentBtn,
+    setFloatingCommentBtn,
+    commentAuthors,
+    visibleCommentAuthorSet,
+    visibleComments,
+    syncCommentHighlightStyles,
+  };
+}


### PR DESCRIPTION
Moves DocxEditor's comment subsystem (thread storage, author-visibility filtering, add-comment flow, DOM highlight sync) into a `useFolioComments` hook. Behavior-preserving: the return is destructured into the same local names, so call sites are unchanged. First step in decomposing the editor component; net -135 lines there.