### PR TITLE
fix(folio): tracked-change list numbering + table-row break alignment

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.list-counters.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.list-counters.test.ts
@@ -11,6 +11,7 @@ function listParagraph(options: {
   abstractNumId?: number;
   startOverride?: number;
   marker?: string;
+  pPrMark?: Paragraph["pPrMark"];
 }): Paragraph {
   const ilvl = options.ilvl ?? 0;
   return {
@@ -24,11 +25,25 @@ function listParagraph(options: {
       isBullet: false,
       numFmt: "decimal",
       levelNumFmts: ["decimal"],
-      abstractNumId: options.abstractNumId,
-      startOverride: options.startOverride,
+      ...(options.abstractNumId !== undefined
+        ? { abstractNumId: options.abstractNumId }
+        : {}),
+      ...(options.startOverride !== undefined
+        ? { startOverride: options.startOverride }
+        : {}),
     },
+    ...(options.pPrMark ? { pPrMark: options.pPrMark } : {}),
   };
 }
+
+const INS_MARK = {
+  kind: "ins",
+  info: { id: 1, author: "A", date: "2026-01-01T00:00:00Z" },
+} as const;
+const DEL_MARK = {
+  kind: "del",
+  info: { id: 2, author: "A", date: "2026-01-01T00:00:00Z" },
+} as const;
 
 function documentWith(content: Paragraph[]): Document {
   return { package: { document: { content } } };
@@ -83,6 +98,45 @@ describe("toFlowBlocks counter sharing by abstractNumId", () => {
       "(2)",
       "(1)",
       "(3)",
+      "(2)",
+    ]);
+  });
+
+  test("tracked insertions and deletions number on independent streams", () => {
+    // An inserted list (a, b) followed by a deleted list (c, d, e) sharing one
+    // numId must restart for the deletion: Word numbers inserted vs deleted runs
+    // as if they never coexist. Regression for the a,b,c,d,e bug.
+    const doc = documentWith([
+      listParagraph({ numId: 6, text: "a", pPrMark: INS_MARK }),
+      listParagraph({ numId: 6, text: "b", pPrMark: INS_MARK }),
+      listParagraph({ numId: 6, text: "c", pPrMark: DEL_MARK }),
+      listParagraph({ numId: 6, text: "d", pPrMark: DEL_MARK }),
+      listParagraph({ numId: 6, text: "e", pPrMark: DEL_MARK }),
+    ]);
+
+    expect(markersOf(toFlowBlocks(toProseDoc(doc), {}))).toEqual([
+      "(1)",
+      "(2)",
+      "(1)",
+      "(2)",
+      "(3)",
+    ]);
+  });
+
+  test("normal items advance both streams so a deleted sibling continues from survivors", () => {
+    // final doc: a=1, c=2 ; original doc: a=1, (deleted)=2, c=3.
+    // The surviving normal items show final numbering; the deletion keeps its
+    // original number (2), which requires the preceding normal item to have
+    // advanced the original stream too.
+    const doc = documentWith([
+      listParagraph({ numId: 6, text: "a" }),
+      listParagraph({ numId: 6, text: "b", pPrMark: DEL_MARK }),
+      listParagraph({ numId: 6, text: "c" }),
+    ]);
+
+    expect(markersOf(toFlowBlocks(toProseDoc(doc), {}))).toEqual([
+      "(1)",
+      "(2)",
       "(2)",
     ]);
   });

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -502,6 +502,97 @@ describe("toFlowBlocks list numbering", () => {
     });
   });
 
+  test("removed-numbering deletion numbers off the original stream", () => {
+    // An inserted list item (numId 6) advances the final stream to (1). The
+    // next item shares that numId but had its numbering removed; in the
+    // pre-revision document the inserted item did not exist, so the deleted
+    // marker restarts at 1 rather than continuing to 2 off the insertion.
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 6, ilvl: 0 },
+          listMarker: "%1.",
+          _propertyChanges: [
+            {
+              type: "paragraphPropertyChange",
+              info: { id: 21, author: "Reviewer", date: "2026-01-01" },
+              previousFormatting: { numPr: null },
+            },
+          ],
+        },
+        [schema.text("Inserted list item")],
+      ),
+      schema.node(
+        "paragraph",
+        {
+          _propertyChanges: [
+            {
+              type: "paragraphPropertyChange",
+              info: { id: 22, author: "Reviewer", date: "2026-01-02" },
+              previousFormatting: {
+                numPr: { numId: 6, ilvl: 0 },
+                listIsBullet: false,
+                listNumFmt: "decimal",
+                listMarker: "%1.",
+              },
+            },
+          ],
+        },
+        [schema.text("Numbering removed")],
+      ),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const inserted = blocks.at(0);
+    const removed = blocks.at(1);
+    if (inserted?.kind !== "paragraph" || removed?.kind !== "paragraph") {
+      throw new Error("Expected paragraph blocks");
+    }
+
+    expect(inserted.attrs?.listMarkerRevision?.kind).toBe("ins");
+    expect(removed.attrs?.listMarker).toBe("1.");
+    expect(removed.attrs?.listMarkerRevision?.kind).toBe("del");
+  });
+
+  test("consecutive removed-numbering deletions advance the original stream", () => {
+    // Two adjacent items (numId 6) whose numbering was removed keep their
+    // original 1, 2 ordering: the deletion stream advances between them.
+    const removedItem = (id: number, text: string) =>
+      schema.node(
+        "paragraph",
+        {
+          _propertyChanges: [
+            {
+              type: "paragraphPropertyChange",
+              info: { id, author: "Reviewer", date: "2026-01-02" },
+              previousFormatting: {
+                numPr: { numId: 6, ilvl: 0 },
+                listIsBullet: false,
+                listNumFmt: "decimal",
+                listMarker: "%1.",
+              },
+            },
+          ],
+        },
+        [schema.text(text)],
+      );
+    const doc = schema.node("doc", null, [
+      removedItem(31, "first"),
+      removedItem(32, "second"),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const first = blocks.at(0);
+    const second = blocks.at(1);
+    if (first?.kind !== "paragraph" || second?.kind !== "paragraph") {
+      throw new Error("Expected paragraph blocks");
+    }
+
+    expect(first.attrs?.listMarker).toBe("1.");
+    expect(second.attrs?.listMarker).toBe("2.");
+  });
+
   test("marks changed numbering as a tracked insertion marker", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -593,6 +593,60 @@ describe("toFlowBlocks list numbering", () => {
     expect(second.attrs?.listMarker).toBe("2.");
   });
 
+  test("changed numbering advances the original stream for the previous numId", () => {
+    // Item 2's numbering changed from numId 7 to 8 (tracked) — shown as an
+    // insertion of the new numId, but in the original document it sat under
+    // numId 7. A later numId-7 deletion must continue from that consumed
+    // count: a=1, [7->8 changed], deleted=3 — not 2.
+    const renumbered = {
+      type: "paragraphPropertyChange",
+      info: { id: 41, author: "Reviewer", date: "2026-01-01" },
+      previousFormatting: {
+        numPr: { numId: 7, ilvl: 0 },
+        listIsBullet: false,
+        listNumFmt: "decimal",
+        listMarker: "%1.",
+      },
+    };
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        { numPr: { numId: 7, ilvl: 0 }, listMarker: "%1." },
+        [schema.text("a")],
+      ),
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 8, ilvl: 0 },
+          listMarker: "%1.",
+          _propertyChanges: [renumbered],
+        },
+        [schema.text("renumbered")],
+      ),
+      schema.node(
+        "paragraph",
+        {
+          numPr: { numId: 7, ilvl: 0 },
+          listMarker: "%1.",
+          pPrMark: {
+            kind: "del",
+            info: { id: 42, author: "Reviewer", date: "2026-01-02" },
+          },
+        },
+        [schema.text("deleted")],
+      ),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const deleted = blocks.at(2);
+    if (deleted?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+
+    expect(deleted.attrs?.listMarker).toBe("3.");
+    expect(deleted.attrs?.listMarkerRevision?.kind).toBe("del");
+  });
+
   test("marks changed numbering as a tracked insertion marker", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1590,6 +1590,9 @@ function convertParagraphAttrs(
   // List properties
   const pPrChange = pmAttrs._propertyChanges as ListPropertyChange[] | null;
   const propertyChanges = Array.isArray(pPrChange) ? pPrChange : [];
+  let changedNumberingChange:
+    | (ListPropertyChange & { previousFormatting: Record<string, unknown> })
+    | undefined;
   if (pmAttrs.numPr) {
     const numPr: ParagraphAttrs["numPr"] & object = {};
     if (pmAttrs.numPr.numId !== undefined) {
@@ -1613,11 +1616,15 @@ function convertParagraphAttrs(
     } else {
       const numberingAddedChange = propertyChanges.find(isAddedNumberingChange);
       const currentNumPr = pmAttrs.numPr;
-      const numberingChangedChange = propertyChanges.find((change) =>
-        isChangedNumberingChange(currentNumPr, change),
+      changedNumberingChange = propertyChanges.find(
+        (
+          change,
+        ): change is ListPropertyChange & {
+          previousFormatting: Record<string, unknown>;
+        } => isChangedNumberingChange(currentNumPr, change),
       );
       const numberingInsertionChange =
-        numberingAddedChange ?? numberingChangedChange;
+        numberingAddedChange ?? changedNumberingChange;
       if (numberingInsertionChange) {
         attrs.listMarkerRevision = toListMarkerRevision(
           "ins",
@@ -1668,6 +1675,25 @@ function convertParagraphAttrs(
       originalListAbstractCounters ?? new Map(),
       originalListSeenNumIds ?? new Set(),
     );
+  } else if (
+    changedNumberingChange !== undefined &&
+    originalListCounters !== undefined
+  ) {
+    // Changed numbering is shown as an insertion of the new numId, but in the
+    // pre-revision document the paragraph sat under its PREVIOUS numId. Advance
+    // that original stream so a later deletion on the old numId continues from
+    // the right count instead of reusing this item's number.
+    const previousListAttrs = toPreviousListAttrs(
+      changedNumberingChange.previousFormatting,
+    );
+    if (previousListAttrs.numPr && !previousListAttrs.listIsBullet) {
+      computeListMarker(
+        previousListAttrs,
+        originalListCounters,
+        originalListAbstractCounters ?? new Map(),
+        originalListSeenNumIds ?? new Set(),
+      );
+    }
   }
   if (resolvedMarker !== null) {
     attrs.listMarker = resolvedMarker;

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -100,6 +100,19 @@ export type ToFlowBlocksOptions = {
   /** Shared startOverride state for nested containers. */
   listSeenNumIds?: Set<string>;
   /**
+   * Parallel counter state for the "original" (pre-revision) document, used to
+   * number tracked-deletion list items. Word numbers inserted and deleted list
+   * runs as if they never coexist: insertions get final-document numbering,
+   * deletions keep their original numbering. Without a separate stream a deleted
+   * item continues the counter of the inserted item before it (a, b → c, d, e
+   * instead of a, b and a, b, c). Normal items advance both streams.
+   */
+  originalListCounters?: Map<number, number[]>;
+  /** Latest concrete original-stream counters by abstract numbering definition. */
+  originalListAbstractCounters?: Map<number, number[]>;
+  /** Original-stream startOverride state. */
+  originalListSeenNumIds?: Set<string>;
+  /**
    * Document-wide `w:defaultTabStop` (§17.6.13) in twips. Stamped onto
    * every paragraph block so paragraph-local layout helpers (list marker
    * tab-stop math) can read it without taking a `Document` reference.
@@ -1353,6 +1366,9 @@ function convertParagraphAttrs(
   listAbstractCounters?: Map<number, number[]>,
   listSeenNumIds?: Set<string>,
   defaultTabStopTwips?: number,
+  originalListCounters?: Map<number, number[]>,
+  originalListAbstractCounters?: Map<number, number[]>,
+  originalListSeenNumIds?: Set<string>,
 ): ParagraphAttrs {
   const attrs: ParagraphAttrs = {};
 
@@ -1616,17 +1632,49 @@ function convertParagraphAttrs(
       }
     }
   }
+  // Tracked-deletion list items number off a separate "original" stream so the
+  // inserted list (a, b) and the deleted list (a, b, c) restart independently
+  // instead of running one shared counter (a, b, c, d, e). Insertions and normal
+  // items use the final stream; normal items also advance the original stream so
+  // a later deleted sibling continues from the surviving count (Word parity).
+  const useOriginalStream =
+    attrs.listMarkerRevision?.kind === "del" &&
+    originalListCounters !== undefined;
+  const streamCounters = useOriginalStream
+    ? originalListCounters
+    : listCounters;
+  const streamAbstractCounters = useOriginalStream
+    ? originalListAbstractCounters
+    : listAbstractCounters;
+  const streamSeenNumIds = useOriginalStream
+    ? originalListSeenNumIds
+    : listSeenNumIds;
   const resolvedMarker = applyMarkerAllCaps(
-    listCounters
+    streamCounters
       ? computeListMarker(
           pmAttrs,
-          listCounters,
-          listAbstractCounters ?? new Map(),
-          listSeenNumIds ?? new Set(),
+          streamCounters,
+          streamAbstractCounters ?? new Map(),
+          streamSeenNumIds ?? new Set(),
         )
       : null,
     pmAttrs.listMarkerAllCaps,
   );
+  const numberedNumId = pmAttrs.numPr?.numId;
+  if (
+    attrs.listMarkerRevision === undefined &&
+    !pmAttrs.listIsBullet &&
+    originalListCounters !== undefined &&
+    numberedNumId !== undefined &&
+    numberedNumId !== 0
+  ) {
+    computeListMarker(
+      pmAttrs,
+      originalListCounters,
+      originalListAbstractCounters ?? new Map(),
+      originalListSeenNumIds ?? new Set(),
+    );
+  }
   if (resolvedMarker !== null) {
     attrs.listMarker = resolvedMarker;
   } else if (pmAttrs.listMarker) {
@@ -1734,6 +1782,9 @@ function convertParagraph(
     options.listAbstractCounters,
     options.listSeenNumIds,
     options.defaultTabStopTwips,
+    options.originalListCounters,
+    options.originalListAbstractCounters,
+    options.originalListSeenNumIds,
   );
 
   return {
@@ -2296,6 +2347,11 @@ export function toFlowBlocks(
     listAbstractCounters:
       options.listAbstractCounters ?? new Map<number, number[]>(),
     listSeenNumIds: options.listSeenNumIds ?? new Set<string>(),
+    originalListCounters:
+      options.originalListCounters ?? new Map<number, number[]>(),
+    originalListAbstractCounters:
+      options.originalListAbstractCounters ?? new Map<number, number[]>(),
+    originalListSeenNumIds: options.originalListSeenNumIds ?? new Set<string>(),
   };
 
   const blocks: FlowBlock[] = [];

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1279,16 +1279,6 @@ function toPreviousListAttrs(
   return attrs;
 }
 
-function cloneListCounterMap(
-  counters: Map<number, number[]>,
-): Map<number, number[]> {
-  const cloned = new Map<number, number[]>();
-  for (const [key, value] of counters) {
-    cloned.set(key, [...value]);
-  }
-  return cloned;
-}
-
 function resolveDeletedListMarker(
   previousListAttrs: PMParagraphAttrs,
   listCounters: Map<number, number[]> | undefined,
@@ -1296,11 +1286,15 @@ function resolveDeletedListMarker(
   listSeenNumIds: Set<string> | undefined,
 ): string | null {
   if (listCounters && previousListAttrs.numPr) {
+    // Advance the original counter stream in place (no clone): a
+    // removed-numbering deletion occupied a number in the pre-revision
+    // document, so it must progress the counter exactly like a deleted list
+    // item — otherwise a following deletion on the same numId reuses it.
     const marker = computeListMarker(
       previousListAttrs,
-      cloneListCounterMap(listCounters),
-      cloneListCounterMap(listAbstractCounters ?? new Map<number, number[]>()),
-      new Set(listSeenNumIds),
+      listCounters,
+      listAbstractCounters ?? new Map<number, number[]>(),
+      listSeenNumIds ?? new Set<string>(),
     );
     if (marker) {
       return marker;
@@ -1706,12 +1700,15 @@ function convertParagraphAttrs(
       isRemovedNumberingChange,
     );
     if (numberingRemovedChange) {
+      // Number removed-numbering deletions off the original stream too (like
+      // deleted list items): the struck-through marker must reflect the
+      // pre-revision number, not the final counter that insertions advanced.
       applyDeletedListMarkerAttrs(
         attrs,
         numberingRemovedChange,
-        listCounters,
-        listAbstractCounters,
-        listSeenNumIds,
+        originalListCounters,
+        originalListAbstractCounters,
+        originalListSeenNumIds,
       );
     }
   }

--- a/packages/folio/src/core/layout-engine/tableRowBreak.test.ts
+++ b/packages/folio/src/core/layout-engine/tableRowBreak.test.ts
@@ -238,6 +238,67 @@ describe("buildTableRowBreakInfo / snapRowBreak", () => {
     expect(info.breakOffsets[0]).toEqual([LINE, 2 * LINE, 3 * LINE]);
   });
 
+  test("seats break offsets on painted line boundaries despite paragraph space-before", () => {
+    // The painter stacks the cell paragraph by its full height (before + lines +
+    // after = 8 + 80 + 8 = 96) but paints lines from the cell top with no
+    // leading space-before, so painted line bottoms are 20/40/60/80. The break
+    // offsets must match those, not the +8-shifted 28/48/68/88 — otherwise an
+    // oversized-row split lands mid-line and a glyph row straddles the page
+    // boundary. Regression for the table-cell space-before drift.
+    const block: TableBlock = {
+      kind: "table",
+      id: "t",
+      rows: [
+        {
+          id: "r0",
+          cells: [
+            {
+              id: "c0",
+              padding: { top: 0, right: 0, bottom: 0, left: 0 },
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "p0",
+                  attrs: { spacing: { before: 8, after: 8 } },
+                  runs: [{ kind: "text", text: "x" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      columnWidths: [220],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                {
+                  kind: "paragraph",
+                  lines: linesWithHeight(4, LINE),
+                  totalHeight: 8 + 4 * LINE + 8,
+                },
+              ],
+              width: 220,
+              height: 8 + 4 * LINE + 8,
+            },
+          ],
+          height: 8 + 4 * LINE + 8,
+        },
+      ],
+      columnWidths: [220],
+      totalWidth: 220,
+      totalHeight: 8 + 4 * LINE + 8,
+    };
+
+    const info = buildTableRowBreakInfo(block, measure);
+
+    expect(info.breakOffsets[0]).toEqual([20, 40, 60, 80, 96]);
+  });
+
   test("treats height-based cell blocks as atomic break offsets", () => {
     const block: TableBlock = {
       kind: "table",

--- a/packages/folio/src/core/layout-engine/tableRowBreak.ts
+++ b/packages/folio/src/core/layout-engine/tableRowBreak.ts
@@ -90,10 +90,11 @@ function cellBreakGeometry(
   cell: TableCell | undefined,
   measure: TableCellMeasure,
 ): CellBreakGeometry {
-  // Mirror measureTableBlock's cell-height model: each block contributes
-  // before + lines + after with no inter-paragraph collapse (the paragraph
-  // measure's totalHeight already bundles before/after). Keeping the same model
-  // means these line bottoms line up with the row height the paginator splits.
+  // Mirror the PAINTER's cell-content stacking (renderCellContent), not just the
+  // cell-height model: each block advances by its `totalHeight` (which bundles
+  // space-before/after), but its lines paint from the block top with no leading
+  // space-before. Seating line bottoms this way keeps them on the painted line
+  // boundaries so an oversized-row break never cuts through a glyph row.
   const bottoms: number[] = [];
   const unsafeRanges: UnsafeBreakRange[] = [];
   const cellBlocks = cell?.blocks;
@@ -114,15 +115,21 @@ function cellBreakGeometry(
     let blockMeasure = blockMeasures[i];
     if (blockMeasure?.kind === "paragraph") {
       const block = cellBlocks?.[i];
-      const spacing =
-        block?.kind === "paragraph" ? block.attrs?.spacing : undefined;
       if (block?.kind === "paragraph" && floatingZones.length > 0) {
         blockMeasure = measureParagraph(block, contentWidth, {
           floatingZones,
           paragraphYOffset: paragraphY,
         });
       }
-      y += spacing?.before ?? 0;
+      // The painter (renderCellContent) stacks each cell paragraph by its full
+      // measured height (`totalHeight`, which bundles space-before/after) yet
+      // paints the lines from the fragment top with NO leading space-before; the
+      // before/after surface as trailing space. Mirror that exactly: seat line
+      // bottoms from the block top and advance by `totalHeight`. Offsetting the
+      // lines by `spacing.before` (as the cell-height model does) shifted every
+      // break offset off the painted line boundary, so an oversized row split
+      // through the middle of a glyph row across the page break.
+      const blockTop = y;
       for (const line of blockMeasure.lines) {
         y += line.floatSkipBefore ?? 0;
         const top = y;
@@ -130,7 +137,7 @@ function cellBreakGeometry(
         unsafeRanges.push({ top, bottom: y });
         bottoms.push(y);
       }
-      y += spacing?.after ?? 0;
+      y = blockTop + blockMeasure.totalHeight;
       paragraphY += blockMeasure.totalHeight;
     } else if (blockMeasure) {
       // Nested table / non-paragraph: one atomic block (break only at its bottom).


### PR DESCRIPTION
Two layout fixes in `@stll/folio`, both surfaced by redline (track-changes) documents.

### 1. List numbering across tracked insertions/deletions
When a list's items are split between tracked insertions and deletions that share a `numId`, the deleted run continued the inserted run's counter (e.g. `a, b, c, d, e`) instead of restarting (`a, b` for the insertion and `a, b, c` for the deletion). Insertions and deletions never coexist in either the original or the final document, so each numbers independently.

`computeListMarker` now keeps a separate "original document" counter stream alongside the final one: deleted items number off the original stream, inserted items off the final stream, and normal items advance both. Regression test in `toFlowBlocks.list-counters.test.ts`.

### 2. Oversized table-row break alignment
When a table row is taller than the remaining page space and must split across pages, `cellBreakGeometry` seated line-bottom break offsets *after* a paragraph's `space-before`. The painter stacks cell paragraphs by their full height but paints lines from the block top with no leading space-before, so the offsets drifted and a row could split through the middle of a text line across the page boundary.

Break offsets are now seated from the block top and advance by each block's total height, mirroring the painter exactly. Regression test in `tableRowBreak.test.ts`.