### PR TITLE
feat(folio): invert document text-colour lightness in dark mode

### DIFF
--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -622,6 +622,9 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.color).toBe("#0563c1");
     expect(anchorEl?.style.color).toBe("#0563c1");
+    // The anchor paints over the span, so it must carry --doc-run-color for the
+    // dark-mode inversion rule to reach it (otherwise links stay dim on dark).
+    expect(anchorEl?.style.getPropertyValue("--doc-run-color")).toBe("#0563c1");
   });
 
   test("uses the higher-contrast text color on mid-tone DOCX highlights", () => {

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -12,11 +12,36 @@ import type {
 import { AUTHOR_COLORS, resetAuthorColors } from "../utils/authorColors";
 import { renderLine, renderParagraphFragment } from "./renderParagraph";
 
+// Runtime shim: prod code calls element.style.setProperty("--doc-run-color", …)
+// (real CSSStyleDeclaration has it); the mock stores it like any other prop so
+// direct `style.color` access and `setProperty` both work. Typed as a plain
+// Record so existing dot-access assertions stay valid.
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      if (prop === "getPropertyValue") {
+        return (key: string) => target[key] ?? "";
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
 class FakeElement {
   className = "";
   dataset: Record<string, string> = {};
   innerHTML = "";
-  style: Record<string, string> = {};
+  style: Record<string, string> = createFakeStyle();
   children: FakeElement[] = [];
   classList = {
     add: (...tokens: string[]) => {
@@ -690,6 +715,36 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
+  });
+
+  test("exposes explicit run color as --doc-run-color for dark-mode inversion", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        { kind: "text", text: "Colored", color: TEST_EXPLICIT_TEXT_COLOR },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 7,
+      width: 50,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    // Inline color is kept verbatim (light mode); the custom property lets the
+    // dark-mode CSS invert lightness while preserving hue/chroma.
+    expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
+    expect(textEl?.style.getPropertyValue("--doc-run-color")).toBe(
+      TEST_EXPLICIT_TEXT_COLOR,
+    );
   });
 
   test("preserves explicit black text colors on DOCX highlights", () => {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -527,6 +527,12 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
       anchor.style.textDecoration = "underline";
       // Override span color to match anchor (prevents color mismatch in selection)
       span.style.color = hyperlinkColor;
+      // Expose the link colour on the anchor (which paints over the span) so
+      // dark mode inverts its lightness via the same --doc-run-color rule.
+      // `noDefaultStyle` (e.g. TOC) anchors set no colour and keep inheriting
+      // the paragraph's inverted colour.
+      anchor.style.setProperty("--doc-run-color", hyperlinkColor);
+      span.style.setProperty("--doc-run-color", hyperlinkColor);
     }
     span.append(anchor);
   } else {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -217,11 +217,19 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     element.style.fontStyle = "italic";
   }
 
-  // Color — skip black/auto so the CSS variable --doc-canvas-text can adapt to dark mode
+  // Color — black/auto are skipped so --doc-canvas-text can adapt to dark mode.
+  // Explicit colors are exposed as a custom property (--doc-run-color) and read
+  // back via var(); dark mode then inverts their lightness with relative-color
+  // CSS (hue/chroma preserved), matching Word's dark-mode rendering instead of
+  // leaving authored colors dim on the dark canvas.
   let hasExplicitTextColor = false;
   const textColor = getRenderableTextColor(run);
   if (textColor) {
     element.style.color = textColor;
+    // Also expose the authored color so dark mode can invert its lightness
+    // (hue/chroma preserved) via relative-color CSS. The dark rule overrides
+    // this inline color with !important; light mode keeps it verbatim.
+    element.style.setProperty("--doc-run-color", textColor);
     hasExplicitTextColor = true;
   }
 

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -319,9 +319,31 @@
 .dark .ProseMirror {
   color: var(--doc-canvas-text) !important;
 }
-/* Preserve explicit non-black colors set by the layout painter */
-.dark .layout-page [style*="color:"] {
-  /* inline styles with explicit color win — no override needed */
+/* Dark mode: invert the LIGHTNESS of explicit run colors while preserving hue
+ * and chroma, matching Word's dark-mode rendering. Plain runs expose their
+ * authored color as --doc-run-color (see renderParagraph.ts); black/auto runs
+ * have no var and keep --doc-canvas-text above. Relative-color syntax computes
+ * the inverted OKLCH lightness, so e.g. #575757 reads near-#B2B2B2, amber
+ * darkens to brown, and saturated hues stay on-hue. */
+.dark
+  .layout-page
+  [style*="--doc-run-color"]:not(.docx-insertion):not(.docx-deletion) {
+  color: oklch(
+    from var(--doc-run-color) clamp(0, 1.22 - 0.95 * l, 1) calc(c * 0.6) h
+  ) !important;
+}
+
+/* Tracked-change spans color from --tc-color (author colour), not
+ * --doc-run-color, so invert that channel instead — otherwise the broad rule
+ * above would repaint the red insertions/deletions as inverted body grey.
+ * Decoration (underline/strike) follows the same inverted colour. */
+.dark .layout-page .docx-insertion,
+.dark .layout-page .docx-deletion {
+  --tc-inverted: oklch(
+    from var(--tc-color, #c00000) clamp(0, 1.22 - 0.95 * l, 1) calc(c * 0.6) h
+  );
+  color: var(--tc-inverted) !important;
+  text-decoration-color: var(--tc-inverted) !important;
 }
 
 /* ============================================================================


### PR DESCRIPTION
Dark mode previously flipped only pure-black/auto text to light (via `--doc-canvas-text`) and left every **explicit** colour verbatim. A document whose body text is an authored grey (e.g. `#575757`) therefore stayed dim and low-contrast (~2.3:1) on the dark canvas, while a word processor's dark mode renders it near-white.

This adds a **hue/chroma-preserving lightness inversion** of explicit document colours in dark mode, so greys lighten, light colours (e.g. amber) darken, and saturated hues stay on-hue — matching common word-processor dark-mode rendering.

### How
- **Painter** (`renderParagraph.ts`): each explicit run colour is also exposed as a `--doc-run-color` custom property; the inline `color` is kept verbatim so light mode is unchanged.
- **CSS** (`editor.css`): dark mode inverts lightness with relative-colour syntax — `oklch(from var(--doc-run-color) clamp(0, 1.22 - 0.95*l, 1) calc(c * 0.6) h)`. Reactive (no re-paint); black/auto text keeps the existing `--doc-canvas-text` path.
- **Tracked changes**: `--tc-color` (insertion/deletion author colour) is inverted on the same curve, including the underline/strike decoration, so changes stay legible on dark instead of dim red.

### Notes
- The lightness curve is linear in OKLCH `L` (CSS `calc` constraint) fit to typical body-text greys; very dark inputs lighten slightly more than a perceptual curve would. Chroma is scaled (`×0.6`) to approximate the desaturation a luminance flip produces.
- Regression test asserts the painter exposes `--doc-run-color` for explicit colours.