### PR TITLE
fix(dev): match TanStack Start SSR shell in web readiness gate

### DIFF
--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -59,7 +59,11 @@ const MAX_INFRA_OFFSET =
   MAX_PORT - Math.max(...Object.values(DEFAULT_INFRA_PORTS));
 const MAX_PORT_OFFSET = MAX_PORT - Math.max(...Object.values(DEFAULT_PORTS));
 const PORT_SEARCH_LIMIT = 2000;
-const WEB_HTML_MARKER = 'id="app"';
+// The web app renders via TanStack Start SSR (root document from __root.tsx),
+// which mounts into <body> directly — there is no `<div id="app">` SPA mount.
+// Match the shell's stable dark-mode-init script, not the user-facing <title>
+// (which can change with branding), so readiness reflects a real rendered shell.
+const WEB_HTML_MARKER = 'src="/dark-mode-init.js"';
 
 export type DevMode = (typeof DEV_MODES)[number];
 


### PR DESCRIPTION
The dev-runner's web readiness probe matched the old SPA mount marker `id="app"`. After the TanStack Start SSR migration the web server renders the root document (`__root.tsx`) and mounts into `<body>`, so a healthy server never emits that marker — the gate concludes web never became ready and tears down the whole dev process (api + web) after its timeout. Probe for the rendered `<title>` instead, which the SSR shell always emits.