### PR TITLE
fix: support Windows dev loopback and env parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,6 +732,69 @@ jobs:
         env:
           NPM_TOKEN: ""
 
+  # Narrow Windows smoke for the dev runner. Full app CI stays on Linux,
+  # but this catches path and shell assumptions in the scripts package
+  # before Windows contributors hit them locally.
+  windows-scripts:
+    needs: trust-check
+    if: >-
+      needs.trust-check.outputs.trusted == 'true'
+      || github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether scripts-affecting paths changed
+        id: changed
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base_ref="origin/$BASE_REF"
+          mapfile -t changed_files < <(git diff --name-only "$base_ref"...HEAD)
+          run=false
+          for file in "${changed_files[@]}"; do
+            case "$file" in
+              packages/scripts/*|package.json|bun.lock|.github/workflows/ci.yml)
+                run=true
+                break
+                ;;
+            esac
+          done
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          if [[ "$run" != "true" ]]; then
+            echo "::notice::No scripts-affecting paths changed; skipping Windows scripts smoke."
+          fi
+
+      - name: Setup Bun
+        if: steps.changed.outputs.run == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install scripts workspace dependencies
+        if: steps.changed.outputs.run == 'true'
+        run: bun install --frozen-lockfile --ignore-scripts --filter @stll/scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Test dev runner
+        if: steps.changed.outputs.run == 'true'
+        run: bun test packages/scripts/src/dev-runner.test.ts
+
   # Aggregation job for branch protection. The ruleset requires
   # this check to pass, which ensures untrusted PRs cannot be
   # merged without CI and trusted PRs must pass all checks.
@@ -746,7 +809,15 @@ jobs:
       }}
     if: always()
     needs:
-      [trust-check, ci-checks, web-build, landing-build, e2e, api-image-deps]
+      [
+        trust-check,
+        ci-checks,
+        web-build,
+        landing-build,
+        e2e,
+        api-image-deps,
+        windows-scripts,
+      ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -761,6 +832,7 @@ jobs:
           TRUSTED: ${{ needs.trust-check.outputs.trusted }}
           TRUST_RESULT: ${{ needs.trust-check.result }}
           WEB_RESULT: ${{ needs.web-build.result }}
+          WINDOWS_SCRIPTS_RESULT: ${{ needs.windows-scripts.result }}
         run: |
           # When the trust-check job was skipped (draft PR or
           # irrelevant label event), all downstream jobs are also
@@ -775,7 +847,8 @@ jobs:
                   || "$WEB_RESULT" == "failure" || "$WEB_RESULT" == "cancelled" \
                   || "$LANDING_RESULT" == "failure" || "$LANDING_RESULT" == "cancelled" \
                   || "$E2E_RESULT" == "failure" || "$E2E_RESULT" == "cancelled" \
-                  || "$API_IMAGE_DEPS_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "cancelled" ]]; then
+                  || "$API_IMAGE_DEPS_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "cancelled" \
+                  || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" ]]; then
               echo "::error::CI checks failed."
               exit 1
             fi
@@ -789,12 +862,12 @@ jobs:
 
           # "cancelled" means cancel-in-progress replaced this
           # run with a newer one; the newer run is authoritative.
-          if [[ "$CI_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" ]]; then
+          if [[ "$CI_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" ]]; then
             echo "CI run was superseded by a newer run (cancel-in-progress). Passing."
             exit 0
           fi
 
-          if [[ "$CI_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" ]]; then
+          if [[ "$CI_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" ]]; then
             echo "::error::CI checks failed."
             exit 1
           fi

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -55,7 +55,7 @@ import { workspacesRoute } from "@/api/handlers/workspaces/routes";
 import { captureRequestError, getAnalytics } from "@/api/lib/analytics";
 import { getAuth } from "@/api/lib/auth";
 import { assertMigrationsApplied } from "@/api/lib/db/assert-migrations-applied";
-import { DEV_INSPECTOR_ORIGINS } from "@/api/lib/dev-origins";
+import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
 import { httpError } from "@/api/lib/errors/http-error";
 import { errorTag } from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
@@ -180,7 +180,10 @@ const api = new Elysia()
   .use(
     cors({
       origin: (() => {
-        const origins: (string | RegExp)[] = [env.FRONTEND_URL];
+        const origins: (string | RegExp)[] = frontendOrigins({
+          frontendUrl: env.FRONTEND_URL,
+          isDev: env.isDev,
+        });
         if (env.isDev) {
           origins.push(/^chrome-extension:\/\//u);
           origins.push(...DEV_INSPECTOR_ORIGINS);

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -33,7 +33,7 @@ import { revokeOrganizationMemberAuthArtifacts } from "@/api/lib/auth-artifacts"
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tUuid } from "@/api/lib/custom-schema";
-import { DEV_INSPECTOR_ORIGINS } from "@/api/lib/dev-origins";
+import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
 import { stashDevOtp } from "@/api/lib/dev-otp-store";
 import {
   sendNewDeviceLoginEmail,
@@ -187,7 +187,10 @@ const isMcpResourceScope = (
 const createAuth = () => {
   const auth = betterAuth({
     trustedOrigins: [
-      env.FRONTEND_URL,
+      ...frontendOrigins({
+        frontendUrl: env.FRONTEND_URL,
+        isDev: env.isDev,
+      }),
       ...(env.isDev ? ["chrome-extension://*"] : []),
       ...(env.isDev ? DEV_INSPECTOR_ORIGINS : []),
       ...(env.EXTENSION_ORIGIN ? [env.EXTENSION_ORIGIN] : []),

--- a/apps/api/src/lib/dev-origins.test.ts
+++ b/apps/api/src/lib/dev-origins.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { frontendOrigins } from "@/api/lib/dev-origins";
+
+describe("frontend origins", () => {
+  test("keeps production origins exact", () => {
+    expect(
+      frontendOrigins({
+        frontendUrl: "http://localhost:3000",
+        isDev: false,
+      }),
+    ).toEqual(["http://localhost:3000"]);
+  });
+
+  test("adds a 127.0.0.1 dev alias for localhost", () => {
+    expect(
+      frontendOrigins({
+        frontendUrl: "http://localhost:3000",
+        isDev: true,
+      }),
+    ).toEqual(["http://localhost:3000", "http://127.0.0.1:3000"]);
+  });
+
+  test("adds a localhost dev alias for 127.0.0.1", () => {
+    expect(
+      frontendOrigins({
+        frontendUrl: "http://127.0.0.1:3000",
+        isDev: true,
+      }),
+    ).toEqual(["http://127.0.0.1:3000", "http://localhost:3000"]);
+  });
+
+  test("only swaps exact loopback hostnames", () => {
+    expect(
+      frontendOrigins({
+        frontendUrl: "http://app.localhost:3000",
+        isDev: true,
+      }),
+    ).toEqual(["http://app.localhost:3000"]);
+    expect(
+      frontendOrigins({
+        frontendUrl: "http://localhost.example:3000",
+        isDev: true,
+      }),
+    ).toEqual(["http://localhost.example:3000"]);
+  });
+
+  test("leaves non-parseable origins unchanged", () => {
+    expect(
+      frontendOrigins({
+        frontendUrl: "localhost:3000",
+        isDev: true,
+      }),
+    ).toEqual(["localhost:3000"]);
+  });
+});

--- a/apps/api/src/lib/dev-origins.test.ts
+++ b/apps/api/src/lib/dev-origins.test.ts
@@ -30,6 +30,15 @@ describe("frontend origins", () => {
     ).toEqual(["http://127.0.0.1:3000", "http://localhost:3000"]);
   });
 
+  test("normalizes a trailing slash on a loopback origin", () => {
+    expect(
+      frontendOrigins({
+        frontendUrl: "http://localhost:3000/",
+        isDev: true,
+      }),
+    ).toEqual(["http://localhost:3000", "http://127.0.0.1:3000"]);
+  });
+
   test("only swaps exact loopback hostnames", () => {
     expect(
       frontendOrigins({

--- a/apps/api/src/lib/dev-origins.ts
+++ b/apps/api/src/lib/dev-origins.ts
@@ -18,21 +18,30 @@ export const frontendOrigins = ({
 
 const expandLoopbackOrigin = (origin: string) => {
   const parsed = safeParseUrl(origin);
-  if (!parsed) {
+  // Only http(s) URLs carry a comparable origin; others (e.g. "localhost:3000",
+  // parsed with scheme "localhost") have a "null" origin, so keep them raw.
+  if (
+    !parsed ||
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+  ) {
     return [origin];
   }
 
+  // Normalize to the URL origin (scheme://host:port) so a trailing slash or
+  // path on FRONTEND_URL can't make one loopback alias match the browser's
+  // Origin header while the other does not.
+  const normalizedOrigin = parsed.origin;
   const hostname = alternateLoopbackHostname(parsed.hostname);
   if (!hostname) {
-    return [origin];
+    return [normalizedOrigin];
   }
 
   parsed.hostname = hostname;
   const alternateOrigin = parsed.origin;
-  if (alternateOrigin === origin) {
-    return [origin];
+  if (alternateOrigin === normalizedOrigin) {
+    return [normalizedOrigin];
   }
-  return [origin, alternateOrigin];
+  return [normalizedOrigin, alternateOrigin];
 };
 
 const alternateLoopbackHostname = (hostname: string) => {

--- a/apps/api/src/lib/dev-origins.ts
+++ b/apps/api/src/lib/dev-origins.ts
@@ -2,3 +2,53 @@ export const DEV_INSPECTOR_ORIGINS = [
   "http://localhost:6274",
   "http://127.0.0.1:6274",
 ] as const;
+
+export const frontendOrigins = ({
+  frontendUrl,
+  isDev,
+}: {
+  frontendUrl: string;
+  isDev: boolean;
+}) => {
+  if (!isDev) {
+    return [frontendUrl];
+  }
+  return expandLoopbackOrigin(frontendUrl);
+};
+
+const expandLoopbackOrigin = (origin: string) => {
+  const parsed = safeParseUrl(origin);
+  if (!parsed) {
+    return [origin];
+  }
+
+  const hostname = alternateLoopbackHostname(parsed.hostname);
+  if (!hostname) {
+    return [origin];
+  }
+
+  parsed.hostname = hostname;
+  const alternateOrigin = parsed.origin;
+  if (alternateOrigin === origin) {
+    return [origin];
+  }
+  return [origin, alternateOrigin];
+};
+
+const alternateLoopbackHostname = (hostname: string) => {
+  if (hostname === "localhost") {
+    return "127.0.0.1";
+  }
+  if (hostname === "127.0.0.1") {
+    return "localhost";
+  }
+  return undefined;
+};
+
+const safeParseUrl = (value: string) => {
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -545,7 +545,11 @@ describe("worktree helpers", () => {
   });
 
   test("resolves the main root from the common git dir", () => {
-    expect(resolveMainRootFromCommonDir("/repo/.git")).toBe("/repo");
+    const mainRoot = createTempDir();
+
+    expect(resolveMainRootFromCommonDir(resolve(mainRoot, ".git"))).toBe(
+      mainRoot,
+    );
   });
 
   test("symlinks missing env files from the main worktree", () => {

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -18,6 +18,7 @@ import {
   parseArgs,
   parseForeignPortOwners,
   portsForOffset,
+  readEnvFlag,
   requiredPortsForMode,
   resolveMainRootFromCommonDir,
   resolveOffset,
@@ -621,6 +622,60 @@ describe("worktree helpers", () => {
     expect(Bun.file(resolve(worktreeRoot, "apps/api/.env")).size).toBe(
       "LOCAL=1\n".length,
     );
+  });
+});
+
+describe("env flag parsing", () => {
+  test("accepts single-quoted truthy values from env files", () => {
+    const rootDir = createTempDir();
+    const envFilePath = resolve(rootDir, ".env");
+    writeFileSync(envFilePath, "AI_DEVTOOLS_ENABLED='true'\n");
+
+    expect(
+      readEnvFlag({
+        envFilePath,
+        key: "AI_DEVTOOLS_ENABLED",
+        processEnv: {},
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps hash characters inside quoted env file values", () => {
+    const rootDir = createTempDir();
+    const envFilePath = resolve(rootDir, ".env");
+    writeFileSync(envFilePath, 'AI_DEVTOOLS_ENABLED="true#still-value"\n');
+
+    expect(
+      readEnvFlag({
+        envFilePath,
+        key: "AI_DEVTOOLS_ENABLED",
+        processEnv: {},
+      }),
+    ).toBe(false);
+  });
+
+  test("strips comments from unquoted env file values", () => {
+    const rootDir = createTempDir();
+    const envFilePath = resolve(rootDir, ".env");
+    writeFileSync(envFilePath, "AI_DEVTOOLS_ENABLED=true # local devtools\n");
+
+    expect(
+      readEnvFlag({
+        envFilePath,
+        key: "AI_DEVTOOLS_ENABLED",
+        processEnv: {},
+      }),
+    ).toBe(true);
+  });
+
+  test("parses quoted process env values consistently", () => {
+    expect(
+      readEnvFlag({
+        envFilePath: resolve(createTempDir(), ".env"),
+        key: "AI_DEVTOOLS_ENABLED",
+        processEnv: { AI_DEVTOOLS_ENABLED: "'yes'" },
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -1029,7 +1029,37 @@ const TRUTHY_ENV_VALUES: ReadonlySet<string> = new Set([
   "on",
 ]);
 
-const readEnvFlag = ({
+const stripEnvValueCommentsAndQuotes = (rawValue: string) => {
+  const value = rawValue.trimStart();
+  let quoteChar: '"' | "'" | undefined;
+  if (value.startsWith('"')) {
+    quoteChar = '"';
+  }
+  if (value.startsWith("'")) {
+    quoteChar = "'";
+  }
+  let endIndex = value.length;
+
+  if (quoteChar) {
+    const closingQuote = value.indexOf(quoteChar, 1);
+    if (closingQuote !== -1) {
+      endIndex = closingQuote + 1;
+    }
+  } else {
+    const hashIndex = value.indexOf("#");
+    if (hashIndex !== -1) {
+      endIndex = hashIndex;
+    }
+  }
+
+  const trimmedValue = value.slice(0, endIndex).trim();
+  if (quoteChar && trimmedValue.endsWith(quoteChar)) {
+    return trimmedValue.slice(1, -1);
+  }
+  return trimmedValue;
+};
+
+export const readEnvFlag = ({
   envFilePath,
   key,
   processEnv,
@@ -1041,7 +1071,7 @@ const readEnvFlag = ({
   const raw = processEnv[key];
   if (raw !== undefined) {
     return TRUTHY_ENV_VALUES.has(
-      raw.trim().toLowerCase().replace(/^"|"$/gu, ""),
+      stripEnvValueCommentsAndQuotes(raw).toLowerCase(),
     );
   }
   if (!existsSync(envFilePath)) {
@@ -1062,28 +1092,9 @@ const readEnvFlag = ({
     if (withoutExport.slice(0, eqIndex).trim() !== key) {
       continue;
     }
-    const rawValue = withoutExport.slice(eqIndex + 1).trimStart();
-    // Strip trailing comments. A `#` inside double quotes is part of
-    // the value, so only honor `#` once the opening quote has closed
-    // (or when no quotes were used at all).
-    const isQuoted = rawValue.startsWith('"');
-    let endIndex = rawValue.length;
-    if (isQuoted) {
-      const closingQuote = rawValue.indexOf('"', 1);
-      if (closingQuote !== -1) {
-        endIndex = closingQuote + 1;
-      }
-    } else {
-      const hashIndex = rawValue.indexOf("#");
-      if (hashIndex !== -1) {
-        endIndex = hashIndex;
-      }
-    }
-    const value = rawValue
-      .slice(0, endIndex)
-      .trim()
-      .replace(/^"|"$/gu, "")
-      .toLowerCase();
+    const value = stripEnvValueCommentsAndQuotes(
+      withoutExport.slice(eqIndex + 1),
+    ).toLowerCase();
     return TRUTHY_ENV_VALUES.has(value);
   }
   return false;


### PR DESCRIPTION
## Summary

- support single-quoted dev env flag values in the dev runner
- add dev-only exact loopback origin aliases for API CORS and Better Auth trusted origins
- add a Windows scripts CI smoke and make the dev-runner worktree path test platform-native
