### PR TITLE
feat: add persistent chat compaction

### DIFF
--- a/apps/api/drizzle/20260607120000_chat-context-compaction/migration.sql
+++ b/apps/api/drizzle/20260607120000_chat-context-compaction/migration.sql
@@ -1,0 +1,194 @@
+CREATE TABLE "chat_message_search_documents" (
+	"message_id" uuid PRIMARY KEY,
+	"thread_id" uuid NOT NULL,
+	"role" varchar(16) NOT NULL,
+	"searchable_text" text DEFAULT '' NOT NULL,
+	"tsv" tsvector,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "chat_thread_compactions" (
+	"id" uuid PRIMARY KEY,
+	"thread_id" uuid NOT NULL,
+	"status" varchar(16) DEFAULT 'active' NOT NULL,
+	"summary" jsonb NOT NULL,
+	"summary_markdown" text NOT NULL,
+	"first_summarized_message_id" uuid NOT NULL,
+	"last_summarized_message_id" uuid NOT NULL,
+	"first_kept_message_id" uuid NOT NULL,
+	"summarized_message_count" integer NOT NULL,
+	"total_tokens" integer NOT NULL,
+	"preserved_tokens" integer NOT NULL,
+	"prompt_version" smallint NOT NULL,
+	"model_provider" text,
+	"model_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "chat_message_search_documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "chat_thread_compactions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "chat_message_search_documents" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "chat_thread_compactions" TO stella;--> statement-breakpoint
+CREATE INDEX "chat_message_search_docs_tsv_idx" ON "chat_message_search_documents" USING gin ("tsv");--> statement-breakpoint
+CREATE INDEX "chat_message_search_docs_thread_created_idx" ON "chat_message_search_documents" ("thread_id", "created_at", "message_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "chat_thread_compactions_active_thread_uidx" ON "chat_thread_compactions" ("thread_id") WHERE status = 'active';--> statement-breakpoint
+CREATE INDEX "chat_thread_compactions_thread_status_created_idx" ON "chat_thread_compactions" ("thread_id", "status", "created_at");--> statement-breakpoint
+ALTER TABLE "chat_message_search_documents" ADD CONSTRAINT "chat_message_search_documents_message_id_chat_messages_id_fkey" FOREIGN KEY ("message_id") REFERENCES "chat_messages"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "chat_message_search_documents" ADD CONSTRAINT "chat_message_search_documents_thread_id_chat_threads_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "chat_threads"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "chat_thread_compactions" ADD CONSTRAINT "chat_thread_compactions_thread_id_chat_threads_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "chat_threads"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "chat_thread_compactions" ADD CONSTRAINT "chat_thread_compactions_first_summarized_message_id_chat_messages_id_fkey" FOREIGN KEY ("first_summarized_message_id") REFERENCES "chat_messages"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "chat_thread_compactions" ADD CONSTRAINT "chat_thread_compactions_last_summarized_message_id_chat_messages_id_fkey" FOREIGN KEY ("last_summarized_message_id") REFERENCES "chat_messages"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "chat_thread_compactions" ADD CONSTRAINT "chat_thread_compactions_first_kept_message_id_chat_messages_id_fkey" FOREIGN KEY ("first_kept_message_id") REFERENCES "chat_messages"("id") ON DELETE CASCADE;--> statement-breakpoint
+CREATE POLICY "chat_message_search_document_select" ON "chat_message_search_documents" AS PERMISSIVE FOR SELECT TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_message_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_message_search_document_insert" ON "chat_message_search_documents" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_message_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_message_search_document_update" ON "chat_message_search_documents" AS PERMISSIVE FOR UPDATE TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_message_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_message_search_document_delete" ON "chat_message_search_documents" AS PERMISSIVE FOR DELETE TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_message_search_documents.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_compaction_select" ON "chat_thread_compactions" AS PERMISSIVE FOR SELECT TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_compactions.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_compaction_insert" ON "chat_thread_compactions" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_compactions.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_compaction_update" ON "chat_thread_compactions" AS PERMISSIVE FOR UPDATE TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_compactions.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));--> statement-breakpoint
+CREATE POLICY "chat_thread_compaction_delete" ON "chat_thread_compactions" AS PERMISSIVE FOR DELETE TO "stella" USING (EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_thread_compactions.thread_id
+      AND ct.user_id = (SELECT current_setting(
+        'app.user_id', true
+      ))
+      AND ct.organization_id = (SELECT current_setting(
+        'app.organization_id', true
+      ))
+      AND (ct.workspace_id IS NULL OR ct.workspace_id = ANY((SELECT current_setting(
+        'app.workspace_ids', true
+      ))::uuid[]))
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ (SELECT current_setting(
+          'app.workspace_ids', true
+        ))::uuid[]
+      )
+  ));

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import * as p from "drizzle-orm/pg-core";
 
 export const stella = p.pgRole("stella").existing();
@@ -102,16 +103,16 @@ const fileChatThreadScopeCheck = sql`(
   ${workspaceCheck}
 )`;
 
-// The chat search-document table stores only `thread_id` and derives
-// all tenancy from its owning thread, so RLS joins `chat_threads` and
-// applies the same scope the thread enforces. This is defence in
-// depth: global search reads this table via the RLS-bypassing root
-// connection and filters by user explicitly, but any stella-role
-// reader is still held to the thread's own visibility.
-const chatThreadSearchDocumentScopeCheck = sql`(
+// Derived chat tables store only `thread_id` and derive all tenancy
+// from their owning thread, so RLS joins `chat_threads` and applies
+// the same scope the thread enforces. This is defence in depth:
+// some search maintenance reads via the RLS-bypassing root connection
+// and filters explicitly, but any stella-role reader is still held to
+// the thread's own visibility.
+const chatDerivedThreadScopeCheck = (threadIdSql: SQL) => sql`(
   EXISTS (
     SELECT 1 FROM chat_threads ct
-    WHERE ct.id = chat_thread_search_documents.thread_id
+    WHERE ct.id = ${threadIdSql}
       AND ct.user_id = (SELECT current_setting(
         '${sql.raw(SETTING_USER_ID)}', true
       ))
@@ -550,22 +551,86 @@ export const chatThreadSearchDocumentPolicies = () => [
   p.pgPolicy("chat_thread_search_document_select", {
     for: "select",
     to: stella,
-    using: chatThreadSearchDocumentScopeCheck,
+    using: chatDerivedThreadScopeCheck(
+      sql`chat_thread_search_documents.thread_id`,
+    ),
   }),
   p.pgPolicy("chat_thread_search_document_insert", {
     for: "insert",
     to: stella,
-    withCheck: chatThreadSearchDocumentScopeCheck,
+    withCheck: chatDerivedThreadScopeCheck(
+      sql`chat_thread_search_documents.thread_id`,
+    ),
   }),
   p.pgPolicy("chat_thread_search_document_update", {
     for: "update",
     to: stella,
-    using: chatThreadSearchDocumentScopeCheck,
+    using: chatDerivedThreadScopeCheck(
+      sql`chat_thread_search_documents.thread_id`,
+    ),
   }),
   p.pgPolicy("chat_thread_search_document_delete", {
     for: "delete",
     to: stella,
-    using: chatThreadSearchDocumentScopeCheck,
+    using: chatDerivedThreadScopeCheck(
+      sql`chat_thread_search_documents.thread_id`,
+    ),
+  }),
+];
+
+export const chatMessageSearchDocumentPolicies = () => [
+  p.pgPolicy("chat_message_search_document_select", {
+    for: "select",
+    to: stella,
+    using: chatDerivedThreadScopeCheck(
+      sql`chat_message_search_documents.thread_id`,
+    ),
+  }),
+  p.pgPolicy("chat_message_search_document_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: chatDerivedThreadScopeCheck(
+      sql`chat_message_search_documents.thread_id`,
+    ),
+  }),
+  p.pgPolicy("chat_message_search_document_update", {
+    for: "update",
+    to: stella,
+    using: chatDerivedThreadScopeCheck(
+      sql`chat_message_search_documents.thread_id`,
+    ),
+  }),
+  p.pgPolicy("chat_message_search_document_delete", {
+    for: "delete",
+    to: stella,
+    using: chatDerivedThreadScopeCheck(
+      sql`chat_message_search_documents.thread_id`,
+    ),
+  }),
+];
+
+export const chatThreadCompactionPolicies = () => [
+  p.pgPolicy("chat_thread_compaction_select", {
+    for: "select",
+    to: stella,
+    using: chatDerivedThreadScopeCheck(sql`chat_thread_compactions.thread_id`),
+  }),
+  p.pgPolicy("chat_thread_compaction_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: chatDerivedThreadScopeCheck(
+      sql`chat_thread_compactions.thread_id`,
+    ),
+  }),
+  p.pgPolicy("chat_thread_compaction_update", {
+    for: "update",
+    to: stella,
+    using: chatDerivedThreadScopeCheck(sql`chat_thread_compactions.thread_id`),
+  }),
+  p.pgPolicy("chat_thread_compaction_delete", {
+    for: "delete",
+    to: stella,
+    using: chatDerivedThreadScopeCheck(sql`chat_thread_compactions.thread_id`),
   }),
 ];
 

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -12,7 +12,9 @@ import { jsonb } from "@/api/db/columns";
 import {
   agentSkillPolicies,
   agentSkillResourcePolicies,
+  chatMessageSearchDocumentPolicies,
   chatMessagePolicies,
+  chatThreadCompactionPolicies,
   chatThreadPolicies,
   chatThreadSearchDocumentPolicies,
   fileChatThreadPolicies,
@@ -48,6 +50,7 @@ import type {
 import type { EmptyAst } from "@/api/handlers/case-law/ingestion/adapter";
 import type { DecisionSection } from "@/api/handlers/case-law/types";
 import type {
+  ChatCompactionSummary,
   ChatMessageRole,
   PersistedChatMessageContent,
 } from "@/api/handlers/chat/types";
@@ -1758,6 +1761,79 @@ export const chatThreadSearchDocuments = p.pgTable(
   (table) => [
     p.index("chat_thread_search_docs_tsv_idx").using("gin", table.tsv),
     ...chatThreadSearchDocumentPolicies(),
+  ],
+);
+
+export const chatMessageSearchDocuments = p.pgTable(
+  "chat_message_search_documents",
+  {
+    messageId: safeUuid<"chatMessage">("message_id")
+      .primaryKey()
+      .references(() => chatMessages.id, { onDelete: "cascade" }),
+    threadId: safeUuid<"chatThread">("thread_id")
+      .notNull()
+      .references(() => chatThreads.id, { onDelete: "cascade" }),
+    role: p.varchar({ length: 16 }).notNull().$type<ChatMessageRole>(),
+    searchableText: p.text("searchable_text").notNull().default(""),
+    tsv: tsvector(),
+    createdAt: p.timestamp("created_at").notNull(),
+    updatedAt: p.timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p.index("chat_message_search_docs_tsv_idx").using("gin", table.tsv),
+    p
+      .index("chat_message_search_docs_thread_created_idx")
+      .on(table.threadId, table.createdAt, table.messageId),
+    ...chatMessageSearchDocumentPolicies(),
+  ],
+);
+
+export const chatThreadCompactions = p.pgTable(
+  "chat_thread_compactions",
+  {
+    id: pUuid<"chatThreadCompaction">().primaryKey(),
+    threadId: safeUuid<"chatThread">("thread_id")
+      .notNull()
+      .references(() => chatThreads.id, { onDelete: "cascade" }),
+    status: p
+      .varchar({ length: 16 })
+      .$type<"active" | "stale">()
+      .notNull()
+      .default("active"),
+    summary: jsonb().$type<ChatCompactionSummary>().notNull(),
+    summaryMarkdown: p.text("summary_markdown").notNull(),
+    firstSummarizedMessageId: safeUuid<"chatMessage">(
+      "first_summarized_message_id",
+    )
+      .notNull()
+      .references(() => chatMessages.id, { onDelete: "cascade" }),
+    lastSummarizedMessageId: safeUuid<"chatMessage">(
+      "last_summarized_message_id",
+    )
+      .notNull()
+      .references(() => chatMessages.id, { onDelete: "cascade" }),
+    firstKeptMessageId: safeUuid<"chatMessage">(
+      "first_kept_message_id",
+    )
+      .notNull()
+      .references(() => chatMessages.id, { onDelete: "cascade" }),
+    summarizedMessageCount: p.integer("summarized_message_count").notNull(),
+    totalTokens: p.integer("total_tokens").notNull(),
+    preservedTokens: p.integer("preserved_tokens").notNull(),
+    promptVersion: p.smallint("prompt_version").notNull(),
+    modelProvider: p.text("model_provider"),
+    modelId: p.text("model_id"),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p
+      .uniqueIndex("chat_thread_compactions_active_thread_uidx")
+      .on(table.threadId)
+      .where(sql`status = 'active'`),
+    p
+      .index("chat_thread_compactions_thread_status_created_idx")
+      .on(table.threadId, table.status, table.createdAt),
+    ...chatThreadCompactionPolicies(),
   ],
 );
 
@@ -3915,6 +3991,9 @@ export const relations = defineRelations(
     caseLawIngestionFailures,
     chatThreads,
     chatMessages,
+    chatMessageSearchDocuments,
+    chatThreadCompactions,
+    chatThreadSearchDocuments,
     fileChatThreads,
     mcpConnectors,
     mcpOAuthClients,
@@ -4590,9 +4669,21 @@ export const relations = defineRelations(
         from: r.chatThreads.id,
         to: r.chatMessages.threadId,
       }),
+      compactions: r.many.chatThreadCompactions({
+        from: r.chatThreads.id,
+        to: r.chatThreadCompactions.threadId,
+      }),
       fileChatThread: r.one.fileChatThreads({
         from: r.chatThreads.id,
         to: r.fileChatThreads.chatThreadId,
+      }),
+      messageSearchDocuments: r.many.chatMessageSearchDocuments({
+        from: r.chatThreads.id,
+        to: r.chatMessageSearchDocuments.threadId,
+      }),
+      searchDocument: r.one.chatThreadSearchDocuments({
+        from: r.chatThreads.id,
+        to: r.chatThreadSearchDocuments.threadId,
       }),
       userFiles: r.many.userFiles({
         from: r.chatThreads.id,
@@ -4607,6 +4698,32 @@ export const relations = defineRelations(
       workspace: r.one.workspaces({
         from: r.chatMessages.workspaceId,
         to: r.workspaces.id,
+      }),
+      searchDocument: r.one.chatMessageSearchDocuments({
+        from: r.chatMessages.id,
+        to: r.chatMessageSearchDocuments.messageId,
+      }),
+    },
+    chatMessageSearchDocuments: {
+      message: r.one.chatMessages({
+        from: r.chatMessageSearchDocuments.messageId,
+        to: r.chatMessages.id,
+      }),
+      thread: r.one.chatThreads({
+        from: r.chatMessageSearchDocuments.threadId,
+        to: r.chatThreads.id,
+      }),
+    },
+    chatThreadCompactions: {
+      thread: r.one.chatThreads({
+        from: r.chatThreadCompactions.threadId,
+        to: r.chatThreads.id,
+      }),
+    },
+    chatThreadSearchDocuments: {
+      thread: r.one.chatThreads({
+        from: r.chatThreadSearchDocuments.threadId,
+        to: r.chatThreads.id,
       }),
     },
     fileChatThreads: {

--- a/apps/api/src/handlers/chat/compaction.test.ts
+++ b/apps/api/src/handlers/chat/compaction.test.ts
@@ -14,10 +14,12 @@ import {
   compactChatMessages,
   compactModelMessagesForModel,
   compactModelMessages,
+  parseChatCompactionSummary,
   planChatCompaction,
   planModelCompaction,
   renderChatMessagesForCompaction,
   renderModelMessagesForCompaction,
+  summarizeChatCompaction,
 } from "./compaction";
 
 const textMessage = ({
@@ -208,6 +210,118 @@ describe("chat history compaction", () => {
 
     expect(observedSummaryError).toBe(true);
     expect(compacted.value.map((message) => message.id)).toEqual(["msg_2"]);
+  });
+
+  test("parses structured chat compaction summaries", () => {
+    const summary = parseChatCompactionSummary(`
+## Goal
+Continue drafting the termination analysis.
+
+## Constraints
+- Czech governing law
+- Preserve party placeholders
+
+## Progress
+### Done
+- Reviewed clause 12
+### In Progress
+- Comparing notice periods
+### Blocked
+- Need signed amendment
+
+## Key Decisions
+- Use conservative interpretation - clause text is ambiguous
+
+## Next Steps
+- Pull amendment file
+
+## Critical Context
+- User prefers concise answers
+
+<read-files>
+- contracts/main-agreement.pdf
+</read-files>
+<modified-files>
+- drafts/termination.md
+</modified-files>
+`);
+
+    expect(summary).toEqual({
+      version: 1,
+      blocked: ["Need signed amendment"],
+      constraints: ["Czech governing law", "Preserve party placeholders"],
+      criticalContext: ["User prefers concise answers"],
+      done: ["Reviewed clause 12"],
+      goal: "Continue drafting the termination analysis.",
+      inProgress: ["Comparing notice periods"],
+      keyDecisions: [
+        {
+          decision: "Use conservative interpretation",
+          rationale: "clause text is ambiguous",
+        },
+      ],
+      modifiedFiles: ["drafts/termination.md"],
+      nextSteps: ["Pull amendment file"],
+      readFiles: ["contracts/main-agreement.pdf"],
+    });
+  });
+
+  test("returns a structured checkpoint for persistent compaction", async () => {
+    const messages = [
+      textMessage({ id: "msg_1", role: "user", text: "old fact ".repeat(80) }),
+      textMessage({ id: "msg_2", role: "assistant", text: "old answer" }),
+      textMessage({ id: "msg_3", role: "user", text: "latest question" }),
+    ];
+
+    const checkpoint = await summarizeChatCompaction({
+      messages,
+      preserveTokens: 20,
+      summarizeTranscript: async () => `
+## Goal
+Answer the latest question.
+
+## Constraints
+- None
+
+## Progress
+### Done
+- Captured old fact
+### In Progress
+- None
+### Blocked
+- None
+
+## Key Decisions
+- None
+
+## Next Steps
+- Answer user
+
+## Critical Context
+- old fact matters
+
+<read-files>
+</read-files>
+<modified-files>
+</modified-files>
+`,
+      triggerTokens: 50,
+    });
+
+    expect(Result.isOk(checkpoint)).toBe(true);
+    if (Result.isError(checkpoint) || checkpoint.value === null) {
+      return;
+    }
+
+    expect(checkpoint.value.plan.messagesToSummarize.map((m) => m.id)).toEqual([
+      "msg_1",
+      "msg_2",
+    ]);
+    expect(checkpoint.value.summary.goal).toBe("Answer the latest question.");
+    expect(checkpoint.value.summary.done).toEqual(["Captured old fact"]);
+    expect(checkpoint.value.plan.recentMessages.map((m) => m.id)).toEqual([
+      "msg_3",
+    ]);
   });
 
   test("compacts model messages for step-level tool loops", async () => {

--- a/apps/api/src/handlers/chat/compaction.ts
+++ b/apps/api/src/handlers/chat/compaction.ts
@@ -4,7 +4,10 @@ import { Result } from "better-result";
 
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import { prepareTextForThirdParty } from "@/api/handlers/chat/third-party-boundary";
-import type { ChatMessage } from "@/api/handlers/chat/types";
+import type {
+  ChatCompactionSummary,
+  ChatMessage,
+} from "@/api/handlers/chat/types";
 import type { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
@@ -18,6 +21,7 @@ const MAX_STRUCTURED_PART_CHARS = 4000;
 const MAX_SUMMARY_OUTPUT_TOKENS = 1800;
 
 const COMPACTION_SUMMARY_MESSAGE_ID = "stella-chat-compaction-summary";
+export const CHAT_COMPACTION_PROMPT_VERSION = 1;
 
 const COMPACTION_SYSTEM_PROMPT = [
   "You compact chat history for stella, a legal workspace.",
@@ -31,7 +35,30 @@ type CompactionAIAnalytics = Pick<
   "captureError" | "stepCallbacks"
 >;
 
-type ChatCompactionPlan =
+const CHAT_COMPACTION_FORMAT_PROMPT = [
+  "Return markdown with exactly this structure:",
+  "## Goal",
+  "## Constraints",
+  "## Progress",
+  "### Done",
+  "### In Progress",
+  "### Blocked",
+  "## Key Decisions",
+  "## Next Steps",
+  "## Critical Context",
+  "<read-files>",
+  "</read-files>",
+  "<modified-files>",
+  "</modified-files>",
+  "Use bullet lists for every list section. Put one path per line inside read-files and modified-files. Write 'None' for empty sections.",
+].join("\n");
+
+const CHAT_COMPACTION_SYSTEM_PROMPT = [
+  COMPACTION_SYSTEM_PROMPT,
+  CHAT_COMPACTION_FORMAT_PROMPT,
+].join("\n\n");
+
+export type ChatCompactionPlan =
   | {
       totalTokens: number;
       type: "none";
@@ -173,6 +200,14 @@ type CompactChatMessagesOptions = PlanChatCompactionOptions & {
   summarizeTranscript: (transcript: string) => Promise<string>;
 };
 
+export type ChatCompactionCheckpoint = {
+  plan: Extract<ChatCompactionPlan, { type: "compact" }>;
+  summary: ChatCompactionSummary;
+  summaryMarkdown: string;
+};
+
+type SummarizeChatCompactionOptions = CompactChatMessagesOptions;
+
 type CompactModelMessagesOptions = {
   messages: ModelMessage[];
   onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
@@ -181,19 +216,19 @@ type CompactModelMessagesOptions = {
   triggerTokens?: number | undefined;
 };
 
-export const compactChatMessages = async ({
+export const summarizeChatCompaction = async ({
   messages,
   onSummaryError,
   prepareTranscript,
   preserveTokens,
   summarizeTranscript,
   triggerTokens,
-}: CompactChatMessagesOptions): Promise<
-  Result<ChatMessage[], HandlerError<422 | 500>>
+}: SummarizeChatCompactionOptions): Promise<
+  Result<ChatCompactionCheckpoint | null, HandlerError<422 | 500>>
 > => {
   const plan = planChatCompaction({ messages, preserveTokens, triggerTokens });
   if (plan.type === "none") {
-    return Result.ok(messages);
+    return Result.ok(null);
   }
 
   const transcript = renderChatMessagesForCompaction(plan.messagesToSummarize);
@@ -215,20 +250,59 @@ export const compactChatMessages = async ({
   });
   if (Result.isError(summaryResult)) {
     onSummaryError?.(summaryResult.error);
-    return Result.ok(plan.recentMessages);
+    return Result.ok(null);
   }
 
-  const summary = summaryResult.value.trim();
-  if (summary.length === 0) {
+  const summaryMarkdown = summaryResult.value.trim();
+  if (summaryMarkdown.length === 0) {
+    return Result.ok(null);
+  }
+
+  return Result.ok({
+    plan,
+    summary: parseChatCompactionSummary(summaryMarkdown),
+    summaryMarkdown,
+  });
+};
+
+export const compactChatMessages = async ({
+  messages,
+  onSummaryError,
+  prepareTranscript,
+  preserveTokens,
+  summarizeTranscript,
+  triggerTokens,
+}: CompactChatMessagesOptions): Promise<
+  Result<ChatMessage[], HandlerError<422 | 500>>
+> => {
+  const plan = planChatCompaction({ messages, preserveTokens, triggerTokens });
+  if (plan.type === "none") {
+    return Result.ok(messages);
+  }
+
+  const checkpointResult = await summarizeChatCompaction({
+    messages,
+    onSummaryError,
+    prepareTranscript,
+    preserveTokens,
+    summarizeTranscript,
+    triggerTokens,
+  });
+  if (Result.isError(checkpointResult)) {
+    return Result.err(checkpointResult.error);
+  }
+
+  if (checkpointResult.value === null) {
     return Result.ok(plan.recentMessages);
   }
 
   return Result.ok([
     createCompactionSummaryMessage({
-      summarizedMessageCount: plan.messagesToSummarize.length,
-      summary,
+      summarizedMessageCount:
+        checkpointResult.value.plan.messagesToSummarize.length,
+      summary: checkpointResult.value.summaryMarkdown,
     }),
-    ...plan.recentMessages,
+    ...checkpointResult.value.plan.recentMessages,
   ]);
 };
 
@@ -325,7 +399,56 @@ export const compactChatMessagesForModel = async ({
               "",
               transcript,
             ].join("\n"),
-            system: COMPACTION_SYSTEM_PROMPT,
+            system: CHAT_COMPACTION_SYSTEM_PROMPT,
+            temperature: 0,
+            ...aiAnalytics?.stepCallbacks,
+          }),
+        catch: (error) => {
+          aiAnalytics?.captureError(error);
+          return error;
+        },
+      });
+      if (Result.isError(result)) {
+        throw result.error;
+      }
+
+      return result.value.text;
+    },
+  });
+
+export const summarizeChatCompactionForModel = async ({
+  abortSignal,
+  aiAnalytics,
+  boundary,
+  messages,
+  model,
+  onSummaryError,
+  preserveTokens,
+  triggerTokens,
+}: CompactChatMessagesForModelOptions): Promise<
+  Result<ChatCompactionCheckpoint | null, HandlerError<422 | 500>>
+> =>
+  await summarizeChatCompaction({
+    messages,
+    onSummaryError,
+    preserveTokens,
+    triggerTokens,
+    prepareTranscript: async (transcript) =>
+      await prepareTextForThirdParty({ boundary, text: transcript }),
+    summarizeTranscript: async (transcript) => {
+      const result = await Result.tryPromise({
+        try: async () =>
+          await generateText({
+            abortSignal,
+            maxOutputTokens: MAX_SUMMARY_OUTPUT_TOKENS,
+            model,
+            prompt: [
+              "Compact the earlier conversation transcript below.",
+              "Return only the checkpoint summary.",
+              "",
+              transcript,
+            ].join("\n"),
+            system: CHAT_COMPACTION_SYSTEM_PROMPT,
             temperature: 0,
             ...aiAnalytics?.stepCallbacks,
           }),
@@ -420,7 +543,7 @@ export const renderModelMessagesForCompaction = (
     )
     .join("\n\n");
 
-const createCompactionSummaryMessage = ({
+export const createCompactionSummaryMessage = ({
   summarizedMessageCount,
   summary,
 }: {
@@ -439,6 +562,115 @@ const createCompactionSummaryMessage = ({
     },
   ],
 });
+
+export const parseChatCompactionSummary = (
+  summaryMarkdown: string,
+): ChatCompactionSummary => ({
+  version: CHAT_COMPACTION_PROMPT_VERSION,
+  blocked: parseListSection(summaryMarkdown, "Blocked"),
+  constraints: parseListSection(summaryMarkdown, "Constraints"),
+  criticalContext: parseListSection(summaryMarkdown, "Critical Context"),
+  done: parseListSection(summaryMarkdown, "Done"),
+  goal: firstMeaningfulLine(readMarkdownSection(summaryMarkdown, "Goal")),
+  inProgress: parseListSection(summaryMarkdown, "In Progress"),
+  keyDecisions: parseKeyDecisions(
+    parseListSection(summaryMarkdown, "Key Decisions"),
+  ),
+  modifiedFiles: parseTaggedList(summaryMarkdown, "modified-files"),
+  nextSteps: parseListSection(summaryMarkdown, "Next Steps"),
+  readFiles: parseTaggedList(summaryMarkdown, "read-files"),
+});
+
+const readMarkdownSection = (markdown: string, heading: string): string => {
+  const match = new RegExp(
+    `^#{2,3}\\s+${escapeRegExp(heading)}\\s*$`,
+    "imu",
+  ).exec(markdown);
+  if (!match) {
+    return "";
+  }
+
+  const sectionStart = match.index + match[0].length;
+  const rest = markdown.slice(sectionStart);
+  const nextBoundary =
+    /^(?:#{2,3}\s+\S.*|<read-files>|<modified-files>)$/imu.exec(rest);
+  const sectionEnd = nextBoundary ? nextBoundary.index : rest.length;
+
+  return rest.slice(0, sectionEnd).trim();
+};
+
+const parseListSection = (markdown: string, heading: string): string[] =>
+  parseListLines(readMarkdownSection(markdown, heading));
+
+const parseTaggedList = (markdown: string, tag: string): string[] => {
+  const match = new RegExp(
+    `<${escapeRegExp(tag)}>\\s*([\\s\\S]*?)\\s*</${escapeRegExp(tag)}>`,
+    "iu",
+  ).exec(markdown);
+  return parseListLines(match?.at(1) ?? "");
+};
+
+const parseListLines = (section: string): string[] =>
+  section
+    .split(/\r?\n/u)
+    .map((line) => normalizeListLine(line))
+    .flatMap((line) => (isMeaningfulSummaryLine(line) ? [line] : []));
+
+const parseKeyDecisions = (
+  lines: readonly string[],
+): ChatCompactionSummary["keyDecisions"] => lines.map(parseKeyDecision);
+
+const parseKeyDecision = (
+  line: string,
+): ChatCompactionSummary["keyDecisions"][number] => {
+  const dashIndex = line.indexOf(" - ");
+  if (dashIndex !== -1) {
+    return {
+      decision: line.slice(0, dashIndex).trim(),
+      rationale: line.slice(dashIndex + 3).trim(),
+    };
+  }
+
+  const becauseNeedle = " because ";
+  const becauseIndex = line.toLowerCase().indexOf(becauseNeedle);
+  if (becauseIndex !== -1) {
+    return {
+      decision: line.slice(0, becauseIndex).trim(),
+      rationale: line.slice(becauseIndex + becauseNeedle.length).trim(),
+    };
+  }
+
+  return {
+    decision: line,
+    rationale: null,
+  };
+};
+
+const firstMeaningfulLine = (section: string): string | null =>
+  parseListLines(section).at(0) ?? null;
+
+const normalizeListLine = (line: string): string =>
+  line
+    .trim()
+    .replace(/^[-*]\s+/u, "")
+    .replace(/^\d+[.)]\s+/u, "")
+    .trim();
+
+const isMeaningfulSummaryLine = (line: string): boolean => {
+  if (!line || /^#{2,3}\s+/u.test(line)) {
+    return false;
+  }
+
+  const normalized = line.toLowerCase();
+  return (
+    normalized !== "none" &&
+    normalized !== "n/a" &&
+    normalized !== "not applicable"
+  );
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
 const createModelCompactionSummaryMessage = ({
   summarizedMessageCount,

--- a/apps/api/src/handlers/chat/persistent-compaction.test.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, test } from "bun:test";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import { toSafeId } from "@/api/lib/branded-types";
 
-import { applyChatCompactionCheckpoint } from "./persistent-compaction";
+import {
+  applyChatCompactionCheckpoint,
+  shouldInvalidateChatCompactionCheckpoint,
+} from "./persistent-compaction";
 
 const message = (id: string, text: string): ChatMessage => ({
   id,
@@ -81,5 +84,23 @@ describe("persistent chat compaction", () => {
     });
 
     expect(applied).toBeNull();
+  });
+
+  test("invalidates active checkpoints when a retained message is updated", () => {
+    expect(
+      shouldInvalidateChatCompactionCheckpoint({
+        deletedMessageCount: 0,
+        persistencePlan: { type: "update" },
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps active checkpoints valid for append-only inserts", () => {
+    expect(
+      shouldInvalidateChatCompactionCheckpoint({
+        deletedMessageCount: 0,
+        persistencePlan: { type: "insert" },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/handlers/chat/persistent-compaction.test.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import { toSafeId } from "@/api/lib/branded-types";
+
+import { applyChatCompactionCheckpoint } from "./persistent-compaction";
+
+const message = (id: string, text: string): ChatMessage => ({
+  id,
+  role: "user",
+  parts: [{ type: "text", text }],
+});
+
+describe("persistent chat compaction", () => {
+  test("re-expands a checkpoint into summary plus kept tail", () => {
+    const keptId = "22222222-2222-4222-8222-222222222222";
+    const messages = [
+      message("11111111-1111-4111-8111-111111111111", "old"),
+      message(keptId, "kept"),
+      message("33333333-3333-4333-8333-333333333333", "latest"),
+    ];
+
+    const applied = applyChatCompactionCheckpoint({
+      messages,
+      checkpoint: {
+        id: toSafeId<"chatThreadCompaction">(
+          "44444444-4444-4444-8444-444444444444",
+        ),
+        firstKeptMessageId: toSafeId<"chatMessage">(keptId),
+        summarizedMessageCount: 1,
+        summaryMarkdown: "## Goal\nContinue the matter.",
+        summary: {
+          version: 1,
+          blocked: [],
+          constraints: [],
+          criticalContext: [],
+          done: [],
+          goal: "Continue the matter.",
+          inProgress: [],
+          keyDecisions: [],
+          modifiedFiles: [],
+          nextSteps: [],
+          readFiles: [],
+        },
+      },
+    });
+
+    expect(applied?.map((item) => item.id)).toEqual([
+      "stella-chat-compaction-summary",
+      keptId,
+      "33333333-3333-4333-8333-333333333333",
+    ]);
+  });
+
+  test("ignores a checkpoint whose first kept message is absent", () => {
+    const applied = applyChatCompactionCheckpoint({
+      messages: [message("11111111-1111-4111-8111-111111111111", "old")],
+      checkpoint: {
+        id: toSafeId<"chatThreadCompaction">(
+          "44444444-4444-4444-8444-444444444444",
+        ),
+        firstKeptMessageId: toSafeId<"chatMessage">(
+          "22222222-2222-4222-8222-222222222222",
+        ),
+        summarizedMessageCount: 1,
+        summaryMarkdown: "summary",
+        summary: {
+          version: 1,
+          blocked: [],
+          constraints: [],
+          criticalContext: [],
+          done: [],
+          goal: null,
+          inProgress: [],
+          keyDecisions: [],
+          modifiedFiles: [],
+          nextSteps: [],
+          readFiles: [],
+        },
+      },
+    });
+
+    expect(applied).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/chat/persistent-compaction.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.ts
@@ -1,0 +1,166 @@
+import type { LanguageModel } from "ai";
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import type { SafeDb, SafeDbError } from "@/api/db";
+import { chatThreadCompactions } from "@/api/db/schema";
+import {
+  CHAT_COMPACTION_PROMPT_VERSION,
+  createCompactionSummaryMessage,
+  summarizeChatCompactionForModel,
+} from "@/api/handlers/chat/compaction";
+import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
+import type {
+  ChatCompactionSummary,
+  ChatMessage,
+} from "@/api/handlers/chat/types";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
+
+export type ChatThreadCompactionCheckpoint = {
+  firstKeptMessageId: SafeId<"chatMessage">;
+  id: SafeId<"chatThreadCompaction">;
+  summarizedMessageCount: number;
+  summary: ChatCompactionSummary;
+  summaryMarkdown: string;
+};
+
+type ReadLatestChatCompactionProps = {
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+};
+
+export const readLatestChatCompaction = async ({
+  safeDb,
+  threadId,
+}: ReadLatestChatCompactionProps): Promise<
+  Result<ChatThreadCompactionCheckpoint | null, SafeDbError>
+> => {
+  const result = await safeDb((tx) =>
+    tx.query.chatThreadCompactions.findFirst({
+      where: {
+        threadId: { eq: threadId },
+        status: { eq: "active" },
+      },
+      columns: {
+        id: true,
+        firstKeptMessageId: true,
+        summarizedMessageCount: true,
+        summary: true,
+        summaryMarkdown: true,
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  );
+  if (Result.isError(result)) {
+    return Result.err(result.error);
+  }
+
+  return Result.ok(result.value ?? null);
+};
+
+type ApplyChatCompactionCheckpointProps = {
+  checkpoint: ChatThreadCompactionCheckpoint;
+  messages: ChatMessage[];
+};
+
+export const applyChatCompactionCheckpoint = ({
+  checkpoint,
+  messages,
+}: ApplyChatCompactionCheckpointProps): ChatMessage[] | null => {
+  const firstKeptIndex = messages.findIndex(
+    (message) => message.id === checkpoint.firstKeptMessageId,
+  );
+  if (firstKeptIndex === -1) {
+    return null;
+  }
+
+  return [
+    createCompactionSummaryMessage({
+      summarizedMessageCount: checkpoint.summarizedMessageCount,
+      summary: checkpoint.summaryMarkdown,
+    }),
+    ...messages.slice(firstKeptIndex),
+  ];
+};
+
+type PersistChatCompactionCheckpointProps = {
+  abortSignal: AbortSignal;
+  boundary: ChatThirdPartyBoundary;
+  messages: ChatMessage[];
+  model: LanguageModel;
+  onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+};
+
+export const persistChatCompactionCheckpoint = async ({
+  abortSignal,
+  boundary,
+  messages,
+  model,
+  onSummaryError,
+  safeDb,
+  threadId,
+}: PersistChatCompactionCheckpointProps): Promise<
+  Result<void, HandlerError<422 | 500> | SafeDbError>
+> => {
+  const checkpointResult = await summarizeChatCompactionForModel({
+    abortSignal,
+    boundary,
+    messages,
+    model,
+    onSummaryError,
+  });
+  if (Result.isError(checkpointResult)) {
+    return Result.err(checkpointResult.error);
+  }
+  const checkpoint = checkpointResult.value;
+  if (checkpoint === null) {
+    return Result.ok();
+  }
+
+  const firstSummarizedMessage = checkpoint.plan.messagesToSummarize.at(0)?.id;
+  const lastSummarizedMessage = checkpoint.plan.messagesToSummarize.at(-1)?.id;
+  const firstKeptMessage = checkpoint.plan.recentMessages.at(0)?.id;
+  if (!firstSummarizedMessage || !lastSummarizedMessage || !firstKeptMessage) {
+    return Result.ok();
+  }
+
+  const persistResult = await safeDb(async (tx) => {
+    // audit: skip — derived compaction checkpoint cache; no user-authored state change
+    await tx
+      .update(chatThreadCompactions)
+      .set({ status: "stale" })
+      .where(
+        and(
+          eq(chatThreadCompactions.threadId, threadId),
+          eq(chatThreadCompactions.status, "active"),
+        ),
+      );
+
+    // audit: skip — derived compaction checkpoint cache; no user-authored state change
+    await tx.insert(chatThreadCompactions).values({
+      id: createSafeId<"chatThreadCompaction">(),
+      threadId,
+      status: "active",
+      summary: checkpoint.summary,
+      summaryMarkdown: checkpoint.summaryMarkdown,
+      firstSummarizedMessageId: brandPersistedChatMessageId(
+        firstSummarizedMessage,
+      ),
+      lastSummarizedMessageId: brandPersistedChatMessageId(
+        lastSummarizedMessage,
+      ),
+      firstKeptMessageId: brandPersistedChatMessageId(firstKeptMessage),
+      summarizedMessageCount: checkpoint.plan.messagesToSummarize.length,
+      totalTokens: checkpoint.plan.totalTokens,
+      preservedTokens: checkpoint.plan.preservedTokens,
+      promptVersion: CHAT_COMPACTION_PROMPT_VERSION,
+    });
+  });
+
+  return persistResult.andThen(() => Result.ok());
+};

--- a/apps/api/src/handlers/chat/persistent-compaction.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.ts
@@ -2,13 +2,14 @@ import type { LanguageModel } from "ai";
 import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 
-import type { SafeDb, SafeDbError } from "@/api/db";
+import type { SafeDb, SafeDbError, Transaction } from "@/api/db";
 import { chatThreadCompactions } from "@/api/db/schema";
 import {
   CHAT_COMPACTION_PROMPT_VERSION,
   createCompactionSummaryMessage,
   summarizeChatCompactionForModel,
 } from "@/api/handlers/chat/compaction";
+import type { MessagePersistencePlan } from "@/api/handlers/chat/persist-message";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import type {
   ChatCompactionSummary,
@@ -86,6 +87,54 @@ export const applyChatCompactionCheckpoint = ({
   ];
 };
 
+type ShouldInvalidateChatCompactionCheckpointProps = {
+  deletedMessageCount: number;
+  persistencePlan: Pick<MessagePersistencePlan, "type">;
+};
+
+export const shouldInvalidateChatCompactionCheckpoint = ({
+  deletedMessageCount,
+  persistencePlan,
+}: ShouldInvalidateChatCompactionCheckpointProps): boolean => {
+  if (deletedMessageCount > 0) {
+    return true;
+  }
+
+  switch (persistencePlan.type) {
+    case "update":
+    case "replace-last-assistant":
+      return true;
+    case "insert":
+    case "none":
+      return false;
+    default: {
+      const exhaustive: never = persistencePlan.type;
+      return exhaustive;
+    }
+  }
+};
+
+type MarkActiveChatCompactionCheckpointStaleProps = {
+  threadId: SafeId<"chatThread">;
+  tx: Transaction;
+};
+
+export const markActiveChatCompactionCheckpointStale = async ({
+  threadId,
+  tx,
+}: MarkActiveChatCompactionCheckpointStaleProps): Promise<void> => {
+  // audit: skip - derived compaction checkpoint cache; no user-authored state change
+  await tx
+    .update(chatThreadCompactions)
+    .set({ status: "stale" })
+    .where(
+      and(
+        eq(chatThreadCompactions.threadId, threadId),
+        eq(chatThreadCompactions.status, "active"),
+      ),
+    );
+};
+
 type PersistChatCompactionCheckpointProps = {
   abortSignal: AbortSignal;
   boundary: ChatThirdPartyBoundary;
@@ -130,16 +179,7 @@ export const persistChatCompactionCheckpoint = async ({
   }
 
   const persistResult = await safeDb(async (tx) => {
-    // audit: skip — derived compaction checkpoint cache; no user-authored state change
-    await tx
-      .update(chatThreadCompactions)
-      .set({ status: "stale" })
-      .where(
-        and(
-          eq(chatThreadCompactions.threadId, threadId),
-          eq(chatThreadCompactions.status, "active"),
-        ),
-      );
+    await markActiveChatCompactionCheckpointStale({ threadId, tx });
 
     // audit: skip — derived compaction checkpoint cache; no user-authored state change
     await tx.insert(chatThreadCompactions).values({

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -518,6 +518,7 @@ const sendMessage = createSafeRootHandler(
       safeDb,
       scopedDb,
       threadId: body.threadId,
+      excludedChatHistoryMessageIds: deleteMessageIdsBeforeLatest,
       userId: user.id,
       toolWorkspaceIds: resolveToolWorkspaceIds({
         pinnedIds: effectiveContextMatterIds,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -7,7 +7,11 @@ import type { ChatSendMode } from "@stll/anonymize-chat";
 import type { SkillMetadata } from "@stll/skills";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
-import { chatMessages, chatThreads } from "@/api/db/schema";
+import {
+  chatMessages,
+  chatThreadCompactions,
+  chatThreads,
+} from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import { env } from "@/api/env";
 import {
@@ -48,6 +52,11 @@ import {
   planAssistantFinishPersistence,
   planMessagePersistence,
 } from "@/api/handlers/chat/persist-message";
+import {
+  applyChatCompactionCheckpoint,
+  persistChatCompactionCheckpoint,
+  readLatestChatCompaction,
+} from "@/api/handlers/chat/persistent-compaction";
 import { hydrateMessages, streamChat } from "@/api/handlers/chat/stream-chat";
 import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import { shouldMarkThreadUsedAnonymization } from "@/api/handlers/chat/thread-anonymization";
@@ -95,6 +104,8 @@ import { getS3 } from "@/api/lib/s3";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
 import { upsertChatThreadSearchDocument } from "@/api/lib/search/index-chat";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
+
+const CHAT_COMPACTION_CHECKPOINT_TIMEOUT_MS = 120_000;
 
 const config = {
   permissions: { chat: ["create"] },
@@ -208,6 +219,7 @@ const sendMessage = createSafeRootHandler(
       refRegistry,
       safeDb,
       scopedDb,
+      threadId: body.threadId,
       userId: user.id,
       // Schema validation runs against the user's full accessible
       // set; per-tool scope checks happen at execute time below.
@@ -370,11 +382,18 @@ const sendMessage = createSafeRootHandler(
           })
         : null;
 
+    const messagesForContextInput = await selectMessagesForContextInput({
+      messages: latestMessagePlan.messages,
+      safeDb,
+      skipCheckpoint: body.truncateAfterMessageId !== undefined,
+      threadId: body.threadId,
+    });
+
     const messagesForContextResult = await compactMessagesForContext({
       abortSignal: request.signal,
       boundary: thirdPartyBoundary,
       devModelId: body.devModelId,
-      messages: latestMessagePlan.messages,
+      messages: messagesForContextInput,
       organizationId: session.activeOrganizationId,
       orgAIConfig,
       safeDb,
@@ -500,6 +519,7 @@ const sendMessage = createSafeRootHandler(
       refRegistry,
       safeDb,
       scopedDb,
+      threadId: body.threadId,
       userId: user.id,
       toolWorkspaceIds: resolveToolWorkspaceIds({
         pinnedIds: effectiveContextMatterIds,
@@ -626,24 +646,49 @@ const sendMessage = createSafeRootHandler(
                     captureError(persistResult.error, {
                       threadId: body.threadId,
                     });
-                  } else if (
-                    thread.type === "created" &&
-                    body.sendMode !== CHAT_SEND_MODE.anonymized
-                  ) {
-                    void generateThreadTitle({
-                      messages: [
-                        parsedMessage.message,
-                        resolvedResponseMessage,
-                      ],
-                      organizationId: session.activeOrganizationId,
-                      orgAIConfig,
-                      promptCachingEnabled,
-                      recordAuditEvent,
-                      safeDb,
-                      threadId: body.threadId,
-                      threadWorkspaceId: workspaceId,
-                      userId: user.id,
-                    });
+                  } else {
+                    const messagesAfterAssistantPersist =
+                      applyAssistantPersistencePlan({
+                        messages: latestMessagePlan.messages,
+                        persistencePlan,
+                      });
+                    if (
+                      messagesAfterAssistantPersist !== null &&
+                      body.sendMode !== CHAT_SEND_MODE.anonymized
+                    ) {
+                      scheduleChatCompactionCheckpoint({
+                        abortSignal: AbortSignal.timeout(
+                          CHAT_COMPACTION_CHECKPOINT_TIMEOUT_MS,
+                        ),
+                        boundary: thirdPartyBoundary,
+                        devModelId: body.devModelId,
+                        messages: messagesAfterAssistantPersist,
+                        organizationId: session.activeOrganizationId,
+                        orgAIConfig,
+                        safeDb,
+                        threadId: body.threadId,
+                      });
+                    }
+
+                    if (
+                      thread.type === "created" &&
+                      body.sendMode !== CHAT_SEND_MODE.anonymized
+                    ) {
+                      void generateThreadTitle({
+                        messages: [
+                          parsedMessage.message,
+                          resolvedResponseMessage,
+                        ],
+                        organizationId: session.activeOrganizationId,
+                        orgAIConfig,
+                        promptCachingEnabled,
+                        recordAuditEvent,
+                        safeDb,
+                        threadId: body.threadId,
+                        threadWorkspaceId: workspaceId,
+                        userId: user.id,
+                      });
+                    }
                   }
                 } finally {
                   await closeExternalMcpTools();
@@ -705,6 +750,47 @@ type CompactMessagesForContextProps = ResolveChatCompactionModelProps & {
   threadId: SafeId<"chatThread">;
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace"> | null;
+};
+
+type SelectMessagesForContextInputProps = {
+  messages: ChatMessage[];
+  safeDb: SafeDb;
+  skipCheckpoint: boolean;
+  threadId: SafeId<"chatThread">;
+};
+
+const selectMessagesForContextInput = async ({
+  messages,
+  safeDb,
+  skipCheckpoint,
+  threadId,
+}: SelectMessagesForContextInputProps): Promise<ChatMessage[]> => {
+  if (skipCheckpoint) {
+    return messages;
+  }
+
+  const checkpointResult = await readLatestChatCompaction({
+    safeDb,
+    threadId,
+  });
+  if (Result.isError(checkpointResult)) {
+    captureError(checkpointResult.error, {
+      threadId,
+      feature: "chat.compaction_checkpoint_read",
+    });
+    return messages;
+  }
+
+  if (checkpointResult.value === null) {
+    return messages;
+  }
+
+  return (
+    applyChatCompactionCheckpoint({
+      checkpoint: checkpointResult.value,
+      messages,
+    }) ?? messages
+  );
 };
 
 const compactMessagesForContext = async ({
@@ -793,6 +879,102 @@ const resolveChatCompactionModel = ({
             cause,
           }),
   });
+
+type ApplyAssistantPersistencePlanProps = {
+  messages: ChatMessage[];
+  persistencePlan: MessagePersistencePlan;
+};
+
+const applyAssistantPersistencePlan = ({
+  messages,
+  persistencePlan,
+}: ApplyAssistantPersistencePlanProps): ChatMessage[] | null => {
+  switch (persistencePlan.type) {
+    case "none":
+      return null;
+    case "insert":
+      return [...messages, persistencePlan.message];
+    case "update":
+      return messages.map((message) =>
+        message.id === persistencePlan.messageId
+          ? persistencePlan.message
+          : message,
+      );
+    case "replace-last-assistant":
+      return [
+        ...messages.filter(
+          (message) => message.id !== persistencePlan.deleteMessageId,
+        ),
+        persistencePlan.insertMessage,
+      ];
+    default: {
+      const exhaustive: never = persistencePlan;
+      return exhaustive;
+    }
+  }
+};
+
+type ScheduleChatCompactionCheckpointProps = ResolveChatCompactionModelProps & {
+  abortSignal: AbortSignal;
+  boundary: ReturnType<typeof createChatThirdPartyBoundary>;
+  messages: ChatMessage[];
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+};
+
+const scheduleChatCompactionCheckpoint = ({
+  abortSignal,
+  boundary,
+  devModelId,
+  messages,
+  organizationId,
+  orgAIConfig,
+  safeDb,
+  threadId,
+}: ScheduleChatCompactionCheckpointProps): void => {
+  const modelResult = resolveChatCompactionModel({
+    devModelId,
+    organizationId,
+    orgAIConfig,
+  });
+  if (Result.isError(modelResult)) {
+    captureError(modelResult.error, {
+      threadId,
+      feature: "chat.compaction_checkpoint_model",
+    });
+    return;
+  }
+
+  void persistChatCompactionCheckpoint({
+    abortSignal,
+    boundary,
+    messages,
+    model: modelResult.value,
+    onSummaryError: (error) => {
+      captureError(error, {
+        threadId,
+        feature: "chat.compaction_checkpoint_summary",
+      });
+    },
+    safeDb,
+    threadId,
+  })
+    .then((result) => {
+      if (Result.isError(result)) {
+        captureError(result.error, {
+          threadId,
+          feature: "chat.compaction_checkpoint_persist",
+        });
+      }
+      return undefined;
+    })
+    .catch((error: unknown) => {
+      captureError(error, {
+        threadId,
+        feature: "chat.compaction_checkpoint_persist",
+      });
+    });
+};
 
 const isChatStreamResponse = (response: Response): boolean => {
   const contentType = response.headers.get("content-type");
@@ -1696,6 +1878,16 @@ const runPersistMessage = async ({
             ),
           );
 
+        await tx
+          .update(chatThreadCompactions)
+          .set({ status: "stale" })
+          .where(
+            and(
+              eq(chatThreadCompactions.threadId, threadId),
+              eq(chatThreadCompactions.status, "active"),
+            ),
+          );
+
         for (const deletedMessageId of deleteMessageIds) {
           await recordAuditEvent(tx, {
             action: AUDIT_ACTION.DELETE,
@@ -1782,6 +1974,16 @@ const runPersistMessage = async ({
         await tx
           .delete(chatMessages)
           .where(and(eq(chatMessages.id, deletedMessageId)));
+
+        await tx
+          .update(chatThreadCompactions)
+          .set({ status: "stale" })
+          .where(
+            and(
+              eq(chatThreadCompactions.threadId, threadId),
+              eq(chatThreadCompactions.status, "active"),
+            ),
+          );
 
         await recordAuditEvent(tx, {
           action: AUDIT_ACTION.DELETE,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -7,11 +7,7 @@ import type { ChatSendMode } from "@stll/anonymize-chat";
 import type { SkillMetadata } from "@stll/skills";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
-import {
-  chatMessages,
-  chatThreadCompactions,
-  chatThreads,
-} from "@/api/db/schema";
+import { chatMessages, chatThreads } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import { env } from "@/api/env";
 import {
@@ -54,8 +50,10 @@ import {
 } from "@/api/handlers/chat/persist-message";
 import {
   applyChatCompactionCheckpoint,
+  markActiveChatCompactionCheckpointStale,
   persistChatCompactionCheckpoint,
   readLatestChatCompaction,
+  shouldInvalidateChatCompactionCheckpoint,
 } from "@/api/handlers/chat/persistent-compaction";
 import { hydrateMessages, streamChat } from "@/api/handlers/chat/stream-chat";
 import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
@@ -1878,16 +1876,6 @@ const runPersistMessage = async ({
             ),
           );
 
-        await tx
-          .update(chatThreadCompactions)
-          .set({ status: "stale" })
-          .where(
-            and(
-              eq(chatThreadCompactions.threadId, threadId),
-              eq(chatThreadCompactions.status, "active"),
-            ),
-          );
-
         for (const deletedMessageId of deleteMessageIds) {
           await recordAuditEvent(tx, {
             action: AUDIT_ACTION.DELETE,
@@ -1897,6 +1885,15 @@ const runPersistMessage = async ({
             metadata: { threadId, reason: "truncate_for_replay" },
           });
         }
+      }
+
+      if (
+        shouldInvalidateChatCompactionCheckpoint({
+          deletedMessageCount: deleteMessageIds.length,
+          persistencePlan,
+        })
+      ) {
+        await markActiveChatCompactionCheckpointStale({ threadId, tx });
       }
 
       const updatedMessageId = brandPersistedChatMessageId(
@@ -1975,15 +1972,14 @@ const runPersistMessage = async ({
           .delete(chatMessages)
           .where(and(eq(chatMessages.id, deletedMessageId)));
 
-        await tx
-          .update(chatThreadCompactions)
-          .set({ status: "stale" })
-          .where(
-            and(
-              eq(chatThreadCompactions.threadId, threadId),
-              eq(chatThreadCompactions.status, "active"),
-            ),
-          );
+        if (
+          shouldInvalidateChatCompactionCheckpoint({
+            deletedMessageCount: 1,
+            persistencePlan,
+          })
+        ) {
+          await markActiveChatCompactionCheckpointStale({ threadId, tx });
+        }
 
         await recordAuditEvent(tx, {
           action: AUDIT_ACTION.DELETE,

--- a/apps/api/src/handlers/chat/tools/chat-history-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/chat-history-tools.test.ts
@@ -1,0 +1,81 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import type { SafeDb, Transaction } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+import {
+  createChatHistoryTools,
+  EXPAND_CHAT_HISTORY_TOOL_NAME,
+  SEARCH_CHAT_HISTORY_TOOL_NAME,
+} from "./chat-history-tools";
+
+const threadId = toSafeId<"chatThread">("11111111-1111-4111-8111-111111111111");
+const hiddenMessageId = toSafeId<"chatMessage">(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+const createSafeDbCapture = () => {
+  const queries: SQL[] = [];
+  const tx = {
+    execute: async (query: SQL) => {
+      queries.push(query);
+      return [];
+    },
+  };
+  const safeDb: SafeDb = async (callback) =>
+    Result.ok(await callback(asTestRaw<Transaction>(tx)));
+
+  return { queries, safeDb };
+};
+
+describe("chat history tools", () => {
+  test("exclude replay-truncated messages from history search", async () => {
+    const { queries, safeDb } = createSafeDbCapture();
+    const tools = createChatHistoryTools({
+      excludedMessageIds: [hiddenMessageId],
+      safeDb,
+      threadId,
+    });
+    const searchTool = tools[SEARCH_CHAT_HISTORY_TOOL_NAME];
+
+    await searchTool.execute?.(
+      { limit: 3, query: "old branch" },
+      asTestRaw<Parameters<NonNullable<typeof searchTool.execute>>[1]>({}),
+    );
+
+    const query = queries.at(0);
+    expect(query).toBeDefined();
+    if (!query) {
+      return;
+    }
+
+    const compiled = new PgDialect().sqlToQuery(query);
+    expect(compiled.sql).toContain("message_id NOT IN");
+    expect(compiled.params).toContain(hiddenMessageId);
+  });
+
+  test("does not expand a replay-truncated target message", async () => {
+    const { queries, safeDb } = createSafeDbCapture();
+    const tools = createChatHistoryTools({
+      excludedMessageIds: [hiddenMessageId],
+      safeDb,
+      threadId,
+    });
+    const expandTool = tools[EXPAND_CHAT_HISTORY_TOOL_NAME];
+
+    const result = await expandTool.execute?.(
+      { after: 2, before: 2, messageId: hiddenMessageId },
+      asTestRaw<Parameters<NonNullable<typeof expandTool.execute>>[1]>({}),
+    );
+
+    expect(result).toEqual({
+      targetMessageId: hiddenMessageId,
+      messages: [],
+    });
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/apps/api/src/handlers/chat/tools/chat-history-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-history-tools.ts
@@ -1,0 +1,251 @@
+import { valibotSchema } from "@ai-sdk/valibot";
+import { tool } from "ai";
+import { Result } from "better-result";
+import { sql } from "drizzle-orm";
+import * as v from "valibot";
+
+import type { SafeDb } from "@/api/db";
+import { renderChatMessagesForCompaction } from "@/api/handlers/chat/compaction";
+import type {
+  ChatMessage,
+  ChatMessageContent,
+  ChatMessageRole,
+} from "@/api/handlers/chat/types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
+import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
+import { buildSearchTsQuery } from "@/api/lib/search/query";
+
+const CHAT_HISTORY_HEADLINE_CONFIG =
+  "StartSel=<hit>, StopSel=</hit>, MaxWords=40, MinWords=10, ShortWord=3";
+
+export const SEARCH_CHAT_HISTORY_TOOL_NAME = "search-chat-history";
+export const EXPAND_CHAT_HISTORY_TOOL_NAME = "expand-chat-history";
+
+const searchChatHistoryInputSchema = v.strictObject({
+  query: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.maxLength(LIMITS.searchQueryMaxLength),
+    v.description("Text to search in earlier messages in this chat thread."),
+  ),
+  limit: v.optional(
+    v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(1),
+      v.maxValue(LIMITS.chatHistorySearchPageSizeMax),
+      v.description("Maximum number of matching messages to return."),
+    ),
+    LIMITS.chatHistorySearchPageSizeDefault,
+  ),
+});
+
+const expandChatHistoryInputSchema = v.strictObject({
+  messageId: v.pipe(
+    v.string(),
+    v.uuid(),
+    v.description("Message ID returned by search-chat-history."),
+  ),
+  before: v.optional(
+    v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(0),
+      v.maxValue(LIMITS.chatHistoryExpansionSideMax),
+      v.description("Messages to include before the target message."),
+    ),
+    2,
+  ),
+  after: v.optional(
+    v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(0),
+      v.maxValue(LIMITS.chatHistoryExpansionSideMax),
+      v.description("Messages to include after the target message."),
+    ),
+    2,
+  ),
+});
+
+const searchChatHistoryOutputSchema = v.strictObject({
+  query: v.string(),
+  results: v.array(
+    v.strictObject({
+      messageId: v.string(),
+      role: v.string(),
+      excerpt: v.string(),
+      createdAt: v.string(),
+    }),
+  ),
+});
+
+const expandChatHistoryOutputSchema = v.strictObject({
+  targetMessageId: v.string(),
+  messages: v.array(
+    v.strictObject({
+      messageId: v.string(),
+      role: v.string(),
+      createdAt: v.string(),
+      content: v.string(),
+    }),
+  ),
+});
+
+type CreateChatHistoryToolsProps = {
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+};
+
+type ChatHistorySearchRow = {
+  createdAt: Date;
+  excerpt: string;
+  messageId: SafeId<"chatMessage">;
+  role: ChatMessageRole;
+};
+
+type ChatHistoryExpansionRow = {
+  content: ChatMessageContent;
+  createdAt: Date;
+  id: SafeId<"chatMessage">;
+  role: ChatMessageRole;
+};
+
+export const createChatHistoryTools = ({
+  safeDb,
+  threadId,
+}: CreateChatHistoryToolsProps) => ({
+  [SEARCH_CHAT_HISTORY_TOOL_NAME]: tool({
+    description:
+      "Search earlier persisted messages in this same chat thread. Use this when compacted context may omit a detail, prior instruction, cited source, or unresolved task. Follow up with expand-chat-history when exact surrounding context matters.",
+    inputSchema: valibotSchema(searchChatHistoryInputSchema),
+    outputSchema: valibotSchema(searchChatHistoryOutputSchema),
+    execute: async ({ query, limit }) => {
+      const normalizedQuery = query.trim();
+      if (!normalizedQuery) {
+        throw new ChatToolError({
+          message: "Chat history search query must not be empty.",
+        });
+      }
+
+      const tsQuery = buildSearchTsQuery(normalizedQuery);
+      const result = await safeDb((tx) =>
+        tx.execute<ChatHistorySearchRow>(sql`
+          SELECT
+            message_id AS "messageId",
+            role,
+            ts_headline(
+              'simple',
+              left(searchable_text, 2000),
+              ${tsQuery},
+              ${CHAT_HISTORY_HEADLINE_CONFIG}
+            ) AS excerpt,
+            created_at AS "createdAt"
+          FROM chat_message_search_documents
+          WHERE thread_id = ${threadId}
+            AND tsv @@ ${tsQuery}
+          ORDER BY ts_rank(tsv, ${tsQuery}) DESC, created_at DESC, message_id DESC
+          LIMIT ${limit}
+        `),
+      );
+
+      if (Result.isError(result)) {
+        throw new ChatToolError({
+          message: "Failed to search chat history.",
+          cause: result.error,
+        });
+      }
+
+      return {
+        query: normalizedQuery,
+        results: result.value.map((row) => ({
+          messageId: row.messageId,
+          role: row.role,
+          excerpt: row.excerpt,
+          createdAt: row.createdAt.toISOString(),
+        })),
+      };
+    },
+  }),
+  [EXPAND_CHAT_HISTORY_TOOL_NAME]: tool({
+    description:
+      "Expand one persisted chat-history search result into a small transcript window from this same thread. Use only with a messageId returned by search-chat-history.",
+    inputSchema: valibotSchema(expandChatHistoryInputSchema),
+    outputSchema: valibotSchema(expandChatHistoryOutputSchema),
+    execute: async ({ messageId, before, after }) => {
+      const persistedMessageId = brandPersistedChatMessageId(messageId);
+      const result = await safeDb((tx) =>
+        tx.execute<ChatHistoryExpansionRow>(sql`
+          WITH target AS (
+            SELECT id, created_at
+            FROM chat_messages
+            WHERE thread_id = ${threadId}
+              AND id = ${persistedMessageId}
+            LIMIT 1
+          ),
+          before_rows AS (
+            SELECT m.id, m.role, m.content, m.created_at
+            FROM chat_messages m, target t
+            WHERE m.thread_id = ${threadId}
+              AND (m.created_at, m.id) < (t.created_at, t.id)
+            ORDER BY m.created_at DESC, m.id DESC
+            LIMIT ${before}
+          ),
+          target_row AS (
+            SELECT m.id, m.role, m.content, m.created_at
+            FROM chat_messages m
+            WHERE m.thread_id = ${threadId}
+              AND m.id = ${persistedMessageId}
+          ),
+          after_rows AS (
+            SELECT m.id, m.role, m.content, m.created_at
+            FROM chat_messages m, target t
+            WHERE m.thread_id = ${threadId}
+              AND (m.created_at, m.id) > (t.created_at, t.id)
+            ORDER BY m.created_at ASC, m.id ASC
+            LIMIT ${after}
+          )
+          SELECT id, role, content, created_at AS "createdAt"
+          FROM (
+            SELECT * FROM before_rows
+            UNION ALL
+            SELECT * FROM target_row
+            UNION ALL
+            SELECT * FROM after_rows
+          ) history_rows
+          ORDER BY created_at ASC, id ASC
+        `),
+      );
+
+      if (Result.isError(result)) {
+        throw new ChatToolError({
+          message: "Failed to expand chat history.",
+          cause: result.error,
+        });
+      }
+
+      return {
+        targetMessageId: messageId,
+        messages: result.value.map((row) => {
+          const message = persistedRowToChatMessage(row);
+          return {
+            messageId: row.id,
+            role: row.role,
+            createdAt: row.createdAt.toISOString(),
+            content: renderChatMessagesForCompaction([message]),
+          };
+        }),
+      };
+    },
+  }),
+});
+
+const persistedRowToChatMessage = (
+  row: ChatHistoryExpansionRow,
+): ChatMessage => ({
+  id: row.id,
+  role: row.role,
+  parts: row.content.data,
+});

--- a/apps/api/src/handlers/chat/tools/chat-history-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-history-tools.ts
@@ -1,6 +1,7 @@
 import { valibotSchema } from "@ai-sdk/valibot";
 import { tool } from "ai";
 import { Result } from "better-result";
+import type { SQL } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import * as v from "valibot";
 
@@ -95,6 +96,7 @@ const expandChatHistoryOutputSchema = v.strictObject({
 });
 
 type CreateChatHistoryToolsProps = {
+  excludedMessageIds?: readonly SafeId<"chatMessage">[] | undefined;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
 };
@@ -114,25 +116,37 @@ type ChatHistoryExpansionRow = {
 };
 
 export const createChatHistoryTools = ({
+  excludedMessageIds = [],
   safeDb,
   threadId,
-}: CreateChatHistoryToolsProps) => ({
-  [SEARCH_CHAT_HISTORY_TOOL_NAME]: tool({
-    description:
-      "Search earlier persisted messages in this same chat thread. Use this when compacted context may omit a detail, prior instruction, cited source, or unresolved task. Follow up with expand-chat-history when exact surrounding context matters.",
-    inputSchema: valibotSchema(searchChatHistoryInputSchema),
-    outputSchema: valibotSchema(searchChatHistoryOutputSchema),
-    execute: async ({ query, limit }) => {
-      const normalizedQuery = query.trim();
-      if (!normalizedQuery) {
-        throw new ChatToolError({
-          message: "Chat history search query must not be empty.",
-        });
-      }
+}: CreateChatHistoryToolsProps) => {
+  const excludedMessageIdSet = new Set<string>(excludedMessageIds);
+  const excludedMessageIdValues = excludedMessageIds.map((id) => sql`${id}`);
+  const excludeMessageSql = (messageIdSql: SQL) =>
+    excludedMessageIdValues.length === 0
+      ? sql``
+      : sql`AND ${messageIdSql} NOT IN (${sql.join(
+          excludedMessageIdValues,
+          sql`, `,
+        )})`;
 
-      const tsQuery = buildSearchTsQuery(normalizedQuery);
-      const result = await safeDb((tx) =>
-        tx.execute<ChatHistorySearchRow>(sql`
+  return {
+    [SEARCH_CHAT_HISTORY_TOOL_NAME]: tool({
+      description:
+        "Search earlier persisted messages in this same chat thread. Use this when compacted context may omit a detail, prior instruction, cited source, or unresolved task. Follow up with expand-chat-history when exact surrounding context matters.",
+      inputSchema: valibotSchema(searchChatHistoryInputSchema),
+      outputSchema: valibotSchema(searchChatHistoryOutputSchema),
+      execute: async ({ query, limit }) => {
+        const normalizedQuery = query.trim();
+        if (!normalizedQuery) {
+          throw new ChatToolError({
+            message: "Chat history search query must not be empty.",
+          });
+        }
+
+        const tsQuery = buildSearchTsQuery(normalizedQuery);
+        const result = await safeDb((tx) =>
+          tx.execute<ChatHistorySearchRow>(sql`
           SELECT
             message_id AS "messageId",
             role,
@@ -146,38 +160,46 @@ export const createChatHistoryTools = ({
           FROM chat_message_search_documents
           WHERE thread_id = ${threadId}
             AND tsv @@ ${tsQuery}
+            ${excludeMessageSql(sql`message_id`)}
           ORDER BY ts_rank(tsv, ${tsQuery}) DESC, created_at DESC, message_id DESC
           LIMIT ${limit}
         `),
-      );
+        );
 
-      if (Result.isError(result)) {
-        throw new ChatToolError({
-          message: "Failed to search chat history.",
-          cause: result.error,
-        });
-      }
+        if (Result.isError(result)) {
+          throw new ChatToolError({
+            message: "Failed to search chat history.",
+            cause: result.error,
+          });
+        }
 
-      return {
-        query: normalizedQuery,
-        results: result.value.map((row) => ({
-          messageId: row.messageId,
-          role: row.role,
-          excerpt: row.excerpt,
-          createdAt: row.createdAt.toISOString(),
-        })),
-      };
-    },
-  }),
-  [EXPAND_CHAT_HISTORY_TOOL_NAME]: tool({
-    description:
-      "Expand one persisted chat-history search result into a small transcript window from this same thread. Use only with a messageId returned by search-chat-history.",
-    inputSchema: valibotSchema(expandChatHistoryInputSchema),
-    outputSchema: valibotSchema(expandChatHistoryOutputSchema),
-    execute: async ({ messageId, before, after }) => {
-      const persistedMessageId = brandPersistedChatMessageId(messageId);
-      const result = await safeDb((tx) =>
-        tx.execute<ChatHistoryExpansionRow>(sql`
+        return {
+          query: normalizedQuery,
+          results: result.value.map((row) => ({
+            messageId: row.messageId,
+            role: row.role,
+            excerpt: row.excerpt,
+            createdAt: row.createdAt.toISOString(),
+          })),
+        };
+      },
+    }),
+    [EXPAND_CHAT_HISTORY_TOOL_NAME]: tool({
+      description:
+        "Expand one persisted chat-history search result into a small transcript window from this same thread. Use only with a messageId returned by search-chat-history.",
+      inputSchema: valibotSchema(expandChatHistoryInputSchema),
+      outputSchema: valibotSchema(expandChatHistoryOutputSchema),
+      execute: async ({ messageId, before, after }) => {
+        if (excludedMessageIdSet.has(messageId)) {
+          return {
+            targetMessageId: messageId,
+            messages: [],
+          };
+        }
+
+        const persistedMessageId = brandPersistedChatMessageId(messageId);
+        const result = await safeDb((tx) =>
+          tx.execute<ChatHistoryExpansionRow>(sql`
           WITH target AS (
             SELECT id, created_at
             FROM chat_messages
@@ -189,6 +211,7 @@ export const createChatHistoryTools = ({
             SELECT m.id, m.role, m.content, m.created_at
             FROM chat_messages m, target t
             WHERE m.thread_id = ${threadId}
+              ${excludeMessageSql(sql`m.id`)}
               AND (m.created_at, m.id) < (t.created_at, t.id)
             ORDER BY m.created_at DESC, m.id DESC
             LIMIT ${before}
@@ -198,11 +221,13 @@ export const createChatHistoryTools = ({
             FROM chat_messages m
             WHERE m.thread_id = ${threadId}
               AND m.id = ${persistedMessageId}
+              ${excludeMessageSql(sql`m.id`)}
           ),
           after_rows AS (
             SELECT m.id, m.role, m.content, m.created_at
             FROM chat_messages m, target t
             WHERE m.thread_id = ${threadId}
+              ${excludeMessageSql(sql`m.id`)}
               AND (m.created_at, m.id) > (t.created_at, t.id)
             ORDER BY m.created_at ASC, m.id ASC
             LIMIT ${after}
@@ -217,30 +242,31 @@ export const createChatHistoryTools = ({
           ) history_rows
           ORDER BY created_at ASC, id ASC
         `),
-      );
+        );
 
-      if (Result.isError(result)) {
-        throw new ChatToolError({
-          message: "Failed to expand chat history.",
-          cause: result.error,
-        });
-      }
+        if (Result.isError(result)) {
+          throw new ChatToolError({
+            message: "Failed to expand chat history.",
+            cause: result.error,
+          });
+        }
 
-      return {
-        targetMessageId: messageId,
-        messages: result.value.map((row) => {
-          const message = persistedRowToChatMessage(row);
-          return {
-            messageId: row.id,
-            role: row.role,
-            createdAt: row.createdAt.toISOString(),
-            content: renderChatMessagesForCompaction([message]),
-          };
-        }),
-      };
-    },
-  }),
-});
+        return {
+          targetMessageId: messageId,
+          messages: result.value.map((row) => {
+            const message = persistedRowToChatMessage(row);
+            return {
+              messageId: row.id,
+              role: row.role,
+              createdAt: row.createdAt.toISOString(),
+              content: renderChatMessagesForCompaction([message]),
+            };
+          }),
+        };
+      },
+    }),
+  };
+};
 
 const persistedRowToChatMessage = (
   row: ChatHistoryExpansionRow,

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -83,6 +83,7 @@ type GetChatToolsProps = {
   scopedDb: ScopedDb;
   organizationId: SafeId<"organization">;
   threadId: SafeId<"chatThread">;
+  excludedChatHistoryMessageIds?: readonly SafeId<"chatMessage">[] | undefined;
   userId: SafeId<"user">;
   // Use `resolveToolWorkspaceIds` to construct this — that helper is
   // the only path that intersects pinned IDs with the currently
@@ -161,6 +162,7 @@ export const getChatTools = ({
   scopedDb,
   organizationId,
   threadId,
+  excludedChatHistoryMessageIds,
   userId,
   toolWorkspaceIds,
   refRegistry,
@@ -216,6 +218,7 @@ export const getChatTools = ({
     ? createActiveDocxEditTools()
     : {};
   const historyTools = createChatHistoryTools({
+    excludedMessageIds: excludedChatHistoryMessageIds,
     safeDb,
     threadId,
   });

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -15,6 +15,11 @@ import {
   createBusinessRegistryTools,
 } from "@/api/handlers/chat/tools/business-registry-tools";
 import {
+  EXPAND_CHAT_HISTORY_TOOL_NAME,
+  createChatHistoryTools,
+  SEARCH_CHAT_HISTORY_TOOL_NAME,
+} from "@/api/handlers/chat/tools/chat-history-tools";
+import {
   CREATE_DOCUMENT_TOOL_NAME,
   createCreateDocumentTool,
 } from "@/api/handlers/chat/tools/create-document-tool";
@@ -57,6 +62,7 @@ type InfosoudTools = ReturnType<typeof createInfosoudTools>;
 type ActiveDocxEditTools = ReturnType<typeof createActiveDocxEditTools>;
 type CreateDocumentTools = ReturnType<typeof createCreateDocumentTools>;
 type WebSearchTools = ReturnType<typeof createWebSearchTools>;
+type ChatHistoryTools = ReturnType<typeof createChatHistoryTools>;
 
 type BuiltInChatTools = OrgTools &
   ChatExecutionTools &
@@ -67,7 +73,8 @@ type BuiltInChatTools = OrgTools &
   WorkspaceTools &
   ActiveDocxEditTools &
   CreateDocumentTools &
-  WebSearchTools;
+  WebSearchTools &
+  ChatHistoryTools;
 
 export type ChatTools = BuiltInChatTools;
 
@@ -75,6 +82,7 @@ type GetChatToolsProps = {
   safeDb: SafeDb;
   scopedDb: ScopedDb;
   organizationId: SafeId<"organization">;
+  threadId: SafeId<"chatThread">;
   userId: SafeId<"user">;
   // Use `resolveToolWorkspaceIds` to construct this — that helper is
   // the only path that intersects pinned IDs with the currently
@@ -129,6 +137,7 @@ const BUILT_IN_CHAT_TOOL_POLICY_KINDS = {
   [BUSINESS_REGISTRY_LOOKUP_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.publicOfficial,
   "create-document": CHAT_TOOL_POLICY_KIND.internal,
   "describe-stella-api": CHAT_TOOL_POLICY_KIND.internal,
+  [EXPAND_CHAT_HISTORY_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.internal,
   // Per-thread `webSearchEnabled` already gates the tools; an
   // additional per-call approval would double-gate and block
   // streaming until the user clicks Allow. Classify alongside the
@@ -139,6 +148,7 @@ const BUILT_IN_CHAT_TOOL_POLICY_KINDS = {
   "load-skill": CHAT_TOOL_POLICY_KIND.internal,
   "read-skill-resource": CHAT_TOOL_POLICY_KIND.internal,
   "run-stella-query": CHAT_TOOL_POLICY_KIND.internal,
+  [SEARCH_CHAT_HISTORY_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.internal,
   "update-entity-fields": CHAT_TOOL_POLICY_KIND.mutation,
   [WEB_SEARCH_TOOL_NAME]: CHAT_TOOL_POLICY_KIND.publicOfficial,
 } as const satisfies Record<
@@ -150,6 +160,7 @@ export const getChatTools = ({
   safeDb,
   scopedDb,
   organizationId,
+  threadId,
   userId,
   toolWorkspaceIds,
   refRegistry,
@@ -204,6 +215,10 @@ export const getChatTools = ({
   const activeDocxEditTools = hasActiveFileChat
     ? createActiveDocxEditTools()
     : {};
+  const historyTools = createChatHistoryTools({
+    safeDb,
+    threadId,
+  });
   const externalChatTools = applyChatToolPolicies({
     defaultPolicyKind: CHAT_TOOL_POLICY_KIND.external,
     tools: externalTools,
@@ -234,6 +249,7 @@ export const getChatTools = ({
       ...boeTools,
       ...infosoudTools,
       ...workspaceTools,
+      ...historyTools,
       ...createDocumentTools,
       ...activeDocxEditTools,
       ...webSearchTools,

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import type { SafeDb, ScopedDb } from "@/api/db";
 import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import {
+  EXPAND_CHAT_HISTORY_TOOL_NAME,
+  SEARCH_CHAT_HISTORY_TOOL_NAME,
+} from "@/api/handlers/chat/tools/chat-history-tools";
 import { getChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import { getChatToolPolicy } from "@/api/handlers/chat/tools/tool-policy";
@@ -22,6 +26,7 @@ const workspaceId = toSafeId<"workspace">(
   "33333333-3333-4333-8333-333333333333",
 );
 const entityId = toSafeId<"entity">("44444444-4444-4444-8444-444444444444");
+const threadId = toSafeId<"chatThread">("55555555-5555-4555-8555-555555555555");
 
 const unusedScopedDb: ScopedDb = async () => {
   throw new Error("This test only constructs tool schemas.");
@@ -91,6 +96,7 @@ describe("chat tool schemas", () => {
       refRegistry: createChatRefRegistry(),
       safeDb: unusedSafeDb,
       scopedDb: unusedScopedDb,
+      threadId,
       userId,
       toolWorkspaceIds: resolveToolWorkspaceIds({
         pinnedIds: [],
@@ -101,6 +107,8 @@ describe("chat tool schemas", () => {
     });
 
     expect(tools).toHaveProperty("ask-user");
+    expect(tools).toHaveProperty(SEARCH_CHAT_HISTORY_TOOL_NAME);
+    expect(tools).toHaveProperty(EXPAND_CHAT_HISTORY_TOOL_NAME);
     expect(tools).toHaveProperty("run-stella-query");
     expect(tools).toHaveProperty("create-document");
     expect(tools).toHaveProperty("update-entity-fields");
@@ -115,6 +123,7 @@ describe("chat tool schemas", () => {
       refRegistry: createChatRefRegistry(),
       safeDb: unusedSafeDb,
       scopedDb: unusedScopedDb,
+      threadId,
       userId,
       toolWorkspaceIds: resolveToolWorkspaceIds({
         pinnedIds: [],
@@ -128,13 +137,20 @@ describe("chat tool schemas", () => {
     const updateEntityFields = tools["update-entity-fields"];
     const createDocument = tools["create-document"];
     const runStellaQuery = tools["run-stella-query"];
+    const searchChatHistory = tools[SEARCH_CHAT_HISTORY_TOOL_NAME];
 
     expect(businessRegistryLookup).toBeDefined();
     expect(updateEntityFields).toBeDefined();
     expect(createDocument).toBeDefined();
     expect(runStellaQuery).toBeDefined();
+    expect(searchChatHistory).toBeDefined();
 
-    if (!businessRegistryLookup || !updateEntityFields || !createDocument) {
+    if (
+      !businessRegistryLookup ||
+      !updateEntityFields ||
+      !createDocument ||
+      !searchChatHistory
+    ) {
       throw new Error("Expected chat tools to be registered");
     }
 
@@ -157,6 +173,11 @@ describe("chat tool schemas", () => {
       requiresAnonymization: false,
     });
     expect(runStellaQuery?.needsApproval).toBeUndefined();
+    expect(getChatToolPolicy(searchChatHistory)).toEqual({
+      kind: "internal",
+      needsApproval: false,
+      requiresAnonymization: false,
+    });
   });
 
   test("created document output includes the canonical entity mention", () => {

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -70,6 +70,23 @@ export type ChatPart = ChatMessage["parts"][number];
 
 export type ChatMessageRole = UIMessage["role"];
 
+export type ChatCompactionSummary = {
+  version: 1;
+  blocked: string[];
+  constraints: string[];
+  criticalContext: string[];
+  done: string[];
+  goal: string | null;
+  inProgress: string[];
+  keyDecisions: {
+    decision: string;
+    rationale: string | null;
+  }[];
+  modifiedFiles: string[];
+  nextSteps: string[];
+  readFiles: string[];
+};
+
 /** Versioned envelope for the chatMessages JSONB column.
  *  Bump the version and add a new variant when the parts
  *  shape changes; migrate in-place by reading the version

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -16,6 +16,7 @@ export type SafeIdType =
   | "caseLawPolarityRule"
   | "caseLawSource"
   | "chatMessage"
+  | "chatThreadCompaction"
   | "chatThread"
   | "fileChatThread"
   | "clause"

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -74,6 +74,14 @@ export const LIMITS = {
    *  cannot blow up the index; the headline only reads the first
    *  2000 chars anyway. */
   chatSearchTextMaxLength: 50_000,
+  /** Cap on searchable text indexed for one chat message. */
+  chatMessageSearchTextMaxLength: 8000,
+  /** Default result count for the internal chat-history search tool. */
+  chatHistorySearchPageSizeDefault: 6,
+  /** Max result count for the internal chat-history search tool. */
+  chatHistorySearchPageSizeMax: 10,
+  /** Max messages returned before or after a history expansion target. */
+  chatHistoryExpansionSideMax: 5,
   extractedContentMaxChars: 500_000,
   /** Hard timeout (ms) for the sandboxed extraction subprocess. */
   extractionTimeoutMs: 30_000,

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -71,4 +71,50 @@ describe("chat search indexing", () => {
       "WHERE EXCLUDED.updated_at >= chat_message_search_documents.updated_at",
     );
   });
+
+  test("indexes malformed source-document parts without throwing", async () => {
+    rootDbChatThreadFindFirstMock.mockImplementation(
+      async () =>
+        await Promise.resolve({
+          id: toSafeId<"chatThread">("thread_1"),
+          title: "Contract review",
+          updatedAt: new Date("2026-06-06T08:00:00.000Z"),
+          messages: [
+            {
+              id: toSafeId<"chatMessage">(
+                "11111111-1111-4111-8111-111111111111",
+              ),
+              role: "assistant",
+              createdAt: new Date("2026-06-06T07:55:00.000Z"),
+              content: {
+                version: 1 as const,
+                data: [{ type: "data-stella-source-document" }],
+              },
+            },
+          ],
+        }),
+    );
+    const { upsertChatThreadSearchDocument } = await import("./index-chat");
+
+    await upsertChatThreadSearchDocument(toSafeId<"chatThread">("thread_1"));
+
+    expect(rootDbExecuteMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("backfills threads missing per-message search documents", async () => {
+    const { backfillChatThreadSearchIndex } = await import("./index-chat");
+
+    await backfillChatThreadSearchIndex();
+
+    const query = rootDbExecuteMock.mock.calls.at(0)?.[0];
+    expect(query).toBeDefined();
+    if (query === undefined) {
+      return;
+    }
+
+    const compiled = new PgDialect().sqlToQuery(query);
+    expect(compiled.sql).toContain("LEFT JOIN chat_thread_search_documents");
+    expect(compiled.sql).toContain("LEFT JOIN chat_message_search_documents");
+    expect(compiled.sql).toContain("md.message_id IS NULL");
+  });
 });

--- a/apps/api/src/lib/search/index-chat.test.ts
+++ b/apps/api/src/lib/search/index-chat.test.ts
@@ -18,6 +18,9 @@ beforeEach(() => {
         updatedAt: new Date("2026-06-06T08:00:00.000Z"),
         messages: [
           {
+            id: toSafeId<"chatMessage">("11111111-1111-4111-8111-111111111111"),
+            role: "user",
+            createdAt: new Date("2026-06-06T07:55:00.000Z"),
             content: {
               version: 1 as const,
               data: [
@@ -48,6 +51,24 @@ describe("chat search indexing", () => {
     const compiled = new PgDialect().sqlToQuery(query);
     expect(compiled.sql).toContain(
       "WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at",
+    );
+  });
+
+  test("does not let stale upserts overwrite newer message search documents", async () => {
+    const { upsertChatThreadSearchDocument } = await import("./index-chat");
+
+    await upsertChatThreadSearchDocument(toSafeId<"chatThread">("thread_1"));
+
+    const query = rootDbExecuteMock.mock.calls.at(1)?.[0];
+    expect(query).toBeDefined();
+    if (query === undefined) {
+      return;
+    }
+
+    const compiled = new PgDialect().sqlToQuery(query);
+    expect(compiled.sql).toContain("INSERT INTO chat_message_search_documents");
+    expect(compiled.sql).toContain(
+      "WHERE EXCLUDED.updated_at >= chat_message_search_documents.updated_at",
     );
   });
 });

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -1,7 +1,10 @@
 import { sql } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
-import type { PersistedChatMessageContent } from "@/api/handlers/chat/types";
+import type {
+  ChatMessageRole,
+  PersistedChatMessageContent,
+} from "@/api/handlers/chat/types";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
@@ -20,23 +23,58 @@ const extractThreadText = (
 ): string => {
   const parts: string[] = [];
   for (const message of messages) {
-    for (const part of message.content.data) {
-      if (part.type !== "text") {
-        continue;
-      }
-      const trimmed = part.text.trim();
-      if (trimmed) {
-        parts.push(trimmed);
-      }
+    const messageText = extractMessageSearchText(message.content);
+    if (messageText) {
+      parts.push(messageText);
     }
   }
   return parts.join(" ").slice(0, LIMITS.chatSearchTextMaxLength);
 };
 
+const extractMessageSearchText = (
+  content: PersistedChatMessageContent,
+): string => {
+  const parts: string[] = [];
+  for (const part of content.data) {
+    if (part.type === "text") {
+      const trimmed = part.text.trim();
+      if (trimmed) {
+        parts.push(trimmed);
+      }
+      continue;
+    }
+
+    if (part.type === "data-stella-source-document") {
+      for (const value of [
+        part.data.title,
+        part.data.mention,
+        part.data.entityRef,
+        part.data.matterRef,
+        part.data.kind,
+      ]) {
+        const trimmed = value?.trim();
+        if (trimmed) {
+          parts.push(trimmed);
+        }
+      }
+    }
+  }
+
+  return parts.join(" ").slice(0, LIMITS.chatMessageSearchTextMaxLength);
+};
+
+type ChatSearchMessageRow = {
+  content: PersistedChatMessageContent;
+  createdAt: Date;
+  id: SafeId<"chatMessage">;
+  role: ChatMessageRole;
+};
+
 /** Recompute the search document for one thread (title + rolled-up
- *  message text). Tenancy is not stored here; the global-search query
- *  derives it by joining back to `chat_threads`. Safe to call after
- *  any thread mutation; a missing thread is a no-op. */
+ *  message text) plus the per-message history search documents.
+ *  Tenancy is not stored here; search queries derive it by joining
+ *  back to `chat_threads` or through RLS on the owning thread. Safe
+ *  to call after any thread mutation; a missing thread is a no-op. */
 export const upsertChatThreadSearchDocument = async (
   threadId: SafeId<"chatThread">,
 ): Promise<void> => {
@@ -45,7 +83,12 @@ export const upsertChatThreadSearchDocument = async (
     columns: { id: true, title: true, updatedAt: true },
     with: {
       messages: {
-        columns: { content: true },
+        columns: {
+          id: true,
+          role: true,
+          content: true,
+          createdAt: true,
+        },
         orderBy: { createdAt: "asc" },
       },
     },
@@ -79,6 +122,53 @@ export const upsertChatThreadSearchDocument = async (
       updated_at = EXCLUDED.updated_at,
       tsv = EXCLUDED.tsv
     WHERE EXCLUDED.updated_at >= chat_thread_search_documents.updated_at
+  `);
+
+  await upsertChatMessageSearchDocuments({
+    messages: thread.messages,
+    threadId: thread.id,
+    threadUpdatedAt: thread.updatedAt,
+  });
+};
+
+const upsertChatMessageSearchDocuments = async ({
+  messages,
+  threadId,
+  threadUpdatedAt,
+}: {
+  messages: readonly ChatSearchMessageRow[];
+  threadId: SafeId<"chatThread">;
+  threadUpdatedAt: Date;
+}): Promise<void> => {
+  if (messages.length === 0) {
+    return;
+  }
+
+  const values = messages.map((message) => {
+    const searchableText = extractMessageSearchText(message.content);
+    return sql`(
+      ${message.id},
+      ${threadId},
+      ${message.role},
+      ${searchableText},
+      to_tsvector('simple', unaccent(coalesce(${searchableText}, ''))),
+      ${message.createdAt},
+      ${threadUpdatedAt}
+    )`;
+  });
+
+  await rootDb.execute(sql`
+    INSERT INTO chat_message_search_documents (
+      message_id, thread_id, role, searchable_text, tsv, created_at, updated_at
+    ) VALUES ${sql.join(values, sql`, `)}
+    ON CONFLICT (message_id) DO UPDATE SET
+      thread_id = EXCLUDED.thread_id,
+      role = EXCLUDED.role,
+      searchable_text = EXCLUDED.searchable_text,
+      tsv = EXCLUDED.tsv,
+      created_at = EXCLUDED.created_at,
+      updated_at = EXCLUDED.updated_at
+    WHERE EXCLUDED.updated_at >= chat_message_search_documents.updated_at
   `);
 };
 

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -35,24 +35,37 @@ const extractMessageSearchText = (
   content: PersistedChatMessageContent,
 ): string => {
   const parts: string[] = [];
-  for (const part of content.data) {
-    if (part.type === "text") {
-      const trimmed = part.text.trim();
+  const messageParts: readonly unknown[] = content.data;
+  for (const part of messageParts) {
+    if (!isRecord(part) || typeof part["type"] !== "string") {
+      continue;
+    }
+
+    if (part["type"] === "text" && typeof part["text"] === "string") {
+      const trimmed = part["text"].trim();
       if (trimmed) {
         parts.push(trimmed);
       }
       continue;
     }
 
-    if (part.type === "data-stella-source-document") {
+    const sourceDocumentData = part["data"];
+    if (
+      part["type"] === "data-stella-source-document" &&
+      isRecord(sourceDocumentData)
+    ) {
       for (const value of [
-        part.data.title,
-        part.data.mention,
-        part.data.entityRef,
-        part.data.matterRef,
-        part.data.kind,
+        sourceDocumentData["title"],
+        sourceDocumentData["mention"],
+        sourceDocumentData["entityRef"],
+        sourceDocumentData["matterRef"],
+        sourceDocumentData["kind"],
       ]) {
-        const trimmed = value?.trim();
+        if (typeof value !== "string") {
+          continue;
+        }
+
+        const trimmed = value.trim();
         if (trimmed) {
           parts.push(trimmed);
         }
@@ -62,6 +75,9 @@ const extractMessageSearchText = (
 
   return parts.join(" ").slice(0, LIMITS.chatMessageSearchTextMaxLength);
 };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
 
 type ChatSearchMessageRow = {
   content: PersistedChatMessageContent;
@@ -172,10 +188,11 @@ const upsertChatMessageSearchDocuments = async ({
   `);
 };
 
-/** One-time backfill: index every thread that has no search document
- *  yet. Idempotent and resumable. Keyset-paginates by thread id so a
- *  thread that cannot be indexed (e.g. deleted mid-run) advances the
- *  cursor instead of looping. */
+/** One-time backfill: index every thread missing either a thread-level
+ *  search document or per-message search documents. Idempotent and
+ *  resumable. Keyset-paginates by thread id so a thread that cannot
+ *  be indexed (e.g. deleted mid-run) advances the cursor instead of
+ *  looping. */
 export const backfillChatThreadSearchIndex = async (): Promise<number> => {
   let cursor = ZERO_UUID;
   let total = 0;
@@ -185,7 +202,17 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
       SELECT t.id
       FROM chat_threads t
       LEFT JOIN chat_thread_search_documents d ON d.thread_id = t.id
-      WHERE d.thread_id IS NULL
+      WHERE (
+          d.thread_id IS NULL
+          OR EXISTS (
+            SELECT 1
+            FROM chat_messages m
+            LEFT JOIN chat_message_search_documents md
+              ON md.message_id = m.id
+            WHERE m.thread_id = t.id
+              AND md.message_id IS NULL
+          )
+        )
         AND t.id > ${cursor}::uuid
       ORDER BY t.id
       LIMIT ${BACKFILL_BATCH_SIZE}

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -75,11 +75,13 @@ const CHAT_TOOL_TITLE_KEYS = {
   business_registry_lookup: "chat.tool.business_registry_lookup",
   "create-document": "chat.tool.create-document",
   "describe-stella-api": "chat.tool.describe-stella-api",
+  "expand-chat-history": "chat.tool.expand-chat-history",
   fetch_url: "chat.tool.fetch_url",
   infosoud_lookup_case: "chat.tool.infosoud_lookup_case",
   "run-stella-query": "chat.tool.run-stella-query",
   "load-skill": "chat.tool.load-skill",
   "read-skill-resource": "chat.tool.read-skill-resource",
+  "search-chat-history": "chat.tool.search-chat-history",
   "update-entity-fields": "chat.tool.update-entity-fields",
   web_search: "chat.tool.web_search",
 } as const satisfies Record<keyof ChatUITools, TranslationKey>;

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Nahradit „{find}“ za „{replace}“",
       "docxSignatureTableSummary": "Vložit podpisovou tabulku poblíž {blockId}",
       "execute-typescript": "Čtu data věci",
+      "expand-chat-history": "Čtení historie chatu",
       "fetch_url": "Čtení stránky",
       "infosoud_lookup_case": "Vyhledání spisu v InfoSoudu",
       "load-skill": "Čtu pokyny",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Čtu pokyny",
       "run-stella-query": "Čtu data spisu",
       "search-across-matters": "Vyhledávání napříč věcmi",
+      "search-chat-history": "Prohledávání historie chatu",
       "unknown": "Použití nástroje",
       "update-entity-fields": "Aktualizace metadat",
       "web_search": "Vyhledávání na webu"

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "„{find}“ durch „{replace}“ ersetzen",
       "docxSignatureTableSummary": "Signaturtabelle in der Nähe von {blockId} einfügen",
       "execute-typescript": "Mandatsdaten lesen",
+      "expand-chat-history": "Chatverlauf lesen",
       "fetch_url": "Seite lesen",
       "infosoud_lookup_case": "InfoSoud Aktensuche",
       "load-skill": "Hinweise lesen",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Hinweise lesen",
       "run-stella-query": "Mandatsdaten lesen",
       "search-across-matters": "In allen Mandaten suchen",
+      "search-chat-history": "Chatverlauf durchsuchen",
       "unknown": "Werkzeug verwenden",
       "update-entity-fields": "Metadaten aktualisieren",
       "web_search": "Web wird durchsucht"

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Replace “{find}” with “{replace}”",
       "docxSignatureTableSummary": "Insert signature table near {blockId}",
       "execute-typescript": "Reading workspace data",
+      "expand-chat-history": "Reading chat history",
       "fetch_url": "Reading page",
       "infosoud_lookup_case": "InfoSoud case lookup",
       "load-skill": "Reading guidance",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Reading guidance",
       "run-stella-query": "Reading workspace data",
       "search-across-matters": "Searching across matters",
+      "search-chat-history": "Searching chat history",
       "unknown": "Using tool",
       "update-entity-fields": "Updating metadata",
       "web_search": "Searching the web"

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Reemplazar «{find}» por «{replace}»",
       "docxSignatureTableSummary": "Insertar una tabla de firmas cerca de {blockId}",
       "execute-typescript": "Leyendo datos del asunto",
+      "expand-chat-history": "Leyendo el historial del chat",
       "fetch_url": "Leyendo página",
       "infosoud_lookup_case": "Búsqueda de expediente InfoSoud",
       "load-skill": "Leyendo instrucciones",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Leyendo instrucciones",
       "run-stella-query": "Leyendo datos del asunto",
       "search-across-matters": "Buscando entre asuntos",
+      "search-chat-history": "Buscando en el historial del chat",
       "unknown": "Usando herramienta",
       "update-entity-fields": "Actualizando metadatos",
       "web_search": "Buscando en la web"

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Asenda „{find}“ sõnaga „{replace}“",
       "docxSignatureTableSummary": "Lisa allkirjatabel ploki {blockId} lähedale",
       "execute-typescript": "Asja andmete lugemine",
+      "expand-chat-history": "Vestlusajaloo lugemine",
       "fetch_url": "Lehe lugemine",
       "infosoud_lookup_case": "InfoSoudi kohtuasja otsing",
       "load-skill": "Juhiste lugemine",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Juhiste lugemine",
       "run-stella-query": "Asja andmete lugemine",
       "search-across-matters": "Otsing kõigis asjades",
+      "search-chat-history": "Vestlusajaloo otsimine",
       "unknown": "Tööriista kasutamine",
       "update-entity-fields": "Metaandmete uuendamine",
       "web_search": "Veebist otsimine"

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Remplacer « {find} » par « {replace} »",
       "docxSignatureTableSummary": "Insérer un bloc de signature près de {blockId}",
       "execute-typescript": "Lecture des données du dossier",
+      "expand-chat-history": "Lecture de l’historique du chat",
       "fetch_url": "Lecture de la page",
       "infosoud_lookup_case": "Recherche d'affaire InfoSoud",
       "load-skill": "Lecture des consignes",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Lecture des consignes",
       "run-stella-query": "Lecture des données du dossier",
       "search-across-matters": "Recherche dans tous les dossiers",
+      "search-chat-history": "Recherche dans l’historique du chat",
       "unknown": "Utilisation d’un outil",
       "update-entity-fields": "Mise à jour des métadonnées",
       "web_search": "Recherche web"

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "A(z) „{find}” cseréje erre: „{replace}”",
       "docxSignatureTableSummary": "Aláírási táblázat beszúrása ide: {blockId}",
       "execute-typescript": "Ügyadatok olvasása",
+      "expand-chat-history": "Csevegési előzmények olvasása",
       "fetch_url": "Oldal olvasása",
       "infosoud_lookup_case": "InfoSoud ügykeresés",
       "load-skill": "Útmutató olvasása",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Útmutató olvasása",
       "run-stella-query": "Ügyadatok olvasása",
       "search-across-matters": "Keresés az ügyek között",
+      "search-chat-history": "Csevegési előzmények keresése",
       "unknown": "Eszköz használata",
       "update-entity-fields": "Metaadatok frissítése",
       "web_search": "Keresés az interneten"

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Pakeisti „{find}“ į „{replace}“",
       "docxSignatureTableSummary": "Įterpti parašų lentelę prie {blockId}",
       "execute-typescript": "Skaitomi bylos duomenys",
+      "expand-chat-history": "Skaitoma pokalbio istorija",
       "fetch_url": "Skaitomas puslapis",
       "infosoud_lookup_case": "InfoSoud bylos paieška",
       "load-skill": "Skaitomos gairės",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Skaitomos gairės",
       "run-stella-query": "Skaitomi bylos duomenys",
       "search-across-matters": "Ieškoma keliose bylose",
+      "search-chat-history": "Ieškoma pokalbio istorijoje",
       "unknown": "Naudojamas įrankis",
       "update-entity-fields": "Atnaujinami metaduomenys",
       "web_search": "Ieškoma internete"

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Aizstāt „{find}” ar „{replace}”",
       "docxSignatureTableSummary": "Ievietot parakstu tabulu pie {blockId}",
       "execute-typescript": "Lietas datu lasīšana",
+      "expand-chat-history": "Lasa tērzēšanas vēsturi",
       "fetch_url": "Lapas lasīšana",
       "infosoud_lookup_case": "InfoSoud lietas meklēšana",
       "load-skill": "Norādījumu lasīšana",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Norādījumu lasīšana",
       "run-stella-query": "Lietas datu lasīšana",
       "search-across-matters": "Meklēšana vairākās lietās",
+      "search-chat-history": "Meklē tērzēšanas vēsturē",
       "unknown": "Rīka izmantošana",
       "update-entity-fields": "Metadatu atjaunināšana",
       "web_search": "Meklēšana tīmeklī"

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -534,6 +534,7 @@ type Messages = {
       "docxReplaceSummary": "Replace “{find}” with “{replace}”";
       "docxSignatureTableSummary": "Insert signature table near {blockId}";
       "execute-typescript": "Reading workspace data";
+      "expand-chat-history": "Reading chat history";
       "fetch_url": "Reading page";
       "infosoud_lookup_case": "InfoSoud case lookup";
       "load-skill": "Reading guidance";
@@ -542,6 +543,7 @@ type Messages = {
       "read-skill-resource": "Reading guidance";
       "run-stella-query": "Reading workspace data";
       "search-across-matters": "Searching across matters";
+      "search-chat-history": "Searching chat history";
       "unknown": "Using tool";
       "update-entity-fields": "Updating metadata";
       "web_search": "Searching the web";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Zastąp „{find}” tekstem „{replace}”",
       "docxSignatureTableSummary": "Wstaw tabelę podpisów w pobliżu {blockId}",
       "execute-typescript": "Odczytywanie danych sprawy",
+      "expand-chat-history": "Odczytywanie historii czatu",
       "fetch_url": "Czytanie strony",
       "infosoud_lookup_case": "Wyszukiwanie sprawy w InfoSoud",
       "load-skill": "Odczytywanie wskazówek",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Odczytywanie wskazówek",
       "run-stella-query": "Odczytywanie danych sprawy",
       "search-across-matters": "Wyszukiwanie w różnych sprawach",
+      "search-chat-history": "Przeszukiwanie historii czatu",
       "unknown": "Używanie narzędzia",
       "update-entity-fields": "Aktualizacja metadanych",
       "web_search": "Wyszukiwanie w sieci"

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Substitua “{find}” por “{replace}”",
       "docxSignatureTableSummary": "Inserir tabela de assinaturas perto de {blockId}",
       "execute-typescript": "Lendo dados do caso",
+      "expand-chat-history": "Lendo o histórico do chat",
       "fetch_url": "Lendo página",
       "infosoud_lookup_case": "Busca de processo no InfoSoud",
       "load-skill": "Lendo orientações",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Lendo orientações",
       "run-stella-query": "Lendo dados do caso",
       "search-across-matters": "Pesquisando casos",
+      "search-chat-history": "Pesquisando no histórico do chat",
       "unknown": "Usando ferramenta",
       "update-entity-fields": "Atualizando metadados",
       "web_search": "Pesquisando na web"

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -531,6 +531,7 @@
       "docxReplaceSummary": "Nahradiť „{find}“ za „{replace}“",
       "docxSignatureTableSummary": "Vložiť podpisovú tabuľku k {blockId}",
       "execute-typescript": "Čítam dáta veci",
+      "expand-chat-history": "Čítanie histórie chatu",
       "fetch_url": "Čítanie stránky",
       "infosoud_lookup_case": "Vyhľadanie spisu v InfoSoude",
       "load-skill": "Čítam pokyny",
@@ -539,6 +540,7 @@
       "read-skill-resource": "Čítam pokyny",
       "run-stella-query": "Čítam dáta veci",
       "search-across-matters": "Vyhľadávanie naprieč vecami",
+      "search-chat-history": "Prehľadávanie histórie chatu",
       "unknown": "Používanie nástroja",
       "update-entity-fields": "Aktualizácia metadát",
       "web_search": "Vyhľadávanie na webe"


### PR DESCRIPTION
## Summary
- persist structured chat compaction checkpoints as thread-derived records
- add bounded same-thread history search/expand tools over per-message chat search documents
- keep replay/delete flows from reusing stale compaction checkpoints
- add schema, migration, RLS policies, tests, and chat tool labels