### PR TITLE
feat(files): image thumbnails + blur placeholders via Bun.Image

### DIFF
--- a/.agents/plans/043-image-thumbnails-thumbhash.md
+++ b/.agents/plans/043-image-thumbnails-thumbhash.md
@@ -1,0 +1,201 @@
+# Plan: Image Thumbnails + Thumbhash Derivatives
+
+Date: 2026-06-06
+
+## Goal
+
+Generate a small WebP thumbnail and a thumbhash placeholder string for
+uploaded image files using the built-in `Bun.Image` API (Bun 1.3.14), so the
+UI can render real, legible image previews with instant blur-up placeholders
+instead of a generic file-type icon. Originals are never altered.
+
+## Design Decisions
+
+- **Async derivative job, not inline at finalize.** Mirror the existing PDF
+  derivative pattern (`apps/api/src/lib/file-derivative-queue.ts`): finalize
+  stays fast, generation runs on the BullMQ worker, the UI invalidates via SSE
+  when the derivative is ready. We do *not* block `finalize.ts` on image
+  encoding. Rationale: same failure isolation, retry, and backpressure the PDF
+  path already proved; avoids regressing upload latency.
+- **Reuse the `file-derivatives` queue, add a second job type.** The queue and
+  worker infra already exist; add a `generate-thumbnail` job alongside
+  `generate-pdf` rather than standing up a parallel queue. One worker, two job
+  names, shared connection/concurrency config.
+- **Thumbhash stored inline in JSONB; thumbnail stored as a separate S3
+  object.** Thumbhash is a tiny (~25–30 byte) base64 string — it lives directly
+  in the `file` variant of `FieldContent` so it ships with the entity payload
+  and needs zero extra fetch to render the blur. The thumbnail WebP is a real
+  image binary, so it gets its own `fileId` + S3 key, referenced the same way
+  `pdfFileId` references the PDF derivative.
+- **`Bun.Image` over any native dep.** Zero install, already on Bun 1.3.14
+  (`oven/bun:1.3.14-slim`). Statically-linked codecs cover exactly our accepted
+  formats. No Sharp/Jimp to add or maintain.
+- **Linux-safe format gating.** Only `image/png`, `image/jpeg`, `image/webp`,
+  `image/gif` are eligible — these use Bun's statically-linked codecs that
+  decode identically on Linux prod. HEIC/AVIF/TIFF only decode on macOS/Windows
+  and would silently fail in prod, so they are explicitly excluded from the
+  eligibility check (and we don't accept them on upload today anyway).
+- **`placeholder()` gives a rendered PNG data URL, not a raw hash.**
+  `Bun.Image.placeholder()` returns a ThumbHash-rendered
+  `data:image/png;base64,…` (~400–700 bytes, ≤32px blur). We store that string
+  directly — the frontend drops it into `<img src>` / a CSS background with
+  **zero client-side decoder dependency**. No `thumbhash`/`blurhash` npm package.
+- **Force `Bun.Image.backend = "bun"` in the worker.** Static-codec mode is
+  byte-identical to the Linux build and makes HEIC/AVIF reject consistently, so
+  dev (macOS) output matches prod (Linux) and unsupported formats fail the same
+  way everywhere instead of silently succeeding on a Mac.
+- **Icon stays at tiny sizes; thumbnail only where legible.** The
+  icon-vs-thumbnail decision is gated by render size, not blanket-applied.
+  Surfaces at `size-3`/`size-4` (12–16px) keep the generic `FileImage` icon (a
+  blur/thumbnail is illegible there). Surfaces ≥ ~24px opt into the real
+  thumbnail + thumbhash placeholder.
+
+## Scope
+
+**In scope:**
+
+- New eligibility helper `shouldGenerateImageThumbnail({ encrypted, mimeType })`
+  parallel to `shouldGeneratePdfDerivative` (excludes encrypted + non-Linux-safe
+  formats).
+- `Bun.Image` thumbnail generation (resize to fit a bounded box, e.g. longest
+  edge ~512px, `withoutEnlargement`, WebP output) + `.placeholder()` thumbhash,
+  in a new `generate-thumbnail` worker job.
+- **Entity-file path (JSONB).** Add `thumbnailFileId`, `placeholder` (the
+  data-URL string from `.placeholder()`), and a `thumbnailDerivative` status
+  union (`not-required`/`pending`/`ready`/`failed`) to the `file` content
+  variant, mirroring `pdfDerivative`. Enqueue at finalize; backfill existing
+  rows.
+- **Chat-file path (`userFiles` table).** Add `thumbnail_file_id` +
+  `placeholder` columns to the `user_files` table (real Drizzle migration), a
+  thumbnail content endpoint, generation on chat upload, and read-path
+  enrichment so the message attachment carries the placeholder + thumbnail URL.
+  Backfill existing `user_files` image rows.
+- Single 512px-longest-edge WebP thumbnail per image (no multi-size set).
+- Batched backfill enqueue for both paths (worker concurrency + retry absorbs
+  it); log/monitor queue depth.
+- Frontend: a `<FilePreview>` that renders the thumbnail with the `placeholder`
+  data URL as the blur-up, wired into the size-appropriate surfaces (search
+  results, file tree, inspector tabs; chat 128px attachments). Tiny chip/cell
+  surfaces (12–16px) keep `DocumentIcon`.
+- Cleanup: deleting a file field / user file also deletes its thumbnail S3
+  object (extend the existing sweep that handles `pdfFileId`).
+
+**Out of scope:**
+
+- Re-encoding or replacing originals (originals stay byte-identical).
+- HEIC/AVIF/TIFF support (Linux can't decode; not accepted on upload).
+- A new gallery/grid view (the highest-value consumer, but its own feature).
+- Animated-GIF motion thumbnails (we take the first frame only).
+- Multi-resolution thumbnails (single 512px for now; revisit if a gallery lands).
+
+## Implementation
+
+- `apps/api/src/handlers/files/gotenberg.ts` (or a new
+  `apps/api/src/handlers/files/image-derivative.ts`) — add
+  `IMAGE_THUMBNAIL_MIME_TYPES` (the 4 Linux-safe formats) and
+  `shouldGenerateImageThumbnail`. Keep image-thumbnail logic separate from the
+  PDF/gotenberg concern if it grows.
+- `apps/api/src/handlers/files/image-derivative.ts` (new) — the shared
+  `Bun.Image` helper: `IMAGE_THUMBNAIL_MIME_TYPES`, `shouldGenerateImageThumbnail`,
+  and `generateImageThumbnail(buffer)` returning `{ webp, placeholder }`. Sets
+  `Bun.Image.backend = "bun"` for Linux-parity; wraps the pipeline in `Result`.
+  Single 512px longest-edge, `withoutEnlargement`, `webp({ quality })`.
+
+**Entity-file path:**
+
+- `apps/api/src/lib/file-derivative-queue.ts` — add `ImageThumbnailJobData`, a
+  `generate-thumbnail` job name, `enqueueImageThumbnail`, and
+  `processImageThumbnailJob` that loads the field, reads the source from S3,
+  runs `generateImageThumbnail`, writes the WebP to a new file key, and
+  atomically patches the JSONB content (`thumbnailFileId`, `placeholder`,
+  `thumbnailDerivative.status='ready'`) with the same optimistic `WHERE` guards
+  the PDF path uses. Broadcast the same `invalidate-query` SSE events.
+- `apps/api/src/handlers/uploads/finalize.ts` / per-purpose entity finalizers —
+  enqueue `generate-thumbnail` for eligible image fields next to the PDF enqueue.
+- `apps/api/src/db/schema-validators.ts` (lines ~131–158, `file` variant) — add
+  `thumbnailFileId: t.Nullable(...)`, `placeholder: t.Optional(t.String({ maxLength: 2048 }))`,
+  `thumbnailDerivative: t.Optional(t.Union([...]))`. Additive + optional → no
+  data migration; existing rows read fine.
+- `apps/api/src/handlers/files/utils.ts` — thumbnail key reuses `createFileKey`
+  with the thumbnail's own `fileId` + `image/webp`; extend the S3 delete sweep
+  to include `thumbnailFileId`.
+
+**Chat-file path:**
+
+- `apps/api/src/db/schema.ts` (`userFiles`, lines ~3223–3258) — add
+  `thumbnailFileId text` + `placeholder text` columns. **Hand-authored
+  timestamped Drizzle migration** per project convention (never `drizzle-kit
+  generate`).
+- `apps/api/src/handlers/chat/upload-files.ts` (`uploadUserFile`) — after the
+  `userFiles` insert, enqueue a `generate-thumbnail` job variant keyed by
+  `userFileId` (or generate inline if simpler) that writes
+  `${userId}/${thumbnailFileId}.webp` and patches the row.
+- `apps/api/src/handlers/user-files/read-content.ts` (+ routes) — add a
+  `GET /user-files/:fileId/thumbnail` redirect parallel to `/content`, resolving
+  `thumbnailFileId` → presigned URL with the same ownership scoping.
+- Chat thread read path — enrich the persisted `FileUIPart` on the way out with
+  the attachment's `placeholder` + thumbnail URL (join `userFiles`) so the
+  frontend can render the blur + thumbnail without a separate metadata call.
+
+**Backfill:**
+
+- One-off batched scripts (under `apps/api/scripts/`): scan `fields`
+  (`type='file'` images lacking `thumbnailDerivative`) and `user_files` (image
+  rows with null `thumbnailFileId`) and enqueue jobs in batches; log queue depth.
+
+**Frontend:**
+
+- `apps/web/.../-components/document-icon.tsx` (line 140 chokepoint) — keep
+  `FileImage` for tiny sizes; introduce a sibling `FilePreview` that takes
+  `{ mimeType, thumbnailUrl, placeholder }` + a size hint and renders the
+  thumbnail with the `placeholder` data URL as the blur-up (plain `<img src>` /
+  CSS background, **no decoder dependency**). Callers at 12–16px stay on
+  `DocumentIcon`; larger surfaces opt in.
+- `apps/web/src/components/chat/chat-thread-messages.tsx` (lines 175–221) — use
+  the enriched `placeholder` as the 128px image's blur-up, and point `src` at
+  the thumbnail URL (fall back to full `/content` on error).
+
+## Test Cases
+
+- `shouldGenerateImageThumbnail`: true for the 4 Linux-safe formats unencrypted;
+  false for encrypted, for HEIC/AVIF/TIFF, and for non-image mimes.
+- Thumbnail job: produces a WebP within the bounded box, does not enlarge a
+  small source, sets `thumbnailDerivative='ready'`, populates `thumbhash`, and
+  the optimistic `WHERE` no-ops on a concurrent/duplicate run (mirror the PDF
+  job's idempotency test).
+- `placeholder` data-URL round-trips through the schema validator / DB column
+  and renders directly in an `<img src>` with no client decoder.
+- Deleting a file field / user file also deletes the thumbnail object (no
+  orphaned S3 keys).
+- Frontend: thumbnail renders at large surfaces; `DocumentIcon` (generic icon)
+  still renders at 12–16px surfaces; missing/failed derivative falls back to the
+  generic icon without layout shift.
+- Corrupt/truncated image bytes: job fails cleanly, marks
+  `thumbnailDerivative='failed'` (entity) / leaves null (chat), original remains
+  downloadable.
+- Chat: `user_files` migration applies cleanly; thumbnail endpoint enforces the
+  same `userId` ownership scoping as `/content`.
+
+## Resolved Decisions
+
+- **Single 512px WebP** (no multi-size set).
+- **Chat folded in now** (`user_files` columns + thumbnail endpoint + read-path
+  enrichment), not deferred. Chat is the one ≥24px surface today (128px
+  attachment), so it is the only wired consumer.
+- **Batched backfill enqueue** for both paths; monitor queue depth.
+- **Entity-file frontend deferred.** Every current entity surface that renders a
+  file icon is 12–16px, where the agreed guidance keeps the generic icon. No
+  ≥24px entity surface exists yet (no gallery / large file cards), so there is
+  nowhere legible to show an entity thumbnail. A generic photo gallery is niche
+  for legal work; the real future consumer is a file-list grid/card density for
+  document/scan recognition and image-heavy matters (PI, property, IP).
+- **Entity-file generation kept dormant.** The async job stays wired at all
+  upload sites so images get thumbnails now; a future grid/card surface lands
+  with thumbnails already populated. The `FilePreview` component + entity
+  thumbnail-serving endpoint are intentionally NOT built yet — add them when the
+  surface is greenlit.
+
+## Open Questions
+
+- Animated GIF: confirm `Bun.Image` takes frame 0 deterministically for our
+  inputs; if not, gate GIF behind a flag.

--- a/apps/api/drizzle/20260606130000_user_files_image_thumbnail/migration.sql
+++ b/apps/api/drizzle/20260606130000_user_files_image_thumbnail/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user_files" ADD COLUMN "thumbnail_file_id" text;
+--> statement-breakpoint
+ALTER TABLE "user_files" ADD COLUMN "placeholder" text;

--- a/apps/api/scripts/backfill-image-thumbnails.ts
+++ b/apps/api/scripts/backfill-image-thumbnails.ts
@@ -56,8 +56,18 @@ type EntityFieldRow = {
   organization_id: string;
 };
 
+const deleteThumbnailBestEffort = async (thumbnailKey: string) => {
+  const cleanup = await Result.tryPromise({
+    try: async () => await getS3().delete(thumbnailKey),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(cleanup)) {
+    console.warn(`  chat: thumbnail cleanup failed for ${thumbnailKey}`);
+  }
+};
+
 const backfillEntityFields = async (): Promise<number> => {
-  let cursor = "";
+  let cursor: string | null = null;
   let enqueued = 0;
 
   for (;;) {
@@ -79,7 +89,7 @@ const backfillEntityFields = async (): Promise<number> => {
         AND coalesce(f.content->'thumbnailDerivative'->>'status', 'pending') = 'pending'
         AND f.content->>'mimeType' IN ('image/jpeg', 'image/png', 'image/gif', 'image/webp')
         AND coalesce((f.content->>'encrypted')::boolean, false) = false
-        AND f.id > ${cursor}
+        ${cursor ? sql`AND f.id > ${cursor}` : sql``}
       ORDER BY f.id ASC
       LIMIT ${BATCH_SIZE}
     `);
@@ -106,7 +116,11 @@ const backfillEntityFields = async (): Promise<number> => {
       enqueued += 1;
     }
 
-    cursor = rows[rows.length - 1].field_id;
+    const lastRow = rows.at(-1);
+    if (!lastRow) {
+      break;
+    }
+    cursor = lastRow.field_id;
     console.log(`  entities: ${enqueued} job(s) enqueued so far...`);
   }
 
@@ -114,7 +128,7 @@ const backfillEntityFields = async (): Promise<number> => {
 };
 
 const backfillChatFiles = async (): Promise<number> => {
-  let cursor = "";
+  let cursor: string | null = null;
   let generated = 0;
 
   for (;;) {
@@ -130,7 +144,7 @@ const backfillChatFiles = async (): Promise<number> => {
         and(
           isNull(userFiles.thumbnailFileId),
           inArray(userFiles.mimeType, THUMBNAILABLE_MIME_TYPES),
-          gt(userFiles.id, cursor),
+          cursor ? gt(userFiles.id, cursor) : undefined,
         ),
       )
       .orderBy(asc(userFiles.id))
@@ -163,14 +177,33 @@ const backfillChatFiles = async (): Promise<number> => {
         userId: row.userId,
       });
       await getS3().write(thumbnailKey, thumbnail.value.webp);
-      await rootDb
-        .update(userFiles)
-        .set({ thumbnailFileId, placeholder: thumbnail.value.placeholder })
-        .where(eq(userFiles.id, row.id));
+      const updatedRows = await Result.tryPromise({
+        try: async () =>
+          await rootDb
+            .update(userFiles)
+            .set({ thumbnailFileId, placeholder: thumbnail.value.placeholder })
+            .where(
+              and(eq(userFiles.id, row.id), isNull(userFiles.thumbnailFileId)),
+            )
+            .returning({ id: userFiles.id }),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(updatedRows)) {
+        await deleteThumbnailBestEffort(thumbnailKey);
+        throw updatedRows.error;
+      }
+      if (updatedRows.value.length === 0) {
+        await deleteThumbnailBestEffort(thumbnailKey);
+        continue;
+      }
       generated += 1;
     }
 
-    cursor = rows[rows.length - 1].id;
+    const lastRow = rows.at(-1);
+    if (!lastRow) {
+      break;
+    }
+    cursor = lastRow.id;
     console.log(`  chat: ${generated} thumbnail(s) generated so far...`);
   }
 

--- a/apps/api/scripts/backfill-image-thumbnails.ts
+++ b/apps/api/scripts/backfill-image-thumbnails.ts
@@ -1,0 +1,201 @@
+/**
+ * Backfill image thumbnails + blur placeholders for uploads that predate the
+ * thumbnail feature. Two independent passes:
+ *
+ *  - Entity file fields: enqueue async `generate-thumbnail` jobs; the
+ *    file-derivative worker produces the WebP + placeholder. The BullMQ
+ *    jobId dedupes, so a re-run never double-processes.
+ *  - Chat user files: generate inline (read source from S3, resize, write the
+ *    WebP, patch the row) since chat thumbnails are not queue-driven.
+ *
+ * Both passes are idempotent and resumable: only rows still missing a
+ * thumbnail are touched, and each pass walks the primary key with keyset
+ * pagination so concurrent completion never causes a skip.
+ *
+ * Usage:
+ *   bun apps/api/scripts/backfill-image-thumbnails.ts          # both passes
+ *   bun apps/api/scripts/backfill-image-thumbnails.ts entities # entity fields only
+ *   bun apps/api/scripts/backfill-image-thumbnails.ts chat     # chat files only
+ */
+
+import { Result } from "better-result";
+import { and, asc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { userFiles } from "@/api/db/schema";
+import {
+  generateImageThumbnail,
+  THUMBNAIL_MIME_TYPE,
+} from "@/api/handlers/files/image-derivative";
+import { createUserFileKey } from "@/api/handlers/files/utils";
+import { enqueueImageThumbnailOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import { getS3 } from "@/api/lib/s3";
+import {
+  brandPersistedEntityId,
+  brandPersistedFieldId,
+  brandPersistedUserId,
+  brandValidatedWorkflowActorKey,
+} from "@/api/lib/safe-id-boundaries";
+
+const BATCH_SIZE = 200;
+
+const THUMBNAILABLE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+
+type EntityFieldRow = {
+  field_id: string;
+  mime_type: string;
+  encrypted: boolean;
+  entity_id: string;
+  user_id: string;
+  workspace_id: string;
+  organization_id: string;
+};
+
+const backfillEntityFields = async (): Promise<number> => {
+  let cursor = "";
+  let enqueued = 0;
+
+  for (;;) {
+    const batch = await rootDb.execute<EntityFieldRow>(sql`
+      SELECT
+        f.id AS field_id,
+        f.content->>'mimeType' AS mime_type,
+        coalesce((f.content->>'encrypted')::boolean, false) AS encrypted,
+        e.id AS entity_id,
+        e.created_by AS user_id,
+        e.workspace_id AS workspace_id,
+        w.organization_id AS organization_id
+      FROM fields f
+      JOIN entity_versions ev ON ev.id = f.entity_version_id
+      JOIN entities e ON e.id = ev.entity_id AND e.current_version_id = f.entity_version_id
+      JOIN workspaces w ON w.id = e.workspace_id
+      WHERE f.content->>'type' = 'file'
+        AND f.content->>'thumbnailFileId' IS NULL
+        AND coalesce(f.content->'thumbnailDerivative'->>'status', 'pending') = 'pending'
+        AND f.content->>'mimeType' IN ('image/jpeg', 'image/png', 'image/gif', 'image/webp')
+        AND coalesce((f.content->>'encrypted')::boolean, false) = false
+        AND f.id > ${cursor}
+      ORDER BY f.id ASC
+      LIMIT ${BATCH_SIZE}
+    `);
+
+    const rows = [...batch];
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      const actor = brandValidatedWorkflowActorKey({
+        organizationId: row.organization_id,
+        workspaceId: row.workspace_id,
+      });
+      await enqueueImageThumbnailOrMarkFailed({
+        encrypted: row.encrypted,
+        entityId: brandPersistedEntityId(row.entity_id),
+        fieldId: brandPersistedFieldId(row.field_id),
+        mimeType: row.mime_type,
+        organizationId: actor.organizationId,
+        userId: brandPersistedUserId(row.user_id),
+        workspaceId: actor.workspaceId,
+      });
+      enqueued += 1;
+    }
+
+    cursor = rows[rows.length - 1].field_id;
+    console.log(`  entities: ${enqueued} job(s) enqueued so far...`);
+  }
+
+  return enqueued;
+};
+
+const backfillChatFiles = async (): Promise<number> => {
+  let cursor = "";
+  let generated = 0;
+
+  for (;;) {
+    const rows = await rootDb
+      .select({
+        id: userFiles.id,
+        userId: userFiles.userId,
+        mimeType: userFiles.mimeType,
+        s3Key: userFiles.s3Key,
+      })
+      .from(userFiles)
+      .where(
+        and(
+          isNull(userFiles.thumbnailFileId),
+          inArray(userFiles.mimeType, THUMBNAILABLE_MIME_TYPES),
+          gt(userFiles.id, cursor),
+        ),
+      )
+      .orderBy(asc(userFiles.id))
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      const source = await Result.tryPromise({
+        try: async () => await getS3().file(row.s3Key).bytes(),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(source)) {
+        console.warn(`  chat: skip ${row.id} (source read failed)`);
+        continue;
+      }
+
+      const thumbnail = await generateImageThumbnail(source.value);
+      if (Result.isError(thumbnail)) {
+        console.warn(`  chat: skip ${row.id} (generate failed)`);
+        continue;
+      }
+
+      const thumbnailFileId = Bun.randomUUIDv7();
+      const thumbnailKey = createUserFileKey({
+        fileId: thumbnailFileId,
+        mimeType: THUMBNAIL_MIME_TYPE,
+        userId: row.userId,
+      });
+      await getS3().write(thumbnailKey, thumbnail.value.webp);
+      await rootDb
+        .update(userFiles)
+        .set({ thumbnailFileId, placeholder: thumbnail.value.placeholder })
+        .where(eq(userFiles.id, row.id));
+      generated += 1;
+    }
+
+    cursor = rows[rows.length - 1].id;
+    console.log(`  chat: ${generated} thumbnail(s) generated so far...`);
+  }
+
+  return generated;
+};
+
+const main = async () => {
+  const mode = process.argv[2] ?? "both";
+
+  if (mode === "entities" || mode === "both") {
+    console.log("Enqueuing entity-field thumbnail jobs...");
+    const enqueued = await backfillEntityFields();
+    console.log(`Entity backfill complete: ${enqueued} job(s) enqueued.`);
+  }
+
+  if (mode === "chat" || mode === "both") {
+    console.log("Generating chat user-file thumbnails...");
+    const generated = await backfillChatFiles();
+    console.log(`Chat backfill complete: ${generated} thumbnail(s) generated.`);
+  }
+
+  process.exit(0);
+};
+
+main().catch((error: unknown) => {
+  console.error("Image thumbnail backfill failed:", error);
+  process.exit(1);
+});

--- a/apps/api/src/db/schema-validators.ts
+++ b/apps/api/src/db/schema-validators.ts
@@ -154,6 +154,26 @@ export const fieldContentSchema = t.Union([
         }),
       ]),
     ),
+    thumbnailFileId: t.Optional(t.Nullable(t.String({ format: "uuid" }))),
+    // ThumbHash-rendered `data:image/png;base64,...` blur of the source
+    // image (~400-700 bytes); rendered directly in an <img src>.
+    placeholder: t.Optional(t.String({ maxLength: 2048 })),
+    thumbnailDerivative: t.Optional(
+      t.Union([
+        t.Object({
+          status: t.Literal("not-required"),
+        }),
+        t.Object({
+          status: t.Literal("pending"),
+        }),
+        t.Object({
+          status: t.Literal("ready"),
+        }),
+        t.Object({
+          status: t.Literal("failed"),
+        }),
+      ]),
+    ),
     scanWarnings: t.Optional(t.Array(t.String({ maxLength: 256 }))),
   }),
   t.Object({

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -3238,6 +3238,10 @@ export const userFiles = p.pgTable(
       .references(() => chatThreads.id, {
         onDelete: "restrict",
       }),
+    thumbnailFileId: p.text("thumbnail_file_id"),
+    // ThumbHash-rendered `data:image/png;base64,...` blur of the source
+    // image; rendered directly in an <img src> with no client decoder.
+    placeholder: p.text("placeholder"),
     scanWarnings: p.text("scan_warnings").array(),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p

--- a/apps/api/src/handlers/chat/delete-thread.ts
+++ b/apps/api/src/handlers/chat/delete-thread.ts
@@ -12,6 +12,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 
 const config = {
   permissions: { chat: ["delete"] },
@@ -36,6 +37,30 @@ const deleteThread = createSafeRootHandler(
       workspaceId,
     });
 
+    const thread = yield* Result.await(
+      safeDb(async (tx) => {
+        const rows = await tx
+          .select({ id: chatThreads.id })
+          .from(chatThreads)
+          .where(
+            and(
+              eq(chatThreads.id, params.threadId),
+              eq(chatThreads.userId, user.id),
+              scope.scope === "workspace"
+                ? eq(chatThreads.workspaceId, scope.workspaceId)
+                : isNull(chatThreads.workspaceId),
+            ),
+          )
+          .limit(1);
+
+        return rows.at(0);
+      }),
+    );
+
+    if (!thread) {
+      return Result.ok();
+    }
+
     const files = yield* Result.await(
       safeDb((tx) =>
         tx.query.userFiles.findMany({
@@ -47,6 +72,7 @@ const deleteThread = createSafeRootHandler(
             id: true,
             s3Key: true,
             thumbnailFileId: true,
+            userId: true,
           },
         }),
       ),
@@ -60,7 +86,7 @@ const deleteThread = createSafeRootHandler(
               createUserFileKey({
                 fileId: file.thumbnailFileId,
                 mimeType: THUMBNAIL_MIME_TYPE,
-                userId: user.id,
+                userId: brandPersistedUserId(file.userId),
               }),
             ]
           : [file.s3Key],

--- a/apps/api/src/handlers/chat/delete-thread.ts
+++ b/apps/api/src/handlers/chat/delete-thread.ts
@@ -5,7 +5,8 @@ import { t } from "elysia";
 import { defaultDatabaseRetry } from "@/api/db";
 import { chatThreads, userFiles } from "@/api/db/schema";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
-import { deleteS3Keys } from "@/api/handlers/files/utils";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
+import { createUserFileKey, deleteS3Keys } from "@/api/handlers/files/utils";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -45,13 +46,26 @@ const deleteThread = createSafeRootHandler(
           columns: {
             id: true,
             s3Key: true,
+            thumbnailFileId: true,
           },
         }),
       ),
     );
 
     if (files.length > 0) {
-      const deleteResult = await deleteS3Keys(files.map((file) => file.s3Key));
+      const s3Keys = files.flatMap((file) =>
+        file.thumbnailFileId
+          ? [
+              file.s3Key,
+              createUserFileKey({
+                fileId: file.thumbnailFileId,
+                mimeType: THUMBNAIL_MIME_TYPE,
+                userId: user.id,
+              }),
+            ]
+          : [file.s3Key],
+      );
+      const deleteResult = await deleteS3Keys(s3Keys);
       if (Result.isError(deleteResult)) {
         yield* Result.err(
           new HandlerError({

--- a/apps/api/src/handlers/chat/get-messages.ts
+++ b/apps/api/src/handlers/chat/get-messages.ts
@@ -5,10 +5,33 @@ import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
 import { normalizeLegacyToolInputs } from "@/api/handlers/chat/legacy-tool-compat";
 import { isWebSearchAvailable } from "@/api/handlers/chat/tools/chat-tools";
 import { getDisabledNativeToolSlugs } from "@/api/handlers/mcp-connectors/catalog-metadata";
+import { parseUserFileId } from "@/api/handlers/user-files/types";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+type ChatPart = ReturnType<typeof normalizeLegacyToolInputs>[number];
+
+/**
+ * Attach the stored blur placeholder to image file parts so the client can
+ * render a blur-up while the thumbnail loads. The thumbnail URL itself is
+ * derived client-side from the user-file id, so only the DB-sourced
+ * placeholder needs to travel with the message.
+ */
+const attachPlaceholders = (
+  parts: ChatPart[],
+  placeholderById: Map<string, string>,
+): ChatPart[] =>
+  parts.map((part) => {
+    if (part.type !== "file") {
+      return part;
+    }
+    const fileId = parseUserFileId(part.url);
+    const placeholder = fileId ? placeholderById.get(fileId) : undefined;
+    return placeholder ? { ...part, placeholder } : part;
+  });
 
 const config = {
   permissions: { chat: ["create"] },
@@ -120,11 +143,47 @@ const getMessages = createSafeRootHandler(
     const lastActivityAt =
       thread.messages.at(-1)?.createdAt.toISOString() ?? null;
 
+    const referencedFileIds = new Set<SafeId<"userFile">>();
+    for (const row of thread.messages) {
+      for (const part of row.content.data) {
+        if (part.type !== "file") {
+          continue;
+        }
+        const fileId = parseUserFileId(part.url);
+        if (fileId) {
+          referencedFileIds.add(fileId);
+        }
+      }
+    }
+
+    const placeholderById = new Map<string, string>();
+    if (referencedFileIds.size > 0) {
+      const fileRows = yield* Result.await(
+        safeDb((tx) =>
+          tx.query.userFiles.findMany({
+            where: {
+              id: { in: [...referencedFileIds] },
+              userId: { eq: user.id },
+            },
+            columns: { id: true, placeholder: true },
+          }),
+        ),
+      );
+      for (const fileRow of fileRows) {
+        if (fileRow.placeholder !== null) {
+          placeholderById.set(fileRow.id, fileRow.placeholder);
+        }
+      }
+    }
+
     return Result.ok({
       messages: thread.messages.map((row) => ({
         id: row.id,
         role: row.role,
-        parts: normalizeLegacyToolInputs(row.content.data),
+        parts: attachPlaceholders(
+          normalizeLegacyToolInputs(row.content.data),
+          placeholderById,
+        ),
       })),
       contextMatterIds: thread.contextMatterIds,
       lastActivityAt,

--- a/apps/api/src/handlers/chat/tools/execute/workspace-manifest.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-manifest.test.ts
@@ -118,9 +118,12 @@ describe("workspace manifest helpers", () => {
                   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 pdfDerivative: { status: "not-required" },
                 pdfFileId: null,
+                placeholder: "data:image/png;base64,AAAA",
                 sha256Hex:
                   "7079424dfa5247d9f4745e86a487dc9602f78b5944d640e589927fea6b4b4eda",
                 sizeBytes: 3978,
+                thumbnailDerivative: { status: "ready" },
+                thumbnailFileId: "241d8c88-2fa5-5127-8e37-3ea75f52f890",
                 type: "file",
                 version: 1,
               },

--- a/apps/api/src/handlers/chat/tools/execute/workspace-manifest.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-manifest.ts
@@ -147,7 +147,7 @@ const sourceDocumentSchema = v.strictObject({
 /** Mirrors `fieldContentSchema` in `@/api/db/schema-validators` for tool output. */
 const fieldVersionSchema = v.literal(1);
 
-const pdfDerivativeSchema = v.optional(
+const fileDerivativeStateSchema = v.optional(
   v.variant("status", [
     v.strictObject({
       status: v.literal("failed"),
@@ -182,11 +182,14 @@ const fieldContentSchema = v.variant("type", [
     fileName: v.pipe(v.string(), v.minLength(1), v.maxLength(256)),
     id: storedFileIdSchema,
     mimeType: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
-    pdfDerivative: pdfDerivativeSchema,
+    pdfDerivative: fileDerivativeStateSchema,
     pdfFileId: v.nullable(storedFileIdSchema),
+    placeholder: v.optional(v.pipe(v.string(), v.maxLength(2048))),
     scanWarnings: v.optional(v.array(v.pipe(v.string(), v.maxLength(256)))),
     sha256Hex: v.pipe(v.string(), v.minLength(64), v.maxLength(64)),
     sizeBytes: v.pipe(v.number(), v.integer(), v.minValue(0)),
+    thumbnailDerivative: fileDerivativeStateSchema,
+    thumbnailFileId: v.optional(v.nullable(storedFileIdSchema)),
     type: v.literal("file"),
     version: fieldVersionSchema,
   }),

--- a/apps/api/src/handlers/chat/upload-files.ts
+++ b/apps/api/src/handlers/chat/upload-files.ts
@@ -18,6 +18,11 @@ import {
   TEXT_PLAIN_MIME_TYPE,
 } from "@/api/handlers/chat/attachment-validation";
 import { ChatError } from "@/api/handlers/chat/errors";
+import {
+  generateImageThumbnail,
+  shouldGenerateImageThumbnail,
+  THUMBNAIL_MIME_TYPE,
+} from "@/api/handlers/files/image-derivative";
 import { createUserFileKey, deleteS3Keys } from "@/api/handlers/files/utils";
 import { isUserFileUrl, toUserFileUrl } from "@/api/handlers/user-files/types";
 import { captureError } from "@/api/lib/analytics";
@@ -62,6 +67,7 @@ type UploadMessageFilesReturn = Result<
 export type UploadedChatFile = {
   id: SafeId<"userFile">;
   s3Key: string;
+  thumbnailS3Key: string | null;
 };
 
 type UploadedChatMessage = {
@@ -133,6 +139,7 @@ export const uploadMessageFiles = async ({
     uploadedFiles.push({
       id: uploadedFile.value.id,
       s3Key: uploadedFile.value.s3Key,
+      thumbnailS3Key: uploadedFile.value.thumbnailS3Key,
     });
     parts.push({
       ...part,
@@ -170,7 +177,11 @@ export const deleteUploadedChatFiles = async ({
     return Result.ok();
   }
 
-  const deleteS3Result = await deleteS3Keys(files.map((file) => file.s3Key));
+  const deleteS3Result = await deleteS3Keys(
+    files.flatMap((file) =>
+      file.thumbnailS3Key ? [file.s3Key, file.thumbnailS3Key] : [file.s3Key],
+    ),
+  );
   if (Result.isError(deleteS3Result)) {
     return Result.err(
       new HandlerError({
@@ -428,6 +439,43 @@ export const uploadUserFile = async ({
       }),
     );
 
+    // Best-effort image thumbnail + blur placeholder. A failure here never
+    // blocks the upload: the original still serves; the row just carries no
+    // derivative.
+    let thumbnailFileId: string | null = null;
+    let placeholder: string | null = null;
+    let thumbnailKey: string | null = null;
+    if (shouldGenerateImageThumbnail({ mimeType: file.mimeType })) {
+      const thumbnailResult = await generateImageThumbnail(file.bytes);
+      if (Result.isError(thumbnailResult)) {
+        captureError(thumbnailResult.error, {
+          stage: "chat-thumbnail-generate",
+          userFileId: id,
+        });
+      } else {
+        const generatedThumbnailId = Bun.randomUUIDv7();
+        const key = createUserFileKey({
+          fileId: generatedThumbnailId,
+          mimeType: THUMBNAIL_MIME_TYPE,
+          userId,
+        });
+        const writeThumbnailResult = await Result.tryPromise({
+          try: async () => await getS3().write(key, thumbnailResult.value.webp),
+          catch: (cause) => cause,
+        });
+        if (Result.isError(writeThumbnailResult)) {
+          captureError(writeThumbnailResult.error, {
+            stage: "chat-thumbnail-write",
+            userFileId: id,
+          });
+        } else {
+          thumbnailFileId = generatedThumbnailId;
+          placeholder = thumbnailResult.value.placeholder;
+          thumbnailKey = key;
+        }
+      }
+    }
+
     const saveResult = await safeDb(async (tx) => {
       await tx.insert(userFiles).values({
         id,
@@ -439,6 +487,8 @@ export const uploadUserFile = async ({
         sha256Hex,
         sizeBytes: file.bytes.byteLength,
         threadId,
+        thumbnailFileId,
+        placeholder,
       });
 
       await recordAuditEvent(tx, {
@@ -462,11 +512,17 @@ export const uploadUserFile = async ({
         mimeType: file.mimeType,
         fileName: sanitizedFileName,
         s3Key,
+        thumbnailS3Key: thumbnailKey,
       });
     }
 
     const cleanupResult = await Result.tryPromise({
-      try: async () => await getS3().delete(s3Key),
+      try: async () => {
+        await getS3().delete(s3Key);
+        if (thumbnailKey) {
+          await getS3().delete(thumbnailKey);
+        }
+      },
       catch: (cleanupError) =>
         new HandlerError({
           status: 500,

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -53,6 +53,18 @@ void mock.module("@/api/lib/search/index-global", () => ({
   upsertWorkspaceSearchDocuments: mock(async () => undefined),
 }));
 
+const enqueueImageThumbnailOrMarkFailedMock = mock(async () => undefined);
+const enqueueImageThumbnailMock = mock(async () => undefined);
+const enqueuePdfDerivativeMock = mock(async () => undefined);
+const enqueuePdfDerivativeOrMarkFailedMock = mock(async () => undefined);
+void mock.module("@/api/lib/file-derivative-queue", () => ({
+  enqueueImageThumbnail: enqueueImageThumbnailMock,
+  enqueueImageThumbnailOrMarkFailed: enqueueImageThumbnailOrMarkFailedMock,
+  enqueuePdfDerivative: enqueuePdfDerivativeMock,
+  enqueuePdfDerivativeOrMarkFailed: enqueuePdfDerivativeOrMarkFailedMock,
+  initFileDerivativeWorker: mock(() => undefined),
+}));
+
 const { default: copyToWorkspace } = await import("./copy-to-workspace");
 
 const sourceWorkspaceId = toSafeId<"workspace">("source_workspace");
@@ -132,6 +144,10 @@ beforeEach(() => {
   processExtractionMock.mockClear();
   syncWorkspaceSearchActivityMock.mockClear();
   broadcastQueryInvalidationToTargetWorkspaceMock.mockClear();
+  enqueueImageThumbnailMock.mockClear();
+  enqueueImageThumbnailOrMarkFailedMock.mockClear();
+  enqueuePdfDerivativeMock.mockClear();
+  enqueuePdfDerivativeOrMarkFailedMock.mockClear();
 });
 
 const createContext = ({
@@ -544,7 +560,14 @@ describe("copy-to-workspace", () => {
         fields: [
           {
             propertyId: sourceFilePropertyId,
-            content: { ...fileContent, id: originalFileId },
+            content: {
+              ...fileContent,
+              id: originalFileId,
+              mimeType: "image/png",
+              placeholder: "data:image/png;base64,AAAA",
+              thumbnailDerivative: { status: "ready" },
+              thumbnailFileId: "original-thumbnail-uuid",
+            },
           },
         ],
       },
@@ -634,6 +657,11 @@ describe("copy-to-workspace", () => {
       expect(copiedField.content.id).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu,
       );
+      expect(copiedField.content.thumbnailFileId).toBeNull();
+      expect(copiedField.content.thumbnailDerivative).toEqual({
+        status: "pending",
+      });
+      expect("placeholder" in copiedField.content).toBe(false);
     }
   });
 

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -11,6 +11,7 @@ import {
   getFolderSubtree,
 } from "@/api/handlers/entities/copy-utils";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -20,7 +21,10 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { broadcastQueryInvalidationToTargetWorkspace } from "@/api/lib/invalidate-query-macro";
 import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
@@ -157,6 +161,11 @@ const remapFileIds = (
           id: newFileId,
           pdfFileId: null,
           pdfDerivative: pdfDerivativeStateForFile({
+            encrypted: field.content.encrypted,
+            mimeType: field.content.mimeType,
+          }),
+          thumbnailFileId: null,
+          thumbnailDerivative: thumbnailDerivativeStateForFile({
             encrypted: field.content.encrypted,
             mimeType: field.content.mimeType,
           }),
@@ -496,6 +505,15 @@ const copyToWorkspaceHandler = async function* ({
   // Enqueue PDF derivative generation for copied file fields
   for (const fileField of txResult.fileFields) {
     enqueuePdfDerivativeOrMarkFailed({
+      entityId: fileField.entityId,
+      fieldId: fileField.fieldId,
+      mimeType: fileField.mimeType,
+      encrypted: fileField.encrypted,
+      organizationId,
+      userId,
+      workspaceId: targetWorkspaceId,
+    }).catch(captureError);
+    enqueueImageThumbnailOrMarkFailed({
       entityId: fileField.entityId,
       fieldId: fileField.fieldId,
       mimeType: fileField.mimeType,

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -152,7 +152,12 @@ const remapFileIds = (
         return field;
       }
 
-      const { pdfDerivative: _, ...restContent } = field.content;
+      const {
+        pdfDerivative: _pdfDerivative,
+        placeholder: _placeholder,
+        thumbnailDerivative: _thumbnailDerivative,
+        ...restContent
+      } = field.content;
 
       return {
         ...field,

--- a/apps/api/src/handlers/entities/create-from-buffer.test.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.test.ts
@@ -13,6 +13,9 @@ import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 const s3WriteMock = mock(async () => {});
 const s3DeleteMock = mock(async () => {});
 const processExtractionMock = mock(async () => {});
+const enqueueImageThumbnailMock = mock(async () => {});
+const enqueueImageThumbnailOrMarkFailedMock = mock(async () => {});
+const enqueuePdfDerivativeMock = mock(async () => {});
 const enqueuePdfDerivativeOrMarkFailedMock = mock(async () => {});
 
 void mock.module("@/api/lib/s3", () => ({
@@ -27,7 +30,11 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
 }));
 
 void mock.module("@/api/lib/file-derivative-queue", () => ({
+  enqueueImageThumbnail: enqueueImageThumbnailMock,
+  enqueueImageThumbnailOrMarkFailed: enqueueImageThumbnailOrMarkFailedMock,
+  enqueuePdfDerivative: enqueuePdfDerivativeMock,
   enqueuePdfDerivativeOrMarkFailed: enqueuePdfDerivativeOrMarkFailedMock,
+  initFileDerivativeWorker: mock(() => undefined),
 }));
 
 const { createEntityFromBuffer } = await import("./create-from-buffer");

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import type { ScopedDb } from "@/api/db";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -11,7 +12,10 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
-import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
@@ -185,6 +189,11 @@ export const createEntityFromBuffer = async ({
             encrypted: false,
             mimeType,
           }),
+          thumbnailFileId: null,
+          thumbnailDerivative: thumbnailDerivativeStateForFile({
+            encrypted: false,
+            mimeType,
+          }),
           ...(scanWarnings !== undefined && { scanWarnings }),
         },
       });
@@ -225,6 +234,16 @@ export const createEntityFromBuffer = async ({
   processExtraction(entityId).catch(captureError);
 
   enqueuePdfDerivativeOrMarkFailed({
+    encrypted: false,
+    entityId,
+    fieldId,
+    mimeType,
+    organizationId,
+    userId,
+    workspaceId,
+  }).catch(captureError);
+
+  enqueueImageThumbnailOrMarkFailed({
     encrypted: false,
     entityId,
     fieldId,

--- a/apps/api/src/handlers/entities/delete-version.ts
+++ b/apps/api/src/handlers/entities/delete-version.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, ne } from "drizzle-orm";
 
 import { entities, entityVersions } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
 import { deleteS3Objects } from "@/api/handlers/files/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -32,6 +33,12 @@ const extractFileRefs = (content: FieldContent): FileRef[] => {
   const refs: FileRef[] = [{ fileId: content.id, mimeType: content.mimeType }];
   if (content.pdfFileId) {
     refs.push({ fileId: content.pdfFileId, mimeType: PDF_MIME_TYPE });
+  }
+  if (content.thumbnailFileId) {
+    refs.push({
+      fileId: content.thumbnailFileId,
+      mimeType: THUMBNAIL_MIME_TYPE,
+    });
   }
   return refs;
 };

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -6,6 +6,7 @@ import type { Static } from "elysia";
 import type { SafeDb } from "@/api/db";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
 import { deleteS3Objects } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -45,6 +46,13 @@ const extractFileRefs = (content: FieldContent): FileRef[] => {
     refs.push({
       fileId: content.pdfFileId,
       mimeType: PDF_MIME_TYPE,
+    });
+  }
+
+  if (content.thumbnailFileId) {
+    refs.push({
+      fileId: content.thumbnailFileId,
+      mimeType: THUMBNAIL_MIME_TYPE,
     });
   }
 

--- a/apps/api/src/handlers/entities/translate.test.ts
+++ b/apps/api/src/handlers/entities/translate.test.ts
@@ -33,6 +33,9 @@ const scanFileMock = mock(async (_input: ScanFileInput) =>
 const s3WriteMock = mock(async () => {});
 const s3DeleteMock = mock(async () => {});
 const processExtractionMock = mock(async () => {});
+const enqueueImageThumbnailMock = mock(async () => {});
+const enqueueImageThumbnailOrMarkFailedMock = mock(async () => {});
+const enqueuePdfDerivativeMock = mock(async () => {});
 const enqueuePdfDerivativeOrMarkFailedMock = mock(async () => {});
 const captureErrorMock = mock(() => {});
 
@@ -67,7 +70,11 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
 }));
 
 void mock.module("@/api/lib/file-derivative-queue", () => ({
+  enqueueImageThumbnail: enqueueImageThumbnailMock,
+  enqueueImageThumbnailOrMarkFailed: enqueueImageThumbnailOrMarkFailedMock,
+  enqueuePdfDerivative: enqueuePdfDerivativeMock,
   enqueuePdfDerivativeOrMarkFailed: enqueuePdfDerivativeOrMarkFailedMock,
+  initFileDerivativeWorker: mock(() => undefined),
 }));
 
 void mock.module("@/api/lib/analytics", () => ({

--- a/apps/api/src/handlers/entities/upload-version.ts
+++ b/apps/api/src/handlers/entities/upload-version.ts
@@ -15,6 +15,7 @@ import {
   cloneFieldsForRevision,
 } from "@/api/handlers/entities/version-utils";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -22,7 +23,10 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
 import { getS3 } from "@/api/lib/s3";
@@ -266,6 +270,11 @@ export default createSafeHandler(
                 encrypted: false,
                 mimeType: file.type,
               }),
+              thumbnailFileId: null,
+              thumbnailDerivative: thumbnailDerivativeStateForFile({
+                encrypted: false,
+                mimeType: file.type,
+              }),
               ...(scanWarnings !== undefined && { scanWarnings }),
             },
             workspaceId,
@@ -404,6 +413,22 @@ export default createSafeHandler(
     });
 
     enqueuePdfDerivativeOrMarkFailed({
+      encrypted: false,
+      entityId,
+      fieldId: fileFieldId,
+      mimeType: file.type,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch((error: unknown) => {
+      captureError(error, {
+        entityId,
+        fieldId: fileFieldId,
+        mimeType: file.type,
+      });
+    });
+
+    enqueueImageThumbnailOrMarkFailed({
       encrypted: false,
       entityId,
       fieldId: fileFieldId,

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -7,6 +7,7 @@ import type { SafeDb, Transaction } from "@/api/db";
 import { jsonField } from "@/api/db/json-utils";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { isEncryptedPdf } from "@/api/handlers/files/pdf-utils";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
@@ -20,7 +21,10 @@ import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
-import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { scanFile } from "@/api/lib/file-scan/scan";
 import { FILE_SIZE_LIMITS, LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
@@ -253,6 +257,11 @@ const uploadEntityHandler = async function* ({
               encrypted,
               mimeType: file.type,
             }),
+            thumbnailFileId: null,
+            thumbnailDerivative: thumbnailDerivativeStateForFile({
+              encrypted,
+              mimeType: file.type,
+            }),
             ...(scanWarnings !== undefined && { scanWarnings }),
           },
         });
@@ -289,6 +298,22 @@ const uploadEntityHandler = async function* ({
     );
 
     enqueuePdfDerivativeOrMarkFailed({
+      encrypted,
+      entityId,
+      fieldId,
+      mimeType: file.type,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch((error: unknown) => {
+      captureError(error, {
+        entityId,
+        fieldId,
+        mimeType: file.type,
+      });
+    });
+
+    enqueueImageThumbnailOrMarkFailed({
       encrypted,
       entityId,
       fieldId,

--- a/apps/api/src/handlers/files/image-derivative.test.ts
+++ b/apps/api/src/handlers/files/image-derivative.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isThumbnailableMimeType,
+  shouldGenerateImageThumbnail,
+} from "@/api/handlers/files/image-derivative";
+
+describe("image thumbnail eligibility", () => {
+  test("accepts only supported unencrypted image formats", () => {
+    expect(shouldGenerateImageThumbnail({ mimeType: "image/jpeg" })).toBe(true);
+    expect(shouldGenerateImageThumbnail({ mimeType: "image/png" })).toBe(true);
+    expect(shouldGenerateImageThumbnail({ mimeType: "image/gif" })).toBe(true);
+    expect(shouldGenerateImageThumbnail({ mimeType: "image/webp" })).toBe(true);
+
+    expect(shouldGenerateImageThumbnail({ mimeType: "image/avif" })).toBe(
+      false,
+    );
+    expect(shouldGenerateImageThumbnail({ mimeType: "image/heic" })).toBe(
+      false,
+    );
+    expect(shouldGenerateImageThumbnail({ mimeType: "application/pdf" })).toBe(
+      false,
+    );
+  });
+
+  test("rejects encrypted images and prototype names", () => {
+    expect(
+      shouldGenerateImageThumbnail({
+        encrypted: true,
+        mimeType: "image/png",
+      }),
+    ).toBe(false);
+    expect(isThumbnailableMimeType("toString")).toBe(false);
+    expect(isThumbnailableMimeType("constructor")).toBe(false);
+  });
+});

--- a/apps/api/src/handlers/files/image-derivative.ts
+++ b/apps/api/src/handlers/files/image-derivative.ts
@@ -15,7 +15,7 @@ const IMAGE_THUMBNAIL_MIME_TYPES = {
 } as const satisfies Record<string, null>;
 
 export const isThumbnailableMimeType = (mimeType: string): boolean =>
-  mimeType in IMAGE_THUMBNAIL_MIME_TYPES;
+  Object.hasOwn(IMAGE_THUMBNAIL_MIME_TYPES, mimeType);
 
 type ShouldGenerateImageThumbnailOptions = {
   encrypted?: boolean;
@@ -70,16 +70,17 @@ export const generateImageThumbnail = async (
 ): Promise<Result<ImageThumbnailResult, ImageDerivativeError>> => {
   Bun.Image.backend = "bun";
 
-  return Result.tryPromise({
+  return await Result.tryPromise({
     try: async () => {
-      const webp = await new Bun.Image(source)
+      const image = new Bun.Image(source);
+      const webp = await image
         .resize(THUMBNAIL_MAX_EDGE, THUMBNAIL_MAX_EDGE, {
           fit: "inside",
           withoutEnlargement: true,
         })
         .webp({ quality: THUMBNAIL_WEBP_QUALITY })
         .bytes();
-      const placeholder = await new Bun.Image(source).placeholder();
+      const placeholder = await image.placeholder();
       return { webp, placeholder } satisfies ImageThumbnailResult;
     },
     catch: (error) =>

--- a/apps/api/src/handlers/files/image-derivative.ts
+++ b/apps/api/src/handlers/files/image-derivative.ts
@@ -1,0 +1,94 @@
+import { Result, TaggedError } from "better-result";
+
+/**
+ * Image MIME types we generate WebP thumbnails + blur placeholders for.
+ * Restricted to the formats Bun ships as statically-linked codecs so the
+ * pipeline is byte-identical on Linux (prod) and macOS/Windows (dev). HEIC,
+ * AVIF, and TIFF only decode on macOS/Windows and would reject on Linux, so
+ * they are deliberately excluded (we also don't accept them on upload).
+ */
+const IMAGE_THUMBNAIL_MIME_TYPES = {
+  "image/jpeg": null,
+  "image/png": null,
+  "image/gif": null,
+  "image/webp": null,
+} as const satisfies Record<string, null>;
+
+export const isThumbnailableMimeType = (mimeType: string): boolean =>
+  mimeType in IMAGE_THUMBNAIL_MIME_TYPES;
+
+type ShouldGenerateImageThumbnailOptions = {
+  encrypted?: boolean;
+  mimeType: string;
+};
+
+export const shouldGenerateImageThumbnail = ({
+  encrypted = false,
+  mimeType,
+}: ShouldGenerateImageThumbnailOptions): boolean =>
+  !encrypted && isThumbnailableMimeType(mimeType);
+
+export const thumbnailDerivativeStateForFile = (
+  options: ShouldGenerateImageThumbnailOptions,
+) =>
+  shouldGenerateImageThumbnail(options)
+    ? ({ status: "pending" } as const)
+    : ({ status: "not-required" } as const);
+
+/** Longest edge of the generated thumbnail, in pixels. */
+const THUMBNAIL_MAX_EDGE = 512;
+/** WebP quality for the generated thumbnail (1-100). */
+const THUMBNAIL_WEBP_QUALITY = 80;
+
+export const THUMBNAIL_MIME_TYPE = "image/webp";
+
+export class ImageDerivativeError extends TaggedError("ImageDerivativeError")<{
+  message: string;
+  code?: string | undefined;
+}>() {}
+
+type ImageThumbnailResult = {
+  /** Encoded WebP thumbnail bytes, longest edge <= THUMBNAIL_MAX_EDGE. */
+  webp: Uint8Array;
+  /**
+   * ThumbHash-rendered `data:image/png;base64,...` blur of the source image
+   * (~400-700 bytes). Drops straight into an `<img src>`; no client decoder.
+   */
+  placeholder: string;
+};
+
+/**
+ * Decode an uploaded image and produce a bounded WebP thumbnail plus a blur
+ * placeholder via the built-in `Bun.Image` pipeline. The source bytes are
+ * never mutated; this only reads them.
+ *
+ * Forces `Bun.Image.backend = "bun"` (static-codec mode) so output matches the
+ * Linux build and unsupported formats reject the same way in dev and prod.
+ */
+export const generateImageThumbnail = async (
+  source: Uint8Array,
+): Promise<Result<ImageThumbnailResult, ImageDerivativeError>> => {
+  Bun.Image.backend = "bun";
+
+  return Result.tryPromise({
+    try: async () => {
+      const webp = await new Bun.Image(source)
+        .resize(THUMBNAIL_MAX_EDGE, THUMBNAIL_MAX_EDGE, {
+          fit: "inside",
+          withoutEnlargement: true,
+        })
+        .webp({ quality: THUMBNAIL_WEBP_QUALITY })
+        .bytes();
+      const placeholder = await new Bun.Image(source).placeholder();
+      return { webp, placeholder } satisfies ImageThumbnailResult;
+    },
+    catch: (error) =>
+      new ImageDerivativeError({
+        message: "Failed to generate image thumbnail",
+        code:
+          error instanceof Error && "code" in error
+            ? String(error.code)
+            : undefined,
+      }),
+  });
+};

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -36,6 +36,7 @@ import {
   workspaces,
 } from "@/api/db/schema";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { isEncryptedPdf } from "@/api/handlers/files/pdf-utils";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
@@ -46,7 +47,10 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
-import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import type { SanitizedFileName } from "@/api/lib/sanitize-filename";
@@ -324,6 +328,11 @@ export const finalizeEntityCreate = async function* ({
           encrypted,
           mimeType: declaredMime,
         }),
+        thumbnailFileId: null,
+        thumbnailDerivative: thumbnailDerivativeStateForFile({
+          encrypted,
+          mimeType: declaredMime,
+        }),
         ...(scanWarnings !== undefined && { scanWarnings }),
       },
     });
@@ -411,6 +420,17 @@ export const finalizeEntityCreate = async function* ({
       captureError(error, { entityId, mimeType: declaredMime });
     });
     enqueuePdfDerivativeOrMarkFailed({
+      encrypted,
+      entityId,
+      fieldId,
+      mimeType: declaredMime,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch((error: unknown) => {
+      captureError(error, { entityId, fieldId, mimeType: declaredMime });
+    });
+    enqueueImageThumbnailOrMarkFailed({
       encrypted,
       entityId,
       fieldId,

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -31,6 +31,7 @@ import {
   cloneFieldsForRevision,
 } from "@/api/handlers/entities/version-utils";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -38,7 +39,10 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
 import { getS3 } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
@@ -272,6 +276,11 @@ export const finalizeEntityVersion = async function* ({
             encrypted: false,
             mimeType: declaredMime,
           }),
+          thumbnailFileId: null,
+          thumbnailDerivative: thumbnailDerivativeStateForFile({
+            encrypted: false,
+            mimeType: declaredMime,
+          }),
           ...(scanWarnings !== undefined && { scanWarnings }),
         },
         workspaceId,
@@ -454,6 +463,21 @@ export const finalizeEntityVersion = async function* ({
       captureError(error, { entityId });
     });
     enqueuePdfDerivativeOrMarkFailed({
+      encrypted: false,
+      entityId,
+      fieldId: fileFieldId,
+      mimeType: declaredMime,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch((error: unknown) => {
+      captureError(error, {
+        entityId,
+        fieldId: fileFieldId,
+        mimeType: declaredMime,
+      });
+    });
+    enqueueImageThumbnailOrMarkFailed({
       encrypted: false,
       entityId,
       fieldId: fileFieldId,

--- a/apps/api/src/handlers/user-files/read-thumbnail.ts
+++ b/apps/api/src/handlers/user-files/read-thumbnail.ts
@@ -1,0 +1,76 @@
+import { panic, Result } from "better-result";
+import { t } from "elysia";
+
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
+import { createUserFileKey } from "@/api/handlers/files/utils";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import { AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import { auditedPresignDownload } from "@/api/lib/audited-download";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const readUserFileThumbnail = createSafeRootHandler(
+  {
+    permissions: { chat: ["create"] },
+    params: t.Object({ fileId: tSafeId("userFile") }),
+  },
+  async function* ({ params: { fileId }, safeDb, user, recordAuditEvent }) {
+    const result = yield* Result.await(
+      safeDb(async (tx) => {
+        const file = await tx.query.userFiles.findFirst({
+          where: {
+            id: { eq: fileId },
+            userId: { eq: user.id },
+          },
+          columns: {
+            thumbnailFileId: true,
+          },
+          with: {
+            thread: {
+              columns: {
+                workspaceId: true,
+              },
+            },
+          },
+        });
+
+        if (!file?.thumbnailFileId) {
+          return null;
+        }
+        const thread =
+          file.thread ?? panic("User file thread relation missing");
+
+        const thumbnailKey = createUserFileKey({
+          fileId: file.thumbnailFileId,
+          mimeType: THUMBNAIL_MIME_TYPE,
+          userId: user.id,
+        });
+
+        const presignedUrl = await auditedPresignDownload({
+          tx,
+          recordAuditEvent,
+          resourceType: AUDIT_RESOURCE_TYPE.USER_FILE,
+          resourceId: fileId,
+          s3Key: thumbnailKey,
+          expiresInSeconds: 900,
+          workspaceId: thread.workspaceId,
+        });
+
+        return presignedUrl;
+      }),
+    );
+
+    if (!result) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "User file thumbnail not found",
+        }),
+      );
+    }
+
+    return Result.ok(Response.redirect(result, 302));
+  },
+);
+
+export default readUserFileThumbnail;

--- a/apps/api/src/handlers/user-files/routes.ts
+++ b/apps/api/src/handlers/user-files/routes.ts
@@ -1,6 +1,7 @@
 import Elysia from "elysia";
 
 import readUserFileContent from "@/api/handlers/user-files/read-content";
+import readUserFileThumbnail from "@/api/handlers/user-files/read-thumbnail";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 
 export const userFilesRoute = new Elysia({ prefix: "/user-files" })
@@ -10,4 +11,8 @@ export const userFilesRoute = new Elysia({ prefix: "/user-files" })
   .get("/:fileId/content", readUserFileContent.handler, {
     params: readUserFileContent.config.params,
     permissions: readUserFileContent.config.permissions,
+  })
+  .get("/:fileId/thumbnail", readUserFileThumbnail.handler, {
+    params: readUserFileThumbnail.config.params,
+    permissions: readUserFileThumbnail.config.permissions,
   });

--- a/apps/api/src/handlers/workspaces/delete-by-id.ts
+++ b/apps/api/src/handlers/workspaces/delete-by-id.ts
@@ -15,12 +15,17 @@ import {
 } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
 import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
-import { deleteS3Keys, deleteS3Objects } from "@/api/handlers/files/utils";
+import {
+  createUserFileKey,
+  deleteS3Keys,
+  deleteS3Objects,
+} from "@/api/handlers/files/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const changeWorkspaceStatus = async (
@@ -106,6 +111,8 @@ const deleteWorkspace = createSafeHandler(
         .select({
           id: userFiles.id,
           s3Key: userFiles.s3Key,
+          thumbnailFileId: userFiles.thumbnailFileId,
+          userId: userFiles.userId,
         })
         .from(userFiles)
         .innerJoin(chatThreads, eq(userFiles.threadId, chatThreads.id))
@@ -143,9 +150,20 @@ const deleteWorkspace = createSafeHandler(
 
     if (chatFileRefs.length > 0) {
       s3Deletes.push(
-        deleteS3Keys(chatFileRefs.map((file) => file.s3Key)).then((result) =>
-          Result.unwrap(result),
-        ),
+        deleteS3Keys(
+          chatFileRefs.flatMap((file) =>
+            file.thumbnailFileId
+              ? [
+                  file.s3Key,
+                  createUserFileKey({
+                    fileId: file.thumbnailFileId,
+                    mimeType: THUMBNAIL_MIME_TYPE,
+                    userId: brandPersistedUserId(file.userId),
+                  }),
+                ]
+              : [file.s3Key],
+          ),
+        ).then((result) => Result.unwrap(result)),
       );
     }
 

--- a/apps/api/src/handlers/workspaces/delete-by-id.ts
+++ b/apps/api/src/handlers/workspaces/delete-by-id.ts
@@ -14,6 +14,7 @@ import {
   workspaces,
 } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
 import { deleteS3Keys, deleteS3Objects } from "@/api/handlers/files/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -50,6 +51,13 @@ const extractFileRefs = (content: FieldContent): FileRef[] => {
     refs.push({
       fileId: content.pdfFileId,
       mimeType: PDF_MIME_TYPE,
+    });
+  }
+
+  if (content.thumbnailFileId) {
+    refs.push({
+      fileId: content.thumbnailFileId,
+      mimeType: THUMBNAIL_MIME_TYPE,
     });
   }
 

--- a/apps/api/src/handlers/workspaces/duplicate.test.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.test.ts
@@ -1,25 +1,70 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import { member } from "@/api/db/auth-schema";
 import {
   auditLogs,
+  documentCounters,
+  entities,
+  entityVersions,
+  fields,
   matterCounters,
+  properties,
   workspaceMembers,
   workspaces,
 } from "@/api/db/schema";
+import type { FieldContent, PropertyContent } from "@/api/db/schema-validators";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-import duplicateWorkspace from "./duplicate";
+const s3FileMock = mock((key: string) => ({ key }));
+const s3WriteMock = mock(async () => undefined);
+const s3DeleteMock = mock(async () => undefined);
+
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({
+    delete: s3DeleteMock,
+    file: s3FileMock,
+    write: s3WriteMock,
+  }),
+}));
+
+const processExtractionMock = mock(async () => undefined);
+void mock.module("@/api/lib/search/process-extraction", () => ({
+  processExtraction: processExtractionMock,
+}));
+
+const upsertWorkspaceSearchDocumentMock = mock(async () => undefined);
+const syncWorkspaceSearchActivityMock = mock(async () => undefined);
+void mock.module("@/api/lib/search/index-global", () => ({
+  syncWorkspaceSearchActivity: syncWorkspaceSearchActivityMock,
+  upsertWorkspaceSearchDocument: upsertWorkspaceSearchDocumentMock,
+}));
+
+const { default: duplicateWorkspace } = await import("./duplicate");
 
 type DuplicateWorkspaceCtx = Parameters<typeof duplicateWorkspace.handler>[0];
+type InsertedWorkspaceField = {
+  content: FieldContent;
+  propertyId: SafeId<"property">;
+};
+
+const isInsertedWorkspaceField = (
+  value: unknown,
+): value is InsertedWorkspaceField =>
+  typeof value === "object" &&
+  value !== null &&
+  "content" in value &&
+  "propertyId" in value;
 
 const createContext = ({
+  includeContent = false,
   safeDb,
   scopedDb,
 }: {
+  includeContent?: boolean;
   safeDb: DuplicateWorkspaceCtx["safeDb"];
   scopedDb: DuplicateWorkspaceCtx["scopedDb"];
 }): DuplicateWorkspaceCtx => {
@@ -34,7 +79,7 @@ const createContext = ({
   };
 
   return asTestRaw<DuplicateWorkspaceCtx>({
-    body: { includeContent: false },
+    body: { includeContent },
     safeDb,
     scopedDb,
     memberRole: { role: "owner" },
@@ -88,8 +133,8 @@ describe("duplicateWorkspace", () => {
           findFirst: async () => null,
         },
       },
-      select: (fields: Record<string, unknown>) => {
-        if ("total" in fields) {
+      select: (selectedFields: Record<string, unknown>) => {
+        if ("total" in selectedFields) {
           return {
             from: () => ({
               where: async () => [{ total: 0 }],
@@ -97,7 +142,7 @@ describe("duplicateWorkspace", () => {
           };
         }
 
-        if ("name" in fields) {
+        if ("name" in selectedFields) {
           return {
             from: () => ({
               where: async () => [],
@@ -105,7 +150,7 @@ describe("duplicateWorkspace", () => {
           };
         }
 
-        if ("userId" in fields) {
+        if ("userId" in selectedFields) {
           return {
             from: (table: unknown) => {
               expect(table).toBe(member);
@@ -171,5 +216,197 @@ describe("duplicateWorkspace", () => {
       ],
     ]);
     expect(insertedAuditLogs).toHaveLength(1);
+  });
+
+  test("copies and remaps image thumbnail refs when duplicating content", async () => {
+    s3FileMock.mockClear();
+    s3WriteMock.mockClear();
+    s3DeleteMock.mockClear();
+    processExtractionMock.mockClear();
+    syncWorkspaceSearchActivityMock.mockClear();
+    upsertWorkspaceSearchDocumentMock.mockClear();
+
+    const insertedFields: InsertedWorkspaceField[] = [];
+
+    const filePropertyId = toSafeId<"property">("prop_file");
+    const filePropertyContent: PropertyContent = { type: "file", version: 1 };
+    const imageContent: FieldContent = {
+      type: "file",
+      version: 1,
+      id: "source-file-id",
+      fileName: "evidence.png",
+      mimeType: "image/png",
+      sizeBytes: 1024,
+      encrypted: false,
+      sha256Hex: "a".repeat(64),
+      pdfFileId: "source-pdf-id",
+      pdfDerivative: { status: "ready" },
+      placeholder: "data:image/png;base64,AAAA",
+      thumbnailDerivative: { status: "ready" },
+      thumbnailFileId: "source-thumbnail-id",
+    };
+    let nextMatterSequence = 0;
+
+    const tx = {
+      query: {
+        workspaces: {
+          findFirst: async () => ({
+            id: "ws_source123",
+            name: "Smith v Jones",
+            clientId: null,
+            billingReference: null,
+            color: null,
+            leadUserId: null,
+          }),
+        },
+        properties: {
+          findMany: async () => [
+            {
+              id: filePropertyId,
+              workspaceId: "ws_source123",
+              name: "Document",
+              status: "active",
+              content: filePropertyContent,
+              tool: null,
+              system: false,
+              kinds: ["document"],
+            },
+          ],
+        },
+        propertyDependencies: {
+          findMany: async () => [],
+        },
+        workspaceViews: {
+          findMany: async () => [],
+        },
+        workspaceMembers: {
+          findMany: async () => [],
+        },
+        workspaceContacts: {
+          findMany: async () => [],
+        },
+        organizationSettings: {
+          findFirst: async () => null,
+        },
+        entities: {
+          findMany: async () => [
+            {
+              id: "entity_source",
+              kind: "document",
+              name: "evidence.png",
+              parentId: null,
+              status: "open",
+              priority: null,
+              dueDate: null,
+              agendaKind: null,
+              startAt: null,
+              endAt: null,
+              occurredAt: null,
+              remindAt: null,
+              allDay: null,
+              timeZone: null,
+              location: null,
+              onlineMeetingUrl: null,
+              availability: null,
+              sensitivity: null,
+              organizer: null,
+              attendees: null,
+              recurrence: null,
+              agendaSource: null,
+              sortOrder: null,
+              metadata: null,
+              currentVersion: {
+                id: "version_source",
+                fields: [{ propertyId: filePropertyId, content: imageContent }],
+              },
+            },
+          ],
+        },
+      },
+      select: (selectedFields: Record<string, unknown>) => {
+        if ("total" in selectedFields) {
+          return {
+            from: () => ({
+              where: async () => [{ total: 0 }],
+            }),
+          };
+        }
+
+        if ("name" in selectedFields) {
+          return {
+            from: () => ({
+              where: async () => [],
+            }),
+          };
+        }
+
+        throw new Error("Unexpected select fields");
+      },
+      insert: (table: unknown) => ({
+        values: (value: unknown) => {
+          if (table === documentCounters || table === matterCounters) {
+            return {
+              onConflictDoUpdate: () => ({
+                returning: async () => {
+                  nextMatterSequence += 1;
+                  return [{ lastValue: nextMatterSequence }];
+                },
+              }),
+            };
+          }
+
+          if (table === fields) {
+            const fieldValues = Array.isArray(value) ? value : [value];
+            for (const fieldValue of fieldValues) {
+              if (isInsertedWorkspaceField(fieldValue)) {
+                insertedFields.push(fieldValue);
+              }
+            }
+            return undefined;
+          }
+
+          if (
+            table === auditLogs ||
+            table === entities ||
+            table === entityVersions ||
+            table === properties ||
+            table === workspaces
+          ) {
+            return undefined;
+          }
+
+          throw new Error("Unexpected insert table");
+        },
+      }),
+      update: () => ({
+        set: () => ({
+          where: async () => undefined,
+        }),
+      }),
+      execute: async () => undefined,
+    };
+
+    const { safeDb, scopedDb } = createScopedDbMock(tx);
+    const result = await duplicateWorkspace.handler(
+      createContext({ includeContent: true, safeDb, scopedDb }),
+    );
+
+    expect(result).toEqual({ workspaceId: expect.any(String) });
+    expect(s3WriteMock).toHaveBeenCalledTimes(3);
+    expect(insertedFields).toHaveLength(1);
+
+    const copiedContent = insertedFields.at(0)?.content;
+    expect(copiedContent?.type).toBe("file");
+    if (copiedContent?.type !== "file") {
+      throw new Error("Expected copied field content to be a file");
+    }
+
+    expect(copiedContent.id).not.toBe(imageContent.id);
+    expect(copiedContent.pdfFileId).not.toBe(imageContent.pdfFileId);
+    expect(copiedContent.thumbnailFileId).not.toBe(
+      imageContent.thumbnailFileId,
+    );
+    expect(copiedContent.placeholder).toBe(imageContent.placeholder);
+    expect(copiedContent.thumbnailDerivative).toEqual({ status: "ready" });
   });
 });

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -17,6 +17,7 @@ import {
   workspaceViews,
 } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -158,6 +159,14 @@ const collectFileCopies = (content: FieldContent): FileCopy[] => {
     });
   }
 
+  if (content.thumbnailFileId) {
+    copies.push({
+      sourceFileId: content.thumbnailFileId,
+      targetFileId: Bun.randomUUIDv7(),
+      mimeType: THUMBNAIL_MIME_TYPE,
+    });
+  }
+
   return copies;
 };
 
@@ -195,6 +204,9 @@ const remapFieldContent = (
     id: fileIdMap.get(content.id) ?? content.id,
     pdfFileId: content.pdfFileId
       ? (fileIdMap.get(content.pdfFileId) ?? content.pdfFileId)
+      : null,
+    thumbnailFileId: content.thumbnailFileId
+      ? (fileIdMap.get(content.thumbnailFileId) ?? content.thumbnailFileId)
       : null,
   };
 };

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -8,6 +8,11 @@ import {
   convertToPdf,
   shouldGeneratePdfDerivative,
 } from "@/api/handlers/files/gotenberg";
+import {
+  generateImageThumbnail,
+  shouldGenerateImageThumbnail,
+  THUMBNAIL_MIME_TYPE,
+} from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -28,10 +33,13 @@ import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const QUEUE_NAME = "file-derivatives";
 const GENERATE_PDF_JOB_NAME = "generate-pdf";
+const GENERATE_THUMBNAIL_JOB_NAME = "generate-thumbnail";
 const WORKER_CONCURRENCY = 3;
 const DEFAULT_JOB_ATTEMPTS = 3;
 
-type PdfDerivativeJobData = {
+// PDF and thumbnail jobs carry the same identifiers; the job name on the
+// BullMQ job distinguishes which derivative to produce.
+type FileDerivativeJobData = {
   entityId: string;
   fieldId: string;
   organizationId: string;
@@ -39,7 +47,7 @@ type PdfDerivativeJobData = {
   workspaceId: string;
 };
 
-type EnqueuePdfDerivativeArgs = {
+type EnqueueFileDerivativeArgs = {
   encrypted: boolean;
   entityId: SafeId<"entity">;
   fieldId: SafeId<"field">;
@@ -49,7 +57,7 @@ type EnqueuePdfDerivativeArgs = {
   workspaceId: SafeId<"workspace">;
 };
 
-let queue: Queue<PdfDerivativeJobData> | null = null;
+let queue: Queue<FileDerivativeJobData> | null = null;
 let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
 
 const getQueueConnection = () => {
@@ -57,8 +65,8 @@ const getQueueConnection = () => {
   return queueConnection;
 };
 
-const getQueue = (): Queue<PdfDerivativeJobData> => {
-  queue ??= new Queue<PdfDerivativeJobData>(QUEUE_NAME, {
+const getQueue = (): Queue<FileDerivativeJobData> => {
+  queue ??= new Queue<FileDerivativeJobData>(QUEUE_NAME, {
     connection: getQueueConnection(),
     defaultJobOptions: {
       attempts: DEFAULT_JOB_ATTEMPTS,
@@ -78,7 +86,7 @@ export const enqueuePdfDerivative = async ({
   organizationId,
   userId,
   workspaceId,
-}: EnqueuePdfDerivativeArgs): Promise<void> => {
+}: EnqueueFileDerivativeArgs): Promise<void> => {
   if (!shouldGeneratePdfDerivative({ encrypted, mimeType })) {
     return;
   }
@@ -99,7 +107,7 @@ export const enqueuePdfDerivative = async ({
 };
 
 export const enqueuePdfDerivativeOrMarkFailed = async (
-  args: EnqueuePdfDerivativeArgs,
+  args: EnqueueFileDerivativeArgs,
 ): Promise<void> => {
   if (
     !shouldGeneratePdfDerivative({
@@ -125,14 +133,73 @@ export const enqueuePdfDerivativeOrMarkFailed = async (
   }
 };
 
+export const enqueueImageThumbnail = async ({
+  encrypted,
+  entityId,
+  fieldId,
+  mimeType,
+  organizationId,
+  userId,
+  workspaceId,
+}: EnqueueFileDerivativeArgs): Promise<void> => {
+  if (!shouldGenerateImageThumbnail({ encrypted, mimeType })) {
+    return;
+  }
+
+  await getQueue().add(
+    GENERATE_THUMBNAIL_JOB_NAME,
+    {
+      entityId,
+      fieldId,
+      organizationId,
+      userId,
+      workspaceId,
+    },
+    {
+      jobId: `${workspaceId}:${fieldId}:thumbnail`,
+    },
+  );
+};
+
+export const enqueueImageThumbnailOrMarkFailed = async (
+  args: EnqueueFileDerivativeArgs,
+): Promise<void> => {
+  if (
+    !shouldGenerateImageThumbnail({
+      encrypted: args.encrypted,
+      mimeType: args.mimeType,
+    })
+  ) {
+    return;
+  }
+
+  try {
+    await enqueueImageThumbnail(args);
+  } catch (error) {
+    await markImageThumbnailFailed(args).catch((markError: unknown) => {
+      captureError(markError, {
+        entityId: args.entityId,
+        fieldId: args.fieldId,
+        workspaceId: args.workspaceId,
+      });
+    });
+
+    throw error;
+  }
+};
+
 export const initFileDerivativeWorker = () => {
   // BullMQ workers use blocking commands and need a dedicated connection
   // separate from the queue's. Create a fresh raw client per worker init.
   const workerConnection = createBullMqConnection();
 
-  const worker = new Worker<PdfDerivativeJobData>(
+  const worker = new Worker<FileDerivativeJobData>(
     QUEUE_NAME,
     async (job) => {
+      if (job.name === GENERATE_THUMBNAIL_JOB_NAME) {
+        await processImageThumbnailJob(job.data);
+        return;
+      }
       await processPdfDerivativeJob(job.data);
     },
     {
@@ -142,10 +209,17 @@ export const initFileDerivativeWorker = () => {
   );
 
   worker.on("failed", (job, error) => {
-    if (
-      job &&
-      job.attemptsMade >= (job.opts.attempts ?? DEFAULT_JOB_ATTEMPTS)
-    ) {
+    const exhausted =
+      job && job.attemptsMade >= (job.opts.attempts ?? DEFAULT_JOB_ATTEMPTS);
+    if (exhausted && job.name === GENERATE_THUMBNAIL_JOB_NAME) {
+      markImageThumbnailFailed(job.data).catch((markError: unknown) => {
+        captureError(markError, {
+          entityId: job.data.entityId,
+          fieldId: job.data.fieldId,
+          workspaceId: job.data.workspaceId,
+        });
+      });
+    } else if (exhausted) {
       markPdfDerivativeFailed(job.data).catch((markError: unknown) => {
         captureError(markError, {
           entityId: job.data.entityId,
@@ -160,10 +234,11 @@ export const initFileDerivativeWorker = () => {
       fieldId: job?.data.fieldId ?? "",
       workspaceId: job?.data.workspaceId ?? "",
     });
-    logger.error("file_derivative.pdf_failed", {
+    logger.error("file_derivative.failed", {
       entityId: job?.data.entityId ?? "",
       "error.type": errorTag(error),
       fieldId: job?.data.fieldId ?? "",
+      jobName: job?.name ?? "",
       workspaceId: job?.data.workspaceId ?? "",
     });
   });
@@ -185,7 +260,7 @@ const processPdfDerivativeJob = async ({
   organizationId,
   userId,
   workspaceId,
-}: PdfDerivativeJobData): Promise<void> => {
+}: FileDerivativeJobData): Promise<void> => {
   const branded = brandValidatedWorkflowActorKey({
     organizationId,
     workspaceId,
@@ -338,7 +413,7 @@ const markPdfDerivativeFailed = async ({
   organizationId,
   userId,
   workspaceId,
-}: PdfDerivativeJobData): Promise<void> => {
+}: FileDerivativeJobData): Promise<void> => {
   const branded = brandValidatedWorkflowActorKey({
     organizationId,
     workspaceId,
@@ -362,6 +437,193 @@ const markPdfDerivativeFailed = async ({
           sql`${fields.content}->>'type' = 'file'`,
           sql`${fields.content}->>'pdfFileId' is null`,
           sql`coalesce(${fields.content}->'pdfDerivative'->>'status', 'pending') = 'pending'`,
+        ),
+      ),
+  );
+};
+
+const processImageThumbnailJob = async ({
+  organizationId,
+  fieldId,
+  userId,
+  workspaceId,
+}: FileDerivativeJobData): Promise<void> => {
+  const branded = brandValidatedWorkflowActorKey({
+    organizationId,
+    workspaceId,
+  });
+  const scopedDb = createRootScopedDb({
+    organizationId: branded.organizationId,
+    userId: brandPersistedUserId(userId),
+    workspaceIds: [branded.workspaceId],
+  });
+  const brandedFieldId = brandPersistedFieldId(fieldId);
+
+  const row = await scopedDb((tx) =>
+    tx.query.fields.findFirst({
+      columns: { content: true },
+      where: {
+        id: { eq: brandedFieldId },
+        workspaceId: { eq: branded.workspaceId },
+      },
+    }),
+  );
+
+  if (
+    !row ||
+    row.content.type !== "file" ||
+    (row.content.thumbnailFileId ?? null) !== null ||
+    !isPendingThumbnailDerivative(row.content)
+  ) {
+    return;
+  }
+
+  const content = row.content;
+  if (
+    !shouldGenerateImageThumbnail({
+      encrypted: content.encrypted,
+      mimeType: content.mimeType,
+    })
+  ) {
+    return;
+  }
+
+  const sourceKey = createFileKey({
+    organizationId: branded.organizationId,
+    workspaceId: branded.workspaceId,
+    fileId: content.id,
+    mimeType: content.mimeType,
+  });
+  const sourceBuffer = await getS3File(sourceKey);
+  const thumbnailResult = await generateImageThumbnail(
+    new Uint8Array(sourceBuffer),
+  );
+
+  if (Result.isError(thumbnailResult)) {
+    throw thumbnailResult.error;
+  }
+
+  const thumbnailFileId = Bun.randomUUIDv7();
+  const sourceFileId = content.id;
+  const thumbnailKey = createFileKey({
+    organizationId: branded.organizationId,
+    workspaceId: branded.workspaceId,
+    fileId: thumbnailFileId,
+    mimeType: THUMBNAIL_MIME_TYPE,
+  });
+
+  await getS3().write(thumbnailKey, thumbnailResult.value.webp);
+
+  try {
+    const updatedRows = await scopedDb((tx) =>
+      tx
+        .update(fields)
+        .set({
+          content: readyThumbnailContent(
+            thumbnailFileId,
+            thumbnailResult.value.placeholder,
+          ),
+        })
+        .where(
+          and(
+            eq(fields.id, brandedFieldId),
+            eq(fields.workspaceId, branded.workspaceId),
+            sql`${fields.content}->>'type' = 'file'`,
+            sql`${fields.content}->>'id' = ${sourceFileId}`,
+            sql`${fields.content}->>'thumbnailFileId' is null`,
+            sql`coalesce(${fields.content}->'thumbnailDerivative'->>'status', 'pending') = 'pending'`,
+          ),
+        )
+        .returning({ id: fields.id }),
+    );
+
+    if (updatedRows.length === 0) {
+      await getS3().delete(thumbnailKey);
+      return;
+    }
+  } catch (error) {
+    await getS3()
+      .delete(thumbnailKey)
+      .catch((deleteError: unknown) => {
+        captureError(deleteError, {
+          fieldId: brandedFieldId,
+          workspaceId: branded.workspaceId,
+        });
+      });
+    throw error;
+  }
+
+  broadcast(branded.workspaceId, {
+    type: "invalidate-query",
+    data: ["entities", branded.workspaceId],
+  });
+  broadcast(branded.workspaceId, {
+    type: "invalidate-query",
+    data: ["files", branded.workspaceId, brandedFieldId],
+  });
+  broadcast(branded.workspaceId, {
+    type: "invalidate-query",
+    data: ["files", "metadata", branded.workspaceId, brandedFieldId],
+  });
+};
+
+const isPendingThumbnailDerivative = (
+  content: Extract<FieldContent, { type: "file" }>,
+): boolean =>
+  content.thumbnailDerivative?.status !== "not-required" &&
+  content.thumbnailDerivative?.status !== "ready" &&
+  content.thumbnailDerivative?.status !== "failed";
+
+const readyThumbnailContent = (thumbnailFileId: string, placeholder: string) =>
+  sql<FieldContent>`jsonb_set(
+    jsonb_set(
+      jsonb_set(${fields.content}, '{thumbnailFileId}', to_jsonb(${thumbnailFileId}::text), true),
+      '{placeholder}',
+      to_jsonb(${placeholder}::text),
+      true
+    ),
+    '{thumbnailDerivative}',
+    ${JSON.stringify({ status: "ready" })}::jsonb,
+    true
+  )`;
+
+const failedThumbnailContent = () =>
+  sql<FieldContent>`jsonb_set(
+    ${fields.content},
+    '{thumbnailDerivative}',
+    ${JSON.stringify({ status: "failed" })}::jsonb,
+    true
+  )`;
+
+const markImageThumbnailFailed = async ({
+  fieldId,
+  organizationId,
+  userId,
+  workspaceId,
+}: FileDerivativeJobData): Promise<void> => {
+  const branded = brandValidatedWorkflowActorKey({
+    organizationId,
+    workspaceId,
+  });
+  const scopedDb = createRootScopedDb({
+    organizationId: branded.organizationId,
+    userId: brandPersistedUserId(userId),
+    workspaceIds: [branded.workspaceId],
+  });
+
+  await scopedDb((tx) =>
+    tx
+      .update(fields)
+      .set({
+        content: failedThumbnailContent(),
+      })
+      .where(
+        and(
+          eq(fields.id, brandPersistedFieldId(fieldId)),
+          eq(fields.workspaceId, branded.workspaceId),
+          sql`${fields.content}->>'type' = 'file'`,
+          sql`${fields.content}->>'thumbnailFileId' is null`,
+          sql`coalesce(${fields.content}->'thumbnailDerivative'->>'status', 'pending') = 'pending'`,
         ),
       ),
   );

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -90,6 +90,42 @@ describe("chat thread messages", () => {
     expect(html).toContain(">Copy</button>");
   });
 
+  test("uses generated thumbnail URLs for image attachments with placeholders", () => {
+    const imagePart = {
+      type: "file",
+      filename: "evidence.png",
+      mediaType: "image/png",
+      placeholder: "data:image/png;base64,AAAA",
+      url: "stella://file::file_test123",
+    } as const;
+    const chatMessages: PersistedChatMessage[] = [
+      {
+        id: "message-A",
+        parts: [imagePart],
+        role: "user",
+      },
+    ];
+
+    const html = renderWithProviders(
+      <ChatThreadMessages
+        approvalPendingMessageId={null}
+        messages={chatMessages}
+        onAskUserSubmit={() => {}}
+        onCreateDocumentResolve={() => {}}
+        onOpenCreatedDocument={() => {}}
+        showToolCalls={false}
+        streamdownComponents={{
+          a: ({ children, ...props }) => <a {...props}>{children}</a>,
+        }}
+      />,
+    );
+
+    expect(html).toContain("/v1/user-files/file_test123/content");
+    expect(html).toContain("/v1/user-files/file_test123/thumbnail");
+    expect(html).toContain("background-image");
+    expect(html).toContain("data:image/png;base64,AAAA");
+  });
+
   test("shows retry only on the latest assistant response", () => {
     const chatMessages: PersistedChatMessage[] = [
       {

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -43,7 +43,10 @@ import { ToolApprovalCard } from "@/components/chat/tool-approval-card";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
 import { WebSearchSources } from "@/components/chat/web-search-sources";
 import type { TranslationKey } from "@/i18n/types";
-import { getUserFileContentUrl } from "@/lib/user-files";
+import {
+  getUserFileContentUrl,
+  getUserFileThumbnailUrl,
+} from "@/lib/user-files";
 import type { QueuedChatMessage } from "@/routes/_protected.chat/-hooks/use-chat-session";
 
 const USER_STREAMDOWN_COMPONENTS = {
@@ -186,13 +189,32 @@ const UserAttachments = ({ parts }: { parts: readonly FileUIPart[] }) => {
         const contentUrl = getUserFileContentUrl(part.url) ?? part.url;
         const fallbackLabel = t("chat.attachment");
         if (IMAGE_MEDIA_TYPES.has(part.mediaType)) {
+          // The backend sets `placeholder` (a blur data URL) only when a
+          // thumbnail was generated, so its presence doubles as "serve the
+          // smaller thumbnail instead of the full original."
+          const placeholder =
+            "placeholder" in part && typeof part.placeholder === "string"
+              ? part.placeholder
+              : undefined;
+          const imageSrc = placeholder
+            ? (getUserFileThumbnailUrl(part.url) ?? contentUrl)
+            : contentUrl;
           return (
             <a href={contentUrl} key={key} rel="noreferrer" target="_blank">
               <img
                 alt={part.filename ?? t("chat.attachedImage")}
                 className="max-h-32 rounded-md object-cover"
                 height={128}
-                src={contentUrl}
+                src={imageSrc}
+                style={
+                  placeholder
+                    ? {
+                        backgroundImage: `url("${placeholder}")`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                      }
+                    : undefined
+                }
                 width={128}
               />
             </a>

--- a/apps/web/src/lib/user-files.ts
+++ b/apps/web/src/lib/user-files.ts
@@ -19,3 +19,12 @@ export const getUserFileContentUrl = (url: string): string | null => {
 
   return apiUrl(`/user-files/${fileId}/content`);
 };
+
+export const getUserFileThumbnailUrl = (url: string): string | null => {
+  const fileId = parseUserFileId(url);
+  if (fileId === null) {
+    return null;
+  }
+
+  return apiUrl(`/user-files/${fileId}/thumbnail`);
+};


### PR DESCRIPTION
## What

Generate a bounded 512px WebP thumbnail and a rendered blur placeholder
data URL for uploaded images using the built-in `Bun.Image` API
(Bun 1.3.14). Originals are never altered.

## Why

Image attachments currently download the full original to paint a small
preview box. Serving a bounded WebP plus an instant blur-up placeholder
cuts bytes and avoids blank-then-pop on the rendered surfaces.

## How

- **Shared helper** (`image-derivative.ts`): Linux-safe format gating
  (png/jpeg/webp/gif), forced static-codec backend for dev/prod parity,
  `Result`-wrapped generation returning `{ webp, placeholder }`.
- **Chat attachments** (`user_files`): inline best-effort generation on
  upload, `thumbnail_file_id` + `placeholder` columns, a
  `GET /user-files/:fileId/thumbnail` endpoint with the same ownership
  scoping as `/content`, read-path enrichment, and 128px attachment
  blur-up + thumbnail `src`.
- **Entity files**: async `generate-thumbnail` job on the existing
  `file-derivatives` queue, additive JSONB derivative state, enqueue at
  every image upload site, thumbnail cleanup at every delete site.
- **Backfill** script for both paths.

Generation fails closed: a decode error leaves the original downloadable
and simply omits the thumbnail.

## Notes

- HEIC/AVIF/TIFF are excluded (Linux can't decode them with the static
  codecs; not accepted on upload today).
- The entity-side generation has no rendering surface yet and is wired but
  dormant; the only live consumer is the 128px chat attachment. Open to
  carving the entity path out of this PR if reviewers prefer a chat-only
  slice.
