### PR TITLE
fix(files): wrap direct-to-storage fetch with tagged errors

### DIFF
--- a/apps/web/src/components/route-components.logic.test.ts
+++ b/apps/web/src/components/route-components.logic.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { APIError } from "@/lib/errors";
+import { CriticalQueryTimeoutError } from "@/lib/react-query";
+
+import { isNetworkError } from "./route-components.logic";
+
+describe("route network error classification", () => {
+  test("recognises query timeouts and browser network errors", () => {
+    expect(
+      isNetworkError(
+        new CriticalQueryTimeoutError({
+          message: "Critical query timed out",
+          queryKey: ["files", "field_1"],
+          timeoutMs: 10_000,
+        }),
+      ),
+    ).toBe(true);
+    expect(isNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(
+      isNetworkError(
+        new TypeError("NetworkError when attempting to fetch resource."),
+      ),
+    ).toBe(true);
+    expect(isNetworkError(new TypeError("Load failed"))).toBe(true);
+  });
+
+  test("treats APIError status 0 as transient network failure", () => {
+    expect(
+      isNetworkError(
+        new APIError({
+          status: 0,
+          message: "Storage fetch failed before response (purpose=display)",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not classify ordinary API or type errors as network failures", () => {
+    expect(
+      isNetworkError(new APIError({ status: 500, message: "Server error" })),
+    ).toBe(false);
+    expect(
+      isNetworkError(new TypeError("Cannot read properties of null")),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/route-components.logic.ts
+++ b/apps/web/src/components/route-components.logic.ts
@@ -1,0 +1,19 @@
+import { APIError } from "@/lib/errors";
+import { CriticalQueryTimeoutError } from "@/lib/react-query";
+
+/** Network errors that indicate a transient connectivity
+ *  issue (API down, DNS failure, etc.).
+ *  Message varies by browser engine:
+ *  - Chromium: "Failed to fetch"
+ *  - Firefox:  "NetworkError when attempting to fetch resource."
+ *  - Safari:   "Load failed" */
+const NETWORK_ERROR_MESSAGES = new Set([
+  "Failed to fetch",
+  "NetworkError when attempting to fetch resource.",
+  "Load failed",
+]);
+
+export const isNetworkError = (error: unknown): boolean =>
+  CriticalQueryTimeoutError.is(error) ||
+  (APIError.is(error) && error.status === 0) ||
+  (error instanceof TypeError && NETWORK_ERROR_MESSAGES.has(error.message));

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -15,31 +15,15 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
+import { isNetworkError } from "@/components/route-components.logic";
 import { StellaMark } from "@/components/stella-mark";
 import { useSignOut } from "@/hooks/use-sign-out";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { isMemberError, isUnauthorizedError } from "@/lib/errors";
-import { CriticalQueryTimeoutError } from "@/lib/react-query";
 
 type DefaultErrorComponentProps = ErrorComponentProps & {
   className?: string;
 };
-
-/** Network errors that indicate a transient connectivity
- *  issue (API down, DNS failure, etc.).
- *  Message varies by browser engine:
- *  - Chromium: "Failed to fetch"
- *  - Firefox:  "NetworkError when attempting to fetch resource."
- *  - Safari:   "Load failed" */
-const NETWORK_ERROR_MESSAGES = new Set([
-  "Failed to fetch",
-  "NetworkError when attempting to fetch resource.",
-  "Load failed",
-]);
-
-const isNetworkError = (error: unknown): boolean =>
-  CriticalQueryTimeoutError.is(error) ||
-  (error instanceof TypeError && NETWORK_ERROR_MESSAGES.has(error.message));
 
 /** Max number of automatic recovery attempts before
  *  falling back to the manual "Try again" button.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/queries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/queries.ts
@@ -1,13 +1,17 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
-import { APIError, toAPIError } from "@/lib/errors";
+import { toAPIError } from "@/lib/errors";
 import type { QueryOptionsInput } from "@/lib/react-query";
+import {
+  fetchStorageArrayBuffer,
+  type StorageFetchPurpose,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/files/storage-fetch";
 
 type FileByFieldIdKey = {
   workspaceId: string;
   fieldId: string;
-  purpose?: "display" | "download" | "native-display";
+  purpose?: StorageFetchPurpose;
 };
 
 type FileData = {
@@ -67,48 +71,6 @@ export const filesKeys = {
 
 type FileOptionsProps = QueryOptionsInput<FileByFieldIdKey>;
 
-type FetchFromStorageOptions = {
-  signal: AbortSignal;
-  purpose: NonNullable<FileByFieldIdKey["purpose"]>;
-};
-
-// Presigned URLs are fetched directly from S3 (cross-origin), so a
-// failure here can be CORS, TLS, DNS, offline, or a content blocker —
-// none of which produce an HTTP response. Wrapping the bare fetch keeps
-// the raw browser string ("NetworkError when attempting to fetch
-// resource.") out of telemetry and records which fetch + purpose failed
-// instead. Aborts are re-thrown untouched so React Query treats a
-// cancelled query as a cancellation, not a real error.
-const fetchFromStorage = async (
-  presignedUrl: string,
-  { signal, purpose }: FetchFromStorageOptions,
-) => {
-  let file: Response;
-  try {
-    file = await fetch(presignedUrl, { signal });
-  } catch (cause) {
-    if (signal.aborted) {
-      throw cause;
-    }
-    throw new APIError({
-      status: 0,
-      message: `Storage fetch failed before response (purpose=${purpose})`,
-      details: {
-        cause: cause instanceof Error ? cause.message : String(cause),
-      },
-    });
-  }
-
-  if (!file.ok) {
-    throw new APIError({
-      status: file.status,
-      message: `Failed to fetch file from storage (purpose=${purpose})`,
-    });
-  }
-
-  return file;
-};
-
 export const fileMetadataOptions = (props: FileOptionsProps) =>
   queryOptions({
     queryKey: filesKeys.metadataByFieldId(props),
@@ -150,7 +112,7 @@ export const fileOptions = (props: FileOptionsProps) =>
         throw toAPIError(response.error);
       }
 
-      const file = await fetchFromStorage(response.data.presignedUrl, {
+      const buffer = await fetchStorageArrayBuffer(response.data.presignedUrl, {
         signal,
         purpose: props.purpose ?? "display",
       });
@@ -160,7 +122,7 @@ export const fileOptions = (props: FileOptionsProps) =>
         fileName: response.data.fileName,
         mimeType: response.data.mimeType,
         originalMimeType: response.data.originalMimeType,
-        buffer: await file.arrayBuffer(),
+        buffer,
       } satisfies FileData;
     },
   });
@@ -204,7 +166,7 @@ export const textFileOptions = (props: FileOptionsProps) =>
         throw toAPIError(response.error);
       }
 
-      const file = await fetchFromStorage(response.data.presignedUrl, {
+      const buffer = await fetchStorageArrayBuffer(response.data.presignedUrl, {
         signal,
         purpose: "download",
       });
@@ -214,7 +176,7 @@ export const textFileOptions = (props: FileOptionsProps) =>
         fileName: response.data.fileName,
         mimeType: response.data.mimeType,
         originalMimeType: response.data.originalMimeType,
-        text: new TextDecoder().decode(await file.arrayBuffer()),
+        text: new TextDecoder().decode(buffer),
       } satisfies TextFileData;
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/queries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/queries.ts
@@ -67,6 +67,48 @@ export const filesKeys = {
 
 type FileOptionsProps = QueryOptionsInput<FileByFieldIdKey>;
 
+type FetchFromStorageOptions = {
+  signal: AbortSignal;
+  purpose: NonNullable<FileByFieldIdKey["purpose"]>;
+};
+
+// Presigned URLs are fetched directly from S3 (cross-origin), so a
+// failure here can be CORS, TLS, DNS, offline, or a content blocker —
+// none of which produce an HTTP response. Wrapping the bare fetch keeps
+// the raw browser string ("NetworkError when attempting to fetch
+// resource.") out of telemetry and records which fetch + purpose failed
+// instead. Aborts are re-thrown untouched so React Query treats a
+// cancelled query as a cancellation, not a real error.
+const fetchFromStorage = async (
+  presignedUrl: string,
+  { signal, purpose }: FetchFromStorageOptions,
+) => {
+  let file: Response;
+  try {
+    file = await fetch(presignedUrl, { signal });
+  } catch (cause) {
+    if (signal.aborted) {
+      throw cause;
+    }
+    throw new APIError({
+      status: 0,
+      message: `Storage fetch failed before response (purpose=${purpose})`,
+      details: {
+        cause: cause instanceof Error ? cause.message : String(cause),
+      },
+    });
+  }
+
+  if (!file.ok) {
+    throw new APIError({
+      status: file.status,
+      message: `Failed to fetch file from storage (purpose=${purpose})`,
+    });
+  }
+
+  return file;
+};
+
 export const fileMetadataOptions = (props: FileOptionsProps) =>
   queryOptions({
     queryKey: filesKeys.metadataByFieldId(props),
@@ -108,14 +150,10 @@ export const fileOptions = (props: FileOptionsProps) =>
         throw toAPIError(response.error);
       }
 
-      const file = await fetch(response.data.presignedUrl, { signal });
-
-      if (!file.ok) {
-        throw new APIError({
-          status: file.status,
-          message: "Failed to fetch file from storage",
-        });
-      }
+      const file = await fetchFromStorage(response.data.presignedUrl, {
+        signal,
+        purpose: props.purpose ?? "display",
+      });
 
       return {
         fileId: response.data.fileId,
@@ -166,14 +204,10 @@ export const textFileOptions = (props: FileOptionsProps) =>
         throw toAPIError(response.error);
       }
 
-      const file = await fetch(response.data.presignedUrl, { signal });
-
-      if (!file.ok) {
-        throw new APIError({
-          status: file.status,
-          message: "Failed to fetch file from storage",
-        });
-      }
+      const file = await fetchFromStorage(response.data.presignedUrl, {
+        signal,
+        purpose: "download",
+      });
 
       return {
         fileId: response.data.fileId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/storage-fetch.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/storage-fetch.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { APIError } from "@/lib/errors";
+import { fetchStorageArrayBuffer } from "@/routes/_protected.workspaces/$workspaceId/-components/files/storage-fetch";
+
+const originalFetch = globalThis.fetch;
+type FetchHandler = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => ReturnType<typeof fetch>;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("storage fetches", () => {
+  test("returns the response body and forwards the abort signal", async () => {
+    const controller = new AbortController();
+    const response = new Response("hello");
+    const fetchMock = setFetch(mock(async () => response));
+
+    const buffer = await fetchStorageArrayBuffer("https://storage.local/file", {
+      signal: controller.signal,
+      purpose: "display",
+    });
+
+    expect(new TextDecoder().decode(buffer)).toBe("hello");
+    expect(fetchMock).toHaveBeenCalledWith("https://storage.local/file", {
+      signal: controller.signal,
+    });
+  });
+
+  test("preserves storage HTTP status failures", async () => {
+    setFetch(mock(async () => new Response("denied", { status: 403 })));
+
+    const error = await catchError(
+      async () =>
+        await fetchStorageArrayBuffer("https://storage.local/file", {
+          signal: new AbortController().signal,
+          purpose: "download",
+        }),
+    );
+
+    expect(APIError.is(error)).toBe(true);
+    expect(error).toMatchObject({
+      status: 403,
+      details: { phase: "response", purpose: "download" },
+    });
+  });
+
+  test("wraps pre-response storage network failures without raw browser text", async () => {
+    setFetch(
+      mock(async () => {
+        throw new TypeError("Failed to fetch");
+      }),
+    );
+
+    const error = await catchError(
+      async () =>
+        await fetchStorageArrayBuffer("https://storage.local/file", {
+          signal: new AbortController().signal,
+          purpose: "display",
+        }),
+    );
+
+    expect(APIError.is(error)).toBe(true);
+    expect(error).toMatchObject({
+      status: 0,
+      details: {
+        causeType: "TypeError",
+        phase: "response",
+        purpose: "display",
+      },
+    });
+    expect(
+      error instanceof Error ? error.message : String(error),
+    ).not.toContain("Failed to fetch");
+    expect(JSON.stringify(error)).not.toContain("Failed to fetch");
+  });
+
+  test("wraps response body storage network failures", async () => {
+    const response = new Response("ignored");
+    Object.defineProperty(response, "arrayBuffer", {
+      value: mock(async () => {
+        throw new TypeError("NetworkError when attempting to fetch resource.");
+      }),
+    });
+    setFetch(mock(async () => response));
+
+    const error = await catchError(
+      async () =>
+        await fetchStorageArrayBuffer("https://storage.local/file", {
+          signal: new AbortController().signal,
+          purpose: "native-display",
+        }),
+    );
+
+    expect(APIError.is(error)).toBe(true);
+    expect(error).toMatchObject({
+      status: 0,
+      details: {
+        causeType: "TypeError",
+        phase: "body",
+        purpose: "native-display",
+      },
+    });
+    expect(JSON.stringify(error)).not.toContain(
+      "NetworkError when attempting to fetch resource.",
+    );
+  });
+
+  test("rethrows aborted fetch and body-read errors", async () => {
+    const fetchAbort = new DOMException("Aborted", "AbortError");
+    const fetchController = new AbortController();
+    fetchController.abort();
+    setFetch(
+      mock(async () => {
+        throw fetchAbort;
+      }),
+    );
+
+    const fetchError = await catchError(
+      async () =>
+        await fetchStorageArrayBuffer("https://storage.local/file", {
+          signal: fetchController.signal,
+          purpose: "display",
+        }),
+    );
+
+    expect(fetchError).toBe(fetchAbort);
+
+    const bodyAbort = new DOMException("Aborted", "AbortError");
+    const bodyController = new AbortController();
+    bodyController.abort();
+    const response = new Response("ignored");
+    Object.defineProperty(response, "arrayBuffer", {
+      value: mock(async () => {
+        throw bodyAbort;
+      }),
+    });
+    setFetch(mock(async () => response));
+
+    const bodyError = await catchError(
+      async () =>
+        await fetchStorageArrayBuffer("https://storage.local/file", {
+          signal: bodyController.signal,
+          purpose: "download",
+        }),
+    );
+
+    expect(bodyError).toBe(bodyAbort);
+  });
+});
+
+const setFetch = (handler: FetchHandler) => {
+  const nextFetch = Object.assign(handler, {
+    preconnect: originalFetch.preconnect,
+  });
+  globalThis.fetch = nextFetch;
+  return nextFetch;
+};
+
+const catchError = async (run: () => Promise<unknown>) => {
+  try {
+    await run();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("Expected operation to throw");
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/storage-fetch.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/files/storage-fetch.ts
@@ -1,0 +1,83 @@
+import { APIError } from "@/lib/errors";
+
+export type StorageFetchPurpose = "display" | "download" | "native-display";
+
+type FetchStorageArrayBufferOptions = {
+  signal: AbortSignal;
+  purpose: StorageFetchPurpose;
+};
+
+type StorageFetchPhase = "response" | "body";
+
+type StorageNetworkErrorOptions = {
+  error: unknown;
+  phase: StorageFetchPhase;
+  purpose: StorageFetchPurpose;
+};
+
+// Direct presigned URL fetches fail without an HTTP response for CORS,
+// TLS, DNS, offline, and content-blocker cases. Keep those failures
+// network-shaped for the route boundary while recording the storage phase.
+export const fetchStorageArrayBuffer = async (
+  presignedUrl: string,
+  { signal, purpose }: FetchStorageArrayBufferOptions,
+) => {
+  let response: Response;
+  try {
+    response = await fetch(presignedUrl, { signal });
+  } catch (error) {
+    if (signal.aborted) {
+      throw error;
+    }
+
+    throw toStorageNetworkError({ error, phase: "response", purpose });
+  }
+
+  if (!response.ok) {
+    throw new APIError({
+      status: response.status,
+      message: `Failed to fetch file from storage (purpose=${purpose})`,
+      details: { phase: "response", purpose },
+    });
+  }
+
+  try {
+    return await response.arrayBuffer();
+  } catch (error) {
+    if (signal.aborted) {
+      throw error;
+    }
+
+    throw toStorageNetworkError({ error, phase: "body", purpose });
+  }
+};
+
+const toStorageNetworkError = ({
+  error,
+  phase,
+  purpose,
+}: StorageNetworkErrorOptions) =>
+  new APIError({
+    status: 0,
+    message:
+      phase === "response"
+        ? `Storage fetch failed before response (purpose=${purpose})`
+        : `Storage response body read failed (purpose=${purpose})`,
+    details: {
+      causeType: getCauseType(error),
+      phase,
+      purpose,
+    },
+  });
+
+const getCauseType = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.name;
+  }
+
+  if (error === null) {
+    return "null";
+  }
+
+  return typeof error;
+};


### PR DESCRIPTION
## Summary

Browser fetches of presigned storage URLs go directly to S3 (cross-origin). The bare `fetch()` in `fileOptions`/`textFileOptions` threw the raw browser rejection straight into telemetry (e.g. Firefox's `NetworkError when attempting to fetch resource.`), which made several distinct failures indistinguishable:

- CORS / TLS / DNS / offline / content-blocker (no HTTP response) vs. an actual HTTP error status
- the API presign call vs. the storage download

It also gave no signal for *which* file purpose failed.

## Change

Extract a shared `fetchFromStorage` helper used by both `fileOptions` and `textFileOptions` that:

- throws a tagged `APIError` carrying the `purpose` and the original cause message in `details`
- distinguishes never-reached-storage (`status: 0`) from HTTP errors (real status)
- re-throws aborts untouched so a cancelled query stays a cancellation (not logged as an error)

Pure observability/robustness change; no behavioral change on the success path.