### PR TITLE
fix(dev-runner): pass allocated API port to Bun API process in Windows

### DIFF
--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -1507,6 +1507,8 @@ const buildPersistentSteps = ({
         resolveCommandPath("bun"),
         "--preload",
         "./src/dev/register-mock-ai.ts",
+        "--port",
+        String(ports.api),
         "--watch",
         "src/index.ts",
       ],


### PR DESCRIPTION
## Problem

The dev runner allocates ports dynamically, but the API process was not receiving the assigned API port because it was removed in [4fd9d68](https://github.com/stella/stella/pull/660/commits/4fd9d6873afefbf2a38a90f55df25709d1bee8ab) which was already  added in #660 .

As a result, the API could start on its default port instead of the port selected by the runner, causing readiness checks and service coordination to fail in Windows environments.

```shell
anifest.json is not in the project directory and will not be watched
warn: File Started development server: http://localhost:3000
4:44:37 pm [vite] (client) Re-optimizing dependencies because lockfile has changed
4:44:40 pm [vite] (client) [optimizer] scanning dependencies...
error when starting dev server:
Error: listen EACCES: permission denied ::1:3000
    at Server.setupListenHandle [as _listen2] (node:net:1918:21)
    at listenInCluster (node:net:1997:12)
    at GetAddrInfoReqWrap.callback (node:net:2206:7)
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:134:8) {
  code: 'EACCES',
  errno: -4092,
  syscall: 'listen',
  address: '::1',
  port: 3000
}
error: script "dev" exited with code 1
Timed out waiting for Web server: expected 200 from web root, received 404.
error: script "dev" exited with code 1
```

## Solution

Pass the allocated API port to the Bun API process:

--port : allocated-port

This ensures the API server binds to the same port that the dev runner expects and uses for readiness checks.
