### PR TITLE
fix: harden tabular AI extraction workflow

### DIFF
--- a/apps/api/src/handlers/workspaces/read-workflow-target-count.ts
+++ b/apps/api/src/handlers/workspaces/read-workflow-target-count.ts
@@ -1,0 +1,42 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { countWorkflowTargetEntities } from "@/api/lib/workflow-target-queries";
+
+const config = {
+  permissions: { workspace: ["update"] },
+  body: t.Object({
+    entityIds: t.Optional(t.Array(tSafeId("entity"))),
+  }),
+} satisfies HandlerConfig;
+
+const workflowTargetCount = createSafeHandler(
+  config,
+  async function* ({ body, scopedDb, workspaceId }) {
+    const count = yield* Result.await(
+      Result.tryPromise({
+        try: async () =>
+          await countWorkflowTargetEntities({
+            scopedDb,
+            workspaceId,
+            ...(body.entityIds !== undefined &&
+              body.entityIds.length > 0 && { inputEntityIds: body.entityIds }),
+          }),
+        catch: (cause) =>
+          new HandlerError({
+            status: 500,
+            message: "Internal server error",
+            cause,
+          }),
+      }),
+    );
+
+    return Result.ok({ count });
+  },
+);
+
+export default workflowTargetCount;

--- a/apps/api/src/handlers/workspaces/routes.ts
+++ b/apps/api/src/handlers/workspaces/routes.ts
@@ -27,6 +27,7 @@ import { readJustificationsHandler } from "@/api/handlers/workspaces/read-justif
 import readWorkspaceNavigation from "@/api/handlers/workspaces/read-navigation";
 import { readOverviewHandler } from "@/api/handlers/workspaces/read-overview";
 import { readWorkflowHandler } from "@/api/handlers/workspaces/read-workflow-status";
+import workflowTargetCount from "@/api/handlers/workspaces/read-workflow-target-count";
 import unarchiveWorkspace from "@/api/handlers/workspaces/unarchive";
 import updateActiveWorkspace from "@/api/handlers/workspaces/update-active";
 import updateWorkspace from "@/api/handlers/workspaces/update-by-id";
@@ -198,6 +199,10 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
         .post("/workflow/start", workflowStart.handler, {
           body: workflowStart.config.body,
           permissions: workflowStart.config.permissions,
+        })
+        .post("/workflow/target-count", workflowTargetCount.handler, {
+          body: workflowTargetCount.config.body,
+          permissions: workflowTargetCount.config.permissions,
         })
         .post("/cell-retry", cellRetry.handler, {
           body: cellRetry.config.body,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1,4 +1,4 @@
-import { matchError, panic, Result } from "better-result";
+import { panic, Result } from "better-result";
 import { Queue, Worker } from "bullmq";
 import type { RedisClient } from "bun";
 import { sleep } from "bun";
@@ -60,6 +60,11 @@ import {
   selectRecoverableOrphanWorkspaceIds,
   selectRunningLockReservation,
 } from "@/api/lib/workflow/orphan-recovery";
+import {
+  computeWorkflowJobTimeoutMs,
+  runWorkflowBatchGenerationWithRetry,
+  WORKFLOW_BATCH_AI_TIMEOUT_MS,
+} from "@/api/lib/workflow/run-logic";
 import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { prepareBatch } from "@/api/lib/workflow/utils";
 
@@ -196,28 +201,6 @@ const LOCK_DURATION_MS = 5 * 60 * 1000;
 const STALLED_INTERVAL_MS = 30 * 1000;
 const MAX_STALLED_COUNT = 2;
 
-// Per-batch AI timeout. The same constant feeds into both the AI SDK
-// abort signal in `processOneBatch` and the per-job timeout below so
-// changes stay coupled.
-const BATCH_AI_TIMEOUT_MS = 120 * 1000;
-const INTEGRATION_ERROR_RETRY_DELAY_MS = 5 * 1000;
-const INTEGRATION_ERROR_ATTEMPTS = 2;
-// Floor for the per-job hard timeout — even a single-level plan gets
-// a generous window for setup, network blips, and the post-AI DB
-// writes.
-const JOB_TIMEOUT_FLOOR_MS = 6 * 60 * 1000;
-// Each dependency level runs sequentially and may itself contain
-// multiple batches sharing the per-batch timeout. The 1.5× factor
-// accommodates one retry within a batch plus DB write overhead.
-const JOB_TIMEOUT_PER_LEVEL_MS = Math.ceil(BATCH_AI_TIMEOUT_MS * 1.5);
-
-const computeJobTimeoutMs = (executionPlan: ExecutionLevel[]): number => {
-  const levels = executionPlan.length;
-  return Math.max(
-    JOB_TIMEOUT_FLOOR_MS,
-    levels * JOB_TIMEOUT_PER_LEVEL_MS + JOB_TIMEOUT_FLOOR_MS,
-  );
-};
 // Workflow-level Redis lock TTL. Long enough to outlast a single batch
 // even on big workspaces, short enough to self-heal an uncleanly-killed
 // worker without stranding the workspace for hours. The lock is also
@@ -1144,7 +1127,7 @@ export const initWorkflowWorker = () => {
       // AI timeout. A fixed 6-min ceiling would deterministically
       // abort entities with several slow levels even when each
       // individual batch stays within budget.
-      const jobTimeoutMs = computeJobTimeoutMs(job.data.executionPlan);
+      const jobTimeoutMs = computeWorkflowJobTimeoutMs(job.data.executionPlan);
       const timeoutHandle = setTimeout(() => {
         controller.abort(
           new Error(
@@ -1610,56 +1593,40 @@ const processOneBatch = async ({
     ]);
     const generateFn = getBatchGenerator();
 
-    let batchResult: Awaited<ReturnType<typeof generateFn>> | undefined;
-    for (let attempt = 1; attempt <= INTEGRATION_ERROR_ATTEMPTS; attempt++) {
-      // generateBatch returns a Result<T, E> directly. The combined
-      // signal aborts when EITHER the per-batch AI timeout fires OR the
-      // worker-level per-job timeout does, so the AI SDK actually cancels
-      // the in-flight request.
-      batchResult = await generateFn({
-        abortSignal: AbortSignal.any([
-          AbortSignal.timeout(BATCH_AI_TIMEOUT_MS),
-          signal,
-        ]),
-        batch,
-        entityVersionId,
-        organizationId,
-        workspaceId,
-        scopedDb,
-        orgAIConfig,
-        promptCachingEnabled,
-        onPartialAnswer: previewPublisher.publish,
-      });
-
-      if (!Result.isError(batchResult)) {
-        break;
-      }
-
-      const retryIntegrationError: boolean = matchError(batchResult.error, {
-        WorkflowIntegrationError: () => true,
-        WorkflowValidationError: () => false,
-      });
-      if (!retryIntegrationError || attempt >= INTEGRATION_ERROR_ATTEMPTS) {
-        break;
-      }
-
-      captureError(batchResult.error, {
-        workspaceId,
-        entityId,
-        batchId: batch.id,
-        level: String(level),
-        requestId,
-        attempt: String(attempt),
-        retry: "true",
-      });
-      signal.throwIfAborted();
-      await sleep(INTEGRATION_ERROR_RETRY_DELAY_MS);
-      signal.throwIfAborted();
-    }
-
-    if (batchResult === undefined) {
-      return;
-    }
+    // generateBatch returns a Result<T, E> directly. The combined
+    // signal aborts when EITHER the per-batch AI timeout fires OR the
+    // worker-level per-job timeout does, so the AI SDK actually cancels
+    // the in-flight request.
+    const batchResult = await runWorkflowBatchGenerationWithRetry({
+      generate: async () =>
+        await generateFn({
+          abortSignal: AbortSignal.any([
+            AbortSignal.timeout(WORKFLOW_BATCH_AI_TIMEOUT_MS),
+            signal,
+          ]),
+          batch,
+          entityVersionId,
+          organizationId,
+          workspaceId,
+          scopedDb,
+          orgAIConfig,
+          promptCachingEnabled,
+          onPartialAnswer: previewPublisher.publish,
+        }),
+      onRetryError: (error, attempt) => {
+        captureError(error, {
+          workspaceId,
+          entityId,
+          batchId: batch.id,
+          level: String(level),
+          requestId,
+          attempt: String(attempt),
+          retry: "true",
+        });
+      },
+      sleep,
+      throwIfAborted: () => signal.throwIfAborted(),
+    });
 
     if (Result.isError(batchResult)) {
       captureError(batchResult.error, {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -2,19 +2,18 @@ import { panic, Result } from "better-result";
 import { Queue, Worker } from "bullmq";
 import type { RedisClient } from "bun";
 import { sleep } from "bun";
-import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db";
 import { jsonField } from "@/api/db/json-utils";
 import { rootDb } from "@/api/db/root";
 import {
   cellMetadata,
-  entities,
   fields,
   justifications,
   properties,
 } from "@/api/db/schema";
-import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
+import type { FieldContent } from "@/api/db/schema-validators";
 import {
   loadOrgAIConfig,
   loadPromptCachingPreference,
@@ -43,6 +42,11 @@ import {
   brandValidatedWorkflowActorKey,
 } from "@/api/lib/safe-id-boundaries";
 import { broadcast } from "@/api/lib/sse";
+import {
+  collectFullWorkflowTargetIds,
+  fetchExplicitWorkflowTargetRows,
+  readFullWorkflowSnapshotCursor,
+} from "@/api/lib/workflow-target-queries";
 import { resolveWorkflowTargetEntityIds } from "@/api/lib/workflow-targets";
 import { getBatchGenerator } from "@/api/lib/workflow/generate-batch-provider";
 import type {
@@ -249,16 +253,6 @@ type StartWorkflowResult = {
   status: "started" | "already-running" | "skipped" | "failed";
 };
 
-type WorkflowTargetEntityRow = {
-  id: SafeId<"entity">;
-  kind: EntityKind;
-};
-
-type FullWorkflowTargetCursor = {
-  createdAt: string;
-  id: SafeId<"entity">;
-};
-
 type EnqueueEntityJobsArgs = {
   entityIds: readonly SafeId<"entity">[];
   executionPlan: ExecutionLevel[];
@@ -342,135 +336,6 @@ const removeQueuedWorkflowJobs = async (
         }
       }),
     );
-  }
-};
-
-const fetchExplicitWorkflowTargetRows = async ({
-  inputEntityIds,
-  scopedDb,
-  workspaceId,
-}: {
-  inputEntityIds: readonly SafeId<"entity">[];
-  scopedDb: ScopedDb;
-  workspaceId: SafeId<"workspace">;
-}): Promise<WorkflowTargetEntityRow[]> => {
-  const entityRows: WorkflowTargetEntityRow[] = [];
-  for (const chunk of chunkItems(
-    inputEntityIds,
-    LIMITS.workflowEntityBatchSize,
-  )) {
-    const rows = await scopedDb((tx) =>
-      tx
-        .select({ id: entities.id, kind: entities.kind })
-        .from(entities)
-        .where(
-          and(
-            eq(entities.workspaceId, workspaceId),
-            inArray(entities.id, chunk),
-          ),
-        ),
-    );
-    for (const row of rows) {
-      entityRows.push(row);
-    }
-  }
-
-  return entityRows;
-};
-
-const WORKFLOW_TIMESTAMP_CURSOR_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
-
-const readFullWorkflowSnapshotCursor = async ({
-  scopedDb,
-}: {
-  scopedDb: ScopedDb;
-}): Promise<string> => {
-  const rows = await scopedDb((tx) =>
-    tx.execute<{ value: string }>(
-      sql`SELECT to_char(now(), ${WORKFLOW_TIMESTAMP_CURSOR_FORMAT}) AS value`,
-    ),
-  );
-  const row = rows.at(0);
-  if (!row) {
-    return panic("Workflow snapshot cursor query returned no rows");
-  }
-
-  return row.value;
-};
-
-const fetchFullWorkflowTargetBatch = async ({
-  createdAtCutoff,
-  lastCursor,
-  scopedDb,
-  workspaceId,
-}: {
-  createdAtCutoff: string;
-  lastCursor: FullWorkflowTargetCursor | null;
-  scopedDb: ScopedDb;
-  workspaceId: SafeId<"workspace">;
-}): Promise<FullWorkflowTargetCursor[]> =>
-  await scopedDb((tx) =>
-    tx
-      .select({
-        createdAt: sql<string>`to_char(${entities.createdAt}, ${WORKFLOW_TIMESTAMP_CURSOR_FORMAT})`,
-        id: entities.id,
-      })
-      .from(entities)
-      .where(
-        and(
-          eq(entities.workspaceId, workspaceId),
-          eq(entities.kind, "document"),
-          sql`${entities.createdAt} <= ${createdAtCutoff}::timestamp`,
-          ...(lastCursor === null
-            ? []
-            : [
-                or(
-                  sql`${entities.createdAt} > ${lastCursor.createdAt}::timestamp`,
-                  and(
-                    sql`${entities.createdAt} = ${lastCursor.createdAt}::timestamp`,
-                    gt(entities.id, lastCursor.id),
-                  ),
-                ),
-              ]),
-        ),
-      )
-      .orderBy(asc(entities.createdAt), asc(entities.id))
-      .limit(LIMITS.workflowEntityBatchSize),
-  );
-
-const collectFullWorkflowTargetIds = async ({
-  createdAtCutoff,
-  scopedDb,
-  workspaceId,
-}: {
-  createdAtCutoff: string;
-  scopedDb: ScopedDb;
-  workspaceId: SafeId<"workspace">;
-}): Promise<SafeId<"entity">[]> => {
-  const entityIds: SafeId<"entity">[] = [];
-  let lastCursor: FullWorkflowTargetCursor | null = null;
-
-  while (true) {
-    const rows = await fetchFullWorkflowTargetBatch({
-      createdAtCutoff,
-      lastCursor,
-      scopedDb,
-      workspaceId,
-    });
-
-    if (rows.length === 0) {
-      return entityIds;
-    }
-
-    for (const row of rows) {
-      entityIds.push(row.id);
-    }
-
-    const lastRow = rows.at(-1);
-    if (!lastRow) {
-      return entityIds;
-    }
-    lastCursor = lastRow;
   }
 };
 

--- a/apps/api/src/lib/workflow-target-queries.ts
+++ b/apps/api/src/lib/workflow-target-queries.ts
@@ -1,0 +1,211 @@
+import { panic } from "better-result";
+import { and, asc, count, eq, gt, inArray, or, sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db";
+import { entities } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+import { resolveWorkflowTargetEntityIds } from "@/api/lib/workflow-targets";
+import type { WorkflowTargetEntityRow } from "@/api/lib/workflow-targets";
+
+type FullWorkflowTargetCursor = {
+  createdAt: string;
+  id: SafeId<"entity">;
+};
+
+const WORKFLOW_TIMESTAMP_CURSOR_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
+
+const chunkEntityIds = (
+  entityIds: readonly SafeId<"entity">[],
+): SafeId<"entity">[][] => {
+  const chunks: SafeId<"entity">[][] = [];
+  for (
+    let index = 0;
+    index < entityIds.length;
+    index += LIMITS.workflowEntityBatchSize
+  ) {
+    chunks.push(entityIds.slice(index, index + LIMITS.workflowEntityBatchSize));
+  }
+  return chunks;
+};
+
+export const fetchExplicitWorkflowTargetRows = async ({
+  inputEntityIds,
+  scopedDb,
+  workspaceId,
+}: {
+  inputEntityIds: readonly SafeId<"entity">[];
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<WorkflowTargetEntityRow[]> => {
+  const entityRows: WorkflowTargetEntityRow[] = [];
+  for (const chunk of chunkEntityIds(inputEntityIds)) {
+    const rows = await scopedDb((tx) =>
+      tx
+        .select({ id: entities.id, kind: entities.kind })
+        .from(entities)
+        .where(
+          and(
+            eq(entities.workspaceId, workspaceId),
+            inArray(entities.id, chunk),
+          ),
+        ),
+    );
+    for (const row of rows) {
+      entityRows.push(row);
+    }
+  }
+
+  return entityRows;
+};
+
+export const readFullWorkflowSnapshotCursor = async ({
+  scopedDb,
+}: {
+  scopedDb: ScopedDb;
+}): Promise<string> => {
+  const rows = await scopedDb((tx) =>
+    tx.execute<{ value: string }>(
+      sql`SELECT to_char(now(), ${WORKFLOW_TIMESTAMP_CURSOR_FORMAT}) AS value`,
+    ),
+  );
+  const row = rows.at(0);
+  if (!row) {
+    return panic("Workflow snapshot cursor query returned no rows");
+  }
+
+  return row.value;
+};
+
+const fetchFullWorkflowTargetBatch = async ({
+  createdAtCutoff,
+  lastCursor,
+  scopedDb,
+  workspaceId,
+}: {
+  createdAtCutoff: string;
+  lastCursor: FullWorkflowTargetCursor | null;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<FullWorkflowTargetCursor[]> =>
+  await scopedDb((tx) =>
+    tx
+      .select({
+        createdAt: sql<string>`to_char(${entities.createdAt}, ${WORKFLOW_TIMESTAMP_CURSOR_FORMAT})`,
+        id: entities.id,
+      })
+      .from(entities)
+      .where(
+        and(
+          eq(entities.workspaceId, workspaceId),
+          eq(entities.kind, "document"),
+          sql`${entities.createdAt} <= ${createdAtCutoff}::timestamp`,
+          ...(lastCursor === null
+            ? []
+            : [
+                or(
+                  sql`${entities.createdAt} > ${lastCursor.createdAt}::timestamp`,
+                  and(
+                    sql`${entities.createdAt} = ${lastCursor.createdAt}::timestamp`,
+                    gt(entities.id, lastCursor.id),
+                  ),
+                ),
+              ]),
+        ),
+      )
+      .orderBy(asc(entities.createdAt), asc(entities.id))
+      .limit(LIMITS.workflowEntityBatchSize),
+  );
+
+export const collectFullWorkflowTargetIds = async ({
+  createdAtCutoff,
+  scopedDb,
+  workspaceId,
+}: {
+  createdAtCutoff: string;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<SafeId<"entity">[]> => {
+  const entityIds: SafeId<"entity">[] = [];
+  let lastCursor: FullWorkflowTargetCursor | null = null;
+
+  while (true) {
+    const rows = await fetchFullWorkflowTargetBatch({
+      createdAtCutoff,
+      lastCursor,
+      scopedDb,
+      workspaceId,
+    });
+
+    if (rows.length === 0) {
+      return entityIds;
+    }
+
+    for (const row of rows) {
+      entityIds.push(row.id);
+    }
+
+    const lastRow = rows.at(-1);
+    if (!lastRow) {
+      return entityIds;
+    }
+    lastCursor = lastRow;
+  }
+};
+
+const countFullWorkflowTargets = async ({
+  createdAtCutoff,
+  scopedDb,
+  workspaceId,
+}: {
+  createdAtCutoff: string;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<number> => {
+  const rows = await scopedDb((tx) =>
+    tx
+      .select({ value: count() })
+      .from(entities)
+      .where(
+        and(
+          eq(entities.workspaceId, workspaceId),
+          eq(entities.kind, "document"),
+          sql`${entities.createdAt} <= ${createdAtCutoff}::timestamp`,
+        ),
+      ),
+  );
+  const row = rows.at(0);
+  if (!row) {
+    return panic("Full workflow target count query returned no rows");
+  }
+
+  return row.value;
+};
+
+export const countWorkflowTargetEntities = async ({
+  inputEntityIds,
+  scopedDb,
+  workspaceId,
+}: {
+  inputEntityIds?: readonly SafeId<"entity">[] | undefined;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<number> => {
+  if (inputEntityIds !== undefined && inputEntityIds.length > 0) {
+    const targetEntityIds = resolveWorkflowTargetEntityIds({
+      entityRows: await fetchExplicitWorkflowTargetRows({
+        inputEntityIds,
+        scopedDb,
+        workspaceId,
+      }),
+      inputEntityIds,
+    });
+    return targetEntityIds.length;
+  }
+
+  return await countFullWorkflowTargets({
+    createdAtCutoff: await readFullWorkflowSnapshotCursor({ scopedDb }),
+    scopedDb,
+    workspaceId,
+  });
+};

--- a/apps/api/src/lib/workflow-targets.ts
+++ b/apps/api/src/lib/workflow-targets.ts
@@ -1,7 +1,7 @@
 import type { EntityKind } from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
 
-type WorkflowTargetEntityRow = {
+export type WorkflowTargetEntityRow = {
   id: SafeId<"entity">;
   kind: EntityKind;
 };

--- a/apps/api/src/lib/workflow/run-logic.test.ts
+++ b/apps/api/src/lib/workflow/run-logic.test.ts
@@ -1,0 +1,116 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import {
+  WorkflowIntegrationError,
+  WorkflowValidationError,
+} from "@/api/lib/errors/tagged-errors";
+import {
+  computeWorkflowJobTimeoutMs,
+  runWorkflowBatchGenerationWithRetry,
+  WORKFLOW_BATCH_AI_TIMEOUT_MS,
+  WORKFLOW_INTEGRATION_ERROR_RETRY_DELAY_MS,
+} from "@/api/lib/workflow/run-logic";
+
+describe("workflow batch retry", () => {
+  test("retries a transient integration failure and returns the later success", async () => {
+    const retryErrors: string[] = [];
+    const sleepDelays: number[] = [];
+    let attempts = 0;
+
+    const result = await runWorkflowBatchGenerationWithRetry({
+      generate: async () => {
+        attempts++;
+        if (attempts === 1) {
+          return Result.err(
+            new WorkflowIntegrationError({
+              message: "temporary provider failure",
+            }),
+          );
+        }
+
+        return Result.ok("processed");
+      },
+      onRetryError: (error) => {
+        retryErrors.push(error.message);
+      },
+      sleep: async (milliseconds) => {
+        sleepDelays.push(milliseconds);
+      },
+      throwIfAborted: () => {},
+    });
+
+    expect(Result.isError(result)).toBe(false);
+    if (Result.isError(result)) {
+      return;
+    }
+
+    expect(result.value).toBe("processed");
+    expect(attempts).toBe(2);
+    expect(retryErrors).toEqual(["temporary provider failure"]);
+    expect(sleepDelays).toEqual([WORKFLOW_INTEGRATION_ERROR_RETRY_DELAY_MS]);
+  });
+
+  test("does not retry a workflow validation failure", async () => {
+    const retryErrors: string[] = [];
+    let attempts = 0;
+
+    const result = await runWorkflowBatchGenerationWithRetry({
+      generate: async () => {
+        attempts++;
+        return Result.err(
+          new WorkflowValidationError({
+            message: "AI output did not match the property schema",
+          }),
+        );
+      },
+      onRetryError: (error) => {
+        retryErrors.push(error.message);
+      },
+      sleep: async () => {},
+      throwIfAborted: () => {},
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    expect(attempts).toBe(1);
+    expect(retryErrors).toEqual([]);
+  });
+
+  test("returns the final integration error after the retry budget is exhausted", async () => {
+    const retryErrors: string[] = [];
+    let attempts = 0;
+
+    const result = await runWorkflowBatchGenerationWithRetry({
+      generate: async () => {
+        attempts++;
+        return Result.err(
+          new WorkflowIntegrationError({
+            message: `provider failure ${attempts}`,
+          }),
+        );
+      },
+      onRetryError: (error) => {
+        retryErrors.push(error.message);
+      },
+      sleep: async () => {},
+      throwIfAborted: () => {},
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+
+    expect(result.error.message).toBe("provider failure 2");
+    expect(attempts).toBe(2);
+    expect(retryErrors).toEqual(["provider failure 1"]);
+  });
+});
+
+describe("workflow timeout budget", () => {
+  test("scales entity job timeout above the per-batch timeout and retry budget", () => {
+    expect(computeWorkflowJobTimeoutMs([[]])).toBeGreaterThan(
+      WORKFLOW_BATCH_AI_TIMEOUT_MS * 2,
+    );
+  });
+});

--- a/apps/api/src/lib/workflow/run-logic.ts
+++ b/apps/api/src/lib/workflow/run-logic.ts
@@ -1,0 +1,97 @@
+import { matchError, Result } from "better-result";
+
+import type {
+  WorkflowIntegrationError,
+  WorkflowValidationError,
+} from "@/api/lib/errors/tagged-errors";
+import type { ExecutionLevel } from "@/api/lib/workflow/get-execution-plan";
+
+export const WORKFLOW_BATCH_AI_TIMEOUT_MS = 120 * 1000;
+export const WORKFLOW_INTEGRATION_ERROR_RETRY_DELAY_MS = 5 * 1000;
+export const WORKFLOW_INTEGRATION_ERROR_ATTEMPTS = 2;
+
+const JOB_TIMEOUT_FLOOR_MS = 6 * 60 * 1000;
+const JOB_TIMEOUT_PER_LEVEL_OVERHEAD_MS = 60 * 1000;
+
+type WorkflowBatchError = WorkflowIntegrationError | WorkflowValidationError;
+
+type WorkflowBatchGenerationResult<TValue> = Result<TValue, WorkflowBatchError>;
+
+type ShouldRetryWorkflowBatchErrorArgs = {
+  attempt: number;
+  error: WorkflowBatchError;
+  maxAttempts?: number;
+};
+
+export const computeWorkflowJobTimeoutMs = (
+  executionPlan: ExecutionLevel[],
+): number => {
+  const levels = executionPlan.length;
+  const retryDelayMs =
+    WORKFLOW_INTEGRATION_ERROR_RETRY_DELAY_MS *
+    Math.max(0, WORKFLOW_INTEGRATION_ERROR_ATTEMPTS - 1);
+  const perLevelTimeoutMs =
+    WORKFLOW_BATCH_AI_TIMEOUT_MS * WORKFLOW_INTEGRATION_ERROR_ATTEMPTS +
+    retryDelayMs +
+    JOB_TIMEOUT_PER_LEVEL_OVERHEAD_MS;
+  return Math.max(
+    JOB_TIMEOUT_FLOOR_MS,
+    levels * perLevelTimeoutMs + JOB_TIMEOUT_FLOOR_MS,
+  );
+};
+
+export const shouldRetryWorkflowBatchError = ({
+  attempt,
+  error,
+  maxAttempts = WORKFLOW_INTEGRATION_ERROR_ATTEMPTS,
+}: ShouldRetryWorkflowBatchErrorArgs): boolean => {
+  if (attempt >= maxAttempts) {
+    return false;
+  }
+
+  return matchError(error, {
+    WorkflowIntegrationError: () => true,
+    WorkflowValidationError: () => false,
+  });
+};
+
+type RunWorkflowBatchGenerationWithRetryArgs<TValue> = {
+  generate: () => Promise<WorkflowBatchGenerationResult<TValue>>;
+  onRetryError: (error: WorkflowBatchError, attempt: number) => void;
+  sleep: (milliseconds: number) => Promise<void>;
+  throwIfAborted: () => void;
+};
+
+export const runWorkflowBatchGenerationWithRetry = async <TValue>({
+  generate,
+  onRetryError,
+  sleep,
+  throwIfAborted,
+}: RunWorkflowBatchGenerationWithRetryArgs<TValue>): Promise<
+  WorkflowBatchGenerationResult<TValue>
+> => {
+  let attempt = 1;
+
+  while (true) {
+    const batchResult = await generate();
+
+    if (!Result.isError(batchResult)) {
+      return batchResult;
+    }
+
+    if (
+      !shouldRetryWorkflowBatchError({
+        attempt,
+        error: batchResult.error,
+      })
+    ) {
+      return batchResult;
+    }
+
+    onRetryError(batchResult.error, attempt);
+    throwIfAborted();
+    await sleep(WORKFLOW_INTEGRATION_ERROR_RETRY_DELAY_MS);
+    throwIfAborted();
+    attempt++;
+  }
+};

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Pro spuštění pracovního postupu přidejte alespoň jednu AI vlastnost",
       "allManualInputsTitle": "Všechny vlastnosti jsou ruční vstupy",
       "generate": "Generovat",
+      "largeRunPrompt": {
+        "description": "Do fronty se zařadí extrakce AI pro {count} entit. Spusťte ji jen tehdy, pokud chcete nyní zpracovat tolik souborů.",
+        "start": "Spustit extrakci",
+        "title": "Spustit extrakci AI?"
+      },
       "noFieldsToProcess": "Žádná pole ke zpracování",
       "someFieldsOutdatedDescription": "Aktualizujte pole jednoduchého a vícenásobného výběru tak, aby odpovídala možnostem vlastností",
       "someFieldsOutdatedTitle": "Některá pole jsou zastaralá",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Fügen Sie mindestens eine KI-Eigenschaft hinzu, um den Arbeitsablauf zu starten",
       "allManualInputsTitle": "Alle Eigenschaften sind manuelle Eingaben",
       "generate": "Generieren",
+      "largeRunPrompt": {
+        "description": "Dadurch wird die KI-Extraktion für {count} Entitäten in die Warteschlange gestellt. Starten Sie sie nur, wenn Sie jetzt so viele Dateien verarbeiten möchten.",
+        "start": "Extraktion starten",
+        "title": "KI-Extraktion starten?"
+      },
       "noFieldsToProcess": "Keine Felder zum Verarbeiten",
       "someFieldsOutdatedDescription": "Aktualisieren Sie die Einfach- und Mehrfachauswahlfelder, um den Eigenschaftsoptionen zu entsprechen",
       "someFieldsOutdatedTitle": "Einige Felder sind veraltet",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Please add at least one AI property to start the workflow",
       "allManualInputsTitle": "All properties are manual inputs",
       "generate": "Generate",
+      "largeRunPrompt": {
+        "description": "This will queue AI extraction for {count} entities. Start it only if you want to process this many files now.",
+        "start": "Start extraction",
+        "title": "Start AI extraction?"
+      },
       "noFieldsToProcess": "No fields to process",
       "someFieldsOutdatedDescription": "Please update Single and Multi Select fields to match their property options",
       "someFieldsOutdatedTitle": "Some fields are outdated",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Añada al menos una propiedad de IA para iniciar el flujo de trabajo",
       "allManualInputsTitle": "Todas las propiedades son entradas manuales",
       "generate": "Generar",
+      "largeRunPrompt": {
+        "description": "Esto pondrá en cola la extracción con IA para {count} entidades. Iníciala solo si quieres procesar ahora tantos archivos.",
+        "start": "Iniciar extracción",
+        "title": "¿Iniciar extracción con IA?"
+      },
       "noFieldsToProcess": "No hay campos para procesar",
       "someFieldsOutdatedDescription": "Actualice los campos de selección única y múltiple para que coincidan con las opciones de la propiedad",
       "someFieldsOutdatedTitle": "Algunos campos están desactualizados",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Töövoo käivitamiseks lisage vähemalt üks tehisintellekti omadus",
       "allManualInputsTitle": "Kõik omadused on käsitsi sisestatavad",
       "generate": "Genereeri",
+      "largeRunPrompt": {
+        "description": "See lisab AI väljavõtte järjekorda {count} üksuse jaoks. Käivita see ainult siis, kui soovid praegu nii palju faile töödelda.",
+        "start": "Käivita väljavõte",
+        "title": "Käivitada AI väljavõte?"
+      },
       "noFieldsToProcess": "Töödeldavad väljad puuduvad",
       "someFieldsOutdatedDescription": "Uuendage ühekordse ja mitmikvaliku väljad, et need vastaksid omaduse valikutele",
       "someFieldsOutdatedTitle": "Mõned väljad on aegunud",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Veuillez ajouter au moins une propriété IA pour démarrer le flux de travail",
       "allManualInputsTitle": "Toutes les propriétés sont des saisies manuelles",
       "generate": "Générer",
+      "largeRunPrompt": {
+        "description": "Cela mettra en file d’attente l’extraction par IA pour {count} entités. Lancez-la uniquement si vous voulez traiter autant de fichiers maintenant.",
+        "start": "Lancer l’extraction",
+        "title": "Lancer l’extraction par IA ?"
+      },
       "noFieldsToProcess": "Aucun champ à traiter",
       "someFieldsOutdatedDescription": "Veuillez mettre à jour les champs à sélection unique et multiple pour correspondre aux options des propriétés",
       "someFieldsOutdatedTitle": "Certains champs sont obsolètes",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "A munkafolyamat indításához adjon hozzá legalább egy AI tulajdonságot",
       "allManualInputsTitle": "Minden tulajdonság kézi bevitel",
       "generate": "Generálás",
+      "largeRunPrompt": {
+        "description": "Ez {count} entitáshoz sorolja be az AI-kivonatolást. Csak akkor indítsa el, ha most ennyi fájlt szeretne feldolgozni.",
+        "start": "Kivonatolás indítása",
+        "title": "Elindítja az AI-kivonatolást?"
+      },
       "noFieldsToProcess": "Nincsenek feldolgozandó mezők",
       "someFieldsOutdatedDescription": "Frissítse az egyszeres és többszörös választás mezőket, hogy megfeleljenek a tulajdonság opcióinak",
       "someFieldsOutdatedTitle": "Egyes mezők elavultak",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Norėdami paleisti darbo eigą, pridėkite bent vieną AI savybę",
       "allManualInputsTitle": "Visos savybės yra rankinis įvedimas",
       "generate": "Generuoti",
+      "largeRunPrompt": {
+        "description": "Į eilę bus įtrauktas DI išgavimas {count} objektams. Pradėkite tik jei dabar norite apdoroti tiek failų.",
+        "start": "Pradėti išgavimą",
+        "title": "Pradėti DI išgavimą?"
+      },
       "noFieldsToProcess": "Nėra laukų apdorojimui",
       "someFieldsOutdatedDescription": "Atnaujinkite vieno ir kelių pasirinkimų laukus, kad atitiktų savybių parinktis",
       "someFieldsOutdatedTitle": "Kai kurie laukai yra pasenę",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Lai palaistu darbplūsmu, pievienojiet vismaz vienu AI rekvizītu",
       "allManualInputsTitle": "Visi rekvizīti ir manuālās ievades",
       "generate": "Ģenerēt",
+      "largeRunPrompt": {
+        "description": "Tiks ieplānota MI izgūšana {count} entītijām. Sāciet to tikai tad, ja tagad vēlaties apstrādāt tik daudz failu.",
+        "start": "Sākt izgūšanu",
+        "title": "Sākt MI izgūšanu?"
+      },
       "noFieldsToProcess": "Nav lauku apstrādei",
       "someFieldsOutdatedDescription": "Atjauniniet vienas un vairāku izvēļu laukus, lai tie atbilstu rekvizītu opcijām",
       "someFieldsOutdatedTitle": "Daži lauki ir novecojuši",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2618,6 +2618,11 @@ type Messages = {
       "allManualInputsDescription": "Please add at least one AI property to start the workflow";
       "allManualInputsTitle": "All properties are manual inputs";
       "generate": "Generate";
+      "largeRunPrompt": {
+        "description": "This will queue AI extraction for {count} entities. Start it only if you want to process this many files now.";
+        "start": "Start extraction";
+        "title": "Start AI extraction?";
+      };
       "noFieldsToProcess": "No fields to process";
       "someFieldsOutdatedDescription": "Please update Single and Multi Select fields to match their property options";
       "someFieldsOutdatedTitle": "Some fields are outdated";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Dodaj co najmniej jedną właściwość AI, aby uruchomić proces",
       "allManualInputsTitle": "Wszystkie właściwości to ręczne wprowadzanie",
       "generate": "Generuj",
+      "largeRunPrompt": {
+        "description": "Spowoduje to dodanie ekstrakcji AI dla {count} encji do kolejki. Uruchom ją tylko wtedy, gdy chcesz teraz przetworzyć tyle plików.",
+        "start": "Uruchom ekstrakcję",
+        "title": "Uruchomić ekstrakcję AI?"
+      },
       "noFieldsToProcess": "Brak pól do przetworzenia",
       "someFieldsOutdatedDescription": "Zaktualizuj pola jednokrotnego i wielokrotnego wyboru, aby odpowiadały opcjom właściwości",
       "someFieldsOutdatedTitle": "Niektóre pola są nieaktualne",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Adicione pelo menos uma propriedade de IA para iniciar o fluxo de trabalho",
       "allManualInputsTitle": "Todas as propriedades são entradas manuais",
       "generate": "Gerar",
+      "largeRunPrompt": {
+        "description": "Isso colocará na fila a extração com IA para {count} entidades. Inicie apenas se quiser processar essa quantidade de arquivos agora.",
+        "start": "Iniciar extração",
+        "title": "Iniciar extração com IA?"
+      },
       "noFieldsToProcess": "Nenhum campo para processar",
       "someFieldsOutdatedDescription": "Atualize os campos de seleção única e múltipla para corresponder às opções de propriedade",
       "someFieldsOutdatedTitle": "Alguns campos estão desatualizados",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2615,6 +2615,11 @@
       "allManualInputsDescription": "Na spustenie pracovného postupu pridajte aspoň jednu AI vlastnosť",
       "allManualInputsTitle": "Všetky vlastnosti sú ručné vstupy",
       "generate": "Generovať",
+      "largeRunPrompt": {
+        "description": "Do frontu sa zaradí extrakcia AI pre {count} entít. Spustite ju iba vtedy, ak chcete teraz spracovať toľko súborov.",
+        "start": "Spustiť extrakciu",
+        "title": "Spustiť extrakciu AI?"
+      },
       "noFieldsToProcess": "Žiadne polia na spracovanie",
       "someFieldsOutdatedDescription": "Aktualizujte polia jednoduchého a viacnásobného výberu tak, aby zodpovedali možnostiam vlastností",
       "someFieldsOutdatedTitle": "Niektoré polia sú zastarané",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt.tsx
@@ -46,6 +46,7 @@ export const WorkflowStartConfirmationPromptProvider = ({
   const [pendingPrompt, setPendingPrompt] = useState<PendingPrompt | null>(
     null,
   );
+  const lastEntityCountRef = useRef(0);
 
   const settlePrompt = useCallback((confirmed: boolean) => {
     const prompt = pendingPromptRef.current;
@@ -61,6 +62,7 @@ export const WorkflowStartConfirmationPromptProvider = ({
       return await new Promise((resolve) => {
         const nextPrompt = { ...input, resolve };
         pendingPromptRef.current = nextPrompt;
+        lastEntityCountRef.current = input.entityCount;
         setPendingPrompt(nextPrompt);
       });
     },
@@ -94,7 +96,7 @@ export const WorkflowStartConfirmationPromptProvider = ({
             </AlertDialogTitle>
             <AlertDialogDescription>
               {t("workspaces.workflow.largeRunPrompt.description", {
-                count: String(pendingPrompt?.entityCount ?? 0),
+                count: String(lastEntityCountRef.current),
               })}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt.tsx
@@ -1,0 +1,116 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { PropsWithChildren } from "react";
+
+import { useTranslations } from "use-intl";
+
+import {
+  AlertDialog,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "@stll/ui/components/alert-dialog";
+import { Button } from "@stll/ui/components/button";
+
+type WorkflowStartConfirmationInput = {
+  entityCount: number;
+};
+
+type WorkflowStartConfirmationPrompt = (
+  input: WorkflowStartConfirmationInput,
+) => Promise<boolean>;
+
+type PendingPrompt = WorkflowStartConfirmationInput & {
+  resolve: (confirmed: boolean) => void;
+};
+
+const defaultPrompt: WorkflowStartConfirmationPrompt = async () =>
+  await Promise.resolve(false);
+
+const WorkflowStartConfirmationPromptContext =
+  createContext<WorkflowStartConfirmationPrompt>(defaultPrompt);
+
+export const WorkflowStartConfirmationPromptProvider = ({
+  children,
+}: PropsWithChildren) => {
+  const t = useTranslations();
+  const pendingPromptRef = useRef<PendingPrompt | null>(null);
+  const [pendingPrompt, setPendingPrompt] = useState<PendingPrompt | null>(
+    null,
+  );
+
+  const settlePrompt = useCallback((confirmed: boolean) => {
+    const prompt = pendingPromptRef.current;
+    pendingPromptRef.current = null;
+    setPendingPrompt(null);
+    prompt?.resolve(confirmed);
+  }, []);
+
+  const confirmLargeRun = useCallback<WorkflowStartConfirmationPrompt>(
+    async (input) => {
+      pendingPromptRef.current?.resolve(false);
+
+      return await new Promise((resolve) => {
+        const nextPrompt = { ...input, resolve };
+        pendingPromptRef.current = nextPrompt;
+        setPendingPrompt(nextPrompt);
+      });
+    },
+    [],
+  );
+
+  useEffect(
+    () => () => {
+      const prompt = pendingPromptRef.current;
+      pendingPromptRef.current = null;
+      prompt?.resolve(false);
+    },
+    [],
+  );
+
+  return (
+    <WorkflowStartConfirmationPromptContext.Provider value={confirmLargeRun}>
+      {children}
+      <AlertDialog
+        onOpenChange={(open) => {
+          if (!open) {
+            settlePrompt(false);
+          }
+        }}
+        open={pendingPrompt !== null}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("workspaces.workflow.largeRunPrompt.title")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("workspaces.workflow.largeRunPrompt.description", {
+                count: String(pendingPrompt?.entityCount ?? 0),
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button onClick={() => settlePrompt(false)} variant="ghost">
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={() => settlePrompt(true)}>
+              {t("workspaces.workflow.largeRunPrompt.start")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </WorkflowStartConfirmationPromptContext.Provider>
+  );
+};
+
+export const useWorkflowStartConfirmationPrompt = () =>
+  useContext(WorkflowStartConfirmationPromptContext);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
@@ -113,4 +113,26 @@ describe("workflow start decision", () => {
       options.queryKey,
     ]);
   });
+
+  test("propagates target count load failures", async () => {
+    const expectedError = new Error("target count failed");
+    const queryClient: WorkflowTargetCountQueryClient = {
+      fetchQuery: async () => {
+        throw expectedError;
+      },
+    };
+
+    await estimateWorkflowTargetCount({
+      args: undefined,
+      queryClient,
+      workspaceId: "workspace-a",
+    }).then(
+      () => {
+        throw new Error("Expected target count failure");
+      },
+      (error: unknown) => {
+        expect(error).toBe(expectedError);
+      },
+    );
+  });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
@@ -1,0 +1,91 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, test } from "bun:test";
+
+import { entitySummariesCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+
+import {
+  estimateWorkflowEntityCount,
+  LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD,
+  resolveWorkflowStartDecision,
+} from "./use-start-workflow.logic";
+
+describe("workflow start decision", () => {
+  test("starts small workflows without prompting", async () => {
+    const promptCounts: number[] = [];
+
+    const decision = await resolveWorkflowStartDecision({
+      confirmLargeRun: async ({ entityCount }) => {
+        promptCounts.push(entityCount);
+        return false;
+      },
+      estimateEntityCount: async () =>
+        LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD - 1,
+    });
+
+    expect(decision).toEqual({ type: "start" });
+    expect(promptCounts).toEqual([]);
+  });
+
+  test("prompts large workflows using the estimated entity count", async () => {
+    const promptCounts: number[] = [];
+
+    const decision = await resolveWorkflowStartDecision({
+      confirmLargeRun: async ({ entityCount }) => {
+        promptCounts.push(entityCount);
+        return true;
+      },
+      estimateEntityCount: async () => LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD,
+    });
+
+    expect(decision).toEqual({ type: "start" });
+    expect(promptCounts).toEqual([LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD]);
+  });
+
+  test("cancels a large workflow when the user dismisses or cancels", async () => {
+    const decision = await resolveWorkflowStartDecision({
+      confirmLargeRun: async () => false,
+      estimateEntityCount: async () => 1000,
+    });
+
+    expect(decision).toEqual({ type: "cancel" });
+  });
+
+  test("cancels workflows when the entity count cannot be loaded", async () => {
+    const decision = await resolveWorkflowStartDecision({
+      confirmLargeRun: async () => true,
+      estimateEntityCount: async () => null,
+    });
+
+    expect(decision).toEqual({ type: "cancel" });
+  });
+
+  test("counts scoped entity ids without loading workspace summaries", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const count = await estimateWorkflowEntityCount({
+      args: { entityIds: ["entity-a", "entity-b"] },
+      queryClient,
+      workspaceId: "workspace-a",
+    });
+
+    expect(count).toBe(2);
+  });
+
+  test("loads workspace summaries when scoped entity ids are empty", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const options = entitySummariesCountOptions("workspace-a");
+    queryClient.setQueryData(options.queryKey, 128);
+
+    const count = await estimateWorkflowEntityCount({
+      args: { entityIds: [] },
+      queryClient,
+      workspaceId: "workspace-a",
+    });
+
+    expect(count).toBe(128);
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
@@ -1,10 +1,10 @@
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, test } from "bun:test";
 
-import { entitySummariesCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+import { workflowTargetCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 import {
-  estimateWorkflowEntityCount,
+  estimateWorkflowTargetCount,
   LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD,
   resolveWorkflowStartDecision,
 } from "./use-start-workflow.logic";
@@ -59,28 +59,36 @@ describe("workflow start decision", () => {
     expect(decision).toEqual({ type: "cancel" });
   });
 
-  test("counts scoped entity ids without loading workspace summaries", async () => {
+  test("loads the backend target count for scoped entity ids", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
+    const options = workflowTargetCountOptions({
+      entityIds: ["entity-folder", "entity-document"],
+      workspaceId: "workspace-a",
+    });
+    queryClient.setQueryData(options.queryKey, 1);
 
-    const count = await estimateWorkflowEntityCount({
-      args: { entityIds: ["entity-a", "entity-b"] },
+    const count = await estimateWorkflowTargetCount({
+      args: { entityIds: ["entity-folder", "entity-document"] },
       queryClient,
       workspaceId: "workspace-a",
     });
 
-    expect(count).toBe(2);
+    expect(count).toBe(1);
   });
 
-  test("loads workspace summaries when scoped entity ids are empty", async () => {
+  test("loads the full-workspace target count when scoped entity ids are empty", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    const options = entitySummariesCountOptions("workspace-a");
+    const options = workflowTargetCountOptions({
+      entityIds: [],
+      workspaceId: "workspace-a",
+    });
     queryClient.setQueryData(options.queryKey, 128);
 
-    const count = await estimateWorkflowEntityCount({
+    const count = await estimateWorkflowTargetCount({
       args: { entityIds: [] },
       queryClient,
       workspaceId: "workspace-a",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.test.ts
@@ -1,4 +1,3 @@
-import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, test } from "bun:test";
 
 import { workflowTargetCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
@@ -8,6 +7,23 @@ import {
   LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD,
   resolveWorkflowStartDecision,
 } from "./use-start-workflow.logic";
+import type { WorkflowTargetCountQueryClient } from "./use-start-workflow.logic";
+
+type WorkflowTargetCountOptions = Parameters<
+  WorkflowTargetCountQueryClient["fetchQuery"]
+>[0];
+
+const createWorkflowTargetCountClient = (count: number) => {
+  const fetchQueryCalls: WorkflowTargetCountOptions[] = [];
+  const queryClient: WorkflowTargetCountQueryClient = {
+    fetchQuery: async (options) => {
+      fetchQueryCalls.push(options);
+      return count;
+    },
+  };
+
+  return { fetchQueryCalls, queryClient };
+};
 
 describe("workflow start decision", () => {
   test("starts small workflows without prompting", async () => {
@@ -60,14 +76,11 @@ describe("workflow start decision", () => {
   });
 
   test("loads the backend target count for scoped entity ids", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { fetchQueryCalls, queryClient } = createWorkflowTargetCountClient(1);
     const options = workflowTargetCountOptions({
       entityIds: ["entity-folder", "entity-document"],
       workspaceId: "workspace-a",
     });
-    queryClient.setQueryData(options.queryKey, 1);
 
     const count = await estimateWorkflowTargetCount({
       args: { entityIds: ["entity-folder", "entity-document"] },
@@ -76,17 +89,18 @@ describe("workflow start decision", () => {
     });
 
     expect(count).toBe(1);
+    expect(fetchQueryCalls.map((call) => call.queryKey)).toEqual([
+      options.queryKey,
+    ]);
   });
 
   test("loads the full-workspace target count when scoped entity ids are empty", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { fetchQueryCalls, queryClient } =
+      createWorkflowTargetCountClient(128);
     const options = workflowTargetCountOptions({
       entityIds: [],
       workspaceId: "workspace-a",
     });
-    queryClient.setQueryData(options.queryKey, 128);
 
     const count = await estimateWorkflowTargetCount({
       args: { entityIds: [] },
@@ -95,5 +109,8 @@ describe("workflow start decision", () => {
     });
 
     expect(count).toBe(128);
+    expect(fetchQueryCalls.map((call) => call.queryKey)).toEqual([
+      options.queryKey,
+    ]);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
@@ -1,5 +1,3 @@
-import type { QueryClient } from "@tanstack/react-query";
-
 import { workflowTargetCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 export type StartWorkflowArgs = {
@@ -11,6 +9,12 @@ export type StartWorkflowArgs = {
 export type WorkflowStartDecision = { type: "start" } | { type: "cancel" };
 
 export const LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD = 50;
+
+export type WorkflowTargetCountQueryClient = {
+  fetchQuery: (
+    options: ReturnType<typeof workflowTargetCountOptions>,
+  ) => Promise<number>;
+};
 
 type ResolveWorkflowStartDecisionArgs = {
   confirmLargeRun: (input: { entityCount: number }) => Promise<boolean>;
@@ -40,7 +44,7 @@ export const resolveWorkflowStartDecision = async ({
 
 type EstimateWorkflowTargetCountArgs = {
   args: StartWorkflowArgs | undefined;
-  queryClient: QueryClient;
+  queryClient: WorkflowTargetCountQueryClient;
   workspaceId: string;
 };
 
@@ -52,7 +56,7 @@ export const estimateWorkflowTargetCount = async ({
   const entityIds = args?.entityIds === undefined ? [] : [...args.entityIds];
 
   try {
-    return await queryClient.ensureQueryData(
+    return await queryClient.fetchQuery(
       workflowTargetCountOptions({
         entityIds,
         workspaceId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
@@ -1,0 +1,63 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { entitySummariesCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+
+export type StartWorkflowArgs = {
+  entityIds?: string[];
+  entityIdsOrder?: string[];
+  propertyIds?: string[];
+};
+
+export type WorkflowStartDecision = { type: "start" } | { type: "cancel" };
+
+export const LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD = 50;
+
+type ResolveWorkflowStartDecisionArgs = {
+  confirmLargeRun: (input: { entityCount: number }) => Promise<boolean>;
+  estimateEntityCount: () => Promise<number | null>;
+};
+
+export const resolveWorkflowStartDecision = async ({
+  confirmLargeRun,
+  estimateEntityCount,
+}: ResolveWorkflowStartDecisionArgs): Promise<WorkflowStartDecision> => {
+  const entityCount = await estimateEntityCount();
+  if (entityCount === null) {
+    return { type: "cancel" };
+  }
+
+  if (entityCount < LARGE_WORKFLOW_ENTITY_PROMPT_THRESHOLD) {
+    return { type: "start" };
+  }
+
+  const confirmed = await confirmLargeRun({ entityCount });
+  if (!confirmed) {
+    return { type: "cancel" };
+  }
+
+  return { type: "start" };
+};
+
+type EstimateWorkflowEntityCountArgs = {
+  args: StartWorkflowArgs | undefined;
+  queryClient: QueryClient;
+  workspaceId: string;
+};
+
+export const estimateWorkflowEntityCount = async ({
+  args,
+  queryClient,
+  workspaceId,
+}: EstimateWorkflowEntityCountArgs): Promise<number | null> => {
+  if (args?.entityIds !== undefined && args.entityIds.length > 0) {
+    return args.entityIds.length;
+  }
+
+  try {
+    return await queryClient.ensureQueryData(
+      entitySummariesCountOptions(workspaceId),
+    );
+  } catch {
+    return null;
+  }
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
@@ -52,17 +52,13 @@ export const estimateWorkflowTargetCount = async ({
   args,
   queryClient,
   workspaceId,
-}: EstimateWorkflowTargetCountArgs): Promise<number | null> => {
+}: EstimateWorkflowTargetCountArgs): Promise<number> => {
   const entityIds = args?.entityIds === undefined ? [] : [...args.entityIds];
 
-  try {
-    return await queryClient.fetchQuery(
-      workflowTargetCountOptions({
-        entityIds,
-        workspaceId,
-      }),
-    );
-  } catch {
-    return null;
-  }
+  return await queryClient.fetchQuery(
+    workflowTargetCountOptions({
+      entityIds,
+      workspaceId,
+    }),
+  );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 
-import { entitySummariesCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+import { workflowTargetCountOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 export type StartWorkflowArgs = {
   entityIds?: string[];
@@ -38,24 +38,25 @@ export const resolveWorkflowStartDecision = async ({
   return { type: "start" };
 };
 
-type EstimateWorkflowEntityCountArgs = {
+type EstimateWorkflowTargetCountArgs = {
   args: StartWorkflowArgs | undefined;
   queryClient: QueryClient;
   workspaceId: string;
 };
 
-export const estimateWorkflowEntityCount = async ({
+export const estimateWorkflowTargetCount = async ({
   args,
   queryClient,
   workspaceId,
-}: EstimateWorkflowEntityCountArgs): Promise<number | null> => {
-  if (args?.entityIds !== undefined && args.entityIds.length > 0) {
-    return args.entityIds.length;
-  }
+}: EstimateWorkflowTargetCountArgs): Promise<number | null> => {
+  const entityIds = args?.entityIds === undefined ? [] : [...args.entityIds];
 
   try {
     return await queryClient.ensureQueryData(
-      entitySummariesCountOptions(workspaceId),
+      workflowTargetCountOptions({
+        entityIds,
+        workspaceId,
+      }),
     );
   } catch {
     return null;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
@@ -7,7 +7,7 @@ import { toSafeId } from "@/lib/safe-id";
 import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
 import { useWorkflowStartConfirmationPrompt } from "@/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt";
 import {
-  estimateWorkflowEntityCount,
+  estimateWorkflowTargetCount,
   resolveWorkflowStartDecision,
 } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic";
 import type { StartWorkflowArgs } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic";
@@ -38,7 +38,7 @@ export const useStartWorkflow = (workspaceId: string) => {
       const decision = await resolveWorkflowStartDecision({
         confirmLargeRun,
         estimateEntityCount: async () =>
-          await estimateWorkflowEntityCount({
+          await estimateWorkflowTargetCount({
             args,
             queryClient,
             workspaceId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
@@ -5,6 +5,12 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";
 import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
+import { useWorkflowStartConfirmationPrompt } from "@/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt";
+import {
+  estimateWorkflowEntityCount,
+  resolveWorkflowStartDecision,
+} from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic";
+import type { StartWorkflowArgs } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.logic";
 import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 /**
@@ -21,31 +27,46 @@ export const useStartWorkflow = (workspaceId: string) => {
   const { data: aiAvailability } = useQuery(
     aiAvailabilityOptions({ organizationId: activeOrganizationId }),
   );
+  const confirmLargeRun = useWorkflowStartConfirmationPrompt();
 
-  return async (args?: {
-    entityIds?: string[];
-    entityIdsOrder?: string[];
-    propertyIds?: string[];
-  }) => {
+  return async (args?: StartWorkflowArgs) => {
     if (!aiAvailability?.available) {
       return undefined;
     }
 
     try {
+      const decision = await resolveWorkflowStartDecision({
+        confirmLargeRun,
+        estimateEntityCount: async () =>
+          await estimateWorkflowEntityCount({
+            args,
+            queryClient,
+            workspaceId,
+          }),
+      });
+      if (decision.type === "cancel") {
+        return undefined;
+      }
+
       const response = await api
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .workflow.start.post({
-          ...(args?.entityIds && {
-            entityIds: args.entityIds.map((id) => toSafeId<"entity">(id)),
-          }),
-          ...(args?.entityIdsOrder && {
-            entityIdsOrder: args.entityIdsOrder.map((id) =>
-              toSafeId<"entity">(id),
-            ),
-          }),
-          ...(args?.propertyIds && {
-            propertyIds: args.propertyIds.map((id) => toSafeId<"property">(id)),
-          }),
+          ...(args?.entityIds !== undefined &&
+            args.entityIds.length > 0 && {
+              entityIds: args.entityIds.map((id) => toSafeId<"entity">(id)),
+            }),
+          ...(args?.entityIdsOrder !== undefined &&
+            args.entityIdsOrder.length > 0 && {
+              entityIdsOrder: args.entityIdsOrder.map((id) =>
+                toSafeId<"entity">(id),
+              ),
+            }),
+          ...(args?.propertyIds !== undefined &&
+            args.propertyIds.length > 0 && {
+              propertyIds: args.propertyIds.map((id) =>
+                toSafeId<"property">(id),
+              ),
+            }),
         });
 
       if (response.error) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/workspace.ts
@@ -12,10 +12,20 @@ type JustificationsKey = {
   entityIds: string[];
 };
 
+type WorkflowTargetCountKey = {
+  workspaceId: string;
+  entityIds: string[];
+};
+
 export const workspaceKeys = {
   workflow: (workspaceId: string) => [
     ...workspacesKeys.byId(workspaceId),
     "workflow",
+  ],
+  workflowTargetCount: ({ entityIds, workspaceId }: WorkflowTargetCountKey) => [
+    ...workspaceKeys.workflow(workspaceId),
+    "target-count",
+    { entityIds },
   ],
   justifications: (workspaceId: string) => [
     ...workspacesKeys.byId(workspaceId),
@@ -28,6 +38,8 @@ export const workspaceKeys = {
 };
 
 type WorkflowKey = { workspaceId: string };
+type WorkflowTargetCountOptionsInput =
+  QueryOptionsInput<WorkflowTargetCountKey>;
 
 const WORKFLOW_DEFAULT_STATUS = { running: false } as const;
 
@@ -46,6 +58,32 @@ export const workflowOptions = ({ key }: { key: WorkflowKey }) =>
       }
 
       return response.data;
+    },
+  });
+
+export const workflowTargetCountOptions = ({
+  entityIds,
+  workspaceId,
+}: WorkflowTargetCountOptionsInput) =>
+  queryOptions({
+    queryKey: workspaceKeys.workflowTargetCount({ entityIds, workspaceId }),
+    queryFn: async ({ signal }) => {
+      const response = await api
+        .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        .workflow["target-count"].post(
+          {
+            ...(entityIds.length > 0 && {
+              entityIds: entityIds.map((id) => toSafeId<"entity">(id)),
+            }),
+          },
+          { fetch: { signal } },
+        );
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data.count;
     },
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -25,6 +25,7 @@ import {
 import { useWorkspaceSSE } from "@/lib/sse";
 import { useWorkspaceChatMentionRegistration } from "@/routes/_protected.chat/-hooks/use-workspace-chat-mention-registration";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+import { WorkflowStartConfirmationPromptProvider } from "@/routes/_protected.workspaces/$workspaceId/-components/workflow-start-confirmation-prompt";
 import { WorkspaceDropZone } from "@/routes/_protected.workspaces/$workspaceId/-components/workspace-drop-zone";
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
@@ -271,13 +272,18 @@ function RouteComponent() {
   // Timesheets, invoices, and entity detail bypass the
   // WorkspaceDropZone (they have their own layouts), but the inspector
   // pane is still available everywhere inside a workspace.
-  if (timesheetsMatch || invoicesMatch || entityDetailMatch) {
-    return <Outlet />;
-  }
+  const content =
+    timesheetsMatch || invoicesMatch || entityDetailMatch ? (
+      <Outlet />
+    ) : (
+      <WorkspaceDropZone workspaceId={workspaceId}>
+        <Outlet />
+      </WorkspaceDropZone>
+    );
 
   return (
-    <WorkspaceDropZone workspaceId={workspaceId}>
-      <Outlet />
-    </WorkspaceDropZone>
+    <WorkflowStartConfirmationPromptProvider>
+      {content}
+    </WorkflowStartConfirmationPromptProvider>
   );
 }


### PR DESCRIPTION
Fixes #28.

Summary:
- Add a tested retry and timeout policy for workflow batch AI generation.
- Treat validation failures as permanent while retrying transient integration failures once.
- Add a confirmation prompt before large workflow starts; dismissals and count-load failures cancel instead of starting.
- Update localized prompt copy.