### PR TITLE
feat(folio): DOCX-document → Markdown export (toMarkdown)

### DIFF
--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -11,6 +11,7 @@
   ],
   "exports": {
     ".": "./src/index.ts",
+    "./markdown": "./src/core/markdown/index.ts",
     "./server": "./src/server.ts",
     "./editor.css": "./src/styles/editor.css"
   },

--- a/packages/folio/src/core/markdown/annotations.ts
+++ b/packages/folio/src/core/markdown/annotations.ts
@@ -1,0 +1,124 @@
+/**
+ * Encoders for constructs markdown can't express natively: tracked changes and
+ * comments. Three modes: `html` (default), `pandoc`, `strip`. Renderers call
+ * the wrap functions with the already-rendered inner text; the wrappers decide
+ * whether to emit an `<ins>`/`<del>`/`<comment>` HTML tag, the Pandoc-flavoured
+ * bracketed span equivalent, or to drop the wrapper entirely.
+ *
+ * Ported from eigenpal/docx-editor PR #595.
+ */
+
+import type { TrackedChangeInfo } from "../types/document";
+import type { RenderContext } from "./types";
+
+type Mode = "tracked" | "comment";
+
+function escapeAttr(value: string): string {
+  return value.replace(/"/gu, "&quot;");
+}
+
+function attrString(info: {
+  author?: string;
+  date?: string;
+  id?: number;
+}): string {
+  const parts: string[] = [];
+  if (info.author) {
+    parts.push(`author="${escapeAttr(info.author)}"`);
+  }
+  if (info.date) {
+    parts.push(`date="${escapeAttr(info.date)}"`);
+  }
+  if (typeof info.id === "number") {
+    parts.push(`id="${info.id}"`);
+  }
+  return parts.length ? ` ${parts.join(" ")}` : "";
+}
+
+/**
+ * Wrap `inner` with the active annotations mode's encoding.
+ *
+ * `keepWhenStripped` controls what to emit when `annotations === "strip"`:
+ * insertions and comments keep the visible text; deletions drop entirely.
+ */
+function wrap(
+  ctx: RenderContext,
+  inner: string,
+  htmlTag: string,
+  pandocClass: string,
+  info: { author?: string; date?: string; id?: number },
+  extraHtmlAttrs: string,
+  mode: Mode,
+  keepWhenStripped: boolean,
+): string {
+  if (ctx.opts.annotations === "strip") {
+    return keepWhenStripped ? inner : "";
+  }
+  if (ctx.opts.annotations === "pandoc") {
+    const author = info.author ? ` author="${escapeAttr(info.author)}"` : "";
+    const id =
+      mode === "comment" && typeof info.id === "number"
+        ? ` id="${info.id}"`
+        : "";
+    return `[${inner}]{.${pandocClass}${id}${author}}`;
+  }
+  return `<${htmlTag}${attrString(info)}${extraHtmlAttrs}>${inner}</${htmlTag}>`;
+}
+
+export function wrapInsertion(
+  ctx: RenderContext,
+  info: TrackedChangeInfo,
+  inner: string,
+): string {
+  return wrap(ctx, inner, "ins", "ins", info, "", "tracked", true);
+}
+
+export function wrapDeletion(
+  ctx: RenderContext,
+  info: TrackedChangeInfo,
+  inner: string,
+): string {
+  return wrap(ctx, inner, "del", "del", info, "", "tracked", false);
+}
+
+export function wrapMoveFrom(
+  ctx: RenderContext,
+  info: TrackedChangeInfo,
+  inner: string,
+): string {
+  return wrap(
+    ctx,
+    inner,
+    "del",
+    "move-from",
+    info,
+    ' data-move="from"',
+    "tracked",
+    false,
+  );
+}
+
+export function wrapMoveTo(
+  ctx: RenderContext,
+  info: TrackedChangeInfo,
+  inner: string,
+): string {
+  return wrap(
+    ctx,
+    inner,
+    "ins",
+    "move-to",
+    info,
+    ' data-move="to"',
+    "tracked",
+    true,
+  );
+}
+
+export function wrapComment(
+  ctx: RenderContext,
+  meta: { id: number; author?: string },
+  inner: string,
+): string {
+  return wrap(ctx, inner, "comment", "comment", meta, "", "comment", true);
+}

--- a/packages/folio/src/core/markdown/annotations.ts
+++ b/packages/folio/src/core/markdown/annotations.ts
@@ -14,7 +14,11 @@ import type { RenderContext } from "./types";
 type Mode = "tracked" | "comment";
 
 function escapeAttr(value: string): string {
-  return value.replace(/"/gu, "&quot;");
+  return value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;");
 }
 
 function attrString(info: {

--- a/packages/folio/src/core/markdown/escape.ts
+++ b/packages/folio/src/core/markdown/escape.ts
@@ -28,13 +28,15 @@ export function escapeInline(text: string): string {
 }
 
 /**
- * Cells use `|` as the column separator. Newlines inside a cell become `<br>`
- * so the row stays on one line. The input is already markdown (each cell is a
- * rendered paragraph that ran through {@link escapeInline}), so backslashes are
- * part of existing escape sequences and must NOT be re-escaped here.
+ * Cells use `|` as the column separator. The input is already markdown (each
+ * cell is a rendered paragraph that ran through {@link escapeInline}), so a
+ * backslash escape would interact with existing escape sequences — encode the
+ * pipe as the HTML entity instead, which GFM renders as a literal `|` without
+ * treating it as a delimiter. Newlines become `<br>` to keep the row on one
+ * line.
  */
 export function escapeTableCell(text: string): string {
-  return text.replace(/\|/gu, "\\|").replace(/\r?\n/gu, "<br>");
+  return text.replace(/\|/gu, "&#124;").replace(/\r?\n/gu, "<br>");
 }
 
 /**

--- a/packages/folio/src/core/markdown/escape.ts
+++ b/packages/folio/src/core/markdown/escape.ts
@@ -1,0 +1,52 @@
+/**
+ * Markdown escaping. Only characters that would change the parsed structure
+ * get escaped. Context-sensitive: pipes only matter inside table cells.
+ *
+ * Ported from eigenpal/docx-editor PR #595 (`@eigenpal/docx-editor-core/markdown`).
+ */
+
+/**
+ * Escape only characters that would change markdown structure mid-text:
+ *   - backslash, backtick, asterisk, brackets (always)
+ *   - underscore: only at word boundaries (emphasis trigger)
+ *   - angle brackets: only when they look like a tag/autolink
+ *
+ * Characters like `.` `-` `+` `#` `(` `)` `!` are only meaningful at line
+ * starts or in specific adjacency; we let the block-level renderer decide
+ * when to escape those.
+ */
+export function escapeInline(text: string): string {
+  let out = text.replace(/([\\`*[\]])/gu, "\\$1");
+  // Underscore as emphasis marker: only at word boundaries.
+  out = out.replace(/(^|\s)_/gu, "$1\\_");
+  out = out.replace(/_(\s|$)/gu, "\\_$1");
+  // Angle brackets only escaped when they form a plausible HTML tag — an
+  // alphabetic name immediately followed by attributes/end. Prose like `x < y`
+  // and `i < n` stays untouched.
+  out = out.replace(/<(\/?[A-Za-z][\w-]*)(?=[\s/>])/gu, "\\<$1");
+  return out;
+}
+
+/**
+ * Cells use `|` as the column separator. Newlines inside a cell become `<br>`
+ * so the row stays on one line.
+ */
+export function escapeTableCell(text: string): string {
+  return text.replace(/\|/gu, "\\|").replace(/\r?\n/gu, "<br>");
+}
+
+/**
+ * Hyperlink URLs in inline form need parens balanced; we URL-encode the
+ * problematic characters rather than escape, so the link still resolves.
+ */
+export function escapeLinkUrl(url: string): string {
+  return url.replace(/[()<>"\s]/gu, encodeURIComponent);
+}
+
+/**
+ * Alt text inside `![alt](url)`. Escape brackets so the link parser doesn't
+ * get confused, and collapse newlines so the alt stays single-line.
+ */
+export function escapeAltText(text: string): string {
+  return text.replace(/([[\]])/gu, "\\$1").replace(/\r?\n/gu, " ");
+}

--- a/packages/folio/src/core/markdown/escape.ts
+++ b/packages/folio/src/core/markdown/escape.ts
@@ -42,9 +42,17 @@ export function escapeTableCell(text: string): string {
 /**
  * Hyperlink URLs in inline form need parens balanced; we URL-encode the
  * problematic characters rather than escape, so the link still resolves.
+ * `encodeURIComponent` leaves `(` and `)` untouched, so an unbalanced paren in
+ * a DOCX URL (e.g. `https://example.com/a)b`) would close the inline
+ * `[text](url)` destination early; encode the parens explicitly.
  */
+const LINK_URL_ENCODED: Record<string, string> = { "(": "%28", ")": "%29" };
+
 export function escapeLinkUrl(url: string): string {
-  return url.replace(/[()<>"\s]/gu, encodeURIComponent);
+  return url.replace(
+    /[()<>"\s]/gu,
+    (ch) => LINK_URL_ENCODED[ch] ?? encodeURIComponent(ch),
+  );
 }
 
 /**

--- a/packages/folio/src/core/markdown/escape.ts
+++ b/packages/folio/src/core/markdown/escape.ts
@@ -29,7 +29,9 @@ export function escapeInline(text: string): string {
 
 /**
  * Cells use `|` as the column separator. Newlines inside a cell become `<br>`
- * so the row stays on one line.
+ * so the row stays on one line. The input is already markdown (each cell is a
+ * rendered paragraph that ran through {@link escapeInline}), so backslashes are
+ * part of existing escape sequences and must NOT be re-escaped here.
  */
 export function escapeTableCell(text: string): string {
   return text.replace(/\|/gu, "\\|").replace(/\r?\n/gu, "<br>");
@@ -44,9 +46,10 @@ export function escapeLinkUrl(url: string): string {
 }
 
 /**
- * Alt text inside `![alt](url)`. Escape brackets so the link parser doesn't
- * get confused, and collapse newlines so the alt stays single-line.
+ * Alt text inside `![alt](url)`. Raw (un-escaped) text, so escape the backslash
+ * first, then the brackets that would confuse the link parser, and collapse
+ * newlines so the alt stays single-line.
  */
 export function escapeAltText(text: string): string {
-  return text.replace(/([[\]])/gu, "\\$1").replace(/\r?\n/gu, " ");
+  return text.replace(/([\\[\]])/gu, "\\$1").replace(/\r?\n/gu, " ");
 }

--- a/packages/folio/src/core/markdown/headings.ts
+++ b/packages/folio/src/core/markdown/headings.ts
@@ -1,0 +1,26 @@
+/**
+ * Heading-style detection from a paragraph style id. Ported from eigenpal
+ * `agent/text-utils` (PR #595) so the markdown exporter stays self-contained
+ * (folio has no `agent/text-utils` module). Word's built-in heading styles are
+ * `Heading1`…`Heading9` (and localised aliases that still contain "heading").
+ */
+
+/** True when the style id denotes a Word heading style. */
+export function isHeadingStyle(styleId?: string): boolean {
+  if (!styleId) {
+    return false;
+  }
+  return styleId.toLowerCase().includes("heading");
+}
+
+/** Extract the 1-based heading level from a style id, or undefined. */
+export function parseHeadingLevel(styleId?: string): number | undefined {
+  if (!styleId) {
+    return undefined;
+  }
+  const match = /heading\s*(\d)/iu.exec(styleId);
+  if (match) {
+    return Number.parseInt(match[1]!, 10);
+  }
+  return undefined;
+}

--- a/packages/folio/src/core/markdown/headings.ts
+++ b/packages/folio/src/core/markdown/headings.ts
@@ -18,9 +18,9 @@ export function parseHeadingLevel(styleId?: string): number | undefined {
   if (!styleId) {
     return undefined;
   }
-  const match = /heading\s*(\d)/iu.exec(styleId);
-  if (match) {
-    return Number.parseInt(match[1]!, 10);
+  const digit = /heading\s*(\d)/iu.exec(styleId)?.[1];
+  if (digit) {
+    return Number.parseInt(digit, 10);
   }
   return undefined;
 }

--- a/packages/folio/src/core/markdown/images.ts
+++ b/packages/folio/src/core/markdown/images.ts
@@ -1,0 +1,94 @@
+/**
+ * Image handling: virtual-path generation and ImageRef construction from
+ * MediaFile entries. Ported from eigenpal/docx-editor PR #595.
+ *
+ * Default virtual path: `./images/{paraId}-img{n}.{ext}` when paraId is known,
+ * otherwise `./images/img{n}.{ext}`. Callers can override via `opts.imagePath`.
+ *
+ * A media file referenced multiple times by the same document is registered
+ * once: the first `registerImage` call computes base64 and stores the
+ * `ImageRef`; subsequent calls return the same ref.
+ */
+
+import type { Image, MediaFile } from "../types/document";
+import type { ImageMeta, ImageRef, RenderContext } from "./types";
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/gif": "gif",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+  "image/tiff": "tiff",
+  "image/bmp": "bmp",
+  "image/x-emf": "emf",
+  "image/x-wmf": "wmf",
+};
+
+function extFor(mimeType: string, fallback: string): string {
+  return MIME_TO_EXT[mimeType] ?? fallback;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function toUint8(data: ArrayBuffer | Uint8Array): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  return new Uint8Array(data);
+}
+
+/**
+ * Build an `ImageRef` from a `MediaFile` and store it in the context's image
+ * map. If the same `media.path` has already been registered for this render,
+ * the existing ref is returned without re-encoding base64 or assigning a new
+ * virtual path.
+ */
+export function registerImage(
+  ctx: RenderContext,
+  media: MediaFile,
+  image: Image | undefined,
+  paraId: string | undefined,
+): ImageRef {
+  const existing = ctx.imagesByPath.get(media.path);
+  if (existing) {
+    return existing;
+  }
+
+  ctx.imageCounter += 1;
+  const ext = extFor(media.mimeType, "png");
+  const meta: ImageMeta = {
+    paraId,
+    index: ctx.imageCounter,
+    originalPath: media.path,
+    mimeType: media.mimeType,
+    alt: image?.alt ?? image?.title ?? image?.filename,
+  };
+  const virtualPath = ctx.opts.imagePath
+    ? ctx.opts.imagePath(meta)
+    : defaultVirtualPath(meta, ext);
+  const data = toUint8(media.data);
+  const base64 = media.base64 ?? bytesToBase64(data);
+  const dataUrl = media.dataUrl ?? `data:${media.mimeType};base64,${base64}`;
+  const ref: ImageRef = { ...meta, data, base64, dataUrl, virtualPath };
+  ctx.images.set(virtualPath, ref);
+  ctx.imagesByPath.set(media.path, ref);
+  return ref;
+}
+
+function defaultVirtualPath(meta: ImageMeta, ext: string): string {
+  if (meta.paraId) {
+    return `./images/${meta.paraId}-img${meta.index}.${ext}`;
+  }
+  return `./images/img${meta.index}.${ext}`;
+}

--- a/packages/folio/src/core/markdown/images.ts
+++ b/packages/folio/src/core/markdown/images.ts
@@ -34,11 +34,9 @@ function bytesToBase64(bytes: Uint8Array): string {
   if (typeof Buffer !== "undefined") {
     return Buffer.from(bytes).toString("base64");
   }
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
+  // `latin1` maps each byte 1:1 to a code unit, so this is a fast binary-string
+  // build (no per-byte concatenation) for the browser `btoa` path.
+  return btoa(new TextDecoder("latin1").decode(bytes));
 }
 
 function toUint8(data: ArrayBuffer | Uint8Array): Uint8Array {

--- a/packages/folio/src/core/markdown/index.ts
+++ b/packages/folio/src/core/markdown/index.ts
@@ -23,8 +23,9 @@
  */
 
 import type { Document } from "../types/document";
-import { appendTrailers, newContext } from "./internals";
+import { newContext } from "./internals";
 import { renderBlocks } from "./renderBlock";
+import { appendTrailers } from "./trailers";
 import type { MarkdownOptions, MarkdownResult } from "./types";
 
 export type {

--- a/packages/folio/src/core/markdown/index.ts
+++ b/packages/folio/src/core/markdown/index.ts
@@ -1,0 +1,71 @@
+/**
+ * DOCX-document → Markdown converter. Ported from eigenpal/docx-editor PR #595,
+ * scoped to the synchronous, continuous (non-paged) `Document → string` path
+ * that the skills bridge needs. The upstream paged + async + image-handler
+ * variants are intentionally not ported (skill bodies have no images today);
+ * they can be added later from the same branch.
+ *
+ * The clean-markdown preset for an AI-facing skill body is:
+ *
+ * ```ts
+ * toMarkdown(doc, {
+ *   annotations: "strip",
+ *   trackedChanges: "clean",
+ *   comments: "strip",
+ *   hyperlinks: "inline",
+ *   footnotes: "strip",
+ * });
+ * ```
+ *
+ * GFM tables are emitted automatically (simple tables → pipe tables; merged or
+ * nested cells → inline HTML `<table>`). Headers/footers never appear: they
+ * live outside `document.content`, which is the only block stream walked here.
+ */
+
+import type { Document } from "../types/document";
+import { appendTrailers, newContext } from "./internals";
+import { renderBlocks } from "./renderBlock";
+import type { MarkdownOptions, MarkdownResult } from "./types";
+
+export type {
+  ImageMeta,
+  ImageRef,
+  MarkdownOptions,
+  MarkdownResult,
+} from "./types";
+
+/**
+ * Convert a parsed `Document` to a markdown string. Synchronous; pre-parse the
+ * DOCX (e.g. via the editor or `parseDocx`) before calling.
+ */
+export function toMarkdown(doc: Document, opts?: MarkdownOptions): string {
+  return renderDocument(doc, opts).markdown;
+}
+
+/**
+ * Like {@link toMarkdown}, but also returns the registered images and any
+ * non-fatal warnings. Use when post-processing image bytes or surfacing
+ * diagnostics; skill bodies only need {@link toMarkdown}.
+ */
+export function toMarkdownResult(
+  doc: Document,
+  opts?: MarkdownOptions,
+): MarkdownResult {
+  return renderDocument(doc, opts);
+}
+
+function renderDocument(
+  doc: Document,
+  opts: MarkdownOptions = {},
+): MarkdownResult {
+  const ctx = newContext(opts);
+  const body = renderBlocks(ctx, doc.package, doc.package.document.content);
+  const markdown = appendTrailers(ctx, doc, body);
+  if (doc.warnings) {
+    ctx.warnings.unshift(...doc.warnings);
+  }
+  if (!markdown.trim()) {
+    ctx.warnings.push("document has no content");
+  }
+  return { markdown, images: ctx.images, warnings: ctx.warnings };
+}

--- a/packages/folio/src/core/markdown/internals.ts
+++ b/packages/folio/src/core/markdown/internals.ts
@@ -1,12 +1,11 @@
 /**
- * Internal helpers shared by the markdown converter: context construction,
- * warning dedupe, and trailer (footnote / hyperlink-reference / comment
- * sidecar) emission. Ported from eigenpal/docx-editor PR #595, trimmed to the
- * sync continuous path (no byte-input narrowing, no paged header/footer).
+ * Internal helpers shared by the markdown converter: context construction and
+ * warning dedupe. Kept free of renderer imports so the renderers can import
+ * `pushWarning` without forming an import cycle (trailer emission, which needs
+ * `renderBlock`, lives in `trailers.ts`). Ported from eigenpal/docx-editor
+ * PR #595, trimmed to the sync continuous path.
  */
 
-import type { Comment, Document, Footnote } from "../types/document";
-import { renderBlocks } from "./renderBlock";
 import type { MarkdownOptions, RenderContext } from "./types";
 
 /**
@@ -41,74 +40,4 @@ export function pushWarning(ctx: RenderContext, message: string): void {
   if (!ctx.warnings.includes(message)) {
     ctx.warnings.push(message);
   }
-}
-
-/**
- * Append footnote definitions, the hyperlink reference list (for
- * `hyperlinks: "reference"`), and the comments sidecar block (for
- * `comments: "sidecar"`) to the rendered body. Each section is emitted only
- * when its corresponding refs accumulator has entries.
- */
-export function appendTrailers(
-  ctx: RenderContext,
-  doc: Document,
-  body: string,
-): string {
-  const sections: string[] = body.trim() ? [body] : [];
-
-  if (ctx.footnoteRefs.length) {
-    const refs = ctx.footnoteRefs.map(({ refId, markerNumber }) => {
-      const note = doc.package.footnotes?.find((f) => f.id === refId);
-      return `[^${markerNumber}]: ${note ? footnoteText(ctx, doc, note) : ""}`;
-    });
-    sections.push(refs.join("\n"));
-  }
-
-  if (ctx.opts.hyperlinks === "reference" && ctx.hyperlinkRefs.length) {
-    sections.push(
-      ctx.hyperlinkRefs
-        .map(({ href, refNumber }) => `[${refNumber}]: ${href}`)
-        .join("\n"),
-    );
-  }
-
-  if (ctx.opts.comments === "sidecar" && ctx.commentRefs.length) {
-    const lines: string[] = ["## Comments"];
-    for (const { commentId, markerNumber } of ctx.commentRefs) {
-      const c = doc.package.document.comments?.find(
-        (cm) => cm.id === commentId,
-      );
-      const author = c?.author ? `${c.author}: ` : "";
-      const text = c ? commentText(c) : "";
-      lines.push(`[^c${markerNumber}]: ${author}${text}`);
-    }
-    sections.push(lines.join("\n"));
-  }
-
-  return sections.join("\n\n");
-}
-
-function footnoteText(
-  ctx: RenderContext,
-  doc: Document,
-  note: Footnote,
-): string {
-  return renderBlocks(ctx, doc.package, note.content)
-    .replace(/\n+/gu, " ")
-    .trim();
-}
-
-function commentText(comment: Comment): string {
-  return comment.content
-    .map((p) =>
-      p.content
-        .map((c) =>
-          c.type === "run"
-            ? c.content.map((x) => (x.type === "text" ? x.text : "")).join("")
-            : "",
-        )
-        .join(""),
-    )
-    .join(" ")
-    .trim();
 }

--- a/packages/folio/src/core/markdown/internals.ts
+++ b/packages/folio/src/core/markdown/internals.ts
@@ -1,0 +1,114 @@
+/**
+ * Internal helpers shared by the markdown converter: context construction,
+ * warning dedupe, and trailer (footnote / hyperlink-reference / comment
+ * sidecar) emission. Ported from eigenpal/docx-editor PR #595, trimmed to the
+ * sync continuous path (no byte-input narrowing, no paged header/footer).
+ */
+
+import type { Comment, Document, Footnote } from "../types/document";
+import { renderBlocks } from "./renderBlock";
+import type { MarkdownOptions, RenderContext } from "./types";
+
+/**
+ * Build a fresh `RenderContext` from caller options, applying defaults. The
+ * `footnotes` default is `"keep"` (folio addition over upstream #595).
+ */
+export function newContext(opts: MarkdownOptions = {}): RenderContext {
+  return {
+    opts: {
+      annotations: opts.annotations ?? "html",
+      trackedChanges: opts.trackedChanges ?? "annotate",
+      comments: opts.comments ?? "inline",
+      hyperlinks: opts.hyperlinks ?? "inline",
+      footnotes: opts.footnotes ?? "keep",
+      imagePath: opts.imagePath,
+    },
+    images: new Map(),
+    imagesByPath: new Map(),
+    warnings: [],
+    footnoteRefs: [],
+    commentRefs: [],
+    hyperlinkRefs: [],
+    imageCounter: 0,
+  };
+}
+
+/**
+ * Push a warning into the context, deduplicating against existing entries so
+ * recurring messages appear at most once.
+ */
+export function pushWarning(ctx: RenderContext, message: string): void {
+  if (!ctx.warnings.includes(message)) {
+    ctx.warnings.push(message);
+  }
+}
+
+/**
+ * Append footnote definitions, the hyperlink reference list (for
+ * `hyperlinks: "reference"`), and the comments sidecar block (for
+ * `comments: "sidecar"`) to the rendered body. Each section is emitted only
+ * when its corresponding refs accumulator has entries.
+ */
+export function appendTrailers(
+  ctx: RenderContext,
+  doc: Document,
+  body: string,
+): string {
+  const sections: string[] = body.trim() ? [body] : [];
+
+  if (ctx.footnoteRefs.length) {
+    const refs = ctx.footnoteRefs.map(({ refId, markerNumber }) => {
+      const note = doc.package.footnotes?.find((f) => f.id === refId);
+      return `[^${markerNumber}]: ${note ? footnoteText(ctx, doc, note) : ""}`;
+    });
+    sections.push(refs.join("\n"));
+  }
+
+  if (ctx.opts.hyperlinks === "reference" && ctx.hyperlinkRefs.length) {
+    sections.push(
+      ctx.hyperlinkRefs
+        .map(({ href, refNumber }) => `[${refNumber}]: ${href}`)
+        .join("\n"),
+    );
+  }
+
+  if (ctx.opts.comments === "sidecar" && ctx.commentRefs.length) {
+    const lines: string[] = ["## Comments"];
+    for (const { commentId, markerNumber } of ctx.commentRefs) {
+      const c = doc.package.document.comments?.find(
+        (cm) => cm.id === commentId,
+      );
+      const author = c?.author ? `${c.author}: ` : "";
+      const text = c ? commentText(c) : "";
+      lines.push(`[^c${markerNumber}]: ${author}${text}`);
+    }
+    sections.push(lines.join("\n"));
+  }
+
+  return sections.join("\n\n");
+}
+
+function footnoteText(
+  ctx: RenderContext,
+  doc: Document,
+  note: Footnote,
+): string {
+  return renderBlocks(ctx, doc.package, note.content)
+    .replace(/\n+/gu, " ")
+    .trim();
+}
+
+function commentText(comment: Comment): string {
+  return comment.content
+    .map((p) =>
+      p.content
+        .map((c) =>
+          c.type === "run"
+            ? c.content.map((x) => (x.type === "text" ? x.text : "")).join("")
+            : "",
+        )
+        .join(""),
+    )
+    .join(" ")
+    .trim();
+}

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -146,6 +146,19 @@ describe("toMarkdown — tables", () => {
     expect(md([table])).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
   });
 
+  test("a literal pipe in a cell is encoded so it is not a column break", () => {
+    const table: BlockContent = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [{ type: "tableCell", content: [para([run("a|b")])] }],
+        },
+      ],
+    };
+    expect(md([table])).toBe("| a&#124;b |\n| --- |");
+  });
+
   test("a merged cell falls back to inline HTML with colspan", () => {
     const table: BlockContent = {
       type: "table",

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -257,6 +257,38 @@ describe("toMarkdown — tables", () => {
       '<table>\n  <tr>\n    <th colspan="2">Span</th>\n  </tr>\n  <tr>\n    <td>L</td>\n    <td>R</td>\n  </tr>\n</table>',
     );
   });
+
+  test("math in an HTML-fallback table cell exports its fallback", () => {
+    const table: BlockContent = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: { gridSpan: 2 },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    run("E="),
+                    {
+                      type: "mathEquation",
+                      display: "inline",
+                      ommlXml: "<m/>",
+                      plainText: "mc^2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(md([table])).toContain("E=mc^2");
+  });
 });
 
 describe("toMarkdown — clean preset for skills", () => {
@@ -320,5 +352,35 @@ describe("toMarkdown — clean preset for skills", () => {
       { comments: "sidecar" },
     );
     expect(out).toBe("text[^c1]\n\n## Comments\n[^c1]: R: note");
+  });
+
+  test("comment sidecar text includes hyperlink/field text, not just runs", () => {
+    const commentPara: Paragraph = {
+      type: "paragraph",
+      content: [
+        run("see "),
+        {
+          type: "hyperlink",
+          href: "https://x",
+          children: [run("link")],
+        },
+      ],
+    };
+    const content: Paragraph["content"] = [
+      run("x"),
+      { type: "commentReference", id: 7 },
+    ];
+    const out = toMarkdown(
+      {
+        package: {
+          document: {
+            content: [{ type: "paragraph", content }],
+            comments: [{ id: 7, author: "A", content: [commentPara] }],
+          },
+        },
+      },
+      { comments: "sidecar" },
+    );
+    expect(out).toBe("x[^c1]\n\n## Comments\n[^c1]: A: see link");
   });
 });

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -162,6 +162,18 @@ describe("toMarkdown — inline marks", () => {
       "[here](https://example.com)",
     );
   });
+
+  test("reference-mode link destinations are escaped", () => {
+    const link: Hyperlink = {
+      type: "hyperlink",
+      href: "https://x.com/a b(c)",
+      children: [run("t")],
+    };
+    const out = toMarkdown(doc([{ type: "paragraph", content: [link] }]), {
+      hyperlinks: "reference",
+    });
+    expect(out).toBe("[t][1]\n\n[1]: https://x.com/a%20b(c)");
+  });
 });
 
 describe("toMarkdown — tables", () => {

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -68,6 +68,14 @@ describe("toMarkdown — block structure", () => {
     expect(md([para([run("Cited")], { styleId: "Quote" })])).toBe("> Cited");
   });
 
+  test("a plain paragraph that begins with block syntax is escaped", () => {
+    // Literal legal text must not be reclassified as a heading/list/quote.
+    expect(md([para([run("# Not a heading")])])).toBe("\\# Not a heading");
+    expect(md([para([run("- not a bullet")])])).toBe("\\- not a bullet");
+    expect(md([para([run("1. not a list")])])).toBe("1\\. not a list");
+    expect(md([para([run("> not a quote")])])).toBe("\\> not a quote");
+  });
+
   test("bullet and ordered lists keep Word's exact marker", () => {
     const out = md([
       para([run("first")], { listRendering: list(0, true, "•") }),

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -105,6 +105,12 @@ describe("toMarkdown — inline marks", () => {
     );
   });
 
+  test("hidden runs (w:vanish) are dropped", () => {
+    expect(md([para([run("Keep"), run("Hidden", { hidden: true })])])).toBe(
+      "Keep",
+    );
+  });
+
   test("strikethrough", () => {
     expect(md([para([run("x", { strike: true })])])).toBe("~~x~~");
   });

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -89,6 +89,11 @@ describe("toMarkdown — block structure", () => {
     ]);
     expect(ordered).toBe("1. a\n2. b");
   });
+
+  test("a hidden list marker (w:vanish) exports as plain prose", () => {
+    const hidden: ListRendering = { ...list(0, true, "•"), markerHidden: true };
+    expect(md([para([run("text")], { listRendering: hidden })])).toBe("text");
+  });
 });
 
 describe("toMarkdown — inline marks", () => {
@@ -230,5 +235,24 @@ describe("toMarkdown — clean preset for skills", () => {
       },
     });
     expect(out).toBe("text[^1]\n\n[^1]: note");
+  });
+
+  test("a point comment (commentReference) is preserved in sidecar mode", () => {
+    const content: Paragraph["content"] = [
+      run("text"),
+      { type: "commentReference", id: 5 },
+    ];
+    const out = toMarkdown(
+      {
+        package: {
+          document: {
+            content: [{ type: "paragraph", content }],
+            comments: [{ id: 5, author: "R", content: [para([run("note")])] }],
+          },
+        },
+      },
+      { comments: "sidecar" },
+    );
+    expect(out).toBe("text[^c1]\n\n## Comments\n[^c1]: R: note");
   });
 });

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -189,7 +189,20 @@ describe("toMarkdown — inline marks", () => {
     const out = toMarkdown(doc([{ type: "paragraph", content: [link] }]), {
       hyperlinks: "reference",
     });
-    expect(out).toBe("[t][1]\n\n[1]: https://x.com/a%20b(c)");
+    expect(out).toBe("[t][1]\n\n[1]: https://x.com/a%20b%28c%29");
+  });
+
+  test("an unbalanced paren in an inline link destination is encoded", () => {
+    const link: Hyperlink = {
+      type: "hyperlink",
+      href: "https://example.com/a)b",
+      children: [run("x")],
+    };
+    // `encodeURIComponent` leaves parens untouched, so without explicit
+    // encoding the `)` would close the `[x](…)` destination early.
+    expect(toMarkdown(doc([{ type: "paragraph", content: [link] }]))).toBe(
+      "[x](https://example.com/a%29b)",
+    );
   });
 });
 
@@ -382,5 +395,64 @@ describe("toMarkdown — clean preset for skills", () => {
       { comments: "sidecar" },
     );
     expect(out).toBe("x[^c1]\n\n## Comments\n[^c1]: A: see link");
+  });
+
+  const delMark = (): Paragraph["pPrMark"] => ({
+    kind: "del",
+    info: { id: 1, author: "A" },
+  });
+
+  test("a deleted paragraph mark merges into the next paragraph on accept", () => {
+    const first: Paragraph = {
+      type: "paragraph",
+      content: [run("Hello")],
+      pPrMark: delMark(),
+    };
+    // Word's join keeps the first paragraph's properties and concatenates the
+    // runs; "annotate" mode (default) leaves both paragraphs intact.
+    expect(md([first, para([run(" world")])], clean)).toBe("Hello world");
+    expect(md([first, para([run(" world")])])).toBe("Hello\n\n world");
+  });
+
+  test("the merged paragraph keeps the first paragraph's heading style", () => {
+    const heading: Paragraph = {
+      type: "paragraph",
+      content: [run("Title")],
+      formatting: { styleId: "Heading1" },
+      pPrMark: delMark(),
+    };
+    expect(md([heading, para([run(" tail")])], clean)).toBe("# Title tail");
+  });
+
+  test("a chain of deleted marks collapses into one paragraph", () => {
+    const a: Paragraph = {
+      type: "paragraph",
+      content: [run("A")],
+      pPrMark: delMark(),
+    };
+    const b: Paragraph = {
+      type: "paragraph",
+      content: [run("B")],
+      pPrMark: delMark(),
+    };
+    expect(md([a, b, para([run("C")])], clean)).toBe("ABC");
+  });
+
+  test("a deleted mark before a table is left unmerged (no structural join)", () => {
+    const para1: Paragraph = {
+      type: "paragraph",
+      content: [run("Lead")],
+      pPrMark: delMark(),
+    };
+    const table: BlockContent = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [{ type: "tableCell", content: [para([run("X")])] }],
+        },
+      ],
+    };
+    expect(md([para1, table], clean)).toBe("Lead\n\n| X |\n| --- |");
   });
 });

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -1,0 +1,213 @@
+// Feature coverage for the DOCX-document → Markdown export (eigenpal #595 port).
+// Asserts the markdown subset skills rely on (headings, paragraphs, bold/italic,
+// bullet + ordered lists, GFM tables, inline code, blockquotes, links) plus the
+// clean-markdown preset (strip annotations/comments, flatten tracked changes,
+// strip footnotes). The MD↔Document round-trip stability test lives with the
+// skills bridge fixtures.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  BlockContent,
+  Document,
+  Hyperlink,
+  ListRendering,
+  Paragraph,
+  Run,
+  TextFormatting,
+} from "../types/document";
+import { toMarkdown } from "./index";
+import type { MarkdownOptions } from "./types";
+
+const run = (text: string, formatting?: TextFormatting): Run => ({
+  type: "run",
+  content: [{ type: "text", text }],
+  ...(formatting ? { formatting } : {}),
+});
+
+const para = (
+  content: Run[],
+  extra?: { styleId?: string; listRendering?: ListRendering; paraId?: string },
+): Paragraph => ({
+  type: "paragraph",
+  content,
+  ...(extra?.styleId ? { formatting: { styleId: extra.styleId } } : {}),
+  ...(extra?.listRendering ? { listRendering: extra.listRendering } : {}),
+  ...(extra?.paraId ? { paraId: extra.paraId } : {}),
+});
+
+const doc = (content: BlockContent[]): Document => ({
+  package: { document: { content } },
+});
+
+const md = (content: BlockContent[], opts?: MarkdownOptions): string =>
+  toMarkdown(doc(content), opts);
+
+const list = (
+  level: number,
+  isBullet: boolean,
+  marker: string,
+): ListRendering => ({
+  marker,
+  level,
+  numId: 1,
+  isBullet,
+});
+
+describe("toMarkdown — block structure", () => {
+  test("heading style → ATX heading at the matching level", () => {
+    expect(md([para([run("Title")], { styleId: "Heading1" })])).toBe("# Title");
+    expect(md([para([run("Sub")], { styleId: "Heading3" })])).toBe("### Sub");
+  });
+
+  test("plain paragraphs join with a blank line", () => {
+    expect(md([para([run("One")]), para([run("Two")])])).toBe("One\n\nTwo");
+  });
+
+  test("Quote style becomes a blockquote", () => {
+    expect(md([para([run("Cited")], { styleId: "Quote" })])).toBe("> Cited");
+  });
+
+  test("bullet and ordered lists keep Word's exact marker", () => {
+    const out = md([
+      para([run("first")], { listRendering: list(0, true, "•") }),
+      para([run("second")], { listRendering: list(0, true, "•") }),
+    ]);
+    expect(out).toBe("- first\n- second");
+
+    const ordered = md([
+      para([run("a")], { listRendering: list(0, false, "1.") }),
+      para([run("b")], { listRendering: list(0, false, "2.") }),
+    ]);
+    expect(ordered).toBe("1. a\n2. b");
+  });
+});
+
+describe("toMarkdown — inline marks", () => {
+  test("bold, italic, and combined", () => {
+    expect(md([para([run("x", { bold: true })])])).toBe("**x**");
+    expect(md([para([run("x", { italic: true })])])).toBe("*x*");
+    expect(md([para([run("x", { bold: true, italic: true })])])).toBe(
+      "***x***",
+    );
+  });
+
+  test("strikethrough", () => {
+    expect(md([para([run("x", { strike: true })])])).toBe("~~x~~");
+  });
+
+  test("inline code is inferred from a monospace font", () => {
+    expect(
+      md([para([run("code()", { fontFamily: { ascii: "Consolas" } })])]),
+    ).toBe("`code()`");
+  });
+
+  test("a hyperlink renders inline", () => {
+    const link: Hyperlink = {
+      type: "hyperlink",
+      href: "https://example.com",
+      children: [run("here")],
+    };
+    expect(toMarkdown(doc([{ type: "paragraph", content: [link] }]))).toBe(
+      "[here](https://example.com)",
+    );
+  });
+});
+
+describe("toMarkdown — tables", () => {
+  test("a simple table renders as GFM", () => {
+    const table: BlockContent = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            { type: "tableCell", content: [para([run("A")])] },
+            { type: "tableCell", content: [para([run("B")])] },
+          ],
+        },
+        {
+          type: "tableRow",
+          cells: [
+            { type: "tableCell", content: [para([run("1")])] },
+            { type: "tableCell", content: [para([run("2")])] },
+          ],
+        },
+      ],
+    };
+    expect(md([table])).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
+  });
+
+  test("a merged cell falls back to inline HTML with colspan", () => {
+    const table: BlockContent = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: { gridSpan: 2 },
+              content: [para([run("Span")])],
+            },
+          ],
+        },
+        {
+          type: "tableRow",
+          cells: [
+            { type: "tableCell", content: [para([run("L")])] },
+            { type: "tableCell", content: [para([run("R")])] },
+          ],
+        },
+      ],
+    };
+    expect(md([table])).toBe(
+      '<table>\n  <tr>\n    <th colspan="2">Span</th>\n  </tr>\n  <tr>\n    <td>L</td>\n    <td>R</td>\n  </tr>\n</table>',
+    );
+  });
+});
+
+describe("toMarkdown — clean preset for skills", () => {
+  const clean: MarkdownOptions = {
+    annotations: "strip",
+    trackedChanges: "clean",
+    comments: "strip",
+    hyperlinks: "inline",
+    footnotes: "strip",
+  };
+
+  test("a footnote reference is dropped (no marker, no trailer)", () => {
+    const content: Paragraph["content"] = [
+      run("text"),
+      { type: "run", content: [{ type: "footnoteRef", id: 1 }] },
+    ];
+    const out = toMarkdown(
+      {
+        package: {
+          document: { content: [{ type: "paragraph", content }] },
+          footnotes: [
+            { type: "footnote", id: 1, content: [para([run("note")])] },
+          ],
+        },
+      },
+      clean,
+    );
+    expect(out).toBe("text");
+  });
+
+  test("footnotes are kept by default", () => {
+    const content: Paragraph["content"] = [
+      run("text"),
+      { type: "run", content: [{ type: "footnoteRef", id: 1 }] },
+    ];
+    const out = toMarkdown({
+      package: {
+        document: { content: [{ type: "paragraph", content }] },
+        footnotes: [
+          { type: "footnote", id: 1, content: [para([run("note")])] },
+        ],
+      },
+    });
+    expect(out).toBe("text[^1]\n\n[^1]: note");
+  });
+});

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -68,6 +68,23 @@ describe("toMarkdown — block structure", () => {
     expect(md([para([run("Cited")], { styleId: "Quote" })])).toBe("> Cited");
   });
 
+  test("block markers after an inline break are escaped", () => {
+    const para1: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "run",
+          content: [
+            { type: "text", text: "Intro" },
+            { type: "break" },
+            { type: "text", text: "# Clause" },
+          ],
+        },
+      ],
+    };
+    expect(md([para1])).toBe("Intro  \n\\# Clause");
+  });
+
   test("a plain paragraph that begins with block syntax is escaped", () => {
     // Literal legal text must not be reclassified as a heading/list/quote.
     expect(md([para([run("# Not a heading")])])).toBe("\\# Not a heading");

--- a/packages/folio/src/core/markdown/markdown.test.ts
+++ b/packages/folio/src/core/markdown/markdown.test.ts
@@ -121,6 +121,37 @@ describe("toMarkdown — inline marks", () => {
     ).toBe("`code()`");
   });
 
+  test("inline code with backticks uses a longer fence", () => {
+    const mono = { fontFamily: { ascii: "Consolas" } };
+    expect(md([para([run("a``b", mono)])])).toBe("```a``b```");
+    // Content beginning with a backtick gets an inner space.
+    expect(md([para([run("`x", mono)])])).toBe("`` `x ``");
+  });
+
+  test("a math equation exports its plain-text fallback", () => {
+    const out = toMarkdown({
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                run("E="),
+                {
+                  type: "mathEquation",
+                  display: "inline",
+                  ommlXml: "<m/>",
+                  plainText: "mc^2",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(out).toBe("E=mc^2");
+  });
+
   test("a hyperlink renders inline", () => {
     const link: Hyperlink = {
       type: "hyperlink",

--- a/packages/folio/src/core/markdown/renderBlock.ts
+++ b/packages/folio/src/core/markdown/renderBlock.ts
@@ -1,0 +1,58 @@
+/**
+ * Block-level dispatcher. Walks `BlockContent[]` and joins the rendered
+ * markdown for each block, suppressing redundant blank lines between list items
+ * of the same list. Ported from eigenpal/docx-editor PR #595.
+ */
+
+import type { BlockContent, DocxPackage } from "../types/document";
+import { renderParagraph } from "./renderParagraph";
+import { renderTable } from "./renderTable";
+import type { RenderContext } from "./types";
+
+export function renderBlocks(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  blocks: BlockContent[],
+): string {
+  const out: string[] = [];
+  let prevWasListItem = false;
+
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      const isListItem = !!block.listRendering;
+      const md = renderParagraph(ctx, pkg, block);
+      if (!md) {
+        prevWasListItem = false;
+        continue;
+      }
+      if (isListItem && prevWasListItem) {
+        out.push(md);
+      } else if (out.length) {
+        out.push("", md);
+      } else {
+        out.push(md);
+      }
+      prevWasListItem = isListItem;
+    } else if (block.type === "table") {
+      const md = renderTable(ctx, pkg, block);
+      if (md) {
+        if (out.length) {
+          out.push("");
+        }
+        out.push(md);
+      }
+      prevWasListItem = false;
+    } else if (block.type === "blockSdt") {
+      // `BlockSdt.content` is `(Paragraph | Table)[]` — a subset of BlockContent.
+      const nested = renderBlocks(ctx, pkg, block.content);
+      if (nested) {
+        if (out.length) {
+          out.push("");
+        }
+        out.push(nested);
+      }
+    }
+  }
+
+  return out.join("\n");
+}

--- a/packages/folio/src/core/markdown/renderBlock.ts
+++ b/packages/folio/src/core/markdown/renderBlock.ts
@@ -19,7 +19,11 @@ export function renderBlocks(
 
   for (const block of blocks) {
     if (block.type === "paragraph") {
-      const isListItem = !!block.listRendering;
+      // A hidden-marker (`w:vanish`) list paragraph renders as plain prose, so
+      // treat it as prose here too (it must not suppress the blank line after a
+      // real list item).
+      const isListItem =
+        !!block.listRendering && !block.listRendering.markerHidden;
       const md = renderParagraph(ctx, pkg, block);
       if (!md) {
         prevWasListItem = false;

--- a/packages/folio/src/core/markdown/renderBlock.ts
+++ b/packages/folio/src/core/markdown/renderBlock.ts
@@ -9,6 +9,40 @@ import { renderParagraph } from "./renderParagraph";
 import { renderTable } from "./renderTable";
 import type { RenderContext } from "./types";
 
+/**
+ * In `trackedChanges: "clean"` mode every change is accepted. A paragraph whose
+ * end-of-paragraph mark is a pending deletion (`pPrMark.kind === "del"`) loses
+ * its break on accept and merges with the following paragraph. Word's join
+ * keeps the FIRST paragraph's properties (style, list) and drops the resolved
+ * mark; the surviving break is the next paragraph's, so a run of consecutive
+ * deletions collapses into one paragraph. A non-paragraph next block (table,
+ * SDT) is structurally incompatible and stays unmerged, matching the editor's
+ * accept-change join guard (`commands/comments.ts`).
+ */
+function mergeAcceptedParagraphBreaks(blocks: BlockContent[]): BlockContent[] {
+  const merged: BlockContent[] = [];
+  for (const block of blocks) {
+    const prev = merged.at(-1);
+    if (
+      prev?.type === "paragraph" &&
+      prev.pPrMark?.kind === "del" &&
+      block.type === "paragraph"
+    ) {
+      // Drop the resolved deletion mark; inherit the next paragraph's mark so a
+      // chain keeps merging.
+      const { pPrMark: _resolved, ...base } = prev;
+      const next = block.pPrMark;
+      const content = [...prev.content, ...block.content];
+      merged[merged.length - 1] = next
+        ? { ...base, content, pPrMark: next }
+        : { ...base, content };
+      continue;
+    }
+    merged.push(block);
+  }
+  return merged;
+}
+
 export function renderBlocks(
   ctx: RenderContext,
   pkg: DocxPackage | undefined,
@@ -17,7 +51,12 @@ export function renderBlocks(
   const out: string[] = [];
   let prevWasListItem = false;
 
-  for (const block of blocks) {
+  const ordered =
+    ctx.opts.trackedChanges === "clean"
+      ? mergeAcceptedParagraphBreaks(blocks)
+      : blocks;
+
+  for (const block of ordered) {
     if (block.type === "paragraph") {
       // A hidden-marker (`w:vanish`) list paragraph renders as plain prose, so
       // treat it as prose here too (it must not suppress the blank line after a

--- a/packages/folio/src/core/markdown/renderBlock.ts
+++ b/packages/folio/src/core/markdown/renderBlock.ts
@@ -42,8 +42,8 @@ export function renderBlocks(
         out.push(md);
       }
       prevWasListItem = false;
-    } else if (block.type === "blockSdt") {
-      // `BlockSdt.content` is `(Paragraph | Table)[]` — a subset of BlockContent.
+    } else {
+      // blockSdt — `BlockSdt.content` is a subset of BlockContent.
       const nested = renderBlocks(ctx, pkg, block.content);
       if (nested) {
         if (out.length) {

--- a/packages/folio/src/core/markdown/renderParagraph.ts
+++ b/packages/folio/src/core/markdown/renderParagraph.ts
@@ -57,10 +57,14 @@ export function renderParagraph(
  * style/list metadata. Escape the leading marker so literal text round-trips.
  */
 function escapeLeadingBlockMarker(text: string): string {
+  // Escape at the start of every line (`m` flag), not just the paragraph: an
+  // inline break (soft break / page break) can put block syntax at the start of
+  // a later line. Only horizontal whitespace `[ \t]` leads the marker so the
+  // anchor doesn't cross the newline.
   return text
-    .replace(/^(\s*)([#>])/u, "$1\\$2")
-    .replace(/^(\s*)([-+*])(\s)/u, "$1\\$2$3")
-    .replace(/^(\s*)(\d{1,9})([.)])(\s)/u, "$1$2\\$3$4");
+    .replace(/^([ \t]*)([#>])/gmu, "$1\\$2")
+    .replace(/^([ \t]*)([-+*])([ \t])/gmu, "$1\\$2$3")
+    .replace(/^([ \t]*)(\d{1,9})([.)])([ \t])/gmu, "$1$2\\$3$4");
 }
 
 function renderListItem(list: ListRendering, inline: string): string {

--- a/packages/folio/src/core/markdown/renderParagraph.ts
+++ b/packages/folio/src/core/markdown/renderParagraph.ts
@@ -32,7 +32,9 @@ export function renderParagraph(
     return `${hashes} ${inline}`;
   }
 
-  if (para.listRendering) {
+  // A numbering level with `w:vanish` keeps `listRendering` but hides the
+  // marker, so render it as plain prose rather than a Markdown list item.
+  if (para.listRendering && !para.listRendering.markerHidden) {
     return renderListItem(para.listRendering, inline);
   }
 

--- a/packages/folio/src/core/markdown/renderParagraph.ts
+++ b/packages/folio/src/core/markdown/renderParagraph.ts
@@ -1,0 +1,61 @@
+/**
+ * Render a single paragraph as a block of markdown. Three cases: heading style
+ * → `#`…`######`; list item → indented marker + inline content (Word's exact
+ * marker preserved); plain prose → escaped inline content. Word's `Quote` /
+ * `IntenseQuote` styles become blockquotes. Ported from eigenpal/docx-editor
+ * PR #595.
+ */
+
+import type { DocxPackage, Paragraph } from "../types/document";
+import { isHeadingStyle, parseHeadingLevel } from "./headings";
+import { renderParagraphInline } from "./renderRuns";
+import type { RenderContext } from "./types";
+
+/**
+ * Render a paragraph and return the block text. No surrounding blank line: the
+ * caller joins blocks.
+ */
+export function renderParagraph(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  para: Paragraph,
+): string {
+  const inline = renderParagraphInline(ctx, pkg, para.content, para.paraId);
+  const styleId = para.formatting?.styleId;
+
+  if (isHeadingStyle(styleId)) {
+    if (!inline) {
+      return ""; // Drop empty headings — `#` alone is just literal text.
+    }
+    const level = parseHeadingLevel(styleId) ?? 1;
+    const hashes = "#".repeat(Math.max(1, Math.min(6, level)));
+    return `${hashes} ${inline}`;
+  }
+
+  if (para.listRendering) {
+    return renderListItem(para, inline);
+  }
+
+  // Word's built-in quote styles: `Quote`, `IntenseQuote`. Avoid loose matches
+  // like `/quote/i` that catch `BlockQuoteCustom` or even `NoQuote`.
+  if (styleId === "Quote" || styleId === "IntenseQuote") {
+    return inline
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+  }
+
+  return inline;
+}
+
+function renderListItem(para: Paragraph, inline: string): string {
+  const list = para.listRendering!;
+  const indent = "  ".repeat(list.level);
+  if (list.isBullet) {
+    return `${indent}- ${inline}`.trimEnd();
+  }
+  // Preserve Word's exact marker (e.g. "1.", "a)", "i."). Strip trailing
+  // whitespace from the marker but keep its punctuation intact.
+  const marker = list.marker.trim();
+  return `${indent}${marker} ${inline}`.trimEnd();
+}

--- a/packages/folio/src/core/markdown/renderParagraph.ts
+++ b/packages/folio/src/core/markdown/renderParagraph.ts
@@ -6,7 +6,7 @@
  * PR #595.
  */
 
-import type { DocxPackage, Paragraph } from "../types/document";
+import type { DocxPackage, ListRendering, Paragraph } from "../types/document";
 import { isHeadingStyle, parseHeadingLevel } from "./headings";
 import { renderParagraphInline } from "./renderRuns";
 import type { RenderContext } from "./types";
@@ -33,7 +33,7 @@ export function renderParagraph(
   }
 
   if (para.listRendering) {
-    return renderListItem(para, inline);
+    return renderListItem(para.listRendering, inline);
   }
 
   // Word's built-in quote styles: `Quote`, `IntenseQuote`. Avoid loose matches
@@ -45,11 +45,23 @@ export function renderParagraph(
       .join("\n");
   }
 
-  return inline;
+  return escapeLeadingBlockMarker(inline);
 }
 
-function renderListItem(para: Paragraph, inline: string): string {
-  const list = para.listRendering!;
+/**
+ * A plain paragraph whose visible text begins with markdown block syntax (e.g.
+ * `# Not a heading`, `- value`, `1. value`, `> quote`) would be reclassified as
+ * a heading/list/blockquote on re-parse, even though Word carries no matching
+ * style/list metadata. Escape the leading marker so literal text round-trips.
+ */
+function escapeLeadingBlockMarker(text: string): string {
+  return text
+    .replace(/^(\s*)([#>])/u, "$1\\$2")
+    .replace(/^(\s*)([-+*])(\s)/u, "$1\\$2$3")
+    .replace(/^(\s*)(\d{1,9})([.)])(\s)/u, "$1$2\\$3$4");
+}
+
+function renderListItem(list: ListRendering, inline: string): string {
   const indent = "  ".repeat(list.level);
   if (list.isBullet) {
     return `${indent}- ${inline}`.trimEnd();

--- a/packages/folio/src/core/markdown/renderRuns.ts
+++ b/packages/folio/src/core/markdown/renderRuns.ts
@@ -204,6 +204,11 @@ function renderRun(
   run: Run,
   paraId: string | undefined,
 ): string {
+  // Hidden text (`w:vanish`) is suppressed in Word's normal view; drop it from
+  // the markdown so hidden clauses / drafting notes don't leak into the export.
+  if (run.formatting?.hidden) {
+    return "";
+  }
   const inner = renderRunContent(ctx, pkg, run.content, paraId);
   if (!inner) {
     return "";

--- a/packages/folio/src/core/markdown/renderRuns.ts
+++ b/packages/folio/src/core/markdown/renderRuns.ts
@@ -94,13 +94,19 @@ function applyMarks(text: string, marks: MarkKey[]): string {
   if (!text) {
     return text;
   }
-  // Code overrides other marks: code is literal.
+  // Code overrides other marks: a code span is literal, so undo the inline
+  // markdown escaping `escapeInline` applied to the run text. Per CommonMark the
+  // fence must be longer than the longest backtick run in the content, and a
+  // space is padded inside when the content begins or ends with a backtick.
   if (marks.includes("code")) {
-    // If text contains backticks, use a longer fence.
-    if (text.includes("`")) {
-      return `\`\`${text}\`\``;
+    const literal = text.replace(/\\([\\`*[\]_<])/gu, "$1");
+    let longestRun = 0;
+    for (const m of literal.matchAll(/`+/gu)) {
+      longestRun = Math.max(longestRun, m[0].length);
     }
-    return `\`${text}\``;
+    const fence = "`".repeat(longestRun + 1);
+    const pad = literal.startsWith("`") || literal.endsWith("`") ? " " : "";
+    return `${fence}${pad}${literal}${pad}${fence}`;
   }
   let out = text;
   for (const m of marks) {
@@ -360,6 +366,12 @@ export function renderParagraphInline(
           item.content as ParagraphContent[],
           paraId,
         );
+        break;
+      case "mathEquation":
+        // Markdown can't carry OMML; emit the plain-text fallback when present.
+        if (item.plainText) {
+          out += escapeInline(item.plainText);
+        }
         break;
       default:
         // Range markers without inline payload (bookmark*, move*Range*,

--- a/packages/folio/src/core/markdown/renderRuns.ts
+++ b/packages/folio/src/core/markdown/renderRuns.ts
@@ -1,0 +1,426 @@
+/**
+ * Render inline content (runs, hyperlinks, comment-range markers, tracked
+ * changes) to markdown. Operates on the `ParagraphContent[]` of a paragraph, or
+ * the equivalent inline lists inside hyperlinks and tracked-change wrappers.
+ *
+ * Inline marks are rendered as character-precise wrappers around the affected
+ * runs. Comments and tracked changes become configurable annotation tags via
+ * `./annotations`. Ported from eigenpal/docx-editor PR #595 (folio adds the
+ * `footnotes: "strip"` gate).
+ */
+
+import type {
+  Comment,
+  CommentRangeEnd,
+  CommentRangeStart,
+  Deletion,
+  DocxPackage,
+  Hyperlink,
+  Insertion,
+  MoveFrom,
+  MoveTo,
+  ParagraphContent,
+  Run,
+  RunContent,
+} from "../types/document";
+import {
+  wrapComment,
+  wrapDeletion,
+  wrapInsertion,
+  wrapMoveFrom,
+  wrapMoveTo,
+} from "./annotations";
+import { escapeAltText, escapeInline, escapeLinkUrl } from "./escape";
+import { registerImage } from "./images";
+import { pushWarning } from "./internals";
+import type { RenderContext } from "./types";
+
+/**
+ * Inline marks we recognize. Order matters: we open from outermost to innermost
+ * so the output reads cleanly (`***bold italic***`), not the reverse.
+ */
+type MarkKey = "bold" | "italic" | "code" | "strike";
+
+const MARK_DELIMS: Record<MarkKey, string> = {
+  bold: "**",
+  italic: "*",
+  code: "`",
+  strike: "~~",
+};
+
+// Word has no `code` run property. We infer it from a small whitelist of
+// monospace font families so prose set in fonts like `Monotype Corsiva` is not
+// wrapped in backticks.
+const MONOSPACE_FONTS = new Set([
+  "consolas",
+  "courier",
+  "courier new",
+  "menlo",
+  "monaco",
+  "sf mono",
+  "jetbrains mono",
+  "fira code",
+  "fira mono",
+  "source code pro",
+  "roboto mono",
+  "inconsolata",
+  "lucida console",
+  "monospace",
+]);
+
+function marksFor(run: Run): MarkKey[] {
+  const f = run.formatting;
+  if (!f) {
+    return [];
+  }
+  const out: MarkKey[] = [];
+  if (f.bold) {
+    out.push("bold");
+  }
+  if (f.italic) {
+    out.push("italic");
+  }
+  if (f.strike) {
+    out.push("strike");
+  }
+  const ascii = f.fontFamily?.ascii?.toLowerCase();
+  if (ascii && MONOSPACE_FONTS.has(ascii)) {
+    out.push("code");
+  }
+  return out;
+}
+
+function applyMarks(text: string, marks: MarkKey[]): string {
+  if (!text) {
+    return text;
+  }
+  // Code overrides other marks: code is literal.
+  if (marks.includes("code")) {
+    // If text contains backticks, use a longer fence.
+    if (text.includes("`")) {
+      return `\`\`${text}\`\``;
+    }
+    return `\`${text}\``;
+  }
+  let out = text;
+  for (const m of marks) {
+    const d = MARK_DELIMS[m];
+    out = `${d}${out}${d}`;
+  }
+  return out;
+}
+
+/** Render a single run's RunContent array into the inline text fragment. */
+function renderRunContent(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  content: RunContent[],
+  paraId: string | undefined,
+): string {
+  let out = "";
+  for (const item of content) {
+    switch (item.type) {
+      case "text":
+        out += escapeInline(item.text);
+        break;
+      case "tab":
+        out += "    ";
+        break;
+      case "break":
+        if (item.breakType === "page") {
+          // Page break inside text; in unpaged output we emit a paragraph break.
+          out += "\n\n";
+        } else {
+          // Soft break: markdown's two-space hard wrap.
+          out += "  \n";
+        }
+        break;
+      case "symbol":
+        out += escapeInline(item.char);
+        break;
+      case "softHyphen":
+        // U+00AD soft hyphen. Word displays it only when needed for line
+        // breaks; drop it from the markdown output.
+        break;
+      case "noBreakHyphen":
+        out += "‑";
+        break;
+      case "footnoteRef":
+      case "endnoteRef": {
+        if (ctx.opts.footnotes === "strip") {
+          break;
+        }
+        const markerNumber = ctx.footnoteRefs.length + 1;
+        ctx.footnoteRefs.push({ refId: item.id, markerNumber });
+        out += `[^${markerNumber}]`;
+        break;
+      }
+      case "drawing": {
+        // Preferred path: resolve via the package's rels → media chain. That
+        // returns raw bytes, so we register a stable virtual path and expose
+        // the image in `result.images`.
+        const ref = pkg?.relationships?.get(item.image.rId);
+        const media = ref ? pkg?.media?.get(ref.target) : undefined;
+        if (media) {
+          const reg = registerImage(ctx, media, item.image, paraId);
+          const alt = reg.alt ? escapeAltText(reg.alt) : "";
+          out += `![${alt}](${reg.virtualPath})`;
+          break;
+        }
+        // Fallback: header/footer images use a separate rels file that does not
+        // live in `pkg.relationships`. The parser inlines the bytes into
+        // `image.src` (typically a data URL) — emit that directly.
+        if (item.image.src) {
+          const alt =
+            item.image.alt ?? item.image.title ?? item.image.filename ?? "";
+          out += `![${escapeAltText(alt)}](${item.image.src})`;
+          break;
+        }
+        pushWarning(ctx, `image rId=${item.image.rId} not resolvable`);
+        break;
+      }
+      case "shape":
+        pushWarning(ctx, "shape not representable in markdown");
+        break;
+      case "fieldChar":
+      case "instrText":
+        // Field chrome. Skip: the field result text lives in surrounding runs.
+        break;
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+/** Render a single Run with its formatting applied. */
+function renderRun(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  run: Run,
+  paraId: string | undefined,
+): string {
+  const inner = renderRunContent(ctx, pkg, run.content, paraId);
+  if (!inner) {
+    return "";
+  }
+  // Markdown can't carry whitespace at the boundaries of a mark, so we split
+  // leading/trailing whitespace out of the wrapped text.
+  const match = /^(\s*)(.*?)(\s*)$/su.exec(inner);
+  if (!match) {
+    return applyMarks(inner, marksFor(run));
+  }
+  const [, lead, core, trail] = match;
+  if (!core) {
+    return inner;
+  }
+  return `${lead}${applyMarks(core, marksFor(run))}${trail}`;
+}
+
+function renderHyperlink(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  link: Hyperlink,
+  paraId: string | undefined,
+): string {
+  const inner = link.children
+    .map((child) =>
+      child.type === "run" ? renderRun(ctx, pkg, child, paraId) : "",
+    )
+    .join("");
+  if (!inner) {
+    return "";
+  }
+  const href = link.href ?? (link.anchor ? `#${link.anchor}` : "");
+  if (!href) {
+    pushWarning(
+      ctx,
+      "hyperlink missing href and anchor; rendered as plain text",
+    );
+    return inner;
+  }
+  if (ctx.opts.hyperlinks === "reference") {
+    const refNumber = ctx.hyperlinkRefs.length + 1;
+    ctx.hyperlinkRefs.push({ href, refNumber });
+    return `[${inner}][${refNumber}]`;
+  }
+  return `[${inner}](${escapeLinkUrl(href)})`;
+}
+
+function renderTrackedWrapper(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  wrapper: Insertion | Deletion | MoveFrom | MoveTo,
+  paraId: string | undefined,
+): string {
+  if (ctx.opts.trackedChanges === "clean") {
+    // Insertions become real text; deletions vanish.
+    if (wrapper.type === "insertion" || wrapper.type === "moveTo") {
+      return wrapper.content
+        .map((child) =>
+          child.type === "run"
+            ? renderRun(ctx, pkg, child, paraId)
+            : renderHyperlink(ctx, pkg, child, paraId),
+        )
+        .join("");
+    }
+    return "";
+  }
+  const inner = wrapper.content
+    .map((child) =>
+      child.type === "run"
+        ? renderRun(ctx, pkg, child, paraId)
+        : renderHyperlink(ctx, pkg, child, paraId),
+    )
+    .join("");
+  switch (wrapper.type) {
+    case "insertion":
+      return wrapInsertion(ctx, wrapper.info, inner);
+    case "deletion":
+      return wrapDeletion(ctx, wrapper.info, inner);
+    case "moveFrom":
+      return wrapMoveFrom(ctx, wrapper.info, inner);
+    case "moveTo":
+      return wrapMoveTo(ctx, wrapper.info, inner);
+  }
+}
+
+interface CommentSlot {
+  start: number;
+  comment?: Comment | undefined;
+}
+
+/**
+ * Render the full inline content of a paragraph, tracking comment-range
+ * boundaries to apply the configured wrapper.
+ */
+export function renderParagraphInline(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  content: ParagraphContent[],
+  paraId: string | undefined,
+): string {
+  let out = "";
+  // Stack of open comment ranges (document order) so nested comments wrap right.
+  const openComments: CommentSlot[] = [];
+
+  for (const item of content) {
+    switch (item.type) {
+      case "run":
+        out += renderRun(ctx, pkg, item, paraId);
+        break;
+      case "hyperlink":
+        out += renderHyperlink(ctx, pkg, item, paraId);
+        break;
+      case "insertion":
+      case "deletion":
+      case "moveFrom":
+      case "moveTo":
+        out += renderTrackedWrapper(ctx, pkg, item, paraId);
+        break;
+      case "commentRangeStart":
+        out += handleCommentStart(ctx, pkg, item, openComments, out.length);
+        break;
+      case "commentRangeEnd":
+        out = handleCommentEnd(ctx, item, openComments, out);
+        break;
+      case "simpleField":
+      case "complexField": {
+        // Render the visible result content.
+        const runs =
+          item.type === "simpleField" ? item.content : item.fieldResult;
+        for (const child of runs) {
+          out +=
+            child.type === "run"
+              ? renderRun(ctx, pkg, child, paraId)
+              : renderHyperlink(ctx, pkg, child, paraId);
+        }
+        break;
+      }
+      case "inlineSdt": {
+        // `InlineSdt.content` is a subset of `ParagraphContent`.
+        if (item.content) {
+          out += renderParagraphInline(
+            ctx,
+            pkg,
+            item.content as ParagraphContent[],
+            paraId,
+          );
+        }
+        break;
+      }
+      default:
+        // Range markers without inline payload (bookmark*, move*Range*,
+        // commentReference, math) contribute nothing here.
+        break;
+    }
+  }
+
+  // Close any still-open comment ranges defensively.
+  while (openComments.length) {
+    const slot = openComments.pop();
+    if (!slot) {
+      break;
+    }
+    if (!slot.comment || ctx.opts.comments === "strip") {
+      continue;
+    }
+    out = applyCommentWrapping(ctx, slot, out);
+  }
+
+  return out;
+}
+
+function handleCommentStart(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  marker: CommentRangeStart,
+  openComments: CommentSlot[],
+  startPos: number,
+): string {
+  if (ctx.opts.comments === "strip") {
+    openComments.push({ start: startPos, comment: undefined });
+    return "";
+  }
+  const comment = pkg?.document.comments?.find((c) => c.id === marker.id);
+  openComments.push({ start: startPos, comment });
+  return "";
+}
+
+function handleCommentEnd(
+  ctx: RenderContext,
+  _marker: CommentRangeEnd,
+  openComments: CommentSlot[],
+  current: string,
+): string {
+  const slot = openComments.pop();
+  if (!slot || !slot.comment || ctx.opts.comments === "strip") {
+    return current;
+  }
+  return applyCommentWrapping(ctx, slot, current);
+}
+
+function applyCommentWrapping(
+  ctx: RenderContext,
+  slot: CommentSlot,
+  current: string,
+): string {
+  if (!slot.comment) {
+    return current;
+  }
+  const before = current.slice(0, slot.start);
+  const inner = current.slice(slot.start);
+  if (ctx.opts.comments === "sidecar") {
+    const markerNumber = ctx.commentRefs.length + 1;
+    ctx.commentRefs.push({ commentId: slot.comment.id, markerNumber });
+    return `${before}${inner}[^c${markerNumber}]`;
+  }
+  return (
+    before +
+    wrapComment(
+      ctx,
+      { id: slot.comment.id, author: slot.comment.author },
+      inner,
+    )
+  );
+}

--- a/packages/folio/src/core/markdown/renderRuns.ts
+++ b/packages/folio/src/core/markdown/renderRuns.ts
@@ -151,7 +151,11 @@ function renderRunContent(
           break;
         }
         const markerNumber = ctx.footnoteRefs.length + 1;
-        ctx.footnoteRefs.push({ refId: item.id, markerNumber });
+        ctx.footnoteRefs.push({
+          refId: item.id,
+          markerNumber,
+          kind: item.type === "endnoteRef" ? "endnote" : "footnote",
+        });
         out += `[^${markerNumber}]`;
         break;
       }
@@ -205,15 +209,16 @@ function renderRun(
     return "";
   }
   // Markdown can't carry whitespace at the boundaries of a mark, so we split
-  // leading/trailing whitespace out of the wrapped text.
-  const match = /^(\s*)(.*?)(\s*)$/su.exec(inner);
-  if (!match) {
-    return applyMarks(inner, marksFor(run));
-  }
-  const [, lead, core, trail] = match;
+  // leading/trailing whitespace out of the wrapped text. Done with trim-length
+  // math rather than a regex to avoid backtracking on long runs.
+  const leadLen = inner.length - inner.trimStart().length;
+  const trailLen = inner.length - inner.trimEnd().length;
+  const core = inner.slice(leadLen, inner.length - trailLen);
   if (!core) {
     return inner;
   }
+  const lead = inner.slice(0, leadLen);
+  const trail = inner.slice(inner.length - trailLen);
   return `${lead}${applyMarks(core, marksFor(run))}${trail}`;
 }
 
@@ -280,15 +285,15 @@ function renderTrackedWrapper(
       return wrapDeletion(ctx, wrapper.info, inner);
     case "moveFrom":
       return wrapMoveFrom(ctx, wrapper.info, inner);
-    case "moveTo":
+    default:
       return wrapMoveTo(ctx, wrapper.info, inner);
   }
 }
 
-interface CommentSlot {
+type CommentSlot = {
   start: number;
   comment?: Comment | undefined;
-}
+};
 
 /**
  * Render the full inline content of a paragraph, tracking comment-range
@@ -337,18 +342,15 @@ export function renderParagraphInline(
         }
         break;
       }
-      case "inlineSdt": {
+      case "inlineSdt":
         // `InlineSdt.content` is a subset of `ParagraphContent`.
-        if (item.content) {
-          out += renderParagraphInline(
-            ctx,
-            pkg,
-            item.content as ParagraphContent[],
-            paraId,
-          );
-        }
+        out += renderParagraphInline(
+          ctx,
+          pkg,
+          item.content as ParagraphContent[],
+          paraId,
+        );
         break;
-      }
       default:
         // Range markers without inline payload (bookmark*, move*Range*,
         // commentReference, math) contribute nothing here.

--- a/packages/folio/src/core/markdown/renderRuns.ts
+++ b/packages/folio/src/core/markdown/renderRuns.ts
@@ -329,6 +329,11 @@ export function renderParagraphInline(
       case "commentRangeEnd":
         out = handleCommentEnd(ctx, item, openComments, out);
         break;
+      case "commentReference":
+        // A point comment (or a range the parser collapsed to a reference).
+        // It has no covered text, so emit just the marker.
+        out += renderPointComment(ctx, pkg, item.id);
+        break;
       case "simpleField":
       case "complexField": {
         // Render the visible result content.
@@ -387,6 +392,27 @@ function handleCommentStart(
   const comment = pkg?.document.comments?.find((c) => c.id === marker.id);
   openComments.push({ start: startPos, comment });
   return "";
+}
+
+function renderPointComment(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  id: number,
+): string {
+  if (ctx.opts.comments === "strip") {
+    return "";
+  }
+  const comment = pkg?.document.comments?.find((c) => c.id === id);
+  if (!comment) {
+    return "";
+  }
+  if (ctx.opts.comments === "sidecar") {
+    const markerNumber = ctx.commentRefs.length + 1;
+    ctx.commentRefs.push({ commentId: comment.id, markerNumber });
+    return `[^c${markerNumber}]`;
+  }
+  // Inline: a point comment covers no text, so wrap an empty span.
+  return wrapComment(ctx, { id: comment.id, author: comment.author }, "");
 }
 
 function handleCommentEnd(

--- a/packages/folio/src/core/markdown/renderTable.ts
+++ b/packages/folio/src/core/markdown/renderTable.ts
@@ -308,6 +308,12 @@ function renderHtmlInline(
           paraId,
         );
         break;
+      case "mathEquation":
+        // Markdown can't carry OMML; emit the plain-text fallback when present.
+        if (item.plainText) {
+          out += escapeHtml(item.plainText);
+        }
+        break;
       default:
         // Range markers carry no visible payload inside table cells.
         break;

--- a/packages/folio/src/core/markdown/renderTable.ts
+++ b/packages/folio/src/core/markdown/renderTable.ts
@@ -278,9 +278,14 @@ function renderHtmlInline(
         out += renderHtmlHyperlink(ctx, pkg, item, paraId);
         break;
       case "insertion":
-      case "moveTo":
-        out += renderHtmlChildren(ctx, pkg, item.content, paraId);
+      case "moveTo": {
+        const inner = renderHtmlChildren(ctx, pkg, item.content, paraId);
+        out +=
+          ctx.opts.trackedChanges === "annotate"
+            ? `<ins>${inner}</ins>`
+            : inner;
         break;
+      }
       case "deletion":
       case "moveFrom":
         if (ctx.opts.trackedChanges === "annotate") {

--- a/packages/folio/src/core/markdown/renderTable.ts
+++ b/packages/folio/src/core/markdown/renderTable.ts
@@ -337,6 +337,10 @@ function renderHtmlRun(
   run: Run,
   paraId: string | undefined,
 ): string {
+  // Hidden text (`w:vanish`) is suppressed in Word's normal view; drop it.
+  if (run.formatting?.hidden) {
+    return "";
+  }
   let text = "";
   for (const item of run.content) {
     switch (item.type) {

--- a/packages/folio/src/core/markdown/renderTable.ts
+++ b/packages/folio/src/core/markdown/renderTable.ts
@@ -1,0 +1,416 @@
+/**
+ * Render a Word table as markdown. Two output modes, picked automatically per
+ * table: GFM for simple tables (no merged cells, no nested tables); inline HTML
+ * `<table>` with `colspan`/`rowspan` when the table has `gridSpan`, `vMerge`, or
+ * a nested table. Multi-paragraph cells join their paragraphs with `<br>` in
+ * both modes. Ported from eigenpal/docx-editor PR #595.
+ */
+
+import type {
+  DocxPackage,
+  Hyperlink,
+  ParagraphContent,
+  Run,
+  Table,
+  TableCell,
+  TableRow,
+} from "../types/document";
+import { escapeTableCell } from "./escape";
+import { registerImage } from "./images";
+import { pushWarning } from "./internals";
+import { renderParagraph } from "./renderParagraph";
+import type { RenderContext } from "./types";
+
+/** Render a `Table` as markdown. Picks GFM vs HTML based on cell features. */
+export function renderTable(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  table: Table,
+): string {
+  const { rows } = table;
+  if (!rows.length) {
+    return "";
+  }
+  if (needsHtmlFallback(rows)) {
+    return renderHtmlTable(ctx, pkg, rows, true);
+  }
+  return renderGfmTable(ctx, pkg, rows, true);
+}
+
+function needsHtmlFallback(rows: TableRow[]): boolean {
+  for (const row of rows) {
+    for (const cell of row.cells) {
+      if ((cell.formatting?.gridSpan ?? 1) > 1) {
+        return true;
+      }
+      if (cell.formatting?.vMerge) {
+        return true;
+      }
+      if (cell.content.some((b) => b.type === "table")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// GFM path
+// ---------------------------------------------------------------------------
+
+function renderGfmTable(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  rows: TableRow[],
+  firstRowIsHeader: boolean,
+): string {
+  const cellTexts = rows.map((row) => renderGfmRow(ctx, pkg, row));
+  const maxCols = cellTexts.reduce((m, c) => Math.max(m, c.length), 0);
+  if (!maxCols) {
+    return "";
+  }
+
+  const padded = cellTexts.map((row) => {
+    const filled = row.slice();
+    while (filled.length < maxCols) {
+      filled.push("");
+    }
+    return filled;
+  });
+
+  const lines: string[] = [];
+  if (firstRowIsHeader) {
+    lines.push(toRowLine(padded[0]!));
+    lines.push(`| ${new Array(maxCols).fill("---").join(" | ")} |`);
+    for (let i = 1; i < padded.length; i++) {
+      lines.push(toRowLine(padded[i]!));
+    }
+  } else {
+    lines.push(`| ${new Array(maxCols).fill("").join(" | ")} |`);
+    lines.push(`| ${new Array(maxCols).fill("---").join(" | ")} |`);
+    for (const row of padded) {
+      lines.push(toRowLine(row));
+    }
+  }
+  return lines.join("\n");
+}
+
+function toRowLine(cells: string[]): string {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function renderGfmRow(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  row: TableRow,
+): string[] {
+  const out: string[] = [];
+  for (const cell of row.cells) {
+    out.push(renderGfmCell(ctx, pkg, cell));
+  }
+  return out;
+}
+
+function renderGfmCell(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  cell: TableCell,
+): string {
+  const blocks: string[] = [];
+  for (const item of cell.content) {
+    if (item.type === "paragraph") {
+      const md = renderParagraph(ctx, pkg, item);
+      if (md.trim()) {
+        blocks.push(md);
+      }
+    }
+  }
+  return escapeTableCell(blocks.join("\n"));
+}
+
+// ---------------------------------------------------------------------------
+// HTML path
+// ---------------------------------------------------------------------------
+
+function renderHtmlTable(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  rows: TableRow[],
+  firstRowIsHeader: boolean,
+): string {
+  const out: string[] = ["<table>"];
+  rows.forEach((row, rowIdx) => {
+    const tag = firstRowIsHeader && rowIdx === 0 ? "th" : "td";
+    out.push("  <tr>");
+    let gridCol = 0;
+    for (const cell of row.cells) {
+      const colspan = cell.formatting?.gridSpan ?? 1;
+      if (cell.formatting?.vMerge !== "continue") {
+        const rowspan = countRowSpan(rows, rowIdx, gridCol, colspan);
+        const attrs: string[] = [];
+        if (colspan > 1) {
+          attrs.push(`colspan="${colspan}"`);
+        }
+        if (rowspan > 1) {
+          attrs.push(`rowspan="${rowspan}"`);
+        }
+        const attrStr = attrs.length ? ` ${attrs.join(" ")}` : "";
+        out.push(
+          `    <${tag}${attrStr}>${renderHtmlCell(ctx, pkg, cell)}</${tag}>`,
+        );
+      }
+      gridCol += colspan;
+    }
+    out.push("  </tr>");
+  });
+  out.push("</table>");
+  return out.join("\n");
+}
+
+/**
+ * Count how many rows beyond `rowIdx` have a `vMerge: "continue"` cell aligned
+ * to the same grid column as the anchor. Cells are indexed by array position,
+ * but vertical merges align on the visual grid column, so a horizontal merge
+ * (`gridSpan > 1`) above shifts array indices — we walk by cumulative gridSpan.
+ */
+function countRowSpan(
+  rows: TableRow[],
+  rowIdx: number,
+  gridCol: number,
+  colspan: number,
+): number {
+  let span = 1;
+  for (let r = rowIdx + 1; r < rows.length; r++) {
+    const target = cellAtGridColumn(rows[r]!, gridCol);
+    if (
+      target &&
+      target.formatting?.vMerge === "continue" &&
+      (target.formatting?.gridSpan ?? 1) === colspan
+    ) {
+      span += 1;
+    } else {
+      break;
+    }
+  }
+  return span;
+}
+
+function cellAtGridColumn(
+  row: TableRow,
+  gridCol: number,
+): TableCell | undefined {
+  let col = 0;
+  for (const cell of row.cells) {
+    if (col === gridCol) {
+      return cell;
+    }
+    col += cell.formatting?.gridSpan ?? 1;
+    if (col > gridCol) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function renderHtmlCell(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  cell: TableCell,
+): string {
+  const parts: string[] = [];
+  for (const item of cell.content) {
+    if (item.type === "paragraph") {
+      const inner = renderHtmlInline(ctx, pkg, item.content, item.paraId);
+      if (inner) {
+        parts.push(inner);
+      }
+    } else if (item.type === "table") {
+      // Nested tables inside an HTML cell stay HTML: GFM is not parsed inside
+      // HTML blocks, so a pipe-table here would render as literal text.
+      const nested = renderHtmlTable(ctx, pkg, item.rows, true);
+      if (nested) {
+        parts.push(nested);
+      }
+    }
+  }
+  return parts.join("<br>");
+}
+
+// ---------------------------------------------------------------------------
+// HTML inline rendering for table cells. Markdown is not parsed inside HTML
+// blocks, so cells inside an HTML `<table>` emit HTML tags for marks and links.
+// ---------------------------------------------------------------------------
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;");
+}
+
+function renderHtmlInline(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  content: ParagraphContent[],
+  paraId: string | undefined,
+): string {
+  let out = "";
+  for (const item of content) {
+    switch (item.type) {
+      case "run":
+        out += renderHtmlRun(ctx, pkg, item, paraId);
+        break;
+      case "hyperlink":
+        out += renderHtmlHyperlink(ctx, pkg, item, paraId);
+        break;
+      case "insertion":
+      case "moveTo":
+        out += renderHtmlChildren(ctx, pkg, item.content, paraId);
+        break;
+      case "deletion":
+      case "moveFrom":
+        if (ctx.opts.trackedChanges === "annotate") {
+          out += `<del>${renderHtmlChildren(ctx, pkg, item.content, paraId)}</del>`;
+        }
+        break;
+      case "simpleField":
+      case "complexField": {
+        const runs =
+          item.type === "simpleField" ? item.content : item.fieldResult;
+        out += renderHtmlChildren(ctx, pkg, runs, paraId);
+        break;
+      }
+      case "inlineSdt":
+        if (item.content) {
+          out += renderHtmlInline(
+            ctx,
+            pkg,
+            item.content as ParagraphContent[],
+            paraId,
+          );
+        }
+        break;
+      default:
+        // Range markers carry no visible payload inside table cells.
+        break;
+    }
+  }
+  return out;
+}
+
+function renderHtmlChildren(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  children: Array<Run | Hyperlink>,
+  paraId: string | undefined,
+): string {
+  return children
+    .map((c) =>
+      c.type === "run"
+        ? renderHtmlRun(ctx, pkg, c, paraId)
+        : renderHtmlHyperlink(ctx, pkg, c, paraId),
+    )
+    .join("");
+}
+
+function renderHtmlRun(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  run: Run,
+  paraId: string | undefined,
+): string {
+  let text = "";
+  for (const item of run.content) {
+    switch (item.type) {
+      case "text":
+        text += escapeHtml(item.text);
+        break;
+      case "tab":
+        text += "&emsp;";
+        break;
+      case "break":
+        text += "<br>";
+        break;
+      case "symbol":
+        text += escapeHtml(item.char);
+        break;
+      case "noBreakHyphen":
+        text += "&#8209;";
+        break;
+      case "softHyphen":
+        break;
+      case "drawing": {
+        const ref = pkg?.relationships?.get(item.image.rId);
+        const media = ref ? pkg?.media?.get(ref.target) : undefined;
+        if (media) {
+          const reg = registerImage(ctx, media, item.image, paraId);
+          const alt = reg.alt ? escapeHtml(reg.alt) : "";
+          text += `<img src="${escapeHtml(reg.virtualPath)}" alt="${alt}">`;
+          break;
+        }
+        if (item.image.src) {
+          const alt = escapeHtml(
+            item.image.alt ?? item.image.title ?? item.image.filename ?? "",
+          );
+          text += `<img src="${escapeHtml(item.image.src)}" alt="${alt}">`;
+          break;
+        }
+        pushWarning(ctx, `image rId=${item.image.rId} not resolvable`);
+        break;
+      }
+      case "footnoteRef":
+      case "endnoteRef": {
+        if (ctx.opts.footnotes === "strip") {
+          break;
+        }
+        const markerNumber = ctx.footnoteRefs.length + 1;
+        ctx.footnoteRefs.push({ refId: item.id, markerNumber });
+        text += `<sup>[${markerNumber}]</sup>`;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  if (!text) {
+    return "";
+  }
+  const f = run.formatting;
+  if (!f) {
+    return text;
+  }
+  if (f.bold) {
+    text = `<strong>${text}</strong>`;
+  }
+  if (f.italic) {
+    text = `<em>${text}</em>`;
+  }
+  if (f.strike) {
+    text = `<s>${text}</s>`;
+  }
+  if (f.underline?.style && f.underline.style !== "none") {
+    text = `<u>${text}</u>`;
+  }
+  return text;
+}
+
+function renderHtmlHyperlink(
+  ctx: RenderContext,
+  pkg: DocxPackage | undefined,
+  link: Hyperlink,
+  paraId: string | undefined,
+): string {
+  // Hyperlink.children may include BookmarkStart/End markers; only runs
+  // contribute visible content.
+  const runs = link.children.filter((c): c is Run => c.type === "run");
+  const inner = runs.map((r) => renderHtmlRun(ctx, pkg, r, paraId)).join("");
+  if (!inner) {
+    return "";
+  }
+  const href = link.href ?? (link.anchor ? `#${link.anchor}` : "");
+  if (!href) {
+    return inner;
+  }
+  return `<a href="${escapeHtml(href)}">${inner}</a>`;
+}

--- a/packages/folio/src/core/markdown/renderTable.ts
+++ b/packages/folio/src/core/markdown/renderTable.ts
@@ -65,7 +65,12 @@ function renderGfmTable(
   firstRowIsHeader: boolean,
 ): string {
   const cellTexts = rows.map((row) => renderGfmRow(ctx, pkg, row));
-  const maxCols = cellTexts.reduce((m, c) => Math.max(m, c.length), 0);
+  let maxCols = 0;
+  for (const cells of cellTexts) {
+    if (cells.length > maxCols) {
+      maxCols = cells.length;
+    }
+  }
   if (!maxCols) {
     return "";
   }
@@ -78,16 +83,20 @@ function renderGfmTable(
     return filled;
   });
 
+  const separator = `| ${Array.from({ length: maxCols }, () => "---").join(" | ")} |`;
   const lines: string[] = [];
   if (firstRowIsHeader) {
-    lines.push(toRowLine(padded[0]!));
-    lines.push(`| ${new Array(maxCols).fill("---").join(" | ")} |`);
-    for (let i = 1; i < padded.length; i++) {
-      lines.push(toRowLine(padded[i]!));
+    const [header, ...body] = padded;
+    if (header) {
+      lines.push(toRowLine(header));
+    }
+    lines.push(separator);
+    for (const row of body) {
+      lines.push(toRowLine(row));
     }
   } else {
-    lines.push(`| ${new Array(maxCols).fill("").join(" | ")} |`);
-    lines.push(`| ${new Array(maxCols).fill("---").join(" | ")} |`);
+    lines.push(`| ${Array.from({ length: maxCols }, () => "").join(" | ")} |`);
+    lines.push(separator);
     for (const row of padded) {
       lines.push(toRowLine(row));
     }
@@ -139,7 +148,7 @@ function renderHtmlTable(
   firstRowIsHeader: boolean,
 ): string {
   const out: string[] = ["<table>"];
-  rows.forEach((row, rowIdx) => {
+  for (const [rowIdx, row] of rows.entries()) {
     const tag = firstRowIsHeader && rowIdx === 0 ? "th" : "td";
     out.push("  <tr>");
     let gridCol = 0;
@@ -162,7 +171,7 @@ function renderHtmlTable(
       gridCol += colspan;
     }
     out.push("  </tr>");
-  });
+  }
   out.push("</table>");
   return out.join("\n");
 }
@@ -181,11 +190,15 @@ function countRowSpan(
 ): number {
   let span = 1;
   for (let r = rowIdx + 1; r < rows.length; r++) {
-    const target = cellAtGridColumn(rows[r]!, gridCol);
+    const row = rows[r];
+    if (!row) {
+      break;
+    }
+    const target = cellAtGridColumn(row, gridCol);
     if (
       target &&
       target.formatting?.vMerge === "continue" &&
-      (target.formatting?.gridSpan ?? 1) === colspan
+      (target.formatting.gridSpan ?? 1) === colspan
     ) {
       span += 1;
     } else {
@@ -224,7 +237,7 @@ function renderHtmlCell(
       if (inner) {
         parts.push(inner);
       }
-    } else if (item.type === "table") {
+    } else {
       // Nested tables inside an HTML cell stay HTML: GFM is not parsed inside
       // HTML blocks, so a pipe-table here would render as literal text.
       const nested = renderHtmlTable(ctx, pkg, item.rows, true);
@@ -282,14 +295,13 @@ function renderHtmlInline(
         break;
       }
       case "inlineSdt":
-        if (item.content) {
-          out += renderHtmlInline(
-            ctx,
-            pkg,
-            item.content as ParagraphContent[],
-            paraId,
-          );
-        }
+        // `InlineSdt.content` is a subset of `ParagraphContent`.
+        out += renderHtmlInline(
+          ctx,
+          pkg,
+          item.content as ParagraphContent[],
+          paraId,
+        );
         break;
       default:
         // Range markers carry no visible payload inside table cells.
@@ -302,7 +314,7 @@ function renderHtmlInline(
 function renderHtmlChildren(
   ctx: RenderContext,
   pkg: DocxPackage | undefined,
-  children: Array<Run | Hyperlink>,
+  children: (Run | Hyperlink)[],
   paraId: string | undefined,
 ): string {
   return children
@@ -365,7 +377,11 @@ function renderHtmlRun(
           break;
         }
         const markerNumber = ctx.footnoteRefs.length + 1;
-        ctx.footnoteRefs.push({ refId: item.id, markerNumber });
+        ctx.footnoteRefs.push({
+          refId: item.id,
+          markerNumber,
+          kind: item.type === "endnoteRef" ? "endnote" : "footnote",
+        });
         text += `<sup>[${markerNumber}]</sup>`;
         break;
       }

--- a/packages/folio/src/core/markdown/trailers.ts
+++ b/packages/folio/src/core/markdown/trailers.ts
@@ -1,0 +1,84 @@
+/**
+ * Trailer sections appended after the document body: footnote definitions, the
+ * hyperlink reference list (`hyperlinks: "reference"`), and the comments
+ * sidecar (`comments: "sidecar"`). Split out of `internals` so the renderers
+ * can import `pushWarning` without pulling in `renderBlock` (which would form an
+ * import cycle). Ported from eigenpal/docx-editor PR #595.
+ */
+
+import type { Comment, Document, Endnote, Footnote } from "../types/document";
+import { renderBlocks } from "./renderBlock";
+import type { RenderContext } from "./types";
+
+/**
+ * Append footnote definitions, the hyperlink reference list (for
+ * `hyperlinks: "reference"`), and the comments sidecar block (for
+ * `comments: "sidecar"`). Each section is emitted only when its corresponding
+ * refs accumulator has entries.
+ */
+export function appendTrailers(
+  ctx: RenderContext,
+  doc: Document,
+  body: string,
+): string {
+  const sections: string[] = body.trim() ? [body] : [];
+
+  if (ctx.footnoteRefs.length > 0) {
+    const refs = ctx.footnoteRefs.map(({ refId, markerNumber, kind }) => {
+      const note =
+        kind === "endnote"
+          ? doc.package.endnotes?.find((n) => n.id === refId)
+          : doc.package.footnotes?.find((f) => f.id === refId);
+      return `[^${markerNumber}]: ${note ? noteText(ctx, doc, note) : ""}`;
+    });
+    sections.push(refs.join("\n"));
+  }
+
+  if (ctx.opts.hyperlinks === "reference" && ctx.hyperlinkRefs.length > 0) {
+    sections.push(
+      ctx.hyperlinkRefs
+        .map(({ href, refNumber }) => `[${refNumber}]: ${href}`)
+        .join("\n"),
+    );
+  }
+
+  if (ctx.opts.comments === "sidecar" && ctx.commentRefs.length > 0) {
+    const lines: string[] = ["## Comments"];
+    for (const { commentId, markerNumber } of ctx.commentRefs) {
+      const c = doc.package.document.comments?.find(
+        (cm) => cm.id === commentId,
+      );
+      const author = c?.author ? `${c.author}: ` : "";
+      const text = c ? commentText(c) : "";
+      lines.push(`[^c${markerNumber}]: ${author}${text}`);
+    }
+    sections.push(lines.join("\n"));
+  }
+
+  return sections.join("\n\n");
+}
+
+function noteText(
+  ctx: RenderContext,
+  doc: Document,
+  note: Footnote | Endnote,
+): string {
+  return renderBlocks(ctx, doc.package, note.content)
+    .replace(/\n+/gu, " ")
+    .trim();
+}
+
+function commentText(comment: Comment): string {
+  return comment.content
+    .map((p) =>
+      p.content
+        .map((c) =>
+          c.type === "run"
+            ? c.content.map((x) => (x.type === "text" ? x.text : "")).join("")
+            : "",
+        )
+        .join(""),
+    )
+    .join(" ")
+    .trim();
+}

--- a/packages/folio/src/core/markdown/trailers.ts
+++ b/packages/folio/src/core/markdown/trailers.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Comment, Document, Endnote, Footnote } from "../types/document";
+import { escapeLinkUrl } from "./escape";
 import { renderBlocks } from "./renderBlock";
 import type { RenderContext } from "./types";
 
@@ -37,7 +38,7 @@ export function appendTrailers(
   if (ctx.opts.hyperlinks === "reference" && ctx.hyperlinkRefs.length > 0) {
     sections.push(
       ctx.hyperlinkRefs
-        .map(({ href, refNumber }) => `[${refNumber}]: ${href}`)
+        .map(({ href, refNumber }) => `[${refNumber}]: ${escapeLinkUrl(href)}`)
         .join("\n"),
     );
   }

--- a/packages/folio/src/core/markdown/trailers.ts
+++ b/packages/folio/src/core/markdown/trailers.ts
@@ -6,7 +6,14 @@
  * import cycle). Ported from eigenpal/docx-editor PR #595.
  */
 
-import type { Comment, Document, Endnote, Footnote } from "../types/document";
+import type {
+  Comment,
+  Document,
+  Endnote,
+  Footnote,
+  ParagraphContent,
+  Run,
+} from "../types/document";
 import { escapeLinkUrl } from "./escape";
 import { renderBlocks } from "./renderBlock";
 import type { RenderContext } from "./types";
@@ -71,15 +78,41 @@ function noteText(
 
 function commentText(comment: Comment): string {
   return comment.content
-    .map((p) =>
-      p.content
-        .map((c) =>
-          c.type === "run"
-            ? c.content.map((x) => (x.type === "text" ? x.text : "")).join("")
-            : "",
-        )
-        .join(""),
-    )
+    .map((p) => inlineText(p.content))
     .join(" ")
     .trim();
+}
+
+function runText(run: Run): string {
+  return run.content.map((x) => (x.type === "text" ? x.text : "")).join("");
+}
+
+/** Flatten paragraph inline content to plain text, recursing through wrappers. */
+function inlineText(content: ParagraphContent[]): string {
+  let out = "";
+  for (const item of content) {
+    if (item.type === "run") {
+      out += runText(item);
+    } else if (item.type === "hyperlink") {
+      for (const child of item.children) {
+        if (child.type === "run") {
+          out += runText(child);
+        }
+      }
+    } else if (item.type === "simpleField") {
+      out += inlineText(item.content);
+    } else if (item.type === "complexField") {
+      out += inlineText(item.fieldResult);
+    } else if (
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
+      out += inlineText(item.content);
+    } else if (item.type === "inlineSdt") {
+      out += inlineText(item.content as ParagraphContent[]);
+    }
+  }
+  return out;
 }

--- a/packages/folio/src/core/markdown/types.ts
+++ b/packages/folio/src/core/markdown/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Types for the DOCX-document → Markdown converter (ported from eigenpal
+ * /docx-editor PR #595). This is folio's v1 surface: the synchronous,
+ * continuous (non-paged) `toMarkdown(Document)` path. The paged + async +
+ * image-handler variants from upstream are not ported (skills bodies have no
+ * images today); they can be added later if needed.
+ */
+
+/**
+ * Metadata describing a single image registration. Owned by the markdown
+ * module so its public surface is independent of the docx model's drawing
+ * types.
+ */
+export interface ImageMeta {
+  /** `paraId` of the containing paragraph, when the source paragraph has one. */
+  paraId?: string | undefined;
+  /** 1-based ordinal in registration order. Unique per render call. */
+  index: number;
+  /** Path inside the DOCX zip (e.g. `word/media/image1.png`). */
+  originalPath: string;
+  /** MIME type (`image/png`, `image/jpeg`, …). */
+  mimeType: string;
+  /** Alt text from the drawing, when present. */
+  alt?: string | undefined;
+}
+
+/** Full registration record for an image, keyed by `virtualPath`. */
+export interface ImageRef extends ImageMeta {
+  /** Raw bytes as exposed by the DOCX parser. */
+  data: Uint8Array;
+  /** Base64-encoded contents, without the `data:` prefix. */
+  base64: string;
+  /** `data:<mime>;base64,<base64>` URL. */
+  dataUrl: string;
+  /** The path that appears inside the markdown's `![alt](…)` reference. */
+  virtualPath: string;
+}
+
+/**
+ * Options for {@link toMarkdown}. The clean-markdown preset skills use is
+ * `{ annotations: "strip", trackedChanges: "clean", comments: "strip",
+ * hyperlinks: "inline", footnotes: "strip" }`.
+ */
+export interface MarkdownOptions {
+  /**
+   * How to encode constructs markdown can't express natively (comments,
+   * tracked changes).
+   * - `"html"` (default): emit `<ins>`, `<del>`, `<comment>` tags.
+   * - `"pandoc"`: Pandoc-flavoured bracketed spans (`[text]{.ins}`).
+   * - `"strip"`: drop the wrapper, keep the visible text.
+   */
+  annotations?: "html" | "pandoc" | "strip";
+  /**
+   * Word tracked changes (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`).
+   * - `"annotate"` (default): preserve via the `annotations` wrapper.
+   * - `"clean"`: flatten — insertions become text, deletions vanish.
+   */
+  trackedChanges?: "clean" | "annotate";
+  /**
+   * Word margin comments.
+   * - `"inline"` (default): wrap the commented text via `annotations`.
+   * - `"strip"`: ignore comments entirely.
+   * - `"sidecar"`: inline marker + a `## Comments` trailer section.
+   */
+  comments?: "strip" | "inline" | "sidecar";
+  /**
+   * Hyperlink rendering.
+   * - `"inline"` (default): `[text](https://url)`.
+   * - `"reference"`: `[text][N]` + a reference list trailer.
+   */
+  hyperlinks?: "inline" | "reference";
+  /**
+   * Footnote/endnote references. Folio addition over upstream #595 (which
+   * always emitted `[^N]` markers + a definitions trailer).
+   * - `"keep"` (default): `[^N]` markers + a definitions trailer.
+   * - `"strip"`: drop footnote markers and their definitions entirely.
+   */
+  footnotes?: "keep" | "strip";
+  /**
+   * Receives the {@link ImageMeta} for each image and returns the virtual path
+   * placed inside the markdown's `![alt](virtualPath)` reference. Defaults to
+   * `./images/{paraId}-img{n}.{ext}` (or `./images/img{n}.{ext}`).
+   */
+  imagePath?: (info: ImageMeta) => string;
+}
+
+/** Result of a render, when the caller needs images/warnings as well as text. */
+export interface MarkdownResult {
+  /** The full rendered markdown string. */
+  markdown: string;
+  /** Every image referenced in `markdown`, keyed by its virtual path. */
+  images: Map<string, ImageRef>;
+  /** Non-fatal diagnostics; recurring messages are deduped. */
+  warnings: string[];
+}
+
+/** Resolved option values with defaults applied. Used internally. */
+export interface ResolvedOptions {
+  annotations: "html" | "pandoc" | "strip";
+  trackedChanges: "clean" | "annotate";
+  comments: "strip" | "inline" | "sidecar";
+  hyperlinks: "inline" | "reference";
+  footnotes: "keep" | "strip";
+  imagePath?: ((info: ImageMeta) => string) | undefined;
+}
+
+/**
+ * Internal rendering context threaded through every render call. Aggregates
+ * side-channel output: image map, warnings, and footnote/comment/hyperlink
+ * reference lists. Exported only so the split renderer files share the shape.
+ */
+export interface RenderContext {
+  opts: ResolvedOptions;
+  /** Accumulated images keyed by virtual path. */
+  images: Map<string, ImageRef>;
+  /** Same images keyed by source `MediaFile.path` for dedupe on re-reference. */
+  imagesByPath: Map<string, ImageRef>;
+  /** Diagnostics accumulator. */
+  warnings: string[];
+  /** Footnote refs collected during this render, in document order. */
+  footnoteRefs: Array<{ refId: number; markerNumber: number }>;
+  /** Comment refs collected during this render (sidecar mode only). */
+  commentRefs: Array<{ commentId: number; markerNumber: number }>;
+  /** Hyperlink refs collected during this render (reference mode only). */
+  hyperlinkRefs: Array<{ href: string; refNumber: number }>;
+  /** 1-based counter for default virtual paths. */
+  imageCounter: number;
+}

--- a/packages/folio/src/core/markdown/types.ts
+++ b/packages/folio/src/core/markdown/types.ts
@@ -11,7 +11,7 @@
  * module so its public surface is independent of the docx model's drawing
  * types.
  */
-export interface ImageMeta {
+export type ImageMeta = {
   /** `paraId` of the containing paragraph, when the source paragraph has one. */
   paraId?: string | undefined;
   /** 1-based ordinal in registration order. Unique per render call. */
@@ -22,10 +22,10 @@ export interface ImageMeta {
   mimeType: string;
   /** Alt text from the drawing, when present. */
   alt?: string | undefined;
-}
+};
 
 /** Full registration record for an image, keyed by `virtualPath`. */
-export interface ImageRef extends ImageMeta {
+export type ImageRef = {
   /** Raw bytes as exposed by the DOCX parser. */
   data: Uint8Array;
   /** Base64-encoded contents, without the `data:` prefix. */
@@ -34,14 +34,14 @@ export interface ImageRef extends ImageMeta {
   dataUrl: string;
   /** The path that appears inside the markdown's `![alt](…)` reference. */
   virtualPath: string;
-}
+} & ImageMeta;
 
 /**
  * Options for {@link toMarkdown}. The clean-markdown preset skills use is
  * `{ annotations: "strip", trackedChanges: "clean", comments: "strip",
  * hyperlinks: "inline", footnotes: "strip" }`.
  */
-export interface MarkdownOptions {
+export type MarkdownOptions = {
   /**
    * How to encode constructs markdown can't express natively (comments,
    * tracked changes).
@@ -82,34 +82,34 @@ export interface MarkdownOptions {
    * `./images/{paraId}-img{n}.{ext}` (or `./images/img{n}.{ext}`).
    */
   imagePath?: (info: ImageMeta) => string;
-}
+};
 
 /** Result of a render, when the caller needs images/warnings as well as text. */
-export interface MarkdownResult {
+export type MarkdownResult = {
   /** The full rendered markdown string. */
   markdown: string;
   /** Every image referenced in `markdown`, keyed by its virtual path. */
   images: Map<string, ImageRef>;
   /** Non-fatal diagnostics; recurring messages are deduped. */
   warnings: string[];
-}
+};
 
 /** Resolved option values with defaults applied. Used internally. */
-export interface ResolvedOptions {
+export type ResolvedOptions = {
   annotations: "html" | "pandoc" | "strip";
   trackedChanges: "clean" | "annotate";
   comments: "strip" | "inline" | "sidecar";
   hyperlinks: "inline" | "reference";
   footnotes: "keep" | "strip";
   imagePath?: ((info: ImageMeta) => string) | undefined;
-}
+};
 
 /**
  * Internal rendering context threaded through every render call. Aggregates
  * side-channel output: image map, warnings, and footnote/comment/hyperlink
  * reference lists. Exported only so the split renderer files share the shape.
  */
-export interface RenderContext {
+export type RenderContext = {
   opts: ResolvedOptions;
   /** Accumulated images keyed by virtual path. */
   images: Map<string, ImageRef>;
@@ -117,12 +117,16 @@ export interface RenderContext {
   imagesByPath: Map<string, ImageRef>;
   /** Diagnostics accumulator. */
   warnings: string[];
-  /** Footnote refs collected during this render, in document order. */
-  footnoteRefs: Array<{ refId: number; markerNumber: number }>;
+  /** Footnote/endnote refs collected during this render, in document order. */
+  footnoteRefs: {
+    refId: number;
+    markerNumber: number;
+    kind: "footnote" | "endnote";
+  }[];
   /** Comment refs collected during this render (sidecar mode only). */
-  commentRefs: Array<{ commentId: number; markerNumber: number }>;
+  commentRefs: { commentId: number; markerNumber: number }[];
   /** Hyperlink refs collected during this render (reference mode only). */
-  hyperlinkRefs: Array<{ href: string; refNumber: number }>;
+  hyperlinkRefs: { href: string; refNumber: number }[];
   /** 1-based counter for default virtual paths. */
   imageCounter: number;
-}
+};

--- a/packages/folio/src/index.ts
+++ b/packages/folio/src/index.ts
@@ -114,3 +114,13 @@ export {
   type AutocompleteCaretOverlayProps,
   type AutocompleteCaretRect,
 } from "./paged-editor/AutocompleteCaretOverlay";
+
+// DOCX-document → Markdown export (also available at `@stll/folio/markdown`).
+export {
+  toMarkdown,
+  toMarkdownResult,
+  type ImageMeta,
+  type ImageRef,
+  type MarkdownOptions,
+  type MarkdownResult,
+} from "./core/markdown";


### PR DESCRIPTION
## What

Adds a DOCX-document → Markdown exporter to `@stll/folio`:

```ts
import { toMarkdown } from "@stll/folio";            // or "@stll/folio/markdown"
const md: string = toMarkdown(document, options);
```

Ported from upstream `eigenpal/docx-editor` PR #595 (branch `feat/docx-to-markdown`), scoped to the **synchronous, continuous (non-paged)** `Document → string` path.

## Why

Pairs with the skills↔Folio bridge's Markdown → Document import so a skill body can round-trip through the editor (open → save with no edits should not churn the AI-facing markdown). The exporter walks the docx **Document model** (`doc.package.document.content`), not ProseMirror.

## Scope

Ported: `toMarkdown` (+ `toMarkdownResult` returning `{ markdown, images, warnings }`). Covers headings, paragraphs, bullet/ordered lists (Word's marker preserved), bold/italic/strike, monospace-inferred inline code, GFM tables (simple → pipe table; `gridSpan`/`vMerge`/nested → inline HTML `<table>` with colspan/rowspan), blockquotes (`Quote`/`IntenseQuote`), inline + reference hyperlinks, comments (inline/strip/sidecar), and tracked changes (annotate/clean).

Not ported (deferred): the paged, async, image-handler, and layout-engine variants.

## Options

`MarkdownOptions`: `annotations` (`html`/`pandoc`/`strip`), `trackedChanges` (`annotate`/`clean`), `comments` (`inline`/`strip`/`sidecar`), `hyperlinks` (`inline`/`reference`), `imagePath`, and a folio-added `footnotes` (`keep`/`strip`) — upstream always emitted `[^N]` markers plus a definitions trailer with no off switch.

Clean preset for an AI-facing skill body:

```ts
toMarkdown(doc, { annotations: "strip", trackedChanges: "clean", comments: "strip", hyperlinks: "inline", footnotes: "strip" });
```

## Notes

- Folio's docx-core model shares upstream's lineage, so the port is a faithful copy with only import-path adjustments, local heading helpers (folio has no `agent/text-utils`), and a few `| undefined` annotations for `exactOptionalPropertyTypes`.
- Heading detection and list-marker preservation match upstream so the MD → Document → MD round-trip stays stable; the end-to-end round-trip test against the skills blueprint fixtures lands with the consumer.

## Test

`markdown.test.ts` covers the markdown subset skills rely on (headings, lists, marks, GFM + HTML-fallback tables, links, blockquote, code, footnote keep/strip).
