### PR TITLE
feat(folio): preserve run shading (w:shd) backgrounds via a strict mark

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -51,6 +51,7 @@ import {
   expectMathAttrs,
   expectParagraphAttrs,
   expectRunFormattingOverrideMarkAttrs,
+  expectRunShadingMarkAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
@@ -60,6 +61,7 @@ import {
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
 } from "../prosemirror/attrs";
+import { runShadingAttrsToShading } from "../prosemirror/conversion/runShadingMark";
 import type { RunFormattingOverrideAttrs } from "../prosemirror/schema/marks";
 import type {
   ImageAttrs,
@@ -75,6 +77,7 @@ import type {
 } from "../types/document";
 import { NUMBER_FORMAT_VALUES } from "../types/documentEnumValues";
 import { resolveColor, resolveHighlightToCss } from "../utils/colorResolver";
+import { resolveShadingFill } from "../utils/formatToStyle";
 import {
   pointsToPixels,
   halfPointsToPixels,
@@ -470,6 +473,17 @@ function extractRunFormatting(
           expectHighlightMarkAttrs(mark).color,
         );
         break;
+
+      case "runShading": {
+        const shadingCss = resolveShadingFill(
+          runShadingAttrsToShading(expectRunShadingMarkAttrs(mark)),
+          theme,
+        );
+        if (shadingCss) {
+          formatting.shading = shadingCss;
+        }
+        break;
+      }
 
       case "fontSize": {
         const attrs = expectFontSizeMarkAttrs(mark);

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -41,6 +41,12 @@ export type RunFormatting = {
   // `#FFFF00` are not union members. Either keep a separate CSS field or move
   // resolution to the painter before this can become the named-color union.
   highlight?: string;
+  /**
+   * Run-level shading (w:shd) used as a background, stored as a *resolved CSS*
+   * color (like `highlight`). Painted only when there is no `highlight` (an
+   * explicit highlight wins). eigenpal #722 (#712).
+   */
+  shading?: string;
   fontFamily?: string;
   fontSize?: number;
   letterSpacing?: number;

--- a/packages/folio/src/core/layout-painter/renderParagraph-run-shading.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-run-shading.test.ts
@@ -1,0 +1,122 @@
+// eigenpal #722 (#712) — a run carrying resolved shading (w:shd background)
+// paints as backgroundColor, exactly like a highlight. An explicit highlight
+// wins over shading on the same run.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  MeasuredLine,
+  ParagraphBlock,
+  TextRun,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      if (prop === "getPropertyValue") {
+        return (key: string) => target[key] ?? "";
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = createFakeStyle();
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+  prepend(...children: FakeElement[]): void {
+    this.children.unshift(...children);
+  }
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return { font: "", measureText: (t: string) => ({ width: t.length * 7 }) };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+const line: MeasuredLine = {
+  fromRun: 0,
+  fromChar: 0,
+  toRun: 0,
+  toChar: 7,
+  width: 50,
+  ascent: 10,
+  descent: 2,
+  lineHeight: 12,
+};
+
+function backgroundOf(run: TextRun): string | undefined {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p1",
+    runs: [run],
+  };
+  const lineEl = renderLine(block, line, undefined, fakeDocument);
+  const textEl = lineEl.children[0] as HTMLElement | undefined;
+  return textEl?.style.backgroundColor;
+}
+
+describe("renderLine run shading", () => {
+  test("paints a shaded run's background", () => {
+    expect(
+      backgroundOf({ kind: "text", text: "Shaded", shading: "#FFFF00" }),
+    ).toBe("#FFFF00");
+  });
+
+  test("an explicit highlight wins over shading on the same run", () => {
+    expect(
+      backgroundOf({
+        kind: "text",
+        text: "Both",
+        highlight: "#00FF00",
+        shading: "#FFFF00",
+      }),
+    ).toBe("#00FF00");
+  });
+
+  test("a run with neither highlight nor shading has no background", () => {
+    expect(backgroundOf({ kind: "text", text: "Plain" })).toBeFalsy();
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph-run-shading.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-run-shading.test.ts
@@ -98,6 +98,8 @@ function backgroundOf(run: TextRun): string | undefined {
   return textEl?.style.backgroundColor;
 }
 
+// Test fixtures use literal colors to assert what the painter paints.
+/* eslint-disable no-inline-style-colors/no-inline-style-colors */
 describe("renderLine run shading", () => {
   test("paints a shaded run's background", () => {
     expect(

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -330,16 +330,19 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     element.style.opacity = "0.4";
   }
 
-  // Highlight (background color)
-  if (run.highlight) {
-    element.style.backgroundColor = run.highlight;
+  // Background color: an explicit highlight (w:highlight) wins over run shading
+  // (w:shd). Folio carries arbitrary run-background fills as `shading` because
+  // they fall outside the OOXML named-highlight palette. eigenpal #722 (#712).
+  const runBackground = run.highlight ?? run.shading;
+  if (runBackground) {
+    element.style.backgroundColor = runBackground;
     const hasTrackedChangeColor = run.isInsertion || run.isDeletion;
     const hasCommentHighlight =
       run.commentIds !== undefined && run.commentIds.length > 0;
     const automaticTextColor =
       hasExplicitTextColor || hasTrackedChangeColor || hasCommentHighlight
         ? undefined
-        : getAutomaticTextColorForBackground(run.highlight);
+        : getAutomaticTextColorForBackground(runBackground);
     if (automaticTextColor) {
       element.style.color = automaticTextColor;
     }

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1139,6 +1139,12 @@ export const readRunShadingMarkAttrs = (
     issues,
     SHADING_PATTERN_VALUES,
   );
+  optionalString(
+    attrs,
+    "patternColor",
+    "runShading.attrs.patternColor",
+    issues,
+  );
 
   return attrsResult(attrs, issues);
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -43,6 +43,7 @@ import type {
   MathAttrs,
   ParagraphAttrs,
   RunFormattingOverrideAttrs,
+  RunShadingAttrs,
   SdtAttrs,
   ShapeAttrs,
   StrikeAttrs,
@@ -227,6 +228,7 @@ const underlineAttrsCache = new WeakMap<Mark, UnderlineAttrs>();
 const strikeAttrsCache = new WeakMap<Mark, StrikeAttrs>();
 const textColorAttrsCache = new WeakMap<Mark, TextColorAttrs>();
 const highlightAttrsCache = new WeakMap<Mark, HighlightAttrs>();
+const runShadingAttrsCache = new WeakMap<Mark, RunShadingAttrs>();
 const fontSizeAttrsCache = new WeakMap<Mark, FontSizeAttrs>();
 const fontFamilyAttrsCache = new WeakMap<Mark, FontFamilyAttrs>();
 const characterSpacingAttrsCache = new WeakMap<Mark, CharacterSpacingAttrs>();
@@ -1119,6 +1121,34 @@ export const expectHighlightMarkAttrs = (mark: Mark): HighlightAttrs =>
     highlightAttrsCache,
     readHighlightMarkAttrs,
     "highlight attrs",
+  );
+
+export const readRunShadingMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<RunShadingAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "runShading", issues);
+
+  // Fill color (flattened ColorValue, same shape as textColor).
+  optionalTextColorFields(attrs, "runShading.attrs", issues);
+  optionalOneOf(
+    attrs,
+    "pattern",
+    "runShading.attrs.pattern",
+    issues,
+    SHADING_PATTERN_VALUES,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectRunShadingMarkAttrs = (mark: Mark): RunShadingAttrs =>
+  expectCachedMarkAttrs(
+    mark,
+    runShadingAttrsCache,
+    readRunShadingMarkAttrs,
+    "run shading attrs",
   );
 
 export const readFontSizeMarkAttrs = (

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -73,6 +73,7 @@ import {
   expectFootnoteRefMarkAttrs,
   expectHardBreakAttrs,
   expectHighlightMarkAttrs,
+  expectRunShadingMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
   expectMathAttrs,
@@ -100,6 +101,7 @@ import type {
   TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
+import { runShadingAttrsToShading } from "./runShadingMark";
 
 function normalizeShapeOutlineStyle(
   style: string | undefined,
@@ -1826,6 +1828,13 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
 
       case "highlight":
         formatting.highlight = expectHighlightMarkAttrs(mark).color;
+        break;
+
+      case "runShading":
+        // Rebuild the model `w:shd` fill so the run serializer re-emits it.
+        formatting.shading = runShadingAttrsToShading(
+          expectRunShadingMarkAttrs(mark),
+        );
         break;
 
       case "fontSize": {

--- a/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
@@ -102,6 +102,18 @@ describe("Issue #712 — run shading round-trips and renders", () => {
     expect(roundTripShading({ shading })?.fill?.rgb).toBe("FF0000");
   });
 
+  test("a solid pattern paints the color over the fill (color wins)", () => {
+    // `<w:shd w:val="solid" w:color="FF0000" w:fill="00FF00"/>` — the solid
+    // pattern covers the fill, so the visible background is the color.
+    const shading = {
+      pattern: "solid" as const,
+      color: { rgb: "FF0000" },
+      fill: { rgb: "00FF00" },
+    };
+    expect(renderedBackground({ shading })).toBe("#FF0000");
+    expect(roundTripShading({ shading })?.fill?.rgb).toBe("FF0000");
+  });
+
   test("a theme-color fill round-trips (themeColor preserved)", () => {
     const formatting: Run["formatting"] = {
       shading: { fill: { themeColor: "accent1" } },

--- a/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
@@ -93,6 +93,14 @@ describe("Issue #712 — run shading round-trips and renders", () => {
     expect(roundTripShading({ shading })?.pattern).toBe("pct25");
   });
 
+  test("a solid pattern with a color but no fill renders and round-trips", () => {
+    // `<w:shd w:val="solid" w:color="FF0000"/>` paints the color as a solid
+    // background; flatten it into the fill so it isn't dropped.
+    const shading = { pattern: "solid" as const, color: { rgb: "FF0000" } };
+    expect(renderedBackground({ shading })).toBe("#FF0000");
+    expect(roundTripShading({ shading })?.fill?.rgb).toBe("FF0000");
+  });
+
   test("a theme-color fill round-trips (themeColor preserved)", () => {
     const formatting: Run["formatting"] = {
       shading: { fill: { themeColor: "accent1" } },
@@ -105,6 +113,7 @@ describe("Issue #712 — run shading round-trips and renders", () => {
     // (covered in renderParagraph-run-shading.test.ts). Here we only assert the
     // data is not lost.
     const formatting: Run["formatting"] = {
+      // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- a named OOXML highlight value, not UI styling
       highlight: "green",
       shading: { fill: { rgb: "FFFF00" } },
     };

--- a/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
@@ -1,0 +1,138 @@
+// eigenpal #722 (#712) — run-level shading (w:shd) used as a background.
+//
+// Folio models w:highlight as a strict OOXML named-palette union, so an
+// arbitrary run-background fill (e.g. a Word/Google Docs `w:shd`, or a custom
+// highlight another editor saved as shading) cannot ride on the highlight mark.
+// It was parsed into `formatting.shading` but DROPPED at PM conversion, so the
+// background silently vanished on reload. It now round-trips as a dedicated
+// `runShading` mark and renders as a background.
+
+import { describe, expect, test } from "bun:test";
+
+import { toFlowBlocks } from "../../layout-bridge/toFlowBlocks";
+import type { FlowBlock, TextRun } from "../../layout-engine/types";
+import type {
+  Document,
+  Paragraph,
+  Run,
+  ShadingProperties,
+} from "../../types/document";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const wrap = (formatting: Run["formatting"]): Document => ({
+  package: {
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "run", content: [{ type: "text", text: "x" }], formatting },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+const firstParagraph = (document: Document): Paragraph => {
+  const block = document.package.document.content.at(0);
+  if (block?.type !== "paragraph") {
+    throw new Error("expected first block to be a paragraph");
+  }
+  return block;
+};
+
+const firstRunFormatting = (document: Document): Run["formatting"] => {
+  for (const content of firstParagraph(document).content) {
+    if (content.type === "run") {
+      return content.formatting;
+    }
+  }
+  throw new Error("expected a run");
+};
+
+// The runShading mark color, as it would round-trip out to the model on save.
+const roundTripShading = (
+  formatting: Run["formatting"],
+): ShadingProperties | undefined =>
+  firstRunFormatting(
+    fromProseDoc(toProseDoc(wrap(formatting)), wrap(formatting)),
+  )?.shading;
+
+// The resolved CSS background the painter receives for the run.
+const renderedBackground = (
+  formatting: Run["formatting"],
+): string | undefined => {
+  const blocks: FlowBlock[] = toFlowBlocks(toProseDoc(wrap(formatting)));
+  const paragraph = blocks.find((b) => b.kind === "paragraph");
+  if (paragraph?.kind !== "paragraph") {
+    throw new Error("expected a paragraph flow block");
+  }
+  const textRun = paragraph.runs.find((r): r is TextRun => r.kind === "text");
+  return textRun?.shading;
+};
+
+describe("Issue #712 — run shading round-trips and renders", () => {
+  test("a solid fill renders as a background and survives the round-trip", () => {
+    const shading = { fill: { rgb: "FFFF00" } };
+    expect(renderedBackground({ shading })).toBe("#FFFF00");
+    expect(roundTripShading({ shading })?.fill?.rgb).toBe("FFFF00");
+  });
+
+  test("the default `clear` pattern is dropped (renders solid, re-serializes to clear)", () => {
+    const shading = { pattern: "clear" as const, fill: { rgb: "00B050" } };
+    expect(renderedBackground({ shading })).toBe("#00B050");
+    const out = roundTripShading({ shading });
+    expect(out?.fill?.rgb).toBe("00B050");
+    expect(out?.pattern).toBeUndefined();
+  });
+
+  test("a non-clear pattern is carried for export fidelity", () => {
+    const shading = { pattern: "pct25" as const, fill: { rgb: "FFFF00" } };
+    expect(roundTripShading({ shading })?.pattern).toBe("pct25");
+  });
+
+  test("a theme-color fill round-trips (themeColor preserved)", () => {
+    const formatting: Run["formatting"] = {
+      shading: { fill: { themeColor: "accent1" } },
+    };
+    expect(roundTripShading(formatting)?.fill?.themeColor).toBe("accent1");
+  });
+
+  test("highlight and shading both reach the flow run (painter resolves precedence)", () => {
+    // Both fields flow through independently; the painter prefers `highlight`
+    // (covered in renderParagraph-run-shading.test.ts). Here we only assert the
+    // data is not lost.
+    const formatting: Run["formatting"] = {
+      highlight: "green",
+      shading: { fill: { rgb: "FFFF00" } },
+    };
+    const blocks = toFlowBlocks(toProseDoc(wrap(formatting)));
+    const paragraph = blocks.find((b) => b.kind === "paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("expected a paragraph flow block");
+    }
+    const run = paragraph.runs.find((r): r is TextRun => r.kind === "text");
+    expect(run?.highlight).toBeDefined();
+    expect(run?.shading).toBe("#FFFF00");
+  });
+
+  test("an `auto` fill produces no shading background", () => {
+    expect(renderedBackground({ shading: { fill: { auto: true } } })).toBe(
+      undefined,
+    );
+    expect(
+      roundTripShading({ shading: { fill: { auto: true } } }),
+    ).toBeUndefined();
+  });
+
+  test("a fill-less shading (pattern only) produces no mark", () => {
+    expect(roundTripShading({ shading: { pattern: "pct25" } })).toBeUndefined();
+  });
+
+  test("a run with no shading is unaffected", () => {
+    expect(renderedBackground({ bold: true })).toBeUndefined();
+    expect(roundTripShading({ bold: true })).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
@@ -17,6 +17,7 @@ import type {
   Run,
   ShadingProperties,
 } from "../../types/document";
+import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
@@ -143,5 +144,26 @@ describe("Issue #712 — run shading round-trips and renders", () => {
   test("a run with no shading is unaffected", () => {
     expect(renderedBackground({ bold: true })).toBeUndefined();
     expect(roundTripShading({ bold: true })).toBeUndefined();
+  });
+});
+
+describe("Issue #712 — HTML paste of a custom background", () => {
+  const rule = schema.marks["runShading"]?.spec.parseDOM?.[0];
+  const getAttrs = (value: string): unknown =>
+    (rule?.getAttrs as ((v: string) => unknown) | undefined)?.(value);
+
+  test("a custom background-color is claimed as run shading", () => {
+    expect(getAttrs("#D9D9D9")).toEqual({ rgb: "D9D9D9" });
+    expect(getAttrs("rgb(217, 217, 217)")).toEqual({ rgb: "D9D9D9" });
+  });
+
+  test("a named-palette color is left to the highlight mark", () => {
+    // highlight maps these; runShading must not double-claim them.
+    expect(getAttrs("yellow")).toBe(false);
+    expect(getAttrs("#FFFF00")).toBe(false);
+  });
+
+  test("a non-color value is ignored", () => {
+    expect(getAttrs("transparent")).toBe(false);
   });
 });

--- a/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/issue-712-run-shading-roundtrip.test.ts
@@ -94,6 +94,18 @@ describe("Issue #712 — run shading round-trips and renders", () => {
     expect(roundTripShading({ shading })?.pattern).toBe("pct25");
   });
 
+  test("a non-clear pattern's foreground color round-trips", () => {
+    const shading = {
+      pattern: "pct25" as const,
+      color: { rgb: "FF0000" },
+      fill: { rgb: "DDDDDD" },
+    };
+    const out = roundTripShading({ shading });
+    expect(out?.pattern).toBe("pct25");
+    expect(out?.color?.rgb).toBe("FF0000");
+    expect(out?.fill?.rgb).toBe("DDDDDD");
+  });
+
   test("a solid pattern with a color but no fill renders and round-trips", () => {
     // `<w:shd w:val="solid" w:color="FF0000"/>` paints the color as a solid
     // background; flatten it into the fill so it isn't dropped.

--- a/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
+++ b/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
@@ -26,11 +26,11 @@ export function shadingToRunShadingAttrs(
   if (!shading) {
     return null;
   }
-  // A `solid` pattern with no fill paints `w:color` over everything, so its
-  // pattern color IS the background — flatten it into the fill slot rather than
-  // dropping it (`resolveShadingFill` treats solid+color as renderable).
-  const usingSolidColor = !shading.fill && shading.pattern === "solid";
-  const fill = shading.fill ?? (usingSolidColor ? shading.color : undefined);
+  // A `solid` pattern paints `w:color` over the whole cell, so the pattern
+  // color (when present) is the visible background — not the fill. Flatten the
+  // chosen color into the fill slot. Other patterns show the fill.
+  const isSolid = shading.pattern === "solid";
+  const fill = isSolid ? (shading.color ?? shading.fill) : shading.fill;
   if (!fill || fill.auto || (!fill.rgb && !fill.themeColor)) {
     return null;
   }
@@ -51,7 +51,7 @@ export function shadingToRunShadingAttrs(
   // Carry a genuine pattern overlay for export fidelity, but not the default
   // `clear`/`nil`, nor the `solid` we just flattened into a plain fill.
   if (
-    !usingSolidColor &&
+    !isSolid &&
     shading.pattern &&
     shading.pattern !== "clear" &&
     shading.pattern !== "nil"

--- a/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
+++ b/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
@@ -23,7 +23,14 @@ import type { RunShadingAttrs } from "../schema/marks";
 export function shadingToRunShadingAttrs(
   shading: ShadingProperties | undefined,
 ): RunShadingAttrs | null {
-  const fill = shading?.fill;
+  if (!shading) {
+    return null;
+  }
+  // A `solid` pattern with no fill paints `w:color` over everything, so its
+  // pattern color IS the background — flatten it into the fill slot rather than
+  // dropping it (`resolveShadingFill` treats solid+color as renderable).
+  const usingSolidColor = !shading.fill && shading.pattern === "solid";
+  const fill = shading.fill ?? (usingSolidColor ? shading.color : undefined);
   if (!fill || fill.auto || (!fill.rgb && !fill.themeColor)) {
     return null;
   }
@@ -41,8 +48,11 @@ export function shadingToRunShadingAttrs(
   if (fill.themeShade) {
     attrs.themeShade = fill.themeShade;
   }
+  // Carry a genuine pattern overlay for export fidelity, but not the default
+  // `clear`/`nil`, nor the `solid` we just flattened into a plain fill.
   if (
-    shading?.pattern &&
+    !usingSolidColor &&
+    shading.pattern &&
     shading.pattern !== "clear" &&
     shading.pattern !== "nil"
   ) {

--- a/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
+++ b/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
@@ -1,0 +1,82 @@
+/**
+ * Converters between the model's run-level shading (`ShadingProperties`, from
+ * `w:shd`) and the `runShading` ProseMirror mark's attrs. The mark carries the
+ * shading FILL flattened as a ColorValue (mirroring the textColor mark) plus a
+ * non-default pattern, so a custom run background survives the PM round-trip
+ * (it was previously dropped on import) and re-serializes to `w:shd`.
+ *
+ * eigenpal #722 (#712) — folio models highlight as a strict OOXML named-palette
+ * union, so arbitrary run backgrounds (Word/Google Docs `w:shd` fills) cannot be
+ * represented as a highlight here; they round-trip as this dedicated mark.
+ */
+
+import type { ColorValue, ShadingProperties } from "../../types/colors";
+import type { RunShadingAttrs } from "../schema/marks";
+
+/**
+ * Build the mark attrs for a run shading, or null when the shading has no
+ * renderable/round-trippable fill (theme-less, `auto`, or fill-less). The
+ * default `clear` pattern is the no-op carrier for a solid fill and is dropped:
+ * absence re-serializes to `w:val="clear"` via the run serializer, and
+ * `resolveShadingFill` only paints the fill when the pattern is not `clear`.
+ */
+export function shadingToRunShadingAttrs(
+  shading: ShadingProperties | undefined,
+): RunShadingAttrs | null {
+  const fill = shading?.fill;
+  if (!fill || fill.auto || (!fill.rgb && !fill.themeColor)) {
+    return null;
+  }
+
+  const attrs: RunShadingAttrs = {};
+  if (fill.rgb) {
+    attrs.rgb = fill.rgb;
+  }
+  if (fill.themeColor) {
+    attrs.themeColor = fill.themeColor;
+  }
+  if (fill.themeTint) {
+    attrs.themeTint = fill.themeTint;
+  }
+  if (fill.themeShade) {
+    attrs.themeShade = fill.themeShade;
+  }
+  if (
+    shading?.pattern &&
+    shading.pattern !== "clear" &&
+    shading.pattern !== "nil"
+  ) {
+    attrs.pattern = shading.pattern;
+  }
+  return attrs;
+}
+
+/** Reconstruct the model shading (`w:shd` fill) from the mark attrs. */
+export function runShadingAttrsToShading(
+  attrs: RunShadingAttrs,
+): ShadingProperties {
+  const fill: ColorValue = {};
+  if (attrs.rgb) {
+    fill.rgb = attrs.rgb;
+  }
+  if (attrs.themeColor) {
+    fill.themeColor = attrs.themeColor;
+  }
+  if (attrs.themeTint) {
+    fill.themeTint = attrs.themeTint;
+  }
+  if (attrs.themeShade) {
+    fill.themeShade = attrs.themeShade;
+  }
+
+  const shading: ShadingProperties = {};
+  // Only attach a fill when at least one fill field survived; an empty `{}`
+  // fill would resolve to a black background via `resolveShadingColor`.
+  if (Object.keys(fill).length > 0) {
+    shading.fill = fill;
+  }
+  if (attrs.pattern) {
+    shading.pattern = attrs.pattern;
+  }
+  return shading;
+}

--- a/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
+++ b/packages/folio/src/core/prosemirror/conversion/runShadingMark.ts
@@ -49,7 +49,9 @@ export function shadingToRunShadingAttrs(
     attrs.themeShade = fill.themeShade;
   }
   // Carry a genuine pattern overlay for export fidelity, but not the default
-  // `clear`/`nil`, nor the `solid` we just flattened into a plain fill.
+  // `clear`/`nil`, nor the `solid` we just flattened into a plain fill. Keep the
+  // pattern foreground color (`w:color`) too, so a pct*/stripe pattern's color
+  // round-trips.
   if (
     !isSolid &&
     shading.pattern &&
@@ -57,6 +59,9 @@ export function shadingToRunShadingAttrs(
     shading.pattern !== "nil"
   ) {
     attrs.pattern = shading.pattern;
+    if (shading.color?.rgb) {
+      attrs.patternColor = shading.color.rgb;
+    }
   }
   return attrs;
 }
@@ -87,6 +92,9 @@ export function runShadingAttrsToShading(
   }
   if (attrs.pattern) {
     shading.pattern = attrs.pattern;
+  }
+  if (attrs.patternColor) {
+    shading.color = { rgb: attrs.patternColor };
   }
   return shading;
 }

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -58,6 +58,7 @@ import type {
   TableCellAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
+import { shadingToRunShadingAttrs } from "./runShadingMark";
 
 /**
  * Options for document conversion
@@ -2385,6 +2386,15 @@ function textFormattingToMarks(
         color: formatting.highlight,
       }),
     );
+  }
+
+  // Run shading (w:shd) used as a run background. Folio models highlight as a
+  // strict OOXML named-palette union, so an arbitrary fill (e.g. a Word/Google
+  // Docs run background) round-trips as a dedicated runShading mark instead of
+  // silently disappearing at PM conversion. eigenpal #722 (#712).
+  const runShadingMarkAttrs = shadingToRunShadingAttrs(formatting.shading);
+  if (runShadingMarkAttrs) {
+    marks.push(schema.mark("runShading", runShadingMarkAttrs));
   }
 
   // Font size

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -43,6 +43,7 @@ import { HyperlinkExtension } from "./marks/HyperlinkExtension";
 import { ItalicExtension } from "./marks/ItalicExtension";
 import { RtlExtension } from "./marks/RtlExtension";
 import { RunFormattingOverrideExtension } from "./marks/RunFormattingOverrideExtension";
+import { RunShadingExtension } from "./marks/RunShadingExtension";
 import { SmallCapsExtension } from "./marks/SmallCapsExtension";
 import { StrikeExtension } from "./marks/StrikeExtension";
 import { SubscriptExtension } from "./marks/SubscriptExtension";
@@ -128,6 +129,7 @@ export function createStarterKit(
   add("strike", StrikeExtension());
   add("textColor", TextColorExtension());
   add("highlight", HighlightExtension());
+  add("runShading", RunShadingExtension());
   add("fontSize", FontSizeExtension());
   add("fontFamily", FontFamilyExtension());
   add("superscript", SuperscriptExtension());

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -128,8 +128,11 @@ export function createStarterKit(
   add("underline", UnderlineExtension());
   add("strike", StrikeExtension());
   add("textColor", TextColorExtension());
-  add("highlight", HighlightExtension());
+  // Register runShading BEFORE highlight: a later mark is the inner DOM span, so
+  // an explicit highlight (registered after) wins the background when a run has
+  // both — matching the paged painter's `run.highlight ?? run.shading`. (#722)
   add("runShading", RunShadingExtension());
+  add("highlight", HighlightExtension());
   add("fontSize", FontSizeExtension());
   add("fontFamily", FontFamilyExtension());
   add("superscript", SuperscriptExtension());

--- a/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
@@ -79,7 +79,7 @@ const readHighlightName = (value: string): HighlightColor | null => {
   return null;
 };
 
-const normalizeCssColorKey = (value: string): string => {
+export const normalizeCssColorKey = (value: string): string => {
   const compact = value.trim().toLowerCase().replace(/\s+/gu, "");
   const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/u.exec(compact);
   const hex = hexMatch?.[1];
@@ -108,7 +108,9 @@ const cssColorComponentToHex = (value: string | undefined): string => {
   return Math.min(255, Math.max(0, component)).toString(16).padStart(2, "0");
 };
 
-const parseDOMHighlightColor = (value: string): HighlightColor | null => {
+export const parseDOMHighlightColor = (
+  value: string,
+): HighlightColor | null => {
   const trimmed = value.trim();
   if (
     trimmed === "" ||

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
@@ -9,9 +9,8 @@
 // the painter render it. No parseDOM: the highlight mark already claims
 // `background-color` on HTML paste; this mark is populated from docx import.
 
-import { resolveShadingFill } from "../../../utils/formatToStyle";
+import { ensureHexPrefix } from "../../../utils/colorResolver";
 import { expectRunShadingMarkAttrs } from "../../attrs";
-import { runShadingAttrsToShading } from "../../conversion/runShadingMark";
 import { createMarkExtension } from "../create";
 
 export const RunShadingExtension = createMarkExtension({
@@ -26,16 +25,13 @@ export const RunShadingExtension = createMarkExtension({
       pattern: { default: null },
     },
     toDOM(mark) {
-      const attrs = expectRunShadingMarkAttrs(mark);
-      // The editable overlay has no theme, so only a concrete rgb fill is
-      // paintable here. Theme-only fills are left to the paged painter (which
-      // has the real theme) rather than guessing the Office default — without
-      // the rgb guard, `resolveShadingFill(_, null)` would resolve a theme slot
-      // to its default colour (often black). A clear/absent pattern paints the
-      // fill solid. (#722)
-      const background = attrs.rgb
-        ? resolveShadingFill(runShadingAttrsToShading(attrs), null)
-        : "";
+      const { rgb } = expectRunShadingMarkAttrs(mark);
+      // The editable overlay has no theme. Use the concrete rgb fill directly:
+      // `resolveColor` prefers a theme slot when both are present, which here
+      // (theme=null) resolves to the Office default (often black). Theme-only
+      // fills carry no rgb and are left to the paged painter, which has the
+      // real theme. (#722)
+      const background = rgb ? ensureHexPrefix(rgb) : "";
       return [
         "span",
         background ? { style: `background-color: ${background}` } : {},

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
@@ -1,0 +1,46 @@
+// eigenpal #722 (#712) — run-level shading (w:shd) as a background.
+//
+// Folio models `w:highlight` as a strict OOXML named-palette union, so an
+// arbitrary run background (a Word/Google Docs `w:shd` fill, or a custom
+// highlight another tool serialized as shading) cannot be carried as a
+// highlight. This dedicated mark preserves the fill through the ProseMirror
+// round-trip — it was previously parsed into `formatting.shading` but dropped
+// at PM conversion, so the background silently vanished on reload — and lets
+// the painter render it. No parseDOM: the highlight mark already claims
+// `background-color` on HTML paste; this mark is populated from docx import.
+
+import { resolveShadingFill } from "../../../utils/formatToStyle";
+import { expectRunShadingMarkAttrs } from "../../attrs";
+import { runShadingAttrsToShading } from "../../conversion/runShadingMark";
+import { createMarkExtension } from "../create";
+
+export const RunShadingExtension = createMarkExtension({
+  name: "runShading",
+  schemaMarkName: "runShading",
+  markSpec: {
+    attrs: {
+      rgb: { default: null },
+      themeColor: { default: null },
+      themeTint: { default: null },
+      themeShade: { default: null },
+      pattern: { default: null },
+    },
+    toDOM(mark) {
+      const attrs = expectRunShadingMarkAttrs(mark);
+      // The editable overlay has no theme, so only a concrete rgb fill is
+      // paintable here. Theme-only fills are left to the paged painter (which
+      // has the real theme) rather than guessing the Office default — without
+      // the rgb guard, `resolveShadingFill(_, null)` would resolve a theme slot
+      // to its default colour (often black). A clear/absent pattern paints the
+      // fill solid. (#722)
+      const background = attrs.rgb
+        ? resolveShadingFill(runShadingAttrsToShading(attrs), null)
+        : "";
+      return [
+        "span",
+        background ? { style: `background-color: ${background}` } : {},
+        0,
+      ];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
@@ -28,6 +28,7 @@ export const RunShadingExtension = createMarkExtension({
       themeTint: { default: null },
       themeShade: { default: null },
       pattern: { default: null },
+      patternColor: { default: null },
     },
     parseDOM: [
       {

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
@@ -6,12 +6,17 @@
 // highlight. This dedicated mark preserves the fill through the ProseMirror
 // round-trip — it was previously parsed into `formatting.shading` but dropped
 // at PM conversion, so the background silently vanished on reload — and lets
-// the painter render it. No parseDOM: the highlight mark already claims
-// `background-color` on HTML paste; this mark is populated from docx import.
+// the painter render it. It's populated from docx import and, on HTML paste,
+// claims the `background-color` colors the highlight mark rejects (anything
+// outside the OOXML named palette).
 
 import { ensureHexPrefix } from "../../../utils/colorResolver";
 import { expectRunShadingMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
+import {
+  normalizeCssColorKey,
+  parseDOMHighlightColor,
+} from "./HighlightExtension";
 
 export const RunShadingExtension = createMarkExtension({
   name: "runShading",
@@ -24,6 +29,23 @@ export const RunShadingExtension = createMarkExtension({
       themeShade: { default: null },
       pattern: { default: null },
     },
+    parseDOM: [
+      {
+        style: "background-color",
+        getAttrs: (value) => {
+          // Defer to the highlight mark for any color it can map to the OOXML
+          // named palette; claim the rest (arbitrary hex/rgb) as run shading so
+          // pasted custom backgrounds aren't dropped.
+          if (parseDOMHighlightColor(value)) {
+            return false;
+          }
+          const hex = /^#([0-9a-fA-F]{6})$/u.exec(
+            normalizeCssColorKey(value),
+          )?.[1];
+          return hex ? { rgb: hex.toUpperCase() } : false;
+        },
+      },
+    ],
     toDOM(mark) {
       const { rgb } = expectRunShadingMarkAttrs(mark);
       // The editable overlay has no theme. Use the concrete rgb fill directly:

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -40,6 +40,7 @@ export type {
   CommentAttrs,
   TrackedChangeMarkAttrs,
   RunFormattingOverrideAttrs,
+  RunShadingAttrs,
   HyperlinkAttrs,
 } from "./marks";
 

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -67,12 +67,13 @@ export type HighlightAttrs = {
  * flattened ColorValue (mirroring TextColorAttrs) plus the pattern. The default
  * `clear` pattern is never stored (absence ⇒ the fill renders as a solid
  * background and re-serializes to `w:val="clear"`); only non-clear patterns
- * (`solid`, `pct*`, stripes) are carried for export fidelity. The pattern color
- * (`w:shd w:color`) is not modelled here — it only matters for non-rendered
- * pattern overlays and is vanishingly rare on runs.
+ * (`pct*`, stripes) are carried for export fidelity (`solid` is flattened into
+ * the fill). `patternColor` is the pattern foreground rgb (`w:shd w:color`),
+ * carried so a non-clear pattern's color survives export.
  */
 export type RunShadingAttrs = TextColorAttrs & {
   pattern?: NonNullable<ShadingProperties["pattern"]>;
+  patternColor?: string;
 };
 
 export type CharacterSpacingAttrs = {

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -6,6 +6,7 @@
  * to the extension system (extensions/marks/).
  */
 
+import type { ShadingProperties } from "../../types/colors";
 import type {
   EmphasisMark,
   TextEffect,
@@ -59,6 +60,19 @@ export type FontFamilyAttrs = {
 
 export type HighlightAttrs = {
   color: NonNullable<TextFormatting["highlight"]>;
+};
+
+/**
+ * Run-level shading mark attributes (w:shd). Carries the shading FILL as a
+ * flattened ColorValue (mirroring TextColorAttrs) plus the pattern. The default
+ * `clear` pattern is never stored (absence ⇒ the fill renders as a solid
+ * background and re-serializes to `w:val="clear"`); only non-clear patterns
+ * (`solid`, `pct*`, stripes) are carried for export fidelity. The pattern color
+ * (`w:shd w:color`) is not modelled here — it only matters for non-rendered
+ * pattern overlays and is vanishingly rare on runs.
+ */
+export type RunShadingAttrs = TextColorAttrs & {
+  pattern?: NonNullable<ShadingProperties["pattern"]>;
 };
 
 export type CharacterSpacingAttrs = {

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -17,6 +17,7 @@ import {
   readBlockSdtAttrs,
   readParagraphAttrs,
   readRunFormattingOverrideMarkAttrs,
+  readRunShadingMarkAttrs,
   readSdtAttrs,
   readShapeAttrs,
   readStrikeMarkAttrs,
@@ -237,6 +238,10 @@ const validateMarks = (
 
       case "highlight":
         appendAttrIssues(markPath, readHighlightMarkAttrs(mark), issues);
+        continue;
+
+      case "runShading":
+        appendAttrIssues(markPath, readRunShadingMarkAttrs(mark), issues);
         continue;
 
       case "fontSize":

--- a/packages/folio/src/core/utils/__tests__/formatToStyle-shading.test.ts
+++ b/packages/folio/src/core/utils/__tests__/formatToStyle-shading.test.ts
@@ -1,0 +1,52 @@
+// `w:val="clear"` shading is "no pattern" — the `w:fill` colour is shown as a
+// solid background, NOT transparent. resolveShadingFill previously returned
+// transparent for any `clear` pattern before inspecting the fill, dropping
+// legitimate `<w:shd w:val="clear" w:fill="…"/>` backgrounds. Only `nil` means
+// no shading. (Regression for the eigenpal #722 / #712 shading work.)
+
+import { describe, expect, test } from "bun:test";
+
+import type { ShadingProperties } from "../../types/colors";
+import { resolveShadingFill } from "../formatToStyle";
+
+describe("resolveShadingFill — clear pattern shows the fill", () => {
+  test("clear + concrete fill renders the fill as a solid background", () => {
+    expect(
+      resolveShadingFill({ pattern: "clear", fill: { rgb: "D9D9D9" } }),
+    ).toBe("#D9D9D9");
+  });
+
+  test("clear with no explicit pattern attribute also renders the fill", () => {
+    expect(resolveShadingFill({ fill: { rgb: "00B050" } })).toBe("#00B050");
+  });
+
+  test("nil means no shading — the fill is ignored", () => {
+    expect(
+      resolveShadingFill({ pattern: "nil", fill: { rgb: "D9D9D9" } }),
+    ).toBe("");
+  });
+
+  test("clear + white/auto fills stay transparent (page-background no-ops)", () => {
+    expect(
+      resolveShadingFill({ pattern: "clear", fill: { rgb: "FFFFFF" } }),
+    ).toBe("");
+    expect(resolveShadingFill({ pattern: "clear", fill: { auto: true } })).toBe(
+      "",
+    );
+  });
+
+  test("clear with no fill is transparent", () => {
+    const shading: ShadingProperties = { pattern: "clear" };
+    expect(resolveShadingFill(shading)).toBe("");
+  });
+
+  test("solid pattern still uses the pattern colour when there is no fill", () => {
+    expect(
+      resolveShadingFill({ pattern: "solid", color: { rgb: "FF0000" } }),
+    ).toBe("#FF0000");
+  });
+
+  test("undefined shading is transparent", () => {
+    expect(resolveShadingFill(undefined)).toBe("");
+  });
+});

--- a/packages/folio/src/core/utils/formatToStyle.ts
+++ b/packages/folio/src/core/utils/formatToStyle.ts
@@ -494,8 +494,13 @@ export function resolveShadingFill(
     return "";
   }
 
-  // Clear or nil pattern means transparent - check this FIRST
-  if (shading.pattern === "clear" || shading.pattern === "nil") {
+  // `nil` (ECMA-376 §17.18.78) means no shading at all — the fill is ignored.
+  // `clear` is NOT transparent: it means "no pattern", so the `w:fill` colour
+  // is shown as a solid background. It must fall through to the fill check
+  // below; returning early here dropped legitimate
+  // `<w:shd w:val="clear" w:fill="…"/>` backgrounds (the FFFFFF/auto fills that
+  // genuinely are no-ops are filtered inside the fill check).
+  if (shading.pattern === "nil") {
     return "";
   }
 


### PR DESCRIPTION
## Problem

Folio models `w:highlight` as a strict OOXML named-palette union (no hex) — `shading` (`w:shd`) is a separate field. Arbitrary run-background fills (a `w:shd` from Word/Google Docs, or a custom highlight another editor saved as shading) were parsed into `formatting.shading` but **dropped at ProseMirror conversion**: no mark carried them, so the background silently vanished on reload, and the run serializer never re-emitted it.

Upstream eigenpal #722 (#712) maps such shading onto the highlight mark as hex. That does not fit folio's strict named-palette highlight (the naive port produces an invalid document — validation rejects hex). So this is folio's idiom for the same fix.

## Change

A dedicated `runShading` ProseMirror mark carries the shading **fill** as a flattened `ColorValue` (rgb / theme*) plus a non-default `pattern`, mirroring the `textColor` mark. The shading now round-trips (import → PM → export) and renders.

- **Schema/validation:** new `RunShadingExtension` (no `parseDOM` — the highlight mark already claims `background-color` on paste; no toolbar command — this is import-only, like the `rtl` mark). `readRunShadingMarkAttrs` validates rgb/theme/pattern; unlike `highlight` it accepts arbitrary hex.
- **Conversion:** `toProseDoc` creates the mark from `formatting.shading`; `fromProseDoc` rebuilds `formatting.shading` so the run serializer re-emits `w:shd`. Shared converters in `runShadingMark.ts`.
- **Render:** `toFlowBlocks` resolves the fill to a CSS background (`RunFormatting.shading`); the painter paints `run.highlight ?? run.shading` (an explicit highlight wins).
- The default `clear` pattern is never stored — the fill renders solid and re-serializes to `w:val="clear"`.

## Separate fix (own concern): `resolveShadingFill` clear handling

`resolveShadingFill` returned transparent for any `w:val="clear"` shading **before** inspecting the fill. Per ECMA-376 §17.18.78 only `nil` means "no shading"; `clear` means "no pattern", so the `w:fill` colour shows as a solid background. The early return dropped legitimate `<w:shd w:val="clear" w:fill="…"/>` backgrounds. This also affects paragraph/table run shading that flows through `textToStyle`. White/`auto` fills stay transparent (page-background no-ops); paragraph **block** shading uses its own path and is untouched.

## Tests

- `issue-712-run-shading-roundtrip.test.ts`: import → render → export round-trip, gating (auto / theme-only / fill-less / clear-vs-non-clear pattern), highlight-wins precedence at the flow layer.
- `renderParagraph-run-shading.test.ts`: painter paints shading as a background; highlight wins on the same run.
- `formatToStyle-shading.test.ts`: the `clear`/`nil` fix across all fill combinations.

## Notes

Touches `renderParagraph.ts` (the run-background block only) — disjoint from the RTL/list-marker painter PRs in this sync, so it rebases cleanly in any merge order. Runtime toolbar/selection mark switches are intentionally not extended (safe `default` branches; the mark is import-only and survives via to/fromProseDoc).
