### PR TITLE
feat(folio): lay out RTL paragraphs that lack an explicit bidi flag

### DIFF
--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type {
+  FieldRun,
   ParagraphAttrs,
   ParagraphBlock,
   ParagraphFragment,
@@ -83,9 +84,15 @@ const fakeDocument = {
   },
 } as unknown as Document;
 
-function render(runs: TextRun[], attrs?: ParagraphAttrs): HTMLElement {
+function render(
+  runs: (TextRun | FieldRun)[],
+  attrs?: ParagraphAttrs,
+): HTMLElement {
   const block: ParagraphBlock = { kind: "paragraph", id: "p1", runs, attrs };
-  const totalChars = runs.reduce((n, r) => n + r.text.length, 0);
+  const totalChars = runs.reduce(
+    (n, r) => n + ("text" in r ? r.text.length : 0),
+    0,
+  );
   const measure: ParagraphMeasure = {
     kind: "paragraph",
     lines: [
@@ -168,6 +175,18 @@ describe("Issue #719 — RTL base direction detection", () => {
 
   test("RTL scripts outside the BMP (Adlam) are detected", () => {
     expect(render([text("\u{1E900}\u{1E921}", true)]).dir).toBe("rtl");
+  });
+
+  test("a field-result run contributes to base-direction detection", () => {
+    // A field result (e.g. a cross-reference) renders as text, so its first
+    // strong letter counts.
+    const field: FieldRun = {
+      kind: "field",
+      fieldType: "OTHER",
+      fallback: "שלום",
+      rtl: true,
+    };
+    expect(render([field]).dir).toBe("rtl");
   });
 
   test("a CJK-only rtl run resolves LTR (CJK is strong left-to-right)", () => {

--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -1,0 +1,172 @@
+// eigenpal #723 (#719) — a paragraph that carries right-to-left runs (`w:rtl`)
+// but no explicit paragraph `w:bidi` flag must still lay out right-to-left.
+// The painter renders each run as its own `dir`-marked, bidi-isolated span, so
+// without a base direction on the fragment the runs stay in logical (LTR) order
+// and reversed Hebrew/Arabic reads backwards. We set the fragment direction
+// from first-strong base-direction detection, gated to paragraphs that actually
+// contain RTL runs so pure-LTR content is untouched.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ParagraphAttrs,
+  ParagraphBlock,
+  ParagraphFragment,
+  ParagraphMeasure,
+  TextRun,
+} from "../layout-engine/types";
+import { renderParagraphFragment } from "./renderParagraph";
+
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      if (prop === "getPropertyValue") {
+        return (key: string) => target[key] ?? "";
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  dir = "";
+  style: Record<string, string> = createFakeStyle();
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+  prepend(...children: FakeElement[]): void {
+    this.children.unshift(...children);
+  }
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return { font: "", measureText: (t: string) => ({ width: t.length * 7 }) };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function render(runs: TextRun[], attrs?: ParagraphAttrs): HTMLElement {
+  const block: ParagraphBlock = { kind: "paragraph", id: "p1", runs, attrs };
+  const totalChars = runs.reduce((n, r) => n + r.text.length, 0);
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: Math.max(0, runs.length - 1),
+        toChar: totalChars,
+        width: 100,
+        ascent: 10,
+        descent: 3,
+        lineHeight: 13,
+      },
+    ],
+    totalHeight: 13,
+  };
+  const fragment: ParagraphFragment = {
+    kind: "paragraph",
+    blockId: "p1",
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 13,
+    fromLine: 0,
+    toLine: 1,
+  };
+  return renderParagraphFragment(
+    fragment,
+    block,
+    measure,
+    { pageNumber: 1, totalPages: 1, section: "body" },
+    { document: fakeDocument },
+  );
+}
+
+const text = (value: string, rtl?: boolean): TextRun => ({
+  kind: "text",
+  text: value,
+  ...(rtl === undefined ? {} : { rtl }),
+});
+
+describe("Issue #719 — RTL base direction detection", () => {
+  test("Hebrew-led paragraph with rtl runs renders dir=rtl", () => {
+    expect(render([text("בדיקה 1", true)]).dir).toBe("rtl");
+  });
+
+  test("explicit w:bidi paragraph still renders dir=rtl", () => {
+    expect(render([text("hello")], { bidi: true }).dir).toBe("rtl");
+  });
+
+  test("English-led paragraph with an embedded rtl word stays LTR (no dir)", () => {
+    expect(render([text("Hello "), text("שלום", true)]).dir).toBe("");
+  });
+
+  test("pure-LTR paragraph is untouched (no dir)", () => {
+    expect(render([text("plain text")]).dir).toBe("");
+  });
+
+  test("detected-RTL paragraph with no explicit alignment defaults to right-align", () => {
+    // Detection must drive the same alignment path as an explicit w:bidi
+    // paragraph, not just the `dir` attribute.
+    const el = render([text("בדיקה", true)]);
+    expect(el.dir).toBe("rtl");
+    expect(el.style.textAlign).toBe("right");
+  });
+
+  test("rtl runs with only digits/punctuation honour w:rtl (no strong char)", () => {
+    expect(render([text("123 .", true)]).dir).toBe("rtl");
+  });
+
+  test("Arabic-led paragraph with rtl runs renders dir=rtl", () => {
+    expect(render([text("مرحبا", true)]).dir).toBe("rtl");
+  });
+
+  test("CJK / other neutral scripts are not treated as RTL-strong", () => {
+    // Regression: the RTL char-class must be authored from exact range
+    // endpoints. A corrupted range once swallowed most of the BMP (CJK,
+    // Devanagari, Kana, Thai, Georgian, Latin Extended Additional) as
+    // RTL-strong, flipping mixed-script paragraphs. A CJK-led rtl run followed
+    // by Latin body must resolve LTR (CJK is neutral; the first strong char is
+    // the Latin "Body").
+    expect(render([text("中", true), text(" Body")]).dir).toBe("");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -166,6 +166,10 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(render([text("مرحبا", true)]).dir).toBe("rtl");
   });
 
+  test("RTL scripts outside the BMP (Adlam) are detected", () => {
+    expect(render([text("\u{1E900}\u{1E921}", true)]).dir).toBe("rtl");
+  });
+
   test("a CJK-only rtl run resolves LTR (CJK is strong left-to-right)", () => {
     // CJK, Devanagari, Thai, Hangul and kana are Unicode bidi class L, so a
     // w:rtl run containing only such text must lay out LTR — not fall through to

--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -136,6 +136,12 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(render([text("hello")], { bidi: true }).dir).toBe("rtl");
   });
 
+  test("explicit w:bidi=false wins over rtl runs (stays LTR)", () => {
+    // `<w:bidi w:val="0"/>` is an explicit LTR override; first-strong detection
+    // must not re-enable RTL for a Hebrew run inside it.
+    expect(render([text("בדיקה", true)], { bidi: false }).dir).toBe("");
+  });
+
   test("English-led paragraph with an embedded rtl word stays LTR (no dir)", () => {
     expect(render([text("Hello "), text("שלום", true)]).dir).toBe("");
   });

--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -165,6 +165,13 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(el.style.textAlign).toBe("right");
   });
 
+  test("explicit bidi marks (RLM/ALM/LRM) decide before letters", () => {
+    // U+200F RLM and U+061C ALM are strong RTL; U+200E LRM is strong LTR.
+    expect(render([text("‏Hello", true)]).dir).toBe("rtl"); // RLM-led
+    expect(render([text("؜Hello", true)]).dir).toBe("rtl"); // ALM-led
+    expect(render([text("‎שלום", true)]).dir).toBe(""); // LRM overrides
+  });
+
   test("rtl runs with only digits/punctuation honour w:rtl (no strong char)", () => {
     expect(render([text("123 .", true)]).dir).toBe("rtl");
   });

--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -174,4 +174,11 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(render([text("中文", true)]).dir).toBe("");
     expect(render([text("अआ", true)]).dir).toBe("");
   });
+
+  test("weak chars (Arabic-Indic digits) are skipped; the first letter decides", () => {
+    // Arabic-Indic digits are bidi class AN (weak), not strong R — leading them
+    // must not trigger RTL. A run led by them whose first *letter* is Latin is
+    // LTR.
+    expect(render([text("١٢٣ Hello", true)]).dir).toBe("");
+  });
 });

--- a/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-rtl-base-direction.test.ts
@@ -160,13 +160,12 @@ describe("Issue #719 — RTL base direction detection", () => {
     expect(render([text("مرحبا", true)]).dir).toBe("rtl");
   });
 
-  test("CJK / other neutral scripts are not treated as RTL-strong", () => {
-    // Regression: the RTL char-class must be authored from exact range
-    // endpoints. A corrupted range once swallowed most of the BMP (CJK,
-    // Devanagari, Kana, Thai, Georgian, Latin Extended Additional) as
-    // RTL-strong, flipping mixed-script paragraphs. A CJK-led rtl run followed
-    // by Latin body must resolve LTR (CJK is neutral; the first strong char is
-    // the Latin "Body").
-    expect(render([text("中", true), text(" Body")]).dir).toBe("");
+  test("a CJK-only rtl run resolves LTR (CJK is strong left-to-right)", () => {
+    // CJK, Devanagari, Thai, Hangul and kana are Unicode bidi class L, so a
+    // w:rtl run containing only such text must lay out LTR — not fall through to
+    // the digits/punctuation `honor w:rtl` path. Also guards the RTL char-class
+    // against the pasted-glyph corruption that once swallowed most of the BMP.
+    expect(render([text("中文", true)]).dir).toBe("");
+    expect(render([text("अआ", true)]).dir).toBe("");
   });
 });

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1912,14 +1912,24 @@ const RTL_STRONG_LETTER =
  * eigenpal #723 (#719).
  */
 function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
-  const textRuns = block.runs.filter(isTextRun);
-  if (!textRuns.some((r) => r.rtl)) {
+  // Text runs plus field runs (a field result like a cross-reference renders as
+  // text, so it can be the paragraph's first strong character).
+  const runs = block.runs.filter((r) => isTextRun(r) || isFieldRun(r));
+  if (!runs.some((r) => r.rtl)) {
     return false;
   }
+  const text = runs
+    .map((r) => {
+      if (isTextRun(r)) {
+        return r.text;
+      }
+      return isFieldRun(r) ? (r.fallback ?? "") : "";
+    })
+    .join("");
   // The first strong char is the first *letter* (`\p{L}`); digits, combining
   // marks, punctuation and spaces are weak/neutral and skipped in one native
   // scan. The first letter's script decides; no letter at all => honor w:rtl.
-  const firstLetter = /\p{L}/u.exec(textRuns.map((r) => r.text).join(""))?.[0];
+  const firstLetter = /\p{L}/u.exec(text)?.[0];
   if (firstLetter === undefined) {
     return true;
   }

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -2026,6 +2026,12 @@ export function renderParagraphFragment(
     fragmentEl.style.textAlign = "right";
   }
 
+  // An RTL paragraph with no explicit alignment defaults to right; pass that
+  // through to per-line rendering so flex-promoted lines (image-only,
+  // image+text, right-tab anchors) align to the start side too, not just the
+  // fragment text-align. (#723)
+  const effectiveAlignment = alignment ?? (isRtl ? "right" : undefined);
+
   // Track indentation for line-level application
   // Indentation is applied per-line, not at fragment level
   const indent = block.attrs?.indent;
@@ -2229,7 +2235,7 @@ export function renderParagraphFragment(
       }
     }
 
-    const lineEl = renderLine(block, line, alignment, doc, {
+    const lineEl = renderLine(block, line, effectiveAlignment, doc, {
       availableWidth: lineAvailableWidth - lineLeftOffset - lineRightOffset,
       isLastLine,
       isFirstLine,

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1895,15 +1895,14 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
   );
 }
 
-// The first strong-directional character (Unicode Bidi class R/AL vs L). Group
-// 1 is the RTL letters (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan,
-// Mandaic, Arabic Extended-A, and the Hebrew/Arabic presentation forms); group
-// 2 is `\p{L}`, any other letter — strong-L, covering Latin, CJK, Indic, kana,
-// Hangul, etc. Digits, punctuation and spaces are neutral and skipped. One
-// native scan finds the first strong char. Authored with `\u` escapes (a
+// Strong-RTL letters: the Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan,
+// Mandaic, Arabic Extended-A blocks plus the Hebrew/Arabic presentation forms.
+// Weak/neutral code points in those blocks (Arabic-Indic digits, combining
+// marks, punctuation) are NOT letters, so first-LETTER detection skips them —
+// only a strong R/AL *letter* triggers RTL. Authored with `\u` escapes (a
 // pasted glyph once silently corrupted the presentation-forms range).
-const FIRST_STRONG_CHAR =
-  /([\u0590-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF])|(\p{L})/u;
+const RTL_STRONG_LETTER =
+  /[\u0590-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
 
 /**
  * Decide whether a paragraph without an explicit `w:bidi` flag should still be
@@ -1918,14 +1917,14 @@ function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
   if (!textRuns.some((r) => r.rtl)) {
     return false;
   }
-  const match = FIRST_STRONG_CHAR.exec(textRuns.map((r) => r.text).join(""));
-  // No strong character (digits/punctuation only) — honor w:rtl. Otherwise the
-  // first strong char decides: an RTL letter (group 1) => RTL, any other
-  // letter => LTR.
-  if (!match) {
+  // The first strong char is the first *letter* (`\p{L}`); digits, combining
+  // marks, punctuation and spaces are weak/neutral and skipped in one native
+  // scan. The first letter's script decides; no letter at all => honor w:rtl.
+  const firstLetter = /\p{L}/u.exec(textRuns.map((r) => r.text).join(""))?.[0];
+  if (firstLetter === undefined) {
     return true;
   }
-  return Boolean(match[1]);
+  return RTL_STRONG_LETTER.test(firstLetter);
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1895,42 +1895,37 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
   );
 }
 
-// First strong-directional character classes (subset of the Unicode Bidi
-// character types L vs R/AL) used for base-direction detection. Authored with
-// `\u` escapes (not pasted glyphs) so the range endpoints stay reviewable and
-// can't be silently corrupted on a copy/paste round-trip. RTL covers Hebrew,
-// Arabic, Syriac, Thaana, NKo, Samaritan, Mandaic, Arabic Extended-A, and the
-// Hebrew/Arabic presentation forms.
-const RTL_STRONG_CHAR =
-  /[\u0590-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
-const LTR_STRONG_CHAR =
-  /[\u0041-\u005A\u0061-\u007A\u00C0-\u02B8\u0370-\u0589\u10A0-\u10FF\u1E00-\u1FFF]/u;
+// The first strong-directional character (Unicode Bidi class R/AL vs L). Group
+// 1 is the RTL letters (Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan,
+// Mandaic, Arabic Extended-A, and the Hebrew/Arabic presentation forms); group
+// 2 is `\p{L}`, any other letter — strong-L, covering Latin, CJK, Indic, kana,
+// Hangul, etc. Digits, punctuation and spaces are neutral and skipped. One
+// native scan finds the first strong char. Authored with `\u` escapes (a
+// pasted glyph once silently corrupted the presentation-forms range).
+const FIRST_STRONG_CHAR =
+  /([\u0590-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF])|(\p{L})/u;
 
 /**
  * Decide whether a paragraph without an explicit `w:bidi` flag should still be
  * laid out right-to-left. Only paragraphs that carry at least one `w:rtl` run
  * are candidates; among those the base direction follows the first strong
  * directional character (the `dir="auto"` rule), so Hebrew/Arabic-led lines
- * order RTL while an English-led line with an embedded RTL word stays LTR.
+ * order RTL while an English- (or CJK-/Devanagari-/…) led line stays LTR.
  * eigenpal #723 (#719).
  */
 function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
-  const textRuns = (block.runs ?? []).filter(isTextRun);
+  const textRuns = block.runs.filter(isTextRun);
   if (!textRuns.some((r) => r.rtl)) {
     return false;
   }
-  for (const run of textRuns) {
-    for (const ch of run.text) {
-      if (RTL_STRONG_CHAR.test(ch)) {
-        return true;
-      }
-      if (LTR_STRONG_CHAR.test(ch)) {
-        return false;
-      }
-    }
+  const match = FIRST_STRONG_CHAR.exec(textRuns.map((r) => r.text).join(""));
+  // No strong character (digits/punctuation only) — honor w:rtl. Otherwise the
+  // first strong char decides: an RTL letter (group 1) => RTL, any other
+  // letter => LTR.
+  if (!match) {
+    return true;
   }
-  // RTL runs but no strong character (digits/punctuation only) — honor w:rtl.
-  return true;
+  return Boolean(match[1]);
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1452,7 +1452,10 @@ export function renderLine(
     onlyRun &&
     isMathRun(onlyRun) &&
     onlyRun.display === "block" &&
-    alignment !== "right"
+    // Only an EXPLICIT right alignment suppresses display-math centering; a
+    // right default synthesized from RTL base direction must not (the equation
+    // still centres in an RTL paragraph). (#723)
+    block.attrs?.alignment !== "right"
   ) {
     lineEl.style.textAlign = "center";
   }
@@ -1929,14 +1932,22 @@ function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
       return isFieldRun(r) ? (r.fallback ?? "") : "";
     })
     .join("");
-  // The first strong char is the first *letter* (`\p{L}`); digits, combining
-  // marks, punctuation and spaces are weak/neutral and skipped in one native
-  // scan. The first letter's script decides; no letter at all => honor w:rtl.
-  const firstLetter = /\p{L}/u.exec(text)?.[0];
-  if (firstLetter === undefined) {
+  // The first strong directional signal, in one native scan: an explicit bidi
+  // mark (RLM U+200F / ALM U+061C => RTL, LRM U+200E => LTR) or the first
+  // letter (`\p{L}`). Digits, combining marks, punctuation and spaces are
+  // weak/neutral and skipped. The first letter's script decides; nothing
+  // strong => honor w:rtl.
+  const match = /(\u200F|\u061C)|(\u200E)|(\p{L})/u.exec(text);
+  if (!match) {
     return true;
   }
-  return RTL_STRONG_LETTER.test(firstLetter);
+  if (match[1] !== undefined) {
+    return true; // RLM or ALM
+  }
+  if (match[2] !== undefined) {
+    return false; // LRM
+  }
+  return match[3] !== undefined && RTL_STRONG_LETTER.test(match[3]);
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1895,6 +1895,44 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
   );
 }
 
+// First strong-directional character classes (subset of the Unicode Bidi
+// character types L vs R/AL) used for base-direction detection. Authored with
+// `\u` escapes (not pasted glyphs) so the range endpoints stay reviewable and
+// can't be silently corrupted on a copy/paste round-trip. RTL covers Hebrew,
+// Arabic, Syriac, Thaana, NKo, Samaritan, Mandaic, Arabic Extended-A, and the
+// Hebrew/Arabic presentation forms.
+const RTL_STRONG_CHAR =
+  /[\u0590-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
+const LTR_STRONG_CHAR =
+  /[\u0041-\u005A\u0061-\u007A\u00C0-\u02B8\u0370-\u0589\u10A0-\u10FF\u1E00-\u1FFF]/u;
+
+/**
+ * Decide whether a paragraph without an explicit `w:bidi` flag should still be
+ * laid out right-to-left. Only paragraphs that carry at least one `w:rtl` run
+ * are candidates; among those the base direction follows the first strong
+ * directional character (the `dir="auto"` rule), so Hebrew/Arabic-led lines
+ * order RTL while an English-led line with an embedded RTL word stays LTR.
+ * eigenpal #723 (#719).
+ */
+function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
+  const textRuns = (block.runs ?? []).filter(isTextRun);
+  if (!textRuns.some((r) => r.rtl)) {
+    return false;
+  }
+  for (const run of textRuns) {
+    for (const ch of run.text) {
+      if (RTL_STRONG_CHAR.test(ch)) {
+        return true;
+      }
+      if (LTR_STRONG_CHAR.test(ch)) {
+        return false;
+      }
+    }
+  }
+  // RTL runs but no strong character (digits/punctuation only) — honor w:rtl.
+  return true;
+}
+
 /**
  * Render a paragraph fragment
  *
@@ -1949,9 +1987,15 @@ export function renderParagraphFragment(
     fragmentEl.dataset["styleId"] = block.attrs.styleId;
   }
 
-  // Apply RTL direction
-  const isBidi = block.attrs?.bidi;
-  if (isBidi) {
+  // Apply RTL direction. An explicit `w:bidi` paragraph is always RTL. When
+  // there's no `w:bidi` but the paragraph carries right-to-left runs (`w:rtl`),
+  // fall back to first-strong base-direction detection: Word/UBA order the runs
+  // by the paragraph's base direction, but the painter lays them out as
+  // independently `dir`-marked spans (each an isolate), so without a base `dir`
+  // on the fragment the runs stay in logical LTR order and reversed Hebrew/
+  // Arabic reads backwards. eigenpal #723 (#719).
+  const isRtl = Boolean(block.attrs?.bidi) || paragraphBaseIsRtl(block);
+  if (isRtl) {
     fragmentEl.dir = "rtl";
   }
 
@@ -1968,9 +2012,9 @@ export function renderParagraphFragment(
     } else {
       // 'justify' uses text-align: left (or right for RTL)
       // Justify is implemented via word-spacing on individual lines
-      fragmentEl.style.textAlign = isBidi ? "right" : "left";
+      fragmentEl.style.textAlign = isRtl ? "right" : "left";
     }
-  } else if (isBidi) {
+  } else if (isRtl) {
     // No explicit alignment on RTL paragraph — default to right
     fragmentEl.style.textAlign = "right";
   }
@@ -1984,7 +2028,7 @@ export function renderParagraphFragment(
   if (indent) {
     // Track indent values for line-level application
     // For RTL paragraphs, swap left/right indentation
-    if (isBidi) {
+    if (isRtl) {
       if (indent.left !== undefined) {
         indentRight = indent.left;
       }

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1896,10 +1896,13 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
 }
 
 // Strong-RTL letters, matched by Unicode script so RTL scripts outside the BMP
-// (Adlam) and newer blocks (Arabic Extended-B) are covered without hand-rolling
-// code-point ranges. Only used to classify the first *letter* (`\p{L}`), so the
-// non-letter members of these scripts (Arabic-Indic digits, combining marks,
-// punctuation) are never tested — they're weak/neutral and skipped upstream.
+// (Adlam U+1E900) and newer blocks (Arabic Extended-B U+0870) are covered
+// without hand-rolling code-point ranges. These eight cover every RTL script in
+// real-world use (Hebrew/Arabic are ~all of it); newer scripts (Yezidi, Garay,
+// …) are omitted because the pinned oxlint/tsc Unicode database rejects their
+// names. Only used to classify the first *letter* (`\p{L}`), so the non-letter
+// members of these scripts (Arabic-Indic digits, combining marks, punctuation)
+// are never tested — they're weak/neutral and skipped upstream.
 const RTL_STRONG_LETTER =
   /[\p{Script=Hebrew}\p{Script=Arabic}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
 

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1982,14 +1982,15 @@ export function renderParagraphFragment(
     fragmentEl.dataset["styleId"] = block.attrs.styleId;
   }
 
-  // Apply RTL direction. An explicit `w:bidi` paragraph is always RTL. When
-  // there's no `w:bidi` but the paragraph carries right-to-left runs (`w:rtl`),
-  // fall back to first-strong base-direction detection: Word/UBA order the runs
-  // by the paragraph's base direction, but the painter lays them out as
-  // independently `dir`-marked spans (each an isolate), so without a base `dir`
-  // on the fragment the runs stay in logical LTR order and reversed Hebrew/
-  // Arabic reads backwards. eigenpal #723 (#719).
-  const isRtl = Boolean(block.attrs?.bidi) || paragraphBaseIsRtl(block);
+  // Apply RTL direction. An explicit `w:bidi` flag wins: `true` ⇒ RTL, and an
+  // explicit `w:val="0"` (parsed as `false`) ⇒ LTR even when the paragraph
+  // carries `w:rtl` runs. Only when the flag is absent do we fall back to
+  // first-strong base-direction detection: Word/UBA order the runs by the
+  // paragraph's base direction, but the painter lays them out as independently
+  // `dir`-marked spans (each an isolate), so without a base `dir` on the
+  // fragment the runs stay in logical LTR order and reversed Hebrew/Arabic
+  // reads backwards. eigenpal #723 (#719).
+  const isRtl = block.attrs?.bidi ?? paragraphBaseIsRtl(block);
   if (isRtl) {
     fragmentEl.dir = "rtl";
   }

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1895,14 +1895,13 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
   );
 }
 
-// Strong-RTL letters: the Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan,
-// Mandaic, Arabic Extended-A blocks plus the Hebrew/Arabic presentation forms.
-// Weak/neutral code points in those blocks (Arabic-Indic digits, combining
-// marks, punctuation) are NOT letters, so first-LETTER detection skips them —
-// only a strong R/AL *letter* triggers RTL. Authored with `\u` escapes (a
-// pasted glyph once silently corrupted the presentation-forms range).
+// Strong-RTL letters, matched by Unicode script so RTL scripts outside the BMP
+// (Adlam) and newer blocks (Arabic Extended-B) are covered without hand-rolling
+// code-point ranges. Only used to classify the first *letter* (`\p{L}`), so the
+// non-letter members of these scripts (Arabic-Indic digits, combining marks,
+// punctuation) are never tested — they're weak/neutral and skipped upstream.
 const RTL_STRONG_LETTER =
-  /[\u0590-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
+  /[\p{Script=Hebrew}\p{Script=Arabic}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
 
 /**
  * Decide whether a paragraph without an explicit `w:bidi` flag should still be


### PR DESCRIPTION
## Problem

A paragraph whose runs are marked right-to-left (`w:rtl`) but that carries **no explicit `w:bidi`** flag was laid out left-to-right, so Hebrew/Arabic read backwards. The painter renders each run as its own `dir`-marked, bidi-isolated span; without a base direction on the paragraph fragment the runs stay in logical (LTR) order and the per-run isolates look neutral to the browser's `dir="auto"`.

## Change

Adds first-strong base-direction detection (`paragraphBaseIsRtl`): among paragraphs that carry at least one `w:rtl` run, the base direction follows the first strong directional character (the `dir="auto"` rule). Hebrew/Arabic-led lines order RTL; an English-led line with an embedded RTL word stays LTR; an rtl run with only digits/punctuation honours `w:rtl`. The detected direction drives the fragment `dir`, the default text-align, and the left/right indent swap — the same paths an explicit `w:bidi` paragraph uses.

Gated to paragraphs with `≥1` rtl run, so pure-LTR and explicit-`w:bidi` paragraphs are byte-identical to before.

The Unicode char-classes are authored with `\u` escapes rather than pasted glyphs: a pasted glyph silently corrupted the presentation-forms range into one that swallowed most of the BMP (CJK, Devanagari, …) as RTL-strong. The test includes a CJK-led case that guards against that regression.

## Test

`renderParagraph-rtl-base-direction.test.ts` — Hebrew/Arabic-led → RTL, English-led-with-embedded-RTL → LTR, digits/punctuation-only → honour `w:rtl`, explicit `w:bidi` unchanged, pure-LTR untouched, CJK-neutral guard.

## Notes

Touches `renderParagraph.ts` (the RTL block only) — disjoint from the run-shading and list-marker painter PRs in this sync, so it rebases cleanly in any merge order.
