### PR TITLE
fix(folio): hang list markers into the margin when hanging > left indent

### DIFF
--- a/packages/folio/src/core/layout-painter/renderParagraph-list-hanging-indent.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-list-hanging-indent.test.ts
@@ -1,0 +1,181 @@
+// eigenpal #730 (#729) — a numbered list whose direct paragraph indent has
+// `hanging` greater than `left` must hang its marker into the left margin (as
+// Word does), not clamp it to the content edge. The marker line keeps
+// `text-indent: 0` and the hang comes from padding-left; CSS padding can't be
+// negative, so when `left - hanging < 0` the negative portion rides on the
+// marker's own `margin-left`. Without it the old `Math.max(0, left - hanging)`
+// clamp pinned the marker to the content edge, shifting the numbers right of
+// the text above.
+
+import { describe, expect, test } from "bun:test";
+
+import { clearTextWidthCache } from "../layout-engine/measure/cache";
+import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
+import type {
+  ParagraphBlock,
+  ParagraphFragment,
+  ParagraphMeasure,
+} from "../layout-engine/types";
+import { renderParagraphFragment } from "./renderParagraph";
+
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      if (prop === "getPropertyValue") {
+        return (key: string) => target[key] ?? "";
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  dir = "";
+  style: Record<string, string> = createFakeStyle();
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+  prepend(...children: FakeElement[]): void {
+    this.children.unshift(...children);
+  }
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return { font: "", measureText: (t: string) => ({ width: t.length * 7 }) };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function renderListItem(indent: { left: number; hanging: number }): {
+  line: HTMLElement;
+  marker: HTMLElement | undefined;
+} {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p1",
+    runs: [{ kind: "text", text: "TEST1" }],
+    attrs: { listMarker: "1.", indent },
+  };
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 5,
+        width: 40,
+        ascent: 10,
+        descent: 3,
+        lineHeight: 14,
+      },
+    ],
+    totalHeight: 14,
+  };
+  const fragment: ParagraphFragment = {
+    kind: "paragraph",
+    blockId: "p1",
+    x: 0,
+    y: 0,
+    width: 400,
+    height: 14,
+    fromLine: 0,
+    toLine: 1,
+  };
+
+  const originalDocument = globalThis.document;
+  Object.defineProperty(globalThis, "document", {
+    value: fakeDocument,
+    configurable: true,
+  });
+  clearTextWidthCache();
+  resetCanvasContext();
+  try {
+    const fragmentEl = renderParagraphFragment(
+      fragment,
+      block,
+      measure,
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument },
+    );
+    const line = fragmentEl.children[0] as HTMLElement;
+    const marker = line.children[0] as HTMLElement | undefined;
+    return { line, marker };
+  } finally {
+    clearTextWidthCache();
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      value: originalDocument,
+      configurable: true,
+    });
+  }
+}
+
+describe("Issue #729 — list hanging indent exceeding left indent", () => {
+  test("hanging > left: marker hangs into the margin via negative margin-left", () => {
+    // 15px left, 38px hanging — marker should start at 15 - 38 = -23px.
+    const { line, marker } = renderListItem({ left: 15, hanging: 38 });
+    expect(marker?.className).toContain("layout-list-marker");
+    expect(Number.parseFloat(marker?.style.marginLeft ?? "")).toBeCloseTo(
+      -23,
+      1,
+    );
+    // padding clamps to 0 (can't be negative); text-indent stays 0.
+    expect(line.style.paddingLeft).toBe("0px");
+    expect(line.style.textIndent).toBe("0");
+  });
+
+  test("hanging <= left: existing path unchanged (padding, no marker margin)", () => {
+    // 48px left, 24px hanging — marker starts at 48 - 24 = 24px via padding.
+    const { line, marker } = renderListItem({ left: 48, hanging: 24 });
+    expect(marker?.style.marginLeft).toBeFalsy();
+    expect(line.style.paddingLeft).toBe("24px");
+    expect(line.style.textIndent).toBe("0");
+  });
+
+  test("left == 0 with hanging: no negative margin (continuation lines sit at hanging)", () => {
+    // Gating on indentLeft > 0 avoids misaligning the first line with the
+    // continuation lines, which the body-line branch places at `hanging`.
+    const { line, marker } = renderListItem({ left: 0, hanging: 24 });
+    expect(marker?.style.marginLeft).toBeFalsy();
+    expect(line.style.paddingLeft).toBe("0px");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -2302,17 +2302,16 @@ export function renderParagraphFragment(
       //    use this shape — the body of "(i) Tranche Closing..."
       //    wraps to the page margin, only the first line's marker is
       //    indented.
-      const markerHasHanging =
-        indent?.hanging !== undefined && indent.hanging > 0;
-      const markerHasFirstLine =
-        indent?.firstLine !== undefined && indent.firstLine > 0;
-      let markerPos = indentLeft;
-      if (markerHasHanging) {
-        markerPos = Math.max(0, indentLeft - (indent.hanging ?? 0));
-      } else if (markerHasFirstLine) {
-        markerPos = indentLeft + (indent.firstLine ?? 0);
-      }
-      lineEl.style.paddingLeft = `${markerPos}px`;
+      // The marker occupies a `hanging`-wide slot starting `hanging` left of
+      // the body (at `indentLeft - hanging`); the body lands at `indentLeft`.
+      // The offset rides on padding-left (NOT text-indent: Chrome folds
+      // text-indent into the first inline-block's box, overriding the marker's
+      // min-width and breaking tab-stop alignment).
+      const hanging = indent?.hanging ?? 0;
+      const firstLine = indent?.firstLine ?? 0;
+      const markerStart =
+        hanging > 0 ? indentLeft - hanging : indentLeft + firstLine;
+      lineEl.style.paddingLeft = `${Math.max(0, markerStart)}px`;
       lineEl.style.textIndent = "0"; // Don't use textIndent for lists
 
       // Resolve marker font per ECMA-376 §17.9.6:
@@ -2350,6 +2349,16 @@ export function renderParagraphFragment(
         block.attrs.listMarkerRevision,
         block.attrs.listMarkerSecondSlotOffsetTwips,
       );
+      // When the hang exceeds the left indent the marker belongs in the left
+      // margin — exactly where Word puts it (a list whose direct `w:ind` has
+      // `hanging` > `left`, eigenpal #730 / #729). CSS padding can't be
+      // negative, so the negative portion rides on the marker's own margin-left.
+      // Gated to `indentLeft > 0`: with no left indent the body/continuation
+      // lines already sit at `hanging` (see body-line branch above), so hanging
+      // the marker into the margin there would misalign the first line.
+      if (markerStart < 0 && indentLeft > 0) {
+        marker.style.marginLeft = `${markerStart}px`;
+      }
       lineEl.prepend(marker);
     }
 


### PR DESCRIPTION
## Problem

A numbered list whose direct paragraph indent has `hanging` greater than `left` must hang its marker into the left margin (as Word does). Folio clamped the marker position with `Math.max(0, indentLeft - hanging)`, pinning it to the content edge so the numbers shifted right of the text above.

## Change

Computes a signed `markerStart`:

- `hanging > 0` → `indentLeft - hanging` (can be negative)
- else → `indentLeft + firstLine`

`padding-left` clamps to `≥ 0` (CSS padding can't be negative); when `markerStart < 0` the negative portion rides on the marker element's own `margin-left`. `text-indent` stays `0` (Chrome folds a negative text-indent into the marker's inline-block box and breaks its min-width slot).

Gated to `indentLeft > 0`: with no left indent the body/continuation lines already sit at `hanging`, so hanging the first-line marker into the margin there would misalign it. The `hanging <= left` and first-line-indent paths are unchanged.

## Test

`renderParagraph-list-hanging-indent.test.ts` — `hanging > left` hangs via negative margin-left (exact px), `hanging <= left` unchanged (padding, no margin), `left == 0` gated off.

## Notes

Touches `renderParagraph.ts` (the first-line list-marker block only) — disjoint from the RTL and run-shading painter PRs in this sync, so it rebases cleanly in any merge order.
