### PR TITLE
fix(folio): use modern CSS break-* instead of deprecated page-break-*

### DIFF
--- a/packages/folio/src/core/utils/formatToStyle-pagebreak.test.ts
+++ b/packages/folio/src/core/utils/formatToStyle-pagebreak.test.ts
@@ -1,0 +1,31 @@
+// paragraphToStyle must emit the modern CSS Fragmentation `break-*` properties,
+// not the deprecated `page-break-*` aliases. `page-break-before: always` maps to
+// `break-before: page`; the `avoid` values carry over unchanged.
+
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphFormatting } from "../types/document";
+import { paragraphToStyle } from "./formatToStyle";
+
+describe("paragraphToStyle — page-break properties", () => {
+  test("pageBreakBefore forces a page break via break-before", () => {
+    expect(paragraphToStyle({ pageBreakBefore: true }).breakBefore).toBe(
+      "page",
+    );
+  });
+
+  test("keepNext avoids a break after the paragraph", () => {
+    expect(paragraphToStyle({ keepNext: true }).breakAfter).toBe("avoid");
+  });
+
+  test("keepLines avoids breaking inside the paragraph", () => {
+    expect(paragraphToStyle({ keepLines: true }).breakInside).toBe("avoid");
+  });
+
+  test("no break flags emit no break properties", () => {
+    const style = paragraphToStyle({} as ParagraphFormatting);
+    expect(style.breakBefore).toBeUndefined();
+    expect(style.breakAfter).toBeUndefined();
+    expect(style.breakInside).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/utils/formatToStyle.ts
+++ b/packages/folio/src/core/utils/formatToStyle.ts
@@ -415,17 +415,20 @@ export function paragraphToStyle(
   // PAGE BREAK
   // ============================================================================
 
+  // Use the CSS Fragmentation `break-*` properties, not the deprecated
+  // `page-break-*` aliases. `page-break-before: always` maps to
+  // `break-before: page` (force a page break); `avoid` carries over unchanged.
   if (formatting.pageBreakBefore) {
-    style.pageBreakBefore = "always";
+    style.breakBefore = "page";
   }
 
   // Keep with next / keep lines together
   if (formatting.keepNext) {
-    style.pageBreakAfter = "avoid";
+    style.breakAfter = "avoid";
   }
 
   if (formatting.keepLines) {
-    style.pageBreakInside = "avoid";
+    style.breakInside = "avoid";
   }
 
   return style;


### PR DESCRIPTION
## What

`paragraphToStyle` emitted the deprecated `page-break-before` / `page-break-after` / `page-break-inside` CSS properties (deprecated in `lib.dom.d.ts` / React `CSSProperties` in favour of the CSS Fragmentation `break-*` module). Migrated to `break-before` / `break-after` / `break-inside`.

Value remap: `page-break-before: always` → `break-before: page` (force a page break); the `avoid` values for keep-with-next / keep-lines carry over unchanged.

## Why

Removes the only deprecation hints in `formatToStyle.ts`. Browsers honour the modern `break-*` properties (and still alias the legacy names), so rendering and print/PDF behaviour is unchanged.

## Test

`formatToStyle-pagebreak.test.ts`.
