### PR TITLE
feat(folio): field & TOC auto-update

### DIFF
--- a/.agents/plans/044-folio-field-toc-auto-update.md
+++ b/.agents/plans/044-folio-field-toc-auto-update.md
@@ -1,0 +1,168 @@
+# Plan: Folio Field & TOC Auto-Update
+
+Date: 2026-06-08
+
+## Goal
+
+Make folio's dynamic DOCX fields compute live values and regenerate instead of
+rendering only their parsed fallback text: cross-references and counters
+(`PAGEREF`, `REF`, `SEQ`, `SECTIONPAGES`) resolve correctly, page-number fields
+honour their format switches, and a `TOC` field generates entries with live page
+numbers. Today only `PAGE`/`NUMPAGES`/`DATE`/`TIME` resolve, and every other
+field paints stale cached text.
+
+## Background (current state, verified)
+
+- Model: `SimpleField`/`ComplexField` in `@stll/docx-core`
+  (`packages/docx-core/src/model/content.ts`) carry `instruction`, `fieldType`,
+  and cached result runs.
+- Parse: `core/docx/fieldParser.ts` already parses instructions, switches, and
+  has `computePageNumber`/`formatDate` helpers — but they are barely wired in.
+- **Identity loss**: `core/layout-bridge/toFlowBlocks.ts` collapses every field
+  to `FieldRun.fieldType` of `PAGE | NUMPAGES | DATE | TIME | OTHER`
+  (`layout-engine/types.ts:237`). Instruction, switches, and the real type are
+  dropped, so the painter cannot evaluate `SEQ`/`PAGEREF`/etc.
+- Eval today: an ad-hoc `switch` in `layout-painter/renderParagraph.ts`
+  (`renderFieldRun`) substitutes only PAGE/NUMPAGES (from
+  `RenderContext.pageNumber/totalPages`) and DATE/TIME (`new Date()`).
+- **Width skew**: measurement uses `run.fallback` width
+  (`measureParagraph.ts`), but paint uses the live value. When widths differ
+  (e.g. fallback `1`, live `12`; TOC page numbers; dot leaders) the line is
+  mismeasured. No re-layout pass corrects this.
+- TOC scaffolding exists but is static: `core/utils/headingCollector.ts`
+  (outline via `outlineLevel` + `HeadingN` styleId) and a user-invoked
+  `generateTOC` command; `HeadingInfo.pageNumber` is never filled because there
+  is no bookmark/heading -> page map.
+- No bookmark -> page map and no iterate-to-stable relayout loop exist.
+
+## Design Decisions
+
+- **Carry field identity into the layout, don't collapse it.** Widen `FieldRun`
+  to keep `instruction` + the full `fieldType` (or a pre-parsed
+  `ParsedFieldInstruction`) so a single evaluator can compute any supported
+  field. This is the enabling change; everything else builds on it. Aligns with
+  the repo rule "thread the discriminator through the full stack."
+- **One evaluator, not scattered switches.** Replace `renderFieldRun`'s inline
+  switch with `evaluateField(parsed, ctx)` in a new
+  `core/layout-engine/fields/` module (pure, React-free, unit-testable — same
+  posture as the just-extracted `measureBlocks`). The painter calls it; so does
+  the measure pass (see next point).
+- **Resolve fields against a real layout via a bounded iterate-to-stable loop.**
+  Page numbers depend on layout; layout depends on text widths which depend on
+  field values which depend on page numbers. Mirror Word: layout once with
+  best-known values, build the field-resolution context (page map, bookmark
+  map, SEQ counters), re-measure only paragraphs whose field values changed
+  width, re-layout, repeat until stable or a small cap (3) is hit. Most
+  documents converge in 1; header/footer page numbers are width-stable.
+- **Expose a bookmark/heading -> page map from pagination.** The paginator
+  already assigns `Page.number`; record, per bookmark id and per heading
+  anchor, the page it lands on. This single map powers `PAGEREF`, `REF`, and
+  TOC entries.
+- **TOC is generated as real editable doc content, built on the same
+  primitives, in one PR.** Generation needs the outline (already collected) +
+  the page map + the iterate-to-stable loop (inserting entries shifts pages).
+  TOC entries are real PM paragraphs in the document model (not a layout-only
+  synthetic block) so they match Word, round-trip to DOCX, and stay editable.
+  Shipped in the same PR as the field foundation, but built in that order
+  (foundation first, then TOC on top) so the foundation is testable before TOC
+  is layered on.
+- **Preserve round-trip.** Keep emitting `w:instrText` + `fldChar` unchanged;
+  update the cached result run text to the computed value and mark `dirty` so
+  Word re-evaluates on open. Do not regress `@stll/docx-core` serialization.
+
+## Scope
+
+One PR, built in two stages (foundation, then TOC on top).
+
+**Stage 1 — field evaluation foundation:**
+
+- Widen `FieldRun` (instruction + full type + switches) and stop the `OTHER`
+  collapse in `toFlowBlocks.ts`.
+- New `core/layout-engine/fields/evaluateField.ts` evaluator + `FieldContext`
+  (page number, total pages, section pages, bookmark map, SEQ counters, now).
+- Support: `PAGE`, `NUMPAGES`, `SECTIONPAGES` with `\*` numeric-format switches
+  (arabic/ROMAN/alphabetic); `PAGEREF`/`REF` via the bookmark->page map; `SEQ`
+  via a document-order counter pass; `DATE`/`TIME`/`CREATEDATE`/`SAVEDATE` with
+  `\@` format codes (reuse `fieldParser.formatDate`).
+- Bookmark/heading -> page map produced during pagination and exposed on
+  `Layout`.
+- Bounded iterate-to-stable relayout loop in the layout driver (cap 3, converge
+  on no width-affecting field change).
+- Painter + measure both call the evaluator (measure uses the
+  current-best-context value so widths track paint).
+- Golden test on the deterministic harness.
+
+**Stage 2 — live TOC (same PR):**
+
+- `TOC` field generation: outline (`\o "1-3"`) -> entries as **real PM
+  paragraphs** (text + right tab with dot leader + live `PAGEREF` page number),
+  regenerated through the iterate-to-stable loop and round-tripped to DOCX.
+- Make the existing `generateTOC` command emit live entries (or supersede it).
+
+**Out of scope:**
+
+- `IF`/conditional logic, `MERGEFIELD`/mail-merge, `INCLUDETEXT`/
+  `INCLUDEPICTURE`, `INDEX`/`TOA`, `STYLEREF`, nested/calculated fields.
+- User-facing "update fields" affordances beyond automatic recompute on layout.
+- Numbering-restart/legal-numbering (separate roadmap item).
+
+## Implementation
+
+- `packages/folio/src/core/layout-engine/types.ts` — widen `FieldRun`
+  (`instruction: string`, full `fieldType`, parsed switches); add a
+  `bookmarkPages` / `headingAnchors` map type on `Layout`.
+- `packages/folio/src/core/layout-bridge/toFlowBlocks.ts` — stop collapsing to
+  `OTHER`; thread instruction + type from the PM `field` node attrs into
+  `FieldRun`. Emit bookmark anchors as positioned markers the paginator can map.
+- `packages/folio/src/core/layout-engine/fields/evaluateField.ts` (new) +
+  `fieldContext.ts` — pure evaluator and context builder. Reuse
+  `core/docx/fieldParser.ts` (`parseFieldInstruction`, `computePageNumber`,
+  `formatDate`); move/share those compute helpers if cleaner.
+- `packages/folio/src/core/layout-engine/index.ts` / paginator — assign
+  bookmark/heading pages during pagination; return the map.
+- The layout driver that calls `measureBlocks` + `layoutDocument` (in
+  `paged-editor/PagedEditor.tsx`, or extracted alongside the measurement module)
+  — add the bounded re-evaluate/re-measure/re-layout loop.
+- `packages/folio/src/core/layout-painter/renderParagraph.ts` — replace
+  `renderFieldRun`'s switch with `evaluateField`.
+- `packages/folio/src/core/layout-engine/measure/measureParagraph.ts` — measure
+  the evaluated value (from current-best context) instead of raw `fallback`.
+- Stage 2: `core/utils/headingCollector.ts` + a TOC builder
+  (`core/layout-engine/fields/toc.ts`) consuming the page map; emit real PM
+  paragraphs (TOC entry styles, leader tabs, PAGEREF); wire into the
+  iterate-to-stable loop; update `ParagraphExtension` `generateTOC`.
+- Serialize: `packages/folio/src/core/docx/serializer/runSerializer.ts` /
+  `@stll/docx-core` — write computed result text into the cached run, keep
+  `instruction` + `fldChar` round-trip, set `dirty`.
+
+No DB schema, API, or auth changes (folio is client-side). No security/ethical-
+wall surface; all changes are within the editor's layout pipeline.
+
+## Test Cases
+
+- Evaluator units (pure): PAGE/NUMPAGES/SECTIONPAGES with arabic/ROMAN/alpha
+  switches; SEQ increments and `\c`/`\r` reset basics; PAGEREF/REF resolve a
+  bookmark to its page; DATE `\@` formats.
+- Golden layout (deterministic harness): a multi-page doc with PAGE/NUMPAGES in
+  a footer and a PAGEREF/SEQ in the body -> assert each field's painted value
+  and that the field's measured width matches the painted value (no skew).
+- Iterate-to-stable: a doc where the live page-number width pushes content to an
+  extra page -> loop converges and final values are self-consistent (cap not
+  exceeded).
+- Round-trip: parse -> evaluate -> serialize keeps `instruction`, updates cached
+  result, and re-parses cleanly (extend `corpusRoundtrip`/property tests).
+- Stage 2 TOC: headings at levels 1-3 -> generated TOC entries (real PM
+  paragraphs) map to the correct pages with right-aligned leaders; the entries
+  round-trip to DOCX; regeneration after an edit that shifts a heading updates
+  the page number.
+
+## Resolved Decisions
+
+- **Evaluator home**: folio-local (`core/layout-engine/fields/`); promote to
+  `@stll/docx-core` later only if a headless/server renderer needs it.
+- **Phasing**: one PR, foundation then TOC (build order, not separate PRs).
+- **TOC form**: real PM/doc content (editable, round-trips), not a layout-only
+  synthetic block.
+- **To tune during build** (not blockers): iterate-to-stable cap (start 3) and
+  the width-change threshold (start: any integer-width change re-measures just
+  that paragraph); calibrate against the corpus.

--- a/packages/folio/src/core/docx/fieldParser.ts
+++ b/packages/folio/src/core/docx/fieldParser.ts
@@ -695,52 +695,61 @@ export function formatDate(date: Date, format: string): string {
 
   const pad = (n: number) => n.toString().padStart(2, "0");
 
-  let result = format;
-
-  // Year
-  result = result.replace(/yyyy/gu, date.getFullYear().toString());
-  result = result.replace(
-    /yy/gu,
-    (date.getFullYear() % 100).toString().padStart(2, "0"),
-  );
-
-  // Month - do longer patterns first
-  // SAFETY: getMonth() returns 0-11, matching array indices
-  result = result.replace(/MMMM/gu, months[date.getMonth()]!);
-  result = result.replace(/MMM/gu, shortMonths[date.getMonth()]!);
-  result = result.replace(/MM/gu, pad(date.getMonth() + 1));
-  result = result.replace(/M/gu, (date.getMonth() + 1).toString());
-
-  // Day - do longer patterns first
-  // SAFETY: getDay() returns 0-6, matching array indices
-  result = result.replace(/dddd/gu, days[date.getDay()]!);
-  result = result.replace(/ddd/gu, shortDays[date.getDay()]!);
-  result = result.replace(/dd/gu, pad(date.getDate()));
-  result = result.replace(/d/gu, date.getDate().toString());
-
-  // Hour (12-hour)
   const hour12 = date.getHours() % 12 || 12;
-  result = result.replace(/hh/gu, pad(hour12));
-  result = result.replace(/h/gu, hour12.toString());
-
-  // Hour (24-hour)
-  result = result.replace(/HH/gu, pad(date.getHours()));
-  result = result.replace(/H/gu, date.getHours().toString());
-
-  // Minute (use lowercase m for minutes - distinguished by context)
-  // This is simplified - in OOXML, 'm' in date context is month, in time context is minute
-  result = result.replace(/mm/gu, pad(date.getMinutes()));
-
-  // Second
-  result = result.replace(/ss/gu, pad(date.getSeconds()));
-  result = result.replace(/s/gu, date.getSeconds().toString());
-
-  // AM/PM
   const ampm = date.getHours() >= 12 ? "PM" : "AM";
-  result = result.replace(/AM\/PM/gu, ampm);
-  result = result.replace(/am\/pm/gu, ampm.toLowerCase());
-
-  return result;
+  // Single-pass token replacement prevents replacement text from being
+  // interpreted as more tokens (`AM/PM` contains `M`, `Monday` contains `d`).
+  return format.replace(
+    /AM\/PM|am\/pm|yyyy|yy|MMMM|MMM|MM|M|dddd|ddd|dd|d|hh|h|HH|H|mm|m|ss|s/gu,
+    (token) => {
+      switch (token) {
+        case "yyyy":
+          return date.getFullYear().toString();
+        case "yy":
+          return (date.getFullYear() % 100).toString().padStart(2, "0");
+        // SAFETY: getMonth() returns 0-11, matching array indices.
+        case "MMMM":
+          return months[date.getMonth()]!;
+        case "MMM":
+          return shortMonths[date.getMonth()]!;
+        case "MM":
+          return pad(date.getMonth() + 1);
+        case "M":
+          return (date.getMonth() + 1).toString();
+        // SAFETY: getDay() returns 0-6, matching array indices.
+        case "dddd":
+          return days[date.getDay()]!;
+        case "ddd":
+          return shortDays[date.getDay()]!;
+        case "dd":
+          return pad(date.getDate());
+        case "d":
+          return date.getDate().toString();
+        case "hh":
+          return pad(hour12);
+        case "h":
+          return hour12.toString();
+        case "HH":
+          return pad(date.getHours());
+        case "H":
+          return date.getHours().toString();
+        case "mm":
+          return pad(date.getMinutes());
+        case "m":
+          return date.getMinutes().toString();
+        case "ss":
+          return pad(date.getSeconds());
+        case "s":
+          return date.getSeconds().toString();
+        case "AM/PM":
+          return ampm;
+        case "am/pm":
+          return ampm.toLowerCase();
+        default:
+          return token;
+      }
+    },
+  );
 }
 
 // ============================================================================

--- a/packages/folio/src/core/fields/bookmarkPages.test.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.test.ts
@@ -7,6 +7,7 @@ import type {
   ParagraphFragment,
   Page,
   TableBlock,
+  TableFragment,
   TextBoxBlock,
 } from "../layout-engine/types";
 import { buildBookmarkPageMap } from "./bookmarkPages";
@@ -29,6 +30,21 @@ const fragment = (blockId: string): ParagraphFragment => ({
   height: 20,
   fromLine: 0,
   toLine: 1,
+});
+
+const tableFragment = (
+  blockId: string,
+  fromRow: number,
+  toRow: number,
+): TableFragment => ({
+  kind: "table",
+  blockId,
+  x: 0,
+  y: 0,
+  width: 600,
+  height: 20,
+  fromRow,
+  toRow,
 });
 
 const page = (number: number, blockIds: string[]): Page => ({
@@ -80,12 +96,56 @@ describe("buildBookmarkPageMap", () => {
       content: [para("inside-box", ["in-box"])],
     };
     const blocks: FlowBlock[] = [table, textBox];
-    const pages = [page(4, ["table"]), page(5, ["box"])];
+    const pages: Page[] = [
+      {
+        number: 4,
+        fragments: [tableFragment("table", 0, 1)],
+        margins: MARGINS,
+        size: { w: 816, h: 1056 },
+      },
+      page(5, ["box"]),
+    ];
 
     const map = buildBookmarkPageMap(pages, blocks);
 
     expect(map.get("in-table")).toBe(4);
     expect(map.get("in-box")).toBe(5);
+  });
+
+  test("maps bookmarks inside split tables to the row's fragment page", () => {
+    const table: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [
+        {
+          id: "r0",
+          cells: [{ id: "c0", blocks: [para("row0", ["first-row"])] }],
+        },
+        {
+          id: "r1",
+          cells: [{ id: "c1", blocks: [para("row1", ["second-row"])] }],
+        },
+      ],
+    };
+    const pages: Page[] = [
+      {
+        number: 8,
+        fragments: [tableFragment("table", 0, 1)],
+        margins: MARGINS,
+        size: { w: 816, h: 1056 },
+      },
+      {
+        number: 9,
+        fragments: [tableFragment("table", 1, 2)],
+        margins: MARGINS,
+        size: { w: 816, h: 1056 },
+      },
+    ];
+
+    const map = buildBookmarkPageMap(pages, [table]);
+
+    expect(map.get("first-row")).toBe(8);
+    expect(map.get("second-row")).toBe(9);
   });
 
   test("returns an empty map when no block carries a bookmark", () => {

--- a/packages/folio/src/core/fields/bookmarkPages.test.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.test.ts
@@ -6,6 +6,8 @@ import type {
   ParagraphBlock,
   ParagraphFragment,
   Page,
+  TableBlock,
+  TextBoxBlock,
 } from "../layout-engine/types";
 import { buildBookmarkPageMap } from "./bookmarkPages";
 
@@ -58,6 +60,32 @@ describe("buildBookmarkPageMap", () => {
     const pages = [page(2, ["a"]), page(3, ["a"])];
 
     expect(buildBookmarkPageMap(pages, blocks).get("long")).toBe(2);
+  });
+
+  test("maps bookmarks inside tables and text boxes to their container page", () => {
+    const table: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [
+        {
+          id: "row",
+          cells: [{ id: "cell", blocks: [para("nested", ["in-table"])] }],
+        },
+      ],
+    };
+    const textBox: TextBoxBlock = {
+      kind: "textBox",
+      id: "box",
+      width: 200,
+      content: [para("inside-box", ["in-box"])],
+    };
+    const blocks: FlowBlock[] = [table, textBox];
+    const pages = [page(4, ["table"]), page(5, ["box"])];
+
+    const map = buildBookmarkPageMap(pages, blocks);
+
+    expect(map.get("in-table")).toBe(4);
+    expect(map.get("in-box")).toBe(5);
   });
 
   test("returns an empty map when no block carries a bookmark", () => {

--- a/packages/folio/src/core/fields/bookmarkPages.test.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FlowBlock,
+  PageMargins,
+  ParagraphBlock,
+  ParagraphFragment,
+  Page,
+} from "../layout-engine/types";
+import { buildBookmarkPageMap } from "./bookmarkPages";
+
+const MARGINS: PageMargins = { top: 96, right: 96, bottom: 96, left: 96 };
+
+const para = (id: string, bookmarks?: string[]): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: [],
+  ...(bookmarks ? { bookmarks } : {}),
+});
+
+const fragment = (blockId: string): ParagraphFragment => ({
+  kind: "paragraph",
+  blockId,
+  x: 0,
+  y: 0,
+  width: 600,
+  height: 20,
+  fromLine: 0,
+  toLine: 1,
+});
+
+const page = (number: number, blockIds: string[]): Page => ({
+  number,
+  fragments: blockIds.map(fragment),
+  margins: MARGINS,
+  size: { w: 816, h: 1056 },
+});
+
+describe("buildBookmarkPageMap", () => {
+  test("maps each bookmark to the page its paragraph lands on", () => {
+    const blocks: FlowBlock[] = [
+      para("a", ["intro"]),
+      para("b"),
+      para("c", ["schedule", "exhibit"]),
+    ];
+    const pages = [page(1, ["a", "b"]), page(2, ["c"])];
+
+    const map = buildBookmarkPageMap(pages, blocks);
+
+    expect(map.get("intro")).toBe(1);
+    expect(map.get("schedule")).toBe(2);
+    expect(map.get("exhibit")).toBe(2);
+    expect(map.size).toBe(3);
+  });
+
+  test("a bookmark whose paragraph splits across pages takes the first page", () => {
+    const blocks: FlowBlock[] = [para("a", ["long"])];
+    const pages = [page(2, ["a"]), page(3, ["a"])];
+
+    expect(buildBookmarkPageMap(pages, blocks).get("long")).toBe(2);
+  });
+
+  test("returns an empty map when no block carries a bookmark", () => {
+    const blocks: FlowBlock[] = [para("a"), para("b")];
+    const pages = [page(1, ["a", "b"])];
+
+    expect(buildBookmarkPageMap(pages, blocks).size).toBe(0);
+  });
+});

--- a/packages/folio/src/core/fields/bookmarkPages.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.ts
@@ -13,7 +13,11 @@ export function buildBookmarkPageMap(
 ): Map<string, number> {
   const bookmarksByBlockId = new Map<BlockId, readonly string[]>();
   for (const block of blocks) {
-    if (block.kind === "paragraph" && block.bookmarks?.length) {
+    if (
+      block.kind === "paragraph" &&
+      block.bookmarks &&
+      block.bookmarks.length > 0
+    ) {
       bookmarksByBlockId.set(block.id, block.bookmarks);
     }
   }

--- a/packages/folio/src/core/fields/bookmarkPages.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.ts
@@ -1,0 +1,41 @@
+import type { BlockId, FlowBlock, Page } from "../layout-engine/types";
+
+/**
+ * Map each bookmark name to the 1-indexed page its anchoring paragraph lands on,
+ * for PAGEREF resolution. Computed as a post-pass over a finished layout: walk
+ * pages -> fragments -> the source block's bookmarks. A bookmark whose paragraph
+ * splits across pages takes the first (lowest) page it appears on, matching how
+ * Word resolves a PAGEREF to the start of the bookmark.
+ */
+export function buildBookmarkPageMap(
+  pages: readonly Page[],
+  blocks: readonly FlowBlock[],
+): Map<string, number> {
+  const bookmarksByBlockId = new Map<BlockId, readonly string[]>();
+  for (const block of blocks) {
+    if (block.kind === "paragraph" && block.bookmarks?.length) {
+      bookmarksByBlockId.set(block.id, block.bookmarks);
+    }
+  }
+
+  const pageByBookmark = new Map<string, number>();
+  if (bookmarksByBlockId.size === 0) {
+    return pageByBookmark;
+  }
+
+  for (const page of pages) {
+    for (const fragment of page.fragments) {
+      const names = bookmarksByBlockId.get(fragment.blockId);
+      if (!names) {
+        continue;
+      }
+      for (const name of names) {
+        if (!pageByBookmark.has(name)) {
+          pageByBookmark.set(name, page.number);
+        }
+      }
+    }
+  }
+
+  return pageByBookmark;
+}

--- a/packages/folio/src/core/fields/bookmarkPages.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.ts
@@ -1,5 +1,9 @@
 import type { BlockId, FlowBlock, Page } from "../layout-engine/types";
 
+type BookmarkAnchor =
+  | { type: "block"; blockId: BlockId; names: string[] }
+  | { type: "tableRow"; blockId: BlockId; rowIndex: number; names: string[] };
+
 /**
  * Map each bookmark name to the 1-indexed page its anchoring paragraph lands on,
  * for PAGEREF resolution. Computed as a post-pass over a finished layout: walk
@@ -11,26 +15,23 @@ export function buildBookmarkPageMap(
   pages: readonly Page[],
   blocks: readonly FlowBlock[],
 ): Map<string, number> {
-  const bookmarksByBlockId = new Map<BlockId, string[]>();
+  const anchors: BookmarkAnchor[] = [];
   for (const block of blocks) {
-    collectBookmarksByTopLevelBlock(block, block.id, bookmarksByBlockId);
+    collectBookmarkAnchors(block, block.id, anchors);
   }
 
   const pageByBookmark = new Map<string, number>();
-  if (bookmarksByBlockId.size === 0) {
+  if (anchors.length === 0) {
     return pageByBookmark;
   }
 
   for (const page of pages) {
     for (const fragment of page.fragments) {
-      const names = bookmarksByBlockId.get(fragment.blockId);
-      if (!names) {
-        continue;
-      }
-      for (const name of names) {
-        if (!pageByBookmark.has(name)) {
-          pageByBookmark.set(name, page.number);
+      for (const anchor of anchors) {
+        if (!fragmentContainsAnchor(fragment, anchor)) {
+          continue;
         }
+        assignBookmarkPage(pageByBookmark, anchor.names, page.number);
       }
     }
   }
@@ -38,33 +39,32 @@ export function buildBookmarkPageMap(
   return pageByBookmark;
 }
 
-function collectBookmarksByTopLevelBlock(
+function collectBookmarkAnchors(
   block: FlowBlock,
   topLevelId: BlockId,
-  bookmarksByBlockId: Map<BlockId, string[]>,
+  anchors: BookmarkAnchor[],
 ): void {
   if (block.kind === "paragraph") {
     if (!block.bookmarks || block.bookmarks.length === 0) {
       return;
     }
-    let names = bookmarksByBlockId.get(topLevelId);
-    if (!names) {
-      names = [];
-      bookmarksByBlockId.set(topLevelId, names);
-    }
-    names.push(...block.bookmarks);
+    anchors.push({
+      type: "block",
+      blockId: topLevelId,
+      names: [...block.bookmarks],
+    });
     return;
   }
 
   if (block.kind === "table") {
-    for (const row of block.rows) {
+    for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
+      const row = block.rows[rowIndex];
+      if (!row) {
+        continue;
+      }
       for (const cell of row.cells) {
         for (const child of cell.blocks) {
-          collectBookmarksByTopLevelBlock(
-            child,
-            topLevelId,
-            bookmarksByBlockId,
-          );
+          collectTableRowBookmarkAnchors(child, block.id, rowIndex, anchors);
         }
       }
     }
@@ -73,7 +73,73 @@ function collectBookmarksByTopLevelBlock(
 
   if (block.kind === "textBox") {
     for (const child of block.content) {
-      collectBookmarksByTopLevelBlock(child, topLevelId, bookmarksByBlockId);
+      collectBookmarkAnchors(child, topLevelId, anchors);
+    }
+  }
+}
+
+function collectTableRowBookmarkAnchors(
+  block: FlowBlock,
+  tableId: BlockId,
+  rowIndex: number,
+  anchors: BookmarkAnchor[],
+): void {
+  if (block.kind === "paragraph") {
+    if (!block.bookmarks || block.bookmarks.length === 0) {
+      return;
+    }
+    anchors.push({
+      type: "tableRow",
+      blockId: tableId,
+      rowIndex,
+      names: [...block.bookmarks],
+    });
+    return;
+  }
+
+  if (block.kind === "table") {
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        for (const child of cell.blocks) {
+          collectTableRowBookmarkAnchors(child, tableId, rowIndex, anchors);
+        }
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "textBox") {
+    for (const child of block.content) {
+      collectTableRowBookmarkAnchors(child, tableId, rowIndex, anchors);
+    }
+  }
+}
+
+function fragmentContainsAnchor(
+  fragment: Page["fragments"][number],
+  anchor: BookmarkAnchor,
+): boolean {
+  if (fragment.blockId !== anchor.blockId) {
+    return false;
+  }
+  if (anchor.type === "block") {
+    return true;
+  }
+  return (
+    fragment.kind === "table" &&
+    anchor.rowIndex >= fragment.fromRow &&
+    anchor.rowIndex < fragment.toRow
+  );
+}
+
+function assignBookmarkPage(
+  pageByBookmark: Map<string, number>,
+  names: readonly string[],
+  pageNumber: number,
+): void {
+  for (const name of names) {
+    if (!pageByBookmark.has(name)) {
+      pageByBookmark.set(name, pageNumber);
     }
   }
 }

--- a/packages/folio/src/core/fields/bookmarkPages.ts
+++ b/packages/folio/src/core/fields/bookmarkPages.ts
@@ -11,15 +11,9 @@ export function buildBookmarkPageMap(
   pages: readonly Page[],
   blocks: readonly FlowBlock[],
 ): Map<string, number> {
-  const bookmarksByBlockId = new Map<BlockId, readonly string[]>();
+  const bookmarksByBlockId = new Map<BlockId, string[]>();
   for (const block of blocks) {
-    if (
-      block.kind === "paragraph" &&
-      block.bookmarks &&
-      block.bookmarks.length > 0
-    ) {
-      bookmarksByBlockId.set(block.id, block.bookmarks);
-    }
+    collectBookmarksByTopLevelBlock(block, block.id, bookmarksByBlockId);
   }
 
   const pageByBookmark = new Map<string, number>();
@@ -42,4 +36,44 @@ export function buildBookmarkPageMap(
   }
 
   return pageByBookmark;
+}
+
+function collectBookmarksByTopLevelBlock(
+  block: FlowBlock,
+  topLevelId: BlockId,
+  bookmarksByBlockId: Map<BlockId, string[]>,
+): void {
+  if (block.kind === "paragraph") {
+    if (!block.bookmarks || block.bookmarks.length === 0) {
+      return;
+    }
+    let names = bookmarksByBlockId.get(topLevelId);
+    if (!names) {
+      names = [];
+      bookmarksByBlockId.set(topLevelId, names);
+    }
+    names.push(...block.bookmarks);
+    return;
+  }
+
+  if (block.kind === "table") {
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        for (const child of cell.blocks) {
+          collectBookmarksByTopLevelBlock(
+            child,
+            topLevelId,
+            bookmarksByBlockId,
+          );
+        }
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "textBox") {
+    for (const child of block.content) {
+      collectBookmarksByTopLevelBlock(child, topLevelId, bookmarksByBlockId);
+    }
+  }
 }

--- a/packages/folio/src/core/fields/bookmarkText.test.ts
+++ b/packages/folio/src/core/fields/bookmarkText.test.ts
@@ -51,6 +51,29 @@ describe("buildBookmarkText", () => {
     expect(buildBookmarkText(blocks).get("_Ref1")).toBe("Figure : Caption");
   });
 
+  test("includes visible list markers in paragraph text", () => {
+    const blocks: FlowBlock[] = [
+      {
+        ...para("h", [text("Definitions")], ["_Heading"]),
+        attrs: { listMarker: "1." },
+      },
+      {
+        ...para("hidden", [text("Hidden marker")], ["_Hidden"]),
+        attrs: { listMarker: "2.", listMarkerHidden: true },
+      },
+      {
+        ...para("tight", [text("No space")], ["_Tight"]),
+        attrs: { listMarker: "3.", listMarkerSuffix: "nothing" },
+      },
+    ];
+
+    const map = buildBookmarkText(blocks);
+
+    expect(map.get("_Heading")).toBe("1. Definitions");
+    expect(map.get("_Hidden")).toBe("Hidden marker");
+    expect(map.get("_Tight")).toBe("3.No space");
+  });
+
   test("maps bookmarks inside text boxes", () => {
     const textBox: TextBoxBlock = {
       kind: "textBox",

--- a/packages/folio/src/core/fields/bookmarkText.test.ts
+++ b/packages/folio/src/core/fields/bookmarkText.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FieldRun,
+  FlowBlock,
+  ParagraphBlock,
+  TextRun,
+} from "../layout-engine/types";
+import { buildBookmarkText } from "./bookmarkText";
+
+const text = (value: string): TextRun => ({ kind: "text", text: value });
+
+const para = (
+  id: string,
+  runs: (TextRun | FieldRun)[],
+  bookmarks?: string[],
+): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs,
+  ...(bookmarks ? { bookmarks } : {}),
+});
+
+describe("buildBookmarkText", () => {
+  test("maps each bookmark to its paragraph's trimmed text", () => {
+    const blocks: FlowBlock[] = [
+      para("h1", [text("  Section 1. Definitions  ")], ["_Ref1"]),
+      para("body", [text("ignored")]),
+      para("h2", [text("Schedule A")], ["_Ref2", "_Alt"]),
+    ];
+
+    const map = buildBookmarkText(blocks);
+
+    expect(map.get("_Ref1")).toBe("Section 1. Definitions");
+    expect(map.get("_Ref2")).toBe("Schedule A");
+    expect(map.get("_Alt")).toBe("Schedule A");
+    expect(map.size).toBe(3);
+  });
+
+  test("concatenates only text runs, skipping fields and the like", () => {
+    const field: FieldRun = {
+      kind: "field",
+      fieldType: "OTHER",
+      instruction: "SEQ Figure",
+    };
+    const blocks: FlowBlock[] = [
+      para("h", [text("Figure "), field, text(": Caption")], ["_Ref1"]),
+    ];
+
+    expect(buildBookmarkText(blocks).get("_Ref1")).toBe("Figure : Caption");
+  });
+
+  test("returns empty when no paragraph carries a bookmark", () => {
+    const blocks: FlowBlock[] = [para("a", [text("x")])];
+    expect(buildBookmarkText(blocks).size).toBe(0);
+  });
+});

--- a/packages/folio/src/core/fields/bookmarkText.test.ts
+++ b/packages/folio/src/core/fields/bookmarkText.test.ts
@@ -4,6 +4,7 @@ import type {
   FieldRun,
   FlowBlock,
   ParagraphBlock,
+  TextBoxBlock,
   TextRun,
 } from "../layout-engine/types";
 import { buildBookmarkText } from "./bookmarkText";
@@ -48,6 +49,17 @@ describe("buildBookmarkText", () => {
     ];
 
     expect(buildBookmarkText(blocks).get("_Ref1")).toBe("Figure : Caption");
+  });
+
+  test("maps bookmarks inside text boxes", () => {
+    const textBox: TextBoxBlock = {
+      kind: "textBox",
+      id: "box",
+      width: 240,
+      content: [para("inside", [text("Inside shape")], ["_ShapeRef"])],
+    };
+
+    expect(buildBookmarkText([textBox]).get("_ShapeRef")).toBe("Inside shape");
   });
 
   test("returns empty when no paragraph carries a bookmark", () => {

--- a/packages/folio/src/core/fields/bookmarkText.test.ts
+++ b/packages/folio/src/core/fields/bookmarkText.test.ts
@@ -38,17 +38,18 @@ describe("buildBookmarkText", () => {
     expect(map.size).toBe(3);
   });
 
-  test("concatenates only text runs, skipping fields and the like", () => {
+  test("includes cached field results in paragraph text", () => {
     const field: FieldRun = {
       kind: "field",
       fieldType: "OTHER",
       instruction: "SEQ Figure",
+      fallback: "1",
     };
     const blocks: FlowBlock[] = [
       para("h", [text("Figure "), field, text(": Caption")], ["_Ref1"]),
     ];
 
-    expect(buildBookmarkText(blocks).get("_Ref1")).toBe("Figure : Caption");
+    expect(buildBookmarkText(blocks).get("_Ref1")).toBe("Figure 1: Caption");
   });
 
   test("includes visible list markers in paragraph text", () => {

--- a/packages/folio/src/core/fields/bookmarkText.test.ts
+++ b/packages/folio/src/core/fields/bookmarkText.test.ts
@@ -52,6 +52,29 @@ describe("buildBookmarkText", () => {
     expect(buildBookmarkText(blocks).get("_Ref1")).toBe("Figure 1: Caption");
   });
 
+  test("includes live field results in paragraph text", () => {
+    const field: FieldRun = {
+      kind: "field",
+      fieldType: "OTHER",
+      instruction: "SEQ Figure \\* ROMAN",
+      fallback: "I",
+      pmStart: 12,
+    };
+    const blocks: FlowBlock[] = [
+      para("h", [text("Figure "), field, text(": Caption")], ["_Ref1"]),
+    ];
+
+    expect(
+      buildBookmarkText(blocks, { seqValues: new Map([[12, 4]]) }).get("_Ref1"),
+    ).toBe("Figure IV: Caption");
+    expect(
+      buildBookmarkText(blocks, {
+        fieldValues: new Map([[12, "V"]]),
+        seqValues: new Map([[12, 4]]),
+      }).get("_Ref1"),
+    ).toBe("Figure V: Caption");
+  });
+
   test("includes visible list markers in paragraph text", () => {
     const blocks: FlowBlock[] = [
       {

--- a/packages/folio/src/core/fields/bookmarkText.ts
+++ b/packages/folio/src/core/fields/bookmarkText.ts
@@ -48,5 +48,19 @@ function paragraphText(block: ParagraphBlock): string {
       text += run.text;
     }
   }
-  return text.trim();
+  return `${visibleListMarker(block)}${text}`.trim();
+}
+
+function visibleListMarker(block: ParagraphBlock): string {
+  const marker = block.attrs?.listMarker;
+  if (!marker || block.attrs?.listMarkerHidden) {
+    return "";
+  }
+  const normalized = marker.replace(/\t+/gu, " ").trim();
+  if (!normalized) {
+    return "";
+  }
+  return block.attrs?.listMarkerSuffix === "nothing"
+    ? normalized
+    : `${normalized} `;
 }

--- a/packages/folio/src/core/fields/bookmarkText.ts
+++ b/packages/folio/src/core/fields/bookmarkText.ts
@@ -1,4 +1,16 @@
+import { parseFieldInstruction } from "../docx/fieldParser";
 import type { FlowBlock, ParagraphBlock } from "../layout-engine/types";
+import { evaluateField } from "./evaluateField";
+import type { FieldContext } from "./fieldContext";
+
+type BookmarkTextInputs = {
+  fieldValues?: ReadonlyMap<number, string>;
+  seqValues?: ReadonlyMap<number, number>;
+};
+
+const EMPTY_STRING_NUMBER: ReadonlyMap<string, number> = new Map();
+const EMPTY_STRING_STRING: ReadonlyMap<string, string> = new Map();
+const EMPTY_NUMBER_NUMBER: ReadonlyMap<number, number> = new Map();
 
 /**
  * Map each bookmark name to the text of its anchoring paragraph, for REF
@@ -8,22 +20,24 @@ import type { FlowBlock, ParagraphBlock } from "../layout-engine/types";
  */
 export function buildBookmarkText(
   blocks: readonly FlowBlock[],
+  inputs: BookmarkTextInputs = {},
 ): Map<string, string> {
   const map = new Map<string, string>();
-  walkBlocks(blocks, map);
+  walkBlocks(blocks, map, inputs);
   return map;
 }
 
 function walkBlocks(
   blocks: readonly FlowBlock[],
   map: Map<string, string>,
+  inputs: BookmarkTextInputs,
 ): void {
   for (const block of blocks) {
     if (block.kind === "paragraph") {
       if (!block.bookmarks || block.bookmarks.length === 0) {
         continue;
       }
-      const text = paragraphText(block);
+      const text = paragraphText(block, inputs);
       for (const name of block.bookmarks) {
         if (!map.has(name)) {
           map.set(name, text);
@@ -32,25 +46,65 @@ function walkBlocks(
     } else if (block.kind === "table") {
       for (const row of block.rows) {
         for (const cell of row.cells) {
-          walkBlocks(cell.blocks, map);
+          walkBlocks(cell.blocks, map, inputs);
         }
       }
     } else if (block.kind === "textBox") {
-      walkBlocks(block.content, map);
+      walkBlocks(block.content, map, inputs);
     }
   }
 }
 
-function paragraphText(block: ParagraphBlock): string {
+function paragraphText(
+  block: ParagraphBlock,
+  inputs: BookmarkTextInputs,
+): string {
   let text = "";
   for (const run of block.runs) {
     if (run.kind === "text") {
       text += run.text;
     } else if (run.kind === "field") {
-      text += run.fallback ?? "";
+      text += bookmarkFieldText(run, inputs);
     }
   }
   return `${visibleListMarker(block)}${text}`.trim();
+}
+
+function bookmarkFieldText(
+  run: ParagraphBlock["runs"][number],
+  inputs: BookmarkTextInputs,
+): string {
+  if (run.kind !== "field") {
+    return "";
+  }
+  const resolved =
+    run.pmStart === undefined
+      ? undefined
+      : inputs.fieldValues?.get(run.pmStart);
+  if (resolved !== undefined) {
+    return resolved;
+  }
+  if (run.pmStart === undefined || !inputs.seqValues?.has(run.pmStart)) {
+    return run.fallback ?? "";
+  }
+  const parsed = parseFieldInstruction(run.instruction || run.fieldType);
+  if (parsed.type !== "SEQ") {
+    return run.fallback ?? "";
+  }
+  const context: FieldContext = {
+    pageNumber: 1,
+    totalPages: 1,
+    sectionPages: 1,
+    bookmarkPages: EMPTY_STRING_NUMBER,
+    bookmarkText: EMPTY_STRING_STRING,
+    seqValues: inputs.seqValues ?? EMPTY_NUMBER_NUMBER,
+    now: new Date(0),
+  };
+  return evaluateField(parsed, context, {
+    fallback: run.fallback ?? "",
+    instanceId: run.pmStart,
+    ...(run.fldLock ? { locked: true } : {}),
+  });
 }
 
 function visibleListMarker(block: ParagraphBlock): string {

--- a/packages/folio/src/core/fields/bookmarkText.ts
+++ b/packages/folio/src/core/fields/bookmarkText.ts
@@ -1,0 +1,50 @@
+import type { FlowBlock, ParagraphBlock } from "../layout-engine/types";
+
+/**
+ * Map each bookmark name to the text of its anchoring paragraph, for REF
+ * cross-references (e.g. "see Section 1.3"). Folio anchors bookmarks at the
+ * paragraph level, so a REF resolves to that paragraph's visible text. Document
+ * order, independent of layout. First paragraph carrying a name wins.
+ */
+export function buildBookmarkText(
+  blocks: readonly FlowBlock[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  walkBlocks(blocks, map);
+  return map;
+}
+
+function walkBlocks(
+  blocks: readonly FlowBlock[],
+  map: Map<string, string>,
+): void {
+  for (const block of blocks) {
+    if (block.kind === "paragraph") {
+      if (!block.bookmarks || block.bookmarks.length === 0) {
+        continue;
+      }
+      const text = paragraphText(block);
+      for (const name of block.bookmarks) {
+        if (!map.has(name)) {
+          map.set(name, text);
+        }
+      }
+    } else if (block.kind === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          walkBlocks(cell.blocks, map);
+        }
+      }
+    }
+  }
+}
+
+function paragraphText(block: ParagraphBlock): string {
+  let text = "";
+  for (const run of block.runs) {
+    if (run.kind === "text") {
+      text += run.text;
+    }
+  }
+  return text.trim();
+}

--- a/packages/folio/src/core/fields/bookmarkText.ts
+++ b/packages/folio/src/core/fields/bookmarkText.ts
@@ -46,6 +46,8 @@ function paragraphText(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       text += run.text;
+    } else if (run.kind === "field") {
+      text += run.fallback ?? "";
     }
   }
   return `${visibleListMarker(block)}${text}`.trim();

--- a/packages/folio/src/core/fields/bookmarkText.ts
+++ b/packages/folio/src/core/fields/bookmarkText.ts
@@ -35,6 +35,8 @@ function walkBlocks(
           walkBlocks(cell.blocks, map);
         }
       }
+    } else if (block.kind === "textBox") {
+      walkBlocks(block.content, map);
     }
   }
 }

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -92,6 +92,14 @@ describe("evaluateField dates and unsupported types", () => {
     expect(evalInstr('DATE \\@ "yyyy-MM-dd"', ctx)).toBe("2026-06-08");
   });
 
+  test("DATE/TIME pictures do not re-tokenize formatted literals", () => {
+    const ctx = baseContext();
+    expect(evalInstr('TIME \\@ "h:mm AM/PM"', ctx)).toBe("2:30 PM");
+    expect(evalInstr('DATE \\@ "dddd, MMMM d, yyyy"', ctx)).toBe(
+      "Monday, June 8, 2026",
+    );
+  });
+
   test("DATE \\* MERGEFORMAT (no date picture) uses the locale date, not the switch", () => {
     const ctx = baseContext();
     // \* is a general format switch, not a date picture: must fall back to the

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -34,6 +34,16 @@ describe("evaluateField page-number family", () => {
     expect(evalInstr("SECTIONPAGES", ctx)).toBe("5");
   });
 
+  test("locked fields preserve their cached fallback", () => {
+    const ctx = baseContext();
+    expect(
+      evaluateField(parseFieldInstruction("PAGEREF _Ref1"), ctx, {
+        fallback: "cached",
+        locked: true,
+      }),
+    ).toBe("cached");
+  });
+
   test("numeric format switches apply", () => {
     const ctx = baseContext();
     expect(evalInstr("PAGE \\* ROMAN", ctx)).toBe("III");

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseFieldInstruction } from "../docx/fieldParser";
+import { evaluateField, evaluateFieldInstruction } from "./evaluateField";
+import type { FieldContext } from "./fieldContext";
+
+const baseContext = (overrides: Partial<FieldContext> = {}): FieldContext => ({
+  pageNumber: 3,
+  totalPages: 12,
+  sectionPages: 5,
+  bookmarkPages: new Map(),
+  bookmarkText: new Map(),
+  seqValues: new Map(),
+  // Fixed clock so DATE/TIME assertions are deterministic.
+  now: new Date(2026, 5, 8, 14, 30, 0), // 2026-06-08 14:30
+  ...overrides,
+});
+
+const evalInstr = (
+  instruction: string,
+  ctx: FieldContext,
+  instanceId?: number,
+) =>
+  evaluateField(parseFieldInstruction(instruction), ctx, {
+    fallback: "FB",
+    ...(instanceId === undefined ? {} : { instanceId }),
+  });
+
+describe("evaluateField page-number family", () => {
+  test("PAGE / NUMPAGES / SECTIONPAGES read their context counts", () => {
+    const ctx = baseContext();
+    expect(evalInstr("PAGE", ctx)).toBe("3");
+    expect(evalInstr("NUMPAGES", ctx)).toBe("12");
+    expect(evalInstr("SECTIONPAGES", ctx)).toBe("5");
+  });
+
+  test("numeric format switches apply", () => {
+    const ctx = baseContext();
+    expect(evalInstr("PAGE \\* ROMAN", ctx)).toBe("III");
+    expect(evalInstr("PAGE \\* ALPHABETIC", ctx)).toBe("C");
+    expect(evalInstr("NUMPAGES \\* MERGEFORMAT", ctx)).toBe("12");
+  });
+});
+
+describe("evaluateField references", () => {
+  test("PAGEREF resolves a bookmark to its page, formatted", () => {
+    const ctx = baseContext({ bookmarkPages: new Map([["_Ref1", 7]]) });
+    expect(evalInstr("PAGEREF _Ref1 \\h", ctx)).toBe("7");
+    expect(evalInstr("PAGEREF _Ref1 \\* ROMAN", ctx)).toBe("VII");
+  });
+
+  test("REF resolves a bookmark to its text", () => {
+    const ctx = baseContext({
+      bookmarkText: new Map([["_Ref1", "Schedule A"]]),
+    });
+    expect(evalInstr("REF _Ref1", ctx)).toBe("Schedule A");
+  });
+
+  test("unresolved references fall back", () => {
+    const ctx = baseContext();
+    expect(evalInstr("PAGEREF _Missing \\h", ctx)).toBe("FB");
+    expect(evalInstr("REF _Missing", ctx)).toBe("FB");
+  });
+});
+
+describe("evaluateField SEQ", () => {
+  test("looks up the precomputed value by instance id and formats it", () => {
+    const ctx = baseContext({ seqValues: new Map([[42, 4]]) });
+    expect(evalInstr("SEQ Figure", ctx, 42)).toBe("4");
+    expect(evalInstr("SEQ Figure \\* ROMAN", ctx, 42)).toBe("IV");
+  });
+
+  test("falls back when no precomputed value exists for the instance", () => {
+    const ctx = baseContext();
+    expect(evalInstr("SEQ Figure", ctx, 99)).toBe("FB");
+  });
+});
+
+describe("evaluateField dates and unsupported types", () => {
+  test("DATE honours the \\@ format switch against the context clock", () => {
+    const ctx = baseContext();
+    expect(evalInstr('DATE \\@ "yyyy-MM-dd"', ctx)).toBe("2026-06-08");
+  });
+
+  test("unsupported field types return the fallback", () => {
+    const ctx = baseContext();
+    expect(evalInstr("MERGEFIELD client_name", ctx)).toBe("FB");
+    expect(evalInstr('TOC \\o "1-3"', ctx)).toBe("FB");
+  });
+
+  test("evaluateFieldInstruction parses then evaluates", () => {
+    const ctx = baseContext();
+    expect(evaluateFieldInstruction("PAGE", ctx)).toBe("3");
+  });
+});

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -94,6 +94,11 @@ describe("evaluateField SEQ", () => {
     expect(evalInstr("SEQ Figure \\* ROMAN", ctx, 42)).toBe("IV");
   });
 
+  test("hidden SEQ fields preserve the cached result", () => {
+    const ctx = baseContext({ seqValues: new Map([[42, 4]]) });
+    expect(evalInstr("SEQ Figure \\h", ctx, 42)).toBe("FB");
+  });
+
   test("falls back when no precomputed value exists for the instance", () => {
     const ctx = baseContext();
     expect(evalInstr("SEQ Figure", ctx, 99)).toBe("FB");

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -82,6 +82,15 @@ describe("evaluateField dates and unsupported types", () => {
     expect(evalInstr('DATE \\@ "yyyy-MM-dd"', ctx)).toBe("2026-06-08");
   });
 
+  test("DATE \\* MERGEFORMAT (no date picture) uses the locale date, not the switch", () => {
+    const ctx = baseContext();
+    // \* is a general format switch, not a date picture: must fall back to the
+    // locale date instead of formatting the literal "MERGEFORMAT".
+    expect(evalInstr("DATE \\* MERGEFORMAT", ctx)).toBe(
+      ctx.now.toLocaleDateString(),
+    );
+  });
+
   test("unsupported field types return the fallback", () => {
     const ctx = baseContext();
     expect(evalInstr("MERGEFIELD client_name", ctx)).toBe("FB");

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -59,6 +59,11 @@ describe("evaluateField references", () => {
     expect(evalInstr("PAGEREF _Ref1 \\* ROMAN", ctx)).toBe("VII");
   });
 
+  test("PAGEREF position switches preserve the cached result", () => {
+    const ctx = baseContext({ bookmarkPages: new Map([["_Ref1", 7]]) });
+    expect(evalInstr("PAGEREF _Ref1 \\p", ctx)).toBe("FB");
+  });
+
   test("REF resolves a bookmark to its text", () => {
     const ctx = baseContext({
       bookmarkText: new Map([["_Ref1", "Schedule A"]]),

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -62,6 +62,7 @@ describe("evaluateField references", () => {
   test("PAGEREF position switches preserve the cached result", () => {
     const ctx = baseContext({ bookmarkPages: new Map([["_Ref1", 7]]) });
     expect(evalInstr("PAGEREF _Ref1 \\p", ctx)).toBe("FB");
+    expect(evalInstr("PAGEREF _Ref1 \\h \\p", ctx)).toBe("FB");
   });
 
   test("REF resolves a bookmark to its text", () => {

--- a/packages/folio/src/core/fields/evaluateField.test.ts
+++ b/packages/folio/src/core/fields/evaluateField.test.ts
@@ -66,6 +66,15 @@ describe("evaluateField references", () => {
     expect(evalInstr("REF _Ref1", ctx)).toBe("Schedule A");
   });
 
+  test("REF numbering switches preserve the cached result", () => {
+    const ctx = baseContext({
+      bookmarkText: new Map([["_Ref1", "1.2 Definitions"]]),
+    });
+    expect(evalInstr("REF _Ref1 \\r", ctx)).toBe("FB");
+    expect(evalInstr("REF _Ref1 \\n", ctx)).toBe("FB");
+    expect(evalInstr("REF _Ref1 \\w", ctx)).toBe("FB");
+  });
+
   test("unresolved references fall back", () => {
     const ctx = baseContext();
     expect(evalInstr("PAGEREF _Missing \\h", ctx)).toBe("FB");
@@ -107,6 +116,13 @@ describe("evaluateField dates and unsupported types", () => {
     expect(evalInstr("DATE \\* MERGEFORMAT", ctx)).toBe(
       ctx.now.toLocaleDateString(),
     );
+  });
+
+  test("document metadata date fields preserve cached fallback values", () => {
+    const ctx = baseContext();
+    expect(evalInstr('CREATEDATE \\@ "yyyy-MM-dd"', ctx)).toBe("FB");
+    expect(evalInstr('SAVEDATE \\@ "yyyy-MM-dd"', ctx)).toBe("FB");
+    expect(evalInstr('PRINTDATE \\@ "yyyy-MM-dd"', ctx)).toBe("FB");
   });
 
   test("unsupported field types return the fallback", () => {

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -17,6 +17,8 @@ type EvaluateFieldOptions = {
   fallback?: string;
   /** Run identity (`pmStart`) used to look up a precomputed SEQ value. */
   instanceId?: number;
+  /** Locked fields preserve their cached result instead of recalculating. */
+  locked?: boolean;
 };
 
 /**
@@ -33,6 +35,9 @@ export function evaluateField(
   options: EvaluateFieldOptions = {},
 ): string {
   const fallback = options.fallback ?? "";
+  if (options.locked) {
+    return fallback;
+  }
 
   switch (parsed.type) {
     case "PAGE":

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -35,10 +35,18 @@ export function evaluateField(
     case "NUMPAGES":
       return computePageNumber(ctx.totalPages, parsed);
     case "SECTIONPAGES":
-      return computePageNumber(ctx.sectionPages, parsed);
+      return ctx.sectionPages === undefined
+        ? fallback
+        : computePageNumber(ctx.sectionPages, parsed);
+
+    case "TIME": {
+      const format = getFormatSwitch(parsed);
+      return format
+        ? formatDate(ctx.now, format)
+        : ctx.now.toLocaleTimeString();
+    }
 
     case "DATE":
-    case "TIME":
     case "CREATEDATE":
     case "SAVEDATE":
     case "PRINTDATE": {

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -19,6 +19,10 @@ function hasRefNumberingSwitch(parsed: ParsedFieldInstruction): boolean {
   });
 }
 
+function hasPageRefPositionSwitch(parsed: ParsedFieldInstruction): boolean {
+  return parsed.switches.some((s) => s.switch.toLowerCase() === "p");
+}
+
 type EvaluateFieldOptions = {
   /** Shown for unsupported field types and unresolved references. */
   fallback?: string;
@@ -76,6 +80,9 @@ export function evaluateField(
       return fallback;
 
     case "PAGEREF": {
+      if (hasPageRefPositionSwitch(parsed)) {
+        return fallback;
+      }
       const page = parsed.argument
         ? ctx.bookmarkPages.get(parsed.argument)
         : undefined;

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -12,6 +12,13 @@ function dateFormatSwitch(parsed: ParsedFieldInstruction): string | undefined {
   return parsed.switches.find((s) => s.switch === "@")?.value;
 }
 
+function hasRefNumberingSwitch(parsed: ParsedFieldInstruction): boolean {
+  return parsed.switches.some((s) => {
+    const name = s.switch.toLowerCase();
+    return name === "n" || name === "r" || name === "w";
+  });
+}
+
 type EvaluateFieldOptions = {
   /** Shown for unsupported field types and unresolved references. */
   fallback?: string;
@@ -56,15 +63,17 @@ export function evaluateField(
         : ctx.now.toLocaleTimeString();
     }
 
-    case "DATE":
-    case "CREATEDATE":
-    case "SAVEDATE":
-    case "PRINTDATE": {
+    case "DATE": {
       const format = dateFormatSwitch(parsed);
       return format
         ? formatDate(ctx.now, format)
         : ctx.now.toLocaleDateString();
     }
+
+    case "CREATEDATE":
+    case "SAVEDATE":
+    case "PRINTDATE":
+      return fallback;
 
     case "PAGEREF": {
       const page = parsed.argument
@@ -74,6 +83,9 @@ export function evaluateField(
     }
 
     case "REF": {
+      if (hasRefNumberingSwitch(parsed)) {
+        return fallback;
+      }
       const text = parsed.argument
         ? ctx.bookmarkText.get(parsed.argument)
         : undefined;

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -1,11 +1,16 @@
 import {
   computePageNumber,
   formatDate,
-  getFormatSwitch,
   parseFieldInstruction,
 } from "../docx/fieldParser";
 import type { ParsedFieldInstruction } from "../docx/fieldParser";
 import type { FieldContext } from "./fieldContext";
+
+/** The `\@` date picture, or undefined. Unlike the general format switch, this
+ *  must NOT match `\*` (e.g. `\* MERGEFORMAT`), which is not a date format. */
+function dateFormatSwitch(parsed: ParsedFieldInstruction): string | undefined {
+  return parsed.switches.find((s) => s.switch === "@")?.value;
+}
 
 type EvaluateFieldOptions = {
   /** Shown for unsupported field types and unresolved references. */
@@ -40,7 +45,7 @@ export function evaluateField(
         : computePageNumber(ctx.sectionPages, parsed);
 
     case "TIME": {
-      const format = getFormatSwitch(parsed);
+      const format = dateFormatSwitch(parsed);
       return format
         ? formatDate(ctx.now, format)
         : ctx.now.toLocaleTimeString();
@@ -50,7 +55,7 @@ export function evaluateField(
     case "CREATEDATE":
     case "SAVEDATE":
     case "PRINTDATE": {
-      const format = getFormatSwitch(parsed);
+      const format = dateFormatSwitch(parsed);
       return format
         ? formatDate(ctx.now, format)
         : ctx.now.toLocaleDateString();

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -23,6 +23,10 @@ function hasPageRefPositionSwitch(parsed: ParsedFieldInstruction): boolean {
   return parsed.switches.some((s) => s.switch.toLowerCase() === "p");
 }
 
+function hasSeqHiddenSwitch(parsed: ParsedFieldInstruction): boolean {
+  return parsed.switches.some((s) => s.switch.toLowerCase() === "h");
+}
+
 type EvaluateFieldOptions = {
   /** Shown for unsupported field types and unresolved references. */
   fallback?: string;
@@ -100,6 +104,9 @@ export function evaluateField(
     }
 
     case "SEQ": {
+      if (hasSeqHiddenSwitch(parsed)) {
+        return fallback;
+      }
       const value =
         options.instanceId === undefined
           ? undefined

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -13,18 +13,31 @@ function dateFormatSwitch(parsed: ParsedFieldInstruction): string | undefined {
 }
 
 function hasRefNumberingSwitch(parsed: ParsedFieldInstruction): boolean {
-  return parsed.switches.some((s) => {
-    const name = s.switch.toLowerCase();
-    return name === "n" || name === "r" || name === "w";
-  });
+  return hasAnySwitch(parsed, ["n", "r", "w"]);
 }
 
 function hasPageRefPositionSwitch(parsed: ParsedFieldInstruction): boolean {
-  return parsed.switches.some((s) => s.switch.toLowerCase() === "p");
+  return hasAnySwitch(parsed, ["p"]);
 }
 
 function hasSeqHiddenSwitch(parsed: ParsedFieldInstruction): boolean {
-  return parsed.switches.some((s) => s.switch.toLowerCase() === "h");
+  return hasAnySwitch(parsed, ["h"]);
+}
+
+function hasAnySwitch(
+  parsed: ParsedFieldInstruction,
+  names: readonly string[],
+): boolean {
+  return names.some((name) => hasSwitch(parsed, name));
+}
+
+function hasSwitch(parsed: ParsedFieldInstruction, name: string): boolean {
+  const normalized = name.toLowerCase();
+  if (parsed.switches.some((s) => s.switch.toLowerCase() === normalized)) {
+    return true;
+  }
+  const pattern = new RegExp(`\\\\${normalized}\\b`, "iu");
+  return pattern.test(parsed.raw);
 }
 
 type EvaluateFieldOptions = {

--- a/packages/folio/src/core/fields/evaluateField.ts
+++ b/packages/folio/src/core/fields/evaluateField.ts
@@ -1,0 +1,86 @@
+import {
+  computePageNumber,
+  formatDate,
+  getFormatSwitch,
+  parseFieldInstruction,
+} from "../docx/fieldParser";
+import type { ParsedFieldInstruction } from "../docx/fieldParser";
+import type { FieldContext } from "./fieldContext";
+
+type EvaluateFieldOptions = {
+  /** Shown for unsupported field types and unresolved references. */
+  fallback?: string;
+  /** Run identity (`pmStart`) used to look up a precomputed SEQ value. */
+  instanceId?: number;
+};
+
+/**
+ * Evaluate a parsed field instruction to its display string for `ctx`.
+ *
+ * Returns `options.fallback` (default empty) for field types this engine does
+ * not compute and for references that do not resolve in the current layout, so
+ * an unsupported or dangling field keeps its last-known cached text rather than
+ * vanishing. Pure: all position-dependent inputs come from `ctx`.
+ */
+export function evaluateField(
+  parsed: ParsedFieldInstruction,
+  ctx: FieldContext,
+  options: EvaluateFieldOptions = {},
+): string {
+  const fallback = options.fallback ?? "";
+
+  switch (parsed.type) {
+    case "PAGE":
+      return computePageNumber(ctx.pageNumber, parsed);
+    case "NUMPAGES":
+      return computePageNumber(ctx.totalPages, parsed);
+    case "SECTIONPAGES":
+      return computePageNumber(ctx.sectionPages, parsed);
+
+    case "DATE":
+    case "TIME":
+    case "CREATEDATE":
+    case "SAVEDATE":
+    case "PRINTDATE": {
+      const format = getFormatSwitch(parsed);
+      return format
+        ? formatDate(ctx.now, format)
+        : ctx.now.toLocaleDateString();
+    }
+
+    case "PAGEREF": {
+      const page = parsed.argument
+        ? ctx.bookmarkPages.get(parsed.argument)
+        : undefined;
+      return page === undefined ? fallback : computePageNumber(page, parsed);
+    }
+
+    case "REF": {
+      const text = parsed.argument
+        ? ctx.bookmarkText.get(parsed.argument)
+        : undefined;
+      return text ?? fallback;
+    }
+
+    case "SEQ": {
+      const value =
+        options.instanceId === undefined
+          ? undefined
+          : ctx.seqValues.get(options.instanceId);
+      return value === undefined ? fallback : computePageNumber(value, parsed);
+    }
+
+    default:
+      return fallback;
+  }
+}
+
+/** Parse `instruction` then evaluate it; convenience for callers holding the
+ *  raw instruction string rather than a pre-parsed instruction. */
+export function evaluateFieldInstruction(
+  instruction: string,
+  ctx: FieldContext,
+  options: EvaluateFieldOptions = {},
+): string {
+  return evaluateField(parseFieldInstruction(instruction), ctx, options);
+}

--- a/packages/folio/src/core/fields/fieldContext.ts
+++ b/packages/folio/src/core/fields/fieldContext.ts
@@ -10,8 +10,9 @@ export type FieldContext = {
   pageNumber: number;
   /** Total pages in the document (NUMPAGES). */
   totalPages: number;
-  /** Pages in the field's current section (SECTIONPAGES). */
-  sectionPages: number;
+  /** Pages in the field's current section (SECTIONPAGES); omit until the
+   *  per-section page counts are available, in which case the field falls back. */
+  sectionPages?: number;
   /** Bookmark name -> 1-indexed page it lands on (PAGEREF). */
   bookmarkPages: ReadonlyMap<string, number>;
   /** Bookmark name -> resolved display text (REF). */

--- a/packages/folio/src/core/fields/fieldContext.ts
+++ b/packages/folio/src/core/fields/fieldContext.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolution context for evaluating dynamic DOCX fields against a laid-out
+ * document. Built once per layout pass (see the field-resolution pass) and
+ * consumed by {@link evaluateField}. All position-dependent values
+ * (page numbers, bookmark pages, SEQ counters) are resolved against the current
+ * layout so a field paints the same value its width was measured against.
+ */
+export type FieldContext = {
+  /** 1-indexed page the field is on (PAGE). */
+  pageNumber: number;
+  /** Total pages in the document (NUMPAGES). */
+  totalPages: number;
+  /** Pages in the field's current section (SECTIONPAGES). */
+  sectionPages: number;
+  /** Bookmark name -> 1-indexed page it lands on (PAGEREF). */
+  bookmarkPages: ReadonlyMap<string, number>;
+  /** Bookmark name -> resolved display text (REF). */
+  bookmarkText: ReadonlyMap<string, string>;
+  /** Field instance id (the run's `pmStart`) -> precomputed SEQ value. */
+  seqValues: ReadonlyMap<number, number>;
+  /** Clock for DATE/TIME-family fields; passed in so evaluation stays pure. */
+  now: Date;
+};

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -267,4 +267,23 @@ describe("buildHeaderFooterFieldValues", () => {
     expect(values.get(10)).toBe("VIII");
     expect(values.get(20)).toBe("9");
   });
+
+  test("measures SECTIONPAGES against section page counts", () => {
+    const blocks: FlowBlock[] = [
+      para("p", [
+        field(10, "SECTIONPAGES"),
+        field(20, "SECTIONPAGES \\* ROMAN"),
+      ]),
+    ];
+
+    const values = buildHeaderFooterFieldValues(blocks, 9, now, {
+      sectionPageCounts: new Map([
+        [0, 1],
+        [1, 8],
+      ]),
+    });
+
+    expect(values.get(10)).toBe("8");
+    expect(values.get(20)).toBe("VIII");
+  });
 });

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -8,7 +8,10 @@ import type {
   ParagraphFragment,
   Page,
 } from "../layout-engine/types";
-import { resolveFieldValues } from "./resolveFieldValues";
+import {
+  buildHeaderFooterFieldValues,
+  resolveFieldValues,
+} from "./resolveFieldValues";
 import type { SharedFieldInputs } from "./resolveFieldValues";
 
 const MARGINS: PageMargins = { top: 96, right: 96, bottom: 96, left: 96 };
@@ -118,5 +121,37 @@ describe("resolveFieldValues", () => {
       shared(),
     );
     expect(stable.changed).toBe(false);
+  });
+});
+
+describe("buildHeaderFooterFieldValues", () => {
+  const now = new Date(2026, 0, 1);
+
+  test("reserves page-number fields at the widest page width", () => {
+    const blocks: FlowBlock[] = [
+      para("p", [
+        field(10, "PAGE"),
+        field(20, "NUMPAGES"),
+        field(30, "SECTIONPAGES"),
+      ]),
+    ];
+
+    const values = buildHeaderFooterFieldValues(blocks, 42, now);
+
+    // All three reserve the largest page count's width.
+    expect(values.get(10)).toBe("42");
+    expect(values.get(20)).toBe("42");
+    expect(values.get(30)).toBe("42");
+  });
+
+  test("applies format switches and ignores non-page-number fields", () => {
+    const blocks: FlowBlock[] = [
+      para("p", [field(10, "PAGE \\* ROMAN"), field(20, "PAGEREF _x \\h")]),
+    ];
+
+    const values = buildHeaderFooterFieldValues(blocks, 4, now);
+
+    expect(values.get(10)).toBe("IV"); // roman of the widest page
+    expect(values.has(20)).toBe(false); // PAGEREF resolves per-page at paint
   });
 });

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -7,6 +7,8 @@ import type {
   ParagraphBlock,
   ParagraphFragment,
   Page,
+  TableBlock,
+  TableFragment,
 } from "../layout-engine/types";
 import {
   buildHeaderFooterFieldValues,
@@ -39,6 +41,21 @@ const fragment = (blockId: string): ParagraphFragment => ({
   height: 20,
   fromLine: 0,
   toLine: 1,
+});
+
+const tableFragment = (
+  blockId: string,
+  fromRow: number,
+  toRow: number,
+): TableFragment => ({
+  kind: "table",
+  blockId,
+  x: 0,
+  y: 0,
+  width: 600,
+  height: 20,
+  fromRow,
+  toRow,
 });
 
 const page = (number: number, blockIds: string[]): Page => ({
@@ -90,6 +107,56 @@ describe("resolveFieldValues", () => {
 
     expect(values.get(10)).toBe("7");
     expect(values.get(20)).toBe("3");
+  });
+
+  test("evaluates fields inside split tables for their row page", () => {
+    const table: TableBlock = {
+      kind: "table",
+      id: "table",
+      rows: [
+        {
+          id: "r0",
+          cells: [{ id: "c0", blocks: [para("row0", [field(10, "PAGE")])] }],
+        },
+        {
+          id: "r1",
+          cells: [
+            {
+              id: "c1",
+              blocks: [
+                para("row1", [field(20, "PAGE"), field(30, "SECTIONPAGES")]),
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const pages: Page[] = [
+      {
+        number: 9,
+        fragments: [tableFragment("table", 0, 1)],
+        margins: MARGINS,
+        size: { w: 816, h: 1056 },
+        sectionIndex: 0,
+      },
+      {
+        number: 10,
+        fragments: [tableFragment("table", 1, 2)],
+        margins: MARGINS,
+        size: { w: 816, h: 1056 },
+        sectionIndex: 1,
+      },
+    ];
+
+    const { values } = resolveFieldValues(
+      [table],
+      pages,
+      shared({ sectionPageCounts: new Map([[1, 7]]) }),
+    );
+
+    expect(values.get(10)).toBe("9");
+    expect(values.get(20)).toBe("10");
+    expect(values.get(30)).toBe("7");
   });
 
   test("a field with no fragment for its block falls back to page 1", () => {

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -251,9 +251,20 @@ describe("buildHeaderFooterFieldValues", () => {
       seqValues: new Map([[40, 3]]),
     });
 
-    expect(values.get(10)).toBe("IV"); // roman of the widest page
+    expect(values.get(10)).toBe("IV");
     expect(values.get(20)).toBe("12");
     expect(values.get(30)).toBe("Figure 2: Caption");
     expect(values.get(40)).toBe("3");
+  });
+
+  test("reserves formatted PAGE fields at a wider display value", () => {
+    const blocks: FlowBlock[] = [
+      para("p", [field(10, "PAGE \\* ROMAN"), field(20, "PAGE")]),
+    ];
+
+    const values = buildHeaderFooterFieldValues(blocks, 9, now);
+
+    expect(values.get(10)).toBe("VIII");
+    expect(values.get(20)).toBe("9");
   });
 });

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FieldRun,
+  FlowBlock,
+  PageMargins,
+  ParagraphBlock,
+  ParagraphFragment,
+  Page,
+} from "../layout-engine/types";
+import { resolveFieldValues } from "./resolveFieldValues";
+import type { SharedFieldInputs } from "./resolveFieldValues";
+
+const MARGINS: PageMargins = { top: 96, right: 96, bottom: 96, left: 96 };
+
+const field = (pmStart: number, instruction: string): FieldRun => ({
+  kind: "field",
+  fieldType: "OTHER",
+  instruction,
+  pmStart,
+  fallback: "?",
+});
+
+const para = (id: string, fields: FieldRun[]): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: fields,
+});
+
+const fragment = (blockId: string): ParagraphFragment => ({
+  kind: "paragraph",
+  blockId,
+  x: 0,
+  y: 0,
+  width: 600,
+  height: 20,
+  fromLine: 0,
+  toLine: 1,
+});
+
+const page = (number: number, blockIds: string[]): Page => ({
+  number,
+  fragments: blockIds.map(fragment),
+  margins: MARGINS,
+  size: { w: 816, h: 1056 },
+});
+
+const shared = (over: Partial<SharedFieldInputs> = {}): SharedFieldInputs => ({
+  totalPages: 4,
+  bookmarkPages: new Map(),
+  bookmarkText: new Map(),
+  seqValues: new Map(),
+  sectionPageCounts: new Map(),
+  now: new Date(2026, 0, 1),
+  ...over,
+});
+
+describe("resolveFieldValues", () => {
+  test("evaluates each field for the page its block lands on", () => {
+    const blocks: FlowBlock[] = [
+      para("a", [field(10, "PAGE")]),
+      para("b", [field(20, "PAGE"), field(30, "NUMPAGES")]),
+    ];
+    const pages = [page(1, ["a"]), page(3, ["b"])];
+
+    const { values } = resolveFieldValues(blocks, pages, shared());
+
+    expect(values.get(10)).toBe("1"); // block a on page 1
+    expect(values.get(20)).toBe("3"); // block b on page 3
+    expect(values.get(30)).toBe("4"); // NUMPAGES = totalPages
+  });
+
+  test("resolves PAGEREF and SEQ from the shared inputs", () => {
+    const blocks: FlowBlock[] = [
+      para("a", [field(10, "PAGEREF _Ref1 \\h"), field(20, "SEQ Figure")]),
+    ];
+    const pages = [page(1, ["a"])];
+
+    const { values } = resolveFieldValues(
+      blocks,
+      pages,
+      shared({
+        bookmarkPages: new Map([["_Ref1", 7]]),
+        seqValues: new Map([[20, 3]]),
+      }),
+    );
+
+    expect(values.get(10)).toBe("7");
+    expect(values.get(20)).toBe("3");
+  });
+
+  test("a field with no fragment for its block falls back to page 1", () => {
+    const blocks: FlowBlock[] = [para("orphan", [field(10, "PAGE")])];
+    const { values } = resolveFieldValues(blocks, [], shared());
+    expect(values.get(10)).toBe("1");
+  });
+
+  test("changed flags whether a resolved value differs from its fallback", () => {
+    // fallback "?" (from the helper) != resolved page -> changed.
+    const onPage2 = resolveFieldValues(
+      [para("a", [field(10, "PAGE")])],
+      [page(2, ["a"])],
+      shared(),
+    );
+    expect(onPage2.changed).toBe(true);
+
+    // A field whose fallback already equals the resolved value -> unchanged.
+    const matching: FieldRun = {
+      kind: "field",
+      fieldType: "OTHER",
+      instruction: "PAGE",
+      pmStart: 10,
+      fallback: "2",
+    };
+    const stable = resolveFieldValues(
+      [para("a", [matching])],
+      [page(2, ["a"])],
+      shared(),
+    );
+    expect(stable.changed).toBe(false);
+  });
+});

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -235,14 +235,25 @@ describe("buildHeaderFooterFieldValues", () => {
     expect(values.get(30)).toBe("42");
   });
 
-  test("applies format switches and ignores non-page-number fields", () => {
+  test("measures resolvable header/footer fields with shared inputs", () => {
     const blocks: FlowBlock[] = [
-      para("p", [field(10, "PAGE \\* ROMAN"), field(20, "PAGEREF _x \\h")]),
+      para("p", [
+        field(10, "PAGE \\* ROMAN"),
+        field(20, "PAGEREF _x \\h"),
+        field(30, "REF _caption"),
+        field(40, "SEQ Figure"),
+      ]),
     ];
 
-    const values = buildHeaderFooterFieldValues(blocks, 4, now);
+    const values = buildHeaderFooterFieldValues(blocks, 4, now, {
+      bookmarkPages: new Map([["_x", 12]]),
+      bookmarkText: new Map([["_caption", "Figure 2: Caption"]]),
+      seqValues: new Map([[40, 3]]),
+    });
 
     expect(values.get(10)).toBe("IV"); // roman of the widest page
-    expect(values.has(20)).toBe(false); // PAGEREF resolves per-page at paint
+    expect(values.get(20)).toBe("12");
+    expect(values.get(30)).toBe("Figure 2: Caption");
+    expect(values.get(40)).toBe("3");
   });
 });

--- a/packages/folio/src/core/fields/resolveFieldValues.test.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.test.ts
@@ -109,6 +109,30 @@ describe("resolveFieldValues", () => {
     expect(values.get(20)).toBe("3");
   });
 
+  test("preserves locked field fallback values", () => {
+    const lockedPage: FieldRun = {
+      ...field(10, "PAGE"),
+      fallback: "cached page",
+      fldLock: true,
+    };
+    const lockedReference: FieldRun = {
+      ...field(20, "PAGEREF _Ref1 \\h"),
+      fallback: "cached ref",
+      fldLock: true,
+    };
+    const blocks: FlowBlock[] = [para("a", [lockedPage, lockedReference])];
+    const pages = [page(3, ["a"])];
+
+    const { values } = resolveFieldValues(
+      blocks,
+      pages,
+      shared({ bookmarkPages: new Map([["_Ref1", 9]]) }),
+    );
+
+    expect(values.get(10)).toBe("cached page");
+    expect(values.get(20)).toBe("cached ref");
+  });
+
   test("evaluates fields inside split tables for their row page", () => {
     const table: TableBlock = {
       kind: "table",

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -20,6 +20,9 @@ export type SharedFieldInputs = {
 };
 
 type BlockLocation = { page: number; sectionIndex: number };
+type FieldAnchor =
+  | { type: "block"; blockId: BlockId; run: FieldRun }
+  | { type: "tableRow"; blockId: BlockId; rowIndex: number; run: FieldRun };
 
 export type ResolvedFieldValues = {
   /** Field run `pmStart` -> resolved display text. */
@@ -45,39 +48,40 @@ export function resolveFieldValues(
   shared: SharedFieldInputs,
 ): ResolvedFieldValues {
   const blockPage = buildBlockPageMap(pages);
+  const tableRowPage = buildTableRowPageMap(pages);
+  const fields: FieldAnchor[] = [];
+  for (const block of blocks) {
+    collectFieldAnchors(block, block.id, fields);
+  }
   const values = new Map<number, string>();
   let changed = false;
 
-  for (const block of blocks) {
-    const location = blockPage.get(block.id);
-    const fields: FieldRun[] = [];
-    collectFieldRuns(block, fields);
-
-    for (const run of fields) {
-      if (run.pmStart === undefined) {
-        continue;
-      }
-      const sectionPages = location
-        ? shared.sectionPageCounts.get(location.sectionIndex)
-        : undefined;
-      const context: FieldContext = {
-        pageNumber: location?.page ?? 1,
-        totalPages: shared.totalPages,
-        bookmarkPages: shared.bookmarkPages,
-        bookmarkText: shared.bookmarkText,
-        seqValues: shared.seqValues,
-        now: shared.now,
-        ...(sectionPages === undefined ? {} : { sectionPages }),
-      };
-      const value = evaluateField(
-        parseFieldInstruction(run.instruction || run.fieldType),
-        context,
-        { fallback: run.fallback ?? "", instanceId: run.pmStart },
-      );
-      values.set(run.pmStart, value);
-      if (value !== (run.fallback || "1")) {
-        changed = true;
-      }
+  for (const field of fields) {
+    const run = field.run;
+    if (run.pmStart === undefined) {
+      continue;
+    }
+    const location = resolveAnchorLocation(field, blockPage, tableRowPage);
+    const sectionPages = location
+      ? shared.sectionPageCounts.get(location.sectionIndex)
+      : undefined;
+    const context: FieldContext = {
+      pageNumber: location?.page ?? 1,
+      totalPages: shared.totalPages,
+      bookmarkPages: shared.bookmarkPages,
+      bookmarkText: shared.bookmarkText,
+      seqValues: shared.seqValues,
+      now: shared.now,
+      ...(sectionPages === undefined ? {} : { sectionPages }),
+    };
+    const value = evaluateField(
+      parseFieldInstruction(run.instruction || run.fieldType),
+      context,
+      { fallback: run.fallback ?? "", instanceId: run.pmStart },
+    );
+    values.set(run.pmStart, value);
+    if (value !== (run.fallback || "1")) {
+      changed = true;
     }
   }
 
@@ -174,6 +178,120 @@ function buildBlockPageMap(
     }
   }
   return map;
+}
+
+function buildTableRowPageMap(
+  pages: readonly Page[],
+): Map<string, BlockLocation> {
+  const map = new Map<string, BlockLocation>();
+  for (const page of pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== "table") {
+        continue;
+      }
+      for (
+        let rowIndex = fragment.fromRow;
+        rowIndex < fragment.toRow;
+        rowIndex++
+      ) {
+        const key = tableRowKey(fragment.blockId, rowIndex);
+        if (!map.has(key)) {
+          map.set(key, {
+            page: page.number,
+            sectionIndex: page.sectionIndex ?? 0,
+          });
+        }
+      }
+    }
+  }
+  return map;
+}
+
+function tableRowKey(blockId: BlockId, rowIndex: number): string {
+  return `${blockId}:${rowIndex}`;
+}
+
+function resolveAnchorLocation(
+  field: FieldAnchor,
+  blockPage: ReadonlyMap<BlockId, BlockLocation>,
+  tableRowPage: ReadonlyMap<string, BlockLocation>,
+): BlockLocation | undefined {
+  if (field.type === "block") {
+    return blockPage.get(field.blockId);
+  }
+  return (
+    tableRowPage.get(tableRowKey(field.blockId, field.rowIndex)) ??
+    blockPage.get(field.blockId)
+  );
+}
+
+function collectFieldAnchors(
+  block: FlowBlock,
+  topLevelId: BlockId,
+  out: FieldAnchor[],
+): void {
+  if (block.kind === "paragraph") {
+    for (const run of block.runs) {
+      if (run.kind === "field") {
+        out.push({ type: "block", blockId: topLevelId, run });
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "table") {
+    for (let rowIndex = 0; rowIndex < block.rows.length; rowIndex++) {
+      const row = block.rows[rowIndex];
+      if (!row) {
+        continue;
+      }
+      for (const cell of row.cells) {
+        for (const child of cell.blocks) {
+          collectTableRowFieldAnchors(child, block.id, rowIndex, out);
+        }
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "textBox") {
+    for (const child of block.content) {
+      collectFieldAnchors(child, topLevelId, out);
+    }
+  }
+}
+
+function collectTableRowFieldAnchors(
+  block: FlowBlock,
+  tableId: BlockId,
+  rowIndex: number,
+  out: FieldAnchor[],
+): void {
+  if (block.kind === "paragraph") {
+    for (const run of block.runs) {
+      if (run.kind === "field") {
+        out.push({ type: "tableRow", blockId: tableId, rowIndex, run });
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "table") {
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        for (const child of cell.blocks) {
+          collectTableRowFieldAnchors(child, tableId, rowIndex, out);
+        }
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "textBox") {
+    for (const child of block.content) {
+      collectTableRowFieldAnchors(child, tableId, rowIndex, out);
+    }
+  }
 }
 
 function collectFieldRuns(block: FlowBlock, out: FieldRun[]): void {

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -26,7 +26,7 @@ export type SharedFieldInputs = {
 
 export type HeaderFooterFieldInputs = Pick<
   SharedFieldInputs,
-  "bookmarkPages" | "bookmarkText" | "seqValues"
+  "bookmarkPages" | "bookmarkText" | "seqValues" | "sectionPageCounts"
 >;
 
 type BlockLocation = { page: number; sectionIndex: number };
@@ -144,13 +144,21 @@ export function buildHeaderFooterFieldValues(
       continue;
     }
     const parsed = parseFieldInstruction(run.instruction || run.fieldType);
-    const fieldContext =
-      parsed.type === "PAGE"
+    const fieldContext: FieldContext = {
+      ...context,
+      ...(parsed.type === "PAGE"
+        ? { pageNumber: widestFormattedPageNumber(parsed, pageCount) }
+        : {}),
+      ...(parsed.type === "SECTIONPAGES"
         ? {
-            ...context,
-            pageNumber: widestFormattedPageNumber(parsed, pageCount),
+            sectionPages: widestSectionPageCount(
+              parsed,
+              pageCount,
+              inputs?.sectionPageCounts,
+            ),
           }
-        : context;
+        : {}),
+    };
     values.set(
       run.pmStart,
       evaluateField(parsed, fieldContext, {
@@ -163,19 +171,41 @@ export function buildHeaderFooterFieldValues(
   return values;
 }
 
+function widestSectionPageCount(
+  parsed: ParsedFieldInstruction,
+  fallbackPageCount: number,
+  sectionPageCounts: ReadonlyMap<number, number> | undefined,
+): number {
+  if (!sectionPageCounts || sectionPageCounts.size === 0) {
+    return fallbackPageCount;
+  }
+  return widestFormattedCount(parsed, Array.from(sectionPageCounts.values()));
+}
+
 function widestFormattedPageNumber(
   parsed: ParsedFieldInstruction,
   pageCount: number,
 ): number {
+  return widestFormattedCount(
+    parsed,
+    Array.from({ length: pageCount }, (_, index) => index + 1),
+  );
+}
+
+function widestFormattedCount(
+  parsed: ParsedFieldInstruction,
+  counts: readonly number[],
+): number {
   const format = getFormatSwitch(parsed)?.toUpperCase();
   if (format !== "ROMAN" && format !== "ALPHABETIC") {
-    return pageCount;
+    return Math.max(...counts, 1);
   }
 
-  let widestPage = 1;
-  let widestWidth = formattedPageWidthScore(computePageNumber(1, parsed));
+  const first = counts.at(0) ?? 1;
+  let widestPage = first;
+  let widestWidth = formattedPageWidthScore(computePageNumber(first, parsed));
 
-  for (let page = 2; page <= pageCount; page++) {
+  for (const page of counts.slice(1)) {
     const width = formattedPageWidthScore(computePageNumber(page, parsed));
     if (width > widestWidth) {
       widestPage = page;

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -1,4 +1,9 @@
-import { parseFieldInstruction } from "../docx/fieldParser";
+import {
+  computePageNumber,
+  getFormatSwitch,
+  parseFieldInstruction,
+} from "../docx/fieldParser";
+import type { ParsedFieldInstruction } from "../docx/fieldParser";
 import type {
   BlockId,
   FieldRun,
@@ -139,9 +144,16 @@ export function buildHeaderFooterFieldValues(
       continue;
     }
     const parsed = parseFieldInstruction(run.instruction || run.fieldType);
+    const fieldContext =
+      parsed.type === "PAGE"
+        ? {
+            ...context,
+            pageNumber: widestFormattedPageNumber(parsed, pageCount),
+          }
+        : context;
     values.set(
       run.pmStart,
-      evaluateField(parsed, context, {
+      evaluateField(parsed, fieldContext, {
         fallback: run.fallback ?? "",
         instanceId: run.pmStart,
         ...(run.fldLock ? { locked: true } : {}),
@@ -150,6 +162,50 @@ export function buildHeaderFooterFieldValues(
   }
   return values;
 }
+
+function widestFormattedPageNumber(
+  parsed: ParsedFieldInstruction,
+  pageCount: number,
+): number {
+  const format = getFormatSwitch(parsed)?.toUpperCase();
+  if (format !== "ROMAN" && format !== "ALPHABETIC") {
+    return pageCount;
+  }
+
+  let widestPage = 1;
+  let widestWidth = formattedPageWidthScore(computePageNumber(1, parsed));
+
+  for (let page = 2; page <= pageCount; page++) {
+    const width = formattedPageWidthScore(computePageNumber(page, parsed));
+    if (width > widestWidth) {
+      widestPage = page;
+      widestWidth = width;
+    }
+  }
+
+  return widestPage;
+}
+
+function formattedPageWidthScore(value: string): number {
+  let score = 0;
+  for (const char of value) {
+    score += PAGE_WIDTH_SCORE[char] ?? 3;
+  }
+  return score;
+}
+
+// Header/footer field resolution also runs in non-DOM tests; keep this a small
+// deterministic score instead of using canvas-backed text measurement here.
+const PAGE_WIDTH_SCORE: Readonly<Record<string, number>> = {
+  I: 1,
+  L: 3,
+  V: 4,
+  X: 4,
+  C: 5,
+  D: 5,
+  M: 5,
+  W: 5,
+};
 
 /** Whether two resolved-value maps are identical, for loop convergence. */
 export function fieldValuesEqual(

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -77,7 +77,11 @@ export function resolveFieldValues(
     const value = evaluateField(
       parseFieldInstruction(run.instruction || run.fieldType),
       context,
-      { fallback: run.fallback ?? "", instanceId: run.pmStart },
+      {
+        fallback: run.fallback ?? "",
+        instanceId: run.pmStart,
+        ...(run.fldLock ? { locked: true } : {}),
+      },
     );
     values.set(run.pmStart, value);
     if (value !== (run.fallback || "1")) {
@@ -139,6 +143,7 @@ export function buildHeaderFooterFieldValues(
         evaluateField(parsed, context, {
           fallback: run.fallback ?? "",
           instanceId: run.pmStart,
+          ...(run.fldLock ? { locked: true } : {}),
         }),
       );
     }

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -70,7 +70,7 @@ export function resolveFieldValues(
         ...(sectionPages === undefined ? {} : { sectionPages }),
       };
       const value = evaluateField(
-        parseFieldInstruction(run.instruction ?? run.fieldType),
+        parseFieldInstruction(run.instruction || run.fieldType),
         context,
         { fallback: run.fallback ?? "", instanceId: run.pmStart },
       );

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -19,6 +19,11 @@ export type SharedFieldInputs = {
   now: Date;
 };
 
+export type HeaderFooterFieldInputs = Pick<
+  SharedFieldInputs,
+  "bookmarkPages" | "bookmarkText" | "seqValues"
+>;
+
 type BlockLocation = { page: number; sectionIndex: number };
 type FieldAnchor =
   | { type: "block"; blockId: BlockId; run: FieldRun }
@@ -109,6 +114,7 @@ export function buildHeaderFooterFieldValues(
   blocks: readonly FlowBlock[],
   pageCount: number,
   now: Date,
+  inputs?: Partial<HeaderFooterFieldInputs>,
 ): Map<number, string> {
   const values = new Map<number, string>();
   const fields: FieldRun[] = [];
@@ -123,9 +129,9 @@ export function buildHeaderFooterFieldValues(
     pageNumber: pageCount,
     totalPages: pageCount,
     sectionPages: pageCount,
-    bookmarkPages: EMPTY_STRING_NUMBER,
-    bookmarkText: EMPTY_STRING_STRING,
-    seqValues: EMPTY_NUMBER_NUMBER,
+    bookmarkPages: inputs?.bookmarkPages ?? EMPTY_STRING_NUMBER,
+    bookmarkText: inputs?.bookmarkText ?? EMPTY_STRING_STRING,
+    seqValues: inputs?.seqValues ?? EMPTY_NUMBER_NUMBER,
     now,
   };
   for (const run of fields) {
@@ -133,20 +139,14 @@ export function buildHeaderFooterFieldValues(
       continue;
     }
     const parsed = parseFieldInstruction(run.instruction || run.fieldType);
-    if (
-      parsed.type === "PAGE" ||
-      parsed.type === "NUMPAGES" ||
-      parsed.type === "SECTIONPAGES"
-    ) {
-      values.set(
-        run.pmStart,
-        evaluateField(parsed, context, {
-          fallback: run.fallback ?? "",
-          instanceId: run.pmStart,
-          ...(run.fldLock ? { locked: true } : {}),
-        }),
-      );
-    }
+    values.set(
+      run.pmStart,
+      evaluateField(parsed, context, {
+        fallback: run.fallback ?? "",
+        instanceId: run.pmStart,
+        ...(run.fldLock ? { locked: true } : {}),
+      }),
+    );
   }
   return values;
 }

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -1,0 +1,145 @@
+import { parseFieldInstruction } from "../docx/fieldParser";
+import type {
+  BlockId,
+  FieldRun,
+  FlowBlock,
+  Page,
+} from "../layout-engine/types";
+import { evaluateField } from "./evaluateField";
+import type { FieldContext } from "./fieldContext";
+
+/** Layout-derived inputs shared by every field, regardless of its position. */
+export type SharedFieldInputs = {
+  totalPages: number;
+  bookmarkPages: ReadonlyMap<string, number>;
+  bookmarkText: ReadonlyMap<string, string>;
+  seqValues: ReadonlyMap<number, number>;
+  /** Section index -> page count, for SECTIONPAGES. */
+  sectionPageCounts: ReadonlyMap<number, number>;
+  now: Date;
+};
+
+type BlockLocation = { page: number; sectionIndex: number };
+
+export type ResolvedFieldValues = {
+  /** Field run `pmStart` -> resolved display text. */
+  values: Map<number, string>;
+  /**
+   * True when at least one field resolved to a string that differs from the
+   * text it was measured at (`fallback || "1"`), i.e. a re-measure would change
+   * line widths. The driver uses this to skip re-layout when nothing moved.
+   */
+  changed: boolean;
+};
+
+/**
+ * Resolve every field run to its display value against a finished layout, keyed
+ * by the run's `pmStart`. Each field is evaluated for the page its top-level
+ * block lands on (fields inside a table/text box take that container's page).
+ * Feed `values` back into `measureBlocks({ fieldValues })` so fields measure at
+ * their painted width.
+ */
+export function resolveFieldValues(
+  blocks: readonly FlowBlock[],
+  pages: readonly Page[],
+  shared: SharedFieldInputs,
+): ResolvedFieldValues {
+  const blockPage = buildBlockPageMap(pages);
+  const values = new Map<number, string>();
+  let changed = false;
+
+  for (const block of blocks) {
+    const location = blockPage.get(block.id);
+    const fields: FieldRun[] = [];
+    collectFieldRuns(block, fields);
+
+    for (const run of fields) {
+      if (run.pmStart === undefined) {
+        continue;
+      }
+      const sectionPages = location
+        ? shared.sectionPageCounts.get(location.sectionIndex)
+        : undefined;
+      const context: FieldContext = {
+        pageNumber: location?.page ?? 1,
+        totalPages: shared.totalPages,
+        bookmarkPages: shared.bookmarkPages,
+        bookmarkText: shared.bookmarkText,
+        seqValues: shared.seqValues,
+        now: shared.now,
+        ...(sectionPages === undefined ? {} : { sectionPages }),
+      };
+      const value = evaluateField(
+        parseFieldInstruction(run.instruction ?? run.fieldType),
+        context,
+        { fallback: run.fallback ?? "", instanceId: run.pmStart },
+      );
+      values.set(run.pmStart, value);
+      if (value !== (run.fallback || "1")) {
+        changed = true;
+      }
+    }
+  }
+
+  return { values, changed };
+}
+
+/** Whether two resolved-value maps are identical, for loop convergence. */
+export function fieldValuesEqual(
+  a: ReadonlyMap<number, string>,
+  b: ReadonlyMap<number, string>,
+): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const [key, value] of a) {
+    if (b.get(key) !== value) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** First page (and its section) each top-level block lands on. */
+function buildBlockPageMap(
+  pages: readonly Page[],
+): Map<BlockId, BlockLocation> {
+  const map = new Map<BlockId, BlockLocation>();
+  for (const page of pages) {
+    for (const fragment of page.fragments) {
+      if (!map.has(fragment.blockId)) {
+        map.set(fragment.blockId, {
+          page: page.number,
+          sectionIndex: page.sectionIndex ?? 0,
+        });
+      }
+    }
+  }
+  return map;
+}
+
+function collectFieldRuns(block: FlowBlock, out: FieldRun[]): void {
+  if (block.kind === "paragraph") {
+    for (const run of block.runs) {
+      if (run.kind === "field") {
+        out.push(run);
+      }
+    }
+  } else if (block.kind === "table") {
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        for (const cellBlock of cell.blocks) {
+          collectFieldRuns(cellBlock, out);
+        }
+      }
+    }
+  } else if (block.kind === "textBox") {
+    for (const paragraph of block.content) {
+      for (const run of paragraph.runs) {
+        if (run.kind === "field") {
+          out.push(run);
+        }
+      }
+    }
+  }
+}

--- a/packages/folio/src/core/fields/resolveFieldValues.ts
+++ b/packages/folio/src/core/fields/resolveFieldValues.ts
@@ -84,6 +84,64 @@ export function resolveFieldValues(
   return { values, changed };
 }
 
+const EMPTY_STRING_NUMBER: ReadonlyMap<string, number> = new Map();
+const EMPTY_STRING_STRING: ReadonlyMap<string, string> = new Map();
+const EMPTY_NUMBER_NUMBER: ReadonlyMap<number, number> = new Map();
+
+/**
+ * Field values for measuring header/footer blocks, which are laid out once but
+ * painted on every page with a different page number. Page-number fields
+ * (PAGE/NUMPAGES/SECTIONPAGES) are reserved at the width of the largest page
+ * (`pageCount`) so a multi-digit number on a later page can't wrap differently
+ * than the single layout; other fields keep their fallback (resolved per-page at
+ * paint). `pageCount` is the document's page count — a prior render's count is a
+ * fine estimate, since headers are measured before the body is re-laid-out.
+ */
+export function buildHeaderFooterFieldValues(
+  blocks: readonly FlowBlock[],
+  pageCount: number,
+  now: Date,
+): Map<number, string> {
+  const values = new Map<number, string>();
+  const fields: FieldRun[] = [];
+  for (const block of blocks) {
+    collectFieldRuns(block, fields);
+  }
+  if (fields.length === 0) {
+    return values;
+  }
+
+  const context: FieldContext = {
+    pageNumber: pageCount,
+    totalPages: pageCount,
+    sectionPages: pageCount,
+    bookmarkPages: EMPTY_STRING_NUMBER,
+    bookmarkText: EMPTY_STRING_STRING,
+    seqValues: EMPTY_NUMBER_NUMBER,
+    now,
+  };
+  for (const run of fields) {
+    if (run.pmStart === undefined) {
+      continue;
+    }
+    const parsed = parseFieldInstruction(run.instruction || run.fieldType);
+    if (
+      parsed.type === "PAGE" ||
+      parsed.type === "NUMPAGES" ||
+      parsed.type === "SECTIONPAGES"
+    ) {
+      values.set(
+        run.pmStart,
+        evaluateField(parsed, context, {
+          fallback: run.fallback ?? "",
+          instanceId: run.pmStart,
+        }),
+      );
+    }
+  }
+  return values;
+}
+
 /** Whether two resolved-value maps are identical, for loop convergence. */
 export function fieldValuesEqual(
   a: ReadonlyMap<number, string>,

--- a/packages/folio/src/core/fields/sectionPageCounts.test.ts
+++ b/packages/folio/src/core/fields/sectionPageCounts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Page, PageMargins } from "../layout-engine/types";
+import { buildSectionPageCounts } from "./sectionPageCounts";
+
+const MARGINS: PageMargins = { top: 96, right: 96, bottom: 96, left: 96 };
+
+const page = (number: number, sectionIndex?: number): Page => ({
+  number,
+  fragments: [],
+  margins: MARGINS,
+  size: { w: 816, h: 1056 },
+  ...(sectionIndex === undefined ? {} : { sectionIndex }),
+});
+
+describe("buildSectionPageCounts", () => {
+  test("counts pages per section index", () => {
+    const counts = buildSectionPageCounts([
+      page(1, 0),
+      page(2, 0),
+      page(3, 1),
+      page(4, 1),
+      page(5, 1),
+    ]);
+    expect(counts.get(0)).toBe(2);
+    expect(counts.get(1)).toBe(3);
+  });
+
+  test("pages without a section index fall into section 0", () => {
+    const counts = buildSectionPageCounts([page(1), page(2)]);
+    expect(counts.get(0)).toBe(2);
+  });
+});

--- a/packages/folio/src/core/fields/sectionPageCounts.ts
+++ b/packages/folio/src/core/fields/sectionPageCounts.ts
@@ -1,0 +1,17 @@
+import type { Page } from "../layout-engine/types";
+
+/**
+ * Count how many pages belong to each section (by `Page.sectionIndex`, defaulting
+ * to 0 for single-section documents), for resolving SECTIONPAGES. A field on a
+ * page reads the count for that page's section.
+ */
+export function buildSectionPageCounts(
+  pages: readonly Page[],
+): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const page of pages) {
+    const index = page.sectionIndex ?? 0;
+    counts.set(index, (counts.get(index) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/packages/folio/src/core/fields/seqValues.test.ts
+++ b/packages/folio/src/core/fields/seqValues.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FieldRun,
+  FlowBlock,
+  ParagraphBlock,
+  TableBlock,
+} from "../layout-engine/types";
+import { buildSeqValues } from "./seqValues";
+
+const seq = (pmStart: number, instruction: string): FieldRun => ({
+  kind: "field",
+  fieldType: "OTHER",
+  instruction,
+  pmStart,
+});
+
+const para = (id: string, fields: FieldRun[]): ParagraphBlock => ({
+  kind: "paragraph",
+  id,
+  runs: fields,
+});
+
+describe("buildSeqValues", () => {
+  test("counts per identifier independently in document order", () => {
+    const blocks: FlowBlock[] = [
+      para("p1", [seq(10, "SEQ Figure"), seq(20, "SEQ Table")]),
+      para("p2", [seq(30, "SEQ Figure")]),
+      para("p3", [seq(40, "SEQ Figure \\* ROMAN"), seq(50, "SEQ Table")]),
+    ];
+
+    const values = buildSeqValues(blocks);
+
+    expect(values.get(10)).toBe(1); // Figure 1
+    expect(values.get(30)).toBe(2); // Figure 2
+    expect(values.get(40)).toBe(3); // Figure 3 (format applied later by evaluator)
+    expect(values.get(20)).toBe(1); // Table 1
+    expect(values.get(50)).toBe(2); // Table 2
+  });
+
+  test("\\r resets the counter and \\c repeats without advancing", () => {
+    const blocks: FlowBlock[] = [
+      para("p1", [seq(10, "SEQ Figure")]), // 1
+      para("p2", [seq(20, "SEQ Figure \\r 5")]), // reset to 5
+      para("p3", [seq(30, "SEQ Figure \\c")]), // repeat 5
+      para("p4", [seq(40, "SEQ Figure")]), // 6
+    ];
+
+    const values = buildSeqValues(blocks);
+
+    expect(values.get(10)).toBe(1);
+    expect(values.get(20)).toBe(5);
+    expect(values.get(30)).toBe(5);
+    expect(values.get(40)).toBe(6);
+  });
+
+  test("counts SEQ fields inside table cells in document order", () => {
+    const table: TableBlock = {
+      kind: "table",
+      id: "t",
+      columnWidths: [120],
+      rows: [
+        {
+          id: "r0",
+          cells: [
+            { id: "c0", blocks: [para("cap0", [seq(10, "SEQ Figure")])] },
+          ],
+        },
+        {
+          id: "r1",
+          cells: [
+            { id: "c1", blocks: [para("cap1", [seq(20, "SEQ Figure")])] },
+          ],
+        },
+      ],
+    };
+    const blocks: FlowBlock[] = [table, para("after", [seq(30, "SEQ Figure")])];
+
+    const values = buildSeqValues(blocks);
+
+    expect(values.get(10)).toBe(1);
+    expect(values.get(20)).toBe(2);
+    expect(values.get(30)).toBe(3);
+  });
+});

--- a/packages/folio/src/core/fields/seqValues.test.ts
+++ b/packages/folio/src/core/fields/seqValues.test.ts
@@ -54,6 +54,22 @@ describe("buildSeqValues", () => {
     expect(values.get(40)).toBe(6);
   });
 
+  test("SEQ switches are case-insensitive", () => {
+    const blocks: FlowBlock[] = [
+      para("p1", [seq(10, "SEQ Figure")]),
+      para("p2", [seq(20, "SEQ Figure \\R 7")]),
+      para("p3", [seq(30, "SEQ Figure \\C")]),
+      para("p4", [seq(40, "SEQ Figure")]),
+    ];
+
+    const values = buildSeqValues(blocks);
+
+    expect(values.get(10)).toBe(1);
+    expect(values.get(20)).toBe(7);
+    expect(values.get(30)).toBe(7);
+    expect(values.get(40)).toBe(8);
+  });
+
   test("counts SEQ fields inside table cells in document order", () => {
     const table: TableBlock = {
       kind: "table",

--- a/packages/folio/src/core/fields/seqValues.test.ts
+++ b/packages/folio/src/core/fields/seqValues.test.ts
@@ -5,6 +5,7 @@ import type {
   FlowBlock,
   ParagraphBlock,
   TableBlock,
+  TextBoxBlock,
 } from "../layout-engine/types";
 import { buildSeqValues } from "./seqValues";
 
@@ -91,6 +92,26 @@ describe("buildSeqValues", () => {
       ],
     };
     const blocks: FlowBlock[] = [table, para("after", [seq(30, "SEQ Figure")])];
+
+    const values = buildSeqValues(blocks);
+
+    expect(values.get(10)).toBe(1);
+    expect(values.get(20)).toBe(2);
+    expect(values.get(30)).toBe(3);
+  });
+
+  test("counts SEQ fields inside text boxes in document order", () => {
+    const textBox: TextBoxBlock = {
+      kind: "textBox",
+      id: "box",
+      width: 240,
+      content: [para("caption", [seq(20, "SEQ Figure")])],
+    };
+    const blocks: FlowBlock[] = [
+      para("before", [seq(10, "SEQ Figure")]),
+      textBox,
+      para("after", [seq(30, "SEQ Figure")]),
+    ];
 
     const values = buildSeqValues(blocks);
 

--- a/packages/folio/src/core/fields/seqValues.ts
+++ b/packages/folio/src/core/fields/seqValues.ts
@@ -1,0 +1,60 @@
+import { parseFieldInstruction } from "../docx/fieldParser";
+import type { FlowBlock } from "../layout-engine/types";
+
+/**
+ * Assign each SEQ field instance its sequence number in document order, keyed by
+ * the field run's `pmStart`. SEQ counters are per identifier (the field
+ * argument, e.g. `Figure`), so `SEQ Figure` and `SEQ Table` count
+ * independently. Honours `\r n` (reset to n) and `\c` (repeat current without
+ * advancing); every other SEQ advances its counter by one. Independent of
+ * pagination, so it runs once per document, not per layout pass.
+ */
+export function buildSeqValues(
+  blocks: readonly FlowBlock[],
+): Map<number, number> {
+  const counters = new Map<string, number>();
+  const values = new Map<number, number>();
+  walkBlocks(blocks, counters, values);
+  return values;
+}
+
+function walkBlocks(
+  blocks: readonly FlowBlock[],
+  counters: Map<string, number>,
+  values: Map<number, number>,
+): void {
+  for (const block of blocks) {
+    if (block.kind === "paragraph") {
+      for (const run of block.runs) {
+        if (run.kind !== "field" || run.pmStart === undefined) {
+          continue;
+        }
+        const parsed = parseFieldInstruction(run.instruction ?? run.fieldType);
+        if (parsed.type !== "SEQ") {
+          continue;
+        }
+        const id = parsed.argument ?? "";
+        const reset = parsed.switches.find((s) => s.switch === "r")?.value;
+        const repeat = parsed.switches.some((s) => s.switch === "c");
+
+        let value: number;
+        if (reset !== undefined) {
+          value = Number.parseInt(reset, 10) || 1;
+        } else if (repeat) {
+          value = counters.get(id) ?? 0;
+        } else {
+          value = (counters.get(id) ?? 0) + 1;
+        }
+
+        counters.set(id, value);
+        values.set(run.pmStart, value);
+      }
+    } else if (block.kind === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          walkBlocks(cell.blocks, counters, values);
+        }
+      }
+    }
+  }
+}

--- a/packages/folio/src/core/fields/seqValues.ts
+++ b/packages/folio/src/core/fields/seqValues.ts
@@ -29,7 +29,7 @@ function walkBlocks(
         if (run.kind !== "field" || run.pmStart === undefined) {
           continue;
         }
-        const parsed = parseFieldInstruction(run.instruction ?? run.fieldType);
+        const parsed = parseFieldInstruction(run.instruction || run.fieldType);
         if (parsed.type !== "SEQ") {
           continue;
         }

--- a/packages/folio/src/core/fields/seqValues.ts
+++ b/packages/folio/src/core/fields/seqValues.ts
@@ -59,6 +59,8 @@ function walkBlocks(
           walkBlocks(cell.blocks, counters, values);
         }
       }
+    } else if (block.kind === "textBox") {
+      walkBlocks(block.content, counters, values);
     }
   }
 }

--- a/packages/folio/src/core/fields/seqValues.ts
+++ b/packages/folio/src/core/fields/seqValues.ts
@@ -34,8 +34,12 @@ function walkBlocks(
           continue;
         }
         const id = parsed.argument ?? "";
-        const reset = parsed.switches.find((s) => s.switch === "r")?.value;
-        const repeat = parsed.switches.some((s) => s.switch === "c");
+        const reset = parsed.switches.find(
+          (s) => s.switch.toLowerCase() === "r",
+        )?.value;
+        const repeat = parsed.switches.some(
+          (s) => s.switch.toLowerCase() === "c",
+        );
 
         let value: number;
         if (reset !== undefined) {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1061,6 +1061,7 @@ function paragraphToRuns(
       const run: FieldRun = {
         kind: "field",
         fieldType: mappedType,
+        instruction: attrs.instruction,
         fallback: attrs.displayText || "",
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1825,11 +1825,16 @@ function convertParagraph(
     options.originalListSeenNumIds,
   );
 
+  const bookmarkNames = pmAttrs.bookmarks?.map((b) => b.name);
+
   return {
     kind: "paragraph",
     id: nextBlockId(),
     runs,
     attrs,
+    ...(bookmarkNames && bookmarkNames.length > 0
+      ? { bookmarks: bookmarkNames }
+      : {}),
     pmStart: startPos,
     pmEnd: startPos + node.nodeSize,
   };

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1063,6 +1063,7 @@ function paragraphToRuns(
         fieldType: mappedType,
         instruction: attrs.instruction,
         fallback: attrs.displayText || "",
+        ...(attrs.fldLock ? { fldLock: true } : {}),
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
         ...fieldFormatting,

--- a/packages/folio/src/core/layout-engine/measure/measureBlocks.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureBlocks.ts
@@ -177,6 +177,7 @@ function getTableCellVerticalBorderHeight(cell: TableCell | undefined): number {
 export function measureTableBlock(
   tableBlock: TableBlock,
   contentWidth: number,
+  fieldValues?: ReadonlyMap<number, string>,
 ): TableMeasure {
   const DEFAULT_CELL_PADDING_X = 7; // Word default: 108 twips ≈ 7px
   const DEFAULT_CELL_PADDING_Y = 0; // OOXML/TableNormal default: top=0, bottom=0
@@ -288,7 +289,9 @@ export function measureTableBlock(
           ? NO_WRAP_MEASURE_WIDTH
           : cellContentWidth;
         const cellMeasure: TableCellMeasure = {
-          blocks: cell.blocks.map((b) => measureBlock(b, measureWidth)),
+          blocks: cell.blocks.map((b) =>
+            measureBlock(b, measureWidth, undefined, undefined, fieldValues),
+          ),
           width: cellWidth,
           height: 0, // Calculated below
         };
@@ -640,6 +643,7 @@ export function measureBlock(
   contentWidth: number,
   floatingZones?: FloatingImageZone[],
   cumulativeY?: number,
+  fieldValues?: ReadonlyMap<number, string>,
 ): Measure {
   switch (block.kind) {
     case "paragraph": {
@@ -650,7 +654,11 @@ export function measureBlock(
       // and contentWidth (both captured in the cache key). When floating zones
       // ARE present, we always measure fresh since zones depend on inter-block
       // layout context (cumulative Y, neighboring floating tables/images).
-      if (!floatingZones || floatingZones.length === 0) {
+      // Resolved field values also change the measured width and are not part
+      // of the cache key, so bypass the cache when they are supplied.
+      const cacheable =
+        (!floatingZones || floatingZones.length === 0) && !fieldValues;
+      if (cacheable) {
         const cached = getCachedParagraphMeasure(pBlock, contentWidth);
         if (cached) {
           return cached;
@@ -663,9 +671,12 @@ export function measureBlock(
       if (floatingZones) {
         measureOpts.floatingZones = floatingZones;
       }
+      if (fieldValues) {
+        measureOpts.fieldValues = fieldValues;
+      }
       const result = measureParagraph(pBlock, contentWidth, measureOpts);
 
-      if (!floatingZones || floatingZones.length === 0) {
+      if (cacheable) {
         setCachedParagraphMeasure(pBlock, contentWidth, result);
       }
 
@@ -673,7 +684,7 @@ export function measureBlock(
     }
 
     case "table": {
-      return measureTableBlock(block as TableBlock, contentWidth);
+      return measureTableBlock(block as TableBlock, contentWidth, fieldValues);
     }
 
     case "image": {
@@ -686,7 +697,7 @@ export function measureBlock(
     }
 
     case "textBox": {
-      return measureTextBoxBlock(block as TextBoxBlock);
+      return measureTextBoxBlock(block as TextBoxBlock, fieldValues);
     }
 
     case "pageBreak":
@@ -708,10 +719,15 @@ export function measureBlock(
   }
 }
 
-export function measureTextBoxBlock(tb: TextBoxBlock): TextBoxMeasure {
+export function measureTextBoxBlock(
+  tb: TextBoxBlock,
+  fieldValues?: ReadonlyMap<number, string>,
+): TextBoxMeasure {
   const margins = tb.margins ?? DEFAULT_TEXTBOX_MARGINS;
   const innerWidth = tb.width - margins.left - margins.right;
-  const innerMeasures = tb.content.map((p) => measureParagraph(p, innerWidth));
+  const innerMeasures = tb.content.map((p) =>
+    measureParagraph(p, innerWidth, fieldValues ? { fieldValues } : undefined),
+  );
   const contentHeight = innerMeasures.reduce(
     (sum, m) => sum + m.totalHeight,
     0,
@@ -748,6 +764,7 @@ export function measureBlocks(
   contentWidth: number | number[],
   marginTop: number | number[] = 0,
   pageGeometry?: BandPageGeometry,
+  fieldValues?: ReadonlyMap<number, string>,
 ): Measure[] {
   const defaultWidth = Array.isArray(contentWidth)
     ? (contentWidth[0] ?? 0)
@@ -860,7 +877,13 @@ export function measureBlocks(
       const blockWidth = Array.isArray(contentWidth)
         ? (contentWidth[blockIndex] ?? defaultWidth)
         : contentWidth;
-      const measure = measureBlock(block, blockWidth, zones, cumulativeY);
+      const measure = measureBlock(
+        block,
+        blockWidth,
+        zones,
+        cumulativeY,
+        fieldValues,
+      );
 
       // Paragraphs clear a full-width band internally (findClearLineY inside
       // measureParagraph). An in-flow table or inline image does not, so reserve

--- a/packages/folio/src/core/layout-engine/measure/measureBlocks.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureBlocks.ts
@@ -654,10 +654,13 @@ export function measureBlock(
       // and contentWidth (both captured in the cache key). When floating zones
       // ARE present, we always measure fresh since zones depend on inter-block
       // layout context (cumulative Y, neighboring floating tables/images).
-      // Resolved field values also change the measured width and are not part
-      // of the cache key, so bypass the cache when they are supplied.
+      // Resolved field values change measured field width and are not part of
+      // the cache key. Only paragraphs with field runs need a fresh measure in
+      // the stabilization pass; field-free paragraphs stay cacheable.
+      const hasFieldRuns = pBlock.runs.some((run) => run.kind === "field");
       const cacheable =
-        (!floatingZones || floatingZones.length === 0) && !fieldValues;
+        (!floatingZones || floatingZones.length === 0) &&
+        (!fieldValues || !hasFieldRuns);
       if (cacheable) {
         const cached = getCachedParagraphMeasure(pBlock, contentWidth);
         if (cached) {

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -87,6 +87,9 @@ export type MeasureParagraphOptions = {
   floatingZones?: FloatingImageZone[];
   /** Y offset of this paragraph relative to the exclusion zones (default: 0) */
   paragraphYOffset?: number;
+  /** Field run `pmStart` -> resolved display text, so a field measures at its
+   *  painted width instead of the cached fallback. */
+  fieldValues?: ReadonlyMap<number, string>;
 };
 
 /**
@@ -309,6 +312,17 @@ function isFieldRun(run: Run): run is FieldRun {
   return run.kind === "field";
 }
 
+/** Text a field run is measured at: its resolved value when known (so the
+ *  measurer agrees with the painter), else the cached fallback. */
+function fieldMeasureText(
+  run: FieldRun,
+  fieldValues: ReadonlyMap<number, string> | undefined,
+): string {
+  const resolved =
+    run.pmStart === undefined ? undefined : fieldValues?.get(run.pmStart);
+  return resolved ?? (run.fallback || "1");
+}
+
 /**
  * Check if a run is a math equation run
  */
@@ -379,7 +393,11 @@ function isEmptyTextRun(run: TextRun): boolean {
  * desync measurer and painter on tab advance for paragraphs with a tab
  * preceding a floating image.
  */
-function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
+function measureInlineWidthAfterTab(
+  runs: Run[],
+  tabIndex: number,
+  fieldValues?: ReadonlyMap<number, string>,
+): number {
   let width = 0;
   for (let i = tabIndex + 1; i < runs.length; i++) {
     const next = runs[i];
@@ -389,7 +407,10 @@ function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
     if (isTextRun(next)) {
       width += measureTextWidth(next.text || "", runToFontStyle(next));
     } else if (isFieldRun(next)) {
-      width += measureTextWidth(next.fallback || "1", runToFontStyle(next));
+      width += measureTextWidth(
+        fieldMeasureText(next, fieldValues),
+        runToFontStyle(next),
+      );
     } else if (isImageRun(next) && !isFloatingImageRun(next)) {
       width += next.width || 0;
     } else if (isMathRun(next)) {
@@ -414,6 +435,7 @@ function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
 function measureDecimalPrefixWidthAfterTab(
   runs: Run[],
   tabIndex: number,
+  fieldValues?: ReadonlyMap<number, string>,
 ): number {
   let text = "";
   let firstRun: TextRun | FieldRun | MathRun | undefined;
@@ -426,7 +448,7 @@ function measureDecimalPrefixWidthAfterTab(
       text += next.text || "";
       firstRun ??= next;
     } else if (isFieldRun(next)) {
-      text += next.fallback || "1";
+      text += fieldMeasureText(next, fieldValues);
       firstRun ??= next;
     } else if (isMathRun(next)) {
       text += next.plainText || "[equation]";
@@ -896,10 +918,15 @@ export function measureParagraph(
       const style = runToFontStyle(run);
       updateMaxFont(style);
 
-      const followingWidth = measureInlineWidthAfterTab(runs, runIndex);
+      const followingWidth = measureInlineWidthAfterTab(
+        runs,
+        runIndex,
+        options?.fieldValues,
+      );
       const decimalPrefixWidth = measureDecimalPrefixWidthAfterTab(
         runs,
         runIndex,
+        options?.fieldValues,
       );
 
       // Tab width comes from the shared tab-stop model (`calculateTabWidth` —
@@ -1034,8 +1061,9 @@ export function measureParagraph(
     }
 
     if (isFieldRun(run)) {
-      // Measure field using fallback text (actual value substituted at render time)
-      const fallback = run.fallback || "1";
+      // Measure the field at its resolved value when known so the line breaker
+      // agrees with the painter; otherwise the cached fallback text.
+      const fallback = fieldMeasureText(run, options?.fieldValues);
       const style: FontStyle = {
         fontFamily: run.fontFamily ?? DEFAULT_FONT_FAMILY,
         fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -247,6 +247,8 @@ export type FieldRun = RunFormatting & {
   instruction?: string;
   /** Fallback text if field can't be resolved */
   fallback?: string;
+  /** Whether OOXML marked this field as locked (`w:fldLock`). */
+  fldLock?: boolean;
   pmStart?: number;
   pmEnd?: number;
 };

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -240,7 +240,11 @@ export type LineBreakRun = {
  */
 export type FieldRun = RunFormatting & {
   kind: "field";
+  /** Coarse render category, kept for cache keys and caret-width fast paths. */
   fieldType: "PAGE" | "NUMPAGES" | "DATE" | "TIME" | "OTHER";
+  /** Full OOXML field instruction (e.g. `PAGE \* ROMAN`, `PAGEREF _Ref1 \h`)
+   *  for live evaluation; falls back to `fieldType` when absent. */
+  instruction?: string;
   /** Fallback text if field can't be resolved */
   fallback?: string;
   pmStart?: number;

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -450,6 +450,9 @@ export type ParagraphBlock = {
   id: BlockId;
   runs: Run[];
   attrs?: ParagraphAttrs;
+  /** Names of bookmarks anchored to this paragraph; used to map a bookmark to
+   *  the page it lands on for PAGEREF/REF resolution. */
+  bookmarks?: string[];
   /** ProseMirror start position for this block. */
   pmStart?: number;
   /** ProseMirror end position for this block. */

--- a/packages/folio/src/core/layout-painter/renderPage-watermark-incremental.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage-watermark-incremental.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import type { Page } from "../layout-engine/types";
+import type {
+  FieldRun,
+  MeasuredLine,
+  Page,
+  ParagraphBlock,
+  ParagraphFragment,
+  ParagraphMeasure,
+  HeaderFooterContent,
+} from "../layout-engine/types";
 import type { Watermark } from "../types/document";
+import type { BlockLookup } from "./index";
 import { renderPages } from "./renderPage";
 
 class FakeElement {
@@ -144,6 +153,19 @@ class FakeElement {
 
   dispatchEvent(_event: Event): boolean {
     return true;
+  }
+
+  getContext(_contextId: "2d"): CanvasRenderingContext2D {
+    return {
+      font: "",
+      measureText(text: string) {
+        return {
+          width: text.length * 5,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        };
+      },
+    } as CanvasRenderingContext2D;
   }
 
   getBoundingClientRect(): DOMRect {
@@ -314,6 +336,86 @@ function makePage(number: number, headerRId: string): Page {
   };
 }
 
+const fieldRun: FieldRun = {
+  kind: "field",
+  fieldType: "OTHER",
+  instruction: "PAGEREF _Target",
+  fallback: "?",
+  pmStart: 10,
+  pmEnd: 11,
+};
+
+const fieldParagraph: ParagraphBlock = {
+  kind: "paragraph",
+  id: "field-paragraph",
+  runs: [fieldRun],
+};
+
+const fieldLine: MeasuredLine = {
+  fromRun: 0,
+  fromChar: 0,
+  toRun: 0,
+  toChar: 1,
+  width: 10,
+  ascent: 8,
+  descent: 2,
+  lineHeight: 12,
+};
+
+const fieldMeasure: ParagraphMeasure = {
+  kind: "paragraph",
+  lines: [fieldLine],
+  totalHeight: 12,
+};
+
+const fieldFragment: ParagraphFragment = {
+  kind: "paragraph",
+  blockId: "field-paragraph",
+  x: 72,
+  y: 72,
+  width: 600,
+  height: 12,
+  fromLine: 0,
+  toLine: 1,
+};
+
+const fieldBlockLookup: BlockLookup = new Map([
+  [
+    "field-paragraph",
+    {
+      block: fieldParagraph,
+      measure: fieldMeasure,
+    },
+  ],
+]);
+
+const fieldHeaderContent: HeaderFooterContent = {
+  blocks: [fieldParagraph],
+  measures: [fieldMeasure],
+  height: 24,
+  textSig: "field-header",
+};
+
+function makeFieldPages(): Page[] {
+  return Array.from({ length: 8 }, (_unused, index) => ({
+    number: index + 1,
+    sectionPageNumber: index + 1,
+    fragments: index === 0 ? [fieldFragment] : [],
+    margins: { top: 72, right: 72, bottom: 72, left: 72 },
+    size: { w: 816, h: 1056 },
+  }));
+}
+
+function makeEmptyPages(): Page[] {
+  return Array.from({ length: 8 }, (_unused, index) => ({
+    number: index + 1,
+    sectionPageNumber: index + 1,
+    fragments: [],
+    margins: { top: 72, right: 72, bottom: 72, left: 72 },
+    size: { w: 816, h: 1056 },
+  }));
+}
+
 describe("renderPages watermark overlays", () => {
   beforeEach(() => {
     setGlobal("HTMLElement", FakeElement);
@@ -348,5 +450,59 @@ describe("renderPages watermark overlays", () => {
     expect(
       firstShell.querySelector(":scope > .layout-page-watermark"),
     ).toBeNull();
+  });
+
+  test("repaints rendered pages when field resolution maps change", () => {
+    const container = fakeDocument.createElement("div");
+    const pages = makeFieldPages();
+    const options = {
+      blockLookup: fieldBlockLookup,
+      document: fakeDocument as unknown as Document,
+    };
+
+    renderPages(pages, container as unknown as HTMLElement, {
+      ...options,
+      bookmarkPages: new Map([["_Target", 2]]),
+    });
+    const firstShell = container.children.at(0);
+    if (!firstShell) {
+      throw new TypeError("expected first page shell");
+    }
+    expect(firstShell.textContent).toBe("2");
+
+    renderPages(pages, container as unknown as HTMLElement, {
+      ...options,
+      bookmarkPages: new Map([["_Target", 4]]),
+    });
+
+    expect(container.children.at(0)).toBe(firstShell);
+    expect(firstShell.textContent).toBe("4");
+  });
+
+  test("repaints rendered headers when field resolution maps change", () => {
+    const container = fakeDocument.createElement("div");
+    const pages = makeEmptyPages();
+    const options = {
+      document: fakeDocument as unknown as Document,
+      headerContent: fieldHeaderContent,
+    };
+
+    renderPages(pages, container as unknown as HTMLElement, {
+      ...options,
+      bookmarkPages: new Map([["_Target", 2]]),
+    });
+    const firstShell = container.children.at(0);
+    if (!firstShell) {
+      throw new TypeError("expected first page shell");
+    }
+    expect(firstShell.textContent).toBe("2");
+
+    renderPages(pages, container as unknown as HTMLElement, {
+      ...options,
+      bookmarkPages: new Map([["_Target", 4]]),
+    });
+
+    expect(container.children.at(0)).toBe(firstShell);
+    expect(firstShell.textContent).toBe("4");
   });
 });

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { clearAllCaches } from "../layout-engine/measure/cache";
 import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
 import type {
+  FieldRun,
   Page,
   HeaderFooterContent,
   ParagraphBlock,
@@ -357,6 +358,31 @@ describe("render page fingerprint", () => {
       id: "p1",
       runs: [{ kind: "text", text: "world", pmStart: 1, pmEnd: 6 }],
     };
+    expect(computePageFingerprint(page, lookup(before))).not.toBe(
+      computePageFingerprint(page, lookup(after)),
+    );
+  });
+
+  test("changes when a field instruction changes without layout geometry changing", () => {
+    const field = (instruction: string): FieldRun => ({
+      kind: "field",
+      fieldType: "OTHER",
+      instruction,
+      fallback: "cached",
+      pmStart: 1,
+      pmEnd: 2,
+    });
+    const before: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [field("REF _A")],
+    };
+    const after: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [field("REF _B")],
+    };
+
     expect(computePageFingerprint(page, lookup(before))).not.toBe(
       computePageFingerprint(page, lookup(after)),
     );

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2562,6 +2562,7 @@ type PageContainerState = {
   pageStates: PageShellState[];
   totalPages: number;
   optionsHash: string;
+  fieldContextHash: string;
   pageDataMap: Map<
     HTMLElement,
     { page: Page; index: number; rendered: boolean }
@@ -3003,6 +3004,33 @@ function computeOptionsHash(options: RenderPageOptions): string {
   return parts.join("|");
 }
 
+function sortedMapFingerprint<K, V>(
+  prefix: string,
+  map: ReadonlyMap<K, V> | undefined,
+): string[] {
+  if (!map || map.size === 0) {
+    return [];
+  }
+
+  const entries: string[] = [];
+  for (const [key, value] of map) {
+    entries.push(`${String(key)}=${String(value)}`);
+  }
+  entries.sort();
+  return [`${prefix}:${entries.join(",")}`];
+}
+
+function computeFieldContextHash(options: RenderPageOptions): string {
+  const parts: string[] = [];
+  parts.push(...sortedMapFingerprint("bm-page", options.bookmarkPages));
+  parts.push(...sortedMapFingerprint("bm-text", options.bookmarkText));
+  parts.push(...sortedMapFingerprint("seq", options.seqValues));
+  parts.push(
+    ...sortedMapFingerprint("section-pages", options.sectionPageCounts),
+  );
+  return parts.join("|");
+}
+
 /**
  * Apply standard container styles for the pages wrapper.
  */
@@ -3053,6 +3081,7 @@ export function renderPages(
   const pc = container as PageContainer;
   const prevState = pc.__pageRenderState;
   const currentOptionsHash = computeOptionsHash(options);
+  const currentFieldContextHash = computeFieldContextHash(options);
   const useVirtualization = totalPages >= VIRTUALIZATION_THRESHOLD;
 
   // Determine if we can do an incremental update
@@ -3070,6 +3099,8 @@ export function renderPages(
     // If total page count changed, NUMPAGES fields in headers/footers are stale.
     // Force re-render of all currently-rendered pages.
     const totalPagesChanged = prevState.totalPages !== totalPages;
+    const fieldContextChanged =
+      prevState.fieldContextHash !== currentFieldContextHash;
 
     // Update existing pages
     const commonCount = Math.min(prevShells.length, pages.length);
@@ -3100,20 +3131,39 @@ export function renderPages(
 
       const newFp = computePageFingerprint(page, options.blockLookup);
 
-      if (prev.fingerprint === newFp && !totalPagesChanged) {
+      if (
+        prev.fingerprint === newFp &&
+        !totalPagesChanged &&
+        !fieldContextChanged
+      ) {
         // Page unchanged — data map already points at the fresh page object.
         continue;
       }
 
       // Page changed — update the shell
       const shell = prev.element;
+      const pageContextChanged = totalPagesChanged || fieldContextChanged;
+      if (pageContextChanged) {
+        shell.innerHTML = "";
+        data.rendered = false;
+        populatePageShell(shell, prevDataMap, totalPages, options);
+        applyPageStyles(shell, page.size.w, page.size.h, options);
+        syncPageBorderOverlay(
+          shell,
+          page,
+          options,
+          options.document ?? document,
+        );
+        shell.dataset["pageNumber"] = String(page.number);
+        continue;
+      }
+
       const newRenderFp = computePageRenderFingerprint(
         page,
         options.blockLookup,
       );
 
-      const renderChanged =
-        totalPagesChanged || prev.renderFingerprint !== newRenderFp;
+      const renderChanged = prev.renderFingerprint !== newRenderFp;
       const positionsSynced =
         !renderChanged && syncRenderedPmPositionData(shell, oldPage, data.page);
 
@@ -3181,6 +3231,7 @@ export function renderPages(
 
     // Update stored state with fresh options (blockLookup, footnotes, etc.)
     prevState.totalPages = totalPages;
+    prevState.fieldContextHash = currentFieldContextHash;
     prevState.currentOptions = options;
 
     // Incremental path: existing shells were repopulated in place; fire
@@ -3370,6 +3421,7 @@ export function renderPages(
     })),
     totalPages,
     optionsHash: currentOptionsHash,
+    fieldContextHash: currentFieldContextHash,
     pageDataMap,
     currentOptions: options,
   };

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -170,6 +170,8 @@ export type RenderPageOptions = {
   bookmarkPages?: ReadonlyMap<string, number>;
   /** Field run `pmStart` -> precomputed SEQ value, for resolving SEQ fields. */
   seqValues?: ReadonlyMap<number, number>;
+  /** Section index -> page count in that section, for SECTIONPAGES fields. */
+  sectionPageCounts?: ReadonlyMap<number, number>;
   /** Custom page class name */
   pageClassName?: string;
   /** Show page borders (for debugging) */
@@ -2479,6 +2481,19 @@ export function applySectionHeaderFooterOptions(
   return true;
 }
 
+/** SECTIONPAGES context fragment for `page`: the page count of its section, or
+ *  nothing when section counts were not supplied (field then falls back). */
+function sectionPagesContext(
+  page: Page,
+  counts: ReadonlyMap<number, number> | undefined,
+): { sectionPages?: number } {
+  if (!counts) {
+    return {};
+  }
+  const value = counts.get(page.sectionIndex ?? 0);
+  return value === undefined ? {} : { sectionPages: value };
+}
+
 /**
  * Build a RenderContext and resolved page options (with footnotes) for a page.
  * Centralises logic shared by populatePageShell, repopulatePageContent, and the eager render path.
@@ -2494,6 +2509,7 @@ function buildPageRenderArgs(
     section: "body",
     ...(options.bookmarkPages ? { bookmarkPages: options.bookmarkPages } : {}),
     ...(options.seqValues ? { seqValues: options.seqValues } : {}),
+    ...sectionPagesContext(page, options.sectionPageCounts),
   };
   const pageOptions: RenderPageOptions = { ...options };
   const hasSectionHeaderFooter = applySectionHeaderFooterOptions(

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -168,6 +168,8 @@ export type RenderPageOptions = {
   document?: Document;
   /** Bookmark name -> 1-indexed page, for resolving PAGEREF fields at paint. */
   bookmarkPages?: ReadonlyMap<string, number>;
+  /** Bookmark name -> paragraph text, for resolving REF fields at paint. */
+  bookmarkText?: ReadonlyMap<string, string>;
   /** Field run `pmStart` -> precomputed SEQ value, for resolving SEQ fields. */
   seqValues?: ReadonlyMap<number, number>;
   /** Section index -> page count in that section, for SECTIONPAGES fields. */
@@ -2508,6 +2510,7 @@ function buildPageRenderArgs(
     totalPages,
     section: "body",
     ...(options.bookmarkPages ? { bookmarkPages: options.bookmarkPages } : {}),
+    ...(options.bookmarkText ? { bookmarkText: options.bookmarkText } : {}),
     ...(options.seqValues ? { seqValues: options.seqValues } : {}),
     ...sectionPagesContext(page, options.sectionPageCounts),
   };

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -168,6 +168,8 @@ export type RenderPageOptions = {
   document?: Document;
   /** Bookmark name -> 1-indexed page, for resolving PAGEREF fields at paint. */
   bookmarkPages?: ReadonlyMap<string, number>;
+  /** Field run `pmStart` -> precomputed SEQ value, for resolving SEQ fields. */
+  seqValues?: ReadonlyMap<number, number>;
   /** Custom page class name */
   pageClassName?: string;
   /** Show page borders (for debugging) */
@@ -2491,6 +2493,7 @@ function buildPageRenderArgs(
     totalPages,
     section: "body",
     ...(options.bookmarkPages ? { bookmarkPages: options.bookmarkPages } : {}),
+    ...(options.seqValues ? { seqValues: options.seqValues } : {}),
   };
   const pageOptions: RenderPageOptions = { ...options };
   const hasSectionHeaderFooter = applySectionHeaderFooterOptions(

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2812,8 +2812,14 @@ function runContentKey(run: Run): string {
     parts.push(`mx:${run.ommlXml}`);
   } else {
     parts.push(`ft:${run.fieldType}`);
+    if (run.instruction !== undefined) {
+      parts.push(`fi:${run.instruction}`);
+    }
     if (run.fallback !== undefined) {
       parts.push(`fb:${run.fallback}`);
+    }
+    if (run.fldLock) {
+      parts.push("fl");
     }
   }
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -166,6 +166,8 @@ export type FootnoteRenderItem = {
 export type RenderPageOptions = {
   /** Document to create elements in (default: window.document) */
   document?: Document;
+  /** Bookmark name -> 1-indexed page, for resolving PAGEREF fields at paint. */
+  bookmarkPages?: ReadonlyMap<string, number>;
   /** Custom page class name */
   pageClassName?: string;
   /** Show page borders (for debugging) */
@@ -2488,6 +2490,7 @@ function buildPageRenderArgs(
     pageNumber: page.number,
     totalPages,
     section: "body",
+    ...(options.bookmarkPages ? { bookmarkPages: options.bookmarkPages } : {}),
   };
   const pageOptions: RenderPageOptions = { ...options };
   const hasSectionHeaderFooter = applySectionHeaderFooterOptions(

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -982,6 +982,7 @@ function resolveFieldText(
     {
       fallback: run.fallback ?? "",
       ...(run.pmStart === undefined ? {} : { instanceId: run.pmStart }),
+      ...(run.fldLock ? { locked: true } : {}),
     },
   );
 }

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -966,7 +966,7 @@ function renderFieldRun(
     totalPages: context.totalPages,
     bookmarkPages: context.bookmarkPages ?? EMPTY_BOOKMARK_PAGES,
     bookmarkText: EMPTY_BOOKMARK_TEXT,
-    seqValues: EMPTY_SEQ_VALUES,
+    seqValues: context.seqValues ?? EMPTY_SEQ_VALUES,
     now: new Date(),
   };
   const text = evaluateFieldInstruction(

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -965,7 +965,7 @@ function renderFieldRun(
     pageNumber: context.pageNumber,
     totalPages: context.totalPages,
     bookmarkPages: context.bookmarkPages ?? EMPTY_BOOKMARK_PAGES,
-    bookmarkText: EMPTY_BOOKMARK_TEXT,
+    bookmarkText: context.bookmarkText ?? EMPTY_BOOKMARK_TEXT,
     seqValues: context.seqValues ?? EMPTY_SEQ_VALUES,
     now: new Date(),
     ...(context.sectionPages === undefined

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -964,7 +964,7 @@ function renderFieldRun(
   const fieldContext: FieldContext = {
     pageNumber: context.pageNumber,
     totalPages: context.totalPages,
-    bookmarkPages: EMPTY_BOOKMARK_PAGES,
+    bookmarkPages: context.bookmarkPages ?? EMPTY_BOOKMARK_PAGES,
     bookmarkText: EMPTY_BOOKMARK_TEXT,
     seqValues: EMPTY_SEQ_VALUES,
     now: new Date(),

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -951,16 +951,20 @@ const EMPTY_BOOKMARK_PAGES: ReadonlyMap<string, number> = new Map();
 const EMPTY_BOOKMARK_TEXT: ReadonlyMap<string, string> = new Map();
 const EMPTY_SEQ_VALUES: ReadonlyMap<number, number> = new Map();
 
-function renderFieldRun(
+/**
+ * Resolve a field run to its display text against the painted page. Used by the
+ * painter and by the tab-anchor width/text helpers so the width reserved for a
+ * field after a tab and the text actually painted always agree. The instruction
+ * drives evaluation; `fieldType` is the fallback when a node carries none.
+ * Returns the cached fallback when no render context is available.
+ */
+function resolveFieldText(
   run: FieldRun,
-  doc: Document,
-  context: RenderContext,
-): HTMLElement {
-  // Resolve the field against the painted page. PAGE/NUMPAGES/DATE/TIME compute
-  // live here as before; PAGEREF/REF/SEQ/SECTIONPAGES fall back to the cached
-  // text until their resolution maps are plumbed through the layout. The
-  // instruction drives evaluation; `fieldType` is the fallback when a node
-  // carries no instruction string.
+  context: RenderContext | undefined,
+): string {
+  if (!context) {
+    return run.fallback ?? "";
+  }
   const fieldContext: FieldContext = {
     pageNumber: context.pageNumber,
     totalPages: context.totalPages,
@@ -972,7 +976,7 @@ function renderFieldRun(
       ? {}
       : { sectionPages: context.sectionPages }),
   };
-  const text = evaluateFieldInstruction(
+  return evaluateFieldInstruction(
     run.instruction || run.fieldType,
     fieldContext,
     {
@@ -980,6 +984,14 @@ function renderFieldRun(
       ...(run.pmStart === undefined ? {} : { instanceId: run.pmStart }),
     },
   );
+}
+
+function renderFieldRun(
+  run: FieldRun,
+  doc: Document,
+  context: RenderContext,
+): HTMLElement {
+  const text = resolveFieldText(run, context);
 
   // Spread the whole FieldRun so every RunFormatting field carries through —
   // Word renders the field result with the result run's full w:rPr. Explicit
@@ -1258,12 +1270,7 @@ function measureFollowingContentWidth(
         ) *
         (scale / 100);
     } else if (isFieldRun(run)) {
-      let fieldText = run.fallback ?? "";
-      if (run.fieldType === "PAGE" && context) {
-        fieldText = String(context.pageNumber);
-      } else if (run.fieldType === "NUMPAGES" && context) {
-        fieldText = String(context.totalPages);
-      }
+      const fieldText = resolveFieldText(run, context);
       width +=
         measureText(
           run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
@@ -1336,14 +1343,7 @@ function getTextAfterTab(
     if (isTextRun(run)) {
       text += run.text;
     } else if (isFieldRun(run)) {
-      // Resolve field values for TOC page numbers
-      if (run.fieldType === "PAGE" && context) {
-        text += String(context.pageNumber);
-      } else if (run.fieldType === "NUMPAGES" && context) {
-        text += String(context.totalPages);
-      } else {
-        text += run.fallback ?? "";
-      }
+      text += resolveFieldText(run, context);
     } else if (isTabRun(run) || isLineBreakRun(run)) {
       // Stop at next tab or line break
       break;
@@ -1830,13 +1830,9 @@ export function renderLine(
       // Render field run with context for PAGE/NUMPAGES substitution
       const runEl = renderFieldRun(run, doc, options.context);
       lineEl.append(runEl);
-      // Estimate field text width for tab calculations
-      let fieldText = run.fallback ?? "";
-      if (run.fieldType === "PAGE") {
-        fieldText = String(options.context.pageNumber);
-      } else if (run.fieldType === "NUMPAGES") {
-        fieldText = String(options.context.totalPages);
-      }
+      // Estimate field text width for tab calculations (same value the field
+      // painted, so tab math matches).
+      const fieldText = resolveFieldText(run, options.context);
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
       const measuredWidth = measureText(

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -968,6 +968,9 @@ function renderFieldRun(
     bookmarkText: EMPTY_BOOKMARK_TEXT,
     seqValues: context.seqValues ?? EMPTY_SEQ_VALUES,
     now: new Date(),
+    ...(context.sectionPages === undefined
+      ? {}
+      : { sectionPages: context.sectionPages }),
   };
   const text = evaluateFieldInstruction(
     run.instruction || run.fieldType,

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -7,6 +7,8 @@
 
 import { ommlToMathml } from "../docx/mathToMathml";
 import { parseXmlDocument } from "../docx/xmlParser";
+import { evaluateFieldInstruction } from "../fields/evaluateField";
+import type { FieldContext } from "../fields/fieldContext";
 import { getListMarkerInlineWidth } from "../layout-engine/measure/listMarkerWidth";
 import type {
   ParagraphBlock,
@@ -945,31 +947,36 @@ function renderLineBreakRun(run: LineBreakRun, doc: Document): HTMLElement {
  * Render a field run (PAGE, NUMPAGES, etc.)
  * Substitutes the field with actual values from context.
  */
+const EMPTY_BOOKMARK_PAGES: ReadonlyMap<string, number> = new Map();
+const EMPTY_BOOKMARK_TEXT: ReadonlyMap<string, string> = new Map();
+const EMPTY_SEQ_VALUES: ReadonlyMap<number, number> = new Map();
+
 function renderFieldRun(
   run: FieldRun,
   doc: Document,
   context: RenderContext,
 ): HTMLElement {
-  let text = run.fallback ?? "";
-
-  switch (run.fieldType) {
-    case "PAGE":
-      text = String(context.pageNumber);
-      break;
-    case "NUMPAGES":
-      text = String(context.totalPages);
-      break;
-    case "DATE":
-      text = new Date().toLocaleDateString();
-      break;
-    case "TIME":
-      text = new Date().toLocaleTimeString();
-      break;
-    case "OTHER":
-      // Any field we don't recognise — render the cached fallback Word
-      // last computed (already assigned to `text` above).
-      break;
-  }
+  // Resolve the field against the painted page. PAGE/NUMPAGES/DATE/TIME compute
+  // live here as before; PAGEREF/REF/SEQ/SECTIONPAGES fall back to the cached
+  // text until their resolution maps are plumbed through the layout. The
+  // instruction drives evaluation; `fieldType` is the fallback when a node
+  // carries no instruction string.
+  const fieldContext: FieldContext = {
+    pageNumber: context.pageNumber,
+    totalPages: context.totalPages,
+    bookmarkPages: EMPTY_BOOKMARK_PAGES,
+    bookmarkText: EMPTY_BOOKMARK_TEXT,
+    seqValues: EMPTY_SEQ_VALUES,
+    now: new Date(),
+  };
+  const text = evaluateFieldInstruction(
+    run.instruction || run.fieldType,
+    fieldContext,
+    {
+      fallback: run.fallback ?? "",
+      ...(run.pmStart === undefined ? {} : { instanceId: run.pmStart }),
+    },
+  );
 
   // Spread the whole FieldRun so every RunFormatting field carries through —
   // Word renders the field result with the result run's full w:rPr. Explicit

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -24,6 +24,8 @@ export type RenderContext = {
   section: "body" | "header" | "footer";
   /** Bookmark name -> 1-indexed page, for resolving PAGEREF fields. */
   bookmarkPages?: ReadonlyMap<string, number>;
+  /** Field run `pmStart` -> precomputed SEQ value, for resolving SEQ fields. */
+  seqValues?: ReadonlyMap<number, number>;
   /** Content width in pixels (page width minus margins) - used for justify */
   contentWidth?: number;
   /** When true, floating images render in-flow instead of being skipped (for table cells) */

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -24,6 +24,8 @@ export type RenderContext = {
   section: "body" | "header" | "footer";
   /** Bookmark name -> 1-indexed page, for resolving PAGEREF fields. */
   bookmarkPages?: ReadonlyMap<string, number>;
+  /** Bookmark name -> paragraph text, for resolving REF fields. */
+  bookmarkText?: ReadonlyMap<string, string>;
   /** Field run `pmStart` -> precomputed SEQ value, for resolving SEQ fields. */
   seqValues?: ReadonlyMap<number, number>;
   /** Pages in this page's section, for resolving SECTIONPAGES fields. */

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -22,6 +22,8 @@ export type RenderContext = {
   totalPages: number;
   /** Which section is being rendered */
   section: "body" | "header" | "footer";
+  /** Bookmark name -> 1-indexed page, for resolving PAGEREF fields. */
+  bookmarkPages?: ReadonlyMap<string, number>;
   /** Content width in pixels (page width minus margins) - used for justify */
   contentWidth?: number;
   /** When true, floating images render in-flow instead of being skipped (for table cells) */

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -26,6 +26,8 @@ export type RenderContext = {
   bookmarkPages?: ReadonlyMap<string, number>;
   /** Field run `pmStart` -> precomputed SEQ value, for resolving SEQ fields. */
   seqValues?: ReadonlyMap<number, number>;
+  /** Pages in this page's section, for resolving SECTIONPAGES fields. */
+  sectionPages?: number;
   /** Content width in pixels (page width minus margins) - used for justify */
   contentWidth?: number;
   /** When true, floating images render in-flow instead of being skipped (for table cells) */

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -916,6 +916,40 @@ export const ParagraphExtension = createNodeExtension({
             );
 
             // TOC entries with hyperlinks
+            // Right tab with a dot leader so each entry's page number aligns at
+            // the section's content width (page width minus left/right margins,
+            // in twips). Read from the document's section properties; fall back
+            // to US Letter with 1in margins when none are present.
+            const DEFAULT_MARGIN_TWIPS = 1440;
+            let tocTabStopTwips = 12_240 - 2 * DEFAULT_MARGIN_TWIPS; // 9360
+            let tabStopResolved = false;
+            state.doc.descendants((node) => {
+              if (tabStopResolved || node.type.name !== "paragraph") {
+                return undefined;
+              }
+              const sp = node.attrs["_sectionProperties"] as {
+                pageWidth?: number;
+                marginLeft?: number;
+                marginRight?: number;
+              } | null;
+              if (sp && typeof sp.pageWidth === "number" && sp.pageWidth > 0) {
+                const left =
+                  typeof sp.marginLeft === "number"
+                    ? sp.marginLeft
+                    : DEFAULT_MARGIN_TWIPS;
+                const right =
+                  typeof sp.marginRight === "number"
+                    ? sp.marginRight
+                    : DEFAULT_MARGIN_TWIPS;
+                tocTabStopTwips = sp.pageWidth - left - right;
+                tabStopResolved = true;
+              }
+              return undefined;
+            });
+            // Each entry ends with a PAGEREF to the heading's bookmark, which
+            // resolves to the heading's live page number at paint.
+            const canPageNumber = Boolean(s.nodes["field"] && s.nodes["tab"]);
+
             for (const entry of bookmarkEntries) {
               const indent = entry.level * 720; // 0.5 inch per level in twips
               const tocStyleId = `TOC${entry.level + 1}`; // TOC1, TOC2, etc.
@@ -926,14 +960,40 @@ export const ParagraphExtension = createNodeExtension({
                 href: `#${entry.name}`,
               });
 
+              const content = [s.text(entry.text, [linkMark])];
+              if (canPageNumber) {
+                content.push(
+                  s.node("tab"),
+                  s.node("field", {
+                    fieldType: "PAGEREF",
+                    instruction: `PAGEREF ${entry.name} \\h`,
+                    displayText: "1",
+                    fieldKind: "complex",
+                    fldLock: false,
+                    dirty: true,
+                  }),
+                );
+              }
+
               tocNodes.push(
                 s.node(
                   "paragraph",
                   {
                     styleId: tocStyleId,
                     indentLeft: indent > 0 ? indent : null,
+                    ...(canPageNumber
+                      ? {
+                          tabs: [
+                            {
+                              position: tocTabStopTwips,
+                              alignment: "right",
+                              leader: "dot",
+                            },
+                          ],
+                        }
+                      : {}),
                   },
-                  [s.text(entry.text, [linkMark])],
+                  content,
                 ),
               );
             }

--- a/packages/folio/src/core/prosemirror/extensions/core/generateTOC.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/generateTOC.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import { schema, singletonManager } from "../../schema";
+
+const docWithHeadings = (): PMNode =>
+  schema.node("doc", null, [
+    schema.node("paragraph", { styleId: "Heading1" }, [
+      schema.text("Introduction"),
+    ]),
+    schema.node("paragraph", {}, [schema.text("Body text.")]),
+    schema.node("paragraph", { styleId: "Heading2" }, [
+      schema.text("Background"),
+    ]),
+  ]);
+
+const runGenerateTOC = (doc: PMNode): PMNode => {
+  const generateTOC = singletonManager.getCommands()["generateTOC"];
+  if (!generateTOC) {
+    throw new Error("generateTOC command not registered");
+  }
+  let state = EditorState.create({ schema, doc });
+  state = state.apply(state.tr.setSelection(TextSelection.atStart(state.doc)));
+
+  let captured: Transaction | undefined;
+  const ok = generateTOC()(state, (tr) => {
+    captured = tr;
+  });
+  expect(ok).toBe(true);
+  if (!captured) {
+    throw new Error("generateTOC did not dispatch a transaction");
+  }
+  return captured.doc;
+};
+
+const tocEntryParagraphs = (doc: PMNode): PMNode[] => {
+  const entries: PMNode[] = [];
+  doc.descendants((node) => {
+    const styleId = node.attrs["styleId"];
+    if (
+      node.type.name === "paragraph" &&
+      typeof styleId === "string" &&
+      /^TOC\d$/u.test(styleId)
+    ) {
+      entries.push(node);
+    }
+  });
+  return entries;
+};
+
+describe("generateTOC", () => {
+  test("creates one entry per heading with a PAGEREF field and a dot-leader right tab", () => {
+    const result = runGenerateTOC(docWithHeadings());
+    const entries = tocEntryParagraphs(result);
+
+    expect(entries).toHaveLength(2);
+
+    for (const entry of entries) {
+      let pagerefInstruction: string | undefined;
+      let hasTab = false;
+      entry.descendants((node) => {
+        if (
+          node.type.name === "field" &&
+          node.attrs["fieldType"] === "PAGEREF"
+        ) {
+          pagerefInstruction = node.attrs["instruction"] as string;
+        }
+        if (node.type.name === "tab") {
+          hasTab = true;
+        }
+      });
+
+      // PAGEREF points at a generated heading bookmark.
+      expect(pagerefInstruction).toMatch(/^PAGEREF _Toc\d+ \\h$/u);
+      expect(hasTab).toBe(true);
+
+      const tabs = entry.attrs["tabs"] as
+        | { alignment?: string; leader?: string }[]
+        | null;
+      expect(
+        tabs?.some((t) => t.alignment === "right" && t.leader === "dot"),
+      ).toBe(true);
+    }
+  });
+
+  test("each entry's PAGEREF targets a bookmark anchored on a heading", () => {
+    const result = runGenerateTOC(docWithHeadings());
+
+    // Bookmark names anchored on heading paragraphs.
+    const headingBookmarks = new Set<string>();
+    result.descendants((node) => {
+      if (node.type.name !== "paragraph") {
+        return;
+      }
+      const styleId = node.attrs["styleId"];
+      if (typeof styleId === "string" && /^Heading\d$/u.test(styleId)) {
+        const bookmarks = node.attrs["bookmarks"] as
+          | { name: string }[]
+          | undefined;
+        for (const b of bookmarks ?? []) {
+          headingBookmarks.add(b.name);
+        }
+      }
+    });
+
+    const entries = tocEntryParagraphs(result);
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      let target: string | undefined;
+      entry.descendants((node) => {
+        if (
+          node.type.name === "field" &&
+          node.attrs["fieldType"] === "PAGEREF"
+        ) {
+          target = /^PAGEREF (\S+) /u.exec(
+            node.attrs["instruction"] as string,
+          )?.[1];
+        }
+      });
+      expect(target).toBeDefined();
+      // The referenced bookmark really exists on a heading, so the page map
+      // resolves it at paint.
+      expect(headingBookmarks.has(target as string)).toBe(true);
+    }
+  });
+});

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -37,6 +37,7 @@ import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
+import { buildSeqValues } from "../core/fields/seqValues";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
 import { clickToPositionDom } from "../core/layout-bridge/clickToPositionDom";
 import {
@@ -2636,6 +2637,11 @@ export function PagedEditor(
           );
           if (bookmarkPages.size > 0) {
             renderOpts.bookmarkPages = bookmarkPages;
+          }
+          // Assign SEQ caption numbers in document order so SEQ fields resolve.
+          const seqValues = buildSeqValues(newBlocks);
+          if (seqValues.size > 0) {
+            renderOpts.seqValues = seqValues;
           }
           // Document watermark (rendered behind every page). Build a
           // per-header-rId map so titlePg / even-odd / per-section

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2561,6 +2561,9 @@ export function PagedEditor(
         // (typing) path to keep keystrokes cheap.
         if (!incrementalResult) {
           const MAX_FIELD_STABILIZATION_PASSES = 3;
+          // One clock for all passes so a TIME field cannot tick between
+          // iterations and prevent convergence.
+          const fieldClock = new Date();
           let previousFieldValues: Map<number, string> | null = null;
           for (let pass = 0; pass < MAX_FIELD_STABILIZATION_PASSES; pass++) {
             const { values, changed } = resolveFieldValues(
@@ -2572,7 +2575,7 @@ export function PagedEditor(
                 bookmarkText: buildBookmarkText(newBlocks),
                 seqValues: buildSeqValues(newBlocks),
                 sectionPageCounts: buildSectionPageCounts(newLayout.pages),
-                now: new Date(),
+                now: fieldClock,
               },
             );
             const settled =

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -37,6 +37,7 @@ import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
+import { buildBookmarkText } from "../core/fields/bookmarkText";
 import { buildSectionPageCounts } from "../core/fields/sectionPageCounts";
 import { buildSeqValues } from "../core/fields/seqValues";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
@@ -2638,6 +2639,11 @@ export function PagedEditor(
           );
           if (bookmarkPages.size > 0) {
             renderOpts.bookmarkPages = bookmarkPages;
+          }
+          // Bookmark text for REF cross-references.
+          const bookmarkText = buildBookmarkText(newBlocks);
+          if (bookmarkText.size > 0) {
+            renderOpts.bookmarkText = bookmarkText;
           }
           // Assign SEQ caption numbers in document order so SEQ fields resolve.
           const seqValues = buildSeqValues(newBlocks);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2680,14 +2680,19 @@ export function PagedEditor(
           const fieldClock = new Date();
           let previousFieldValues: Map<number, string> | null = null;
           for (let pass = 0; pass < MAX_FIELD_STABILIZATION_PASSES; pass++) {
+            const seqValues = buildSeqValues(newBlocks);
+            const bookmarkTextInputs =
+              previousFieldValues === null
+                ? { seqValues }
+                : { fieldValues: previousFieldValues, seqValues };
             const { values, changed } = resolveFieldValues(
               newBlocks,
               newLayout.pages,
               {
                 totalPages: newLayout.pages.length,
                 bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
-                bookmarkText: buildBookmarkText(newBlocks),
-                seqValues: buildSeqValues(newBlocks),
+                bookmarkText: buildBookmarkText(newBlocks, bookmarkTextInputs),
+                seqValues,
                 sectionPageCounts: buildSectionPageCounts(newLayout.pages),
                 now: fieldClock,
               },
@@ -2697,9 +2702,11 @@ export function PagedEditor(
                 ? !changed
                 : fieldValuesEqual(previousFieldValues, values);
             if (settled) {
+              stabilizedFieldValues = values;
               break;
             }
             previousFieldValues = values;
+            stabilizedFieldValues = values;
             newMeasures = measureBlocks(
               newBlocks,
               blockWidths,
@@ -2728,13 +2735,20 @@ export function PagedEditor(
         // fixed point with a small cap. Gated on a real change, so field-free
         // documents and most edits do zero passes; skipped on the incremental
         // (typing) path to keep keystrokes cheap.
+        let stabilizedFieldValues: Map<number, string> | undefined;
         stabilizeFieldWidths();
 
         const rebuildHeaderFooterForLayout = (): typeof hfExtenderContent => {
+          const seqValues = buildSeqValues(newBlocks);
+          const bookmarkTextInputs =
+            stabilizedFieldValues === undefined
+              ? { seqValues }
+              : { fieldValues: stabilizedFieldValues, seqValues };
           const finalHfFieldInputs: HeaderFooterFieldInputs = {
             bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
-            bookmarkText: buildBookmarkText(newBlocks),
-            seqValues: buildSeqValues(newBlocks),
+            bookmarkText: buildBookmarkText(newBlocks, bookmarkTextInputs),
+            seqValues,
+            sectionPageCounts: buildSectionPageCounts(newLayout.pages),
           };
           const finalHfOptions = buildHfOptions(
             newLayout.pages.length,
@@ -2956,15 +2970,19 @@ export function PagedEditor(
           if (bookmarkPages.size > 0) {
             renderOpts.bookmarkPages = bookmarkPages;
           }
-          // Bookmark text for REF cross-references.
-          const bookmarkText = buildBookmarkText(newBlocks);
-          if (bookmarkText.size > 0) {
-            renderOpts.bookmarkText = bookmarkText;
-          }
           // Assign SEQ caption numbers in document order so SEQ fields resolve.
           const seqValues = buildSeqValues(newBlocks);
           if (seqValues.size > 0) {
             renderOpts.seqValues = seqValues;
+          }
+          // Bookmark text for REF cross-references.
+          const bookmarkTextInputs =
+            stabilizedFieldValues === undefined
+              ? { seqValues }
+              : { fieldValues: stabilizedFieldValues, seqValues };
+          const bookmarkText = buildBookmarkText(newBlocks, bookmarkTextInputs);
+          if (bookmarkText.size > 0) {
+            renderOpts.bookmarkText = bookmarkText;
           }
           // Per-section page counts so SECTIONPAGES fields resolve.
           renderOpts.sectionPageCounts = buildSectionPageCounts(

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -1690,6 +1690,27 @@ function getMargins(
   };
 }
 
+function pageMarginsEqual(left: PageMargins, right: PageMargins): boolean {
+  return (
+    left.top === right.top &&
+    left.right === right.right &&
+    left.bottom === right.bottom &&
+    left.left === right.left &&
+    left.header === right.header &&
+    left.footer === right.footer
+  );
+}
+
+function optionalPageMarginsEqual(
+  left: PageMargins | undefined,
+  right: PageMargins | undefined,
+): boolean {
+  if (left === undefined || right === undefined) {
+    return left === right;
+  }
+  return pageMarginsEqual(left, right);
+}
+
 /**
  * Extract column layout from section properties.
  * Returns undefined for single-column (default) to avoid unnecessary paginator overhead.
@@ -2406,27 +2427,53 @@ export function PagedEditor(
           pageSize,
           warn: hfWarn,
         });
-        const effectiveMargins = extendForHfOverflow(margins);
-        const effectiveFirstPageMargins = hasTitlePg
+        let effectiveMargins = extendForHfOverflow(margins);
+        let effectiveFirstPageMargins = hasTitlePg
           ? extendForFirstPage(margins)
           : undefined;
-        // Section-break blocks carry their own `pageSize`/`margins` from
-        // `<w:sectPr>` and the layout engine prefers those over the
-        // body-level fallback. Extend each against its own resolved page
-        // so an overflowing footer never re-overlaps body text on the next
-        // section. (Eigenpal #400.)
-        extendSectionBreakMargins(
-          newBlocks.filter(
-            (block): block is SectionBreakBlock =>
-              block.kind === "sectionBreak",
-          ),
-          {
-            content: hfExtenderContent,
-            bodyPageSize: pageSize,
-            bodyMargins: effectiveMargins,
-            warn: hfWarn,
-          },
+        const sectionBreaks = newBlocks.filter(
+          (block): block is SectionBreakBlock => block.kind === "sectionBreak",
         );
+        const originalSectionBreakMargins = new Map<
+          SectionBreakBlock["id"],
+          PageMargins | undefined
+        >();
+        for (const sectionBreak of sectionBreaks) {
+          originalSectionBreakMargins.set(
+            sectionBreak.id,
+            sectionBreak.margins ? { ...sectionBreak.margins } : undefined,
+          );
+        }
+        const restoreSectionBreakMargins = (): void => {
+          for (const sectionBreak of sectionBreaks) {
+            const originalMargins = originalSectionBreakMargins.get(
+              sectionBreak.id,
+            );
+            if (originalMargins === undefined) {
+              delete sectionBreak.margins;
+              continue;
+            }
+            sectionBreak.margins = { ...originalMargins };
+          }
+        };
+        const applySectionBreakMargins = (
+          content: typeof hfExtenderContent,
+          bodyMargins: PageMargins,
+        ): void => {
+          restoreSectionBreakMargins();
+          // Section-break blocks carry their own `pageSize`/`margins` from
+          // `<w:sectPr>` and the layout engine prefers those over the
+          // body-level fallback. Extend each against its own resolved page
+          // so an overflowing footer never re-overlaps body text on the next
+          // section. (Eigenpal #400.)
+          extendSectionBreakMargins(sectionBreaks, {
+            content,
+            bodyPageSize: pageSize,
+            bodyMargins,
+            warn: hfWarn,
+          });
+        };
+        applySectionBreakMargins(hfExtenderContent, effectiveMargins);
         recordPhaseDuration("header-footer", phaseStartedAt);
 
         // Compute per-block widths + band geometry from the EFFECTIVE margins
@@ -2436,19 +2483,19 @@ export function PagedEditor(
         // raw margins would mis-place the reserved band when a tall header/footer
         // extends the margins. eigenpal #694.
         phaseStartedAt = performance.now();
-        const bodyLayoutConfig: SectionLayoutConfig = {
+        let bodyLayoutConfig: SectionLayoutConfig = {
           pageSize,
           margins: effectiveMargins,
         };
         if (columns !== undefined) {
           bodyLayoutConfig.columns = columns;
         }
-        const blockMeasureInputs = computePerBlockMeasureInputs({
+        let blockMeasureInputs = computePerBlockMeasureInputs({
           blocks: newBlocks,
           bodyConfig: bodyLayoutConfig,
           finalConfig: bodyLayoutConfig,
         });
-        const blockWidths = blockMeasureInputs.widths;
+        let blockWidths = blockMeasureInputs.widths;
         const incrementalResult =
           options.dirtyRange && !options.forceFull && layoutArtifactsRef.current
             ? tryBuildIncrementalMeasures({
@@ -2488,23 +2535,33 @@ export function PagedEditor(
           | "evenPage"
           | "oddPage"
           | undefined;
-        const layoutOpts: Parameters<typeof layoutDocument>[2] = {
-          pageSize,
-          margins: effectiveMargins,
-          pageGap,
+        const buildLayoutOpts = (
+          nextMargins: PageMargins,
+          nextFirstPageMargins: PageMargins | undefined,
+        ): Parameters<typeof layoutDocument>[2] => {
+          const nextLayoutOpts: Parameters<typeof layoutDocument>[2] = {
+            pageSize,
+            margins: nextMargins,
+            pageGap,
+          };
+          if (nextFirstPageMargins !== undefined) {
+            nextLayoutOpts.firstPageMargins = nextFirstPageMargins;
+          }
+          if (columns !== undefined) {
+            nextLayoutOpts.columns = columns;
+          }
+          if (bodyBreakType !== undefined) {
+            nextLayoutOpts.bodyBreakType = bodyBreakType;
+          }
+          if (sectionHeaderFooterRefs !== undefined) {
+            nextLayoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
+          }
+          return nextLayoutOpts;
         };
-        if (effectiveFirstPageMargins !== undefined) {
-          layoutOpts.firstPageMargins = effectiveFirstPageMargins;
-        }
-        if (columns !== undefined) {
-          layoutOpts.columns = columns;
-        }
-        if (bodyBreakType !== undefined) {
-          layoutOpts.bodyBreakType = bodyBreakType;
-        }
-        if (sectionHeaderFooterRefs !== undefined) {
-          layoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
-        }
+        const layoutOpts = buildLayoutOpts(
+          effectiveMargins,
+          effectiveFirstPageMargins,
+        );
         // The exact options the layout was produced with, reused if the field-
         // width stabilization pass re-lays-out below.
         let layoutOptsUsed: Parameters<typeof layoutDocument>[2] = layoutOpts;
@@ -2571,18 +2628,46 @@ export function PagedEditor(
           newLayout = layoutDocument(newBlocks, newMeasures, layoutOpts);
         }
 
-        // Field-width stabilization: fields were measured at their cached
-        // fallback text. Resolve them against this layout and, if a value's
-        // width differs, re-measure and re-lay-out so wrapping matches what the
-        // painter draws. PAGE/NUMPAGES depend on the layout they help produce,
-        // so a re-layout can shift pages and change values again — iterate to a
-        // fixed point with a small cap. Gated on a real change, so field-free
-        // documents and most edits do zero passes; skipped on the incremental
-        // (typing) path to keep keystrokes cheap.
-        if (!incrementalResult) {
+        const rebuildFootnotePageMap = (): void => {
+          pageFootnoteMap = new Map<number, number[]>();
+          for (const page of newLayout.pages) {
+            if (page.footnoteIds && page.footnoteIds.length > 0) {
+              pageFootnoteMap.set(page.number, page.footnoteIds);
+            }
+          }
+        };
+
+        const withFootnoteHeights = (
+          nextLayoutOpts: Parameters<typeof layoutDocument>[2],
+        ): Parameters<typeof layoutDocument>[2] => {
+          if (!hasFootnotes) {
+            return nextLayoutOpts;
+          }
+          const footnoteHeightById = new Map<number, number>();
+          for (const [id, content] of footnoteContentMap) {
+            footnoteHeightById.set(
+              id,
+              content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+            );
+          }
+          return { ...nextLayoutOpts, footnoteHeightById };
+        };
+
+        const relayoutWithCurrentMeasures = (
+          nextLayoutOpts: Parameters<typeof layoutDocument>[2],
+        ): void => {
+          layoutOptsUsed = withFootnoteHeights(nextLayoutOpts);
+          newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
+          if (hasFootnotes) {
+            rebuildFootnotePageMap();
+          }
+        };
+
+        const stabilizeFieldWidths = (): void => {
+          if (incrementalResult) {
+            return;
+          }
           const MAX_FIELD_STABILIZATION_PASSES = 3;
-          // One clock for all passes so a TIME field cannot tick between
-          // iterations and prevent convergence.
           const fieldClock = new Date();
           let previousFieldValues: Map<number, string> | null = null;
           for (let pass = 0; pass < MAX_FIELD_STABILIZATION_PASSES; pass++) {
@@ -2616,19 +2701,25 @@ export function PagedEditor(
               },
               values,
             );
-            newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
-            if (hasFootnotes) {
-              pageFootnoteMap = new Map<number, number[]>();
-              for (const page of newLayout.pages) {
-                if (page.footnoteIds && page.footnoteIds.length > 0) {
-                  pageFootnoteMap.set(page.number, page.footnoteIds);
-                }
-              }
-            }
-            layoutArtifactsRef.current.measures = newMeasures;
+            relayoutWithCurrentMeasures(layoutOptsUsed);
+            layoutArtifactsRef.current = {
+              blocks: newBlocks,
+              blockWidths,
+              measures: newMeasures,
+            };
             setMeasures(newMeasures);
           }
-        }
+        };
+
+        // Field-width stabilization: fields were measured at their cached
+        // fallback text. Resolve them against this layout and, if a value's
+        // width differs, re-measure and re-lay-out so wrapping matches what the
+        // painter draws. PAGE/NUMPAGES depend on the layout they help produce,
+        // so a re-layout can shift pages and change values again — iterate to a
+        // fixed point with a small cap. Gated on a real change, so field-free
+        // documents and most edits do zero passes; skipped on the incremental
+        // (typing) path to keep keystrokes cheap.
+        stabilizeFieldWidths();
 
         if (newLayout.pages.length !== hfPageCountEstimate) {
           const finalHfOptions = buildHfOptions(newLayout.pages.length);
@@ -2682,6 +2773,65 @@ export function PagedEditor(
             hfMetricsFooter,
             finalHfOptions,
           );
+          const finalHfExtenderContent = {
+            headerContent: headerContentForRender,
+            footerContent: footerContentForRender,
+            firstPageHeaderContent: firstPageHeaderForRender,
+            firstPageFooterContent: firstPageFooterForRender,
+          };
+          const finalEffectiveMargins = computeHeaderFooterMarginExtender({
+            ...finalHfExtenderContent,
+            pageSize,
+            warn: hfWarn,
+          })(margins);
+          const finalEffectiveFirstPageMargins = hasTitlePg
+            ? computeFirstPageHeaderFooterMarginExtender({
+                ...finalHfExtenderContent,
+                pageSize,
+                warn: hfWarn,
+              })(margins)
+            : undefined;
+
+          if (
+            !pageMarginsEqual(effectiveMargins, finalEffectiveMargins) ||
+            !optionalPageMarginsEqual(
+              effectiveFirstPageMargins,
+              finalEffectiveFirstPageMargins,
+            )
+          ) {
+            effectiveMargins = finalEffectiveMargins;
+            effectiveFirstPageMargins = finalEffectiveFirstPageMargins;
+            applySectionBreakMargins(finalHfExtenderContent, effectiveMargins);
+            bodyLayoutConfig = { pageSize, margins: effectiveMargins };
+            if (columns !== undefined) {
+              bodyLayoutConfig.columns = columns;
+            }
+            blockMeasureInputs = computePerBlockMeasureInputs({
+              blocks: newBlocks,
+              bodyConfig: bodyLayoutConfig,
+              finalConfig: bodyLayoutConfig,
+            });
+            blockWidths = blockMeasureInputs.widths;
+            newMeasures = measureBlocks(
+              newBlocks,
+              blockWidths,
+              blockMeasureInputs.marginTops,
+              {
+                pageHeight: blockMeasureInputs.pageHeights,
+                marginBottom: blockMeasureInputs.marginBottoms,
+              },
+            );
+            layoutArtifactsRef.current = {
+              blocks: newBlocks,
+              blockWidths,
+              measures: newMeasures,
+            };
+            setMeasures(newMeasures);
+            relayoutWithCurrentMeasures(
+              buildLayoutOpts(effectiveMargins, effectiveFirstPageMargins),
+            );
+            stabilizeFieldWidths();
+          }
         }
 
         setLayout(newLayout);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2299,33 +2299,32 @@ export function PagedEditor(
           margins,
         };
         // Header/footer blocks are measured once but painted on every page with
-        // a different page number. Reserve the widest page-number width (from
-        // the prior render's page count — headers are measured before the body
-        // re-lays-out) so a multi-digit page number can't wrap a near-full-width
-        // line differently than the single layout.
+        // a different page number. Measure with the prior render's page count
+        // first, then rebuild the prepared HF content with the final page count
+        // after body layout stabilizes so digit-boundary changes are reflected
+        // before paint.
         const hfPageCountEstimate = layout?.pages.length ?? 1;
         const hfClock = new Date();
-        const hfMeasureBlocks: MeasureBlocksFn = (hfBlocks, hfWidth) =>
-          measureBlocks(
-            hfBlocks,
-            hfWidth,
-            undefined,
-            undefined,
-            buildHeaderFooterFieldValues(
+        const buildHfOptions = (pageCount: number) => {
+          const hfMeasureBlocks: MeasureBlocksFn = (hfBlocks, hfWidth) =>
+            measureBlocks(
               hfBlocks,
-              hfPageCountEstimate,
-              hfClock,
-            ),
-          );
-        const hfOptions = {
-          ...(styles ? { styles } : {}),
-          ...(_theme !== undefined ? { theme: _theme } : {}),
-          measureBlocks: hfMeasureBlocks,
-          ...(defaultTabStop !== undefined
-            ? { defaultTabStopTwips: defaultTabStop }
-            : {}),
+              hfWidth,
+              undefined,
+              undefined,
+              buildHeaderFooterFieldValues(hfBlocks, pageCount, hfClock),
+            );
+          return {
+            ...(styles ? { styles } : {}),
+            ...(_theme !== undefined ? { theme: _theme } : {}),
+            measureBlocks: hfMeasureBlocks,
+            ...(defaultTabStop !== undefined
+              ? { defaultTabStopTwips: defaultTabStop }
+              : {}),
+          };
         };
-        const headerContentForRender = renderHfFromContentOrPm(
+        const hfOptions = buildHfOptions(hfPageCountEstimate);
+        let headerContentForRender = renderHfFromContentOrPm(
           headerContent,
           headerContentRId,
           hfPMsRef.current,
@@ -2333,7 +2332,7 @@ export function PagedEditor(
           hfMetricsHeader,
           hfOptions,
         );
-        const footerContentForRender = renderHfFromContentOrPm(
+        let footerContentForRender = renderHfFromContentOrPm(
           footerContent,
           footerContentRId,
           hfPMsRef.current,
@@ -2342,7 +2341,7 @@ export function PagedEditor(
           hfOptions,
         );
         const hasTitlePg = sectionProperties?.titlePg === true;
-        const firstPageHeaderForRender = hasTitlePg
+        let firstPageHeaderForRender = hasTitlePg
           ? renderHfFromContentOrPm(
               firstPageHeaderContent,
               firstPageHeaderContentRId,
@@ -2352,7 +2351,7 @@ export function PagedEditor(
               hfOptions,
             )
           : undefined;
-        const firstPageFooterForRender = hasTitlePg
+        let firstPageFooterForRender = hasTitlePg
           ? renderHfFromContentOrPm(
               firstPageFooterContent,
               firstPageFooterContentRId,
@@ -2362,14 +2361,14 @@ export function PagedEditor(
               hfOptions,
             )
           : undefined;
-        const headerContentByRId = renderHeaderFooterContentByRId(
+        let headerContentByRId = renderHeaderFooterContentByRId(
           document?.package.headers,
           hfPMsRef.current,
           contentWidth,
           hfMetricsHeader,
           hfOptions,
         );
-        const footerContentByRId = renderHeaderFooterContentByRId(
+        let footerContentByRId = renderHeaderFooterContentByRId(
           document?.package.footers,
           hfPMsRef.current,
           contentWidth,
@@ -2629,6 +2628,60 @@ export function PagedEditor(
             layoutArtifactsRef.current.measures = newMeasures;
             setMeasures(newMeasures);
           }
+        }
+
+        if (newLayout.pages.length !== hfPageCountEstimate) {
+          const finalHfOptions = buildHfOptions(newLayout.pages.length);
+          headerContentForRender = renderHfFromContentOrPm(
+            headerContent,
+            headerContentRId,
+            hfPMsRef.current,
+            contentWidth,
+            hfMetricsHeader,
+            finalHfOptions,
+          );
+          footerContentForRender = renderHfFromContentOrPm(
+            footerContent,
+            footerContentRId,
+            hfPMsRef.current,
+            contentWidth,
+            hfMetricsFooter,
+            finalHfOptions,
+          );
+          firstPageHeaderForRender = hasTitlePg
+            ? renderHfFromContentOrPm(
+                firstPageHeaderContent,
+                firstPageHeaderContentRId,
+                hfPMsRef.current,
+                contentWidth,
+                hfMetricsHeader,
+                finalHfOptions,
+              )
+            : undefined;
+          firstPageFooterForRender = hasTitlePg
+            ? renderHfFromContentOrPm(
+                firstPageFooterContent,
+                firstPageFooterContentRId,
+                hfPMsRef.current,
+                contentWidth,
+                hfMetricsFooter,
+                finalHfOptions,
+              )
+            : undefined;
+          headerContentByRId = renderHeaderFooterContentByRId(
+            document?.package.headers,
+            hfPMsRef.current,
+            contentWidth,
+            hfMetricsHeader,
+            finalHfOptions,
+          );
+          footerContentByRId = renderHeaderFooterContentByRId(
+            document?.package.footers,
+            hfPMsRef.current,
+            contentWidth,
+            hfMetricsFooter,
+            finalHfOptions,
+          );
         }
 
         setLayout(newLayout);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -38,6 +38,10 @@ import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterP
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
 import { buildBookmarkText } from "../core/fields/bookmarkText";
+import {
+  fieldValuesEqual,
+  resolveFieldValues,
+} from "../core/fields/resolveFieldValues";
 import { buildSectionPageCounts } from "../core/fields/sectionPageCounts";
 import { buildSeqValues } from "../core/fields/seqValues";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
@@ -2437,7 +2441,7 @@ export function PagedEditor(
                 measureBlock: measureSingleBlockWithoutFloatingZones,
               })
             : null;
-        const newMeasures =
+        let newMeasures =
           incrementalResult?.measures ??
           measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
             pageHeight: blockMeasureInputs.pageHeights,
@@ -2481,6 +2485,9 @@ export function PagedEditor(
         if (sectionHeaderFooterRefs !== undefined) {
           layoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
         }
+        // The exact options the layout was produced with, reused if the field-
+        // width stabilization pass re-lays-out below.
+        let layoutOptsUsed: Parameters<typeof layoutDocument>[2] = layoutOpts;
 
         if (hasFootnotes) {
           // Build footnote content and measure heights up front. The
@@ -2523,10 +2530,8 @@ export function PagedEditor(
           // fn-bearing page (in paginator.addFootnoteHeight); we pass per-fn
           // content plus any wrapper margin here.
 
-          newLayout = layoutDocument(newBlocks, newMeasures, {
-            ...layoutOpts,
-            footnoteHeightById,
-          });
+          layoutOptsUsed = { ...layoutOpts, footnoteHeightById };
+          newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
 
           // The layout engine assigned `page.footnoteIds` line-by-
           // line via `paginator.addFootnoteHeight(_, ids)`, so a fn
@@ -2544,6 +2549,62 @@ export function PagedEditor(
         } else {
           // No footnotes — single pass
           newLayout = layoutDocument(newBlocks, newMeasures, layoutOpts);
+        }
+
+        // Field-width stabilization: fields were measured at their cached
+        // fallback text. Resolve them against this layout and, if a value's
+        // width differs, re-measure and re-lay-out so wrapping matches what the
+        // painter draws. PAGE/NUMPAGES depend on the layout they help produce,
+        // so a re-layout can shift pages and change values again — iterate to a
+        // fixed point with a small cap. Gated on a real change, so field-free
+        // documents and most edits do zero passes; skipped on the incremental
+        // (typing) path to keep keystrokes cheap.
+        if (!incrementalResult) {
+          const MAX_FIELD_STABILIZATION_PASSES = 3;
+          let previousFieldValues: Map<number, string> | null = null;
+          for (let pass = 0; pass < MAX_FIELD_STABILIZATION_PASSES; pass++) {
+            const { values, changed } = resolveFieldValues(
+              newBlocks,
+              newLayout.pages,
+              {
+                totalPages: newLayout.pages.length,
+                bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
+                bookmarkText: buildBookmarkText(newBlocks),
+                seqValues: buildSeqValues(newBlocks),
+                sectionPageCounts: buildSectionPageCounts(newLayout.pages),
+                now: new Date(),
+              },
+            );
+            const settled =
+              previousFieldValues === null
+                ? !changed
+                : fieldValuesEqual(previousFieldValues, values);
+            if (settled) {
+              break;
+            }
+            previousFieldValues = values;
+            newMeasures = measureBlocks(
+              newBlocks,
+              blockWidths,
+              blockMeasureInputs.marginTops,
+              {
+                pageHeight: blockMeasureInputs.pageHeights,
+                marginBottom: blockMeasureInputs.marginBottoms,
+              },
+              values,
+            );
+            newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
+            if (hasFootnotes) {
+              pageFootnoteMap = new Map<number, number[]>();
+              for (const page of newLayout.pages) {
+                if (page.footnoteIds && page.footnoteIds.length > 0) {
+                  pageFootnoteMap.set(page.number, page.footnoteIds);
+                }
+              }
+            }
+            layoutArtifactsRef.current.measures = newMeasures;
+            setMeasures(newMeasures);
+          }
         }
 
         setLayout(newLayout);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -39,6 +39,7 @@ import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
 import { buildBookmarkText } from "../core/fields/bookmarkText";
 import {
+  buildHeaderFooterFieldValues,
   fieldValuesEqual,
   resolveFieldValues,
 } from "../core/fields/resolveFieldValues";
@@ -63,6 +64,7 @@ import {
   collectFootnoteRefs,
   buildFootnoteContentMap,
 } from "../core/layout-bridge/footnoteLayout";
+import type { MeasureBlocksFn } from "../core/layout-bridge/footnoteLayout";
 import {
   convertHeaderFooterPmDocToContent,
   convertHeaderFooterToContent,
@@ -2296,10 +2298,29 @@ export function PagedEditor(
           pageSize,
           margins,
         };
+        // Header/footer blocks are measured once but painted on every page with
+        // a different page number. Reserve the widest page-number width (from
+        // the prior render's page count — headers are measured before the body
+        // re-lays-out) so a multi-digit page number can't wrap a near-full-width
+        // line differently than the single layout.
+        const hfPageCountEstimate = layout?.pages.length ?? 1;
+        const hfClock = new Date();
+        const hfMeasureBlocks: MeasureBlocksFn = (hfBlocks, hfWidth) =>
+          measureBlocks(
+            hfBlocks,
+            hfWidth,
+            undefined,
+            undefined,
+            buildHeaderFooterFieldValues(
+              hfBlocks,
+              hfPageCountEstimate,
+              hfClock,
+            ),
+          );
         const hfOptions = {
           ...(styles ? { styles } : {}),
           ...(_theme !== undefined ? { theme: _theme } : {}),
-          measureBlocks,
+          measureBlocks: hfMeasureBlocks,
           ...(defaultTabStop !== undefined
             ? { defaultTabStopTwips: defaultTabStop }
             : {}),

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -37,6 +37,7 @@ import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
+import { buildSectionPageCounts } from "../core/fields/sectionPageCounts";
 import { buildSeqValues } from "../core/fields/seqValues";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
 import { clickToPositionDom } from "../core/layout-bridge/clickToPositionDom";
@@ -2643,6 +2644,10 @@ export function PagedEditor(
           if (seqValues.size > 0) {
             renderOpts.seqValues = seqValues;
           }
+          // Per-section page counts so SECTIONPAGES fields resolve.
+          renderOpts.sectionPageCounts = buildSectionPageCounts(
+            newLayout.pages,
+          );
           // Document watermark (rendered behind every page). Build a
           // per-header-rId map so titlePg / even-odd / per-section
           // header parts each paint their own watermark; the painter

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -36,6 +36,7 @@ import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import { getFootnoteText } from "../core/docx/footnoteParser";
+import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
 import { clickToPositionDom } from "../core/layout-bridge/clickToPositionDom";
 import {
@@ -2626,6 +2627,15 @@ export function PagedEditor(
           }
           if (footnotesByPage?.size) {
             renderOpts.footnotesByPage = footnotesByPage;
+          }
+          // Map bookmarks to the pages they land on so PAGEREF fields resolve
+          // to live page numbers at paint.
+          const bookmarkPages = buildBookmarkPageMap(
+            newLayout.pages,
+            newBlocks,
+          );
+          if (bookmarkPages.size > 0) {
+            renderOpts.bookmarkPages = bookmarkPages;
           }
           // Document watermark (rendered behind every page). Build a
           // per-header-rId map so titlePg / even-odd / per-section

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -43,6 +43,7 @@ import {
   fieldValuesEqual,
   resolveFieldValues,
 } from "../core/fields/resolveFieldValues";
+import type { HeaderFooterFieldInputs } from "../core/fields/resolveFieldValues";
 import { buildSectionPageCounts } from "../core/fields/sectionPageCounts";
 import { buildSeqValues } from "../core/fields/seqValues";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
@@ -2326,14 +2327,22 @@ export function PagedEditor(
         // before paint.
         const hfPageCountEstimate = layout?.pages.length ?? 1;
         const hfClock = new Date();
-        const buildHfOptions = (pageCount: number) => {
+        const buildHfOptions = (
+          pageCount: number,
+          fieldInputs?: HeaderFooterFieldInputs,
+        ) => {
           const hfMeasureBlocks: MeasureBlocksFn = (hfBlocks, hfWidth) =>
             measureBlocks(
               hfBlocks,
               hfWidth,
               undefined,
               undefined,
-              buildHeaderFooterFieldValues(hfBlocks, pageCount, hfClock),
+              buildHeaderFooterFieldValues(
+                hfBlocks,
+                pageCount,
+                hfClock,
+                fieldInputs,
+              ),
             );
           return {
             ...(styles ? { styles } : {}),
@@ -2721,8 +2730,16 @@ export function PagedEditor(
         // (typing) path to keep keystrokes cheap.
         stabilizeFieldWidths();
 
-        if (newLayout.pages.length !== hfPageCountEstimate) {
-          const finalHfOptions = buildHfOptions(newLayout.pages.length);
+        const rebuildHeaderFooterForLayout = (): typeof hfExtenderContent => {
+          const finalHfFieldInputs: HeaderFooterFieldInputs = {
+            bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
+            bookmarkText: buildBookmarkText(newBlocks),
+            seqValues: buildSeqValues(newBlocks),
+          };
+          const finalHfOptions = buildHfOptions(
+            newLayout.pages.length,
+            finalHfFieldInputs,
+          );
           headerContentForRender = renderHfFromContentOrPm(
             headerContent,
             headerContentRId,
@@ -2773,12 +2790,21 @@ export function PagedEditor(
             hfMetricsFooter,
             finalHfOptions,
           );
-          const finalHfExtenderContent = {
+          return {
             headerContent: headerContentForRender,
             footerContent: footerContentForRender,
             firstPageHeaderContent: firstPageHeaderForRender,
             firstPageFooterContent: firstPageFooterForRender,
           };
+        };
+
+        const MAX_HEADER_FOOTER_STABILIZATION_PASSES = 3;
+        for (
+          let pass = 0;
+          pass < MAX_HEADER_FOOTER_STABILIZATION_PASSES;
+          pass++
+        ) {
+          const finalHfExtenderContent = rebuildHeaderFooterForLayout();
           const finalEffectiveMargins = computeHeaderFooterMarginExtender({
             ...finalHfExtenderContent,
             pageSize,
@@ -2831,7 +2857,9 @@ export function PagedEditor(
               buildLayoutOpts(effectiveMargins, effectiveFirstPageMargins),
             );
             stabilizeFieldWidths();
+            continue;
           }
+          break;
         }
 
         setLayout(newLayout);

--- a/packages/folio/src/paged-editor/incrementalMeasure.test.ts
+++ b/packages/folio/src/paged-editor/incrementalMeasure.test.ts
@@ -164,6 +164,43 @@ describe("incremental paragraph measurement", () => {
 
     expect(result).toBeNull();
   });
+
+  test("bails out when a paragraph contains live fields", () => {
+    const previousBlocks = makeParagraphBlocks([{ text: "See page " }]);
+    const nextBlock = previousBlocks[0];
+    if (!nextBlock) {
+      throw new Error("Expected test block");
+    }
+    const nextBlocks: FlowBlock[] = [
+      {
+        ...nextBlock,
+        runs: [
+          ...nextBlock.runs,
+          {
+            kind: "field",
+            fieldType: "OTHER",
+            instruction: "PAGEREF _target",
+            fallback: "1",
+            pmStart: nextBlock.pmEnd - 1,
+            pmEnd: nextBlock.pmEnd,
+          },
+        ],
+      },
+    ];
+    const widths = [624];
+
+    const result = tryBuildIncrementalMeasures({
+      previousBlocks,
+      previousMeasures: previousBlocks.map(fakeMeasureBlock),
+      previousBlockWidths: widths,
+      nextBlocks,
+      nextBlockWidths: widths,
+      dirtyRange: { from: 0, to: 10 },
+      measureBlock: fakeMeasureBlock,
+    });
+
+    expect(result).toBeNull();
+  });
 });
 
 function normalizeDirtyRange(range: DirtyRange): DirtyRange {


### PR DESCRIPTION
Makes folio's dynamic DOCX fields compute live values instead of painting only
their cached fallback text. Plan: `.agents/plans/044-folio-field-toc-auto-update.md`.

Stacked on #683 (depends on the extracted `measureBlocks` and the deterministic
harness from that PR); based on its branch so the diff here is field/TOC only.
Retarget to `main` once #683 merges.

## What resolves live now
- **PAGE / NUMPAGES / SECTIONPAGES** with numeric-format switches (`\* ROMAN` etc.)
- **PAGEREF** -> the bookmark's live page; **REF** -> the bookmark's text
- **SEQ** -> document-order caption numbers (per identifier, `\r`/`\c`, table cells)
- **DATE/TIME-family** honoring the `\@` date picture (not `\*`)
- **TOC** -> `generateTOC` entries get live page numbers with dot leaders

## How
- A layer-neutral `core/fields/` module: a pure `evaluateField` + `FieldContext`,
  and pure builders (`buildBookmarkPageMap`, `buildBookmarkText`, `buildSeqValues`,
  `buildSectionPageCounts`, `resolveFieldValues`). All unit-tested.
- `FieldRun` carries the field `instruction`; the painter resolves every field
  through one `resolveFieldText`. The resolution maps are threaded
  driver -> render options -> `RenderContext`.
- **Measure/paint agreement**: `measureBlocks` accepts a `fieldValues` map
  (bypassing the paragraph measure cache); the layout driver runs a gated,
  capped (3) iterate-to-stable loop (resolve -> re-measure -> re-layout,
  converging via `fieldValuesEqual`, one shared clock). Gated so field-free docs
  and the incremental typing path do zero extra passes.
- Header/footer fields (laid out once, painted per page) reserve the widest
  page-number width so a multi-digit page number can't wrap a near-full-width
  line differently than the single layout.

## Tests
Pure builders + evaluator are unit-tested; `generateTOC` is driven through the
extension manager and asserted to produce entries whose PAGEREF targets a real
heading bookmark. Full folio suite green.

## Reviewed
Self-reviewed (adversarial pass over the diff). Caught and fixed a regression:
`DATE \* MERGEFORMAT` was formatting the literal "MERGEFORMAT" into garbage; date
fields now honor `\@` only.