### PR TITLE
refactor(api): constrain safe-handler success payloads

### DIFF
--- a/apps/api/src/handlers/chat/delete-thread.ts
+++ b/apps/api/src/handlers/chat/delete-thread.ts
@@ -58,7 +58,7 @@ const deleteThread = createSafeRootHandler(
     );
 
     if (!thread) {
-      return Result.ok();
+      return Result.ok({});
     }
 
     const files = yield* Result.await(
@@ -143,7 +143,7 @@ const deleteThread = createSafeRootHandler(
       }, defaultDatabaseRetry),
     );
 
-    return Result.ok();
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/clauses/categories.ts
+++ b/apps/api/src/handlers/clauses/categories.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
@@ -160,6 +160,10 @@ export const createCategoryHandler = async function* ({
     }),
   );
 
+  if (!inserted) {
+    panic("Failed to create clause category");
+  }
+
   return Result.ok(inserted);
 };
 
@@ -284,6 +288,10 @@ export const updateCategoryHandler = async function* ({
     }),
   );
 
+  if (!updated) {
+    panic("Failed to update clause category");
+  }
+
   return Result.ok(updated);
 };
 
@@ -362,5 +370,5 @@ export const deleteCategoryHandler = async function* ({
     }),
   );
 
-  return Result.ok(undefined);
+  return Result.ok({});
 };

--- a/apps/api/src/handlers/clauses/create.ts
+++ b/apps/api/src/handlers/clauses/create.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { eq } from "drizzle-orm";
 import { t } from "elysia";
 
@@ -154,6 +154,10 @@ const createClauseHandler = async function* ({
   );
   if (Result.isError(searchVectorResult)) {
     captureError(searchVectorResult.error, { clauseId });
+  }
+
+  if (!inserted) {
+    panic("Failed to create clause");
   }
 
   return Result.ok(inserted);

--- a/apps/api/src/handlers/clauses/delete.ts
+++ b/apps/api/src/handlers/clauses/delete.ts
@@ -88,7 +88,7 @@ const deleteClauseHandler = async function* ({
     }),
   );
 
-  return Result.ok(undefined);
+  return Result.ok({});
 };
 
 const config = {

--- a/apps/api/src/handlers/clauses/template-links.ts
+++ b/apps/api/src/handlers/clauses/template-links.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { and, eq, sql } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
@@ -346,7 +347,7 @@ export const unlinkClauseHandler = async ({
     });
   });
 
-  return undefined;
+  return {};
 };
 
 // ── Sync to latest version ──────────────────────────
@@ -464,6 +465,10 @@ export const syncClauseHandler = async ({
 
     return row;
   });
+
+  if (!updated) {
+    panic("Failed to sync template clause link");
+  }
 
   return updated;
 };

--- a/apps/api/src/handlers/clauses/update.ts
+++ b/apps/api/src/handlers/clauses/update.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
@@ -221,6 +221,10 @@ const updateClauseHandler = async function* ({
     if (Result.isError(searchVectorResult)) {
       captureError(searchVectorResult.error, { clauseId });
     }
+  }
+
+  if (!updated) {
+    panic("Failed to update clause");
   }
 
   return Result.ok(updated);

--- a/apps/api/src/handlers/clauses/variants.ts
+++ b/apps/api/src/handlers/clauses/variants.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
@@ -189,6 +189,10 @@ export const createVariantHandler = async function* ({
     }),
   );
 
+  if (!inserted) {
+    panic("Failed to create clause variant");
+  }
+
   return Result.ok(inserted);
 };
 
@@ -291,6 +295,10 @@ export const updateVariantHandler = async function* ({
     }),
   );
 
+  if (!updated) {
+    panic("Failed to update clause variant");
+  }
+
   return Result.ok(updated);
 };
 
@@ -371,5 +379,5 @@ export const deleteVariantHandler = async function* ({
     }),
   );
 
-  return Result.ok(undefined);
+  return Result.ok({});
 };

--- a/apps/api/src/handlers/contacts/delete-by-id.ts
+++ b/apps/api/src/handlers/contacts/delete-by-id.ts
@@ -127,7 +127,7 @@ const deleteContactById = createSafeRootHandler(
       captureError,
     );
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -170,7 +170,7 @@ const deleteEntitiesHandler = async function* ({
     provider.removeEntity(entity.id).catch(captureError);
   }
 
-  return Result.ok(undefined);
+  return Result.ok({});
 };
 
 const config = {

--- a/apps/api/src/handlers/entities/move.ts
+++ b/apps/api/src/handlers/entities/move.ts
@@ -188,7 +188,7 @@ const moveEntityHandler = async function* ({
 
   syncWorkspaceSearchActivity(workspaceId).catch(captureError);
 
-  return Result.ok(undefined);
+  return Result.ok({});
 };
 
 /**

--- a/apps/api/src/handlers/fields/upsert-by-id.ts
+++ b/apps/api/src/handlers/fields/upsert-by-id.ts
@@ -295,7 +295,7 @@ const upsertField = createSafeHandler(
     }
 
     reindex();
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/properties/delete-by-id.ts
+++ b/apps/api/src/handlers/properties/delete-by-id.ts
@@ -119,7 +119,7 @@ const deleteProperty = createSafeHandler(
       );
     }
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/properties/update-by-id.ts
+++ b/apps/api/src/handlers/properties/update-by-id.ts
@@ -339,7 +339,7 @@ const updateProperty = createSafeHandler(
       );
     }
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/templates/categories.ts
+++ b/apps/api/src/handlers/templates/categories.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { and, eq, sql } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
@@ -130,18 +131,20 @@ export const createTemplateCategoryHandler = async ({
         createdAt: templateCategories.createdAt,
       });
 
-    if (inserted) {
-      await recordAuditEvent(tx, {
-        action: AUDIT_ACTION.CREATE,
-        resourceType: AUDIT_RESOURCE_TYPE.TEMPLATE,
-        resourceId: inserted.id,
-        metadata: {
-          kind: "template-category",
-          name: inserted.name,
-          parentId: inserted.parentId,
-        },
-      });
+    if (!inserted) {
+      panic("Failed to create template category");
     }
+
+    await recordAuditEvent(tx, {
+      action: AUDIT_ACTION.CREATE,
+      resourceType: AUDIT_RESOURCE_TYPE.TEMPLATE,
+      resourceId: inserted.id,
+      metadata: {
+        kind: "template-category",
+        name: inserted.name,
+        parentId: inserted.parentId,
+      },
+    });
 
     return inserted;
   });
@@ -227,7 +230,7 @@ export const updateTemplateCategoryHandler = async ({
     updatedAt: new Date(),
   };
 
-  const [updated] = await scopedDb(async (tx) => {
+  const updatedRows = await scopedDb(async (tx) => {
     const rows = await tx
       .update(templateCategories)
       .set(updates)
@@ -260,6 +263,11 @@ export const updateTemplateCategoryHandler = async ({
 
     return rows;
   });
+
+  const updated = updatedRows.at(0);
+  if (!updated) {
+    panic("Failed to update template category");
+  }
 
   return updated;
 };
@@ -327,5 +335,5 @@ export const deleteTemplateCategoryHandler = async ({
     });
   });
 
-  return undefined;
+  return {};
 };

--- a/apps/api/src/handlers/templates/create.ts
+++ b/apps/api/src/handlers/templates/create.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import { eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 
@@ -270,7 +270,12 @@ const createTemplateHandler = async function* ({
     );
   }
 
-  return Result.ok(txResult.row);
+  const row = txResult.row;
+  if (!row) {
+    panic("Failed to create template");
+  }
+
+  return Result.ok(row);
 };
 
 const config = {

--- a/apps/api/src/handlers/templates/delete.ts
+++ b/apps/api/src/handlers/templates/delete.ts
@@ -94,7 +94,7 @@ const deleteTemplateHandler = async function* ({
     getS3().delete(key).catch(captureError);
   }
 
-  return Result.ok(undefined);
+  return Result.ok({});
 };
 
 const config = {

--- a/apps/api/src/handlers/templates/update.ts
+++ b/apps/api/src/handlers/templates/update.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import { and, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
@@ -229,7 +229,12 @@ const updateTemplateHandler = async function* ({
       );
     }
 
-    return Result.ok(txResult.row);
+    const row = txResult.row;
+    if (!row) {
+      panic("Failed to update template");
+    }
+
+    return Result.ok(row);
   }
 
   const updated = yield* Result.await(
@@ -269,6 +274,10 @@ const updateTemplateHandler = async function* ({
       return row;
     }),
   );
+
+  if (!updated) {
+    panic("Failed to update template");
+  }
 
   return Result.ok(updated);
 };

--- a/apps/api/src/handlers/usage/get-entitlement.ts
+++ b/apps/api/src/handlers/usage/get-entitlement.ts
@@ -47,7 +47,7 @@ const getEntitlement = createSafeRootHandler(
 
         const entitlement = rows.at(0);
         if (!entitlement) {
-          return null;
+          return { entitlement: null } as const;
         }
 
         const remainingUsageUnits = await getRemainingUsageUnits({

--- a/apps/api/src/handlers/view-templates/delete.ts
+++ b/apps/api/src/handlers/view-templates/delete.ts
@@ -56,7 +56,7 @@ const deleteViewTemplate = createSafeHandler(
       }),
     );
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/views/delete.ts
+++ b/apps/api/src/handlers/views/delete.ts
@@ -100,7 +100,7 @@ const deleteView = createSafeHandler(
       data: ["views", workspaceId],
     });
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/views/reorder.ts
+++ b/apps/api/src/handlers/views/reorder.ts
@@ -105,7 +105,7 @@ const reorderViews = createSafeHandler(
       data: ["views", workspaceId],
     });
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/views/update.ts
+++ b/apps/api/src/handlers/views/update.ts
@@ -92,7 +92,7 @@ const updateView = createSafeHandler(
     }
 
     if (Object.keys(updates).length === 0) {
-      return Result.ok(undefined);
+      return Result.ok({});
     }
 
     const updateResult = yield* Result.await(
@@ -165,7 +165,7 @@ const updateView = createSafeHandler(
       data: ["views", workspaceId],
     });
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/workspaces/delete-by-id.ts
+++ b/apps/api/src/handlers/workspaces/delete-by-id.ts
@@ -274,7 +274,7 @@ const deleteWorkspace = createSafeHandler(
       );
     }
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/workspaces/update-active.ts
+++ b/apps/api/src/handlers/workspaces/update-active.ts
@@ -29,7 +29,7 @@ const updateActiveWorkspace = createSafeHandler(
       }),
     );
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/workspaces/update-by-id.ts
+++ b/apps/api/src/handlers/workspaces/update-by-id.ts
@@ -308,7 +308,7 @@ const updateWorkspace = createSafeHandler(
 
     upsertWorkspaceSearchDocument(workspaceId).catch(captureError);
 
-    return Result.ok(undefined);
+    return Result.ok({});
   },
 );
 

--- a/apps/api/src/handlers/workspaces/workspace-contacts-create.ts
+++ b/apps/api/src/handlers/workspaces/workspace-contacts-create.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import { eq } from "drizzle-orm";
 import { t } from "elysia";
 
@@ -132,7 +132,12 @@ const createWorkspaceContact = createSafeHandler(
 
     upsertWorkspaceSearchDocument(workspaceId).catch(captureError);
 
-    return Result.ok(txResult.value.created);
+    const created = txResult.value.created;
+    if (!created) {
+      panic("Failed to create workspace contact");
+    }
+
+    return Result.ok(created);
   },
 );
 

--- a/apps/api/src/handlers/workspaces/workspace-members-add.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-add.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import { eq } from "drizzle-orm";
 import { t } from "elysia";
 
@@ -130,7 +130,11 @@ const addWorkspaceMember = createSafeHandler(
       );
     }
 
-    const [created] = txResult.value.rows;
+    const created = txResult.value.rows.at(0);
+    if (!created) {
+      panic("Failed to add workspace member");
+    }
+
     return Result.ok(created);
   },
 );

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -170,11 +170,22 @@ type SafeStatusResponse<TStatusCode extends HandlerErrorStatusCode> =
     ? ElysiaCustomStatusResponse<TStatusCode, SafeErrorBody>
     : never;
 
+/**
+ * Success payloads must be non-nullish, including every union member.
+ * Elysia serializes a bare `null`/`undefined` return as a 200 with an
+ * empty body, which Eden parses as `""` on the client — so a payload
+ * typed `T | null` arrives as `T | ""` at runtime and breaks optional
+ * chaining one property deep. Model absence as a field instead
+ * (`{ entitlement: null }`, `{ items: [] }`); void mutations return a
+ * minimal object such as `{}`.
+ */
+type SafeHandlerPayload = NonNullable<unknown>;
+
 type SafeHandlerResult<TResult> =
   | TResult
   | SafeStatusResponse<HandlerErrorStatusCode>;
 
-type SafeHandlerFn<TContext, TResult> = (
+type SafeHandlerFn<TContext, TResult extends SafeHandlerPayload> = (
   ctx: TContext,
 ) => AsyncGenerator<
   Err<never, SafeHandlerError>,
@@ -185,7 +196,7 @@ type SafeHandlerFn<TContext, TResult> = (
 type SafeHandlerDefinition<
   TConfig extends InputSchema = InputSchema,
   TContext = Context<UnwrapRoute<TConfig>>,
-  TResult = unknown,
+  TResult extends SafeHandlerPayload = SafeHandlerPayload,
 > = {
   config: TConfig;
   handler: (ctx: TContext) => Promise<SafeHandlerResult<TResult>>;
@@ -214,7 +225,10 @@ type SafeHandlerLogContext = {
   route: string;
 };
 
-const runSafeHandler = async <TContext extends SafeHandlerLogContext, TResult>(
+const runSafeHandler = async <
+  TContext extends SafeHandlerLogContext,
+  TResult extends SafeHandlerPayload,
+>(
   ctx: TContext,
   handler: SafeHandlerFn<TContext, TResult>,
 ): Promise<SafeHandlerResult<TResult>> => {
@@ -308,7 +322,7 @@ const runSafeHandler = async <TContext extends SafeHandlerLogContext, TResult>(
 const createSafeScopedHandler = <
   TConfig extends HandlerConfig,
   TContext extends BaseHandlerContext<TConfig>,
-  TResult,
+  TResult extends SafeHandlerPayload,
 >(
   config: TConfig,
   handler: SafeHandlerFn<TContext, TResult>,
@@ -442,7 +456,7 @@ const runUsagePreflight = async ({
 const createSafeDirectHandler = <
   TConfig extends InputSchema,
   TContext extends SafeHandlerLogContext,
-  TResult,
+  TResult extends SafeHandlerPayload,
 >(
   config: TConfig,
   handler: SafeHandlerFn<TContext, TResult>,
@@ -457,13 +471,19 @@ const safeErrorBody = (error: HandlerError): SafeErrorBody => ({
   message: error.message,
 });
 
-export const createSafeRootHandler = <TConfig extends HandlerConfig, TResult>(
+export const createSafeRootHandler = <
+  TConfig extends HandlerConfig,
+  TResult extends SafeHandlerPayload,
+>(
   config: TConfig,
   handler: SafeHandlerFn<RootHandlerContext<TConfig>, TResult>,
 ): SafeHandlerDefinition<TConfig, RootHandlerContext<TConfig>, TResult> =>
   createSafeScopedHandler(config, handler);
 
-export const createSafeHandler = <TConfig extends HandlerConfig, TResult>(
+export const createSafeHandler = <
+  TConfig extends HandlerConfig,
+  TResult extends SafeHandlerPayload,
+>(
   config: TConfig,
   handler: SafeHandlerFn<WorkspaceHandlerContext<TConfig>, TResult>,
 ): SafeHandlerDefinition<TConfig, WorkspaceHandlerContext<TConfig>, TResult> =>
@@ -471,7 +491,7 @@ export const createSafeHandler = <TConfig extends HandlerConfig, TResult>(
 
 export const createSafeSessionHandler = <
   TConfig extends SessionHandlerConfig,
-  TResult,
+  TResult extends SafeHandlerPayload,
 >(
   config: TConfig,
   handler: SafeHandlerFn<SessionHandlerContext<TConfig>, TResult>,
@@ -494,7 +514,7 @@ type TokenHandlerContext<
  */
 export const createSafeTokenHandler = <
   TConfig extends TokenHandlerConfig,
-  TResult,
+  TResult extends SafeHandlerPayload,
 >(
   config: TConfig,
   handler: SafeHandlerFn<TokenHandlerContext<TConfig>, TResult>,
@@ -514,7 +534,7 @@ type PublicHandlerContext<
  */
 export const createSafePublicHandler = <
   TConfig extends PublicHandlerConfig,
-  TResult,
+  TResult extends SafeHandlerPayload,
 >(
   config: TConfig,
   handler: SafeHandlerFn<PublicHandlerContext<TConfig>, TResult>,

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -172,7 +172,8 @@ export const ChatThreadPage = ({
     enabled: canManageOrganization,
   });
   const usageLimit = useUsageLimit({
-    hasHostedEntitlement: usageEntitlementData?.entitlement.source === "hosted",
+    hasHostedEntitlement:
+      usageEntitlementData?.entitlement?.source === "hosted",
   });
   const handleUsageLimit = usageLimit.handle;
   // Fire only on the *transition* into a new error. Without this,

--- a/apps/web/src/routes/_protected.settings/-queries/usage.ts
+++ b/apps/web/src/routes/_protected.settings/-queries/usage.ts
@@ -18,12 +18,15 @@ export const usageEntitlementKeys = {
 
 type UsageEntitlementOptionsInput = QueryOptionsInput<UsageEntitlementKey>;
 
-/** Returns the org's active usage entitlement state, or null when absent. */
+/** The org's usage entitlement state; `{ entitlement: null }` when absent. */
 export type UsageEntitlementResponse = NonNullable<
   Awaited<ReturnType<typeof api.usage.entitlement.get>>["data"]
-> | null;
+>;
 
-export type UsageEntitlement = NonNullable<UsageEntitlementResponse>;
+export type UsageEntitlement = Exclude<
+  UsageEntitlementResponse,
+  { entitlement: null }
+>;
 
 const fetchUsageEntitlement = async ({
   signal,

--- a/apps/web/src/routes/_protected.settings/organization.usage.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.usage.tsx
@@ -36,7 +36,7 @@ function UsageSettingsPage() {
         description={t("settings.organization.usageDescription")}
         title={t("settings.organization.usage")}
       />
-      <UsageBody data={data ?? null} isLoading={isLoading} />
+      <UsageBody data={data?.entitlement ? data : null} isLoading={isLoading} />
     </>
   );
 }


### PR DESCRIPTION
Tightens the safe-handler factories so success payloads must be non-nullish, including union members. Elysia serializes a bare `null`/`undefined` return as a 200 with an empty body, which Eden parses as `""` on the client, so the declared payload type and the runtime value can disagree; constraining `TResult` at the factory seam keeps the two aligned by construction.

Mechanical follow-through across handlers: void mutations now return `{}`, rows from `INSERT/UPDATE ... RETURNING` are unwrapped with `panic()` (presence is a structural invariant), and nullable reads return an explicit envelope (`{ entitlement: null }`) with the web consumers updated to match.