### PR TITLE
fix(ci): harden staging deploy (attest retry, pinned turbo in pruner stages)

### DIFF
--- a/.github/actions/provenance/action.yml
+++ b/.github/actions/provenance/action.yml
@@ -1,0 +1,33 @@
+name: Attest image provenance
+description: >
+  Attest build provenance for an image digest and push the attestation to the
+  registry. Sigstore endpoints can time out transiently, so a failed attempt is
+  retried once before failing the job.
+
+inputs:
+  subject-name:
+    description: Fully qualified image name (registry/repository)
+    required: true
+  subject-digest:
+    description: Image digest (sha256:...) to attest
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Attest
+      id: attest
+      continue-on-error: true
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with:
+        subject-name: ${{ inputs.subject-name }}
+        subject-digest: ${{ inputs.subject-digest }}
+        push-to-registry: true
+
+    - name: Attest (retry)
+      if: steps.attest.outcome == 'failure'
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with:
+        subject-name: ${{ inputs.subject-name }}
+        subject-digest: ${{ inputs.subject-digest }}
+        push-to-registry: true

--- a/.github/actions/provenance/action.yml
+++ b/.github/actions/provenance/action.yml
@@ -24,6 +24,11 @@ runs:
         subject-digest: ${{ inputs.subject-digest }}
         push-to-registry: true
 
+    - name: Wait before retry
+      if: steps.attest.outcome == 'failure'
+      shell: bash
+      run: sleep 10
+
     - name: Attest (retry)
       if: steps.attest.outcome == 'failure'
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -74,11 +74,10 @@ jobs:
             STELLA_COMMIT_SHA=${{ github.sha }}
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: ./.github/actions/provenance
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
 
       - name: Mint App token for the infra repo
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,11 +278,10 @@ jobs:
             STELLA_COMMIT_SHA=${{ needs.resolve.outputs.release_sha }}
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: ./.github/actions/provenance
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
 
   build-amd64:
     name: Build API image (linux/amd64)
@@ -331,11 +330,10 @@ jobs:
             STELLA_COMMIT_SHA=${{ needs.resolve.outputs.release_sha }}
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: ./.github/actions/provenance
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
 
   manifest:
     name: Assemble multi-arch manifest and GitHub release
@@ -386,11 +384,10 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Attest release image index provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: ./.github/actions/provenance
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.manifest.outputs.digest }}
-          push-to-registry: true
 
       - name: Create release manifest
         env:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 
 # Prune the monorepo for the API
 FROM base AS pruner
-RUN bun install -g turbo@^2
+# Keep in sync with the turbo version in the root package.json; an unpinned
+# major lets a new turbo release change `turbo prune` lockfile output mid-flight.
+RUN bun install -g turbo@2.9.16
 COPY . .
 RUN turbo prune @stll/api --docker
 

--- a/apps/legal-atlas-runner/Dockerfile
+++ b/apps/legal-atlas-runner/Dockerfile
@@ -3,7 +3,9 @@ FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f
 WORKDIR /app
 
 FROM base AS pruner
-RUN bun install -g turbo@^2
+# Keep in sync with the turbo version in the root package.json; an unpinned
+# major lets a new turbo release change `turbo prune` lockfile output mid-flight.
+RUN bun install -g turbo@2.9.16
 COPY . .
 RUN turbo prune @stll/legal-atlas-runner --docker
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,7 +3,9 @@ FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f
 WORKDIR /app
 
 FROM base AS pruner
-RUN bun install -g turbo@^2
+# Keep in sync with the turbo version in the root package.json; an unpinned
+# major lets a new turbo release change `turbo prune` lockfile output mid-flight.
+RUN bun install -g turbo@2.9.16
 COPY . .
 RUN turbo prune @stll/web --docker
 


### PR DESCRIPTION
Two independent fixes for failure modes in the image build/deploy workflows.

## Attestation retry

`actions/attest-build-provenance` talks to Sigstore endpoints that can time out transiently, failing an otherwise healthy deploy before the promote step runs. The attest step now lives in a local composite action (`.github/actions/provenance`) that retries once before failing the job; the pinned upstream action SHA is owned in one place. All four call sites (staging deploy, both release arch builds, release index) use it.

## Pin turbo in Docker pruner stages

The pruner stages installed `turbo@^2`, so image builds resolved whatever the latest turbo 2.x was at build time, independent of the version pinned in the root `package.json`. turbo 2.9.17 changes `turbo prune --docker` bun.lock output such that `bun install --frozen-lockfile` fails in the pruned workspace (`error: lockfile had changes, but lockfile is frozen`). Pin the global install to the workspace version (2.9.16) in all three Dockerfiles; verified locally that 2.9.16 prunes a lockfile that passes the frozen install at current main.