### PR TITLE
fix(e2e): accept the AI-key gate in the staging smoke

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -24,5 +24,5 @@ test("chat thread page renders for an entitlement-less owner", async ({
   // of the composer. Either state proves the route rendered.
   const composer = page.getByRole("textbox", { name: /type your question/iu });
   const aiKeyGate = page.getByText("Connect AI provider");
-  await expect(composer.or(aiKeyGate).first()).toBeVisible();
+  await expect(composer.or(aiKeyGate)).toBeVisible();
 });

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -18,7 +18,11 @@ test("chat thread page renders for an entitlement-less owner", async ({
   // The route error boundary replaces the thread UI wholesale; its
   // title is the canonical signature of a client-side render crash.
   await expect(page.getByText("Something went wrong")).toBeHidden();
-  await expect(
-    page.getByRole("textbox", { name: /type your question/iu }),
-  ).toBeVisible();
+
+  // The smoke org has no AI provider credentials, so RequireAIKey
+  // legitimately gates the thread with "Connect AI provider" instead
+  // of the composer. Either state proves the route rendered.
+  const composer = page.getByRole("textbox", { name: /type your question/iu });
+  const aiKeyGate = page.getByText("Connect AI provider");
+  await expect(composer.or(aiKeyGate).first()).toBeVisible();
 });


### PR DESCRIPTION
The synthetic-monitoring org has no AI provider credentials, so `RequireAIKey` replaces the chat thread UI with the connect-provider card. The post-deploy check now accepts either the composer or that card; both prove the route rendered, and the error-boundary assertion still guards against render crashes.