### PR TITLE
fix(api): give bbox structured output an object root

### DIFF
--- a/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
+++ b/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
@@ -1,5 +1,5 @@
 import { generateText, Output } from "ai";
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 
 import { getModelForRole } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
@@ -13,6 +13,21 @@ import {
 } from "@/api/lib/bbox/ai-prompts";
 import type { SafeId } from "@/api/lib/branded-types";
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
+
+// `bboxItemSchema` already validated `v.length(4)`; this only narrows
+// the static type from `number[]` to the 4-tuple without a cast.
+const toBBoxTuple = (item: number[]): [number, number, number, number] => {
+  const [yMin, xMin, yMax, xMax] = item;
+  if (
+    yMin === undefined ||
+    xMin === undefined ||
+    yMax === undefined ||
+    xMax === undefined
+  ) {
+    panic("BBox element passed length validation but has missing values");
+  }
+  return [yMin, xMin, yMax, xMax];
+};
 
 type GenerateBBoxDataProps = {
   pdfData: Uint8Array;
@@ -108,7 +123,7 @@ export const generateBBoxData = async ({
   });
 
   if (Result.isError(generated)) {
-    return generated;
+    return Result.err(generated.error);
   }
   // Previously enforced by `v.nonEmpty()` on the array schema;
   // `Output.array` validates per element, so the emptiness invariant
@@ -120,5 +135,5 @@ export const generateBBoxData = async ({
     aiAnalytics.captureError(error);
     return Result.err(error);
   }
-  return generated;
+  return Result.ok(generated.value.map(toBBoxTuple));
 };

--- a/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
+++ b/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
@@ -6,8 +6,9 @@ import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { strictOutputSchema } from "@/api/lib/ai-output-schema";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import {
+  BBOX_ARRAY_DESCRIPTION,
   BBOX_SYSTEM_PROMPT,
-  bboxSchema,
+  bboxItemSchema,
   buildBBoxUserMessage,
 } from "@/api/lib/bbox/ai-prompts";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -56,7 +57,7 @@ export const generateBBoxData = async ({
     traceId: Bun.randomUUIDv7(),
   });
 
-  return await Result.tryPromise({
+  const generated = await Result.tryPromise({
     try: async () => {
       const result = await generateText({
         model: getModelForRole("pdf", orgAIConfig, {
@@ -86,7 +87,10 @@ export const generateBBoxData = async ({
             ],
           },
         ],
-        output: Output.object({ schema: strictOutputSchema(bboxSchema) }),
+        output: Output.array({
+          element: strictOutputSchema(bboxItemSchema),
+          description: BBOX_ARRAY_DESCRIPTION,
+        }),
         abortSignal,
         ...aiAnalytics.stepCallbacks,
       });
@@ -102,4 +106,19 @@ export const generateBBoxData = async ({
       });
     },
   });
+
+  if (Result.isError(generated)) {
+    return generated;
+  }
+  // Previously enforced by `v.nonEmpty()` on the array schema;
+  // `Output.array` validates per element, so the emptiness invariant
+  // moves here.
+  if (generated.value.length === 0) {
+    const error = new WorkflowIntegrationError({
+      message: "BBox AI generation returned no bounding boxes",
+    });
+    aiAnalytics.captureError(error);
+    return Result.err(error);
+  }
+  return generated;
 };

--- a/apps/api/src/lib/bbox/ai-prompts.ts
+++ b/apps/api/src/lib/bbox/ai-prompts.ts
@@ -32,8 +32,14 @@ const context = {
 // object root, which OpenAI's strict response format requires (a
 // top-level array schema is rejected). Emptiness is checked by the
 // caller; `Output.array` carries no array-level constraints.
+//
+// A length-4 array, not `v.tuple`: tuples convert to the array form
+// of `items`, which OpenAI strict mode rejects; `v.length(4)`
+// converts to `minItems`/`maxItems`, which it accepts. The caller
+// narrows validated elements back to the 4-tuple.
 export const bboxItemSchema = v.pipe(
-  v.tuple([v.number(), v.number(), v.number(), v.number()]),
+  v.array(v.number()),
+  v.length(4),
   v.description(context.bBoxItem.description),
   v.examples(context.bBoxItem.examples),
 );

--- a/apps/api/src/lib/bbox/ai-prompts.ts
+++ b/apps/api/src/lib/bbox/ai-prompts.ts
@@ -28,17 +28,17 @@ const context = {
 
 // --------------- Schema ---------------
 
-export const bboxSchema = v.pipe(
-  v.array(
-    v.pipe(
-      v.tuple([v.number(), v.number(), v.number(), v.number()]),
-      v.description(context.bBoxItem.description),
-      v.examples(context.bBoxItem.examples),
-    ),
-  ),
-  v.nonEmpty(),
-  v.description(context.bBoxArray.description),
+// Element schema for `Output.array`: the SDK wraps the elements in an
+// object root, which OpenAI's strict response format requires (a
+// top-level array schema is rejected). Emptiness is checked by the
+// caller; `Output.array` carries no array-level constraints.
+export const bboxItemSchema = v.pipe(
+  v.tuple([v.number(), v.number(), v.number(), v.number()]),
+  v.description(context.bBoxItem.description),
+  v.examples(context.bBoxItem.examples),
 );
+
+export const BBOX_ARRAY_DESCRIPTION = context.bBoxArray.description;
 
 // --------------- User message templates ---------------
 


### PR DESCRIPTION
## Summary

Follow-up to #692. `generateBBoxData` passed a top-level array schema to `Output.object`; OpenAI's strict response format rejects that independently of `additionalProperties` (the root must be an object), so the bbox path would 400 whenever the `pdf` role routes to OpenAI or an OpenAI-compatible provider.

- Switch to `Output.array` with the bbox tuple as the element schema: the SDK wraps elements in a strict object root (`{ elements: [...] }`) uniformly across providers and unwraps `result.output` back to the array, so the caller contract is unchanged.
- The array-level `v.nonEmpty()` invariant moves to an explicit check in `generateBBoxData` (same `WorkflowIntegrationError` path, telemetry capture preserved), since `Output.array` validates per element only.
- The array description moves to `Output.array`'s `description` option; the element schema keeps its description/examples.