### PR TITLE
fix(ci): make staging provenance attestation non-blocking

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -73,7 +73,14 @@ jobs:
             STELLA_VERSION=${{ steps.ref.outputs.release_ref }}
             STELLA_COMMIT_SHA=${{ github.sha }}
 
+      # Best-effort on staging: the provenance action already retries
+      # transient Sigstore blips, but a sustained Rekor outage must not
+      # wedge continuous deploys (the image is built and pushed; only
+      # the transparency-log attestation is unavailable). The step still
+      # surfaces as failed in the UI. Production keeps attestation
+      # blocking in release.yml.
       - name: Attest image provenance
+        continue-on-error: true
         uses: ./.github/actions/provenance
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
A sustained Sigstore/Rekor outage returns 404 on every `attest-build-provenance` attempt (the retry in `.github/actions/provenance` covers transient blips but not an outage). Because the step runs before the promote dispatch, that wedged all staging deploys even though the image built and pushed cleanly.

Mark the staging attestation `continue-on-error` so continuous deploys proceed when the transparency log is unavailable; the step still shows as failed in the UI for visibility. Production attestation in `release.yml` stays blocking.