### PR TITLE
fix(e2e): disambiguate the staging smoke AI-gate locator

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -23,10 +23,11 @@ test("chat thread page renders for an entitlement-less owner", async ({
   // legitimately gates the thread with the connect-provider card
   // instead of the composer. Either state proves the route rendered.
   // The gate renders its heading twice (inline card plus an
-  // auto-opened dialog), so first() collapses that duplicate; it
-  // cannot mask a composer-vs-gate bug because those states are
-  // mutually exclusive.
+  // auto-opened dialog), so first() scopes to that locator only; the
+  // composer keeps strict matching so a stray second composer fails.
   const composer = page.getByRole("textbox", { name: /type your question/iu });
-  const aiKeyGate = page.getByRole("heading", { name: "Connect AI provider" });
-  await expect(composer.or(aiKeyGate).first()).toBeVisible();
+  const aiKeyGate = page
+    .getByRole("heading", { name: "Connect AI provider" })
+    .first();
+  await expect(composer.or(aiKeyGate)).toBeVisible();
 });

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -20,9 +20,13 @@ test("chat thread page renders for an entitlement-less owner", async ({
   await expect(page.getByText("Something went wrong")).toBeHidden();
 
   // The smoke org has no AI provider credentials, so RequireAIKey
-  // legitimately gates the thread with "Connect AI provider" instead
-  // of the composer. Either state proves the route rendered.
+  // legitimately gates the thread with the connect-provider card
+  // instead of the composer. Either state proves the route rendered.
+  // The gate renders its heading twice (inline card plus an
+  // auto-opened dialog), so first() collapses that duplicate; it
+  // cannot mask a composer-vs-gate bug because those states are
+  // mutually exclusive.
   const composer = page.getByRole("textbox", { name: /type your question/iu });
-  const aiKeyGate = page.getByText("Connect AI provider");
-  await expect(composer.or(aiKeyGate)).toBeVisible();
+  const aiKeyGate = page.getByRole("heading", { name: "Connect AI provider" });
+  await expect(composer.or(aiKeyGate).first()).toBeVisible();
 });


### PR DESCRIPTION
The connect-provider gate renders its heading in two places — the inline card and an auto-opened dialog — so the bare `getByText("Connect AI provider")` matched two elements and tripped Playwright strict mode in the post-deploy smoke.

Scope to the heading role and `first()` the composer-or-gate locator. `first()` only collapses the gate's duplicated heading; it cannot mask a composer-vs-gate bug because those states are mutually exclusive. Verified against live staging: the chat route renders without the error boundary, and the locator resolves in both the composer and gate states.