### PR TITLE
fix(e2e): gate staging smoke on the deployed revision

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -193,6 +193,9 @@ jobs:
           E2E_WEB_URL: https://staging.stll.app
           E2E_API_URL: https://api-staging.stll.app
           SMOKE_SESSION_SECRET: ${{ secrets.SMOKE_SESSION_SECRET }}
+          # Block the smoke until staging actually serves this commit,
+          # so it doesn't race the ECS task rollover.
+          EXPECTED_COMMIT: ${{ github.sha }}
 
       - name: Upload Playwright report
         if: failure()

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -11,42 +11,55 @@ type SmokeSession = {
 
 const API_URL = process.env["E2E_API_URL"] ?? "https://api-staging.stll.app";
 
-const READINESS_ATTEMPTS = 60;
-const READINESS_INTERVAL_MS = 5_000;
+const READINESS_TIMEOUT_MS = 300_000;
+const READINESS_INTERVAL_MS = 5000;
+// Require several consecutive expected-commit samples before proceeding:
+// during rollover the ALB serves old and new tasks side by side, so a
+// single new-commit hit does not mean later browser traffic avoids the
+// draining task. Consecutive matches signal the old task has drained.
+const READINESS_STABLE_SAMPLES = 3;
 
-const sleep = (ms: number) =>
-  new Promise((resolve) => {
+const sleep = async (ms: number) =>
+  await new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
 
-// Block until the deployed revision is actually serving. verify-staging
+// Block until the deployed revision is stably serving. verify-staging
 // fires the moment the promote returns, while ECS is still rolling the
 // new task in; requests in that window hang or reset and the old task
-// keeps answering with the previous commit. Polling /health until it
-// reports the expected commit removes that race (and any request errors
-// during rollover are just retried). With no expected commit (local
-// runs) a single 200 is enough.
+// keeps answering with the previous commit, which renders a blank page.
+// Time-bounded so a hanging endpoint can't exceed the budget; request
+// errors during rollover reset the streak. With no expected commit
+// (local runs) any healthy 200 counts.
 const waitForDeployedRevision = async (): Promise<void> => {
   const expectedCommit = process.env["EXPECTED_COMMIT"];
-  for (let attempt = 0; attempt < READINESS_ATTEMPTS; attempt++) {
+  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+  let consecutive = 0;
+
+  while (Date.now() < deadline) {
+    let healthy = false;
     try {
       const response = await fetch(`${API_URL}/health`, {
         signal: AbortSignal.timeout(10_000),
       });
       if (response.ok) {
         const { commit } = (await response.json()) as { commit?: string };
-        if (!expectedCommit || commit === expectedCommit) {
-          return;
-        }
+        healthy = !expectedCommit || commit === expectedCommit;
       }
     } catch {
-      // Connection reset/timeout during rollover; fall through to retry.
+      // Connection reset/timeout during rollover; treated as not-ready.
+    }
+
+    consecutive = healthy ? consecutive + 1 : 0;
+    if (consecutive >= READINESS_STABLE_SAMPLES) {
+      return;
     }
     await sleep(READINESS_INTERVAL_MS);
   }
+
   throw new Error(
-    `Staging did not serve ${expectedCommit ?? "a healthy revision"} within ` +
-      `${(READINESS_ATTEMPTS * READINESS_INTERVAL_MS) / 1000}s`,
+    `Staging did not stably serve ${expectedCommit ?? "a healthy revision"} ` +
+      `within ${READINESS_TIMEOUT_MS / 1000}s`,
   );
 };
 

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -10,6 +10,7 @@ type SmokeSession = {
 };
 
 const API_URL = process.env["E2E_API_URL"] ?? "https://api-staging.stll.app";
+const WEB_URL = process.env["E2E_WEB_URL"] ?? "https://staging.stll.app";
 
 const READINESS_TIMEOUT_MS = 300_000;
 const READINESS_INTERVAL_MS = 5000;
@@ -24,33 +25,72 @@ const sleep = async (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-// Block until the deployed revision is stably serving. verify-staging
-// fires the moment the promote returns, while ECS is still rolling the
-// new task in; requests in that window hang or reset and the old task
-// keeps answering with the previous commit, which renders a blank page.
-// Time-bounded so a hanging endpoint can't exceed the budget; request
-// errors during rollover reset the streak. With no expected commit
-// (local runs) any healthy 200 counts.
+type Origin = {
+  label: string;
+  // Returns true when this origin is serving the expected revision.
+  // The web origin's version.json may be absent on the revision being
+  // replaced (it predates this marker), so a missing marker counts as
+  // ready: the API gate covers the dominant rollover race regardless.
+  isReady: (expectedCommit: string | undefined) => Promise<boolean>;
+};
+
+const fetchCommit = async (url: string): Promise<string | null | undefined> => {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      return undefined;
+    }
+    const { commit } = (await response.json()) as { commit?: string };
+    return commit;
+  } catch {
+    // Connection reset/timeout during rollover; treated as not-ready.
+    return undefined;
+  }
+};
+
+const ORIGINS: Origin[] = [
+  {
+    label: "api",
+    isReady: async (expectedCommit) => {
+      const commit = await fetchCommit(`${API_URL}/health`);
+      if (commit === undefined) {
+        return false;
+      }
+      return !expectedCommit || commit === expectedCommit;
+    },
+  },
+  {
+    label: "web",
+    isReady: async (expectedCommit) => {
+      const commit = await fetchCommit(`${WEB_URL}/version.json`);
+      if (commit === undefined) {
+        return false;
+      }
+      return !expectedCommit || commit === null || commit === expectedCommit;
+    },
+  },
+];
+
+// Block until both the API and the web origin stably serve the deployed
+// revision. verify-staging fires the moment the promote returns, while
+// ECS is still rolling the new task in and the CDN may still front the
+// previous bundle; requests in that window render a blank page. Time-
+// bounded so a hanging endpoint can't exceed the budget; any non-ready
+// sample on either origin resets the streak. With no expected commit
+// (local runs) any healthy response counts.
 const waitForDeployedRevision = async (): Promise<void> => {
   const expectedCommit = process.env["EXPECTED_COMMIT"];
   const deadline = Date.now() + READINESS_TIMEOUT_MS;
   let consecutive = 0;
 
   while (Date.now() < deadline) {
-    let healthy = false;
-    try {
-      const response = await fetch(`${API_URL}/health`, {
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (response.ok) {
-        const { commit } = (await response.json()) as { commit?: string };
-        healthy = !expectedCommit || commit === expectedCommit;
-      }
-    } catch {
-      // Connection reset/timeout during rollover; treated as not-ready.
-    }
-
-    consecutive = healthy ? consecutive + 1 : 0;
+    const readiness = await Promise.all(
+      ORIGINS.map(async (origin) => await origin.isReady(expectedCommit)),
+    );
+    consecutive = readiness.every(Boolean) ? consecutive + 1 : 0;
     if (consecutive >= READINESS_STABLE_SAMPLES) {
       return;
     }

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -11,11 +11,52 @@ type SmokeSession = {
 
 const API_URL = process.env["E2E_API_URL"] ?? "https://api-staging.stll.app";
 
+const READINESS_ATTEMPTS = 60;
+const READINESS_INTERVAL_MS = 5_000;
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// Block until the deployed revision is actually serving. verify-staging
+// fires the moment the promote returns, while ECS is still rolling the
+// new task in; requests in that window hang or reset and the old task
+// keeps answering with the previous commit. Polling /health until it
+// reports the expected commit removes that race (and any request errors
+// during rollover are just retried). With no expected commit (local
+// runs) a single 200 is enough.
+const waitForDeployedRevision = async (): Promise<void> => {
+  const expectedCommit = process.env["EXPECTED_COMMIT"];
+  for (let attempt = 0; attempt < READINESS_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(`${API_URL}/health`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (response.ok) {
+        const { commit } = (await response.json()) as { commit?: string };
+        if (!expectedCommit || commit === expectedCommit) {
+          return;
+        }
+      }
+    } catch {
+      // Connection reset/timeout during rollover; fall through to retry.
+    }
+    await sleep(READINESS_INTERVAL_MS);
+  }
+  throw new Error(
+    `Staging did not serve ${expectedCommit ?? "a healthy revision"} within ` +
+      `${(READINESS_ATTEMPTS * READINESS_INTERVAL_MS) / 1000}s`,
+  );
+};
+
 const globalSetup = async (): Promise<void> => {
   const secret = process.env["SMOKE_SESSION_SECRET"];
   if (!secret) {
     throw new Error("SMOKE_SESSION_SECRET is required for the staging smoke");
   }
+
+  await waitForDeployedRevision();
 
   const response = await fetch(`${API_URL}/smoke/session`, {
     method: "POST",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { visualizer } from "rollup-plugin-visualizer";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const APP_ROOT = import.meta.dirname;
 const ANALYZE_MODE = "analyze";
@@ -33,6 +33,23 @@ const readCommitSha = () => {
 };
 
 const APP_COMMIT_SHA = readCommitSha();
+
+// Emit a served version marker so deploy tooling can confirm which
+// frontend revision a CDN origin is actually serving (the commit is
+// otherwise only baked into the hashed JS bundles).
+const versionManifestPlugin = (): Plugin => ({
+  name: "stella-version-manifest",
+  generateBundle() {
+    this.emitFile({
+      type: "asset",
+      fileName: "version.json",
+      source: JSON.stringify({
+        commit: APP_COMMIT_SHA,
+        version: APP_VERSION,
+      }),
+    });
+  },
+});
 
 export default defineConfig(({ mode }) => {
   const shouldAnalyze = mode === ANALYZE_MODE || process.env["ANALYZE"] === "1";
@@ -162,6 +179,7 @@ export default defineConfig(({ mode }) => {
       ],
     },
     plugins: [
+      versionManifestPlugin(),
       devtools({ consolePiping: { enabled: false } }),
       tailwindcss(),
       tanstackStart({


### PR DESCRIPTION
The post-deploy smoke ran the instant the promote returned, racing the ECS task rollover: the first requests hung or hit the draining old task, so `RequireAIKey` stayed in its pending state and rendered a blank page (neither composer nor gate). The spec and locator were correct — verified by running the suite locally against live staging, where it passes in ~1.5s.

`global-setup` now polls `/health` until it reports the expected commit (`EXPECTED_COMMIT`, wired to `github.sha`) before minting the session, tolerating the connection resets that occur during rollover. Local runs without `EXPECTED_COMMIT` accept any healthy 200. Verified against live staging in both modes.