### PR TITLE
fix(desktop): make startup and the local bridge more resilient

### DIFF
--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -7,7 +7,11 @@ use axum::{
 };
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
+
+const BIND_RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const BIND_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
 use crate::session_manager::SessionManager;
 use crate::types::{
@@ -264,16 +268,26 @@ pub async fn start_bridge(
   let addr = std::net::SocketAddr::from(([127, 0, 0, 1], bridge_port));
   tracing::info!(port = bridge_port, "HTTP bridge starting");
 
-  let listener = match tokio::net::TcpListener::bind(addr).await {
-    Ok(l) => l,
-    Err(e) => {
-      tracing::error!(error = %e, "failed to bind bridge port");
-      return;
+  // The bridge is the primary handoff transport while the app runs, so a
+  // transiently occupied port must not disable it for the whole app
+  // lifetime: keep retrying with capped backoff.
+  let mut backoff = BIND_RETRY_INITIAL_BACKOFF;
+  loop {
+    match tokio::net::TcpListener::bind(addr).await {
+      Ok(listener) => {
+        backoff = BIND_RETRY_INITIAL_BACKOFF;
+        tracing::info!(port = bridge_port, "HTTP bridge listening");
+        if let Err(e) = axum::serve(listener, app.clone()).await {
+          tracing::error!(error = %e, "bridge server error");
+        }
+      }
+      Err(e) => {
+        tracing::warn!(error = %e, port = bridge_port, "failed to bind bridge port, retrying");
+      }
     }
-  };
 
-  if let Err(e) = axum::serve(listener, app).await {
-    tracing::error!(error = %e, "bridge server error");
+    tokio::time::sleep(backoff).await;
+    backoff = (backoff * 2).min(BIND_RETRY_MAX_BACKOFF);
   }
 }
 

--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
-const BIND_RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-const BIND_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(30);
-
 use crate::session_manager::SessionManager;
 use crate::types::{
   is_safe_session_id, OpenDocxRequest, BRIDGE_CAPABILITIES, BRIDGE_VERSION,
 };
+
+const BIND_RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const BIND_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct BridgeState {

--- a/apps/desktop/src-tauri/src/keychain.rs
+++ b/apps/desktop/src-tauri/src/keychain.rs
@@ -113,6 +113,30 @@ pub fn get_token(session_id: &str) -> Option<String> {
   }
 }
 
+/// Retrieve a session token without letting a blocked keychain call wedge the
+/// caller. Platform keychain reads can stall on user authorization (e.g. when
+/// the binary changed and the OS re-prompts); the read runs on a blocking
+/// thread and is abandoned after `timeout` so callers holding the session
+/// manager lock stay responsive.
+pub async fn get_token_with_timeout(
+  session_id: &str,
+  timeout: std::time::Duration,
+) -> Option<String> {
+  let id = session_id.to_string();
+  let read = tokio::task::spawn_blocking(move || get_token(&id));
+  match tokio::time::timeout(timeout, read).await {
+    Ok(Ok(token)) => token,
+    Ok(Err(e)) => {
+      tracing::warn!(session_id, error = %e, "keychain read task failed");
+      None
+    }
+    Err(_) => {
+      tracing::warn!(session_id, "keychain read timed out");
+      None
+    }
+  }
+}
+
 /// Delete a session token from the OS keychain.
 /// Silently succeeds if the entry does not exist.
 pub fn delete_token(session_id: &str) {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -66,37 +66,34 @@ pub fn run() {
     .setup(move |app| {
       let handle = app.handle().clone();
 
-      // Set app handle on session manager and restore sessions
+      // Restore sessions and build the initial tray menu off the main thread.
+      // Session restore reads the OS keychain, which can block on user
+      // authorization; the event loop is not running yet, so blocking setup
+      // makes macOS report the app as not responding. The guard is acquired
+      // synchronously here so every other manager consumer (bridge, deep
+      // links, tray actions) queues behind the restore instead of racing it.
       {
         let manager = Arc::clone(&manager);
+        let mut mgr = Arc::clone(&manager)
+          .try_lock_owned()
+          .expect("session manager is uncontended during setup");
         let handle = handle.clone();
-        tauri::async_runtime::block_on(async {
-          let session_ids = {
-            let mut mgr = manager.lock().await;
-            mgr.set_app_handle(handle);
-            mgr.initialize().await;
-            mgr.session_ids_needing_watchers()
-          };
+        tauri::async_runtime::spawn(async move {
+          mgr.set_app_handle(handle.clone());
+          mgr.initialize().await;
+          let session_ids = mgr.session_ids_needing_watchers();
+          drop(mgr);
 
           // Attach file watchers and SSE listeners outside the lock
           for sid in &session_ids {
             SessionManager::attach_watcher(&manager, sid).await;
           }
-          {
-            let mut mgr = manager.lock().await;
-            for sid in &session_ids {
-              mgr.ensure_sse_listener(&manager, sid);
-            }
-          }
-        });
-      }
 
-      // Build initial tray menu
-      {
-        let manager = Arc::clone(&manager);
-        let handle = handle.clone();
-        tauri::async_runtime::block_on(async {
-          let mgr = manager.lock().await;
+          let mut mgr = manager.lock().await;
+          for sid in &session_ids {
+            mgr.ensure_sse_listener(&manager, sid);
+          }
+
           let snapshot = mgr.get_snapshot();
           if let Ok(menu) = tray::build_tray_menu(&handle, &snapshot) {
             if let Some(tray) = handle.tray_by_id("main") {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -74,11 +74,18 @@ pub fn run() {
       // links, tray actions) queues behind the restore instead of racing it.
       {
         let manager = Arc::clone(&manager);
-        let mut mgr = Arc::clone(&manager)
-          .try_lock_owned()
-          .expect("session manager is uncontended during setup");
+        // A second-instance notification can race this lock on Windows and
+        // Linux, so fall back to awaiting instead of panicking.
+        let setup_guard = Arc::clone(&manager).try_lock_owned();
         let handle = handle.clone();
         tauri::async_runtime::spawn(async move {
+          let mut mgr = match setup_guard {
+            Ok(guard) => guard,
+            Err(_) => {
+              tracing::warn!("session manager contended during setup");
+              Arc::clone(&manager).lock_owned().await
+            }
+          };
           mgr.set_app_handle(handle.clone());
           mgr.initialize().await;
           let session_ids = mgr.session_ids_needing_watchers();

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -55,6 +55,7 @@ const CHECKPOINT_DEBOUNCE: Duration = Duration::from_millis(1200);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(20);
 const REMOTE_SAVE_TIMEOUT: Duration = Duration::from_secs(60);
 const RETRY_INTERVAL: Duration = Duration::from_secs(15);
+const KEYCHAIN_RESTORE_TIMEOUT: Duration = Duration::from_secs(10);
 const OPEN_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const CLOSED_RECHECK_COUNT: u8 = 5;
 const TAKEN_OVER_CODE: &str = "desktop_edit_session_taken_over";
@@ -387,8 +388,15 @@ impl SessionManager {
         continue;
       }
 
-      // Token lives in OS keychain; skip sessions without one
-      let session_token = match crate::keychain::get_token(&persisted.id) {
+      // Token lives in OS keychain; skip sessions without one. The timeout
+      // keeps a stalled keychain (pending authorization prompt) from holding
+      // the session manager lock indefinitely during startup.
+      let session_token = match crate::keychain::get_token_with_timeout(
+        &persisted.id,
+        KEYCHAIN_RESTORE_TIMEOUT,
+      )
+      .await
+      {
         Some(t) => t,
         None => {
           tracing::warn!(


### PR DESCRIPTION
Hardening for the desktop companion's startup path and local HTTP bridge.

- Session restore (and the initial tray menu build) now runs as a spawned task instead of `block_on` inside Tauri setup, so slow I/O during restore can no longer stall the main thread before the event loop starts. The session manager lock is acquired synchronously in setup, so all other consumers (bridge, deep links, tray actions) still queue behind the restore; if the lock is contended (second-instance notification racing setup on Windows/Linux), the task awaits it instead of panicking.
- Keychain token reads during restore run on a blocking thread with a 10s timeout. Platform keychain calls can block on user authorization; a stalled read now degrades to the existing missing-token path (session skipped with a warning) instead of holding the session manager lock indefinitely.
- The bridge retries binding its loopback port with capped backoff (1s to 30s) instead of giving up after one failed bind, so a transiently occupied port no longer disables the bridge for the entire app lifetime.

No behavior change on the happy path; `cargo fmt`, `clippy`, and the crate tests pass.