### PR TITLE
feat(mcp): CIMD client registration and bearer fallback for external connectors

### DIFF
--- a/apps/api/src/handlers/mcp-connectors/connect.ts
+++ b/apps/api/src/handlers/mcp-connectors/connect.ts
@@ -12,13 +12,17 @@ import {
 import { encryptMcpSecret } from "@/api/handlers/mcp-connectors/crypto";
 import {
   buildAuthorizeUrl,
+  buildMcpClientMetadataDocument,
+  clientRegistrationMode,
   createOAuthState,
   createPkce,
   discoverOAuthMetadata,
+  getMcpClientMetadataDocumentUrl,
   getMcpOAuthRedirectUri,
   pickRequestedScopes,
   registerOAuthClient,
 } from "@/api/handlers/mcp-connectors/oauth";
+import type { McpClientRegistrationMode } from "@/api/handlers/mcp-connectors/oauth";
 import { redactMcpOAuthRegistrationResponse } from "@/api/handlers/mcp-connectors/oauth-registration-response";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -114,6 +118,20 @@ const connectMcpConnector = createSafeRootHandler(
     }
 
     const metadata = yield* Result.await(discoverOAuthMetadata(connector.url));
+
+    // Servers that advertise OAuth but offer no client registration path
+    // (neither CIMD nor dynamic registration) cannot complete stella's
+    // OAuth flow; a pre-issued static token is the only way to connect.
+    const registrationMode = clientRegistrationMode(
+      metadata.authorizationServer,
+    );
+    if (registrationMode === "unsupported") {
+      return Result.ok<ConnectMcpConnectorResult>({
+        type: "bearer",
+        requiresToken: true,
+      });
+    }
+
     const redirectUri = getMcpOAuthRedirectUri();
     const requestedScopes = pickRequestedScopes({
       connectorScopes: connector.oauthRequestedScopes,
@@ -127,6 +145,7 @@ const connectMcpConnector = createSafeRootHandler(
         organizationId: session.activeOrganizationId,
         redirectUri,
         authorizationServer: metadata.authorizationServer,
+        registrationMode,
         requestedScopes,
       }),
     );
@@ -223,15 +242,7 @@ const loadConnector = async ({
   return Result.ok(connector);
 };
 
-const ensureOAuthClient = async ({
-  authorizationServer,
-  connectorId,
-  connectorSlug,
-  organizationId,
-  redirectUri,
-  requestedScopes,
-  safeDb,
-}: {
+type EnsureOAuthClientOptions = {
   authorizationServer: Parameters<
     typeof registerOAuthClient
   >[0]["authorizationServer"];
@@ -239,9 +250,21 @@ const ensureOAuthClient = async ({
   connectorSlug: string;
   organizationId: NonNullable<typeof mcpConnectors.$inferSelect.organizationId>;
   redirectUri: string;
+  registrationMode: Exclude<McpClientRegistrationMode, "unsupported">;
   requestedScopes: string[];
   safeDb: SafeDb;
-}): Promise<
+};
+
+const ensureOAuthClient = async ({
+  authorizationServer,
+  connectorId,
+  connectorSlug,
+  organizationId,
+  redirectUri,
+  registrationMode,
+  requestedScopes,
+  safeDb,
+}: EnsureOAuthClientOptions): Promise<
   Result<
     { clientId: string; clientSecret: string | null },
     HandlerError<502> | SafeDbError
@@ -272,14 +295,25 @@ const ensureOAuthClient = async ({
       });
     }
 
-    const registered = yield* Result.await(
-      registerOAuthClient({
-        authorizationServer,
-        connectorSlug,
-        redirectUri,
-        requestedScopes,
-      }),
-    );
+    // CIMD: the document URL is the client_id; the authorization server
+    // fetches the metadata itself, so no registration round-trip happens.
+    const registered =
+      registrationMode === "cimd"
+        ? {
+            clientId: getMcpClientMetadataDocumentUrl(),
+            clientSecret: null,
+            registrationResponse: redactMcpOAuthRegistrationResponse(
+              buildMcpClientMetadataDocument(),
+            ),
+          }
+        : yield* Result.await(
+            registerOAuthClient({
+              authorizationServer,
+              connectorSlug,
+              redirectUri,
+              requestedScopes,
+            }),
+          );
     const encryptedSecret = registered.clientSecret
       ? await encryptMcpSecret({
           connectorId,

--- a/apps/api/src/handlers/mcp-connectors/connect.ts
+++ b/apps/api/src/handlers/mcp-connectors/connect.ts
@@ -302,9 +302,7 @@ const ensureOAuthClient = async ({
         ? {
             clientId: getMcpClientMetadataDocumentUrl(),
             clientSecret: null,
-            registrationResponse: redactMcpOAuthRegistrationResponse(
-              buildMcpClientMetadataDocument(),
-            ),
+            registrationResponse: buildMcpClientMetadataDocument(),
           }
         : yield* Result.await(
             registerOAuthClient({

--- a/apps/api/src/handlers/mcp-connectors/create-connection.ts
+++ b/apps/api/src/handlers/mcp-connectors/create-connection.ts
@@ -4,6 +4,10 @@ import { t } from "elysia";
 
 import { mcpConnectors, mcpUserConnections } from "@/api/db/schema";
 import { encryptMcpSecret } from "@/api/handlers/mcp-connectors/crypto";
+import {
+  clientRegistrationMode,
+  discoverOAuthMetadata,
+} from "@/api/handlers/mcp-connectors/oauth";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
@@ -28,6 +32,7 @@ const createMcpConnection = createSafeRootHandler(
           .select({
             id: mcpConnectors.id,
             authType: mcpConnectors.authType,
+            url: mcpConnectors.url,
           })
           .from(mcpConnectors)
           .where(
@@ -50,14 +55,12 @@ const createMcpConnection = createSafeRootHandler(
       );
     }
 
-    if (connector.authType !== "bearer") {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "MCP connector does not accept a static token",
-        }),
-      );
-    }
+    yield* Result.await(
+      assertStaticTokenAccepted({
+        authType: connector.authType,
+        url: connector.url,
+      }),
+    );
 
     const encrypted = await encryptMcpSecret({
       connectorId: connector.id,
@@ -137,3 +140,44 @@ const createMcpConnection = createSafeRootHandler(
 );
 
 export default createMcpConnection;
+
+const staticTokenRejected = () =>
+  Result.err(
+    new HandlerError({
+      status: 400,
+      message: "MCP connector does not accept a static token",
+    }),
+  );
+
+// OAuth connectors normally must not bypass the consent flow with a
+// pasted token. The exception is an authorization server with no client
+// registration path (neither CIMD nor dynamic registration): stella
+// cannot obtain a client_id there, so a pre-issued static token is the
+// only way to connect. Re-checked here at the boundary instead of
+// trusting state the connect endpoint derived earlier.
+const assertStaticTokenAccepted = async ({
+  authType,
+  url,
+}: {
+  authType: typeof mcpConnectors.$inferSelect.authType;
+  url: string;
+}): Promise<Result<void, HandlerError<400>>> => {
+  if (authType === "bearer") {
+    return Result.ok(undefined);
+  }
+  if (authType !== "oauth2") {
+    return staticTokenRejected();
+  }
+
+  const metadata = await discoverOAuthMetadata(url);
+  if (Result.isError(metadata)) {
+    return staticTokenRejected();
+  }
+  if (
+    clientRegistrationMode(metadata.value.authorizationServer) !== "unsupported"
+  ) {
+    return staticTokenRejected();
+  }
+
+  return Result.ok(undefined);
+};

--- a/apps/api/src/handlers/mcp-connectors/oauth-client-metadata-route.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth-client-metadata-route.ts
@@ -1,0 +1,14 @@
+import Elysia from "elysia";
+
+import { buildMcpClientMetadataDocument } from "@/api/handlers/mcp-connectors/oauth";
+
+// OAuth Client ID Metadata Document (draft-ietf-oauth-client-id-metadata-
+// document): external MCP authorization servers fetch this URL to resolve
+// stella's client metadata, so the route must stay public (no auth macro).
+export const mcpOAuthClientMetadataRoute = new Elysia({ prefix: "/mcp" }).get(
+  "/oauth/client-metadata.json",
+  ({ set }) => {
+    set.headers["cache-control"] = "public, max-age=3600";
+    return buildMcpClientMetadataDocument();
+  },
+);

--- a/apps/api/src/handlers/mcp-connectors/oauth.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth.test.ts
@@ -1,6 +1,75 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  buildMcpClientMetadataDocument,
+  clientRegistrationMode,
+  getMcpClientMetadataDocumentUrl,
+  getMcpOAuthRedirectUri,
+} from "@/api/handlers/mcp-connectors/oauth";
+import type { AuthorizationServerMetadata } from "@/api/handlers/mcp-connectors/oauth";
 import { redactMcpOAuthRegistrationResponse } from "@/api/handlers/mcp-connectors/oauth-registration-response";
+
+const authorizationServer = (
+  overrides: Partial<AuthorizationServerMetadata>,
+): AuthorizationServerMetadata => ({
+  issuer: "https://as.example.com",
+  authorization_endpoint: "https://as.example.com/authorize",
+  token_endpoint: "https://as.example.com/token",
+  ...overrides,
+});
+
+describe("clientRegistrationMode", () => {
+  test("prefers CIMD when the server advertises support", () => {
+    expect(
+      clientRegistrationMode(
+        authorizationServer({
+          client_id_metadata_document_supported: true,
+          registration_endpoint: "https://as.example.com/register",
+        }),
+      ),
+    ).toBe("cimd");
+  });
+
+  test("falls back to dynamic registration when only DCR is offered", () => {
+    expect(
+      clientRegistrationMode(
+        authorizationServer({
+          registration_endpoint: "https://as.example.com/register",
+        }),
+      ),
+    ).toBe("dcr");
+  });
+
+  test("reports unsupported when neither mechanism is offered", () => {
+    expect(clientRegistrationMode(authorizationServer({}))).toBe("unsupported");
+    expect(
+      clientRegistrationMode(
+        authorizationServer({
+          client_id_metadata_document_supported: false,
+        }),
+      ),
+    ).toBe("unsupported");
+  });
+});
+
+describe("buildMcpClientMetadataDocument", () => {
+  test("client_id equals the URL the document is served from", () => {
+    const document = buildMcpClientMetadataDocument();
+
+    expect(document.client_id).toBe(getMcpClientMetadataDocumentUrl());
+    expect(new URL(document.client_id).pathname).toBe(
+      "/v1/mcp/oauth/client-metadata.json",
+    );
+  });
+
+  test("describes a public client without any shared secret", () => {
+    const document = buildMcpClientMetadataDocument();
+
+    expect(document.token_endpoint_auth_method).toBe("none");
+    expect(document.redirect_uris).toEqual([getMcpOAuthRedirectUri()]);
+    expect(Object.keys(document)).not.toContain("client_secret");
+  });
+});
 
 describe("redactMcpOAuthRegistrationResponse", () => {
   test("removes client credentials from dynamic registration metadata", () => {

--- a/apps/api/src/handlers/mcp-connectors/oauth.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth.ts
@@ -356,7 +356,7 @@ export const registerOAuthClient = async ({
   }
 
   const registrationBody = {
-    client_name: "Stella",
+    client_name: "stella",
     client_uri: env.FRONTEND_URL,
     grant_types: ["authorization_code", "refresh_token"],
     redirect_uris: [redirectUri],

--- a/apps/api/src/handlers/mcp-connectors/oauth.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth.ts
@@ -49,6 +49,7 @@ const authorizationServerMetadataSchema = v.looseObject({
   code_challenge_methods_supported: v.optional(v.array(v.string())),
   token_endpoint_auth_methods_supported: v.optional(v.array(v.string())),
   grant_types_supported: v.optional(v.array(v.string())),
+  client_id_metadata_document_supported: v.optional(v.boolean()),
 });
 
 const dynamicClientRegistrationResponseSchema = v.intersect([
@@ -247,6 +248,54 @@ export const getMcpOAuthRedirectUri = (): string => {
   const publicUrl = env.PUBLIC_URL ?? env.BETTER_AUTH_URL;
   return new URL("/v1/mcp/oauth/callback", publicUrl).toString();
 };
+
+export type McpClientRegistrationMode = "cimd" | "dcr" | "unsupported";
+
+// Client ID Metadata Documents are the MCP spec's preferred registration
+// mechanism; Dynamic Client Registration is retained for authorization
+// servers that have not adopted CIMD yet.
+export const clientRegistrationMode = (
+  authorizationServer: AuthorizationServerMetadata,
+): McpClientRegistrationMode => {
+  if (authorizationServer.client_id_metadata_document_supported === true) {
+    return "cimd";
+  }
+  if (authorizationServer.registration_endpoint) {
+    return "dcr";
+  }
+  return "unsupported";
+};
+
+const MCP_CLIENT_METADATA_DOCUMENT_PATH = "/v1/mcp/oauth/client-metadata.json";
+
+export const getMcpClientMetadataDocumentUrl = (): string => {
+  const publicUrl = env.PUBLIC_URL ?? env.BETTER_AUTH_URL;
+  return new URL(MCP_CLIENT_METADATA_DOCUMENT_PATH, publicUrl).toString();
+};
+
+export type McpClientMetadataDocument = {
+  client_id: string;
+  client_name: string;
+  client_uri: string;
+  grant_types: string[];
+  redirect_uris: string[];
+  response_types: string[];
+  token_endpoint_auth_method: "none";
+};
+
+// draft-ietf-oauth-client-id-metadata-document: the document's `client_id`
+// must equal the URL it is served from, and it must not carry any shared
+// secret (stella is a public client; PKCE protects the code exchange).
+export const buildMcpClientMetadataDocument =
+  (): McpClientMetadataDocument => ({
+    client_id: getMcpClientMetadataDocumentUrl(),
+    client_name: "stella",
+    client_uri: env.FRONTEND_URL,
+    grant_types: ["authorization_code", "refresh_token"],
+    redirect_uris: [getMcpOAuthRedirectUri()],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  });
 
 export const buildAuthorizeUrl = ({
   authorizationServer,

--- a/apps/api/src/handlers/mcp-connectors/routes.ts
+++ b/apps/api/src/handlers/mcp-connectors/routes.ts
@@ -8,6 +8,7 @@ import deleteMcpConnector from "@/api/handlers/mcp-connectors/delete-connector";
 import listMcpConnections from "@/api/handlers/mcp-connectors/list-connections";
 import listMcpConnectors from "@/api/handlers/mcp-connectors/list-connectors";
 import mcpOAuthCallback from "@/api/handlers/mcp-connectors/oauth-callback";
+import { mcpOAuthClientMetadataRoute } from "@/api/handlers/mcp-connectors/oauth-client-metadata-route";
 import probeMcpConnector from "@/api/handlers/mcp-connectors/probe-connector";
 import updateMcpConnection from "@/api/handlers/mcp-connectors/update-connection";
 import updateNativeTool from "@/api/handlers/mcp-connectors/update-native-tool";
@@ -71,6 +72,6 @@ const authenticatedMcpConnectorsRoute = new Elysia({ prefix: "/mcp" })
     permissions: updateNativeTool.config.permissions,
   });
 
-export const mcpConnectorsRoute = new Elysia().use(
-  authenticatedMcpConnectorsRoute,
-);
+export const mcpConnectorsRoute = new Elysia()
+  .use(mcpOAuthClientMetadataRoute)
+  .use(authenticatedMcpConnectorsRoute);

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1300,6 +1300,7 @@ export default defineConfig({
         "apps/api/src/handlers/folio-collab/routes.ts",
         "apps/api/src/handlers/health/routes.ts",
         "apps/api/src/handlers/mcp/routes.ts",
+        "apps/api/src/handlers/mcp-connectors/oauth-client-metadata-route.ts",
         "apps/api/src/handlers/hosted-usage-webhook/routes.ts",
         "apps/api/src/handlers/smoke/routes.ts",
         "apps/api/src/handlers/verify/routes.ts",


### PR DESCRIPTION
## Summary

External MCP authorization servers increasingly support OAuth Client ID Metadata Documents ([draft-ietf-oauth-client-id-metadata-document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/)), which the MCP spec now prefers over Dynamic Client Registration (DCR is deprecated in the current draft and retained for backwards compatibility). The connect flow now picks a client registration mechanism from the authorization server metadata instead of assuming DCR:

- **CIMD** when `client_id_metadata_document_supported` is advertised: stella serves its client metadata at `/v1/mcp/oauth/client-metadata.json` (new public route; the document is static and secret-free per the spec) and uses that URL as the `client_id`, skipping the registration round-trip.
- **DCR** when only `registration_endpoint` is available (unchanged behaviour).
- **Neither**: connect now returns the existing `{ type: "bearer", requiresToken: true }` response instead of failing with a 502, so the user can paste a pre-issued static token. Servers that publish OAuth discovery metadata but offer no registration path were previously a dead end: the token input only appeared for servers classified as `bearer`, which OAuth discovery preempts.

`create-connection` re-validates the bearer exception at the boundary (re-discovers the authorization server metadata and only accepts a static token when neither CIMD nor DCR is available), so the OAuth consent flow cannot be bypassed for servers where registration works. The discovery fetch reuses the existing safe-outbound-fetch guards.

The frontend add-server wizard already branches on the connect response type, so no web changes are needed.

Also lowercases the `client_name` sent in DCR registration bodies to match brand casing (separate commit).

## Changes

- `oauth.ts`: parse `client_id_metadata_document_supported`, add `clientRegistrationMode()` and the client metadata document builder
- `connect.ts`: registration-mode dispatch, CIMD client persistence (reuses the `mcp_oauth_clients` row shape so the OAuth callback is untouched), bearer fallback
- `create-connection.ts`: boundary re-validation of the static-token exception
- `oauth-client-metadata-route.ts`: public route serving the client metadata document (listed as a route-handler lint exception like the other protocol routes)
- `oauth.test.ts`: registration-mode precedence and document invariants (client_id equals the served URL, public client, no shared secret)