### PR TITLE
feat(web): layout preview pane in the create-view menu

### DIFF
--- a/apps/api/src/handlers/mcp-connectors/connect.ts
+++ b/apps/api/src/handlers/mcp-connectors/connect.ts
@@ -302,7 +302,9 @@ const ensureOAuthClient = async ({
         ? {
             clientId: getMcpClientMetadataDocumentUrl(),
             clientSecret: null,
-            registrationResponse: buildMcpClientMetadataDocument(),
+            registrationResponse: redactMcpOAuthRegistrationResponse(
+              buildMcpClientMetadataDocument(),
+            ),
           }
         : yield* Result.await(
             registerOAuthClient({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog.tsx
@@ -36,8 +36,10 @@ import {
 } from "@stll/ui/components/dialog";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
+import { ViewLayoutPreview } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview";
 import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
 import { useDeleteViewTemplate } from "@/routes/_protected.workspaces/$workspaceId/-mutations/view-templates";
 import { useCreateView } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
@@ -74,6 +76,9 @@ export const TemplatePickerDialog = ({
     select: (ctx) => ctx.user.activeOrganizationId,
   });
   const canDeleteTemplate = usePermissions({ view: ["delete"] });
+  const [previewLayout, setPreviewLayout] = useState<ViewLayoutType | null>(
+    null,
+  );
   const { data: templates, isPending } = useQuery({
     ...viewTemplatesOptions({
       key: { organizationId },
@@ -84,6 +89,7 @@ export const TemplatePickerDialog = ({
   const visibleTemplates = templates?.filter(
     (template) => !disallowedLayoutTypes.has(template.layoutType),
   );
+  const hasTemplates = (visibleTemplates?.length ?? 0) > 0;
 
   const createView = useCreateView(workspaceId);
   const deleteTemplate = useDeleteViewTemplate();
@@ -140,8 +146,18 @@ export const TemplatePickerDialog = ({
   };
 
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogPopup className="sm:max-w-md">
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          setPreviewLayout(null);
+        }
+        onOpenChange(nextOpen);
+      }}
+      open={open}
+    >
+      <DialogPopup
+        className={cn("sm:max-w-md", hasTemplates && "sm:max-w-2xl")}
+      >
         <DialogHeader>
           <DialogTitle>{t("workspaces.views.templates.title")}</DialogTitle>
           <DialogDescription>
@@ -149,14 +165,27 @@ export const TemplatePickerDialog = ({
           </DialogDescription>
         </DialogHeader>
         <DialogPanel>
-          <TemplateList
-            canDeleteTemplate={canDeleteTemplate}
-            isMutating={createView.isPending || deleteTemplate.isPending}
-            isPending={isPending}
-            onDelete={handleDelete}
-            onUse={handleUse}
-            templates={visibleTemplates}
-          />
+          <div className="flex items-stretch">
+            <div className="min-w-0 flex-1">
+              <TemplateList
+                canDeleteTemplate={canDeleteTemplate}
+                isMutating={createView.isPending || deleteTemplate.isPending}
+                isPending={isPending}
+                onDelete={handleDelete}
+                onPreview={setPreviewLayout}
+                onUse={handleUse}
+                templates={visibleTemplates}
+              />
+            </div>
+            {hasTemplates && (
+              <div className="ms-3 hidden border-s ps-1 sm:block">
+                <ViewLayoutPreview
+                  kind={previewLayout}
+                  workspaceId={workspaceId}
+                />
+              </div>
+            )}
+          </div>
         </DialogPanel>
         <DialogFooter>
           <Button onClick={() => onOpenChange(false)} variant="ghost">
@@ -175,6 +204,7 @@ type TemplateListProps = {
   canDeleteTemplate: boolean;
   onUse: (template: WorkspaceViewTemplate) => void;
   onDelete: (templateId: string) => void;
+  onPreview: (layoutType: ViewLayoutType) => void;
 };
 
 const TemplateList = ({
@@ -184,6 +214,7 @@ const TemplateList = ({
   canDeleteTemplate,
   onUse,
   onDelete,
+  onPreview,
 }: TemplateListProps) => {
   const t = useTranslations();
 
@@ -212,6 +243,7 @@ const TemplateList = ({
             isPending={isMutating}
             key={template.id}
             onDelete={() => onDelete(template.id)}
+            onPreview={() => onPreview(template.layoutType)}
             onUse={() => onUse(template)}
             template={template}
           />
@@ -227,6 +259,7 @@ type TemplateRowProps = {
   isPending: boolean;
   onUse: () => void;
   onDelete: () => void;
+  onPreview: () => void;
 };
 
 const TemplateRow = ({
@@ -235,12 +268,17 @@ const TemplateRow = ({
   isPending,
   onUse,
   onDelete,
+  onPreview,
 }: TemplateRowProps) => {
   const t = useTranslations();
   const Icon = layoutIcons[template.layoutType];
 
   return (
-    <li className="hover:bg-muted/50 flex items-center gap-2 rounded p-2">
+    <li
+      className="hover:bg-muted/50 flex items-center gap-2 rounded p-2"
+      onFocus={onPreview}
+      onMouseEnter={onPreview}
+    >
       <Icon className="text-muted-foreground size-4 shrink-0" />
       <button
         className="min-w-0 flex-1 truncate text-start text-sm"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.css
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.css
@@ -1,0 +1,80 @@
+/*
+ * Kanban layout preview: one card is "picked up" from the In-progress
+ * column (lift, tilt, shadow), carried over, and dropped at the top of
+ * the Done column while crossfading between its in-progress and done
+ * renderings. Runs once per mount; with reduced motion the preview
+ * stays in the initial static state.
+ */
+
+.view-layout-preview-fade-in {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .view-layout-preview-move {
+    animation: view-layout-preview-move 2.6s ease-in-out forwards;
+  }
+
+  .view-layout-preview-fade-out {
+    animation: view-layout-preview-fade-out 2.6s linear forwards;
+  }
+
+  .view-layout-preview-fade-in {
+    animation: view-layout-preview-fade-in 2.6s linear forwards;
+  }
+}
+
+/*
+ * Horizontal target: 100% = card width, 1.25rem = column gap plus both
+ * columns' inner padding. Vertical target: -4.5rem lifts the card from
+ * the second slot of the source column to the first slot of the Done
+ * column (height of the card above it plus the column's item gap).
+ */
+@keyframes view-layout-preview-move {
+  0%,
+  28% {
+    transform: none;
+    filter: none;
+  }
+
+  38% {
+    transform: translate(0.25rem, -4.875rem) rotate(2.5deg) scale(1.05);
+    filter: drop-shadow(0 8px 10px rgb(0 0 0 / 0.28));
+  }
+
+  64% {
+    transform: translate(calc(100% + 1.25rem), -4.875rem) rotate(2.5deg)
+      scale(1.05);
+    filter: drop-shadow(0 8px 10px rgb(0 0 0 / 0.28));
+  }
+
+  74%,
+  100% {
+    transform: translate(calc(100% + 1.25rem), -4.5rem) rotate(0deg) scale(1);
+    filter: none;
+  }
+}
+
+@keyframes view-layout-preview-fade-out {
+  0%,
+  64% {
+    opacity: 1;
+  }
+
+  72%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes view-layout-preview-fade-in {
+  0%,
+  64% {
+    opacity: 0;
+  }
+
+  72%,
+  100% {
+    opacity: 1;
+  }
+}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.tsx
@@ -8,6 +8,8 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { PreviewPane } from "@stll/ui/components/preview-pane";
+
 import type { TranslationKey } from "@/i18n/types";
 import { DOCX_MIME } from "@/lib/consts";
 import type { ViewLayoutType, WorkspaceEntity } from "@/lib/types";
@@ -56,14 +58,9 @@ export const ViewLayoutPreview = ({
   kind,
   workspaceId,
 }: ViewLayoutPreviewProps) => (
-  <div className="pointer-events-none w-64 p-2 select-none">
-    <div
-      aria-hidden
-      className="bg-muted/40 h-36 overflow-hidden rounded-md border p-2"
-    >
-      {kind && <PreviewCanvas kind={kind} workspaceId={workspaceId} />}
-    </div>
-  </div>
+  <PreviewPane>
+    {kind && <PreviewCanvas kind={kind} workspaceId={workspaceId} />}
+  </PreviewPane>
 );
 
 type PreviewCanvasProps = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.tsx
@@ -1,0 +1,429 @@
+import {
+  BookmarkIcon,
+  CalendarIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  KanbanIcon,
+  TableIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import type { TranslationKey } from "@/i18n/types";
+import { DOCX_MIME } from "@/lib/consts";
+import type { ViewLayoutType, WorkspaceEntity } from "@/lib/types";
+import {
+  CalendarEntityChip,
+  TASK_STATUS_DOT_COLORS,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip";
+import { EntityKindIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/entity-kind-icon";
+import { KanbanCard } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card";
+import type {
+  TaskPriority,
+  TaskStatus,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-constants";
+import {
+  STATUS_COLORS,
+  STATUS_ICONS,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-constants";
+import type { CalendarTask } from "@/routes/_protected.workspaces/$workspaceId/-queries/calendar-tasks";
+
+import "./view-layout-preview.css";
+
+export type ViewLayoutPreviewKind = ViewLayoutType | "template";
+
+const STATUS_LABEL_KEYS = {
+  open: "tasks.statusValues.open",
+  in_progress: "tasks.statusValues.in_progress",
+  done: "tasks.statusValues.done",
+} as const satisfies Partial<Record<TaskStatus, TranslationKey>>;
+
+// Mock content depicting user data, not interface text; deliberately
+// untranslated to keep the preview free of per-language i18n debt.
+const SAMPLE_NAMES = {
+  draft: "Draft pleading",
+  review: "Review contract",
+  contract: "Service agreement",
+  folder: "Pleadings",
+  evidence: "Evidence",
+} as const;
+
+type ViewLayoutPreviewProps = {
+  kind: ViewLayoutPreviewKind | null;
+  workspaceId: string;
+};
+
+export const ViewLayoutPreview = ({
+  kind,
+  workspaceId,
+}: ViewLayoutPreviewProps) => (
+  <div className="pointer-events-none w-64 p-2 select-none">
+    <div
+      aria-hidden
+      className="bg-muted/40 h-36 overflow-hidden rounded-md border p-2"
+    >
+      {kind && <PreviewCanvas kind={kind} workspaceId={workspaceId} />}
+    </div>
+  </div>
+);
+
+type PreviewCanvasProps = {
+  kind: ViewLayoutPreviewKind;
+  workspaceId: string;
+};
+
+const PreviewCanvas = ({ kind, workspaceId }: PreviewCanvasProps) => {
+  if (kind === "kanban") {
+    return <KanbanPreview workspaceId={workspaceId} />;
+  }
+  if (kind === "calendar") {
+    return <CalendarPreview workspaceId={workspaceId} />;
+  }
+  if (kind === "table") {
+    return <TablePreview />;
+  }
+  if (kind === "filesystem") {
+    return <ListPreview />;
+  }
+  if (kind === "overview") {
+    return <OverviewPreview />;
+  }
+  if (kind === "template") {
+    return <TemplatePreview />;
+  }
+  return <TimelinePreview />;
+};
+
+const KanbanPreview = ({ workspaceId }: { workspaceId: string }) => {
+  const t = useTranslations();
+  const staying = mockTask({
+    entityId: "preview-kanban-staying",
+    name: SAMPLE_NAMES.draft,
+    status: "in_progress",
+    priority: "high",
+  });
+  const movingInProgress = mockTask({
+    entityId: "preview-kanban-moving",
+    name: SAMPLE_NAMES.review,
+    status: "in_progress",
+  });
+  const movingDone = mockTask({
+    entityId: "preview-kanban-moved",
+    name: SAMPLE_NAMES.review,
+    status: "done",
+  });
+
+  return (
+    <div className="h-[150%] w-[150%] origin-top-left scale-[0.667]">
+      <div className="flex h-full gap-2">
+        <PreviewKanbanColumn
+          label={t(STATUS_LABEL_KEYS.in_progress)}
+          status="in_progress"
+        >
+          <KanbanCard entity={staying} workspaceId={workspaceId} />
+          <div className="view-layout-preview-move relative">
+            <div className="view-layout-preview-fade-out">
+              <KanbanCard entity={movingInProgress} workspaceId={workspaceId} />
+            </div>
+            <div className="view-layout-preview-fade-in absolute inset-0">
+              <KanbanCard entity={movingDone} workspaceId={workspaceId} />
+            </div>
+          </div>
+        </PreviewKanbanColumn>
+        <PreviewKanbanColumn label={t(STATUS_LABEL_KEYS.done)} status="done" />
+      </div>
+    </div>
+  );
+};
+
+type PreviewKanbanColumnProps = React.PropsWithChildren<{
+  label: string;
+  status: TaskStatus;
+}>;
+
+const PreviewKanbanColumn = ({
+  label,
+  status,
+  children,
+}: PreviewKanbanColumnProps) => (
+  <div className="bg-muted/50 flex min-w-0 flex-1 flex-col gap-1.5 rounded-md p-1.5">
+    <span className="flex items-center gap-1.5 px-1 text-xs font-medium">
+      <span
+        className="size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: TASK_STATUS_DOT_COLORS[status] }}
+      />
+      <span className="truncate">{label}</span>
+    </span>
+    {children}
+  </div>
+);
+
+const CalendarPreview = ({ workspaceId }: { workspaceId: string }) => {
+  const days = [6, 7, 8, 9, 10, 13, 14, 15, 16, 17];
+  const chips: Record<number, CalendarTask> = {
+    7: mockCalendarTask({
+      taskId: "preview-calendar-draft",
+      name: SAMPLE_NAMES.draft,
+      status: "in_progress",
+    }),
+    15: mockCalendarTask({
+      taskId: "preview-calendar-review",
+      name: SAMPLE_NAMES.review,
+      status: "done",
+    }),
+  };
+
+  return (
+    <div className="h-[133%] w-[133%] origin-top-left scale-75">
+      <div className="grid h-full grid-cols-5 grid-rows-2 gap-1">
+        {days.map((day) => {
+          const chip = chips[day];
+          return (
+            <div
+              className="bg-card flex min-w-0 flex-col gap-0.5 rounded-sm border p-1"
+              key={day}
+            >
+              <span className="text-muted-foreground text-[10px] leading-none">
+                {day}
+              </span>
+              {chip && (
+                <CalendarEntityChip
+                  entity={chip}
+                  isEditable={false}
+                  workspaceId={workspaceId}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const TablePreview = () => {
+  const t = useTranslations();
+
+  return (
+    <div className="flex h-full flex-col justify-center text-xs">
+      <div className="text-muted-foreground grid grid-cols-[1.6fr_1fr] gap-2 border-b px-1 pb-1.5 font-medium">
+        <span className="truncate">{t("common.name")}</span>
+        <span className="truncate">{t("tasks.status")}</span>
+      </div>
+      <PreviewTableRow
+        icon={
+          <EntityKindIcon
+            className="size-3.5 shrink-0"
+            kind="task"
+            status="open"
+          />
+        }
+        name={SAMPLE_NAMES.draft}
+        status="open"
+      />
+      <PreviewTableRow
+        icon={
+          <EntityKindIcon
+            className="size-3.5 shrink-0"
+            kind="document"
+            mimeType={DOCX_MIME}
+          />
+        }
+        name={SAMPLE_NAMES.contract}
+      />
+      <PreviewTableRow
+        icon={<EntityKindIcon className="size-3.5 shrink-0" kind="folder" />}
+        name={SAMPLE_NAMES.folder}
+      />
+    </div>
+  );
+};
+
+type PreviewTableRowProps = {
+  icon: React.ReactNode;
+  name: string;
+  status?: TaskStatus;
+};
+
+const PreviewTableRow = ({ icon, name, status }: PreviewTableRowProps) => (
+  <div className="grid grid-cols-[1.6fr_1fr] items-center gap-2 border-b px-1 py-1.5 last:border-0">
+    <span className="flex min-w-0 items-center gap-1.5">
+      {icon}
+      <span className="truncate">{name}</span>
+    </span>
+    {status ? (
+      <span className="min-w-0">
+        <PreviewStatusChip status={status} />
+      </span>
+    ) : (
+      <span className="text-muted-foreground">–</span>
+    )}
+  </div>
+);
+
+const PreviewStatusChip = ({ status }: { status: TaskStatus }) => {
+  const t = useTranslations();
+  const labelKey =
+    status === "open" || status === "in_progress" || status === "done"
+      ? STATUS_LABEL_KEYS[status]
+      : null;
+  if (!labelKey) {
+    return null;
+  }
+  const Icon = STATUS_ICONS[status];
+
+  return (
+    <span className="bg-muted/60 text-muted-foreground flex max-w-full min-w-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs leading-none">
+      <Icon className={`size-3 shrink-0 ${STATUS_COLORS[status]}`} />
+      <span className="truncate">{t(labelKey)}</span>
+    </span>
+  );
+};
+
+const ListPreview = () => (
+  <div className="flex h-full flex-col justify-center gap-1 text-xs">
+    <span className="flex min-w-0 items-center gap-1.5 px-1 py-0.5 font-medium">
+      <ChevronDownIcon className="text-muted-foreground size-3 shrink-0" />
+      <EntityKindIcon className="size-3.5 shrink-0" kind="folder" />
+      <span className="truncate">{SAMPLE_NAMES.folder}</span>
+    </span>
+    <span className="flex min-w-0 items-center gap-1.5 py-0.5 ps-6">
+      <EntityKindIcon
+        className="size-3.5 shrink-0"
+        kind="document"
+        mimeType={DOCX_MIME}
+      />
+      <span className="truncate">{SAMPLE_NAMES.contract}</span>
+    </span>
+    <span className="flex min-w-0 items-center gap-1.5 px-1 py-0.5 font-medium">
+      <ChevronRightIcon className="text-muted-foreground size-3 shrink-0" />
+      <EntityKindIcon className="size-3.5 shrink-0" kind="folder" />
+      <span className="truncate">{SAMPLE_NAMES.evidence}</span>
+    </span>
+  </div>
+);
+
+const TemplatePreview = () => (
+  <div className="flex h-full flex-col justify-center gap-1.5">
+    <div className="bg-card flex items-center gap-1.5 rounded-sm border p-1.5">
+      <BookmarkIcon className="text-muted-foreground size-3.5 shrink-0" />
+      <div className="bg-muted h-1.5 w-24 rounded-full" />
+      <TableIcon className="text-muted-foreground ms-auto size-3.5 shrink-0" />
+    </div>
+    <div className="bg-card flex items-center gap-1.5 rounded-sm border p-1.5">
+      <BookmarkIcon className="text-muted-foreground size-3.5 shrink-0" />
+      <div className="bg-muted h-1.5 w-16 rounded-full" />
+      <KanbanIcon className="text-muted-foreground ms-auto size-3.5 shrink-0" />
+    </div>
+    <div className="bg-card flex items-center gap-1.5 rounded-sm border p-1.5">
+      <BookmarkIcon className="text-muted-foreground size-3.5 shrink-0" />
+      <div className="bg-muted h-1.5 w-20 rounded-full" />
+      <CalendarIcon className="text-muted-foreground ms-auto size-3.5 shrink-0" />
+    </div>
+  </div>
+);
+
+const OverviewPreview = () => (
+  <div className="flex h-full flex-col gap-1.5">
+    <div className="grid flex-1 grid-cols-2 gap-1.5">
+      <div className="bg-card flex flex-col justify-between rounded-sm border p-1.5">
+        <div className="bg-muted h-1.5 w-10 rounded-full" />
+        <div className="bg-muted-foreground/30 h-3 w-7 rounded-sm" />
+      </div>
+      <div className="bg-card flex flex-col justify-between rounded-sm border p-1.5">
+        <div className="bg-muted h-1.5 w-8 rounded-full" />
+        <div className="bg-muted-foreground/30 h-3 w-5 rounded-sm" />
+      </div>
+    </div>
+    <div className="bg-card flex flex-1 flex-col justify-evenly rounded-sm border p-1.5">
+      <div className="bg-muted h-1.5 w-full rounded-full" />
+      <div className="bg-muted h-1.5 w-4/5 rounded-full" />
+      <div className="bg-muted h-1.5 w-3/5 rounded-full" />
+    </div>
+  </div>
+);
+
+const TimelinePreview = () => (
+  <div className="flex h-full flex-col justify-center gap-2.5 px-1">
+    <div className="bg-primary/50 h-2.5 w-1/2 rounded-full" />
+    <div className="bg-muted-foreground/30 ms-[30%] h-2.5 w-2/5 rounded-full" />
+    <div className="bg-muted-foreground/20 ms-[55%] h-2.5 w-1/3 rounded-full" />
+  </div>
+);
+
+// Fixed timestamp: previews are static mock data, and Date.now() would make
+// the rendered output differ between sessions for no reason.
+const PREVIEW_CREATED_AT = "2026-01-15T09:00:00.000Z";
+
+type MockTaskOptions = {
+  entityId: string;
+  name: string;
+  status: TaskStatus;
+  priority?: TaskPriority;
+};
+
+const mockTask = ({
+  entityId,
+  name,
+  status,
+  priority,
+}: MockTaskOptions): WorkspaceEntity => ({
+  entityId,
+  kind: "task",
+  name,
+  parentId: null,
+  createdAt: PREVIEW_CREATED_AT,
+  createdBy: null,
+  createdByImage: null,
+  updatedAt: null,
+  version: 1,
+  status,
+  priority: priority ?? null,
+  dueDate: null,
+  agendaKind: "task",
+  startAt: null,
+  endAt: null,
+  occurredAt: null,
+  remindAt: null,
+  allDay: false,
+  timeZone: null,
+  location: null,
+  onlineMeetingUrl: null,
+  availability: null,
+  sensitivity: null,
+  organizer: null,
+  attendees: null,
+  recurrence: null,
+  agendaSource: "manual",
+  externalSource: null,
+  externalId: null,
+  externalChangeKey: null,
+  externalICalUid: null,
+  readOnly: true,
+  sortOrder: null,
+  activeEditBy: null,
+  fields: {},
+  cellMetadata: {},
+});
+
+type MockCalendarTaskOptions = {
+  taskId: string;
+  name: string;
+  status: TaskStatus;
+};
+
+const mockCalendarTask = ({
+  taskId,
+  name,
+  status,
+}: MockCalendarTaskOptions): CalendarTask => ({
+  taskId,
+  name,
+  status,
+  createdAt: PREVIEW_CREATED_AT,
+  updatedAt: null,
+  dueDate: null,
+  startAt: null,
+  endAt: null,
+  occurredAt: null,
+  fields: [],
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview.tsx
@@ -92,22 +92,6 @@ const PreviewCanvas = ({ kind, workspaceId }: PreviewCanvasProps) => {
 
 const KanbanPreview = ({ workspaceId }: { workspaceId: string }) => {
   const t = useTranslations();
-  const staying = mockTask({
-    entityId: "preview-kanban-staying",
-    name: SAMPLE_NAMES.draft,
-    status: "in_progress",
-    priority: "high",
-  });
-  const movingInProgress = mockTask({
-    entityId: "preview-kanban-moving",
-    name: SAMPLE_NAMES.review,
-    status: "in_progress",
-  });
-  const movingDone = mockTask({
-    entityId: "preview-kanban-moved",
-    name: SAMPLE_NAMES.review,
-    status: "done",
-  });
 
   return (
     <div className="h-[150%] w-[150%] origin-top-left scale-[0.667]">
@@ -116,13 +100,19 @@ const KanbanPreview = ({ workspaceId }: { workspaceId: string }) => {
           label={t(STATUS_LABEL_KEYS.in_progress)}
           status="in_progress"
         >
-          <KanbanCard entity={staying} workspaceId={workspaceId} />
+          <KanbanCard entity={KANBAN_STAYING_TASK} workspaceId={workspaceId} />
           <div className="view-layout-preview-move relative">
             <div className="view-layout-preview-fade-out">
-              <KanbanCard entity={movingInProgress} workspaceId={workspaceId} />
+              <KanbanCard
+                entity={KANBAN_MOVING_IN_PROGRESS_TASK}
+                workspaceId={workspaceId}
+              />
             </div>
             <div className="view-layout-preview-fade-in absolute inset-0">
-              <KanbanCard entity={movingDone} workspaceId={workspaceId} />
+              <KanbanCard
+                entity={KANBAN_MOVING_DONE_TASK}
+                workspaceId={workspaceId}
+              />
             </div>
           </div>
         </PreviewKanbanColumn>
@@ -154,48 +144,32 @@ const PreviewKanbanColumn = ({
   </div>
 );
 
-const CalendarPreview = ({ workspaceId }: { workspaceId: string }) => {
-  const days = [6, 7, 8, 9, 10, 13, 14, 15, 16, 17];
-  const chips: Record<number, CalendarTask> = {
-    7: mockCalendarTask({
-      taskId: "preview-calendar-draft",
-      name: SAMPLE_NAMES.draft,
-      status: "in_progress",
-    }),
-    15: mockCalendarTask({
-      taskId: "preview-calendar-review",
-      name: SAMPLE_NAMES.review,
-      status: "done",
-    }),
-  };
-
-  return (
-    <div className="h-[133%] w-[133%] origin-top-left scale-75">
-      <div className="grid h-full grid-cols-5 grid-rows-2 gap-1">
-        {days.map((day) => {
-          const chip = chips[day];
-          return (
-            <div
-              className="bg-card flex min-w-0 flex-col gap-0.5 rounded-sm border p-1"
-              key={day}
-            >
-              <span className="text-muted-foreground text-[10px] leading-none">
-                {day}
-              </span>
-              {chip && (
-                <CalendarEntityChip
-                  entity={chip}
-                  isEditable={false}
-                  workspaceId={workspaceId}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
+const CalendarPreview = ({ workspaceId }: { workspaceId: string }) => (
+  <div className="h-[133%] w-[133%] origin-top-left scale-75">
+    <div className="grid h-full grid-cols-5 grid-rows-2 gap-1">
+      {CALENDAR_DAYS.map((day) => {
+        const chip = CALENDAR_CHIPS[day];
+        return (
+          <div
+            className="bg-card flex min-w-0 flex-col gap-0.5 rounded-sm border p-1"
+            key={day}
+          >
+            <span className="text-muted-foreground text-[10px] leading-none">
+              {day}
+            </span>
+            {chip && (
+              <CalendarEntityChip
+                entity={chip}
+                isEditable={false}
+                workspaceId={workspaceId}
+              />
+            )}
+          </div>
+        );
+      })}
     </div>
-  );
-};
+  </div>
+);
 
 const TablePreview = () => {
   const t = useTranslations();
@@ -424,3 +398,37 @@ const mockCalendarTask = ({
   occurredAt: null,
   fields: [],
 });
+
+const KANBAN_STAYING_TASK = mockTask({
+  entityId: "preview-kanban-staying",
+  name: SAMPLE_NAMES.draft,
+  status: "in_progress",
+  priority: "high",
+});
+
+const KANBAN_MOVING_IN_PROGRESS_TASK = mockTask({
+  entityId: "preview-kanban-moving",
+  name: SAMPLE_NAMES.review,
+  status: "in_progress",
+});
+
+const KANBAN_MOVING_DONE_TASK = mockTask({
+  entityId: "preview-kanban-moved",
+  name: SAMPLE_NAMES.review,
+  status: "done",
+});
+
+const CALENDAR_DAYS = [6, 7, 8, 9, 10, 13, 14, 15, 16, 17];
+
+const CALENDAR_CHIPS: Record<number, CalendarTask> = {
+  7: mockCalendarTask({
+    taskId: "preview-calendar-draft",
+    name: SAMPLE_NAMES.draft,
+    status: "in_progress",
+  }),
+  15: mockCalendarTask({
+    taskId: "preview-calendar-review",
+    name: SAMPLE_NAMES.review,
+    status: "done",
+  }),
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -55,6 +55,8 @@ import type { WorkspaceView } from "@/lib/types";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";
 import { SaveAsTemplateDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/view/save-as-template-dialog";
 import { TemplatePickerDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog";
+import type { ViewLayoutPreviewKind } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview";
+import { ViewLayoutPreview } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-layout-preview";
 import {
   useConvertView,
   useCreateView,
@@ -165,6 +167,9 @@ export const ViewSwitcher = ({
   const createView = useCreateView(workspaceId);
   const reorderViews = useReorderViews(workspaceId);
   const [isTemplatePickerOpen, setIsTemplatePickerOpen] = useState(false);
+  const [previewKind, setPreviewKind] = useState<ViewLayoutPreviewKind | null>(
+    null,
+  );
   const hasOverviewView = views.some((view) => view.layout.type === "overview");
   const createLayoutOptions = hasOverviewView
     ? LAYOUT_OPTIONS.filter((layoutType) => layoutType !== "overview")
@@ -223,7 +228,13 @@ export const ViewSwitcher = ({
         </TabsList>
       </Tabs>
       {canCreateView && (
-        <Menu>
+        <Menu
+          onOpenChange={(open) => {
+            if (!open) {
+              setPreviewKind(null);
+            }
+          }}
+        >
           <MenuTrigger
             render={
               <Button
@@ -236,45 +247,61 @@ export const ViewSwitcher = ({
             <PlusIcon />
           </MenuTrigger>
           <MenuPopup>
-            {createLayoutOptions.map((layoutType) => {
-              const Icon = layoutIcons[layoutType];
-              return (
+            <div className="flex items-stretch">
+              <div className="flex min-w-32 flex-1 flex-col">
+                {createLayoutOptions.map((layoutType) => {
+                  const Icon = layoutIcons[layoutType];
+                  return (
+                    <MenuItem
+                      key={layoutType}
+                      onClick={() => {
+                        const viewId = crypto.randomUUID();
+                        createView.mutate(
+                          {
+                            id: viewId,
+                            name: t("workspaces.views.newView", {
+                              layout: t(LAYOUT_LABEL_KEYS[layoutType]),
+                            }),
+                            layout: defaultLayouts[layoutType],
+                          },
+                          {
+                            onSuccess: () => {
+                              onViewChange(viewId);
+                            },
+                            onError: () => {
+                              stellaToast.add({
+                                title: t("errors.failedToCreateView"),
+                                type: "error",
+                              });
+                            },
+                          },
+                        );
+                      }}
+                      onFocus={() => setPreviewKind(layoutType)}
+                      onMouseEnter={() => setPreviewKind(layoutType)}
+                    >
+                      <Icon />
+                      {t(LAYOUT_LABEL_KEYS[layoutType])}
+                    </MenuItem>
+                  );
+                })}
+                <MenuSeparator />
                 <MenuItem
-                  key={layoutType}
-                  onClick={() => {
-                    const viewId = crypto.randomUUID();
-                    createView.mutate(
-                      {
-                        id: viewId,
-                        name: t("workspaces.views.newView", {
-                          layout: t(LAYOUT_LABEL_KEYS[layoutType]),
-                        }),
-                        layout: defaultLayouts[layoutType],
-                      },
-                      {
-                        onSuccess: () => {
-                          onViewChange(viewId);
-                        },
-                        onError: () => {
-                          stellaToast.add({
-                            title: t("errors.failedToCreateView"),
-                            type: "error",
-                          });
-                        },
-                      },
-                    );
-                  }}
+                  onClick={() => setIsTemplatePickerOpen(true)}
+                  onFocus={() => setPreviewKind("template")}
+                  onMouseEnter={() => setPreviewKind("template")}
                 >
-                  <Icon />
-                  {t(LAYOUT_LABEL_KEYS[layoutType])}
+                  <BookmarkIcon />
+                  {t("workspaces.views.useTemplate")}
                 </MenuItem>
-              );
-            })}
-            <MenuSeparator />
-            <MenuItem onClick={() => setIsTemplatePickerOpen(true)}>
-              <BookmarkIcon />
-              {t("workspaces.views.useTemplate")}
-            </MenuItem>
+              </div>
+              <div className="ms-1 hidden border-s ps-1 sm:block">
+                <ViewLayoutPreview
+                  kind={previewKind}
+                  workspaceId={workspaceId}
+                />
+              </div>
+            </div>
           </MenuPopup>
         </Menu>
       )}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -45,6 +45,7 @@ import {
   MenuSubTrigger,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { MenuPreviewLayout } from "@stll/ui/components/preview-pane";
 import { Tabs, TabsList, TabsTab } from "@stll/ui/components/tabs";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
@@ -247,61 +248,60 @@ export const ViewSwitcher = ({
             <PlusIcon />
           </MenuTrigger>
           <MenuPopup>
-            <div className="flex items-stretch">
-              <div className="flex min-w-32 flex-1 flex-col">
-                {createLayoutOptions.map((layoutType) => {
-                  const Icon = layoutIcons[layoutType];
-                  return (
-                    <MenuItem
-                      key={layoutType}
-                      onClick={() => {
-                        const viewId = crypto.randomUUID();
-                        createView.mutate(
-                          {
-                            id: viewId,
-                            name: t("workspaces.views.newView", {
-                              layout: t(LAYOUT_LABEL_KEYS[layoutType]),
-                            }),
-                            layout: defaultLayouts[layoutType],
-                          },
-                          {
-                            onSuccess: () => {
-                              onViewChange(viewId);
-                            },
-                            onError: () => {
-                              stellaToast.add({
-                                title: t("errors.failedToCreateView"),
-                                type: "error",
-                              });
-                            },
-                          },
-                        );
-                      }}
-                      onFocus={() => setPreviewKind(layoutType)}
-                      onMouseEnter={() => setPreviewKind(layoutType)}
-                    >
-                      <Icon />
-                      {t(LAYOUT_LABEL_KEYS[layoutType])}
-                    </MenuItem>
-                  );
-                })}
-                <MenuSeparator />
-                <MenuItem
-                  onClick={() => setIsTemplatePickerOpen(true)}
-                  onFocus={() => setPreviewKind("template")}
-                  onMouseEnter={() => setPreviewKind("template")}
-                >
-                  <BookmarkIcon />
-                  {t("workspaces.views.useTemplate")}
-                </MenuItem>
-              </div>
-              <div className="ms-1 hidden border-s ps-1 sm:block">
+            <MenuPreviewLayout
+              preview={
                 <ViewLayoutPreview
                   kind={previewKind}
                   workspaceId={workspaceId}
                 />
-              </div>
-            </div>
+              }
+            >
+              {createLayoutOptions.map((layoutType) => {
+                const Icon = layoutIcons[layoutType];
+                return (
+                  <MenuItem
+                    key={layoutType}
+                    onClick={() => {
+                      const viewId = crypto.randomUUID();
+                      createView.mutate(
+                        {
+                          id: viewId,
+                          name: t("workspaces.views.newView", {
+                            layout: t(LAYOUT_LABEL_KEYS[layoutType]),
+                          }),
+                          layout: defaultLayouts[layoutType],
+                        },
+                        {
+                          onSuccess: () => {
+                            onViewChange(viewId);
+                          },
+                          onError: () => {
+                            stellaToast.add({
+                              title: t("errors.failedToCreateView"),
+                              type: "error",
+                            });
+                          },
+                        },
+                      );
+                    }}
+                    onFocus={() => setPreviewKind(layoutType)}
+                    onMouseEnter={() => setPreviewKind(layoutType)}
+                  >
+                    <Icon />
+                    {t(LAYOUT_LABEL_KEYS[layoutType])}
+                  </MenuItem>
+                );
+              })}
+              <MenuSeparator />
+              <MenuItem
+                onClick={() => setIsTemplatePickerOpen(true)}
+                onFocus={() => setPreviewKind("template")}
+                onMouseEnter={() => setPreviewKind("template")}
+              >
+                <BookmarkIcon />
+                {t("workspaces.views.useTemplate")}
+              </MenuItem>
+            </MenuPreviewLayout>
           </MenuPopup>
         </Menu>
       )}
@@ -490,6 +490,9 @@ const ViewTabMenu = ({
   const convertView = useConvertView(workspaceId);
   const deleteView = useDeleteView(workspaceId);
   const [isSaveTemplateOpen, setIsSaveTemplateOpen] = useState(false);
+  const [convertPreview, setConvertPreview] = useState<ViewLayoutType | null>(
+    null,
+  );
 
   const Icon = layoutIcons[layout.type];
 
@@ -567,41 +570,58 @@ const ViewTabMenu = ({
             </MenuItem>
           )}
           {canUpdateView && (
-            <MenuSub>
+            <MenuSub
+              onOpenChange={(open) => {
+                if (!open) {
+                  setConvertPreview(null);
+                }
+              }}
+            >
               <MenuSubTrigger>
                 <Icon />
                 {t("common.convertTo")}
               </MenuSubTrigger>
               <MenuSubPopup>
-                {LAYOUT_OPTIONS.filter(
-                  (l) => l !== layout.type && l !== "overview",
-                ).map((l) => {
-                  const LayoutIcon = layoutIcons[l];
-                  return (
-                    <MenuItem
-                      key={l}
-                      onClick={() => {
-                        convertView.mutate(
-                          {
-                            viewId: id,
-                            targetType: l,
-                          },
-                          {
-                            onError: () => {
-                              stellaToast.add({
-                                title: t("errors.failedToChangeViewType"),
-                                type: "error",
-                              });
+                <MenuPreviewLayout
+                  preview={
+                    <ViewLayoutPreview
+                      kind={convertPreview}
+                      workspaceId={workspaceId}
+                    />
+                  }
+                >
+                  {LAYOUT_OPTIONS.filter(
+                    (l) => l !== layout.type && l !== "overview",
+                  ).map((l) => {
+                    const LayoutIcon = layoutIcons[l];
+                    return (
+                      <MenuItem
+                        key={l}
+                        onClick={() => {
+                          convertView.mutate(
+                            {
+                              viewId: id,
+                              targetType: l,
                             },
-                          },
-                        );
-                      }}
-                    >
-                      <LayoutIcon />
-                      {t(LAYOUT_LABEL_KEYS[l])}
-                    </MenuItem>
-                  );
-                })}
+                            {
+                              onError: () => {
+                                stellaToast.add({
+                                  title: t("errors.failedToChangeViewType"),
+                                  type: "error",
+                                });
+                              },
+                            },
+                          );
+                        }}
+                        onFocus={() => setConvertPreview(l)}
+                        onMouseEnter={() => setConvertPreview(l)}
+                      >
+                        <LayoutIcon />
+                        {t(LAYOUT_LABEL_KEYS[l])}
+                      </MenuItem>
+                    );
+                  })}
+                </MenuPreviewLayout>
               </MenuSubPopup>
             </MenuSub>
           )}

--- a/packages/ui/src/components/preview-pane.tsx
+++ b/packages/ui/src/components/preview-pane.tsx
@@ -1,0 +1,53 @@
+import type * as React from "react";
+
+import { cn } from "@stll/ui/lib/utils";
+
+/**
+ * Side-pane preview pattern: a list of options (menu items, rows) with a
+ * fixed-width pane beside it that previews the highlighted option. The pane
+ * stays mounted so the container never resizes mid-interaction; drive it
+ * from `onMouseEnter`/`onFocus` on the options and render `PreviewPane`
+ * empty (no children) while nothing is highlighted.
+ */
+
+function MenuPreviewLayout({
+  children,
+  preview,
+  className,
+}: React.PropsWithChildren<{
+  preview: React.ReactNode;
+  className?: string;
+}>) {
+  return (
+    <div
+      className={cn("flex items-stretch", className)}
+      data-slot="menu-preview-layout"
+    >
+      <div className="flex min-w-32 flex-1 flex-col">{children}</div>
+      <div className="ms-1 hidden border-s ps-1 sm:block">{preview}</div>
+    </div>
+  );
+}
+
+function PreviewPane({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("pointer-events-none w-64 p-2 select-none", className)}
+      data-slot="preview-pane"
+      {...props}
+    >
+      <div
+        aria-hidden
+        className="bg-muted/40 h-36 overflow-hidden rounded-md border p-2"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export { MenuPreviewLayout, PreviewPane };


### PR DESCRIPTION
Adds a hover preview pane to the create-view menu in the workspace view switcher. Highlighting a layout option (pointer or keyboard) shows a live miniature of that layout; the "Use template" item shows a schematic of saved templates. Before the first highlight the pane stays neutral/empty.

- The kanban and calendar miniatures render the real `KanbanCard` and `CalendarEntityChip` components with mock entities, so the previews track the actual views instead of drifting like static screenshots would. Table and list miniatures reuse the shared atoms (`EntityKindIcon`, status icon/colour constants).
- The kanban miniature plays a one-shot, CSS-only drag-and-drop sequence (card lifts, moves to the Done column, crossfades to its done state). Honours `prefers-reduced-motion`.
- The pane is rendered as a flex sibling inside `MenuPopup` and stays mounted while the menu is open, so the popup never resizes mid-interaction. It is `aria-hidden` and `pointer-events-none`; hidden below the `sm` breakpoint.
- Mock content (card/file names) is deliberately untranslated sample data; column and table headers reuse existing translation keys, so the change introduces no new i18n keys.