### PR TITLE
feat(web): unify sidebar collapsed and expanded geometry

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -79,6 +79,7 @@ import {
 } from "@/components/sidebar";
 import { StellaWordmark } from "@/components/stella-wordmark";
 import { PALETTES, THEMES, useTheme } from "@/components/theme-provider";
+import Tooltip from "@/components/tooltip";
 import {
   getWorkspacePrimaryNavItems,
   type WorkspacePrimaryNavId,
@@ -849,15 +850,28 @@ export function AppSidebar(props: AppSidebarProps) {
           }
         >
           {!isCollapsed && <StellaWordmark className="h-5 w-auto" />}
-          <Button
-            className={cn("text-muted-foreground", SIDE_RAIL_ICON_BUTTON_SIZE)}
-            onClick={toggleSidebar}
-            size="icon"
-            variant="ghost"
+          <Tooltip
+            content={
+              isCollapsed ? t("inspector.showPane") : t("inspector.hidePane")
+            }
+            render={
+              <Button
+                className={cn(
+                  "text-muted-foreground",
+                  SIDE_RAIL_ICON_BUTTON_SIZE,
+                )}
+                onClick={toggleSidebar}
+                size="icon"
+                variant="ghost"
+              />
+            }
+            side="right"
           >
             <PanelLeftIcon className="size-4" />
-            <span className="sr-only">{t("navigation.toggleSidebar")}</span>
-          </Button>
+            <span className="sr-only">
+              {isCollapsed ? t("inspector.showPane") : t("inspector.hidePane")}
+            </span>
+          </Tooltip>
         </div>
       </SidebarHeader>
 
@@ -986,12 +1000,17 @@ export function AppSidebar(props: AppSidebarProps) {
           <FeedbackDialog userEmail={user.email} />
           <SidebarMenuItem>
             <Menu>
-              <MenuTrigger
-                className={cn(
-                  "hover:bg-sidebar-accent data-popup-open:bg-sidebar-accent flex w-full items-center overflow-hidden rounded-md p-2 text-start text-sm outline-hidden",
-                  isCollapsed ? "justify-center" : "gap-2",
-                )}
-                title={isCollapsed ? displayName : undefined}
+              <Tooltip
+                content={isCollapsed ? displayName : null}
+                render={
+                  <MenuTrigger
+                    className={cn(
+                      "hover:bg-sidebar-accent data-popup-open:bg-sidebar-accent flex w-full items-center overflow-hidden rounded-md p-2 text-start text-sm outline-hidden",
+                      isCollapsed ? "justify-center" : "gap-2",
+                    )}
+                  />
+                }
+                side="right"
               >
                 <Avatar className="size-7 rounded-full">
                   {user.image && <AvatarImage src={user.image} />}
@@ -1022,7 +1041,7 @@ export function AppSidebar(props: AppSidebarProps) {
                     <ChevronsUpDownIcon className="ms-auto size-4 opacity-50" />
                   </>
                 )}
-              </MenuTrigger>
+              </Tooltip>
               <MenuPopup align="end" className="w-56" side="top" sideOffset={8}>
                 {orgName && (
                   <>

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -347,10 +347,7 @@ function SidebarInput({
 function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn(
-        "flex flex-col gap-2 p-2 group-data-[collapsible=icon]:h-12 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-0",
-        className,
-      )}
+      className={cn("flex flex-col gap-2 p-2", className)}
       data-sidebar="header"
       data-slot="sidebar-header"
       {...props}
@@ -375,10 +372,7 @@ function SidebarSeparator({
 }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
-      className={cn(
-        "bg-sidebar-border group-data-[collapsible=icon]:after:bg-sidebar-border w-auto group-data-[collapsible=icon]:relative group-data-[collapsible=icon]:my-0 group-data-[collapsible=icon]:h-0 group-data-[collapsible=icon]:w-full group-data-[collapsible=icon]:shrink-0 group-data-[collapsible=icon]:overflow-visible group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:after:absolute group-data-[collapsible=icon]:after:inset-x-0 group-data-[collapsible=icon]:after:top-0 group-data-[collapsible=icon]:after:h-px",
-        className,
-      )}
+      className={cn("bg-sidebar-border w-auto", className)}
       data-sidebar="separator"
       data-slot="sidebar-separator"
       {...props}
@@ -390,7 +384,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:[scrollbar-width:none] group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:[scrollbar-width:none] group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
         className,
       )}
       data-sidebar="content"
@@ -403,10 +397,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
 function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn(
-        "relative flex w-full min-w-0 flex-col p-2 group-data-[collapsible=icon]:p-0",
-        className,
-      )}
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
       data-sidebar="group"
       data-slot="sidebar-group"
       {...props}
@@ -475,10 +466,7 @@ function SidebarGroupContent({
 function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
   return (
     <ul
-      className={cn(
-        "flex w-full min-w-0 flex-col gap-1 group-data-[collapsible=icon]:gap-0",
-        className,
-      )}
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
       data-sidebar="menu"
       data-slot="sidebar-menu"
       {...props}
@@ -498,7 +486,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-sidebar-accent-foreground data-[active=true]:hover:bg-sidebar-accent data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm outline-hidden transition-[width,height,padding,border-radius] group-has-data-[sidebar=menu-action]/menu-item:pe-8 group-data-[collapsible=icon]:h-12! group-data-[collapsible=icon]:w-full! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-none group-data-[collapsible=icon]:border-b group-data-[collapsible=icon]:border-transparent group-data-[collapsible=icon]:bg-clip-padding group-data-[collapsible=icon]:p-0! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate group-data-[collapsible=icon]:[&>span:last-child]:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-sidebar-accent-foreground data-[active=true]:hover:bg-sidebar-accent data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm outline-hidden transition-[width,height,padding,border-radius] group-has-data-[sidebar=menu-action]/menu-item:pe-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>span:last-child]:transition-opacity [&>span:last-child]:duration-200 group-data-[collapsible=icon]:[&>span:last-child]:opacity-0 [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -509,7 +497,7 @@ const sidebarMenuButtonVariants = cva(
       size: {
         default: "h-8 text-sm",
         sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+        lg: "h-12 text-sm",
       },
     },
     defaultVariants: {
@@ -610,7 +598,7 @@ function SidebarMenuBadge({
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
         "peer-data-[size=lg]/menu-button:top-2.5",
-        "group-data-[collapsible=icon]:hidden",
+        "transition-opacity duration-200 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
       data-sidebar="menu-badge"


### PR DESCRIPTION
Collapsing the left sidebar no longer changes where the navigation icons live: collapsed mode is now "expanded minus labels" instead of a separately styled icon rail.

- Menu buttons keep the same `size-8 p-2 rounded-md` geometry, group padding, and gaps in both states, so every icon stays at the same x/y across the toggle (the 3rem rail width absorbs it exactly). Previously collapsed rows switched to 48px-tall, full-width, centered, square-cornered slabs with zeroed paddings, so icons jumped and the active highlight changed shape.
- Labels and the shortcut badge now fade (`transition-opacity`, same 200 ms as the width animation) instead of unmounting instantly, so the collapse reads as one motion. Interactive elements (row actions, sub-menus) stay `display`-hidden so they cannot hold focus while invisible; the faded labels remain readable to screen readers.
- The header toggle and footer user trigger get proper tooltips (the user one only when collapsed; expanded shows the name inline). The toggle tooltip is now state-aware and reuses the same `inspector.showPane`/`hidePane` strings as the right inspector rail, so both side rails use identical wording. Replaces a native `title` attribute on the user trigger. No new i18n keys.

Known trade-offs: group labels still hide when collapsed, so items below a label sit one label-height higher in the rail (ghost spacing would leave unexplained gaps); the footer avatar stays centered (28 px cannot hold the 16 px icon offset in a 48 px rail).