### PR TITLE
chore: add CI-parity verify script and type-level strictness guards

### DIFF
--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -18,6 +18,12 @@ shared packages in `packages/`. Use Glob/Grep to explore.
 `build` | `lint` | `format` | `typecheck` | `test` |
 `db:push`
 
+`bun run verify` runs the same checks as the required CI job
+(`ci-checks` in `.github/workflows/ci.yml`); use it to self-verify a
+branch instead of hand-picking individual checks. Green here means
+green on the `ci-result` status. `--all` checks every package instead
+of only those affected vs `origin/main`.
+
 ## Documentation Access
 
 The `stella-docs` MCP server provides on-demand access to library documentation via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,12 @@ shared packages in `packages/`. Use Glob/Grep to explore.
 `build` | `lint` | `format` | `typecheck` | `test` |
 `db:push`
 
+`bun run verify` runs the same checks as the required CI job
+(`ci-checks` in `.github/workflows/ci.yml`); use it to self-verify a
+branch instead of hand-picking individual checks. Green here means
+green on the `ci-result` status. `--all` checks every package instead
+of only those affected vs `origin/main`.
+
 ## Documentation Access
 
 The `stella-docs` MCP server provides on-demand access to library documentation via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,12 @@ to explore the codebase.
 2. Make your changes, following the conventions below.
 3. Run checks before pushing:
    ```bash
-   bun run lint && bun run format && bun run typecheck && bun run test
+   bun run verify
    ```
+   This mirrors the required CI checks (lint, format, typecheck,
+   tests, i18n, dependency hygiene): green here means green on the
+   `ci-result` status. Use `bun run verify --all` to check every
+   package instead of only those affected by your branch.
 4. Open a pull request against `main`.
 5. Fill in the PR template and link a related issue.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -103,6 +103,7 @@
     "@types/bun": "catalog:",
     "@types/nodemailer": "^8.0.0",
     "drizzle-kit": "catalog:",
+    "expect-type": "^1.3.0",
     "fast-check": "catalog:"
   }
 }

--- a/apps/api/src/lib/brand-invariants.test.ts
+++ b/apps/api/src/lib/brand-invariants.test.ts
@@ -1,0 +1,59 @@
+import { test } from "bun:test";
+import { expectTypeOf } from "expect-type";
+
+import type { AuthorizedToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
+import type { PromptSafeText, UntrustedText } from "@/api/lib/prompt-safety";
+import type {
+  ClientSecret,
+  RefreshToken,
+  Secret,
+} from "@/api/lib/secret-brands";
+
+// All assertions here are compile-time: if a refactor widens a brand
+// back to a plain string (or merges two brand families), typecheck
+// fails on this file instead of the protection silently disappearing
+// at every call site.
+
+test("SafeId is nominal, not a string alias", () => {
+  expectTypeOf<string>().not.toExtend<SafeId<"user">>();
+  expectTypeOf<SafeId<"user">>().toExtend<string>();
+});
+
+test("SafeId brands do not cross entity types", () => {
+  expectTypeOf<SafeId<"user">>().not.toExtend<SafeId<"workspace">>();
+  expectTypeOf<SafeId<"workspace">>().not.toExtend<SafeId<"organization">>();
+});
+
+test("SafeId constructors return the requested brand", () => {
+  expectTypeOf(toSafeId<"workspace">("id")).toEqualTypeOf<
+    SafeId<"workspace">
+  >();
+  expectTypeOf(createSafeId<"entity">()).toEqualTypeOf<SafeId<"entity">>();
+});
+
+test("Secret is nominal and kinds do not cross", () => {
+  expectTypeOf<string>().not.toExtend<Secret<"ApiKey">>();
+  expectTypeOf<RefreshToken>().not.toExtend<ClientSecret>();
+  expectTypeOf<ClientSecret>().not.toExtend<RefreshToken>();
+});
+
+test("SafeId and Secret families cannot cross-assign", () => {
+  expectTypeOf<SafeId<"user">>().not.toExtend<Secret<"ApiKey">>();
+  expectTypeOf<Secret<"ApiKey">>().not.toExtend<SafeId<"user">>();
+});
+
+test("prompt-safety brands separate untrusted from safe text", () => {
+  expectTypeOf<string>().not.toExtend<PromptSafeText>();
+  expectTypeOf<string>().not.toExtend<UntrustedText>();
+  expectTypeOf<UntrustedText>().not.toExtend<PromptSafeText>();
+  expectTypeOf<PromptSafeText>().not.toExtend<UntrustedText>();
+});
+
+test("chat tools only accept verified workspace id lists", () => {
+  expectTypeOf<
+    SafeId<"workspace">[]
+  >().not.toExtend<AuthorizedToolWorkspaceIds>();
+  expectTypeOf<string[]>().not.toExtend<AuthorizedToolWorkspaceIds>();
+});

--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
         "@types/bun": "catalog:",
         "@types/nodemailer": "^8.0.0",
         "drizzle-kit": "catalog:",
+        "expect-type": "^1.3.0",
         "fast-check": "catalog:",
       },
     },
@@ -2468,6 +2469,8 @@
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "i18n:sync": "turbo run i18n:sync --",
     "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
     "test": "turbo run test",
+    "verify": "bash scripts/verify.sh",
     "db:push": "bun --filter @stll/api db:push",
     "clean": "turbo run clean && git clean -xdf node_modules",
     "sync:well-known": "cp -r .well-known apps/web/public/",

--- a/packages/boe/tsconfig.json
+++ b/packages/boe/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stll/typescript-config/base.json",
+  "extends": "@stll/typescript-config/published.json",
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/packages/business-registries/tsconfig.json
+++ b/packages/business-registries/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stll/typescript-config/base.json",
+  "extends": "@stll/typescript-config/published.json",
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/packages/country-codes/tsconfig.json
+++ b/packages/country-codes/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stll/typescript-config/base.json",
+  "extends": "@stll/typescript-config/published.json",
   "compilerOptions": {
     "lib": ["ESNext"],
     "module": "ESNext",

--- a/packages/infosoud/src/constants.ts
+++ b/packages/infosoud/src/constants.ts
@@ -5,14 +5,14 @@ export const DEFAULT_DELAY_MS = 500;
 export const DEFAULT_TIMEOUT_MS = 15_000;
 export const DEFAULT_USER_AGENT =
   "infosoud/0.1.0 (+https://github.com/stella/stella/tree/main/packages/infosoud)";
-export const DEFAULT_CASE_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-export const DEFAULT_HEARINGS_CACHE_TTL_MS = 60 * 60 * 1000;
-export const DEFAULT_EVENT_DETAIL_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-export const DEFAULT_COURTS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-export const DEFAULT_DERIVED_COURT_MAP_CACHE_TTL_MS =
+export const DEFAULT_CASE_CACHE_TTL_MS: number = 6 * 60 * 60 * 1000;
+export const DEFAULT_HEARINGS_CACHE_TTL_MS: number = 60 * 60 * 1000;
+export const DEFAULT_EVENT_DETAIL_CACHE_TTL_MS: number = 6 * 60 * 60 * 1000;
+export const DEFAULT_COURTS_CACHE_TTL_MS: number = 24 * 60 * 60 * 1000;
+export const DEFAULT_DERIVED_COURT_MAP_CACHE_TTL_MS: number =
   DEFAULT_COURTS_CACHE_TTL_MS;
 
-export const NS_CASE_TYPES = new Set([
+export const NS_CASE_TYPES: ReadonlySet<string> = new Set([
   "CDO",
   "ICM",
   "NCU",
@@ -23,7 +23,7 @@ export const NS_CASE_TYPES = new Set([
   "TZ",
 ]);
 
-export const PRAGUE_DISTRICT_CODES = Array.from(
+export const PRAGUE_DISTRICT_CODES: readonly string[] = Array.from(
   { length: 10 },
   (_, index) => `OSPHA${String(index + 1).padStart(2, "0")}`,
 );
@@ -55,7 +55,7 @@ export const DEFAULT_EVENT_DETAIL_EVENT_TYPES = [
   "ZRUS_JED",
 ] as const;
 
-export const COURT_PREFIXES = [
+export const COURT_PREFIXES: readonly string[] = [
   "ks",
   "krajsky soud",
   "ms",
@@ -71,7 +71,7 @@ export const COURT_PREFIXES = [
   "vrchni soud",
 ];
 
-export const COURT_GENERIC_TOKENS = new Set([
+export const COURT_GENERIC_TOKENS: ReadonlySet<string> = new Set([
   "krajsky",
   "ks",
   "mestsky",

--- a/packages/infosoud/tsconfig.json
+++ b/packages/infosoud/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stll/typescript-config/base.json",
+  "extends": "@stll/typescript-config/published.json",
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -8,6 +8,7 @@
   "exports": {
     "./base.json": "./base.json",
     "./library.json": "./library.json",
+    "./published.json": "./published.json",
     "./node.json": "./node.json",
     "./bun.json": "./bun.json",
     "./react-library.json": "./react-library.json"

--- a/packages/typescript-config/published.json
+++ b/packages/typescript-config/published.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "stella published library",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "declaration": true,
+    "isolatedDeclarations": true
+  }
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Local mirror of the `ci-checks` job in .github/workflows/ci.yml:
+# one command that answers "will CI pass?" without reverse-engineering
+# the workflow. Green here means green on the required `ci-result`
+# check (the separate build/e2e jobs are not included; they need the
+# full service stack).
+#
+# Keep the step list in sync with ci.yml when adding or removing
+# checks there.
+#
+# Usage:
+#   bun run verify           # affected packages vs origin/main (CI PR behavior)
+#   bun run verify --all     # full run, no --affected (CI nightly behavior)
+set -uo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+affected_flag="--affected"
+base_ref="origin/main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      affected_flag=""
+      shift
+      ;;
+    --base)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --base requires an argument" >&2
+        exit 1
+      fi
+      base_ref="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: bun run verify [--all] [--base <ref>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$affected_flag" ]]; then
+  export TURBO_SCM_BASE="$base_ref"
+fi
+
+# CI seeds .env from .env.example before running checks; do the same
+# for fresh clones, but never touch an existing .env.
+for app in apps/api apps/web; do
+  if [[ ! -f "$app/.env" && -f "$app/.env.example" ]]; then
+    cp "$app/.env.example" "$app/.env"
+    echo "Seeded $app/.env from .env.example"
+  fi
+done
+
+failures=()
+
+run_step() {
+  local name="$1"
+  shift
+  echo
+  echo "=== $name ==="
+  if "$@"; then
+    echo "--- $name: ok"
+  else
+    echo "--- $name: FAILED"
+    failures+=("$name")
+  fi
+}
+
+run_lint() {
+  if [[ -n "$affected_flag" ]]; then
+    bun run lint -- "$affected_flag"
+  else
+    bun run lint
+  fi
+}
+
+run_format() {
+  # Call turbo directly: the package `format` scripts take `--check`
+  # after `--`, so the affected flag must land before it.
+  if [[ -n "$affected_flag" ]]; then
+    bun --bun turbo run format "$affected_flag" -- --check
+  else
+    bun --bun turbo run format -- --check
+  fi
+}
+
+run_rust_format() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo not installed; skipping (CI still checks Rust formatting)"
+    return 0
+  fi
+  cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
+}
+
+run_typecheck() {
+  # tsgo processes are memory-hungry; serialize typecheck tasks so
+  # parallel instances cannot exhaust memory on contributor machines.
+  # CI runs them concurrently on isolated runners; results match.
+  if [[ -n "$affected_flag" ]]; then
+    bun run typecheck -- --concurrency=1 "$affected_flag"
+  else
+    bun run typecheck -- --concurrency=1
+  fi
+}
+
+run_knip() {
+  local workspace
+  for workspace in apps/api apps/legal-atlas-runner apps/web; do
+    bun run knip --production --strict --no-progress \
+      --include unlisted,unresolved --workspace "$workspace" || return 1
+  done
+}
+
+run_test() {
+  if [[ -n "$affected_flag" ]]; then
+    bun run test -- --concurrency=2 "$affected_flag"
+  else
+    bun run test -- --concurrency=2
+  fi
+}
+
+run_step "AI skill sync" bash scripts/sync-ai-skills.sh --check
+run_step "Workspace hygiene" bun run lint:ws
+run_step "i18n" bun run i18n:check
+run_step "Release changelog guard" bash scripts/check-release-changelog.sh --base "$base_ref"
+run_step "Lint" run_lint
+run_step "Format" run_format
+run_step "Rust format" run_rust_format
+run_step "Typecheck" run_typecheck
+run_step "Knip production deps" run_knip
+run_step "Test" run_test
+run_step "Bridge-version guard self-test" bash scripts/check-bridge-version.test.sh
+run_step "Release-channel self-test" bash scripts/release-channel.test.sh
+run_step "Bridge-version guard" bash scripts/check-bridge-version.sh
+
+echo
+if (( ${#failures[@]} > 0 )); then
+  echo "verify: ${#failures[@]} check(s) failed:"
+  printf ' - %s\n' "${failures[@]}"
+  exit 1
+fi
+echo "verify: all checks passed"


### PR DESCRIPTION
## Summary

Three additions that make the repo's correctness gates easier to satisfy and harder to weaken:

- **`bun run verify`** (`scripts/verify.sh`): a single local entry point that mirrors the `ci-checks` job step for step (skill sync, workspace hygiene, i18n, changelog guard, lint, format, Rust format, typecheck, knip production checks, tests, bridge/release-channel guards). Defaults to `--affected` vs `origin/main` like a CI PR run; `--all` mirrors the full nightly run. Runs every step even after a failure and prints a failure summary. Referenced from CONTRIBUTING.md and AGENTS.md so contributors can self-verify a branch instead of reverse-engineering `ci.yml`.
- **Brand invariant type tests** (`apps/api/src/lib/brand-invariants.test.ts`): compile-time assertions (via `expect-type`, dev-only) pinning the nominal-typing guarantees of `SafeId`, `Secret`, the prompt-safety text brands, and `AuthorizedToolWorkspaceIds`, including cross-family non-assignability. If a refactor widens a brand back to a plain string, typecheck now fails on this file instead of the protection silently disappearing at every call site.
- **`isolatedDeclarations` for publishable packages**: new `@stll/typescript-config/published.json` (extends `base.json`; adds `isolatedDeclarations` + `declaration`, disables `allowJs`/`checkJs` which conflict with it), adopted by `boe`, `business-registries`, `country-codes`, and `infosoud`. This makes their public API surfaces explicit in source. `infosoud` needed nine explicit annotations on computed constants; the other three were already compliant.

## Notes

- `verify.sh` serializes typecheck tasks (`--concurrency=1`): tsgo instances are memory-heavy and parallel runs can exhaust memory on contributor machines. CI keeps running them concurrently; results are identical.
- Brand widening was verified to fail typecheck (temporarily widening `SafeId` to `string` produced compile errors at the expected assertion sites).
- All four published packages typecheck, test, and emit declarations cleanly under the new config.