### PR TITLE
fix(api): give duplicated entities their own storage objects

### DIFF
--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -29,6 +29,14 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,
 }));
 
+const captureErrorMock = mock(() => undefined);
+void mock.module("@/api/lib/analytics", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: () => ({ capture: mock(() => undefined) }),
+  isLocalPostHogDebugEnabled: () => false,
+}));
+
 const broadcastQueryInvalidationToTargetWorkspaceMock = mock(() => undefined);
 void mock.module("@/api/lib/invalidate-query-macro", () => ({
   broadcastQueryInvalidationToOrganization: mock(() => undefined),
@@ -141,6 +149,7 @@ beforeEach(() => {
   fileMock.mockClear();
   writeMock.mockClear();
   s3DeleteMock.mockClear();
+  captureErrorMock.mockClear();
   processExtractionMock.mockClear();
   syncWorkspaceSearchActivityMock.mockClear();
   broadcastQueryInvalidationToTargetWorkspaceMock.mockClear();
@@ -447,6 +456,122 @@ describe("copy-to-workspace", () => {
     expect(insertedFields).toHaveLength(0);
     expect(fileMock).not.toHaveBeenCalled();
     expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps move success when source file cleanup lookup fails", async () => {
+    let nextDocumentSequence = 0;
+    let selectCallCount = 0;
+    let deletedEntityCount = 0;
+
+    const sourceEntity = {
+      id: documentId,
+      kind: "document" as const,
+      name: "Move.pdf",
+      parentId: null,
+      readOnly: false,
+      currentVersion: {
+        id: toSafeId<"entityVersion">("version_1"),
+        fields: [{ propertyId: sourceFilePropertyId, content: fileContent }],
+      },
+    };
+
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => sourceEntity,
+          findMany: async () => [sourceEntity],
+        },
+        properties: {
+          findMany: async (opts: {
+            where: { workspaceId: { eq: string } };
+          }) => {
+            if (opts.where.workspaceId.eq === sourceWorkspaceId) {
+              return [
+                {
+                  id: sourceFilePropertyId,
+                  name: "Source File",
+                  content: filePropertyContent,
+                },
+              ];
+            }
+            return [
+              {
+                id: targetFilePropertyId,
+                name: "Source File",
+                content: filePropertyContent,
+              },
+            ];
+          },
+        },
+        workspaces: {
+          findFirst: async () => ({ reference: null }),
+        },
+      },
+      $count: async () => 0,
+      select: () => {
+        selectCallCount += 1;
+
+        return {
+          from: () => ({
+            innerJoin: () => ({
+              where: async () => {
+                throw new Error("cleanup lookup failed");
+              },
+            }),
+            where: async () => {
+              if (selectCallCount === 1) {
+                return [];
+              }
+              throw new Error("unexpected lookup");
+            },
+          }),
+        };
+      },
+      insert: (table: unknown) => ({
+        values: () => {
+          if (table === documentCounters) {
+            return {
+              onConflictDoUpdate: () => ({
+                returning: async () => {
+                  nextDocumentSequence += 1;
+                  return [{ lastValue: nextDocumentSequence }];
+                },
+              }),
+            };
+          }
+
+          return undefined;
+        },
+      }),
+      update: () => ({
+        set: () => ({
+          where: async () => {},
+        }),
+      }),
+      delete: () => ({
+        where: async () => {
+          deletedEntityCount += 1;
+        },
+      }),
+    };
+
+    const { safeDb } = createScopedDbMock(tx);
+    const result = await copyToWorkspace.handler(
+      createContext({
+        safeDb,
+        entityId: documentId,
+        deleteSource: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      entityId: expect.any(String),
+      entityIds: expect.any(Array),
+    });
+    expect(deletedEntityCount).toBe(1);
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(s3DeleteMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
   test("copies folder tree with children", async () => {

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -7,12 +7,12 @@ import type { SafeDb } from "@/api/db";
 import { entities, workspaces } from "@/api/db/schema";
 import type { EntitySnapshot } from "@/api/handlers/entities/copy-utils";
 import {
+  collectFileMappings,
   copyEntities,
   getFolderSubtree,
+  remapFileIds,
+  rollbackS3Copies,
 } from "@/api/handlers/entities/copy-utils";
-import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
-import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
-import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -39,14 +39,6 @@ const copyToWorkspaceBodySchema = t.Object({
 });
 
 type CopyToWorkspaceBody = Static<typeof copyToWorkspaceBodySchema>;
-
-type FileMapping = {
-  sourceKey: string;
-  targetKey: string;
-  newFileId: string;
-  sourceFileId: string;
-  mimeType: string;
-};
 
 type CopyToWorkspaceHandlerProps = {
   safeDb: SafeDb;
@@ -82,113 +74,6 @@ const collectPropertyIds = (
 };
 
 /**
- * Collect all file mappings from entities for S3 copy.
- * Creates new file IDs for the target workspace.
- */
-const collectFileMappings = (
-  sourceEntities: EntitySnapshot[],
-  organizationId: SafeId<"organization">,
-  sourceWorkspaceId: SafeId<"workspace">,
-  targetWorkspaceId: SafeId<"workspace">,
-): FileMapping[] => {
-  const mappings: FileMapping[] = [];
-
-  for (const entity of sourceEntities) {
-    if (!entity.currentVersion) {
-      continue;
-    }
-    for (const field of entity.currentVersion.fields) {
-      if (field.content.type === "file" && field.content.id) {
-        const newFileId = Bun.randomUUIDv7();
-        const { mimeType } = field.content;
-        mappings.push({
-          sourceFileId: field.content.id,
-          newFileId,
-          mimeType,
-          sourceKey: createFileKey({
-            organizationId,
-            workspaceId: sourceWorkspaceId,
-            fileId: field.content.id,
-            mimeType,
-          }),
-          targetKey: createFileKey({
-            organizationId,
-            workspaceId: targetWorkspaceId,
-            fileId: newFileId,
-            mimeType,
-          }),
-        });
-      }
-    }
-  }
-
-  return mappings;
-};
-
-/**
- * Remap file IDs in entity snapshots for cross-workspace copy.
- * S3 keys include workspaceId, so files copied to another workspace
- * get new IDs. This updates field content to reference those new IDs
- * and resets PDF derivative state (each workspace needs its own).
- */
-const remapFileIds = (
-  sourceEntities: EntitySnapshot[],
-  fileMappings: FileMapping[],
-): EntitySnapshot[] => {
-  const idMap = new Map(fileMappings.map((m) => [m.sourceFileId, m.newFileId]));
-
-  return sourceEntities.map((entity) => {
-    if (!entity.currentVersion) {
-      return entity;
-    }
-
-    const remappedFields = entity.currentVersion.fields.map((field) => {
-      if (field.content.type !== "file" || !field.content.id) {
-        return field;
-      }
-
-      const newFileId = idMap.get(field.content.id);
-      if (!newFileId) {
-        return field;
-      }
-
-      const {
-        pdfDerivative: _pdfDerivative,
-        placeholder: _placeholder,
-        thumbnailDerivative: _thumbnailDerivative,
-        ...restContent
-      } = field.content;
-
-      return {
-        ...field,
-        content: {
-          ...restContent,
-          id: newFileId,
-          pdfFileId: null,
-          pdfDerivative: pdfDerivativeStateForFile({
-            encrypted: field.content.encrypted,
-            mimeType: field.content.mimeType,
-          }),
-          thumbnailFileId: null,
-          thumbnailDerivative: thumbnailDerivativeStateForFile({
-            encrypted: field.content.encrypted,
-            mimeType: field.content.mimeType,
-          }),
-        },
-      };
-    });
-
-    return {
-      ...entity,
-      currentVersion: {
-        ...entity.currentVersion,
-        fields: remappedFields,
-      },
-    };
-  });
-};
-
-/**
  * Remap property IDs in entity snapshots for cross-workspace copy.
  * Properties are workspace-scoped, so we match by name+type and remap
  * to the target workspace's property IDs. Fields with no matching
@@ -220,21 +105,6 @@ const remapPropertyIds = (
       },
     };
   });
-
-/**
- * Best-effort cleanup of S3 keys. Failures are silently ignored
- * since this is rollback/cleanup code.
- */
-const rollbackS3Copies = async (keys: string[]): Promise<void> => {
-  const s3 = getS3();
-  await Promise.all(
-    keys.map(async (key) => {
-      await s3.delete(key).catch(() => {
-        // Intentional no-op: best-effort cleanup
-      });
-    }),
-  );
-};
 
 const copyToWorkspaceHandler = async function* ({
   safeDb,
@@ -397,12 +267,12 @@ const copyToWorkspaceHandler = async function* ({
 
   // Collect file mappings for S3 copy after property remapping, so
   // files from dropped fields do not leave orphaned target objects.
-  const fileMappings = collectFileMappings(
-    propertyRemappedEntities,
+  const fileMappings = collectFileMappings({
+    sourceEntities: propertyRemappedEntities,
     organizationId,
     sourceWorkspaceId,
     targetWorkspaceId,
-  );
+  });
 
   // S3 copy phase: copy all files before DB transaction
   const s3 = getS3();

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -5,14 +5,22 @@ import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db";
 import { entities, workspaces } from "@/api/db/schema";
-import type { EntitySnapshot } from "@/api/handlers/entities/copy-utils";
 import {
-  collectFileMappings,
+  collectFileCopySources,
   copyEntities,
+  copyFileObjects,
+  type EntitySnapshot,
+  type FileMapping,
   getFolderSubtree,
   remapFileIds,
   rollbackS3Copies,
 } from "@/api/handlers/entities/copy-utils";
+import {
+  extractFieldFileRefs,
+  filterUnreferencedFieldFileRefs,
+  type FieldFileRef,
+} from "@/api/handlers/files/field-file-refs";
+import { deleteS3Objects } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -27,7 +35,6 @@ import {
 } from "@/api/lib/file-derivative-queue";
 import { broadcastQueryInvalidationToTargetWorkspace } from "@/api/lib/invalidate-query-macro";
 import { LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
 import { syncWorkspaceSearchActivity } from "@/api/lib/search/index-global";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 
@@ -105,6 +112,58 @@ const remapPropertyIds = (
       },
     };
   });
+
+type CleanupMovedSourceFilesOptions = {
+  safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
+  sourceWorkspaceId: SafeId<"workspace">;
+  sourceEntityId: SafeId<"entity">;
+  sourceFileRefs: FieldFileRef[];
+};
+
+const cleanupMovedSourceFiles = async ({
+  safeDb,
+  organizationId,
+  sourceWorkspaceId,
+  sourceEntityId,
+  sourceFileRefs,
+}: CleanupMovedSourceFilesOptions): Promise<void> => {
+  if (sourceFileRefs.length === 0) {
+    return;
+  }
+
+  const unreferencedSourceFileRefsResult = await safeDb(
+    async (tx) =>
+      await filterUnreferencedFieldFileRefs({
+        tx,
+        workspaceId: sourceWorkspaceId,
+        fileRows: sourceFileRefs,
+      }),
+  );
+
+  if (Result.isError(unreferencedSourceFileRefsResult)) {
+    captureError(unreferencedSourceFileRefsResult.error, {
+      operation: "move-cleanup",
+      sourceWorkspaceId,
+      sourceEntityId,
+    });
+    return;
+  }
+
+  const deleteResult = await deleteS3Objects({
+    fileRows: unreferencedSourceFileRefsResult.value,
+    organizationId,
+    workspaceId: sourceWorkspaceId,
+  });
+
+  if (Result.isError(deleteResult)) {
+    captureError(deleteResult.error, {
+      operation: "move-cleanup",
+      sourceWorkspaceId,
+      sourceEntityId,
+    });
+  }
+};
 
 const copyToWorkspaceHandler = async function* ({
   safeDb,
@@ -264,26 +323,32 @@ const copyToWorkspaceHandler = async function* ({
     sourceEntities,
     propertyIdMap,
   );
+  const sourceFileRefs = sourceEntities.flatMap(
+    (entity) =>
+      entity.currentVersion?.fields.flatMap((field) =>
+        extractFieldFileRefs(field.content),
+      ) ?? [],
+  );
 
-  // Collect file mappings for S3 copy after property remapping, so
+  // Collect file objects for S3 copy after property remapping, so
   // files from dropped fields do not leave orphaned target objects.
-  const fileMappings = collectFileMappings({
+  const fileCopySources = collectFileCopySources({
     sourceEntities: propertyRemappedEntities,
     organizationId,
     sourceWorkspaceId,
-    targetWorkspaceId,
   });
 
   // S3 copy phase: copy all files before DB transaction
-  const s3 = getS3();
   const copiedS3Keys: string[] = [];
+  let fileMappings: FileMapping[];
 
   try {
-    for (const { sourceKey, targetKey, mimeType } of fileMappings) {
-      // Stream directly from source to target without buffering in memory
-      await s3.write(targetKey, s3.file(sourceKey), { type: mimeType });
-      copiedS3Keys.push(targetKey);
-    }
+    fileMappings = await copyFileObjects({
+      sources: fileCopySources,
+      organizationId,
+      targetWorkspaceId,
+      copiedS3Keys,
+    });
   } catch (error) {
     await rollbackS3Copies(copiedS3Keys);
     captureError(error, {
@@ -302,55 +367,60 @@ const copyToWorkspaceHandler = async function* ({
   // DB transaction phase: copy (and delete for moves) in a single transaction
   // to ensure atomicity — either both succeed or neither does.
   const sourceEntityIds = sourceEntities.map((e) => e.id);
-  const txResult = yield* Result.await(
-    safeDb(async (tx) => {
-      const copyResult = await copyEntities({
-        tx,
-        targetWorkspaceId,
-        targetParentId,
-        userId,
-        recordAuditEvent: recordTargetAuditEvent,
-        sourceEntityId,
-        sourceEntities: remappedEntities,
-        sourceWorkspaceId,
-      });
+  const txResultResult = await safeDb(async (tx) => {
+    const copyResult = await copyEntities({
+      tx,
+      targetWorkspaceId,
+      targetParentId,
+      userId,
+      recordAuditEvent: recordTargetAuditEvent,
+      sourceEntityId,
+      sourceEntities: remappedEntities,
+      sourceWorkspaceId,
+    });
 
-      if (!copyResult.ok) {
-        return copyResult;
-      }
-
-      // For move operations, delete source entities in the same transaction
-      if (deleteSource) {
-        // Delete in reverse order (children first) to respect FK constraints.
-        // The cascade will handle versions and fields.
-        for (const id of sourceEntityIds.toReversed()) {
-          await tx.delete(entities).where(eq(entities.id, id));
-        }
-
-        await tx
-          .update(workspaces)
-          .set({ lastActivityAt: new Date() })
-          .where(eq(workspaces.id, sourceWorkspaceId));
-
-        await recordSourceAuditEvent(
-          tx,
-          copyResult.copiedEntities.map((entity) => ({
-            action: AUDIT_ACTION.DELETE,
-            resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-            resourceId: entity.sourceId,
-            changes: {
-              deleted: {
-                old: { kind: entity.kind, name: entity.name },
-                new: { movedToWorkspaceId: targetWorkspaceId },
-              },
-            },
-          })),
-        );
-      }
-
+    if (!copyResult.ok) {
       return copyResult;
-    }),
-  );
+    }
+
+    // For move operations, delete source entities in the same transaction
+    if (deleteSource) {
+      // Delete in reverse order (children first) to respect FK constraints.
+      // The cascade will handle versions and fields.
+      for (const id of sourceEntityIds.toReversed()) {
+        await tx.delete(entities).where(eq(entities.id, id));
+      }
+
+      await tx
+        .update(workspaces)
+        .set({ lastActivityAt: new Date() })
+        .where(eq(workspaces.id, sourceWorkspaceId));
+
+      await recordSourceAuditEvent(
+        tx,
+        copyResult.copiedEntities.map((entity) => ({
+          action: AUDIT_ACTION.DELETE,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+          resourceId: entity.sourceId,
+          changes: {
+            deleted: {
+              old: { kind: entity.kind, name: entity.name },
+              new: { movedToWorkspaceId: targetWorkspaceId },
+            },
+          },
+        })),
+      );
+    }
+
+    return copyResult;
+  });
+
+  if (Result.isError(txResultResult)) {
+    await rollbackS3Copies(copiedS3Keys);
+    return Result.err(txResultResult.error);
+  }
+
+  const txResult = txResultResult.value;
 
   if (!txResult.ok) {
     await rollbackS3Copies(copiedS3Keys);
@@ -359,17 +429,14 @@ const copyToWorkspaceHandler = async function* ({
     );
   }
 
-  // Delete source S3 objects after DB transaction succeeds (for moves)
   if (deleteSource) {
-    const sourceKeys = fileMappings.map((m) => m.sourceKey);
-    await Promise.all(
-      sourceKeys.map(
-        async (key) =>
-          await s3.delete(key).catch((error: unknown) => {
-            captureError(error, { key, operation: "move-cleanup" });
-          }),
-      ),
-    );
+    await cleanupMovedSourceFiles({
+      safeDb,
+      organizationId,
+      sourceWorkspaceId,
+      sourceEntityId,
+      sourceFileRefs,
+    });
   }
 
   // Process search extraction for new entities

--- a/apps/api/src/handlers/entities/copy-utils.test.ts
+++ b/apps/api/src/handlers/entities/copy-utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FieldContent } from "@/api/db/schema-validators";
+import { allocateFileObject } from "@/api/handlers/files/file-object-ids";
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  remapFileIds,
+  type EntitySnapshot,
+  type FileMapping,
+} from "./copy-utils";
+
+const workspaceId = toSafeId<"workspace">("workspace_1");
+const organizationId = toSafeId<"organization">("organization_1");
+const firstEntityId = toSafeId<"entity">("entity_1");
+const secondEntityId = toSafeId<"entity">("entity_2");
+const filePropertyId = toSafeId<"property">("property_file");
+
+const sharedSourceFile = {
+  encrypted: false,
+  fileName: "shared.pdf",
+  id: "shared-source-file",
+  mimeType: "application/pdf",
+  pdfFileId: null,
+  sha256Hex: "a".repeat(64),
+  sizeBytes: 42,
+  type: "file",
+  version: 1,
+} satisfies FieldContent;
+
+describe("remapFileIds", () => {
+  test("remaps by field occurrence rather than shared source file id", () => {
+    const sourceEntities: EntitySnapshot[] = [
+      {
+        currentVersion: {
+          fields: [{ content: sharedSourceFile, propertyId: filePropertyId }],
+        },
+        id: firstEntityId,
+        kind: "document",
+        name: "First.pdf",
+        parentId: null,
+      },
+      {
+        currentVersion: {
+          fields: [{ content: sharedSourceFile, propertyId: filePropertyId }],
+        },
+        id: secondEntityId,
+        kind: "document",
+        name: "Second.pdf",
+        parentId: null,
+      },
+    ];
+    const firstNewFileId = allocateFileObject();
+    const secondNewFileId = allocateFileObject();
+    const mappings: FileMapping[] = [
+      {
+        mimeType: sharedSourceFile.mimeType,
+        newFileId: firstNewFileId,
+        sourceEntityId: firstEntityId,
+        sourceFileId: sharedSourceFile.id,
+        sourceKey: `${organizationId}/${workspaceId}/${sharedSourceFile.id}.pdf`,
+        sourcePropertyId: filePropertyId,
+        targetKey: `${organizationId}/${workspaceId}/${firstNewFileId}.pdf`,
+      },
+      {
+        mimeType: sharedSourceFile.mimeType,
+        newFileId: secondNewFileId,
+        sourceEntityId: secondEntityId,
+        sourceFileId: sharedSourceFile.id,
+        sourceKey: `${organizationId}/${workspaceId}/${sharedSourceFile.id}.pdf`,
+        sourcePropertyId: filePropertyId,
+        targetKey: `${organizationId}/${workspaceId}/${secondNewFileId}.pdf`,
+      },
+    ];
+
+    const remapped = remapFileIds(sourceEntities, mappings);
+    const firstContent = remapped.at(0)?.currentVersion?.fields.at(0)?.content;
+    const secondContent = remapped.at(1)?.currentVersion?.fields.at(0)?.content;
+
+    expect(firstContent?.type).toBe("file");
+    expect(secondContent?.type).toBe("file");
+    if (firstContent?.type !== "file" || secondContent?.type !== "file") {
+      throw new Error("Expected remapped file fields");
+    }
+
+    expect(firstContent.id).toBe(firstNewFileId);
+    expect(secondContent.id).toBe(secondNewFileId);
+    expect(firstContent.id).not.toBe(secondContent.id);
+  });
+});

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -3,6 +3,9 @@ import { and, eq, isNull, like } from "drizzle-orm";
 import type { Transaction } from "@/api/db";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
+import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
+import { createFileKey } from "@/api/handlers/files/utils";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -10,6 +13,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { escapeLike } from "@/api/lib/escape-like";
 import { LIMITS } from "@/api/lib/limits";
+import { getS3 } from "@/api/lib/s3";
 
 export type EntityFieldSnapshot = {
   propertyId: SafeId<"property">;
@@ -41,6 +45,145 @@ export type CopiedFileField = {
   fieldId: SafeId<"field">;
   mimeType: string;
   encrypted: boolean;
+};
+
+export type FileMapping = {
+  sourceKey: string;
+  targetKey: string;
+  newFileId: string;
+  sourceFileId: string;
+  mimeType: string;
+};
+
+type CollectFileMappingsOptions = {
+  sourceEntities: EntitySnapshot[];
+  organizationId: SafeId<"organization">;
+  sourceWorkspaceId: SafeId<"workspace">;
+  targetWorkspaceId: SafeId<"workspace">;
+};
+
+/**
+ * Collect all file mappings from entities for S3 copy.
+ * Creates new file IDs for the copies. Copies must never share
+ * storage objects with their source: S3 keys are derived from the
+ * file ID, and entity deletion deletes the underlying objects, so a
+ * shared ID would let deleting the copy destroy the original's file.
+ */
+export const collectFileMappings = ({
+  sourceEntities,
+  organizationId,
+  sourceWorkspaceId,
+  targetWorkspaceId,
+}: CollectFileMappingsOptions): FileMapping[] => {
+  const mappings: FileMapping[] = [];
+
+  for (const entity of sourceEntities) {
+    if (!entity.currentVersion) {
+      continue;
+    }
+    for (const field of entity.currentVersion.fields) {
+      if (field.content.type === "file" && field.content.id) {
+        const newFileId = Bun.randomUUIDv7();
+        const { mimeType } = field.content;
+        mappings.push({
+          sourceFileId: field.content.id,
+          newFileId,
+          mimeType,
+          sourceKey: createFileKey({
+            organizationId,
+            workspaceId: sourceWorkspaceId,
+            fileId: field.content.id,
+            mimeType,
+          }),
+          targetKey: createFileKey({
+            organizationId,
+            workspaceId: targetWorkspaceId,
+            fileId: newFileId,
+            mimeType,
+          }),
+        });
+      }
+    }
+  }
+
+  return mappings;
+};
+
+/**
+ * Remap file IDs in entity snapshots so copied fields reference the
+ * new S3 objects, and reset PDF/thumbnail derivative state (each copy
+ * generates its own derivatives).
+ */
+export const remapFileIds = (
+  sourceEntities: EntitySnapshot[],
+  fileMappings: FileMapping[],
+): EntitySnapshot[] => {
+  const idMap = new Map(fileMappings.map((m) => [m.sourceFileId, m.newFileId]));
+
+  return sourceEntities.map((entity) => {
+    if (!entity.currentVersion) {
+      return entity;
+    }
+
+    const remappedFields = entity.currentVersion.fields.map((field) => {
+      if (field.content.type !== "file" || !field.content.id) {
+        return field;
+      }
+
+      const newFileId = idMap.get(field.content.id);
+      if (!newFileId) {
+        return field;
+      }
+
+      const {
+        pdfDerivative: _pdfDerivative,
+        placeholder: _placeholder,
+        thumbnailDerivative: _thumbnailDerivative,
+        ...restContent
+      } = field.content;
+
+      return {
+        ...field,
+        content: {
+          ...restContent,
+          id: newFileId,
+          pdfFileId: null,
+          pdfDerivative: pdfDerivativeStateForFile({
+            encrypted: field.content.encrypted,
+            mimeType: field.content.mimeType,
+          }),
+          thumbnailFileId: null,
+          thumbnailDerivative: thumbnailDerivativeStateForFile({
+            encrypted: field.content.encrypted,
+            mimeType: field.content.mimeType,
+          }),
+        },
+      };
+    });
+
+    return {
+      ...entity,
+      currentVersion: {
+        ...entity.currentVersion,
+        fields: remappedFields,
+      },
+    };
+  });
+};
+
+/**
+ * Best-effort cleanup of S3 keys. Failures are silently ignored
+ * since this is rollback/cleanup code.
+ */
+export const rollbackS3Copies = async (keys: string[]): Promise<void> => {
+  const s3 = getS3();
+  await Promise.all(
+    keys.map(async (key) => {
+      await s3.delete(key).catch(() => {
+        // Intentional no-op: best-effort cleanup
+      });
+    }),
+  );
 };
 
 /** Escape regex metacharacters. */

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -1,8 +1,15 @@
+import { panic, TaggedError } from "better-result";
 import { and, eq, isNull, like } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+  type MintedFileId,
+  type WritableFieldContent,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
@@ -31,6 +38,17 @@ export type EntitySnapshot = {
   } | null;
 };
 
+type WritableEntityFieldSnapshot = {
+  propertyId: SafeId<"property">;
+  content: WritableFieldContent;
+};
+
+export type WritableEntitySnapshot = Omit<EntitySnapshot, "currentVersion"> & {
+  currentVersion: {
+    fields: WritableEntityFieldSnapshot[];
+  } | null;
+};
+
 export type CopiedEntity = {
   sourceId: SafeId<"entity">;
   entityId: SafeId<"entity">;
@@ -50,32 +68,46 @@ export type CopiedFileField = {
 export type FileMapping = {
   sourceKey: string;
   targetKey: string;
-  newFileId: string;
+  newFileId: MintedFileId;
+  sourceEntityId: SafeId<"entity">;
   sourceFileId: string;
+  sourcePropertyId: SafeId<"property">;
   mimeType: string;
 };
 
-type CollectFileMappingsOptions = {
+export type FileCopySource = {
+  sourceEntityId: SafeId<"entity">;
+  sourceKey: string;
+  sourceFileId: string;
+  sourcePropertyId: SafeId<"property">;
+  mimeType: string;
+};
+
+type FileMappingKeyInput = {
+  sourceEntityId: SafeId<"entity">;
+  sourcePropertyId: SafeId<"property">;
+};
+
+const fileMappingKey = ({
+  sourceEntityId,
+  sourcePropertyId,
+}: FileMappingKeyInput) => `${sourceEntityId}:${sourcePropertyId}`;
+
+type CollectFileCopySourcesOptions = {
   sourceEntities: EntitySnapshot[];
   organizationId: SafeId<"organization">;
   sourceWorkspaceId: SafeId<"workspace">;
-  targetWorkspaceId: SafeId<"workspace">;
 };
 
 /**
- * Collect all file mappings from entities for S3 copy.
- * Creates new file IDs for the copies. Copies must never share
- * storage objects with their source: S3 keys are derived from the
- * file ID, and entity deletion deletes the underlying objects, so a
- * shared ID would let deleting the copy destroy the original's file.
+ * Collect all source file objects needed for S3 copy.
  */
-export const collectFileMappings = ({
+export const collectFileCopySources = ({
   sourceEntities,
   organizationId,
   sourceWorkspaceId,
-  targetWorkspaceId,
-}: CollectFileMappingsOptions): FileMapping[] => {
-  const mappings: FileMapping[] = [];
+}: CollectFileCopySourcesOptions): FileCopySource[] => {
+  const sources: FileCopySource[] = [];
 
   for (const entity of sourceEntities) {
     if (!entity.currentVersion) {
@@ -83,11 +115,11 @@ export const collectFileMappings = ({
     }
     for (const field of entity.currentVersion.fields) {
       if (field.content.type === "file" && field.content.id) {
-        const newFileId = Bun.randomUUIDv7();
         const { mimeType } = field.content;
-        mappings.push({
+        sources.push({
+          sourceEntityId: entity.id,
           sourceFileId: field.content.id,
-          newFileId,
+          sourcePropertyId: field.propertyId,
           mimeType,
           sourceKey: createFileKey({
             organizationId,
@@ -95,15 +127,110 @@ export const collectFileMappings = ({
             fileId: field.content.id,
             mimeType,
           }),
-          targetKey: createFileKey({
-            organizationId,
-            workspaceId: targetWorkspaceId,
-            fileId: newFileId,
-            mimeType,
-          }),
         });
       }
     }
+  }
+
+  return sources;
+};
+
+type CopyFileObjectOptions = FileCopySource & {
+  organizationId: SafeId<"organization">;
+  targetWorkspaceId: SafeId<"workspace">;
+  copiedS3Keys: string[];
+};
+
+/**
+ * Copy one field-backed file object and return the minted target ID.
+ * Copies must never share storage objects with their source: S3 keys
+ * are derived from the file ID, and entity deletion deletes the
+ * underlying objects.
+ */
+export const copyFileObject = async ({
+  sourceEntityId,
+  sourceFileId,
+  sourcePropertyId,
+  sourceKey,
+  mimeType,
+  organizationId,
+  targetWorkspaceId,
+  copiedS3Keys,
+}: CopyFileObjectOptions): Promise<FileMapping> => {
+  const newFileId = allocateFileObject();
+  const targetKey = createFileKey({
+    organizationId,
+    workspaceId: targetWorkspaceId,
+    fileId: newFileId,
+    mimeType,
+  });
+  const s3 = getS3();
+
+  await s3.write(targetKey, s3.file(sourceKey), { type: mimeType });
+  copiedS3Keys.push(targetKey);
+
+  return {
+    sourceEntityId,
+    sourceFileId,
+    sourcePropertyId,
+    sourceKey,
+    targetKey,
+    newFileId,
+    mimeType,
+  };
+};
+
+type CopyFileObjectsOptions = {
+  sources: FileCopySource[];
+  organizationId: SafeId<"organization">;
+  targetWorkspaceId: SafeId<"workspace">;
+  copiedS3Keys: string[];
+};
+
+class FileObjectCopyError extends TaggedError("FileObjectCopyError")<{
+  message: string;
+  cause?: unknown;
+}>() {}
+
+export const copyFileObjects = async ({
+  sources,
+  organizationId,
+  targetWorkspaceId,
+  copiedS3Keys,
+}: CopyFileObjectsOptions): Promise<FileMapping[]> => {
+  const results = await Promise.allSettled(
+    sources.map(
+      async (source) =>
+        await copyFileObject({
+          ...source,
+          organizationId,
+          targetWorkspaceId,
+          copiedS3Keys,
+        }),
+    ),
+  );
+
+  const mappings: FileMapping[] = [];
+  let firstError: unknown;
+  let hasError = false;
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      mappings.push(result.value);
+      continue;
+    }
+
+    if (!hasError) {
+      firstError = result.reason;
+      hasError = true;
+    }
+  }
+
+  if (hasError) {
+    throw new FileObjectCopyError({
+      message: "Failed to copy file object",
+      cause: firstError,
+    });
   }
 
   return mappings;
@@ -117,49 +244,60 @@ export const collectFileMappings = ({
 export const remapFileIds = (
   sourceEntities: EntitySnapshot[],
   fileMappings: FileMapping[],
-): EntitySnapshot[] => {
-  const idMap = new Map(fileMappings.map((m) => [m.sourceFileId, m.newFileId]));
+): WritableEntitySnapshot[] => {
+  const idMap = new Map(
+    fileMappings.map((m) => [fileMappingKey(m), m.newFileId]),
+  );
 
   return sourceEntities.map((entity) => {
     if (!entity.currentVersion) {
-      return entity;
+      return { ...entity, currentVersion: null };
     }
 
-    const remappedFields = entity.currentVersion.fields.map((field) => {
-      if (field.content.type !== "file" || !field.content.id) {
-        return field;
-      }
+    const remappedFields: WritableEntityFieldSnapshot[] =
+      entity.currentVersion.fields.map((field) => {
+        if (field.content.type !== "file") {
+          return {
+            content: field.content,
+            propertyId: field.propertyId,
+          };
+        }
 
-      const newFileId = idMap.get(field.content.id);
-      if (!newFileId) {
-        return field;
-      }
-
-      const {
-        pdfDerivative: _pdfDerivative,
-        placeholder: _placeholder,
-        thumbnailDerivative: _thumbnailDerivative,
-        ...restContent
-      } = field.content;
-
-      return {
-        ...field,
-        content: {
-          ...restContent,
-          id: newFileId,
-          pdfFileId: null,
-          pdfDerivative: pdfDerivativeStateForFile({
-            encrypted: field.content.encrypted,
-            mimeType: field.content.mimeType,
+        const newFileId = idMap.get(
+          fileMappingKey({
+            sourceEntityId: entity.id,
+            sourcePropertyId: field.propertyId,
           }),
-          thumbnailFileId: null,
-          thumbnailDerivative: thumbnailDerivativeStateForFile({
-            encrypted: field.content.encrypted,
-            mimeType: field.content.mimeType,
+        );
+        if (!newFileId) {
+          panic("Missing file mapping for copied file field");
+        }
+
+        const {
+          pdfDerivative: _pdfDerivative,
+          placeholder: _placeholder,
+          thumbnailDerivative: _thumbnailDerivative,
+          ...restContent
+        } = field.content;
+
+        return {
+          ...field,
+          content: fileContentWithMintedObject({
+            ...restContent,
+            id: newFileId,
+            pdfFileId: null,
+            pdfDerivative: pdfDerivativeStateForFile({
+              encrypted: field.content.encrypted,
+              mimeType: field.content.mimeType,
+            }),
+            thumbnailFileId: null,
+            thumbnailDerivative: thumbnailDerivativeStateForFile({
+              encrypted: field.content.encrypted,
+              mimeType: field.content.mimeType,
+            }),
           }),
-        },
-      };
-    });
+        };
+      });
 
     return {
       ...entity,
@@ -338,7 +476,7 @@ type CopyEntitiesProps = {
    */
   recordAuditEvent: AuditRecorder;
   sourceEntityId: SafeId<"entity">;
-  sourceEntities: EntitySnapshot[];
+  sourceEntities: WritableEntitySnapshot[];
   /** Source workspace ID for audit log (cross-workspace only). */
   sourceWorkspaceId?: SafeId<"workspace">;
 };

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -3,6 +3,10 @@ import { eq } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
@@ -94,7 +98,7 @@ export const createEntityFromBuffer = async ({
   scanWarnings,
 }: CreateEntityFromBufferInput): Promise<CreateEntityFromBufferResult> => {
   const fileName = sanitizeFilenamePreservingExtension(rawFileName);
-  const fileId = Bun.randomUUIDv7();
+  const fileId = allocateFileObject();
   const s3Key = createFileKey({
     organizationId,
     workspaceId,
@@ -175,7 +179,7 @@ export const createEntityFromBuffer = async ({
         workspaceId,
         propertyId: fileProperty.id,
         entityVersionId,
-        content: {
+        content: fileContentWithMintedObject({
           type: "file",
           version: 1,
           id: fileId,
@@ -195,7 +199,7 @@ export const createEntityFromBuffer = async ({
             mimeType,
           }),
           ...(scanWarnings !== undefined && { scanWarnings }),
-        },
+        }),
       });
 
       await tx

--- a/apps/api/src/handlers/entities/delete-version.ts
+++ b/apps/api/src/handlers/entities/delete-version.ts
@@ -2,8 +2,10 @@ import { Result } from "better-result";
 import { and, desc, eq, ne } from "drizzle-orm";
 
 import { entities, entityVersions } from "@/api/db/schema";
-import type { FieldContent } from "@/api/db/schema-validators";
-import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
+import {
+  extractFieldFileRefs,
+  filterUnreferencedFieldFileRefs,
+} from "@/api/handlers/files/field-file-refs";
 import { deleteS3Objects } from "@/api/handlers/files/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -12,7 +14,6 @@ import type { AuditEvent } from "@/api/lib/audit-log";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { broadcast } from "@/api/lib/sse";
-import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const paramsSchema = workspaceParams({
   entityId: tSafeId("entity"),
@@ -23,25 +24,6 @@ const config = {
   permissions: { entity: ["update"] },
   params: paramsSchema,
 } satisfies HandlerConfig;
-
-type FileRef = { fileId: string; mimeType: string };
-
-const extractFileRefs = (content: FieldContent): FileRef[] => {
-  if (content.type !== "file") {
-    return [];
-  }
-  const refs: FileRef[] = [{ fileId: content.id, mimeType: content.mimeType }];
-  if (content.pdfFileId) {
-    refs.push({ fileId: content.pdfFileId, mimeType: PDF_MIME_TYPE });
-  }
-  if (content.thumbnailFileId) {
-    refs.push({
-      fileId: content.thumbnailFileId,
-      mimeType: THUMBNAIL_MIME_TYPE,
-    });
-  }
-  return refs;
-};
 
 export default createSafeHandler(
   config,
@@ -127,14 +109,25 @@ export default createSafeHandler(
     );
 
     const fileRefs = versionFields.flatMap((row) =>
-      extractFileRefs(row.content),
+      extractFieldFileRefs(row.content),
+    );
+    const unreferencedFileRefs = yield* Result.await(
+      safeDb(
+        async (tx) =>
+          await filterUnreferencedFieldFileRefs({
+            tx,
+            workspaceId,
+            fileRows: fileRefs,
+            excludedEntityVersionIds: [params.versionId],
+          }),
+      ),
     );
 
     // Delete S3 objects first (idempotent on retry)
-    if (fileRefs.length > 0) {
+    if (unreferencedFileRefs.length > 0) {
       Result.unwrap(
         await deleteS3Objects({
-          fileRows: fileRefs,
+          fileRows: unreferencedFileRefs,
           organizationId,
           workspaceId,
         }),

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -5,8 +5,10 @@ import type { Static } from "elysia";
 
 import type { SafeDb } from "@/api/db";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
-import type { FieldContent } from "@/api/db/schema-validators";
-import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
+import {
+  extractFieldFileRefs,
+  filterUnreferencedFieldFileRefs,
+} from "@/api/handlers/files/field-file-refs";
 import { deleteS3Objects } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -17,7 +19,6 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getSearchProvider } from "@/api/lib/search/provider";
-import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const deleteEntitiesBodySchema = t.Object({
   entityIds: t.Array(tSafeId("entity"), { minItems: 1 }),
@@ -31,32 +32,6 @@ type DeleteEntitiesHandlerProps = {
   workspaceId: SafeId<"workspace">;
   recordAuditEvent: AuditRecorder;
   body: DeleteEntitiesBodySchema;
-};
-
-type FileRef = { fileId: string; mimeType: string };
-
-const extractFileRefs = (content: FieldContent): FileRef[] => {
-  if (content.type !== "file") {
-    return [];
-  }
-
-  const refs: FileRef[] = [{ fileId: content.id, mimeType: content.mimeType }];
-
-  if (content.pdfFileId) {
-    refs.push({
-      fileId: content.pdfFileId,
-      mimeType: PDF_MIME_TYPE,
-    });
-  }
-
-  if (content.thumbnailFileId) {
-    refs.push({
-      fileId: content.thumbnailFileId,
-      mimeType: THUMBNAIL_MIME_TYPE,
-    });
-  }
-
-  return refs;
 };
 
 const deleteEntitiesHandler = async function* ({
@@ -104,14 +79,27 @@ const deleteEntitiesHandler = async function* ({
     }),
   );
 
-  const fileRefs = fieldRows.flatMap((row) => extractFileRefs(row.content));
+  const fileRefs = fieldRows.flatMap((row) =>
+    extractFieldFileRefs(row.content),
+  );
+  const unreferencedFileRefs = yield* Result.await(
+    safeDb(
+      async (tx) =>
+        await filterUnreferencedFieldFileRefs({
+          tx,
+          workspaceId,
+          fileRows: fileRefs,
+          excludedEntityIds: body.entityIds,
+        }),
+    ),
+  );
 
   // Delete S3 objects before the DB delete.
   // On retry, already-deleted objects are no-ops.
 
   Result.unwrap(
     await deleteS3Objects({
-      fileRows: fileRefs,
+      fileRows: unreferencedFileRefs,
       organizationId,
       workspaceId,
     }),

--- a/apps/api/src/handlers/entities/duplicate.test.ts
+++ b/apps/api/src/handlers/entities/duplicate.test.ts
@@ -19,6 +19,14 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
   processExtraction: processExtractionMock,
 }));
 
+const fileMock = mock(() => ({}));
+const writeMock = mock(async () => undefined);
+const s3DeleteMock = mock(async () => undefined);
+
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({ delete: s3DeleteMock, file: fileMock, write: writeMock }),
+}));
+
 const { default: duplicateEntity } = await import("./duplicate");
 
 const workspaceId = toSafeId<"workspace">("workspace_1");
@@ -50,6 +58,10 @@ type InsertedEntity = {
   docSequence?: number | null;
 };
 
+type InsertedField = {
+  content: FieldContent;
+};
+
 const isInsertedEntity = (value: unknown): value is InsertedEntity =>
   typeof value === "object" &&
   value !== null &&
@@ -57,6 +69,9 @@ const isInsertedEntity = (value: unknown): value is InsertedEntity =>
   "kind" in value &&
   "name" in value &&
   "parentId" in value;
+
+const isInsertedField = (value: unknown): value is InsertedField =>
+  typeof value === "object" && value !== null && "content" in value;
 
 const isArrayWithLength = (
   value: unknown,
@@ -190,6 +205,22 @@ describe("duplicate entity", () => {
     expect(insertedAuditLogs).toHaveLength(1);
     const auditBatch = insertedAuditLogs.at(0);
     expect(isArrayWithLength(auditBatch, 3)).toBe(true);
+    const fieldBatch = insertedFields.at(0);
+    expect(isArrayWithLength(fieldBatch, 1)).toBe(true);
+    if (!isArrayWithLength(fieldBatch, 1)) {
+      throw new Error("Expected duplicated file field batch");
+    }
+
+    const duplicatedFileField = fieldBatch.at(0);
+    expect(isInsertedField(duplicatedFileField)).toBe(true);
+    if (!isInsertedField(duplicatedFileField)) {
+      throw new Error("Expected duplicated file field");
+    }
+    expect(duplicatedFileField.content.type).toBe("file");
+    if (duplicatedFileField.content.type === "file") {
+      expect(duplicatedFileField.content.id).not.toBe(fileContent.id);
+    }
+    expect(writeMock).toHaveBeenCalledTimes(1);
 
     const rootDuplicate = insertedEntities.at(0);
     const documentDuplicate = insertedEntities.at(1);

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -3,9 +3,13 @@ import { t } from "elysia";
 import type { Static } from "elysia";
 
 import type { SafeDb } from "@/api/db";
+import type { EntitySnapshot } from "@/api/handlers/entities/copy-utils";
 import {
+  collectFileMappings,
   copyEntities,
   getFolderSubtree,
+  remapFileIds,
+  rollbackS3Copies,
 } from "@/api/handlers/entities/copy-utils";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -14,7 +18,12 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  enqueueImageThumbnailOrMarkFailed,
+  enqueuePdfDerivativeOrMarkFailed,
+} from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
+import { getS3 } from "@/api/lib/s3";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 
 const duplicateEntityBodySchema = t.Object({
@@ -23,6 +32,7 @@ const duplicateEntityBodySchema = t.Object({
 
 type DuplicateEntityHandlerProps = {
   safeDb: SafeDb;
+  organizationId: SafeId<"organization">;
   workspaceId: SafeId<"workspace">;
   userId: SafeId<"user">;
   recordAuditEvent: AuditRecorder;
@@ -31,6 +41,7 @@ type DuplicateEntityHandlerProps = {
 
 const duplicateEntityHandler = async function* ({
   safeDb,
+  organizationId,
   workspaceId,
   userId,
   recordAuditEvent,
@@ -69,66 +80,93 @@ const duplicateEntityHandler = async function* ({
     );
   }
 
+  let sourceEntities: EntitySnapshot[] = [source];
+  if (source.kind === "folder") {
+    const workspaceEntities = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.entities.findMany({
+          where: { workspaceId: { eq: workspaceId } },
+          columns: {
+            id: true,
+            kind: true,
+            name: true,
+            parentId: true,
+          },
+          with: {
+            currentVersion: {
+              columns: { id: true },
+              with: {
+                fields: {
+                  columns: {
+                    propertyId: true,
+                    content: true,
+                  },
+                },
+              },
+            },
+          },
+          limit: LIMITS.entitiesCount,
+        }),
+      ),
+    );
+
+    const subtree = getFolderSubtree(workspaceEntities, sourceEntityId);
+    if (!subtree) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Entity not found" }),
+      );
+    }
+
+    sourceEntities = subtree;
+  }
+
+  // Copies must not share storage objects with their source: deleting
+  // an entity deletes its objects, so a shared reference would let
+  // deleting the duplicate destroy the original's file. Mint new file
+  // IDs and copy the objects before the DB transaction.
+  const fileMappings = collectFileMappings({
+    sourceEntities,
+    organizationId,
+    sourceWorkspaceId: workspaceId,
+    targetWorkspaceId: workspaceId,
+  });
+
+  const s3 = getS3();
+  const copiedS3Keys: string[] = [];
+
+  try {
+    for (const { sourceKey, targetKey, mimeType } of fileMappings) {
+      // Stream directly from source to target without buffering in memory
+      await s3.write(targetKey, s3.file(sourceKey), { type: mimeType });
+      copiedS3Keys.push(targetKey);
+    }
+  } catch (error) {
+    await rollbackS3Copies(copiedS3Keys);
+    captureError(error, { workspaceId, sourceEntityId });
+    return Result.err(
+      new HandlerError({ status: 500, message: "Failed to copy files" }),
+    );
+  }
+
+  const remappedEntities = remapFileIds(sourceEntities, fileMappings);
+
   const txResult = yield* Result.await(
-    safeDb(async (tx) => {
-      if (source.kind !== "folder") {
-        return await copyEntities({
+    safeDb(
+      async (tx) =>
+        await copyEntities({
           tx,
           targetWorkspaceId: workspaceId,
           targetParentId: source.parentId,
           userId,
           recordAuditEvent,
           sourceEntityId,
-          sourceEntities: [source],
-        });
-      }
-
-      const workspaceEntities = await tx.query.entities.findMany({
-        where: { workspaceId: { eq: workspaceId } },
-        columns: {
-          id: true,
-          kind: true,
-          name: true,
-          parentId: true,
-        },
-        with: {
-          currentVersion: {
-            columns: { id: true },
-            with: {
-              fields: {
-                columns: {
-                  propertyId: true,
-                  content: true,
-                },
-              },
-            },
-          },
-        },
-        limit: LIMITS.entitiesCount,
-      });
-
-      const subtree = getFolderSubtree(workspaceEntities, sourceEntityId);
-      if (!subtree) {
-        return {
-          ok: false as const,
-          status: 404 as const,
-          message: "Entity not found",
-        };
-      }
-
-      return await copyEntities({
-        tx,
-        targetWorkspaceId: workspaceId,
-        targetParentId: source.parentId,
-        userId,
-        recordAuditEvent,
-        sourceEntityId,
-        sourceEntities: subtree,
-      });
-    }),
+          sourceEntities: remappedEntities,
+        }),
+    ),
   );
 
   if (!txResult.ok) {
+    await rollbackS3Copies(copiedS3Keys);
     return Result.err(
       new HandlerError({ status: txResult.status, message: txResult.message }),
     );
@@ -136,6 +174,29 @@ const duplicateEntityHandler = async function* ({
 
   for (const entityId of txResult.entityIds) {
     processExtraction(entityId).catch(captureError);
+  }
+
+  // The copies reference fresh file IDs, so each needs its own
+  // PDF/thumbnail derivatives.
+  for (const fileField of txResult.fileFields) {
+    enqueuePdfDerivativeOrMarkFailed({
+      entityId: fileField.entityId,
+      fieldId: fileField.fieldId,
+      mimeType: fileField.mimeType,
+      encrypted: fileField.encrypted,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch(captureError);
+    enqueueImageThumbnailOrMarkFailed({
+      entityId: fileField.entityId,
+      fieldId: fileField.fieldId,
+      mimeType: fileField.mimeType,
+      encrypted: fileField.encrypted,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch(captureError);
   }
 
   return Result.ok({ entityId: txResult.entityId });
@@ -148,9 +209,17 @@ const config = {
 
 const duplicateEntity = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, user, body, recordAuditEvent }) {
+  async function* ({
+    safeDb,
+    session,
+    user,
+    workspaceId,
+    body,
+    recordAuditEvent,
+  }) {
     return yield* duplicateEntityHandler({
       safeDb,
+      organizationId: session.activeOrganizationId,
       workspaceId,
       userId: user.id,
       recordAuditEvent,

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -3,10 +3,12 @@ import { t } from "elysia";
 import type { Static } from "elysia";
 
 import type { SafeDb } from "@/api/db";
-import type { EntitySnapshot } from "@/api/handlers/entities/copy-utils";
 import {
-  collectFileMappings,
+  collectFileCopySources,
   copyEntities,
+  copyFileObjects,
+  type EntitySnapshot,
+  type FileMapping,
   getFolderSubtree,
   remapFileIds,
   rollbackS3Copies,
@@ -23,7 +25,6 @@ import {
   enqueuePdfDerivativeOrMarkFailed,
 } from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
-import { getS3 } from "@/api/lib/s3";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 
 const duplicateEntityBodySchema = t.Object({
@@ -120,26 +121,22 @@ const duplicateEntityHandler = async function* ({
     sourceEntities = subtree;
   }
 
-  // Copies must not share storage objects with their source: deleting
-  // an entity deletes its objects, so a shared reference would let
-  // deleting the duplicate destroy the original's file. Mint new file
-  // IDs and copy the objects before the DB transaction.
-  const fileMappings = collectFileMappings({
+  const fileCopySources = collectFileCopySources({
     sourceEntities,
     organizationId,
     sourceWorkspaceId: workspaceId,
-    targetWorkspaceId: workspaceId,
   });
 
-  const s3 = getS3();
   const copiedS3Keys: string[] = [];
+  let fileMappings: FileMapping[];
 
   try {
-    for (const { sourceKey, targetKey, mimeType } of fileMappings) {
-      // Stream directly from source to target without buffering in memory
-      await s3.write(targetKey, s3.file(sourceKey), { type: mimeType });
-      copiedS3Keys.push(targetKey);
-    }
+    fileMappings = await copyFileObjects({
+      sources: fileCopySources,
+      organizationId,
+      targetWorkspaceId: workspaceId,
+      copiedS3Keys,
+    });
   } catch (error) {
     await rollbackS3Copies(copiedS3Keys);
     captureError(error, { workspaceId, sourceEntityId });
@@ -150,20 +147,25 @@ const duplicateEntityHandler = async function* ({
 
   const remappedEntities = remapFileIds(sourceEntities, fileMappings);
 
-  const txResult = yield* Result.await(
-    safeDb(
-      async (tx) =>
-        await copyEntities({
-          tx,
-          targetWorkspaceId: workspaceId,
-          targetParentId: source.parentId,
-          userId,
-          recordAuditEvent,
-          sourceEntityId,
-          sourceEntities: remappedEntities,
-        }),
-    ),
+  const txResultResult = await safeDb(
+    async (tx) =>
+      await copyEntities({
+        tx,
+        targetWorkspaceId: workspaceId,
+        targetParentId: source.parentId,
+        userId,
+        recordAuditEvent,
+        sourceEntityId,
+        sourceEntities: remappedEntities,
+      }),
   );
+
+  if (Result.isError(txResultResult)) {
+    await rollbackS3Copies(copiedS3Keys);
+    return Result.err(txResultResult.error);
+  }
+
+  const txResult = txResultResult.value;
 
   if (!txResult.ok) {
     await rollbackS3Copies(copiedS3Keys);

--- a/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
@@ -18,6 +18,10 @@ import {
   buildVersionStamp,
   cloneFieldsForRevision,
 } from "@/api/handlers/entities/version-utils";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
@@ -392,7 +396,7 @@ export const finalizeDesktopEditSessionHandler = async ({
 
       const storedBytes = new Uint8Array(checkpointBuffer);
       const nextVersionId = createSafeId<"entityVersion">();
-      const sourceFileId = Bun.randomUUIDv7();
+      const sourceFileId = allocateFileObject();
       const sourceKey = createFileKey({
         fileId: sourceFileId,
         mimeType: DOCX_MIME_TYPE,
@@ -417,7 +421,7 @@ export const finalizeDesktopEditSessionHandler = async ({
         currentFields: baseVersion.fields,
         entityVersionId: nextVersionId,
         propertyId: editSession.propertyId,
-        replacementContent: {
+        replacementContent: fileContentWithMintedObject({
           encrypted: false,
           fileName: editSession.fileName,
           id: sourceFileId,
@@ -434,7 +438,7 @@ export const finalizeDesktopEditSessionHandler = async ({
           ...(editSession.checkpointScanWarnings !== null && {
             scanWarnings: editSession.checkpointScanWarnings,
           }),
-        },
+        }),
         workspaceId: authorizedSession.value.workspaceId,
       });
 

--- a/apps/api/src/handlers/entities/upload-version.ts
+++ b/apps/api/src/handlers/entities/upload-version.ts
@@ -14,6 +14,10 @@ import {
   buildVersionStamp,
   cloneFieldsForRevision,
 } from "@/api/handlers/entities/version-utils";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
@@ -160,7 +164,7 @@ export default createSafeHandler(
 
     // Upload the source file first; PDF derivatives are generated
     // asynchronously by the file-derivative queue.
-    const fileId = Bun.randomUUIDv7();
+    const fileId = allocateFileObject();
     const sha256Hex = new Bun.CryptoHasher("sha256")
       .update(new Uint8Array(fileBuffer))
       .digest("hex");
@@ -256,7 +260,7 @@ export default createSafeHandler(
             entityVersionId: nextVersionId,
             propertyId: freshFileField.propertyId,
             replacementFieldId: fileFieldId,
-            replacementContent: {
+            replacementContent: fileContentWithMintedObject({
               encrypted: false,
               fileName: sanitizedName,
               id: fileId,
@@ -276,7 +280,7 @@ export default createSafeHandler(
                 mimeType: file.type,
               }),
               ...(scanWarnings !== undefined && { scanWarnings }),
-            },
+            }),
             workspaceId,
           }),
         );

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -6,6 +6,10 @@ import type { Static } from "elysia";
 import type { SafeDb, Transaction } from "@/api/db";
 import { jsonField } from "@/api/db/json-utils";
 import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { isEncryptedPdf } from "@/api/handlers/files/pdf-utils";
@@ -193,7 +197,7 @@ const uploadEntityHandler = async function* ({
     encrypted = result.value;
   }
 
-  const fileId = Bun.randomUUIDv7();
+  const fileId = allocateFileObject();
   const sourceKey = createFileKey({
     organizationId,
     workspaceId,
@@ -243,7 +247,7 @@ const uploadEntityHandler = async function* ({
           workspaceId,
           propertyId: property.id,
           entityVersionId,
-          content: {
+          content: fileContentWithMintedObject({
             type: "file",
             version: 1,
             id: fileId,
@@ -263,7 +267,7 @@ const uploadEntityHandler = async function* ({
               mimeType: file.type,
             }),
             ...(scanWarnings !== undefined && { scanWarnings }),
-          },
+          }),
         });
 
         await tx

--- a/apps/api/src/handlers/entities/version-utils.test.ts
+++ b/apps/api/src/handlers/entities/version-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { toSafeId } from "@/api/lib/branded-types";
 
 import { buildVersionStamp, cloneFieldsForRevision } from "./version-utils";
@@ -49,10 +53,10 @@ describe("cloneFieldsForRevision", () => {
     const filePropertyId = toSafeId<"property">("prop_file");
     const textPropertyId = toSafeId<"property">("prop_text");
     const nextVersionId = toSafeId<"entityVersion">("version_next");
-    const replacementFile = {
+    const replacementFile = fileContentWithMintedObject({
       encrypted: false,
       fileName: "agreement.docx",
-      id: Bun.randomUUIDv7(),
+      id: allocateFileObject(),
       mimeType:
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       pdfFileId: null,
@@ -60,7 +64,7 @@ describe("cloneFieldsForRevision", () => {
       sizeBytes: 128,
       type: "file",
       version: 1,
-    } as const;
+    });
 
     const cloned = cloneFieldsForRevision({
       currentFields: [
@@ -120,10 +124,10 @@ describe("cloneFieldsForRevision", () => {
     const textPropertyId = toSafeId<"property">("prop_text");
     const nextVersionId = toSafeId<"entityVersion">("version_next");
     const replacementFieldId = toSafeId<"field">("field_replacement");
-    const replacementFile = {
+    const replacementFile = fileContentWithMintedObject({
       encrypted: false,
       fileName: "agreement.docx",
-      id: Bun.randomUUIDv7(),
+      id: allocateFileObject(),
       mimeType:
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       pdfFileId: null,
@@ -131,7 +135,7 @@ describe("cloneFieldsForRevision", () => {
       sizeBytes: 128,
       type: "file",
       version: 1,
-    } as const;
+    });
 
     const cloned = cloneFieldsForRevision({
       currentFields: [

--- a/apps/api/src/handlers/entities/version-utils.ts
+++ b/apps/api/src/handlers/entities/version-utils.ts
@@ -1,4 +1,8 @@
 import type { FieldContent } from "@/api/db/schema-validators";
+import {
+  reuseFileObjectWithinEntity,
+  type WritableFileFieldContent,
+} from "@/api/handlers/files/file-object-ids";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   generateVerificationCode,
@@ -10,14 +14,12 @@ type RevisionField = {
   propertyId: SafeId<"property">;
 };
 
-type RevisionFileContent = Extract<FieldContent, { type: "file" }>;
-
 type CloneRevisionFieldsInput = {
   currentFields: RevisionField[];
   entityVersionId: SafeId<"entityVersion">;
   replacementFieldId?: SafeId<"field">;
   propertyId: SafeId<"property">;
-  replacementContent: RevisionFileContent;
+  replacementContent: WritableFileFieldContent;
   workspaceId: SafeId<"workspace">;
 };
 
@@ -57,11 +59,34 @@ export const cloneFieldsForRevision = ({
     ...(replacementFieldId &&
       field.propertyId === propertyId &&
       field.content.type === "file" && { id: replacementFieldId }),
-    content:
-      field.propertyId === propertyId && field.content.type === "file"
-        ? replacementContent
-        : field.content,
+    content: contentForRevisionField({
+      field,
+      propertyId,
+      replacementContent,
+    }),
     entityVersionId,
     propertyId: field.propertyId,
     workspaceId,
   }));
+
+type ContentForRevisionFieldOptions = {
+  field: RevisionField;
+  propertyId: SafeId<"property">;
+  replacementContent: WritableFileFieldContent;
+};
+
+const contentForRevisionField = ({
+  field,
+  propertyId,
+  replacementContent,
+}: ContentForRevisionFieldOptions): FieldContent => {
+  if (field.propertyId === propertyId && field.content.type === "file") {
+    return replacementContent;
+  }
+
+  if (field.content.type === "file") {
+    return reuseFileObjectWithinEntity(field.content);
+  }
+
+  return field.content;
+};

--- a/apps/api/src/handlers/files/field-file-refs.test.ts
+++ b/apps/api/src/handlers/files/field-file-refs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Transaction } from "@/api/db";
+import type { FieldContent } from "@/api/db/schema-validators";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
+import { toSafeId } from "@/api/lib/branded-types";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+import {
+  extractFieldFileRefs,
+  filterUnreferencedFieldFileRefs,
+} from "./field-file-refs";
+
+const fileContent = {
+  encrypted: false,
+  fileName: "source.docx",
+  id: "source-file",
+  mimeType:
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  pdfFileId: "pdf-file",
+  sha256Hex: "a".repeat(64),
+  sizeBytes: 64,
+  thumbnailFileId: "thumbnail-file",
+  type: "file",
+  version: 1,
+} satisfies FieldContent;
+
+describe("field file refs", () => {
+  test("extracts source, pdf, and thumbnail refs", () => {
+    expect(extractFieldFileRefs(fileContent)).toEqual([
+      {
+        fileId: "source-file",
+        mimeType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+      { fileId: "pdf-file", mimeType: PDF_MIME_TYPE },
+      { fileId: "thumbnail-file", mimeType: THUMBNAIL_MIME_TYPE },
+    ]);
+  });
+
+  test("keeps only refs with no live field reference", async () => {
+    const tx = asTestRaw<Transaction>({
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({
+            where: async () => [{ content: fileContent }],
+          }),
+        }),
+      }),
+    });
+
+    const result = await filterUnreferencedFieldFileRefs({
+      tx,
+      workspaceId: toSafeId<"workspace">("workspace_1"),
+      fileRows: [
+        { fileId: "source-file", mimeType: fileContent.mimeType },
+        { fileId: "pdf-file", mimeType: PDF_MIME_TYPE },
+        { fileId: "thumbnail-file", mimeType: THUMBNAIL_MIME_TYPE },
+        { fileId: "orphan-file", mimeType: fileContent.mimeType },
+      ],
+    });
+
+    expect(result).toEqual([
+      { fileId: "orphan-file", mimeType: fileContent.mimeType },
+    ]);
+  });
+});

--- a/apps/api/src/handlers/files/field-file-refs.ts
+++ b/apps/api/src/handlers/files/field-file-refs.ts
@@ -1,0 +1,87 @@
+import { and, eq, inArray, not, or, sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db";
+import { entityVersions, fields } from "@/api/db/schema";
+import type { FieldContent } from "@/api/db/schema-validators";
+import { THUMBNAIL_MIME_TYPE } from "@/api/handlers/files/image-derivative";
+import type { SafeId } from "@/api/lib/branded-types";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
+
+export type FieldFileRef = { fileId: string; mimeType: string };
+
+export const extractFieldFileRefs = (content: FieldContent): FieldFileRef[] => {
+  if (content.type !== "file") {
+    return [];
+  }
+
+  const refs: FieldFileRef[] = [
+    { fileId: content.id, mimeType: content.mimeType },
+  ];
+
+  if (content.pdfFileId) {
+    refs.push({
+      fileId: content.pdfFileId,
+      mimeType: PDF_MIME_TYPE,
+    });
+  }
+
+  if (content.thumbnailFileId) {
+    refs.push({
+      fileId: content.thumbnailFileId,
+      mimeType: THUMBNAIL_MIME_TYPE,
+    });
+  }
+
+  return refs;
+};
+
+type FilterUnreferencedFieldFileRefsOptions = {
+  tx: Transaction;
+  workspaceId: SafeId<"workspace">;
+  fileRows: FieldFileRef[];
+  excludedEntityIds?: SafeId<"entity">[];
+  excludedEntityVersionIds?: SafeId<"entityVersion">[];
+};
+
+export const filterUnreferencedFieldFileRefs = async ({
+  tx,
+  workspaceId,
+  fileRows,
+  excludedEntityIds = [],
+  excludedEntityVersionIds = [],
+}: FilterUnreferencedFieldFileRefsOptions): Promise<FieldFileRef[]> => {
+  if (fileRows.length === 0) {
+    return [];
+  }
+
+  const fileIds = [...new Set(fileRows.map((row) => row.fileId))];
+  const liveFileRows = await tx
+    .select({ content: fields.content })
+    .from(fields)
+    .innerJoin(entityVersions, eq(fields.entityVersionId, entityVersions.id))
+    .where(
+      and(
+        eq(fields.workspaceId, workspaceId),
+        sql`${fields.content}->>'type' = 'file'`,
+        or(
+          inArray(sql<string>`${fields.content}->>'id'`, fileIds),
+          inArray(sql<string>`${fields.content}->>'pdfFileId'`, fileIds),
+          inArray(sql<string>`${fields.content}->>'thumbnailFileId'`, fileIds),
+        ),
+        ...(excludedEntityIds.length > 0
+          ? [not(inArray(entityVersions.entityId, excludedEntityIds))]
+          : []),
+        ...(excludedEntityVersionIds.length > 0
+          ? [not(inArray(entityVersions.id, excludedEntityVersionIds))]
+          : []),
+      ),
+    );
+
+  const liveFileIds = new Set(
+    liveFileRows.flatMap((row) =>
+      extractFieldFileRefs(row.content).map((ref) => ref.fileId),
+    ),
+  );
+
+  return fileRows.filter((row) => !liveFileIds.has(row.fileId));
+};

--- a/apps/api/src/handlers/files/file-object-ids.ts
+++ b/apps/api/src/handlers/files/file-object-ids.ts
@@ -1,0 +1,83 @@
+import type { FieldContent } from "@/api/db/schema-validators";
+
+declare const __fileObjectId: unique symbol;
+
+export type MintedFileId = string & {
+  readonly [__fileObjectId]: "MintedFileId";
+};
+
+type ReusedFileId = string & {
+  readonly [__fileObjectId]: "ReusedFileId";
+};
+
+type WritableFileId = MintedFileId | ReusedFileId;
+
+type FileFieldContent = Extract<FieldContent, { type: "file" }>;
+type MintedFileFieldContent = Omit<
+  FileFieldContent,
+  "id" | "pdfFileId" | "thumbnailFileId"
+> & {
+  id: MintedFileId;
+  pdfFileId: MintedFileId | null;
+  thumbnailFileId?: MintedFileId | null;
+};
+
+export type WritableFileFieldContent = Omit<
+  FileFieldContent,
+  "id" | "pdfFileId" | "thumbnailFileId"
+> & {
+  id: WritableFileId;
+  pdfFileId: WritableFileId | null;
+  thumbnailFileId?: WritableFileId | null;
+};
+
+export type WritableFieldContent =
+  | Exclude<FieldContent, { type: "file" }>
+  | WritableFileFieldContent;
+
+export const allocateFileObject = (): MintedFileId =>
+  brandMintedFileId(Bun.randomUUIDv7());
+
+export const fileContentWithMintedObject = (
+  content: MintedFileFieldContent,
+): WritableFileFieldContent => {
+  const { thumbnailFileId, ...contentWithoutThumbnail } = content;
+
+  if (thumbnailFileId === undefined) {
+    return contentWithoutThumbnail;
+  }
+
+  return { ...contentWithoutThumbnail, thumbnailFileId };
+};
+
+export const reuseFileObjectWithinEntity = (
+  content: FileFieldContent,
+): WritableFileFieldContent => {
+  const { thumbnailFileId, ...contentWithoutThumbnail } = content;
+  const reusedContent = {
+    ...contentWithoutThumbnail,
+    id: brandReusedFileId(content.id),
+    pdfFileId: content.pdfFileId ? brandReusedFileId(content.pdfFileId) : null,
+  };
+
+  if (thumbnailFileId === undefined) {
+    return reusedContent;
+  }
+
+  return {
+    ...reusedContent,
+    thumbnailFileId: thumbnailFileId
+      ? brandReusedFileId(thumbnailFileId)
+      : null,
+  };
+};
+
+const brandMintedFileId = (id: string): MintedFileId =>
+  // SAFETY: allocateFileObject is the only public minting boundary for new field-backed file object IDs.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  id as MintedFileId;
+
+const brandReusedFileId = (id: string): ReusedFileId =>
+  // SAFETY: reuseFileObjectWithinEntity is the explicit escape hatch for same-entity version history.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  id as ReusedFileId;

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -16,6 +16,10 @@ import {
   buildVersionStamp,
   cloneFieldsForRevision,
 } from "@/api/handlers/entities/version-utils";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
@@ -281,7 +285,7 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
     const storedBytes = new Uint8Array(checkpointBuffer);
     const nextVersionNumber = baseVersion.versionNumber + 1;
     const nextVersionId = createSafeId<"entityVersion">();
-    const sourceFileId = Bun.randomUUIDv7();
+    const sourceFileId = allocateFileObject();
     const sourceKey = createFileKey({
       fileId: sourceFileId,
       mimeType: DOCX_MIME_TYPE,
@@ -421,7 +425,7 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
           currentFields: baseVersion.fields,
           entityVersionId: nextVersionId,
           propertyId: sessionPreview.propertyId,
-          replacementContent: {
+          replacementContent: fileContentWithMintedObject({
             encrypted: false,
             fileName: sessionPreview.fileName,
             id: sourceFileId,
@@ -438,7 +442,7 @@ const finalizeFolioCollabSession = createSafeTokenHandler<
             ...(sessionPreview.docxCheckpointScanWarnings !== null && {
               scanWarnings: sessionPreview.docxCheckpointScanWarnings,
             }),
-          },
+          }),
           workspaceId,
         });
 

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -35,6 +35,10 @@ import {
   properties,
   workspaces,
 } from "@/api/db/schema";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { isEncryptedPdf } from "@/api/handlers/files/pdf-utils";
@@ -555,7 +559,7 @@ export const finalizeEntityCreate = async function* ({
     encrypted = encryptedResult.value;
   }
 
-  const fileId = Bun.randomUUIDv7();
+  const fileId = allocateFileObject();
   const entityId = createSafeId<"entity">();
   const entityVersionId = createSafeId<"entityVersion">();
   const fieldId = createSafeId<"field">();
@@ -650,7 +654,7 @@ export const finalizeEntityCreate = async function* ({
       workspaceId,
       propertyId: targetResult.value.propertyId,
       entityVersionId,
-      content: {
+      content: fileContentWithMintedObject({
         type: "file",
         version: 1,
         id: fileId,
@@ -670,7 +674,7 @@ export const finalizeEntityCreate = async function* ({
           mimeType: declaredMime,
         }),
         ...(scanWarnings !== undefined && { scanWarnings }),
-      },
+      }),
     });
     await tx
       .update(workspaces)

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -30,6 +30,10 @@ import {
   buildVersionStamp,
   cloneFieldsForRevision,
 } from "@/api/handlers/entities/version-utils";
+import {
+  allocateFileObject,
+  fileContentWithMintedObject,
+} from "@/api/handlers/files/file-object-ids";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { thumbnailDerivativeStateForFile } from "@/api/handlers/files/image-derivative";
 import { createFileKey } from "@/api/handlers/files/utils";
@@ -147,7 +151,7 @@ export const finalizeEntityVersion = async function* ({
   const sanitizedName = sanitizeFilename(declaredName);
   const { entityId } = purposeData;
 
-  const fileId = Bun.randomUUIDv7();
+  const fileId = allocateFileObject();
   const nextVersionId = createSafeId<"entityVersion">();
   const fileFieldId = createSafeId<"field">();
   const finalKey = createFileKey({
@@ -262,7 +266,7 @@ export const finalizeEntityVersion = async function* ({
         entityVersionId: nextVersionId,
         propertyId: freshFileField.propertyId,
         replacementFieldId: fileFieldId,
-        replacementContent: {
+        replacementContent: fileContentWithMintedObject({
           encrypted: false,
           fileName: sanitizedName,
           id: fileId,
@@ -282,7 +286,7 @@ export const finalizeEntityVersion = async function* ({
             mimeType: declaredMime,
           }),
           ...(scanWarnings !== undefined && { scanWarnings }),
-        },
+        }),
         workspaceId,
       }),
     );

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -4,6 +4,7 @@ import { and, eq, sql } from "drizzle-orm";
 
 import { fields } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
+import { allocateFileObject } from "@/api/handlers/files/file-object-ids";
 import {
   convertToPdf,
   shouldGeneratePdfDerivative,
@@ -319,7 +320,7 @@ const processPdfDerivativeJob = async ({
     throw conversionResult.error;
   }
 
-  const pdfFileId = Bun.randomUUIDv7();
+  const pdfFileId = allocateFileObject();
   const sourceFileId = content.id;
   const pdfKey = createFileKey({
     organizationId: branded.organizationId,
@@ -503,7 +504,7 @@ const processImageThumbnailJob = async ({
     throw thumbnailResult.error;
   }
 
-  const thumbnailFileId = Bun.randomUUIDv7();
+  const thumbnailFileId = allocateFileObject();
   const sourceFileId = content.id;
   const thumbnailKey = createFileKey({
     organizationId: branded.organizationId,


### PR DESCRIPTION
Duplicating an entity copied its file field content verbatim, including the storage file ID. Since S3 keys derive from that ID and entity deletion deletes the underlying objects, the duplicate and its source shared storage: deleting either one destroyed the surviving document's file (and its PDF preview, which was also shared).

Fix: `duplicate` now goes through the same pipeline `copy-to-workspace` already used — mint new file IDs, stream-copy the S3 objects before the DB transaction (with best-effort rollback of the copies if the transaction fails), remap field content, and re-enqueue PDF/thumbnail derivatives for the copies. The previously handler-local helpers (`collectFileMappings`, `remapFileIds`, `rollbackS3Copies`) moved to `copy-utils` so both copy paths share one implementation.

Side effect worth noting for review: duplicates now generate their own PDF/thumbnail derivatives instead of borrowing the source's.

Verified against a real MinIO: duplicate produces a second storage object with a distinct ID; deleting the duplicate removes only its own objects and the source document still renders.