### PR TITLE
feat(web): bulk actions for the table row selection

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2098,6 +2098,7 @@
       "copied": "Zkopírováno do spisu",
       "copyOption": "Kopírovat (ponechat originál)",
       "description": "Zkopírovat nebo přesunout \"{name}\" do jiného spisu",
+      "descriptionCount": "Zkopírovat nebo přesunout {count, plural, one {# položku} few {# položky} other {# položek}} do jiného spisu",
       "menuItem": "Kopírovat/Přesunout do spisu",
       "moveButton": "Přesunout",
       "moveOption": "Přesunout (smazat originál)",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2098,6 +2098,7 @@
       "copied": "In Akte kopiert",
       "copyOption": "Kopieren (Original behalten)",
       "description": "\"{name}\" in eine andere Akte kopieren oder verschieben",
+      "descriptionCount": "{count, plural, one {# Element} other {# Elemente}} in eine andere Akte kopieren oder verschieben",
       "menuItem": "In Akte kopieren/verschieben",
       "moveButton": "Verschieben",
       "moveOption": "Verschieben (Original löschen)",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2098,6 +2098,7 @@
       "copied": "Copied to Matter",
       "copyOption": "Copy (keep original)",
       "description": "Copy or move \"{name}\" to another Matter",
+      "descriptionCount": "Copy or move {count, plural, one {# item} other {# items}} to another Matter",
       "menuItem": "Copy/Move to Matter",
       "moveButton": "Move",
       "moveOption": "Move (delete original)",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2098,6 +2098,7 @@
       "copied": "Copiado al asunto",
       "copyOption": "Copiar (mantener original)",
       "description": "Copiar o mover \"{name}\" a otro asunto",
+      "descriptionCount": "Copiar o mover {count, plural, one {# elemento} other {# elementos}} a otro asunto",
       "menuItem": "Copiar/Mover a asunto",
       "moveButton": "Mover",
       "moveOption": "Mover (eliminar original)",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2098,6 +2098,7 @@
       "copied": "Kopeeritud toimikusse",
       "copyOption": "Kopeeri (säilita originaal)",
       "description": "Kopeeri või teisalda \"{name}\" teise toimikusse",
+      "descriptionCount": "Kopeeri või teisalda {count, plural, one {# üksus} other {# üksust}} teise toimikusse",
       "menuItem": "Kopeeri/Teisalda toimikusse",
       "moveButton": "Teisalda",
       "moveOption": "Teisalda (kustuta originaal)",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2098,6 +2098,7 @@
       "copied": "Copié dans le dossier",
       "copyOption": "Copier (conserver l'original)",
       "description": "Copier ou déplacer \"{name}\" vers un autre dossier",
+      "descriptionCount": "Copier ou déplacer {count, plural, one {# élément} other {# éléments}} vers un autre dossier",
       "menuItem": "Copier/Déplacer vers un dossier",
       "moveButton": "Déplacer",
       "moveOption": "Déplacer (supprimer l'original)",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2098,6 +2098,7 @@
       "copied": "Másolva az ügyiratba",
       "copyOption": "Másolás (eredeti megtartása)",
       "description": "\"{name}\" másolása vagy áthelyezése másik ügyiratba",
+      "descriptionCount": "{count, plural, one {# elem} other {# elem}} másolása vagy áthelyezése másik ügyiratba",
       "menuItem": "Másolás/Áthelyezés ügyiratba",
       "moveButton": "Áthelyezés",
       "moveOption": "Áthelyezés (eredeti törlése)",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2098,6 +2098,7 @@
       "copied": "Nukopijuota į bylą",
       "copyOption": "Kopijuoti (palikti originalą)",
       "description": "Kopijuoti arba perkelti \"{name}\" į kitą bylą",
+      "descriptionCount": "Kopijuoti arba perkelti {count, plural, one {# elementą} few {# elementus} other {# elementų}} į kitą bylą",
       "menuItem": "Kopijuoti/Perkelti į bylą",
       "moveButton": "Perkelti",
       "moveOption": "Perkelti (ištrinti originalą)",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2098,6 +2098,7 @@
       "copied": "Nokopēts lietā",
       "copyOption": "Kopēt (saglabāt oriģinālu)",
       "description": "Kopēt vai pārvietot \"{name}\" uz citu lietu",
+      "descriptionCount": "Kopēt vai pārvietot {count, plural, one {# vienību} other {# vienības}} uz citu lietu",
       "menuItem": "Kopēt/Pārvietot uz lietu",
       "moveButton": "Pārvietot",
       "moveOption": "Pārvietot (dzēst oriģinālu)",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2101,6 +2101,7 @@ type Messages = {
       "copied": "Copied to Matter";
       "copyOption": "Copy (keep original)";
       "description": "Copy or move \"{name}\" to another Matter";
+      "descriptionCount": "Copy or move {count, plural, one {# item} other {# items}} to another Matter";
       "menuItem": "Copy/Move to Matter";
       "moveButton": "Move";
       "moveOption": "Move (delete original)";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2098,6 +2098,7 @@
       "copied": "Skopiowano do sprawy",
       "copyOption": "Kopiuj (zachowaj oryginał)",
       "description": "Skopiuj lub przenieś \"{name}\" do innej sprawy",
+      "descriptionCount": "Skopiuj lub przenieś {count, plural, one {# element} few {# elementy} many {# elementów} other {# elementów}} do innej sprawy",
       "menuItem": "Kopiuj/Przenieś do sprawy",
       "moveButton": "Przenieś",
       "moveOption": "Przenieś (usuń oryginał)",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2098,6 +2098,7 @@
       "copied": "Copiado para o caso",
       "copyOption": "Copiar (manter original)",
       "description": "Copiar ou mover \"{name}\" para outro caso",
+      "descriptionCount": "Copiar ou mover {count, plural, one {# item} other {# itens}} para outro caso",
       "menuItem": "Copiar/Mover para caso",
       "moveButton": "Mover",
       "moveOption": "Mover (excluir original)",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2098,6 +2098,7 @@
       "copied": "Skopírované do spisu",
       "copyOption": "Kopírovať (ponechať originál)",
       "description": "Skopírovať alebo presunúť \"{name}\" do iného spisu",
+      "descriptionCount": "Skopírovať alebo presunúť {count, plural, one {# položku} few {# položky} other {# položiek}} do iného spisu",
       "menuItem": "Kopírovať/Presunúť do spisu",
       "moveButton": "Presunúť",
       "moveOption": "Presunúť (vymazať originál)",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCopyToMatterRootEntities,
+  type CopyToMatterEntity,
+} from "./copy-to-matter-dialog.logic";
+
+const entity = ({
+  children = [],
+  entityId,
+  kind = "document",
+  parentId = null,
+}: {
+  children?: CopyToMatterEntity[];
+  entityId: string;
+  kind?: CopyToMatterEntity["kind"];
+  parentId?: string | null;
+}): CopyToMatterEntity => ({
+  children,
+  entityId,
+  entityName: entityId,
+  kind,
+  parentId,
+});
+
+describe("getCopyToMatterRootEntities", () => {
+  test("drops selected descendants when their selected folder already moves the subtree", () => {
+    const grandchild = entity({
+      entityId: "grandchild",
+      parentId: "child-folder",
+    });
+    const childFolder = entity({
+      children: [grandchild],
+      entityId: "child-folder",
+      kind: "folder",
+      parentId: "root-folder",
+    });
+    const rootFolder = entity({
+      children: [childFolder],
+      entityId: "root-folder",
+      kind: "folder",
+    });
+    const sibling = entity({ entityId: "sibling" });
+
+    expect(
+      getCopyToMatterRootEntities([rootFolder, grandchild, sibling]).map(
+        (item) => item.entityId,
+      ),
+    ).toEqual(["root-folder", "sibling"]);
+  });
+
+  test("drops flat selected descendants when their selected parent already moves the subtree", () => {
+    const grandchild = entity({
+      entityId: "grandchild",
+      parentId: "child-folder",
+    });
+    const childFolder = entity({
+      entityId: "child-folder",
+      kind: "folder",
+      parentId: "root-folder",
+    });
+    const rootFolder = entity({
+      entityId: "root-folder",
+      kind: "folder",
+    });
+    const sibling = entity({ entityId: "sibling" });
+
+    expect(
+      getCopyToMatterRootEntities([
+        rootFolder,
+        childFolder,
+        grandchild,
+        sibling,
+      ]).map((item) => item.entityId),
+    ).toEqual(["root-folder", "sibling"]);
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.ts
@@ -1,0 +1,73 @@
+import type { EntityKind } from "@/lib/types";
+
+export type CopyToMatterEntity = {
+  entityId: string;
+  entityName: string;
+  kind: EntityKind;
+  parentId: string | null;
+  children: CopyToMatterEntity[];
+};
+
+export const getCopyToMatterRootEntities = (
+  entities: readonly CopyToMatterEntity[],
+): CopyToMatterEntity[] => {
+  const selectedIds = new Set(entities.map((entity) => entity.entityId));
+  const entitiesById = new Map(
+    entities.map((entity) => [entity.entityId, entity]),
+  );
+  const descendantIds = new Set<string>();
+
+  const collectSelectedDescendants = (entity: CopyToMatterEntity) => {
+    for (const child of entity.children) {
+      if (selectedIds.has(child.entityId)) {
+        descendantIds.add(child.entityId);
+      }
+      collectSelectedDescendants(child);
+    }
+  };
+
+  for (const entity of entities) {
+    if (entity.kind === "folder") {
+      collectSelectedDescendants(entity);
+    }
+  }
+
+  return entities.filter(
+    (entity) =>
+      !descendantIds.has(entity.entityId) &&
+      !hasSelectedAncestor({ entity, entitiesById, selectedIds }),
+  );
+};
+
+type HasSelectedAncestorOptions = {
+  entity: CopyToMatterEntity;
+  entitiesById: ReadonlyMap<string, CopyToMatterEntity>;
+  selectedIds: ReadonlySet<string>;
+};
+
+const hasSelectedAncestor = ({
+  entity,
+  entitiesById,
+  selectedIds,
+}: HasSelectedAncestorOptions): boolean => {
+  const visitedIds = new Set([entity.entityId]);
+  let parentId = entity.parentId;
+
+  while (parentId) {
+    if (visitedIds.has(parentId)) {
+      return false;
+    }
+    if (selectedIds.has(parentId)) {
+      return true;
+    }
+
+    visitedIds.add(parentId);
+    const parent = entitiesById.get(parentId);
+    if (!parent) {
+      return false;
+    }
+    parentId = parent.parentId;
+  }
+
+  return false;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
@@ -24,6 +24,10 @@ import { cn } from "@stll/ui/lib/utils";
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";
 import {
+  getCopyToMatterRootEntities,
+  type CopyToMatterEntity,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic";
+import {
   entitiesKeys,
   workspaceFoldersOptions,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
@@ -31,11 +35,6 @@ import type { WorkspaceFolder } from "@/routes/_protected.workspaces/$workspaceI
 import { workspacesOptions } from "@/routes/_protected.workspaces/-queries";
 
 const routeApi = getRouteApi("/_protected");
-
-type CopyToMatterEntity = {
-  entityId: string;
-  entityName: string;
-};
 
 type CopyToMatterDialogProps = {
   open: boolean;
@@ -69,7 +68,9 @@ export const CopyToMatterDialog = ({
   // Exclude current workspace from target options
   const targetWorkspaces =
     data?.workspaces.filter((w) => w.id !== sourceWorkspaceId) ?? [];
-  const singleEntity = entities.length === 1 ? entities.at(0) : undefined;
+  const transferEntities = getCopyToMatterRootEntities(entities);
+  const singleEntity =
+    transferEntities.length === 1 ? transferEntities.at(0) : undefined;
 
   const handleSubmit = async () => {
     if (!targetWorkspaceId) {
@@ -80,7 +81,7 @@ export const CopyToMatterDialog = ({
 
     let failedCount = 0;
     let firstErrorMessage: string | null = null;
-    for (const { entityId } of entities) {
+    for (const { entityId } of transferEntities) {
       const result = await Result.tryPromise(
         async () =>
           await api
@@ -115,16 +116,18 @@ export const CopyToMatterDialog = ({
 
     // Invalidate both workspaces even on partial failure; some
     // entities may have transferred before the failing one.
-    await queryClient.invalidateQueries({
-      queryKey: entitiesKeys.all(sourceWorkspaceId),
-    });
-    await queryClient.invalidateQueries({
-      queryKey: entitiesKeys.all(targetWorkspaceId),
-    });
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: entitiesKeys.all(sourceWorkspaceId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: entitiesKeys.all(targetWorkspaceId),
+      }),
+    ]);
 
     setIsSubmitting(false);
 
-    if (failedCount === entities.length) {
+    if (failedCount === transferEntities.length) {
       stellaToast.add({
         title: t("errors.actionFailed"),
         description: firstErrorMessage ?? undefined,
@@ -168,7 +171,7 @@ export const CopyToMatterDialog = ({
                   name: singleEntity.entityName,
                 })
               : t("workspaces.copyToMatter.descriptionCount", {
-                  count: entities.length,
+                  count: transferEntities.length,
                 })}
           </DialogDescription>
         </DialogHeader>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
+import { Result } from "better-result";
 import { ChevronRightIcon, FolderIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -31,12 +32,16 @@ import { workspacesOptions } from "@/routes/_protected.workspaces/-queries";
 
 const routeApi = getRouteApi("/_protected");
 
+type CopyToMatterEntity = {
+  entityId: string;
+  entityName: string;
+};
+
 type CopyToMatterDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   sourceWorkspaceId: string;
-  entityId: string;
-  entityName: string;
+  entities: CopyToMatterEntity[];
 };
 
 type MoveMode = "copy" | "move";
@@ -45,8 +50,7 @@ export const CopyToMatterDialog = ({
   open,
   onOpenChange,
   sourceWorkspaceId,
-  entityId,
-  entityName,
+  entities,
 }: CopyToMatterDialogProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
@@ -65,6 +69,7 @@ export const CopyToMatterDialog = ({
   // Exclude current workspace from target options
   const targetWorkspaces =
     data?.workspaces.filter((w) => w.id !== sourceWorkspaceId) ?? [];
+  const singleEntity = entities.length === 1 ? entities.at(0) : undefined;
 
   const handleSubmit = async () => {
     if (!targetWorkspaceId) {
@@ -73,58 +78,76 @@ export const CopyToMatterDialog = ({
 
     setIsSubmitting(true);
 
-    try {
-      const response = await api
-        .entities({ workspaceId: toSafeId<"workspace">(sourceWorkspaceId) })
-        ["copy-to-workspace"].post({
-          queryKey: entitiesKeys.all(sourceWorkspaceId),
-          entityId: toSafeId<"entity">(entityId),
-          targetWorkspaceId: toSafeId<"workspace">(targetWorkspaceId),
-          targetParentId: targetParentId
-            ? toSafeId<"entity">(targetParentId)
-            : null,
-          deleteSource: mode === "move",
-        });
+    let failedCount = 0;
+    let firstErrorMessage: string | null = null;
+    for (const { entityId } of entities) {
+      const result = await Result.tryPromise(
+        async () =>
+          await api
+            .entities({ workspaceId: toSafeId<"workspace">(sourceWorkspaceId) })
+            ["copy-to-workspace"].post({
+              queryKey: entitiesKeys.all(sourceWorkspaceId),
+              entityId: toSafeId<"entity">(entityId),
+              targetWorkspaceId: toSafeId<"workspace">(targetWorkspaceId),
+              targetParentId: targetParentId
+                ? toSafeId<"entity">(targetParentId)
+                : null,
+              deleteSource: mode === "move",
+            }),
+      );
 
-      if (response.error) {
-        const errorMessage =
-          typeof response.error.value === "object" &&
-          "message" in response.error.value
-            ? response.error.value.message
-            : t("errors.actionFailed");
-        stellaToast.add({
-          title: t("errors.actionFailed"),
-          description: errorMessage,
-          type: "error",
-        });
-        return;
+      if (Result.isError(result)) {
+        failedCount++;
+        continue;
       }
+      const { error } = result.value;
+      if (error) {
+        failedCount++;
+        if (
+          firstErrorMessage === null &&
+          typeof error.value === "object" &&
+          "message" in error.value
+        ) {
+          firstErrorMessage = error.value.message;
+        }
+      }
+    }
 
-      stellaToast.add({
-        title:
-          mode === "copy"
-            ? t("workspaces.copyToMatter.copied")
-            : t("workspaces.copyToMatter.moved"),
-        type: "success",
-      });
+    // Invalidate both workspaces even on partial failure; some
+    // entities may have transferred before the failing one.
+    await queryClient.invalidateQueries({
+      queryKey: entitiesKeys.all(sourceWorkspaceId),
+    });
+    await queryClient.invalidateQueries({
+      queryKey: entitiesKeys.all(targetWorkspaceId),
+    });
 
-      // Invalidate both workspaces
-      await queryClient.invalidateQueries({
-        queryKey: entitiesKeys.all(sourceWorkspaceId),
-      });
-      await queryClient.invalidateQueries({
-        queryKey: entitiesKeys.all(targetWorkspaceId),
-      });
+    setIsSubmitting(false);
 
-      onOpenChange(false);
-    } catch {
+    if (failedCount === entities.length) {
       stellaToast.add({
         title: t("errors.actionFailed"),
+        description: firstErrorMessage ?? undefined,
         type: "error",
       });
-    } finally {
-      setIsSubmitting(false);
+      return;
     }
+
+    const successTitle =
+      mode === "copy"
+        ? t("workspaces.copyToMatter.copied")
+        : t("workspaces.copyToMatter.moved");
+    if (failedCount > 0) {
+      stellaToast.add({
+        title: successTitle,
+        description: t("errors.actionFailed"),
+        type: "warning",
+      });
+    } else {
+      stellaToast.add({ title: successTitle, type: "success" });
+    }
+
+    onOpenChange(false);
   };
 
   const handleClose = () => {
@@ -140,7 +163,13 @@ export const CopyToMatterDialog = ({
         <DialogHeader>
           <DialogTitle>{t("workspaces.copyToMatter.title")}</DialogTitle>
           <DialogDescription>
-            {t("workspaces.copyToMatter.description", { name: entityName })}
+            {singleEntity
+              ? t("workspaces.copyToMatter.description", {
+                  name: singleEntity.entityName,
+                })
+              : t("workspaces.copyToMatter.descriptionCount", {
+                  count: entities.length,
+                })}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -387,6 +387,18 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     }
     return map;
   }, [data]);
+  const tree = useMemo(() => buildTree(data), [data]);
+  const treeNodeMap = useMemo(() => {
+    const map = new Map<string, TableTreeNode>();
+    const visit = (nodes: readonly TableTreeNode[]) => {
+      for (const node of nodes) {
+        map.set(node.entityId, node);
+        visit(node.children);
+      }
+    };
+    visit(tree);
+    return map;
+  }, [tree]);
 
   const getSelectedDragItems = useCallback(
     (entityIds: Set<string>): DragPreviewData[] => {
@@ -411,17 +423,16 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     (ids: Set<string>): WorkspaceEntity[] => {
       const entities: WorkspaceEntity[] = [];
       for (const id of ids) {
-        const entity = entityMap.get(id);
+        const entity = treeNodeMap.get(id);
         if (entity) {
           entities.push(entity);
         }
       }
       return entities;
     },
-    [entityMap],
+    [treeNodeMap],
   );
 
-  const tree = useMemo(() => buildTree(data), [data]);
   // Drill-down navigation (persisted in URL search params)
   const currentFolderId = useSearch({
     from: "/_protected/workspaces/$workspaceId/$viewId",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -64,9 +64,11 @@ import {
   CellMetadataMenuSection,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags";
 import { CopyToMatterDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog";
+import type { CopyToMatterEntity } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic";
 import { getExtension } from "@/routes/_protected.workspaces/$workspaceId/-components/file-extension";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { getPdfDownloadFileName } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions.logic";
+import type { TableTreeNode } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import { downloadFile } from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
 import { useEntitiesCountLimit } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-limits";
 import { useRetryCell } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell";
@@ -130,6 +132,9 @@ export const RowActions = ({
   const requestChatAbout = useRequestChatAbout(workspaceId);
   const retryCell = useRetryCell(workspaceId);
   const [copyToMatterOpen, setCopyToMatterOpen] = useState(false);
+  const [copyToMatterEntities, setCopyToMatterEntities] = useState<
+    CopyToMatterEntity[]
+  >([]);
   const [isRetrying, setIsRetrying] = useState(false);
   const { data: properties } = useQuery(propertiesOptions(workspaceId));
   const uploadVersionInputRef = useRef<HTMLInputElement>(null);
@@ -147,6 +152,16 @@ export const RowActions = ({
     isDocx && entity.activeEditBy !== null && !entity.activeEditBy.isMe;
   // Show "Edit in Desktop" when: DOCX + (not locked OR locked by me)
   const canOpenInDesktop = isDocx && !isLockedByOther;
+  const openCopyToMatterDialog = () => {
+    setCopyToMatterEntities(toCopyToMatterEntities(bulkTargets));
+    setCopyToMatterOpen(true);
+  };
+  const handleCopyToMatterOpenChange = (nextOpen: boolean) => {
+    setCopyToMatterOpen(nextOpen);
+    if (!nextOpen) {
+      setCopyToMatterEntities([]);
+    }
+  };
 
   const openVersionHistory = file
     ? () => {
@@ -700,7 +715,7 @@ export const RowActions = ({
             </MenuItem>
             <MenuItem
               onClick={() => {
-                setCopyToMatterOpen(true);
+                openCopyToMatterDialog();
               }}
             >
               <FolderSyncIcon />
@@ -754,8 +769,8 @@ export const RowActions = ({
         )}
       </MenuPopup>
       <CopyToMatterDialog
-        entities={toCopyToMatterEntities(bulkTargets)}
-        onOpenChange={setCopyToMatterOpen}
+        entities={copyToMatterEntities}
+        onOpenChange={handleCopyToMatterOpenChange}
         open={copyToMatterOpen}
         sourceWorkspaceId={workspaceId}
       />
@@ -833,11 +848,20 @@ const CreateSubfolderMenuItem = ({
 
 // -- Helpers (avoid duplicating logic between single/bulk) --
 
-const toCopyToMatterEntities = (targets: WorkspaceEntity[]) =>
-  targets.map((e) => ({
-    entityId: e.entityId,
-    entityName: getEntityName(e),
-  }));
+const toCopyToMatterEntities = (
+  targets: readonly (WorkspaceEntity | TableTreeNode)[],
+): CopyToMatterEntity[] => targets.map(toCopyToMatterEntity);
+
+const toCopyToMatterEntity = (
+  entity: WorkspaceEntity | TableTreeNode,
+): CopyToMatterEntity => ({
+  children:
+    "children" in entity ? entity.children.map(toCopyToMatterEntity) : [],
+  entityId: entity.entityId,
+  entityName: getEntityName(entity),
+  kind: entity.kind,
+  parentId: entity.parentId,
+});
 
 type FileRef = { fieldId: string; fileName: string; mimeType: string | null };
 type Msg = { downloading: string; failed: string };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -137,6 +137,7 @@ export const RowActions = ({
   const name = getEntityName(entity);
   const isFolder = entity.kind === "folder";
   const isBulk = selectedEntities !== undefined && selectedEntities.length > 1;
+  const bulkTargets = isBulk ? selectedEntities : [entity];
   const isCellContext =
     !isBulk && cellMetadataTarget !== null && cellMetadataTarget !== undefined;
   const isDocx = !isBulk && file?.mimeType === DOCX_MIME;
@@ -393,8 +394,7 @@ export const RowActions = ({
   };
 
   const handleChatAbout = () => {
-    const targets = isBulk ? selectedEntities : [entity];
-    const mentions = targets.map((e) => {
+    const mentions = bulkTargets.map((e) => {
       const f = getFirstFile(e);
       return {
         id: e.entityId,
@@ -408,11 +408,10 @@ export const RowActions = ({
   };
 
   const handleDuplicate = async () => {
-    const allTargets = isBulk ? selectedEntities : [entity];
     // Folders cannot be duplicated server-side; silently skip them so a
     // mixed selection (folders + files) does not surface as a generic
     // failure to the user.
-    const targets = allTargets.filter((e) => e.kind !== "folder");
+    const targets = bulkTargets.filter((e) => e.kind !== "folder");
 
     if (targets.length === 0) {
       stellaToast.add({
@@ -699,16 +698,14 @@ export const RowActions = ({
               <CopyIcon />
               {t("common.duplicate")}
             </MenuItem>
-            {!isBulk && (
-              <MenuItem
-                onClick={() => {
-                  setCopyToMatterOpen(true);
-                }}
-              >
-                <FolderSyncIcon />
-                {t("workspaces.copyToMatter.menuItem")}
-              </MenuItem>
-            )}
+            <MenuItem
+              onClick={() => {
+                setCopyToMatterOpen(true);
+              }}
+            >
+              <FolderSyncIcon />
+              {t("workspaces.copyToMatter.menuItem")}
+            </MenuItem>
 
             <MenuSeparator />
 
@@ -756,15 +753,12 @@ export const RowActions = ({
           </>
         )}
       </MenuPopup>
-      {!isBulk && (
-        <CopyToMatterDialog
-          entityId={entity.entityId}
-          entityName={name}
-          onOpenChange={setCopyToMatterOpen}
-          open={copyToMatterOpen}
-          sourceWorkspaceId={workspaceId}
-        />
-      )}
+      <CopyToMatterDialog
+        entities={toCopyToMatterEntities(bulkTargets)}
+        onOpenChange={setCopyToMatterOpen}
+        open={copyToMatterOpen}
+        sourceWorkspaceId={workspaceId}
+      />
       {/* Hidden file input for upload new version */}
       {canUploadVersion && (
         <input
@@ -838,6 +832,12 @@ const CreateSubfolderMenuItem = ({
 };
 
 // -- Helpers (avoid duplicating logic between single/bulk) --
+
+const toCopyToMatterEntities = (targets: WorkspaceEntity[]) =>
+  targets.map((e) => ({
+    entityId: e.entityId,
+    entityName: getEntityName(e),
+  }));
 
 type FileRef = { fieldId: string; fileName: string; mimeType: string | null };
 type Msg = { downloading: string; failed: string };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -26,8 +26,10 @@ import type {
   TableCellContext,
   TableColumnDef,
   TableHeaderContext,
+  TableTreeNode,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table";
+import { useTableStore } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 import { useSyncJustificationChunks } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
 import { useTableState } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state";
 import {
@@ -143,6 +145,25 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
     workspaceId,
     entityIdChunks: justificationEntityIdChunks,
   });
+
+  // Resolve the row selection to entities for chrome outside the
+  // table (the view toolbar's bulk actions menu).
+  const rowSelection = useTableStore((s) => s.rowSelection[view.id]);
+  const setSelectedEntities = useTableStore((s) => s.setSelectedEntities);
+  useEffect(() => {
+    const selected = rowSelection ?? {};
+    const result: TableTreeNode[] = [];
+    const visit = (nodes: TableTreeNode[]) => {
+      for (const node of nodes) {
+        if (selected[node.entityId]) {
+          result.push(node);
+        }
+        visit(node.children);
+      }
+    };
+    visit(treeData);
+    setSelectedEntities(view.id, result);
+  }, [rowSelection, treeData, view.id, setSelectedEntities]);
 
   const columns = useMemo(() => {
     const columnDefs: TableColumnDef[] = [

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -153,7 +153,11 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   useEffect(() => {
     const selected = rowSelection ?? {};
     const result: TableTreeNode[] = [];
-    const visit = (nodes: TableTreeNode[]) => {
+    const visit = (nodes: TableTreeNode[] | undefined) => {
+      if (!nodes) {
+        return;
+      }
+
       for (const node of nodes) {
         if (selected[node.entityId]) {
           result.push(node);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -43,10 +43,16 @@ import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { apiUrl } from "@/lib/api-url";
 import { ClientOperationError } from "@/lib/errors";
-import type { ViewLayout, WorkspaceProperty, WorkspaceView } from "@/lib/types";
+import type {
+  ViewLayout,
+  WorkspaceEntity,
+  WorkspaceProperty,
+  WorkspaceView,
+} from "@/lib/types";
 import { BulkAddColumns } from "@/routes/_protected.workspaces/$workspaceId/-components/bulk-add-columns";
 import { ExistingFileOrganizerDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
+import { RowActions } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
 import { downloadFile } from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
 import { FilterChips } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters";
 import { SortChips } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-sorts";
@@ -75,6 +81,7 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
   const { filters, sorts, hiddenProperties } = view.layout;
   const folderState = useWorkspaceStore((s) => s.folderState);
   const toggleAllFolders = useWorkspaceStore((s) => s.toggleAllFolders);
+  const selectedEntities = useTableStore((s) => s.selectedEntities[view.id]);
 
   // Generic helper preserves the union discriminant. A bare
   // `{ ...layout, ...partial }` would collapse to an invalid union.
@@ -204,6 +211,52 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
           <BulkAddColumns triggerVariant="labelled" workspaceId={workspaceId} />
         </>
       )}
+
+      {view.layout.type === "table" && (
+        <SelectionActions
+          selectedEntities={selectedEntities}
+          workspaceId={workspaceId}
+        />
+      )}
+    </div>
+  );
+};
+
+type SelectionActionsProps = {
+  selectedEntities: WorkspaceEntity[] | undefined;
+  workspaceId: string;
+};
+
+/**
+ * Secondary actions for the current row selection (delete, copy/move
+ * to matter, download, …). Reuses the row actions menu so the
+ * toolbar and the row context menu cannot drift apart.
+ */
+const SelectionActions = ({
+  selectedEntities,
+  workspaceId,
+}: SelectionActionsProps) => {
+  const t = useTranslations();
+  const firstSelected = selectedEntities?.at(0);
+  if (!firstSelected || selectedEntities === undefined) {
+    return null;
+  }
+
+  return (
+    <div className="ms-auto flex items-center gap-1.5">
+      <span className="text-muted-foreground text-xs">
+        {t("workspaces.views.fieldsSelected", {
+          count: selectedEntities.length,
+        })}
+      </span>
+      <RowActions
+        entity={firstSelected}
+        selectedEntities={
+          selectedEntities.length > 1 ? selectedEntities : undefined
+        }
+        triggerClassName=""
+        workspaceId={workspaceId}
+      />
     </div>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.ts
@@ -16,6 +16,24 @@ const TABLE_CONTENT_MODES = ["tight", "fit-content"] as const;
 
 export type TableContentMode = (typeof TABLE_CONTENT_MODES)[number];
 
+const selectedEntitiesEqual = (
+  prev: readonly WorkspaceEntity[] | undefined,
+  next: readonly WorkspaceEntity[],
+): boolean => {
+  if (!prev) {
+    return next.length === 0;
+  }
+
+  if (prev.length !== next.length) {
+    return false;
+  }
+
+  return prev.every((entity, index) => {
+    const nextEntity = next[index];
+    return entity === nextEntity && entity.entityId === nextEntity.entityId;
+  });
+};
+
 const replacer = (_key: string, value: unknown): unknown => {
   if (value instanceof Map) {
     return { [MAP_TAG]: [...value.entries()] };
@@ -145,7 +163,7 @@ export const useTableStore = create<TableStore>()(
       setSelectedEntities: (viewId, entities) => {
         set((state) => {
           const prev = state.selectedEntities[viewId];
-          if (entities.length === 0 && (!prev || prev.length === 0)) {
+          if (selectedEntitiesEqual(prev, entities)) {
             return;
           }
           state.selectedEntities[viewId] = entities;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.ts
@@ -9,6 +9,8 @@ import { persist } from "zustand/middleware";
 import type { PersistStorage, StorageValue } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
+import type { WorkspaceEntity } from "@/lib/types";
+
 const MAP_TAG = "__map";
 const TABLE_CONTENT_MODES = ["tight", "fit-content"] as const;
 
@@ -100,6 +102,13 @@ type TableStore = {
     viewId: string,
     updater: Updater<RowSelectionState>,
   ) => void;
+  /**
+   * Selected entities resolved from `rowSelection`, synced by the
+   * table layout so chrome outside the table (view toolbar) can
+   * offer bulk actions without rebuilding the entities query.
+   */
+  selectedEntities: Record<string, WorkspaceEntity[]>;
+  setSelectedEntities: (viewId: string, entities: WorkspaceEntity[]) => void;
   pruneStaleViews: (activeViewIds: string[]) => void;
 };
 
@@ -109,6 +118,7 @@ export const useTableStore = create<TableStore>()(
       columnSizing: new Map<string, ColumnSizingState>(),
       contentMode: {},
       rowSelection: {},
+      selectedEntities: {},
 
       setContentMode: (viewId, mode) => {
         set((state) => {
@@ -129,6 +139,16 @@ export const useTableStore = create<TableStore>()(
           const prev = state.rowSelection[viewId] ?? {};
           const next = typeof updater === "function" ? updater(prev) : updater;
           state.rowSelection[viewId] = next;
+        });
+      },
+
+      setSelectedEntities: (viewId, entities) => {
+        set((state) => {
+          const prev = state.selectedEntities[viewId];
+          if (entities.length === 0 && (!prev || prev.length === 0)) {
+            return;
+          }
+          state.selectedEntities[viewId] = entities;
         });
       },
 
@@ -154,6 +174,15 @@ export const useTableStore = create<TableStore>()(
             }
           }
           state.rowSelection = pruned;
+          const prunedSelectedEntities: Record<string, WorkspaceEntity[]> = {};
+          for (const [vid, entities] of Object.entries(
+            state.selectedEntities,
+          )) {
+            if (active.has(vid)) {
+              prunedSelectedEntities[vid] = entities;
+            }
+          }
+          state.selectedEntities = prunedSelectedEntities;
         });
       },
     })),


### PR DESCRIPTION
Selecting rows in the workspace table now surfaces a secondary actions menu in the view toolbar: a "{count} selected" label plus the existing row-actions menu (preview, chat about, download, duplicate, copy/move to matter, delete) applied to the whole selection. Reusing `RowActions` keeps the toolbar and the per-row context menu from drifting apart; single-only items (rename, upload version) appear only for single selections.

- The table layout resolves the TanStack row selection to entities and syncs them into the existing table store, so toolbar chrome gets the selection without rebuilding the entities query; the section disappears when the selection empties.
- Copy/Move to Matter gains bulk support: the dialog accepts a list, loops the existing `copy-to-workspace` endpoint per entity, and reports partial failures (success toast with a warning description). One new i18n key for the bulk dialog description (`workspaces.copyToMatter.descriptionCount`, all languages); the selected-count label reuses an existing key.
- Hoisted a small `toCopyToMatterEntities` helper and a shared `bulkTargets` in `RowActions` to stay under the cognitive-complexity lint ceiling.