### PR TITLE
feat(ci): lint changed migrations for lock-safety with squawk

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -11,6 +11,7 @@ on:
       - "apps/api/drizzle.config.ts"
       - "scripts/check-migration-safety.ts"
       - "scripts/check-migrations.sh"
+      - ".squawk.toml"
       - ".github/workflows/db-migrations.yml"
   workflow_dispatch:
 

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,33 @@
+# Squawk lints migration SQL for lock-safety in CI (scripts/check-migrations.sh).
+# Only migration files changed in the PR are linted.
+
+# Keep in sync with the Postgres major version used in production and in
+# .github/workflows/db-migrations.yml.
+pg_version = "18.0"
+
+# `drizzle-kit migrate` wraps every migration in a transaction.
+assume_in_transaction = true
+
+# Keep lock-safety rules active. Migrations that need concurrent indexes can
+# split Drizzle's wrapping transaction and locally ignore the transaction-control
+# warnings on the COMMIT/BEGIN lines.
+excluded_rules = [
+  # Destructive changes are owned by scripts/check-migration-safety.ts, which
+  # requires a reviewed-acknowledgement comment. Excluded here so each rule
+  # class has exactly one suppression mechanism.
+  "ban-drop-column",
+  "ban-drop-table",
+  "ban-drop-database",
+  "renaming-column",
+  "renaming-table",
+  "ban-truncate-cascade",
+  "changing-column-type",
+
+  # Schema house style: drizzle-generated DDL uses varchar, timestamp without
+  # time zone, and int keys throughout. Changing that is a schema-wide
+  # decision, not a per-migration lint.
+  "prefer-text-field",
+  "prefer-timestamp-tz",
+  "prefer-bigint-over-int",
+  "prefer-bigint-over-smallint",
+]

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "oxlint-tsgolint": "^0.23.0",
         "react": "catalog:react19",
         "sherif": "catalog:",
+        "squawk-cli": "2.56.0",
         "turbo": "^2.9.16",
         "typescript": "catalog:",
         "ultracite": "catalog:",
@@ -1601,6 +1602,16 @@
     "@solid-primitives/static-store": ["@solid-primitives/static-store@0.1.3", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ=="],
 
     "@solid-primitives/utils": ["@solid-primitives/utils@6.4.0", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A=="],
+
+    "@squawk-cli/darwin-arm64": ["@squawk-cli/darwin-arm64@2.56.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YnpThEVvISWReuNzSungrm2ZTjSQL+kZ7VTZdjEHl9edYjMEjaOdR6xTAjq8FmphakXIfl4hcmDAlayhQxq0zg=="],
+
+    "@squawk-cli/darwin-x64": ["@squawk-cli/darwin-x64@2.56.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Kn1vZ7hsOm0K3ONTxcZMZWkvVu/xy1cUDO2ngtA9QIYpTkNuK2kmFFj+DcaiRdmx5fqW1L32EyZbWfo6/Yok9g=="],
+
+    "@squawk-cli/linux-arm64": ["@squawk-cli/linux-arm64@2.56.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-abYFYND6Z3BiI8Pq4jpL0RAc5Jq1lIFWMlPXxLxfLRTTXfwtcLGFbKoAFJ+L6u7mmXe9dqWW8vmOxaryaknPYg=="],
+
+    "@squawk-cli/linux-x64": ["@squawk-cli/linux-x64@2.56.0", "", { "os": "linux", "cpu": "x64" }, "sha512-HpdaqeeDfg3ZQwm/Kz+7rrgKhXL8Fl6QKeUteeQUb5N4tPiBNYaFu4xNEilF9O+ga56ii/YvklTW7fYt4c2Ycg=="],
+
+    "@squawk-cli/win32-x64": ["@squawk-cli/win32-x64@2.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-otQoNxVt3gDo1/BmHYW/sKoziRLWzCEnm/J5r+IZoHZHwNdTpEj4pyqPuMcB/iS1DdA1QO0As7pmhR3OUUVtaA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -3415,6 +3426,8 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "squawk-cli": ["squawk-cli@2.56.0", "", { "optionalDependencies": { "@squawk-cli/darwin-arm64": "2.56.0", "@squawk-cli/darwin-x64": "2.56.0", "@squawk-cli/linux-arm64": "2.56.0", "@squawk-cli/linux-x64": "2.56.0", "@squawk-cli/win32-x64": "2.56.0" }, "bin": { "squawk": "js/bin/squawk" } }, "sha512-WIEls1uQR9f42qQnz76JffbZ+spU1QqAUXP8AGFkmF64S25nCoCBh5F3abYLgdC44SaY+O8uu0kPNBNWJyn9ug=="],
 
     "srvx": ["srvx@0.11.16", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw=="],
 

--- a/knip.json
+++ b/knip.json
@@ -13,6 +13,7 @@
         "ultracite",
         "i18n-unused",
         "oxlint",
+        "squawk-cli",
         "vite"
       ],
       "ignoreBinaries": ["scripts/dev.sh"]

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "oxlint-tsgolint": "^0.23.0",
     "react": "catalog:react19",
     "sherif": "catalog:",
+    "squawk-cli": "2.56.0",
     "turbo": "^2.9.16",
     "typescript": "catalog:",
     "ultracite": "catalog:",

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -173,6 +173,15 @@ fi
 if [[ -d apps/api/drizzle ]]; then
   if [[ "${#MIGRATION_SQL_FILES[@]}" -gt 0 ]]; then
     bun scripts/check-migration-safety.ts "${MIGRATION_SQL_FILES[@]}"
+
+    # Lock-safety linting (rule set configured in .squawk.toml). Destructive
+    # changes are covered separately by check-migration-safety.ts above.
+    bun squawk "${MIGRATION_SQL_FILES[@]}" || {
+      echo "ERROR: squawk found DDL in the changed migrations that is unsafe to apply under load." >&2
+      echo "Rewrite the statement (rule docs: https://squawkhq.com/docs/rules), or suppress a" >&2
+      echo "reviewed finding with '-- squawk-ignore <rule-name>' on the line above the statement." >&2
+      exit 1
+    }
   fi
 
   (cd apps/api && bun --bun drizzle-kit check)


### PR DESCRIPTION
## Summary

The db-migrations workflow verifies that migrations exist, apply cleanly to a fresh Postgres, and match `schema.ts`, and `check-migration-safety.ts` gates destructive changes behind a reviewed-acknowledgement comment. Nothing checked that new DDL is safe to apply under load: lock-holding `ALTER`s, `SET NOT NULL` on populated tables, constraints added without `NOT VALID`.

This adds [squawk](https://github.com/sbdchd/squawk) over the migration files changed in a PR, next to the existing safety script in `scripts/check-migrations.sh`. Only changed files are linted, so historical migrations need no baseline.

## Rule configuration (`.squawk.toml`)

- `assume_in_transaction = true`: `drizzle-kit migrate` wraps every migration in a transaction.
- Destructive-change rules (`ban-drop-column`, `renaming-table`, ...) stay excluded; `check-migration-safety.ts` owns those, so each rule class has exactly one suppression mechanism.
- `require-concurrent-index-creation`/`-deletion` are excluded because `CREATE INDEX CONCURRENTLY` cannot run inside the runner's transaction. Re-enable if migrations gain an out-of-transaction path.
- `require-timeout-settings` is excluded as a runner-level concern.
- Type-style rules (`prefer-text-field`, `prefer-timestamp-tz`, `prefer-bigint-over-int`, ...) are excluded because they conflict with the drizzle-generated schema style and would fire on every new migration.

Reviewed findings can be suppressed inline with `-- squawk-ignore <rule-name>` on the line above the statement; the CI error message points there.

## Notes

- `squawk-cli` is pinned exact at the newest version clearing the lockfile's minimum-release-age; binaries ship as platform `optionalDependencies` (no install scripts), so the workflow's `bun ci --ignore-scripts` still works.
- Verified locally: a migration with findings fails the script with guidance (exit 1), clean migrations pass, and ranges without migration changes skip squawk entirely.