### PR TITLE
fix(folio): sync latest docx editor fixes

### DIFF
--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -38,6 +38,7 @@ import { EditorView } from "prosemirror-view";
 
 import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
+import { ensureParaIdsInState } from "../core/prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
 import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
 import { schema } from "../core/prosemirror/schema";
@@ -148,11 +149,13 @@ function buildInitialState(
   // Header/footer paragraphs share the document's style table, so they get
   // the same style-aware behavior (e.g. Enter after a heading → body text).
   const styleResolverPlugin = createDocumentStylesPlugin(styles);
-  return EditorState.create({
-    doc: pmDoc,
-    schema,
-    plugins: [...mgr.getPlugins(), styleResolverPlugin],
-  });
+  return ensureParaIdsInState(
+    EditorState.create({
+      doc: pmDoc,
+      schema,
+      plugins: [...mgr.getPlugins(), styleResolverPlugin],
+    }),
+  );
 }
 
 export function enumerateHfSlots(doc: Document | null): HfPartKey[] {

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom-caret-height.test.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom-caret-height.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getCaretPositionFromDom } from "./clickToPositionDom";
+
+class FakeHTMLElement {
+  dataset: Record<string, string> = {};
+  firstChild: unknown;
+  private readonly rect: Partial<DOMRect>;
+  private readonly height: number;
+  readonly classList = {
+    contains: (className: string) => this.classes.has(className),
+  };
+  private readonly classes = new Set<string>();
+  private readonly children: FakeHTMLElement[] = [];
+  private parent: FakeHTMLElement | null = null;
+
+  constructor(
+    classes: string[] = [],
+    rectInput: Partial<DOMRect> = {},
+    heightInput = 0,
+  ) {
+    this.rect = rectInput;
+    this.height = heightInput;
+    for (const className of classes) {
+      this.classes.add(className);
+    }
+  }
+
+  get offsetHeight(): number {
+    return this.height;
+  }
+
+  get ownerDocument(): { createRange: () => Range } {
+    return fakeDocument;
+  }
+
+  append(...children: FakeHTMLElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+      this.children.push(child);
+    }
+  }
+
+  querySelectorAll(selector: string): FakeHTMLElement[] {
+    const out: FakeHTMLElement[] = [];
+    this.collect(selector, out);
+    return out;
+  }
+
+  querySelector(selector: string): FakeHTMLElement | null {
+    return this.querySelectorAll(selector).at(0) ?? null;
+  }
+
+  closest(selector: string): this | null {
+    if (this.matches(selector)) {
+      return this;
+    }
+    return this.parent?.closest(selector) ?? null;
+  }
+
+  getBoundingClientRect(): DOMRect {
+    return rect(this.rect);
+  }
+
+  private collect(selector: string, out: FakeHTMLElement[]): void {
+    for (const child of this.children) {
+      if (child.matches(selector)) {
+        out.push(child);
+      }
+      child.collect(selector, out);
+    }
+  }
+
+  private matches(selector: string): boolean {
+    if (selector.includes(".layout-page-content")) {
+      return this.classes.has("layout-run-text");
+    }
+    if (selector === ".layout-page") {
+      return this.classes.has("layout-page");
+    }
+    if (selector === ".layout-line") {
+      return this.classes.has("layout-line");
+    }
+    return false;
+  }
+}
+
+const textNode = { nodeType: 3, length: 5 };
+let rangeHeight = 18;
+const fakeDocument = {
+  createRange: () =>
+    ({
+      setStart: () => undefined,
+      setEnd: () => undefined,
+      getBoundingClientRect: () =>
+        rect({ left: 12, top: 20, height: rangeHeight }),
+    }) as Range,
+};
+
+const rect = (values: Partial<DOMRect>): DOMRect =>
+  ({
+    x: values.left ?? 0,
+    y: values.top ?? 0,
+    left: values.left ?? 0,
+    top: values.top ?? 0,
+    right: values.right ?? 0,
+    bottom: values.bottom ?? 0,
+    width: values.width ?? 0,
+    height: values.height ?? 0,
+    toJSON: () => values,
+  }) as DOMRect;
+
+const buildContainer = (): HTMLElement => {
+  const container = new FakeHTMLElement();
+  const page = new FakeHTMLElement(["layout-page"]);
+  page.dataset["pageNumber"] = "1";
+  const content = new FakeHTMLElement(["layout-page-content"]);
+  const line = new FakeHTMLElement(["layout-line"], {}, 80);
+  const span = new FakeHTMLElement(
+    ["layout-run-text"],
+    { left: 10, top: 20 },
+    18,
+  );
+  span.dataset["pmStart"] = "1";
+  span.dataset["pmEnd"] = "6";
+  span.firstChild = textNode;
+
+  container.append(page);
+  page.append(content);
+  content.append(line);
+  line.append(span);
+
+  return container as unknown as HTMLElement;
+};
+
+let originalHTMLElement: unknown;
+let originalNode: unknown;
+
+beforeEach(() => {
+  originalHTMLElement = globalThis.HTMLElement;
+  originalNode = globalThis.Node;
+  Object.assign(globalThis, {
+    HTMLElement: FakeHTMLElement,
+    Node: { TEXT_NODE: 3 },
+  });
+});
+
+afterEach(() => {
+  Object.assign(globalThis, {
+    HTMLElement: originalHTMLElement,
+    Node: originalNode,
+  });
+});
+
+describe("getCaretPositionFromDom caret height", () => {
+  test("uses the collapsed range height instead of the full line height", () => {
+    rangeHeight = 18;
+
+    const caret = getCaretPositionFromDom(buildContainer(), 3, rect({}));
+
+    expect(caret?.height).toBe(18);
+  });
+
+  test("falls back to line height when the range reports zero height", () => {
+    rangeHeight = 0;
+
+    const caret = getCaretPositionFromDom(buildContainer(), 3, rect({}));
+
+    expect(caret?.height).toBe(80);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -606,7 +606,7 @@ export function getCaretPositionFromDom(
       return {
         x: rangeRect.left - overlayRect.left,
         y: rangeRect.top - overlayRect.top,
-        height: lineHeight,
+        height: rangeRect.height || lineHeight,
         pageIndex,
       };
     }

--- a/packages/folio/src/core/prosemirror/conversion/image-wrap-distance-zero.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/image-wrap-distance-zero.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document, Image } from "../../types/document";
+import { toProseDoc } from "./toProseDoc";
+
+const EMUS_PER_INCH = 914_400;
+
+const docWithImage = (image: Image): Document => ({
+  package: {
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "run", content: [{ type: "drawing", image }] }],
+        },
+      ],
+    },
+  },
+});
+
+const floatingImage = (wrap: Image["wrap"]): Image => ({
+  type: "image",
+  rId: "rId1",
+  src: "data:image/png;base64,AA==",
+  size: { width: EMUS_PER_INCH, height: EMUS_PER_INCH },
+  wrap,
+});
+
+const firstImageAttrs = (document: Document): Record<string, unknown> => {
+  let attrs: Record<string, unknown> | undefined;
+  toProseDoc(document).descendants((node) => {
+    if (node.type.name !== "image") {
+      return true;
+    }
+    attrs = node.attrs;
+    return false;
+  });
+
+  if (!attrs) {
+    throw new Error("Expected an image node");
+  }
+  return attrs;
+};
+
+describe("image wrap distance conversion", () => {
+  test("preserves explicit zero wrap distances", () => {
+    const attrs = firstImageAttrs(
+      docWithImage(
+        floatingImage({
+          type: "square",
+          distT: 0,
+          distB: 0,
+          distL: 0,
+          distR: 0,
+        }),
+      ),
+    );
+
+    expect(attrs["distTop"]).toBe(0);
+    expect(attrs["distBottom"]).toBe(0);
+    expect(attrs["distLeft"]).toBe(0);
+    expect(attrs["distRight"]).toBe(0);
+  });
+
+  test("keeps absent wrap distances absent", () => {
+    const attrs = firstImageAttrs(
+      docWithImage(floatingImage({ type: "square" })),
+    );
+
+    expect(attrs["distTop"]).toBeNull();
+    expect(attrs["distLeft"]).toBeNull();
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2157,14 +2157,14 @@ function convertImage(image: Image, rawXml?: string): PMNode {
   }
 
   // Convert wrap distances from EMU to pixels for margins
-  const distTop = image.wrap.distT ? emuToPixels(image.wrap.distT) : undefined;
-  const distBottom = image.wrap.distB
-    ? emuToPixels(image.wrap.distB)
-    : undefined;
-  const distLeft = image.wrap.distL ? emuToPixels(image.wrap.distL) : undefined;
-  const distRight = image.wrap.distR
-    ? emuToPixels(image.wrap.distR)
-    : undefined;
+  const distTop =
+    image.wrap.distT != null ? emuToPixels(image.wrap.distT) : undefined;
+  const distBottom =
+    image.wrap.distB != null ? emuToPixels(image.wrap.distB) : undefined;
+  const distLeft =
+    image.wrap.distL != null ? emuToPixels(image.wrap.distL) : undefined;
+  const distRight =
+    image.wrap.distR != null ? emuToPixels(image.wrap.distR) : undefined;
 
   // Build position data for floating images
   let position:

--- a/packages/folio/src/core/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
@@ -12,7 +12,14 @@ import { describe, test, expect } from "bun:test";
 import { Schema, Slice, Fragment } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 
-import { ParaIdAllocatorExtension } from "./ParaIdAllocatorExtension";
+import {
+  getChangedParagraphIds,
+  ParagraphChangeTrackerExtension,
+} from "./ParagraphChangeTrackerExtension";
+import {
+  ensureParaIdsInState,
+  ParaIdAllocatorExtension,
+} from "./ParaIdAllocatorExtension";
 
 const schema = new Schema({
   nodes: {
@@ -36,6 +43,13 @@ const plugin = runtime.plugins?.[0];
 if (!plugin) {
   throw new Error("Expected plugin from ParaIdAllocatorExtension");
 }
+const changeTrackerRuntime = ParagraphChangeTrackerExtension().onSchemaReady({
+  schema,
+});
+const changeTrackerPlugin = changeTrackerRuntime.plugins?.[0];
+if (!changeTrackerPlugin) {
+  throw new Error("Expected plugin from ParagraphChangeTrackerExtension");
+}
 
 const para = (text: string, paraId: string | null = null) =>
   schema.node(
@@ -48,6 +62,12 @@ const createState = (...paras: ReturnType<typeof para>[]) =>
   EditorState.create({
     doc: schema.node("doc", null, paras),
     plugins: [plugin],
+  });
+
+const createTrackedState = (...paras: ReturnType<typeof para>[]) =>
+  EditorState.create({
+    doc: schema.node("doc", null, paras),
+    plugins: [plugin, changeTrackerPlugin],
   });
 
 const collectParaIds = (state: EditorState): (string | null)[] => {
@@ -64,6 +84,37 @@ const collectParaIds = (state: EditorState): (string | null)[] => {
 };
 
 describe("ParaIdAllocatorExtension", () => {
+  test("allocates missing paraIds on the initial state before the first edit", () => {
+    const initial = createState(para("Needs an id"), para("Also needs one"));
+    expect(collectParaIds(initial)).toEqual([null, null]);
+
+    const next = ensureParaIdsInState(initial);
+    const ids = collectParaIds(next);
+
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[1]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  test("initial allocation does not seed paragraph change tracking", () => {
+    const initial = createTrackedState(para("Needs an id"));
+
+    const next = ensureParaIdsInState(initial);
+
+    expect(collectParaIds(next)[0]).toMatch(/^[0-9A-F]{8}$/u);
+    expect(getChangedParagraphIds(next).size).toBe(0);
+  });
+
+  test("initial allocation is idempotent when all paraIds are unique", () => {
+    const initial = createState(
+      para("First", "11111111"),
+      para("Second", "22222222"),
+    );
+
+    expect(ensureParaIdsInState(initial)).toBe(initial);
+  });
+
   test("does not allocate on a selection-only transaction", () => {
     const initial = createState(para("Already has one", "ABCDEFGH"));
     const tr = initial.tr.setMeta("anything", true); // no doc change

--- a/packages/folio/src/core/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -13,13 +13,68 @@
  * their anchors. This plugin closes both gaps by allocating fresh
  * ids in an `appendTransaction` hook after every doc-changed step.
  */
+import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
+import type { EditorState } from "prosemirror-state";
 
 import { generateHexId } from "../../../utils/hexId";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
+import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
 
 export const paraIdAllocatorKey = new PluginKey("paraIdAllocator");
+
+type ParaIdUpdate = {
+  pos: number;
+  attrs: Record<string, unknown>;
+};
+
+const collectParaIdUpdates = (doc: PMNode): ParaIdUpdate[] => {
+  const seen = new Set<string>();
+  const updates: ParaIdUpdate[] = [];
+
+  doc.descendants((node, pos) => {
+    // Non-paragraph: recurse — paragraphs nested in tables / cells
+    // are still in scope.
+    if (node.type.name !== "paragraph") {
+      return;
+    }
+
+    const id = node.attrs["paraId"];
+    if (typeof id !== "string" || id.length === 0 || seen.has(id)) {
+      let newId = generateHexId();
+      while (seen.has(newId)) {
+        newId = generateHexId();
+      }
+      seen.add(newId);
+      updates.push({ pos, attrs: { ...node.attrs, paraId: newId } });
+    } else {
+      seen.add(id);
+    }
+
+    // Paragraphs only contain inline content (text / runs) — nothing
+    // we'd ever paraId. Skip the subtree.
+    return false;
+  });
+
+  return updates;
+};
+
+export const ensureParaIdsInState = (state: EditorState): EditorState => {
+  const updates = collectParaIdUpdates(state.doc);
+  if (updates.length === 0) {
+    return state;
+  }
+
+  const tr = state.tr;
+  for (const update of updates) {
+    tr.setNodeMarkup(update.pos, undefined, update.attrs);
+  }
+  ignoreTrackedChanges(tr);
+  tr.setMeta(paraIdAllocatorKey, "allocated");
+  tr.setMeta("addToHistory", false);
+  return state.apply(tr);
+};
 
 const createParaIdAllocatorPlugin = (): Plugin =>
   new Plugin({
@@ -31,33 +86,7 @@ const createParaIdAllocatorPlugin = (): Plugin =>
         return null;
       }
 
-      const seen = new Set<string>();
-      const updates: { pos: number; attrs: Record<string, unknown> }[] = [];
-
-      newState.doc.descendants((node, pos) => {
-        // Non-paragraph: recurse — paragraphs nested in tables / cells
-        // are still in scope.
-        if (node.type.name !== "paragraph") {
-          return;
-        }
-
-        const id = node.attrs["paraId"];
-        if (typeof id !== "string" || id.length === 0 || seen.has(id)) {
-          let newId = generateHexId();
-          while (seen.has(newId)) {
-            newId = generateHexId();
-          }
-          seen.add(newId);
-          updates.push({ pos, attrs: { ...node.attrs, paraId: newId } });
-        } else {
-          seen.add(id);
-        }
-
-        // Paragraphs only contain inline content (text / runs) — nothing
-        // we'd ever paraId. Skip the subtree.
-        return false;
-      });
-
+      const updates = collectParaIdUpdates(newState.doc);
       if (updates.length === 0) {
         return null;
       }

--- a/packages/folio/src/core/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
@@ -16,6 +16,7 @@ import {
   hasStructuralChanges,
   hasUntrackedChanges,
   clearTrackedChanges,
+  ignoreTrackedChanges,
   ParagraphChangeTrackerExtension,
 } from "./ParagraphChangeTrackerExtension";
 
@@ -290,6 +291,52 @@ describe("ParagraphChangeTrackerExtension", () => {
       const changed = getChangedParagraphIds(state);
       expect(changed.has("P1")).toBe(false);
       expect(changed.has("P2")).toBe(true);
+    });
+  });
+
+  describe("ignored generated transactions", () => {
+    test("does not record ignored doc-changing transactions", () => {
+      let state = createState([{ text: "Hello", paraId: "P1" }]);
+
+      const tr = state.tr.setNodeMarkup(0, undefined, {
+        ...state.doc.child(0).attrs,
+        paraId: "P2",
+      });
+      state = state.apply(ignoreTrackedChanges(tr));
+
+      expect(getChangedParagraphIds(state).size).toBe(0);
+      expect(hasStructuralChanges(state)).toBe(false);
+      expect(hasUntrackedChanges(state)).toBe(false);
+    });
+
+    test("preserves existing tracked edits while ignoring generated changes", () => {
+      let state = createState([
+        { text: "Hello", paraId: "P1" },
+        { text: "World", paraId: "P2" },
+      ]);
+
+      state = typeText(state, "X", 1);
+      expect(getChangedParagraphIds(state).has("P1")).toBe(true);
+
+      let secondParagraphPos = 0;
+      state.doc.descendants((node, pos) => {
+        if (node.type.name === "paragraph" && node.attrs.paraId === "P2") {
+          secondParagraphPos = pos;
+          return false;
+        }
+        return true;
+      });
+
+      const tr = state.tr.setNodeMarkup(secondParagraphPos, undefined, {
+        ...state.doc.child(1).attrs,
+        paraId: "P3",
+      });
+      state = state.apply(ignoreTrackedChanges(tr));
+
+      const changed = getChangedParagraphIds(state);
+      expect(changed.has("P1")).toBe(true);
+      expect(changed.has("P2")).toBe(false);
+      expect(changed.has("P3")).toBe(false);
     });
   });
 

--- a/packages/folio/src/core/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -22,6 +22,9 @@ import type { ExtensionRuntime } from "../types";
 export const paragraphChangeTrackerKey =
   new PluginKey<ParagraphChangeTrackerState>("paragraphChangeTracker");
 
+const CLEAR_META = "clear";
+const IGNORE_META = "ignore";
+
 export type ParagraphChangeTrackerState = {
   /** Set of paraIds that were modified since last clear */
   changedParaIds: Set<string>;
@@ -130,13 +133,23 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
         tr: Transaction,
         prevState: ParagraphChangeTrackerState,
       ): ParagraphChangeTrackerState {
+        const meta = tr.getMeta(paragraphChangeTrackerKey);
         // Check for explicit clear meta
-        if (tr.getMeta(paragraphChangeTrackerKey) === "clear") {
+        if (meta === CLEAR_META) {
           return {
             changedParaIds: new Set(),
             structuralChange: false,
             hasUntrackedChanges: false,
             paragraphCount: prevState.paragraphCount,
+          };
+        }
+
+        if (meta === IGNORE_META) {
+          return {
+            ...prevState,
+            paragraphCount: tr.docChanged
+              ? countParagraphs(tr.doc)
+              : prevState.paragraphCount,
           };
         }
 
@@ -274,7 +287,11 @@ export function hasUntrackedChanges(state: EditorState): boolean {
  * Create a transaction that clears the change tracker
  */
 export function clearTrackedChanges(state: EditorState): Transaction {
-  return state.tr.setMeta(paragraphChangeTrackerKey, "clear");
+  return state.tr.setMeta(paragraphChangeTrackerKey, CLEAR_META);
+}
+
+export function ignoreTrackedChanges(tr: Transaction): Transaction {
+  return tr.setMeta(paragraphChangeTrackerKey, IGNORE_META);
 }
 
 export const ParagraphChangeTrackerExtension = createExtension({

--- a/packages/folio/src/core/prosemirror/index.ts
+++ b/packages/folio/src/core/prosemirror/index.ts
@@ -52,6 +52,7 @@ export type { SelectionState } from "./selectionState";
 
 // Re-export TextSelection for restoring selections after toolbar interactions
 export { TextSelection } from "prosemirror-state";
+export { ensureParaIdsInState } from "./extensions/features/ParaIdAllocatorExtension";
 
 // Plugins (selection tracker only — keymaps are now in extension system)
 export {

--- a/packages/folio/src/paged-editor/HiddenProseMirror.paraIds.test.ts
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.paraIds.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import * as yProseMirror from "y-prosemirror";
+import * as yjs from "yjs";
+
+import { toProseDoc } from "../core/prosemirror/conversion";
+import type { Document } from "../core/types/document";
+import { createHiddenEditorState } from "./HiddenProseMirror";
+
+const docWithoutParaIds = (): Document => ({
+  package: {
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "Needs an id" }],
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+const collectParaIds = (
+  state: ReturnType<typeof createHiddenEditorState>,
+): string[] => {
+  const ids: string[] = [];
+  state.doc.descendants((node) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    const id = node.attrs["paraId"];
+    if (typeof id === "string") {
+      ids.push(id);
+    }
+    return false;
+  });
+  return ids;
+};
+
+const collaborationModules = { yProseMirror, yjs };
+
+describe("createHiddenEditorState collaborative paraId allocation", () => {
+  test("seeds a collaborative fragment with allocated paraIds", () => {
+    const ydoc = new yjs.Doc();
+    const yXmlFragment = ydoc.get("prosemirror", yjs.XmlFragment);
+
+    const state = createHiddenEditorState(
+      docWithoutParaIds(),
+      null,
+      undefined,
+      [],
+      { shouldSeed: true, yXmlFragment },
+      collaborationModules,
+    );
+
+    expect(collectParaIds(state)[0]).toMatch(/^[0-9A-F]{8}$/u);
+
+    const reloaded = createHiddenEditorState(
+      null,
+      null,
+      undefined,
+      [],
+      { shouldSeed: false, yXmlFragment },
+      collaborationModules,
+    );
+    expect(collectParaIds(reloaded)[0]).toMatch(/^[0-9A-F]{8}$/u);
+  });
+
+  test("allocates paraIds when opening an existing collaborative fragment", () => {
+    const ydoc = new yjs.Doc();
+    const yXmlFragment = ydoc.get("prosemirror", yjs.XmlFragment);
+    yProseMirror.prosemirrorToYXmlFragment(
+      toProseDoc(docWithoutParaIds()),
+      yXmlFragment,
+    );
+
+    const state = createHiddenEditorState(
+      null,
+      null,
+      undefined,
+      [],
+      { shouldSeed: false, yXmlFragment },
+      collaborationModules,
+    );
+
+    expect(collectParaIds(state)[0]).toMatch(/^[0-9A-F]{8}$/u);
+
+    const reloaded = createHiddenEditorState(
+      null,
+      null,
+      undefined,
+      [],
+      { shouldSeed: false, yXmlFragment },
+      collaborationModules,
+    );
+    expect(collectParaIds(reloaded)[0]).toMatch(/^[0-9A-F]{8}$/u);
+  });
+});

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -49,6 +49,7 @@ import {
 import { toProseDoc, createEmptyDoc } from "../core/prosemirror/conversion";
 import { fromProseDoc } from "../core/prosemirror/conversion/fromProseDoc";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
+import { ensureParaIdsInState } from "../core/prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
 import { schema } from "../core/prosemirror/schema";
 import type { Document, Theme, StyleDefinitions } from "../core/types/document";
@@ -397,6 +398,11 @@ export function createHiddenEditorState(
   const styleResolverPlugin = createDocumentStylesPlugin(
     styles ?? document?.package.styles,
   );
+  const plugins: Plugin[] = [
+    ...externalPlugins,
+    ...(manager?.getPlugins() ?? []),
+    styleResolverPlugin,
+  ];
 
   if (collaboration) {
     if (!collaborationModules) {
@@ -406,28 +412,51 @@ export function createHiddenEditorState(
     }
 
     if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
+      const seedState = ensureParaIdsInState(
+        EditorState.create({
+          doc: localDoc,
+          schema: activeSchema,
+          plugins,
+        }),
+      );
       collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
-        localDoc,
+        seedState.doc,
         collaboration.yXmlFragment,
       );
       collaboration.onSeeded?.();
     }
 
-    const { doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
+    let { doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
       collaboration.yXmlFragment,
       activeSchema,
     );
 
+    const initializedState = ensureParaIdsInState(
+      EditorState.create({
+        doc,
+        schema: activeSchema,
+        plugins,
+      }),
+    );
+    if (!initializedState.doc.eq(doc)) {
+      collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
+        initializedState.doc,
+        collaboration.yXmlFragment,
+      );
+      ({ doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
+        collaboration.yXmlFragment,
+        activeSchema,
+      ));
+    }
+
     const startedAt = performance.now();
-    const state = EditorState.create({
-      doc,
-      schema: activeSchema,
-      plugins: [
-        ...externalPlugins,
-        ...(manager?.getPlugins() ?? []),
-        styleResolverPlugin,
-      ],
-    });
+    const state = ensureParaIdsInState(
+      EditorState.create({
+        doc,
+        schema: activeSchema,
+        plugins,
+      }),
+    );
     recordHiddenEditorPhase(
       reason,
       "editor-state",
@@ -436,20 +465,14 @@ export function createHiddenEditorState(
     return state;
   }
 
-  // External plugins go first so they can intercept before extension keymaps
-  // (e.g. suggestion mode must handle Backspace/Delete before deleteSelection)
-  const plugins: Plugin[] = [
-    ...externalPlugins,
-    ...(manager?.getPlugins() ?? []),
-    styleResolverPlugin,
-  ];
-
   const startedAt = performance.now();
-  const state = EditorState.create({
-    doc: localDoc,
-    schema: activeSchema,
-    plugins,
-  });
+  const state = ensureParaIdsInState(
+    EditorState.create({
+      doc: localDoc,
+      schema: activeSchema,
+      plugins,
+    }),
+  );
   recordHiddenEditorPhase(
     reason,
     "editor-state",

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -201,6 +201,12 @@ import {
   prefersReducedMotionBehavior,
 } from "./scrollNavigation";
 import { computePerBlockMeasureInputs } from "./sectionBlockWidths";
+import {
+  DEFAULT_PAGE_HEIGHT_PX,
+  getMargins,
+  getPageSize,
+  twipsToPixels,
+} from "./sectionGeometry";
 import { SelectionOverlay } from "./SelectionOverlay";
 import { getTransactionDirtyRange } from "./transactionDirtyRange";
 import { useDragAutoScroll } from "./useDragAutoScroll";
@@ -413,18 +419,6 @@ type TextInputDispatchTarget<TView> = {
 // =============================================================================
 // CONSTANTS
 // =============================================================================
-
-// Default page size (US Letter at 96 DPI)
-const DEFAULT_PAGE_WIDTH = 816;
-const DEFAULT_PAGE_HEIGHT = 1056;
-
-// Default margins (1 inch at 96 DPI)
-const DEFAULT_MARGINS: PageMargins = {
-  top: 96,
-  right: 96,
-  bottom: 96,
-  left: 96,
-};
 
 export const DEFAULT_PAGE_GAP = 24;
 const COMMENTS_SIDEBAR_SCROLL_GUTTER = 304;
@@ -1632,63 +1626,6 @@ function getTableRowOffset(
     offsetY += (tMeasure as TableMeasure).rows[ri]?.height ?? 0;
   }
   return offsetY;
-}
-
-/**
- * Convert twips to pixels (1 twip = 1/20 point, 96 pixels per inch).
- */
-function twipsToPixels(twips: number): number {
-  return Math.round((twips / 1440) * 96);
-}
-
-/**
- * Extract page size from section properties or use defaults.
- */
-function getPageSize(sectionProps: SectionProperties | null | undefined): {
-  w: number;
-  h: number;
-} {
-  return {
-    w: sectionProps?.pageWidth
-      ? twipsToPixels(sectionProps.pageWidth)
-      : DEFAULT_PAGE_WIDTH,
-    h: sectionProps?.pageHeight
-      ? twipsToPixels(sectionProps.pageHeight)
-      : DEFAULT_PAGE_HEIGHT,
-  };
-}
-
-/**
- * Extract margins from section properties or use defaults.
- */
-function getMargins(
-  sectionProps: SectionProperties | null | undefined,
-): PageMargins {
-  const top = sectionProps?.marginTop
-    ? twipsToPixels(sectionProps.marginTop)
-    : DEFAULT_MARGINS.top;
-  const bottom = sectionProps?.marginBottom
-    ? twipsToPixels(sectionProps.marginBottom)
-    : DEFAULT_MARGINS.bottom;
-
-  return {
-    top,
-    right: sectionProps?.marginRight
-      ? twipsToPixels(sectionProps.marginRight)
-      : DEFAULT_MARGINS.right,
-    bottom,
-    left: sectionProps?.marginLeft
-      ? twipsToPixels(sectionProps.marginLeft)
-      : DEFAULT_MARGINS.left,
-    // Header/footer distances - where the header/footer content starts
-    // Default to 0.5 inch (48px at 96 DPI) if not specified
-    header: sectionProps?.headerDistance
-      ? twipsToPixels(sectionProps.headerDistance)
-      : 48,
-    footer: sectionProps?.footerDistance
-      ? twipsToPixels(sectionProps.footerDistance)
-      : 48,
-  };
 }
 
 function pageMarginsEqual(left: PageMargins, right: PageMargins): boolean {
@@ -6761,7 +6698,7 @@ export function PagedEditor(
   // Calculate total height for scroll
   const totalHeight = useMemo(() => {
     if (!layout) {
-      return DEFAULT_PAGE_HEIGHT + 48;
+      return DEFAULT_PAGE_HEIGHT_PX + 48;
     }
     const numPages = layout.pages.length;
     return numPages * pageSize.h + (numPages - 1) * pageGap + 48;

--- a/packages/folio/src/paged-editor/sectionGeometry.test.ts
+++ b/packages/folio/src/paged-editor/sectionGeometry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_BODY_MARGIN_PX,
+  DEFAULT_HEADER_FOOTER_DISTANCE_PX,
+  DEFAULT_PAGE_WIDTH_PX,
+  getMargins,
+  getPageSize,
+  twipsToPxOr,
+} from "./sectionGeometry";
+
+describe("paged editor section geometry", () => {
+  test("honors explicit zero body and header/footer margins", () => {
+    const margins = getMargins({
+      marginTop: 0,
+      marginRight: 0,
+      marginBottom: 0,
+      marginLeft: 0,
+      headerDistance: 0,
+      footerDistance: 0,
+    });
+
+    expect(margins).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      header: 0,
+      footer: 0,
+    });
+  });
+
+  test("defaults section offsets only when they are absent", () => {
+    const margins = getMargins(null);
+
+    expect(margins.top).toBe(DEFAULT_BODY_MARGIN_PX);
+    expect(margins.header).toBe(DEFAULT_HEADER_FOOTER_DISTANCE_PX);
+  });
+
+  test("keeps page size defensive: zero size falls back to Letter", () => {
+    expect(getPageSize({ pageWidth: 0, pageHeight: 0 }).w).toBe(
+      DEFAULT_PAGE_WIDTH_PX,
+    );
+  });
+
+  test("twipsToPxOr distinguishes explicit zero from absent offsets", () => {
+    expect(twipsToPxOr(0, 96)).toBe(0);
+    expect(twipsToPxOr(1440, 96)).toBe(96);
+    expect(twipsToPxOr(undefined, 96)).toBe(96);
+  });
+});

--- a/packages/folio/src/paged-editor/sectionGeometry.ts
+++ b/packages/folio/src/paged-editor/sectionGeometry.ts
@@ -1,0 +1,55 @@
+import type { PageMargins } from "../core/layout-engine/types";
+import type { SectionProperties } from "../core/types/document";
+
+export const DEFAULT_PAGE_WIDTH_PX = 816;
+export const DEFAULT_PAGE_HEIGHT_PX = 1056;
+export const DEFAULT_BODY_MARGIN_PX = 96;
+export const DEFAULT_HEADER_FOOTER_DISTANCE_PX = 48;
+
+const DEFAULT_MARGINS: PageMargins = {
+  top: DEFAULT_BODY_MARGIN_PX,
+  right: DEFAULT_BODY_MARGIN_PX,
+  bottom: DEFAULT_BODY_MARGIN_PX,
+  left: DEFAULT_BODY_MARGIN_PX,
+};
+
+export const twipsToPixels = (twips: number): number =>
+  Math.round((twips / 1440) * 96);
+
+/**
+ * Convert an offset-like twip dimension to px. Explicit 0 is meaningful for
+ * page margins and header/footer distances; only absence should use fallback.
+ */
+export const twipsToPxOr = (
+  twips: number | null | undefined,
+  fallbackPx: number,
+): number => (twips != null ? twipsToPixels(twips) : fallbackPx);
+
+export const getPageSize = (
+  sectionProps: SectionProperties | null | undefined,
+): { w: number; h: number } => ({
+  // Page size is defensive: a literal 0 is malformed and falls back to Letter.
+  w: sectionProps?.pageWidth
+    ? twipsToPixels(sectionProps.pageWidth)
+    : DEFAULT_PAGE_WIDTH_PX,
+  h: sectionProps?.pageHeight
+    ? twipsToPixels(sectionProps.pageHeight)
+    : DEFAULT_PAGE_HEIGHT_PX,
+});
+
+export const getMargins = (
+  sectionProps: SectionProperties | null | undefined,
+): PageMargins => ({
+  top: twipsToPxOr(sectionProps?.marginTop, DEFAULT_MARGINS.top),
+  right: twipsToPxOr(sectionProps?.marginRight, DEFAULT_MARGINS.right),
+  bottom: twipsToPxOr(sectionProps?.marginBottom, DEFAULT_MARGINS.bottom),
+  left: twipsToPxOr(sectionProps?.marginLeft, DEFAULT_MARGINS.left),
+  header: twipsToPxOr(
+    sectionProps?.headerDistance,
+    DEFAULT_HEADER_FOOTER_DISTANCE_PX,
+  ),
+  footer: twipsToPxOr(
+    sectionProps?.footerDistance,
+    DEFAULT_HEADER_FOOTER_DISTANCE_PX,
+  ),
+});


### PR DESCRIPTION
## What changed

Syncs the latest applicable upstream `eigenpal/docx-editor` fixes into Folio:

- allocate missing paragraph IDs on initial editor state, including hidden header/footer editors
- preserve explicit zero section margins and header/footer distances
- preserve explicit zero image wrap distances through DOCX-to-ProseMirror conversion
- size the DOM caret from the collapsed range at the cursor, with line-height fallback

Vue-only upstream changes, release metadata, CLA metadata, and CI/dependency metadata were not ported.

## Validation

- `bun test packages/folio/src/paged-editor/sectionGeometry.test.ts packages/folio/src/core/prosemirror/conversion/image-wrap-distance-zero.test.ts packages/folio/src/core/layout-bridge/clickToPositionDom-caret-height.test.ts packages/folio/src/core/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts`
- `bun --filter @stll/folio lint`
- `bun --filter @stll/folio typecheck`
- `git diff --check`

Pre-push full affected typecheck is currently blocked by unrelated `@stll/web` TanStack table type errors outside this folio diff; `@stll/folio` typecheck passes.
