### PR TITLE
fix(ci): retry transient dependency install failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed-files.outputs.package_checks_required == 'true'
-        # Transient registry/tarball errors fail the whole run from its
-        # first step; retry once before treating the install as broken.
-        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
           # .npmrc references NPM_TOKEN, but PR installs must not expose
           # the real npm token to dependency lifecycle scripts.
@@ -256,6 +254,9 @@ jobs:
       - name: Test release-channel script
         run: bash scripts/release-channel.test.sh
 
+      - name: Test bun ci retry script
+        run: bash scripts/bun-ci-retry.test.sh
+
       # Fail PRs that change the desktop bridge surface without
       # bumping BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs.
       # See scripts/check-bridge-version.sh for rationale.
@@ -320,9 +321,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.run == 'true'
-        # Transient registry/tarball errors fail the whole run from its
-        # first step; retry once before treating the install as broken.
-        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
           # .npmrc references NPM_TOKEN, but PR installs must not expose
           # the secret to install-time lifecycle scripts. The token is
@@ -433,9 +432,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.run == 'true'
-        # Transient registry/tarball errors fail the whole run from its
-        # first step; retry once before treating the install as broken.
-        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
           # .npmrc references NPM_TOKEN, but PR installs must not expose
           # the real npm token to dependency lifecycle scripts.
@@ -502,9 +499,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.run == 'true'
-        # Transient registry/tarball errors fail the whole run from its
-        # first step; retry once before treating the install as broken.
-        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
           NPM_TOKEN: ""
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed-files.outputs.package_checks_required == 'true'
-        run: bun ci --ignore-scripts
+        # Transient registry/tarball errors fail the whole run from its
+        # first step; retry once before treating the install as broken.
+        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
         env:
           # .npmrc references NPM_TOKEN, but PR installs must not expose
           # the real npm token to dependency lifecycle scripts.
@@ -318,7 +320,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.run == 'true'
-        run: bun ci --ignore-scripts
+        # Transient registry/tarball errors fail the whole run from its
+        # first step; retry once before treating the install as broken.
+        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
         env:
           # .npmrc references NPM_TOKEN, but PR installs must not expose
           # the secret to install-time lifecycle scripts. The token is
@@ -429,7 +433,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.run == 'true'
-        run: bun ci --ignore-scripts
+        # Transient registry/tarball errors fail the whole run from its
+        # first step; retry once before treating the install as broken.
+        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
         env:
           # .npmrc references NPM_TOKEN, but PR installs must not expose
           # the real npm token to dependency lifecycle scripts.
@@ -496,7 +502,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.run == 'true'
-        run: bun ci --ignore-scripts
+        # Transient registry/tarball errors fail the whole run from its
+        # first step; retry once before treating the install as broken.
+        run: bun ci --ignore-scripts || (sleep 10 && bun ci --ignore-scripts)
         env:
           NPM_TOKEN: ""
 

--- a/scripts/bun-ci-retry.sh
+++ b/scripts/bun-ci-retry.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+attempts="${BUN_CI_ATTEMPTS:-2}"
+delay_seconds="${BUN_CI_RETRY_DELAY_SECONDS:-10}"
+
+if [[ ! "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "BUN_CI_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+
+if [[ ! "$delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "BUN_CI_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+  if bun ci "$@"; then
+    exit 0
+  else
+    status=$?
+  fi
+
+  if ((attempt == attempts)); then
+    exit "$status"
+  fi
+
+  echo "::warning::bun ci failed on attempt $attempt/$attempts; retrying in ${delay_seconds}s"
+  sleep "$delay_seconds"
+done

--- a/scripts/bun-ci-retry.test.sh
+++ b/scripts/bun-ci-retry.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/bun-ci-retry.sh"
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+setup_case() {
+  dir=$(mktemp -d)
+  mkdir -p "$dir/bin"
+  cat > "$dir/bin/bun" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+count_file="${FAKE_BUN_COUNT_FILE:?}"
+args_file="${FAKE_BUN_ARGS_FILE:?}"
+succeed_on="${FAKE_BUN_SUCCEED_ON:-1}"
+failure_status="${FAKE_BUN_FAILURE_STATUS:-7}"
+
+count=0
+if [[ -f "$count_file" ]]; then
+  count=$(<"$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+printf '%s\n' "$*" >> "$args_file"
+
+if [[ "$1" != "ci" ]]; then
+  echo "expected bun ci" >&2
+  exit 64
+fi
+
+if ((count >= succeed_on)); then
+  exit 0
+fi
+
+exit "$failure_status"
+EOF
+  chmod +x "$dir/bin/bun"
+
+  cat > "$dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "${FAKE_SLEEP_ARGS_FILE:?}"
+EOF
+  chmod +x "$dir/bin/sleep"
+
+  export FAKE_BUN_COUNT_FILE="$dir/bun-count"
+  export FAKE_BUN_ARGS_FILE="$dir/bun-args"
+  export FAKE_SLEEP_ARGS_FILE="$dir/sleep-args"
+}
+
+teardown_case() {
+  cd /
+  rm -rf "$dir"
+  unset dir
+  unset FAKE_BUN_COUNT_FILE FAKE_BUN_ARGS_FILE FAKE_SLEEP_ARGS_FILE
+  unset FAKE_BUN_SUCCEED_ON FAKE_BUN_FAILURE_STATUS
+  unset BUN_CI_ATTEMPTS BUN_CI_RETRY_DELAY_SECONDS
+}
+
+run_case() {
+  local name="$1" expected_exit="$2"
+  shift 2
+
+  setup_case
+  local output actual
+  output=$(PATH="$dir/bin:$PATH" "$@" 2>&1) && actual=0 || actual=$?
+
+  if [[ "$actual" == "$expected_exit" ]]; then
+    PASS=$((PASS + 1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+    printf '  FAIL  %s (expected exit %s, got %s)\n' "$name" "$expected_exit" "$actual"
+    printf '     output:\n'
+    printf '       %s\n' "${output//$'\n'/$'\n       '}"
+  fi
+
+  teardown_case
+}
+
+assert_file() {
+  local name="$1" file="$2" expected="$3"
+  local actual
+
+  if [[ -f "$file" ]]; then
+    actual=$(<"$file")
+  else
+    actual=""
+  fi
+
+  if [[ "$actual" == "$expected" ]]; then
+    PASS=$((PASS + 1))
+    printf '  PASS  %s\n' "$name"
+    return
+  fi
+
+  FAIL=$((FAIL + 1))
+  FAIL_NAMES+=("$name")
+  printf '  FAIL  %s (expected %q, got %q)\n' "$name" "$expected" "$actual"
+}
+
+echo "Running bun-ci-retry.sh tests..."
+
+setup_case
+PATH="$dir/bin:$PATH" bash "$SCRIPT" --ignore-scripts
+assert_file "passes arguments to bun ci" "$FAKE_BUN_ARGS_FILE" "ci --ignore-scripts"
+assert_file "does not sleep after first-attempt success" "$FAKE_SLEEP_ARGS_FILE" ""
+teardown_case
+
+setup_case
+export FAKE_BUN_SUCCEED_ON=2
+PATH="$dir/bin:$PATH" BUN_CI_RETRY_DELAY_SECONDS=0 bash "$SCRIPT" --ignore-scripts
+assert_file "retries once after transient failure" "$FAKE_BUN_COUNT_FILE" "2"
+assert_file "sleeps between attempts" "$FAKE_SLEEP_ARGS_FILE" "0"
+teardown_case
+
+setup_case
+export FAKE_BUN_SUCCEED_ON=99
+export FAKE_BUN_FAILURE_STATUS=23
+PATH="$dir/bin:$PATH" BUN_CI_RETRY_DELAY_SECONDS=0 bash "$SCRIPT" --ignore-scripts \
+  && actual=0 || actual=$?
+if [[ "$actual" == "23" ]]; then
+  PASS=$((PASS + 1))
+  printf '  PASS  preserves final bun failure status\n'
+else
+  FAIL=$((FAIL + 1))
+  FAIL_NAMES+=("preserves final bun failure status")
+  printf '  FAIL  preserves final bun failure status (got %s)\n' "$actual"
+fi
+assert_file "stops after configured attempts" "$FAKE_BUN_COUNT_FILE" "2"
+teardown_case
+
+run_case "rejects invalid attempts" 2 env BUN_CI_ATTEMPTS=0 bash "$SCRIPT"
+run_case "rejects invalid delay" 2 env BUN_CI_RETRY_DELAY_SECONDS=soon bash "$SCRIPT"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -ne 0 ]]; then
+  printf 'Failed cases:\n'
+  printf '  - %s\n' "${FAIL_NAMES[@]}"
+  exit 1
+fi


### PR DESCRIPTION
Dependency installation is the first step of every CI job, so a transient registry or tarball-extraction error fails the entire run before any code is exercised. Retry the install once after a short delay in the four jobs that run `bun ci --ignore-scripts`; persistent failures still surface on the second attempt.

Scoped deliberately to the install step rather than a workflow-level auto re-run: step retries absorb only the transient class, keep real failures fast, and do not hide flake frequency.

CC on behalf of @jan-kubica