### PR TITLE
fix: replace type suppression boundaries

### DIFF
--- a/apps/api/scripts/benchmark-chat-read-surface.ts
+++ b/apps/api/scripts/benchmark-chat-read-surface.ts
@@ -545,7 +545,6 @@ const buildOldTools = (trace: BenchTrace) => ({
         name: v.optional(v.string()),
       }),
     ),
-    // eslint-disable-next-line require-await
     execute: async ({ name }) => {
       const input = { name };
       addTrace({
@@ -555,16 +554,16 @@ const buildOldTools = (trace: BenchTrace) => ({
       });
 
       if (name) {
-        return {
+        return await Promise.resolve({
           function: `${name} returns { items } or { items, hasMore, nextOffset }.`,
-        };
+        });
       }
 
-      return {
+      return await Promise.resolve({
         functions: readCatalog.map((entry) =>
           entry.replace("read.", "stella."),
         ),
-      };
+      });
     },
   }),
   "execute-typescript": tool({
@@ -575,7 +574,6 @@ const buildOldTools = (trace: BenchTrace) => ({
         code: v.string(),
       }),
     ),
-    // eslint-disable-next-line require-await
     execute: async ({ code }) => {
       const output = simulateSandbox({
         code,
@@ -589,7 +587,7 @@ const buildOldTools = (trace: BenchTrace) => ({
         name: "execute-typescript",
         trace,
       });
-      return output;
+      return await Promise.resolve(output);
     },
   }),
   "read-contact": tool({
@@ -599,7 +597,6 @@ const buildOldTools = (trace: BenchTrace) => ({
         contactRef: v.string(),
       }),
     ),
-    // eslint-disable-next-line require-await
     execute: async ({ contactRef }) => {
       const input = { contactRef };
       const contact = contactItems.find(
@@ -612,7 +609,7 @@ const buildOldTools = (trace: BenchTrace) => ({
         name: "read-contact",
         trace,
       });
-      return contact ?? { error };
+      return await Promise.resolve(contact ?? { error });
     },
   }),
   "read-content-across-matters": tool({
@@ -623,7 +620,6 @@ const buildOldTools = (trace: BenchTrace) => ({
         entityRefs: v.array(v.string()),
       }),
     ),
-    // eslint-disable-next-line require-await
     execute: async ({ entityRefs }) => {
       const input = { entityRefs };
       const contents = contentItems.filter((item) =>
@@ -634,9 +630,9 @@ const buildOldTools = (trace: BenchTrace) => ({
         name: "read-content-across-matters",
         trace,
       });
-      return {
+      return await Promise.resolve({
         contents,
-      };
+      });
     },
   }),
   "search-across-matters": tool({
@@ -647,7 +643,6 @@ const buildOldTools = (trace: BenchTrace) => ({
         query: v.string(),
       }),
     ),
-    // eslint-disable-next-line require-await
     execute: async ({ query }) => {
       const input = { query };
       const normalizedQuery = query.toLowerCase();
@@ -659,9 +654,9 @@ const buildOldTools = (trace: BenchTrace) => ({
         name: "search-across-matters",
         trace,
       });
-      return {
+      return await Promise.resolve({
         hits,
-      };
+      });
     },
   }),
 });
@@ -682,7 +677,6 @@ const buildNewTools = ({
           code: v.string(),
         }),
       ),
-      // eslint-disable-next-line require-await
       execute: async ({ code }) => {
         const output = simulateSandbox({
           code,
@@ -696,7 +690,7 @@ const buildNewTools = ({
           name: "run-stella-query",
           trace,
         });
-        return output;
+        return await Promise.resolve(output);
       },
     }),
   };
@@ -714,7 +708,6 @@ const buildNewTools = ({
           name: v.optional(v.string()),
         }),
       ),
-      // eslint-disable-next-line require-await
       execute: async ({ name }) => {
         const input = { name };
         addTrace({
@@ -724,16 +717,16 @@ const buildNewTools = ({
         });
 
         if (name) {
-          return {
+          return await Promise.resolve({
             function: readCatalog.find((entry) =>
               entry.startsWith(`read.${name}`),
             ),
-          };
+          });
         }
 
-        return {
+        return await Promise.resolve({
           functions: readCatalog,
-        };
+        });
       },
     }),
     ...runner,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -520,12 +520,11 @@ export const czRegionalAdapter: SourceAdapter = {
   // tight for large pages with slow upstream responses.
   pageTimeoutMs: 100_000,
 
-  // eslint-disable-next-line require-await -- interface requires Promise
   async getTotalCount(_signal) {
     // The rozhodnuti.justice.cz API is date-based with no
     // single total count endpoint. There is no efficient way
     // to get the total without crawling all dates.
-    return null;
+    return await Promise.resolve(null);
   },
 
   async fetchPage(cursor, _config, signal) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -314,9 +314,8 @@ export const czUsAdapter: SourceAdapter = {
   // return search results. A GET to the search page returns
   // the form but no count. Implement POST-based total count
   // when we add full ÚS historical ingestion.
-  // eslint-disable-next-line require-await -- interface requires Promise
   async getTotalCount(_signal) {
-    return null;
+    return await Promise.resolve(null);
   },
 
   async fetchPage(cursor, _config, signal) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script */
 /**
  * Adapter health checks.
  *
@@ -22,6 +21,10 @@ import {
   ADAPTER_MODULES,
   loadAdapterByKey,
 } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry-lazy";
+
+const writeStdoutLine = (message = ""): void => {
+  process.stdout.write(`${message}\n`);
+};
 
 type LoadResult =
   | { adapter: SourceAdapter; key: string }
@@ -273,9 +276,10 @@ export const formatHealthReport = (
 
 // Run as standalone script
 if (import.meta.main) {
-  console.log("Running adapter health checks...\n");
+  writeStdoutLine("Running adapter health checks...");
+  writeStdoutLine();
   const results = await checkAllAdapters();
-  console.log(formatHealthReport(results));
+  writeStdoutLine(formatHealthReport(results));
   const failed = results.filter(
     (r) => r.status === "down" || r.status === "degraded",
   );

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -443,9 +443,8 @@ export const skUsAdapter: SourceAdapter = {
   pageTimeoutMs: 120_000,
   maxSyncPages: 10,
 
-  // eslint-disable-next-line require-await -- no async work needed
   async getTotalCount(_signal) {
-    return null;
+    return await Promise.resolve(null);
   },
 
   async fetchPage(cursor, _config, signal) {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script */
 /**
  * Update adapter test fixtures from live APIs.
  *
@@ -19,6 +18,14 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry-lazy";
 
 const FIXTURES_DIR = new URL("__fixtures__/", import.meta.url);
+
+const writeStdoutLine = (message = ""): void => {
+  process.stdout.write(`${message}\n`);
+};
+
+const writeStderrLine = (message = ""): void => {
+  process.stderr.write(`${message}\n`);
+};
 
 type FixtureRecord = {
   /** Adapter key. */
@@ -89,8 +96,8 @@ if (import.meta.main) {
   const allKeys = listAdapterKeys();
 
   if (adapterFlag !== -1 && !rawTarget) {
-    console.error("--adapter requires a value");
-    console.error("Available:", allKeys.join(", "));
+    writeStderrLine("--adapter requires a value");
+    writeStderrLine(`Available: ${allKeys.join(", ")}`);
     process.exit(1);
   }
 
@@ -100,16 +107,17 @@ if (import.meta.main) {
     : allKeys;
 
   if (keysToUpdate.length === 0) {
-    console.error(
+    writeStderrLine(
       targetAdapter
         ? `Unknown adapter: ${targetAdapter}`
         : "No adapters registered",
     );
-    console.error("Available:", allKeys.join(", "));
+    writeStderrLine(`Available: ${allKeys.join(", ")}`);
     process.exit(1);
   }
 
-  console.log(`Updating fixtures for ${keysToUpdate.length} adapter(s)...\n`);
+  writeStdoutLine(`Updating fixtures for ${keysToUpdate.length} adapter(s)...`);
+  writeStdoutLine();
 
   let failures = 0;
   for (const [i, key] of keysToUpdate.entries()) {
@@ -117,10 +125,10 @@ if (import.meta.main) {
     const result = await updateAdapter(key);
 
     if ("error" in result) {
-      console.log(`FAILED: ${result.error}`);
+      writeStdoutLine(`FAILED: ${result.error}`);
       failures++;
     } else {
-      console.log(`OK (${result.count} decisions → ${result.filename})`);
+      writeStdoutLine(`OK (${result.count} decisions → ${result.filename})`);
     }
 
     // Rate limit between adapters
@@ -129,7 +137,7 @@ if (import.meta.main) {
     }
   }
 
-  console.log(
+  writeStdoutLine(
     `\n${keysToUpdate.length - failures}/${keysToUpdate.length} updated`,
   );
   if (failures > 0) {

--- a/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.ts
@@ -122,19 +122,18 @@ export const createChatExecutionTools = ({
           ),
         }),
       ),
-      // eslint-disable-next-line require-await
       execute: async ({ name }) => {
         if (name === undefined) {
           const manifest = buildReadonlyFunctionManifest(
             readonlyFunctionContracts,
           ).unwrap();
-          return {
+          return await Promise.resolve({
             functions: manifest.map((entry) => ({
               name: entry.name,
               summary: entry.summary,
               outputShape: entry.outputShape,
             })),
-          };
+          });
         }
 
         const manifestEntry = findReadonlyFunctionManifestEntry({
@@ -148,9 +147,9 @@ export const createChatExecutionTools = ({
           });
         }
 
-        return {
+        return await Promise.resolve({
           function: manifestEntry,
-        };
+        });
       },
     }),
 

--- a/apps/api/src/handlers/hosted-usage-webhook/receive.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/receive.ts
@@ -47,6 +47,7 @@ import {
   runWebhookTransaction,
   updateWebhookEventResultInTx,
 } from "@/api/lib/hosted-usage-provider/webhook-store";
+import { isRecord } from "@/api/lib/type-guards";
 
 export const HOSTED_USAGE_WEBHOOK_HEADERS = {
   id: "webhook-id",
@@ -118,12 +119,10 @@ export const receiveHostedUsageWebhook = async (
     return respond(400, "Missing webhook-id");
   }
 
-  // SAFETY: envelope validation above accepted parsedJson, which
-  // requires `type: string` — that only matches a plain JSON
-  // object, not an array or primitive. The cast is sound after
-  // validation.
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  const payload = parsedJson as Record<string, unknown>;
+  if (!isRecord(parsedJson)) {
+    return respond(400, "Malformed payload");
+  }
+  const payload = parsedJson;
 
   // Validate the strict schema for the events we actually handle
   // BEFORE opening a transaction. Unknown event types are recorded

--- a/apps/api/src/handlers/search/ai.test.ts
+++ b/apps/api/src/handlers/search/ai.test.ts
@@ -25,16 +25,14 @@ const searchGlobalMock = mock();
 
 // The fire-and-forget chat reindex hook touches rootDb; stub it so the
 // summary-chat tests do not need a live database for the side effect.
-// eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
-mock.module("@/api/lib/search/index-chat", () => ({
+void mock.module("@/api/lib/search/index-chat", () => ({
   upsertChatThreadSearchDocument: mock(async () => undefined),
   backfillChatThreadSearchIndex: mock(async () => 0),
 }));
 
 // Mock index-global directly to prevent transitive db/root imports that
 // require a live database connection and cause flaky failures in CI.
-// eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
-mock.module("@/api/lib/search/index-global", () => ({
+void mock.module("@/api/lib/search/index-global", () => ({
   rebuildSupplementalSearchIndex: mock(async () => undefined),
   reindexWorkspacesForContact: mock(async () => undefined),
   searchGlobal: searchGlobalMock,

--- a/apps/api/src/handlers/templates/fill.ts
+++ b/apps/api/src/handlers/templates/fill.ts
@@ -127,10 +127,7 @@ export const fillHandler = async ({
       structureErrors:
         result.structureErrors.length > 0 ? result.structureErrors : null,
     });
-  })
-    // TODO: fix this
-    // oxlint-disable-next-line no-empty-function
-    .catch(() => {});
+  }).catch(() => undefined);
 
   // PDF conversion via Gotenberg
   if (format === "pdf") {

--- a/apps/api/src/lib/analytics/noop.ts
+++ b/apps/api/src/lib/analytics/noop.ts
@@ -1,9 +1,7 @@
 import type { Analytics } from "@/api/lib/analytics/types";
 
-// eslint-disable-next-line no-empty-function
-const noop = () => {};
-// eslint-disable-next-line no-empty-function
-const asyncNoop = async () => {};
+const noop = () => undefined;
+const asyncNoop = async () => await Promise.resolve();
 
 export const noopAnalytics: Analytics = {
   capture: noop,

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -241,7 +241,6 @@ const createAuth = () => {
     databaseHooks: {
       user: {
         create: {
-          // eslint-disable-next-line require-await -- async required by better-auth hook type
           before: async (user) => {
             validateTimezoneId(user["timezoneId"]);
             // Email-OTP and some social providers leave `name` blank.
@@ -251,15 +250,14 @@ const createAuth = () => {
             // Then trim `preferredName` / `wordEditShortcut` (Word author /
             // initials prefs) before persisting.
             const data = normalizeUserPreferences(ensureDisplayName(user));
-            return { data };
+            return await Promise.resolve({ data });
           },
         },
         update: {
-          // eslint-disable-next-line require-await -- async required by better-auth hook type
           before: async (user) => {
             validateTimezoneId(user["timezoneId"]);
             const data = normalizeUserPreferences(ensureDisplayName(user));
-            return { data };
+            return await Promise.resolve({ data });
           },
         },
       },

--- a/apps/api/src/lib/file-scan/scanner.ts
+++ b/apps/api/src/lib/file-scan/scanner.ts
@@ -46,97 +46,98 @@ type ZipBombGuardOptions = {
 const LOCAL_FILE_HEADER = 0x04_03_4b_50;
 
 export const createZipBombGuard = (opts: ZipBombGuardOptions): Scanner => ({
-  // eslint-disable-next-line require-await -- Scanner interface requires Promise
-  async scan(bytes) {
-    if (bytes.length < 4) {
-      return [];
-    }
-
-    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-
-    if (view.getUint32(0, true) !== LOCAL_FILE_HEADER) {
-      return [];
-    }
-
-    let offset = 0;
-    let entryCount = 0;
-    let totalUncompressed = 0;
-
-    while (
-      offset + 30 <= bytes.length &&
-      view.getUint32(offset, true) === LOCAL_FILE_HEADER
-    ) {
-      entryCount++;
-
-      if (entryCount > opts.maxEntries) {
-        return [
-          {
-            rule: "zip-bomb-entries",
-            severity: "critical" as const,
-            meta: {
-              description: `ZIP contains more than ${opts.maxEntries} entries`,
-            },
-          },
-        ];
-      }
-
-      const flags = view.getUint16(offset + 6, true);
-      const compressedSize = view.getUint32(offset + 18, true);
-      const uncompressedSize = view.getUint32(offset + 22, true);
-      const fileNameLen = view.getUint16(offset + 26, true);
-      const extraLen = view.getUint16(offset + 28, true);
-
-      // Bit 3: sizes are in a data descriptor after the file data, not in the
-      // header. We cannot reliably advance past the entry, so flag it rather
-      // than silently skipping.
-      // eslint-disable-next-line no-bitwise -- ZIP flag check
-      if ((flags & 0x00_08) !== 0 && compressedSize === 0) {
-        return [
-          {
-            rule: "zip-data-descriptor",
-            severity: "suspicious" as const,
-            meta: {
-              description:
-                "ZIP entry uses a data descriptor; header sizes are zero. " +
-                "Cannot verify compression ratio or total size.",
-            },
-          },
-        ];
-      }
-
-      totalUncompressed += uncompressedSize;
-
-      if (
-        compressedSize > 0 &&
-        uncompressedSize / compressedSize > opts.maxCompressionRatio
-      ) {
-        return [
-          {
-            rule: "zip-bomb-ratio",
-            severity: "critical" as const,
-            meta: {
-              description: `Entry has compression ratio ${(uncompressedSize / compressedSize).toFixed(0)}:1 (limit: ${opts.maxCompressionRatio}:1)`,
-            },
-          },
-        ];
-      }
-
-      if (totalUncompressed > opts.maxTotalUncompressedBytes) {
-        return [
-          {
-            rule: "zip-bomb-size",
-            severity: "critical" as const,
-            meta: {
-              description: `Total uncompressed size exceeds limit of ${opts.maxTotalUncompressedBytes} bytes`,
-            },
-          },
-        ];
-      }
-
-      // Skip past header (30 bytes) + filename + extra + compressed data
-      offset += 30 + fileNameLen + extraLen + compressedSize;
-    }
-
-    return [];
-  },
+  scan: async (bytes) => await Promise.resolve(scanZipBomb(bytes, opts)),
 });
+
+const scanZipBomb = (bytes: Uint8Array, opts: ZipBombGuardOptions): Match[] => {
+  if (bytes.length < 4) {
+    return [];
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  if (view.getUint32(0, true) !== LOCAL_FILE_HEADER) {
+    return [];
+  }
+
+  let offset = 0;
+  let entryCount = 0;
+  let totalUncompressed = 0;
+
+  while (
+    offset + 30 <= bytes.length &&
+    view.getUint32(offset, true) === LOCAL_FILE_HEADER
+  ) {
+    entryCount++;
+
+    if (entryCount > opts.maxEntries) {
+      return [
+        {
+          rule: "zip-bomb-entries",
+          severity: "critical" as const,
+          meta: {
+            description: `ZIP contains more than ${opts.maxEntries} entries`,
+          },
+        },
+      ];
+    }
+
+    const flags = view.getUint16(offset + 6, true);
+    const compressedSize = view.getUint32(offset + 18, true);
+    const uncompressedSize = view.getUint32(offset + 22, true);
+    const fileNameLen = view.getUint16(offset + 26, true);
+    const extraLen = view.getUint16(offset + 28, true);
+
+    // Bit 3: sizes are in a data descriptor after the file data, not in the
+    // header. We cannot reliably advance past the entry, so flag it rather
+    // than silently skipping.
+    // eslint-disable-next-line no-bitwise -- ZIP flag check
+    if ((flags & 0x00_08) !== 0 && compressedSize === 0) {
+      return [
+        {
+          rule: "zip-data-descriptor",
+          severity: "suspicious" as const,
+          meta: {
+            description:
+              "ZIP entry uses a data descriptor; header sizes are zero. " +
+              "Cannot verify compression ratio or total size.",
+          },
+        },
+      ];
+    }
+
+    totalUncompressed += uncompressedSize;
+
+    if (
+      compressedSize > 0 &&
+      uncompressedSize / compressedSize > opts.maxCompressionRatio
+    ) {
+      return [
+        {
+          rule: "zip-bomb-ratio",
+          severity: "critical" as const,
+          meta: {
+            description: `Entry has compression ratio ${(uncompressedSize / compressedSize).toFixed(0)}:1 (limit: ${opts.maxCompressionRatio}:1)`,
+          },
+        },
+      ];
+    }
+
+    if (totalUncompressed > opts.maxTotalUncompressedBytes) {
+      return [
+        {
+          rule: "zip-bomb-size",
+          severity: "critical" as const,
+          meta: {
+            description: `Total uncompressed size exceeds limit of ${opts.maxTotalUncompressedBytes} bytes`,
+          },
+        },
+      ];
+    }
+
+    // Skip past header (30 bytes) + filename + extra + compressed data
+    offset += 30 + fileNameLen + extraLen + compressedSize;
+  }
+
+  return [];
+};

--- a/apps/api/src/lib/file-scan/yara.ts
+++ b/apps/api/src/lib/file-scan/yara.ts
@@ -20,27 +20,28 @@ const YARA_SEVERITY_MAP: Record<string, Match["severity"]> = {
 };
 
 export const yaraScanner: Scanner = {
-  // eslint-disable-next-line require-await -- Scanner interface requires Promise
   async scan(bytes) {
     const matches = compiled.scan(Buffer.from(bytes));
 
-    return matches.map((m: RuleMatch): Match => {
-      const { meta } = m;
-      const verdict =
-        "verdict" in meta && typeof meta.verdict === "string"
-          ? meta.verdict
-          : undefined;
+    return await Promise.resolve(
+      matches.map((m: RuleMatch): Match => {
+        const { meta } = m;
+        const verdict =
+          "verdict" in meta && typeof meta.verdict === "string"
+            ? meta.verdict
+            : undefined;
 
-      const severity =
-        (verdict ? YARA_SEVERITY_MAP[verdict] : undefined) ?? "suspicious";
-      const match: Match = {
-        rule: m.ruleIdentifier,
-        severity,
-      };
-      if (isRecord(meta)) {
-        match.meta = meta;
-      }
-      return match;
-    });
+        const severity =
+          (verdict ? YARA_SEVERITY_MAP[verdict] : undefined) ?? "suspicious";
+        const match: Match = {
+          rule: m.ruleIdentifier,
+          severity,
+        };
+        if (isRecord(meta)) {
+          match.meta = meta;
+        }
+        return match;
+      }),
+    );
   },
 };

--- a/apps/api/src/tests/load/upload-load.ts
+++ b/apps/api/src/tests/load/upload-load.ts
@@ -205,8 +205,7 @@ const runPool = async <T>(
 
   const workers = Array.from(
     { length: Math.min(concurrency, tasks.length) },
-    // eslint-disable-next-line require-await
-    async () => worker(),
+    async () => await worker(),
   );
   await Promise.all(workers);
   return results;
@@ -318,10 +317,15 @@ const main = async () => {
 
   // Build task list
   const tasks = files.map(
-    (file, i) =>
-      // eslint-disable-next-line require-await
-      async () =>
-        uploadFile(file, i, args.baseUrl, args.workspaceId, propertyId, cookie),
+    (file, i) => async () =>
+      await uploadFile(
+        file,
+        i,
+        args.baseUrl,
+        args.workspaceId,
+        propertyId,
+        cookie,
+      ),
   );
 
   // Run

--- a/apps/api/src/tests/security/rls-fixture.ts
+++ b/apps/api/src/tests/security/rls-fixture.ts
@@ -41,13 +41,12 @@ const initFixture = async (): Promise<RlsFixture> => {
  * created on first call; subsequent calls await the same
  * promise.
  */
-// eslint-disable-next-line require-await
 export const getRlsFixture = async (): Promise<RlsFixture> => {
   refCount++;
 
   fixturePromise ??= initFixture();
 
-  return fixturePromise;
+  return await fixturePromise;
 };
 
 /**

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -178,13 +178,12 @@ let dbRefCount = 0;
  * is created on first call; subsequent calls await the
  * same promise.
  */
-// eslint-disable-next-line require-await
 export const getTestDb = async (): Promise<TestDatabase> => {
   dbRefCount++;
 
   dbPromise ??= createTestDb();
 
-  return dbPromise;
+  return await dbPromise;
 };
 
 /**

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -113,7 +113,7 @@ impl Default for DesktopUpdateSnapshot {
 /// new bridge endpoint or backwards-compatible field is added so
 /// the web side can gate features on `snapshot.bridgeVersion >= N`
 /// without coupling to the desktop's literal app version.
-pub const BRIDGE_VERSION: u32 = 3;
+pub const BRIDGE_VERSION: u32 = 4;
 
 /// Feature flags advertised to the web app. Add a string here
 /// whenever a new capability lands on the bridge so the web app

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -109,24 +109,23 @@ export type OpenDocxResponse = {
   sessionId: string;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
 export const isAppSnapshot = (value: unknown): value is AppSnapshot => {
-  if (typeof value !== "object" || value === null) {
+  if (!isRecord(value)) {
     return false;
   }
-
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  const record = value as Record<string, unknown>;
-
   return (
-    typeof record["bridgePort"] === "number" &&
-    typeof record["bridgeVersion"] === "number" &&
-    Array.isArray(record["capabilities"]) &&
-    (record["capabilities"] as unknown[]).every((c) => typeof c === "string") &&
-    typeof record["runningSince"] === "string" &&
-    Array.isArray(record["sessions"]) &&
-    typeof record["notificationPreferences"] === "object" &&
-    record["notificationPreferences"] !== null &&
-    typeof record["update"] === "object" &&
-    record["update"] !== null
+    typeof value["bridgePort"] === "number" &&
+    typeof value["bridgeVersion"] === "number" &&
+    isStringArray(value["capabilities"]) &&
+    typeof value["runningSince"] === "string" &&
+    Array.isArray(value["sessions"]) &&
+    isRecord(value["notificationPreferences"]) &&
+    isRecord(value["update"])
   );
 };

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -134,16 +134,16 @@ const MAX_CONCURRENT_DB_WRITES = Math.max(
 let activeDbSlots = 0;
 const dbSlotQueue: (() => void)[] = [];
 
-// eslint-disable-next-line require-await -- returns Promise on queued path
 const acquireDbSlot = async (signal?: AbortSignal): Promise<void> => {
   if (signal?.aborted) {
     throw new DOMException("DB slot acquisition aborted", "AbortError");
   }
   if (activeDbSlots < MAX_CONCURRENT_DB_WRITES) {
     activeDbSlots++;
+    await Promise.resolve();
     return;
   }
-  return new Promise<void>((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const entry = () => {
       signal?.removeEventListener("abort", onAbort);
       activeDbSlots++;

--- a/apps/web/src/components/auth/sign-in-panel.tsx
+++ b/apps/web/src/components/auth/sign-in-panel.tsx
@@ -228,8 +228,7 @@ export function SignInPanel({
         errors={formErrors}
         onSubmit={(e) => {
           e.preventDefault();
-          // eslint-disable-next-line typescript/no-floating-promises
-          form.handleSubmit();
+          void form.handleSubmit();
         }}
       >
         <form.Field name="email">

--- a/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useId, useMemo } from "react";
 
 import { Link, useMatches } from "@tanstack/react-router";
-import type { ResolveParams } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import {
@@ -22,44 +21,60 @@ const PATH_SEPARATOR = "|";
 
 const serializeKey = (paths: readonly RouterFullPath[]) =>
   paths.join(PATH_SEPARATOR);
-// SAFETY: key comes from breadcrumbMap keys built from RouterFullPath[]
-const deserializeKey = (key: string) =>
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  key.split(PATH_SEPARATOR) as RouterFullPath[];
 
 type BreadcrumbEntry =
   | React.JSX.Element
-  | ((params: ResolveParams<RouterFullPath>) => React.ReactNode);
+  | ((params: Record<string, string | undefined>) => React.ReactNode);
+
+type BreadcrumbDefinition = {
+  key: string;
+  paths: readonly RouterFullPath[];
+  entry: BreadcrumbEntry;
+};
 
 const renderPdfBreadcrumb = () => <PdfBreadcrumb />;
 
-const renderWorkspaceBreadcrumb = (params: ResolveParams<RouterFullPath>) => (
-  <WorkspaceBreadcrumb
-    // SAFETY: this renderer is only registered for /workspaces/$workspaceId.
-    {...(params as ResolveParams<"/workspaces/$workspaceId">)}
-  />
-);
+const renderWorkspaceBreadcrumb = ({
+  workspaceId,
+}: Record<string, string | undefined>) => {
+  if (!workspaceId) {
+    return null;
+  }
+  return <WorkspaceBreadcrumb workspaceId={workspaceId} />;
+};
 
-const renderContactBreadcrumb = (params: ResolveParams<RouterFullPath>) => (
-  <ContactBreadcrumb
-    // SAFETY: this renderer is only registered for /contacts/$contactId.
-    {...(params as ResolveParams<"/contacts/$contactId">)}
-  />
-);
+const renderContactBreadcrumb = ({
+  contactId,
+}: Record<string, string | undefined>) => {
+  if (!contactId) {
+    return null;
+  }
+  return <ContactBreadcrumb contactId={contactId} />;
+};
 
 const renderBreadcrumbEntry = (
   entry: BreadcrumbEntry,
-  params: ResolveParams<RouterFullPath>,
+  params: Record<string, string | undefined>,
 ): React.ReactNode => (typeof entry === "function" ? entry(params) : entry);
+
+const defineBreadcrumb = (
+  paths: readonly RouterFullPath[],
+  entry: BreadcrumbEntry,
+): BreadcrumbDefinition => ({
+  key: serializeKey(paths),
+  paths,
+  entry,
+});
 
 export const AppBreadcrumbs = () => {
   const t = useTranslations();
   const matches = useMatches();
   const id = useId();
 
-  const breadcrumbMap: Partial<Record<string, BreadcrumbEntry>> = useMemo(
-    () => ({
-      [serializeKey(["/workspaces/"])]: (
+  const breadcrumbDefinitions: BreadcrumbDefinition[] = useMemo(
+    () => [
+      defineBreadcrumb(
+        ["/workspaces/"],
         <BreadcrumbItem className="min-w-8 shrink">
           <Link
             activeOptions={{ exact: true, includeSearch: false }}
@@ -70,79 +85,98 @@ export const AppBreadcrumbs = () => {
           >
             {t("common.matters")}
           </Link>
-        </BreadcrumbItem>
+        </BreadcrumbItem>,
       ),
-      [serializeKey(["/workspaces/$workspaceId"])]: renderWorkspaceBreadcrumb,
-      [serializeKey(["/workspaces/$workspaceId/$viewId/document"])]:
+      defineBreadcrumb(["/workspaces/$workspaceId"], renderWorkspaceBreadcrumb),
+      defineBreadcrumb(
+        ["/workspaces/$workspaceId/$viewId/document"],
         renderPdfBreadcrumb,
-      [serializeKey(["/todos/"])]: (
-        <BreadcrumbLink to="/todos">{t("navigation.myTodos")}</BreadcrumbLink>
       ),
-      [serializeKey(["/knowledge"])]: (
+      defineBreadcrumb(
+        ["/todos/"],
+        <BreadcrumbLink to="/todos">{t("navigation.myTodos")}</BreadcrumbLink>,
+      ),
+      defineBreadcrumb(
+        ["/knowledge"],
         <BreadcrumbLink to="/knowledge">
           {t("navigation.knowledge")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/knowledge/templates"])]: (
+      defineBreadcrumb(
+        ["/knowledge/templates"],
         <BreadcrumbLink to="/knowledge/templates">
           {t("navigation.templates")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/contacts/"])]: (
+      defineBreadcrumb(
+        ["/contacts/"],
         <BreadcrumbLink to="/contacts">
           {t("navigation.contacts")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/knowledge/clauses"])]: (
+      defineBreadcrumb(
+        ["/knowledge/clauses"],
         <BreadcrumbLink to="/knowledge/clauses">
           {t("common.clauses")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/contacts/$contactId"])]: renderContactBreadcrumb,
-      [serializeKey(["/knowledge/prompts"])]: (
-        <BreadcrumbItem>{t("knowledge.sections.prompts.title")}</BreadcrumbItem>
+      defineBreadcrumb(["/contacts/$contactId"], renderContactBreadcrumb),
+      defineBreadcrumb(
+        ["/knowledge/prompts"],
+        <BreadcrumbItem>
+          {t("knowledge.sections.prompts.title")}
+        </BreadcrumbItem>,
       ),
-      [serializeKey(["/knowledge/tools"])]: (
+      defineBreadcrumb(
+        ["/knowledge/tools"],
         <BreadcrumbLink to="/knowledge/tools">
           {t("knowledge.sections.tools.title")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/knowledge/tools/$skillId"])]: <SkillBreadcrumb />,
-      [serializeKey(["/settings"])]: (
-        <BreadcrumbLink to="/settings">{t("common.settings")}</BreadcrumbLink>
+      defineBreadcrumb(["/knowledge/tools/$skillId"], <SkillBreadcrumb />),
+      defineBreadcrumb(
+        ["/settings"],
+        <BreadcrumbLink to="/settings">{t("common.settings")}</BreadcrumbLink>,
       ),
-      [serializeKey(["/settings/account/profile"])]: (
+      defineBreadcrumb(
+        ["/settings/account/profile"],
         <BreadcrumbLink to="/settings/account/profile">
           {t("settings.account.profile")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/settings/account/desktop"])]: (
+      defineBreadcrumb(
+        ["/settings/account/desktop"],
         <BreadcrumbLink to="/settings/account/desktop">
           {t("settings.account.desktop")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/settings/organization"])]: (
-        <BreadcrumbItem>{t("common.organization")}</BreadcrumbItem>
+      defineBreadcrumb(
+        ["/settings/organization"],
+        <BreadcrumbItem>{t("common.organization")}</BreadcrumbItem>,
       ),
-      [serializeKey(["/settings/organization/members"])]: (
+      defineBreadcrumb(
+        ["/settings/organization/members"],
         <BreadcrumbLink to="/settings/organization/members">
           {t("navigation.members")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/settings/organization/matter-numbering"])]: (
+      defineBreadcrumb(
+        ["/settings/organization/matter-numbering"],
         <BreadcrumbLink to="/settings/organization/matter-numbering">
           {t("settings.organization.matterNumbering")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/settings/organization/ai"])]: (
+      defineBreadcrumb(
+        ["/settings/organization/ai"],
         <BreadcrumbLink to="/settings/organization/ai">
           {t("settings.organization.ai")}
-        </BreadcrumbLink>
+        </BreadcrumbLink>,
       ),
-      [serializeKey(["/chat"])]: (
-        <BreadcrumbLink to="/chat">{t("navigation.chat")}</BreadcrumbLink>
+      defineBreadcrumb(
+        ["/chat"],
+        <BreadcrumbLink to="/chat">{t("navigation.chat")}</BreadcrumbLink>,
       ),
-    }),
+    ],
     [t],
   );
 
@@ -150,32 +184,19 @@ export const AppBreadcrumbs = () => {
     const results = new Map<string, React.ReactNode>();
 
     for (const match of matches) {
-      for (const key of Object.keys(breadcrumbMap)) {
-        const parsedKey = deserializeKey(key);
-
-        if (parsedKey.some((path) => match.fullPath.startsWith(path))) {
-          const entry = breadcrumbMap[key];
-
-          if (entry === undefined) {
-            continue;
-          }
-
-          // SAFETY: match.params from TanStack Router for known route
-          const result = renderBreadcrumbEntry(
-            entry,
-            // eslint-disable-next-line typescript/no-unsafe-type-assertion
-            match.params as ResolveParams<RouterFullPath>,
-          );
+      for (const definition of breadcrumbDefinitions) {
+        if (definition.paths.some((path) => match.fullPath.startsWith(path))) {
+          const result = renderBreadcrumbEntry(definition.entry, match.params);
 
           if (result !== null && result !== undefined && result !== false) {
-            results.set(key, result);
+            results.set(definition.key, result);
           }
         }
       }
     }
 
     return [...results.values()];
-  }, [matches, breadcrumbMap]);
+  }, [matches, breadcrumbDefinitions]);
 
   return (
     <Breadcrumb className="min-w-0">

--- a/apps/web/src/components/chat-mention-node.tsx
+++ b/apps/web/src/components/chat-mention-node.tsx
@@ -10,11 +10,60 @@ import {
 import { cn } from "@stll/ui/lib/utils";
 
 import type { ChatReferenceCategory } from "@/components/chat-mention-extension";
+import { isMentionCategory } from "@/components/chat/chat-mention-href";
 import { getMatterColor } from "@/lib/matter-colors";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 
 const cls = "size-3 shrink-0";
 const CHAT_MENTION_LABEL_MAX_WIDTH_CLASS = "max-w-48";
+
+type ChatMentionAttrs = {
+  id: string;
+  label: string;
+  category: ChatReferenceCategory;
+  kind: string;
+  mimeType: string | null;
+  sourceWorkspaceId: string | null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isChatReferenceCategory = (
+  value: unknown,
+): value is ChatReferenceCategory =>
+  typeof value === "string" &&
+  (value === "decision" || isMentionCategory(value));
+
+const readChatMentionAttrs = (value: unknown): ChatMentionAttrs => {
+  if (!isRecord(value)) {
+    return {
+      id: "",
+      label: "",
+      category: "entity",
+      kind: "document",
+      mimeType: null,
+      sourceWorkspaceId: null,
+    };
+  }
+
+  const id = value["id"];
+  const label = value["label"];
+  const category = value["category"];
+  const kind = value["kind"];
+  const mimeType = value["mimeType"];
+  const sourceWorkspaceId = value["sourceWorkspaceId"];
+
+  return {
+    id: typeof id === "string" ? id : "",
+    label: typeof label === "string" ? label : "",
+    category: isChatReferenceCategory(category) ? category : "entity",
+    kind: typeof kind === "string" ? kind : "document",
+    mimeType: typeof mimeType === "string" ? mimeType : null,
+    sourceWorkspaceId:
+      typeof sourceWorkspaceId === "string" ? sourceWorkspaceId : null,
+  };
+};
 
 const CategoryIcon = ({
   category,
@@ -50,16 +99,7 @@ const CategoryIcon = ({
 };
 
 export const ChatMentionNode = (props: NodeViewProps) => {
-  // SAFETY: attrs from our own mention extension schema
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  const attrs = props.node.attrs as {
-    id: string;
-    label: string;
-    category: ChatReferenceCategory;
-    kind: string;
-    mimeType: string | null;
-    sourceWorkspaceId: string | null;
-  };
+  const attrs = readChatMentionAttrs(props.node.attrs);
   const sourceWorkspaceId = attrs.sourceWorkspaceId;
   const sourceWorkspaceColor = sourceWorkspaceId
     ? getMatterColor(sourceWorkspaceId)

--- a/apps/web/src/components/chat-pasted-text-node.tsx
+++ b/apps/web/src/components/chat-pasted-text-node.tsx
@@ -18,7 +18,10 @@ import {
 } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
 
-import type { PastedTextSource } from "@/components/chat-pasted-text-extension";
+import type {
+  PastedTextAttrs,
+  PastedTextSource,
+} from "@/components/chat-pasted-text-extension";
 
 const CHIP_MAX_LABEL_WIDTH_CLASS = "max-w-48";
 
@@ -32,15 +35,37 @@ const pickChipIcon = (source: PastedTextSource) => {
   return ClipboardPasteIcon;
 };
 
+const PASTED_TEXT_SOURCE_VALUES: ReadonlySet<string> = new Set([
+  "paste",
+  "prompt",
+  "skill",
+]);
+
+const isPastedTextSource = (value: unknown): value is PastedTextSource =>
+  typeof value === "string" && PASTED_TEXT_SOURCE_VALUES.has(value);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readPastedTextAttrs = (value: unknown): PastedTextAttrs => {
+  if (!isRecord(value)) {
+    return { text: "", label: "", source: "paste" };
+  }
+
+  const text = value["text"];
+  const label = value["label"];
+  const source = value["source"];
+
+  return {
+    text: typeof text === "string" ? text : "",
+    label: typeof label === "string" ? label : "",
+    source: isPastedTextSource(source) ? source : "paste",
+  };
+};
+
 export const ChatPastedTextNode = (props: NodeViewProps) => {
   const t = useTranslations();
-  // SAFETY: attrs from our own pastedText node schema
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  const attrs = props.node.attrs as {
-    text: string;
-    label: string;
-    source: PastedTextSource;
-  };
+  const attrs = readPastedTextAttrs(props.node.attrs);
 
   // Local-state-only edits keep the textarea responsive on large
   // pastes; we commit back to the node attrs on blur (which fires

--- a/apps/web/src/components/chat/chat-anon-decorations-plugin.ts
+++ b/apps/web/src/components/chat/chat-anon-decorations-plugin.ts
@@ -35,13 +35,16 @@ export const CHAT_ANON_DECORATIONS_PLUGIN_KEY_PREFIX = `${CHAT_ANON_DECORATIONS_
 // change touching this file. The key has no behaviour, only
 // identity, so caching it indefinitely is safe.
 type AnonGlobals = {
-  __stllAnonPluginKey?: PluginKey<PluginState>;
-  __stllAnonPlugin?: Plugin<PluginState>;
+  __stllAnonPluginKey?: PluginKey<PluginState> | undefined;
+  __stllAnonPlugin?: Plugin<PluginState> | undefined;
 };
-// SAFETY: cross-HMR persistence stash on the global object; keys
-// are intentionally underscored to avoid collisions.
-// oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-const anonGlobals = globalThis as unknown as AnonGlobals;
+
+declare global {
+  var __stllAnonPluginKey: PluginKey<PluginState> | undefined;
+  var __stllAnonPlugin: Plugin<PluginState> | undefined;
+}
+
+const anonGlobals: AnonGlobals = globalThis;
 
 export const chatAnonDecorationsPluginKey: PluginKey<PluginState> =
   (anonGlobals.__stllAnonPluginKey ??= new PluginKey<PluginState>(

--- a/apps/web/src/components/chat/entity-link.tsx
+++ b/apps/web/src/components/chat/entity-link.tsx
@@ -115,8 +115,7 @@ export const EntityLink = ({
       })();
       return;
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    navigate({
+    void navigate({
       to: "/workspaces/$workspaceId",
       params: { workspaceId: id },
     });

--- a/apps/web/src/components/inspector/external-reference-panel.tsx
+++ b/apps/web/src/components/inspector/external-reference-panel.tsx
@@ -416,20 +416,23 @@ const useExternalPdfBuffer = ({
   const query = useQuery({
     queryKey: ["external-pdf", url],
     queryFn: async ({ signal }): Promise<ExternalPdfPayload> => {
-      // SAFETY: `enabled` below guarantees `url` is defined when the
-      // queryFn runs.
-      // eslint-disable-next-line typescript/no-non-null-assertion
-      const response = await fetch(url!, {
+      if (url === undefined) {
+        throw new FetchBoundaryError({
+          url: "",
+          status: 0,
+          statusText: "Missing URL",
+          message: "External PDF URL missing",
+        });
+      }
+
+      const response = await fetch(url, {
         credentials: "include",
         signal,
       });
 
       if (!response.ok) {
         throw new FetchBoundaryError({
-          // SAFETY: `enabled` below guarantees `url` is defined when the
-          // queryFn runs.
-          // eslint-disable-next-line typescript/no-non-null-assertion
-          url: url!,
+          url,
           status: response.status,
           statusText: response.statusText,
           message: `External PDF fetch failed: ${String(response.status)}`,

--- a/apps/web/src/lib/analytics/noop.ts
+++ b/apps/web/src/lib/analytics/noop.ts
@@ -3,8 +3,7 @@ import { CancelledError } from "@tanstack/react-query";
 import type { Analytics } from "@/lib/analytics/types";
 import { logDevError } from "@/lib/errors/utils";
 
-// eslint-disable-next-line no-empty-function
-const noop = () => {};
+const noop = () => undefined;
 
 export const noopAnalytics: Analytics = {
   captureError: (error) => {

--- a/apps/web/src/lib/anonymize/pdf-content-stream.ts
+++ b/apps/web/src/lib/anonymize/pdf-content-stream.ts
@@ -86,8 +86,7 @@ const getContentStreams = (
   }
 
   if (contents.type === "stream") {
-    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- discriminated by type check
-    return [contents as PdfStream];
+    return [contents];
   }
 
   if (contents.type === "array") {
@@ -98,8 +97,7 @@ const getContentStreams = (
       if (item) {
         const resolved = item.type === "ref" ? ctx.resolve(item) : item;
         if (resolved?.type === "stream") {
-          // eslint-disable-next-line typescript/no-unsafe-type-assertion -- discriminated by type check
-          streams.push(resolved as PdfStream);
+          streams.push(resolved);
         }
       }
     }

--- a/apps/web/src/lib/anonymize/pdf-content-stream.ts
+++ b/apps/web/src/lib/anonymize/pdf-content-stream.ts
@@ -1,4 +1,5 @@
-import type { PDF, PdfDict, PdfRef, PdfStream } from "@libpdf/core";
+import { PdfStream } from "@libpdf/core";
+import type { PDF, PdfDict, PdfRef } from "@libpdf/core";
 
 /**
  * A redaction region on a specific page for content stream
@@ -85,7 +86,7 @@ const getContentStreams = (
     return getContentStreams(resolved, ctx);
   }
 
-  if (contents.type === "stream") {
+  if (contents instanceof PdfStream) {
     return [contents];
   }
 
@@ -96,7 +97,7 @@ const getContentStreams = (
       const item = arr.at(i);
       if (item) {
         const resolved = item.type === "ref" ? ctx.resolve(item) : item;
-        if (resolved?.type === "stream") {
+        if (resolved instanceof PdfStream) {
           streams.push(resolved);
         }
       }

--- a/apps/web/src/lib/mcp-oauth-channel.ts
+++ b/apps/web/src/lib/mcp-oauth-channel.ts
@@ -41,13 +41,18 @@ export function broadcastMcpOAuthOutcome(outcome: McpOAuthOutcome): void {
     return;
   }
 
-  // SAFETY: lib.dom types `window.opener` as `any` because the
-  // opener may be a Window from any origin. We post to our own
-  // origin only, so narrowing to the postMessage surface is safe.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-  const opener = window.opener as Pick<Window, "postMessage"> | null;
-  if (opener !== null) {
-    opener.postMessage(message, window.location.origin);
+  const opener: unknown = window.opener;
+  if (
+    typeof opener !== "object" ||
+    opener === null ||
+    !("postMessage" in opener)
+  ) {
+    return;
+  }
+
+  const postMessage = opener.postMessage;
+  if (typeof postMessage === "function") {
+    postMessage.call(opener, message, window.location.origin);
   }
 }
 

--- a/apps/web/src/lib/mcp-oauth-channel.ts
+++ b/apps/web/src/lib/mcp-oauth-channel.ts
@@ -3,6 +3,10 @@ import * as v from "valibot";
 const CHANNEL_NAME = "mcp-oauth";
 const MESSAGE_KIND = "stll.mcp-oauth";
 
+type PostMessageOpener = {
+  postMessage: (message: unknown, targetOrigin: string) => void;
+};
+
 // Wire schema carries a `kind` discriminator so the global
 // `window.message` listener on the opener page can't pick up
 // unrelated messages that happen to share `status`. Callers only
@@ -23,6 +27,15 @@ export type McpOAuthOutcome =
   | { status: "connected" }
   | { status: "error"; reason: string };
 
+const hasPostMessage = (value: object): value is PostMessageOpener => {
+  if (!("postMessage" in value)) {
+    return false;
+  }
+
+  const postMessage: unknown = value.postMessage;
+  return typeof postMessage === "function";
+};
+
 export function broadcastMcpOAuthOutcome(outcome: McpOAuthOutcome): void {
   const message = { kind: MESSAGE_KIND, ...outcome };
 
@@ -42,17 +55,16 @@ export function broadcastMcpOAuthOutcome(outcome: McpOAuthOutcome): void {
   }
 
   const opener: unknown = window.opener;
-  if (
-    typeof opener !== "object" ||
-    opener === null ||
-    !("postMessage" in opener)
-  ) {
+  if (typeof opener !== "object" || opener === null) {
     return;
   }
 
-  const postMessage = opener.postMessage;
-  if (typeof postMessage === "function") {
-    postMessage.call(opener, message, window.location.origin);
+  try {
+    if (hasPostMessage(opener)) {
+      opener.postMessage(message, window.location.origin);
+    }
+  } catch {
+    // Cross-origin opener property access can throw SecurityError.
   }
 }
 

--- a/apps/web/src/lib/pdf/parse-attachments.ts
+++ b/apps/web/src/lib/pdf/parse-attachments.ts
@@ -5,6 +5,9 @@ export type PDFAttachment = {
   filename: string;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const pdfAttachmentSchema = v.strictObject({
   content: v.instance(Uint8Array),
   filename: v.pipe(
@@ -22,11 +25,13 @@ const parsePdfAttachment = v.safeParser(pdfAttachmentSchema);
  * pdfjs-dist v5.5+ returns `null` when there are no attachments;
  * older versions returned `undefined`. This function handles both.
  */
-export const parseAttachments = (
-  attachments?: Record<string, unknown> | null,
-): PDFAttachment[] => {
+export const parseAttachments = (attachments?: unknown): PDFAttachment[] => {
   // eslint-disable-next-line no-eq-null, eqeqeq -- getAttachments() returns null (v5.5) or undefined (older)
   if (attachments == null) {
+    return [];
+  }
+
+  if (!isRecord(attachments)) {
     return [];
   }
 

--- a/apps/web/src/lib/pdf/pdf-loader.ts
+++ b/apps/web/src/lib/pdf/pdf-loader.ts
@@ -171,11 +171,8 @@ export const loadPDF = async ({
 
   return Result.tryPromise({
     try: async () => {
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- pdfjs-dist types getAttachments() as Promise<any>
-      const attachments = await document.getAttachments();
-      const pdfAttachments =
-        // oxlint-disable-next-line typescript/no-unsafe-argument -- attachments is typed as any by pdfjs-dist
-        parseAttachments(attachments);
+      const attachments: unknown = await document.getAttachments();
+      const pdfAttachments = parseAttachments(attachments);
 
       const isPortfolio = pdfAttachments.length > 0 && document.numPages <= 1;
 

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -84,8 +84,9 @@ export const useWorkspaceSSE = (
           parsed.type === INVALIDATE_QUERY_EVENT_TYPE &&
           Array.isArray(parsed.data)
         ) {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClientRef.current.invalidateQueries({ queryKey: parsed.data });
+          void queryClientRef.current.invalidateQueries({
+            queryKey: parsed.data,
+          });
         }
       } catch {
         // Malformed SSE data; ignore.

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -22,8 +22,7 @@ import "@stll/ui/globals.css";
 
 const isDev = import.meta.env.DEV;
 const DevRoot = isDev
-  ? // eslint-disable-next-line require-await -- lazy() requires async import
-    lazy(async () => import("@/components/dev-root"))
+  ? lazy(async () => await import("@/components/dev-root"))
   : null;
 
 export const Route = createRootRouteWithContext<{

--- a/apps/web/src/routes/_protected.contacts/-components/contact-custom-fields-editor.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/contact-custom-fields-editor.tsx
@@ -220,8 +220,7 @@ const CustomFieldRow = ({
         disabled={disabled}
         maxLength={128}
         onBlur={() => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          save();
+          void save();
         }}
         onChange={(event) => setLabel(event.currentTarget.value)}
         value={label}
@@ -231,8 +230,7 @@ const CustomFieldRow = ({
         disabled={disabled}
         maxLength={2000}
         onBlur={() => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          save();
+          void save();
         }}
         onChange={(event) => setValue(event.currentTarget.value)}
         value={value}

--- a/apps/web/src/routes/_protected.contacts/index.tsx
+++ b/apps/web/src/routes/_protected.contacts/index.tsx
@@ -251,8 +251,7 @@ const ContactRow = ({ contact }: { contact: ContactItem }) => {
     contact.phones?.find((p) => p.isPrimary) ?? contact.phones?.at(0);
 
   const openContact = () => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    navigate({
+    void navigate({
       to: "/contacts/$contactId",
       params: { contactId: contact.id },
     });
@@ -263,8 +262,7 @@ const ContactRow = ({ contact }: { contact: ContactItem }) => {
       { contactId: contact.id },
       {
         onSuccess: () => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: contactsKeys.all,
           });
           stellaToast.add({
@@ -619,8 +617,7 @@ const CreateContactDialog = ({
           errors={formErrors}
           onSubmit={(e) => {
             e.preventDefault();
-            // eslint-disable-next-line typescript/no-floating-promises
-            form.handleSubmit();
+            void form.handleSubmit();
           }}
         >
           <DialogHeader>

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/install-pack-button.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/install-pack-button.tsx
@@ -75,8 +75,7 @@ export const InstallPackButton = ({
     <Button
       disabled={busy}
       onClick={() => {
-        // eslint-disable-next-line typescript/no-floating-promises
-        onClick();
+        void onClick();
       }}
       size="xs"
       variant="outline"

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -909,9 +909,7 @@ export const TemplateForm = ({
     (e: React.SubmitEvent<HTMLFormElement>) => {
       e.preventDefault();
       // Errors are surfaced as toasts inside handleDownload
-      // TODO: fix this
-      // oxlint-disable-next-line no-empty-function
-      handleDownload("docx").catch(() => {});
+      handleDownload("docx").catch(() => undefined);
     },
     [handleDownload],
   );

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -528,6 +528,9 @@ const coerceValue = (field: ResolvedField, value: unknown): unknown => {
   return value;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const setNestedValue = (
   obj: Record<string, unknown>,
   path: string,
@@ -542,11 +545,8 @@ const setNestedValue = (
 
   for (const part of parts.slice(0, -1)) {
     const next = current[part];
-    if (typeof next === "object" && next !== null && !Array.isArray(next)) {
-      // SAFETY: a plain object value is structurally compatible with
-      // Record<string, unknown>; we guarded against arrays/null above.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      current = next as Record<string, unknown>;
+    if (isRecord(next)) {
+      current = next;
       continue;
     }
     const child: Record<string, unknown> = {};

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -122,9 +122,7 @@ export const TemplateList = ({
       const file = e.target.files?.item(0);
       if (file) {
         // Errors are surfaced as toasts inside discover
-        // TODO: fix this
-        // oxlint-disable-next-line no-empty-function
-        discover(file).catch(() => {});
+        discover(file).catch(() => undefined);
       }
       e.target.value = "";
     },

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -548,8 +548,7 @@ const TemplateDetail = ({
     (e: React.KeyboardEvent) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        saveRename();
+        void saveRename();
         return;
       }
       if (e.key === "Escape") {

--- a/apps/web/src/routes/_protected.organization/-components/invite-member-dialog.tsx
+++ b/apps/web/src/routes/_protected.organization/-components/invite-member-dialog.tsx
@@ -156,8 +156,7 @@ export const InviteMemberDialog = ({
           errors={formErrors}
           onSubmit={(e) => {
             e.preventDefault();
-            // eslint-disable-next-line typescript/no-floating-promises
-            form.handleSubmit();
+            void form.handleSubmit();
           }}
         >
           <DialogHeader>

--- a/apps/web/src/routes/_protected.organization/-mutations.ts
+++ b/apps/web/src/routes/_protected.organization/-mutations.ts
@@ -30,13 +30,12 @@ export const useRemoveMember = () => {
 
       return result.data;
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       stellaToast.add({
         title: t("success.memberRemoved"),
         type: "success",
       });
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({ queryKey: organizationKeys.all });
+      await queryClient.invalidateQueries({ queryKey: organizationKeys.all });
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -68,9 +67,8 @@ export const useInviteMember = () => {
 
       return result.data;
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({ queryKey: organizationKeys.all });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: organizationKeys.all });
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -99,9 +97,8 @@ export const useCancelInvitation = () => {
 
       return result.data;
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({ queryKey: organizationKeys.all });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: organizationKeys.all });
       stellaToast.add({
         title: t("success.invitationCanceled"),
         type: "success",

--- a/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
@@ -36,8 +36,7 @@ export const OrganizationListToolbar = () => {
   // the value being re-set.
   const [lastSeenUrlQuery, setLastSeenUrlQuery] = useState(q);
   const updateSearch = useDebouncedCallback((value: string) => {
-    // eslint-disable-next-line typescript/no-floating-promises
-    navigate({
+    void navigate({
       to: "/settings/organization/members",
       search: (prev) => ({ ...prev, q: value || undefined }),
     });

--- a/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
@@ -86,8 +86,7 @@ const MatterNumberingCardBody = ({
   }, 300);
 
   useEffect(() => {
-    // eslint-disable-next-line typescript/no-floating-promises
-    fetchPreview(pattern, padding);
+    void fetchPreview(pattern, padding);
   }, [pattern, padding, fetchPreview]);
 
   const updateMutation = useMutation({

--- a/apps/web/src/routes/_protected.settings/-components/organization/profile-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/profile-card.tsx
@@ -86,8 +86,7 @@ export const OrganizationProfileCard = () => {
             errors={formErrors}
             onSubmit={(e) => {
               e.preventDefault();
-              // eslint-disable-next-line typescript/no-floating-promises
-              form.handleSubmit();
+              void form.handleSubmit();
             }}
           >
             <form.Field name="name">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.index.tsx
@@ -1,13 +1,35 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
-import type { WorkspaceView } from "@/lib/types";
+import type { ViewLayout, WorkspaceView } from "@/lib/types";
 import { CalendarView } from "@/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view";
 import { FilesystemView } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view";
 import { KanbanView } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view";
 import { OverviewView } from "@/routes/_protected.workspaces/$workspaceId/-components/overview-view";
 import { TableLayout } from "@/routes/_protected.workspaces/$workspaceId/-components/table/table-layout";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
+
+type TableWorkspaceView = WorkspaceView & {
+  layout: Extract<ViewLayout, { type: "table" }>;
+};
+
+type FilesystemWorkspaceView = WorkspaceView & {
+  layout: Extract<ViewLayout, { type: "filesystem" }>;
+};
+
+type CalendarWorkspaceView = WorkspaceView & {
+  layout: Extract<ViewLayout, { type: "calendar" }>;
+};
+
+const isTableView = (view: WorkspaceView): view is TableWorkspaceView =>
+  view.layout.type === "table";
+
+const isFilesystemView = (
+  view: WorkspaceView,
+): view is FilesystemWorkspaceView => view.layout.type === "filesystem";
+
+const isCalendarView = (view: WorkspaceView): view is CalendarWorkspaceView =>
+  view.layout.type === "calendar";
 
 export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/$viewId/",
@@ -30,39 +52,24 @@ function RouteComponent() {
 
   switch (activeView.layout.type) {
     case "table":
-      return (
-        <TableLayout
-          // SAFETY: switch narrows activeView.layout.type to "table";
-          // TS cannot propagate the narrowing onto the parent because
-          // `WorkspaceView<T>` uses T only inside an `Extract`, so the
-          // generic is treated as invariant.
-          // eslint-disable-next-line typescript/no-unsafe-type-assertion
-          view={activeView as WorkspaceView<"table">}
-          workspaceId={workspaceId}
-        />
-      );
+      if (!isTableView(activeView)) {
+        return null;
+      }
+      return <TableLayout view={activeView} workspaceId={workspaceId} />;
     case "overview":
       return <OverviewView workspaceId={workspaceId} />;
     case "filesystem":
-      return (
-        <FilesystemView
-          // SAFETY: same invariance limitation as the "table" branch above.
-          // eslint-disable-next-line typescript/no-unsafe-type-assertion
-          view={activeView as WorkspaceView<"filesystem">}
-          workspaceId={workspaceId}
-        />
-      );
+      if (!isFilesystemView(activeView)) {
+        return null;
+      }
+      return <FilesystemView view={activeView} workspaceId={workspaceId} />;
     case "kanban":
       return <KanbanView view={activeView} workspaceId={workspaceId} />;
     case "calendar":
-      return (
-        <CalendarView
-          // SAFETY: same invariance limitation as the "table" branch above.
-          // eslint-disable-next-line typescript/no-unsafe-type-assertion
-          view={activeView as WorkspaceView<"calendar">}
-          workspaceId={workspaceId}
-        />
-      );
+      if (!isCalendarView(activeView)) {
+        return null;
+      }
+      return <CalendarView view={activeView} workspaceId={workspaceId} />;
     case "timeline":
       return null;
     default: {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
@@ -294,8 +294,7 @@ const CreateCodeForm = ({
       onSubmit={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        // eslint-disable-next-line typescript/no-floating-promises
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <div className="flex gap-3">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-form.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-form.tsx
@@ -108,8 +108,7 @@ export const ExpenseForm = ({
       onSubmit={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        // eslint-disable-next-line typescript/no-floating-promises
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <div className="flex flex-col gap-1.5">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
@@ -334,8 +334,7 @@ const CreateRateTableForm = ({
       onSubmit={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        // eslint-disable-next-line typescript/no-floating-promises
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <div className="flex gap-3">
@@ -678,8 +677,7 @@ const CreateRateEntryForm = ({
       onSubmit={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        // eslint-disable-next-line typescript/no-floating-promises
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <div className="flex flex-col gap-1.5">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-form.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-form.tsx
@@ -132,8 +132,7 @@ export const TimeEntryForm = ({
       onSubmit={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        // eslint-disable-next-line typescript/no-floating-promises
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <div className="flex flex-col gap-1.5">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
 import { revalidateLogic, useForm } from "@tanstack/react-form";
-import type { AnyFieldApi } from "@tanstack/react-form";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
@@ -194,8 +193,7 @@ export const EditFieldDialog = ({
               errors={errors}
               onSubmit={(e) => {
                 e.preventDefault();
-                // eslint-disable-next-line typescript/no-floating-promises
-                form.handleSubmit();
+                void form.handleSubmit();
               }}
             >
               <DialogHeader>
@@ -349,23 +347,27 @@ export const EditFieldDialog = ({
   );
 };
 
-// TODO: FIXME — replace AnyFieldApi with a properly typed FieldApi
+type TextFieldHandle = {
+  name: string;
+  state: { value: string };
+  handleChange: (value: string) => void;
+  handleBlur: () => void;
+};
+
 type TextFormFieldProps = {
-  field: AnyFieldApi;
+  field: TextFieldHandle;
 };
 
 const TextFormField = ({ field }: TextFormFieldProps) => {
   const t = useTranslations();
 
   return (
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
     <Field name={field.name}>
       <FieldLabel>{t("workspaces.fields.fieldValueLabel")}</FieldLabel>
       <Input
         onBlur={field.handleBlur}
         onChange={(e) => field.handleChange(e.target.value)}
         placeholder={t("workspaces.fields.fieldValuePlaceholder")}
-        // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
         value={field.state.value}
       />
       <FieldError />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -65,11 +65,6 @@ const fieldFormSchema = v.variant("type", [
 
 type FieldFormSchema = v.InferInput<typeof fieldFormSchema>;
 
-type FieldFormValue<T extends FieldFormSchema["type"]> = Extract<
-  FieldFormSchema,
-  { type: T }
->["value"];
-
 const getDefaultValues = (
   fieldContent: EditableFieldContent,
 ): FieldFormSchema => {
@@ -106,6 +101,38 @@ const getDefaultValues = (
     value: fieldContent.value,
     currency: fieldContent.currency,
   };
+};
+
+const toSingleSelectValue = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return null;
+};
+
+const toMultiSelectValue = (value: unknown): string[] => {
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+
+  return [];
+};
+
+const toDateValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return "";
+};
+
+const toIntValue = (value: unknown): number => {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  return 0;
 };
 
 type EditFieldDialogProps = {
@@ -216,11 +243,7 @@ export const EditFieldDialog = ({
                           onChange={(value) => field.handleChange(value)}
                           options={options}
                           type="single-select"
-                          value={
-                            // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                            field.state.value as FieldFormValue<"single-select">
-                          }
+                          value={toSingleSelectValue(field.state.value)}
                         />
                         <FieldError />
                       </Field>
@@ -236,11 +259,7 @@ export const EditFieldDialog = ({
                           onChange={field.handleChange}
                           options={options}
                           type="multi-select"
-                          value={
-                            // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                            field.state.value as FieldFormValue<"multi-select">
-                          }
+                          value={toMultiSelectValue(field.state.value)}
                         />
                         <FieldError />
                       </Field>
@@ -256,11 +275,7 @@ export const EditFieldDialog = ({
                         <FieldLabel>{t("common.date")}</FieldLabel>
                         <DatePickerPopover
                           onChange={(val) => field.handleChange(val)}
-                          value={
-                            // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                            (field.state.value as FieldFormValue<"date">) ?? ""
-                          }
+                          value={toDateValue(field.state.value)}
                         />
                         <FieldError />
                       </Field>
@@ -289,9 +304,7 @@ export const EditFieldDialog = ({
                               "workspaces.fields.numberPlaceholder",
                             )}
                             type="number"
-                            // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                            value={field.state.value as FieldFormValue<"int">}
+                            value={toIntValue(field.state.value)}
                           />
                           <FieldError />
                         </Field>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -111,20 +111,20 @@ const toSingleSelectValue = (value: unknown): string | null => {
   return null;
 };
 
+const toTextValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return "";
+};
+
 const toMultiSelectValue = (value: unknown): string[] => {
   if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
     return value;
   }
 
   return [];
-};
-
-const toDateValue = (value: unknown): string => {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  return "";
 };
 
 const toIntValue = (value: unknown): number => {
@@ -275,7 +275,7 @@ export const EditFieldDialog = ({
                         <FieldLabel>{t("common.date")}</FieldLabel>
                         <DatePickerPopover
                           onChange={(val) => field.handleChange(val)}
-                          value={toDateValue(field.state.value)}
+                          value={toTextValue(field.state.value)}
                         />
                         <FieldError />
                       </Field>
@@ -362,7 +362,7 @@ export const EditFieldDialog = ({
 
 type TextFieldHandle = {
   name: string;
-  state: { value: string };
+  state: { value: unknown };
   handleChange: (value: string) => void;
   handleBlur: () => void;
 };
@@ -381,7 +381,7 @@ const TextFormField = ({ field }: TextFormFieldProps) => {
         onBlur={field.handleBlur}
         onChange={(e) => field.handleChange(e.target.value)}
         placeholder={t("workspaces.fields.fieldValuePlaceholder")}
-        value={field.state.value}
+        value={toTextValue(field.state.value)}
       />
       <FieldError />
     </Field>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -124,9 +124,10 @@ export const KanbanCard = ({
             if (!inner) {
               return;
             }
-            // SAFETY: cloneNode of HTMLElement returns HTMLElement
-            // eslint-disable-next-line typescript/no-unsafe-type-assertion
-            const clone = inner.cloneNode(true) as HTMLElement;
+            const clone = inner.cloneNode(true);
+            if (!(clone instanceof HTMLElement)) {
+              return;
+            }
             const rect = inner.getBoundingClientRect();
             clone.style.width = `${rect.width}px`;
             container.append(clone);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -158,8 +158,7 @@ export const MatterMetadataPanel = ({
       {
         onSuccess: () => {
           setReferenceDirty(false);
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspacesKeys.byId(workspaceId),
           });
         },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
@@ -145,12 +145,10 @@ const MemberRow = ({
             title: t("success.memberRemoved"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspaceMembersKeys.all(workspaceId),
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
+          void queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
         },
         onError: () => {
           stellaToast.add({
@@ -263,8 +261,7 @@ export const AddMemberDialog = ({
             title: t("success.memberAdded"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspaceMembersKeys.all(workspaceId),
           });
           setIsOpen(false);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -165,8 +165,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
       title: t("success.taskCreated"),
       type: "success",
     });
-    // eslint-disable-next-line typescript/no-floating-promises
-    queryClient.invalidateQueries({
+    void queryClient.invalidateQueries({
       queryKey: workspacesKeys.overview(workspaceId),
     });
     useInspectorStore
@@ -398,8 +397,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
           onClick={() => {
             const view = findViewByType("filesystem");
             if (view) {
-              // eslint-disable-next-line typescript/no-floating-promises
-              navigate({
+              void navigate({
                 to: "/workspaces/$workspaceId/$viewId",
                 params: { workspaceId, viewId: view.id },
               });
@@ -413,8 +411,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
           onClick={() => {
             const view = findViewByType("kanban");
             if (view) {
-              // eslint-disable-next-line typescript/no-floating-promises
-              navigate({
+              void navigate({
                 to: "/workspaces/$workspaceId/$viewId",
                 params: { workspaceId, viewId: view.id },
               });
@@ -451,8 +448,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
           icon={<ClockIcon className="size-4" />}
           label={t("workspaces.overview.timeThisWeek")}
           onClick={() => {
-            // eslint-disable-next-line typescript/no-floating-promises
-            navigate({
+            void navigate({
               to: "/workspaces/$workspaceId/timesheets",
               params: { workspaceId },
             });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -83,8 +83,7 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
       { id, type, displayName: name },
       {
         onSuccess: () => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: contactsKeys.all,
           });
           handleSetClient({ id, displayName: name });
@@ -108,8 +107,7 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
             title: t("success.clientUpdated"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspacesKeys.byId(workspaceId),
           });
         },
@@ -302,8 +300,7 @@ const PromoteDialog = ({ workspaceId }: PromoteDialogProps) => {
       { id, type, displayName: name },
       {
         onSuccess: () => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: contactsKeys.all,
           });
           setSelectedContact({ id, displayName: name });
@@ -334,12 +331,10 @@ const PromoteDialog = ({ workspaceId }: PromoteDialogProps) => {
             title: t("workspaces.parties.promotedSuccess"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspacesKeys.byId(workspaceId),
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspacesKeys.all,
           });
           handleClose();
@@ -483,8 +478,7 @@ const PartyRow = ({ party, workspaceId }: PartyRowProps) => {
             title: t("success.partyRemoved"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspaceContactsOptions(workspaceId).queryKey,
           });
         },
@@ -608,8 +602,7 @@ const AddPartyDialog = ({
             title: t("success.partyAdded"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspaceContactsOptions(workspaceId).queryKey,
           });
           setIsOpen(false);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/pdf-viewer.tsx
@@ -57,8 +57,7 @@ const FullscreenPdfViewer = () => {
 
   const handlePageChanged = useCallback(
     (page: number) => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      navigate({
+      void navigate({
         replace: true,
         search: (prev) =>
           produce(prev, (s) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/form.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/form.tsx
@@ -1,7 +1,5 @@
 import type { ComponentProps } from "react";
 
-import type { AnyFieldApi } from "@tanstack/react-form";
-
 import { Field, FieldError } from "@stll/ui/components/field";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -16,9 +14,15 @@ export const PropertyFormField = ({
     {children}
   </Field>
 );
-// TODO: FIXME — replace AnyFieldApi with a properly typed FieldApi
+type TextFieldHandle = {
+  name: string;
+  state: { value: string };
+  handleChange: (value: string) => void;
+  handleBlur: () => void;
+};
+
 type PropertyTextInputProps = {
-  field: AnyFieldApi;
+  field: TextFieldHandle;
   placeholder: string;
 };
 
@@ -26,7 +30,6 @@ export const PropertyTextInput = ({
   field,
   placeholder,
 }: PropertyTextInputProps) => (
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
   <PropertyFormField name={field.name}>
     <input
       autoComplete="off"
@@ -36,7 +39,6 @@ export const PropertyTextInput = ({
       onChange={(e) => field.handleChange(e.target.value)}
       placeholder={placeholder}
       type="text"
-      // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
       value={field.state.value}
     />
     <FieldError />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/input.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/input.tsx
@@ -17,6 +17,7 @@ import { useEditor } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
 import { Loader2Icon, WandSparklesIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+import * as v from "valibot";
 
 import { Button } from "@stll/ui/components/button";
 import { FieldError } from "@stll/ui/components/field";
@@ -49,14 +50,19 @@ import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-
 
 const protectedRouteApi = getRouteApi("/_protected");
 
+const mentionAttrsSchema = v.object({
+  id: v.string(),
+});
+
 const getMentions = (editor: Editor): string[] => {
   const mentions = new Set<string>();
 
   editor.state.doc.descendants((node) => {
     if (node.type.name === "mention") {
-      // TODO: FIXME — ProseMirror node.attrs is Record<string, any>
-      // oxlint-disable-next-line typescript-eslint/no-unsafe-argument
-      mentions.add(node.attrs["id"]);
+      const result = v.safeParse(mentionAttrsSchema, node.attrs);
+      if (result.success) {
+        mentions.add(result.output.id);
+      }
     }
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-node.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-node.tsx
@@ -10,14 +10,34 @@ type MentionNodeProps = NodeViewProps & {
   workspaceId: string;
 };
 
-export const MentionNode = ({ workspaceId, ...props }: MentionNodeProps) => {
-  // SAFETY: attrs from our mention extension schema
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  const attributes = props.node.attrs as {
-    id: string;
-    label: string;
-    mentionSuggestionChar: string;
+type MentionAttrs = {
+  id: string;
+  label: string;
+  mentionSuggestionChar: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readMentionAttrs = (value: unknown): MentionAttrs => {
+  if (!isRecord(value)) {
+    return { id: "", label: "", mentionSuggestionChar: "@" };
+  }
+
+  const id = value["id"];
+  const label = value["label"];
+  const mentionSuggestionChar = value["mentionSuggestionChar"];
+
+  return {
+    id: typeof id === "string" ? id : "",
+    label: typeof label === "string" ? label : "",
+    mentionSuggestionChar:
+      typeof mentionSuggestionChar === "string" ? mentionSuggestionChar : "@",
   };
+};
+
+export const MentionNode = ({ workspaceId, ...props }: MentionNodeProps) => {
+  const attributes = readMentionAttrs(props.node.attrs);
   const { data: propertyName } = useSuspenseQuery({
     ...propertiesOptions(workspaceId),
     select: (data) => data.find((item) => item.id === attributes.id)?.name,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -279,8 +279,7 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={() => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          fetchNextPage();
+          void fetchNextPage();
         }}
         table={table}
         contentMode={tableState.contentMode}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 
+import type { TranslationKey } from "@/i18n/types";
 import type { ViewFilterCondition, WorkspaceProperty } from "@/lib/types";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 
@@ -281,6 +282,34 @@ const STATUS_VALUES = [
 
 const PRIORITY_VALUES = ["none", "urgent", "high", "medium", "low"] as const;
 
+type StatusValue = (typeof STATUS_VALUES)[number];
+type PriorityValue = (typeof PRIORITY_VALUES)[number];
+
+const STATUS_VALUE_LABEL_KEYS = {
+  open: "tasks.statusValues.open",
+  in_progress: "tasks.statusValues.in_progress",
+  in_review: "tasks.statusValues.in_review",
+  done: "tasks.statusValues.done",
+  cancelled: "tasks.statusValues.cancelled",
+} satisfies Record<StatusValue, TranslationKey>;
+
+const PRIORITY_VALUE_LABEL_KEYS = {
+  none: "tasks.priorityValues.none",
+  urgent: "tasks.priorityValues.urgent",
+  high: "tasks.priorityValues.high",
+  medium: "tasks.priorityValues.medium",
+  low: "tasks.priorityValues.low",
+} satisfies Record<PriorityValue, TranslationKey>;
+
+const STATUS_VALUE_SET: ReadonlySet<string> = new Set(STATUS_VALUES);
+const PRIORITY_VALUE_SET: ReadonlySet<string> = new Set(PRIORITY_VALUES);
+
+const isStatusValue = (value: string): value is StatusValue =>
+  STATUS_VALUE_SET.has(value);
+
+const isPriorityValue = (value: string): value is PriorityValue =>
+  PRIORITY_VALUE_SET.has(value);
+
 type BuiltinFilterChipProps = {
   filter: Extract<ViewFilterCondition, { field: "builtin" }>;
   onChange: (filter: ViewFilterCondition) => void;
@@ -297,12 +326,13 @@ const BuiltinFilterChip = ({
   const label = isStatus ? t("common.status") : t("tasks.priority");
   const values = isStatus ? STATUS_VALUES : PRIORITY_VALUES;
 
-  const resolveLabel = (val: string) =>
-    isStatus
-      ? // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        t(`tasks.statusValues.${val}` as "tasks.statusValues.open")
-      : // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        t(`tasks.priorityValues.${val}` as "tasks.priorityValues.none");
+  const resolveLabel = (value: string) => {
+    if (isStatus) {
+      return isStatusValue(value) ? t(STATUS_VALUE_LABEL_KEYS[value]) : value;
+    }
+
+    return isPriorityValue(value) ? t(PRIORITY_VALUE_LABEL_KEYS[value]) : value;
+  };
 
   const opOptions = [
     { value: "eq", label: t("filters.eq") },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -70,8 +70,7 @@ export const useCreateBBoxes = ({
       return response.data;
     },
     onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: workspaceKeys.justifications(workspaceId),
       });
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/properties.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/properties.ts
@@ -70,12 +70,11 @@ export const useCreateProperty = ({ workspaceId }: { workspaceId: string }) => {
 
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       // Reflect the actor's own write immediately instead of waiting on
       // the server-pushed SSE invalidation round-trip; SSE remains the
       // path that propagates the change to other users' tabs.
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: propertiesKeys.all(workspaceId),
       });
     },
@@ -137,9 +136,8 @@ export const useCreatePropertiesBatch = ({
 
       return response.data;
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: propertiesKeys.all(workspaceId),
       });
     },
@@ -194,9 +192,8 @@ export const useUpdateProperty = () => {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: (_data, { workspaceId }) => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async (_data, { workspaceId }) => {
+      await queryClient.invalidateQueries({
         queryKey: propertiesKeys.all(workspaceId),
       });
     },
@@ -323,9 +320,8 @@ export const useDeleteProperty = () => {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: (_data, { workspaceId }) => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async (_data, { workspaceId }) => {
+      await queryClient.invalidateQueries({
         queryKey: propertiesKeys.all(workspaceId),
       });
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
@@ -33,8 +33,7 @@ export const useCreateViewTemplate = () => {
       return { data: response.data, workspaceId };
     },
     onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: viewTemplateKeys.all({ organizationId }),
       });
     },
@@ -70,8 +69,7 @@ export const useDeleteViewTemplate = () => {
       return { data: response.data, workspaceId };
     },
     onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: viewTemplateKeys.all({ organizationId }),
       });
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -34,11 +34,12 @@ export const useCreateView = (workspaceId: string) => {
       }
       return response.data;
     },
-    onSuccess: (_data, variables) => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
-        queryKey: viewsKeys.all(workspaceId),
-      });
+    onSuccess: async (_data, variables) => {
+      const invalidations = [
+        queryClient.invalidateQueries({
+          queryKey: viewsKeys.all(workspaceId),
+        }),
+      ];
       // Applying a template can create properties in this matter.
       // Without invalidating, the table renders with a stale property
       // list and TanStack silently strips the new column IDs from the
@@ -47,11 +48,13 @@ export const useCreateView = (workspaceId: string) => {
         variables.templateProperties &&
         variables.templateProperties.length > 0
       ) {
-        // eslint-disable-next-line typescript/no-floating-promises
-        queryClient.invalidateQueries({
-          queryKey: propertiesKeys.all(workspaceId),
-        });
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: propertiesKeys.all(workspaceId),
+          }),
+        );
       }
+      await Promise.all(invalidations);
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -111,9 +114,8 @@ export const useUpdateView = (workspaceId: string) => {
       }
       analytics.captureError(error);
     },
-    onSettled: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({ queryKey });
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey });
     },
   });
 };
@@ -138,9 +140,8 @@ export const useConvertView = (workspaceId: string) => {
       }
       return response.data;
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: viewsKeys.all(workspaceId),
       });
     },
@@ -170,9 +171,8 @@ export const useReorderViews = (workspaceId: string) => {
       }
       return response.data;
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: viewsKeys.all(workspaceId),
       });
     },
@@ -201,9 +201,8 @@ export const useDeleteView = (workspaceId: string) => {
       }
       return response.data;
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: viewsKeys.all(workspaceId),
       });
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -123,12 +123,10 @@ const InvoiceDetail = ({
   );
 
   const invalidateAll = () => {
-    // eslint-disable-next-line typescript/no-floating-promises
-    queryClient.invalidateQueries({
+    void queryClient.invalidateQueries({
       queryKey: invoicesKeys.all(workspaceId),
     });
-    // eslint-disable-next-line typescript/no-floating-promises
-    queryClient.invalidateQueries({
+    void queryClient.invalidateQueries({
       queryKey: timeEntriesKeys.all(workspaceId),
     });
   };
@@ -705,8 +703,7 @@ const EditInvoiceForm = ({
         showErrorToast(t("billing.failedToSave"));
         return;
       }
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: invoicesKeys.all(workspaceId),
       });
       onClose();
@@ -721,8 +718,7 @@ const EditInvoiceForm = ({
       errors={formErrors}
       onSubmit={(e) => {
         e.preventDefault();
-        // eslint-disable-next-line typescript/no-floating-promises
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <h2 className="text-sm font-semibold">

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -259,8 +259,7 @@ export const useMatterActions = (
             title: t("success.workspaceDeletedSuccessfully"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
+          void queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
           onDeleted?.();
         },
         onError: () => {
@@ -525,12 +524,10 @@ export const AddMemberDialog = ({
             title: t("success.memberAdded"),
             type: "success",
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: workspaceMembersKeys.all(workspaceId),
           });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
+          void queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
           onOpenChange(false);
           setSelectedUserId(null);
         },

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -300,8 +300,7 @@ const MattersTableRow = ({
     if (isEditing) {
       return;
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    navigate({
+    void navigate({
       to: "/workspaces/$workspaceId",
       params: { workspaceId: workspace.id },
     });

--- a/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
@@ -79,8 +79,7 @@ export const PdfViewerControls = ({
   };
 
   const navigateToPage = (pageNumber: number) => {
-    // eslint-disable-next-line typescript/no-floating-promises
-    navigate({
+    void navigate({
       replace: true,
       search: (prev) =>
         produce(prev, (s) => {

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -50,9 +50,8 @@ export const useCreateWorkspace = () => {
 
       return { id: toSafeId<"workspace">(id) };
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: workspacesKeys.all,
       });
     },
@@ -166,9 +165,8 @@ export const useUnarchiveWorkspace = () => {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: () => {
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: workspacesKeys.all,
       });
     },

--- a/apps/web/src/routes/auth/organization.tsx
+++ b/apps/web/src/routes/auth/organization.tsx
@@ -75,8 +75,7 @@ function Organization() {
 
   useEffect(() => {
     if (!isPending && !hasOrganizations && !isOauthPostLogin) {
-      // eslint-disable-next-line typescript/no-floating-promises
-      navigate({ to: "/onboarding", replace: true });
+      void navigate({ to: "/onboarding", replace: true });
     }
   }, [hasOrganizations, isOauthPostLogin, isPending, navigate]);
 
@@ -350,8 +349,7 @@ const CreateOrganizationForm = ({
           errors={formErrors}
           onSubmit={(event) => {
             event.preventDefault();
-            // eslint-disable-next-line typescript/no-floating-promises
-            form.handleSubmit();
+            void form.handleSubmit();
           }}
         >
           <form.Field name="name">

--- a/apps/web/src/routes/consent.tsx
+++ b/apps/web/src/routes/consent.tsx
@@ -248,8 +248,7 @@ function ConsentPage() {
               disabled={isPending}
               loading={isPending}
               onClick={() => {
-                // eslint-disable-next-line typescript/no-floating-promises
-                handleConsent(true);
+                void handleConsent(true);
               }}
               type="button"
             >
@@ -259,8 +258,7 @@ function ConsentPage() {
               className="w-full"
               disabled={isPending}
               onClick={() => {
-                // eslint-disable-next-line typescript/no-floating-promises
-                handleConsent(false);
+                void handleConsent(false);
               }}
               type="button"
               variant="outline"

--- a/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
@@ -749,12 +749,10 @@ export const OnboardingWizard = () => {
       >
         <DownloadStep
           onNext={() => {
-            // eslint-disable-next-line typescript/no-floating-promises
-            executeSetup(data);
+            void executeSetup(data);
           }}
           onSkip={() => {
-            // eslint-disable-next-line typescript/no-floating-promises
-            executeSetup(data);
+            void executeSetup(data);
           }}
         />
       </OnboardingLayout>

--- a/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
@@ -236,11 +236,11 @@ export const OnboardingWizard = () => {
       setStep("creating");
       const startTime = Date.now();
 
-      // eslint-disable-next-line require-await
-      const delay = async (ms: number) =>
-        new Promise<void>((resolve) => {
+      const delay = async (ms: number) => {
+        await new Promise<void>((resolve) => {
           setTimeout(resolve, ms);
         });
+      };
 
       // Phase 1: Create organization
       setCreatingPhase("org");

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
@@ -320,8 +320,7 @@ export const AIStep = ({
             compact
             onProvidersChange={updateProviders}
             onSaveRow={(index) => {
-              // eslint-disable-next-line typescript/no-floating-promises
-              saveRow(index);
+              void saveRow(index);
             }}
             providers={providers}
             rowStatuses={rowStatusList}

--- a/apps/web/src/routes/onboarding/-components/steps/organization-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/organization-step.tsx
@@ -75,8 +75,7 @@ export const OrganizationStep = ({
             flashInput();
             return;
           }
-          // eslint-disable-next-line typescript/no-floating-promises
-          form.handleSubmit();
+          void form.handleSubmit();
         }}
       >
         <form.Field name="name">

--- a/packages/business-registries/src/ares/client.ts
+++ b/packages/business-registries/src/ares/client.ts
@@ -31,6 +31,69 @@ const DEFAULT_SEARCH_LIMIT = 50;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isOptionalRecord = (value: unknown): boolean =>
+  value === undefined || isRecord(value);
+
+const isOptionalStringArray = (value: unknown): boolean =>
+  value === undefined ||
+  (Array.isArray(value) && value.every((item) => typeof item === "string"));
+
+const isOptionalRecordArray = (value: unknown): boolean =>
+  value === undefined || (Array.isArray(value) && value.every(isRecord));
+
+const isAresResRecord = (
+  value: unknown,
+): value is AresResResponse["zaznamy"][number] =>
+  isRecord(value) &&
+  typeof value["ico"] === "string" &&
+  typeof value["obchodniJmeno"] === "string" &&
+  typeof value["primarniZaznam"] === "boolean" &&
+  isOptionalRecord(value["sidlo"]) &&
+  isOptionalStringArray(value["czNace"]);
+
+const isAresResResponse = (value: unknown): value is AresResResponse =>
+  isRecord(value) &&
+  typeof value["icoId"] === "string" &&
+  Array.isArray(value["zaznamy"]) &&
+  value["zaznamy"].every(isAresResRecord);
+
+const isAresVrRecord = (
+  value: unknown,
+): value is AresVrResponse["zaznamy"][number] =>
+  isRecord(value) &&
+  typeof value["primarniZaznam"] === "boolean" &&
+  isOptionalRecordArray(value["obchodniJmeno"]) &&
+  isOptionalRecordArray(value["ico"]) &&
+  isOptionalRecordArray(value["adresy"]) &&
+  (value["pravniForma"] === undefined ||
+    typeof value["pravniForma"] === "string" ||
+    isOptionalRecordArray(value["pravniForma"])) &&
+  isOptionalRecordArray(value["spisovaZnacka"]) &&
+  isOptionalRecordArray(value["zakladniKapital"]) &&
+  isOptionalRecordArray(value["statutarniOrgany"]) &&
+  isOptionalRecordArray(value["ostatniOrgany"]) &&
+  isOptionalRecordArray(value["datumVzniku"]);
+
+const isAresVrResponse = (value: unknown): value is AresVrResponse =>
+  isRecord(value) &&
+  typeof value["icoId"] === "string" &&
+  Array.isArray(value["zaznamy"]) &&
+  value["zaznamy"].every(isAresVrRecord);
+
+const isAresSearchEntry = (
+  value: unknown,
+): value is AresSearchResponse["ekonomickeSubjekty"][number] =>
+  isRecord(value) &&
+  (value["ico"] === undefined || typeof value["ico"] === "string") &&
+  typeof value["obchodniJmeno"] === "string" &&
+  isOptionalRecord(value["sidlo"]);
+
+const isAresSearchResponse = (value: unknown): value is AresSearchResponse =>
+  isRecord(value) &&
+  typeof value["pocetCelkem"] === "number" &&
+  Array.isArray(value["ekonomickeSubjekty"]) &&
+  value["ekonomickeSubjekty"].every(isAresSearchEntry);
+
 const parseErrorBody = (value: unknown): AresErrorResponse => {
   if (!isRecord(value)) {
     return {};
@@ -74,7 +137,35 @@ const handleAresError = async (
   });
 };
 
-const aresGet = async <T>(url: string): Promise<T | null> => {
+const readAresJson = async <T>(
+  response: Response,
+  isExpectedShape: (value: unknown) => value is T,
+): Promise<T> => {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new AresAPIError({
+      message: "ARES returned a non-JSON response",
+      httpStatus: response.status,
+      cause: error,
+    });
+  }
+
+  if (!isExpectedShape(body)) {
+    throw new AresAPIError({
+      message: "ARES returned an unexpected response shape",
+      httpStatus: response.status,
+    });
+  }
+
+  return body;
+};
+
+const aresGet = async <T>(
+  url: string,
+  isExpectedShape: (value: unknown) => value is T,
+): Promise<T | null> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -107,13 +198,14 @@ const aresGet = async <T>(url: string): Promise<T | null> => {
     await handleAresError(response, url);
   }
 
-  // SAFETY: we trust the ARES API to return the expected JSON shape;
-  // runtime validation is not needed for this well-documented public API
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return response.json() as Promise<T>;
+  return readAresJson(response, isExpectedShape);
 };
 
-const aresPost = async <T>(url: string, payload: unknown): Promise<T> => {
+const aresPost = async <T>(
+  url: string,
+  payload: unknown,
+  isExpectedShape: (value: unknown) => value is T,
+): Promise<T> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -133,10 +225,7 @@ const aresPost = async <T>(url: string, payload: unknown): Promise<T> => {
     await handleAresError(response, url);
   }
 
-  // SAFETY: we trust the ARES API to return the expected JSON shape;
-  // runtime validation is not needed for this well-documented public API
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return response.json() as Promise<T>;
+  return readAresJson(response, isExpectedShape);
 };
 
 // ---------------------------------------------------------------------------
@@ -176,9 +265,9 @@ export const lookupByIco = async (
   const includeVr = options?.includeVr ?? true;
 
   // Fetch RES (always) and VR (optionally, in parallel)
-  const resPromise = aresGet<AresResResponse>(`${RES_URL}/${normalized}`);
+  const resPromise = aresGet(`${RES_URL}/${normalized}`, isAresResResponse);
   const vrPromise = includeVr
-    ? aresGet<AresVrResponse>(`${VR_URL}/${normalized}`)
+    ? aresGet(`${VR_URL}/${normalized}`, isAresVrResponse)
     : null;
 
   const [resData, vrData] = await Promise.all([
@@ -234,7 +323,7 @@ export const searchByName = async (
     pocet: limit,
   };
 
-  const data = await aresPost<AresSearchResponse>(SEARCH_URL, payload);
+  const data = await aresPost(SEARCH_URL, payload, isAresSearchResponse);
 
   return data.ekonomickeSubjekty
     .filter((entry) => entry.ico)

--- a/packages/business-registries/src/brreg/client.ts
+++ b/packages/business-registries/src/brreg/client.ts
@@ -26,6 +26,56 @@ const BRREG_RESULT_CAP = 10_000;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isOptionalRecord = (value: unknown): boolean =>
+  value === undefined || isRecord(value);
+
+const isOptionalNumber = (value: unknown): boolean =>
+  value === undefined || typeof value === "number";
+
+const isBrregRawEnhet = (value: unknown): value is BrregRawEnhet =>
+  isRecord(value) &&
+  typeof value["organisasjonsnummer"] === "string" &&
+  typeof value["navn"] === "string" &&
+  isOptionalRecord(value["organisasjonsform"]) &&
+  isOptionalRecord(value["postadresse"]) &&
+  isOptionalRecord(value["forretningsadresse"]) &&
+  isOptionalRecord(value["beliggenhetsadresse"]) &&
+  isOptionalRecord(value["naeringskode1"]) &&
+  isOptionalRecord(value["naeringskode2"]) &&
+  isOptionalRecord(value["naeringskode3"]) &&
+  isOptionalNumber(value["antallAnsatte"]);
+
+const isBrregSearchResponse = (
+  value: unknown,
+): value is BrregSearchResponse => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const embedded = value["_embedded"];
+  if (embedded !== undefined) {
+    if (!isRecord(embedded)) {
+      return false;
+    }
+    const enheter = embedded["enheter"];
+    if (!Array.isArray(enheter) || !enheter.every(isBrregRawEnhet)) {
+      return false;
+    }
+  }
+
+  const page = value["page"];
+  if (page === undefined) {
+    return true;
+  }
+  return (
+    isRecord(page) &&
+    typeof page["size"] === "number" &&
+    typeof page["totalElements"] === "number" &&
+    typeof page["totalPages"] === "number" &&
+    typeof page["number"] === "number"
+  );
+};
+
 const parseErrorBody = (value: unknown): BrregErrorResponse => {
   if (!isRecord(value)) {
     return {};
@@ -43,7 +93,35 @@ const parseErrorBody = (value: unknown): BrregErrorResponse => {
   return result;
 };
 
-const brregGet = async <T>(url: string): Promise<T | null> => {
+const readBrregJson = async <T>(
+  response: Response,
+  isExpectedShape: (value: unknown) => value is T,
+): Promise<T> => {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new BrregAPIError({
+      message: "Brreg returned a non-JSON response",
+      httpStatus: response.status,
+      cause: error,
+    });
+  }
+
+  if (!isExpectedShape(body)) {
+    throw new BrregAPIError({
+      message: "Brreg returned an unexpected response shape",
+      httpStatus: response.status,
+    });
+  }
+
+  return body;
+};
+
+const brregGet = async <T>(
+  url: string,
+  isExpectedShape: (value: unknown) => value is T,
+): Promise<T | null> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -85,10 +163,7 @@ const brregGet = async <T>(url: string): Promise<T | null> => {
     });
   }
 
-  // SAFETY: Brreg is a stable, documented public API. Runtime validation
-  // adds little for well-typed JSON responses.
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return response.json() as Promise<T>;
+  return readBrregJson(response, isExpectedShape);
 };
 
 // ---------------------------------------------------------------------------
@@ -126,14 +201,15 @@ export const lookupByOrgnr = async (
     throw new BrregValidationError(`Invalid orgnr: ${orgnr}`);
   }
 
-  const enhet = await brregGet<BrregRawEnhet>(`${ENHETER_URL}/${normalized}`);
+  const enhet = await brregGet(`${ENHETER_URL}/${normalized}`, isBrregRawEnhet);
   if (enhet) {
     return parseEnhet(enhet, "enhet");
   }
 
   if (options?.includeSubEntities ?? true) {
-    const sub = await brregGet<BrregRawEnhet>(
+    const sub = await brregGet(
       `${UNDERENHETER_URL}/${normalized}`,
+      isBrregRawEnhet,
     );
     if (sub) {
       return parseEnhet(sub, "underenhet");
@@ -181,7 +257,7 @@ export const searchByName = async (
 
   let data: BrregSearchResponse | null;
   try {
-    data = await brregGet<BrregSearchResponse>(url);
+    data = await brregGet(url, isBrregSearchResponse);
   } catch (error) {
     // Brreg short-circuits queries that would exceed its 10k result
     // cap with HTTP 400 — there is no page envelope to inspect — so

--- a/packages/business-registries/src/brreg/roles.ts
+++ b/packages/business-registries/src/brreg/roles.ts
@@ -230,6 +230,51 @@ export const parseRolesResponse = (
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isRawRoleType = (value: unknown): value is BrregRawRoleType =>
+  isRecord(value) && typeof value["kode"] === "string";
+
+const isRawRolePerson = (value: unknown): value is BrregRawRolePerson =>
+  isRecord(value) &&
+  (value["navn"] === undefined || isRecord(value["navn"])) &&
+  (value["erDoed"] === undefined || typeof value["erDoed"] === "boolean");
+
+const isRawRoleEntity = (value: unknown): value is BrregRawRoleEntity =>
+  isRecord(value) &&
+  typeof value["organisasjonsnummer"] === "string" &&
+  (value["navn"] === undefined ||
+    (Array.isArray(value["navn"]) &&
+      value["navn"].every((item) => typeof item === "string"))) &&
+  (value["organisasjonsform"] === undefined ||
+    isRawRoleType(value["organisasjonsform"]));
+
+const isRawRoleTrustee = (value: unknown): value is BrregRawRoleTrustee =>
+  isRecord(value) &&
+  typeof value["navn"] === "string" &&
+  (value["postadresse"] === undefined || isRecord(value["postadresse"]));
+
+const isRawRole = (value: unknown): value is BrregRawRole =>
+  isRecord(value) &&
+  isRawRoleType(value["type"]) &&
+  (value["person"] === undefined || isRawRolePerson(value["person"])) &&
+  (value["enhet"] === undefined || isRawRoleEntity(value["enhet"])) &&
+  (value["bostyrer"] === undefined || isRawRoleTrustee(value["bostyrer"])) &&
+  (value["fratraadt"] === undefined ||
+    typeof value["fratraadt"] === "boolean") &&
+  (value["avregistrert"] === undefined ||
+    typeof value["avregistrert"] === "boolean");
+
+const isRawRoleGroup = (value: unknown): value is BrregRawRoleGroup =>
+  isRecord(value) &&
+  isRawRoleType(value["type"]) &&
+  (value["roller"] === undefined ||
+    (Array.isArray(value["roller"]) && value["roller"].every(isRawRole)));
+
+const isRawRolesResponse = (value: unknown): value is BrregRawRolesResponse =>
+  isRecord(value) &&
+  (value["rollegrupper"] === undefined ||
+    (Array.isArray(value["rollegrupper"]) &&
+      value["rollegrupper"].every(isRawRoleGroup)));
+
 const parseUpstreamMessage = (value: unknown): string | null => {
   if (!isRecord(value)) {
     return null;
@@ -281,11 +326,19 @@ const brregGetRoles = async (
   }
 
   try {
-    // SAFETY: Brreg is a stable, documented public API. Runtime validation
-    // adds little for well-typed JSON responses.
-    // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    return (await response.json()) as BrregRawRolesResponse;
+    const body: unknown = await response.json();
+    if (!isRawRolesResponse(body)) {
+      throw new BrregAPIError({
+        message: `Brreg ${response.status}: unexpected roles payload shape`,
+        httpStatus: response.status,
+        upstreamMessage: null,
+      });
+    }
+    return body;
   } catch (error) {
+    if (error instanceof BrregAPIError) {
+      throw error;
+    }
     throw new BrregAPIError({
       message: `Brreg ${response.status}: invalid JSON payload`,
       httpStatus: response.status,

--- a/packages/business-registries/src/companies-house/client.ts
+++ b/packages/business-registries/src/companies-house/client.ts
@@ -63,6 +63,65 @@ const buildAuthHeader = (apiKey: string): string => {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isOptionalRecord = (value: unknown): boolean =>
+  value === undefined || isRecord(value);
+
+const isOptionalStringArray = (value: unknown): boolean =>
+  value === undefined ||
+  (Array.isArray(value) && value.every((item) => typeof item === "string"));
+
+const isCompaniesHousePreviousName = (value: unknown): boolean =>
+  isRecord(value) && typeof value["name"] === "string";
+
+const isCompaniesHouseRawCompanyProfile = (
+  value: unknown,
+): value is CompaniesHouseRawCompanyProfile =>
+  isRecord(value) &&
+  typeof value["company_name"] === "string" &&
+  typeof value["company_number"] === "string" &&
+  isOptionalRecord(value["registered_office_address"]) &&
+  isOptionalRecord(value["service_address"]) &&
+  isOptionalStringArray(value["sic_codes"]) &&
+  isOptionalRecord(value["accounts"]) &&
+  isOptionalRecord(value["confirmation_statement"]) &&
+  (value["previous_company_names"] === undefined ||
+    (Array.isArray(value["previous_company_names"]) &&
+      value["previous_company_names"].every(isCompaniesHousePreviousName)));
+
+const isCompaniesHouseSearchItem = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value["company_number"] === "string" &&
+  typeof value["title"] === "string" &&
+  isOptionalRecord(value["address"]) &&
+  isOptionalStringArray(value["description_identifier"]);
+
+const isCompaniesHouseRawSearchResponse = (
+  value: unknown,
+): value is CompaniesHouseRawSearchResponse =>
+  isRecord(value) &&
+  (value["items"] === undefined ||
+    (Array.isArray(value["items"]) &&
+      value["items"].every(isCompaniesHouseSearchItem)));
+
+const isCompaniesHouseOfficer = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value["name"] === "string" &&
+  typeof value["officer_role"] === "string" &&
+  isOptionalRecord(value["date_of_birth"]) &&
+  isOptionalRecord(value["address"]) &&
+  isOptionalRecord(value["principal_office_address"]) &&
+  isOptionalRecord(value["identification"]);
+
+const isCompaniesHouseRawOfficersResponse = (
+  value: unknown,
+): value is CompaniesHouseRawOfficersResponse =>
+  isRecord(value) &&
+  (value["items"] === undefined ||
+    (Array.isArray(value["items"]) &&
+      value["items"].every(isCompaniesHouseOfficer))) &&
+  (value["total_results"] === undefined ||
+    typeof value["total_results"] === "number");
+
 const readUpstreamMessage = async (
   response: Response,
 ): Promise<string | null> => {
@@ -104,6 +163,7 @@ const readUpstreamMessage = async (
 const companiesHouseGet = async <T>(
   url: string,
   apiKey: string,
+  isExpectedShape: (value: unknown) => value is T,
 ): Promise<T | null> => {
   let response: Response;
   try {
@@ -154,18 +214,13 @@ const companiesHouseGet = async <T>(
       cause: error,
     });
   }
-  if (!isRecord(json)) {
+  if (!isExpectedShape(json)) {
     throw new CompaniesHouseAPIError({
       message: "Companies House returned an unexpected response shape",
       httpStatus: response.status,
     });
   }
-  // SAFETY: Companies House publishes a stable, documented JSON shape
-  // for every endpoint we call. The parser tolerates absent optional
-  // fields, so we narrow structurally at the top (`isRecord`) and let
-  // the parser handle the rest.
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return json as T;
+  return json;
 };
 
 // ---------------------------------------------------------------------------
@@ -199,6 +254,7 @@ export const lookupByCompanyNumber = async (
   const raw = await companiesHouseGet<CompaniesHouseRawCompanyProfile>(
     url,
     config.apiKey,
+    isCompaniesHouseRawCompanyProfile,
   );
   if (!raw) {
     return null;
@@ -252,6 +308,7 @@ export const searchByName = async (
   const raw = await companiesHouseGet<CompaniesHouseRawSearchResponse>(
     url,
     config.apiKey,
+    isCompaniesHouseRawSearchResponse,
   );
   if (!raw) {
     return [];
@@ -320,6 +377,7 @@ export const lookupOfficersByCompanyNumber = async (
     const raw = await companiesHouseGet<CompaniesHouseRawOfficersResponse>(
       url,
       config.apiKey,
+      isCompaniesHouseRawOfficersResponse,
     );
     if (!raw) {
       return collected;

--- a/packages/business-registries/src/edgar/client.ts
+++ b/packages/business-registries/src/edgar/client.ts
@@ -40,10 +40,32 @@ const assertUserAgent = (userAgent: string): void => {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const edgarGet = async <T>(
+const isOptionalStringArray = (value: unknown): boolean =>
+  value === undefined ||
+  (Array.isArray(value) && value.every((item) => typeof item === "string"));
+
+const isOptionalRecord = (value: unknown): boolean =>
+  value === undefined || isRecord(value);
+
+const isEdgarFormerName = (value: unknown): boolean =>
+  isRecord(value) && typeof value["name"] === "string";
+
+const isEdgarRawSubmission = (value: unknown): value is EdgarRawSubmission =>
+  isRecord(value) &&
+  typeof value["cik"] === "string" &&
+  typeof value["name"] === "string" &&
+  isOptionalStringArray(value["tickers"]) &&
+  isOptionalStringArray(value["exchanges"]) &&
+  isOptionalRecord(value["addresses"]) &&
+  (value["formerNames"] === undefined ||
+    (Array.isArray(value["formerNames"]) &&
+      value["formerNames"].every(isEdgarFormerName))) &&
+  isOptionalRecord(value["filings"]);
+
+const edgarGet = async (
   url: string,
   userAgent: string,
-): Promise<T | null> => {
+): Promise<EdgarRawSubmission | null> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -99,18 +121,13 @@ const edgarGet = async <T>(
       cause: error,
     });
   }
-  if (!isRecord(json)) {
+  if (!isEdgarRawSubmission(json)) {
     throw new EdgarAPIError({
       message: "EDGAR returned an unexpected response shape",
       httpStatus: response.status,
     });
   }
-  // SAFETY: EDGAR's `submissions/CIK*.json` is a documented, stable
-  // public endpoint. The parser tolerates absent fields, so we narrow
-  // structurally at the top (`isRecord`) and let the parser handle
-  // the rest.
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return json as T;
+  return json;
 };
 
 // ---------------------------------------------------------------------------
@@ -140,7 +157,7 @@ export const lookupByCik = async (
 
   const padded = padCik(cik);
   const url = `${SUBMISSIONS_BASE}/CIK${padded}.json`;
-  const raw = await edgarGet<EdgarRawSubmission>(url, config.userAgent);
+  const raw = await edgarGet(url, config.userAgent);
   if (!raw) {
     return null;
   }

--- a/packages/business-registries/src/krs/client.ts
+++ b/packages/business-registries/src/krs/client.ts
@@ -22,6 +22,9 @@ const REGISTER_PROBE_ORDER: readonly KrsRegisterCode[] = ["RejP", "RejS"];
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isKrsLookupResponse = (value: unknown): value is KrsLookupResponse =>
+  isRecord(value) && (value["odpis"] === undefined || isRecord(value["odpis"]));
+
 const parseErrorBody = (value: unknown): KrsErrorResponse => {
   if (!isRecord(value)) {
     return {};
@@ -90,13 +93,13 @@ const krsGet = async (
       cause: error,
     });
   }
-  // SAFETY: the KRS API is a stable, documented public surface and
-  // the shape is captured by `KrsLookupResponse`. The parser
-  // tolerates absent optional fields via defensive `?.` chains, so a
-  // runtime schema mismatch surfaces as `null` properties on the
-  // domain output rather than a 500.
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return { status: response.status, body: body as KrsLookupResponse };
+  if (!isKrsLookupResponse(body)) {
+    throw new KrsAPIError({
+      message: `KRS ${response.status}: unexpected JSON payload shape`,
+      httpStatus: response.status,
+    });
+  }
+  return { status: response.status, body };
 };
 
 const buildLookupUrl = (

--- a/packages/business-registries/src/orsr/client.ts
+++ b/packages/business-registries/src/orsr/client.ts
@@ -29,6 +29,23 @@ const MAX_SEARCH_LIMIT = 100;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isOrsrSearchHit = (value: unknown): value is OrsrRawSearchHit =>
+  isRecord(value) && typeof value["id"] === "number";
+
+const isOrsrSearchResponse = (value: unknown): value is OrsrRawSearchResponse =>
+  isRecord(value) &&
+  (value["filteredCount"] === undefined ||
+    typeof value["filteredCount"] === "number") &&
+  (value["data"] === undefined ||
+    (Array.isArray(value["data"]) && value["data"].every(isOrsrSearchHit)));
+
+const isOrsrExtractResponse = (
+  value: unknown,
+): value is OrsrRawExtractResponse =>
+  isRecord(value) &&
+  (value["fileReference"] === undefined || isRecord(value["fileReference"])) &&
+  (value["legalPerson"] === undefined || isRecord(value["legalPerson"]));
+
 const parseErrorBody = (value: unknown): OrsrRawErrorResponse => {
   if (!isRecord(value)) {
     return {};
@@ -43,7 +60,10 @@ const parseErrorBody = (value: unknown): OrsrRawErrorResponse => {
   return result;
 };
 
-const orsrGet = async <T>(url: string): Promise<T> => {
+const orsrGet = async <T>(
+  url: string,
+  isExpectedShape: (value: unknown) => value is T,
+): Promise<T> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -68,13 +88,9 @@ const orsrGet = async <T>(url: string): Promise<T> => {
     });
   }
 
+  let body: unknown;
   try {
-    // SAFETY: `sluzby.orsr.sk` is a stable, documented Ministry of
-    // Justice surface backed by a published XSD. Runtime validation
-    // adds little for well-typed JSON; the parser tolerates absent
-    // fields so upstream drift surfaces as `null` rather than a throw.
-    // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    return (await response.json()) as T;
+    body = await response.json();
   } catch (error) {
     throw new OrsrAPIError({
       message: `ORSR ${response.status}: invalid JSON payload`,
@@ -83,6 +99,16 @@ const orsrGet = async <T>(url: string): Promise<T> => {
       cause: error,
     });
   }
+
+  if (!isExpectedShape(body)) {
+    throw new OrsrAPIError({
+      message: `ORSR ${response.status}: unexpected JSON payload shape`,
+      httpStatus: response.status,
+      upstreamMessage: null,
+    });
+  }
+
+  return body;
 };
 
 const buildSearchUrl = (filterValue: string, take?: number): string => {
@@ -168,8 +194,9 @@ export const lookupByIco = async (ico: string): Promise<OrsrCompany | null> => {
     throw new OrsrValidationError(`Invalid Slovak IČO: ${ico}`);
   }
 
-  const searchData = await orsrGet<OrsrRawSearchResponse>(
+  const searchData = await orsrGet(
     buildSearchUrl(normalized),
+    isOrsrSearchResponse,
   );
   const hit = pickLatestHit(searchData.data);
   if (!hit) {
@@ -190,8 +217,9 @@ export const lookupByIco = async (ico: string): Promise<OrsrCompany | null> => {
     vlozka: String(fileRef.insertNumber),
     sud: fileRef.court,
   });
-  const extract = await orsrGet<OrsrRawExtractResponse>(
+  const extract = await orsrGet(
     `${EXTRACT_URL}?${extractParams.toString()}`,
+    isOrsrExtractResponse,
   );
   return parseExtract(extract);
 };
@@ -225,8 +253,9 @@ export const searchByName = async (
     Math.max(take, DEFAULT_SEARCH_LIMIT),
     MAX_SEARCH_LIMIT,
   );
-  const data = await orsrGet<OrsrRawSearchResponse>(
+  const data = await orsrGet(
     buildSearchUrl(trimmed, searchTake),
+    isOrsrSearchResponse,
   );
   return dedupeLatestHitsByIco(data.data).slice(0, take).map(parseSearchHit);
 };

--- a/packages/business-registries/src/prh/client.ts
+++ b/packages/business-registries/src/prh/client.ts
@@ -20,6 +20,43 @@ const MAX_SEARCH_LIMIT = 100;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isOptionalRecord = (value: unknown): boolean =>
+  value === undefined || isRecord(value);
+
+const isOptionalRecordArray = (value: unknown): boolean =>
+  value === undefined || (Array.isArray(value) && value.every(isRecord));
+
+const isPrhSourcedValue = (value: unknown): boolean =>
+  isRecord(value) && typeof value["value"] === "string";
+
+const isPrhRawName = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value["name"] === "string" &&
+  typeof value["type"] === "string";
+
+const isPrhAddress = (value: unknown): boolean =>
+  isRecord(value) && typeof value["type"] === "number";
+
+const isPrhRawCompany = (value: unknown): boolean =>
+  isRecord(value) &&
+  isPrhSourcedValue(value["businessId"]) &&
+  (value["names"] === undefined ||
+    (Array.isArray(value["names"]) && value["names"].every(isPrhRawName))) &&
+  isOptionalRecord(value["mainBusinessLine"]) &&
+  isOptionalRecordArray(value["companyForms"]) &&
+  isOptionalRecordArray(value["companySituations"]) &&
+  (value["addresses"] === undefined ||
+    (Array.isArray(value["addresses"]) &&
+      value["addresses"].every(isPrhAddress)));
+
+const isPrhCompaniesResponse = (
+  value: unknown,
+): value is PrhCompaniesResponse =>
+  isRecord(value) &&
+  typeof value["totalResults"] === "number" &&
+  Array.isArray(value["companies"]) &&
+  value["companies"].every(isPrhRawCompany);
+
 const parseErrorBody = (value: unknown): PrhErrorResponse => {
   if (!isRecord(value)) {
     return {};
@@ -37,7 +74,7 @@ const parseErrorBody = (value: unknown): PrhErrorResponse => {
   return result;
 };
 
-const prhGet = async <T>(url: string): Promise<T> => {
+const prhGet = async (url: string): Promise<PrhCompaniesResponse> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -72,11 +109,14 @@ const prhGet = async <T>(url: string): Promise<T> => {
     });
   }
 
-  // SAFETY: PRH AvoinData v3 is a stable, documented public API and
-  // the shape is captured by `PrhCompaniesResponse`. Runtime
-  // validation adds little for well-typed JSON responses.
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return body as T;
+  if (!isPrhCompaniesResponse(body)) {
+    throw new PrhAPIError({
+      message: "PRH returned an unexpected response shape",
+      httpStatus: response.status,
+    });
+  }
+
+  return body;
 };
 
 /**
@@ -99,9 +139,7 @@ export const lookupByBusinessId = async (
     throw new PrhValidationError(`Invalid Y-tunnus: ${businessId}`);
   }
   const params = new URLSearchParams({ businessId: normalized });
-  const data = await prhGet<PrhCompaniesResponse>(
-    `${COMPANIES_URL}?${params.toString()}`,
-  );
+  const data = await prhGet(`${COMPANIES_URL}?${params.toString()}`);
   const hit = data.companies.at(0);
   return hit ? parseCompany(hit) : null;
 };
@@ -135,9 +173,7 @@ export const searchByName = async (
     name: trimmed,
     maxResults: limit.toString(),
   });
-  const data = await prhGet<PrhCompaniesResponse>(
-    `${COMPANIES_URL}?${params.toString()}`,
-  );
+  const data = await prhGet(`${COMPANIES_URL}?${params.toString()}`);
   // Slice defensively in case PRH returns more than the requested
   // maxResults; callers should still get exactly the clamped limit.
   return data.companies.slice(0, limit).map(parseSearchEntry);

--- a/packages/business-registries/src/recherche-entreprises/client.ts
+++ b/packages/business-registries/src/recherche-entreprises/client.ts
@@ -25,6 +25,39 @@ const MAX_SEARCH_LIMIT = 25;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isRechercheEstablishment = (value: unknown): boolean =>
+  isRecord(value) && typeof value["siret"] === "string";
+
+const isRechercheDirector = (value: unknown): boolean =>
+  isRecord(value) &&
+  (value["type_dirigeant"] === "personne physique" ||
+    value["type_dirigeant"] === "personne morale");
+
+const isRechercheCompany = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value["siren"] === "string" &&
+  typeof value["nom_complet"] === "string" &&
+  (value["siege"] === undefined ||
+    value["siege"] === null ||
+    isRechercheEstablishment(value["siege"])) &&
+  (value["matching_etablissements"] === undefined ||
+    (Array.isArray(value["matching_etablissements"]) &&
+      value["matching_etablissements"].every(isRechercheEstablishment))) &&
+  (value["dirigeants"] === undefined ||
+    (Array.isArray(value["dirigeants"]) &&
+      value["dirigeants"].every(isRechercheDirector)));
+
+const isRechercheSearchResponse = (
+  value: unknown,
+): value is RechercheEntreprisesSearchResponse =>
+  isRecord(value) &&
+  Array.isArray(value["results"]) &&
+  value["results"].every(isRechercheCompany) &&
+  typeof value["total_results"] === "number" &&
+  typeof value["page"] === "number" &&
+  typeof value["per_page"] === "number" &&
+  typeof value["total_pages"] === "number";
+
 const parseErrorBody = (value: unknown): RechercheEntreprisesErrorResponse => {
   if (!isRecord(value)) {
     return {};
@@ -39,7 +72,9 @@ const parseErrorBody = (value: unknown): RechercheEntreprisesErrorResponse => {
   return result;
 };
 
-const rechercheEntreprisesGet = async <T>(url: string): Promise<T> => {
+const rechercheEntreprisesGet = async (
+  url: string,
+): Promise<RechercheEntreprisesSearchResponse> => {
   let response: Response;
   try {
     response = await fetch(url, {
@@ -69,9 +104,6 @@ const rechercheEntreprisesGet = async <T>(url: string): Promise<T> => {
     });
   }
 
-  // SAFETY: recherche-entreprises is a stable, documented public API
-  // and the shape is captured by `RechercheEntreprisesSearchResponse`.
-  // Runtime validation adds little for well-typed JSON responses.
   let payload: unknown;
   try {
     payload = await response.json();
@@ -89,8 +121,14 @@ const rechercheEntreprisesGet = async <T>(url: string): Promise<T> => {
       cause: error,
     });
   }
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return payload as T;
+  if (!isRechercheSearchResponse(payload)) {
+    throw new RechercheEntreprisesAPIError({
+      message: `recherche-entreprises returned an unexpected JSON body shape (HTTP ${response.status})`,
+      httpStatus: response.status,
+      upstreamMessage: null,
+    });
+  }
+  return payload;
 };
 
 /**
@@ -114,10 +152,9 @@ export const lookupBySiren = async (
     throw new RechercheEntreprisesValidationError(`Invalid SIREN: ${siren}`);
   }
   const params = new URLSearchParams({ q: normalized });
-  const data =
-    await rechercheEntreprisesGet<RechercheEntreprisesSearchResponse>(
-      `${SEARCH_URL}?${params.toString()}`,
-    );
+  const data = await rechercheEntreprisesGet(
+    `${SEARCH_URL}?${params.toString()}`,
+  );
   const hit = data.results.at(0);
   // Belt-and-braces: the search endpoint matches `q` against any
   // text field, so an unrelated entity could in principle slip in.
@@ -153,10 +190,9 @@ export const lookupBySiret = async (
     throw new RechercheEntreprisesValidationError(`Invalid SIRET: ${siret}`);
   }
   const params = new URLSearchParams({ q: normalized });
-  const data =
-    await rechercheEntreprisesGet<RechercheEntreprisesSearchResponse>(
-      `${SEARCH_URL}?${params.toString()}`,
-    );
+  const data = await rechercheEntreprisesGet(
+    `${SEARCH_URL}?${params.toString()}`,
+  );
   // SIRET = SIREN (first 9) + NIC (last 5). Require BOTH the unité
   // légale's SIREN to match the SIRET prefix AND the establishment
   // itself to appear in `matching_etablissements`. Without the second
@@ -210,9 +246,8 @@ export const searchByName = async (
     q: trimmed,
     per_page: String(perPage),
   });
-  const data =
-    await rechercheEntreprisesGet<RechercheEntreprisesSearchResponse>(
-      `${SEARCH_URL}?${params.toString()}`,
-    );
+  const data = await rechercheEntreprisesGet(
+    `${SEARCH_URL}?${params.toString()}`,
+  );
   return data.results.slice(0, perPage).map(parseSearchEntry);
 };

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -616,16 +616,20 @@ export function DocxEditor({
     return mgr;
   }, []);
 
-  const initialSuggestionModeRef = useRef({
+  const [initialSuggestionMode] = useState(() => ({
     active: editingMode === "suggesting",
     author,
-  });
+  }));
 
   // Suggestion mode plugin
-  const suggestionPlugin = useMemo(() => {
-    const initial = initialSuggestionModeRef.current;
-    return createSuggestionModePlugin(initial.active, initial.author);
-  }, []);
+  const suggestionPlugin = useMemo(
+    () =>
+      createSuggestionModePlugin(
+        initialSuggestionMode.active,
+        initialSuggestionMode.author,
+      ),
+    [initialSuggestionMode],
+  );
   // AI suggestion decorations — non-mutating overlay for the review
   // queue. Always present; the plugin renders nothing until
   // suggestions are pushed in.

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -616,11 +616,16 @@ export function DocxEditor({
     return mgr;
   }, []);
 
+  const initialSuggestionModeRef = useRef({
+    active: editingMode === "suggesting",
+    author,
+  });
+
   // Suggestion mode plugin
-  const suggestionPlugin = useMemo(
-    () => createSuggestionModePlugin(editingMode === "suggesting", author),
-    [], // eslint-disable-line react-hooks/exhaustive-deps
-  );
+  const suggestionPlugin = useMemo(() => {
+    const initial = initialSuggestionModeRef.current;
+    return createSuggestionModePlugin(initial.active, initial.author);
+  }, []);
   // AI suggestion decorations — non-mutating overlay for the review
   // queue. Always present; the plugin renders nothing until
   // suggestions are pushed in.

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.test.ts
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import type { HeaderFooter } from "../core/types/document";
+import { enumerateHfSlotsFromParts } from "./HiddenHeaderFooterPMs";
+
+const headerFooter = (type: HeaderFooter["type"]): HeaderFooter => ({
+  type,
+  hdrFtrType: "default",
+  content: [],
+});
+
+describe("enumerateHfSlotsFromParts", () => {
+  test("enumerates header slots before footer slots", () => {
+    const headers = new Map<string, HeaderFooter>([
+      ["rIdHeader", headerFooter("header")],
+    ]);
+    const footers = new Map<string, HeaderFooter>([
+      ["rIdFooter", headerFooter("footer")],
+    ]);
+
+    expect(enumerateHfSlotsFromParts({ headers, footers })).toEqual([
+      { rId: "rIdHeader", kind: "header" },
+      { rId: "rIdFooter", kind: "footer" },
+    ]);
+  });
+
+  test("dedupes an invalid rId that appears as both header and footer", () => {
+    const headers = new Map<string, HeaderFooter>([
+      ["rIdShared", headerFooter("header")],
+    ]);
+    const footers = new Map<string, HeaderFooter>([
+      ["rIdShared", headerFooter("footer")],
+    ]);
+
+    expect(enumerateHfSlotsFromParts({ headers, footers })).toEqual([
+      { rId: "rIdShared", kind: "header" },
+    ]);
+  });
+
+  test("returns no slots when both maps are absent", () => {
+    expect(
+      enumerateHfSlotsFromParts({ headers: undefined, footers: undefined }),
+    ).toEqual([]);
+  });
+});

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -158,18 +158,19 @@ function buildInitialState(
   );
 }
 
-export function enumerateHfSlots(doc: Document | null): HfPartKey[] {
-  if (!doc?.package) {
-    return [];
-  }
+export function enumerateHfSlotsFromParts({
+  headers,
+  footers,
+}: {
+  headers: Map<string, HeaderFooter> | undefined;
+  footers: Map<string, HeaderFooter> | undefined;
+}): HfPartKey[] {
   const out: HfPartKey[] = [];
-  const headers = doc.package.headers;
   if (headers) {
     for (const rId of headers.keys()) {
       out.push({ rId, kind: "header" });
     }
   }
-  const footers = doc.package.footers;
   if (footers) {
     // A document SHOULD NOT register the same rId under both headers and
     // footers — the OOXML schema keeps them disjoint per
@@ -181,6 +182,16 @@ export function enumerateHfSlots(doc: Document | null): HfPartKey[] {
     }
   }
   return out;
+}
+
+export function enumerateHfSlots(doc: Document | null): HfPartKey[] {
+  if (!doc?.package) {
+    return [];
+  }
+  return enumerateHfSlotsFromParts({
+    headers: doc.package.headers,
+    footers: doc.package.footers,
+  });
 }
 
 // =============================================================================
@@ -228,13 +239,15 @@ export const HiddenHeaderFooterPMs = memo(
         [],
       );
 
+      const headers = document?.package.headers;
+      const footers = document?.package.footers;
+
       const slots = useMemo<HfPartKey[]>(
-        () => enumerateHfSlots(document),
+        () => enumerateHfSlotsFromParts({ headers, footers }),
         // Re-enumerate when the Maps themselves are swapped. Mutations to the
         // existing Map (e.g. external save) intentionally do NOT trigger
         // this — the persistent PM is the source of truth while loaded.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [document?.package.headers, document?.package.footers],
+        [headers, footers],
       );
 
       useEffect(() => {

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -24,6 +24,10 @@ import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Input } from "@stll/ui/components/input";
 
+import {
+  getFindDialogOpenBehavior,
+  shouldRefreshFindDialogSearch,
+} from "./findReplaceDialogBehavior";
 import { getFindReplaceOverlayStyle } from "./findReplaceDialogLayout";
 import { getFindEnterAction } from "./findReplaceInteraction";
 import type { FindOptions, FindResult, FindMatch } from "./findReplaceUtils";
@@ -129,6 +133,22 @@ export function FindReplaceDialog({
 
   // Refs
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const latestFindCallbacksRef = useRef({
+    onFind,
+    onHighlightMatches,
+    onClearHighlights,
+  });
+  latestFindCallbacksRef.current = {
+    onFind,
+    onHighlightMatches,
+    onClearHighlights,
+  };
+
+  const latestFindOptionsRef = useRef({ matchCase, matchWholeWord });
+  latestFindOptionsRef.current = { matchCase, matchWholeWord };
+
+  const latestSearchStateRef = useRef({ isOpen, searchText });
+  latestSearchStateRef.current = { isOpen, searchText };
 
   // Sync with external result if provided
   useEffect(() => {
@@ -139,29 +159,33 @@ export function FindReplaceDialog({
 
   // Initialize when dialog opens
   useEffect(() => {
-    if (isOpen) {
-      setSearchText(initialSearchText);
-      setResult(null);
+    const behavior = getFindDialogOpenBehavior({ isOpen, initialSearchText });
 
-      setTimeout(() => {
-        searchInputRef.current?.focus();
-        searchInputRef.current?.select();
-      }, 100);
-
-      if (initialSearchText) {
-        const searchResult = onFind(initialSearchText, {
-          matchCase,
-          matchWholeWord,
-        });
-        setResult(searchResult);
-        if (searchResult?.matches && onHighlightMatches) {
-          onHighlightMatches(searchResult.matches);
-        }
-      }
-    } else if (onClearHighlights) {
-      onClearHighlights();
+    if (behavior.type === "closed") {
+      latestFindCallbacksRef.current.onClearHighlights?.();
+      return;
     }
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
+
+    setSearchText(behavior.searchText);
+    setResult(null);
+
+    setTimeout(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    }, 100);
+
+    if (behavior.shouldFindInitialText) {
+      const callbacks = latestFindCallbacksRef.current;
+      const options = latestFindOptionsRef.current;
+      const searchResult = callbacks.onFind(behavior.searchText, {
+        matchCase: options.matchCase,
+        matchWholeWord: options.matchWholeWord,
+      });
+      setResult(searchResult);
+      if (searchResult?.matches && callbacks.onHighlightMatches) {
+        callbacks.onHighlightMatches(searchResult.matches);
+      }
+    }
   }, [isOpen, initialSearchText]);
 
   const performSearch = useCallback(() => {
@@ -190,11 +214,13 @@ export function FindReplaceDialog({
     onClearHighlights,
   ]);
 
+  const performSearchRef = useRef(performSearch);
+  performSearchRef.current = performSearch;
+
   useEffect(() => {
-    if (isOpen && searchText.trim()) {
-      performSearch();
+    if (shouldRefreshFindDialogSearch(latestSearchStateRef.current)) {
+      performSearchRef.current();
     }
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [matchCase, matchWholeWord]);
 
   useEffect(() => {

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -217,32 +217,6 @@ export function FindReplaceDialog({
     setResult(null);
   }, []);
 
-  const handleSearchKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        const action = getFindEnterAction({
-          searchText,
-          result,
-          shiftKey: e.shiftKey,
-        });
-        if (action === "search") {
-          performSearch();
-          return;
-        }
-        if (action === "previous") {
-          handleFindPrevious();
-          return;
-        }
-        handleFindNext();
-      } else if (e.key === "Escape") {
-        onClose();
-      }
-    },
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [searchText, result, performSearch, onClose],
-  );
-
   const handleFindNext = useCallback(() => {
     if (!searchText.trim()) {
       performSearch();
@@ -287,6 +261,38 @@ export function FindReplaceDialog({
       });
     }
   }, [searchText, result, performSearch, onFindPrevious]);
+
+  const handleSearchKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const action = getFindEnterAction({
+          searchText,
+          result,
+          shiftKey: e.shiftKey,
+        });
+        if (action === "search") {
+          performSearch();
+          return;
+        }
+        if (action === "previous") {
+          handleFindPrevious();
+          return;
+        }
+        handleFindNext();
+      } else if (e.key === "Escape") {
+        onClose();
+      }
+    },
+    [
+      searchText,
+      result,
+      performSearch,
+      handleFindPrevious,
+      handleFindNext,
+      onClose,
+    ],
+  );
 
   const handleOverlayClick = useCallback((e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {

--- a/packages/folio/src/components/dialogs/findReplaceDialogBehavior.test.ts
+++ b/packages/folio/src/components/dialogs/findReplaceDialogBehavior.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getFindDialogOpenBehavior,
+  shouldRefreshFindDialogSearch,
+} from "./findReplaceDialogBehavior";
+
+describe("find replace dialog behavior", () => {
+  test("opens by resetting the search text from the initial selection", () => {
+    expect(
+      getFindDialogOpenBehavior({
+        isOpen: true,
+        initialSearchText: "contract",
+      }),
+    ).toEqual({
+      type: "open",
+      searchText: "contract",
+      shouldFindInitialText: true,
+    });
+  });
+
+  test("does not run an initial find for empty initial text", () => {
+    expect(
+      getFindDialogOpenBehavior({
+        isOpen: true,
+        initialSearchText: "",
+      }),
+    ).toEqual({
+      type: "open",
+      searchText: "",
+      shouldFindInitialText: false,
+    });
+  });
+
+  test("clears highlights when the dialog closes", () => {
+    expect(
+      getFindDialogOpenBehavior({
+        isOpen: false,
+        initialSearchText: "ignored",
+      }),
+    ).toEqual({
+      type: "closed",
+      shouldClearHighlights: true,
+    });
+  });
+
+  test("refreshes search on option changes only for non-empty open searches", () => {
+    expect(
+      shouldRefreshFindDialogSearch({
+        isOpen: true,
+        searchText: "clause",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefreshFindDialogSearch({
+        isOpen: true,
+        searchText: "   ",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefreshFindDialogSearch({
+        isOpen: false,
+        searchText: "clause",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/folio/src/components/dialogs/findReplaceDialogBehavior.ts
+++ b/packages/folio/src/components/dialogs/findReplaceDialogBehavior.ts
@@ -1,0 +1,36 @@
+export type FindDialogOpenBehavior =
+  | {
+      type: "open";
+      searchText: string;
+      shouldFindInitialText: boolean;
+    }
+  | {
+      type: "closed";
+      shouldClearHighlights: true;
+    };
+
+export const getFindDialogOpenBehavior = ({
+  isOpen,
+  initialSearchText,
+}: {
+  isOpen: boolean;
+  initialSearchText: string;
+}): FindDialogOpenBehavior => {
+  if (!isOpen) {
+    return { type: "closed", shouldClearHighlights: true };
+  }
+
+  return {
+    type: "open",
+    searchText: initialSearchText,
+    shouldFindInitialText: initialSearchText.length > 0,
+  };
+};
+
+export const shouldRefreshFindDialogSearch = ({
+  isOpen,
+  searchText,
+}: {
+  isOpen: boolean;
+  searchText: string;
+}): boolean => isOpen && searchText.trim().length > 0;

--- a/packages/folio/src/components/hooks/documentLoaderBehavior.test.ts
+++ b/packages/folio/src/components/hooks/documentLoaderBehavior.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document } from "../../core/types/document";
+import { getDocumentLoadSource } from "./documentLoaderBehavior";
+
+const document: Document = {
+  package: {
+    document: {
+      content: [],
+    },
+  },
+};
+
+describe("document loader behavior", () => {
+  test("loads the document buffer when one is provided", () => {
+    const buffer = new ArrayBuffer(8);
+
+    expect(
+      getDocumentLoadSource({
+        documentBuffer: buffer,
+        initialDocument: document,
+      }),
+    ).toEqual({ type: "buffer", buffer });
+  });
+
+  test("loads the parsed initial document when no buffer is provided", () => {
+    expect(
+      getDocumentLoadSource({
+        documentBuffer: null,
+        initialDocument: document,
+      }),
+    ).toEqual({ type: "parsed-document", document });
+  });
+
+  test("does not load when neither source is provided", () => {
+    expect(
+      getDocumentLoadSource({
+        documentBuffer: undefined,
+        initialDocument: null,
+      }),
+    ).toEqual({ type: "none" });
+  });
+});

--- a/packages/folio/src/components/hooks/documentLoaderBehavior.ts
+++ b/packages/folio/src/components/hooks/documentLoaderBehavior.ts
@@ -1,0 +1,33 @@
+import type { Document } from "../../core/types/document";
+import type { DocxInput } from "../../core/utils/docxInput";
+
+export type DocumentLoadSource =
+  | {
+      type: "buffer";
+      buffer: DocxInput;
+    }
+  | {
+      type: "parsed-document";
+      document: Document;
+    }
+  | {
+      type: "none";
+    };
+
+export const getDocumentLoadSource = ({
+  documentBuffer,
+  initialDocument,
+}: {
+  documentBuffer: DocxInput | null | undefined;
+  initialDocument: Document | null | undefined;
+}): DocumentLoadSource => {
+  if (documentBuffer) {
+    return { type: "buffer", buffer: documentBuffer };
+  }
+
+  if (initialDocument) {
+    return { type: "parsed-document", document: initialDocument };
+  }
+
+  return { type: "none" };
+};

--- a/packages/folio/src/components/hooks/useDocumentLoader.ts
+++ b/packages/folio/src/components/hooks/useDocumentLoader.ts
@@ -14,6 +14,7 @@ import { resetAuthorColors } from "../../core/utils/authorColors";
 import type { DocxInput } from "../../core/utils/docxInput";
 import { loadFontsWithMapping } from "../../core/utils/fontLoader";
 import type { UseHistoryReturn } from "../../hooks/useHistory";
+import { getDocumentLoadSource } from "./documentLoaderBehavior";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -141,21 +142,27 @@ export const useDocumentLoader = ({
     [history.state, loadParsedDocument, onError, setDocumentLoadState],
   );
 
+  const loaderRef = useRef({ loadBuffer, loadParsedDocument });
+  loaderRef.current = { loadBuffer, loadParsedDocument };
+
   // -------------------------------------------------------------------
   // Effects
   // -------------------------------------------------------------------
 
   // React to document/documentBuffer prop changes
   useEffect(() => {
-    if (!documentBuffer) {
-      if (initialDocument) {
-        loadParsedDocument(initialDocument);
-      }
+    const source = getDocumentLoadSource({ documentBuffer, initialDocument });
+    if (source.type === "none") {
       return;
     }
 
-    void loadBuffer(documentBuffer);
-  }, [documentBuffer, initialDocument]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (source.type === "parsed-document") {
+      loaderRef.current.loadParsedDocument(source.document);
+      return;
+    }
+
+    void loaderRef.current.loadBuffer(source.buffer);
+  }, [documentBuffer, initialDocument]);
 
   // Keep original buffer for save/export
   useEffect(() => {

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -35,6 +35,7 @@ import type {
   TableLook,
   TableMeasurement,
 } from "../types/document";
+import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
 import { mergeTextFormatting } from "../utils/textFormattingMerge";
 import {
   BorderStyleSchema,
@@ -1563,62 +1564,6 @@ function parseDocDefaults(
   }
 
   return result.rPr || result.pPr ? result : undefined;
-}
-
-/**
- * Deep merge paragraph formatting (source overrides target)
- */
-function mergeParagraphFormatting(
-  target: ParagraphFormatting | undefined,
-  source: ParagraphFormatting | undefined,
-): ParagraphFormatting | undefined {
-  if (!source) {
-    return target;
-  }
-  if (!target) {
-    return { ...source };
-  }
-
-  const result: ParagraphFormatting = { ...target };
-
-  // SAFETY: Object.keys returns string[]; widening to ParagraphFormatting's
-  // keys is sound here because source is typed as ParagraphFormatting and
-  // own-enumerable string keys of a typed object are a subset of its keys.
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  const sourceKeys = Object.keys(source) as (keyof ParagraphFormatting)[];
-
-  for (const key of sourceKeys) {
-    const value = source[key];
-    if (value === undefined) {
-      continue;
-    }
-    if (key === "runProperties") {
-      const mergedRunProps = mergeTextFormatting(
-        result.runProperties,
-        source.runProperties,
-      );
-      if (mergedRunProps) {
-        result.runProperties = mergedRunProps;
-      }
-    } else if (key === "borders" || key === "numPr" || key === "frame") {
-      // SAFETY: deep-merge known nested-object keys; both sides have the
-      // same shape per the union narrowing on `key`.
-      const baseValue = result[key] as Record<string, unknown> | undefined;
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const sourceValue = value as Record<string, unknown> | undefined;
-      (result as Record<string, unknown>)[key] = {
-        ...baseValue,
-        ...sourceValue,
-      };
-    } else if (key === "tabs" && Array.isArray(value)) {
-      result.tabs = [...value];
-    } else {
-      // SAFETY: dynamic property copy across matching ParagraphFormatting keys
-      (result as Record<string, unknown>)[key] = value;
-    }
-  }
-
-  return result;
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/extensions/core/HistoryExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/HistoryExtension.ts
@@ -5,12 +5,25 @@
 import { history, undo, redo } from "prosemirror-history";
 
 import { createExtension } from "../create";
-import type { ExtensionRuntime } from "../types";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
+
+type HistoryOptions = {
+  depth: number;
+  newGroupDelay: number;
+};
+
+const defaultHistoryOptions: HistoryOptions = {
+  depth: 100,
+  newGroupDelay: 500,
+};
 
 export const HistoryExtension = createExtension({
   name: "history",
-  defaultOptions: { depth: 100, newGroupDelay: 500 },
-  onSchemaReady(_ctx, options): ExtensionRuntime {
+  defaultOptions: defaultHistoryOptions,
+  onSchemaReady(
+    _ctx: ExtensionContext,
+    options: HistoryOptions,
+  ): ExtensionRuntime {
     return {
       plugins: [
         history({

--- a/packages/folio/src/core/prosemirror/extensions/create.ts
+++ b/packages/folio/src/core/prosemirror/extensions/create.ts
@@ -17,13 +17,9 @@ import type {
   ExtensionRuntime,
 } from "./types";
 
-const copyOptions = (options: object): Record<string, unknown> => {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(options)) {
-    result[key] = value;
-  }
-  return result;
-};
+const copyOptions = (options: object): Record<string, unknown> => ({
+  ...options,
+});
 
 const mergeDefaultOptions = <TOptions extends Record<string, unknown>>(
   defaultOptions: TOptions,

--- a/packages/folio/src/core/prosemirror/extensions/create.ts
+++ b/packages/folio/src/core/prosemirror/extensions/create.ts
@@ -17,6 +17,47 @@ import type {
   ExtensionRuntime,
 } from "./types";
 
+const copyOptions = (options: object): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(options)) {
+    result[key] = value;
+  }
+  return result;
+};
+
+const mergeDefaultOptions = <TOptions extends Record<string, unknown>>(
+  defaultOptions: TOptions,
+  options: Partial<TOptions> | undefined,
+): TOptions => ({
+  ...defaultOptions,
+  ...options,
+});
+
+const extensionHasDefaultOptions = <TOptions extends Record<string, unknown>>(
+  def: ExtensionDefinition<TOptions>,
+): def is Extract<
+  ExtensionDefinition<TOptions>,
+  { defaultOptions: TOptions }
+> => def.defaultOptions !== undefined;
+
+const nodeExtensionHasDefaultOptions = <
+  TOptions extends Record<string, unknown>,
+>(
+  def: NodeExtensionDefinition<TOptions>,
+): def is Extract<
+  NodeExtensionDefinition<TOptions>,
+  { defaultOptions: TOptions }
+> => def.defaultOptions !== undefined;
+
+const markExtensionHasDefaultOptions = <
+  TOptions extends Record<string, unknown>,
+>(
+  def: MarkExtensionDefinition<TOptions>,
+): def is Extract<
+  MarkExtensionDefinition<TOptions>,
+  { defaultOptions: TOptions }
+> => def.defaultOptions !== undefined;
+
 /**
  * Create a generic extension (plugins, commands, keymaps — no schema contribution)
  */
@@ -26,19 +67,29 @@ export function createExtension<
   def: ExtensionDefinition<TOptions>,
 ): (options?: Partial<TOptions>) => Extension {
   return (options?: Partial<TOptions>): Extension => {
-    // SAFETY: spread of optional Partial<TOptions> + Partial<TOptions>
-    // cannot be inferred as TOptions, but the merge is sound: when
-    // a caller passes a definition with TOptions = Record<string, unknown>
-    // (the default), the result already satisfies TOptions.
-    // oxlint-disable-next-line no-dangerous-type-assertions/no-dangerous-type-assertions
-    const mergedOptions = { ...def.defaultOptions, ...options } as TOptions;
+    if (extensionHasDefaultOptions(def)) {
+      const mergedOptions = mergeDefaultOptions(def.defaultOptions, options);
 
+      return {
+        type: "extension",
+        config: {
+          name: def.name,
+          priority: def.priority ?? Priority.Default,
+          options: copyOptions(mergedOptions),
+        },
+        onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
+          return def.onSchemaReady(ctx, mergedOptions);
+        },
+      };
+    }
+
+    const mergedOptions = options ?? {};
     return {
       type: "extension",
       config: {
         name: def.name,
         priority: def.priority ?? Priority.Default,
-        options: mergedOptions as Record<string, unknown>,
+        options: copyOptions(mergedOptions),
       },
       onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
         return def.onSchemaReady(ctx, mergedOptions);
@@ -56,12 +107,29 @@ export function createNodeExtension<
   def: NodeExtensionDefinition<TOptions>,
 ): (options?: Partial<TOptions>) => NodeExtension {
   return (options?: Partial<TOptions>): NodeExtension => {
-    // SAFETY: spread of optional Partial<TOptions> + Partial<TOptions>
-    // cannot be inferred as TOptions, but the merge is sound: when
-    // a caller passes a definition with TOptions = Record<string, unknown>
-    // (the default), the result already satisfies TOptions.
-    // oxlint-disable-next-line no-dangerous-type-assertions/no-dangerous-type-assertions
-    const mergedOptions = { ...def.defaultOptions, ...options } as TOptions;
+    if (nodeExtensionHasDefaultOptions(def)) {
+      const mergedOptions = mergeDefaultOptions(def.defaultOptions, options);
+      const nodeSpec =
+        typeof def.nodeSpec === "function"
+          ? def.nodeSpec(mergedOptions)
+          : def.nodeSpec;
+
+      return {
+        type: "node",
+        config: {
+          name: def.name,
+          priority: def.priority ?? Priority.Default,
+          options: copyOptions(mergedOptions),
+          schemaNodeName: def.schemaNodeName,
+          nodeSpec,
+        },
+        onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
+          return def.onSchemaReady?.(ctx, mergedOptions) ?? {};
+        },
+      };
+    }
+
+    const mergedOptions = options ?? {};
     const nodeSpec =
       typeof def.nodeSpec === "function"
         ? def.nodeSpec(mergedOptions)
@@ -72,7 +140,7 @@ export function createNodeExtension<
       config: {
         name: def.name,
         priority: def.priority ?? Priority.Default,
-        options: mergedOptions as Record<string, unknown>,
+        options: copyOptions(mergedOptions),
         schemaNodeName: def.schemaNodeName,
         nodeSpec,
       },
@@ -92,12 +160,29 @@ export function createMarkExtension<
   def: MarkExtensionDefinition<TOptions>,
 ): (options?: Partial<TOptions>) => MarkExtension {
   return (options?: Partial<TOptions>): MarkExtension => {
-    // SAFETY: spread of optional Partial<TOptions> + Partial<TOptions>
-    // cannot be inferred as TOptions, but the merge is sound: when
-    // a caller passes a definition with TOptions = Record<string, unknown>
-    // (the default), the result already satisfies TOptions.
-    // oxlint-disable-next-line no-dangerous-type-assertions/no-dangerous-type-assertions
-    const mergedOptions = { ...def.defaultOptions, ...options } as TOptions;
+    if (markExtensionHasDefaultOptions(def)) {
+      const mergedOptions = mergeDefaultOptions(def.defaultOptions, options);
+      const markSpec =
+        typeof def.markSpec === "function"
+          ? def.markSpec(mergedOptions)
+          : def.markSpec;
+
+      return {
+        type: "mark",
+        config: {
+          name: def.name,
+          priority: def.priority ?? Priority.Default,
+          options: copyOptions(mergedOptions),
+          schemaMarkName: def.schemaMarkName,
+          markSpec,
+        },
+        onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
+          return def.onSchemaReady?.(ctx, mergedOptions) ?? {};
+        },
+      };
+    }
+
+    const mergedOptions = options ?? {};
     const markSpec =
       typeof def.markSpec === "function"
         ? def.markSpec(mergedOptions)
@@ -108,7 +193,7 @@ export function createMarkExtension<
       config: {
         name: def.name,
         priority: def.priority ?? Priority.Default,
-        options: mergedOptions as Record<string, unknown>,
+        options: copyOptions(mergedOptions),
         schemaMarkName: def.schemaMarkName,
         markSpec,
       },

--- a/packages/folio/src/core/prosemirror/extensions/features/ContentControlWidgetsExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ContentControlWidgetsExtension.ts
@@ -11,11 +11,11 @@
 
 import { createContentControlWidgetsPlugin } from "../../plugins/contentControlWidgets";
 import { createExtension } from "../create";
-import type { ExtensionRuntime } from "../types";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 export const ContentControlWidgetsExtension = createExtension({
   name: "contentControlWidgets",
-  onSchemaReady(_ctx): ExtensionRuntime {
+  onSchemaReady(_ctx: ExtensionContext): ExtensionRuntime {
     return {
       plugins: [createContentControlWidgetsPlugin()],
     };

--- a/packages/folio/src/core/prosemirror/extensions/features/GapCursorExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/GapCursorExtension.ts
@@ -15,11 +15,11 @@
 import { gapCursor } from "prosemirror-gapcursor";
 
 import { createExtension } from "../create";
-import type { ExtensionRuntime } from "../types";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 export const GapCursorExtension = createExtension({
   name: "gapCursor",
-  onSchemaReady(_ctx): ExtensionRuntime {
+  onSchemaReady(_ctx: ExtensionContext): ExtensionRuntime {
     return {
       plugins: [gapCursor()],
     };

--- a/packages/folio/src/core/prosemirror/extensions/features/ImageDragExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ImageDragExtension.ts
@@ -11,13 +11,13 @@
 import { Plugin, PluginKey, NodeSelection } from "prosemirror-state";
 
 import { createExtension } from "../create";
-import type { ExtensionRuntime } from "../types";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 const imageDragKey = new PluginKey("imageDrag");
 
 export const ImageDragExtension = createExtension({
   name: "imageDrag",
-  onSchemaReady(_ctx): ExtensionRuntime {
+  onSchemaReady(_ctx: ExtensionContext): ExtensionRuntime {
     const plugin = new Plugin({
       key: imageDragKey,
       props: {

--- a/packages/folio/src/core/prosemirror/extensions/features/ImagePasteExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ImagePasteExtension.ts
@@ -11,7 +11,7 @@ import type { EditorView } from "prosemirror-view";
 import { getClipboardImageFiles } from "../../../utils/clipboard";
 import { isSafeImageFile } from "../../../utils/imageValidation";
 import { createExtension } from "../create";
-import type { ExtensionRuntime } from "../types";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 const MAX_INLINE_IMAGE_WIDTH = 612; // ~6.375 inches at 96 DPI
 
@@ -108,7 +108,7 @@ async function insertImageFiles(
 
 export const ImagePasteExtension = createExtension({
   name: "imagePaste",
-  onSchemaReady(_ctx): ExtensionRuntime {
+  onSchemaReady(_ctx: ExtensionContext): ExtensionRuntime {
     const plugin = new Plugin({
       props: {
         handleDOMEvents: {

--- a/packages/folio/src/core/prosemirror/extensions/features/SelectionTrackerExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/SelectionTrackerExtension.ts
@@ -8,7 +8,7 @@ import {
 } from "../../plugins/selectionTracker";
 import type { SelectionChangeCallback } from "../../plugins/selectionTracker";
 import { createExtension } from "../create";
-import type { ExtensionRuntime } from "../types";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 type SelectionTrackerOptions = {
   onSelectionChange?: SelectionChangeCallback;
@@ -19,7 +19,10 @@ const defaultSelectionTrackerOptions: SelectionTrackerOptions = {};
 export const SelectionTrackerExtension = createExtension({
   name: "selectionTracker",
   defaultOptions: defaultSelectionTrackerOptions,
-  onSchemaReady(_ctx, options): ExtensionRuntime {
+  onSchemaReady(
+    _ctx: ExtensionContext,
+    options: SelectionTrackerOptions,
+  ): ExtensionRuntime {
     return {
       plugins: [createSelectionTrackerPlugin(options.onSelectionChange)],
       commands: {

--- a/packages/folio/src/core/prosemirror/extensions/types.ts
+++ b/packages/folio/src/core/prosemirror/extensions/types.ts
@@ -91,27 +91,87 @@ export type AnyExtension = Extension | NodeExtension | MarkExtension;
 // DEFINITION TYPES (used by factory functions)
 // ============================================================================
 
-export type ExtensionDefinition<TOptions = Record<string, unknown>> = {
+type ExtensionOptions = Record<string, unknown>;
+
+type ExtensionDefinitionWithDefaults<TOptions extends ExtensionOptions> = {
   name: string;
   priority?: ExtensionPriority;
-  defaultOptions?: TOptions;
+  defaultOptions: TOptions;
   onSchemaReady(ctx: ExtensionContext, options: TOptions): ExtensionRuntime;
 };
 
-export type NodeExtensionDefinition<TOptions = Record<string, unknown>> = {
+type ExtensionDefinitionWithoutDefaults<
+  TOptions extends ExtensionOptions = ExtensionOptions,
+> = {
   name: string;
   priority?: ExtensionPriority;
-  defaultOptions?: TOptions;
+  defaultOptions?: undefined;
+  onSchemaReady(
+    ctx: ExtensionContext,
+    options: Partial<TOptions>,
+  ): ExtensionRuntime;
+};
+
+export type ExtensionDefinition<
+  TOptions extends ExtensionOptions = ExtensionOptions,
+> =
+  | ExtensionDefinitionWithDefaults<TOptions>
+  | ExtensionDefinitionWithoutDefaults<TOptions>;
+
+type NodeExtensionDefinitionWithDefaults<TOptions extends ExtensionOptions> = {
+  name: string;
+  priority?: ExtensionPriority;
+  defaultOptions: TOptions;
   schemaNodeName: string;
   nodeSpec: NodeSpec | ((options: TOptions) => NodeSpec);
   onSchemaReady?(ctx: ExtensionContext, options: TOptions): ExtensionRuntime;
 };
 
-export type MarkExtensionDefinition<TOptions = Record<string, unknown>> = {
+type NodeExtensionDefinitionWithoutDefaults<
+  TOptions extends ExtensionOptions = ExtensionOptions,
+> = {
   name: string;
   priority?: ExtensionPriority;
-  defaultOptions?: TOptions;
+  defaultOptions?: undefined;
+  schemaNodeName: string;
+  nodeSpec: NodeSpec | ((options: Partial<TOptions>) => NodeSpec);
+  onSchemaReady?(
+    ctx: ExtensionContext,
+    options: Partial<TOptions>,
+  ): ExtensionRuntime;
+};
+
+export type NodeExtensionDefinition<
+  TOptions extends ExtensionOptions = ExtensionOptions,
+> =
+  | NodeExtensionDefinitionWithDefaults<TOptions>
+  | NodeExtensionDefinitionWithoutDefaults<TOptions>;
+
+type MarkExtensionDefinitionWithDefaults<TOptions extends ExtensionOptions> = {
+  name: string;
+  priority?: ExtensionPriority;
+  defaultOptions: TOptions;
   schemaMarkName: string;
   markSpec: MarkSpec | ((options: TOptions) => MarkSpec);
   onSchemaReady?(ctx: ExtensionContext, options: TOptions): ExtensionRuntime;
 };
+
+type MarkExtensionDefinitionWithoutDefaults<
+  TOptions extends ExtensionOptions = ExtensionOptions,
+> = {
+  name: string;
+  priority?: ExtensionPriority;
+  defaultOptions?: undefined;
+  schemaMarkName: string;
+  markSpec: MarkSpec | ((options: Partial<TOptions>) => MarkSpec);
+  onSchemaReady?(
+    ctx: ExtensionContext,
+    options: Partial<TOptions>,
+  ): ExtensionRuntime;
+};
+
+export type MarkExtensionDefinition<
+  TOptions extends ExtensionOptions = ExtensionOptions,
+> =
+  | MarkExtensionDefinitionWithDefaults<TOptions>
+  | MarkExtensionDefinitionWithoutDefaults<TOptions>;

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -18,6 +18,7 @@ import type {
   ParagraphFormatting,
   TextFormatting,
 } from "../../types/document";
+import { mergeParagraphFormatting } from "../../utils/paragraphFormattingMerge";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 
 /**
@@ -306,7 +307,7 @@ export class StyleResolver {
     style: Style,
   ): void {
     if (style.pPr) {
-      const merged = this.mergeParagraphFormatting(
+      const merged = mergeParagraphFormatting(
         result.paragraphFormatting,
         style.pPr,
       );
@@ -320,52 +321,6 @@ export class StyleResolver {
         result.runFormatting = merged;
       }
     }
-  }
-
-  /**
-   * Merge paragraph formatting (source overrides target)
-   */
-  private mergeParagraphFormatting(
-    target: ParagraphFormatting | undefined,
-    source: ParagraphFormatting | undefined,
-  ): ParagraphFormatting | undefined {
-    if (!source) {
-      return target;
-    }
-    if (!target) {
-      return { ...source };
-    }
-
-    const result = { ...target };
-
-    for (const key of Object.keys(source) as (keyof ParagraphFormatting)[]) {
-      const value = source[key];
-      if (value !== undefined) {
-        if (key === "runProperties") {
-          const mergedRPr = mergeTextFormatting(
-            result.runProperties,
-            source.runProperties,
-          );
-          if (mergedRPr !== undefined) {
-            result.runProperties = mergedRPr;
-          }
-        } else if (key === "borders" || key === "numPr" || key === "frame") {
-          const baseValue = result[key] as Record<string, unknown> | undefined;
-          const sourceValue = value as Record<string, unknown> | undefined;
-          (result as Record<string, unknown>)[key] = {
-            ...baseValue,
-            ...sourceValue,
-          };
-        } else if (key === "tabs" && Array.isArray(value)) {
-          // Tabs from higher priority source replace lower priority
-          result.tabs = [...value];
-        } else {
-          (result as Record<string, unknown>)[key] = value;
-        }
-      }
-    }
-
-    return result;
   }
 }
 

--- a/packages/folio/src/core/utils/paragraphFormattingMerge.test.ts
+++ b/packages/folio/src/core/utils/paragraphFormattingMerge.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphFormatting } from "../types/document";
+import { mergeParagraphFormatting } from "./paragraphFormattingMerge";
+
+describe("mergeParagraphFormatting", () => {
+  test("preserves explicit false overrides for inherited paragraph toggles", () => {
+    const result = mergeParagraphFormatting(
+      { keepNext: true, bidi: true },
+      { keepNext: false, bidi: false },
+    );
+
+    expect(result?.keepNext).toBe(false);
+    expect(result?.bidi).toBe(false);
+  });
+
+  test("merges nested paragraph property containers by field", () => {
+    const result = mergeParagraphFormatting(
+      {
+        borders: { top: { style: "single", color: { rgb: "FF0000" } } },
+        frame: { width: 1200, hAnchor: "margin" },
+        numPr: { numId: 4 },
+      },
+      {
+        borders: { bottom: { style: "double" } },
+        frame: { height: 800 },
+        numPr: { ilvl: 2 },
+      },
+    );
+
+    expect(result?.borders).toEqual({
+      top: { style: "single", color: { rgb: "FF0000" } },
+      bottom: { style: "double" },
+    });
+    expect(result?.frame).toEqual({
+      width: 1200,
+      hAnchor: "margin",
+      height: 800,
+    });
+    expect(result?.numPr).toEqual({ numId: 4, ilvl: 2 });
+  });
+
+  test("replaces tab collections and merges paragraph mark run properties", () => {
+    const sourceTabs: NonNullable<ParagraphFormatting["tabs"]> = [
+      { position: 720, alignment: "left" },
+    ];
+
+    const result = mergeParagraphFormatting(
+      {
+        tabs: [{ position: 360, alignment: "center" }],
+        runProperties: {
+          underline: { style: "single", color: { rgb: "FF0000" } },
+        },
+      },
+      {
+        tabs: sourceTabs,
+        runProperties: { underline: { style: "double" } },
+      },
+    );
+
+    expect(result?.tabs).toEqual(sourceTabs);
+    expect(result?.tabs).not.toBe(sourceTabs);
+    expect(result?.runProperties?.underline).toEqual({
+      style: "double",
+      color: { rgb: "FF0000" },
+    });
+  });
+});

--- a/packages/folio/src/core/utils/paragraphFormattingMerge.ts
+++ b/packages/folio/src/core/utils/paragraphFormattingMerge.ts
@@ -1,0 +1,95 @@
+import type { ParagraphFormatting } from "../types/document";
+import { mergeTextFormatting } from "./textFormattingMerge";
+
+const PARAGRAPH_REPLACE_KEYS = [
+  "alignment",
+  "bidi",
+  "spaceBefore",
+  "spaceAfter",
+  "lineSpacing",
+  "lineSpacingRule",
+  "beforeAutospacing",
+  "afterAutospacing",
+  "spacingExplicit",
+  "indentLeft",
+  "indentRight",
+  "indentFirstLine",
+  "hangingIndent",
+  "shading",
+  "keepNext",
+  "keepLines",
+  "widowControl",
+  "pageBreakBefore",
+  "contextualSpacing",
+  "outlineLevel",
+  "styleId",
+  "suppressLineNumbers",
+  "suppressAutoHyphens",
+  "runInWithNext",
+] as const satisfies readonly (keyof ParagraphFormatting)[];
+
+type ParagraphReplaceKey = (typeof PARAGRAPH_REPLACE_KEYS)[number];
+
+const copyDefinedParagraphProperty = <K extends ParagraphReplaceKey>(
+  target: Pick<ParagraphFormatting, K>,
+  source: Pick<ParagraphFormatting, K>,
+  key: K,
+): void => {
+  const value = source[key];
+  if (value !== undefined) {
+    target[key] = value;
+  }
+};
+
+/**
+ * Merge paragraph properties for OOXML style cascade resolution.
+ *
+ * The source is the higher-priority layer. Most `w:pPr` properties replace an
+ * inherited value when present; nested child containers merge by child field;
+ * tabs replace as a complete ordered collection; paragraph mark `w:rPr` uses
+ * the run-formatting merge rules.
+ */
+export function mergeParagraphFormatting(
+  target: ParagraphFormatting | undefined,
+  source: ParagraphFormatting | undefined,
+): ParagraphFormatting | undefined {
+  if (!source) {
+    return target;
+  }
+  if (!target) {
+    const result = { ...source };
+    if (source.tabs !== undefined) {
+      result.tabs = [...source.tabs];
+    }
+    return result;
+  }
+
+  const result: ParagraphFormatting = { ...target };
+
+  for (const key of PARAGRAPH_REPLACE_KEYS) {
+    copyDefinedParagraphProperty(result, source, key);
+  }
+
+  const mergedRunProperties = mergeTextFormatting(
+    result.runProperties,
+    source.runProperties,
+  );
+  if (mergedRunProperties) {
+    result.runProperties = mergedRunProperties;
+  }
+
+  if (source.borders !== undefined) {
+    result.borders = { ...result.borders, ...source.borders };
+  }
+  if (source.numPr !== undefined) {
+    result.numPr = { ...result.numPr, ...source.numPr };
+  }
+  if (source.frame !== undefined) {
+    result.frame = { ...result.frame, ...source.frame };
+  }
+  if (source.tabs !== undefined) {
+    result.tabs = [...source.tabs];
+  }
+
+  return result;
+}

--- a/packages/infosoud/src/cli.ts
+++ b/packages/infosoud/src/cli.ts
@@ -36,13 +36,11 @@ type CliFlags = {
 };
 
 const printStdout = (value: string): void => {
-  // eslint-disable-next-line no-console -- CLI output
-  console.log(value);
+  process.stdout.write(`${value}\n`);
 };
 
 const printStderr = (value: string): void => {
-  // eslint-disable-next-line no-console -- CLI error output
-  console.error(value);
+  process.stderr.write(`${value}\n`);
 };
 
 const parseArgs = (args: readonly string[]): CliFlags => {

--- a/packages/ui/src/components/hex-color-picker.tsx
+++ b/packages/ui/src/components/hex-color-picker.tsx
@@ -235,11 +235,11 @@ const useColorManipulation = (
 
 const isTouch = (e: MouseEvent | TouchEvent): e is TouchEvent => "touches" in e;
 
-const isMoveEvent = (
-  event: Event,
-  win: Window,
-): event is MouseEvent | TouchEvent =>
-  event instanceof win.MouseEvent || "touches" in event;
+const isMouseMoveEvent = (event: Event): event is MouseEvent =>
+  "buttons" in event && "pageX" in event && "pageY" in event;
+
+const isMoveEvent = (event: Event): event is MouseEvent | TouchEvent =>
+  isMouseMoveEvent(event) || "touches" in event;
 
 const getTouchPoint = (touches: TouchList, id: number | null): Touch | null => {
   const found = Array.from(touches).find((t) => t.identifier === id);
@@ -311,7 +311,7 @@ const InteractiveArea = ({
     const endType = touch ? "touchend" : "mouseup";
 
     const handleMove: EventListener = (event) => {
-      if (!isMoveEvent(event, win)) {
+      if (!isMoveEvent(event)) {
         detachListeners();
         return;
       }

--- a/packages/ui/src/components/hex-color-picker.tsx
+++ b/packages/ui/src/components/hex-color-picker.tsx
@@ -235,11 +235,15 @@ const useColorManipulation = (
 
 const isTouch = (e: MouseEvent | TouchEvent): e is TouchEvent => "touches" in e;
 
-const getTouchPoint = (touches: TouchList, id: number | null): Touch => {
+const isMoveEvent = (
+  event: Event,
+  win: Window,
+): event is MouseEvent | TouchEvent =>
+  event instanceof win.MouseEvent || "touches" in event;
+
+const getTouchPoint = (touches: TouchList, id: number | null): Touch | null => {
   const found = Array.from(touches).find((t) => t.identifier === id);
-  // SAFETY: callers only invoke this when touches.length > 0
-  // eslint-disable-next-line typescript/no-non-null-assertion
-  return found ?? touches.item(0)!;
+  return found ?? touches.item(0);
 };
 
 const getParentWindow = (node?: HTMLDivElement | null): Window =>
@@ -249,11 +253,15 @@ const getRelativePosition = (
   node: HTMLDivElement,
   event: MouseEvent | TouchEvent,
   touchId: number | null,
-): Interaction => {
+): Interaction | null => {
   const rect = node.getBoundingClientRect();
   const pointer = isTouch(event)
     ? getTouchPoint(event.touches, touchId)
     : event;
+  if (!pointer) {
+    return null;
+  }
+
   const win = getParentWindow(node);
   return {
     left: clamp((pointer.pageX - (rect.left + win.pageXOffset)) / rect.width),
@@ -303,14 +311,26 @@ const InteractiveArea = ({
     const endType = touch ? "touchend" : "mouseup";
 
     const handleMove: EventListener = (event) => {
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion -- EventListener receives Event; we only attach to mouse/touch events
-      const e = event as MouseEvent | TouchEvent;
-      if (!isTouch(e)) {
-        e.preventDefault();
+      if (!isMoveEvent(event, win)) {
+        detachListeners();
+        return;
       }
-      const isDown = isTouch(e) ? e.touches.length > 0 : e.buttons > 0;
+
+      if (!isTouch(event)) {
+        event.preventDefault();
+      }
+      const isDown = isTouch(event)
+        ? event.touches.length > 0
+        : event.buttons > 0;
       if (isDown && container.current) {
-        onMoveRef(getRelativePosition(container.current, e, touchId.current));
+        const position = getRelativePosition(
+          container.current,
+          event,
+          touchId.current,
+        );
+        if (position) {
+          onMoveRef(position);
+        }
       } else {
         detachListeners();
       }
@@ -349,7 +369,10 @@ const InteractiveArea = ({
     }
 
     el.focus();
-    onMoveRef(getRelativePosition(el, native, touchId.current));
+    const position = getRelativePosition(el, native, touchId.current);
+    if (position) {
+      onMoveRef(position);
+    }
     attachListeners();
   };
 


### PR DESCRIPTION
## Summary
- replace suppression-heavy type boundaries with typed helpers across web, API, registries, UI, desktop, and Folio
- tighten Folio extension/runtime typing and share tested paragraph formatting merge behavior
- add focused behavior coverage for Folio find dialog, document loader, and header/footer slot dependency behavior

## Checks
- bun run lint
- bun run format
- bun run typecheck
- bun run test
- pre-push hook: format, i18n, filtered typecheck