### PR TITLE
feat(legal-atlas): bounded sample runs for case-law ingest

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -54,8 +54,10 @@ type PipelineInput = {
   signal?: AbortSignal;
   /**
    * Hard caps for bounded sample runs (staging smoke): stop after this
-   * many pages / processed decisions without advancing the cursor past
-   * unprocessed work. Defaults to the adapter's own cycle limits.
+   * many pages / newly stored decisions without advancing the cursor
+   * past unprocessed work. Dedup-skipped and failed decisions do not
+   * count toward the cap, so a re-run with the same cap continues past
+   * already-ingested work. Defaults to the adapter's own cycle limits.
    */
   maxPages?: number;
   maxDecisions?: number;
@@ -656,7 +658,7 @@ export const runIngestionPipeline = async ({
     const s3FailuresBefore = s3UploadFailures;
     try {
       for (const result of page.decisions) {
-        if (maxDecisions !== undefined && inserted + skipped >= maxDecisions) {
+        if (maxDecisions !== undefined && inserted >= maxDecisions) {
           // Halting (instead of breaking quietly) keeps the cursor at
           // this page so the unprocessed remainder is not skipped.
           haltReason = `Decision cap (${maxDecisions}) reached`;

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -53,6 +53,13 @@ type PipelineInput = {
   /** Per-cycle abort signal. Fires when the adapter's time budget is exhausted. */
   signal?: AbortSignal;
   /**
+   * Hard caps for bounded sample runs (staging smoke): stop after this
+   * many pages / processed decisions without advancing the cursor past
+   * unprocessed work. Defaults to the adapter's own cycle limits.
+   */
+  maxPages?: number;
+  maxDecisions?: number;
+  /**
    * Optional concurrency limiter for DB-heavy operations.
    * When provided, the pipeline acquires a slot before
    * processing decisions (insert, index, citations) and
@@ -556,6 +563,8 @@ export const runIngestionPipeline = async ({
   source,
   scopedDb,
   signal,
+  maxPages: maxPagesOverride,
+  maxDecisions,
   dbSlot,
 }: PipelineInput): Promise<PipelineResult> => {
   const adapter = getAdapter(source.adapterKey);
@@ -581,7 +590,7 @@ export const runIngestionPipeline = async ({
   const MAX_CONSECUTIVE_FAILURES = 10;
   let haltReason: string | null = null;
 
-  const maxPages = adapter.maxSyncPages ?? MAX_SYNC_PAGES;
+  const maxPages = maxPagesOverride ?? adapter.maxSyncPages ?? MAX_SYNC_PAGES;
 
   while (pagesProcessed < maxPages) {
     if (signal?.aborted) {
@@ -647,6 +656,12 @@ export const runIngestionPipeline = async ({
     const s3FailuresBefore = s3UploadFailures;
     try {
       for (const result of page.decisions) {
+        if (maxDecisions !== undefined && inserted + skipped >= maxDecisions) {
+          // Halting (instead of breaking quietly) keeps the cursor at
+          // this page so the unprocessed remainder is not skipped.
+          haltReason = `Decision cap (${maxDecisions}) reached`;
+          break;
+        }
         try {
           const outcome = await processDecision(result, source.id, scopedDb);
 

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -297,9 +297,15 @@ type CycleResult = {
  * "timeout" means the cycle hit MAX_CYCLE_MS but progress
  * was made (cursor advanced) — not a true failure.
  */
+type CycleBounds = {
+  maxPages?: number | undefined;
+  maxDecisions?: number | undefined;
+};
+
 const runOneCycle = async (
   adapterKey: string,
   name: string,
+  bounds: CycleBounds = {},
 ): Promise<CycleResult> => {
   const initialCursor =
     adapterKey === ADAPTER_KEYS.CZ_REGIONAL ? daysAgoCursor(7) : null;
@@ -325,8 +331,15 @@ const runOneCycle = async (
       scopedDb: ingestionDb,
       dbSlot: { acquire: acquireDbSlot, release: releaseDbSlot },
       signal: AbortSignal.timeout(cycleMs),
+      ...(bounds.maxPages !== undefined && { maxPages: bounds.maxPages }),
+      ...(bounds.maxDecisions !== undefined && {
+        maxDecisions: bounds.maxDecisions,
+      }),
     });
-    if (result.haltReason) {
+    if (result.haltReason?.startsWith("Decision cap")) {
+      // A requested sample bound is a successful outcome, not a failure.
+      logInfo(`[${adapterKey}] ${result.haltReason}`);
+    } else if (result.haltReason) {
       outcome =
         result.haltReason === "Cycle timeout exceeded" ? "timeout" : "failed";
       errorMessage = result.haltReason.slice(0, 2048);
@@ -462,12 +475,62 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
   }
 };
 
+type IngestCliArgs = {
+  filterKey: string | undefined;
+  maxPages: number | undefined;
+  maxDecisions: number | undefined;
+};
+
+const parseIngestArgs = (argv: readonly string[]): IngestCliArgs | null => {
+  const args: IngestCliArgs = {
+    filterKey: undefined,
+    maxPages: undefined,
+    maxDecisions: undefined,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--max-pages" || arg === "--max-decisions") {
+      const parsed = Number(argv[i + 1]);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        logError(`${arg} requires a positive integer`);
+        return null;
+      }
+      if (arg === "--max-pages") {
+        args.maxPages = parsed;
+      } else {
+        args.maxDecisions = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg !== undefined && !arg.startsWith("--") && !args.filterKey) {
+      args.filterKey = arg;
+      continue;
+    }
+    logError(`Unknown option: ${arg ?? "(missing)"}`);
+    return null;
+  }
+  return args;
+};
+
 export const runCaseLawIngest = async (
   argv: readonly string[],
 ): Promise<number> => {
-  const filterKey = argv.at(0);
+  const parsed = parseIngestArgs(argv);
+  if (parsed === null) {
+    return 64;
+  }
+  const { filterKey, maxPages, maxDecisions } = parsed;
 
-  // Single adapter: run once and exit (useful for debugging).
+  if ((maxPages !== undefined || maxDecisions !== undefined) && !filterKey) {
+    logError(
+      "--max-pages/--max-decisions require an adapter key (bounded sample runs are single-adapter)",
+    );
+    return 64;
+  }
+
+  // Single adapter: run once and exit (useful for debugging and for
+  // bounded staging sample runs).
   if (filterKey) {
     const match = SOURCES.find((s) => s.adapterKey === filterKey);
     if (!match) {
@@ -479,7 +542,10 @@ export const runCaseLawIngest = async (
     }
     await refreshS3();
     await refreshCorpusS3();
-    const { outcome } = await runOneCycle(match.adapterKey, match.name);
+    const { outcome } = await runOneCycle(match.adapterKey, match.name, {
+      maxPages,
+      maxDecisions,
+    });
     return outcome === "completed" ? 0 : 1;
   }
 


### PR DESCRIPTION
Adds explicit hard bounds to the single-adapter ingest path: `legal-atlas run case-law-ingest <adapter> [--max-pages N] [--max-decisions N]`. The decisions cap halts the cycle without advancing the cursor past unprocessed work (re-running continues where it stopped, dedup skips what was already stored), and a cap-halt is reported as success. Daemon mode is unchanged; the flags require an adapter key.

Purpose: environment smoke runs should load a deliberately tiny corpus sample, with the bound stated in the command rather than implied by adapter cycle limits.

CC on behalf of @jan-kubica