### PR TITLE
feat(web): beta features settings page with case law toggle

### DIFF
--- a/apps/web/src/hooks/use-public-law-preview.ts
+++ b/apps/web/src/hooks/use-public-law-preview.ts
@@ -1,10 +1,11 @@
 import { env } from "@/env";
+import { betaFeaturesAvailable } from "@/lib/beta-features";
 import { useDevStore } from "@/lib/dev-store";
 
 const isPublicLawPreviewEnabledForDevState = (
   devPreviewEnabled: boolean,
 ): boolean =>
-  env.VITE_PUBLIC_LAW_ENABLED || (import.meta.env.DEV && devPreviewEnabled);
+  env.VITE_PUBLIC_LAW_ENABLED || (betaFeaturesAvailable() && devPreviewEnabled);
 
 export const isPublicLawPreviewEnabled = (): boolean =>
   isPublicLawPreviewEnabledForDevState(useDevStore.getState().publicLawPreview);

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beta funkce",
+      "betaCaseLawDescription": "Zobrazit veřejné vyhledávání a čtečku judikatury v postranním panelu",
+      "betaDescription": "Vyzkoušejte funkce, které jsou stále ve vývoji",
       "desktop": "Aplikace pro počítač",
       "desktopAppDescription": "Otevírejte dokumenty a soubory přímo ve stella z vašeho počítače.",
       "desktopDescription": "Nainstalujte si stella na svůj počítač",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beta-Funktionen",
+      "betaCaseLawDescription": "Öffentliche Rechtsprechungssuche und -ansicht in der Seitenleiste anzeigen",
+      "betaDescription": "Funktionen ausprobieren, die sich noch in der Entwicklung befinden",
       "desktop": "Desktop",
       "desktopAppDescription": "Öffnen Sie Dokumente und Dateien direkt in stella von Ihrem Computer aus.",
       "desktopDescription": "Installieren Sie stella auf Ihrem Computer",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beta Features",
+      "betaCaseLawDescription": "Show the public case law search and reader in the sidebar",
+      "betaDescription": "Try features that are still in development",
       "desktop": "Desktop",
       "desktopAppDescription": "Open documents and files directly in stella from your computer.",
       "desktopDescription": "Install stella on your computer",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Funciones beta",
+      "betaCaseLawDescription": "Mostrar la búsqueda y el lector de jurisprudencia pública en la barra lateral",
+      "betaDescription": "Prueba funciones que aún están en desarrollo",
       "desktop": "Escritorio",
       "desktopAppDescription": "Abre documentos y archivos directamente en stella desde tu ordenador.",
       "desktopDescription": "Instala stella en tu ordenador",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beetafunktsioonid",
+      "betaCaseLawDescription": "Kuva avalik kohtupraktika otsing ja lugeja külgribal",
+      "betaDescription": "Proovige funktsioone, mis on alles arendamisel",
       "desktop": "Töölaud",
       "desktopAppDescription": "Avage dokumendid ja failid otse stella-s oma arvutist.",
       "desktopDescription": "Installige stella oma arvutisse",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Fonctionnalités bêta",
+      "betaCaseLawDescription": "Afficher la recherche et le lecteur de jurisprudence publique dans la barre latérale",
+      "betaDescription": "Essayez des fonctionnalités encore en développement",
       "desktop": "Bureau",
       "desktopAppDescription": "Ouvrez des documents et des fichiers directement dans stella depuis votre ordinateur.",
       "desktopDescription": "Installez stella sur votre ordinateur",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Béta funkciók",
+      "betaCaseLawDescription": "Nyilvános joggyakorlat-keresés és -olvasó megjelenítése az oldalsávban",
+      "betaDescription": "Próbálja ki a még fejlesztés alatt álló funkciókat",
       "desktop": "Asztali alkalmazás",
       "desktopAppDescription": "Nyisson meg dokumentumokat és fájlokat közvetlenül a stella-ban a számítógépéről.",
       "desktopDescription": "Telepítse a Stellát a számítógépére",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beta funkcijos",
+      "betaCaseLawDescription": "Rodyti viešą teismų praktikos paiešką ir skaityklę šoninėje juostoje",
+      "betaDescription": "Išbandykite funkcijas, kurios dar kuriamos",
       "desktop": "Darbalaukis",
       "desktopAppDescription": "Atidarykite dokumentus ir failus tiesiai „stella“ iš savo kompiuterio.",
       "desktopDescription": "Įdiekite „stella“ į savo kompiuterį",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beta funkcijas",
+      "betaCaseLawDescription": "Rādīt publisko tiesu prakses meklēšanu un lasītāju sānjoslā",
+      "betaDescription": "Izmēģiniet funkcijas, kas vēl tiek izstrādātas",
       "desktop": "Datorlietotne",
       "desktopAppDescription": "Atveriet dokumentus un failus tieši stella no sava datora.",
       "desktopDescription": "Instalējiet stella savā datorā",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1816,6 +1816,9 @@ type Messages = {
   };
   "settings": {
     "account": {
+      "beta": "Beta Features";
+      "betaCaseLawDescription": "Show the public case law search and reader in the sidebar";
+      "betaDescription": "Try features that are still in development";
       "desktop": "Desktop";
       "desktopAppDescription": "Open documents and files directly in stella from your computer.";
       "desktopDescription": "Install stella on your computer";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Funkcje beta",
+      "betaCaseLawDescription": "Pokaż publiczne wyszukiwanie i czytnik orzecznictwa w pasku bocznym",
+      "betaDescription": "Wypróbuj funkcje, które są wciąż w fazie rozwoju",
       "desktop": "Aplikacja na komputer",
       "desktopAppDescription": "Otwieraj dokumenty i pliki bezpośrednio w stella ze swojego komputera.",
       "desktopDescription": "Zainstaluj stella na swoim komputerze",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Recursos beta",
+      "betaCaseLawDescription": "Mostrar a pesquisa e o leitor de jurisprudência pública na barra lateral",
+      "betaDescription": "Experimente recursos que ainda estão em desenvolvimento",
       "desktop": "Área de trabalho",
       "desktopAppDescription": "Abra documentos e arquivos diretamente na stella pelo seu computador.",
       "desktopDescription": "Instale a stella no seu computador",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1813,6 +1813,9 @@
   },
   "settings": {
     "account": {
+      "beta": "Beta funkcie",
+      "betaCaseLawDescription": "Zobraziť verejné vyhľadávanie a čítačku judikatúry v bočnom paneli",
+      "betaDescription": "Vyskúšajte funkcie, ktoré sú stále vo vývoji",
       "desktop": "Aplikácia pre počítač",
       "desktopAppDescription": "Otvárajte dokumenty a súbory priamo v stella z vášho počítača.",
       "desktopDescription": "Nainštalujte si stella do počítača",

--- a/apps/web/src/lib/beta-features.ts
+++ b/apps/web/src/lib/beta-features.ts
@@ -1,0 +1,9 @@
+// Hosts where users may flip beta features themselves (Settings →
+// Beta features). Production is deliberately excluded: launches there
+// go through real feature flags, not per-browser toggles.
+const BETA_FEATURES_HOSTS = new Set(["staging.stll.app"]);
+
+export const betaFeaturesAvailable = (): boolean =>
+  import.meta.env.DEV ||
+  (typeof window !== "undefined" &&
+    BETA_FEATURES_HOSTS.has(window.location.hostname));

--- a/apps/web/src/lib/beta-features.ts
+++ b/apps/web/src/lib/beta-features.ts
@@ -1,9 +1,17 @@
+import { createIsomorphicFn } from "@tanstack/react-start";
+import { getRequestHost } from "@tanstack/react-start/server";
+
 // Hosts where users may flip beta features themselves (Settings →
 // Beta features). Production is deliberately excluded: launches there
 // go through real feature flags, not per-browser toggles.
 const BETA_FEATURES_HOSTS = new Set(["staging.stll.app"]);
 
+// /law paths are selectively server-rendered, so availability must
+// resolve identically on the server (request Host header) and the
+// client (location), or direct loads would 404 on beta hosts.
+const requestHostname = createIsomorphicFn()
+  .server((): string | null => getRequestHost().split(":")[0] ?? null)
+  .client((): string | null => window.location.hostname);
+
 export const betaFeaturesAvailable = (): boolean =>
-  import.meta.env.DEV ||
-  (typeof window !== "undefined" &&
-    BETA_FEATURES_HOSTS.has(window.location.hostname));
+  import.meta.env.DEV || BETA_FEATURES_HOSTS.has(requestHostname() ?? "");

--- a/apps/web/src/lib/public-law-launch.ts
+++ b/apps/web/src/lib/public-law-launch.ts
@@ -1,7 +1,11 @@
 import { env } from "@/env";
+import { isPublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
 
+// Includes the beta-features preview state so hosts where users can
+// flip the toggle (dev, staging) also serve the /law routes; without
+// it the sidebar entry would lead to a 404.
 export const isPublicLawRouteEnabled = (): boolean =>
-  import.meta.env.DEV || env.VITE_PUBLIC_LAW_ENABLED;
+  import.meta.env.DEV || isPublicLawPreviewEnabled();
 
 export const isPublicLawIndexingEnabled = (): boolean =>
   env.VITE_PUBLIC_LAW_ENABLED && env.VITE_PUBLIC_LAW_INDEXING_ENABLED;

--- a/apps/web/src/lib/public-law-launch.ts
+++ b/apps/web/src/lib/public-law-launch.ts
@@ -1,11 +1,13 @@
 import { env } from "@/env";
-import { isPublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
+import { betaFeaturesAvailable } from "@/lib/beta-features";
 
-// Includes the beta-features preview state so hosts where users can
-// flip the toggle (dev, staging) also serve the /law routes; without
-// it the sidebar entry would lead to a 404.
+// Beta hosts always serve the /law routes; the Settings toggle only
+// governs discoverability (sidebar entry, search kinds). The gate must
+// not depend on the localStorage-backed toggle because /law paths are
+// server-rendered and the server cannot see it — host and env flag
+// resolve identically on both sides.
 export const isPublicLawRouteEnabled = (): boolean =>
-  import.meta.env.DEV || isPublicLawPreviewEnabled();
+  import.meta.env.DEV || env.VITE_PUBLIC_LAW_ENABLED || betaFeaturesAvailable();
 
 export const isPublicLawIndexingEnabled = (): boolean =>
   env.VITE_PUBLIC_LAW_ENABLED && env.VITE_PUBLIC_LAW_INDEXING_ENABLED;

--- a/apps/web/src/lib/public-law-sitemap.test.ts
+++ b/apps/web/src/lib/public-law-sitemap.test.ts
@@ -575,7 +575,10 @@ describe("public law sitemap", () => {
     expect(navSource).toContain("getWorkspacePrimaryNavItems");
     expect(navSource).toContain('item.id !== "caseLaw"');
     expect(appSidebarSource).toContain("usePublicLawPreviewEnabled");
-    expect(publicShellSource).toContain("usePublicLawPreviewEnabled");
+    // The server-rendered shell must use the isomorphic host/env gate;
+    // the browser-only preview hook would mismatch hydration there.
+    expect(publicShellSource).toContain("isPublicLawRouteEnabled");
+    expect(publicShellSource).not.toContain("usePublicLawPreviewEnabled");
   });
 
   test("direct case-law callers are filtered by the shared dark-launch helper", async () => {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -60,6 +60,7 @@ import { Route as ProtectedSettingsOrganizationAnonymizationRouteImport } from '
 import { Route as ProtectedSettingsOrganizationAiRouteImport } from './routes/_protected.settings/organization.ai'
 import { Route as ProtectedSettingsAccountProfileRouteImport } from './routes/_protected.settings/account.profile'
 import { Route as ProtectedSettingsAccountDesktopRouteImport } from './routes/_protected.settings/account.desktop'
+import { Route as ProtectedSettingsAccountBetaRouteImport } from './routes/_protected.settings/account.beta'
 import { Route as ProtectedKnowledgeToolsSkillIdRouteImport } from './routes/_protected.knowledge/tools_.$skillId'
 import { Route as ProtectedWorkspacesWorkspaceIdViewIdRouteRouteImport } from './routes/_protected.workspaces/$workspaceId/$viewId.route'
 import { Route as ProtectedWorkspacesWorkspaceIdViewIdIndexRouteImport } from './routes/_protected.workspaces/$workspaceId/$viewId.index'
@@ -350,6 +351,12 @@ const ProtectedSettingsAccountDesktopRoute =
     path: '/account/desktop',
     getParentRoute: () => ProtectedSettingsRouteRoute,
   } as any)
+const ProtectedSettingsAccountBetaRoute =
+  ProtectedSettingsAccountBetaRouteImport.update({
+    id: '/account/beta',
+    path: '/account/beta',
+    getParentRoute: () => ProtectedSettingsRouteRoute,
+  } as any)
 const ProtectedKnowledgeToolsSkillIdRoute =
   ProtectedKnowledgeToolsSkillIdRouteImport.update({
     id: '/tools_/$skillId',
@@ -463,6 +470,7 @@ export interface FileRoutesByFullPath {
   '/law/cases/': typeof LawCasesIndexRoute
   '/workspaces/$workspaceId/$viewId': typeof ProtectedWorkspacesWorkspaceIdViewIdRouteRouteWithChildren
   '/knowledge/tools/$skillId': typeof ProtectedKnowledgeToolsSkillIdRoute
+  '/settings/account/beta': typeof ProtectedSettingsAccountBetaRoute
   '/settings/account/desktop': typeof ProtectedSettingsAccountDesktopRoute
   '/settings/account/profile': typeof ProtectedSettingsAccountProfileRoute
   '/settings/organization/ai': typeof ProtectedSettingsOrganizationAiRoute
@@ -519,6 +527,7 @@ export interface FileRoutesByTo {
   '/workspaces': typeof ProtectedWorkspacesIndexRoute
   '/law/cases': typeof LawCasesIndexRoute
   '/knowledge/tools/$skillId': typeof ProtectedKnowledgeToolsSkillIdRoute
+  '/settings/account/beta': typeof ProtectedSettingsAccountBetaRoute
   '/settings/account/desktop': typeof ProtectedSettingsAccountDesktopRoute
   '/settings/account/profile': typeof ProtectedSettingsAccountProfileRoute
   '/settings/organization/ai': typeof ProtectedSettingsOrganizationAiRoute
@@ -585,6 +594,7 @@ export interface FileRoutesById {
   '/law/cases/': typeof LawCasesIndexRoute
   '/_protected/workspaces/$workspaceId/$viewId': typeof ProtectedWorkspacesWorkspaceIdViewIdRouteRouteWithChildren
   '/_protected/knowledge/tools_/$skillId': typeof ProtectedKnowledgeToolsSkillIdRoute
+  '/_protected/settings/account/beta': typeof ProtectedSettingsAccountBetaRoute
   '/_protected/settings/account/desktop': typeof ProtectedSettingsAccountDesktopRoute
   '/_protected/settings/account/profile': typeof ProtectedSettingsAccountProfileRoute
   '/_protected/settings/organization/ai': typeof ProtectedSettingsOrganizationAiRoute
@@ -651,6 +661,7 @@ export interface FileRouteTypes {
     | '/law/cases/'
     | '/workspaces/$workspaceId/$viewId'
     | '/knowledge/tools/$skillId'
+    | '/settings/account/beta'
     | '/settings/account/desktop'
     | '/settings/account/profile'
     | '/settings/organization/ai'
@@ -707,6 +718,7 @@ export interface FileRouteTypes {
     | '/workspaces'
     | '/law/cases'
     | '/knowledge/tools/$skillId'
+    | '/settings/account/beta'
     | '/settings/account/desktop'
     | '/settings/account/profile'
     | '/settings/organization/ai'
@@ -772,6 +784,7 @@ export interface FileRouteTypes {
     | '/law/cases/'
     | '/_protected/workspaces/$workspaceId/$viewId'
     | '/_protected/knowledge/tools_/$skillId'
+    | '/_protected/settings/account/beta'
     | '/_protected/settings/account/desktop'
     | '/_protected/settings/account/profile'
     | '/_protected/settings/organization/ai'
@@ -1172,6 +1185,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedSettingsAccountDesktopRouteImport
       parentRoute: typeof ProtectedSettingsRouteRoute
     }
+    '/_protected/settings/account/beta': {
+      id: '/_protected/settings/account/beta'
+      path: '/account/beta'
+      fullPath: '/settings/account/beta'
+      preLoaderRoute: typeof ProtectedSettingsAccountBetaRouteImport
+      parentRoute: typeof ProtectedSettingsRouteRoute
+    }
     '/_protected/knowledge/tools_/$skillId': {
       id: '/_protected/knowledge/tools_/$skillId'
       path: '/tools/$skillId'
@@ -1378,6 +1398,7 @@ const ProtectedSettingsOrganizationRouteRouteWithChildren =
 interface ProtectedSettingsRouteRouteChildren {
   ProtectedSettingsOrganizationRouteRoute: typeof ProtectedSettingsOrganizationRouteRouteWithChildren
   ProtectedSettingsIndexRoute: typeof ProtectedSettingsIndexRoute
+  ProtectedSettingsAccountBetaRoute: typeof ProtectedSettingsAccountBetaRoute
   ProtectedSettingsAccountDesktopRoute: typeof ProtectedSettingsAccountDesktopRoute
   ProtectedSettingsAccountProfileRoute: typeof ProtectedSettingsAccountProfileRoute
 }
@@ -1387,6 +1408,7 @@ const ProtectedSettingsRouteRouteChildren: ProtectedSettingsRouteRouteChildren =
     ProtectedSettingsOrganizationRouteRoute:
       ProtectedSettingsOrganizationRouteRouteWithChildren,
     ProtectedSettingsIndexRoute: ProtectedSettingsIndexRoute,
+    ProtectedSettingsAccountBetaRoute: ProtectedSettingsAccountBetaRoute,
     ProtectedSettingsAccountDesktopRoute: ProtectedSettingsAccountDesktopRoute,
     ProtectedSettingsAccountProfileRoute: ProtectedSettingsAccountProfileRoute,
   }

--- a/apps/web/src/routes/_protected.settings/account.beta.tsx
+++ b/apps/web/src/routes/_protected.settings/account.beta.tsx
@@ -1,0 +1,53 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
+import { Checkbox } from "@stll/ui/components/checkbox";
+import { Field, FieldLabel } from "@stll/ui/components/field";
+import { Frame, FramePanel } from "@stll/ui/components/frame";
+
+import { betaFeaturesAvailable } from "@/lib/beta-features";
+import { useDevStore } from "@/lib/dev-store";
+import { SettingsPageHeader } from "@/routes/_protected.settings/-components/settings-page-header";
+
+export const Route = createFileRoute("/_protected/settings/account/beta")({
+  beforeLoad: () => {
+    if (!betaFeaturesAvailable()) {
+      throw redirect({ to: "/settings/account/profile" });
+    }
+  },
+  component: BetaFeaturesPage,
+});
+
+function BetaFeaturesPage() {
+  const t = useTranslations();
+  const publicLawPreview = useDevStore((s) => s.publicLawPreview);
+  const setPublicLawPreview = useDevStore((s) => s.setPublicLawPreview);
+
+  return (
+    <>
+      <SettingsPageHeader
+        description={t("settings.account.betaDescription")}
+        title={t("settings.account.beta")}
+      />
+      <Frame>
+        <FramePanel>
+          <div className="flex flex-col gap-3 p-1">
+            <h2 className="text-sm font-medium">{t("common.caseLaw")}</h2>
+            <p className="text-muted-foreground text-xs">
+              {t("settings.account.betaCaseLawDescription")}
+            </p>
+            <Field className="flex-row items-center gap-2">
+              <Checkbox
+                checked={publicLawPreview}
+                onCheckedChange={(next) => {
+                  setPublicLawPreview(next);
+                }}
+              />
+              <FieldLabel>{t("common.caseLaw")}</FieldLabel>
+            </Field>
+          </div>
+        </FramePanel>
+      </Frame>
+    </>
+  );
+}

--- a/apps/web/src/routes/_protected.settings/route.tsx
+++ b/apps/web/src/routes/_protected.settings/route.tsx
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
 import {
+  FlaskConicalIcon,
   GaugeIcon,
   HashIcon,
   MonitorIcon,
@@ -15,6 +16,7 @@ import { useTranslations } from "use-intl";
 import { cn } from "@stll/ui/lib/utils";
 
 import type { TranslationKey } from "@/i18n/types";
+import { betaFeaturesAvailable } from "@/lib/beta-features";
 import { pageTitle } from "@/lib/page-title";
 import { roleOptions } from "@/routes/-queries";
 import { managementRoles } from "@/routes/_protected.organization/-consts";
@@ -29,6 +31,7 @@ export const Route = createFileRoute("/_protected/settings")({
 type NavTo =
   | "/settings/account/profile"
   | "/settings/account/desktop"
+  | "/settings/account/beta"
   | "/settings/organization/members"
   | "/settings/organization/matter-numbering"
   | "/settings/organization/ai"
@@ -47,6 +50,12 @@ type Section = {
   readonly items: readonly NavItem[];
 };
 
+const BETA_NAV_ITEM = {
+  to: "/settings/account/beta",
+  labelKey: "settings.account.beta",
+  icon: FlaskConicalIcon,
+} as const satisfies NavItem;
+
 const ACCOUNT_SECTION = {
   id: "account",
   labelKey: "settings.account.title",
@@ -61,6 +70,8 @@ const ACCOUNT_SECTION = {
       labelKey: "settings.account.desktop",
       icon: MonitorIcon,
     },
+    // Beta features: only on hosts where users may flip them (dev,
+    // staging); appended conditionally in SettingsLayout.
   ],
 } as const satisfies Section;
 
@@ -101,9 +112,12 @@ function SettingsLayout() {
   const { data: role } = useSuspenseQuery(roleOptions);
   const showOrganization = managementRoles.includes(role);
 
+  const accountSection: Section = betaFeaturesAvailable()
+    ? { ...ACCOUNT_SECTION, items: [...ACCOUNT_SECTION.items, BETA_NAV_ITEM] }
+    : ACCOUNT_SECTION;
   const sections = showOrganization
-    ? [ACCOUNT_SECTION, ORGANIZATION_SECTION]
-    : [ACCOUNT_SECTION];
+    ? [accountSection, ORGANIZATION_SECTION]
+    : [accountSection];
 
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden border-t">

--- a/apps/web/src/routes/_protected.settings/route.tsx
+++ b/apps/web/src/routes/_protected.settings/route.tsx
@@ -112,8 +112,14 @@ function SettingsLayout() {
   const { data: role } = useSuspenseQuery(roleOptions);
   const showOrganization = managementRoles.includes(role);
 
-  const accountSection: Section = betaFeaturesAvailable()
-    ? { ...ACCOUNT_SECTION, items: [...ACCOUNT_SECTION.items, BETA_NAV_ITEM] }
+  // No `Section` annotation: it would widen labelKey to the full
+  // TranslationKey union, whose ICU-variable members make t() demand a
+  // values argument. The literal key types stay narrow this way.
+  const accountSection = betaFeaturesAvailable()
+    ? ({
+        ...ACCOUNT_SECTION,
+        items: [...ACCOUNT_SECTION.items, BETA_NAV_ITEM],
+      } as const)
     : ACCOUNT_SECTION;
   const sections = showOrganization
     ? [accountSection, ORGANIZATION_SECTION]

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -29,9 +29,9 @@ import {
 import { StellaWordmark } from "@/components/stella-wordmark";
 import { getWorkspacePrimaryNavItems } from "@/components/workspace-primary-nav";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
-import { usePublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
 import { AuthenticatedUserProvider } from "@/lib/authenticated-user-context";
 import { HOTKEYS } from "@/lib/hotkeys";
+import { isPublicLawRouteEnabled } from "@/lib/public-law-launch";
 
 const SignInDialog = lazy(async () => {
   const module = await import("@/components/auth/sign-in-dialog");
@@ -98,9 +98,11 @@ function PublicLawSidebar({
   const { state, toggleSidebar } = useSidebar();
   const isCollapsed = state === "collapsed";
   const [searchOpen, setSearchOpen] = useState(false);
-  const publicLawPreviewEnabled = usePublicLawPreviewEnabled();
+  // This shell is server-rendered; the localStorage-backed preview
+  // toggle is browser-only and would mismatch hydration. The host/env
+  // gate is isomorphic, and anyone rendering this shell passed it.
   const primaryNavItems = getWorkspacePrimaryNavItems({
-    includePublicLaw: publicLawPreviewEnabled,
+    includePublicLaw: isPublicLawRouteEnabled(),
   });
 
   const requestPrivateFeature = (redirectTo: string) => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -134,6 +134,14 @@ export default defineConfig(({ mode }) => {
       // deps here makes the optimizer finish them up front. Dev-only:
       // production uses Rollup and ignores optimizeDeps.
       include: [
+        // 3. @tanstack/react-start's isomorphic-fn/server entrypoints
+        //    (lib/beta-features.ts) reach these only at runtime.
+        "@tanstack/history",
+        "@tanstack/router-core",
+        "@tanstack/router-core/ssr/client",
+        "@tanstack/router-core/ssr/server",
+        "h3-v2",
+        "seroval",
         "@better-auth/core/env",
         "@better-auth/core/error",
         "@better-auth/core/utils/error-codes",


### PR DESCRIPTION
Adds Settings → Account → Beta Features with a toggle for the public case law preview. The page and its nav entry appear on hosts where users may flip beta features themselves — dev builds and the staging host — via a small allowlist helper (`betaFeaturesAvailable`); production keeps real feature flags only, and the route redirects away when unavailable.

The toggle drives the same persisted `publicLawPreview` state the dev sidebar uses, so the sidebar nav item and search kinds react immediately. Previously the preview was reachable only through the dev-build sidebar, leaving no way to see the case law UI on staging. Keys translated for all 12 locales.