### PR TITLE
fix(web): hydrate SSR public pages without the i18n boot gate

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -46,3 +46,31 @@ test("chat thread page renders for an entitlement-less owner", async ({
     .first();
   await expect(composer.or(aiKeyGate)).toBeVisible();
 });
+
+test("server-rendered public law pages hydrate cleanly", async ({ page }) => {
+  // Hydration mismatches surface as pageerrors (React #418 + a router
+  // invariant) and end in the error boundary; collect them explicitly
+  // so the failure names the real exception instead of a timeout.
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  await page.goto("/law/cases");
+  const firstDecision = page
+    .locator('a[href*="/law/"][href*="/cases/"]')
+    .first();
+
+  await expect(firstDecision).toBeVisible();
+  await firstDecision.click();
+  await expect(page).toHaveURL(/\/law\/[a-z]{2,3}\/cases\//u);
+
+  // Force a full server-rendered load of the decision page: client-side
+  // navigation alone would never exercise the hydration path that broke.
+  await page.reload();
+
+  // Case numbers look like "6 Tdo 647/2017"; anchoring on the slash-year
+  // tail keeps the regex linear.
+  await expect(page.getByRole("heading", { name: /\/\d{4}/u })).toBeVisible();
+  expect(pageErrors).toEqual([]);
+});

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -48,6 +48,19 @@ test("chat thread page renders for an entitlement-less owner", async ({
 });
 
 test("server-rendered public law pages hydrate cleanly", async ({ page }) => {
+  // A persisted non-English locale is the harder hydration case: the
+  // client holds translated messages before hydrating against the
+  // server's English markup. The bug class this guards against only
+  // reproduced with a non-default locale.
+  // String form: the e2e tsconfig has no DOM lib, so a function body
+  // referencing browser globals would not typecheck in this context.
+  await page.addInitScript({
+    content: `window.localStorage.setItem(
+      "stella-i18n",
+      JSON.stringify({ state: { lang: "cs" }, version: 0 }),
+    );`,
+  });
+
   // Hydration mismatches surface as pageerrors (React #418 + a router
   // invariant) and end in the error boundary; collect them explicitly
   // so the failure names the real exception instead of a timeout.

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -70,8 +70,11 @@ test("server-rendered public law pages hydrate cleanly", async ({ page }) => {
   });
 
   await page.goto("/law/cases");
+  // Scoped to the decisions table: the shell sidebar also carries a
+  // /law/cases nav link that a page-wide href filter could match.
   const firstDecision = page
-    .locator('a[href*="/law/"][href*="/cases/"]')
+    .getByRole("table")
+    .locator('a[href*="/cases/"]')
     .first();
 
   await expect(firstDecision).toBeVisible();

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import type { PropsWithChildren } from "react";
 
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
 import { IntlProvider } from "use-intl";
 
 import { ToastProvider } from "@stll/ui/components/toast";
@@ -54,6 +55,21 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
   // on the client the gate only matters for the initial document load.
   const onPublicSsrPath =
     typeof window !== "undefined" && isPublicSsrPath(window.location.pathname);
+
+  // Head content (the document title) renders outside this provider and
+  // only re-evaluates on router invalidation; refresh it when a new
+  // locale finishes loading post-hydration so the title localizes
+  // without a navigation. Ref-guarded to locale CHANGES so the initial
+  // mount does not re-run route loaders.
+  const router = useRouter();
+  const previousLocaleRef = useRef(locale);
+  useEffect(() => {
+    if (!onPublicSsrPath || previousLocaleRef.current === locale) {
+      return;
+    }
+    previousLocaleRef.current = locale;
+    void router.invalidate();
+  }, [router, locale, onPublicSsrPath]);
 
   // Gate the boot spinner on the first load, not on isLoaded: a language
   // switch flips isLoaded false while the new locale streams in, and gating

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -1,10 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import type { PropsWithChildren } from "react";
 
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
-import { useRouterState } from "@tanstack/react-router";
 import { IntlProvider } from "use-intl";
 
 import { ToastProvider } from "@stll/ui/components/toast";
@@ -13,7 +12,7 @@ import { TooltipProvider } from "@stll/ui/components/tooltip";
 import { DefaultPendingComponent } from "@/components/route-components";
 import { ThemeProvider } from "@/components/theme-provider";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
-import { useI18nStore } from "@/i18n/i18n-store";
+import { bundledEnglishMessages, useI18nStore } from "@/i18n/i18n-store";
 import type Messages from "@/i18n/langs/messages.gen";
 import { AnalyticsProvider, useAnalytics } from "@/lib/analytics/provider";
 import type { AnalyticsValue } from "@/lib/analytics/provider";
@@ -29,14 +28,32 @@ const resolveAppI18nTimeZone = (): string => {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 };
 
+const noopSubscribe = () => () => undefined;
+
+/**
+ * False during server render AND the client's hydration pass, true
+ * immediately after. The canonical hydration-safe two-phase signal:
+ * useSyncExternalStore serves getServerSnapshot to both sides of
+ * hydration, so flipping to true afterwards is an ordinary update, not
+ * a markup mismatch.
+ */
+const useHydrated = (): boolean =>
+  useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+
 const I18nProvider = ({ children }: PropsWithChildren) => {
   const locale = useI18nStore((s) => s.loadedLang);
   const messages = useI18nStore((s) => s.messages);
   const hasLoadedOnce = useI18nStore((s) => s.hasLoadedOnce);
+  const hydrated = useHydrated();
 
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
+  // window.location is safe here: the server branch never reads it, and
+  // on the client the gate only matters for the initial document load.
+  const onPublicSsrPath =
+    typeof window !== "undefined" && isPublicSsrPath(window.location.pathname);
 
   // Gate the boot spinner on the first load, not on isLoaded: a language
   // switch flips isLoaded false while the new locale streams in, and gating
@@ -46,26 +63,30 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
   //
   // Server-rendered public paths must skip the spinner entirely: the
   // server renders full content, so the client's first render has to
-  // produce identical markup or hydration fails. Both sides render the
-  // statically bundled English there, and the persisted locale swaps in
-  // place after mount.
-  if (
-    !hasLoadedOnce &&
-    typeof window !== "undefined" &&
-    !isPublicSsrPath(pathname)
-  ) {
+  // produce identical markup or hydration fails.
+  if (!hasLoadedOnce && typeof window !== "undefined" && !onPublicSsrPath) {
     return <DefaultPendingComponent />;
   }
 
+  // On those same paths the client may already hold the persisted
+  // locale before hydration (client.tsx awaits initializeI18n first),
+  // so render the bundled English the server used until hydration
+  // completes; the persisted locale then swaps in place.
+  const preHydrationEnglish = onPublicSsrPath && !hydrated;
+
+  // SAFETY: locale JSON files are shape-checked in i18n-store.ts; this
+  // cast is only at the provider boundary because use-intl's Messages
+  // type preserves English literal message values while translated
+  // locale JSONs necessarily contain different strings.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  const activeMessages = (
+    preHydrationEnglish ? bundledEnglishMessages : messages
+  ) as Messages;
+
   return (
     <IntlProvider
-      locale={locale}
-      // SAFETY: locale JSON files are shape-checked in i18n-store.ts;
-      // this cast is only at the provider boundary because use-intl's
-      // Messages type preserves English literal message values while
-      // translated locale JSONs necessarily contain different strings.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      messages={messages as Messages}
+      locale={preHydrationEnglish ? "en" : locale}
+      messages={activeMessages}
       timeZone={resolveAppI18nTimeZone()}
     >
       {children}

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react";
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
+import { useRouterState } from "@tanstack/react-router";
 import { IntlProvider } from "use-intl";
 
 import { ToastProvider } from "@stll/ui/components/toast";
@@ -16,6 +17,7 @@ import { useI18nStore } from "@/i18n/i18n-store";
 import type Messages from "@/i18n/langs/messages.gen";
 import { AnalyticsProvider, useAnalytics } from "@/lib/analytics/provider";
 import type { AnalyticsValue } from "@/lib/analytics/provider";
+import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 
 const SERVER_I18N_TIME_ZONE = "UTC";
 
@@ -32,12 +34,26 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
   const messages = useI18nStore((s) => s.messages);
   const hasLoadedOnce = useI18nStore((s) => s.hasLoadedOnce);
 
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+
   // Gate the boot spinner on the first load, not on isLoaded: a language
   // switch flips isLoaded false while the new locale streams in, and gating
   // the whole subtree on it would unmount the app (losing in-progress state
   // like onboarding) on every switch. loadedLang/messages are always a
   // consistent already-loaded pair, so the locale swaps in place instead.
-  if (!hasLoadedOnce && typeof window !== "undefined") {
+  //
+  // Server-rendered public paths must skip the spinner entirely: the
+  // server renders full content, so the client's first render has to
+  // produce identical markup or hydration fails. Both sides render the
+  // statically bundled English there, and the persisted locale swaps in
+  // place after mount.
+  if (
+    !hasLoadedOnce &&
+    typeof window !== "undefined" &&
+    !isPublicSsrPath(pathname)
+  ) {
     return <DefaultPendingComponent />;
   }
 

--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -5,8 +5,9 @@ import { CancelledError } from "@tanstack/react-query";
 import { StartClient } from "@tanstack/react-start/client";
 
 import { initializeI18n } from "@/i18n/i18n-store";
+import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 
-void initializeI18n().finally(() => {
+const hydrate = () => {
   startTransition(() => {
     hydrateRoot(
       document,
@@ -26,4 +27,20 @@ void initializeI18n().finally(() => {
       },
     );
   });
-});
+};
+
+if (isPublicSsrPath(window.location.pathname)) {
+  // The server rendered these paths with the bundled English (the only
+  // locale it has). Hydration must run against identical i18n state, so
+  // the persisted locale loads only after the first paint and then
+  // swaps in place — both the IntlProvider subtree and the module-level
+  // translator behind pageTitle()/HeadContent stay English until then.
+  hydrate();
+  requestAnimationFrame(() => {
+    setTimeout(() => {
+      void initializeI18n();
+    }, 0);
+  });
+} else {
+  void initializeI18n().finally(hydrate);
+}

--- a/apps/web/src/i18n/i18n-store.ts
+++ b/apps/web/src/i18n/i18n-store.ts
@@ -110,6 +110,13 @@ const detectLang = (): SupportedLanguage => {
 const defaultLanguage = detectLang();
 const defaultMessages = en;
 
+/**
+ * The statically bundled English messages. Server-rendered public pages
+ * render with these until hydration completes, so client markup can
+ * match the server's regardless of the persisted locale.
+ */
+export const bundledEnglishMessages = en;
+
 export const loadLocaleMessages = async (
   lang: SupportedLanguage,
 ): Promise<LocaleMessages> => await messageLoaders[lang]();

--- a/apps/web/src/i18n/i18n-store.ts
+++ b/apps/web/src/i18n/i18n-store.ts
@@ -5,6 +5,7 @@ import { persist } from "zustand/middleware";
 import { getStorageKey } from "@/consts";
 import en from "@/i18n/langs/en.json";
 import type Messages from "@/i18n/langs/messages.gen";
+import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 
 type LocalizedMessages<T> = {
   [K in keyof T]: T[K] extends string ? string : LocalizedMessages<T[K]>;
@@ -230,9 +231,19 @@ export const useI18nStore = create<State & Actions>()(
       version: 0,
       partialize: (state) => ({ lang: state.lang }),
       onRehydrateStorage: () => (state) => {
-        if (state) {
-          void state.loadMessages(state.lang);
+        if (!state) {
+          return;
         }
+        // Public SSR paths hydrate against server-rendered English; the
+        // client entrypoint loads the persisted locale after first paint
+        // instead of this eager rehydration hook.
+        if (
+          typeof window !== "undefined" &&
+          isPublicSsrPath(window.location.pathname)
+        ) {
+          return;
+        }
+        void state.loadMessages(state.lang);
       },
     },
   ),

--- a/apps/web/src/lib/public-law-sitemap.test.ts
+++ b/apps/web/src/lib/public-law-sitemap.test.ts
@@ -598,13 +598,22 @@ describe("public law sitemap", () => {
     expect(searchSource).toContain("usePublicLawPreviewEnabled");
   });
 
-  test("start client initializes i18n before hydrating", async () => {
+  test("start client orders i18n around hydration per path kind", async () => {
     const source = await readSource("apps/web/src/client.tsx");
-    const initializeIndex = source.indexOf("initializeI18n().finally");
-    const hydrateIndex = source.indexOf("hydrateRoot(");
 
-    expect(initializeIndex).toBeGreaterThan(-1);
-    expect(hydrateIndex).toBeGreaterThan(initializeIndex);
+    // Public SSR paths hydrate first (against the server's English) and
+    // load the persisted locale after first paint; app paths keep the
+    // resolve-locale-then-hydrate boot model.
+    expect(source).toContain("isPublicSsrPath(window.location.pathname)");
+    expect(source).toContain("void initializeI18n().finally(hydrate);");
+    const ssrBranchIndex = source.indexOf(
+      "isPublicSsrPath(window.location.pathname)",
+    );
+    const appBranchIndex = source.indexOf(
+      "void initializeI18n().finally(hydrate);",
+    );
+    expect(ssrBranchIndex).toBeGreaterThan(-1);
+    expect(appBranchIndex).toBeGreaterThan(ssrBranchIndex);
   });
 
   test("app provider preserves browser time zones for app timestamps", async () => {


### PR DESCRIPTION
The i18n boot gate returns the spinner on the client's first render until the persisted locale loads, while the server (no `window`) renders full content. Server-rendered paths now skip the gate: both sides first-render the statically bundled English and the persisted locale swaps in place after mount. SPA boot behavior is unchanged.

Adds a staging smoke test that opens the public case-law list, navigates to a decision, reloads to force the SSR + hydration path, and asserts the heading renders with zero page errors.