### PR TITLE
fix(web): source saved prompts org from the auth context

### DIFF
--- a/apps/web/src/lib/authenticated-user-context.tsx
+++ b/apps/web/src/lib/authenticated-user-context.tsx
@@ -34,3 +34,12 @@ export const useAuthenticatedUser = (): AuthenticatedUser => {
   }
   return user;
 };
+
+/**
+ * Like useAuthenticatedUser, but returns null outside the provider.
+ * For account-bound garnish on surfaces that anonymous visitors can
+ * reach (public law pages, pre-signup AI features): render without the
+ * account data instead of requiring the provider.
+ */
+export const useMaybeAuthenticatedUser = (): AuthenticatedUser | null =>
+  use(AuthenticatedUserContext);

--- a/apps/web/src/lib/prompts/use-saved-prompts.ts
+++ b/apps/web/src/lib/prompts/use-saved-prompts.ts
@@ -1,15 +1,13 @@
 import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
-import { getRouteApi } from "@tanstack/react-router";
 
+import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { skillCommandsOptions } from "@/routes/_protected.knowledge/-queries";
 
 import type { ChatPrompt } from "./types";
 
 const MAX_SUGGESTIONS = 4;
-
-const protectedRouteApi = getRouteApi("/_protected");
 
 /**
  * Returns up to 4 of the most recently created skills with a slash
@@ -20,9 +18,10 @@ const protectedRouteApi = getRouteApi("/_protected");
  * sampling causes across stale→fresh refetches.
  */
 export const useSavedPrompts = (): ChatPrompt[] => {
-  const activeOrganizationId = protectedRouteApi.useRouteContext({
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
+  // Sourced from the auth context, not the /_protected route context:
+  // this hook also renders inside the public law workspace's
+  // authenticated branch, where no /_protected match exists.
+  const { activeOrganizationId } = useAuthenticatedUser();
   const { data = [] } = useQuery(skillCommandsOptions(activeOrganizationId));
 
   return useMemo(

--- a/apps/web/src/lib/prompts/use-saved-prompts.ts
+++ b/apps/web/src/lib/prompts/use-saved-prompts.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
-import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
+import { useMaybeAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { skillCommandsOptions } from "@/routes/_protected.knowledge/-queries";
 
 import type { ChatPrompt } from "./types";
@@ -19,10 +19,15 @@ const MAX_SUGGESTIONS = 4;
  */
 export const useSavedPrompts = (): ChatPrompt[] => {
   // Sourced from the auth context, not the /_protected route context:
-  // this hook also renders inside the public law workspace's
-  // authenticated branch, where no /_protected match exists.
-  const { activeOrganizationId } = useAuthenticatedUser();
-  const { data = [] } = useQuery(skillCommandsOptions(activeOrganizationId));
+  // this hook also renders inside the public law workspace, where no
+  // /_protected match exists. Anonymous visitors (pre-signup AI
+  // surfaces) simply have no saved prompts.
+  const activeOrganizationId =
+    useMaybeAuthenticatedUser()?.activeOrganizationId;
+  const { data = [] } = useQuery({
+    ...skillCommandsOptions(activeOrganizationId ?? ""),
+    enabled: activeOrganizationId !== undefined,
+  });
 
   return useMemo(
     () =>


### PR DESCRIPTION
`useSavedPrompts` read `activeOrganizationId` via `getRouteApi("/_protected").useRouteContext`, which throws `Could not find an active match` when the hook renders outside that route tree — concretely, the public law decision workspace mounts the inspector chat panel for authenticated users (whenever persisted inspector tabs exist), taking the whole page to the error boundary. Source the organization from `useAuthenticatedUser()` instead, which both the `/_protected` tree and the public law workspace provide; the panel itself already uses it.