### PR TITLE
fix(web): suppress html-element hydration warning

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -71,7 +71,11 @@ function RootComponent() {
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <html lang="en">
+    // dark-mode-init.js mutates the html element's class before React
+    // hydrates the document, so the attribute set never matches the
+    // server markup; suppress the per-element warning rather than
+    // letting every SSR page log a recovered hydration error.
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
         <script src="/dark-mode-init.js" />


### PR DESCRIPTION
The dark-mode init script mutates the `<html>` element's class before React hydrates the document, so the attribute set never matches the server markup and every server-rendered page logs a recovered React #418. Standard remedy: `suppressHydrationWarning` on the element whose attributes are intentionally client-managed; element content checking is unaffected.

CC on behalf of @jan-kubica