### PR TITLE
fix(web): public law chrome parity, inspector layout, legacy URL fallback

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -14,51 +14,31 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { getRouteApi, Link, useMatch } from "@tanstack/react-router";
 import {
-  ChevronsUpDownIcon,
   EllipsisVerticalIcon,
-  GlobeIcon,
   LayersIcon,
-  LogOutIcon,
-  MonitorIcon,
-  MoonIcon,
   PanelLeftIcon,
   PinIcon,
   PinOffIcon,
   PlusIcon,
   SearchIcon,
-  Settings2Icon,
-  SunIcon,
   UsersIcon,
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
 
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@stll/ui/components/avatar";
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import {
   Menu,
-  MenuGroup,
-  MenuGroupLabel,
   MenuItem,
   MenuPopup,
-  MenuRadioGroup,
-  MenuRadioItem,
   MenuSeparator,
-  MenuSub,
-  MenuSubPopup,
-  MenuSubTrigger,
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
-import { DevSidebarGroup } from "@/components/dev-sidebar-group";
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import { SearchDialog } from "@/components/search-dialog";
 import {
@@ -77,8 +57,8 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "@/components/sidebar";
+import { SidebarUserMenu } from "@/components/sidebar-user-menu";
 import { StellaWordmark } from "@/components/stella-wordmark";
-import { PALETTES, THEMES, useTheme } from "@/components/theme-provider";
 import Tooltip from "@/components/tooltip";
 import {
   getWorkspacePrimaryNavItems,
@@ -87,20 +67,13 @@ import {
 import { useInlineRename } from "@/hooks/use-inline-rename";
 import { usePermissions } from "@/hooks/use-permissions";
 import { usePublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
-import { useSignOut } from "@/hooks/use-sign-out";
-import {
-  LANG_ENDONYMS,
-  supportedLanguages,
-  useI18nStore,
-} from "@/i18n/i18n-store";
+import { useI18nStore } from "@/i18n/i18n-store";
 import { SIDE_RAIL_ICON_BUTTON_SIZE } from "@/lib/consts";
-import { getInitials } from "@/lib/get-initials";
 import { HOTKEYS, NAV_KEY } from "@/lib/hotkeys";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { usePinnedStore } from "@/lib/pinned-store";
 import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";
 import { knowledgeSections } from "@/routes/_protected.knowledge/index";
-import { organizationOptions } from "@/routes/_protected.organization/-queries";
 import {
   MatterMenuHeader,
   MatterMenuItems,
@@ -110,10 +83,8 @@ import { useUpdateWorkspace } from "@/routes/_protected.workspaces/-mutations";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
 import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 
-const isDev = import.meta.env.DEV;
 const RECENTS_LIMIT = 5;
 const HOLD_DELAY_MS = 500;
-const CHANGELOG_URL = "https://stll.app/changelog";
 // TODO: Persist pinned workspaces on the backend (user
 // preference or a `pinned` flag on the workspace member).
 
@@ -554,7 +525,6 @@ const SidebarContextArea = ({
 const routeApi = getRouteApi("/_protected");
 
 export function AppSidebar(props: AppSidebarProps) {
-  const signOut = useSignOut();
   const t = useTranslations();
   const navigate = routeApi.useNavigate();
   const canCreateMatter = usePermissions({ workspace: ["create"] });
@@ -565,9 +535,6 @@ export function AppSidebar(props: AppSidebarProps) {
   const primaryNavItems = getWorkspacePrimaryNavItems({
     includePublicLaw: publicLawPreviewEnabled,
   });
-  const { theme, setTheme, palette, setPalette } = useTheme();
-  const lang = useI18nStore((s) => s.lang);
-  const setLang = useI18nStore((s) => s.setLang);
   const user = routeApi.useRouteContext({
     select: (ctx) => ctx.user,
   });
@@ -585,10 +552,6 @@ export function AppSidebar(props: AppSidebarProps) {
     workspacesNavigationOptions(user.activeOrganizationId),
   );
   const workspaces = workspacesData?.workspaces;
-  const { data: organization } = useQuery(organizationOptions);
-
-  const displayName = user.name ?? user.email;
-  const orgName = organization?.name;
 
   const workspaceMatch = useMatch({
     from: "/_protected/workspaces/$workspaceId",
@@ -998,165 +961,7 @@ export function AppSidebar(props: AppSidebarProps) {
       <SidebarFooter>
         <SidebarMenu>
           <FeedbackDialog userEmail={user.email} />
-          <SidebarMenuItem>
-            <Menu>
-              <Tooltip
-                content={isCollapsed ? displayName : null}
-                render={
-                  <MenuTrigger
-                    className={cn(
-                      "hover:bg-sidebar-accent data-popup-open:bg-sidebar-accent flex w-full items-center overflow-hidden rounded-md p-2 text-start text-sm outline-hidden",
-                      isCollapsed ? "justify-center" : "gap-2",
-                    )}
-                  />
-                }
-                side="right"
-              >
-                <Avatar className="size-7 rounded-full">
-                  {user.image && <AvatarImage src={user.image} />}
-                  <AvatarFallback className="text-[0.625rem]">
-                    {getInitials(displayName)}
-                  </AvatarFallback>
-                </Avatar>
-                {!isCollapsed && (
-                  <>
-                    <div className="flex min-w-0 flex-col justify-center">
-                      {user.name ? (
-                        <>
-                          <span className="truncate text-sm font-medium">
-                            {user.name}
-                          </span>
-                          {user.email && (
-                            <span className="text-muted-foreground truncate text-xs">
-                              {user.email}
-                            </span>
-                          )}
-                        </>
-                      ) : (
-                        <span className="truncate text-sm font-medium">
-                          {user.email || t("common.user")}
-                        </span>
-                      )}
-                    </div>
-                    <ChevronsUpDownIcon className="ms-auto size-4 opacity-50" />
-                  </>
-                )}
-              </Tooltip>
-              <MenuPopup align="end" className="w-56" side="top" sideOffset={8}>
-                {orgName && (
-                  <>
-                    <MenuGroup>
-                      <MenuGroupLabel className="text-sm">
-                        {orgName}
-                      </MenuGroupLabel>
-                    </MenuGroup>
-                    <MenuSeparator />
-                  </>
-                )}
-                <MenuItem
-                  onClick={() => {
-                    void navigate({
-                      to: "/settings",
-                    });
-                  }}
-                >
-                  <Settings2Icon />
-                  {t("common.settings")}
-                </MenuItem>
-                <MenuSeparator />
-                <MenuSub>
-                  <MenuSubTrigger>
-                    <SunIcon />
-                    {t("appearance.title")}
-                  </MenuSubTrigger>
-                  <MenuSubPopup>
-                    <MenuGroup>
-                      <MenuGroupLabel>{t("appearance.theme")}</MenuGroupLabel>
-                      <MenuRadioGroup value={theme}>
-                        {THEMES.map((themeOption) => (
-                          <MenuRadioItem
-                            key={themeOption}
-                            onClick={() => setTheme(themeOption)}
-                            value={themeOption}
-                          >
-                            <div className="flex items-center gap-1.5">
-                              {
-                                {
-                                  light: <SunIcon />,
-                                  dark: <MoonIcon />,
-                                  system: <MonitorIcon />,
-                                }[themeOption]
-                              }
-                              {t(`appearance.${themeOption}`)}
-                            </div>
-                          </MenuRadioItem>
-                        ))}
-                      </MenuRadioGroup>
-                    </MenuGroup>
-                    <MenuSeparator />
-                    <MenuGroup>
-                      <MenuGroupLabel>{t("appearance.palette")}</MenuGroupLabel>
-                      <MenuRadioGroup value={palette}>
-                        {PALETTES.map((p) => (
-                          <MenuRadioItem
-                            key={p}
-                            onClick={() => setPalette(p)}
-                            value={p}
-                          >
-                            {t(`appearance.${p}`)}
-                          </MenuRadioItem>
-                        ))}
-                      </MenuRadioGroup>
-                    </MenuGroup>
-                  </MenuSubPopup>
-                </MenuSub>
-                <MenuSub>
-                  <MenuSubTrigger>
-                    <GlobeIcon />
-                    {t("common.language")}
-                  </MenuSubTrigger>
-                  <MenuSubPopup>
-                    <MenuRadioGroup value={lang}>
-                      {supportedLanguages.map((langCode) => (
-                        <MenuRadioItem
-                          key={langCode}
-                          onClick={() => void setLang(langCode)}
-                          value={langCode}
-                        >
-                          {LANG_ENDONYMS[langCode]}
-                        </MenuRadioItem>
-                      ))}
-                    </MenuRadioGroup>
-                  </MenuSubPopup>
-                </MenuSub>
-                {isDev && <DevSidebarGroup />}
-                <MenuSeparator />
-                <MenuItem
-                  disabled={signOut.isPending}
-                  onClick={() => signOut.mutate()}
-                >
-                  <LogOutIcon />
-                  {t("common.signOut")}
-                </MenuItem>
-                <MenuItem
-                  aria-label={t("selfhost.viewReleaseNotes")}
-                  className="text-foreground-ghost data-highlighted:text-foreground min-h-0 px-2 pt-1.5 pb-1 text-[0.6875rem] tabular-nums"
-                  label={t("selfhost.viewReleaseNotes")}
-                  nativeButton={false}
-                  render={
-                    <a
-                      aria-label={t("selfhost.viewReleaseNotes")}
-                      href={CHANGELOG_URL}
-                      rel="noopener"
-                      target="_blank"
-                    />
-                  }
-                >
-                  v{__APP_VERSION__} · {__APP_COMMIT_SHA__.slice(0, 12)}
-                </MenuItem>
-              </MenuPopup>
-            </Menu>
-          </SidebarMenuItem>
+          <SidebarUserMenu user={user} />
         </SidebarMenu>
       </SidebarFooter>
 

--- a/apps/web/src/components/authenticated-case-law-workspace.tsx
+++ b/apps/web/src/components/authenticated-case-law-workspace.tsx
@@ -37,11 +37,13 @@ export function AuthenticatedCaseLawWorkspace({
       <ChatMentionProviders>
         <AIAvailabilityProvider>
           <ChatEditorProvider>
-            <AuthenticatedDecisionWorkspace
-              decision={decision}
-              decisionId={decisionId}
-              initialSearchQuery={initialSearchQuery}
-            />
+            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+              <AuthenticatedDecisionWorkspace
+                decision={decision}
+                decisionId={decisionId}
+                initialSearchQuery={initialSearchQuery}
+              />
+            </div>
             <CaseLawInspector decisionId={decisionId} />
           </ChatEditorProvider>
         </AIAvailabilityProvider>

--- a/apps/web/src/components/feedback-dialog.tsx
+++ b/apps/web/src/components/feedback-dialog.tsx
@@ -5,14 +5,22 @@ import { SidebarMenuButton, SidebarMenuItem } from "@/components/sidebar";
 import { env } from "@/env";
 
 type Props = {
-  userEmail: string;
+  userEmail?: string | undefined;
 };
 
-const buildMailto = (recipient: string, userEmail: string, route: string) => {
+const buildMailto = (
+  recipient: string,
+  userEmail: string | undefined,
+  route: string,
+) => {
   const subject = `Feedback (${route})`;
-  const body = ["", "", "---", `From: ${userEmail}`, `Route: ${route}`].join(
-    "\n",
-  );
+  const body = [
+    "",
+    "",
+    "---",
+    ...(userEmail ? [`From: ${userEmail}`] : []),
+    `Route: ${route}`,
+  ].join("\n");
   return `mailto:${recipient}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 };
 

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -1,0 +1,235 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  ChevronsUpDownIcon,
+  GlobeIcon,
+  LogOutIcon,
+  MonitorIcon,
+  MoonIcon,
+  Settings2Icon,
+  SunIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@stll/ui/components/avatar";
+import {
+  Menu,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import { cn } from "@stll/ui/lib/utils";
+
+import { DevSidebarGroup } from "@/components/dev-sidebar-group";
+import { SidebarMenuItem, useSidebar } from "@/components/sidebar";
+import { PALETTES, THEMES, useTheme } from "@/components/theme-provider";
+import Tooltip from "@/components/tooltip";
+import { useSignOut } from "@/hooks/use-sign-out";
+import {
+  LANG_ENDONYMS,
+  supportedLanguages,
+  useI18nStore,
+} from "@/i18n/i18n-store";
+import { getInitials } from "@/lib/get-initials";
+import { organizationOptions } from "@/routes/_protected.organization/-queries";
+
+const CHANGELOG_URL = "https://stll.app/changelog";
+const isDev = import.meta.env.DEV;
+
+type SidebarUserMenuProps = {
+  user: {
+    email: string;
+    image: string | null | undefined;
+    name: string | undefined;
+  };
+};
+
+/** Sidebar footer block with the user avatar and account menu. Shared
+ * between the workspace sidebar and the public law shell so the chrome
+ * stays identical on both surfaces. */
+export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
+  const t = useTranslations();
+  const navigate = useNavigate();
+  const signOut = useSignOut();
+  const { state, isMobile } = useSidebar();
+  const isCollapsed = state === "collapsed" && !isMobile;
+  const { theme, setTheme, palette, setPalette } = useTheme();
+  const lang = useI18nStore((s) => s.lang);
+  const setLang = useI18nStore((s) => s.setLang);
+  const { data: organization } = useQuery(organizationOptions);
+
+  const displayName = user.name ?? user.email;
+  const orgName = organization?.name;
+
+  return (
+    <SidebarMenuItem>
+      <Menu>
+        <Tooltip
+          content={isCollapsed ? displayName : null}
+          render={
+            <MenuTrigger
+              className={cn(
+                "hover:bg-sidebar-accent data-popup-open:bg-sidebar-accent flex w-full items-center overflow-hidden rounded-md p-2 text-start text-sm outline-hidden",
+                isCollapsed ? "justify-center" : "gap-2",
+              )}
+            />
+          }
+          side="right"
+        >
+          <Avatar className="size-7 rounded-full">
+            {user.image && <AvatarImage src={user.image} />}
+            <AvatarFallback className="text-[0.625rem]">
+              {getInitials(displayName)}
+            </AvatarFallback>
+          </Avatar>
+          {!isCollapsed && (
+            <>
+              <div className="flex min-w-0 flex-col justify-center">
+                {user.name ? (
+                  <>
+                    <span className="truncate text-sm font-medium">
+                      {user.name}
+                    </span>
+                    {user.email && (
+                      <span className="text-muted-foreground truncate text-xs">
+                        {user.email}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="truncate text-sm font-medium">
+                    {user.email || t("common.user")}
+                  </span>
+                )}
+              </div>
+              <ChevronsUpDownIcon className="ms-auto size-4 opacity-50" />
+            </>
+          )}
+        </Tooltip>
+        <MenuPopup align="end" className="w-56" side="top" sideOffset={8}>
+          {orgName && (
+            <>
+              <MenuGroup>
+                <MenuGroupLabel className="text-sm">{orgName}</MenuGroupLabel>
+              </MenuGroup>
+              <MenuSeparator />
+            </>
+          )}
+          <MenuItem
+            onClick={() => {
+              void navigate({
+                to: "/settings",
+              });
+            }}
+          >
+            <Settings2Icon />
+            {t("common.settings")}
+          </MenuItem>
+          <MenuSeparator />
+          <MenuSub>
+            <MenuSubTrigger>
+              <SunIcon />
+              {t("appearance.title")}
+            </MenuSubTrigger>
+            <MenuSubPopup>
+              <MenuGroup>
+                <MenuGroupLabel>{t("appearance.theme")}</MenuGroupLabel>
+                <MenuRadioGroup value={theme}>
+                  {THEMES.map((themeOption) => (
+                    <MenuRadioItem
+                      key={themeOption}
+                      onClick={() => setTheme(themeOption)}
+                      value={themeOption}
+                    >
+                      <div className="flex items-center gap-1.5">
+                        {
+                          {
+                            light: <SunIcon />,
+                            dark: <MoonIcon />,
+                            system: <MonitorIcon />,
+                          }[themeOption]
+                        }
+                        {t(`appearance.${themeOption}`)}
+                      </div>
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              </MenuGroup>
+              <MenuSeparator />
+              <MenuGroup>
+                <MenuGroupLabel>{t("appearance.palette")}</MenuGroupLabel>
+                <MenuRadioGroup value={palette}>
+                  {PALETTES.map((p) => (
+                    <MenuRadioItem
+                      key={p}
+                      onClick={() => setPalette(p)}
+                      value={p}
+                    >
+                      {t(`appearance.${p}`)}
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              </MenuGroup>
+            </MenuSubPopup>
+          </MenuSub>
+          <MenuSub>
+            <MenuSubTrigger>
+              <GlobeIcon />
+              {t("common.language")}
+            </MenuSubTrigger>
+            <MenuSubPopup>
+              <MenuRadioGroup value={lang}>
+                {supportedLanguages.map((langCode) => (
+                  <MenuRadioItem
+                    key={langCode}
+                    onClick={() => void setLang(langCode)}
+                    value={langCode}
+                  >
+                    {LANG_ENDONYMS[langCode]}
+                  </MenuRadioItem>
+                ))}
+              </MenuRadioGroup>
+            </MenuSubPopup>
+          </MenuSub>
+          {isDev && <DevSidebarGroup />}
+          <MenuSeparator />
+          <MenuItem
+            disabled={signOut.isPending}
+            onClick={() => signOut.mutate()}
+          >
+            <LogOutIcon />
+            {t("common.signOut")}
+          </MenuItem>
+          <MenuItem
+            aria-label={t("selfhost.viewReleaseNotes")}
+            className="text-foreground-ghost data-highlighted:text-foreground min-h-0 px-2 pt-1.5 pb-1 text-[0.6875rem] tabular-nums"
+            label={t("selfhost.viewReleaseNotes")}
+            nativeButton={false}
+            render={
+              <a
+                aria-label={t("selfhost.viewReleaseNotes")}
+                href={CHANGELOG_URL}
+                rel="noopener"
+                target="_blank"
+              />
+            }
+          >
+            v{__APP_VERSION__} · {__APP_COMMIT_SHA__.slice(0, 12)}
+          </MenuItem>
+        </MenuPopup>
+      </Menu>
+    </SidebarMenuItem>
+  );
+}

--- a/apps/web/src/routes/law/-case-detail.tsx
+++ b/apps/web/src/routes/law/-case-detail.tsx
@@ -18,6 +18,7 @@ import {
   extractLegacyCaseLawDecisionIdFromRouteParam,
   normalizeCaseLawLanguageSegment,
 } from "@/lib/case-law-route";
+import { APIError } from "@/lib/errors";
 import { pageTitleLiteral } from "@/lib/page-title";
 import {
   createCaseLawDecisionJsonLd,
@@ -128,6 +129,21 @@ const buildDescription = (decision: {
     .filter(Boolean)
     .join(", ");
 
+const ensurePublicDecision = async <T,>(load: () => Promise<T>): Promise<T> => {
+  try {
+    return await load();
+  } catch (error) {
+    if (error instanceof APIError && error.status === 404) {
+      throw redirect({
+        to: "/law/cases",
+        search: { notFound: true },
+        replace: true,
+      });
+    }
+    throw error;
+  }
+};
+
 const redirectToCanonicalDecisionPath = ({
   canonicalParams,
   search,
@@ -189,9 +205,12 @@ export const loadPublicCaseLawDecisionRoute = async ({
     params.slug,
   );
   if (legacyDecisionId) {
-    const decision = await ensureCriticalQueryData(
-      queryClient,
-      decisionOptions(extractId(legacyDecisionId)),
+    const decision = await ensurePublicDecision(
+      async () =>
+        await ensureCriticalQueryData(
+          queryClient,
+          decisionOptions(extractId(legacyDecisionId)),
+        ),
     );
     const canonicalParams = createCaseLawDecisionRouteParams({
       caseNumber: decision.caseNumber,
@@ -214,16 +233,16 @@ export const loadPublicCaseLawDecisionRoute = async ({
   const normalizedRouteLanguage = normalizeCaseLawLanguageSegment(
     params.language,
   );
-  const decision = await ensureCriticalQueryData(
-    queryClient,
-    decisionBySlugOptions(
-      params.language === undefined
-        ? { slug: params.slug }
-        : {
-            language: normalizedRouteLanguage ?? params.language,
-            slug: params.slug,
-          },
-    ),
+  const decision = await ensurePublicDecision(
+    async () =>
+      await ensureCriticalQueryData(
+        queryClient,
+        decisionBySlugOptions(
+          params.language === undefined || normalizedRouteLanguage === null
+            ? { slug: params.slug }
+            : { language: normalizedRouteLanguage, slug: params.slug },
+        ),
+      ),
   );
   const canonicalParams = createCaseLawDecisionRouteParams({
     caseNumber: decision.caseNumber,
@@ -286,18 +305,20 @@ export function PublicDecisionViewer({
   const publicPath = createCaseLawDecisionPath(params);
 
   return (
-    <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <main className="flex min-h-0 flex-1 overflow-hidden">
       {authStatus.isAuthenticated ? (
         <Suspense
           fallback={
-            <DecisionWorkspace
-              aiMode="locked"
-              decision={decision}
-              decisionId={decisionId}
-              initialSearchQuery={initialSearchQuery}
-              publicPath={publicPath}
-              requestAuth={requestAuth}
-            />
+            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+              <DecisionWorkspace
+                aiMode="locked"
+                decision={decision}
+                decisionId={decisionId}
+                initialSearchQuery={initialSearchQuery}
+                publicPath={publicPath}
+                requestAuth={requestAuth}
+              />
+            </div>
           }
         >
           <AuthenticatedCaseLawWorkspace
@@ -308,14 +329,16 @@ export function PublicDecisionViewer({
           />
         </Suspense>
       ) : (
-        <DecisionWorkspace
-          aiMode="locked"
-          decision={decision}
-          decisionId={decisionId}
-          initialSearchQuery={initialSearchQuery}
-          publicPath={publicPath}
-          requestAuth={requestAuth}
-        />
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <DecisionWorkspace
+            aiMode="locked"
+            decision={decision}
+            decisionId={decisionId}
+            initialSearchQuery={initialSearchQuery}
+            publicPath={publicPath}
+            requestAuth={requestAuth}
+          />
+        </div>
       )}
       {authRedirectTo !== null && (
         <Suspense fallback={null}>

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -339,7 +339,7 @@ function PublicInspectorRail({
     select: (state) => state.location.href,
   });
 
-  const railButton = (icon: ReactNode, edgeClass: string) => (
+  const railButton = (icon: ReactNode, label: string, edgeClass: string) => (
     <div
       className={cn(
         "flex w-full shrink-0 items-center justify-center",
@@ -348,10 +348,10 @@ function PublicInspectorRail({
       )}
     >
       <Tooltip
-        content={t("inspector.openChat")}
+        content={label}
         render={
           <button
-            aria-label={t("inspector.openChat")}
+            aria-label={label}
             className={cn(
               "text-muted-foreground hover:bg-accent hover:text-foreground flex items-center justify-center rounded-md transition-colors",
               SIDE_RAIL_ICON_BUTTON_SIZE,
@@ -382,10 +382,15 @@ function PublicInspectorRail({
         <div className="bg-sidebar flex h-full w-full flex-col">
           <div className="bg-background flex h-full border-s shadow-lg">
             <div className={SIDE_RAIL_CONTAINER_CLASS}>
-              {railButton(<PanelRightIcon className="size-4" />, "border-b")}
+              {railButton(
+                <PanelRightIcon className="size-4" />,
+                t("inspector.showPane"),
+                "border-b",
+              )}
               <div className="flex-1" />
               {railButton(
                 <MessageSquarePlusIcon className="size-4" />,
+                t("inspector.openChat"),
                 "border-t",
               )}
             </div>

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -286,7 +286,6 @@ function PublicLawTopBar() {
     select: (state) => {
       const loaderData = state.matches.at(-1)?.loaderData;
       if (
-        loaderData !== null &&
         typeof loaderData === "object" &&
         "caseNumber" in loaderData &&
         typeof loaderData.caseNumber === "string"

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useState } from "react";
+import type { ReactNode } from "react";
 
 import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys";
 import {
@@ -7,11 +8,20 @@ import {
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router";
-import { CircleUserRoundIcon, PanelLeftIcon } from "lucide-react";
+import {
+  CircleUserRoundIcon,
+  MessageSquarePlusIcon,
+  PanelLeftIcon,
+  PanelRightIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { Avatar, AvatarFallback } from "@stll/ui/components/avatar";
 import { Button } from "@stll/ui/components/button";
+import { Separator } from "@stll/ui/components/separator";
+import { cn } from "@stll/ui/lib/utils";
 
+import { FeedbackDialog } from "@/components/feedback-dialog";
 import {
   Sidebar,
   SidebarContent,
@@ -24,12 +34,21 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
+  SidebarTrigger,
   useSidebar,
 } from "@/components/sidebar";
+import { SidebarUserMenu } from "@/components/sidebar-user-menu";
 import { StellaWordmark } from "@/components/stella-wordmark";
+import Tooltip from "@/components/tooltip";
 import { getWorkspacePrimaryNavItems } from "@/components/workspace-primary-nav";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
 import { AuthenticatedUserProvider } from "@/lib/authenticated-user-context";
+import {
+  SIDE_RAIL_CONTAINER_CLASS,
+  SIDE_RAIL_ICON_BUTTON_SIZE,
+  SIDE_RAIL_WIDTH,
+  TOOLBAR_ROW_HEIGHT,
+} from "@/lib/consts";
 import { HOTKEYS } from "@/lib/hotkeys";
 import { isPublicLawRouteEnabled } from "@/lib/public-law-launch";
 
@@ -54,8 +73,12 @@ export function PublicLawShell() {
     <SidebarProvider>
       <PublicLawSidebar authStatus={authStatus} requestAuth={requestAuth} />
       <SidebarInset className="flex flex-col">
+        <PublicLawTopBar />
         <Outlet />
       </SidebarInset>
+      {!authStatus.isAuthenticated && (
+        <PublicInspectorRail requestAuth={requestAuth} />
+      )}
       {authRedirectTo !== null && (
         <Suspense fallback={null}>
           <SignInDialog
@@ -218,27 +241,158 @@ function PublicLawSidebar({
           </SidebarMenu>
         </SidebarGroup>
       </SidebarContent>
-      {authStatus.status === "anonymous" && (
-        <SidebarFooter className="group-data-[collapsible=icon]:p-0">
-          <SidebarMenu>
+      <SidebarFooter>
+        <SidebarMenu>
+          <FeedbackDialog
+            userEmail={
+              authStatus.isAuthenticated ? authStatus.user.email : undefined
+            }
+          />
+          {authStatus.status === "anonymous" && (
             <SidebarMenuItem>
               <SidebarMenuButton
                 aria-label={t("auth.signIn")}
-                onClick={() => requestAuth("/law/cases")}
+                className="h-auto gap-2 p-2"
+                onClick={() => requestAuth(currentHref)}
                 tooltip={t("auth.signIn")}
               >
-                <CircleUserRoundIcon />
+                <Avatar className="size-7 rounded-full">
+                  <AvatarFallback>
+                    <CircleUserRoundIcon className="size-4" />
+                  </AvatarFallback>
+                </Avatar>
                 <span>{t("auth.signIn")}</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarFooter>
-      )}
+          )}
+          {authStatus.isAuthenticated && (
+            <SidebarUserMenu user={authStatus.user} />
+          )}
+        </SidebarMenu>
+      </SidebarFooter>
       {authStatus.isAuthenticated && (
         <Suspense fallback={null}>
           <SearchDialog onOpenChange={setSearchOpen} open={searchOpen} />
         </Suspense>
       )}
     </Sidebar>
+  );
+}
+
+function PublicLawTopBar() {
+  const t = useTranslations();
+  const { isMobile } = useSidebar();
+  const caseNumber = useRouterState({
+    select: (state) => {
+      const loaderData = state.matches.at(-1)?.loaderData;
+      if (
+        loaderData !== null &&
+        typeof loaderData === "object" &&
+        "caseNumber" in loaderData &&
+        typeof loaderData.caseNumber === "string"
+      ) {
+        return loaderData.caseNumber;
+      }
+      return null;
+    },
+  });
+
+  return (
+    <header className="bg-sidebar flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4">
+      {isMobile && (
+        <>
+          <SidebarTrigger className="-ms-1" />
+          <Separator className="me-2 h-4" orientation="vertical" />
+        </>
+      )}
+      <nav
+        aria-label={t("common.caseLaw")}
+        className="flex min-w-0 items-center gap-1.5 text-sm"
+      >
+        <Link
+          className="text-muted-foreground hover:text-foreground shrink-0 transition-colors"
+          to="/law/cases"
+        >
+          {t("common.caseLaw")}
+        </Link>
+        {caseNumber !== null && (
+          <>
+            <span className="text-foreground-placeholder">/</span>
+            <span className="text-foreground truncate font-medium">
+              {caseNumber}
+            </span>
+          </>
+        )}
+      </nav>
+    </header>
+  );
+}
+
+/** Anonymous twin of the inspector side rail: same geometry and chrome
+ * as the authenticated rail, with every affordance routed to sign-in. */
+function PublicInspectorRail({
+  requestAuth,
+}: {
+  requestAuth: (redirectTo: string) => void;
+}) {
+  const t = useTranslations();
+  const currentHref = useRouterState({
+    select: (state) => state.location.href,
+  });
+
+  const railButton = (icon: ReactNode, edgeClass: string) => (
+    <div
+      className={cn(
+        "flex w-full shrink-0 items-center justify-center",
+        edgeClass,
+        TOOLBAR_ROW_HEIGHT,
+      )}
+    >
+      <Tooltip
+        content={t("inspector.openChat")}
+        render={
+          <button
+            aria-label={t("inspector.openChat")}
+            className={cn(
+              "text-muted-foreground hover:bg-accent hover:text-foreground flex items-center justify-center rounded-md transition-colors",
+              SIDE_RAIL_ICON_BUTTON_SIZE,
+            )}
+            onClick={() => requestAuth(currentHref)}
+            type="button"
+          />
+        }
+      >
+        {icon}
+      </Tooltip>
+    </div>
+  );
+
+  return (
+    <div
+      className="text-sidebar-foreground hidden md:block"
+      data-side="right"
+      data-state="collapsed"
+    >
+      <div className={cn("bg-sidebar relative", SIDE_RAIL_WIDTH)} />
+      <div
+        className={cn(
+          "fixed inset-y-0 end-0 z-10 hidden h-svh md:flex",
+          SIDE_RAIL_WIDTH,
+        )}
+      >
+        <div className="bg-sidebar flex h-full w-full flex-col">
+          <div className="bg-background flex h-full border-s shadow-lg">
+            <div className={SIDE_RAIL_CONTAINER_CLASS}>
+              {railButton(<PanelRightIcon className="size-4" />, "border-b")}
+              <div className="flex-1" />
+              {railButton(
+                <MessageSquarePlusIcon className="size-4" />,
+                "border-t",
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/law/cases/index.tsx
+++ b/apps/web/src/routes/law/cases/index.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { DecisionFilters } from "@/features/case-law/components/decision-filters";
 import { DecisionTable } from "@/features/case-law/components/decision-table";
@@ -48,6 +49,7 @@ const optionalBrowseStringSchema = (maxLength: number) =>
 const searchSchema = v.object({
   country: optionalBrowseStringSchema(3),
   court: optionalBrowseStringSchema(512),
+  notFound: v.optional(v.boolean()),
   year: optionalBrowseStringSchema(4),
 });
 
@@ -170,6 +172,22 @@ function PublicCaseLawIndex() {
     select: ({ country, court, year }) => ({ country, court, year }),
   });
   const { country, court, year } = search;
+  const notFound = Route.useSearch({ select: (s) => s.notFound });
+  const navigate = Route.useNavigate();
+
+  useEffect(() => {
+    if (!notFound) {
+      return;
+    }
+    stellaToast.add({
+      title: t("caseLaw.decisionNotFound"),
+      type: "error",
+    });
+    void navigate({
+      replace: true,
+      search: (prev) => ({ ...prev, notFound: undefined }),
+    });
+  }, [notFound, navigate, t]);
   const routeFilters = createDecisionFiltersFromSearch(search);
   const [filters, setFilters] = useState<DecisionListFilters>(routeFilters);
   const { data: browseFacets } = useSuspenseQuery(decisionFacetsOptions());


### PR DESCRIPTION
## Summary
Re-lands the workspace-chrome parity plus two fixes found on staging:

### Chrome parity
- All `/law` pages get the app's `h-12` top bar with a breadcrumb showing the current case number.
- Sidebar footer matches the app: feedback entry for everyone, avatar menu for signed-in users (extracted from `app-sidebar.tsx` into a shared `SidebarUserMenu`).
- Anonymous visitors get the inspector rail with sign-in-gated affordances; the anonymous sign-in row uses an avatar-sized icon.
- `FeedbackDialog` accepts a missing email.

### Inspector no longer overlays the decision text
The decision page `<main>` is now a flex row and the workspace is wrapped in a `min-w-0 flex-1` column, so the inspector pane and rail take layout space (same spacer pattern the protected layout uses) instead of covering the text.

### Legacy dated URLs and missing decisions
`/law/cze/cases/nejvyssi-soud/2014-01-28/30-cdo-2248-2013` matched the `$language` route and 500'd during SSR. An invalid language segment now falls back to a slug-only lookup, so legacy dated URLs land on the canonical date-less page via the existing redirect. A genuinely missing decision redirects to `/law/cases` with a "Decision not found" toast instead of an error screen.

## Testing
- Web tests (558 pass), web typecheck clean.
- Verified the dated URL currently returns HTTP 500 on staging; the new path resolves by slug and redirects.