### PR TITLE
chore: tighten TS inference hygiene in web app

### DIFF
--- a/apps/web/src/features/case-law/components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/analysis/use-decision-analysis.ts
@@ -96,7 +96,7 @@ export const useDecisionAnalysis = (
 
   const enabled = isGenerating && !hasFreshAnalysis;
 
-  const query = useQuery<AnalysisQueryResult>({
+  const query = useQuery({
     queryKey: ["decision-analysis", decisionId],
     queryFn: async ({ signal }): Promise<AnalysisQueryResult> => {
       const response = await fetch(

--- a/apps/web/src/routes/onboarding/route.tsx
+++ b/apps/web/src/routes/onboarding/route.tsx
@@ -33,11 +33,12 @@ export const Route = createFileRoute("/onboarding")({
 
     return authContext;
   },
-  loader: async ({ context: { queryClient } }) =>
+  loader: async ({ context: { queryClient } }) => {
     await ensureCriticalQueryData(
       queryClient,
       nativeToolDeployAvailabilityOptions,
-    ),
+    );
+  },
   head: () => ({
     meta: [{ title: pageTitle("onboarding.orgTitle") }],
   }),


### PR DESCRIPTION
Two small type-inference hygiene fixes in `apps/web`:

- `use-decision-analysis.ts`: drop the explicit `useQuery<AnalysisQueryResult>` generic. The `queryFn` is already annotated `Promise<AnalysisQueryResult>`, so inference produces the identical result type; the explicit generic only duplicated it and broke the inference chain.
- `onboarding/route.tsx`: return `void` from the route loader. It only primes the TanStack Query cache (the component reads via the query; the loader return is unconsumed), so voiding keeps its return type out of the route tree.

No behavior change.