### PR TITLE
fix(folio): paged-layout fidelity for blank break lines and inline images

### DIFF
--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -238,6 +238,13 @@ function findNearestSpanInElement(
   // Check for empty paragraphs within this element
   const emptyRun = queryHtmlElement(element, ".layout-empty-run");
   if (emptyRun) {
+    // Prefer the empty-run's own PM position — the renderer sets it to the
+    // hard-break position for a paragraph ending in `<w:br/>`, so a click on
+    // that trailing blank row lands after the break rather than at the
+    // paragraph start. Fall back to the paragraph start. (eigenpal/docx-editor#752.)
+    if (emptyRun.dataset["pmStart"]) {
+      return Number(emptyRun.dataset["pmStart"]);
+    }
     const paragraph = closestHtmlElement(emptyRun, ".layout-paragraph");
     if (paragraph && paragraph.dataset["pmStart"]) {
       return Number(paragraph.dataset["pmStart"]);

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.test.ts
@@ -367,6 +367,101 @@ describe("inline image paragraph measurement", () => {
     }, fakeMeasure);
   });
 
+  // Regression (eigenpal/docx-editor#767, fixes #766): an inline image that
+  // wraps to its own line must inflate only the line it lands on. The footprint
+  // was recorded on the current line *before* the wrap check, so the preceding
+  // text line inflated to image height while the image's own line stayed
+  // text-height — and following content painted over the overflowing image.
+  test("inline image that wraps reserves its height on its own line, not the text line", () => {
+    withFakeTextMeasure(() => {
+      const imageHeight = 151;
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "wrap-img",
+          runs: [
+            { kind: "text", text: "Some preceding text" },
+            // One px shy of the column, so any preceding text forces the image
+            // onto its own line where it still fits.
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 599,
+              height: imageHeight,
+            },
+            { kind: "text", text: "Description" },
+          ],
+        },
+        600,
+      );
+
+      expect(measure.lines.length).toBeGreaterThanOrEqual(2);
+      // The preceding text line stays text-height, not inflated to the image.
+      expect(measure.lines.at(0)?.lineHeight ?? 0).toBeLessThan(imageHeight);
+      // The image lands on the next line, which reserves its full height.
+      expect(measure.lines.at(1)?.lineHeight ?? 0).toBeGreaterThanOrEqual(
+        imageHeight,
+      );
+    }, fakeMeasure);
+  });
+
+  test("inline image that fits inline still grows its shared line to image height", () => {
+    withFakeTextMeasure(() => {
+      const imageHeight = 151;
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "fit-img",
+          runs: [
+            { kind: "text", text: "Hi" },
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 100,
+              height: imageHeight,
+            },
+          ],
+        },
+        600,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines.at(0)?.lineHeight ?? 0).toBeGreaterThanOrEqual(
+        imageHeight,
+      );
+    }, fakeMeasure);
+  });
+
+  // An inline image that is the only run on its line stays on that line even
+  // when it is wider than the column, instead of being wrapped to a fresh blank
+  // row above it — wrapping an image that is already alone can't make it fit.
+  // The measurer reserves its intrinsic box (the painter caps the paint with
+  // CSS max-width:100%; see measureParagraph.ts). (eigenpal/docx-editor#760.)
+  test("inline image wider than the column stays on its line and reserves its full height", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "wide-img",
+          runs: [
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 1200,
+              height: 800,
+            },
+          ],
+        },
+        600,
+      );
+
+      // No spurious leading empty line; the image is the only line.
+      expect(measure.lines).toHaveLength(1);
+      // The intrinsic height (800) is reserved, never under-reserved.
+      expect(measure.lines.at(0)?.lineHeight ?? 0).toBeGreaterThanOrEqual(800);
+    }, fakeMeasure);
+  });
+
   // Regression: a 100×200 inline image rotated 90° should reserve a 200×100
   // axis-aligned bbox in the measurer, matching the painter's wrapper span
   // (eigenpal #424 follow-up; gemini/codex review on PR 518). Without this,

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -1035,23 +1035,40 @@ export function measureParagraph(
       const imageWidth = inlineBbox.width;
       const imageHeight = inlineBbox.height;
 
+      if (
+        currentLine.width > 0 &&
+        currentLine.width + imageWidth >
+          currentLine.availableWidth + WIDTH_TOLERANCE
+      ) {
+        // Image doesn't fit, start new line. Guarded on a non-empty line:
+        // wrapping an image that is already alone on the line can't make it fit
+        // and would just insert a blank row above it.
+        startNewLine(runIndex, 0);
+      }
+
+      // The measurer reserves the image's intrinsic box. The painter fits an
+      // over-wide plain inline image down with CSS `max-width: 100%`
+      // (eigenpal/docx-editor#760), but that is left as a purely visual cap: a
+      // CSS percentage of the line element doesn't correspond to a single
+      // computed width once first-line indents, list markers, or floating-image
+      // line offsets are in play, so predicting it here would under-reserve
+      // height and risk overlap. Reserving the intrinsic box keeps measurement,
+      // selection, and click geometry mutually consistent and never short.
+
       // The image's vertical footprint in the line includes its wp:inline
       // distT/distB wrap distances. These default to 0 for inline images
       // (unlike the block path's synthetic 6px). The painter applies them as
       // top/bottom margins on the <img>, so the run's flex baseline (the
-      // margin-box edge) stays consistent with this reserved height.
+      // margin-box edge) stays consistent with this reserved height. Record it
+      // only after the wrap check above: the footprint belongs to the line the
+      // image actually lands on, not the line it wrapped away from — otherwise
+      // the previous line inflates to image height while the image's own line
+      // stays text-height and following content paints over the overflow.
+      // (eigenpal/docx-editor#767, fixes #766.)
       const imageFootprintPx =
         imageHeight + (run.distTop ?? 0) + (run.distBottom ?? 0);
       if (imageFootprintPx > currentLine.maxImageHeightPx) {
         currentLine.maxImageHeightPx = imageFootprintPx;
-      }
-
-      if (
-        currentLine.width + imageWidth >
-        currentLine.availableWidth + WIDTH_TOLERANCE
-      ) {
-        // Image doesn't fit, start new line
-        startNewLine(runIndex, 0);
       }
 
       currentLine.width += imageWidth;

--- a/packages/folio/src/core/layout-painter/renderImage-rotation.test.ts
+++ b/packages/folio/src/core/layout-painter/renderImage-rotation.test.ts
@@ -198,8 +198,11 @@ describe("inline image rotation bbox wrapper", () => {
     // Fast path: the rendered element is the <img> itself, no <span> wrapper.
     expect(direct.tagName).toBe("img");
     expect(direct.style["position"]).not.toBe("absolute");
+    // Width is pinned; height is `auto` with an aspect ratio so the plain image
+    // fits its container without squashing (eigenpal/docx-editor#760).
     expect(direct.style["width"]).toBe("100px");
-    expect(direct.style["height"]).toBe("200px");
+    expect(direct.style["height"]).toBe("auto");
+    expect(direct.style["aspectRatio"]).toBe("100 / 200");
   });
 
   test("does NOT wrap an image with a 0deg rotation transform", () => {

--- a/packages/folio/src/core/layout-painter/renderParagraph-empty-line-break-position.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-empty-line-break-position.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression — a blank row produced by a hard line break (`<w:br/>`) must carry
+ * a position the click/caret/visual-line resolvers can resolve.
+ *
+ * Such a line's only run is a line break, which renders as a bare `<br>`. The
+ * resolvers in `clickToPositionDom.ts` only look for `span[data-pm-start]`, so
+ * without a positioned span the blank row is invisible to them and they fall
+ * back to the paragraph's start — collapsing clicks, the caret, and arrow
+ * navigation onto the first line. `renderLine` injects a zero-width positioned
+ * marker span carrying the break's pmStart so the row can be located.
+ * (eigenpal/docx-editor#752.)
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { MeasuredLine, ParagraphBlock, Run } from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  textContent = "";
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  prepend(...children: FakeElement[]): void {
+    this.children.unshift(...children);
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+// "Hello" <br> <br> "World" — the middle visual line is empty (it spans only
+// the second break, whose pmStart is 7).
+const runs: Run[] = [
+  { kind: "text", text: "Hello", pmStart: 1, pmEnd: 6 },
+  { kind: "lineBreak", pmStart: 6, pmEnd: 7 },
+  { kind: "lineBreak", pmStart: 7, pmEnd: 8 },
+  { kind: "text", text: "World", pmStart: 8, pmEnd: 13 },
+];
+const block: ParagraphBlock = { kind: "paragraph", id: "p1", runs };
+
+function line(fromRun: number, toRun: number, toChar: number): MeasuredLine {
+  return {
+    fromRun,
+    fromChar: 0,
+    toRun,
+    toChar,
+    width: 100,
+    ascent: 10,
+    descent: 3,
+    lineHeight: 13,
+  };
+}
+
+function render(measuredLine: MeasuredLine): FakeElement {
+  return renderLine(block, measuredLine, undefined, fakeDocument, {
+    availableWidth: 360,
+    isLastLine: false,
+    isFirstLine: false,
+    paragraphEndsWithLineBreak: false,
+    leftIndentPx: 0,
+  }) as unknown as FakeElement;
+}
+
+function positionedSpans(lineEl: FakeElement): FakeElement[] {
+  return lineEl.children.filter(
+    (child) =>
+      child.tagName === "span" &&
+      child.dataset["pmStart"] !== undefined &&
+      child.dataset["pmEnd"] !== undefined,
+  );
+}
+
+describe("blank line-break rows carry a resolvable position", () => {
+  test("the empty row gets a positioned marker span at the break position", () => {
+    const lineEl = render(line(2, 2, 0));
+    const marker = positionedSpans(lineEl).at(0);
+
+    expect(marker).toBeDefined();
+    expect(marker?.dataset["pmStart"]).toBe("7");
+    expect(marker?.dataset["pmEnd"]).toBe("7");
+    expect(marker?.textContent).toBe("\u200B");
+  });
+
+  test("the marker is placed before the <br> so its rect is on the blank row", () => {
+    const lineEl = render(line(2, 2, 0));
+
+    // The render loop appends the `<br>`, then the marker is prepended ahead of
+    // it: a marker after the break would lay out one visual line lower, giving
+    // the caret/click resolvers the wrong Y for the blank row.
+    expect(lineEl.children.at(0)?.tagName).toBe("span");
+    expect(lineEl.children.at(0)?.dataset["pmStart"]).toBe("7");
+    expect(lineEl.children.at(1)?.tagName).toBe("br");
+  });
+
+  test("text rows are untouched (no injected marker)", () => {
+    const lineEl = render(line(0, 0, 5));
+    const spans = positionedSpans(lineEl);
+
+    // Only the "Hello" run's span — no zero-width marker appended.
+    expect(spans.map((s) => s.dataset["pmStart"])).toEqual(["1"]);
+    expect(spans.every((s) => s.textContent !== "\u200B")).toBe(true);
+  });
+
+  test("a text+break row keeps the text span's position (no marker)", () => {
+    const lineEl = render(line(0, 1, 0));
+    const spans = positionedSpans(lineEl);
+
+    expect(spans.map((s) => s.dataset["pmStart"])).toEqual(["1"]);
+  });
+
+  test("a trailing hard break resolves the blank row to after the break", () => {
+    // "Hello" <br> — the paragraph ends with a break, so its final blank row has
+    // no sliced runs and lands in the empty-line branch. It must resolve to the
+    // position *after* the break (its pmEnd, 7), not before it (6) or the
+    // paragraph start, or navigation would land back on the previous line.
+    const trailingBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p2",
+      pmStart: 0,
+      pmEnd: 8,
+      runs: [
+        { kind: "text", text: "Hello", pmStart: 1, pmEnd: 6 },
+        { kind: "lineBreak", pmStart: 6, pmEnd: 7 },
+      ],
+    };
+    const lineEl = renderLine(
+      trailingBlock,
+      line(2, 2, 0),
+      undefined,
+      fakeDocument,
+      {
+        availableWidth: 360,
+        isLastLine: true,
+        isFirstLine: false,
+        paragraphEndsWithLineBreak: true,
+        leftIndentPx: 0,
+      },
+    ) as unknown as FakeElement;
+
+    // Collapsed at 7 so a click anywhere on the row resolves to after the break.
+    expect(lineEl.children.at(0)?.dataset["pmStart"]).toBe("7");
+    expect(lineEl.children.at(0)?.dataset["pmEnd"]).toBe("7");
+  });
+
+  test("a floating image on a break row still gets a positioned marker", () => {
+    // A floating image sits in the line's run range but the painter renders it
+    // in a separate layer, so the visual row is just a `<br>`. The marker must
+    // still be emitted (keyed off the in-flow break run) so the row is
+    // resolvable. (eigenpal/docx-editor#752.)
+    const floatBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p3",
+      pmStart: 0,
+      pmEnd: 4,
+      runs: [
+        {
+          kind: "image",
+          src: "data:image/png;base64,",
+          width: 40,
+          height: 40,
+          wrapType: "square",
+          pmStart: 1,
+          pmEnd: 2,
+        },
+        { kind: "lineBreak", pmStart: 2, pmEnd: 3 },
+      ],
+    };
+    const lineEl = renderLine(
+      floatBlock,
+      line(0, 1, 0),
+      undefined,
+      fakeDocument,
+      {
+        availableWidth: 360,
+        isLastLine: true,
+        isFirstLine: false,
+        paragraphEndsWithLineBreak: true,
+        leftIndentPx: 0,
+      },
+    ) as unknown as FakeElement;
+
+    const marker = positionedSpans(lineEl).at(0);
+    expect(marker?.dataset["pmStart"]).toBe("2");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -102,7 +102,12 @@ const TEST_EXPLICIT_BLACK_COLOR = " #000000 ";
 const TEST_EXPLICIT_TEXT_COLOR = "#C00000";
 
 describe("renderLine inline image handling", () => {
-  test("pins image dimensions and centers an image-only line", () => {
+  // The plain inline image fits to its container's content width while keeping
+  // the run's aspect ratio: width is pinned but `max-width: 100%` + `aspect-ratio`
+  // let a wide image scale down inside a narrow column/cell instead of squashing
+  // or overflowing the page (eigenpal/docx-editor#760). Height becomes `auto` so
+  // the aspect ratio drives it.
+  test("fits an inline image to the container width and centers an image-only line", () => {
     const imageRun: ImageRun = {
       kind: "image",
       src: "data:image/png;base64,",
@@ -135,7 +140,9 @@ describe("renderLine inline image handling", () => {
     expect(lineEl.style.display).toBe("flex");
     expect(lineEl.style.alignItems).toBe("center");
     expect(imageEl?.style.width).toBe("186px");
-    expect(imageEl?.style.height).toBe("29px");
+    expect(imageEl?.style.height).toBe("auto");
+    expect(imageEl?.style.aspectRatio).toBe("186 / 29");
+    expect(imageEl?.style.maxWidth).toBe("100%");
   });
 
   // eigenpal #424 (image-crop subset): an inline image with crop fractions

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -752,6 +752,20 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   img.style.display = "inline";
   img.style.verticalAlign = "middle";
 
+  // Fit the image to its container's content width (the text column or table
+  // cell) while preserving the run's aspect ratio: cap the width at 100% of the
+  // container and let `aspect-ratio` drive the height. Without this a wide image
+  // in a narrow cell squashes (the explicit height stays while the width is
+  // clamped) or overflows the page. The run's own aspect ratio is used — not the
+  // image's natural one — so a deliberately stretched image keeps its shape.
+  // (eigenpal/docx-editor#760.) Only the plain inline path opts in: the rotated
+  // and cropped paths return earlier and need their explicit pixel geometry.
+  if (run.width > 0 && run.height > 0) {
+    img.style.height = "auto";
+    img.style.aspectRatio = `${run.width} / ${run.height}`;
+    img.style.maxWidth = "100%";
+  }
+
   // wp:inline distT/distB: the measurer folds these into maxImageHeightPx;
   // applying them as margins here keeps the margin-box footprint consistent
   // with the line height the measurer reserved.
@@ -1517,9 +1531,33 @@ export function renderLine(
   if (runsForLine.length === 0) {
     const emptySpan = doc.createElement("span");
     emptySpan.className = `${PARAGRAPH_CLASS_NAMES.run} layout-empty-run`;
+    // A paragraph that ends with a hard break has a trailing blank row whose
+    // sliced runs are empty (measurement starts it past the last run), so it
+    // lands here rather than in the line-break marker path below. Resolve it to
+    // the position *after* that break (the break's `pmEnd`, since a break spans
+    // `[pmStart, pmEnd)`), not the paragraph start, so a click or caret on the
+    // blank line lands after the break rather than back on the previous line.
+    // (eigenpal/docx-editor#752.)
+    const trailingRun = block.runs.at(-1);
+    const trailingBreakEnd =
+      line.fromRun > block.runs.length - 1 &&
+      trailingRun !== undefined &&
+      isLineBreakRun(trailingRun)
+        ? trailingRun.pmEnd
+        : undefined;
     const contentStart =
-      block.pmStart === undefined ? undefined : block.pmStart + 1;
-    applyPmPositions(emptySpan, contentStart, block.pmEnd ?? contentStart);
+      trailingBreakEnd ??
+      (block.pmStart === undefined ? undefined : block.pmStart + 1);
+    // For a trailing break, collapse the span to the after-break position. Its
+    // `&nbsp;` is matched by the generic `span[data-pm-start][data-pm-end]`
+    // resolver (which runs before the empty-run fallback), so a wide range would
+    // let a right-half click resolve to the paragraph end instead of after the
+    // break — disagreeing with vertical navigation. (eigenpal/docx-editor#752.)
+    const contentEnd =
+      trailingBreakEnd !== undefined
+        ? contentStart
+        : (block.pmEnd ?? contentStart);
+    applyPmPositions(emptySpan, contentStart, contentEnd);
     emptySpan.innerHTML = "&nbsp;";
     lineEl.append(emptySpan);
     return lineEl;
@@ -1867,6 +1905,37 @@ export function renderLine(
       const runEl = renderRun(run, doc, options?.context);
       lineEl.append(runEl);
     }
+  }
+
+  // A line whose in-flow runs are all line breaks (a blank row from consecutive
+  // `<w:br/>`) renders as just a `<br>`, whose PM position the click/caret/
+  // visual-line resolvers don't read — they query `span[data-pm-start]`. With no
+  // positioned span on the row those resolvers fall back to the paragraph start,
+  // collapsing clicks, the caret, and arrow navigation onto the first line. Emit
+  // a zero-width positioned marker carrying the break's position so the existing
+  // resolvers can locate the row. (eigenpal/docx-editor#752; derived from the
+  // runs instead of a `querySelector` so the painter stays testable with a
+  // minimal fake Document.) Prepended ahead of the `<br>`: the break pushes any
+  // following node onto the next visual line, so a marker after it would carry
+  // the wrong Y and the caret would land a row too low.
+  //
+  // Floating image runs stay in the line's run range but the painter renders
+  // them in a separate layer (it `continue`s past them), so a break row that
+  // also carries a floating image still paints as only a `<br>`. Exclude them
+  // when deciding whether the row is blank, else the marker is suppressed.
+  const inFlowRuns = runsForLine.filter(
+    (run) => !(isImageRun(run) && isFloatingImageRun(run)),
+  );
+  const blankBreakRun =
+    inFlowRuns.length > 0 && inFlowRuns.every(isLineBreakRun)
+      ? inFlowRuns.find(isLineBreakRun)
+      : undefined;
+  if (blankBreakRun?.pmStart !== undefined) {
+    const marker = doc.createElement("span");
+    marker.className = PARAGRAPH_CLASS_NAMES.run;
+    applyPmPositions(marker, blankBreakRun.pmStart, blankBreakRun.pmStart);
+    marker.textContent = "\u200B";
+    lineEl.prepend(marker);
   }
 
   return lineEl;

--- a/packages/folio/src/paged-editor/useVisualLineNavigation.ts
+++ b/packages/folio/src/paged-editor/useVisualLineNavigation.ts
@@ -190,12 +190,17 @@ export function useVisualLineNavigation({
 
       const emptyRun = lineEl.querySelector(".layout-empty-run");
       if (emptyRun) {
+        // Prefer the empty-run's own PM position — the renderer sets it to the
+        // hard-break position for a paragraph ending in `<w:br/>`, so vertical
+        // navigation into that trailing blank row lands after the break rather
+        // than at the paragraph start. Fall back to the paragraph content start.
+        // (eigenpal/docx-editor#752.)
+        if (emptyRun instanceof HTMLElement && emptyRun.dataset["pmStart"]) {
+          return Number(emptyRun.dataset["pmStart"]);
+        }
         const paragraph = closestHtmlElement(lineEl, ".layout-paragraph");
         if (paragraph?.dataset["pmStart"]) {
           return Number(paragraph.dataset["pmStart"]) + 1;
-        }
-        if (emptyRun instanceof HTMLElement && emptyRun.dataset["pmStart"]) {
-          return Number(emptyRun.dataset["pmStart"]);
         }
         return null;
       }


### PR DESCRIPTION
## Summary

Ports three upstream `eigenpal/docx-editor` layout fixes into folio's paged
layout engine. All three live in the painter/measure layer and share
`renderParagraph.ts` / `measureParagraph.ts`, so they ship together.

- **Blank hard-break lines are click/caret/nav-resolvable
  (`eigenpal/docx-editor#752`).** A row whose only run is a line break
  (`<w:br/>`) rendered as a bare `<br>`, which the click/caret/visual-line
  resolvers (`clickToPositionDom.ts`, which query `span[data-pm-start]`) cannot
  see — so clicking a blank row, the caret, and arrow navigation collapsed onto
  the paragraph start. `renderLine` now appends a zero-width positioned marker
  span for break-only rows. Computed from the line's runs rather than upstream's
  `lineEl.querySelector(...)`, so the painter stays testable with folio's
  fake-Document harness.
- **Inline image wrap height (`eigenpal/docx-editor#767`, upstream issue 766).**
  An inline image that wraps to its own line recorded its vertical footprint on
  the *current* line before the wrap check ran, so the preceding text line
  inflated to image height while the image's own line stayed text-height and
  following content painted over the overflow. The wrap check now runs first;
  folio's rotation-aware bbox height is preserved.
- **Inline image fit (`eigenpal/docx-editor#760`).** A plain inline image set an
  explicit width and height, so a wide image in a narrow column/cell squashed or
  overflowed the page. It now caps `max-width: 100%` with `aspect-ratio` and
  `height: auto` (the rotated and cropped paths keep their explicit geometry).
  This matches upstream; the measurer reserves the run height as before.

## Test plan

- `bun test src/core/layout-painter src/core/layout-engine/measure` — 322 pass.
- New `renderParagraph-empty-line-break-position.test.ts` (blank break row gets
  a resolvable marker at the break position; text rows untouched).
- New cases in `measureParagraph.test.ts` (a wrapped image reserves its height
  on its own line, not the text line; a fitting image grows its shared line).
- Updated assertions in `renderParagraph-inline-image.test.ts` and
  `renderImage-rotation.test.ts` for the new fit attributes.

CC on behalf of @jan-kubica
