### PR TITLE
fix(folio): custom-style numbering (zero-padded, indent precedence, picker)

### DIFF
--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -311,6 +311,19 @@ export type ParagraphFormatting = {
     /** List level (0-8) (w:ilvl) */
     ilvl?: number;
   };
+  /**
+   * When `numPr` was resolved from the paragraph STYLE's pPr rather than the
+   * paragraph's own `<w:numPr>`, this records the style-sourced value. The
+   * serializer omits `numPr` while it still equals this value — writing it as
+   * direct formatting would flip Word's indent precedence (a directly
+   * referenced level's indents beat the style's; a style-referenced level's
+   * do not) and break the document on save/reload. Cleared the moment the
+   * user changes the numbering (values diverge).
+   */
+  numPrFromStyle?: {
+    numId?: number;
+    ilvl?: number;
+  };
 
   // Outline level (for TOC)
   /** Outline level 0-9 (w:outlineLvl) */

--- a/packages/docx-core/src/model/lists.ts
+++ b/packages/docx-core/src/model/lists.ts
@@ -37,6 +37,14 @@ export type NumberFormat =
   | "aiueoFullWidth"
   | "irohaFullWidth"
   | "decimalZero"
+  // Synthetic in-memory formats for Word's `w:numFmt w:val="custom"` with an
+  // XSLT-style zero-padded format string ("001, 002, ...", "0001, ...",
+  // "00001, ..."). Not OOXML enum values — never serialized (numbering.xml is
+  // preserved as-is on save); they exist so the render pipeline can carry the
+  // pad width through the existing NumberFormat plumbing.
+  | "decimalZero3"
+  | "decimalZero4"
+  | "decimalZero5"
   | "bullet"
   | "ganada"
   | "chosung"

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -60,6 +60,7 @@ import {
   applyFolioAIEditOperations,
   createFolioAIEditSnapshot,
 } from "../core/ai-edits";
+import { getCachedNumberingMap } from "../core/docx/numberingParser";
 // ProseMirror editor
 import {
   TextSelection,
@@ -2166,6 +2167,9 @@ export function DocxEditor({
               if (resolved.runFormatting) {
                 styleAttrs.runFormatting = resolved.runFormatting;
               }
+              styleAttrs.numbering = currentDoc?.package.numbering
+                ? getCachedNumberingMap(currentDoc.package.numbering)
+                : null;
               applyStyle(action.value, styleAttrs)(commandState, view.dispatch);
             } else {
               // No styles available, just set the styleId

--- a/packages/folio/src/core/docx/blockContentParser.ts
+++ b/packages/folio/src/core/docx/blockContentParser.ts
@@ -27,7 +27,7 @@ import {
 } from "./bookmarkPlacement";
 import type { BookmarkMarker } from "./bookmarkPlacement";
 import { convertBulletToUnicode } from "./bulletMarkers";
-import type { NumberingMap } from "./numberingParser";
+import { padDecimal, type NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
 import { parseSdtProperties } from "./sdtProperties";
 import type { StyleMap } from "./styleParser";
@@ -91,8 +91,15 @@ const toRepeatedLetter = (value: number, baseCodePoint: number): string => {
 const formatNumber = (value: number, numFmt: string): string => {
   switch (numFmt) {
     case "decimal":
-    case "decimalZero":
       return String(value);
+    case "decimalZero":
+      return padDecimal(value, 2);
+    case "decimalZero3":
+      return padDecimal(value, 3);
+    case "decimalZero4":
+      return padDecimal(value, 4);
+    case "decimalZero5":
+      return padDecimal(value, 5);
     case "lowerLetter":
       return toRepeatedLetter(value, 97);
     case "upperLetter":

--- a/packages/folio/src/core/docx/numberingParser-custom-format.test.ts
+++ b/packages/folio/src/core/docx/numberingParser-custom-format.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveListTemplate } from "../layout-bridge/toFlowBlocks";
+import { formatNumber, parseNumbering } from "./numberingParser";
+
+const W =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+const MC =
+  'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"';
+
+// Word emits custom number formats (here: zero-padded to 4 digits) wrapped in
+// mc:AlternateContent — the Choice carries the custom format, the Fallback a
+// plain decimal for pre-w14 readers. Mirrors the numbering.xml from #765.
+const NUMBERING_CUSTOM = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W} ${MC}>
+  <w:abstractNum w:abstractNumId="6">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <mc:AlternateContent>
+        <mc:Choice Requires="w14">
+          <w:numFmt w:val="custom" w:format="0001, 0002, 0003, ..."/>
+        </mc:Choice>
+        <mc:Fallback>
+          <w:numFmt w:val="decimal"/>
+        </mc:Fallback>
+      </mc:AlternateContent>
+      <w:lvlText w:val="[%1]"/>
+      <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="6"/></w:num>
+</w:numbering>`;
+
+describe("custom numFmt inside mc:AlternateContent (#765)", () => {
+  const numbering = parseNumbering(NUMBERING_CUSTOM);
+
+  test('parses w:numFmt val="custom" format="0001, ..." as decimalZero4', () => {
+    expect(numbering.getLevel(1, 0)?.numFmt).toBe("decimalZero4");
+  });
+
+  test("renders zero-padded markers through the lvlText template", () => {
+    expect(resolveListTemplate("[%1]", [1], ["decimalZero4"])).toBe("[0001]");
+    expect(resolveListTemplate("[%1]", [12], ["decimalZero4"])).toBe("[0012]");
+    expect(resolveListTemplate("[%1]", [12_345], ["decimalZero4"])).toBe(
+      "[12345]",
+    );
+  });
+
+  test("uses the mc:Fallback when the Choice format is not implemented", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W} ${MC}>
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <mc:AlternateContent>
+        <mc:Choice Requires="w16du">
+          <w:numFmt w:val="futureFmt"/>
+        </mc:Choice>
+        <mc:Fallback>
+          <w:numFmt w:val="lowerRoman"/>
+        </mc:Fallback>
+      </mc:AlternateContent>
+      <w:lvlText w:val="%1."/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+</w:numbering>`;
+    expect(parseNumbering(xml).getLevel(1, 0)?.numFmt).toBe("lowerRoman");
+  });
+
+  test("custom 3- and 5-digit pad widths map to decimalZero3/5", () => {
+    const xml = (
+      format: string,
+    ) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W} ${MC}>
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <mc:AlternateContent>
+        <mc:Choice Requires="w14">
+          <w:numFmt w:val="custom" w:format="${format}"/>
+        </mc:Choice>
+        <mc:Fallback><w:numFmt w:val="decimal"/></mc:Fallback>
+      </mc:AlternateContent>
+      <w:lvlText w:val="%1."/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+</w:numbering>`;
+    expect(parseNumbering(xml("001, 002, ...")).getLevel(1, 0)?.numFmt).toBe(
+      "decimalZero3",
+    );
+    expect(parseNumbering(xml("00001, ...")).getLevel(1, 0)?.numFmt).toBe(
+      "decimalZero5",
+    );
+    // 6+ digits clamp to 5.
+    expect(parseNumbering(xml("0000001, ...")).getLevel(1, 0)?.numFmt).toBe(
+      "decimalZero5",
+    );
+  });
+
+  test("unrecognized custom format with no fallback falls back to decimal", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W} ${MC}>
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0">
+      <w:numFmt w:val="custom" w:format="ABC, DEF, ..."/>
+      <w:lvlText w:val="%1."/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+</w:numbering>`;
+    expect(parseNumbering(xml).getLevel(1, 0)?.numFmt).toBe("decimal");
+  });
+
+  test("formatNumber pads the decimalZero family", () => {
+    expect(formatNumber(7, "decimalZero")).toBe("07");
+    expect(formatNumber(7, "decimalZero3")).toBe("007");
+    expect(formatNumber(7, "decimalZero4")).toBe("0007");
+    expect(formatNumber(7, "decimalZero5")).toBe("00007");
+  });
+});

--- a/packages/folio/src/core/docx/numberingParser.ts
+++ b/packages/folio/src/core/docx/numberingParser.ts
@@ -16,6 +16,7 @@ import type {
   AbstractNumbering,
   NumberingInstance,
   ListLevel,
+  ListRendering,
   NumberFormat,
   ParagraphFormatting,
   TextFormatting,
@@ -27,6 +28,7 @@ import {
 } from "./parserEnums";
 import {
   parseXmlDocument,
+  findChild,
   findChildren,
   getAttribute,
   parseBooleanElement,
@@ -392,6 +394,7 @@ function parseListLevel(element: XmlElement): ListLevel | null {
 
   let startEl: XmlElement | undefined;
   let numFmtEl: XmlElement | undefined;
+  let alternateEl: XmlElement | undefined;
   let lvlTextEl: XmlElement | undefined;
   let lvlJcEl: XmlElement | undefined;
   let suffEl: XmlElement | undefined;
@@ -412,6 +415,9 @@ function parseListLevel(element: XmlElement): ListLevel | null {
         break;
       case "w:numFmt":
         numFmtEl ??= child;
+        break;
+      case "mc:AlternateContent":
+        alternateEl ??= child;
         break;
       case "w:lvlText":
         lvlTextEl ??= child;
@@ -453,12 +459,22 @@ function parseListLevel(element: XmlElement): ListLevel | null {
     }
   }
 
-  // Parse number format
+  // Parse number format. Word wraps custom formats in mc:AlternateContent —
+  // <mc:Choice Requires="w14"> holds <w:numFmt w:val="custom" w:format="..."/>
+  // and <mc:Fallback> holds the plain format for pre-w14 readers. Prefer the
+  // Choice when its format resolves to something we implement; otherwise the
+  // Fallback is the closer rendering (ECMA-376 Part 3 §10.2.1 — a consumer
+  // that doesn't understand a Choice must take the Fallback).
   if (numFmtEl) {
-    const fmtVal = getAttribute(numFmtEl, "w", "val");
-    if (fmtVal) {
-      level.numFmt = parseNumberFormat(fmtVal);
-    }
+    level.numFmt = resolveNumFmt(numFmtEl) ?? "decimal";
+  } else if (alternateEl) {
+    const choiceFmt = resolveNumFmt(
+      findChild(findChild(alternateEl, "mc", "Choice"), "w", "numFmt"),
+    );
+    const fallbackFmt = resolveNumFmt(
+      findChild(findChild(alternateEl, "mc", "Fallback"), "w", "numFmt"),
+    );
+    level.numFmt = choiceFmt ?? fallbackFmt ?? level.numFmt;
   }
 
   // Parse level text (the pattern like "%1." or "•")
@@ -526,10 +542,46 @@ function parseListLevel(element: XmlElement): ListLevel | null {
 }
 
 /**
- * Parse number format string to NumberFormat type
+ * Resolve a `<w:numFmt>` element to a NumberFormat we can render, or null
+ * when the element is absent or its format is one we don't implement (an
+ * mc:Fallback can then supply a closer rendering).
  */
-function parseNumberFormat(format: string): NumberFormat {
-  return NUMBER_FORMAT_MAP[format] ?? "decimal";
+function resolveNumFmt(numFmtEl: XmlElement | null): NumberFormat | null {
+  if (!numFmtEl) {
+    return null;
+  }
+  const fmtVal = getAttribute(numFmtEl, "w", "val");
+  if (!fmtVal) {
+    return null;
+  }
+  if (fmtVal === "custom") {
+    return parseCustomNumberFormat(getAttribute(numFmtEl, "w", "format"));
+  }
+  return NUMBER_FORMAT_MAP[fmtVal] ?? null;
+}
+
+/**
+ * Map a `w:numFmt w:val="custom"` format string (ECMA-376 §17.9.17 — an XSLT
+ * `format` token list like "0001, 0002, 0003, ...") to a NumberFormat. Word
+ * only emits zero-padded decimal customs this way; the pad width is the digit
+ * count of the first token (clamped to 5). Unknown patterns return null so
+ * the caller can fall back to an mc:Fallback or plain decimal.
+ */
+function parseCustomNumberFormat(format: string | null): NumberFormat | null {
+  const firstToken = format?.split(",")[0]?.trim() ?? "";
+  if (/^0+1$/u.test(firstToken)) {
+    switch (Math.min(firstToken.length, 5)) {
+      case 2:
+        return "decimalZero";
+      case 3:
+        return "decimalZero3";
+      case 4:
+        return "decimalZero4";
+      case 5:
+        return "decimalZero5";
+    }
+  }
+  return null;
 }
 
 /**
@@ -770,9 +822,29 @@ function parseLevelRunProps(rPr: XmlElement): TextFormatting {
 }
 
 /**
+ * Per-definitions cache for `createNumberingMap`. Style application rebuilds
+ * the lookup map on every picker click otherwise; the definitions object is
+ * stable for a document's lifetime, so cache by identity.
+ */
+const numberingMapCache = new WeakMap<NumberingDefinitions, NumberingMap>();
+
+export function getCachedNumberingMap(
+  definitions: NumberingDefinitions,
+): NumberingMap {
+  let map = numberingMapCache.get(definitions);
+  if (!map) {
+    map = createNumberingMap(definitions);
+    numberingMapCache.set(definitions, map);
+  }
+  return map;
+}
+
+/**
  * Create a NumberingMap with helper functions
  */
-function createNumberingMap(definitions: NumberingDefinitions): NumberingMap {
+export function createNumberingMap(
+  definitions: NumberingDefinitions,
+): NumberingMap {
   // Build lookup maps for efficient access
   const abstractMap = new Map<number, AbstractNumbering>();
   for (const abs of definitions.abstractNums) {
@@ -858,6 +930,86 @@ function createNumberingMap(definitions: NumberingDefinitions): NumberingMap {
 }
 
 /**
+ * Resolve a paragraph's `numPr` against the numbering definitions into the
+ * base `ListRendering` the layout pipeline needs (marker template, per-level
+ * numFmts, counter key, start override). Returns null when the numPr doesn't
+ * name a real level — including `numId === 0`, "no numbering" per ECMA-376.
+ *
+ * Shared by the style picker (`listAttrsFromResolvedStyle`) so a style-attached
+ * list renders the same marker the document loader produces. The loader's
+ * `parseParagraph` block additionally folds inline LISTNUM markers and computes
+ * the second-slot offset from the paragraph's content; those fields are absent
+ * here because the picker has no paragraph content to inspect.
+ */
+export function computeListRendering(
+  numPr: { numId?: number; ilvl?: number },
+  numbering: NumberingMap,
+): ListRendering | null {
+  const { numId, ilvl = 0 } = numPr;
+  if (numId === undefined || numId === 0) {
+    return null;
+  }
+
+  const level = numbering.getLevel(numId, ilvl);
+  if (!level) {
+    return null;
+  }
+
+  // Collect numFmts for levels 0..ilvl so multi-level templates like "%1.%2."
+  // can resolve each %N with its own format (legal numbering forces decimal).
+  const levelNumFmts: NumberFormat[] = [];
+  for (let i = 0; i <= ilvl; i += 1) {
+    levelNumFmts.push(
+      level.isLgl
+        ? "decimal"
+        : (numbering.getLevel(numId, i)?.numFmt ?? "decimal"),
+    );
+  }
+
+  const instance = numbering.getInstance(numId);
+  const overrideForLevel = instance?.levelOverrides?.find(
+    (override) => override.ilvl === ilvl,
+  );
+
+  const rendering: ListRendering = {
+    level: ilvl,
+    numId,
+    marker: level.lvlText,
+    isBullet: level.numFmt === "bullet",
+    numFmt: level.isLgl ? "decimal" : level.numFmt,
+    levelNumFmts,
+  };
+  if (level.isLgl) {
+    rendering.isLegal = true;
+  }
+  if (level.rPr?.hidden) {
+    rendering.markerHidden = true;
+  }
+  const markerFont =
+    level.rPr?.fontFamily?.ascii || level.rPr?.fontFamily?.hAnsi;
+  if (markerFont) {
+    rendering.markerFontFamily = markerFont;
+  }
+  // w:sz is in half-points; convert to points for downstream use
+  if (level.rPr?.fontSize) {
+    rendering.markerFontSize = level.rPr.fontSize / 2;
+  }
+  if (level.rPr?.allCaps) {
+    rendering.markerAllCaps = true;
+  }
+  if (level.suffix) {
+    rendering.markerSuffix = level.suffix;
+  }
+  if (instance?.abstractNumId !== undefined) {
+    rendering.abstractNumId = instance.abstractNumId;
+  }
+  if (overrideForLevel?.startOverride !== undefined) {
+    rendering.startOverride = overrideForLevel.startOverride;
+  }
+  return rendering;
+}
+
+/**
  * Format a number according to the specified format
  *
  * @param num - The number to format
@@ -872,8 +1024,19 @@ export function formatNumber(num: number, format: NumberFormat): string {
   // glyphs are absent.
   switch (format) {
     case "decimal":
-    case "decimalZero":
       return num.toString();
+
+    case "decimalZero":
+      return padDecimal(num, 2);
+
+    case "decimalZero3":
+      return padDecimal(num, 3);
+
+    case "decimalZero4":
+      return padDecimal(num, 4);
+
+    case "decimalZero5":
+      return padDecimal(num, 5);
 
     case "upperRoman":
       return toRoman(num).toUpperCase();
@@ -906,6 +1069,29 @@ export function formatNumber(num: number, format: NumberFormat): string {
       // For CJK and other special formats, fall back to decimal
       return num.toString();
   }
+}
+
+/** Zero-pad a counter to `width` digits ("decimalZero" family, §17.18.59). */
+export function padDecimal(num: number, width: number): string {
+  if (num < 0) {
+    return num.toString();
+  }
+  return num.toString().padStart(width, "0");
+}
+
+/**
+ * Compare two `numPr` references by value — `numId` plus `ilvl` (a missing
+ * `ilvl` is level 0). Used for the style-sourced-numbering provenance check;
+ * avoids JSON.stringify equality, which is sensitive to key order.
+ */
+export function numPrEqual(
+  a: { numId?: number; ilvl?: number } | null | undefined,
+  b: { numId?: number; ilvl?: number } | null | undefined,
+): boolean {
+  if (a == null || b == null) {
+    return a == null && b == null;
+  }
+  return a.numId === b.numId && (a.ilvl ?? 0) === (b.ilvl ?? 0);
 }
 
 /**

--- a/packages/folio/src/core/docx/paragraphParser-numbering-indent.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser-numbering-indent.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { parseNumbering } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
+import { parseStyles } from "./styleParser";
 import type { XmlElement } from "./xmlParser";
 import { parseXmlDocument } from "./xmlParser";
 
@@ -101,5 +102,120 @@ describe("paragraphParser direct ind vs numbering level indent", () => {
 
     expect(paragraph.formatting?.indentFirstLine).toBe(-180);
     expect(paragraph.formatting?.hangingIndent).toBe(true);
+  });
+});
+
+const W =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+// abstractNum 10 / numId 2 — level 0 carries a 360/360 hanging slot, the same
+// level a style with its own wider indent references (#765 AppBody-Claim).
+const NUMBERING_360 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W}>
+  <w:abstractNum w:abstractNumId="10">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="[Claim %1]"/>
+      <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="2"><w:abstractNumId w:val="10"/></w:num>
+</w:numbering>`;
+
+// AppBody-Claim attaches numbering via the style pPr and defines its own wider
+// indent (1134/1134); NoIndentNumbered attaches the same numbering but defines
+// no indent of its own.
+const STYLES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles ${W}>
+  <w:style w:type="paragraph" w:styleId="ListParagraph">
+    <w:name w:val="List Paragraph"/>
+    <w:pPr><w:ind w:left="720"/></w:pPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="AppBody-Claim">
+    <w:name w:val="AppBody-Claim"/>
+    <w:basedOn w:val="ListParagraph"/>
+    <w:pPr>
+      <w:numPr><w:numId w:val="2"/></w:numPr>
+      <w:ind w:left="1134" w:hanging="1134"/>
+    </w:pPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="NoIndentNumbered">
+    <w:name w:val="NoIndentNumbered"/>
+    <w:pPr>
+      <w:numPr><w:numId w:val="2"/></w:numPr>
+    </w:pPr>
+  </w:style>
+</w:styles>`;
+
+function parseStyledParagraph(
+  inner: string,
+  styles: ReturnType<typeof parseStyles>,
+  numbering: ReturnType<typeof parseNumbering>,
+) {
+  const root = parseXmlDocument(
+    `<w:p ${W}>${inner}</w:p>`,
+  ) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML");
+  }
+  return parseParagraph(root, styles, null, numbering, null, null);
+}
+
+describe("style-attached numbering and indentation (#765)", () => {
+  const numbering = parseNumbering(NUMBERING_360);
+  const styles = parseStyles(STYLES_XML, null);
+
+  test("style ind wins over numbering level ind when numPr comes from the style", () => {
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="AppBody-Claim"/></w:pPr>',
+      styles,
+      numbering,
+    );
+    expect(para.listRendering?.marker).toBe("[Claim %1]");
+    // The level's 360/360 must NOT be baked into the paragraph formatting;
+    // the style's 1134/1134 flows in via the style fallback downstream.
+    expect(para.formatting?.indentLeft).toBeUndefined();
+    expect(para.formatting?.indentFirstLine).toBeUndefined();
+  });
+
+  test("numbering level ind still applies when the style chain defines none", () => {
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="NoIndentNumbered"/></w:pPr>',
+      styles,
+      numbering,
+    );
+    expect(para.formatting?.indentLeft).toBe(360);
+    expect(para.formatting?.indentFirstLine).toBe(-360);
+  });
+
+  test("numbering level ind still applies for direct (non-style) numPr", () => {
+    const root = parseXmlDocument(
+      `<w:p ${W}><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr></w:pPr></w:p>`,
+    ) as XmlElement | null;
+    if (!root) {
+      throw new Error("Failed to parse paragraph XML");
+    }
+    const para = parseParagraph(root, null, null, numbering, null, null);
+    expect(para.formatting?.indentLeft).toBe(360);
+  });
+
+  test("style-attached numbering records numPrFromStyle provenance", () => {
+    const para = parseStyledParagraph(
+      '<w:pPr><w:pStyle w:val="AppBody-Claim"/></w:pPr>',
+      styles,
+      numbering,
+    );
+    expect(para.formatting?.numPr).toEqual({ numId: 2 });
+    expect(para.formatting?.numPrFromStyle).toEqual({ numId: 2 });
+  });
+
+  test("direct numPr records no provenance", () => {
+    const para = parseStyledParagraph(
+      '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr></w:pPr>',
+      styles,
+      numbering,
+    );
+    expect(para.formatting?.numPrFromStyle).toBeUndefined();
   });
 });

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -1722,12 +1722,18 @@ export function parseParagraph(
   // Compute list rendering if this is a list item.
   // numPr can come from inline pPr or from the referenced paragraph style.
   let effectiveNumPr = paragraph.formatting?.numPr;
+  let numPrFromStyle = false;
   if (!effectiveNumPr && paragraph.formatting?.styleId && styles) {
     const style = styles.get(paragraph.formatting.styleId);
     if (style?.pPr?.numPr) {
       effectiveNumPr = style.pPr.numPr;
-      // Store it on the paragraph formatting so downstream code sees it
+      numPrFromStyle = true;
+      // Store it on the paragraph formatting so downstream code sees it,
+      // and record the provenance so the serializer can drop it again —
+      // materializing style numbering as direct <w:numPr> flips Word's
+      // level-indent precedence on the saved file.
       paragraph.formatting.numPr = effectiveNumPr;
+      paragraph.formatting.numPrFromStyle = effectiveNumPr;
     }
   }
 
@@ -1862,6 +1868,21 @@ export function parseParagraph(
         // Apply level's paragraph properties (indentation) as defaults.
         // Per OOXML spec, direct w:ind on the paragraph overrides numbering
         // level indent — only use numbering indent as fallback.
+        //
+        // When the numbering reference itself comes from the paragraph STYLE
+        // (style pPr numPr), Word gives the style chain's own w:ind
+        // precedence over the numbering level's — e.g. a "Claim" style with
+        // ind left=1134 hanging=1134 referencing a level with 360/360 lays
+        // out at 1134. Skip the level indents the style chain covers; the
+        // toProseDoc style fallback supplies the style values. Resolution is
+        // per group (left vs firstLine/hanging) so a chain that only defines
+        // `left` (e.g. ListParagraph) still takes the level's hanging —
+        // mirrors listAttrsFromResolvedStyle so the picker and the loader
+        // resolve a style identically. Direct paragraph numPr keeps the
+        // level-over-style behavior (Word's toolbar-list case).
+        const chainInd = numPrFromStyle
+          ? styleChainInd(paragraph.formatting?.styleId, styles)
+          : { left: false, firstLine: false };
         if (level.pPr) {
           if (!paragraph.formatting) {
             paragraph.formatting = {};
@@ -1885,10 +1906,14 @@ export function parseParagraph(
             (directFirstLine !== undefined && directFirstLine !== 0) ||
             (directHanging !== undefined && directHanging !== 0);
 
-          if (!hasDirectLeft && level.pPr.indentLeft !== undefined) {
+          if (
+            !hasDirectLeft &&
+            !chainInd.left &&
+            level.pPr.indentLeft !== undefined
+          ) {
             paragraph.formatting.indentLeft = level.pPr.indentLeft;
           }
-          if (!hasDirectFirstLineOrHanging) {
+          if (!hasDirectFirstLineOrHanging && !chainInd.firstLine) {
             if (level.pPr.indentFirstLine !== undefined) {
               paragraph.formatting.indentFirstLine = level.pPr.indentFirstLine;
             }
@@ -1902,6 +1927,41 @@ export function parseParagraph(
   }
 
   return paragraph;
+}
+
+/**
+ * Which indent groups the basedOn chain defines: `left` (w:ind left) and
+ * `firstLine` (w:ind firstLine/hanging). Walks from the given style up the
+ * chain; cycles are guarded. Grouping matches listAttrsFromResolvedStyle.
+ */
+function styleChainInd(
+  styleId: string | undefined,
+  styles?: StyleMap | null,
+): { left: boolean; firstLine: boolean } {
+  const result = { left: false, firstLine: false };
+  if (!styleId || !styles) {
+    return result;
+  }
+  const seen = new Set<string>();
+  let current: string | undefined = styleId;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    const style = styles.get(current);
+    if (!style) {
+      break;
+    }
+    const p = style.pPr;
+    if (p) {
+      result.left ||= p.indentLeft !== undefined;
+      result.firstLine ||=
+        p.indentFirstLine !== undefined || p.hangingIndent !== undefined;
+    }
+    if (result.left && result.firstLine) {
+      break;
+    }
+    current = style.basedOn;
+  }
+  return result;
 }
 
 // ============================================================================

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -35,6 +35,7 @@ import type {
   TextFormatting,
   TrackedChangeInfo,
 } from "../../types/document";
+import { numPrEqual } from "../numberingParser";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: paragraphs hold runs, shape-textbox runs hold paragraphs
 import { serializeRun, serializeTextFormatting } from "./runSerializer";
 import { serializeSectionProperties } from "./sectionPropertiesSerializer";
@@ -463,8 +464,18 @@ export function serializeParagraphFormatting(
     // Widow control
     pushToggle("widowControl", formatting.widowControl);
 
-    // Numbering
-    const numPrXml = serializeNumbering(formatting.numPr);
+    // Numbering. Skip numPr that still equals its style-sourced value (see
+    // ParagraphFormatting.numPrFromStyle) — the parser materialized it from
+    // the style and writing it back as direct formatting would flip Word's
+    // level-indent precedence on the saved file. Guards the direct
+    // serialize-a-parsed-Document path; the PM save path already drops it
+    // in fromProseDoc.
+    const styleSourcedNumPr =
+      formatting.numPrFromStyle != null &&
+      numPrEqual(formatting.numPr, formatting.numPrFromStyle);
+    const numPrXml = styleSourcedNumPr
+      ? ""
+      : serializeNumbering(formatting.numPr);
     if (numPrXml) {
       parts.push(numPrXml);
     }

--- a/packages/folio/src/core/docx/serializer/styleNumPrRoundtrip.test.ts
+++ b/packages/folio/src/core/docx/serializer/styleNumPrRoundtrip.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import type { Document, ParagraphFormatting } from "../../types/document";
+import { serializeParagraphFormatting } from "./paragraphSerializer";
+
+describe("serializeParagraphFormatting style-sourced numPr (#765)", () => {
+  test("a style-sourced numPr serializes no direct <w:numPr>", () => {
+    const formatting: ParagraphFormatting = {
+      styleId: "AppBody-Claim",
+      numPr: { numId: 2 },
+      numPrFromStyle: { numId: 2 },
+    };
+    const xml = serializeParagraphFormatting(formatting);
+    expect(xml).not.toContain("<w:numPr>");
+    expect(xml).toContain('<w:pStyle w:val="AppBody-Claim"/>');
+  });
+
+  test("a diverged numPr (user changed numbering) still serializes <w:numPr>", () => {
+    const formatting: ParagraphFormatting = {
+      styleId: "AppBody-Claim",
+      numPr: { numId: 5, ilvl: 0 },
+      numPrFromStyle: { numId: 2 },
+    };
+    const xml = serializeParagraphFormatting(formatting);
+    expect(xml).toContain("<w:numPr>");
+    expect(xml).toContain('<w:numId w:val="5"/>');
+  });
+
+  test("a direct numPr with no provenance serializes <w:numPr>", () => {
+    const formatting: ParagraphFormatting = {
+      numPr: { numId: 2, ilvl: 0 },
+    };
+    const xml = serializeParagraphFormatting(formatting);
+    expect(xml).toContain("<w:numPr>");
+  });
+});
+
+// toProseDoc load-side: a paragraph that removes the style's numbering
+// (direct numId=0 under a numbered style) drops the style's hanging slot too
+// and keeps only the indent it states itself.
+const STYLE_DEFS = {
+  styles: [
+    {
+      styleId: "Numbered",
+      type: "paragraph" as const,
+      pPr: {
+        numPr: { numId: 1 },
+        indentLeft: 357,
+        indentFirstLine: -357,
+        hangingIndent: true,
+      },
+    },
+  ],
+};
+
+function pmAttrsFor(formatting: ParagraphFormatting): Record<string, unknown> {
+  const document: Document = {
+    package: {
+      document: {
+        content: [{ type: "paragraph", content: [], formatting }],
+      },
+    },
+  };
+  const pmDoc = toProseDoc(document, { styles: STYLE_DEFS });
+  let attrs: Record<string, unknown> = {};
+  pmDoc.descendants((node) => {
+    if (node.type.name === "paragraph") {
+      attrs = node.attrs;
+    }
+    return false;
+  });
+  return attrs;
+}
+
+describe("style vs direct w:ind merge in toProseDoc (#765)", () => {
+  test("removing style numbering (numId 0) drops the style hanging too", () => {
+    const attrs = pmAttrsFor({
+      styleId: "Numbered",
+      numPr: { numId: 0, ilvl: 0 },
+      indentLeft: 357,
+    });
+    expect(attrs["indentLeft"]).toBe(357);
+    expect(attrs["indentFirstLine"] ?? null).toBeNull();
+    expect(attrs["hangingIndent"] ?? false).toBe(false);
+  });
+
+  test("a numbered style without a direct numId keeps the style hanging", () => {
+    const attrs = pmAttrsFor({ styleId: "Numbered" });
+    expect(attrs["indentLeft"]).toBe(357);
+    expect(attrs["indentFirstLine"]).toBe(-357);
+    expect(attrs["hangingIndent"]).toBe(true);
+    // The style-sourced numPr is projected with provenance.
+    expect(attrs["numPr"]).toEqual({ numId: 1 });
+    expect(attrs["numPrFromStyle"]).toEqual({ numId: 1 });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -8,6 +8,7 @@
 import type { Node as PMNode, Mark } from "prosemirror-model";
 
 import { convertBulletToUnicode } from "../docx/bulletMarkers";
+import { padDecimal } from "../docx/numberingParser";
 import type {
   FlowBlock,
   ParagraphBlock,
@@ -257,7 +258,13 @@ export function formatCounter(
     case "lowerLetter":
       return toLetter(value, false);
     case "decimalZero":
-      return value < 10 ? `0${value}` : String(value);
+      return padDecimal(value, 2);
+    case "decimalZero3":
+      return padDecimal(value, 3);
+    case "decimalZero4":
+      return padDecimal(value, 4);
+    case "decimalZero5":
+      return padDecimal(value, 5);
     case "none":
       return "";
     default:

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -12,6 +12,7 @@
 
 import type { Node as PMNode, Mark } from "prosemirror-model";
 
+import { numPrEqual } from "../../docx/numberingParser";
 import { narrowEnum, ShapeOutlineStyleSchema } from "../../docx/parserEnums";
 import type {
   ImageWrap,
@@ -678,6 +679,20 @@ function convertPMParagraph(
   return paragraph;
 }
 
+/**
+ * Whether the paragraph's numbering still comes verbatim from its style —
+ * serialize no direct `<w:numPr>` then. The moment a list command changes
+ * `numPr` the values diverge and the numbering serializes as direct
+ * formatting, so a stale provenance value can never swallow a user edit.
+ */
+function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
+  return (
+    attrs.numPrFromStyle != null &&
+    attrs.numPr != null &&
+    numPrEqual(attrs.numPr, attrs.numPrFromStyle)
+  );
+}
+
 function paragraphAttrsToFormatting(
   attrs: ParagraphAttrs,
 ): ParagraphFormatting | undefined {
@@ -703,15 +718,21 @@ function paragraphAttrsToFormatting(
         delete result.alignment;
       }
     }
-    if (
+    if (isStyleSourcedNumPr(attrs)) {
+      // The numbering still comes verbatim from the paragraph style — don't
+      // materialize it as direct formatting (see ParagraphAttrs.numPrFromStyle).
+      delete result.numPr;
+      delete result.numPrFromStyle;
+    } else if (
       attrs.numPr !== orig.numPr &&
-      JSON.stringify(attrs.numPr) !== JSON.stringify(orig.numPr)
+      !numPrEqual(attrs.numPr, orig.numPr)
     ) {
       if (attrs.numPr) {
         result.numPr = attrs.numPr;
       } else {
         delete result.numPr;
       }
+      delete result.numPrFromStyle;
     }
     if (attrs.styleId !== (orig.styleId ?? undefined)) {
       if (attrs.styleId) {
@@ -801,7 +822,7 @@ function paragraphAttrsToFormatting(
   if (attrs.hangingIndent) {
     f.hangingIndent = attrs.hangingIndent;
   }
-  if (attrs.numPr) {
+  if (attrs.numPr && !isStyleSourcedNumPr(attrs)) {
     f.numPr = attrs.numPr;
   }
   if (attrs.styleId) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -491,6 +491,9 @@ function paragraphFormattingToAttrs(
   if (formatting?.numPr) {
     attrs.numPr = formatting.numPr;
   }
+  if (formatting?.numPrFromStyle) {
+    attrs.numPrFromStyle = formatting.numPrFromStyle;
+  }
   // List rendering info from parsed numbering definitions
   if (paragraph.listRendering?.numFmt) {
     attrs.listNumFmt = paragraph.listRendering.numFmt;
@@ -580,11 +583,26 @@ function paragraphFormattingToAttrs(
     set("spacingExplicit", formatting?.spacingExplicit);
     set("indentLeft", formatting?.indentLeft ?? stylePpr?.indentLeft);
     set("indentRight", formatting?.indentRight ?? stylePpr?.indentRight);
+    // When the paragraph explicitly removes the style's numbering (direct
+    // numId=0 under a numbered style), Word also drops the style's
+    // marker-positioning firstLine/hanging — the paragraph keeps only the
+    // indents it states itself (#765: a direct left=357 renders indented
+    // instead of hanging the first line back to the margin). Outside that
+    // case w:ind merges per attribute: a direct left-only indent keeps the
+    // style's firstLine (Word's own Increase Indent emits exactly that).
+    const numberingRemoved =
+      formatting?.numPr?.numId === 0 &&
+      stylePpr?.numPr !== undefined &&
+      stylePpr.numPr.numId !== 0;
+    const styleFirstLine = numberingRemoved ? undefined : stylePpr;
     set(
       "indentFirstLine",
-      formatting?.indentFirstLine ?? stylePpr?.indentFirstLine,
+      formatting?.indentFirstLine ?? styleFirstLine?.indentFirstLine,
     );
-    set("hangingIndent", formatting?.hangingIndent ?? stylePpr?.hangingIndent);
+    set(
+      "hangingIndent",
+      formatting?.hangingIndent ?? styleFirstLine?.hangingIndent,
+    );
     set("borders", formatting?.borders ?? stylePpr?.borders);
     set("shading", formatting?.shading ?? stylePpr?.shading);
     set("tabs", formatting?.tabs ?? stylePpr?.tabs);
@@ -619,6 +637,7 @@ function paragraphFormattingToAttrs(
     // numId === 0 means "no numbering" per OOXML spec — skip it
     if (!formatting?.numPr && stylePpr?.numPr && stylePpr.numPr.numId !== 0) {
       attrs.numPr = stylePpr.numPr;
+      attrs.numPrFromStyle = stylePpr.numPr;
     }
   } else {
     // No style resolver - use inline formatting only

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -10,6 +10,7 @@ import { Fragment } from "prosemirror-model";
 import type { Mark, Node as PMNode, NodeSpec, Schema } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 
+import type { NumberingMap } from "../../../docx/numberingParser";
 import type {
   ParagraphAlignment,
   LineSpacingRule,
@@ -24,7 +25,10 @@ import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
 import { expectParagraphAttrs } from "../../attrs";
 import type { ParagraphAttrs } from "../../schema/nodes";
-import { paragraphAttrsFromResolvedStyle } from "../../styles/resolvedStyleAttrs";
+import {
+  paragraphAttrsFromResolvedStyle,
+  listAttrsFromResolvedStyle,
+} from "../../styles/resolvedStyleAttrs";
 import { createNodeExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
@@ -335,6 +339,7 @@ const paragraphNodeSpec: NodeSpec = {
     indentFirstLine: { default: null },
     hangingIndent: { default: false },
     numPr: { default: null },
+    numPrFromStyle: { default: null },
     listNumFmt: { default: null },
     listIsBullet: { default: null },
     listIsLegal: { default: null },
@@ -539,6 +544,14 @@ function setParagraphAttrsCmd(attrs: Record<string, unknown>): Command {
 export type ResolvedStyleAttrs = {
   paragraphFormatting?: ParagraphFormatting;
   runFormatting?: TextFormatting;
+  /**
+   * Numbering definitions from the document package. When the applied style
+   * carries a `w:numPr`, these resolve the numbering level into the list
+   * marker attrs (template, per-level formats, counter key) so the painter
+   * renders the style's numbering — e.g. "[Claim 1]" — instead of falling
+   * back to a plain decimal marker.
+   */
+  numbering?: NumberingMap | null;
 };
 
 // ============================================================================
@@ -717,6 +730,16 @@ function makeApplyStyle(schema: Schema) {
               newAttrs,
               paragraphAttrsFromResolvedStyle(resolvedAttrs),
             );
+            // A style with `w:numPr` attaches its numbering (numPr + marker
+            // attrs). A style without numbering leaves existing list attrs
+            // untouched — direct numbering survives a style switch in Word.
+            const listAttrs = listAttrsFromResolvedStyle(
+              resolvedAttrs,
+              resolvedAttrs.numbering,
+            );
+            if (listAttrs) {
+              Object.assign(newAttrs, listAttrs);
+            }
           }
 
           tr = tr.setNodeMarkup(pos, undefined, newAttrs);

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -69,6 +69,18 @@ export type ParagraphAttrs = {
     numId?: number;
     ilvl?: number;
   };
+  /**
+   * The style-sourced numPr value when `numPr` came from the paragraph
+   * style rather than direct formatting. While `numPr` still equals this,
+   * fromProseDoc omits it from serialized formatting (writing it as direct
+   * `<w:numPr>` would flip Word's level-indent precedence on reload). List
+   * commands that change `numPr` make the values diverge, which re-enables
+   * direct serialization — no explicit clearing needed.
+   */
+  numPrFromStyle?: {
+    numId?: number;
+    ilvl?: number;
+  };
   /** List number format (decimal, lowerRoman, upperRoman, etc.) for CSS counter styling */
   listNumFmt?: NumberFormat;
   /** Whether this is a bullet list */

--- a/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs-list.test.ts
+++ b/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs-list.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import { createNumberingMap, parseNumbering } from "../../docx/numberingParser";
+import { listAttrsFromResolvedStyle } from "./resolvedStyleAttrs";
+
+const W =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+const MC =
+  'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"';
+
+// numId 1 -> abstractNum 6 (custom decimalZero4, "[%1]", level ind 360/360)
+// numId 2 -> abstractNum 10 (decimal, "[Claim %1]", level ind 360/360)
+const NUMBERING_CUSTOM = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering ${W} ${MC}>
+  <w:abstractNum w:abstractNumId="6">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <mc:AlternateContent>
+        <mc:Choice Requires="w14">
+          <w:numFmt w:val="custom" w:format="0001, 0002, ..."/>
+        </mc:Choice>
+        <mc:Fallback><w:numFmt w:val="decimal"/></mc:Fallback>
+      </mc:AlternateContent>
+      <w:lvlText w:val="[%1]"/>
+      <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:abstractNum w:abstractNumId="10">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="[Claim %1]"/>
+      <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="6"/></w:num>
+  <w:num w:numId="2"><w:abstractNumId w:val="10"/></w:num>
+</w:numbering>`;
+
+describe("listAttrsFromResolvedStyle (#765 applyStyle)", () => {
+  const numbering = parseNumbering(NUMBERING_CUSTOM);
+  const map = createNumberingMap({
+    abstractNums: numbering.definitions.abstractNums,
+    nums: numbering.definitions.nums,
+  });
+
+  test("projects the style numPr into numPr + marker attrs", () => {
+    const attrs = listAttrsFromResolvedStyle(
+      { paragraphFormatting: { numPr: { numId: 2 }, indentLeft: 1134 } },
+      map,
+    );
+    expect(attrs).not.toBeNull();
+    expect(attrs?.["numPr"]).toEqual({ numId: 2, ilvl: 0 });
+    expect(attrs?.["numPrFromStyle"]).toEqual({ numId: 2, ilvl: 0 });
+    expect(attrs?.["listMarker"]).toBe("[Claim %1]");
+    expect(attrs?.["listNumFmt"]).toBe("decimal");
+    expect(attrs?.["listAbstractNumId"]).toBe(10);
+    // Style defines its own indent — the level's must not be projected.
+    expect(attrs?.["indentLeft"]).toBeUndefined();
+  });
+
+  test("projects a custom zero-padded style numbering", () => {
+    const attrs = listAttrsFromResolvedStyle(
+      { paragraphFormatting: { numPr: { numId: 1 } } },
+      map,
+    );
+    expect(attrs?.["listMarker"]).toBe("[%1]");
+    expect(attrs?.["listNumFmt"]).toBe("decimalZero4");
+    expect(attrs?.["listLevelNumFmts"]).toEqual(["decimalZero4"]);
+  });
+
+  test("falls back to the numbering level indents when the style has none", () => {
+    const attrs = listAttrsFromResolvedStyle(
+      { paragraphFormatting: { numPr: { numId: 2 } } },
+      map,
+    );
+    expect(attrs?.["indentLeft"]).toBe(360);
+    expect(attrs?.["indentFirstLine"]).toBe(-360);
+    expect(attrs?.["hangingIndent"]).toBe(true);
+  });
+
+  test("returns null for styles without numbering or with numId 0", () => {
+    expect(
+      listAttrsFromResolvedStyle(
+        { paragraphFormatting: { indentLeft: 100 } },
+        map,
+      ),
+    ).toBeNull();
+    expect(
+      listAttrsFromResolvedStyle(
+        { paragraphFormatting: { numPr: { numId: 0 } } },
+        map,
+      ),
+    ).toBeNull();
+  });
+
+  test("without numbering definitions returns numPr but null marker attrs", () => {
+    const attrs = listAttrsFromResolvedStyle(
+      { paragraphFormatting: { numPr: { numId: 2 } } },
+      null,
+    );
+    expect(attrs?.["numPr"]).toEqual({ numId: 2, ilvl: 0 });
+    expect(attrs?.["listMarker"]).toBeNull();
+  });
+});

--- a/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
@@ -9,6 +9,10 @@
  * identical paragraph attrs.
  */
 
+import {
+  computeListRendering,
+  type NumberingMap,
+} from "../../docx/numberingParser";
 import type { ResolvedParagraphStyle } from "./styleResolver";
 
 /**
@@ -49,4 +53,78 @@ export function paragraphAttrsFromResolvedStyle(
     // and the formatting typed text inherits (see EmptyParagraphFormatExtension).
     defaultTextFormatting: hasRunFormatting ? runFormatting : null,
   };
+}
+
+/**
+ * The list attrs a style's `w:pPr/w:numPr` controls (numbering reference plus
+ * the baked marker-rendering attrs that `toProseDoc` normally derives from
+ * `listRendering` at load time). Returns null when the style defines no
+ * numbering — applying such a style leaves any existing list attrs alone, so
+ * directly-applied (toolbar) lists survive a style switch the way they do in
+ * Word, where numbering is not cleared by applying an unnumbered style.
+ *
+ * When the style does define numbering, the full attr group is reset so a
+ * previous list's marker attrs never leak into the new one. Without the
+ * numbering definitions the marker template can't be resolved and the painter
+ * falls back to a plain decimal marker.
+ *
+ * The content-derived marker attrs (`listImplicitChildLevelAdvances`,
+ * `listMarkerSecondSlotOffsetTwips`) are nulled — they depend on the
+ * paragraph's inline LISTNUM fields, which the picker has no view of. A
+ * subsequent save + reload re-derives them from the document content.
+ */
+export function listAttrsFromResolvedStyle(
+  resolved: ResolvedParagraphStyle,
+  numbering: NumberingMap | null | undefined,
+): Record<string, unknown> | null {
+  const numPr = resolved.paragraphFormatting?.numPr;
+  if (!numPr || numPr.numId === undefined || numPr.numId === 0) {
+    return null;
+  }
+
+  const rendering = numbering ? computeListRendering(numPr, numbering) : null;
+  const level = numbering?.getLevel(numPr.numId, numPr.ilvl ?? 0);
+
+  const attrs: Record<string, unknown> = {
+    numPr: { numId: numPr.numId, ilvl: numPr.ilvl ?? 0 },
+    // The numbering belongs to the style — mark it so a save doesn't
+    // materialize a direct <w:numPr> (see ParagraphAttrs.numPrFromStyle).
+    numPrFromStyle: { numId: numPr.numId, ilvl: numPr.ilvl ?? 0 },
+    listNumFmt: rendering?.numFmt ?? null,
+    listIsBullet: rendering?.isBullet ?? null,
+    listIsLegal: rendering?.isLegal ?? null,
+    listMarker: rendering?.marker ?? null,
+    listMarkerHidden: rendering?.markerHidden ?? null,
+    listMarkerFontFamily: rendering?.markerFontFamily ?? null,
+    listMarkerFontSize: rendering?.markerFontSize ?? null,
+    listMarkerSuffix: rendering?.markerSuffix ?? null,
+    listMarkerAllCaps: rendering?.markerAllCaps ?? null,
+    listImplicitChildLevelAdvances: null,
+    listMarkerSecondSlotOffsetTwips: null,
+    listLevelNumFmts: rendering?.levelNumFmts ?? null,
+    listAbstractNumId: rendering?.abstractNumId ?? null,
+    listStartOverride: rendering?.startOverride ?? null,
+  };
+
+  // The numbering level's own indents apply beneath the style's (ECMA-376
+  // numbering pPr sits below the style in the cascade) — use them only where
+  // the style doesn't specify its own indentation.
+  const ppr = resolved.paragraphFormatting;
+  if (level?.pPr) {
+    if (ppr?.indentLeft === undefined && level.pPr.indentLeft !== undefined) {
+      attrs["indentLeft"] = level.pPr.indentLeft;
+    }
+    const styleHasFirstLine =
+      ppr?.indentFirstLine !== undefined || ppr?.hangingIndent !== undefined;
+    if (!styleHasFirstLine) {
+      if (level.pPr.indentFirstLine !== undefined) {
+        attrs["indentFirstLine"] = level.pPr.indentFirstLine;
+      }
+      if (level.pPr.hangingIndent !== undefined) {
+        attrs["hangingIndent"] = level.pPr.hangingIndent;
+      }
+    }
+  }
+
+  return attrs;
 }

--- a/packages/folio/src/core/types/documentEnumValues.ts
+++ b/packages/folio/src/core/types/documentEnumValues.ts
@@ -749,6 +749,12 @@ export const NUMBER_FORMAT_VALUES = [
   "aiueoFullWidth",
   "irohaFullWidth",
   "decimalZero",
+  // Synthetic zero-padded decimal formats (Word `w:numFmt w:val="custom"`).
+  // Included here so the marker pipeline's `isNumberFormat` guard accepts
+  // `listLevelNumFmts` carrying them; they are never serialized back out.
+  "decimalZero3",
+  "decimalZero4",
+  "decimalZero5",
   "bullet",
   "ganada",
   "chosung",


### PR DESCRIPTION
## Summary

Ports the custom-style numbering fixes from `eigenpal/docx-editor#767` (upstream
issue 765) into folio. Three independent sub-fixes, sharing the
`@stll/docx-core` model types:

- **Custom zero-padded numbering.** Word emits 4-digit list numbering as
  `<w:numFmt w:val="custom" w:format="0001, ...">` wrapped in
  `<mc:AlternateContent>`. The parser now reads the Choice/Fallback and maps the
  pad width to synthetic `decimalZero3/4/5` formats — carried through the
  existing `NumberFormat` plumbing and **never serialized** (`numbering.xml` is
  preserved as-is on save). A shared `padDecimal` consolidates the zero-pad
  family across the parser, the layout bridge, and the block-content marker
  substitution (also fixing a latent `decimalZero` pad inconsistency).
- **Style-attached numbering precedence + provenance.** When a paragraph's
  `numPr` is inherited from its paragraph style, Word gives the style chain's
  `w:ind` precedence over the numbering level's. The parser records the
  numbering as style-sourced (`numPrFromStyle`) and gates the level-indent
  application per group (`left` vs `firstLine`/`hanging`); the serializer and PM
  round-trip drop `numPr` while it still equals the style value, so it is never
  written back as direct `<w:numPr>` (which would flip Word's precedence on
  reload). A direct `numId=0` under a numbered style drops the style's hanging,
  matching Word.
- **Toolbar style-picker projection.** Applying a numbered paragraph style now
  attaches its numbering + resolved marker attributes live, so the list renders
  immediately instead of only after a reload.

Folio's richer list-resolution block (LISTNUM folding, marker offsets, `isLgl`,
all-caps markers) is kept intact — only the indent-precedence gate and the
provenance were added. `computeListRendering` is a **new** picker-path helper,
not an extraction of the parser block.

## Test plan

- `bun test src/core/docx src/core/layout-bridge src/core/prosemirror` (folio) —
  1179 pass.
- `bun test` (`@stll/docx-core`) — 23 pass.
- New tests: `numberingParser-custom-format.test.ts` (custom/Fallback resolution
  + `formatNumber`/template padding), `serializer/styleNumPrRoundtrip.test.ts`
  (style-sourced `numPr` serializes no `<w:numPr>`; `numId=0` drops style
  hanging), `prosemirror/styles/resolvedStyleAttrs-list.test.ts` (picker
  projection: marker, indent precedence, no-numbering/`numId=0` → null), and new
  cases in `paragraphParser-numbering-indent.test.ts` (style indent wins; level
  indent still applies without a style indent; direct `numPr` keeps provenance
  clear).

CC on behalf of @jan-kubica
