### PR TITLE
chore(business-registries): single-source ID checksums to @stll/stdnum

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -365,7 +365,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@stll/country-codes": "workspace:*",
-        "@stll/stdnum": "^2.0.1",
+        "@stll/stdnum": "^2.1.1",
       },
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
@@ -1661,7 +1661,7 @@
 
     "@stll/skills": ["@stll/skills@workspace:packages/skills"],
 
-    "@stll/stdnum": ["@stll/stdnum@2.1.0", "", {}, "sha512-8IdWPXIgqZqvL05qaAQQPPsgS7gzjbXMDHvXFFjv3xepPyIUuxJPkZLHmnmjoExsBJGaz0sbr1gyUYr+A2pVng=="],
+    "@stll/stdnum": ["@stll/stdnum@2.1.1", "", {}, "sha512-VV+9w+u3tLYjos2Z0idJBsl+iCmE171u4rhUNEh/QDqljPBjKETKyLkf81Z1sR0QeaAcn3rg+0Y4vauPVU566w=="],
 
     "@stll/template-conditions": ["@stll/template-conditions@workspace:packages/template-conditions"],
 
@@ -3778,6 +3778,8 @@
     "@react-grab/cli/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@selderee/plugin-htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "@stll/anonymize-wasm/@stll/stdnum": ["@stll/stdnum@2.1.0", "", {}, "sha512-8IdWPXIgqZqvL05qaAQQPPsgS7gzjbXMDHvXFFjv3xepPyIUuxJPkZLHmnmjoExsBJGaz0sbr1gyUYr+A2pVng=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -120,7 +120,7 @@
   },
   "dependencies": {
     "@stll/country-codes": "workspace:*",
-    "@stll/stdnum": "^2.0.1"
+    "@stll/stdnum": "^2.1.1"
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",

--- a/packages/business-registries/src/brreg/validation.ts
+++ b/packages/business-registries/src/brreg/validation.ts
@@ -1,35 +1,13 @@
-// Norwegian organisasjonsnummer (orgnr).
-//
-// Nine digits with a MOD-11 check digit. Weights for digits 1..8 are
-// [3, 2, 7, 6, 5, 4, 3, 2]; the control digit is the 9th. If the
-// MOD-11 remainder would resolve to 10, the orgnr is invalid (since
-// the control digit only has room for one digit).
+// Norwegian organisasjonsnummer (orgnr): 9 digits with a MOD-11 check
+// digit. The checksum lives in `@stll/stdnum`; we keep a local
+// normalizer because the brreg API is queried with the separator-free
+// 9-digit form (see client.ts).
 //
 // See: https://www.brreg.no/om-oss/oppgavene-vare/registrene-vare/
 
-const ORGNR_WEIGHTS = [3, 2, 7, 6, 5, 4, 3, 2] as const;
+import { validate } from "@stll/stdnum/no/orgnr";
 
 export const normalizeOrgnr = (input: string): string =>
   input.replaceAll(/[\s-]/gu, "");
 
-export const validateOrgnr = (input: string): boolean => {
-  const compact = normalizeOrgnr(input);
-  if (!/^\d{9}$/u.test(compact)) {
-    return false;
-  }
-  let sum = 0;
-  for (let i = 0; i < ORGNR_WEIGHTS.length; i++) {
-    const digit = Number(compact[i]);
-    const weight = ORGNR_WEIGHTS[i];
-    if (weight === undefined) {
-      return false;
-    }
-    sum += digit * weight;
-  }
-  const remainder = sum % 11;
-  const expectedControl = remainder === 0 ? 0 : 11 - remainder;
-  if (expectedControl === 10) {
-    return false;
-  }
-  return expectedControl === Number(compact[8]);
-};
+export const validateOrgnr = (input: string): boolean => validate(input).valid;

--- a/packages/business-registries/src/gcis/validation.ts
+++ b/packages/business-registries/src/gcis/validation.ts
@@ -1,47 +1,15 @@
 // 統一編號 (tongbian / Business Administration Number) — Taiwanese
-// 8-digit company tax ID issued by the Ministry of Finance and used
-// by GCIS as the canonical identifier.
-//
-// Check-digit algorithm:
-//
-//   * Weights [1, 2, 1, 2, 1, 2, 4, 1] applied per digit.
-//   * For each weighted product p, accumulate `floor(p / 10) + (p % 10)`
-//     (i.e. the sum of the product's tens and units digits).
-//   * Valid iff `sum % 10 === 0`.
-//   * Special case: if the 7th digit (index 6) is `7`, the entity is
-//     also valid when `(sum + 1) % 10 === 0`. The 7th digit is the
-//     "industry / type" segment and `7` historically aliased to two
-//     check totals on legacy paper certificates; the MoF preserved
-//     both as valid when modernising the algorithm.
+// 8-digit company tax ID used by GCIS as the canonical identifier. The
+// weighted check-digit algorithm (including the 7th-digit-is-7
+// fallback) lives in `@stll/stdnum`; we keep a local normalizer because
+// the GCIS API is queried with the separator-free 8-digit form (see
+// client.ts).
 //
 // Reference: Ministry of Finance, 統一編號 issuance manual.
-// Wikipedia summary: https://zh.wikipedia.org/wiki/统一编号
 
-const TONGBIAN_WEIGHTS = [1, 2, 1, 2, 1, 2, 4, 1] as const;
-const SPECIAL_SEVENTH_DIGIT = 7;
+import { validate } from "@stll/stdnum/tw/ubn";
 
 export const normalizeTaxId = (input: string): string =>
   input.trim().replaceAll(/[\s-]/gu, "");
 
-export const validateTaxId = (input: string): boolean => {
-  const compact = normalizeTaxId(input);
-  if (!/^\d{8}$/u.test(compact)) {
-    return false;
-  }
-  let sum = 0;
-  for (let i = 0; i < TONGBIAN_WEIGHTS.length; i++) {
-    const digit = Number(compact[i]);
-    const weight = TONGBIAN_WEIGHTS[i];
-    if (weight === undefined) {
-      return false;
-    }
-    const product = digit * weight;
-    sum += Math.floor(product / 10) + (product % 10);
-  }
-  if (sum % 10 === 0) {
-    return true;
-  }
-  // The 7th-digit-is-7 fallback: a single match window above the
-  // base check, no broader tolerance. Anything else fails.
-  return Number(compact[6]) === SPECIAL_SEVENTH_DIGIT && (sum + 1) % 10 === 0;
-};
+export const validateTaxId = (input: string): boolean => validate(input).valid;

--- a/packages/business-registries/src/index.ts
+++ b/packages/business-registries/src/index.ts
@@ -9,6 +9,7 @@
 //
 //   import { ares } from "@stll/business-registries";
 //   await ares.lookupByIco("27082440");
+// oxlint-disable-next-line oxc/no-barrel-file -- published package's convenience entry; the per-registry subpaths (@stll/business-registries/<registry>) are the tree-shakeable import path
 export * as ares from "./ares/index.js";
 export * as brreg from "./brreg/index.js";
 export * as companiesHouse from "./companies-house/index.js";

--- a/packages/business-registries/src/prh/validation.ts
+++ b/packages/business-registries/src/prh/validation.ts
@@ -1,40 +1,18 @@
-// Finnish Y-tunnus (business ID).
+// Finnish Y-tunnus (business ID), canonical format `NNNNNNN-C`.
 //
-// Format `NNNNNNN-C`: seven digits, a hyphen, then a single check
-// digit. The check digit is MOD-11 over the seven payload digits with
-// weights [7, 9, 10, 5, 8, 4, 2]. Remainder 0 → check 0; remainder 1
-// is invalid (no single digit fits); else check = 11 - remainder.
+// The MOD-11 checksum lives in `@stll/stdnum`. We keep the hyphenated-
+// format check locally: unlike stdnum (which also accepts the bare
+// 8-digit form), this adapter requires `NNNNNNN-C` because the PRH API
+// is queried with the hyphenated id (see client.ts).
 //
 // PRH spec: https://www.vero.fi/en/businesses-and-corporations/about-corporate-taxes/business-id/
 
-const YTUNNUS_WEIGHTS = [7, 9, 10, 5, 8, 4, 2] as const;
+import { validate } from "@stll/stdnum/fi/ytunnus";
+
+const YTUNNUS_FORMAT = /^\d{7}-\d$/u;
 
 export const normalizeBusinessId = (input: string): string =>
   input.trim().replaceAll(/\s/gu, "");
 
-export const validateBusinessId = (input: string): boolean => {
-  const compact = normalizeBusinessId(input);
-  const match = /^(\d{7})-(\d)$/u.exec(compact);
-  if (!match) {
-    return false;
-  }
-  const [, payload, control] = match;
-  if (payload === undefined || control === undefined) {
-    return false;
-  }
-  let sum = 0;
-  for (let i = 0; i < YTUNNUS_WEIGHTS.length; i++) {
-    const digit = Number(payload[i]);
-    const weight = YTUNNUS_WEIGHTS[i];
-    if (weight === undefined) {
-      return false;
-    }
-    sum += digit * weight;
-  }
-  const remainder = sum % 11;
-  if (remainder === 1) {
-    return false;
-  }
-  const expectedControl = remainder === 0 ? 0 : 11 - remainder;
-  return expectedControl === Number(control);
-};
+export const validateBusinessId = (input: string): boolean =>
+  YTUNNUS_FORMAT.test(normalizeBusinessId(input)) && validate(input).valid;

--- a/packages/business-registries/src/recherche-entreprises/validation.test.ts
+++ b/packages/business-registries/src/recherche-entreprises/validation.test.ts
@@ -12,6 +12,14 @@ describe("normalizeSiren", () => {
     expect(normalizeSiren(" 552 032 534 ")).toBe("552032534");
     expect(normalizeSiren("552032534\n")).toBe("552032534");
   });
+
+  test("strips dot and dash separators the validators also accept", () => {
+    // Must match what stdnum compacts, so a valid dotted/dashed id
+    // canonicalizes to the digits used for the API query (see client.ts)
+    // instead of resolving to null.
+    expect(normalizeSiren("780.129.987")).toBe("780129987");
+    expect(normalizeSiren("780-129-987")).toBe("780129987");
+  });
 });
 
 describe("validateSiren", () => {

--- a/packages/business-registries/src/recherche-entreprises/validation.ts
+++ b/packages/business-registries/src/recherche-entreprises/validation.ts
@@ -1,77 +1,26 @@
 // French SIREN (9 digits) and SIRET (14 digits) validators.
 //
-// Both identifiers carry a Luhn (MOD-10) check digit in their final
-// position. SIRET = SIREN (9) + NIC (5); the Luhn checksum runs over
-// the full 9-digit SIREN for SIREN validation and over the full
-// 14-digit SIRET for SIRET validation.
-//
-// Two notable carve-outs of the SIRET checksum:
-//
-// - La Poste's SIREN 356000000 has a true Luhn-valid SIREN but every
-//   SIRET allocated under it intentionally fails Luhn. INSEE's
-//   documented workaround is to validate La Poste SIRETs by summing
-//   the 14 digits and checking divisibility by 5. We implement the
-//   carve-out so government / utility entities owned by La Poste do
-//   not surface as "invalid SIRET".
-// - "Monégasque" SIRENs in the 998xxxxxx and 999xxxxxx ranges are
-//   reserved for Monaco; they do follow Luhn so no special handling.
+// Both checksums — SIREN/SIRET Luhn plus the La Poste digit-sum
+// carve-out — live in `@stll/stdnum` (which also correctly exempts the
+// La Poste head office, validated by standard Luhn). We keep a local
+// normalizer and shape-only check here because the dispatch layer
+// routes on shape (see dispatch.ts) and the recherche-entreprises API
+// is queried with the separator-free numeric form (see client.ts).
 //
 // SIREN reference: https://en.wikipedia.org/wiki/SIREN_code
 // SIRET reference: https://www.insee.fr/fr/information/2017372
-// La Poste carve-out reference:
-// https://fr.wikipedia.org/wiki/Système_d%27identification_du_répertoire_des_établissements
-//   ("Notation des SIRET de La Poste")
 
-const LA_POSTE_SIREN = "356000000";
+import { validate as validateSirenStdnum } from "@stll/stdnum/fr/siren";
+import { validate as validateSiretStdnum } from "@stll/stdnum/fr/siret";
 
 export const normalizeSiren = (input: string): string =>
   input.trim().replaceAll(/\s/gu, "");
 
-const luhnValid = (digits: string): boolean => {
-  // Standard Luhn (right-to-left, double every second digit).
-  let sum = 0;
-  for (let i = 0; i < digits.length; i++) {
-    const reverseIndex = digits.length - 1 - i;
-    const ch = digits[reverseIndex];
-    if (ch === undefined) {
-      return false;
-    }
-    let digit = Number(ch);
-    if (i % 2 === 1) {
-      digit *= 2;
-      if (digit > 9) {
-        digit -= 9;
-      }
-    }
-    sum += digit;
-  }
-  return sum % 10 === 0;
-};
+export const validateSiren = (input: string): boolean =>
+  validateSirenStdnum(input).valid;
 
-export const validateSiren = (input: string): boolean => {
-  const compact = normalizeSiren(input);
-  if (!/^\d{9}$/u.test(compact)) {
-    return false;
-  }
-  return luhnValid(compact);
-};
-
-export const validateSiret = (input: string): boolean => {
-  const compact = normalizeSiren(input);
-  if (!/^\d{14}$/u.test(compact)) {
-    return false;
-  }
-  // La Poste carve-out: every SIRET under SIREN 356000000 must satisfy
-  // "sum of 14 digits divisible by 5" instead of Luhn.
-  if (compact.startsWith(LA_POSTE_SIREN)) {
-    let total = 0;
-    for (const ch of compact) {
-      total += Number(ch);
-    }
-    return total % 5 === 0;
-  }
-  return luhnValid(compact);
-};
+export const validateSiret = (input: string): boolean =>
+  validateSiretStdnum(input).valid;
 
 // Cheap shape-only check used by the dispatch layer's `isCanonicalId`
 // (which deliberately does not validate checksums — see dispatch.ts).

--- a/packages/business-registries/src/recherche-entreprises/validation.ts
+++ b/packages/business-registries/src/recherche-entreprises/validation.ts
@@ -2,19 +2,22 @@
 //
 // Both checksums — SIREN/SIRET Luhn plus the La Poste digit-sum
 // carve-out — live in `@stll/stdnum` (which also correctly exempts the
-// La Poste head office, validated by standard Luhn). We keep a local
-// normalizer and shape-only check here because the dispatch layer
-// routes on shape (see dispatch.ts) and the recherche-entreprises API
-// is queried with the separator-free numeric form (see client.ts).
+// La Poste head office, validated by standard Luhn). normalizeSiren
+// reuses stdnum's `compact` so the canonical form matches exactly what
+// the validators accept: a valid spaced or dotted id collapses to the
+// digits used for the API query and exact-match (see client.ts), and
+// the shape check stays in sync with validation.
 //
 // SIREN reference: https://en.wikipedia.org/wiki/SIREN_code
 // SIRET reference: https://www.insee.fr/fr/information/2017372
 
-import { validate as validateSirenStdnum } from "@stll/stdnum/fr/siren";
+import {
+  compact,
+  validate as validateSirenStdnum,
+} from "@stll/stdnum/fr/siren";
 import { validate as validateSiretStdnum } from "@stll/stdnum/fr/siret";
 
-export const normalizeSiren = (input: string): string =>
-  input.trim().replaceAll(/\s/gu, "");
+export const normalizeSiren = (input: string): string => compact(input);
 
 export const validateSiren = (input: string): boolean =>
   validateSirenStdnum(input).valid;


### PR DESCRIPTION
Replace the hand-rolled check-digit algorithms in four registry adapters with the corresponding validators from `@stll/stdnum`, matching the existing `ares`/`orsr` pattern:

- `brreg` — NO organisasjonsnummer (`no/orgnr`)
- `prh` — FI y-tunnus (`fi/ytunnus`)
- `recherche-entreprises` — FR SIREN/SIRET (`fr/siren`, `fr/siret`)
- `gcis` — TW 統一編號 / UBN (`tw/ubn`)

Each adapter keeps its own normalizer, which owns the API/canonical form: `prh` retains the hyphenated-format guard (stdnum also accepts the bare 8-digit form), and the FR/`gcis` normalizers keep newline handling that stdnum's `compact` does not.

The `edgar`, `companies-house`, and `krs` adapters have no check digit and `vies` is format-only, so every checksum-bearing adapter now sources its algorithm from `@stll/stdnum`.

Behaviour change: the FR La Poste head office (`35600000000048`) now validates via standard Luhn instead of being rejected by the digit-sum carve-out.
