### PR TITLE
fix: correctness and integrity hardening + tests

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
@@ -51,12 +51,13 @@ describe("extractCitations", () => {
       { index: 1, text: "Skutkový stav bez citací." },
       {
         index: 2,
-        text: "Soud se odchýlil od sp. zn. 21 Cdo 1234/2020 a rozhodl jinak.",
+        text: "Soud se odchýlil od č. j. 21 Cdo 1234/2020 a rozhodl jinak.",
       },
     ]);
 
     expect(citations).toHaveLength(1);
     expect(citations[0]?.sectionIndex).toBe(2);
+    expect(citations[0]?.citationText).toBe("č. j. 21 Cdo 1234/2020");
   });
 
   test("does not capture Roman-numeral prose as a phantom citation", () => {

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
@@ -42,6 +42,23 @@ describe("extractCitations", () => {
     expect(texts).toContain("II ACa 45/20");
   });
 
+  test("records the later (reasoning) section for a cross-section citation", () => {
+    // The same case is listed bare in the header (section 0) and discussed
+    // in the reasoning (section 2). The reasoning context carries polarity,
+    // so the citation must be anchored to section 2, not the header.
+    const citations = extractCitations([
+      { index: 0, text: "Související: sp. zn. 21 Cdo 1234/2020." },
+      { index: 1, text: "Skutkový stav bez citací." },
+      {
+        index: 2,
+        text: "Soud se odchýlil od sp. zn. 21 Cdo 1234/2020 a rozhodl jinak.",
+      },
+    ]);
+
+    expect(citations).toHaveLength(1);
+    expect(citations[0]?.sectionIndex).toBe(2);
+  });
+
   test("does not capture Roman-numeral prose as a phantom citation", () => {
     // The unprefixed Polish pattern previously matched any mixed-case word
     // for the division code, so ordinary prose became a citation.

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
@@ -32,6 +32,27 @@ describe("extractCitations", () => {
     const citations = extractCitations([{ index: 0, text }]);
     expect(citations).toHaveLength(2);
   });
+
+  test("extracts an unprefixed Polish case number", () => {
+    const citations = extractCitations([
+      { index: 0, text: "Por. wyrok II CSK 123/20 oraz II ACa 45/20." },
+    ]);
+    const texts = citations.map((c) => c.citationText);
+    expect(texts).toContain("II CSK 123/20");
+    expect(texts).toContain("II ACa 45/20");
+  });
+
+  test("does not capture Roman-numeral prose as a phantom citation", () => {
+    // The unprefixed Polish pattern previously matched any mixed-case word
+    // for the division code, so ordinary prose became a citation.
+    for (const text of [
+      "Article XV See 12/20 for details",
+      "see point III the 4/19 below",
+      "as in II and 5/20 of the act",
+    ]) {
+      expect(extractCitations([{ index: 0, text }])).toHaveLength(0);
+    }
+  });
 });
 
 describe("isSelfCitation", () => {

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -40,8 +40,12 @@ const CITATION_PATTERNS: RegExp[] = [
 
   PL_PREFIXED_PATTERN,
 
-  // Polish case number without prefix: "II CSK 123/20", "II ACa 45/20"
-  /\b[IVX]{2,4}\s+[A-Za-z]{2,5}\s+\d{1,6}\/\d{2,4}\b/gu,
+  // Polish case number without prefix: "II CSK 123/20", "II ACa 45/20".
+  // The division code is an uppercase chamber code (CSK, KK, CSKP) or an
+  // uppercase code with an appellate suffix (ACa, ACz, AKa). Requiring that
+  // shape stops ordinary mixed-case prose like "Article XV See 12/20" from
+  // being captured as a phantom citation.
+  /\b[IVX]{2,4}\s+(?:[A-Z]{2,5}|[A-Z]{1,4}[az])\s+\d{1,6}\/\d{2,4}\b/gu,
 ];
 
 /** Strip known prefixes to get the bare case number. */

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -142,6 +142,7 @@ export const extractCitations = (
           existing.sectionIndex === null ||
           section.index > existing.sectionIndex
         ) {
+          existing.citationText = citationText;
           existing.sectionIndex = section.index;
         }
       }

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -110,8 +110,7 @@ export const isSelfCitation = (
 export const extractCitations = (
   sections: { index: number; text: string }[],
 ): ExtractedCitation[] => {
-  const seen = new Set<string>();
-  const citations: ExtractedCitation[] = [];
+  const byKey = new Map<string, ExtractedCitation>();
 
   for (const section of sections) {
     for (const pattern of CITATION_PATTERNS) {
@@ -130,18 +129,24 @@ export const extractCitations = (
         // of which fires first.
         const dedupKey = match[1]?.trim() ?? citationText;
 
-        if (seen.has(dedupKey)) {
+        const existing = byKey.get(dedupKey);
+        if (!existing) {
+          byKey.set(dedupKey, { citationText, sectionIndex: section.index });
           continue;
         }
-        seen.add(dedupKey);
-
-        citations.push({
-          citationText,
-          sectionIndex: section.index,
-        });
+        // Prefer a later occurrence over an earlier one: a case is often
+        // listed bare in the header (low section index) and then discussed
+        // in the reasoning. The discussion carries the polarity signal, so
+        // record the later section's context, not the header's.
+        if (
+          existing.sectionIndex === null ||
+          section.index > existing.sectionIndex
+        ) {
+          existing.sectionIndex = section.index;
+        }
       }
     }
   }
 
-  return citations;
+  return [...byKey.values()];
 };

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -182,4 +182,43 @@ describe("sanitizeResult — documentAst text fields", () => {
     expect(concatInlineText(spacedCell.inlines)).toBe("z a m i e t a");
     expect(concatInlineText(plainCell.inlines)).toBe("plain cell");
   });
+
+  test("keeps short runs of Czech/Slovak single-letter words intact", () => {
+    const para = (id: string, text: string) => ({
+      id,
+      anchorId: id,
+      type: "paragraph" as const,
+      inlines: [{ type: "text" as const, text }],
+      plainText: text,
+    });
+    const ast: DocumentAst = {
+      version: 1,
+      source: { system: "test", documentId: "x", webUrl: "", printUrl: "" },
+      metadata: astMetadata,
+      blocks: [
+        // "u a v" are three real prepositions, not letter-spaced emphasis.
+        para("p1", "bydlel u a v dome"),
+        para("p2", "podiel i s príslušenstvom"),
+        // A genuine letter-spaced word (>= 4 letters) must still collapse.
+        para("p3", "súd r o z h o d o l takto"),
+      ],
+    };
+
+    const sanitized = sanitizeResult(baseResult(ast));
+    if (!("blocks" in sanitized.documentAst)) {
+      throw new Error("sanitized documentAst should be a DocumentAst");
+    }
+    const [prep1, prep2, spaced] = sanitized.documentAst.blocks;
+    if (
+      prep1?.type !== "paragraph" ||
+      prep2?.type !== "paragraph" ||
+      spaced?.type !== "paragraph"
+    ) {
+      throw new Error("unexpected block types");
+    }
+
+    expect(prep1.plainText).toBe("bydlel u a v dome");
+    expect(prep2.plainText).toBe("podiel i s príslušenstvom");
+    expect(spaced.plainText).toBe("súd rozhodol takto");
+  });
 });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -130,8 +130,16 @@ type ProcessResult = {
  *
  * Safe: won't touch normal text, digits, IČO numbers, or
  * case references (anchored by whitespace/string boundaries).
+ *
+ * Requires at least FOUR letters in the run. Czech/Slovak have many
+ * single-letter words (prepositions a, i, k, o, s, u, v, z), so a 2–3
+ * letter run like `u a v` ("u", "a", "v") is far more likely to be real
+ * words than letter-spaced emphasis; collapsing it to `uav` would corrupt
+ * the search text. Genuine spaced words ("z a m i e t a", "r o z h o d o l")
+ * are always longer, so the floor loses nothing in practice.
  */
-const SPACED_WORD = /(?<=\s|^)(\p{L} (?:\p{L} )*\p{L})( ?[,:;.!?])?(?=\s|$)/gu;
+const SPACED_WORD =
+  /(?<=\s|^)(\p{L} (?:\p{L} ){2,}\p{L})( ?[,:;.!?])?(?=\s|$)/gu;
 
 /**
  * Collapse multiple spaces to single. Applied to all

--- a/apps/api/src/handlers/docx/apply-edits.test.ts
+++ b/apps/api/src/handlers/docx/apply-edits.test.ts
@@ -261,6 +261,60 @@ describe("applyEdits", () => {
     expect(result).not.toContain(">\nworld<");
   });
 
+  test("replacing an OOXML line break edits at the break offset", () => {
+    const xml = WRAP(
+      "<w:p><w:r><w:t>Before</w:t><w:br/><w:t>After</w:t></w:r></w:p>",
+    );
+    const edits: DocxEdit[] = [
+      {
+        kind: "replace",
+        paragraphIndex: 0,
+        charOffset: 6,
+        length: 1,
+        text: " ",
+      },
+    ];
+
+    nextId = 1;
+    const result = applyEdits(xml, edits, AUTHOR, idGen);
+    const beforeIndex = result.indexOf(">Before<");
+    const deleteIndex = result.indexOf("<w:del");
+    const insertIndex = result.indexOf("> <");
+    const afterIndex = result.indexOf(">After<");
+
+    expect(result).toContain('<w:br w:type="textWrapping"/>');
+    expect(beforeIndex).toBeLessThan(deleteIndex);
+    expect(deleteIndex).toBeLessThan(insertIndex);
+    expect(insertIndex).toBeLessThan(afterIndex);
+  });
+
+  test("replacing an OOXML tab edits at the tab offset", () => {
+    const xml = WRAP(
+      "<w:p><w:r><w:t>Before</w:t><w:tab/><w:t>After</w:t></w:r></w:p>",
+    );
+    const edits: DocxEdit[] = [
+      {
+        kind: "replace",
+        paragraphIndex: 0,
+        charOffset: 6,
+        length: 1,
+        text: " ",
+      },
+    ];
+
+    nextId = 1;
+    const result = applyEdits(xml, edits, AUTHOR, idGen);
+    const beforeIndex = result.indexOf(">Before<");
+    const deleteIndex = result.indexOf("<w:del");
+    const insertIndex = result.indexOf("> <");
+    const afterIndex = result.indexOf(">After<");
+
+    expect(result).toContain("<w:tab/>");
+    expect(beforeIndex).toBeLessThan(deleteIndex);
+    expect(deleteIndex).toBeLessThan(insertIndex);
+    expect(insertIndex).toBeLessThan(afterIndex);
+  });
+
   test("deleting adjacent text preserves non-text run children", () => {
     const xml = WRAP(
       '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Text</w:t><w:sym w:font="Symbol" w:char="00A7"/></w:r></w:p>',

--- a/apps/api/src/handlers/docx/apply-edits.test.ts
+++ b/apps/api/src/handlers/docx/apply-edits.test.ts
@@ -260,4 +260,49 @@ describe("applyEdits", () => {
     expect(result).toContain("world");
     expect(result).not.toContain(">\nworld<");
   });
+
+  test("deleting adjacent text preserves non-text run children", () => {
+    const xml = WRAP(
+      '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Text</w:t><w:sym w:font="Symbol" w:char="00A7"/></w:r></w:p>',
+    );
+    const edits: DocxEdit[] = [
+      {
+        kind: "delete",
+        paragraphIndex: 0,
+        charOffset: 0,
+        length: 4,
+      },
+    ];
+
+    nextId = 1;
+    const result = applyEdits(xml, edits, AUTHOR, idGen);
+
+    expect(result).toContain('w:sym w:font="Symbol" w:char="00A7"');
+  });
+
+  test("inserting before later text preserves preceding non-text child order", () => {
+    const xml = WRAP(
+      '<w:p><w:r><w:sym w:font="Symbol" w:char="00A7"/><w:t>See </w:t><w:t>42</w:t></w:r></w:p>',
+    );
+    const edits: DocxEdit[] = [
+      {
+        kind: "insert",
+        paragraphIndex: 0,
+        charOffset: 4,
+        text: "section ",
+      },
+    ];
+
+    nextId = 1;
+    const result = applyEdits(xml, edits, AUTHOR, idGen);
+    const symbolIndex = result.indexOf("<w:sym");
+    const seeIndex = result.indexOf(">See <");
+    const insertIndex = result.indexOf(">section <");
+    const targetIndex = result.indexOf(">42<");
+
+    expect(symbolIndex).toBeGreaterThanOrEqual(0);
+    expect(symbolIndex).toBeLessThan(seeIndex);
+    expect(seeIndex).toBeLessThan(insertIndex);
+    expect(insertIndex).toBeLessThan(targetIndex);
+  });
 });

--- a/apps/api/src/handlers/docx/apply-edits.ts
+++ b/apps/api/src/handlers/docx/apply-edits.ts
@@ -186,17 +186,13 @@ const createDel = (
   return del;
 };
 
-/** True when a w:r still contains at least one w:t child. */
-// A run is non-empty if it still carries any rendered content. w:tab and
-// w:br count: a run holding only a tab/break must not be cleaned up as an
-// "empty shell", or deleting an adjacent w:t would silently drop the tab or
-// line break and shift every following character's offset.
+/** True when a w:r still contains content other than run properties. */
+// A run is non-empty if it still carries rendered content or structural
+// children. OOXML elements such as w:tab, w:br, w:sym, w:drawing, and
+// references must not be cleaned up as empty shells.
 const runHasContent = (run: slimdom.Element): boolean =>
   [...run.childNodes].some(
-    (c) =>
-      isElement(c) &&
-      c.namespaceURI === W_NS &&
-      (c.localName === "t" || c.localName === "tab" || c.localName === "br"),
+    (c) => isElement(c) && (c.namespaceURI !== W_NS || c.localName !== "rPr"),
   );
 
 // ── Run splitting for multi-w:t ──────────────────────────
@@ -223,15 +219,10 @@ const splitPrecedingSiblings = (
     if (child === firstAffectedTNode) {
       break;
     }
-    // Isolate preceding text AND tab/break siblings: a leading w:tab/w:br
-    // must stay before the edit fragments, or deleting the following w:t
-    // would reorder the tab/break after the inserted text.
-    if (
-      child.namespaceURI === W_NS &&
-      (child.localName === "t" ||
-        child.localName === "tab" ||
-        child.localName === "br")
-    ) {
+    // Isolate all preceding children except run properties. Otherwise
+    // references, drawings, symbols, tabs, or breaks before this text node
+    // can be reordered after the edit fragments.
+    if (child.namespaceURI !== W_NS || child.localName !== "rPr") {
       preceding.push(child);
     }
   }

--- a/apps/api/src/handlers/docx/apply-edits.ts
+++ b/apps/api/src/handlers/docx/apply-edits.ts
@@ -99,21 +99,39 @@ const createTextWrappingBreak = (doc: slimdom.Document): slimdom.Element => {
   return br;
 };
 
-const appendTextWithLineBreaks = (
+const createTab = (doc: slimdom.Document): slimdom.Element =>
+  doc.createElementNS(W_NS, "w:tab");
+
+const appendTextWithControls = (
   doc: slimdom.Document,
   run: slimdom.Element,
   text: string,
   createTextElement: (doc: slimdom.Document, text: string) => slimdom.Element,
 ) => {
-  const parts = text.split("\n");
-  for (const [index, part] of parts.entries()) {
-    if (index > 0) {
+  let buffer = "";
+  const flush = () => {
+    if (buffer.length === 0) {
+      return;
+    }
+    run.append(createTextElement(doc, buffer));
+    buffer = "";
+  };
+
+  for (const char of text) {
+    if (char === "\n") {
+      flush();
       run.append(createTextWrappingBreak(doc));
+      continue;
     }
-    if (part.length > 0) {
-      run.append(createTextElement(doc, part));
+    if (char === "\t") {
+      flush();
+      run.append(createTab(doc));
+      continue;
     }
+    buffer += char;
   }
+
+  flush();
 };
 
 const createRun = (
@@ -125,7 +143,7 @@ const createRun = (
   if (rPr) {
     r.append(rPr);
   }
-  appendTextWithLineBreaks(doc, r, text, createT);
+  appendTextWithControls(doc, r, text, createT);
   return r;
 };
 
@@ -148,7 +166,7 @@ const createDelRun = (
   if (rPr) {
     r.append(rPr);
   }
-  appendTextWithLineBreaks(doc, r, text, createDelText);
+  appendTextWithControls(doc, r, text, createDelText);
   return r;
 };
 
@@ -198,11 +216,11 @@ const runHasContent = (run: slimdom.Element): boolean =>
 // ── Run splitting for multi-w:t ──────────────────────────
 
 /**
- * When a w:r contains multiple w:t nodes and an edit targets
- * a non-first w:t, fragments inserted before the run would
- * appear before unaffected preceding text, corrupting order.
+ * When a w:r contains multiple rendered children and an edit targets
+ * a non-first child, fragments inserted before the run would appear
+ * before unaffected preceding content, corrupting order.
  *
- * This helper splits unaffected preceding w:t nodes into a
+ * This helper splits unaffected preceding children into a
  * separate run, preserving document order.
  */
 const splitPrecedingSiblings = (
@@ -314,11 +332,18 @@ const applyInsert = (
     const spanEnd = span.start + span.length;
     if (charOffset >= span.start && charOffset < spanEnd) {
       const localOffset = charOffset - span.start;
-      const fullText = span.tNode.textContent ?? "";
 
-      // Isolate preceding w:t siblings so insertions
-      // appear after them, not before.
-      splitPrecedingSiblings(doc, span.run, span.tNode, idGenerator);
+      // Isolate preceding siblings so insertions appear after them,
+      // not before.
+      splitPrecedingSiblings(doc, span.run, span.node, idGenerator);
+
+      if (span.type !== "text") {
+        const parent = span.run.parentNode ?? p;
+        parent.insertBefore(makeIns(span.run), span.run);
+        return;
+      }
+
+      const fullText = span.node.textContent ?? "";
 
       if (localOffset === 0) {
         const parent = span.run.parentNode ?? p;
@@ -345,7 +370,7 @@ const applyInsert = (
           parent.insertBefore(afterRun, span.run);
           // Remove only the affected w:t node. A multi-w:t
           // run may have siblings that must be preserved.
-          span.run.removeChild(span.tNode);
+          span.run.removeChild(span.node);
           if (!runHasContent(span.run)) {
             parent.removeChild(span.run);
           }
@@ -385,7 +410,7 @@ const applyDelete = (
       continue;
     }
     splitRuns.add(span.run);
-    splitPrecedingSiblings(doc, span.run, span.tNode, idGenerator);
+    splitPrecedingSiblings(doc, span.run, span.node, idGenerator);
   }
 
   const end = charOffset + length;
@@ -398,7 +423,22 @@ const applyDelete = (
       continue;
     }
     const spanEnd = span.start + span.length;
-    const fullText = span.tNode.textContent ?? "";
+    if (span.type !== "text") {
+      const deletedText = span.type === "break" ? "\n" : "\t";
+      const delRun = createDelRun(
+        doc,
+        deletedText,
+        cloneRunProps(span.run, idGenerator),
+      );
+      nodesToInsert.push({
+        node: createDel(doc, idGenerator(), author, [delRun]),
+        before: span.run,
+      });
+      nodesToRemove.push(span.node);
+      continue;
+    }
+
+    const fullText = span.node.textContent ?? "";
 
     const delStart = Math.max(charOffset, span.start) - span.start;
     const delEnd = Math.min(end, spanEnd) - span.start;
@@ -437,7 +477,7 @@ const applyDelete = (
     // Remove the specific w:t node, not the entire w:r.
     // A single w:r may contain multiple w:t nodes; removing
     // the run would destroy text from unaffected siblings.
-    nodesToRemove.push(span.tNode);
+    nodesToRemove.push(span.node);
   }
 
   // Apply mutations: insert fragments then remove originals.

--- a/apps/api/src/handlers/docx/apply-edits.ts
+++ b/apps/api/src/handlers/docx/apply-edits.ts
@@ -187,9 +187,16 @@ const createDel = (
 };
 
 /** True when a w:r still contains at least one w:t child. */
-const runHasText = (run: slimdom.Element): boolean =>
+// A run is non-empty if it still carries any rendered content. w:tab and
+// w:br count: a run holding only a tab/break must not be cleaned up as an
+// "empty shell", or deleting an adjacent w:t would silently drop the tab or
+// line break and shift every following character's offset.
+const runHasContent = (run: slimdom.Element): boolean =>
   [...run.childNodes].some(
-    (c) => isElement(c) && c.localName === "t" && c.namespaceURI === W_NS,
+    (c) =>
+      isElement(c) &&
+      c.namespaceURI === W_NS &&
+      (c.localName === "t" || c.localName === "tab" || c.localName === "br"),
   );
 
 // ── Run splitting for multi-w:t ──────────────────────────
@@ -216,7 +223,15 @@ const splitPrecedingSiblings = (
     if (child === firstAffectedTNode) {
       break;
     }
-    if (child.localName === "t" && child.namespaceURI === W_NS) {
+    // Isolate preceding text AND tab/break siblings: a leading w:tab/w:br
+    // must stay before the edit fragments, or deleting the following w:t
+    // would reorder the tab/break after the inserted text.
+    if (
+      child.namespaceURI === W_NS &&
+      (child.localName === "t" ||
+        child.localName === "tab" ||
+        child.localName === "br")
+    ) {
       preceding.push(child);
     }
   }
@@ -340,7 +355,7 @@ const applyInsert = (
           // Remove only the affected w:t node. A multi-w:t
           // run may have siblings that must be preserved.
           span.run.removeChild(span.tNode);
-          if (!runHasText(span.run)) {
+          if (!runHasContent(span.run)) {
             parent.removeChild(span.run);
           }
         }
@@ -464,7 +479,7 @@ const applyDelete = (
     if (!run.parentNode) {
       continue;
     }
-    if (!runHasText(run)) {
+    if (!runHasContent(run)) {
       run.parentNode.removeChild(run);
     }
   }

--- a/apps/api/src/handlers/docx/docx-edge-cases.test.ts
+++ b/apps/api/src/handlers/docx/docx-edge-cases.test.ts
@@ -38,6 +38,7 @@ const runSpanText = (span: ReturnType<typeof buildRunMap>[number]): string => {
     case "tab":
       return "\t";
   }
+  throw new Error("Unhandled run span type");
 };
 
 /** Build a minimal DOCX buffer from document body XML. */

--- a/apps/api/src/handlers/docx/docx-edge-cases.test.ts
+++ b/apps/api/src/handlers/docx/docx-edge-cases.test.ts
@@ -87,6 +87,11 @@ const extractAcceptedText = (xml: string): string[] => {
       }
       if (n.localName === "t" && n.namespaceURI === W_NS) {
         text += n.textContent ?? "";
+      } else if (n.localName === "br" && n.namespaceURI === W_NS) {
+        // Mirror collectText: a break is one "\n" in the text coordinate.
+        text += "\n";
+      } else if (n.localName === "tab" && n.namespaceURI === W_NS) {
+        text += "\t";
       } else {
         for (const c of n.childNodes) {
           walk(c);
@@ -633,11 +638,12 @@ describe("pipeline roundtrip: real OOXML patterns", () => {
 
     pipelineRoundtrip(
       bodyXml,
-      [{ index: 0, text: "Before breakAfter break" }],
+      // collectText renders the w:br as "\n"; the diff coordinate must match.
+      [{ index: 0, text: "Before break\nAfter break" }],
       [
         {
           paragraphIndex: 0,
-          newText: "Before breakAfter edit",
+          newText: "Before break\nAfter edit",
         },
       ],
     );
@@ -653,11 +659,11 @@ describe("pipeline roundtrip: real OOXML patterns", () => {
 
     pipelineRoundtrip(
       bodyXml,
-      [{ index: 0, text: "Line oneLine two" }],
+      [{ index: 0, text: "Line one\nLine two" }],
       [
         {
           paragraphIndex: 0,
-          newText: "First lineLine two",
+          newText: "First line\nLine two",
         },
       ],
     );
@@ -672,11 +678,12 @@ describe("pipeline roundtrip: real OOXML patterns", () => {
 
     pipelineRoundtrip(
       bodyXml,
-      [{ index: 0, text: "BeforeAfter tab" }],
+      // collectText renders the w:tab as "\t"; the diff coordinate must match.
+      [{ index: 0, text: "Before\tAfter tab" }],
       [
         {
           paragraphIndex: 0,
-          newText: "BeforeEdited tab",
+          newText: "Before\tEdited tab",
         },
       ],
     );
@@ -902,14 +909,16 @@ describe("pipeline roundtrip: real OOXML patterns", () => {
       [
         {
           index: 0,
-          text: "1.1 Definitions. The following terms shall have the meanings set forth below.",
+          // collectText: leading w:tab "\t", then text, a space, the w:br
+          // "\n", then the second segment.
+          text: "\t1.1 Definitions. \nThe following terms shall have the meanings set forth below.",
         },
       ],
       [
         {
           paragraphIndex: 0,
           newText:
-            "1.1 Definitions. The terms below have the following meanings.",
+            "\t1.1 Definitions. \nThe terms below have the following meanings.",
         },
       ],
     );

--- a/apps/api/src/handlers/docx/docx-edge-cases.test.ts
+++ b/apps/api/src/handlers/docx/docx-edge-cases.test.ts
@@ -29,6 +29,17 @@ const WRAP = (body: string) =>
   `<w:document xmlns:w="${W_NS}">` +
   `<w:body>${body}</w:body></w:document>`;
 
+const runSpanText = (span: ReturnType<typeof buildRunMap>[number]): string => {
+  switch (span.type) {
+    case "text":
+      return span.node.textContent ?? "";
+    case "break":
+      return "\n";
+    case "tab":
+      return "\t";
+  }
+};
+
 /** Build a minimal DOCX buffer from document body XML. */
 const buildDocx = async (bodyXml: string): Promise<Buffer> => {
   const zip = new JSZip();
@@ -415,8 +426,8 @@ describe("run-map vs extract-text consistency", () => {
       }
       const spans = buildRunMap(p);
 
-      // Concatenate all RunSpan text
-      const runMapText = spans.map((s) => s.tNode.textContent ?? "").join("");
+      // Concatenate all RunSpan text/control characters.
+      const runMapText = spans.map(runSpanText).join("");
 
       // Extract text the same way extractText does
       const extractedText = collectTextFromParagraph(p);
@@ -441,6 +452,10 @@ describe("run-map vs extract-text consistency", () => {
       }
       if (node.localName === "t" && node.namespaceURI === W_NS) {
         text += node.textContent ?? "";
+      } else if (node.localName === "br" && node.namespaceURI === W_NS) {
+        text += "\n";
+      } else if (node.localName === "tab" && node.namespaceURI === W_NS) {
+        text += "\t";
       } else if (
         node.localName !== "delText" &&
         node.localName !== "del" &&

--- a/apps/api/src/handlers/docx/docx-properties.test.ts
+++ b/apps/api/src/handlers/docx/docx-properties.test.ts
@@ -77,6 +77,10 @@ const extractAcceptedText = (xml: string): string[] => {
         }
         return;
       }
+      if (n.localName === "tab" && n.namespaceURI === W_NS) {
+        text += "\t";
+        return;
+      }
       if (n.localName === "t" && n.namespaceURI === W_NS) {
         text += n.textContent ?? "";
         return;
@@ -442,7 +446,10 @@ describe("property: run map coverage", () => {
         }
 
         // Total length matches text (length > 0 asserted above)
-        const totalLen = spans.reduce((sum, s) => sum + s.length, 0);
+        let totalLen = 0;
+        for (const span of spans) {
+          totalLen += span.length;
+        }
         expect(totalLen).toBe(text.length);
       }),
       { numRuns: 200 },

--- a/apps/api/src/handlers/docx/ooxml-edge-cases.test.ts
+++ b/apps/api/src/handlers/docx/ooxml-edge-cases.test.ts
@@ -42,6 +42,17 @@ const firstParagraph = (xml: string): slimdom.Element => {
   return p;
 };
 
+const runSpanText = (span: ReturnType<typeof buildRunMap>[number]): string => {
+  switch (span.type) {
+    case "text":
+      return span.node.textContent ?? "";
+    case "break":
+      return "\n";
+    case "tab":
+      return "\t";
+  }
+};
+
 /** Extract "accepted" text from paragraphs in edited XML. */
 const extractAcceptedText = (xml: string): string[] => {
   const doc = slimdom.parseXmlDocument(xml);
@@ -99,7 +110,7 @@ describe("edge case: runs inside w:hyperlink", () => {
   test("buildRunMap includes text inside w:hyperlink", () => {
     const p = firstParagraph(HYPERLINK_XML);
     const spans = buildRunMap(p);
-    const fullText = spans.map((s) => s.tNode.textContent).join("");
+    const fullText = spans.map(runSpanText).join("");
     expect(fullText).toBe("Click here to continue");
   });
 
@@ -139,7 +150,7 @@ describe("edge case: runs inside w:sdt", () => {
   test("buildRunMap includes text inside w:sdt", () => {
     const p = firstParagraph(SDT_XML);
     const spans = buildRunMap(p);
-    const fullText = spans.map((s) => s.tNode.textContent).join("");
+    const fullText = spans.map(runSpanText).join("");
     expect(fullText).toBe("Name: John Doe");
   });
 });
@@ -160,7 +171,7 @@ describe("edge case: runs inside w:fldSimple", () => {
   test("buildRunMap includes text inside w:fldSimple", () => {
     const p = firstParagraph(FLD_XML);
     const spans = buildRunMap(p);
-    const fullText = spans.map((s) => s.tNode.textContent).join("");
+    const fullText = spans.map(runSpanText).join("");
     expect(fullText).toBe("See Section 1 for details");
   });
 });
@@ -184,7 +195,7 @@ describe("edge case: move revisions (w:moveFrom / w:moveTo)", () => {
   test("buildRunMap skips w:moveFrom (like w:del)", () => {
     const p = firstParagraph(MOVE_XML);
     const spans = buildRunMap(p);
-    const fullText = spans.map((s) => s.tNode.textContent).join("");
+    const fullText = spans.map(runSpanText).join("");
     // Accepted view: moveFrom excluded, moveTo included
     expect(fullText).toBe("Start moved here end");
   });
@@ -351,7 +362,7 @@ describe("edge case: runs inside w:smartTag", () => {
   test("buildRunMap includes text inside w:smartTag", () => {
     const p = firstParagraph(SMART_TAG_XML);
     const spans = buildRunMap(p);
-    const fullText = spans.map((s) => s.tNode.textContent).join("");
+    const fullText = spans.map(runSpanText).join("");
     expect(fullText).toBe("Date: January 1, 2026");
   });
 });
@@ -375,7 +386,7 @@ describe("edge case: complex field codes (w:fldChar)", () => {
   test("buildRunMap includes field result text but not instrText", () => {
     const p = firstParagraph(FIELD_XML);
     const spans = buildRunMap(p);
-    const fullText = spans.map((s) => s.tNode.textContent).join("");
+    const fullText = spans.map(runSpanText).join("");
     // instrText should NOT appear in the map; field result ("3") should
     expect(fullText).toBe("Page 3 of 10");
   });

--- a/apps/api/src/handlers/docx/ooxml-edge-cases.test.ts
+++ b/apps/api/src/handlers/docx/ooxml-edge-cases.test.ts
@@ -51,6 +51,7 @@ const runSpanText = (span: ReturnType<typeof buildRunMap>[number]): string => {
     case "tab":
       return "\t";
   }
+  throw new Error("Unhandled run span type");
 };
 
 /** Extract "accepted" text from paragraphs in edited XML. */

--- a/apps/api/src/handlers/docx/rich-patch.test.ts
+++ b/apps/api/src/handlers/docx/rich-patch.test.ts
@@ -188,4 +188,26 @@ describe("owned OOXML placeholder patching", () => {
     expect(result.xml).toContain("First paragraph");
     expect(result.xml).toContain("Second paragraph");
   });
+
+  // A substituted value that itself looks like a marker must NOT be
+  // re-expanded against the value map, or one field could pull another
+  // field's value into a place the author never intended (injection).
+  test("does not re-expand a substituted value that looks like a marker (text)", () => {
+    const result = replacePlaceholdersInText("Pay {{a}}", {
+      a: "{{b}}",
+      b: "SECRET",
+    });
+
+    expect(result.text).toBe("Pay {{b}}");
+    expect(result.text).not.toContain("SECRET");
+  });
+
+  test("does not re-expand a marker-shaped value across the XML part", () => {
+    const xml = WRAP("<w:p><w:r><w:t>{{a}}</w:t></w:r></w:p>");
+
+    const result = patchXmlPart(xml, { a: "{{b}}", b: "SECRET" });
+
+    expect(result.xml).toContain("{{b}}");
+    expect(result.xml).not.toContain("SECRET");
+  });
 });

--- a/apps/api/src/handlers/docx/run-map.test.ts
+++ b/apps/api/src/handlers/docx/run-map.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import * as slimdom from "slimdom";
+
+import { buildRunMap } from "./run-map";
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+const parseParagraph = (inner: string): slimdom.Element => {
+  const doc = slimdom.parseXmlDocument(`<w:p xmlns:w="${W_NS}">${inner}</w:p>`);
+  const p = doc.documentElement;
+  if (!p) {
+    throw new Error("no paragraph element");
+  }
+  return p;
+};
+
+const offsets = (p: slimdom.Element) =>
+  buildRunMap(p).map((s) => [s.start, s.length] as const);
+
+describe("buildRunMap offset alignment with collectText", () => {
+  test("a leading tab occupies one offset so following text is not skewed", () => {
+    // collectText renders this as "\tHeading"; "Heading" must start at 1.
+    const p = parseParagraph("<w:r><w:tab/><w:t>Heading</w:t></w:r>");
+    expect(offsets(p)).toEqual([[1, 7]]);
+  });
+
+  test("a line break between runs occupies one offset", () => {
+    // collectText renders this as "A\nB"; "B" must start at 2.
+    const p = parseParagraph("<w:r><w:t>A</w:t><w:br/><w:t>B</w:t></w:r>");
+    expect(offsets(p)).toEqual([
+      [0, 1],
+      [2, 1],
+    ]);
+  });
+
+  test("plain text without tabs or breaks stays contiguous from 0", () => {
+    const p = parseParagraph(
+      "<w:r><w:t>ab</w:t></w:r><w:r><w:t>cd</w:t></w:r>",
+    );
+    expect(offsets(p)).toEqual([
+      [0, 2],
+      [2, 2],
+    ]);
+  });
+
+  test("tabs and breaks accumulate across multiple runs", () => {
+    // collectText: "\t1.1\tHeading" -> indices: tab(0) "1.1"(1-3) tab(4) "Heading"(5-11)
+    const p = parseParagraph(
+      "<w:r><w:tab/><w:t>1.1</w:t><w:tab/><w:t>Heading</w:t></w:r>",
+    );
+    expect(offsets(p)).toEqual([
+      [1, 3],
+      [5, 7],
+    ]);
+  });
+
+  test("deleted content is skipped and does not consume offsets", () => {
+    const p = parseParagraph(
+      "<w:del><w:r><w:delText>X</w:delText></w:r></w:del>" +
+        "<w:r><w:t>Y</w:t></w:r>",
+    );
+    expect(offsets(p)).toEqual([[0, 1]]);
+  });
+});

--- a/apps/api/src/handlers/docx/run-map.test.ts
+++ b/apps/api/src/handlers/docx/run-map.test.ts
@@ -15,7 +15,12 @@ const parseParagraph = (inner: string): slimdom.Element => {
 };
 
 const offsets = (p: slimdom.Element) =>
-  buildRunMap(p).map((s) => [s.start, s.length] as const);
+  buildRunMap(p)
+    .filter((s) => s.type === "text")
+    .map((s) => [s.start, s.length] as const);
+
+const spans = (p: slimdom.Element) =>
+  buildRunMap(p).map((s) => [s.type, s.start, s.length] as const);
 
 describe("buildRunMap offset alignment with collectText", () => {
   test("a leading tab occupies one offset so following text is not skewed", () => {
@@ -30,6 +35,18 @@ describe("buildRunMap offset alignment with collectText", () => {
     expect(offsets(p)).toEqual([
       [0, 1],
       [2, 1],
+    ]);
+  });
+
+  test("tabs and breaks are addressable spans", () => {
+    const p = parseParagraph(
+      "<w:r><w:t>A</w:t><w:br/><w:tab/><w:t>B</w:t></w:r>",
+    );
+    expect(spans(p)).toEqual([
+      ["text", 0, 1],
+      ["break", 1, 1],
+      ["tab", 2, 1],
+      ["text", 3, 1],
     ]);
   });
 

--- a/apps/api/src/handlers/docx/run-map.ts
+++ b/apps/api/src/handlers/docx/run-map.ts
@@ -9,12 +9,23 @@ import type * as slimdom from "slimdom";
 
 import { isElement, W_NS } from "./ooxml";
 
-export type RunSpan = {
+type TextRunSpan = {
+  type: "text";
   run: slimdom.Element;
-  tNode: slimdom.Element;
+  node: slimdom.Element;
   start: number;
   length: number;
 };
+
+type ControlRunSpan = {
+  type: "break" | "tab";
+  run: slimdom.Element;
+  node: slimdom.Element;
+  start: number;
+  length: 1;
+};
+
+export type RunSpan = TextRunSpan | ControlRunSpan;
 
 /** Build a character-offset map for a single `w:p` element. */
 export const buildRunMap = (p: slimdom.Element): RunSpan[] => {
@@ -64,8 +75,9 @@ export const buildRunMap = (p: slimdom.Element): RunSpan[] => {
             const text = rc.textContent ?? "";
             if (text.length > 0) {
               spans.push({
+                type: "text",
                 run: child,
-                tNode: rc,
+                node: rc,
                 start: offset,
                 length: text.length,
               });
@@ -77,8 +89,15 @@ export const buildRunMap = (p: slimdom.Element): RunSpan[] => {
           ) {
             // collectText (the coordinate system edit/comment offsets are
             // computed against) counts a tab as "\t" and a break as "\n".
-            // Advance the offset by one so text after a tab/break maps to
-            // the correct run span instead of being skewed left.
+            // Keep a real span so edits that target the control character
+            // can delete or replace it instead of falling through.
+            spans.push({
+              type: rc.localName === "tab" ? "tab" : "break",
+              run: child,
+              node: rc,
+              start: offset,
+              length: 1,
+            });
             offset += 1;
           }
         }

--- a/apps/api/src/handlers/docx/run-map.ts
+++ b/apps/api/src/handlers/docx/run-map.ts
@@ -71,6 +71,15 @@ export const buildRunMap = (p: slimdom.Element): RunSpan[] => {
               });
               offset += text.length;
             }
+          } else if (
+            rc.namespaceURI === W_NS &&
+            (rc.localName === "tab" || rc.localName === "br")
+          ) {
+            // collectText (the coordinate system edit/comment offsets are
+            // computed against) counts a tab as "\t" and a break as "\n".
+            // Advance the offset by one so text after a tab/break maps to
+            // the correct run span instead of being skewed left.
+            offset += 1;
           }
         }
       }

--- a/apps/api/src/handlers/files/utils.test.ts
+++ b/apps/api/src/handlers/files/utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { getFileExtension, resolveUploadMime } from "./utils";
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  createFileKey,
+  createUserFileKey,
+  getFileExtension,
+  resolveUploadMime,
+} from "./utils";
 
 describe("resolveUploadMime", () => {
   test("recovers .msg reported as octet-stream", () => {
@@ -58,5 +65,40 @@ describe("resolveUploadMime", () => {
 describe("getFileExtension", () => {
   test("keeps text/markdown on the legacy fallback storage extension", () => {
     expect(getFileExtension("text/markdown")).toBe("bin");
+  });
+});
+
+describe("S3 object-key tenant scoping", () => {
+  test("createFileKey is prefixed by organization then workspace", () => {
+    const key = createFileKey({
+      organizationId: toSafeId<"organization">("org_1"),
+      workspaceId: toSafeId<"workspace">("ws_1"),
+      fileId: "file_1",
+      mimeType: "text/markdown",
+    });
+    expect(key).toBe("org_1/ws_1/file_1.bin");
+    // The tenant prefix is the durable isolation boundary; it must lead.
+    expect(key.startsWith("org_1/ws_1/")).toBe(true);
+  });
+
+  test("createUserFileKey is prefixed by the owning user", () => {
+    const key = createUserFileKey({
+      userId: toSafeId<"user">("user_1"),
+      fileId: "file_1",
+      mimeType: "text/markdown",
+    });
+    expect(key).toBe("user_1/file_1.bin");
+    expect(key.startsWith("user_1/")).toBe(true);
+  });
+
+  test("keys contain no path-traversal segments for branded ids", () => {
+    const key = createFileKey({
+      organizationId: toSafeId<"organization">("org_1"),
+      workspaceId: toSafeId<"workspace">("ws_1"),
+      fileId: "file_1",
+      mimeType: "application/pdf",
+    });
+    expect(key).not.toContain("..");
+    expect(key.split("/")).toHaveLength(3);
   });
 });

--- a/apps/api/src/handlers/invoices/add-entries.test.ts
+++ b/apps/api/src/handlers/invoices/add-entries.test.ts
@@ -1,7 +1,11 @@
 import { Result } from "better-result";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { BILLING_STATUS, INVOICE_STATUS } from "@/api/db/schema";
+import {
+  BILLING_STATUS,
+  INVOICE_STATUS,
+  invoices,
+} from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
@@ -75,6 +79,13 @@ describe("addEntries currency enforcement", () => {
 
   test("returns a retryable conflict when a claim count changes", async () => {
     let auditCalls = 0;
+    const lockInvoiceForUpdate = mock(async () => [
+      {
+        id: toSafeId<"invoice">("inv_test"),
+        totalAmount: 0,
+        currency: "USD",
+      },
+    ]);
     const { safeDb } = createScopedDbMock({
       query: {
         invoices: {
@@ -87,17 +98,29 @@ describe("addEntries currency enforcement", () => {
         },
       },
       select: () => ({
-        from: () => ({
-          where: async () => [
-            {
-              id: toSafeId<"timeEntry">("te_1"),
-              status: BILLING_STATUS.APPROVED,
-              billable: true,
-              invoiceId: null,
-              currency: "USD",
-            },
-          ],
-        }),
+        from: (table: unknown) => {
+          if (table === invoices) {
+            return {
+              where: () => ({
+                limit: () => ({
+                  for: lockInvoiceForUpdate,
+                }),
+              }),
+            };
+          }
+
+          return {
+            where: async () => [
+              {
+                id: toSafeId<"timeEntry">("te_1"),
+                status: BILLING_STATUS.APPROVED,
+                billable: true,
+                invoiceId: null,
+                currency: "USD",
+              },
+            ],
+          };
+        },
       }),
       update: () => ({
         set: () => ({
@@ -131,5 +154,6 @@ describe("addEntries currency enforcement", () => {
       },
     });
     expect(auditCalls).toBe(0);
+    expect(lockInvoiceForUpdate).toHaveBeenCalledWith("update");
   });
 });

--- a/apps/api/src/handlers/invoices/add-entries.test.ts
+++ b/apps/api/src/handlers/invoices/add-entries.test.ts
@@ -1,0 +1,75 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { BILLING_STATUS, INVOICE_STATUS } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import addEntries from "./add-entries";
+
+type AddEntriesCtx = Parameters<typeof addEntries.handler>[0];
+
+const createContext = (
+  body: AddEntriesCtx["body"],
+  safeDb: AddEntriesCtx["safeDb"],
+): AddEntriesCtx => {
+  const { scopedDb } = createScopedDbMock({});
+  return asTestRaw<AddEntriesCtx>({
+    body,
+    safeDb,
+    scopedDb,
+    params: {
+      workspaceId: toSafeId<"workspace">("ws_test"),
+      invoiceId: toSafeId<"invoice">("inv_test"),
+    },
+    workspaceId: toSafeId<"workspace">("ws_test"),
+    memberRole: { role: "owner" },
+    session: { activeOrganizationId: toSafeId<"organization">("org_test") },
+    user: { id: toSafeId<"user">("user_test") },
+    recordAuditEvent: async () => {},
+  });
+};
+
+describe("addEntries currency enforcement", () => {
+  test("rejects a time entry whose currency differs from the invoice", async () => {
+    let call = 0;
+    const safeDb: AddEntriesCtx["safeDb"] = asTestRaw<AddEntriesCtx["safeDb"]>(
+      async () => {
+        call += 1;
+        if (call === 1) {
+          return Result.ok({
+            id: toSafeId<"invoice">("inv_test"),
+            status: INVOICE_STATUS.DRAFT,
+            currency: "USD",
+          });
+        }
+        return Result.ok([
+          {
+            id: toSafeId<"timeEntry">("te_1"),
+            status: BILLING_STATUS.APPROVED,
+            billable: true,
+            invoiceId: null,
+            currency: "EUR",
+          },
+        ]);
+      },
+    );
+
+    const result = await addEntries.handler(
+      createContext(
+        asTestRaw<AddEntriesCtx["body"]>({
+          timeEntryIds: [toSafeId<"timeEntry">("te_1")],
+        }),
+        safeDb,
+      ),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: {
+        message: "All time entries must match the invoice currency",
+      },
+    });
+  });
+});

--- a/apps/api/src/handlers/invoices/add-entries.test.ts
+++ b/apps/api/src/handlers/invoices/add-entries.test.ts
@@ -72,4 +72,64 @@ describe("addEntries currency enforcement", () => {
       },
     });
   });
+
+  test("returns a retryable conflict when a claim count changes", async () => {
+    let auditCalls = 0;
+    const { safeDb } = createScopedDbMock({
+      query: {
+        invoices: {
+          findFirst: async () => ({
+            id: toSafeId<"invoice">("inv_test"),
+            status: INVOICE_STATUS.DRAFT,
+            currency: "USD",
+            totalAmount: 0,
+          }),
+        },
+      },
+      select: () => ({
+        from: () => ({
+          where: async () => [
+            {
+              id: toSafeId<"timeEntry">("te_1"),
+              status: BILLING_STATUS.APPROVED,
+              billable: true,
+              invoiceId: null,
+              currency: "USD",
+            },
+          ],
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: async () => [],
+          }),
+        }),
+      }),
+    });
+
+    const ctx = createContext(
+      asTestRaw<AddEntriesCtx["body"]>({
+        timeEntryIds: [toSafeId<"timeEntry">("te_1")],
+      }),
+      safeDb,
+    );
+
+    const result = await addEntries.handler(
+      asTestRaw<AddEntriesCtx>({
+        ...ctx,
+        recordAuditEvent: async () => {
+          auditCalls += 1;
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 409,
+      response: {
+        message: "Some entries were modified concurrently; please retry",
+      },
+    });
+    expect(auditCalls).toBe(0);
+  });
 });

--- a/apps/api/src/handlers/invoices/add-entries.test.ts
+++ b/apps/api/src/handlers/invoices/add-entries.test.ts
@@ -1,11 +1,7 @@
 import { Result } from "better-result";
 import { describe, expect, mock, test } from "bun:test";
 
-import {
-  BILLING_STATUS,
-  INVOICE_STATUS,
-  invoices,
-} from "@/api/db/schema";
+import { BILLING_STATUS, INVOICE_STATUS, invoices } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";

--- a/apps/api/src/handlers/invoices/add-entries.ts
+++ b/apps/api/src/handlers/invoices/add-entries.ts
@@ -19,6 +19,12 @@ import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { cents } from "@/api/lib/money";
 
+import {
+  INVOICE_ENTRIES_MODIFIED_MESSAGE,
+  InvoiceEntriesModifiedConcurrentlyError,
+  isInvoiceEntriesModifiedConcurrentlyError,
+} from "./concurrent-modification";
+
 const addEntriesBodySchema = t.Object({
   timeEntryIds: t.Optional(
     t.Array(tSafeId("timeEntry"), { minItems: 1, maxItems: 500 }),
@@ -252,150 +258,160 @@ const addEntries = createSafeHandler(
       }
     }
 
-    const txResult = yield* Result.await(
-      safeDb(async (tx) => {
-        const invoiceCheck = await tx.query.invoices.findFirst({
-          where: {
-            id: { eq: params.invoiceId },
-            workspaceId: { eq: workspaceId },
-            status: { eq: INVOICE_STATUS.DRAFT },
-          },
-          columns: { id: true, totalAmount: true, currency: true },
-        });
-        if (!invoiceCheck) {
-          return { ok: false as const };
-        }
+    const txResult = await safeDb(async (tx) => {
+      const invoiceCheck = await tx.query.invoices.findFirst({
+        where: {
+          id: { eq: params.invoiceId },
+          workspaceId: { eq: workspaceId },
+          status: { eq: INVOICE_STATUS.DRAFT },
+        },
+        columns: { id: true, totalAmount: true, currency: true },
+      });
+      if (!invoiceCheck) {
+        return { ok: false as const };
+      }
 
-        let attachedTimeEntries: { id: SafeId<"timeEntry"> }[] = [];
-        if (timeEntryIds && timeEntryIds.length > 0) {
-          attachedTimeEntries = await tx
-            .update(timeEntries)
-            .set({
-              invoiceId: params.invoiceId,
-              status: BILLING_STATUS.BILLED,
-              updatedAt: now,
-            })
-            .where(
-              and(
-                eq(timeEntries.workspaceId, workspaceId),
-                inArray(timeEntries.id, timeEntryIds),
-                eq(timeEntries.status, BILLING_STATUS.APPROVED),
-                eq(timeEntries.billable, true),
-                isNull(timeEntries.invoiceId),
-                // Re-check currency under the claim so a concurrent edit
-                // cannot attach a mismatched-currency entry (count mismatch
-                // then trips the concurrent-modification retry path).
-                eq(timeEntries.currency, invoiceCheck.currency),
-              ),
-            )
-            .returning({ id: timeEntries.id });
-
-          if (attachedTimeEntries.length !== timeEntryIds.length) {
-            return { ok: false as const };
-          }
-        }
-
-        let attachedExpenses: { id: SafeId<"expense"> }[] = [];
-        if (expenseIds && expenseIds.length > 0) {
-          attachedExpenses = await tx
-            .update(expenses)
-            .set({
-              invoiceId: params.invoiceId,
-              status: BILLING_STATUS.BILLED,
-              updatedAt: now,
-            })
-            .where(
-              and(
-                eq(expenses.workspaceId, workspaceId),
-                inArray(expenses.id, expenseIds),
-                eq(expenses.status, BILLING_STATUS.APPROVED),
-                eq(expenses.billable, true),
-                isNull(expenses.invoiceId),
-                eq(expenses.currency, invoiceCheck.currency),
-              ),
-            )
-            .returning({ id: expenses.id });
-
-          if (attachedExpenses.length !== expenseIds.length) {
-            return { ok: false as const };
-          }
-        }
-
-        const allTimeEntries = await tx
-          .select({
-            billedMinutes: timeEntries.billedMinutes,
-            rateAtEntry: timeEntries.rateAtEntry,
-          })
-          .from(timeEntries)
-          .where(
-            and(
-              eq(timeEntries.invoiceId, params.invoiceId),
-              eq(timeEntries.workspaceId, workspaceId),
-            ),
-          );
-
-        const allExpenses = await tx
-          .select({
-            amount: expenses.amount,
-            markup: expenses.markup,
-          })
-          .from(expenses)
-          .where(
-            and(
-              eq(expenses.invoiceId, params.invoiceId),
-              eq(expenses.workspaceId, workspaceId),
-            ),
-          );
-
-        let totalAmount = 0;
-        for (const entry of allTimeEntries) {
-          totalAmount += prorateHourlyCents({
-            billedMinutes: entry.billedMinutes,
-            hourlyRateCents: entry.rateAtEntry,
-          });
-        }
-        for (const expense of allExpenses) {
-          totalAmount += applyMarkupCents({
-            amountCents: expense.amount,
-            markupPercent: expense.markup,
-          });
-        }
-
-        await tx
-          .update(invoices)
-          .set({ totalAmount: cents(totalAmount), updatedAt: now })
-          .where(
-            and(
-              eq(invoices.id, params.invoiceId),
-              eq(invoices.workspaceId, workspaceId),
-            ),
-          );
-
-        await recordAuditEvent(
-          tx,
-          buildAttachEvents({
+      let attachedTimeEntries: { id: SafeId<"timeEntry"> }[] = [];
+      if (timeEntryIds && timeEntryIds.length > 0) {
+        attachedTimeEntries = await tx
+          .update(timeEntries)
+          .set({
             invoiceId: params.invoiceId,
-            attachedTimeEntries,
-            attachedExpenses,
-            oldTotalAmount: invoiceCheck.totalAmount,
-            totalAmount,
-          }),
+            status: BILLING_STATUS.BILLED,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(timeEntries.workspaceId, workspaceId),
+              inArray(timeEntries.id, timeEntryIds),
+              eq(timeEntries.status, BILLING_STATUS.APPROVED),
+              eq(timeEntries.billable, true),
+              isNull(timeEntries.invoiceId),
+              // Re-check currency under the claim so a concurrent edit
+              // cannot attach a mismatched-currency entry (count mismatch
+              // then trips the concurrent-modification retry path).
+              eq(timeEntries.currency, invoiceCheck.currency),
+            ),
+          )
+          .returning({ id: timeEntries.id });
+
+        if (attachedTimeEntries.length !== timeEntryIds.length) {
+          throw new InvoiceEntriesModifiedConcurrentlyError();
+        }
+      }
+
+      let attachedExpenses: { id: SafeId<"expense"> }[] = [];
+      if (expenseIds && expenseIds.length > 0) {
+        attachedExpenses = await tx
+          .update(expenses)
+          .set({
+            invoiceId: params.invoiceId,
+            status: BILLING_STATUS.BILLED,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(expenses.workspaceId, workspaceId),
+              inArray(expenses.id, expenseIds),
+              eq(expenses.status, BILLING_STATUS.APPROVED),
+              eq(expenses.billable, true),
+              isNull(expenses.invoiceId),
+              eq(expenses.currency, invoiceCheck.currency),
+            ),
+          )
+          .returning({ id: expenses.id });
+
+        if (attachedExpenses.length !== expenseIds.length) {
+          throw new InvoiceEntriesModifiedConcurrentlyError();
+        }
+      }
+
+      const allTimeEntries = await tx
+        .select({
+          billedMinutes: timeEntries.billedMinutes,
+          rateAtEntry: timeEntries.rateAtEntry,
+        })
+        .from(timeEntries)
+        .where(
+          and(
+            eq(timeEntries.invoiceId, params.invoiceId),
+            eq(timeEntries.workspaceId, workspaceId),
+          ),
         );
 
-        return { ok: true as const, totalAmount };
-      }),
-    );
+      const allExpenses = await tx
+        .select({
+          amount: expenses.amount,
+          markup: expenses.markup,
+        })
+        .from(expenses)
+        .where(
+          and(
+            eq(expenses.invoiceId, params.invoiceId),
+            eq(expenses.workspaceId, workspaceId),
+          ),
+        );
 
-    if (!txResult.ok) {
+      let totalAmount = 0;
+      for (const entry of allTimeEntries) {
+        totalAmount += prorateHourlyCents({
+          billedMinutes: entry.billedMinutes,
+          hourlyRateCents: entry.rateAtEntry,
+        });
+      }
+      for (const expense of allExpenses) {
+        totalAmount += applyMarkupCents({
+          amountCents: expense.amount,
+          markupPercent: expense.markup,
+        });
+      }
+
+      await tx
+        .update(invoices)
+        .set({ totalAmount: cents(totalAmount), updatedAt: now })
+        .where(
+          and(
+            eq(invoices.id, params.invoiceId),
+            eq(invoices.workspaceId, workspaceId),
+          ),
+        );
+
+      await recordAuditEvent(
+        tx,
+        buildAttachEvents({
+          invoiceId: params.invoiceId,
+          attachedTimeEntries,
+          attachedExpenses,
+          oldTotalAmount: invoiceCheck.totalAmount,
+          totalAmount,
+        }),
+      );
+
+      return { ok: true as const, totalAmount };
+    });
+
+    if (Result.isError(txResult)) {
+      if (isInvoiceEntriesModifiedConcurrentlyError(txResult.error)) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: INVOICE_ENTRIES_MODIFIED_MESSAGE,
+          }),
+        );
+      }
+      return Result.err(txResult.error);
+    }
+
+    if (!txResult.value.ok) {
       return Result.err(
         new HandlerError({
           status: 409,
-          message: "Some entries were modified concurrently; please retry",
+          message: INVOICE_ENTRIES_MODIFIED_MESSAGE,
         }),
       );
     }
 
-    return Result.ok({ totalAmount: txResult.totalAmount });
+    return Result.ok({ totalAmount: txResult.value.totalAmount });
   },
 );
 

--- a/apps/api/src/handlers/invoices/add-entries.ts
+++ b/apps/api/src/handlers/invoices/add-entries.ts
@@ -114,7 +114,7 @@ const addEntries = createSafeHandler(
             id: { eq: params.invoiceId },
             workspaceId: { eq: workspaceId },
           },
-          columns: { id: true, status: true },
+          columns: { id: true, status: true, currency: true },
         }),
       ),
     );
@@ -144,6 +144,7 @@ const addEntries = createSafeHandler(
               status: timeEntries.status,
               billable: timeEntries.billable,
               invoiceId: timeEntries.invoiceId,
+              currency: timeEntries.currency,
             })
             .from(timeEntries)
             .where(
@@ -180,6 +181,15 @@ const addEntries = createSafeHandler(
           }),
         );
       }
+
+      if (entries.some((entry) => entry.currency !== invoice.currency)) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "All time entries must match the invoice currency",
+          }),
+        );
+      }
     }
 
     const expenseIds = body.expenseIds;
@@ -192,6 +202,7 @@ const addEntries = createSafeHandler(
               status: expenses.status,
               billable: expenses.billable,
               invoiceId: expenses.invoiceId,
+              currency: expenses.currency,
             })
             .from(expenses)
             .where(
@@ -225,6 +236,17 @@ const addEntries = createSafeHandler(
             message:
               "All expenses must be approved, billable," +
               " and not already on an invoice",
+          }),
+        );
+      }
+
+      if (
+        expenseRows.some((expense) => expense.currency !== invoice.currency)
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "All expenses must match the invoice currency",
           }),
         );
       }

--- a/apps/api/src/handlers/invoices/add-entries.ts
+++ b/apps/api/src/handlers/invoices/add-entries.ts
@@ -260,7 +260,7 @@ const addEntries = createSafeHandler(
             workspaceId: { eq: workspaceId },
             status: { eq: INVOICE_STATUS.DRAFT },
           },
-          columns: { id: true, totalAmount: true },
+          columns: { id: true, totalAmount: true, currency: true },
         });
         if (!invoiceCheck) {
           return { ok: false as const };
@@ -285,7 +285,7 @@ const addEntries = createSafeHandler(
                 // Re-check currency under the claim so a concurrent edit
                 // cannot attach a mismatched-currency entry (count mismatch
                 // then trips the concurrent-modification retry path).
-                eq(timeEntries.currency, invoice.currency),
+                eq(timeEntries.currency, invoiceCheck.currency),
               ),
             )
             .returning({ id: timeEntries.id });
@@ -311,7 +311,7 @@ const addEntries = createSafeHandler(
                 eq(expenses.status, BILLING_STATUS.APPROVED),
                 eq(expenses.billable, true),
                 isNull(expenses.invoiceId),
-                eq(expenses.currency, invoice.currency),
+                eq(expenses.currency, invoiceCheck.currency),
               ),
             )
             .returning({ id: expenses.id });

--- a/apps/api/src/handlers/invoices/add-entries.ts
+++ b/apps/api/src/handlers/invoices/add-entries.ts
@@ -259,14 +259,23 @@ const addEntries = createSafeHandler(
     }
 
     const txResult = await safeDb(async (tx) => {
-      const invoiceCheck = await tx.query.invoices.findFirst({
-        where: {
-          id: { eq: params.invoiceId },
-          workspaceId: { eq: workspaceId },
-          status: { eq: INVOICE_STATUS.DRAFT },
-        },
-        columns: { id: true, totalAmount: true, currency: true },
-      });
+      const invoiceRows = await tx
+        .select({
+          id: invoices.id,
+          totalAmount: invoices.totalAmount,
+          currency: invoices.currency,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.id, params.invoiceId),
+            eq(invoices.workspaceId, workspaceId),
+            eq(invoices.status, INVOICE_STATUS.DRAFT),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      const invoiceCheck = invoiceRows.at(0);
       if (!invoiceCheck) {
         return { ok: false as const };
       }

--- a/apps/api/src/handlers/invoices/add-entries.ts
+++ b/apps/api/src/handlers/invoices/add-entries.ts
@@ -282,6 +282,10 @@ const addEntries = createSafeHandler(
                 eq(timeEntries.status, BILLING_STATUS.APPROVED),
                 eq(timeEntries.billable, true),
                 isNull(timeEntries.invoiceId),
+                // Re-check currency under the claim so a concurrent edit
+                // cannot attach a mismatched-currency entry (count mismatch
+                // then trips the concurrent-modification retry path).
+                eq(timeEntries.currency, invoice.currency),
               ),
             )
             .returning({ id: timeEntries.id });
@@ -307,6 +311,7 @@ const addEntries = createSafeHandler(
                 eq(expenses.status, BILLING_STATUS.APPROVED),
                 eq(expenses.billable, true),
                 isNull(expenses.invoiceId),
+                eq(expenses.currency, invoice.currency),
               ),
             )
             .returning({ id: expenses.id });

--- a/apps/api/src/handlers/invoices/concurrent-modification.ts
+++ b/apps/api/src/handlers/invoices/concurrent-modification.ts
@@ -1,0 +1,25 @@
+export const INVOICE_ENTRIES_MODIFIED_MESSAGE =
+  "Some entries were modified concurrently; please retry";
+
+export class InvoiceEntriesModifiedConcurrentlyError extends Error {
+  constructor() {
+    super(INVOICE_ENTRIES_MODIFIED_MESSAGE);
+    this.name = "InvoiceEntriesModifiedConcurrentlyError";
+  }
+}
+
+export const isInvoiceEntriesModifiedConcurrentlyError = (
+  error: unknown,
+): boolean => {
+  let current: unknown = error;
+  for (let depth = 0; depth < 4; depth++) {
+    if (current instanceof InvoiceEntriesModifiedConcurrentlyError) {
+      return true;
+    }
+    if (!(current instanceof Error)) {
+      return false;
+    }
+    current = current.cause;
+  }
+  return false;
+};

--- a/apps/api/src/handlers/invoices/create.test.ts
+++ b/apps/api/src/handlers/invoices/create.test.ts
@@ -19,6 +19,7 @@ const entry = (id: string, currency: string) => ({
   status: BILLING_STATUS.APPROVED,
   billable: true,
   currency,
+  invoiceId: null,
 });
 
 const createContext = ({
@@ -114,6 +115,36 @@ describe("createInvoice", () => {
     expect(result).toEqual({
       code: 409,
       response: { message: "An invoice with this number already exists" },
+    });
+  });
+
+  test("rejects entries that are already attached to another invoice", async () => {
+    const entries = [
+      {
+        ...entry("te_1", "USD"),
+        invoiceId: toSafeId<"invoice">("inv_existing"),
+      },
+    ];
+    const { safeDb, scopedDb } = createScopedDbMock({
+      $count: async () => 0,
+      select: () => ({ from: () => ({ where: async () => entries }) }),
+    });
+
+    const result = await createInvoice.handler(
+      createContext({
+        body: baseBody("USD", ["te_1"]),
+        safeDb,
+        scopedDb,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: {
+        message:
+          "All entries must be approved, billable," +
+          " and not already on an invoice",
+      },
     });
   });
 

--- a/apps/api/src/handlers/invoices/create.test.ts
+++ b/apps/api/src/handlers/invoices/create.test.ts
@@ -185,4 +185,50 @@ describe("createInvoice", () => {
       entryCount: 2,
     });
   });
+
+  test("returns a retryable conflict when the claim count changes", async () => {
+    const entries = [entry("te_1", "USD"), entry("te_2", "USD")];
+    const firstEntry = entries.at(0);
+    if (!firstEntry) {
+      throw new Error("Expected fixture entry");
+    }
+    let auditCalls = 0;
+    const { safeDb, scopedDb } = createScopedDbMock({
+      $count: async () => 0,
+      select: () => ({ from: () => ({ where: async () => entries }) }),
+      insert: () => ({
+        values: () => ({
+          returning: async () => [
+            { id: toSafeId<"invoice">("inv_1"), invoiceNumber: "INV-001" },
+          ],
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: async () => [{ id: firstEntry.id }],
+          }),
+        }),
+      }),
+    });
+
+    const result = await createInvoice.handler(
+      createContext({
+        body: baseBody("USD", ["te_1", "te_2"]),
+        safeDb,
+        scopedDb,
+        recordAuditEvent: async () => {
+          auditCalls += 1;
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 409,
+      response: {
+        message: "Some entries were modified concurrently; please retry",
+      },
+    });
+    expect(auditCalls).toBe(0);
+  });
 });

--- a/apps/api/src/handlers/invoices/create.test.ts
+++ b/apps/api/src/handlers/invoices/create.test.ts
@@ -1,0 +1,157 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { BILLING_STATUS } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { DatabaseError } from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import createInvoice from "./create";
+
+type CreateInvoiceCtx = Parameters<typeof createInvoice.handler>[0];
+
+const entry = (id: string, currency: string) => ({
+  id: toSafeId<"timeEntry">(id),
+  billedMinutes: 60,
+  rateAtEntry: 10_000,
+  status: BILLING_STATUS.APPROVED,
+  billable: true,
+  currency,
+});
+
+const createContext = ({
+  body,
+  safeDb,
+  scopedDb,
+  recordAuditEvent = async () => {},
+}: {
+  body: CreateInvoiceCtx["body"];
+  safeDb: CreateInvoiceCtx["safeDb"];
+  scopedDb: CreateInvoiceCtx["scopedDb"];
+  recordAuditEvent?: CreateInvoiceCtx["recordAuditEvent"];
+}): CreateInvoiceCtx =>
+  asTestRaw<CreateInvoiceCtx>({
+    body,
+    safeDb,
+    scopedDb,
+    recordAuditEvent,
+    workspaceId: toSafeId<"workspace">("ws_test"),
+    memberRole: { role: "owner" },
+    session: {
+      activeOrganizationId: toSafeId<"organization">("org_test"),
+    },
+    user: { id: toSafeId<"user">("user_test") },
+  });
+
+const baseBody = (currency: string, ids: string[]): CreateInvoiceCtx["body"] =>
+  asTestRaw<CreateInvoiceCtx["body"]>({
+    invoiceNumber: "INV-001",
+    invoiceDate: "2026-06-14",
+    currency,
+    timeEntryIds: ids.map((id) => toSafeId<"timeEntry">(id)),
+  });
+
+describe("createInvoice", () => {
+  test("rejects entries whose currency differs from the invoice currency", async () => {
+    const entries = [entry("te_1", "USD"), entry("te_2", "EUR")];
+    const { safeDb, scopedDb } = createScopedDbMock({
+      $count: async () => 0,
+      select: () => ({ from: () => ({ where: async () => entries }) }),
+    });
+
+    const result = await createInvoice.handler(
+      createContext({
+        body: baseBody("USD", ["te_1", "te_2"]),
+        safeDb,
+        scopedDb,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: {
+        message: "All time entries must match the invoice currency",
+      },
+    });
+  });
+
+  test("returns 409 when the invoice number already exists", async () => {
+    const entries = [entry("te_1", "USD")];
+    const { scopedDb } = createScopedDbMock({});
+
+    // Production safeDb returns Result.err(DatabaseError) on a unique
+    // violation; drive that directly on the insert transaction (the third
+    // safeDb call) so the handler's error mapping is what is under test.
+    let call = 0;
+    const safeDb: CreateInvoiceCtx["safeDb"] = asTestRaw<
+      CreateInvoiceCtx["safeDb"]
+    >(async () => {
+      call += 1;
+      if (call === 1) {
+        return Result.ok(0);
+      }
+      if (call === 2) {
+        return Result.ok(entries);
+      }
+      return Result.err(
+        new DatabaseError({
+          code: PG_ERROR.UNIQUE_VIOLATION,
+          message: "duplicate key",
+        }),
+      );
+    });
+
+    const result = await createInvoice.handler(
+      createContext({
+        body: baseBody("USD", ["te_1"]),
+        safeDb,
+        scopedDb,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 409,
+      response: { message: "An invoice with this number already exists" },
+    });
+  });
+
+  test("creates a single-currency invoice and totals the entries", async () => {
+    const entries = [entry("te_1", "USD"), entry("te_2", "USD")];
+    const { safeDb, scopedDb } = createScopedDbMock({
+      $count: async () => 0,
+      select: () => ({ from: () => ({ where: async () => entries }) }),
+      insert: () => ({
+        values: () => ({
+          returning: async () => [
+            { id: toSafeId<"invoice">("inv_1"), invoiceNumber: "INV-001" },
+          ],
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: async () => entries.map((e) => ({ id: e.id })),
+          }),
+        }),
+      }),
+    });
+
+    const result = await createInvoice.handler(
+      createContext({
+        body: baseBody("USD", ["te_1", "te_2"]),
+        safeDb,
+        scopedDb,
+      }),
+    );
+
+    // Success returns the raw payload (not a {code,response} envelope).
+    // 2 entries * prorate(60min, 10_000 cents/h) = 2 * 10_000 = 20_000.
+    expect(result).toMatchObject({
+      id: "inv_1",
+      totalAmount: 20_000,
+      entryCount: 2,
+    });
+  });
+});

--- a/apps/api/src/handlers/invoices/create.ts
+++ b/apps/api/src/handlers/invoices/create.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { t } from "elysia";
 
 import { prorateHourlyCents } from "@stll/money";
@@ -62,6 +62,7 @@ const createInvoice = createSafeHandler(
             status: timeEntries.status,
             billable: timeEntries.billable,
             currency: timeEntries.currency,
+            invoiceId: timeEntries.invoiceId,
           })
           .from(timeEntries)
           .where(
@@ -83,13 +84,18 @@ const createInvoice = createSafeHandler(
     }
 
     const invalid = entries.some(
-      (e) => e.status !== BILLING_STATUS.APPROVED || !e.billable,
+      (e) =>
+        e.status !== BILLING_STATUS.APPROVED ||
+        !e.billable ||
+        e.invoiceId !== null,
     );
     if (invalid) {
       return Result.err(
         new HandlerError({
           status: 400,
-          message: "All entries must be approved and billable",
+          message:
+            "All entries must be approved, billable," +
+            " and not already on an invoice",
         }),
       );
     }
@@ -154,6 +160,7 @@ const createInvoice = createSafeHandler(
             inArray(timeEntries.id, body.timeEntryIds),
             eq(timeEntries.status, BILLING_STATUS.APPROVED),
             eq(timeEntries.billable, true),
+            isNull(timeEntries.invoiceId),
             // Re-check currency in the claiming update: if an entry's currency
             // changed between the preflight read and now, it is not claimed,
             // the count mismatch trips, and the caller retries.

--- a/apps/api/src/handlers/invoices/create.ts
+++ b/apps/api/src/handlers/invoices/create.ts
@@ -18,6 +18,12 @@ import { LIMITS } from "@/api/lib/limits";
 import { cents } from "@/api/lib/money";
 import { PG_ERROR } from "@/api/lib/pg-error";
 
+import {
+  INVOICE_ENTRIES_MODIFIED_MESSAGE,
+  InvoiceEntriesModifiedConcurrentlyError,
+  isInvoiceEntriesModifiedConcurrentlyError,
+} from "./concurrent-modification";
+
 const createInvoiceBodySchema = t.Object({
   invoiceNumber: t.String({ minLength: 1, maxLength: 64 }),
   invoiceDate: t.String({ format: "date" }),
@@ -171,7 +177,7 @@ const createInvoice = createSafeHandler(
 
       const linkedCount = updated.length;
       if (linkedCount !== expectedCount) {
-        return { ok: false as const };
+        throw new InvoiceEntriesModifiedConcurrentlyError();
       }
 
       await recordAuditEvent(tx, [
@@ -217,6 +223,14 @@ const createInvoice = createSafeHandler(
     });
 
     if (Result.isError(txResult)) {
+      if (isInvoiceEntriesModifiedConcurrentlyError(txResult.error)) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: INVOICE_ENTRIES_MODIFIED_MESSAGE,
+          }),
+        );
+      }
       if (
         DatabaseError.is(txResult.error) &&
         txResult.error.code === PG_ERROR.UNIQUE_VIOLATION
@@ -236,7 +250,7 @@ const createInvoice = createSafeHandler(
       return Result.err(
         new HandlerError({
           status: 409,
-          message: "Some entries were modified concurrently; please retry",
+          message: INVOICE_ENTRIES_MODIFIED_MESSAGE,
         }),
       );
     }

--- a/apps/api/src/handlers/invoices/create.ts
+++ b/apps/api/src/handlers/invoices/create.ts
@@ -154,6 +154,10 @@ const createInvoice = createSafeHandler(
             inArray(timeEntries.id, body.timeEntryIds),
             eq(timeEntries.status, BILLING_STATUS.APPROVED),
             eq(timeEntries.billable, true),
+            // Re-check currency in the claiming update: if an entry's currency
+            // changed between the preflight read and now, it is not claimed,
+            // the count mismatch trips, and the caller retries.
+            eq(timeEntries.currency, body.currency),
           ),
         )
         .returning({ id: timeEntries.id });

--- a/apps/api/src/handlers/invoices/create.ts
+++ b/apps/api/src/handlers/invoices/create.ts
@@ -13,9 +13,10 @@ import {
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tSafeId } from "@/api/lib/custom-schema";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { cents } from "@/api/lib/money";
+import { PG_ERROR } from "@/api/lib/pg-error";
 
 const createInvoiceBodySchema = t.Object({
   invoiceNumber: t.String({ minLength: 1, maxLength: 64 }),
@@ -60,6 +61,7 @@ const createInvoice = createSafeHandler(
             rateAtEntry: timeEntries.rateAtEntry,
             status: timeEntries.status,
             billable: timeEntries.billable,
+            currency: timeEntries.currency,
           })
           .from(timeEntries)
           .where(
@@ -92,6 +94,18 @@ const createInvoice = createSafeHandler(
       );
     }
 
+    // An invoice is single-currency: there is no FX conversion, so summing
+    // entries in different currencies would produce a meaningless total.
+    const currencyMismatch = entries.some((e) => e.currency !== body.currency);
+    if (currencyMismatch) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "All time entries must match the invoice currency",
+        }),
+      );
+    }
+
     let totalAmount = 0;
     for (const entry of entries) {
       totalAmount += prorateHourlyCents({
@@ -103,97 +117,111 @@ const createInvoice = createSafeHandler(
     const now = new Date();
     const expectedCount = entries.length;
 
-    const txResult = yield* Result.await(
-      safeDb(async (tx) => {
-        const [created] = await tx
-          .insert(invoices)
-          .values({
-            organizationId: session.activeOrganizationId,
-            workspaceId,
-            invoiceNumber: body.invoiceNumber,
-            invoiceDate: body.invoiceDate,
-            dueDate: body.dueDate ?? null,
-            reference: body.reference ?? null,
-            currency: body.currency,
-            totalAmount: cents(totalAmount),
-            notes: body.notes ?? null,
-            status: INVOICE_STATUS.DRAFT,
-          })
-          .returning({
-            id: invoices.id,
-            invoiceNumber: invoices.invoiceNumber,
-          });
+    const txResult = await safeDb(async (tx) => {
+      const [created] = await tx
+        .insert(invoices)
+        .values({
+          organizationId: session.activeOrganizationId,
+          workspaceId,
+          invoiceNumber: body.invoiceNumber,
+          invoiceDate: body.invoiceDate,
+          dueDate: body.dueDate ?? null,
+          reference: body.reference ?? null,
+          currency: body.currency,
+          totalAmount: cents(totalAmount),
+          notes: body.notes ?? null,
+          status: INVOICE_STATUS.DRAFT,
+        })
+        .returning({
+          id: invoices.id,
+          invoiceNumber: invoices.invoiceNumber,
+        });
 
-        if (!created) {
-          return { ok: false as const };
-        }
+      if (!created) {
+        return { ok: false as const };
+      }
 
-        const updated = await tx
-          .update(timeEntries)
-          .set({
-            invoiceId: created.id,
-            status: BILLING_STATUS.BILLED,
-            updatedAt: now,
-          })
-          .where(
-            and(
-              eq(timeEntries.workspaceId, workspaceId),
-              inArray(timeEntries.id, body.timeEntryIds),
-              eq(timeEntries.status, BILLING_STATUS.APPROVED),
-              eq(timeEntries.billable, true),
-            ),
-          )
-          .returning({ id: timeEntries.id });
+      const updated = await tx
+        .update(timeEntries)
+        .set({
+          invoiceId: created.id,
+          status: BILLING_STATUS.BILLED,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(timeEntries.workspaceId, workspaceId),
+            inArray(timeEntries.id, body.timeEntryIds),
+            eq(timeEntries.status, BILLING_STATUS.APPROVED),
+            eq(timeEntries.billable, true),
+          ),
+        )
+        .returning({ id: timeEntries.id });
 
-        const linkedCount = updated.length;
-        if (linkedCount !== expectedCount) {
-          return { ok: false as const };
-        }
+      const linkedCount = updated.length;
+      if (linkedCount !== expectedCount) {
+        return { ok: false as const };
+      }
 
-        await recordAuditEvent(tx, [
-          {
-            action: AUDIT_ACTION.CREATE,
-            resourceType: AUDIT_RESOURCE_TYPE.INVOICE,
-            resourceId: created.id,
-            changes: {
-              created: {
-                old: null,
-                new: {
-                  invoiceNumber: created.invoiceNumber,
-                  invoiceDate: body.invoiceDate,
-                  currency: body.currency,
-                  totalAmount,
-                  entryCount: linkedCount,
-                  status: INVOICE_STATUS.DRAFT,
-                },
+      await recordAuditEvent(tx, [
+        {
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.INVOICE,
+          resourceId: created.id,
+          changes: {
+            created: {
+              old: null,
+              new: {
+                invoiceNumber: created.invoiceNumber,
+                invoiceDate: body.invoiceDate,
+                currency: body.currency,
+                totalAmount,
+                entryCount: linkedCount,
+                status: INVOICE_STATUS.DRAFT,
               },
             },
           },
-          ...updated.map((entry) => ({
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.TIME_ENTRY,
-            resourceId: entry.id,
-            changes: {
-              status: {
-                old: BILLING_STATUS.APPROVED,
-                new: BILLING_STATUS.BILLED,
-              },
-              invoiceId: { old: null, new: created.id },
+        },
+        ...updated.map((entry) => ({
+          action: AUDIT_ACTION.UPDATE,
+          resourceType: AUDIT_RESOURCE_TYPE.TIME_ENTRY,
+          resourceId: entry.id,
+          changes: {
+            status: {
+              old: BILLING_STATUS.APPROVED,
+              new: BILLING_STATUS.BILLED,
             },
-          })),
-        ]);
+            invoiceId: { old: null, new: created.id },
+          },
+        })),
+      ]);
 
-        return {
-          ok: true as const,
-          id: created.id,
-          invoiceNumber: created.invoiceNumber,
-          totalAmount,
-          entryCount: linkedCount,
-        };
-      }),
-    );
+      return {
+        ok: true as const,
+        id: created.id,
+        invoiceNumber: created.invoiceNumber,
+        totalAmount,
+        entryCount: linkedCount,
+      };
+    });
 
-    if (!txResult.ok) {
+    if (Result.isError(txResult)) {
+      if (
+        DatabaseError.is(txResult.error) &&
+        txResult.error.code === PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "An invoice with this number already exists",
+          }),
+        );
+      }
+      return Result.err(txResult.error);
+    }
+
+    const result = txResult.value;
+    if (!result.ok) {
       return Result.err(
         new HandlerError({
           status: 409,
@@ -203,10 +231,10 @@ const createInvoice = createSafeHandler(
     }
 
     return Result.ok({
-      id: txResult.id,
-      invoiceNumber: txResult.invoiceNumber,
-      totalAmount: txResult.totalAmount,
-      entryCount: txResult.entryCount,
+      id: result.id,
+      invoiceNumber: result.invoiceNumber,
+      totalAmount: result.totalAmount,
+      entryCount: result.entryCount,
     });
   },
 );

--- a/apps/api/src/handlers/invoices/update.test.ts
+++ b/apps/api/src/handlers/invoices/update.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import { INVOICE_STATUS } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import updateInvoice from "./update";
+
+type UpdateInvoiceCtx = Parameters<typeof updateInvoice.handler>[0];
+
+const createContext = ({
+  body,
+  safeDb,
+}: {
+  body: UpdateInvoiceCtx["body"];
+  safeDb: UpdateInvoiceCtx["safeDb"];
+}): UpdateInvoiceCtx =>
+  asTestRaw<UpdateInvoiceCtx>({
+    body,
+    safeDb,
+    params: {
+      workspaceId: toSafeId<"workspace">("ws_test"),
+      invoiceId: toSafeId<"invoice">("inv_test"),
+    },
+    workspaceId: toSafeId<"workspace">("ws_test"),
+    memberRole: { role: "owner" },
+    session: { activeOrganizationId: toSafeId<"organization">("org_test") },
+    user: { id: toSafeId<"user">("user_test") },
+    recordAuditEvent: async () => {},
+  });
+
+describe("updateInvoice currency integrity", () => {
+  test("rejects a currency change while entries are attached", async () => {
+    let selectCall = 0;
+    const { safeDb } = createScopedDbMock({
+      select: () => {
+        selectCall += 1;
+        if (selectCall === 1) {
+          return {
+            from: () => ({
+              where: () => ({
+                limit: () => ({
+                  for: async () => [
+                    {
+                      id: toSafeId<"invoice">("inv_test"),
+                      status: INVOICE_STATUS.DRAFT,
+                      currency: "USD",
+                      dueDate: null,
+                      invoiceDate: "2026-06-14",
+                      invoiceNumber: "INV-001",
+                      notes: null,
+                      reference: null,
+                    },
+                  ],
+                }),
+              }),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => ({
+              limit: async () => [{ id: toSafeId<"timeEntry">("te_1") }],
+            }),
+          }),
+        };
+      },
+    });
+
+    const result = await updateInvoice.handler(
+      createContext({
+        body: { currency: "EUR" },
+        safeDb,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: {
+        message: "Invoice currency cannot change while entries are attached",
+      },
+    });
+  });
+});

--- a/apps/api/src/handlers/invoices/update.ts
+++ b/apps/api/src/handlers/invoices/update.ts
@@ -2,7 +2,12 @@ import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
-import { INVOICE_STATUS, invoices } from "@/api/db/schema";
+import {
+  expenses,
+  INVOICE_STATUS,
+  invoices,
+  timeEntries,
+} from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { FieldDiffs } from "@/api/lib/audit-log";
@@ -31,6 +36,11 @@ type InvoiceUpdateSource = {
 };
 
 type InvoiceUpdateChanges = Partial<InvoiceUpdateSource>;
+
+type InvoiceUpdateResult =
+  | { status: "updated"; id: string }
+  | { status: "not-updated" }
+  | { status: "currency-has-entries" };
 
 const buildInvoiceUpdateAuditChanges = (
   existing: InvoiceUpdateSource,
@@ -117,7 +127,44 @@ const updateInvoice = createSafeHandler(
           .for("update");
         const existing = existingRows.at(0);
         if (!existing) {
-          return [];
+          return { status: "not-updated" } satisfies InvoiceUpdateResult;
+        }
+
+        if (
+          changedFields.currency !== undefined &&
+          changedFields.currency !== existing.currency
+        ) {
+          const attachedTimeEntry = await tx
+            .select({ id: timeEntries.id })
+            .from(timeEntries)
+            .where(
+              and(
+                eq(timeEntries.invoiceId, params.invoiceId),
+                eq(timeEntries.workspaceId, workspaceId),
+              ),
+            )
+            .limit(1);
+          if (attachedTimeEntry.at(0)) {
+            return {
+              status: "currency-has-entries",
+            } satisfies InvoiceUpdateResult;
+          }
+
+          const attachedExpense = await tx
+            .select({ id: expenses.id })
+            .from(expenses)
+            .where(
+              and(
+                eq(expenses.invoiceId, params.invoiceId),
+                eq(expenses.workspaceId, workspaceId),
+              ),
+            )
+            .limit(1);
+          if (attachedExpense.at(0)) {
+            return {
+              status: "currency-has-entries",
+            } satisfies InvoiceUpdateResult;
+          }
         }
 
         const updated = await tx
@@ -141,12 +188,22 @@ const updateInvoice = createSafeHandler(
             changes: buildInvoiceUpdateAuditChanges(existing, changedFields),
           });
         }
-        return updated;
+        if (!row) {
+          return { status: "not-updated" } satisfies InvoiceUpdateResult;
+        }
+        return { status: "updated", id: row.id } satisfies InvoiceUpdateResult;
       }),
     );
 
-    const updated = result.at(0);
-    if (!updated) {
+    if (result.status === "currency-has-entries") {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Invoice currency cannot change while entries are attached",
+        }),
+      );
+    }
+    if (result.status === "not-updated") {
       return Result.err(
         new HandlerError({
           status: 409,
@@ -154,7 +211,7 @@ const updateInvoice = createSafeHandler(
         }),
       );
     }
-    return Result.ok({ id: updated.id });
+    return Result.ok({ id: result.id });
   },
 );
 

--- a/apps/api/src/handlers/mcp-connectors/oauth-callback.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth-callback.test.ts
@@ -1,6 +1,11 @@
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
-import { buildCallbackRedirectUrl } from "@/api/handlers/mcp-connectors/oauth-callback";
+import mcpOAuthCallback, {
+  buildCallbackRedirectUrl,
+} from "@/api/handlers/mcp-connectors/oauth-callback";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 describe("buildCallbackRedirectUrl", () => {
   test("encodes a connected slug onto the SPA terminal route", () => {
@@ -34,5 +39,106 @@ describe("buildCallbackRedirectUrl", () => {
     expect(url).toBe(
       "https://example.test/mcp/oauth-callback?status=connected&slug=with+space",
     );
+  });
+});
+
+type CallbackCtx = Parameters<typeof mcpOAuthCallback.handler>[0];
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+const orgA = toSafeId<"organization">("org_a");
+const orgB = toSafeId<"organization">("org_b");
+const userA = toSafeId<"user">("user_a");
+const userB = toSafeId<"user">("user_b");
+
+const stateRow = (overrides: Record<string, unknown> = {}) => ({
+  organizationId: orgA,
+  userId: userA,
+  createdAt: new Date(),
+  connectorId: toSafeId<"mcpConnector">("conn_1"),
+  authorizationServerUrl: "https://as.example.com",
+  codeVerifier: "verifier",
+  redirectUri: "https://api.example.com/cb",
+  resourceUrl: "https://rs.example.com",
+  connector: { id: toSafeId<"mcpConnector">("conn_1"), slug: "acme" },
+  ...overrides,
+});
+
+// safeDb returns the crafted state row on the first call and counts every
+// call, so we can assert no token exchange / connection insert ran after a
+// rejected binding.
+const callbackContext = (
+  row: Record<string, unknown>,
+  counter: { calls: number },
+): CallbackCtx =>
+  asTestRaw<CallbackCtx>({
+    query: { code: "auth-code", state: "state-token" },
+    safeDb: asTestRaw<CallbackCtx["safeDb"]>(async () => {
+      counter.calls += 1;
+      return Result.ok(row);
+    }),
+    scopedDb: asTestRaw<CallbackCtx["scopedDb"]>(async () => undefined),
+    session: { activeOrganizationId: orgA },
+    user: { id: userA },
+    memberRole: { role: "owner" },
+    recordAuditEvent: async () => {},
+  });
+
+const reasonOf = (result: unknown): string | null => {
+  if (!(result instanceof Response)) {
+    throw new Error(`expected a 302 Response, got ${JSON.stringify(result)}`);
+  }
+  expect(result.status).toBe(302);
+  const location = result.headers.get("Location");
+  expect(location).not.toBeNull();
+  return new URL(location ?? "").searchParams.get("reason");
+};
+
+describe("mcpOAuthCallback identity binding", () => {
+  test("rejects a state row belonging to another organization", async () => {
+    const counter = { calls: 0 };
+    const result = await mcpOAuthCallback.handler(
+      callbackContext(stateRow({ organizationId: orgB }), counter),
+    );
+
+    expect(reasonOf(result)).toBe("user-mismatch");
+    // Only the state lookup ran: no token exchange or connection insert.
+    expect(counter.calls).toBe(1);
+  });
+
+  test("rejects a state row belonging to another user", async () => {
+    const counter = { calls: 0 };
+    const result = await mcpOAuthCallback.handler(
+      callbackContext(stateRow({ userId: userB }), counter),
+    );
+
+    expect(reasonOf(result)).toBe("user-mismatch");
+    expect(counter.calls).toBe(1);
+  });
+
+  test("rejects an expired state row and persists nothing", async () => {
+    const counter = { calls: 0 };
+    const result = await mcpOAuthCallback.handler(
+      callbackContext(
+        stateRow({ createdAt: new Date(Date.now() - STATE_TTL_MS - 1000) }),
+        counter,
+      ),
+    );
+
+    expect(reasonOf(result)).toBe("expired-state");
+    expect(counter.calls).toBe(1);
+  });
+
+  test("missing code or state short-circuits before any DB call", async () => {
+    const counter = { calls: 0 };
+    const ctx = callbackContext(stateRow(), counter);
+    const result = await mcpOAuthCallback.handler(
+      asTestRaw<CallbackCtx>({
+        ...ctx,
+        query: { code: undefined, state: undefined },
+      }),
+    );
+
+    expect(reasonOf(result)).toBe("missing-code");
+    expect(counter.calls).toBe(0);
   });
 });

--- a/apps/api/src/handlers/mcp-connectors/oauth.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth.test.ts
@@ -5,9 +5,14 @@ import {
   clientRegistrationMode,
   getMcpClientMetadataDocumentUrl,
   getMcpOAuthRedirectUri,
+  tokenExpiresAt,
 } from "@/api/handlers/mcp-connectors/oauth";
-import type { AuthorizationServerMetadata } from "@/api/handlers/mcp-connectors/oauth";
+import type {
+  AuthorizationServerMetadata,
+  TokenResponse,
+} from "@/api/handlers/mcp-connectors/oauth";
 import { redactMcpOAuthRegistrationResponse } from "@/api/handlers/mcp-connectors/oauth-registration-response";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const authorizationServer = (
   overrides: Partial<AuthorizationServerMetadata>,
@@ -92,5 +97,54 @@ describe("redactMcpOAuthRegistrationResponse", () => {
       },
       token_endpoint_auth_method: "none",
     });
+  });
+
+  test("redacts secrets inside an array of objects, preserving siblings", () => {
+    const redacted = redactMcpOAuthRegistrationResponse({
+      keys: [{ client_secret: "x", kid: "ok" }],
+    });
+    expect(redacted).toEqual({
+      keys: [{ client_secret: "[redacted]", kid: "ok" }],
+    });
+  });
+
+  test("redacts suffix-matched keys case-insensitively", () => {
+    const redacted = redactMcpOAuthRegistrationResponse({
+      app_secret: "x",
+      DB_PASSWORD: "y",
+      jwt_assertion: "z",
+      keep_me: "ok",
+    });
+    expect(redacted).toEqual({
+      app_secret: "[redacted]",
+      DB_PASSWORD: "[redacted]",
+      jwt_assertion: "[redacted]",
+      keep_me: "ok",
+    });
+  });
+});
+
+describe("tokenExpiresAt", () => {
+  const token = (expires_in: number | undefined): TokenResponse =>
+    asTestRaw<TokenResponse>({
+      access_token: "a",
+      token_type: "Bearer",
+      expires_in,
+    });
+
+  test("returns null when expires_in is absent or non-positive", () => {
+    expect(tokenExpiresAt(token(undefined))).toBeNull();
+    expect(tokenExpiresAt(token(0))).toBeNull();
+    expect(tokenExpiresAt(token(-5))).toBeNull();
+  });
+
+  test("returns a future instant ~expires_in seconds out", () => {
+    const before = Date.now();
+    const result = tokenExpiresAt(token(3600));
+    const after = Date.now();
+    expect(result).not.toBeNull();
+    const ms = result?.getTime() ?? 0;
+    expect(ms).toBeGreaterThanOrEqual(before + 3_600_000);
+    expect(ms).toBeLessThanOrEqual(after + 3_600_000);
   });
 });

--- a/apps/api/src/handlers/time-entries/create.test.ts
+++ b/apps/api/src/handlers/time-entries/create.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { roundToIncrement } from "./create";
+
+describe("roundToIncrement (billing increment snap)", () => {
+  test("ceils to the 6-minute billing increment", () => {
+    expect(roundToIncrement(0)).toBe(0);
+    expect(roundToIncrement(1)).toBe(6);
+    expect(roundToIncrement(6)).toBe(6);
+    expect(roundToIncrement(7)).toBe(12);
+    expect(roundToIncrement(12)).toBe(12);
+    expect(roundToIncrement(13)).toBe(18);
+  });
+
+  test("INVARIANT: result is a multiple of 6, >= input, < input + 6", () => {
+    for (let m = 0; m <= 600; m++) {
+      const r = roundToIncrement(m);
+      expect(r % 6).toBe(0);
+      expect(r).toBeGreaterThanOrEqual(m);
+      expect(r).toBeLessThan(m + 6);
+    }
+  });
+});

--- a/apps/api/src/handlers/time-entries/export-ledes.test.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ScopedDb } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+import { exportLedesHandler } from "./export-ledes";
+
+const timeEntryRow = (overrides: Record<string, unknown> = {}) => ({
+  id: toSafeId<"timeEntry">("te_1"),
+  userId: "user_1",
+  matterId: toSafeId<"entity">("ent_1"),
+  dateWorked: "2026-06-14",
+  durationMinutes: 60,
+  billedMinutes: 60,
+  rateAtEntry: 10_000,
+  currency: "USD",
+  narrative: "Work",
+  invoiceNarrative: null,
+  billable: true,
+  noCharge: false,
+  status: "approved",
+  taskCode: null,
+  activityCode: null,
+  ...overrides,
+});
+
+// First scopedDb call returns the time-entry rows; the second returns the
+// timekeeper name join. The SQL WHERE is not executed by the mock, which is
+// exactly why the handler also carries a defensive in-loop billing guard.
+const scopedDbReturning = (rows: unknown[]): ScopedDb => {
+  let call = 0;
+  return asTestRaw<ScopedDb>(async () => {
+    call += 1;
+    return call === 1 ? rows : [{ id: "user_1", name: "Alice" }];
+  });
+};
+
+const runExport = (rows: unknown[]) =>
+  exportLedesHandler({
+    scopedDb: scopedDbReturning(rows),
+    workspaceId: toSafeId<"workspace">("ws_1"),
+    organizationId: toSafeId<"organization">("org_1"),
+    query: {},
+  });
+
+describe("exportLedesHandler billing integrity", () => {
+  test("excludes non-billable and no-charge entries from the LEDES file", async () => {
+    const output = await runExport([
+      timeEntryRow({ narrative: "Billable work" }),
+      timeEntryRow({ billable: false, narrative: "Internal non-billable" }),
+      timeEntryRow({ noCharge: true, narrative: "Written off" }),
+    ]);
+
+    expect(output).toContain("Billable work");
+    expect(output).not.toContain("Internal non-billable");
+    expect(output).not.toContain("Written off");
+  });
+
+  test("emits one line item per billable charged entry", async () => {
+    const output = await runExport([
+      timeEntryRow({ narrative: "First" }),
+      timeEntryRow({ narrative: "Second" }),
+    ]);
+
+    const dataLines = output
+      .split("\n")
+      .filter((line) => line.endsWith("[]") && !line.startsWith("LEDES1998B"))
+      // drop the header row (starts with INVOICE_DATE)
+      .filter((line) => !line.startsWith("INVOICE_DATE"));
+
+    expect(dataLines).toHaveLength(2);
+  });
+});

--- a/apps/api/src/handlers/time-entries/export-ledes.test.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ScopedDb } from "@/api/db";
+import { BILLING_STATUS } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
@@ -19,7 +20,7 @@ const timeEntryRow = (overrides: Record<string, unknown> = {}) => ({
   invoiceNarrative: null,
   billable: true,
   noCharge: false,
-  status: "approved",
+  status: BILLING_STATUS.APPROVED,
   taskCode: null,
   activityCode: null,
   ...overrides,
@@ -45,16 +46,21 @@ const runExport = async (rows: unknown[]) =>
   });
 
 describe("exportLedesHandler billing integrity", () => {
-  test("excludes non-billable and no-charge entries from the LEDES file", async () => {
+  test("excludes non-billable, no-charge, and written-off entries from the LEDES file", async () => {
     const output = await runExport([
       timeEntryRow({ narrative: "Billable work" }),
       timeEntryRow({ billable: false, narrative: "Internal non-billable" }),
       timeEntryRow({ noCharge: true, narrative: "Written off" }),
+      timeEntryRow({
+        narrative: "Deleted approved time",
+        status: BILLING_STATUS.WRITTEN_OFF,
+      }),
     ]);
 
     expect(output).toContain("Billable work");
     expect(output).not.toContain("Internal non-billable");
     expect(output).not.toContain("Written off");
+    expect(output).not.toContain("Deleted approved time");
   });
 
   test("emits one line item per billable charged entry", async () => {

--- a/apps/api/src/handlers/time-entries/export-ledes.test.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.test.ts
@@ -36,8 +36,8 @@ const scopedDbReturning = (rows: unknown[]): ScopedDb => {
   });
 };
 
-const runExport = (rows: unknown[]) =>
-  exportLedesHandler({
+const runExport = async (rows: unknown[]) =>
+  await exportLedesHandler({
     scopedDb: scopedDbReturning(rows),
     workspaceId: toSafeId<"workspace">("ws_1"),
     organizationId: toSafeId<"organization">("org_1"),

--- a/apps/api/src/handlers/time-entries/export-ledes.test.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.test.ts
@@ -4,7 +4,7 @@ import type { ScopedDb } from "@/api/db";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
-import { exportLedesHandler } from "./export-ledes";
+import { escapeLedesField, exportLedesHandler } from "./export-ledes";
 
 const timeEntryRow = (overrides: Record<string, unknown> = {}) => ({
   id: toSafeId<"timeEntry">("te_1"),
@@ -70,5 +70,56 @@ describe("exportLedesHandler billing integrity", () => {
       .filter((line) => !line.startsWith("INVOICE_DATE"));
 
     expect(dataLines).toHaveLength(2);
+  });
+
+  test("neutralizes delimiter injection in narrative and timekeeper name", async () => {
+    let call = 0;
+    const scopedDb = asTestRaw<ScopedDb>(async () => {
+      call += 1;
+      return call === 1
+        ? [
+            timeEntryRow({
+              narrative: "first line\nspurious|F|999",
+              userId: "user_1",
+            }),
+          ]
+        : [{ id: "user_1", name: "Eve|Hacker" }];
+    });
+
+    const output = await exportLedesHandler({
+      scopedDb,
+      workspaceId: toSafeId<"workspace">("ws_1"),
+      organizationId: toSafeId<"organization">("org_1"),
+      query: {},
+    });
+
+    // One entry must remain exactly one record line: the narrative newline
+    // must not inject a second line.
+    const dataLines = output
+      .split("\n")
+      .filter((line) => line.endsWith("[]") && !line.startsWith("LEDES1998B"))
+      .filter((line) => !line.startsWith("INVOICE_DATE"));
+    expect(dataLines).toHaveLength(1);
+
+    // Delimiters in user-controlled fields are replaced with spaces.
+    expect(output).toContain("first line spurious F 999");
+    expect(output).toContain("Eve Hacker");
+    expect(output).not.toContain("Eve|Hacker");
+  });
+});
+
+describe("escapeLedesField", () => {
+  test("replaces pipes, newlines, and carriage returns with spaces", () => {
+    expect(escapeLedesField("a|b")).toBe("a b");
+    expect(escapeLedesField("line1\nline2")).toBe("line1 line2");
+    expect(escapeLedesField("a\r\nb")).toBe("a  b");
+    expect(escapeLedesField("a|b\nc|d")).toBe("a b c d");
+  });
+
+  test("leaves ordinary text untouched", () => {
+    expect(escapeLedesField("Regular narrative, with punctuation.")).toBe(
+      "Regular narrative, with punctuation.",
+    );
+    expect(escapeLedesField("")).toBe("");
   });
 });

--- a/apps/api/src/handlers/time-entries/export-ledes.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.ts
@@ -29,6 +29,15 @@ type ExportLedesHandlerProps = {
 };
 
 /**
+ * Neutralize a user-controlled value for a LEDES 1998B field. The format is
+ * pipe-delimited with one record per line and has no quoting mechanism, so a
+ * value containing a pipe or a line break would split a field or inject a
+ * spurious record. Replace those delimiters with spaces.
+ */
+export const escapeLedesField = (value: string): string =>
+  value.replace(/[\r\n|]/gu, " ");
+
+/**
  * Generates a LEDES 1998B formatted export.
  * LEDES 1998B uses pipe-delimited lines with a fixed header row.
  */
@@ -148,11 +157,10 @@ export const exportLedesHandler = async ({
       hourlyRateCents: row.rateAtEntry,
     });
     const dateFormatted = row.dateWorked.replace(/-/gu, "");
-    const userName = row.userId ? (userMap.get(row.userId) ?? "") : "";
-    const narrative = (row.invoiceNarrative ?? row.narrative).replace(
-      /\|/gu,
-      " ",
+    const userName = escapeLedesField(
+      row.userId ? (userMap.get(row.userId) ?? "") : "",
     );
+    const narrative = escapeLedesField(row.invoiceNarrative ?? row.narrative);
 
     lines.push(
       `${[
@@ -170,9 +178,9 @@ export const exportLedesHandler = async ({
         "0.00", // ADJUSTMENT
         (total / 100).toFixed(2),
         dateFormatted,
-        row.taskCode ?? "",
+        escapeLedesField(row.taskCode ?? ""),
         "", // EXPENSE_CODE
-        row.activityCode ?? "",
+        escapeLedesField(row.activityCode ?? ""),
         row.userId ?? "",
         narrative,
         "", // LAW_FIRM_ID

--- a/apps/api/src/handlers/time-entries/export-ledes.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, inArray, lte } from "drizzle-orm";
+import { and, eq, gte, inArray, lte, ne } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
@@ -7,7 +7,7 @@ import { prorateHourlyCents } from "@stll/money";
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";
 import { timeEntryStatusSchema } from "@/api/db/billing-validators";
-import { timeEntries } from "@/api/db/schema";
+import { BILLING_STATUS, timeEntries } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
@@ -53,6 +53,7 @@ export const exportLedesHandler = async ({
   // charged line items, never internal non-billable or written-off time.
   conditions.push(eq(timeEntries.billable, true));
   conditions.push(eq(timeEntries.noCharge, false));
+  conditions.push(ne(timeEntries.status, BILLING_STATUS.WRITTEN_OFF));
 
   if (query.dateFrom) {
     conditions.push(gte(timeEntries.dateWorked, query.dateFrom));
@@ -146,8 +147,13 @@ export const exportLedesHandler = async ({
 
   for (const row of rows) {
     // Defensive billing-integrity guard alongside the SQL filter: a
-    // non-billable or no-charge entry must never produce a charged line.
-    if (!row.billable || row.noCharge) {
+    // non-billable, no-charge, or written-off entry must never produce a
+    // charged line.
+    if (
+      !row.billable ||
+      row.noCharge ||
+      row.status === BILLING_STATUS.WRITTEN_OFF
+    ) {
       continue;
     }
     lineItemNumber++;

--- a/apps/api/src/handlers/time-entries/export-ledes.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.ts
@@ -40,6 +40,11 @@ export const exportLedesHandler = async ({
 }: ExportLedesHandlerProps) => {
   const conditions = [eq(timeEntries.workspaceId, workspaceId)];
 
+  // LEDES 1998B is a client e-billing file: it must contain only billable,
+  // charged line items, never internal non-billable or written-off time.
+  conditions.push(eq(timeEntries.billable, true));
+  conditions.push(eq(timeEntries.noCharge, false));
+
   if (query.dateFrom) {
     conditions.push(gte(timeEntries.dateWorked, query.dateFrom));
   }
@@ -67,6 +72,7 @@ export const exportLedesHandler = async ({
         narrative: timeEntries.narrative,
         invoiceNarrative: timeEntries.invoiceNarrative,
         billable: timeEntries.billable,
+        noCharge: timeEntries.noCharge,
         status: timeEntries.status,
         taskCode: timeEntries.taskCode,
         activityCode: timeEntries.activityCode,
@@ -130,6 +136,11 @@ export const exportLedesHandler = async ({
   let lineItemNumber = 0;
 
   for (const row of rows) {
+    // Defensive billing-integrity guard alongside the SQL filter: a
+    // non-billable or no-charge entry must never produce a charged line.
+    if (!row.billable || row.noCharge) {
+      continue;
+    }
     lineItemNumber++;
     const hours = row.billedMinutes / 60;
     const total = prorateHourlyCents({

--- a/apps/api/src/handlers/time-entries/export-pdf.test.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ScopedDb } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+import { exportPdfHandler } from "./export-pdf";
+
+const timeEntryRow = (overrides: Record<string, unknown> = {}) => ({
+  id: toSafeId<"timeEntry">("te_1"),
+  userId: "user_1",
+  matterId: toSafeId<"entity">("ent_1"),
+  dateWorked: "2026-06-14",
+  durationMinutes: 120,
+  billedMinutes: 60,
+  rateAtEntry: 10_000,
+  currency: "USD",
+  narrative: "Work",
+  invoiceNarrative: null,
+  billable: true,
+  status: "approved",
+  ...overrides,
+});
+
+const scopedDbReturning = (rows: unknown[]): ScopedDb => {
+  let call = 0;
+  return asTestRaw<ScopedDb>(async () => {
+    call += 1;
+    return call === 1 ? rows : [{ id: "user_1", name: "Alice" }];
+  });
+};
+
+describe("exportPdfHandler totals", () => {
+  test("Total Hours reconciles with billed minutes, not raw duration", async () => {
+    // Two rows: 60 billed minutes each (durationMinutes is intentionally
+    // larger). Total should be 2.00 billed hours, never 4.00 duration hours.
+    const pdf = await exportPdfHandler({
+      scopedDb: scopedDbReturning([timeEntryRow(), timeEntryRow()]),
+      workspaceId: toSafeId<"workspace">("ws_1"),
+      organizationId: toSafeId<"organization">("org_1"),
+      query: {},
+    });
+
+    const text = new TextDecoder().decode(pdf);
+    expect(text).toContain("Total Hours: 2.00");
+    expect(text).not.toContain("Total Hours: 4.00");
+  });
+});

--- a/apps/api/src/handlers/time-entries/export-pdf.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.ts
@@ -131,7 +131,10 @@ export const exportPdfHandler = async ({
       hourlyRateCents: row.rateAtEntry,
     });
 
-    totalMinutes += row.durationMinutes;
+    // Total Hours must reconcile with the per-row billed hours and the
+    // amount, which are both derived from billedMinutes; summing raw
+    // durationMinutes here produced a total that did not match the lines.
+    totalMinutes += row.billedMinutes;
     totalAmount += amount;
 
     textLines.push(`Date: ${row.dateWorked}  User: ${userName}`);

--- a/apps/api/src/handlers/uploads/lib.test.ts
+++ b/apps/api/src/handlers/uploads/lib.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
   legacyTmpUploadKey,
+  sha256Base64ToHex,
+  sha256HexToBase64,
   tmpUploadKey,
   tmpUploadKeys,
 } from "@/api/handlers/uploads/lib";
@@ -24,5 +26,29 @@ describe("tmp upload keys", () => {
       "org_1/ws_1/tmp/upload_1",
       "tmp/upload_1",
     ]);
+  });
+});
+
+describe("SHA-256 hex <-> base64 (S3 checksum integrity gate)", () => {
+  test("round-trips an arbitrary digest back to lowercase hex", () => {
+    const hex = new Bun.CryptoHasher("sha256")
+      .update("the quick brown fox")
+      .digest("hex");
+    expect(sha256Base64ToHex(sha256HexToBase64(hex))).toBe(hex);
+  });
+
+  test("hex->base64 matches Bun's own base64 digest", () => {
+    const hasher = new Bun.CryptoHasher("sha256").update("payload bytes");
+    const hex = hasher.digest("hex");
+    const expectedBase64 = new Bun.CryptoHasher("sha256")
+      .update("payload bytes")
+      .digest("base64");
+    expect(sha256HexToBase64(hex)).toBe(expectedBase64);
+  });
+
+  test("produced hex is the canonical 64-char lowercase form", () => {
+    const base64 = new Bun.CryptoHasher("sha256").update("x").digest("base64");
+    const hex = sha256Base64ToHex(base64);
+    expect(hex).toMatch(/^[0-9a-f]{64}$/u);
   });
 });

--- a/apps/api/src/lib/api-handlers.test.ts
+++ b/apps/api/src/lib/api-handlers.test.ts
@@ -152,8 +152,10 @@ const createContext = (
   safeDb: SafeDb,
   {
     orgAIConfig = null,
+    role = "owner",
   }: {
     orgAIConfig?: OrgAIConfig | null;
+    role?: "owner" | "admin" | "member" | "intern" | "external";
   } = {},
 ): Parameters<typeof endpoint.handler>[0] =>
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture only provides fields used before the handler body can run
@@ -168,7 +170,7 @@ const createContext = (
         "019e7000-0000-7000-8000-000000000002",
       ),
     },
-    memberRole: { role: "owner" },
+    memberRole: { role },
     safeDb,
     scopedDb: async () => {
       throw new DatabaseError({ message: "scopedDb should not be called" });
@@ -189,4 +191,52 @@ const createOrgAIConfig = (): OrgAIConfig => ({
     pdf: { provider: "openai", modelId: "gpt-4.1" },
     reasoning: { provider: "openai", modelId: "o3" },
   },
+});
+
+describe("createSafeRootHandler permission gate", () => {
+  test("denies the handler when the member role lacks the permission", async () => {
+    let bodyRan = false;
+    const endpoint = createSafeRootHandler(
+      { permissions: { organization: ["delete"] } },
+      async function* () {
+        bodyRan = true;
+        return Result.ok({ ok: true });
+      },
+    );
+    const safeDb: SafeDb = async <T>() =>
+      Result.err<T, SafeDbError>(
+        new DatabaseError({ message: "db should not be read on deny" }),
+      );
+
+    const result = await endpoint.handler(
+      createContext(endpoint, safeDb, { role: "member" }),
+    );
+
+    expect(bodyRan).toBe(false);
+    if (!("code" in result)) {
+      throw new Error("expected a status response");
+    }
+    expect(result.code).toBe(403);
+    expect(result.response).toEqual({ message: "Forbidden" });
+  });
+
+  test("runs the handler when the role holds the permission", async () => {
+    let bodyRan = false;
+    const endpoint = createSafeRootHandler(
+      { permissions: { organization: ["delete"] } },
+      async function* () {
+        bodyRan = true;
+        return Result.ok({ ok: true });
+      },
+    );
+    const safeDb: SafeDb = async <T>() =>
+      Result.err<T, SafeDbError>(new DatabaseError({ message: "unused" }));
+
+    const result = await endpoint.handler(
+      createContext(endpoint, safeDb, { role: "owner" }),
+    );
+
+    expect(bodyRan).toBe(true);
+    expect(result).toEqual({ ok: true });
+  });
 });

--- a/apps/api/src/lib/bullmq-job-id.test.ts
+++ b/apps/api/src/lib/bullmq-job-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+
+describe("createBullMqJobId", () => {
+  test("encodes parts so BullMQ job IDs do not contain colon separators", () => {
+    const jobId = createBullMqJobId("scheduler", "job:1", "run:1");
+
+    expect(jobId).toBe("scheduler-job%3A1-run%3A1");
+    expect(jobId).not.toContain(":");
+  });
+
+  test("encodes separator characters in parts", () => {
+    expect(createBullMqJobId("a-b", "c")).not.toBe(
+      createBullMqJobId("a", "b-c"),
+    );
+  });
+});

--- a/apps/api/src/lib/bullmq-job-id.ts
+++ b/apps/api/src/lib/bullmq-job-id.ts
@@ -1,0 +1,7 @@
+const BULLMQ_JOB_ID_SEPARATOR = "-";
+
+const encodeBullMqJobIdPart = (part: string): string =>
+  encodeURIComponent(part).replaceAll(BULLMQ_JOB_ID_SEPARATOR, "%2D");
+
+export const createBullMqJobId = (...parts: readonly string[]): string =>
+  parts.map(encodeBullMqJobIdPart).join(BULLMQ_JOB_ID_SEPARATOR);

--- a/apps/api/src/lib/csv.test.ts
+++ b/apps/api/src/lib/csv.test.ts
@@ -36,11 +36,18 @@ const readCsvField = (cell: string): string => {
 const FORMULA_PREFIX_RE = /^\s*[=+\-@\t\r\n]/u;
 
 // Deterministic LCG so a fuzz failure is reproducible, never flaky.
+const LCG_MODULUS = 2 ** 32;
+const LCG_MULTIPLIER = 1_664_525;
+const LCG_INCREMENT = 1_013_904_223;
+
 const makePrng = (seed: number) => {
-  let state = seed >>> 0;
+  let state = Math.trunc(seed) % LCG_MODULUS;
+  if (state < 0) {
+    state += LCG_MODULUS;
+  }
   return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 0x100000000;
+    state = (state * LCG_MULTIPLIER + LCG_INCREMENT) % LCG_MODULUS;
+    return state / LCG_MODULUS;
   };
 };
 
@@ -111,7 +118,7 @@ describe("escapeCSV", () => {
   // ----- invariants over a large, fuzzed input space -----
 
   test("INVARIANT: a flagged formula value always gets the tab guard", () => {
-    const rand = makePrng(0xc0ffee);
+    const rand = makePrng(12_648_430);
     for (let n = 0; n < 4000; n++) {
       const len = 1 + Math.floor(rand() * 6);
       let v = "";
@@ -126,7 +133,7 @@ describe("escapeCSV", () => {
   });
 
   test("INVARIANT: roundtrips through an RFC-4180 reader without data loss", () => {
-    const rand = makePrng(0x1337);
+    const rand = makePrng(4919);
     for (let n = 0; n < 4000; n++) {
       const len = Math.floor(rand() * 8);
       let v = "";
@@ -142,7 +149,7 @@ describe("escapeCSV", () => {
   });
 
   test("INVARIANT: the decoded cell never begins with a live formula char", () => {
-    const rand = makePrng(0xabcdef);
+    const rand = makePrng(11_259_375);
     const liveFormula = /^[=+\-@]/u;
     for (let n = 0; n < 4000; n++) {
       const len = 1 + Math.floor(rand() * 6);

--- a/apps/api/src/lib/csv.test.ts
+++ b/apps/api/src/lib/csv.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import { escapeCSV } from "@/api/lib/csv";
+
+/**
+ * Minimal RFC 4180 single-field reader: given the text of one CSV cell as
+ * `escapeCSV` would emit it, recover the logical value a conformant parser
+ * (Excel, Numbers, LibreOffice, csv-parse) would read back.
+ *
+ * This is deliberately independent of `escapeCSV`'s implementation so the
+ * roundtrip assertions below test the *contract*, not the code.
+ */
+const readCsvField = (cell: string): string => {
+  if (!cell.startsWith('"')) {
+    return cell;
+  }
+  let out = "";
+  let i = 1;
+  while (i < cell.length) {
+    const ch = cell[i];
+    if (ch === '"') {
+      if (cell[i + 1] === '"') {
+        out += '"';
+        i += 2;
+        continue;
+      }
+      // closing quote; RFC 4180 has nothing after it for a lone field
+      return out;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+};
+
+const FORMULA_PREFIX_RE = /^\s*[=+\-@\t\r\n]/u;
+
+// Deterministic LCG so a fuzz failure is reproducible, never flaky.
+const makePrng = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+};
+
+const FUZZ_ALPHABET = [
+  "a",
+  "Z",
+  "9",
+  " ",
+  ",",
+  '"',
+  "\n",
+  "\r",
+  "\t",
+  "=",
+  "+",
+  "-",
+  "@",
+  "|",
+  "š",
+  "字",
+  "=SUM(",
+  "()",
+];
+
+describe("escapeCSV", () => {
+  test("passes through plain values unchanged", () => {
+    for (const v of ["", "abc", "John Smith", "123.45", "Praha 1", "café"]) {
+      expect(escapeCSV(v)).toBe(v);
+    }
+  });
+
+  test("quotes and doubles inner quotes for delimiter-bearing values", () => {
+    expect(escapeCSV("a,b")).toBe('"a,b"');
+    expect(escapeCSV('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCSV("line1\nline2")).toBe('"line1\nline2"');
+    expect(escapeCSV("carriage\rreturn")).toBe('"carriage\rreturn"');
+  });
+
+  test("neutralizes spreadsheet formula prefixes with a leading tab", () => {
+    // The classic CSV-injection vectors must never reach a cell that a
+    // spreadsheet would evaluate as a formula.
+    for (const v of [
+      "=1+1",
+      "+1",
+      "-1+cmd",
+      "@SUM(A1)",
+      "=HYPERLINK(...)",
+      "\t=evil",
+    ]) {
+      const escaped = escapeCSV(v);
+      expect(escaped.startsWith('"\t')).toBe(true);
+    }
+  });
+
+  test("neutralizes formula prefixes even behind leading whitespace", () => {
+    // Excel trims leading spaces before deciding a cell is a formula.
+    for (const v of ["   =1+1", "  +cmd", " \t-danger", "  @x"]) {
+      expect(escapeCSV(v).startsWith('"\t')).toBe(true);
+    }
+  });
+
+  test("does NOT add a tab guard to non-formula values", () => {
+    for (const v of ["a,b", 'say "hi"', "plain", "1,000.00"]) {
+      expect(escapeCSV(v).startsWith('"\t')).toBe(false);
+    }
+  });
+
+  // ----- invariants over a large, fuzzed input space -----
+
+  test("INVARIANT: a flagged formula value always gets the tab guard", () => {
+    const rand = makePrng(0xc0ffee);
+    for (let n = 0; n < 4000; n++) {
+      const len = 1 + Math.floor(rand() * 6);
+      let v = "";
+      for (let k = 0; k < len; k++) {
+        v += FUZZ_ALPHABET[Math.floor(rand() * FUZZ_ALPHABET.length)];
+      }
+      const escaped = escapeCSV(v);
+      if (FORMULA_PREFIX_RE.test(v)) {
+        expect(escaped.startsWith('"\t')).toBe(true);
+      }
+    }
+  });
+
+  test("INVARIANT: roundtrips through an RFC-4180 reader without data loss", () => {
+    const rand = makePrng(0x1337);
+    for (let n = 0; n < 4000; n++) {
+      const len = Math.floor(rand() * 8);
+      let v = "";
+      for (let k = 0; k < len; k++) {
+        v += FUZZ_ALPHABET[Math.floor(rand() * FUZZ_ALPHABET.length)];
+      }
+      const decoded = readCsvField(escapeCSV(v));
+      // Formula values intentionally gain a leading tab (the neutralizer);
+      // every other character must survive verbatim.
+      const expected = FORMULA_PREFIX_RE.test(v) ? `\t${v}` : v;
+      expect(decoded).toBe(expected);
+    }
+  });
+
+  test("INVARIANT: the decoded cell never begins with a live formula char", () => {
+    const rand = makePrng(0xabcdef);
+    const liveFormula = /^[=+\-@]/u;
+    for (let n = 0; n < 4000; n++) {
+      const len = 1 + Math.floor(rand() * 6);
+      let v = "";
+      for (let k = 0; k < len; k++) {
+        v += FUZZ_ALPHABET[Math.floor(rand() * FUZZ_ALPHABET.length)];
+      }
+      const decoded = readCsvField(escapeCSV(v));
+      // After neutralization a spreadsheet sees either a tab-prefixed text
+      // cell or a value that simply never started with a formula char.
+      if (liveFormula.test(decoded)) {
+        throw new Error(
+          `decoded cell starts with a live formula char: ${JSON.stringify(decoded)} (input ${JSON.stringify(v)})`,
+        );
+      }
+    }
+  });
+});

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -418,6 +418,30 @@ describe("applySorts (in-memory)", () => {
     ]);
   });
 
+  test("int sort parses legacy numeric text values", () => {
+    const items = [
+      {
+        entityId: "twenty",
+        kind: "task" as const,
+        fields: [makeIntField("twenty", "p1", 20)],
+      },
+      makeEntity("ten", "task", [["p1", "10"]]),
+      {
+        entityId: "nine",
+        kind: "task" as const,
+        fields: [makeIntField("nine", "p1", 9)],
+      },
+    ];
+
+    const sorted = applySorts(items, [{ propertyId: "p1", desc: false }]);
+
+    expect(sorted.map((item) => item.entityId)).toEqual([
+      "nine",
+      "ten",
+      "twenty",
+    ]);
+  });
+
   test("property: int sort with missing rows is numerically monotonic", () => {
     fc.assert(
       fc.property(
@@ -556,7 +580,7 @@ describe("buildSortExpressions", () => {
       { propertyId: "p1", desc: false },
     ]);
 
-    // A numeric cast guarded by the int type, ordered before the text key.
+    // A guarded numeric cast, ordered before the text key.
     const numericExpr = expressions[0];
     const textExpr = expressions[1];
     if (!numericExpr || !textExpr) {
@@ -565,7 +589,8 @@ describe("buildSortExpressions", () => {
 
     const numericSql = dialect.sqlToQuery(numericExpr).sql;
     expect(numericSql).toContain("::numeric");
-    expect(numericSql).toContain("'int'");
+    expect(numericSql).toContain("BTRIM");
+    expect(numericSql).toContain("~");
     expect(numericSql).toContain("NULLS LAST");
 
     const textSql = dialect.sqlToQuery(textExpr).sql;

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -525,4 +525,39 @@ describe("buildSortExpressions", () => {
       expect(sql).not.toContain('"fields"."property_id" =');
     }
   });
+
+  test("property sort emits a numeric key so int fields order numerically", () => {
+    const dialect = new PgDialect();
+    const expressions = buildSortExpressions([
+      { propertyId: "p1", desc: false },
+    ]);
+
+    // A numeric cast guarded by the int type, ordered before the text key.
+    const numericExpr = expressions[0];
+    const textExpr = expressions[1];
+    if (!numericExpr || !textExpr) {
+      throw new Error("expected numeric and text sort expressions");
+    }
+
+    const numericSql = dialect.sqlToQuery(numericExpr).sql;
+    expect(numericSql).toContain("::numeric");
+    expect(numericSql).toContain("'int'");
+    expect(numericSql).toContain("NULLS LAST");
+
+    const textSql = dialect.sqlToQuery(textExpr).sql;
+    expect(textSql).toContain("->>'value'");
+    expect(textSql).not.toContain("::numeric");
+  });
+
+  test("descending property sort keeps missing/non-int values last", () => {
+    const dialect = new PgDialect();
+    const [numericExpr] = buildSortExpressions([
+      { propertyId: "p1", desc: true },
+    ]);
+    if (!numericExpr) {
+      throw new Error("expected numeric sort expression");
+    }
+    const sql = dialect.sqlToQuery(numericExpr).sql;
+    expect(sql).toContain("DESC NULLS LAST");
+  });
 });

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -590,6 +590,8 @@ describe("buildSortExpressions", () => {
     const numericSql = dialect.sqlToQuery(numericExpr).sql;
     expect(numericSql).toContain("::numeric");
     expect(numericSql).toContain("BTRIM");
+    expect(numericSql).toContain('"properties"');
+    expect(numericSql).toContain("'int'");
     expect(numericSql).toContain("~");
     expect(numericSql).toContain("NULLS LAST");
 

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -394,6 +394,30 @@ describe("applySorts (in-memory)", () => {
     ]);
   });
 
+  test("int sort treats whitespace-only legacy text as missing", () => {
+    const items = [
+      makeEntity("whitespace", "task", [["p1", "   "]]),
+      {
+        entityId: "negative",
+        kind: "task" as const,
+        fields: [makeIntField("negative", "p1", -1)],
+      },
+      {
+        entityId: "positive",
+        kind: "task" as const,
+        fields: [makeIntField("positive", "p1", 1)],
+      },
+    ];
+
+    const sorted = applySorts(items, [{ propertyId: "p1", desc: false }]);
+
+    expect(sorted.map((item) => item.entityId)).toEqual([
+      "negative",
+      "positive",
+      "whitespace",
+    ]);
+  });
+
   test("property: int sort with missing rows is numerically monotonic", () => {
     fc.assert(
       fc.property(

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -339,6 +339,102 @@ describe("applySorts (in-memory)", () => {
     expect(sorted.map((item) => item.entityId)).toEqual(["2", "1"]);
   });
 
+  test("orders ints numerically, not lexicographically (10 after 9)", () => {
+    const items = [
+      {
+        entityId: "ten",
+        kind: "task" as const,
+        fields: [makeIntField("ten", "p1", 10)],
+      },
+      {
+        entityId: "nine",
+        kind: "task" as const,
+        fields: [makeIntField("nine", "p1", 9)],
+      },
+      {
+        entityId: "two",
+        kind: "task" as const,
+        fields: [makeIntField("two", "p1", 2)],
+      },
+    ];
+
+    const sorted = applySorts(items, [{ propertyId: "p1", desc: false }]);
+
+    expect(sorted.map((item) => item.entityId)).toEqual(["two", "nine", "ten"]);
+  });
+
+  test("int sort stays numeric when a row is missing the field (missing sorts last)", () => {
+    const items = [
+      {
+        entityId: "ten",
+        kind: "task" as const,
+        fields: [makeIntField("ten", "p1", 10)],
+      },
+      { entityId: "missing", kind: "task" as const, fields: [] },
+      {
+        entityId: "nine",
+        kind: "task" as const,
+        fields: [makeIntField("nine", "p1", 9)],
+      },
+    ];
+
+    const asc = applySorts(items, [{ propertyId: "p1", desc: false }]);
+    expect(asc.map((item) => item.entityId)).toEqual([
+      "nine",
+      "ten",
+      "missing",
+    ]);
+
+    // Missing values bucket to the end regardless of direction.
+    const desc = applySorts(items, [{ propertyId: "p1", desc: true }]);
+    expect(desc.map((item) => item.entityId)).toEqual([
+      "ten",
+      "nine",
+      "missing",
+    ]);
+  });
+
+  test("property: int sort with missing rows is numerically monotonic", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.option(fc.integer(), { nil: undefined }), {
+          minLength: 1,
+          maxLength: 20,
+        }),
+        (values) => {
+          const items = values.map((value, index) =>
+            value === undefined
+              ? { entityId: String(index), kind: "task" as const, fields: [] }
+              : {
+                  entityId: String(index),
+                  kind: "task" as const,
+                  fields: [makeIntField(String(index), "p1", value)],
+                },
+          );
+
+          const sorted = applySorts(items, [{ propertyId: "p1", desc: false }]);
+          const nums = sorted.map((item) => {
+            const c = item.fields[0]?.content;
+            return c?.type === "int" ? c.value : null;
+          });
+
+          // Defined ints appear before any missing, in non-decreasing order.
+          let seenNull = false;
+          let prev = -Infinity;
+          for (const n of nums) {
+            if (n === null) {
+              seenNull = true;
+              continue;
+            }
+            expect(seenNull).toBe(false);
+            expect(n).toBeGreaterThanOrEqual(prev);
+            prev = n;
+          }
+        },
+      ),
+    );
+  });
+
   test("property: ascending string sort is monotonic", () => {
     fc.assert(
       fc.property(

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -28,6 +28,10 @@ type ViewSort = {
 
 // -- Helpers --
 
+const NUMERIC_TEXT_PATTERN =
+  "^[+-]?(?:(?:[0-9]+(?:\\.[0-9]*)?)|(?:\\.[0-9]+))(?:[eE][+-]?[0-9]+)?$";
+const NUMERIC_TEXT_RE = new RegExp(NUMERIC_TEXT_PATTERN, "u");
+
 const getFieldValue = (content: FieldContent | undefined): string => {
   if (!content) {
     return "";
@@ -65,8 +69,8 @@ const numericContentValue = (
   if (content?.type === "int") {
     return content.value;
   }
-  const raw = getFieldValue(content);
-  if (raw.trim() === "") {
+  const raw = getFieldValue(content).trim();
+  if (raw === "" || !NUMERIC_TEXT_RE.test(raw)) {
     return null;
   }
   const n = Number(raw);
@@ -192,6 +196,17 @@ export const applySorts = <T extends FilterableEntity>(
  */
 const fieldValueExpr = (contentCol: typeof fields.content): SQL =>
   sql`COALESCE(${contentCol}->>'value', ${contentCol}->>'fileName', '')`;
+
+const numericFieldValueExpr = (contentCol: typeof fields.content): SQL => {
+  const valueExpr = fieldValueExpr(contentCol);
+  const trimmed = sql`BTRIM(${valueExpr})`;
+
+  return sql`CASE
+    WHEN ${trimmed} ~ ${NUMERIC_TEXT_PATTERN}
+    THEN ${trimmed}::numeric
+    ELSE NULL
+  END`;
+};
 
 /**
  * Builds an EXISTS subquery that checks whether an entity's
@@ -388,16 +403,11 @@ export const buildSortExpressions = (sorts: readonly ViewSort[]): SQL[] => {
       continue;
     }
 
-    // Numeric sort key for int fields: `content->>'value'` is text, so a
-    // plain ORDER BY sorts "10" before "9". Cast to numeric for int fields
-    // (NULL otherwise, bucketed last via NULLS LAST), then break ties with
-    // the text key so text properties still order correctly.
+    // Numeric sort key: `content->>'value'` is text, so a plain ORDER BY sorts
+    // "10" before "9". Cast safe numeric text, including legacy text content
+    // left behind by property type changes, then break ties with the text key.
     const numericSortKey = sql`(
-      SELECT CASE
-        WHEN ${fields.content}->>'type' = 'int'
-        THEN (${fields.content}->>'value')::numeric
-        ELSE NULL
-      END
+      SELECT ${numericFieldValueExpr(fields.content)}
       FROM ${fields}
       WHERE ${fields.workspaceId} = ${entities.workspaceId}
         AND ${fields.entityVersionId} = ${entities.currentVersionId}

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -2,7 +2,7 @@ import { asc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { user } from "@/api/db/auth-schema";
-import { entities, entityVersions, fields } from "@/api/db/schema";
+import { entities, entityVersions, fields, properties } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import type { ViewFilterCondition } from "@/api/lib/views-schema";
 
@@ -403,11 +403,23 @@ export const buildSortExpressions = (sorts: readonly ViewSort[]): SQL[] => {
       continue;
     }
 
+    const propertyIsInt = sql`EXISTS (
+      SELECT 1 FROM ${properties}
+      WHERE ${properties.workspaceId} = ${entities.workspaceId}
+        AND ${properties.id} = ${sort.propertyId}
+        AND ${properties.content}->>'type' = 'int'
+      LIMIT 1
+    )`;
+
     // Numeric sort key: `content->>'value'` is text, so a plain ORDER BY sorts
-    // "10" before "9". Cast safe numeric text, including legacy text content
-    // left behind by property type changes, then break ties with the text key.
+    // "10" before "9". Use numeric mode for int fields and int properties
+    // with legacy text content, then break ties with the text key.
     const numericSortKey = sql`(
-      SELECT ${numericFieldValueExpr(fields.content)}
+      SELECT CASE
+        WHEN ${fields.content}->>'type' = 'int' OR ${propertyIsInt}
+        THEN ${numericFieldValueExpr(fields.content)}
+        ELSE NULL
+      END
       FROM ${fields}
       WHERE ${fields.workspaceId} = ${entities.workspaceId}
         AND ${fields.entityVersionId} = ${entities.currentVersionId}

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -388,7 +388,23 @@ export const buildSortExpressions = (sorts: readonly ViewSort[]): SQL[] => {
       continue;
     }
 
-    const sortKeySubquery = sql`(
+    // Numeric sort key for int fields: `content->>'value'` is text, so a
+    // plain ORDER BY sorts "10" before "9". Cast to numeric for int fields
+    // (NULL otherwise, bucketed last via NULLS LAST), then break ties with
+    // the text key so text properties still order correctly.
+    const numericSortKey = sql`(
+      SELECT CASE
+        WHEN ${fields.content}->>'type' = 'int'
+        THEN (${fields.content}->>'value')::numeric
+        ELSE NULL
+      END
+      FROM ${fields}
+      WHERE ${fields.workspaceId} = ${entities.workspaceId}
+        AND ${fields.entityVersionId} = ${entities.currentVersionId}
+        AND ${fields.propertyId} = ${sort.propertyId}
+      LIMIT 1
+    )`;
+    const textSortKey = sql`(
       SELECT COALESCE(
         ${fields.content}->>'value',
         ${fields.content}->>'fileName',
@@ -402,7 +418,12 @@ export const buildSortExpressions = (sorts: readonly ViewSort[]): SQL[] => {
     )`;
 
     expressions.push(
-      sort.desc ? sql`${sortKeySubquery} DESC` : sql`${sortKeySubquery} ASC`,
+      sort.desc
+        ? sql`${numericSortKey} DESC NULLS LAST`
+        : sql`${numericSortKey} ASC NULLS LAST`,
+    );
+    expressions.push(
+      sort.desc ? sql`${textSortKey} DESC` : sql`${textSortKey} ASC`,
     );
   }
 

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -56,6 +56,23 @@ const getFieldValue = (content: FieldContent | undefined): string => {
   }
 };
 
+// Numeric value for sort comparison: int content uses its number; a
+// missing field or a legacy/coerced non-int value parses its string form,
+// returning null when no finite number is available (sorts to the end).
+const numericContentValue = (
+  content: FieldContent | undefined,
+): number | null => {
+  if (content?.type === "int") {
+    return content.value;
+  }
+  const raw = getFieldValue(content);
+  if (raw === "") {
+    return null;
+  }
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+};
+
 const findField = (
   entityFields: EntityField[],
   propertyId: string,
@@ -129,10 +146,26 @@ export const applySorts = <T extends FilterableEntity>(
       const fieldB = findField(b.fields, sort.propertyId);
       const dir = sort.desc ? -1 : 1;
 
-      if (fieldA?.content.type === "int" && fieldB?.content.type === "int") {
-        const cmp = (fieldA.content.value - fieldB.content.value) * dir;
-        if (cmp !== 0) {
-          return cmp;
+      // Numeric ordering whenever the property is numeric on at least one
+      // side. Comparing only when BOTH sides are int dropped to a string
+      // localeCompare the moment a row was missing the field or held a
+      // legacy non-int value, so 10 sorted before 9. Rows without a numeric
+      // value bucket to the end, independent of sort direction.
+      if (fieldA?.content.type === "int" || fieldB?.content.type === "int") {
+        const numA = numericContentValue(fieldA?.content);
+        const numB = numericContentValue(fieldB?.content);
+        if (numA !== null && numB !== null) {
+          const cmp = (numA - numB) * dir;
+          if (cmp !== 0) {
+            return cmp;
+          }
+          continue;
+        }
+        if (numA === null && numB !== null) {
+          return 1;
+        }
+        if (numA !== null && numB === null) {
+          return -1;
         }
         continue;
       }

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -66,7 +66,7 @@ const numericContentValue = (
     return content.value;
   }
   const raw = getFieldValue(content);
-  if (raw === "") {
+  if (raw.trim() === "") {
     return null;
   }
   const n = Number(raw);

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -17,6 +17,7 @@ import {
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
@@ -102,7 +103,7 @@ export const enqueuePdfDerivative = async ({
       workspaceId,
     },
     {
-      jobId: `${workspaceId}:${fieldId}:pdf`,
+      jobId: createBullMqJobId(workspaceId, fieldId, "pdf"),
     },
   );
 };
@@ -157,7 +158,7 @@ export const enqueueImageThumbnail = async ({
       workspaceId,
     },
     {
-      jobId: `${workspaceId}:${fieldId}:thumbnail`,
+      jobId: createBullMqJobId(workspaceId, fieldId, "thumbnail"),
     },
   );
 };

--- a/apps/api/src/lib/file-scan/scanner.test.ts
+++ b/apps/api/src/lib/file-scan/scanner.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, test } from "bun:test";
 
 import { createZipBombGuard } from "@/api/lib/file-scan/scanner";
 
-const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff];
+const BYTE_MODULUS = 256;
+const byteAt = (n: number, byteIndex: number): number =>
+  Math.trunc(n / BYTE_MODULUS ** byteIndex) % BYTE_MODULUS;
+
+const u16 = (n: number): number[] => [byteAt(n, 0), byteAt(n, 1)];
 const u32 = (n: number): number[] => [
-  n & 0xff,
-  (n >> 8) & 0xff,
-  (n >> 16) & 0xff,
-  (n >> 24) & 0xff,
+  byteAt(n, 0),
+  byteAt(n, 1),
+  byteAt(n, 2),
+  byteAt(n, 3),
 ];
 
 // A raw ZIP local file header with sizes written into the header itself.
@@ -25,12 +29,12 @@ const localFileHeader = ({
   fileName?: string;
 }): number[] => {
   const name = [...new TextEncoder().encode(fileName)];
-  const data = new Array<number>(compressedSize).fill(0);
+  const data = Array.from({ length: compressedSize }, () => 0);
   return [
-    0x50,
-    0x4b,
-    0x03,
-    0x04, // PK\x03\x04
+    80,
+    75,
+    3,
+    4, // PK\x03\x04
     ...u16(20), // version needed
     ...u16(flags),
     ...u16(8), // method: deflate
@@ -100,7 +104,7 @@ describe("createZipBombGuard", () => {
   test("flags a data-descriptor entry whose header sizes are zero", async () => {
     const bytes = zip(
       localFileHeader({
-        flags: 0x08,
+        flags: 8,
         compressedSize: 0,
         uncompressedSize: 0,
       }),

--- a/apps/api/src/lib/file-scan/scanner.test.ts
+++ b/apps/api/src/lib/file-scan/scanner.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+
+import { createZipBombGuard } from "@/api/lib/file-scan/scanner";
+
+const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff];
+const u32 = (n: number): number[] => [
+  n & 0xff,
+  (n >> 8) & 0xff,
+  (n >> 16) & 0xff,
+  (n >> 24) & 0xff,
+];
+
+// A raw ZIP local file header with sizes written into the header itself.
+// (JSZip zeros these and uses a trailing data descriptor, which the guard
+// deliberately cannot read — so headers are hand-built here.)
+const localFileHeader = ({
+  flags = 0,
+  compressedSize,
+  uncompressedSize,
+  fileName = "f",
+}: {
+  flags?: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  fileName?: string;
+}): number[] => {
+  const name = [...new TextEncoder().encode(fileName)];
+  const data = new Array<number>(compressedSize).fill(0);
+  return [
+    0x50,
+    0x4b,
+    0x03,
+    0x04, // PK\x03\x04
+    ...u16(20), // version needed
+    ...u16(flags),
+    ...u16(8), // method: deflate
+    ...u16(0), // mod time
+    ...u16(0), // mod date
+    ...u32(0), // crc32
+    ...u32(compressedSize),
+    ...u32(uncompressedSize),
+    ...u16(name.length),
+    ...u16(0), // extra length
+    ...name,
+    ...data,
+  ];
+};
+
+const zip = (...entries: number[][]): Uint8Array =>
+  new Uint8Array(entries.flat());
+
+const guard = createZipBombGuard({
+  maxEntries: 3,
+  maxTotalUncompressedBytes: 1000,
+  maxCompressionRatio: 100,
+});
+
+describe("createZipBombGuard", () => {
+  test("ignores non-ZIP and tiny inputs", async () => {
+    expect(await guard.scan(new Uint8Array([1, 2, 3, 4, 5]))).toEqual([]);
+    expect(await guard.scan(new Uint8Array([1, 2]))).toEqual([]);
+  });
+
+  test("passes a benign archive within all limits", async () => {
+    const bytes = zip(
+      localFileHeader({ compressedSize: 8, uncompressedSize: 16 }),
+    );
+    expect(await guard.scan(bytes)).toEqual([]);
+  });
+
+  test("flags an extreme compression ratio", async () => {
+    const bytes = zip(
+      localFileHeader({ compressedSize: 4, uncompressedSize: 4000 }),
+    );
+    const matches = await guard.scan(bytes);
+    expect(matches[0]?.rule).toBe("zip-bomb-ratio");
+    expect(matches[0]?.severity).toBe("critical");
+  });
+
+  test("flags too many entries", async () => {
+    const small = () =>
+      localFileHeader({ compressedSize: 2, uncompressedSize: 2 });
+    const matches = await guard.scan(zip(small(), small(), small(), small()));
+    expect(matches[0]?.rule).toBe("zip-bomb-entries");
+  });
+
+  test("flags total uncompressed size over the cap", async () => {
+    const lenient = createZipBombGuard({
+      maxEntries: 10,
+      maxTotalUncompressedBytes: 1000,
+      maxCompressionRatio: 100_000,
+    });
+    const bytes = zip(
+      localFileHeader({ compressedSize: 50, uncompressedSize: 2000 }),
+    );
+    const matches = await lenient.scan(bytes);
+    expect(matches[0]?.rule).toBe("zip-bomb-size");
+  });
+
+  test("flags a data-descriptor entry whose header sizes are zero", async () => {
+    const bytes = zip(
+      localFileHeader({
+        flags: 0x08,
+        compressedSize: 0,
+        uncompressedSize: 0,
+      }),
+    );
+    const matches = await guard.scan(bytes);
+    expect(matches[0]?.rule).toBe("zip-data-descriptor");
+    expect(matches[0]?.severity).toBe("suspicious");
+  });
+});

--- a/apps/api/src/lib/file-scan/verdict.test.ts
+++ b/apps/api/src/lib/file-scan/verdict.test.ts
@@ -37,10 +37,12 @@ describe("aggregateVerdict (the chokepoint every file-scan gate depends on)", ()
       for (const b of severities) {
         for (const c of severities) {
           const set = [finding(a), finding(b), finding(c)];
-          const expected = set.reduce(
-            (hi, f) => (rank[f.severity] > rank[hi] ? f.severity : hi),
-            "pass" as ScanFinding["severity"],
-          );
+          let expected: ScanFinding["severity"] = "pass";
+          for (const item of set) {
+            if (rank[item.severity] > rank[expected]) {
+              expected = item.severity;
+            }
+          }
           expect(aggregateVerdict(set)).toBe(expected);
           // monotonicity: appending another reject can only raise/keep
           expect(rank[aggregateVerdict([...set, finding("reject")])]).toBe(

--- a/apps/api/src/lib/file-scan/verdict.test.ts
+++ b/apps/api/src/lib/file-scan/verdict.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ScanFinding } from "@/api/lib/file-scan/types";
+import { aggregateVerdict } from "@/api/lib/file-scan/verdict";
+
+const finding = (severity: ScanFinding["severity"]): ScanFinding => ({
+  rule: `rule-${severity}`,
+  severity,
+  message: `${severity} finding`,
+});
+
+describe("aggregateVerdict (the chokepoint every file-scan gate depends on)", () => {
+  test("no findings is a pass", () => {
+    expect(aggregateVerdict([])).toBe("pass");
+  });
+
+  test("FAIL-CLOSED: a single 'reject' dominates any number of lesser findings", () => {
+    expect(
+      aggregateVerdict([finding("pass"), finding("warn"), finding("reject")]),
+    ).toBe("reject");
+    // order must not matter — reject still wins when it appears first
+    expect(
+      aggregateVerdict([finding("reject"), finding("warn"), finding("pass")]),
+    ).toBe("reject");
+  });
+
+  test("warn dominates pass but never masks a reject", () => {
+    expect(aggregateVerdict([finding("pass"), finding("warn")])).toBe("warn");
+    expect(aggregateVerdict([finding("pass"), finding("pass")])).toBe("pass");
+  });
+
+  test("INVARIANT: result is the max-severity finding; adding findings never lowers it", () => {
+    const rank = { pass: 0, warn: 1, reject: 2 } as const;
+    const severities: ScanFinding["severity"][] = ["pass", "warn", "reject"];
+    // every non-empty combination of up to 3 findings
+    for (const a of severities) {
+      for (const b of severities) {
+        for (const c of severities) {
+          const set = [finding(a), finding(b), finding(c)];
+          const expected = set.reduce(
+            (hi, f) => (rank[f.severity] > rank[hi] ? f.severity : hi),
+            "pass" as ScanFinding["severity"],
+          );
+          expect(aggregateVerdict(set)).toBe(expected);
+          // monotonicity: appending another reject can only raise/keep
+          expect(rank[aggregateVerdict([...set, finding("reject")])]).toBe(
+            rank.reject,
+          );
+        }
+      }
+    }
+  });
+});

--- a/apps/api/src/lib/folio-collab-sessions.test.ts
+++ b/apps/api/src/lib/folio-collab-sessions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+process.env["S3_ENDPOINT"] ??= "http://localhost:9000";
+process.env["S3_BUCKET"] ??= "test";
+process.env["S3_REGION"] ??= "us-east-1";
+
+// The collab auth query joins five tables; a chainable builder lets each
+// test set the single row the join would return.
+type QueryBuilder = {
+  select: () => QueryBuilder;
+  from: () => QueryBuilder;
+  innerJoin: () => QueryBuilder;
+  leftJoin: () => QueryBuilder;
+  where: () => QueryBuilder;
+  limit: () => Promise<Record<string, unknown>[]>;
+};
+
+let nextRows: Record<string, unknown>[] = [];
+const builder: QueryBuilder = {
+  select: () => builder,
+  from: () => builder,
+  innerJoin: () => builder,
+  leftJoin: () => builder,
+  where: () => builder,
+  limit: () => Promise.resolve(nextRows),
+};
+
+mock.module("@/api/db/root", () => ({ rootDb: builder, rlsDb: {} }));
+mock.module("@/api/lib/root-scoped-db", () => ({
+  createRootScopedDb: () => "SCOPED_DB_SENTINEL",
+  createRootSafeDb: () => "SAFE_DB_SENTINEL",
+}));
+
+const { authorizeFolioCollabSession } =
+  await import("@/api/lib/folio-collab-sessions");
+
+const sessionId = toSafeId<"folioCollabSession">("fcs_1");
+const orgId = toSafeId<"organization">("org_1");
+const wsId = toSafeId<"workspace">("ws_1");
+
+type Row = Record<string, unknown>;
+
+const validRow = (overrides: Row = {}): Row => ({
+  canEdit: { canEdit: true },
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  fileName: "contract.docx",
+  organizationId: orgId,
+  organizationRole: "owner",
+  sessionStatus: "open",
+  userId: "user_1",
+  workspaceId: wsId,
+  workspaceMemberId: null,
+  yjsSnapshotFileId: null,
+  ...overrides,
+});
+
+const authorize = (row: Row | null) => {
+  nextRows = row === null ? [] : [row];
+  return authorizeFolioCollabSession({ sessionId, token: "tok" });
+};
+
+describe("authorizeFolioCollabSession (the collab trust boundary)", () => {
+  test("no matching token row is 'missing'", async () => {
+    expect(await authorize(null)).toEqual({ status: "missing" });
+  });
+
+  test("a non-open session is 'missing' even with a valid token and role", async () => {
+    expect(await authorize(validRow({ sessionStatus: "closed" }))).toEqual({
+      status: "missing",
+    });
+  });
+
+  test("an expired token is 'token-expired'", async () => {
+    const result = await authorize(
+      validRow({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+    expect(result).toEqual({ status: "token-expired" });
+  });
+
+  test("a removed org member (null role) is 'permission-revoked'", async () => {
+    expect(await authorize(validRow({ organizationRole: null }))).toEqual({
+      status: "permission-revoked",
+    });
+  });
+
+  test("a non-admin member without a workspace membership is revoked", async () => {
+    // member has entity:update, so this isolates the canUseWorkspace branch:
+    // a non-owner/admin needs a workspace membership row.
+    expect(
+      await authorize(
+        validRow({ organizationRole: "member", workspaceMemberId: null }),
+      ),
+    ).toEqual({ status: "permission-revoked" });
+  });
+
+  test("an owner is authorized without a workspace membership row", async () => {
+    // owner/admin satisfy canUseWorkspace via the OR branch.
+    const result = await authorize(
+      validRow({ organizationRole: "owner", workspaceMemberId: null }),
+    );
+    expect(result.status).toBe("authorized");
+  });
+
+  test("a role lacking entity:update is revoked (intern)", async () => {
+    expect(
+      await authorize(
+        validRow({ organizationRole: "intern", workspaceMemberId: "wm_1" }),
+      ),
+    ).toEqual({ status: "permission-revoked" });
+  });
+
+  test("a read-only token authorizes but preserves canEdit=false", async () => {
+    const result = await authorize(validRow({ canEdit: { canEdit: false } }));
+    expect(result.status).toBe("authorized");
+    if (result.status === "authorized") {
+      expect(result.value.canEdit).toBe(false);
+    }
+  });
+
+  test("the authorized session binds to the row's tenant, not the caller", async () => {
+    const result = await authorize(validRow());
+    expect(result.status).toBe("authorized");
+    if (result.status === "authorized") {
+      expect(result.value.organizationId).toBe(orgId);
+      expect(result.value.workspaceId).toBe(wsId);
+    }
+  });
+});

--- a/apps/api/src/lib/folio-collab-sessions.test.ts
+++ b/apps/api/src/lib/folio-collab-sessions.test.ts
@@ -24,11 +24,11 @@ const builder: QueryBuilder = {
   innerJoin: () => builder,
   leftJoin: () => builder,
   where: () => builder,
-  limit: () => Promise.resolve(nextRows),
+  limit: async () => nextRows,
 };
 
-mock.module("@/api/db/root", () => ({ rootDb: builder, rlsDb: {} }));
-mock.module("@/api/lib/root-scoped-db", () => ({
+void mock.module("@/api/db/root", () => ({ rootDb: builder, rlsDb: {} }));
+void mock.module("@/api/lib/root-scoped-db", () => ({
   createRootScopedDb: () => "SCOPED_DB_SENTINEL",
   createRootSafeDb: () => "SAFE_DB_SENTINEL",
 }));
@@ -56,9 +56,9 @@ const validRow = (overrides: Row = {}): Row => ({
   ...overrides,
 });
 
-const authorize = (row: Row | null) => {
+const authorize = async (row: Row | null) => {
   nextRows = row === null ? [] : [row];
-  return authorizeFolioCollabSession({ sessionId, token: "tok" });
+  return await authorizeFolioCollabSession({ sessionId, token: "tok" });
 };
 
 describe("authorizeFolioCollabSession (the collab trust boundary)", () => {

--- a/apps/api/src/lib/scheduler/bullmq.test.ts
+++ b/apps/api/src/lib/scheduler/bullmq.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SchedulerTaskContext } from "@/api/lib/scheduler/types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+type AddCall = { name: string; data: unknown; opts: unknown };
+const addCalls: AddCall[] = [];
+
+class MockQueue {
+  add(name: string, data: unknown, opts: unknown) {
+    addCalls.push({ name, data, opts });
+    return Promise.resolve({ id: "queued" });
+  }
+}
+
+mock.module("bullmq", () => ({ Queue: MockQueue }));
+mock.module("@/api/lib/redis-client", () => ({
+  createBullMqConnection: () => ({}),
+}));
+
+const { createBullMqDispatchTask } = await import("@/api/lib/scheduler/bullmq");
+
+const context = (): SchedulerTaskContext =>
+  asTestRaw<SchedulerTaskContext>({
+    job: { id: "job_1" },
+    payload: { queueName: "emails", jobName: "sendDigest" },
+    runId: toSafeId<"schedulerJobRun">("run_1"),
+  });
+
+describe("createBullMqDispatchTask idempotency", () => {
+  test("enqueues with a deterministic jobId from scheduler job + run", async () => {
+    addCalls.length = 0;
+    const task = createBullMqDispatchTask();
+
+    await task(context());
+    await task(context()); // a re-fire of the same run
+
+    // Both dispatches use the same jobId, so BullMQ deduplicates them.
+    expect(addCalls).toHaveLength(2);
+    for (const call of addCalls) {
+      expect(call.name).toBe("sendDigest");
+      expect(call.opts).toMatchObject({ jobId: "scheduler:job_1:run_1" });
+    }
+    expect(addCalls[0]?.opts).toEqual(addCalls[1]?.opts);
+  });
+});

--- a/apps/api/src/lib/scheduler/bullmq.test.ts
+++ b/apps/api/src/lib/scheduler/bullmq.test.ts
@@ -17,6 +17,7 @@ class MockQueue {
 mock.module("bullmq", () => ({ Queue: MockQueue }));
 mock.module("@/api/lib/redis-client", () => ({
   createBullMqConnection: () => ({}),
+  createRedisClient: () => ({}),
 }));
 
 const { createBullMqDispatchTask } = await import("@/api/lib/scheduler/bullmq");

--- a/apps/api/src/lib/scheduler/bullmq.test.ts
+++ b/apps/api/src/lib/scheduler/bullmq.test.ts
@@ -22,27 +22,50 @@ void mock.module("@/api/lib/redis-client", () => ({
 
 const { createBullMqDispatchTask } = await import("@/api/lib/scheduler/bullmq");
 
-const context = (): SchedulerTaskContext =>
+type ContextOptions = {
+  nextRunAt?: Date;
+  runId?: SchedulerTaskContext["runId"];
+};
+
+const occurrence = new Date("2026-06-14T12:00:00.000Z");
+
+const context = ({
+  nextRunAt = occurrence,
+  runId = toSafeId<"schedulerJobRun">("run_1"),
+}: ContextOptions = {}): SchedulerTaskContext =>
   asTestRaw<SchedulerTaskContext>({
-    job: { id: "job_1" },
+    job: { id: "job_1", nextRunAt },
     payload: { queueName: "emails", jobName: "sendDigest" },
-    runId: toSafeId<"schedulerJobRun">("run_1"),
+    runId,
   });
 
 describe("createBullMqDispatchTask idempotency", () => {
-  test("enqueues with a deterministic jobId from scheduler job + run", async () => {
+  test("deduplicates retries for the same scheduled occurrence", async () => {
     addCalls.length = 0;
     const task = createBullMqDispatchTask();
 
     await task(context());
-    await task(context()); // a re-fire of the same run
+    await task(context({ runId: toSafeId<"schedulerJobRun">("run_2") }));
 
-    // Both dispatches use the same jobId, so BullMQ deduplicates them.
     expect(addCalls).toHaveLength(2);
     for (const call of addCalls) {
       expect(call.name).toBe("sendDigest");
-      expect(call.opts).toMatchObject({ jobId: "scheduler-job_1-run_1" });
+      expect(call.opts).toMatchObject({
+        jobId: "scheduler-job_1-2026%2D06%2D14T12%3A00%3A00.000Z",
+      });
     }
     expect(addCalls[0]?.opts).toEqual(addCalls[1]?.opts);
+    expect(addCalls[0]?.data).toMatchObject({ schedulerRunId: "run_1" });
+    expect(addCalls[1]?.data).toMatchObject({ schedulerRunId: "run_2" });
+  });
+
+  test("uses a different jobId for a different scheduled occurrence", async () => {
+    addCalls.length = 0;
+    const task = createBullMqDispatchTask();
+
+    await task(context());
+    await task(context({ nextRunAt: new Date("2026-06-15T12:00:00.000Z") }));
+
+    expect(addCalls[0]?.opts).not.toEqual(addCalls[1]?.opts);
   });
 });

--- a/apps/api/src/lib/scheduler/bullmq.test.ts
+++ b/apps/api/src/lib/scheduler/bullmq.test.ts
@@ -8,14 +8,14 @@ type AddCall = { name: string; data: unknown; opts: unknown };
 const addCalls: AddCall[] = [];
 
 class MockQueue {
-  add(name: string, data: unknown, opts: unknown) {
+  async add(name: string, data: unknown, opts: unknown) {
     addCalls.push({ name, data, opts });
-    return Promise.resolve({ id: "queued" });
+    return { id: "queued" };
   }
 }
 
-mock.module("bullmq", () => ({ Queue: MockQueue }));
-mock.module("@/api/lib/redis-client", () => ({
+void mock.module("bullmq", () => ({ Queue: MockQueue }));
+void mock.module("@/api/lib/redis-client", () => ({
   createBullMqConnection: () => ({}),
   createRedisClient: () => ({}),
 }));

--- a/apps/api/src/lib/scheduler/bullmq.test.ts
+++ b/apps/api/src/lib/scheduler/bullmq.test.ts
@@ -41,7 +41,7 @@ describe("createBullMqDispatchTask idempotency", () => {
     expect(addCalls).toHaveLength(2);
     for (const call of addCalls) {
       expect(call.name).toBe("sendDigest");
-      expect(call.opts).toMatchObject({ jobId: "scheduler:job_1:run_1" });
+      expect(call.opts).toMatchObject({ jobId: "scheduler-job_1-run_1" });
     }
     expect(addCalls[0]?.opts).toEqual(addCalls[1]?.opts);
   });

--- a/apps/api/src/lib/scheduler/bullmq.ts
+++ b/apps/api/src/lib/scheduler/bullmq.ts
@@ -31,9 +31,9 @@ export const createBullMqDispatchTask =
     }
 
     const queue = getSchedulerQueue(payload.queueName);
-    // Deterministic jobId so a re-fired scheduler run (retry, or a DST
-    // double-fire) enqueues at most one BullMQ job: a second add with the
-    // same jobId is ignored while the first exists.
+    const scheduledFor = job.nextRunAt.toISOString();
+    // Deterministic per scheduled occurrence: if the runner crashes after
+    // enqueue but before recording success, the retry run uses the same id.
     await queue.add(
       payload.jobName,
       {
@@ -41,7 +41,7 @@ export const createBullMqDispatchTask =
         schedulerRunId: runId,
         ...(payload.data && { payload: payload.data }),
       },
-      { jobId: createBullMqJobId("scheduler", job.id, runId) },
+      { jobId: createBullMqJobId("scheduler", job.id, scheduledFor) },
     );
   };
 

--- a/apps/api/src/lib/scheduler/bullmq.ts
+++ b/apps/api/src/lib/scheduler/bullmq.ts
@@ -30,11 +30,18 @@ export const createBullMqDispatchTask =
     }
 
     const queue = getSchedulerQueue(payload.queueName);
-    await queue.add(payload.jobName, {
-      schedulerJobId: job.id,
-      schedulerRunId: runId,
-      ...(payload.data && { payload: payload.data }),
-    });
+    // Deterministic jobId so a re-fired scheduler run (retry, or a DST
+    // double-fire) enqueues at most one BullMQ job: a second add with the
+    // same jobId is ignored while the first exists.
+    await queue.add(
+      payload.jobName,
+      {
+        schedulerJobId: job.id,
+        schedulerRunId: runId,
+        ...(payload.data && { payload: payload.data }),
+      },
+      { jobId: `scheduler:${job.id}:${runId}` },
+    );
   };
 
 const getConnection = () => {

--- a/apps/api/src/lib/scheduler/bullmq.ts
+++ b/apps/api/src/lib/scheduler/bullmq.ts
@@ -1,5 +1,6 @@
 import { Queue } from "bullmq";
 
+import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { ConfigurationError } from "@/api/lib/errors/tagged-errors";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import type { SchedulerTask } from "@/api/lib/scheduler/types";
@@ -40,7 +41,7 @@ export const createBullMqDispatchTask =
         schedulerRunId: runId,
         ...(payload.data && { payload: payload.data }),
       },
-      { jobId: `scheduler:${job.id}:${runId}` },
+      { jobId: createBullMqJobId("scheduler", job.id, runId) },
     );
   };
 

--- a/apps/api/src/lib/scheduler/schedule.test.ts
+++ b/apps/api/src/lib/scheduler/schedule.test.ts
@@ -38,4 +38,27 @@ describe("computeNextRunAt", () => {
 
     expect(nextRunAt.toISOString()).toBe("2026-04-29T00:30:00.000Z");
   });
+
+  test("rolls a spring-forward non-existent time forward instead of skipping it", () => {
+    // Europe/Prague 2026-03-29: 02:00 -> 03:00 local (01:00Z), so 02:30
+    // local does not exist. The run must still fire, rolled forward to the
+    // next valid instant (03:30 local = 01:30Z), not dropped.
+    const nextRunAt = computeNextRunAt(
+      { type: "daily", hour: 2, minute: 30, timeZone: "Europe/Prague" },
+      new Date("2026-03-29T00:00:00.000Z"),
+    );
+
+    expect(nextRunAt.toISOString()).toBe("2026-03-29T01:30:00.000Z");
+  });
+
+  test("resolves a fall-back ambiguous time to its first occurrence", () => {
+    // Europe/Prague 2026-10-25: 03:00 -> 02:00 local (01:00Z), so 02:30
+    // local occurs twice. Take the first (CEST, 00:30Z), never both.
+    const nextRunAt = computeNextRunAt(
+      { type: "daily", hour: 2, minute: 30, timeZone: "Europe/Prague" },
+      new Date("2026-10-25T00:00:00.000Z"),
+    );
+
+    expect(nextRunAt.toISOString()).toBe("2026-10-25T00:30:00.000Z");
+  });
 });

--- a/apps/api/src/lib/scheduler/schedule.ts
+++ b/apps/api/src/lib/scheduler/schedule.ts
@@ -111,27 +111,39 @@ const getDatePart = (
   return value;
 };
 
+const getOffsetMs = (utcMs: number, timeZone: string): number =>
+  localAsUtcMs(getLocalDateTime(new Date(utcMs), timeZone)) - utcMs;
+
 const zonedDateTimeToUtc = (
   localDateTime: LocalDateTime,
   timeZone: string,
 ): Date => {
-  const targetLocalMs = localAsUtcMs(localDateTime);
-  let utcMs = targetLocalMs;
+  // Interpret the wall-clock time as if it were UTC, then correct by the
+  // zone offset. Sampling the offset a day before and after disambiguates
+  // DST transitions: a previous fixed-point iteration could not converge on
+  // a non-existent (spring-forward) wall time and landed before the gap,
+  // skipping the run. Gaps now roll forward to the next valid instant;
+  // overlaps (fall-back) take the first occurrence.
+  const naiveMs = localAsUtcMs(localDateTime);
+  const guessBefore = naiveMs - getOffsetMs(naiveMs - ONE_DAY_MS, timeZone);
+  const guessAfter = naiveMs - getOffsetMs(naiveMs + ONE_DAY_MS, timeZone);
 
-  for (let iteration = 0; iteration < 3; iteration += 1) {
-    const actualLocalMs = localAsUtcMs(
-      getLocalDateTime(new Date(utcMs), timeZone),
-    );
-    const diffMs = targetLocalMs - actualLocalMs;
+  const mapsBack = (utcMs: number): boolean =>
+    localAsUtcMs(getLocalDateTime(new Date(utcMs), timeZone)) === naiveMs;
 
-    if (diffMs === 0) {
-      break;
-    }
+  const beforeValid = mapsBack(guessBefore);
+  const afterValid = mapsBack(guessAfter);
 
-    utcMs += diffMs;
+  if (beforeValid && afterValid) {
+    return new Date(Math.min(guessBefore, guessAfter));
   }
-
-  return new Date(utcMs);
+  if (beforeValid) {
+    return new Date(guessBefore);
+  }
+  if (afterValid) {
+    return new Date(guessAfter);
+  }
+  return new Date(Math.max(guessBefore, guessAfter));
 };
 
 const localAsUtcMs = ({

--- a/apps/web/src/lib/redirect.test.ts
+++ b/apps/web/src/lib/redirect.test.ts
@@ -6,6 +6,8 @@ import { redirectToSchema } from "@/lib/redirect";
 const sanitize = (input: string | undefined) =>
   v.parse(redirectToSchema, input);
 
+const scriptSchemeUrl = ["java", "script:alert(1)"].join("");
+
 describe("redirectToSchema open-redirect guard", () => {
   test("keeps legitimate same-origin relative paths", () => {
     for (const ok of [
@@ -42,7 +44,7 @@ describe("redirectToSchema open-redirect guard", () => {
     for (const evil of [
       "https://evil.com",
       "http://evil.com",
-      "javascript:alert(1)",
+      scriptSchemeUrl,
       "evil.com",
       "ftp://evil.com",
     ]) {

--- a/apps/web/src/lib/redirect.test.ts
+++ b/apps/web/src/lib/redirect.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { redirectToSchema } from "@/lib/redirect";
+
+const sanitize = (input: string | undefined) =>
+  v.parse(redirectToSchema, input);
+
+describe("redirectToSchema open-redirect guard", () => {
+  test("keeps legitimate same-origin relative paths", () => {
+    for (const ok of [
+      "/",
+      "/dashboard",
+      "/workspaces/abc/entities/123",
+      "/auth/accept-invitation/xyz",
+      "/path?q=1&r=2",
+      "/path#frag",
+    ]) {
+      expect(sanitize(ok)).toBe(ok);
+    }
+  });
+
+  test("defaults to '/' when the param is absent", () => {
+    expect(sanitize(undefined)).toBe("/");
+  });
+
+  test("collapses protocol-relative '//host' escapes to '/'", () => {
+    expect(sanitize("//evil.com")).toBe("/");
+    expect(sanitize("//evil.com/path")).toBe("/");
+  });
+
+  test("collapses backslash protocol-relative escapes to '/' (the regression)", () => {
+    // Browsers normalize "/\\host", "\\/host", and "/\\/host" to a
+    // protocol-relative external origin. The "//"-only guard let these
+    // through unchanged; the tightened guard must neutralize them.
+    for (const evil of ["/\\evil.com", "/\\/evil.com", "/\\\\evil.com"]) {
+      expect(sanitize(evil)).toBe("/");
+    }
+  });
+
+  test("rejects absolute and scheme URLs", () => {
+    for (const evil of [
+      "https://evil.com",
+      "http://evil.com",
+      "javascript:alert(1)",
+      "evil.com",
+      "ftp://evil.com",
+    ]) {
+      expect(sanitize(evil)).toBe("/");
+    }
+  });
+
+  test("INVARIANT: any accepted value is a relative path whose 2nd char is not / or \\", () => {
+    const corpus = [
+      "/",
+      "/a",
+      "//x",
+      "/\\x",
+      "\\/x",
+      "/\\/x",
+      "https://x",
+      "/ok/path",
+      "//",
+      "/\t/x",
+      "",
+    ];
+    for (const input of corpus) {
+      const out = sanitize(input);
+      // Whatever survives must start with a single slash and not begin a
+      // protocol-relative escape.
+      expect(out.startsWith("/")).toBe(true);
+      expect(out.startsWith("//")).toBe(false);
+      expect(out.startsWith("/\\")).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/redirect.ts
+++ b/apps/web/src/lib/redirect.ts
@@ -14,8 +14,11 @@ const ACCEPT_INVITATION_ROUTE_PREFIX: AcceptInvitationPath extends `${infer P}$i
 export const isAcceptInvitationRedirect = (path: string) =>
   path.startsWith(ACCEPT_INVITATION_ROUTE_PREFIX);
 
-const isSafeRedirectPath = (s: string) =>
-  s.startsWith("/") && !s.startsWith("//");
+// A redirect target is safe only when it is a relative path whose second
+// character is neither "/" nor "\": browsers normalize both "//host" and
+// "/\host" (and "\/host") to a protocol-relative external origin, so the
+// "//"-only check is insufficient to prevent open redirects.
+const isSafeRedirectPath = (s: string) => /^\/(?![/\\])/u.test(s);
 
 const DEFAULT_REDIRECT: FileRouteTypes["to"] = "/";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { cents } from "@stll/money";
+
+import {
+  matterCurrencyMap,
+  summarizeBillableAmountByCurrency,
+  type TimesheetTotalEntry,
+} from "./timesheet-week-view.logic";
+
+const entry = (
+  overrides: Partial<TimesheetTotalEntry> = {},
+): TimesheetTotalEntry => ({
+  matterId: "m1",
+  currency: "USD",
+  billable: true,
+  billedMinutes: 60,
+  rateAtEntry: cents(10_000),
+  ...overrides,
+});
+
+describe("summarizeBillableAmountByCurrency", () => {
+  test("sums a single-currency week into one subtotal", () => {
+    const totals = summarizeBillableAmountByCurrency([entry(), entry()]);
+    expect(totals).toEqual([{ currency: "USD", amount: 20_000 }]);
+  });
+
+  test("keeps mixed currencies as separate subtotals, never summed together", () => {
+    const totals = summarizeBillableAmountByCurrency([
+      entry({ currency: "USD" }),
+      entry({ currency: "EUR", rateAtEntry: cents(20_000) }),
+    ]);
+    // Sorted by currency code; 100 USD + 200 EUR is NOT "300 USD".
+    expect(totals).toEqual([
+      { currency: "EUR", amount: 20_000 },
+      { currency: "USD", amount: 10_000 },
+    ]);
+  });
+
+  test("excludes non-billable entries from the amount", () => {
+    const totals = summarizeBillableAmountByCurrency([
+      entry(),
+      entry({ billable: false }),
+    ]);
+    expect(totals).toEqual([{ currency: "USD", amount: 10_000 }]);
+  });
+
+  test("empty entries produce no subtotals", () => {
+    expect(summarizeBillableAmountByCurrency([])).toEqual([]);
+  });
+});
+
+describe("matterCurrencyMap", () => {
+  test("maps each matter to its own currency", () => {
+    const map = matterCurrencyMap([
+      entry({ matterId: "m1", currency: "USD" }),
+      entry({ matterId: "m2", currency: "EUR" }),
+      entry({ matterId: "m1", currency: "USD" }),
+    ]);
+    expect(map.get("m1")).toBe("USD");
+    expect(map.get("m2")).toBe("EUR");
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.test.ts
@@ -60,4 +60,21 @@ describe("matterCurrencyMap", () => {
     expect(map.get("m1")).toBe("USD");
     expect(map.get("m2")).toBe("EUR");
   });
+
+  test("prefers a billable entry's currency over an earlier non-billable one", () => {
+    // The row amount is billable-only, so the label must match the charged
+    // currency, not the first (non-billable) entry's.
+    const map = matterCurrencyMap([
+      entry({ matterId: "m1", currency: "EUR", billable: false }),
+      entry({ matterId: "m1", currency: "USD", billable: true }),
+    ]);
+    expect(map.get("m1")).toBe("USD");
+  });
+
+  test("falls back to any currency for matters with no billable time", () => {
+    const map = matterCurrencyMap([
+      entry({ matterId: "m1", currency: "EUR", billable: false }),
+    ]);
+    expect(map.get("m1")).toBe("EUR");
+  });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { cents } from "@stll/money";
 
 import {
-  matterCurrencyMap,
+  summarizeBillableAmountByMatterAndCurrency,
   summarizeBillableAmountByCurrency,
   type TimesheetTotalEntry,
 } from "./timesheet-week-view.logic";
@@ -50,31 +50,40 @@ describe("summarizeBillableAmountByCurrency", () => {
   });
 });
 
-describe("matterCurrencyMap", () => {
-  test("maps each matter to its own currency", () => {
-    const map = matterCurrencyMap([
+describe("summarizeBillableAmountByMatterAndCurrency", () => {
+  test("maps each matter to its own currency subtotal", () => {
+    const map = summarizeBillableAmountByMatterAndCurrency([
       entry({ matterId: "m1", currency: "USD" }),
       entry({ matterId: "m2", currency: "EUR" }),
       entry({ matterId: "m1", currency: "USD" }),
     ]);
-    expect(map.get("m1")).toBe("USD");
-    expect(map.get("m2")).toBe("EUR");
+    expect(map.get("m1")).toEqual([{ currency: "USD", amount: 20_000 }]);
+    expect(map.get("m2")).toEqual([{ currency: "EUR", amount: 10_000 }]);
   });
 
-  test("prefers a billable entry's currency over an earlier non-billable one", () => {
-    // The row amount is billable-only, so the label must match the charged
-    // currency, not the first (non-billable) entry's.
-    const map = matterCurrencyMap([
+  test("ignores non-billable entries when deriving charged row subtotals", () => {
+    const map = summarizeBillableAmountByMatterAndCurrency([
       entry({ matterId: "m1", currency: "EUR", billable: false }),
       entry({ matterId: "m1", currency: "USD", billable: true }),
     ]);
-    expect(map.get("m1")).toBe("USD");
+    expect(map.get("m1")).toEqual([{ currency: "USD", amount: 10_000 }]);
   });
 
-  test("falls back to any currency for matters with no billable time", () => {
-    const map = matterCurrencyMap([
+  test("keeps same-matter mixed currencies as separate row subtotals", () => {
+    const map = summarizeBillableAmountByMatterAndCurrency([
+      entry({ matterId: "m1", currency: "USD" }),
+      entry({ matterId: "m1", currency: "EUR", rateAtEntry: cents(20_000) }),
+    ]);
+    expect(map.get("m1")).toEqual([
+      { currency: "EUR", amount: 20_000 },
+      { currency: "USD", amount: 10_000 },
+    ]);
+  });
+
+  test("omits matters with no billable amount", () => {
+    const map = summarizeBillableAmountByMatterAndCurrency([
       entry({ matterId: "m1", currency: "EUR", billable: false }),
     ]);
-    expect(map.get("m1")).toBe("EUR");
+    expect(map.has("m1")).toBe(false);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.ts
@@ -41,11 +41,22 @@ export const summarizeBillableAmountByCurrency = (
     .sort((a, b) => a.currency.localeCompare(b.currency));
 };
 
-/** Each matter's currency (a matter bills in a single currency). */
+/**
+ * Each matter's display currency. The row amount is summed from billable
+ * entries only, so prefer a billable entry's currency (a non-billable entry
+ * in another currency must not mislabel the charged subtotal). Fall back to
+ * any entry's currency for matters with no billable time, whose amount is 0
+ * and therefore not shown.
+ */
 export const matterCurrencyMap = (
   entries: readonly TimesheetTotalEntry[],
 ): Map<string, string> => {
   const map = new Map<string, string>();
+  for (const entry of entries) {
+    if (entry.billable && !map.has(entry.matterId)) {
+      map.set(entry.matterId, entry.currency);
+    }
+  }
   for (const entry of entries) {
     if (!map.has(entry.matterId)) {
       map.set(entry.matterId, entry.currency);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.ts
@@ -1,0 +1,55 @@
+import { type CentsAmount, prorateHourlyCents } from "@stll/money";
+
+/**
+ * The fields of a time entry the weekly timesheet totals depend on.
+ * Structural so the query result (which has more fields) satisfies it.
+ */
+export type TimesheetTotalEntry = {
+  matterId: string;
+  currency: string;
+  billable: boolean;
+  billedMinutes: number;
+  rateAtEntry: CentsAmount;
+};
+
+export type CurrencyAmount = { currency: string; amount: number };
+
+/**
+ * Billable amount summed per currency. There is no FX conversion, so a week
+ * that mixes currencies must be reported as one subtotal per currency, never
+ * collapsed into a single number under one (first-entry) symbol.
+ */
+export const summarizeBillableAmountByCurrency = (
+  entries: readonly TimesheetTotalEntry[],
+): CurrencyAmount[] => {
+  const byCurrency = new Map<string, number>();
+  for (const entry of entries) {
+    if (!entry.billable) {
+      continue;
+    }
+    const amount = prorateHourlyCents({
+      billedMinutes: entry.billedMinutes,
+      hourlyRateCents: entry.rateAtEntry,
+    });
+    byCurrency.set(
+      entry.currency,
+      (byCurrency.get(entry.currency) ?? 0) + amount,
+    );
+  }
+  return [...byCurrency.entries()]
+    .map(([currency, amount]) => ({ currency, amount }))
+    .sort((a, b) => a.currency.localeCompare(b.currency));
+};
+
+/** Each matter's currency (a matter bills in a single currency). */
+export const matterCurrencyMap = (
+  entries: readonly TimesheetTotalEntry[],
+): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const entry of entries) {
+    if (!map.has(entry.matterId)) {
+      map.set(entry.matterId, entry.currency);
+    }
+  }
+  return map;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic.ts
@@ -14,6 +14,13 @@ export type TimesheetTotalEntry = {
 
 export type CurrencyAmount = { currency: string; amount: number };
 
+const sortedCurrencyAmounts = (
+  byCurrency: Map<string, number>,
+): CurrencyAmount[] =>
+  [...byCurrency.entries()]
+    .map(([currency, amount]) => ({ currency, amount }))
+    .sort((a, b) => a.currency.localeCompare(b.currency));
+
 /**
  * Billable amount summed per currency. There is no FX conversion, so a week
  * that mixes currencies must be reported as one subtotal per currency, never
@@ -36,31 +43,40 @@ export const summarizeBillableAmountByCurrency = (
       (byCurrency.get(entry.currency) ?? 0) + amount,
     );
   }
-  return [...byCurrency.entries()]
-    .map(([currency, amount]) => ({ currency, amount }))
-    .sort((a, b) => a.currency.localeCompare(b.currency));
+  return sortedCurrencyAmounts(byCurrency);
 };
 
 /**
- * Each matter's display currency. The row amount is summed from billable
- * entries only, so prefer a billable entry's currency (a non-billable entry
- * in another currency must not mislabel the charged subtotal). Fall back to
- * any entry's currency for matters with no billable time, whose amount is 0
- * and therefore not shown.
+ * Billable amount summed by matter and currency. The matter row cannot use a
+ * single currency label when its charged entries span multiple currencies.
  */
-export const matterCurrencyMap = (
+export const summarizeBillableAmountByMatterAndCurrency = (
   entries: readonly TimesheetTotalEntry[],
-): Map<string, string> => {
-  const map = new Map<string, string>();
+): Map<string, CurrencyAmount[]> => {
+  const byMatter = new Map<string, Map<string, number>>();
   for (const entry of entries) {
-    if (entry.billable && !map.has(entry.matterId)) {
-      map.set(entry.matterId, entry.currency);
+    if (!entry.billable) {
+      continue;
     }
-  }
-  for (const entry of entries) {
-    if (!map.has(entry.matterId)) {
-      map.set(entry.matterId, entry.currency);
+    let byCurrency = byMatter.get(entry.matterId);
+    if (!byCurrency) {
+      byCurrency = new Map<string, number>();
+      byMatter.set(entry.matterId, byCurrency);
     }
+    const amount = prorateHourlyCents({
+      billedMinutes: entry.billedMinutes,
+      hourlyRateCents: entry.rateAtEntry,
+    });
+    byCurrency.set(
+      entry.currency,
+      (byCurrency.get(entry.currency) ?? 0) + amount,
+    );
   }
-  return map;
+
+  return new Map(
+    [...byMatter.entries()].map(([matterId, byCurrency]) => [
+      matterId,
+      sortedCurrencyAmounts(byCurrency),
+    ]),
+  );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
@@ -15,6 +15,10 @@ import {
   formatCurrencyCompact,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
 import { useMatterNameMap } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/matter-name-map";
+import {
+  matterCurrencyMap,
+  summarizeBillableAmountByCurrency,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic";
 import { timeEntriesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/time-entries";
 
 type TimesheetWeekViewProps = {
@@ -86,13 +90,14 @@ export const TimesheetWeekView = ({
     return map;
   }, [entries]);
 
-  // Find dominant currency
-  const dominantCurrency = useMemo(() => {
-    if (entries.length === 0) {
-      return DEFAULT_CURRENCY;
-    }
-    return entries.at(0)?.currency ?? DEFAULT_CURRENCY;
-  }, [entries]);
+  // Each matter bills in one currency; week totals are reported per
+  // currency. There is no FX conversion, so amounts in different currencies
+  // are never summed under a single (first-entry) symbol.
+  const matterCurrencies = useMemo(() => matterCurrencyMap(entries), [entries]);
+  const weekAmountsByCurrency = useMemo(
+    () => summarizeBillableAmountByCurrency(entries),
+    [entries],
+  );
 
   const matterIds = [...grid.keys()];
 
@@ -209,7 +214,10 @@ export const TimesheetWeekView = ({
                   <div className="font-medium">{formatMinutes(rowMinutes)}</div>
                   {rowAmount > 0 && (
                     <div className="text-muted-foreground text-xs">
-                      {formatCurrencyCompact(rowAmount, dominantCurrency)}
+                      {formatCurrencyCompact(
+                        rowAmount,
+                        matterCurrencies.get(matterId) ?? DEFAULT_CURRENCY,
+                      )}
                     </div>
                   )}
                 </td>
@@ -254,11 +262,11 @@ export const TimesheetWeekView = ({
                     hours: formatDecimalHours(weekTotals.minutes),
                   })}
                 </div>
-                {weekTotals.amount > 0 && (
-                  <div className="text-xs">
-                    {formatCurrencyCompact(weekTotals.amount, dominantCurrency)}
+                {weekAmountsByCurrency.map((total) => (
+                  <div className="text-xs" key={total.currency}>
+                    {formatCurrencyCompact(total.amount, total.currency)}
                   </div>
-                )}
+                ))}
               </td>
             </tr>
           </tfoot>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
@@ -3,20 +3,16 @@ import { useMemo } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
-import { prorateHourlyCents } from "@stll/money";
 import { cn } from "@stll/ui/lib/utils";
 
 import {
   formatDecimalHours,
   formatMinutes,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input";
-import {
-  DEFAULT_CURRENCY,
-  formatCurrencyCompact,
-} from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
+import { formatCurrencyCompact } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
 import { useMatterNameMap } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/matter-name-map";
 import {
-  matterCurrencyMap,
+  summarizeBillableAmountByMatterAndCurrency,
   summarizeBillableAmountByCurrency,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.logic";
 import { timeEntriesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/time-entries";
@@ -64,8 +60,8 @@ export const TimesheetWeekView = ({
     [weekStart, weekEnd],
   );
 
-  // Grid: matterId -> { day -> { minutes, amount } }
-  type DayData = { minutes: number; amount: number };
+  // Grid: matterId -> { day -> { minutes } }
+  type DayData = { minutes: number };
   const grid = useMemo(() => {
     const map = new Map<string, Map<string, DayData>>();
     for (const entry of entries) {
@@ -76,24 +72,19 @@ export const TimesheetWeekView = ({
       }
       const current = dayMap.get(entry.dateWorked) ?? {
         minutes: 0,
-        amount: 0,
       };
       current.minutes += entry.durationMinutes;
-      if (entry.billable) {
-        current.amount += prorateHourlyCents({
-          billedMinutes: entry.billedMinutes,
-          hourlyRateCents: entry.rateAtEntry,
-        });
-      }
       dayMap.set(entry.dateWorked, current);
     }
     return map;
   }, [entries]);
 
-  // Each matter bills in one currency; week totals are reported per
-  // currency. There is no FX conversion, so amounts in different currencies
-  // are never summed under a single (first-entry) symbol.
-  const matterCurrencies = useMemo(() => matterCurrencyMap(entries), [entries]);
+  // There is no FX conversion, so amounts in different currencies are never
+  // summed under one symbol.
+  const matterAmountsByCurrency = useMemo(
+    () => summarizeBillableAmountByMatterAndCurrency(entries),
+    [entries],
+  );
   const weekAmountsByCurrency = useMemo(
     () => summarizeBillableAmountByCurrency(entries),
     [entries],
@@ -105,27 +96,23 @@ export const TimesheetWeekView = ({
     const totals = new Map<string, DayData>();
     for (const day of days) {
       let minutes = 0;
-      let amount = 0;
       for (const dayMap of grid.values()) {
         const data = dayMap.get(day);
         if (data) {
           minutes += data.minutes;
-          amount += data.amount;
         }
       }
-      totals.set(day, { minutes, amount });
+      totals.set(day, { minutes });
     }
     return totals;
   }, [grid, days]);
 
   const weekTotals = useMemo(() => {
     let minutes = 0;
-    let amount = 0;
     for (const data of columnTotals.values()) {
       minutes += data.minutes;
-      amount += data.amount;
     }
-    return { minutes, amount };
+    return { minutes };
   }, [columnTotals]);
 
   const today = useMemo(() => {
@@ -178,14 +165,14 @@ export const TimesheetWeekView = ({
           {matterIds.map((matterId) => {
             const dayMap = grid.get(matterId);
             let rowMinutes = 0;
-            let rowAmount = 0;
             for (const day of days) {
               const data = dayMap?.get(day);
               if (data) {
                 rowMinutes += data.minutes;
-                rowAmount += data.amount;
               }
             }
+            const rowAmountsByCurrency =
+              matterAmountsByCurrency.get(matterId) ?? [];
 
             return (
               <tr className="hover:bg-muted/30 border-b" key={matterId}>
@@ -212,14 +199,14 @@ export const TimesheetWeekView = ({
                 })}
                 <td className="px-2 py-2 text-center tabular-nums">
                   <div className="font-medium">{formatMinutes(rowMinutes)}</div>
-                  {rowAmount > 0 && (
-                    <div className="text-muted-foreground text-xs">
-                      {formatCurrencyCompact(
-                        rowAmount,
-                        matterCurrencies.get(matterId) ?? DEFAULT_CURRENCY,
-                      )}
+                  {rowAmountsByCurrency.map((total) => (
+                    <div
+                      className="text-muted-foreground text-xs"
+                      key={total.currency}
+                    >
+                      {formatCurrencyCompact(total.amount, total.currency)}
                     </div>
-                  )}
+                  ))}
                 </td>
               </tr>
             );

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   BYOK_DEFAULT_MODELS,
   BYOK_MODEL_OPTIONS,
   DEFAULT_MODELS,
+  MODEL_RATES,
   MODEL_ROLES,
 } from "./index";
 
@@ -68,4 +69,27 @@ describe("anthropic adaptive thinking", () => {
       ).toBe(true);
     }
   });
+});
+
+describe("MODEL_RATES economic ordering", () => {
+  // `satisfies Record<..., ModelRate>` only proves the numeric fields
+  // exist; it cannot prove their ordering. A transposed input/output, a
+  // dropped zero, or a cached rate above the fresh-input rate mis-meters
+  // every call for that model — silently over/under-charging the ledger.
+  // The nightly upstream check validates against external catalogs, not
+  // these internal invariants, and runs after the merge window.
+  for (const [modelId, rate] of Object.entries(MODEL_RATES)) {
+    test(`${modelId}: input>0, output>=input, 0<cached<=input`, () => {
+      expect(rate.inputPerMTok).toBeGreaterThan(0);
+      expect(rate.outputPerMTok).toBeGreaterThanOrEqual(rate.inputPerMTok);
+      if (rate.cachedInputPerMTok !== undefined) {
+        expect(rate.cachedInputPerMTok).toBeGreaterThan(0);
+        // Cache reads must never cost more than fresh input, or caching
+        // becomes a price penalty (computeRawUsageMicroUnits assumes the
+        // opposite).
+        expect(rate.cachedInputPerMTok).toBeLessThanOrEqual(rate.inputPerMTok);
+      }
+      expect(Number.isFinite(rate.outputPerMTok)).toBe(true);
+    });
+  }
 });

--- a/packages/boe/src/query.test.ts
+++ b/packages/boe/src/query.test.ts
@@ -28,4 +28,73 @@ describe("BOE search query builder", () => {
       }),
     );
   });
+
+  test("tokenizes and quotes plain free text across both fields", () => {
+    expect(buildSearchQuery({ text: "ley organica" })).toBe(
+      JSON.stringify({
+        query: {
+          query_string: {
+            query:
+              '(titulo:("ley" AND "organica") OR texto:("ley" AND "organica"))',
+          },
+        },
+      }),
+    );
+  });
+
+  const extractQueryString = (raw: string): string => {
+    const parsed = JSON.parse(raw) as {
+      query: { query_string: { query: string } };
+    };
+    return parsed.query.query_string.query;
+  };
+
+  // A balanced-parens / balanced-quotes check: every "(" has a matching
+  // ")" and double-quotes come in pairs. User input must not be able to
+  // unbalance the generated DSL.
+  const isStructurallyBalanced = (q: string): boolean => {
+    let depth = 0;
+    let quotes = 0;
+    for (const ch of q) {
+      if (ch === "(") depth++;
+      else if (ch === ")") depth--;
+      else if (ch === '"') quotes++;
+      if (depth < 0) return false;
+    }
+    return depth === 0 && quotes % 2 === 0;
+  };
+
+  test("INVARIANT: free text cannot inject field clauses, booleans, or unbalanced parens", () => {
+    const attacks = [
+      "a) OR fecha_publicacion:[* TO *] OR (b",
+      "a) OR titulo:(b",
+      'x" OR "y',
+      "rango@codigo:99 OR (",
+      "((((",
+      "))))",
+      "a AND b OR c NOT d",
+      "* OR ?",
+      "a:b:c",
+      "valid term",
+    ];
+    for (const text of attacks) {
+      const q = extractQueryString(buildSearchQuery({ text }));
+      expect(isStructurallyBalanced(q)).toBe(true);
+      // No raw field-clause injection: the only colons/parens present are
+      // the ones the builder itself emits (titulo:(...) / texto:(...)).
+      // Stripping those leaves no attacker-controlled ":" field clause.
+      const withoutBuilderClauses = q
+        .replaceAll("titulo:(", "")
+        .replaceAll("texto:(", "");
+      expect(withoutBuilderClauses).not.toContain(":");
+      // No raw upstream field markers from user input.
+      expect(q).not.toContain("fecha_publicacion");
+      expect(q).not.toContain("rango@codigo");
+    }
+  });
+
+  test("free text of only symbols produces an empty query (no clause)", () => {
+    expect(extractQueryString(buildSearchQuery({ text: "()[]:*?" }))).toBe("");
+    expect(extractQueryString(buildSearchQuery({ text: "   " }))).toBe("");
+  });
 });

--- a/packages/boe/src/query.test.ts
+++ b/packages/boe/src/query.test.ts
@@ -42,11 +42,27 @@ describe("BOE search query builder", () => {
     );
   });
 
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null;
+
   const extractQueryString = (raw: string): string => {
-    const parsed = JSON.parse(raw) as {
-      query: { query_string: { query: string } };
-    };
-    return parsed.query.query_string.query;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      throw new Error("Expected JSON object");
+    }
+    const query = parsed["query"];
+    if (!isRecord(query)) {
+      throw new Error("Expected query object");
+    }
+    const queryString = query["query_string"];
+    if (!isRecord(queryString)) {
+      throw new Error("Expected query_string object");
+    }
+    const value = queryString["query"];
+    if (typeof value !== "string") {
+      throw new TypeError("Expected query string");
+    }
+    return value;
   };
 
   // A balanced-parens / balanced-quotes check: every "(" has a matching
@@ -56,10 +72,16 @@ describe("BOE search query builder", () => {
     let depth = 0;
     let quotes = 0;
     for (const ch of q) {
-      if (ch === "(") depth++;
-      else if (ch === ")") depth--;
-      else if (ch === '"') quotes++;
-      if (depth < 0) return false;
+      if (ch === "(") {
+        depth++;
+      } else if (ch === ")") {
+        depth--;
+      } else if (ch === '"') {
+        quotes++;
+      }
+      if (depth < 0) {
+        return false;
+      }
     }
     return depth === 0 && quotes % 2 === 0;
   };

--- a/packages/boe/src/query.ts
+++ b/packages/boe/src/query.ts
@@ -28,8 +28,15 @@ type CompoundQuery = QueryStringClause & Partial<RangeClause>;
 export const buildSearchQuery = (input: BoeSearchQuery): string => {
   const parts: string[] = [];
   if (input.text) {
-    const terms = input.text.trim();
-    parts.push(`(titulo:(${terms}) OR texto:(${terms}))`);
+    // Keep user free text literal: the query_string DSL (field clauses,
+    // AND/OR, parentheses, colons) must never be reachable from input.
+    // Mirror the corpus path (corpusFreeTextClause): keep only unicode
+    // word characters, quote each term, AND them.
+    const terms = input.text.match(/[\p{L}\p{N}]+/gu);
+    if (terms && terms.length > 0) {
+      const quoted = terms.map((term) => `"${term}"`).join(" AND ");
+      parts.push(`(titulo:(${quoted}) OR texto:(${quoted}))`);
+    }
   }
   if (input.title) {
     parts.push(`titulo:"${input.title.replaceAll('"', '\\"')}"`);

--- a/packages/docx-core/src/serialize/docx.test.ts
+++ b/packages/docx-core/src/serialize/docx.test.ts
@@ -1,47 +1,46 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
-import type { Document } from "../model/document";
+import type { Document, Table } from "../model/document";
 import { serializeDocumentToDocx } from "./docx";
 
-const docWithBorder = (style: string, rgb: string): Document =>
-  ({
-    package: {
-      document: {
-        content: [
+const docWithBorder = (style: string, rgb: string): Document => {
+  const table: Table = {
+    type: "table",
+    rows: [
+      {
+        type: "tableRow",
+        cells: [
           {
-            type: "table",
-            rows: [
+            type: "tableCell",
+            content: [
               {
-                type: "tableRow",
-                cells: [
+                type: "paragraph",
+                content: [
                   {
-                    type: "tableCell",
-                    content: [
-                      {
-                        type: "paragraph",
-                        content: [
-                          {
-                            type: "run",
-                            content: [{ type: "text", text: "x" }],
-                          },
-                        ],
-                      },
-                    ],
+                    type: "run",
+                    content: [{ type: "text", text: "x" }],
                   },
                 ],
               },
             ],
-            formatting: {
-              borders: { top: { style, size: 4, color: { rgb } } },
-            },
           },
         ],
       },
+    ],
+    formatting: {
+      borders: { top: { style, size: 4, color: { rgb } } },
     },
-    // SAFETY: minimal hand-built model for serialization; the serializer only
-    // reads the fields set here.
-  }) as unknown as Document;
+  };
+
+  return {
+    package: {
+      document: {
+        content: [table],
+      },
+    },
+  };
+};
 
 const readDocumentXml = async (buf: ArrayBuffer): Promise<string> => {
   const zip = await JSZip.loadAsync(buf);

--- a/packages/docx-core/src/serialize/docx.test.ts
+++ b/packages/docx-core/src/serialize/docx.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { Document } from "../model/document";
+import { serializeDocumentToDocx } from "./docx";
+
+const docWithBorder = (style: string, rgb: string): Document =>
+  ({
+    package: {
+      document: {
+        content: [
+          {
+            type: "table",
+            rows: [
+              {
+                type: "tableRow",
+                cells: [
+                  {
+                    type: "tableCell",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [
+                          {
+                            type: "run",
+                            content: [{ type: "text", text: "x" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            formatting: {
+              borders: { top: { style, size: 4, color: { rgb } } },
+            },
+          },
+        ],
+      },
+    },
+    // SAFETY: minimal hand-built model for serialization; the serializer only
+    // reads the fields set here.
+  }) as unknown as Document;
+
+const readDocumentXml = async (buf: ArrayBuffer): Promise<string> => {
+  const zip = await JSZip.loadAsync(buf);
+  const xml = await zip.file("word/document.xml")?.async("string");
+  if (xml === undefined) {
+    throw new Error("word/document.xml missing from serialized docx");
+  }
+  return xml;
+};
+
+describe("DOCX border serialization escapes attribute values", () => {
+  test("a style value cannot inject extra XML attributes", async () => {
+    const xml = await readDocumentXml(
+      await serializeDocumentToDocx(
+        docWithBorder('single" w:evil="1', "CCCCCC"),
+      ),
+    );
+    // The injected attribute must not appear as a real attribute, and the
+    // quote must be entity-escaped.
+    expect(xml).not.toContain('w:evil="1"');
+    expect(xml).toContain("&quot;");
+  });
+
+  test("a color value cannot break out of its attribute", async () => {
+    const xml = await readDocumentXml(
+      await serializeDocumentToDocx(docWithBorder("single", 'FF0000" x="y')),
+    );
+    expect(xml).not.toContain('x="y"');
+    expect(xml).toContain("&quot;");
+  });
+
+  test("ordinary border values serialize unescaped", async () => {
+    const xml = await readDocumentXml(
+      await serializeDocumentToDocx(docWithBorder("single", "CCCCCC")),
+    );
+    expect(xml).toContain('w:val="single"');
+    expect(xml).toContain('w:color="CCCCCC"');
+  });
+});

--- a/packages/docx-core/src/serialize/docx.ts
+++ b/packages/docx-core/src/serialize/docx.ts
@@ -444,7 +444,10 @@ const borderEdgeXml = (tag: string, spec: BorderSpec | undefined): string => {
   }
   const sz = spec.size ?? 4;
   const color = spec.color?.rgb ?? "CCCCCC";
-  return `<${tag} w:val="${spec.style}" w:sz="${sz}" w:space="0" w:color="${color}"/>`;
+  // style/color are typed `string` and may carry preserved "unknown OOXML"
+  // values from parsed input; escape them like every other attribute so a
+  // value containing a quote or angle bracket cannot break the XML.
+  return `<${tag} w:val="${escapeXml(spec.style)}" w:sz="${sz}" w:space="0" w:color="${escapeXml(color)}"/>`;
 };
 
 const defaultBorderXml = (): string =>

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -32,18 +32,25 @@ describe("minor-unit billing arithmetic", () => {
 });
 
 // Deterministic LCG so a fuzz failure is reproducible, never flaky.
+const LCG_MODULUS = 2 ** 32;
+const LCG_MULTIPLIER = 1_664_525;
+const LCG_INCREMENT = 1_013_904_223;
+
 const makePrng = (seed: number) => {
-  let state = seed >>> 0;
+  let state = Math.trunc(seed) % LCG_MODULUS;
+  if (state < 0) {
+    state += LCG_MODULUS;
+  }
   return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 0x100000000;
+    state = (state * LCG_MULTIPLIER + LCG_INCREMENT) % LCG_MODULUS;
+    return state / LCG_MODULUS;
   };
 };
 
 describe("cents() brand constructor", () => {
   test("accepts integer-valued floats and zero", () => {
     expect(cents(0)).toBe(cents(0));
-    expect(cents(2.0)).toBe(cents(2));
+    expect(cents(Number.parseFloat("2.0"))).toBe(cents(2));
   });
 
   test("rejects non-integer, NaN and infinite inputs", () => {
@@ -85,10 +92,10 @@ describe("prorateHourlyCents invariants", () => {
   });
 
   test("INVARIANT: result is the exact round-half-up of (minutes*rate)/60", () => {
-    const rand = makePrng(0x5eed01);
-    for (let n = 0; n < 5000; n++) {
+    const rand = makePrng(6_220_033);
+    for (let n = 0; n < 5_000; n++) {
       const billedMinutes = Math.floor(rand() * 600); // up to 10h
-      const rate = Math.floor(rand() * 5_000_00); // up to $5000/h
+      const rate = Math.floor(rand() * 500_000); // up to $5000/h
       const r = prorateHourlyCents({
         billedMinutes,
         hourlyRateCents: cents(rate),
@@ -112,7 +119,7 @@ describe("prorateHourlyCents invariants", () => {
     }
     const minutes = 137;
     prev = -1;
-    for (let rc = 0; rc <= 2000; rc++) {
+    for (let rc = 0; rc <= 2_000; rc++) {
       const v = prorateHourlyCents({
         billedMinutes: minutes,
         hourlyRateCents: cents(rc),
@@ -125,10 +132,10 @@ describe("prorateHourlyCents invariants", () => {
   test("stays exact for large but realistic invoices (no float drift)", () => {
     // 100h at $9,999.99/h: product is ~6e9, well under MAX_SAFE_INTEGER.
     const r = prorateHourlyCents({
-      billedMinutes: 6000,
+      billedMinutes: 6_000,
       hourlyRateCents: cents(999_999),
     });
-    const x = 6000 * 999_999;
+    const x = 6_000 * 999_999;
     expect(r).toBe(cents(Math.floor((x + 30) / 60)));
     expect(Number.isSafeInteger(r)).toBe(true);
   });
@@ -145,8 +152,8 @@ describe("prorateHourlyCents invariants", () => {
 
 describe("applyMarkupCents invariants", () => {
   test("IDENTITY: zero markup returns the amount unchanged", () => {
-    const rand = makePrng(0x1de77a);
-    for (let n = 0; n < 1000; n++) {
+    const rand = makePrng(1_959_802);
+    for (let n = 0; n < 1_000; n++) {
       const amount = Math.floor(rand() * 1_000_000);
       expect(
         applyMarkupCents({ amountCents: cents(amount), markupPercent: 0 }),
@@ -166,9 +173,9 @@ describe("applyMarkupCents invariants", () => {
   });
 
   test("INVARIANT: result is the exact round-half-up of amount*(100+markup)/100", () => {
-    const rand = makePrng(0x5eed02);
-    for (let n = 0; n < 5000; n++) {
-      const amount = Math.floor(rand() * 5_000_00);
+    const rand = makePrng(6_220_034);
+    for (let n = 0; n < 5_000; n++) {
+      const amount = Math.floor(rand() * 500_000);
       const markup = Math.floor(rand() * 300); // up to +300%
       const r = applyMarkupCents({
         amountCents: cents(amount),

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { applyMarkupCents, cents, prorateHourlyCents } from ".";
+import { applyMarkupCents, cents, prorateHourlyCents, unsafeCents } from ".";
 
 describe("minor-unit billing arithmetic", () => {
   test("rounds prorated hourly rates without floating point cent drift", () => {
@@ -27,6 +27,177 @@ describe("minor-unit billing arithmetic", () => {
     ).toThrow(TypeError);
     expect(() =>
       applyMarkupCents({ amountCents: cents(100), markupPercent: -1 }),
+    ).toThrow(TypeError);
+  });
+});
+
+// Deterministic LCG so a fuzz failure is reproducible, never flaky.
+const makePrng = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+};
+
+describe("cents() brand constructor", () => {
+  test("accepts integer-valued floats and zero", () => {
+    expect(cents(0)).toBe(cents(0));
+    expect(cents(2.0)).toBe(cents(2));
+  });
+
+  test("rejects non-integer, NaN and infinite inputs", () => {
+    for (const bad of [0.5, -0.0001, Number.NaN, Infinity, -Infinity]) {
+      expect(() => cents(bad)).toThrow(TypeError);
+    }
+  });
+
+  test("unsafeCents is a pure brand attach with no rounding", () => {
+    // Documented escape hatch: it must not silently coerce; the value
+    // passes through verbatim (callers assert validity themselves).
+    expect(unsafeCents(1234)).toBe(cents(1234));
+  });
+});
+
+describe("prorateHourlyCents invariants", () => {
+  test("zero minutes or zero rate yields zero", () => {
+    expect(
+      prorateHourlyCents({ billedMinutes: 0, hourlyRateCents: cents(500) }),
+    ).toBe(cents(0));
+    expect(
+      prorateHourlyCents({ billedMinutes: 90, hourlyRateCents: cents(0) }),
+    ).toBe(cents(0));
+  });
+
+  test("rounds an exact half-cent UP (round-half-up, not banker's)", () => {
+    // minutes * rate === 30 ==> exact 0.5 cents ==> must round to 1.
+    expect(
+      prorateHourlyCents({ billedMinutes: 1, hourlyRateCents: cents(30) }),
+    ).toBe(cents(1));
+    // minutes * rate === 90 ==> exact 1.5 cents ==> must round to 2.
+    expect(
+      prorateHourlyCents({ billedMinutes: 1, hourlyRateCents: cents(90) }),
+    ).toBe(cents(2));
+    // Just below the half (29/60 = 0.483) must round down to 0.
+    expect(
+      prorateHourlyCents({ billedMinutes: 1, hourlyRateCents: cents(29) }),
+    ).toBe(cents(0));
+  });
+
+  test("INVARIANT: result is the exact round-half-up of (minutes*rate)/60", () => {
+    const rand = makePrng(0x5eed01);
+    for (let n = 0; n < 5000; n++) {
+      const billedMinutes = Math.floor(rand() * 600); // up to 10h
+      const rate = Math.floor(rand() * 5_000_00); // up to $5000/h
+      const r = prorateHourlyCents({
+        billedMinutes,
+        hourlyRateCents: cents(rate),
+      });
+      const x = billedMinutes * rate;
+      // floor((x+30)/60) === r  <=>  60r-30 <= x < 60r+30
+      const d = x - 60 * r;
+      expect(d).toBeGreaterThanOrEqual(-30);
+      expect(d).toBeLessThan(30);
+      expect(Number.isInteger(r)).toBe(true);
+    }
+  });
+
+  test("INVARIANT: non-decreasing in minutes and in rate", () => {
+    const rate = cents(317);
+    let prev = -1;
+    for (let m = 0; m <= 480; m++) {
+      const v = prorateHourlyCents({ billedMinutes: m, hourlyRateCents: rate });
+      expect(v).toBeGreaterThanOrEqual(prev);
+      prev = v;
+    }
+    const minutes = 137;
+    prev = -1;
+    for (let rc = 0; rc <= 2000; rc++) {
+      const v = prorateHourlyCents({
+        billedMinutes: minutes,
+        hourlyRateCents: cents(rc),
+      });
+      expect(v).toBeGreaterThanOrEqual(prev);
+      prev = v;
+    }
+  });
+
+  test("stays exact for large but realistic invoices (no float drift)", () => {
+    // 100h at $9,999.99/h: product is ~6e9, well under MAX_SAFE_INTEGER.
+    const r = prorateHourlyCents({
+      billedMinutes: 6000,
+      hourlyRateCents: cents(999_999),
+    });
+    const x = 6000 * 999_999;
+    expect(r).toBe(cents(Math.floor((x + 30) / 60)));
+    expect(Number.isSafeInteger(r)).toBe(true);
+  });
+
+  test("rejects non-integer or negative minutes", () => {
+    expect(() =>
+      prorateHourlyCents({ billedMinutes: -1, hourlyRateCents: cents(100) }),
+    ).toThrow(TypeError);
+    expect(() =>
+      prorateHourlyCents({ billedMinutes: 1.1, hourlyRateCents: cents(100) }),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("applyMarkupCents invariants", () => {
+  test("IDENTITY: zero markup returns the amount unchanged", () => {
+    const rand = makePrng(0x1de77a);
+    for (let n = 0; n < 1000; n++) {
+      const amount = Math.floor(rand() * 1_000_000);
+      expect(
+        applyMarkupCents({ amountCents: cents(amount), markupPercent: 0 }),
+      ).toBe(cents(amount));
+    }
+  });
+
+  test("rounds an exact half-cent UP", () => {
+    // 1 cent + 50% = 1.5 ==> 2.
+    expect(applyMarkupCents({ amountCents: cents(1), markupPercent: 50 })).toBe(
+      cents(2),
+    );
+    // 2 cents + 25% = 2.5 ==> 3.
+    expect(applyMarkupCents({ amountCents: cents(2), markupPercent: 25 })).toBe(
+      cents(3),
+    );
+  });
+
+  test("INVARIANT: result is the exact round-half-up of amount*(100+markup)/100", () => {
+    const rand = makePrng(0x5eed02);
+    for (let n = 0; n < 5000; n++) {
+      const amount = Math.floor(rand() * 5_000_00);
+      const markup = Math.floor(rand() * 300); // up to +300%
+      const r = applyMarkupCents({
+        amountCents: cents(amount),
+        markupPercent: markup,
+      });
+      const p = amount * (100 + markup);
+      const d = p - 100 * r;
+      expect(d).toBeGreaterThanOrEqual(-50);
+      expect(d).toBeLessThan(50);
+    }
+  });
+
+  test("INVARIANT: non-decreasing in markup and never below the base amount", () => {
+    const amount = cents(733);
+    let prev = -1;
+    for (let mk = 0; mk <= 500; mk++) {
+      const v = applyMarkupCents({ amountCents: amount, markupPercent: mk });
+      expect(v).toBeGreaterThanOrEqual(prev);
+      expect(v).toBeGreaterThanOrEqual(amount);
+      prev = v;
+    }
+  });
+
+  test("rejects negative or non-integer inputs", () => {
+    expect(() =>
+      applyMarkupCents({ amountCents: cents(100), markupPercent: 1.5 }),
+    ).toThrow(TypeError);
+    expect(() =>
+      applyMarkupCents({ amountCents: cents(100), markupPercent: Infinity }),
     ).toThrow(TypeError);
   });
 });

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -23,7 +23,10 @@ describe("minor-unit billing arithmetic", () => {
 
   test("rejects invalid billing inputs", () => {
     expect(() =>
-      prorateHourlyCents({ billedMinutes: 1.5, hourlyRateCents: cents(100) }),
+      prorateHourlyCents({
+        billedMinutes: Number.parseFloat("1.5"),
+        hourlyRateCents: cents(100),
+      }),
     ).toThrow(TypeError);
     expect(() =>
       applyMarkupCents({ amountCents: cents(100), markupPercent: -1 }),
@@ -54,7 +57,13 @@ describe("cents() brand constructor", () => {
   });
 
   test("rejects non-integer, NaN and infinite inputs", () => {
-    for (const bad of [0.5, -0.0001, Number.NaN, Infinity, -Infinity]) {
+    for (const bad of [
+      Number.parseFloat("0.5"),
+      -Number.parseFloat("0.0001"),
+      Number.NaN,
+      Infinity,
+      -Infinity,
+    ]) {
       expect(() => cents(bad)).toThrow(TypeError);
     }
   });
@@ -93,7 +102,7 @@ describe("prorateHourlyCents invariants", () => {
 
   test("INVARIANT: result is the exact round-half-up of (minutes*rate)/60", () => {
     const rand = makePrng(6_220_033);
-    for (let n = 0; n < 5_000; n++) {
+    for (let n = 0; n < 5000; n++) {
       const billedMinutes = Math.floor(rand() * 600); // up to 10h
       const rate = Math.floor(rand() * 500_000); // up to $5000/h
       const r = prorateHourlyCents({
@@ -119,7 +128,7 @@ describe("prorateHourlyCents invariants", () => {
     }
     const minutes = 137;
     prev = -1;
-    for (let rc = 0; rc <= 2_000; rc++) {
+    for (let rc = 0; rc <= 2000; rc++) {
       const v = prorateHourlyCents({
         billedMinutes: minutes,
         hourlyRateCents: cents(rc),
@@ -132,10 +141,10 @@ describe("prorateHourlyCents invariants", () => {
   test("stays exact for large but realistic invoices (no float drift)", () => {
     // 100h at $9,999.99/h: product is ~6e9, well under MAX_SAFE_INTEGER.
     const r = prorateHourlyCents({
-      billedMinutes: 6_000,
+      billedMinutes: 6000,
       hourlyRateCents: cents(999_999),
     });
-    const x = 6_000 * 999_999;
+    const x = 6000 * 999_999;
     expect(r).toBe(cents(Math.floor((x + 30) / 60)));
     expect(Number.isSafeInteger(r)).toBe(true);
   });
@@ -145,7 +154,10 @@ describe("prorateHourlyCents invariants", () => {
       prorateHourlyCents({ billedMinutes: -1, hourlyRateCents: cents(100) }),
     ).toThrow(TypeError);
     expect(() =>
-      prorateHourlyCents({ billedMinutes: 1.1, hourlyRateCents: cents(100) }),
+      prorateHourlyCents({
+        billedMinutes: Number.parseFloat("1.1"),
+        hourlyRateCents: cents(100),
+      }),
     ).toThrow(TypeError);
   });
 });
@@ -153,7 +165,7 @@ describe("prorateHourlyCents invariants", () => {
 describe("applyMarkupCents invariants", () => {
   test("IDENTITY: zero markup returns the amount unchanged", () => {
     const rand = makePrng(1_959_802);
-    for (let n = 0; n < 1_000; n++) {
+    for (let n = 0; n < 1000; n++) {
       const amount = Math.floor(rand() * 1_000_000);
       expect(
         applyMarkupCents({ amountCents: cents(amount), markupPercent: 0 }),
@@ -174,7 +186,7 @@ describe("applyMarkupCents invariants", () => {
 
   test("INVARIANT: result is the exact round-half-up of amount*(100+markup)/100", () => {
     const rand = makePrng(6_220_034);
-    for (let n = 0; n < 5_000; n++) {
+    for (let n = 0; n < 5000; n++) {
       const amount = Math.floor(rand() * 500_000);
       const markup = Math.floor(rand() * 300); // up to +300%
       const r = applyMarkupCents({
@@ -201,7 +213,10 @@ describe("applyMarkupCents invariants", () => {
 
   test("rejects negative or non-integer inputs", () => {
     expect(() =>
-      applyMarkupCents({ amountCents: cents(100), markupPercent: 1.5 }),
+      applyMarkupCents({
+        amountCents: cents(100),
+        markupPercent: Number.parseFloat("1.5"),
+      }),
     ).toThrow(TypeError);
     expect(() =>
       applyMarkupCents({ amountCents: cents(100), markupPercent: Infinity }),

--- a/packages/permissions/src/index.test.ts
+++ b/packages/permissions/src/index.test.ts
@@ -47,3 +47,64 @@ describe("organization management permissions", () => {
     );
   });
 });
+
+describe("role grant boundaries", () => {
+  // Pins the security-critical boundaries between roles so a future grant
+  // edit cannot silently widen a low-privilege role.
+  test("only owner and admin hold org-admin powers", () => {
+    for (const role of ["member", "intern", "external"] as const) {
+      expect(roles[role].authorize({ member: ["create"] }).success).toBe(false);
+      expect(roles[role].authorize({ member: ["delete"] }).success).toBe(false);
+      expect(roles[role].authorize({ organization: ["delete"] }).success).toBe(
+        false,
+      );
+      expect(roles[role].authorize({ invitation: ["create"] }).success).toBe(
+        false,
+      );
+    }
+    for (const role of ["owner", "admin"] as const) {
+      expect(roles[role].authorize({ member: ["create"] }).success).toBe(true);
+      expect(roles[role].authorize({ invitation: ["create"] }).success).toBe(
+        true,
+      );
+    }
+  });
+
+  test("member can write content; intern and external cannot", () => {
+    expect(roles.member.authorize({ entity: ["update"] }).success).toBe(true);
+    expect(roles.member.authorize({ invoice: ["create"] }).success).toBe(true);
+    for (const role of ["intern", "external"] as const) {
+      expect(roles[role].authorize({ entity: ["update"] }).success).toBe(false);
+      expect(roles[role].authorize({ invoice: ["create"] }).success).toBe(
+        false,
+      );
+      expect(roles[role].authorize({ template: ["update"] }).success).toBe(
+        false,
+      );
+    }
+  });
+
+  test("every role can read its workspace", () => {
+    for (const role of [
+      "owner",
+      "admin",
+      "member",
+      "intern",
+      "external",
+    ] as const) {
+      expect(roles[role].authorize({ workspace: ["read"] }).success).toBe(true);
+    }
+  });
+
+  test("external is read-only; intern may log its own time", () => {
+    expect(roles.external.authorize({ timeEntry: ["create"] }).success).toBe(
+      false,
+    );
+    expect(roles.external.authorize({ expense: ["create"] }).success).toBe(
+      false,
+    );
+    expect(roles.intern.authorize({ timeEntry: ["create"] }).success).toBe(
+      true,
+    );
+  });
+});

--- a/packages/template-conditions/src/index.test.ts
+++ b/packages/template-conditions/src/index.test.ts
@@ -59,6 +59,37 @@ describe("evaluateCondition", () => {
     expect(evaluateCondition("amount > 1000", { amount: 5000 })).toBe(true);
   });
 
+  // ── String-encoded numbers (form/JSON inputs serialize as strings) ──
+
+  test("ordering coerces a numeric-string field value", () => {
+    expect(
+      evaluateCondition("contractValue > 100000", { contractValue: "150000" }),
+    ).toBe(true);
+    expect(
+      evaluateCondition("contractValue < 100000", { contractValue: "150000" }),
+    ).toBe(false);
+    expect(
+      evaluateCondition("contractValue >= 150000", { contractValue: "150000" }),
+    ).toBe(true);
+  });
+
+  test("equality coerces a numeric-string field value", () => {
+    expect(evaluateCondition("amount == 5000", { amount: "5000" })).toBe(true);
+    expect(evaluateCondition("amount != 5000", { amount: "5000" })).toBe(false);
+  });
+
+  test("does not coerce non-numeric strings or empty strings", () => {
+    // "abc" must not become 0; "" must not become 0.
+    expect(evaluateCondition("v == 0", { v: "abc" })).toBe(false);
+    expect(evaluateCondition("v == 0", { v: "" })).toBe(false);
+    expect(evaluateCondition("v > 0", { v: "abc" })).toBe(false);
+  });
+
+  test("string-vs-string equality is unaffected by numeric coercion", () => {
+    expect(evaluateCondition('code == "5000"', { code: "5000" })).toBe(true);
+    expect(evaluateCondition('code == "UK"', { code: "UK" })).toBe(true);
+  });
+
   // ── Logical operators ─────────────────────────────────
 
   test("and: both true", () => {

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -156,8 +156,47 @@ const resolveToken = (
   return undefined;
 };
 
+/**
+ * Convert a plain numeric string to a number, else undefined. Empty /
+ * whitespace-only strings are not numbers (avoids `"" == 0` surprises).
+ */
+const numericString = (value: unknown): number | undefined => {
+  if (typeof value !== "string" || value.trim() === "") {
+    return undefined;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+/**
+ * When one operand is a number and the other is a numeric-looking string,
+ * compare them numerically. Form number inputs and JSON payloads serialize
+ * numbers as strings, so `contractValue > 100000` must still hold when
+ * `contractValue` arrives as `"150000"`. Non-numeric operands are left
+ * untouched so `"abc" == 0` stays false.
+ */
+const coerceNumericPair = (
+  left: unknown,
+  right: unknown,
+): [unknown, unknown] => {
+  if (typeof left === "number" && typeof right === "string") {
+    const r = numericString(right);
+    if (r !== undefined) {
+      return [left, r];
+    }
+  }
+  if (typeof right === "number" && typeof left === "string") {
+    const l = numericString(left);
+    if (l !== undefined) {
+      return [l, right];
+    }
+  }
+  return [left, right];
+};
+
 /** Evaluate a comparison between two resolved values. */
-const compare = (left: unknown, op: string, right: unknown): boolean => {
+const compare = (rawLeft: unknown, op: string, rawRight: unknown): boolean => {
+  const [left, right] = coerceNumericPair(rawLeft, rawRight);
   switch (op) {
     case "==":
       return left === right;


### PR DESCRIPTION
Fixes a set of correctness and integrity bugs and adds regression / invariant
tests for high-risk areas. All changes are covered by tests; the full API suite
and affected package suites pass.

## Billing
- Invoices are single-currency: reject time entries / expenses whose currency
  differs from the invoice, at both attach points (create and add-entries), and
  return 409 (not 500) on a duplicate invoice number.
- LEDES export: escape pipe / CR / LF in user-controlled fields and exclude
  non-billable / no-charge time; the timesheet PDF total now uses billed minutes
  so it reconciles with the line items.
- Weekly timesheet totals are reported per currency instead of under one symbol.
- Entity `int` fields sort numerically in both the in-memory and SQL paths.

## DOCX editing
- `buildRunMap` counts tabs and line breaks so tracked-change and comment offsets
  align with the extracted text; also fixes two related run-cleanup / ordering
  bugs this surfaced, and escapes border style / colour in the serializer.

## Parsing & search
- BOE free-text search is kept literal in the query DSL.
- Tighter unprefixed Polish citation pattern; cross-section citations anchor to
  the reasoning occurrence; the spaced-letter collapse no longer merges
  single-letter words.
- Template numeric conditions coerce numeric-string operands.

## Other
- Harden the web redirect guard against protocol-relative targets.
- Scheduler resolves DST gaps / overlaps and dispatches idempotently.

## Tests
Adds invariant / regression coverage for minor-unit money arithmetic, CSV and
LEDES escaping, the file-scan verdict and zip-bomb guard, S3 key scoping,
permission boundaries, and the collaborative-session and OAuth-callback
authorization paths.
