### PR TITLE
feat(conditions): unify filter & extraction conditions onto one structured AST

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -80,6 +80,7 @@ jobs:
             pkg:npm/@stll/ai-catalog,
             pkg:npm/@stll/anonymize-chat,
             pkg:npm/@stll/anonymize-wasm,
+            pkg:npm/@stll/conditions,
             pkg:npm/@stll/docx-core,
             pkg:npm/@stll/errors,
             pkg:npm/@t3-oss/env-core,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -61,6 +61,7 @@
     "@stll/boe": "workspace:*",
     "@stll/business-registries": "workspace:*",
     "@stll/catalogue": "workspace:*",
+    "@stll/conditions": "workspace:*",
     "@stll/country-codes": "workspace:*",
     "@stll/docx-core": "workspace:*",
     "@stll/docx-utils": "workspace:*",

--- a/apps/api/src/db/schema-validators.ts
+++ b/apps/api/src/db/schema-validators.ts
@@ -259,25 +259,6 @@ export const boundingBoxesSchema = t.Object({
 
 export type BoundingBoxes = Static<typeof boundingBoxesSchema>;
 
-export const propertyConditionSchema = t.Union([
-  t.Object({
-    version: v1,
-    type: t.Literal("string"),
-    operator: t.UnionEnum(["eq"]),
-    value: t.String({ minLength: 1, maxLength: 1000 }),
-  }),
-  t.Object({
-    version: v1,
-    type: t.Literal("string-array"),
-    operator: t.UnionEnum(["contains-every"]),
-    value: t.Array(t.String({ minLength: 1, maxLength: 1000 }), {
-      minItems: 1,
-    }),
-  }),
-]);
-
-export type PropertyCondition = Static<typeof propertyConditionSchema>;
-
 // -- Billing schemas --
 
 export const bankAccountSchema = t.Object({

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,3 +1,4 @@
+import type { ConditionNode } from "@stll/conditions";
 import type { PersistedDecisionAnalysis } from "@stll/legal-ast/analysis";
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 import type { CountryCode } from "@stll/country-codes";
@@ -43,7 +44,6 @@ import type {
   ContactPhone,
   EntityKind,
   FieldContent,
-  PropertyCondition,
   PropertyContent,
   PropertyTool,
 } from "@/api/db/schema-validators";
@@ -754,7 +754,7 @@ export const propertyDependencies = p.pgTable(
     dependsOnPropertyId: safeUuid<"property">(
       "depends_on_property_id",
     ).notNull(),
-    condition: jsonb().$type<PropertyCondition>(),
+    condition: jsonb().$type<ConditionNode>(),
   },
   (table) => [
     p

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -3,6 +3,8 @@ import { and, count, eq, inArray, notInArray, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
+import type { ConditionNode } from "@stll/conditions";
+
 import type { SafeDb, Transaction } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";
 import {
@@ -38,7 +40,7 @@ import type {
 } from "@/api/lib/entity-constants";
 import { buildFilterConditions } from "@/api/lib/entity-filters";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import type { ViewFilterCondition, ViewSort } from "@/api/lib/views-schema";
+import type { ViewSort } from "@/api/lib/views-schema";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 export type QueryEntitiesFieldMode = "full" | "visible";
@@ -115,7 +117,7 @@ type QueryEntitiesProps = {
   workspaceId: SafeId<"workspace">;
   currentUserId: string;
   currentOrganizationId: SafeId<"organization">;
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
   sorts: ViewSort[];
   search?: string | undefined;
   cursor?: EntitiesWindowCursorValues | null | undefined;

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -4,15 +4,13 @@ import { t } from "elysia";
 import { queryEntities } from "@/api/handlers/entities/query-entities";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
-import {
-  tViewFilterConditionSchema,
-  tViewSortSchema,
-} from "@/api/lib/views-schema";
+import { tViewSortSchema } from "@/api/lib/views-schema";
 
 const readFilesystemTreeBodySchema = t.Object({
-  filters: t.Optional(t.Array(tViewFilterConditionSchema)),
+  filters: t.Optional(t.Array(tConditionNode)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
   search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
   fieldMode: t.Optional(t.Union([t.Literal("full"), t.Literal("visible")])),

--- a/apps/api/src/handlers/entities/read-kanban-group.ts
+++ b/apps/api/src/handlers/entities/read-kanban-group.ts
@@ -11,14 +11,12 @@ import {
 } from "@/api/handlers/entities/window-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
-import {
-  tViewFilterConditionSchema,
-  tViewSortSchema,
-} from "@/api/lib/views-schema";
+import { tViewSortSchema } from "@/api/lib/views-schema";
 
 const STATUS_GROUP_ID = "_status";
 const KIND_GROUP_ID = "_kind";
@@ -45,7 +43,7 @@ const isEntityKindValue = (value: string): value is EntityKindValue =>
   ENTITY_KIND_VALUES.some((kind) => kind === value);
 
 const readKanbanGroupBodySchema = t.Object({
-  filters: t.Optional(t.Array(tViewFilterConditionSchema)),
+  filters: t.Optional(t.Array(tConditionNode)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
   limit: t.Optional(
     t.Integer({

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -8,16 +8,14 @@ import {
 } from "@/api/handlers/entities/window-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
-import {
-  tViewFilterConditionSchema,
-  tViewSortSchema,
-} from "@/api/lib/views-schema";
+import { tViewSortSchema } from "@/api/lib/views-schema";
 
 const readEntitiesWindowBodySchema = t.Object({
-  filters: t.Optional(t.Array(tViewFilterConditionSchema)),
+  filters: t.Optional(t.Array(tConditionNode)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
   search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
   limit: t.Optional(

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -8,16 +8,14 @@ import {
 } from "@/api/handlers/entities/window-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
-import {
-  tViewFilterConditionSchema,
-  tViewSortSchema,
-} from "@/api/lib/views-schema";
+import { tViewSortSchema } from "@/api/lib/views-schema";
 
 const readEntitiesBodySchema = t.Object({
-  filters: t.Optional(t.Array(tViewFilterConditionSchema)),
+  filters: t.Optional(t.Array(tConditionNode)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
   page: t.Optional(t.Integer({ minimum: 1 })),
   cursor: t.Optional(t.String()),

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -11,6 +11,8 @@ import {
 } from "drizzle-orm";
 import { t } from "elysia";
 
+import type { ConditionNode } from "@stll/conditions";
+
 import type { SafeDb, SafeDbError } from "@/api/db";
 import { cellMetadata, entities, properties } from "@/api/db/schema";
 import type { EntityKind } from "@/api/db/schema-validators";
@@ -19,13 +21,10 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { acquireCellLock } from "@/api/lib/cell-lock";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { buildFilterConditions } from "@/api/lib/entity-filters";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import {
-  tViewFilterConditionSchema,
-  type ViewFilterCondition,
-} from "@/api/lib/views-schema";
 
 import {
   buildColumnFlagMutation,
@@ -46,7 +45,7 @@ const config = {
   body: t.Object({
     propertyId: tSafeId("property"),
     flag: t.Literal(VERIFIED_COLUMN_FLAG),
-    filters: t.Array(tViewFilterConditionSchema),
+    filters: t.Array(tConditionNode),
   }),
 } satisfies HandlerConfig;
 
@@ -66,7 +65,7 @@ type ProcessColumnFlagBatchArgs = {
   workspaceId: SafeId<"workspace">;
   propertyId: SafeId<"property">;
   flag: string;
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
   userId: SafeId<"user">;
   cursor: SafeId<"entity"> | null;
   addedAt: string;

--- a/apps/api/src/handlers/properties/create-schema.ts
+++ b/apps/api/src/handlers/properties/create-schema.ts
@@ -2,11 +2,11 @@ import { Value } from "@sinclair/typebox/value";
 import { t } from "elysia";
 
 import {
-  propertyConditionSchema,
   propertyContentSchema,
   propertyContentTypeSchema,
 } from "@/api/db/schema-validators";
 import type { PropertyContent, PropertyTool } from "@/api/db/schema-validators";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 import { serializeAITool } from "@/api/lib/markdown/ai-tool";
 
@@ -31,7 +31,7 @@ export const createPropertyBodySchema = t.Object({
     t.Array(
       t.Object({
         dependsOnPropertyId: tSafeId("property"),
-        condition: t.Nullable(propertyConditionSchema),
+        condition: t.Nullable(tConditionNode),
       }),
     ),
   ),

--- a/apps/api/src/handlers/properties/update-by-id.ts
+++ b/apps/api/src/handlers/properties/update-by-id.ts
@@ -6,7 +6,6 @@ import { properties, propertyDependencies } from "@/api/db/schema";
 import {
   aiModelToolSchema,
   manualInputToolSchema,
-  propertyConditionSchema,
   propertyContentSchema,
 } from "@/api/db/schema-validators";
 import type { PropertyTool } from "@/api/db/schema-validators";
@@ -15,6 +14,7 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import {
   tDefaultVarchar,
   tSafeId,
@@ -135,7 +135,7 @@ const updatePropertyBodySchema = t.Object({
         dependencies: t.Array(
           t.Object({
             dependsOnPropertyId: tSafeId("property"),
-            condition: t.Nullable(propertyConditionSchema),
+            condition: t.Nullable(tConditionNode),
           }),
         ),
       }),

--- a/apps/api/src/handlers/properties/utils.ts
+++ b/apps/api/src/handlers/properties/utils.ts
@@ -2,6 +2,8 @@ import type { Err } from "better-result";
 import { Result } from "better-result";
 import { deepEquals } from "bun";
 
+import type { ConditionNode } from "@stll/conditions";
+
 import type { SafeDb, SafeDbError } from "@/api/db";
 import type {
   AIModelTool,
@@ -10,7 +12,6 @@ import type {
 } from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
 import { sortDeep } from "@/api/lib/sort-deep";
-import type { PropertyCondition } from "@/api/types";
 
 type PropertyForComparison = {
   content: PropertyContent;
@@ -19,7 +20,7 @@ type PropertyForComparison = {
     | (AIModelTool & {
         dependencies: {
           dependsOnPropertyId: string;
-          condition: PropertyCondition | null;
+          condition: ConditionNode | null;
         }[];
       });
 };

--- a/apps/api/src/handlers/tasks/calendar.ts
+++ b/apps/api/src/handlers/tasks/calendar.ts
@@ -5,16 +5,14 @@ import { t } from "elysia";
 import { entities, fields } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import {
   buildFilterConditions,
   buildSortExpressions,
 } from "@/api/lib/entity-filters";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
-import {
-  tViewFilterConditionSchema,
-  tViewSortSchema,
-} from "@/api/lib/views-schema";
+import { tViewSortSchema } from "@/api/lib/views-schema";
 
 const INTERNAL_DATE_IDS = ["_created-at", "_updated-at"] as const;
 const TASK_DATE_IDS = ["_due-date", "_start-date"] as const;
@@ -29,7 +27,7 @@ const calendarTasksBodySchema = t.Object({
     maxItems: LIMITS.propertiesCount + BUILT_IN_DATE_IDS.length,
   }),
   endDatePropertyId: t.Optional(t.String({ minLength: 1 })),
-  filters: t.Optional(t.Array(tViewFilterConditionSchema)),
+  filters: t.Optional(t.Array(tConditionNode)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
 });
 

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -10,6 +10,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   collectNodePropertyIds,
+  remapDependencyRefs,
   remapNodePropertyIds,
 } from "@/api/lib/conditions/ast-utils";
 import { parseStoredCondition } from "@/api/lib/conditions/parse-stored";
@@ -372,29 +373,27 @@ const recreateTemplateDependencies = async ({
 
     const resolvedEdges = (templateProperty.dependencies ?? []).flatMap(
       (dep) => {
-        const dependsOnPropertyId = propertyIdBySourceId.get(
-          dep.dependsOnSourceId,
+        // Remaps the edge and the gate condition together (so neither is
+        // forgotten); null when the edge endpoint did not remap — the workflow
+        // planner then treats the property as having no inputs.
+        const refs = remapDependencyRefs(
+          {
+            dependsOnPropertyId: dep.dependsOnSourceId,
+            condition: dep.condition,
+          },
+          (id) => propertyIdBySourceId.get(id),
         );
-        // Drop edges where either endpoint failed to remap; the
-        // missing-property branch above already declined to create
-        // them, so the workflow planner will treat the property as
-        // having no inputs rather than crashing.
-        if (!dependsOnPropertyId || dependsOnPropertyId === propertyId) {
+        if (!refs || refs.dependsOnPropertyId === propertyId) {
           return [];
         }
         return [
           {
             workspaceId,
             propertyId: brandPersistedPropertyId(propertyId),
-            dependsOnPropertyId: brandPersistedPropertyId(dependsOnPropertyId),
-            // The gate's operands carry source ids too; remap them like the
-            // edge so the applied gate resolves against the target columns.
-            condition: dep.condition
-              ? remapNodePropertyIds(
-                  dep.condition,
-                  (id) => propertyIdBySourceId.get(id) ?? id,
-                )
-              : null,
+            dependsOnPropertyId: brandPersistedPropertyId(
+              refs.dependsOnPropertyId,
+            ),
+            condition: refs.condition,
           },
         ];
       },

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -387,7 +387,14 @@ const recreateTemplateDependencies = async ({
             workspaceId,
             propertyId: brandPersistedPropertyId(propertyId),
             dependsOnPropertyId: brandPersistedPropertyId(dependsOnPropertyId),
-            condition: dep.condition,
+            // The gate's operands carry source ids too; remap them like the
+            // edge so the applied gate resolves against the target columns.
+            condition: dep.condition
+              ? remapNodePropertyIds(
+                  dep.condition,
+                  (id) => propertyIdBySourceId.get(id) ?? id,
+                )
+              : null,
           },
         ];
       },

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -7,15 +7,15 @@ import { lockWorkspacePropertyWrites } from "@/api/handlers/properties/property-
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  collectNodePropertyIds,
+  remapNodePropertyIds,
+} from "@/api/lib/conditions/ast-utils";
 import { LIMITS } from "@/api/lib/limits";
 import { serializeAITool } from "@/api/lib/markdown/ai-tool";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
 import { sortDeep } from "@/api/lib/sort-deep";
-import type {
-  ViewFilterCondition,
-  ViewLayout,
-  ViewTemplateProperty,
-} from "@/api/lib/views-schema";
+import type { ViewLayout, ViewTemplateProperty } from "@/api/lib/views-schema";
 
 type WorkspacePropertyTemplateSource = {
   id: string;
@@ -665,10 +665,12 @@ const collectLayoutPropertyIds = (layout: ViewLayout): Set<string> => {
     add(sort.propertyId);
   }
 
-  for (const filter of layout.filters) {
-    if (filter.field === "property") {
-      add(filter.propertyId);
-    }
+  const filterPropertyIds = new Set<string>();
+  for (const node of layout.filters) {
+    collectNodePropertyIds(node, filterPropertyIds);
+  }
+  for (const id of filterPropertyIds) {
+    add(id);
   }
 
   if (layout.type === "table") {
@@ -716,16 +718,9 @@ const remapLayoutPropertyIds = (
     ...sort,
     propertyId: remap(sort.propertyId),
   }));
-  layout.filters = layout.filters.map((filter): ViewFilterCondition => {
-    if (filter.field !== "property") {
-      return filter;
-    }
-
-    return {
-      ...filter,
-      propertyId: remap(filter.propertyId),
-    };
-  });
+  layout.filters = layout.filters.map((node) =>
+    remapNodePropertyIds(node, remap),
+  );
 
   if (layout.type === "table") {
     layout.columnOrder = layout.columnOrder.map(remap);

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -1,8 +1,9 @@
 import { deepEquals } from "bun";
 
+import type { ConditionNode } from "@stll/conditions";
+
 import type { Transaction } from "@/api/db";
 import { properties, propertyDependencies } from "@/api/db/schema";
-import type { PropertyCondition } from "@/api/db/schema-validators";
 import { lockWorkspacePropertyWrites } from "@/api/handlers/properties/property-lock";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
@@ -11,6 +12,7 @@ import {
   collectNodePropertyIds,
   remapNodePropertyIds,
 } from "@/api/lib/conditions/ast-utils";
+import { parseStoredCondition } from "@/api/lib/conditions/parse-stored";
 import { LIMITS } from "@/api/lib/limits";
 import { serializeAITool } from "@/api/lib/markdown/ai-tool";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
@@ -28,7 +30,7 @@ type WorkspacePropertyTemplateSource = {
 type WorkspacePropertyDependencySource = {
   propertyId: string;
   dependsOnPropertyId: string;
-  condition: PropertyCondition | null;
+  condition: ConditionNode | null;
 };
 
 type ResolveTemplatePropertiesOptions = {
@@ -60,13 +62,13 @@ export const collectTemplateProperties = ({
   });
   const dependenciesByPropertyId = new Map<
     string,
-    { dependsOnSourceId: string; condition: PropertyCondition | null }[]
+    { dependsOnSourceId: string; condition: ConditionNode | null }[]
   >();
   for (const dep of dependencies) {
     const list = dependenciesByPropertyId.get(dep.propertyId) ?? [];
     list.push({
       dependsOnSourceId: dep.dependsOnPropertyId,
-      condition: dep.condition,
+      condition: parseStoredCondition(dep.condition),
     });
     dependenciesByPropertyId.set(dep.propertyId, list);
   }
@@ -106,7 +108,7 @@ const addDependencySourceIds = (
     string,
     readonly {
       dependsOnSourceId: string;
-      condition: PropertyCondition | null;
+      condition: ConditionNode | null;
     }[]
   >,
 ): void => {

--- a/apps/api/src/handlers/views/utils.ts
+++ b/apps/api/src/handlers/views/utils.ts
@@ -1,3 +1,6 @@
+import type { ConditionNode } from "@stll/conditions";
+
+import { nodeReferencesOnlyValidProperties } from "@/api/lib/conditions/ast-utils";
 import type {
   ViewLayout,
   ViewLayoutBase,
@@ -28,11 +31,9 @@ export const cleanStalePropertyIds = (
     changed = true;
   }
 
-  const cleanedFilters = layout.filters.filter(
-    (f) =>
-      f.field === "kind" ||
-      f.field === "builtin" ||
-      propertyIds.includes(f.propertyId),
+  const isValidPropertyId = (id: string) => propertyIds.includes(id);
+  const cleanedFilters = layout.filters.filter((node) =>
+    nodeReferencesOnlyValidProperties(node, isValidPropertyId),
   );
   if (cleanedFilters.length !== layout.filters.length) {
     layout.filters = cleanedFilters;
@@ -123,9 +124,12 @@ export const hasDuplicateSorts = (
   return false;
 };
 
+const isKindNode = (node: ConditionNode): boolean =>
+  node.type === "predicate" && node.operand.type === "kind";
+
 export const hasMultipleKindFilters = (
-  filters: readonly { field: string }[],
-): boolean => filters.filter((f) => f.field === "kind").length > 1;
+  filters: readonly ConditionNode[],
+): boolean => filters.filter(isKindNode).length > 1;
 
 export const convertLayout = (
   source: ViewLayout,

--- a/apps/api/src/handlers/views/utils.ts
+++ b/apps/api/src/handlers/views/utils.ts
@@ -1,6 +1,6 @@
 import type { ConditionNode } from "@stll/conditions";
 
-import { nodeReferencesOnlyValidProperties } from "@/api/lib/conditions/ast-utils";
+import { pruneStaleNode } from "@/api/lib/conditions/ast-utils";
 import type {
   ViewLayout,
   ViewLayoutBase,
@@ -32,10 +32,13 @@ export const cleanStalePropertyIds = (
   }
 
   const isValidPropertyId = (id: string) => propertyIds.includes(id);
-  const cleanedFilters = layout.filters.filter((node) =>
-    nodeReferencesOnlyValidProperties(node, isValidPropertyId),
-  );
-  if (cleanedFilters.length !== layout.filters.length) {
+  // Prune stale leaves recursively so an advanced group keeps its valid
+  // siblings instead of being dropped whole. Compare structurally because
+  // in-group pruning may not change the top-level array length.
+  const cleanedFilters = layout.filters
+    .map((node) => pruneStaleNode(node, isValidPropertyId))
+    .filter((node): node is ConditionNode => node !== null);
+  if (JSON.stringify(cleanedFilters) !== JSON.stringify(layout.filters)) {
     layout.filters = cleanedFilters;
     changed = true;
   }

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -643,7 +643,13 @@ const duplicateWorkspace = createSafeHandler(
             workspaceId: targetWorkspaceId,
             propertyId,
             dependsOnPropertyId,
-            condition: dependency.condition,
+            // The gate's operands reference source property ids too, so remap
+            // them like the edge — otherwise the copied gate resolves nothing.
+            condition: dependency.condition
+              ? remapNodePropertyIds(dependency.condition, (id) =>
+                  remapPropertyId(id, propertyIdMap),
+                )
+              : null,
           };
         })
         .filter((dependency) => dependency !== null);

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -25,6 +25,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { remapNodePropertyIds } from "@/api/lib/conditions/ast-utils";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
@@ -39,6 +40,7 @@ import { getS3 } from "@/api/lib/s3";
 import { upsertWorkspaceSearchDocument } from "@/api/lib/search/index-global";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import type { ViewLayout } from "@/api/lib/views-schema";
+import { parseViewLayout } from "@/api/lib/views-schema";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const config = {
@@ -62,18 +64,13 @@ const remapPropertyId = (
 ) => propertyIdMap.get(propertyId) ?? propertyId;
 
 const remapLayout = (
-  layout: ViewLayout,
+  storedLayout: unknown,
   propertyIdMap: Map<string, SafeId<"property">>,
 ): ViewLayout => {
-  const remapFilters = layout.filters.map((filter) => {
-    if (filter.field !== "property") {
-      return filter;
-    }
-    return {
-      ...filter,
-      propertyId: remapPropertyId(filter.propertyId, propertyIdMap),
-    };
-  });
+  const layout = parseViewLayout(storedLayout);
+  const remapFilters = layout.filters.map((node) =>
+    remapNodePropertyIds(node, (id) => remapPropertyId(id, propertyIdMap)),
+  );
   const remapSorts = layout.sorts.map((sort) => ({
     ...sort,
     propertyId: remapPropertyId(sort.propertyId, propertyIdMap),

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -25,7 +25,10 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import { remapNodePropertyIds } from "@/api/lib/conditions/ast-utils";
+import {
+  remapDependencyRefs,
+  remapNodePropertyIds,
+} from "@/api/lib/conditions/ast-utils";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
@@ -632,24 +635,24 @@ const duplicateWorkspace = createSafeHandler(
       const newDependencies = snapshot.dependencies
         .map((dependency) => {
           const propertyId = propertyIdMap.get(dependency.propertyId);
-          const dependsOnPropertyId = propertyIdMap.get(
-            dependency.dependsOnPropertyId,
+          // Remaps the edge and the gate condition together so the copy can't
+          // remap one without the other; null when the edge endpoint is gone.
+          const refs = remapDependencyRefs(
+            {
+              dependsOnPropertyId: dependency.dependsOnPropertyId,
+              condition: dependency.condition,
+            },
+            (id) => propertyIdMap.get(id),
           );
-          if (!propertyId || !dependsOnPropertyId) {
+          if (!propertyId || !refs) {
             return null;
           }
           return {
             id: createSafeId<"propertyDependency">(),
             workspaceId: targetWorkspaceId,
             propertyId,
-            dependsOnPropertyId,
-            // The gate's operands reference source property ids too, so remap
-            // them like the edge — otherwise the copied gate resolves nothing.
-            condition: dependency.condition
-              ? remapNodePropertyIds(dependency.condition, (id) =>
-                  remapPropertyId(id, propertyIdMap),
-                )
-              : null,
+            dependsOnPropertyId: refs.dependsOnPropertyId,
+            condition: refs.condition,
           };
         })
         .filter((dependency) => dependency !== null);

--- a/apps/api/src/lib/conditions/ast-utils.ts
+++ b/apps/api/src/lib/conditions/ast-utils.ts
@@ -89,3 +89,26 @@ export const nodeReferencesOnlyValidProperties = (
   }
   return true;
 };
+
+/**
+ * Drops only the leaf conditions that reference a deleted property, recursing
+ * into groups so valid siblings survive. Returns `null` when a leaf is invalid
+ * or a group is left empty — so one stale child no longer drops a whole group.
+ */
+export const pruneStaleNode = (
+  node: ConditionNode,
+  isValidPropertyId: (id: string) => boolean,
+): ConditionNode | null => {
+  if (node.type === "group") {
+    const children = node.children
+      .map((child) => pruneStaleNode(child, isValidPropertyId))
+      .filter((child): child is ConditionNode => child !== null);
+    if (children.length === 0) {
+      return null;
+    }
+    return { ...node, children };
+  }
+  return nodeReferencesOnlyValidProperties(node, isValidPropertyId)
+    ? node
+    : null;
+};

--- a/apps/api/src/lib/conditions/ast-utils.ts
+++ b/apps/api/src/lib/conditions/ast-utils.ts
@@ -1,0 +1,91 @@
+/**
+ * Structural helpers for walking and rewriting the condition AST in
+ * view layouts: remapping property ids, collecting referenced
+ * property ids, and dropping nodes that reference deleted properties.
+ * These operate on `ConditionNode` so the legacy `field`-keyed shape
+ * is never touched (callers upgrade first via `parseViewLayout`).
+ */
+import type { ConditionNode, Operand } from "@stll/conditions";
+
+const remapOperand = (
+  operand: Operand,
+  remap: (id: string) => string,
+): Operand => {
+  if (operand.type === "property") {
+    return { type: "property", propertyId: remap(operand.propertyId) };
+  }
+  return operand;
+};
+
+/** Returns a new node with every `property` operand id remapped. */
+export const remapNodePropertyIds = (
+  node: ConditionNode,
+  remap: (id: string) => string,
+): ConditionNode => {
+  switch (node.type) {
+    case "group":
+      return {
+        ...node,
+        children: node.children.map((child) =>
+          remapNodePropertyIds(child, remap),
+        ),
+      };
+    case "compare":
+      return {
+        ...node,
+        left: remapOperand(node.left, remap),
+        right: remapOperand(node.right, remap),
+      };
+    case "predicate":
+      return { ...node, operand: remapOperand(node.operand, remap) };
+    default:
+      return node;
+  }
+};
+
+const collectOperand = (operand: Operand, into: Set<string>): void => {
+  if (operand.type === "property") {
+    into.add(operand.propertyId);
+  }
+};
+
+/** Adds every `property` operand id referenced by the node to `into`. */
+export const collectNodePropertyIds = (
+  node: ConditionNode,
+  into: Set<string>,
+): void => {
+  switch (node.type) {
+    case "group":
+      for (const child of node.children) {
+        collectNodePropertyIds(child, into);
+      }
+      return;
+    case "compare":
+      collectOperand(node.left, into);
+      collectOperand(node.right, into);
+      return;
+    case "predicate":
+      collectOperand(node.operand, into);
+      return;
+    default:
+  }
+};
+
+/**
+ * A node is retained when every `property` operand it references is
+ * still valid. Kind/builtin operands carry no property id, so nodes
+ * built solely on them are always retained.
+ */
+export const nodeReferencesOnlyValidProperties = (
+  node: ConditionNode,
+  isValidPropertyId: (id: string) => boolean,
+): boolean => {
+  const referenced = new Set<string>();
+  collectNodePropertyIds(node, referenced);
+  for (const id of referenced) {
+    if (!isValidPropertyId(id)) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/apps/api/src/lib/conditions/ast-utils.ts
+++ b/apps/api/src/lib/conditions/ast-utils.ts
@@ -112,3 +112,26 @@ export const pruneStaleNode = (
     ? node
     : null;
 };
+
+/**
+ * Remaps both property references a dependency carries — the edge
+ * (`dependsOnPropertyId`) and the gate `condition`'s operands — through one
+ * `remap`, so a copy (workspace duplicate, template apply) can never remap one
+ * without the other. Returns `null` when the edge endpoint does not remap, so
+ * the caller drops the dependency rather than creating a dangling edge.
+ */
+export const remapDependencyRefs = <T extends string>(
+  source: { dependsOnPropertyId: string; condition: ConditionNode | null },
+  remap: (id: string) => T | undefined,
+): { dependsOnPropertyId: T; condition: ConditionNode | null } | null => {
+  const dependsOnPropertyId = remap(source.dependsOnPropertyId);
+  if (dependsOnPropertyId === undefined) {
+    return null;
+  }
+  return {
+    dependsOnPropertyId,
+    condition: source.condition
+      ? remapNodePropertyIds(source.condition, (id) => remap(id) ?? id)
+      : null,
+  };
+};

--- a/apps/api/src/lib/conditions/contract.ts
+++ b/apps/api/src/lib/conditions/contract.ts
@@ -6,6 +6,7 @@
  * bodies are typed with `t`. The `_conditionParity` guard below
  * fails typecheck if the two ever drift.
  */
+import { Type } from "@sinclair/typebox";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
@@ -34,7 +35,7 @@ const tOperand = t.Union([
   }),
 ]);
 
-export const tConditionNode = t.Recursive((self) =>
+const tConditionNodeRecursive = t.Recursive((self) =>
   t.Union([
     t.Object({
       type: t.Literal("compare"),
@@ -46,15 +47,28 @@ export const tConditionNode = t.Recursive((self) =>
       type: t.Literal("predicate"),
       operand: tOperand,
       op: t.UnionEnum([...PREDICATE_OPS]),
-      value: t.Optional(t.Union([t.String(), t.Array(t.String())])),
+      value: t.Optional(
+        t.Union([t.String(), t.Array(t.String()), t.Undefined()]),
+      ),
     }),
     t.Object({
       type: t.Literal("group"),
       combinator: t.UnionEnum([...COMBINATORS]),
-      negated: t.Optional(t.Boolean()),
+      negated: t.Optional(t.Union([t.Boolean(), t.Undefined()])),
       children: t.Array(self),
     }),
   ]),
+);
+
+/**
+ * Route-contract schema. Validates with the recursive structure above
+ * but presents the canonical `ConditionNode` static type to Eden: the
+ * recursive self-reference otherwise collapses `children` to `never[]`
+ * in TypeScript inference, which would reject every group node at the
+ * client boundary.
+ */
+export const tConditionNode = Type.Unsafe<ConditionNode>(
+  tConditionNodeRecursive,
 );
 
 /** Top-level condition: always the AND/OR root group. */
@@ -70,6 +84,7 @@ export const tCondition = t.Object({
 // constants. The reverse direction is intentionally omitted: TypeBox optionals
 // drop `| undefined` under exactOptionalPropertyTypes, so canonical→mirror
 // would false-positive without guarding anything the spreads don't already.)
-const _mirrorToCanonical = (n: Static<typeof tConditionNode>): ConditionNode =>
-  n;
+const _mirrorToCanonical = (
+  n: Static<typeof tConditionNodeRecursive>,
+): ConditionNode => n;
 void _mirrorToCanonical;

--- a/apps/api/src/lib/conditions/contract.ts
+++ b/apps/api/src/lib/conditions/contract.ts
@@ -1,0 +1,75 @@
+/**
+ * Elysia (TypeBox) mirror of the canonical `@stll/conditions`
+ * AST, for HTTP route contracts. The valibot schema in the
+ * package stays the source of truth for general runtime
+ * validation; this mirror exists only because Elysia route
+ * bodies are typed with `t`. The `_conditionParity` guard below
+ * fails typecheck if the two ever drift.
+ */
+import { t } from "elysia";
+import type { Static } from "elysia";
+
+import {
+  BUILTIN_FIELDS,
+  COMBINATORS,
+  COMPARE_OPS,
+  type ConditionNode,
+  PREDICATE_OPS,
+} from "@stll/conditions";
+
+const tOperand = t.Union([
+  t.Object({
+    type: t.Literal("property"),
+    propertyId: t.String({ minLength: 1 }),
+  }),
+  t.Object({
+    type: t.Literal("builtin"),
+    field: t.UnionEnum([...BUILTIN_FIELDS]),
+  }),
+  t.Object({ type: t.Literal("kind") }),
+  t.Object({ type: t.Literal("path"), path: t.String({ minLength: 1 }) }),
+  t.Object({
+    type: t.Literal("literal"),
+    value: t.Union([t.String(), t.Number(), t.Boolean(), t.Array(t.String())]),
+  }),
+]);
+
+export const tConditionNode = t.Recursive((self) =>
+  t.Union([
+    t.Object({
+      type: t.Literal("compare"),
+      left: tOperand,
+      op: t.UnionEnum([...COMPARE_OPS]),
+      right: tOperand,
+    }),
+    t.Object({
+      type: t.Literal("predicate"),
+      operand: tOperand,
+      op: t.UnionEnum([...PREDICATE_OPS]),
+      value: t.Optional(t.Union([t.String(), t.Array(t.String())])),
+    }),
+    t.Object({
+      type: t.Literal("group"),
+      combinator: t.UnionEnum([...COMBINATORS]),
+      negated: t.Optional(t.Boolean()),
+      children: t.Array(self),
+    }),
+  ]),
+);
+
+/** Top-level condition: always the AND/OR root group. */
+export const tCondition = t.Object({
+  type: t.Literal("group"),
+  combinator: t.UnionEnum([...COMBINATORS]),
+  negated: t.Optional(t.Boolean()),
+  children: t.Array(tConditionNode),
+});
+
+// Fails typecheck if the TypeBox mirror admits a shape outside the canonical
+// AST. (Operators/fields can't drift — they're spread from the same package
+// constants. The reverse direction is intentionally omitted: TypeBox optionals
+// drop `| undefined` under exactOptionalPropertyTypes, so canonical→mirror
+// would false-positive without guarding anything the spreads don't already.)
+const _mirrorToCanonical = (n: Static<typeof tConditionNode>): ConditionNode =>
+  n;
+void _mirrorToCanonical;

--- a/apps/api/src/lib/conditions/parse-stored.ts
+++ b/apps/api/src/lib/conditions/parse-stored.ts
@@ -1,0 +1,14 @@
+/**
+ * Reads a stored extraction-gating condition back into the canonical
+ * AST. Property dependencies persist a `ConditionNode | null`; a value
+ * that does not validate as a `ConditionNode` (e.g. a stray pre-AST
+ * row) is read as `null`, meaning "no gate" so the dependent property
+ * always runs. There is no legacy-shape reader: resetting a stale
+ * condition is acceptable (gating conditions are sparse and new).
+ */
+import * as v from "valibot";
+
+import { type ConditionNode, conditionNodeSchema } from "@stll/conditions";
+
+export const parseStoredCondition = (value: unknown): ConditionNode | null =>
+  v.is(conditionNodeSchema, value) ? value : null;

--- a/apps/api/src/lib/entity-filters.differential.test.ts
+++ b/apps/api/src/lib/entity-filters.differential.test.ts
@@ -1,0 +1,497 @@
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api-postgres";
+import { and, eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import fc from "fast-check";
+
+import type { ConditionNode } from "@stll/conditions";
+
+import * as authSchema from "@/api/db/auth-schema";
+import * as rlsExports from "@/api/db/rls";
+import * as schema from "@/api/db/schema";
+import { entities, entityVersions, fields, properties } from "@/api/db/schema";
+import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
+import { toSafeId } from "@/api/lib/branded-types";
+import { applyFilters, buildFilterConditions } from "@/api/lib/entity-filters";
+
+// ── Differential property test ──────────────────────────────
+//
+// Stella evaluates view-filter conditions twice: in memory via
+// `applyFilters` (the `@stll/conditions` evaluator) and in SQL via
+// `buildFilterConditions` (a WHERE clause). This test generates random
+// rows + a random condition, runs both paths against the same data, and
+// asserts the matching entity-id sets are identical. Any disagreement is
+// a real bug in one of the two implementations (or a by-design divergence
+// that is deliberately excluded from the generator below, with a reason).
+
+const allSchema = { ...schema, ...authSchema, ...rlsExports };
+
+type RawDb = ReturnType<typeof drizzle>;
+
+let client: PGlite;
+let db: RawDb;
+
+const ORG_ID = toSafeId<"organization">(Bun.randomUUIDv7());
+const WS_ID = toSafeId<"workspace">(Bun.randomUUIDv7());
+const CONTACT_ID = toSafeId<"contact">(Bun.randomUUIDv7());
+
+// ── Fixed property catalogue ────────────────────────────────
+//
+// One property per supported value type. Select properties carry a small
+// fixed option set so generated values land both inside and outside it.
+
+const SELECT_OPTIONS = ["alpha", "beta", "gamma"] as const;
+type SelectOption = (typeof SELECT_OPTIONS)[number];
+
+const PROP = {
+  text: toSafeId<"property">(Bun.randomUUIDv7()),
+  single: toSafeId<"property">(Bun.randomUUIDv7()),
+  multi: toSafeId<"property">(Bun.randomUUIDv7()),
+  int: toSafeId<"property">(Bun.randomUUIDv7()),
+  date: toSafeId<"property">(Bun.randomUUIDv7()),
+} as const;
+
+type PropKey = keyof typeof PROP;
+const PROP_KEYS: readonly PropKey[] = [
+  "text",
+  "single",
+  "multi",
+  "int",
+  "date",
+];
+
+const PROP_TOOL = { version: 1 as const, type: "manual-input" as const };
+
+const propertyContent = (key: PropKey) => {
+  if (key === "text") {
+    return { version: 1 as const, type: "text" as const };
+  }
+  if (key === "int") {
+    return { version: 1 as const, type: "int" as const };
+  }
+  if (key === "date") {
+    return { version: 1 as const, type: "date" as const };
+  }
+  return {
+    version: 1 as const,
+    type:
+      key === "single" ? ("single-select" as const) : ("multi-select" as const),
+    options: SELECT_OPTIONS.map((value) => ({ color: "gray", value })),
+    fallback: null,
+  };
+};
+
+const ENTITY_KINDS: readonly EntityKind[] = [
+  "document",
+  "task",
+  "message",
+  "link",
+];
+
+beforeAll(async () => {
+  client = await PGlite.create();
+  db = drizzle({ client });
+  const pushDb = drizzle({ client });
+
+  await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
+  await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+
+  const { sqlStatements } = await pushSchema(allSchema, pushDb);
+  for (const statement of sqlStatements) {
+    await db.execute(sql.raw(statement));
+  }
+
+  await db.insert(authSchema.user).values({
+    id: "user_diff_test",
+    name: "Diff",
+    email: "diff@test.local",
+  });
+  await db.insert(authSchema.organization).values({
+    id: ORG_ID,
+    name: "Diff Org",
+    slug: "diff-org",
+    createdAt: new Date(),
+  });
+  await db.insert(schema.contacts).values({
+    id: CONTACT_ID,
+    organizationId: ORG_ID,
+    type: "person",
+    displayName: "Diff Contact",
+  });
+  await db.insert(schema.workspaces).values({
+    id: WS_ID,
+    organizationId: ORG_ID,
+    clientId: CONTACT_ID,
+    name: "Diff WS",
+    reference: "REF-DIFF",
+    status: "active",
+  });
+
+  await db.insert(properties).values(
+    PROP_KEYS.map((key) => ({
+      id: PROP[key],
+      workspaceId: WS_ID,
+      name: key,
+      content: propertyContent(key),
+      tool: PROP_TOOL,
+      status: "fresh" as const,
+    })),
+  );
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+// ── Generated row model ─────────────────────────────────────
+
+type FilterableEntity = {
+  entityId: string;
+  kind: EntityKind;
+  fields: {
+    id: string;
+    propertyId: string;
+    entityId: string;
+    content: FieldContent;
+  }[];
+};
+
+type GeneratedRow = {
+  kind: EntityKind;
+  // A field per property, or null for "field absent".
+  values: Record<PropKey, FieldContent | null>;
+};
+
+// Safe text alphabet: lowercase letters only. Excludes SQL LIKE
+// metacharacters (`%`, `_`) — `contains`/`starts_with`/`ends_with` map to
+// ILIKE patterns in SQL but plain substring checks in memory, so a literal
+// `%` would legitimately diverge (a surface-syntax escaping concern, not a
+// filter-semantics bug).
+const safeText = fc.stringMatching(/^[a-z]{1,6}$/u);
+
+const fieldContentArb = (key: PropKey): fc.Arbitrary<FieldContent> => {
+  if (key === "text") {
+    return safeText.map((value) => ({ version: 1, type: "text", value }));
+  }
+  if (key === "int") {
+    return fc
+      .integer({ min: -20, max: 20 })
+      .map((value) => ({ version: 1, type: "int", value, currency: null }));
+  }
+  if (key === "date") {
+    return fc
+      .date({
+        min: new Date("2020-01-01T00:00:00Z"),
+        max: new Date("2026-12-31T00:00:00Z"),
+        noInvalidDate: true,
+      })
+      .map((d) => ({
+        version: 1,
+        type: "date",
+        value: d.toISOString().slice(0, 10),
+      }));
+  }
+  // single-select / multi-select draw from options plus an extra value that
+  // is not a current option (legacy/stale data).
+  const optionPool: SelectOption[] = [...SELECT_OPTIONS];
+  if (key === "single") {
+    return fc
+      .constantFrom<SelectOption | null>(...optionPool, null)
+      .map((value) => ({ version: 1, type: "single-select", value }));
+  }
+  return fc
+    .uniqueArray(fc.constantFrom<SelectOption>(...optionPool), {
+      minLength: 0,
+      maxLength: 3,
+    })
+    .map((value) => ({ version: 1, type: "multi-select", value }));
+};
+
+const rowArb: fc.Arbitrary<GeneratedRow> = fc.record({
+  kind: fc.constantFrom<EntityKind>(...ENTITY_KINDS),
+  values: fc.record({
+    text: fc.option(fieldContentArb("text"), { nil: null }),
+    single: fc.option(fieldContentArb("single"), { nil: null }),
+    multi: fc.option(fieldContentArb("multi"), { nil: null }),
+    int: fc.option(fieldContentArb("int"), { nil: null }),
+    date: fc.option(fieldContentArb("date"), { nil: null }),
+  }),
+});
+
+const rowsArb = fc.array(rowArb, { minLength: 1, maxLength: 8 });
+
+// ── Generated condition model ───────────────────────────────
+//
+// Operands are restricted to `property` (the inserted ones) and `kind`.
+// `builtin` and `path` operands are excluded: the in-memory evaluator
+// treats them as server-side pass-through by design, so they legitimately
+// diverge from SQL and are not in scope for this differential test.
+//
+// Each property only pairs with the operators the filter builder actually
+// offers for its value type (`OPERATORS_BY_VALUE_TYPE` in the web
+// condition-builder). Generating operator/type pairs the UI can never produce
+// (e.g. `gt` on a multi-select, `in` on text) would compare two
+// implementations on inputs neither is designed to handle, surfacing
+// divergences that no real filter can hit.
+
+const propertyOperand = (key: PropKey) => ({
+  type: "property" as const,
+  propertyId: PROP[key],
+});
+
+const dateLiteral = fc
+  .date({
+    min: new Date("2020-01-01T00:00:00Z"),
+    max: new Date("2026-12-31T00:00:00Z"),
+    noInvalidDate: true,
+  })
+  .map((d) => d.toISOString().slice(0, 10));
+
+// Scalar literal pools per value type, drawn so generated filters land both
+// on and off the row values inserted for that property.
+const scalarLiteralArb = (key: PropKey): fc.Arbitrary<string> => {
+  if (key === "int") {
+    return fc.integer({ min: -20, max: 20 }).map(String);
+  }
+  if (key === "date") {
+    return dateLiteral;
+  }
+  if (key === "single") {
+    return fc.constantFrom<string>(...SELECT_OPTIONS, "stale");
+  }
+  return safeText;
+};
+
+// `in` payloads carry at least one value. An empty payload is an incomplete
+// filter (no values chosen yet): SQL drops it to a no-op (`compileNode`
+// returns null → matches all), while the pure evaluator scores it concretely
+// (`[].includes(x)` is false). That gap is a deliberate server-side
+// incomplete-filter prune, not a filter-semantics disagreement, so it is out
+// of scope for this differential comparison.
+const singleSelectInPayload = fc.uniqueArray(
+  fc.constantFrom<string>(...SELECT_OPTIONS, "stale"),
+  { minLength: 1, maxLength: 3 },
+);
+
+const compareLeaf = (
+  key: PropKey,
+  ops: readonly ("eq" | "neq" | "gt" | "lt" | "gte" | "lte")[],
+): fc.Arbitrary<ConditionNode> =>
+  fc
+    .record({ op: fc.constantFrom(...ops), value: scalarLiteralArb(key) })
+    .map(({ op, value }) => ({
+      type: "compare",
+      left: propertyOperand(key),
+      op,
+      right: { type: "literal", value },
+    }));
+
+const emptinessLeaf = (key: PropKey): fc.Arbitrary<ConditionNode> =>
+  fc
+    .constantFrom("is_empty", "is_not_empty")
+    .map((op) => ({ type: "predicate", operand: propertyOperand(key), op }));
+
+const textPredicateLeaf = (
+  key: PropKey,
+  ops: readonly ("contains" | "not_contains" | "starts_with" | "ends_with")[],
+): fc.Arbitrary<ConditionNode> =>
+  fc
+    .record({ op: fc.constantFrom(...ops), value: scalarLiteralArb(key) })
+    .map(({ op, value }) => ({
+      type: "predicate",
+      operand: propertyOperand(key),
+      op,
+      value,
+    }));
+
+// Per value type, mirroring OPERATORS_BY_VALUE_TYPE in the web builder.
+const textLeaf = fc.oneof(
+  compareLeaf("text", ["eq", "neq"]),
+  textPredicateLeaf("text", [
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+  ]),
+  emptinessLeaf("text"),
+);
+
+const singleSelectLeaf = fc.oneof(
+  compareLeaf("single", ["eq", "neq"]),
+  singleSelectInPayload.map((value) => ({
+    type: "predicate" as const,
+    operand: propertyOperand("single"),
+    op: "in" as const,
+    value,
+  })),
+  emptinessLeaf("single"),
+);
+
+// multi-select offers only membership predicates (contains/not_contains) plus
+// emptiness — no compare ops and no `in`/`contains_all`.
+const multiSelectLeaf = fc.oneof(
+  textPredicateLeaf("multi", ["contains", "not_contains"]),
+  emptinessLeaf("multi"),
+);
+
+const numericLeaf = (key: "int" | "date") =>
+  fc.oneof(
+    compareLeaf(key, ["eq", "neq", "gt", "lt", "gte", "lte"]),
+    emptinessLeaf(key),
+  );
+
+const kindLeaf: fc.Arbitrary<ConditionNode> = fc
+  // minLength 1: an empty kind `in` is the same incomplete-filter no-op excluded
+  // for the `in` payload above (SQL drops it; the evaluator scores it false).
+  .uniqueArray(fc.constantFrom<EntityKind>(...ENTITY_KINDS), {
+    minLength: 1,
+    maxLength: 4,
+  })
+  .map((value) => ({
+    type: "predicate",
+    operand: { type: "kind" },
+    op: "in",
+    value,
+  }));
+
+const leafArb: fc.Arbitrary<ConditionNode> = fc.oneof(
+  textLeaf,
+  singleSelectLeaf,
+  multiSelectLeaf,
+  numericLeaf("int"),
+  numericLeaf("date"),
+  kindLeaf,
+);
+
+const { node: conditionArb } = fc.letrec<{
+  node: ConditionNode;
+  group: ConditionNode;
+}>((tie) => ({
+  node: fc.oneof({ maxDepth: 3, withCrossShrink: true }, leafArb, tie("group")),
+  group: fc
+    .record({
+      combinator: fc.constantFrom("and", "or"),
+      negated: fc.boolean(),
+      children: fc.array(tie("node"), { minLength: 1, maxLength: 3 }),
+    })
+    .map(({ combinator, negated, children }) => ({
+      type: "group",
+      combinator,
+      negated,
+      children,
+    })),
+}));
+
+// ── Both evaluation paths ───────────────────────────────────
+
+const toFilterableEntities = (
+  rows: GeneratedRow[],
+  ids: string[],
+): FilterableEntity[] =>
+  rows.map((row, index) => {
+    const entityId = ids[index] ?? "";
+    const entityFields: FilterableEntity["fields"] = [];
+    for (const key of PROP_KEYS) {
+      const content = row.values[key];
+      if (content !== null) {
+        entityFields.push({
+          id: `field_${key}_${entityId}`,
+          propertyId: PROP[key],
+          entityId,
+          content,
+        });
+      }
+    }
+    return { entityId, kind: row.kind, fields: entityFields };
+  });
+
+const seedRows = async (rows: GeneratedRow[]): Promise<string[]> => {
+  const ids = rows.map(() => toSafeId<"entity">(Bun.randomUUIDv7()));
+  const versionIds = rows.map(() =>
+    toSafeId<"entityVersion">(Bun.randomUUIDv7()),
+  );
+
+  await db.insert(entities).values(
+    rows.map((row, index) => ({
+      id: ids[index] ?? toSafeId<"entity">(""),
+      workspaceId: WS_ID,
+      kind: row.kind,
+      name: `entity_${index}`,
+    })),
+  );
+  await db.insert(entityVersions).values(
+    rows.map((_, index) => ({
+      id: versionIds[index] ?? toSafeId<"entityVersion">(""),
+      workspaceId: WS_ID,
+      entityId: ids[index] ?? toSafeId<"entity">(""),
+    })),
+  );
+  for (const [index, entityId] of ids.entries()) {
+    await db
+      .update(entities)
+      .set({ currentVersionId: versionIds[index] ?? null })
+      .where(eq(entities.id, entityId));
+  }
+
+  const fieldRows = rows.flatMap((row, index) =>
+    PROP_KEYS.flatMap((key) => {
+      const content = row.values[key];
+      if (content === null) {
+        return [];
+      }
+      return [
+        {
+          id: toSafeId<"field">(Bun.randomUUIDv7()),
+          workspaceId: WS_ID,
+          propertyId: PROP[key],
+          entityVersionId: versionIds[index] ?? toSafeId<"entityVersion">(""),
+          content,
+        },
+      ];
+    }),
+  );
+  if (fieldRows.length > 0) {
+    await db.insert(fields).values(fieldRows);
+  }
+
+  return ids;
+};
+
+const clearRows = async () => {
+  await db.delete(fields).where(eq(fields.workspaceId, WS_ID));
+  await db
+    .update(entities)
+    .set({ currentVersionId: null })
+    .where(eq(entities.workspaceId, WS_ID));
+  await db.delete(entityVersions).where(eq(entityVersions.workspaceId, WS_ID));
+  await db.delete(entities).where(eq(entities.workspaceId, WS_ID));
+};
+
+const sqlMatchIds = async (condition: ConditionNode): Promise<Set<string>> => {
+  const conditions = buildFilterConditions([condition]);
+  const rows = await db
+    .select({ id: entities.id })
+    .from(entities)
+    .where(and(eq(entities.workspaceId, WS_ID), ...conditions));
+  return new Set(rows.map((r) => r.id));
+};
+
+test("in-memory and SQL filter evaluation agree", async () => {
+  await fc.assert(
+    fc.asyncProperty(rowsArb, conditionArb, async (rows, condition) => {
+      const ids = await seedRows(rows);
+      try {
+        const sqlIds = await sqlMatchIds(condition);
+        const memoryEntities = toFilterableEntities(rows, ids);
+        const memoryIds = new Set(
+          applyFilters(memoryEntities, [condition]).map((e) => e.entityId),
+        );
+        expect([...sqlIds].toSorted()).toEqual([...memoryIds].toSorted());
+      } finally {
+        await clearRows();
+      }
+    }),
+    { numRuns: 300 },
+  );
+});

--- a/apps/api/src/lib/entity-filters.differential.test.ts
+++ b/apps/api/src/lib/entity-filters.differential.test.ts
@@ -98,7 +98,9 @@ beforeAll(async () => {
   await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
 
   const { sqlStatements } = await pushSchema(allSchema, pushDb);
+  // Schema DDL must apply in dependency order, so these run sequentially.
   for (const statement of sqlStatements) {
+    // eslint-disable-next-line no-await-in-loop -- ordered DDL, can't parallelize
     await db.execute(sql.raw(statement));
   }
 
@@ -263,15 +265,17 @@ const scalarLiteralArb = (key: PropKey): fc.Arbitrary<string> => {
   return safeText;
 };
 
-// `in` payloads carry at least one value. An empty payload is an incomplete
-// filter (no values chosen yet): SQL drops it to a no-op (`compileNode`
-// returns null → matches all), while the pure evaluator scores it concretely
-// (`[].includes(x)` is false). That gap is a deliberate server-side
-// incomplete-filter prune, not a filter-semantics disagreement, so it is out
-// of scope for this differential comparison.
+// Sometimes emit an empty value/payload: an incomplete filter (operator chosen,
+// value not entered). Both paths must treat it as a no-op, so it's in scope.
+const maybeEmpty = (arb: fc.Arbitrary<string>): fc.Arbitrary<string> =>
+  fc.oneof(
+    { weight: 1, arbitrary: fc.constant("") },
+    { weight: 4, arbitrary: arb },
+  );
+
 const singleSelectInPayload = fc.uniqueArray(
   fc.constantFrom<string>(...SELECT_OPTIONS, "stale"),
-  { minLength: 1, maxLength: 3 },
+  { minLength: 0, maxLength: 3 },
 );
 
 const compareLeaf = (
@@ -279,7 +283,10 @@ const compareLeaf = (
   ops: readonly ("eq" | "neq" | "gt" | "lt" | "gte" | "lte")[],
 ): fc.Arbitrary<ConditionNode> =>
   fc
-    .record({ op: fc.constantFrom(...ops), value: scalarLiteralArb(key) })
+    .record({
+      op: fc.constantFrom(...ops),
+      value: maybeEmpty(scalarLiteralArb(key)),
+    })
     .map(({ op, value }) => ({
       type: "compare",
       left: propertyOperand(key),
@@ -297,7 +304,10 @@ const textPredicateLeaf = (
   ops: readonly ("contains" | "not_contains" | "starts_with" | "ends_with")[],
 ): fc.Arbitrary<ConditionNode> =>
   fc
-    .record({ op: fc.constantFrom(...ops), value: scalarLiteralArb(key) })
+    .record({
+      op: fc.constantFrom(...ops),
+      value: maybeEmpty(scalarLiteralArb(key)),
+    })
     .map(({ op, value }) => ({
       type: "predicate",
       operand: propertyOperand(key),
@@ -342,10 +352,10 @@ const numericLeaf = (key: "int" | "date") =>
   );
 
 const kindLeaf: fc.Arbitrary<ConditionNode> = fc
-  // minLength 1: an empty kind `in` is the same incomplete-filter no-op excluded
-  // for the `in` payload above (SQL drops it; the evaluator scores it false).
+  // Empty kind `in` is an incomplete filter — both paths no-op it (SQL drops it,
+  // the evaluator returns vacuously true), so it is in scope here.
   .uniqueArray(fc.constantFrom<EntityKind>(...ENTITY_KINDS), {
-    minLength: 1,
+    minLength: 0,
     maxLength: 4,
   })
   .map((value) => ({
@@ -427,12 +437,15 @@ const seedRows = async (rows: GeneratedRow[]): Promise<string[]> => {
       entityId: ids[index] ?? toSafeId<"entity">(""),
     })),
   );
-  for (const [index, entityId] of ids.entries()) {
-    await db
-      .update(entities)
-      .set({ currentVersionId: versionIds[index] ?? null })
-      .where(eq(entities.id, entityId));
-  }
+  // Independent per-entity updates (FK requires the version to exist first).
+  await Promise.all(
+    ids.map((entityId, index) =>
+      db
+        .update(entities)
+        .set({ currentVersionId: versionIds[index] ?? null })
+        .where(eq(entities.id, entityId)),
+    ),
+  );
 
   const fieldRows = rows.flatMap((row, index) =>
     PROP_KEYS.flatMap((key) => {

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { PgDialect } from "drizzle-orm/pg-core";
 import fc from "fast-check";
 
-import type { ViewFilterCondition } from "@/api/lib/views-schema";
+import type { ConditionNode } from "@stll/conditions";
 
 import {
   applyFilters,
@@ -13,104 +13,76 @@ import {
 
 // -- buildFilterConditions (builtin filters) --
 
-const builtinFilter = (
-  overrides: Partial<Extract<ViewFilterCondition, { field: "builtin" }>>,
-): ViewFilterCondition =>
-  ({
-    id: "f1",
-    field: "builtin" as const,
-    builtinField: "status" as const,
-    op: "eq" as const,
-    value: undefined,
-    ...overrides,
-  }) as ViewFilterCondition;
+const builtinCompare = (
+  field: "status" | "priority",
+  op: "eq" | "neq",
+  value: string,
+): ConditionNode => ({
+  type: "compare",
+  left: { type: "builtin", field },
+  op,
+  right: { type: "literal", value },
+});
+
+const builtinPredicate = (
+  field: "status" | "priority",
+  op: "in" | "is_empty",
+  value?: string[],
+): ConditionNode => ({
+  type: "predicate",
+  operand: { type: "builtin", field },
+  op,
+  ...(value !== undefined && { value }),
+});
 
 describe("buildFilterConditions (builtin)", () => {
   test("eq with empty string returns no conditions", () => {
-    const conds = buildFilterConditions([
-      builtinFilter({ op: "eq", value: "" }),
-    ]);
-    expect(conds).toHaveLength(0);
-  });
-
-  test("eq with undefined value returns no conditions", () => {
-    const conds = buildFilterConditions([
-      builtinFilter({ op: "eq", value: undefined }),
-    ]);
+    const conds = buildFilterConditions([builtinCompare("status", "eq", "")]);
     expect(conds).toHaveLength(0);
   });
 
   test("eq with valid value returns one condition", () => {
     const conds = buildFilterConditions([
-      builtinFilter({ op: "eq", value: "open" }),
+      builtinCompare("status", "eq", "open"),
     ]);
     expect(conds).toHaveLength(1);
   });
 
   test("neq with empty string returns no conditions", () => {
-    const conds = buildFilterConditions([
-      builtinFilter({ op: "neq", value: "" }),
-    ]);
-    expect(conds).toHaveLength(0);
-  });
-
-  test("neq with undefined value returns no conditions", () => {
-    const conds = buildFilterConditions([
-      builtinFilter({ op: "neq", value: undefined }),
-    ]);
+    const conds = buildFilterConditions([builtinCompare("status", "neq", "")]);
     expect(conds).toHaveLength(0);
   });
 
   test("neq with valid value returns one condition", () => {
     const conds = buildFilterConditions([
-      builtinFilter({ op: "neq", value: "done" }),
+      builtinCompare("status", "neq", "done"),
     ]);
     expect(conds).toHaveLength(1);
   });
 
   test("in with empty array returns no conditions", () => {
-    const conds = buildFilterConditions([
-      builtinFilter({ op: "in", value: [] }),
-    ]);
+    const conds = buildFilterConditions([builtinPredicate("status", "in", [])]);
     expect(conds).toHaveLength(0);
   });
 
   test("in with values returns one condition", () => {
     const conds = buildFilterConditions([
-      builtinFilter({ op: "in", value: ["open", "done"] }),
+      builtinPredicate("status", "in", ["open", "done"]),
     ]);
     expect(conds).toHaveLength(1);
   });
 
   test("is_empty returns one condition", () => {
-    const conds = buildFilterConditions([builtinFilter({ op: "is_empty" })]);
-    expect(conds).toHaveLength(1);
-  });
-
-  test("unknown builtinField returns no conditions", () => {
     const conds = buildFilterConditions([
-      builtinFilter({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- intentionally invalid value
-        builtinField: "nonexistent" as "status",
-      }),
+      builtinPredicate("status", "is_empty"),
     ]);
-    expect(conds).toHaveLength(0);
+    expect(conds).toHaveLength(1);
   });
 
   test("multiple filters produce multiple conditions", () => {
     const conds = buildFilterConditions([
-      builtinFilter({
-        id: "f1",
-        builtinField: "status",
-        op: "eq",
-        value: "open",
-      }),
-      builtinFilter({
-        id: "f2",
-        builtinField: "priority",
-        op: "neq",
-        value: "low",
-      }),
+      builtinCompare("status", "eq", "open"),
+      builtinCompare("priority", "neq", "low"),
     ]);
     expect(conds).toHaveLength(2);
   });
@@ -118,29 +90,33 @@ describe("buildFilterConditions (builtin)", () => {
 
 // -- buildFilterConditions (kind filters) --
 
+const kindIn = (value: string[]): ConditionNode => ({
+  type: "predicate",
+  operand: { type: "kind" },
+  op: "in",
+  value,
+});
+
 describe("buildFilterConditions (kind)", () => {
   test("kind filter with empty value produces no conditions", () => {
-    const conds = buildFilterConditions([
-      {
-        id: "f1",
-        field: "kind",
-        op: "in",
-        value: [],
-      },
-    ]);
+    const conds = buildFilterConditions([kindIn([])]);
     expect(conds).toHaveLength(0);
   });
 
   test("kind filter with values produces one condition", () => {
-    const conds = buildFilterConditions([
-      {
-        id: "f1",
-        field: "kind",
-        op: "in",
-        value: ["task"],
-      },
-    ]);
+    const conds = buildFilterConditions([kindIn(["task"])]);
     expect(conds).toHaveLength(1);
+  });
+
+  test("kind filter including document expands to folder", () => {
+    const dialect = new PgDialect();
+    const [cond] = buildFilterConditions([kindIn(["document"])]);
+    if (!cond) {
+      throw new Error("expected kind condition");
+    }
+    const { sql, params } = dialect.sqlToQuery(cond);
+    expect(sql).toContain('"kind"');
+    expect(params).toContain("folder");
   });
 });
 
@@ -184,6 +160,28 @@ const makeIntField = (entityId: string, propertyId: string, value: number) => ({
   },
 });
 
+const propertyCompare = (
+  propertyId: string,
+  op: "eq" | "neq",
+  value: string,
+): ConditionNode => ({
+  type: "compare",
+  left: { type: "property", propertyId },
+  op,
+  right: { type: "literal", value },
+});
+
+const propertyPredicate = (
+  propertyId: string,
+  op: "contains" | "is_empty",
+  value?: string,
+): ConditionNode => ({
+  type: "predicate",
+  operand: { type: "property", propertyId },
+  op,
+  ...(value !== undefined && { value }),
+});
+
 describe("applyFilters (in-memory)", () => {
   test("empty filters returns all items", () => {
     const items = [makeEntity("1", "task"), makeEntity("2", "task")];
@@ -192,9 +190,7 @@ describe("applyFilters (in-memory)", () => {
 
   test("kind filter includes matching entities", () => {
     const items = [makeEntity("1", "task"), makeEntity("2", "document")];
-    const filtered = applyFilters(items, [
-      { id: "f1", field: "kind", op: "in", value: ["task"] },
-    ]);
+    const filtered = applyFilters(items, [kindIn(["task"])]);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.entityId).toBe("1");
   });
@@ -205,9 +201,7 @@ describe("applyFilters (in-memory)", () => {
       makeEntity("2", "folder"),
       makeEntity("3", "task"),
     ];
-    const filtered = applyFilters(items, [
-      { id: "f1", field: "kind", op: "in", value: ["document"] },
-    ]);
+    const filtered = applyFilters(items, [kindIn(["document"])]);
     expect(filtered).toHaveLength(2);
   });
 
@@ -217,13 +211,7 @@ describe("applyFilters (in-memory)", () => {
       makeEntity("2", "task", [["p1", "beta"]]),
     ];
     const filtered = applyFilters(items, [
-      {
-        id: "f1",
-        field: "property",
-        propertyId: "p1",
-        op: "eq",
-        value: "alpha",
-      },
+      propertyCompare("p1", "eq", "alpha"),
     ]);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.entityId).toBe("1");
@@ -235,13 +223,7 @@ describe("applyFilters (in-memory)", () => {
       makeEntity("2", "task", [["p1", "beta"]]),
     ];
     const filtered = applyFilters(items, [
-      {
-        id: "f1",
-        field: "property",
-        propertyId: "p1",
-        op: "neq",
-        value: "alpha",
-      },
+      propertyCompare("p1", "neq", "alpha"),
     ]);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.entityId).toBe("2");
@@ -253,13 +235,7 @@ describe("applyFilters (in-memory)", () => {
       makeEntity("2", "task", [["p1", "goodbye"]]),
     ];
     const filtered = applyFilters(items, [
-      {
-        id: "f1",
-        field: "property",
-        propertyId: "p1",
-        op: "contains",
-        value: "hello",
-      },
+      propertyPredicate("p1", "contains", "hello"),
     ]);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.entityId).toBe("1");
@@ -270,31 +246,18 @@ describe("applyFilters (in-memory)", () => {
       makeEntity("1", "task", [["p1", "value"]]),
       makeEntity("2", "task", []),
     ];
-    const filtered = applyFilters(items, [
-      {
-        id: "f1",
-        field: "property",
-        propertyId: "p1",
-        op: "is_empty",
-      },
-    ]);
+    const filtered = applyFilters(items, [propertyPredicate("p1", "is_empty")]);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.entityId).toBe("2");
   });
 
   test("builtin filters pass through in-memory (always true)", () => {
     const items = [makeEntity("1", "task"), makeEntity("2", "task")];
+    // Builtin filters are server-side only; nodes referencing builtin
+    // operands pass through in-memory.
     const filtered = applyFilters(items, [
-      {
-        id: "f1",
-        field: "builtin",
-        builtinField: "status",
-        op: "eq",
-        value: "open",
-      },
+      builtinCompare("status", "eq", "open"),
     ]);
-    // Builtin filters are server-side only; in-memory always
-    // returns true
     expect(filtered).toHaveLength(2);
   });
 });

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -353,7 +353,9 @@ const compareOpSql = (op: CompareNode["op"], expr: SQL, value: string): SQL => {
   if (NUMERIC_TEXT_RE.test(value.trim())) {
     return orderedSql(op, safeNumericExpr(expr), sql`${Number(value)}`);
   }
-  return orderedSql(op, expr, sql`${value}`);
+  // Exclude blank/absent values: '' would otherwise sort before every date and
+  // leak rows with no value into "is before/on or before" filters.
+  return sql`${expr} <> '' AND ${orderedSql(op, expr, sql`${value}`)}`;
 };
 
 const literalString = (operand: Operand): string | null =>

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -340,7 +340,7 @@ const compareOpSql = (op: CompareNode["op"], expr: SQL, value: string): SQL => {
 };
 
 const literalString = (operand: Operand): string | null =>
-  operand.type === "literal" ? String(operand.value ?? "") : null;
+  operand.type === "literal" ? String(operand.value) : null;
 
 const compileBuiltinCompare = (
   field: "status" | "priority",

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -10,6 +10,7 @@ import {
   type PredicateNode,
   type RefOperand,
   evaluateCondition,
+  pruneIncomplete,
 } from "@stll/conditions";
 
 import { user } from "@/api/db/auth-schema";
@@ -247,7 +248,12 @@ export const applyFilters = <T extends FilterableEntity>(
     return items;
   }
 
-  const prepared = filters.map(expandKindNode);
+  // Prune incomplete leaves first, exactly as the SQL compiler drops them, so
+  // both paths see the same shape (an incomplete leaf must not match under OR).
+  const prepared = filters
+    .map(expandKindNode)
+    .map(pruneIncomplete)
+    .filter((node): node is ConditionNode => node !== null);
 
   return items.filter((entity) => {
     const resolveOrPass = buildResolver(entity);
@@ -504,6 +510,17 @@ const compilePropertyPredicate = (
   node: PredicateNode,
 ): SQL | null => {
   const text = String(node.value ?? "");
+  // Incomplete value-bearing text predicate (no value yet) is a no-op, like the
+  // ordered compare path; contains_all/in already null out on an empty payload.
+  if (
+    text === "" &&
+    (node.op === "contains" ||
+      node.op === "not_contains" ||
+      node.op === "starts_with" ||
+      node.op === "ends_with")
+  ) {
+    return null;
+  }
   // Same matcher for arrays and scalars (membership/emptiness ops).
   const same = (match: (v: SQL) => SQL) =>
     propertyValueMatches(propertyId, match, match);
@@ -644,7 +661,8 @@ const compileNode = (node: ConditionNode): SQL | null => {
 export const buildFilterConditions = (filters: ConditionNode[]): SQL[] => {
   const conditions: SQL[] = [];
   for (const node of filters) {
-    const compiled = compileNode(node);
+    const pruned = pruneIncomplete(node);
+    const compiled = pruned ? compileNode(pruned) : null;
     if (compiled) {
       conditions.push(compiled);
     }

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -15,6 +15,7 @@ import {
 import { user } from "@/api/db/auth-schema";
 import { entities, entityVersions, fields, properties } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
+import { typedPgArray } from "@/api/lib/search/sql";
 
 // -- Types --
 
@@ -93,6 +94,25 @@ const findField = (
 ): EntityField | undefined =>
   entityFields.find((f) => f.propertyId === propertyId);
 
+/**
+ * Resolves a field's content to the value the condition evaluator should see,
+ * mirroring how SQL reads the JSONB `content`:
+ *  - multi-select stays an array, so membership/`in`/`contains` operate on
+ *    discrete options (SQL's `jsonb_array_elements_text` path) instead of a
+ *    joined string that would substring-match across option boundaries;
+ *  - everything else collapses to the same scalar text SQL's
+ *    `content->>'value'` (or `->>'fileName'`) produces.
+ *
+ * Distinct from `getFieldValue`, which the sort comparators need as a plain
+ * string; filtering must not flatten multi-select arrays.
+ */
+const getFilterValue = (content: FieldContent | undefined): ConditionValue => {
+  if (content?.type === "multi-select") {
+    return content.value;
+  }
+  return getFieldValue(content);
+};
+
 // -- In-memory evaluation --
 
 const PASS_THROUGH = Symbol("builtin-pass-through");
@@ -112,7 +132,7 @@ const buildResolver =
       case "kind":
         return entity.kind;
       case "property":
-        return getFieldValue(
+        return getFilterValue(
           findField(entity.fields, operand.propertyId)?.content,
         );
       case "builtin":
@@ -141,6 +161,59 @@ const nodeIsServerSideOnly = (node: ConditionNode): boolean => {
     default:
       return false;
   }
+};
+
+/**
+ * Mirrors SQL's `propertyExists` gate for `compare` nodes: every property
+ * comparison runs inside `EXISTS (... WHERE property_id = ... AND <op>)`, so a
+ * row missing the field never matches — including `neq`/`eq ''`, where an
+ * absent field would otherwise read as the empty string and match in memory.
+ * Predicates need no such gate here: their absent-field behaviour
+ * (`is_empty`/`not_contains` match, everything else fails on `[]`) already
+ * mirrors SQL via the evaluator's empty-value handling.
+ */
+const comparePropertyFieldMissing = (
+  node: ConditionNode,
+  entity: FilterableEntity,
+): boolean => {
+  if (node.type !== "compare") {
+    return false;
+  }
+  const propertyOperand = [node.left, node.right].find(
+    (operand): operand is Extract<RefOperand, { type: "property" }> =>
+      operand.type === "property",
+  );
+  if (!propertyOperand) {
+    return false;
+  }
+  return findField(entity.fields, propertyOperand.propertyId) === undefined;
+};
+
+// Empty OR group: matches nothing (the evaluator's `false` identity). Used to
+// replace a property `compare` whose field is absent, so the surrounding
+// AND/OR/negate combination sees the same `false` SQL produces.
+const NEVER_MATCHES: GroupNode = {
+  type: "group",
+  combinator: "or",
+  children: [],
+};
+
+const gateMissingCompareFields = (
+  node: ConditionNode,
+  entity: FilterableEntity,
+): ConditionNode => {
+  if (node.type === "group") {
+    return {
+      ...node,
+      children: node.children.map((child) =>
+        gateMissingCompareFields(child, entity),
+      ),
+    };
+  }
+  if (comparePropertyFieldMissing(node, entity)) {
+    return NEVER_MATCHES;
+  }
+  return node;
 };
 
 const isKindInPredicate = (node: ConditionNode): node is PredicateNode =>
@@ -187,7 +260,7 @@ export const applyFilters = <T extends FilterableEntity>(
       if (nodeIsServerSideOnly(node)) {
         return true;
       }
-      return evaluateCondition(node, resolve);
+      return evaluateCondition(gateMissingCompareFields(node, entity), resolve);
     });
   });
 };
@@ -472,7 +545,9 @@ const compilePropertyPredicate = (
       if (values.length === 0) {
         return null;
       }
-      return same((v) => sql`${v} = ANY(${values})`);
+      // `typedPgArray` binds a real `ARRAY[...]::text[]`; a bare `ANY(${values})`
+      // expands to a row constructor `ANY(($1, $2))`, which Postgres rejects.
+      return same((v) => sql`${v} = ANY(${typedPgArray(values, "text")})`);
     }
     default:
       return null;

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -378,25 +378,25 @@ const compileBuiltinCompare = (
 
 const compileCompare = (node: CompareNode): SQL | null => {
   // The filter UI always compares a ref operand against a literal.
+  const value = literalString(node.right);
+  if (value === null) {
+    return null;
+  }
+  // An ordered comparison with an empty literal is an incomplete filter
+  // (operator chosen, value not yet entered); drop it so an in-progress
+  // "date is before …" doesn't match nearly every row.
+  if (value === "" && node.op !== "eq" && node.op !== "neq") {
+    return null;
+  }
   if (node.left.type === "property") {
-    const value = literalString(node.right);
-    if (value === null) {
-      return null;
-    }
     return propertyExists(
       node.left.propertyId,
       compareOpSql(node.op, fieldValueExpr(fields.content), value),
     );
   }
-
   if (node.left.type === "builtin") {
-    const value = literalString(node.right);
-    if (value === null) {
-      return null;
-    }
     return compileBuiltinCompare(node.left.field, node.op, value);
   }
-
   return null;
 };
 

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -383,19 +383,32 @@ const compileCompare = (node: CompareNode): SQL | null => {
 
 // -- Predicate nodes --
 
+const propertyLike = (propertyId: string, pattern: string): SQL =>
+  propertyExists(
+    propertyId,
+    sql`${fieldValueExpr(fields.content)} ILIKE ${pattern}`,
+  );
+
 const compilePropertyPredicate = (
   propertyId: string,
   node: PredicateNode,
 ): SQL | null => {
   const valExpr = fieldValueExpr(fields.content);
+  const text = String(node.value ?? "");
   switch (node.op) {
     case "contains":
-      return propertyExists(
-        propertyId,
-        sql`${valExpr} ILIKE ${`%${String(node.value ?? "")}%`}`,
-      );
+      return propertyLike(propertyId, `%${text}%`);
+    case "not_contains":
+      // NOT EXISTS so absent/empty fields count as "does not contain".
+      return sql`NOT ${propertyLike(propertyId, `%${text}%`)}`;
+    case "starts_with":
+      return propertyLike(propertyId, `${text}%`);
+    case "ends_with":
+      return propertyLike(propertyId, `%${text}`);
     case "is_empty":
       return propertyExists(propertyId, sql`${valExpr} = ''`);
+    case "is_not_empty":
+      return propertyExists(propertyId, sql`${valExpr} <> ''`);
     case "contains_all": {
       const wanted = asValueArray(node.value);
       if (wanted.length === 0) {
@@ -433,6 +446,8 @@ const compileBuiltinPredicate = (
     }
     case "is_empty":
       return sql`(${col} IS NULL OR ${col} = '')`;
+    case "is_not_empty":
+      return sql`(${col} IS NOT NULL AND ${col} <> '')`;
     default:
       return null;
   }

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -1,10 +1,20 @@
-import { asc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, ne, not, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
+
+import {
+  type CompareNode,
+  type ConditionNode,
+  type ConditionValue,
+  type GroupNode,
+  type Operand,
+  type PredicateNode,
+  type RefOperand,
+  evaluateCondition,
+} from "@stll/conditions";
 
 import { user } from "@/api/db/auth-schema";
 import { entities, entityVersions, fields, properties } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
-import type { ViewFilterCondition } from "@/api/lib/views-schema";
 
 // -- Types --
 
@@ -83,57 +93,103 @@ const findField = (
 ): EntityField | undefined =>
   entityFields.find((f) => f.propertyId === propertyId);
 
-const matchesFilter = (
-  entity: FilterableEntity,
-  filter: ViewFilterCondition,
-): boolean => {
-  if (filter.field === "kind") {
-    if (filter.value.length === 0) {
-      return true;
+// -- In-memory evaluation --
+
+const PASS_THROUGH = Symbol("builtin-pass-through");
+
+/**
+ * Resolves an operand to a concrete value for in-memory evaluation.
+ *
+ * Builtin filters narrow only in SQL; the in-memory evaluator never
+ * sees the underlying status/priority columns, so a builtin operand
+ * resolves to a sentinel that callers treat as "matches". `kind` and
+ * `property` resolve from the entity itself.
+ */
+const buildResolver =
+  (entity: FilterableEntity) =>
+  (operand: RefOperand): ConditionValue | typeof PASS_THROUGH => {
+    switch (operand.type) {
+      case "kind":
+        return entity.kind;
+      case "property":
+        return getFieldValue(
+          findField(entity.fields, operand.propertyId)?.content,
+        );
+      case "builtin":
+        return PASS_THROUGH;
+      case "path":
+        return PASS_THROUGH;
+      default:
+        return PASS_THROUGH;
     }
-    if (filter.value.includes("document") && entity.kind === "folder") {
-      return true;
-    }
-    return filter.value.includes(entity.kind);
-  }
+  };
 
-  if (filter.field === "builtin") {
-    // Builtin filters are handled server-side only.
-    return true;
-  }
+const referencesPassThroughOperand = (operand: Operand): boolean =>
+  operand.type === "builtin" || operand.type === "path";
 
-  const field = findField(entity.fields, filter.propertyId);
-  const value = getFieldValue(field?.content);
-
-  switch (filter.op) {
-    case "eq":
-      return value === (filter.value ?? "");
-    case "neq":
-      return value !== (filter.value ?? "");
-    case "contains":
-      return value
-        .toLowerCase()
-        .includes(String(filter.value ?? "").toLowerCase());
-    case "is_empty":
-      return value === "";
+const nodeIsServerSideOnly = (node: ConditionNode): boolean => {
+  switch (node.type) {
+    case "group":
+      return node.children.some(nodeIsServerSideOnly);
+    case "compare":
+      return (
+        referencesPassThroughOperand(node.left) ||
+        referencesPassThroughOperand(node.right)
+      );
+    case "predicate":
+      return referencesPassThroughOperand(node.operand);
     default:
-      return true;
+      return false;
   }
 };
 
-// -- Public API --
+const isKindInPredicate = (node: ConditionNode): node is PredicateNode =>
+  node.type === "predicate" && node.operand.type === "kind" && node.op === "in";
 
+/**
+ * Mirrors the SQL document→folder expansion in-memory: a kind filter
+ * that includes "document" also matches folders.
+ */
+const expandKindNode = (node: ConditionNode): ConditionNode => {
+  if (!isKindInPredicate(node)) {
+    return node;
+  }
+  const values = asValueArray(node.value);
+  if (!values.includes(KIND_DOCUMENT) || values.includes(KIND_FOLDER)) {
+    return node;
+  }
+  return { ...node, value: [...values, KIND_FOLDER] };
+};
+
+/**
+ * In-memory filtering preserves the established semantics: builtin
+ * (and path) operands are server-side only, so any node referencing
+ * them passes through here and is enforced by SQL instead.
+ */
 export const applyFilters = <T extends FilterableEntity>(
   items: T[],
-  filters: ViewFilterCondition[],
+  filters: ConditionNode[],
 ): T[] => {
   if (filters.length === 0) {
     return items;
   }
 
-  return items.filter((entity) =>
-    filters.every((filter) => matchesFilter(entity, filter)),
-  );
+  const prepared = filters.map(expandKindNode);
+
+  return items.filter((entity) => {
+    const resolveOrPass = buildResolver(entity);
+    const resolve = (operand: RefOperand): ConditionValue => {
+      const resolved = resolveOrPass(operand);
+      return resolved === PASS_THROUGH ? undefined : resolved;
+    };
+
+    return prepared.every((node) => {
+      if (nodeIsServerSideOnly(node)) {
+        return true;
+      }
+      return evaluateCondition(node, resolve);
+    });
+  });
 };
 
 export const applySorts = <T extends FilterableEntity>(
@@ -209,88 +265,171 @@ const numericFieldValueExpr = (contentCol: typeof fields.content): SQL => {
 };
 
 /**
- * Builds an EXISTS subquery that checks whether an entity's
- * current version has a field matching the given condition.
+ * Wraps a per-field predicate in an EXISTS subquery against the
+ * entity's current version.
  */
-const buildPropertyFilterCondition = (
-  filter: Extract<ViewFilterCondition, { field: "property" }>,
-): SQL => {
-  const valExpr = fieldValueExpr(fields.content);
-
-  let opCondition: SQL;
-  switch (filter.op) {
-    case "eq":
-      opCondition = sql`${valExpr} = ${String(filter.value ?? "")}`;
-      break;
-    case "neq":
-      opCondition = sql`${valExpr} != ${String(filter.value ?? "")}`;
-      break;
-    case "contains":
-      opCondition = sql`${valExpr} ILIKE ${`%${String(filter.value ?? "")}%`}`;
-      break;
-    case "is_empty":
-      opCondition = sql`${valExpr} = ''`;
-      break;
-    default:
-      opCondition = sql`TRUE`;
-      break;
-  }
-
-  return sql`EXISTS (
+const propertyExists = (propertyId: string, opCondition: SQL): SQL =>
+  sql`EXISTS (
     SELECT 1 FROM ${fields}
     WHERE ${fields.entityVersionId} = ${entities.currentVersionId}
-      AND ${fields.propertyId} = ${filter.propertyId}
+      AND ${fields.propertyId} = ${propertyId}
       AND ${opCondition}
   )`;
-};
+
+const builtinColumn = (field: "status" | "priority") =>
+  field === "status" ? entities.status : entities.priority;
+
+const KIND_DOCUMENT = "document" as const;
+const KIND_FOLDER = "folder" as const;
 
 /**
- * Maps a builtin field name to its database column.
+ * "document" implies "folder": folders are part of the document
+ * hierarchy, not independently filterable, so a kind filter that
+ * includes documents also matches folders.
  */
-const builtinColumn = (field: string) => {
-  switch (field) {
-    case "status":
-      return entities.status;
-    case "priority":
-      return entities.priority;
+const expandKindValues = (values: readonly string[]): EntityKind[] => {
+  const kinds = values.filter((value): value is EntityKind =>
+    isEntityKind(value),
+  );
+  if (kinds.includes(KIND_DOCUMENT)) {
+    return [...new Set([...kinds, KIND_FOLDER])];
+  }
+  return kinds;
+};
+
+const ENTITY_KINDS: readonly EntityKind[] = [
+  "document",
+  "folder",
+  "task",
+  "message",
+  "link",
+];
+
+const isEntityKind = (value: string): value is EntityKind =>
+  (ENTITY_KINDS as readonly string[]).includes(value);
+
+const asValueArray = (value: string | string[] | undefined): string[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === "") {
+    return [];
+  }
+  return [value];
+};
+
+// -- Compare nodes --
+
+const compareOpSql = (op: CompareNode["op"], expr: SQL, value: string): SQL => {
+  switch (op) {
+    case "eq":
+      return sql`${expr} = ${value}`;
+    case "neq":
+      return sql`${expr} != ${value}`;
+    case "gt":
+      return sql`(${expr})::numeric > ${value}::numeric`;
+    case "lt":
+      return sql`(${expr})::numeric < ${value}::numeric`;
+    case "gte":
+      return sql`(${expr})::numeric >= ${value}::numeric`;
+    case "lte":
+      return sql`(${expr})::numeric <= ${value}::numeric`;
+    default:
+      return sql`TRUE`;
+  }
+};
+
+const literalString = (operand: Operand): string | null =>
+  operand.type === "literal" ? String(operand.value ?? "") : null;
+
+const compileBuiltinCompare = (
+  field: "status" | "priority",
+  op: CompareNode["op"],
+  value: string,
+): SQL | null => {
+  const col = builtinColumn(field);
+  if (op === "eq") {
+    return value === "" ? null : eq(col, value);
+  }
+  if (op === "neq") {
+    return value === "" ? null : (or(ne(col, value), isNull(col)) ?? null);
+  }
+  return compareOpSql(op, sql`${col}`, value);
+};
+
+const compileCompare = (node: CompareNode): SQL | null => {
+  // The filter UI always compares a ref operand against a literal.
+  if (node.left.type === "property") {
+    const value = literalString(node.right);
+    if (value === null) {
+      return null;
+    }
+    return propertyExists(
+      node.left.propertyId,
+      compareOpSql(node.op, fieldValueExpr(fields.content), value),
+    );
+  }
+
+  if (node.left.type === "builtin") {
+    const value = literalString(node.right);
+    if (value === null) {
+      return null;
+    }
+    return compileBuiltinCompare(node.left.field, node.op, value);
+  }
+
+  return null;
+};
+
+// -- Predicate nodes --
+
+const compilePropertyPredicate = (
+  propertyId: string,
+  node: PredicateNode,
+): SQL | null => {
+  const valExpr = fieldValueExpr(fields.content);
+  switch (node.op) {
+    case "contains":
+      return propertyExists(
+        propertyId,
+        sql`${valExpr} ILIKE ${`%${String(node.value ?? "")}%`}`,
+      );
+    case "is_empty":
+      return propertyExists(propertyId, sql`${valExpr} = ''`);
+    case "contains_all": {
+      const wanted = asValueArray(node.value);
+      if (wanted.length === 0) {
+        return null;
+      }
+      const clauses = wanted.map((want) =>
+        propertyExists(propertyId, sql`${valExpr} = ${want}`),
+      );
+      return and(...clauses) ?? null;
+    }
+    case "in": {
+      const values = asValueArray(node.value);
+      if (values.length === 0) {
+        return null;
+      }
+      return propertyExists(propertyId, sql`${valExpr} = ANY(${values})`);
+    }
     default:
       return null;
   }
 };
 
-const buildBuiltinFilterCondition = (
-  filter: Extract<ViewFilterCondition, { field: "builtin" }>,
+const compileBuiltinPredicate = (
+  field: "status" | "priority",
+  node: PredicateNode,
 ): SQL | null => {
-  const col = builtinColumn(filter.builtinField);
-  if (!col) {
-    return null;
-  }
-
-  switch (filter.op) {
-    case "eq":
-      if (filter.value === undefined || filter.value === "") {
-        return null;
-      }
-      return eq(col, String(filter.value));
-    case "neq":
-      if (filter.value === undefined || filter.value === "") {
-        return null;
-      }
-      return or(ne(col, String(filter.value)), isNull(col)) ?? null;
+  const col = builtinColumn(field);
+  switch (node.op) {
     case "in": {
-      const vals = (() => {
-        if (Array.isArray(filter.value)) {
-          return filter.value;
-        }
-        if (filter.value) {
-          return [filter.value];
-        }
-        return [];
-      })();
-      if (vals.length === 0) {
+      const values = asValueArray(node.value);
+      if (values.length === 0) {
         return null;
       }
-      return inArray(col, vals);
+      return inArray(col, values);
     }
     case "is_empty":
       return sql`(${col} IS NULL OR ${col} = '')`;
@@ -299,35 +438,79 @@ const buildBuiltinFilterCondition = (
   }
 };
 
-/**
- * Converts ViewFilterCondition[] into SQL WHERE conditions
- * that can be combined with `and()`.
- */
-export const buildFilterConditions = (
-  filters: ViewFilterCondition[],
-): SQL[] => {
-  const conditions: SQL[] = [];
+const compileKindPredicate = (node: PredicateNode): SQL | null => {
+  if (node.op !== "in") {
+    return null;
+  }
+  const expanded = expandKindValues(asValueArray(node.value));
+  if (expanded.length === 0) {
+    return null;
+  }
+  return inArray(entities.kind, expanded);
+};
 
-  for (const filter of filters) {
-    if (filter.field === "kind") {
-      if (filter.value.length > 0) {
-        // "document" implies "folder" (folders are part of
-        // the document hierarchy, not independently filterable)
-        const expanded = filter.value.includes("document")
-          ? [...new Set([...filter.value, "folder" as const])]
-          : filter.value;
-        conditions.push(inArray(entities.kind, expanded));
-      }
-    } else if (filter.field === "builtin") {
-      const cond = buildBuiltinFilterCondition(filter);
-      if (cond) {
-        conditions.push(cond);
-      }
-    } else {
-      conditions.push(buildPropertyFilterCondition(filter));
+const compilePredicate = (node: PredicateNode): SQL | null => {
+  switch (node.operand.type) {
+    case "kind":
+      return compileKindPredicate(node);
+    case "property":
+      return compilePropertyPredicate(node.operand.propertyId, node);
+    case "builtin":
+      return compileBuiltinPredicate(node.operand.field, node);
+    default:
+      return null;
+  }
+};
+
+// -- Group nodes --
+
+const compileGroup = (node: GroupNode): SQL | null => {
+  const children: SQL[] = [];
+  for (const child of node.children) {
+    const compiled = compileNode(child);
+    if (compiled) {
+      children.push(compiled);
     }
   }
+  if (children.length === 0) {
+    return null;
+  }
 
+  const combined =
+    node.combinator === "and" ? and(...children) : or(...children);
+  if (!combined) {
+    return null;
+  }
+  return node.negated ? not(combined) : combined;
+};
+
+const compileNode = (node: ConditionNode): SQL | null => {
+  switch (node.type) {
+    case "group":
+      return compileGroup(node);
+    case "compare":
+      return compileCompare(node);
+    case "predicate":
+      return compilePredicate(node);
+    default:
+      return null;
+  }
+};
+
+/**
+ * Compiles the implicit-AND filter array into SQL WHERE conditions
+ * that can be combined with `and()`. The array is an implicit AND
+ * group, so each node compiles independently and `null` results
+ * (no-op filters) are dropped.
+ */
+export const buildFilterConditions = (filters: ConditionNode[]): SQL[] => {
+  const conditions: SQL[] = [];
+  for (const node of filters) {
+    const compiled = compileNode(node);
+    if (compiled) {
+      conditions.push(compiled);
+    }
+  }
   return conditions;
 };
 

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -407,18 +407,19 @@ const compileCompare = (node: CompareNode): SQL | null => {
  */
 const propertyValueMatches = (
   propertyId: string,
-  elemMatch: (valueExpr: SQL) => SQL,
+  arrayMatch: (valueExpr: SQL) => SQL,
+  scalarMatch: (valueExpr: SQL) => SQL,
 ): SQL => {
   const content = fields.content;
   const anyElement = sql`EXISTS (
     SELECT 1 FROM jsonb_array_elements_text(${content}->'value') AS elem
-    WHERE ${elemMatch(sql`elem`)}
+    WHERE ${arrayMatch(sql`elem`)}
   )`;
   return propertyExists(
     propertyId,
     sql`CASE WHEN jsonb_typeof(${content}->'value') = 'array'
       THEN ${anyElement}
-      ELSE ${elemMatch(fieldValueExpr(content))}
+      ELSE ${scalarMatch(fieldValueExpr(content))}
     END`,
   );
 };
@@ -428,32 +429,40 @@ const compilePropertyPredicate = (
   node: PredicateNode,
 ): SQL | null => {
   const text = String(node.value ?? "");
-  const like = (pattern: string) =>
-    propertyValueMatches(propertyId, (v) => sql`${v} ILIKE ${pattern}`);
+  // Same matcher for arrays and scalars (membership/emptiness ops).
+  const same = (match: (v: SQL) => SQL) =>
+    propertyValueMatches(propertyId, match, match);
+  // `contains` differs by shape: exact (case-insensitive) option membership for
+  // multi-select array elements, substring for scalar text — matching the
+  // in-memory evaluator (so e.g. "NDA" does not match the option "Non-NDA").
+  const contains = () =>
+    propertyValueMatches(
+      propertyId,
+      (v) => sql`LOWER(${v}) = LOWER(${text})`,
+      (v) => sql`${v} ILIKE ${`%${text}%`}`,
+    );
   switch (node.op) {
     case "contains":
-      return like(`%${text}%`);
+      return contains();
     case "not_contains":
       // NOT EXISTS so absent/empty fields count as "does not contain".
-      return sql`NOT ${like(`%${text}%`)}`;
+      return sql`NOT ${contains()}`;
     case "starts_with":
-      return like(`${text}%`);
+      return same((v) => sql`${v} ILIKE ${`${text}%`}`);
     case "ends_with":
-      return like(`%${text}`);
+      return same((v) => sql`${v} ILIKE ${`%${text}`}`);
     case "is_not_empty":
-      return propertyValueMatches(propertyId, (v) => sql`${v} <> ''`);
+      return same((v) => sql`${v} <> ''`);
     case "is_empty":
       // Empty when no non-empty value exists: covers an absent field, an empty
       // scalar, and an empty array.
-      return sql`NOT ${propertyValueMatches(propertyId, (v) => sql`${v} <> ''`)}`;
+      return sql`NOT ${same((v) => sql`${v} <> ''`)}`;
     case "contains_all": {
       const wanted = asValueArray(node.value);
       if (wanted.length === 0) {
         return null;
       }
-      const clauses = wanted.map((want) =>
-        propertyValueMatches(propertyId, (v) => sql`${v} = ${want}`),
-      );
+      const clauses = wanted.map((want) => same((v) => sql`${v} = ${want}`));
       return and(...clauses) ?? null;
     }
     case "in": {
@@ -461,10 +470,7 @@ const compilePropertyPredicate = (
       if (values.length === 0) {
         return null;
       }
-      return propertyValueMatches(
-        propertyId,
-        (v) => sql`${v} = ANY(${values})`,
-      );
+      return same((v) => sql`${v} = ANY(${values})`);
     }
     default:
       return null;

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -320,23 +320,40 @@ const asValueArray = (value: string | string[] | undefined): string[] => {
 
 // -- Compare nodes --
 
-const compareOpSql = (op: CompareNode["op"], expr: SQL, value: string): SQL => {
-  switch (op) {
-    case "eq":
-      return sql`${expr} = ${value}`;
-    case "neq":
-      return sql`${expr} != ${value}`;
-    case "gt":
-      return sql`(${expr})::numeric > ${value}::numeric`;
-    case "lt":
-      return sql`(${expr})::numeric < ${value}::numeric`;
-    case "gte":
-      return sql`(${expr})::numeric >= ${value}::numeric`;
-    case "lte":
-      return sql`(${expr})::numeric <= ${value}::numeric`;
-    default:
-      return sql`TRUE`;
+// Safe numeric form of an arbitrary text expression: non-numeric content
+// becomes NULL (and drops out of comparisons) instead of crashing the cast.
+const safeNumericExpr = (expr: SQL): SQL =>
+  sql`CASE WHEN BTRIM(${expr}::text) ~ ${NUMERIC_TEXT_PATTERN}
+    THEN BTRIM(${expr}::text)::numeric ELSE NULL END`;
+
+const orderedSql = (op: "gt" | "lt" | "gte" | "lte", l: SQL, r: SQL): SQL => {
+  if (op === "gt") {
+    return sql`${l} > ${r}`;
   }
+  if (op === "lt") {
+    return sql`${l} < ${r}`;
+  }
+  if (op === "gte") {
+    return sql`${l} >= ${r}`;
+  }
+  return sql`${l} <= ${r}`;
+};
+
+const compareOpSql = (op: CompareNode["op"], expr: SQL, value: string): SQL => {
+  if (op === "eq") {
+    return sql`${expr} = ${value}`;
+  }
+  if (op === "neq") {
+    return sql`${expr} != ${value}`;
+  }
+  // Ordered comparison: numeric when the literal is a number (non-numeric
+  // field values become NULL and drop out); otherwise a plain text compare so
+  // ISO dates and other strings order correctly, without a cast that would
+  // crash on non-numeric input.
+  if (NUMERIC_TEXT_RE.test(value.trim())) {
+    return orderedSql(op, safeNumericExpr(expr), sql`${Number(value)}`);
+  }
+  return orderedSql(op, expr, sql`${value}`);
 };
 
 const literalString = (operand: Operand): string | null =>
@@ -383,39 +400,59 @@ const compileCompare = (node: CompareNode): SQL | null => {
 
 // -- Predicate nodes --
 
-const propertyLike = (propertyId: string, pattern: string): SQL =>
-  propertyExists(
+/**
+ * Builds an EXISTS predicate over a property's value, transparently handling
+ * multi-select arrays (the value matches if ANY element does) and scalar
+ * values. `elemMatch` receives the per-element/per-scalar text expression.
+ */
+const propertyValueMatches = (
+  propertyId: string,
+  elemMatch: (valueExpr: SQL) => SQL,
+): SQL => {
+  const content = fields.content;
+  const anyElement = sql`EXISTS (
+    SELECT 1 FROM jsonb_array_elements_text(${content}->'value') AS elem
+    WHERE ${elemMatch(sql`elem`)}
+  )`;
+  return propertyExists(
     propertyId,
-    sql`${fieldValueExpr(fields.content)} ILIKE ${pattern}`,
+    sql`CASE WHEN jsonb_typeof(${content}->'value') = 'array'
+      THEN ${anyElement}
+      ELSE ${elemMatch(fieldValueExpr(content))}
+    END`,
   );
+};
 
 const compilePropertyPredicate = (
   propertyId: string,
   node: PredicateNode,
 ): SQL | null => {
-  const valExpr = fieldValueExpr(fields.content);
   const text = String(node.value ?? "");
+  const like = (pattern: string) =>
+    propertyValueMatches(propertyId, (v) => sql`${v} ILIKE ${pattern}`);
   switch (node.op) {
     case "contains":
-      return propertyLike(propertyId, `%${text}%`);
+      return like(`%${text}%`);
     case "not_contains":
       // NOT EXISTS so absent/empty fields count as "does not contain".
-      return sql`NOT ${propertyLike(propertyId, `%${text}%`)}`;
+      return sql`NOT ${like(`%${text}%`)}`;
     case "starts_with":
-      return propertyLike(propertyId, `${text}%`);
+      return like(`${text}%`);
     case "ends_with":
-      return propertyLike(propertyId, `%${text}`);
-    case "is_empty":
-      return propertyExists(propertyId, sql`${valExpr} = ''`);
+      return like(`%${text}`);
     case "is_not_empty":
-      return propertyExists(propertyId, sql`${valExpr} <> ''`);
+      return propertyValueMatches(propertyId, (v) => sql`${v} <> ''`);
+    case "is_empty":
+      // Empty when no non-empty value exists: covers an absent field, an empty
+      // scalar, and an empty array.
+      return sql`NOT ${propertyValueMatches(propertyId, (v) => sql`${v} <> ''`)}`;
     case "contains_all": {
       const wanted = asValueArray(node.value);
       if (wanted.length === 0) {
         return null;
       }
       const clauses = wanted.map((want) =>
-        propertyExists(propertyId, sql`${valExpr} = ${want}`),
+        propertyValueMatches(propertyId, (v) => sql`${v} = ${want}`),
       );
       return and(...clauses) ?? null;
     }
@@ -424,7 +461,10 @@ const compilePropertyPredicate = (
       if (values.length === 0) {
         return null;
       }
-      return propertyExists(propertyId, sql`${valExpr} = ANY(${values})`);
+      return propertyValueMatches(
+        propertyId,
+        (v) => sql`${v} = ANY(${values})`,
+      );
     }
     default:
       return null;

--- a/apps/api/src/lib/markdown/ai-tool.ts
+++ b/apps/api/src/lib/markdown/ai-tool.ts
@@ -1,6 +1,7 @@
 import * as cheerio from "cheerio";
 
-import type { PropertyCondition } from "@/api/db/schema-validators";
+import type { ConditionNode } from "@stll/conditions";
+
 import { htmlToMarkdown } from "@/api/lib/markdown/html-to-markdown";
 
 /**
@@ -111,7 +112,7 @@ export type AITool = {
   prompt: string;
   dependencies: {
     dependsOnPropertyId: string;
-    condition: PropertyCondition | null;
+    condition: ConditionNode | null;
   }[];
 };
 

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -60,35 +60,32 @@ describe("parseViewLayoutSafe", () => {
   });
 
   test("recovers a layout whose filters use a retired grammar by dropping them", () => {
-    // Legacy group/predicate filter AST the current schema no longer accepts.
+    // Legacy ViewFilterCondition grammar (field/op/value) that the current AST
+    // schema no longer accepts.
     const legacy = {
       version: 1,
       type: "table",
-      filters: [
-        {
-          type: "group",
-          combinator: "and",
-          children: [
-            {
-              type: "predicate",
-              operand: { type: "kind" },
-              op: "in",
-              value: [],
-            },
-          ],
-        },
-      ],
+      filters: [{ id: "f1", field: "kind", op: "in", value: ["document"] }],
       sorts: [],
       hiddenProperties: [],
       columnOrder: ["name"],
       columnPinning: ["name"],
     };
 
-    // The raw layout throws under strict parsing...
-    expect(() => parseViewLayout(legacy)).toThrow();
+    // The strict parser now drops the unparseable legacy filters itself rather
+    // than throwing, keeping the table view with an empty filter set...
+    expect(parseViewLayout(legacy)).toEqual({
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: ["name"],
+      columnPinning: ["name"],
+    });
 
-    // ...but the safe parser keeps the table view and its columns, only
-    // dropping the unparseable filters so one legacy view can't fail the list.
+    // ...and the safe parser returns the same recovered layout, so one legacy
+    // view can't fail the list.
     expect(parseViewLayoutSafe(legacy)).toEqual({
       version: 1,
       type: "table",

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 import * as v from "valibot";
 
+import { conditionNodeSchema } from "@stll/conditions";
+
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import {
   parseViewLayout,
   parseViewLayoutSafe,
-  tViewFilterConditionSchema,
   tViewLayoutSchema,
   tViewTemplatePropertySchema,
-  viewFilterConditionSchema,
   viewLayoutSchema,
 } from "@/api/lib/views-schema";
 import type { ViewLayout } from "@/api/lib/views-schema";
@@ -132,53 +133,60 @@ describe("view template property validation", () => {
 // every layout and filter shape. Drift between them lets payloads slip past the
 // route validator and fail at parseViewLayout, or vice versa.
 
-const arbId = fc.string({ minLength: 1, maxLength: 16 });
 const arbPropertyId = fc.string({ minLength: 1, maxLength: 16 });
 const arbHiddenProperties = fc.array(fc.string({ maxLength: 16 }), {
   maxLength: 5,
 });
 
-const arbEntityKind = fc.constantFrom(
-  "document",
-  "folder",
-  "task",
-  "message",
-  "link",
-);
 const arbBuiltinField = fc.constantFrom("status", "priority");
-const arbStringOrArray = fc.oneof(
+const arbLiteralValue = fc.oneof(
   fc.string({ maxLength: 16 }),
+  fc.integer(),
+  fc.boolean(),
   fc.array(fc.string({ maxLength: 16 }), { maxLength: 4 }),
 );
 
-const arbFilter = fc.oneof(
+const arbRefOperand = fc.oneof(
   fc.record({
-    id: arbId,
-    field: fc.constant("kind" as const),
-    op: fc.constant("in" as const),
-    value: fc.array(arbEntityKind, { maxLength: 5 }),
+    type: fc.constant("property" as const),
+    propertyId: arbPropertyId,
   }),
-  fc.record(
-    {
-      id: arbId,
-      field: fc.constant("property" as const),
-      propertyId: arbPropertyId,
-      op: fc.constantFrom("eq", "neq", "contains", "is_empty"),
-      value: arbStringOrArray,
-    },
-    { requiredKeys: ["id", "field", "propertyId", "op"] },
-  ),
-  fc.record(
-    {
-      id: arbId,
-      field: fc.constant("builtin" as const),
-      builtinField: arbBuiltinField,
-      op: fc.constantFrom("eq", "neq", "in", "is_empty"),
-      value: arbStringOrArray,
-    },
-    { requiredKeys: ["id", "field", "builtinField", "op"] },
-  ),
+  fc.record({ type: fc.constant("builtin" as const), field: arbBuiltinField }),
+  fc.record({ type: fc.constant("kind" as const) }),
 );
+
+const arbLiteralOperand = fc.record({
+  type: fc.constant("literal" as const),
+  value: arbLiteralValue,
+});
+
+const arbCompareNode = fc.record({
+  type: fc.constant("compare" as const),
+  left: arbRefOperand,
+  op: fc.constantFrom("eq", "neq", "gt", "lt", "gte", "lte"),
+  right: arbLiteralOperand,
+});
+
+const arbPredicateNode = fc.record(
+  {
+    type: fc.constant("predicate" as const),
+    operand: arbRefOperand,
+    op: fc.constantFrom(
+      "is_empty",
+      "is_truthy",
+      "contains",
+      "contains_all",
+      "in",
+    ),
+    value: fc.oneof(
+      fc.string({ maxLength: 16 }),
+      fc.array(fc.string({ maxLength: 16 }), { maxLength: 4 }),
+    ),
+  },
+  { requiredKeys: ["type", "operand", "op"] },
+);
+
+const arbFilter = fc.oneof(arbCompareNode, arbPredicateNode);
 
 const arbSort = fc.record({
   propertyId: arbPropertyId,
@@ -288,12 +296,12 @@ const objectPrototypeKeys = new Set(
   Object.getOwnPropertyNames(Object.prototype),
 );
 
-describe("viewFilterConditionSchema — properties", () => {
-  test("Valibot and TypeBox agree on every well-formed filter", () => {
+describe("conditionNodeSchema — properties", () => {
+  test("Valibot and TypeBox agree on every well-formed condition node", () => {
     fc.assert(
       fc.property(arbFilter, (filter) => {
-        expect(v.is(viewFilterConditionSchema, filter)).toBe(true);
-        expect(Value.Check(tViewFilterConditionSchema, filter)).toBe(true);
+        expect(v.is(conditionNodeSchema, filter)).toBe(true);
+        expect(Value.Check(tConditionNode, filter)).toBe(true);
       }),
     );
   });

--- a/apps/api/src/lib/views-schema.ts
+++ b/apps/api/src/lib/views-schema.ts
@@ -2,24 +2,17 @@ import { Type } from "@sinclair/typebox";
 import { t } from "elysia";
 import * as v from "valibot";
 
+import { conditionNodeSchema } from "@stll/conditions";
+
 import {
   manualInputToolSchema,
   propertyConditionSchema,
   propertyContentSchema,
 } from "@/api/db/schema-validators";
+import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 
 const v1 = v.literal(1);
-
-const entityKindValues = [
-  "document",
-  "folder",
-  "task",
-  "message",
-  "link",
-] as const;
-
-const builtinFieldValues = ["status", "priority"] as const;
 
 const viewLayoutTypeValues = [
   "overview",
@@ -32,93 +25,12 @@ const viewLayoutTypeValues = [
 
 const strictObjectOptions = { additionalProperties: false } as const;
 
-export const viewFilterConditionSchema = v.union([
-  v.strictObject({
-    id: v.string(),
-    field: v.literal("kind"),
-    op: v.literal("in"),
-    value: v.array(v.picklist(entityKindValues)),
-  }),
-  v.strictObject({
-    id: v.string(),
-    field: v.literal("property"),
-    propertyId: v.pipe(v.string(), v.minLength(1)),
-    op: v.picklist(["eq", "neq", "contains", "is_empty"]),
-    value: v.optional(v.union([v.string(), v.array(v.string())])),
-  }),
-  v.strictObject({
-    id: v.string(),
-    field: v.literal("builtin"),
-    builtinField: v.picklist(builtinFieldValues),
-    op: v.picklist(["eq", "neq", "in", "is_empty"]),
-    value: v.optional(v.union([v.string(), v.array(v.string())])),
-  }),
-]);
-
-export type ViewFilterCondition = v.InferOutput<
-  typeof viewFilterConditionSchema
->;
-
 export const viewSortSchema = v.strictObject({
   propertyId: v.pipe(v.string(), v.minLength(1)),
   desc: v.boolean(),
 });
 
 export type ViewSort = v.InferOutput<typeof viewSortSchema>;
-
-export const tViewFilterConditionSchema = t.Union([
-  t.Object(
-    {
-      id: t.String(),
-      field: t.Literal("kind"),
-      op: t.Literal("in"),
-      value: t.Array(
-        t.Union([
-          t.Literal("document"),
-          t.Literal("folder"),
-          t.Literal("task"),
-          t.Literal("message"),
-          t.Literal("link"),
-        ]),
-      ),
-    },
-    strictObjectOptions,
-  ),
-  t.Object(
-    {
-      id: t.String(),
-      field: t.Literal("property"),
-      propertyId: t.String({ minLength: 1 }),
-      op: t.Union([
-        t.Literal("eq"),
-        t.Literal("neq"),
-        t.Literal("contains"),
-        t.Literal("is_empty"),
-      ]),
-      value: t.Optional(
-        t.Union([t.String(), t.Array(t.String()), t.Undefined()]),
-      ),
-    },
-    strictObjectOptions,
-  ),
-  t.Object(
-    {
-      id: t.String(),
-      field: t.Literal("builtin"),
-      builtinField: t.Union([t.Literal("status"), t.Literal("priority")]),
-      op: t.Union([
-        t.Literal("eq"),
-        t.Literal("neq"),
-        t.Literal("in"),
-        t.Literal("is_empty"),
-      ]),
-      value: t.Optional(
-        t.Union([t.String(), t.Array(t.String()), t.Undefined()]),
-      ),
-    },
-    strictObjectOptions,
-  ),
-]);
 
 export const tViewSortSchema = t.Object(
   {
@@ -129,7 +41,7 @@ export const tViewSortSchema = t.Object(
 );
 
 const baseLayoutSchema = {
-  filters: v.array(viewFilterConditionSchema),
+  filters: v.array(conditionNodeSchema),
   sorts: v.array(viewSortSchema),
   hiddenProperties: v.array(v.string()),
 };
@@ -201,8 +113,27 @@ export const viewLayoutSchema = v.variant("type", layoutSchemas);
 export type ViewLayout = v.InferOutput<typeof viewLayoutSchema>;
 export type ViewLayoutType = ViewLayout["type"];
 
+const hasFiltersField = (value: unknown): value is { filters: unknown } =>
+  typeof value === "object" && value !== null && "filters" in value;
+
+/**
+ * Stored filters are validated leniently: any node that does not parse as the
+ * canonical condition AST is dropped, so a stray pre-AST row resets to an empty
+ * filter instead of failing the whole layout read. New writes are AST nodes and
+ * pass through untouched.
+ */
+const withValidFilters = (value: unknown): unknown => {
+  if (!hasFiltersField(value)) {
+    return value;
+  }
+  const filters = Array.isArray(value.filters)
+    ? value.filters.filter((node) => v.is(conditionNodeSchema, node))
+    : [];
+  return { ...value, filters };
+};
+
 export const parseViewLayout = (value: unknown): ViewLayout =>
-  v.parse(viewLayoutSchema, value);
+  v.parse(viewLayoutSchema, withValidFilters(value));
 
 // Recovers a stored layout that fails strict parsing: older views can carry a
 // filter grammar the current schema rejects. Drop the unparseable filters/sorts
@@ -235,7 +166,7 @@ export const parseViewLayoutSafe = (value: unknown): ViewLayout => {
 };
 
 const tBaseLayoutSchema = {
-  filters: t.Array(tViewFilterConditionSchema),
+  filters: t.Array(tConditionNode),
   sorts: t.Array(tViewSortSchema),
   hiddenProperties: t.Array(t.String()),
 };

--- a/apps/api/src/lib/views-schema.ts
+++ b/apps/api/src/lib/views-schema.ts
@@ -6,7 +6,6 @@ import { conditionNodeSchema } from "@stll/conditions";
 
 import {
   manualInputToolSchema,
-  propertyConditionSchema,
   propertyContentSchema,
 } from "@/api/db/schema-validators";
 import { tConditionNode } from "@/api/lib/conditions/contract";
@@ -266,7 +265,7 @@ export const tViewTemplatePropertySchema = t.Object(
         t.Object(
           {
             dependsOnSourceId: t.String({ minLength: 1 }),
-            condition: t.Union([propertyConditionSchema, t.Null()]),
+            condition: t.Union([tConditionNode, t.Null()]),
           },
           strictObjectOptions,
         ),

--- a/apps/api/src/lib/workflow/generate-batch-shared.ts
+++ b/apps/api/src/lib/workflow/generate-batch-shared.ts
@@ -18,7 +18,7 @@ import type {
   PropertyBatch,
 } from "@/api/lib/workflow/get-execution-plan";
 import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
-import { evaluateCondition } from "@/api/lib/workflow/utils";
+import { evaluateGatingCondition } from "@/api/lib/workflow/utils";
 
 // Types shared between mock and real AI implementations
 export type FieldContentForAI = Exclude<
@@ -160,20 +160,15 @@ export const prepareBatchInput = (
 ): PrepareBatchInputResult => {
   const skippedPropertyIds: SafeId<"property">[] = [];
 
+  const fieldContentByPropertyId = new Map<string, FieldContent>(
+    inputFields.map((field) => [field.propertyId, field.content]),
+  );
+
   // Filter properties based on dependency conditions
   const inputProperties = batch.properties.filter((property) => {
-    const conditionsMet = property.dependencies.every((dep) => {
-      if (!dep.condition) {
-        return true;
-      }
-      const depFieldContent = inputFields.find(
-        (field) => field.propertyId === dep.dependsOnPropertyId,
-      )?.content;
-      if (!depFieldContent) {
-        return false;
-      }
-      return evaluateCondition(depFieldContent, dep.condition);
-    });
+    const conditionsMet = property.dependencies.every((dep) =>
+      evaluateGatingCondition(dep.condition, fieldContentByPropertyId),
+    );
 
     if (!conditionsMet) {
       skippedPropertyIds.push(property.id);

--- a/apps/api/src/lib/workflow/get-execution-plan.ts
+++ b/apps/api/src/lib/workflow/get-execution-plan.ts
@@ -1,13 +1,12 @@
 import { panic } from "better-result";
 
+import type { ConditionNode } from "@stll/conditions";
+
 import type { ScopedDb } from "@/api/db";
 import type { PropertyStatus } from "@/api/db/schema";
-import type {
-  AIModelTool,
-  PropertyCondition,
-  PropertyTool,
-} from "@/api/db/schema-validators";
+import type { AIModelTool, PropertyTool } from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
+import { parseStoredCondition } from "@/api/lib/conditions/parse-stored";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
 import type { PropertyContent } from "@/api/types";
 
@@ -38,7 +37,7 @@ const toPropertyId = (value: string) => brandPersistedPropertyId(value);
 
 export type BatchPropertyDependency = {
   dependsOnPropertyId: string;
-  condition: PropertyCondition | null;
+  condition: ConditionNode | null;
 };
 
 export type BatchProperty = {
@@ -67,7 +66,7 @@ export type ExecutionPlanProperty = {
 export type PropertyDependency = {
   propertyId: string;
   dependsOnPropertyId: string;
-  condition: PropertyCondition | null;
+  condition: ConditionNode | null;
 };
 
 type DependencyGraph = {
@@ -122,7 +121,7 @@ export const getExecutionPlanData = async (
     property.dependencies.map((dep) => ({
       propertyId: property.id,
       dependsOnPropertyId: dep.dependsOnPropertyId,
-      condition: dep.condition,
+      condition: parseStoredCondition(dep.condition),
     })),
   );
 

--- a/apps/api/src/lib/workflow/utils.test.ts
+++ b/apps/api/src/lib/workflow/utils.test.ts
@@ -1,9 +1,8 @@
 import { afterAll, describe, expect, mock, test } from "bun:test";
 
-import type {
-  FieldContent,
-  PropertyCondition,
-} from "@/api/db/schema-validators";
+import type { ConditionNode } from "@stll/conditions";
+
+import type { FieldContent } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
 import type {
   BatchProperty,
@@ -21,7 +20,7 @@ afterAll(() => {
   mock.restore();
 });
 
-const { evaluateCondition, prepareBatch } =
+const { evaluateGatingCondition, prepareBatch } =
   await import("@/api/lib/workflow/utils");
 
 const propertyId = (value: string) => toSafeId<"property">(value);
@@ -48,40 +47,42 @@ const createRawBatch = (
   ...overrides,
 });
 
-describe("evaluateCondition", () => {
-  const eqCondition: PropertyCondition = {
-    version: 1,
-    type: "string",
-    operator: "eq",
-    value: "x",
+describe("evaluateGatingCondition", () => {
+  const DEP = "dep-prop";
+
+  const eqCondition: ConditionNode = {
+    type: "compare",
+    left: { type: "property", propertyId: DEP },
+    op: "eq",
+    right: { type: "literal", value: "x" },
   };
 
-  const textFieldX: FieldContent = {
-    type: "text",
-    version: 1,
-    value: "x",
-  };
-
-  test("returns false for error field content regardless of condition", () => {
-    const fieldContent: FieldContent = {
-      type: "error",
-      version: 1,
-    };
-
-    expect(evaluateCondition(fieldContent, eqCondition)).toBe(false);
+  const containsEvery = (value: string[]): ConditionNode => ({
+    type: "predicate",
+    operand: { type: "property", propertyId: DEP },
+    op: "contains_all",
+    value,
   });
 
-  test("returns false for pending field content regardless of condition", () => {
-    const fieldContent: FieldContent = {
-      type: "pending",
-      version: 1,
-    };
+  const map = (content: FieldContent): Map<string, FieldContent> =>
+    new Map([[DEP, content]]);
 
-    expect(evaluateCondition(fieldContent, eqCondition)).toBe(false);
+  test("returns true for a null condition (no gate)", () => {
+    expect(evaluateGatingCondition(null, new Map())).toBe(true);
   });
 
-  test("returns false for file field content regardless of condition", () => {
-    const fieldContent: FieldContent = {
+  test("returns false for error field content against an eq gate", () => {
+    const content: FieldContent = { type: "error", version: 1 };
+    expect(evaluateGatingCondition(eqCondition, map(content))).toBe(false);
+  });
+
+  test("returns false for pending field content against an eq gate", () => {
+    const content: FieldContent = { type: "pending", version: 1 };
+    expect(evaluateGatingCondition(eqCondition, map(content))).toBe(false);
+  });
+
+  test("returns false for file field content against an eq gate", () => {
+    const content: FieldContent = {
       type: "file",
       version: 1,
       id: "test-id-000000000000",
@@ -93,133 +94,83 @@ describe("evaluateCondition", () => {
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       pdfFileId: null,
     };
+    expect(evaluateGatingCondition(eqCondition, map(content))).toBe(false);
+  });
 
-    expect(evaluateCondition(fieldContent, eqCondition)).toBe(false);
+  test("returns false when the dependency field is absent from the map", () => {
+    expect(evaluateGatingCondition(eqCondition, new Map())).toBe(false);
   });
 
   test("returns true for string eq when values match exactly", () => {
-    expect(evaluateCondition(textFieldX, eqCondition)).toBe(true);
+    const content: FieldContent = { type: "text", version: 1, value: "x" };
+    expect(evaluateGatingCondition(eqCondition, map(content))).toBe(true);
   });
 
-  test("returns false for string eq when field has empty string and condition expects non-empty", () => {
-    const fieldContent: FieldContent = {
-      type: "text",
-      version: 1,
-      value: "",
-    };
-
-    expect(evaluateCondition(fieldContent, eqCondition)).toBe(false);
+  test("returns false for string eq when field is empty", () => {
+    const content: FieldContent = { type: "text", version: 1, value: "" };
+    expect(evaluateGatingCondition(eqCondition, map(content))).toBe(false);
   });
 
-  test("returns true for contains-every when field array is superset of condition values", () => {
-    const condition: PropertyCondition = {
-      version: 1,
-      type: "string-array",
-      operator: "contains-every",
-      value: ["a", "b"],
-    };
-    const fieldContent: FieldContent = {
+  test("returns true for contains_all when field is a superset", () => {
+    const content: FieldContent = {
       type: "multi-select",
       version: 1,
       value: ["a", "b", "c"],
     };
-
-    expect(evaluateCondition(fieldContent, condition)).toBe(true);
+    expect(
+      evaluateGatingCondition(containsEvery(["a", "b"]), map(content)),
+    ).toBe(true);
   });
 
-  test("returns true for contains-every when field array matches exactly", () => {
-    const condition: PropertyCondition = {
-      version: 1,
-      type: "string-array",
-      operator: "contains-every",
-      value: ["a", "b"],
-    };
-    const fieldContent: FieldContent = {
+  test("returns true for contains_all when field matches exactly", () => {
+    const content: FieldContent = {
       type: "multi-select",
       version: 1,
       value: ["a", "b"],
     };
-
-    expect(evaluateCondition(fieldContent, condition)).toBe(true);
+    expect(
+      evaluateGatingCondition(containsEvery(["a", "b"]), map(content)),
+    ).toBe(true);
   });
 
-  test("returns false for contains-every when field array lacks one required value", () => {
-    const condition: PropertyCondition = {
-      version: 1,
-      type: "string-array",
-      operator: "contains-every",
-      value: ["a", "b", "c"],
-    };
-    const fieldContent: FieldContent = {
+  test("returns false for contains_all when field lacks a required value", () => {
+    const content: FieldContent = {
       type: "multi-select",
       version: 1,
       value: ["a", "b"],
     };
-
-    expect(evaluateCondition(fieldContent, condition)).toBe(false);
+    expect(
+      evaluateGatingCondition(containsEvery(["a", "b", "c"]), map(content)),
+    ).toBe(false);
   });
 
-  test("returns false for contains-every when field array is empty", () => {
-    const condition: PropertyCondition = {
-      version: 1,
-      type: "string-array",
-      operator: "contains-every",
-      value: ["a"],
-    };
-    const fieldContent: FieldContent = {
+  test("returns false for contains_all when field array is empty", () => {
+    const content: FieldContent = {
       type: "multi-select",
       version: 1,
       value: [],
     };
-
-    expect(evaluateCondition(fieldContent, condition)).toBe(false);
+    expect(evaluateGatingCondition(containsEvery(["a"]), map(content))).toBe(
+      false,
+    );
   });
 
-  test("returns false when condition type is string but field is multi-select", () => {
-    const fieldContent: FieldContent = {
-      type: "multi-select",
-      version: 1,
-      value: ["a"],
-    };
-
-    expect(evaluateCondition(fieldContent, eqCondition)).toBe(false);
-  });
-
-  test("returns false when condition type is string-array but field is text", () => {
-    const condition: PropertyCondition = {
-      version: 1,
-      type: "string-array",
-      operator: "contains-every",
-      value: ["a"],
-    };
-
-    expect(evaluateCondition(textFieldX, condition)).toBe(false);
-  });
-
-  test("returns false for single-select with null value and string condition", () => {
-    const fieldContent: FieldContent = {
+  test("returns false for single-select null value against an eq gate", () => {
+    const content: FieldContent = {
       type: "single-select",
       version: 1,
       value: null,
     };
-
-    expect(evaluateCondition(fieldContent, eqCondition)).toBe(false);
+    expect(evaluateGatingCondition(eqCondition, map(content))).toBe(false);
   });
 
-  test("returns true for contains-every when condition value is empty array (false positive, bad DB data)", () => {
-    const condition: PropertyCondition = {
-      version: 1,
-      type: "string-array",
-      operator: "contains-every",
-      value: [],
-    };
-    const fieldContent: FieldContent = {
+  test("returns true for contains_all when the wanted list is empty", () => {
+    const content: FieldContent = {
       type: "multi-select",
       version: 1,
       value: ["a"],
     };
-
-    expect(evaluateCondition(fieldContent, condition)).toBe(true);
+    expect(evaluateGatingCondition(containsEvery([]), map(content))).toBe(true);
   });
 });
 

--- a/apps/api/src/lib/workflow/utils.ts
+++ b/apps/api/src/lib/workflow/utils.ts
@@ -4,6 +4,7 @@ import {
   type OperandResolver,
   type RefOperand,
   evaluateCondition as evaluateConditionNode,
+  pruneIncomplete,
 } from "@stll/conditions";
 
 import type { FieldContent } from "@/api/db/schema-validators";
@@ -106,8 +107,13 @@ export const evaluateGatingCondition = (
   if (!condition) {
     return true;
   }
+  // An incomplete gate (a leaf whose value was never entered) is no gate.
+  const pruned = pruneIncomplete(condition);
+  if (!pruned) {
+    return true;
+  }
   return evaluateConditionNode(
-    condition,
+    pruned,
     buildGatingResolver(fieldContentByPropertyId),
   );
 };

--- a/apps/api/src/lib/workflow/utils.ts
+++ b/apps/api/src/lib/workflow/utils.ts
@@ -1,7 +1,12 @@
-import type {
-  FieldContent,
-  PropertyCondition,
-} from "@/api/db/schema-validators";
+import {
+  type ConditionNode,
+  type ConditionValue,
+  type OperandResolver,
+  type RefOperand,
+  evaluateCondition as evaluateConditionNode,
+} from "@stll/conditions";
+
+import type { FieldContent } from "@/api/db/schema-validators";
 import type { PropertyBatch } from "@/api/lib/workflow/get-execution-plan";
 
 export const prepareBatch = (
@@ -36,51 +41,73 @@ export const prepareBatch = (
   };
 };
 
-export const evaluateCondition = (
-  fieldContent: FieldContent,
-  condition: PropertyCondition,
-): boolean => {
-  if (
-    fieldContent.type === "error" ||
-    fieldContent.type === "pending" ||
-    fieldContent.type === "unsupported" ||
-    fieldContent.type === "file" ||
-    fieldContent.type === "clip"
-  ) {
-    return false;
-  }
-
-  switch (condition.type) {
-    case "string": {
-      if (typeof fieldContent.value !== "string") {
-        return false;
-      }
-      return evaluateStringCondition(condition, fieldContent.value);
+/**
+ * Projects a field's content onto a concrete condition value. Content
+ * types that cannot gate (file, clip, error, pending, unsupported)
+ * resolve to `undefined`, which the evaluator treats as empty/absent.
+ */
+export const fieldContentToValue = (content: FieldContent): ConditionValue => {
+  switch (content.type) {
+    case "text":
+      return content.value;
+    case "single-select":
+      return content.value;
+    case "multi-select":
+      return content.value;
+    case "int":
+      return content.value;
+    case "date":
+      return content.value;
+    case "file":
+    case "clip":
+    case "error":
+    case "pending":
+    case "unsupported":
+      return undefined;
+    default: {
+      const exhaustive: never = content;
+      void exhaustive;
+      return undefined;
     }
-    case "string-array": {
-      if (!Array.isArray(fieldContent.value)) {
-        return false;
-      }
-      return evaluateStringArrayCondition(condition, fieldContent.value);
-    }
-    default:
-      return false;
   }
 };
 
-type StringCondition = Extract<PropertyCondition, { type: "string" }>;
+/**
+ * Builds an `OperandResolver` over the field contents available to a
+ * batch row. Extraction gating only references the dependency property
+ * by id, so a `property` operand resolves from the map; every other
+ * operand kind (builtin/kind/path) is irrelevant here and resolves to
+ * `undefined`.
+ */
+const buildGatingResolver =
+  (
+    fieldContentByPropertyId: ReadonlyMap<string, FieldContent>,
+  ): OperandResolver =>
+  (operand: RefOperand): ConditionValue => {
+    if (operand.type !== "property") {
+      return undefined;
+    }
+    const content = fieldContentByPropertyId.get(operand.propertyId);
+    if (!content) {
+      return undefined;
+    }
+    return fieldContentToValue(content);
+  };
 
-const evaluateStringCondition = (
-  condition: StringCondition,
-  fieldValue: string,
-) => fieldValue === condition.value;
-
-type StringArrayCondition = Extract<
-  PropertyCondition,
-  { type: "string-array" }
->;
-
-const evaluateStringArrayCondition = (
-  condition: StringArrayCondition,
-  fieldValue: string[],
-) => condition.value.every((v) => fieldValue.includes(v));
+/**
+ * Whether a dependent property's AI extraction should run, given the
+ * gating condition and the field contents available to its batch.
+ * A `null` condition always runs (no gate).
+ */
+export const evaluateGatingCondition = (
+  condition: ConditionNode | null,
+  fieldContentByPropertyId: ReadonlyMap<string, FieldContent>,
+): boolean => {
+  if (!condition) {
+    return true;
+  }
+  return evaluateConditionNode(
+    condition,
+    buildGatingResolver(fieldContentByPropertyId),
+  );
+};

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -48,8 +48,8 @@ export type {
 } from "@/api/handlers/chat/types";
 export type ViewLayout = ViewSchemas.ViewLayout;
 export type ViewLayoutType = ViewSchemas.ViewLayoutType;
-export type ViewFilterCondition = ViewSchemas.ViewFilterCondition;
 export type ViewTemplateProperty = ViewSchemas.ViewTemplateProperty;
+export type { ConditionNode } from "@stll/conditions";
 export type { ChatMentionsData } from "@/api/handlers/chat/types";
 export type { ChatSourceDocument } from "@/api/handlers/chat/tools/chat-source-document";
 export type { UserFileUrl } from "@/api/handlers/user-files/types";

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -19,8 +19,6 @@ export type OptionColor = SchemaValidators.OptionColor;
 
 export type BoundingBox = SchemaValidators.BoundingBoxes["boxes"][number];
 
-export type PropertyCondition = SchemaValidators.PropertyCondition;
-
 export type EntityKind = SchemaValidators.EntityKind;
 export type {
   AgendaItemKind,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@stll/anonymize-wasm": "catalog:",
     "@stll/api": "workspace:*",
     "@stll/catalogue": "workspace:*",
+    "@stll/conditions": "workspace:*",
     "@stll/country-codes": "workspace:*",
     "@stll/errors": "workspace:*",
     "@stll/folio": "workspace:*",

--- a/apps/web/src/components/chat-mention-helpers.test.ts
+++ b/apps/web/src/components/chat-mention-helpers.test.ts
@@ -113,9 +113,8 @@ describe("getMentionViewScope", () => {
       getMentionViewScope({
         filters: [
           {
-            id: "filter-1",
-            field: "property",
-            propertyId: "name",
+            type: "predicate",
+            operand: { type: "property", propertyId: "name" },
             op: "contains",
             value: "nda",
           },
@@ -125,9 +124,8 @@ describe("getMentionViewScope", () => {
     ).toEqual({
       filters: [
         {
-          id: "filter-1",
-          field: "property",
-          propertyId: "name",
+          type: "predicate",
+          operand: { type: "property", propertyId: "name" },
           op: "contains",
           value: "nda",
         },

--- a/apps/web/src/components/chat-mention-helpers.ts
+++ b/apps/web/src/components/chat-mention-helpers.ts
@@ -1,5 +1,5 @@
 import type { ChatMentionOption } from "@/components/chat-mention-extension";
-import type { ViewFilterCondition, WorkspaceEntity } from "@/lib/types";
+import type { ConditionNode, WorkspaceEntity } from "@/lib/types";
 import {
   getEntityName,
   getFirstFile,
@@ -19,7 +19,7 @@ type ViewSort = {
 };
 
 type ViewLayout = {
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
   sorts: ViewSort[];
 };
 

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -1220,6 +1220,19 @@
     "workspaces.views.calendar.additionalDates": [
       "fr"
     ],
+    "workspaces.views.clearFilters": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "workspaces.views.filter": [
       "cs",
       "de",
@@ -1260,6 +1273,32 @@
       "sk"
     ],
     "workspaces.views.layouts.kanban": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.noFilterResults": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.noFilterResultsHint": [
       "cs",
       "de",
       "es",

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -319,6 +319,71 @@
       "pt-BR",
       "sk"
     ],
+    "filters.dateAfter": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.dateBefore": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.dateOnOrAfter": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.dateOnOrBefore": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.ends_with": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "filters.gt": [
       "cs",
       "de",
@@ -358,6 +423,19 @@
       "pt-BR",
       "sk"
     ],
+    "filters.is_not_empty": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "filters.lt": [
       "cs",
       "de",
@@ -372,6 +450,32 @@
       "sk"
     ],
     "filters.lte": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.not_contains": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.starts_with": [
       "cs",
       "de",
       "es",
@@ -1071,6 +1175,45 @@
     "workspaces.team": [
       "de"
     ],
+    "workspaces.views.addAdvancedFilter": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.advancedFilter": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.advancedFilterCount": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "workspaces.views.calendar.addDates": [
       "fr"
     ],
@@ -1078,6 +1221,19 @@
       "fr"
     ],
     "workspaces.views.filter": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.filterByPlaceholder": [
       "cs",
       "de",
       "es",
@@ -1104,6 +1260,19 @@
       "sk"
     ],
     "workspaces.views.layouts.kanban": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.removeAdvancedFilter": [
       "cs",
       "de",
       "es",

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -28,7 +28,8 @@
     "templates.inputTypes.date",
     "translate.settings.remove",
     "translate.settings.save",
-    "workspaces.properties.optionsLabel"
+    "workspaces.properties.optionsLabel",
+    "workspaces.views.filter"
   ],
   "identicalToSource": {
     "appearance.flexoki": [
@@ -137,6 +138,19 @@
     "common.actions": [
       "fr"
     ],
+    "common.and": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "common.anonymizationLabels.date": [
       "fr"
     ],
@@ -175,6 +189,19 @@
     ],
     "common.options": [
       "fr"
+    ],
+    "common.or": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
     ],
     "common.reference": [
       "cs"
@@ -279,6 +306,84 @@
       "de",
       "fr"
     ],
+    "filters.contains_all": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.gt": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.gte": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.in": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.lt": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "filters.lte": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "folio.fontGroup": [
       "et"
     ],
@@ -352,19 +457,6 @@
       "hu",
       "lv",
       "pl",
-      "sk"
-    ],
-    "knowledge.agentSkills.newFolderFilenamePlaceholder": [
-      "cs",
-      "de",
-      "es",
-      "et",
-      "fr",
-      "hu",
-      "lt",
-      "lv",
-      "pl",
-      "pt-BR",
       "sk"
     ],
     "knowledge.agentSkills.selectFileHint": [
@@ -890,6 +982,19 @@
     "workspaces.parties.personalLabel": [
       "es"
     ],
+    "workspaces.properties.addCondition": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "workspaces.properties.chipSingle": [
       "pl"
     ],
@@ -907,8 +1012,47 @@
     "workspaces.properties.documentsLabel": [
       "fr"
     ],
+    "workspaces.properties.editConditionsWhen": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.properties.noConditionFields": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
     "workspaces.properties.optionsLabel": [
       "fr"
+    ],
+    "workspaces.properties.selectField": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
     ],
     "workspaces.properties.text": [
       "cs",
@@ -932,6 +1076,32 @@
     ],
     "workspaces.views.calendar.additionalDates": [
       "fr"
+    ],
+    "workspaces.views.filter": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
+    ],
+    "workspaces.views.filtersWithCount": [
+      "cs",
+      "de",
+      "es",
+      "et",
+      "fr",
+      "hu",
+      "lt",
+      "lv",
+      "pl",
+      "pt-BR",
+      "sk"
     ],
     "workspaces.views.layouts.kanban": [
       "cs",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2626,6 +2626,7 @@
         "year": "Rok"
       },
       "cannotDeleteRequired": "Je vyžadováno alespoň jedno zobrazení tohoto typu",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (kopie)",
       "deleteView": "Smazat pohled",
       "exportCsv": "Exportovat CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Časová osa"
       },
       "newView": "Nový {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Uložit jako šablonu…",
       "selectProperty": "Vybrat vlastnost",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -650,6 +650,7 @@
     "actions": "Akce",
     "add": "Přidat",
     "all": "Vše",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adresa",
       "bankAccountNumber": "Číslo bankovního účtu",
@@ -778,6 +779,7 @@
     "open": "Otevřít",
     "openInNewTab": "Otevřít na nové kartě",
     "options": "Možnosti",
+    "or": "Or",
     "organization": "Organizace",
     "organizationName": "Název organizace",
     "pin": "Připnout",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "obsahuje",
+    "contains_all": "contains all of",
     "eq": "je",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "je prázdné",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "není"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Možné duplicity",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Přidejte alespoň jednu vstupní vlastnost pomocí \"@\"",
       "addOption": "Přidat možnost",
       "addPromptForBetterResults": "Přidejte prompt pro lepší výsledky",
@@ -2478,6 +2487,7 @@
       "editColumn": "Upravit sloupec",
       "editConditions": "Upravit podmínky",
       "editConditionsDescription": "Nastavte podmínky, za kterých se má tato vlastnost generovat.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Zadejte hodnotu",
       "extractEntityType": "Vytěžit informaci",
       "extractEntityTypeDescription": "Sloupec doplňovaný AI.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Nový sloupec",
       "newColumnDescription": "Vyberte, jak se má tento sloupec tabulky vyplňovat.",
       "newColumnName": "Název sloupce",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Zatím žádné dokumenty pro náhled.",
       "noPropertiesFound": "Nebyly nalezeny žádné vlastnosti",
       "optionsHelp": "Zadej hodnoty, ze kterých může AI vybírat.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Použít všechny sloupce souborů a spustit celý spis.",
       "searchOrAddOptions": "Hledat nebo přidat možnosti",
       "selectColor": "Vyberte barvu",
+      "selectField": "Select field",
       "selectOperator": "Vyberte operátor",
       "setPromptPlaceholder": "Nastavte prompt pro extrakci informací",
       "singleSelect": "Jednoduchý výběr",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Exportovat XLSX",
       "fields": "Pole:",
       "fieldsSelected": "{count, plural, one {# vybraný} few {# vybrané} other {# vybraných}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Seskupit podle:",
       "hideColumn": "Skrýt sloupec",
       "layouts": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "obsahuje",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "je",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "je prázdné",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "není"
+    "neq": "není",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Přijmout změnu",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Obnovit z archivu",
     "uploadDocuments": "Nahrát dokumenty",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Přidat pole",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Generováno AI",
       "calendar": {
         "addDates": "+ Datumy",
@@ -2618,6 +2635,7 @@
       "fields": "Pole:",
       "fieldsSelected": "{count, plural, one {# vybraný} few {# vybrané} other {# vybraných}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Seskupit podle:",
       "hideColumn": "Skrýt sloupec",
@@ -2632,6 +2650,7 @@
         "timeline": "Časová osa"
       },
       "newView": "Nový {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Uložit jako šablonu…",
       "selectProperty": "Vybrat vlastnost",
       "templates": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -650,6 +650,7 @@
     "actions": "Aktionen",
     "add": "Hinzufügen",
     "all": "Alle",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adresse",
       "bankAccountNumber": "Bankkontonummer",
@@ -778,6 +779,7 @@
     "open": "Öffnen",
     "openInNewTab": "In neuem Tab öffnen",
     "options": "Optionen",
+    "or": "Or",
     "organization": "Organisation",
     "organizationName": "Organisationsname",
     "pin": "Anheften",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "enthält",
+    "contains_all": "contains all of",
     "eq": "ist",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "ist leer",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "ist nicht"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Mögliche Duplikate",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Fügen Sie mindestens eine Eingabeeigenschaft mit \"@\" hinzu",
       "addOption": "Option hinzufügen",
       "addPromptForBetterResults": "Fügen Sie einen Prompt für bessere Ergebnisse hinzu",
@@ -2478,6 +2487,7 @@
       "editColumn": "Spalte bearbeiten",
       "editConditions": "Bedingungen bearbeiten",
       "editConditionsDescription": "Legen Sie Bedingungen fest, wann diese Eigenschaft generiert werden soll.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Wert eingeben",
       "extractEntityType": "Entitätstyp extrahieren",
       "extractEntityTypeDescription": "Erstellen Sie eine KI-gefüllte Tabellenspalte.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Neue Spalte",
       "newColumnDescription": "Wählen Sie, wie diese Tabellenspalte gefüllt werden soll.",
       "newColumnName": "Spaltenname",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Noch keine Dokumente für die Vorschau.",
       "noPropertiesFound": "Keine Eigenschaften gefunden",
       "optionsHelp": "Lege die Werte fest, aus denen die KI wählen darf.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Alle Dateispalten verwenden und die Akte ausführen.",
       "searchOrAddOptions": "Optionen suchen oder hinzufügen",
       "selectColor": "Farbe auswählen",
+      "selectField": "Select field",
       "selectOperator": "Operator auswählen",
       "setPromptPlaceholder": "Prompt zum Extrahieren der Informationen festlegen",
       "singleSelect": "Einfachauswahl",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "XLSX exportieren",
       "fields": "Felder:",
       "fieldsSelected": "{count, plural, one {# ausgewählt} other {# ausgewählt}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Gruppieren nach:",
       "hideColumn": "Spalte ausblenden",
       "layouts": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2626,6 +2626,7 @@
         "year": "Jahr"
       },
       "cannotDeleteRequired": "Mindestens eine Ansicht dieses Typs ist erforderlich",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (Kopie)",
       "deleteView": "Ansicht löschen",
       "exportCsv": "CSV exportieren",
@@ -2650,6 +2651,8 @@
         "timeline": "Zeitleiste"
       },
       "newView": "Neue {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Als Vorlage speichern…",
       "selectProperty": "Eigenschaft auswählen",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "enthält",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "ist",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "ist leer",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "ist nicht"
+    "neq": "ist nicht",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Änderung annehmen",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Archivierung aufheben",
     "uploadDocuments": "Dokumente hochladen",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Felder hinzufügen",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "KI-generiert",
       "calendar": {
         "addDates": "+ Daten",
@@ -2618,6 +2635,7 @@
       "fields": "Felder:",
       "fieldsSelected": "{count, plural, one {# ausgewählt} other {# ausgewählt}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Gruppieren nach:",
       "hideColumn": "Spalte ausblenden",
@@ -2632,6 +2650,7 @@
         "timeline": "Zeitleiste"
       },
       "newView": "Neue {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Als Vorlage speichern…",
       "selectProperty": "Eigenschaft auswählen",
       "templates": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2626,6 +2626,7 @@
         "year": "Year"
       },
       "cannotDeleteRequired": "At least one view of this type is required",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (copy)",
       "deleteView": "Delete view",
       "exportCsv": "Export CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Timeline"
       },
       "newView": "New {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Save as template…",
       "selectProperty": "Select property",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "contains",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "is",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "is empty",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "is not"
+    "neq": "is not",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Accept Change",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Unarchive",
     "uploadDocuments": "Upload documents",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Add fields",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "AI-generated",
       "calendar": {
         "addDates": "+ Dates",
@@ -2618,6 +2635,7 @@
       "fields": "Fields:",
       "fieldsSelected": "{count, plural, one {# selected} other {# selected}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Group by:",
       "hideColumn": "Hide column",
@@ -2632,6 +2650,7 @@
         "timeline": "Timeline"
       },
       "newView": "New {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Save as template…",
       "selectProperty": "Select property",
       "templates": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -650,6 +650,7 @@
     "actions": "Actions",
     "add": "Add",
     "all": "All",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Address",
       "bankAccountNumber": "Bank account number",
@@ -778,6 +779,7 @@
     "open": "Open",
     "openInNewTab": "Open in new tab",
     "options": "Options",
+    "or": "Or",
     "organization": "Organization",
     "organizationName": "Organization name",
     "pin": "Pin",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "contains",
+    "contains_all": "contains all of",
     "eq": "is",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "is empty",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "is not"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Possible duplicates",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Add at least one input property using \"@\"",
       "addOption": "Add option",
       "addPromptForBetterResults": "Add a prompt for better results",
@@ -2478,6 +2487,7 @@
       "editColumn": "Edit column",
       "editConditions": "Edit conditions",
       "editConditionsDescription": "Set conditions for when this property should be generated.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Enter a value",
       "extractEntityType": "Extract entity type",
       "extractEntityTypeDescription": "Create an AI-extracted table column.",
@@ -2502,6 +2512,7 @@
       "newColumn": "New column",
       "newColumnDescription": "Choose how this table column should be filled.",
       "newColumnName": "Column name",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "No documents to preview yet.",
       "noPropertiesFound": "No properties found",
       "optionsHelp": "Define the values the AI may pick from.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Use all file columns and run the matter.",
       "searchOrAddOptions": "Search or add options",
       "selectColor": "Select color",
+      "selectField": "Select field",
       "selectOperator": "Select operator",
       "setPromptPlaceholder": "Set a prompt to extract the information",
       "singleSelect": "Single Select",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Export XLSX",
       "fields": "Fields:",
       "fieldsSelected": "{count, plural, one {# selected} other {# selected}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Group by:",
       "hideColumn": "Hide column",
       "layouts": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "contiene",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "es",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "está vacío",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "no es"
+    "neq": "no es",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Aceptar cambio",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Desarchivar",
     "uploadDocuments": "Subir documentos",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Añadir campos",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Generado por IA",
       "calendar": {
         "addDates": "+ Fechas",
@@ -2618,6 +2635,7 @@
       "fields": "Campos:",
       "fieldsSelected": "{count, plural, one {# seleccionado} other {# seleccionados}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Agrupar por:",
       "hideColumn": "Ocultar columna",
@@ -2632,6 +2650,7 @@
         "timeline": "Línea de tiempo"
       },
       "newView": "Nueva {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Guardar como plantilla…",
       "selectProperty": "Seleccionar propiedad",
       "templates": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -650,6 +650,7 @@
     "actions": "Acciones",
     "add": "Añadir",
     "all": "Todos",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Dirección",
       "bankAccountNumber": "Número de cuenta bancaria",
@@ -778,6 +779,7 @@
     "open": "Abrir",
     "openInNewTab": "Abrir en una pestaña nueva",
     "options": "Opciones",
+    "or": "Or",
     "organization": "Organización",
     "organizationName": "Nombre de la organización",
     "pin": "Fijar",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "contiene",
+    "contains_all": "contains all of",
     "eq": "es",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "está vacío",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "no es"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Posibles duplicados",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Añada al menos una propiedad de entrada usando \"@\"",
       "addOption": "Añadir opción",
       "addPromptForBetterResults": "Añada una instrucción para mejores resultados",
@@ -2478,6 +2487,7 @@
       "editColumn": "Editar columna",
       "editConditions": "Editar condiciones",
       "editConditionsDescription": "Establezca las condiciones para generar esta propiedad.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Introduzca un valor",
       "extractEntityType": "Extraer tipo de entidad",
       "extractEntityTypeDescription": "Cree una columna de tabla extraída por IA.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Nueva columna",
       "newColumnDescription": "Elija cómo se debe rellenar esta columna de la tabla.",
       "newColumnName": "Nombre de columna",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Aún no hay documentos para previsualizar.",
       "noPropertiesFound": "No se encontraron propiedades",
       "optionsHelp": "Define los valores entre los que la IA puede elegir.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Use todas las columnas de archivo y ejecute el Matter.",
       "searchOrAddOptions": "Buscar o añadir opciones",
       "selectColor": "Seleccionar color",
+      "selectField": "Select field",
       "selectOperator": "Seleccionar operador",
       "setPromptPlaceholder": "Defina una instrucción para extraer la información",
       "singleSelect": "Selección única",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Exportar XLSX",
       "fields": "Campos:",
       "fieldsSelected": "{count, plural, one {# seleccionado} other {# seleccionados}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Agrupar por:",
       "hideColumn": "Ocultar columna",
       "layouts": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2626,6 +2626,7 @@
         "year": "Año"
       },
       "cannotDeleteRequired": "Se requiere al menos una vista de este tipo",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (copia)",
       "deleteView": "Eliminar vista",
       "exportCsv": "Exportar CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Línea de tiempo"
       },
       "newView": "Nueva {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Guardar como plantilla…",
       "selectProperty": "Seleccionar propiedad",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2626,6 +2626,7 @@
         "year": "Aasta"
       },
       "cannotDeleteRequired": "Vähemalt üks seda tüüpi vaade on nõutav",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (koopia)",
       "deleteView": "Kustuta vaade",
       "exportCsv": "Ekspordi CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Ajajoon"
       },
       "newView": "Uus {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Salvesta mallina…",
       "selectProperty": "Valige omadus",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -650,6 +650,7 @@
     "actions": "Toimingud",
     "add": "Lisa",
     "all": "Kõik",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Aadress",
       "bankAccountNumber": "Pangakonto number",
@@ -778,6 +779,7 @@
     "open": "Ava",
     "openInNewTab": "Ava uuel vahekaardil",
     "options": "Valikud",
+    "or": "Or",
     "organization": "Organisatsioon",
     "organizationName": "Organisatsiooni nimi",
     "pin": "Kinnita",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "sisaldab",
+    "contains_all": "contains all of",
     "eq": "on",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "on tühi",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "ei ole"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Võimalikud duplikaadid",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Lisage vähemalt üks sisestusomadus, kasutades \"@\"",
       "addOption": "Lisa valik",
       "addPromptForBetterResults": "Lisage paremaks tulemuseks päring",
@@ -2478,6 +2487,7 @@
       "editColumn": "Muuda veergu",
       "editConditions": "Muuda tingimusi",
       "editConditionsDescription": "Määrake tingimused, millal seda omadust genereeritakse.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Sisestage väärtus",
       "extractEntityType": "Ekstrakti olemi tüüp",
       "extractEntityTypeDescription": "Looge AI täidetav tabeliveerg.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Uus veerg",
       "newColumnDescription": "Valige, kuidas seda tabeli veergu täidetakse.",
       "newColumnName": "Veeru nimi",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Eelvaateks pole veel dokumente.",
       "noPropertiesFound": "Omadusi ei leitud",
       "optionsHelp": "Määra väärtused, mille hulgast AI võib valida.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Kasutage kõiki failiveerge ja käivitage asi.",
       "searchOrAddOptions": "Otsi või lisa valikuid",
       "selectColor": "Valige värv",
+      "selectField": "Select field",
       "selectOperator": "Valige operaator",
       "setPromptPlaceholder": "Määrake päring teabe eraldamiseks",
       "singleSelect": "Ühekordne valik",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Ekspordi XLSX",
       "fields": "Väljad:",
       "fieldsSelected": "{count, plural, one {# valitud} other {# valitud}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Rühmita:",
       "hideColumn": "Peida veerg",
       "layouts": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "sisaldab",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "on",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "on tühi",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "ei ole"
+    "neq": "ei ole",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Nõustu muudatusega",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Taasta arhiivist",
     "uploadDocuments": "Laadi dokumendid üles",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Lisa väljad",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Tehisintellektiga loodud",
       "calendar": {
         "addDates": "+ Kuupäevad",
@@ -2618,6 +2635,7 @@
       "fields": "Väljad:",
       "fieldsSelected": "{count, plural, one {# valitud} other {# valitud}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Rühmita:",
       "hideColumn": "Peida veerg",
@@ -2632,6 +2650,7 @@
         "timeline": "Ajajoon"
       },
       "newView": "Uus {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Salvesta mallina…",
       "selectProperty": "Valige omadus",
       "templates": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2626,6 +2626,7 @@
         "year": "Année"
       },
       "cannotDeleteRequired": "Au moins une vue de ce type est requise",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (copie)",
       "deleteView": "Supprimer la vue",
       "exportCsv": "Exporter en CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Chronologie"
       },
       "newView": "Nouvelle {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Enregistrer comme modèle…",
       "selectProperty": "Sélectionner une propriété",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -650,6 +650,7 @@
     "actions": "Actions",
     "add": "Ajouter",
     "all": "Tous",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adresse",
       "bankAccountNumber": "Numéro de compte bancaire",
@@ -778,6 +779,7 @@
     "open": "Ouvrir",
     "openInNewTab": "Ouvrir dans un nouvel onglet",
     "options": "Options",
+    "or": "Or",
     "organization": "Organisation",
     "organizationName": "Nom de l'organisation",
     "pin": "Épingler",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "contient",
+    "contains_all": "contains all of",
     "eq": "est",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "est vide",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "n’est pas"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Doublons possibles",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Ajoutez au moins une propriété d'entrée avec « @ »",
       "addOption": "Ajouter une option",
       "addPromptForBetterResults": "Ajoutez un prompt pour de meilleurs résultats",
@@ -2478,6 +2487,7 @@
       "editColumn": "Modifier la colonne",
       "editConditions": "Modifier les conditions",
       "editConditionsDescription": "Définissez les conditions de génération de cette propriété.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Saisir une valeur",
       "extractEntityType": "Extraire un type d'entité",
       "extractEntityTypeDescription": "Créez une colonne de tableau extraite par l'IA.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Nouvelle colonne",
       "newColumnDescription": "Choisissez comment cette colonne du tableau doit être remplie.",
       "newColumnName": "Nom de la colonne",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Aucun document à prévisualiser.",
       "noPropertiesFound": "Aucune propriété trouvée",
       "optionsHelp": "Définis les valeurs parmi lesquelles l'IA peut choisir.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Utiliser toutes les colonnes de fichiers et lancer le Matter.",
       "searchOrAddOptions": "Rechercher ou ajouter des options",
       "selectColor": "Sélectionner une couleur",
+      "selectField": "Select field",
       "selectOperator": "Sélectionner un opérateur",
       "setPromptPlaceholder": "Définir un prompt pour extraire l'information",
       "singleSelect": "Sélection unique",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Exporter en XLSX",
       "fields": "Champs :",
       "fieldsSelected": "{count, plural, one {# sélectionné} many {# sélectionnés} other {# sélectionnés}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Regrouper par :",
       "hideColumn": "Masquer la colonne",
       "layouts": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "contient",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "est",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "est vide",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "n’est pas"
+    "neq": "n’est pas",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Accepter la modification",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Désarchiver",
     "uploadDocuments": "Importer des documents",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Ajouter des champs",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Généré par IA",
       "calendar": {
         "addDates": "+ Dates",
@@ -2618,6 +2635,7 @@
       "fields": "Champs :",
       "fieldsSelected": "{count, plural, one {# sélectionné} many {# sélectionnés} other {# sélectionnés}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Regrouper par :",
       "hideColumn": "Masquer la colonne",
@@ -2632,6 +2650,7 @@
         "timeline": "Chronologie"
       },
       "newView": "Nouvelle {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Enregistrer comme modèle…",
       "selectProperty": "Sélectionner une propriété",
       "templates": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2626,6 +2626,7 @@
         "year": "Év"
       },
       "cannotDeleteRequired": "Legalább egy ilyen típusú nézet szükséges",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (másolat)",
       "deleteView": "Nézet törlése",
       "exportCsv": "CSV exportálása",
@@ -2650,6 +2651,8 @@
         "timeline": "Idővonal"
       },
       "newView": "Új {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Mentés sablonként…",
       "selectProperty": "Tulajdonság kiválasztása",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -650,6 +650,7 @@
     "actions": "Műveletek",
     "add": "Hozzáadás",
     "all": "Összes",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Cím",
       "bankAccountNumber": "Bankszámlaszám",
@@ -778,6 +779,7 @@
     "open": "Megnyitás",
     "openInNewTab": "Megnyitás új lapon",
     "options": "Beállítások",
+    "or": "Or",
     "organization": "Szervezet",
     "organizationName": "Szervezet neve",
     "pin": "Rögzítés",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "tartalmazza",
+    "contains_all": "contains all of",
     "eq": "egyenlő",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "üres",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "nem egyenlő"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Lehetséges duplikátumok",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Adjon hozzá legalább egy bemeneti tulajdonságot a \"@\" használatával",
       "addOption": "Opció hozzáadása",
       "addPromptForBetterResults": "Adjon hozzá promptot a jobb eredményekért",
@@ -2478,6 +2487,7 @@
       "editColumn": "Oszlop szerkesztése",
       "editConditions": "Feltételek szerkesztése",
       "editConditionsDescription": "Adja meg a feltételeket, amelyek mellett ez a tulajdonság generálódjon.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Adjon meg egy értéket",
       "extractEntityType": "Entitástípus kinyerése",
       "extractEntityTypeDescription": "Hozzon létre AI által kitöltött táblázatoszlopot.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Új oszlop",
       "newColumnDescription": "Válassza ki, hogyan töltődjön ki ez a táblázatoszlop.",
       "newColumnName": "Oszlop neve",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Még nincsenek dokumentumok az előnézethez.",
       "noPropertiesFound": "Nincsenek tulajdonságok",
       "optionsHelp": "Add meg az értékeket, amelyek közül az AI választhat.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Használja az összes fájloszlopot, és futtassa az ügyet.",
       "searchOrAddOptions": "Opciók keresése vagy hozzáadása",
       "selectColor": "Szín kiválasztása",
+      "selectField": "Select field",
       "selectOperator": "Operátor kiválasztása",
       "setPromptPlaceholder": "Adjon meg promptot az információ kinyeréséhez",
       "singleSelect": "Egyszeres választás",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "XLSX exportálása",
       "fields": "Mezők:",
       "fieldsSelected": "{count, plural, one {# kiválasztva} other {# kiválasztva}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Csoportosítás:",
       "hideColumn": "Oszlop elrejtése",
       "layouts": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "tartalmazza",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "egyenlő",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "üres",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "nem egyenlő"
+    "neq": "nem egyenlő",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Módosítás elfogadása",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Visszaállítás",
     "uploadDocuments": "Dokumentumok feltöltése",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Mezők hozzáadása",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "MI által generált",
       "calendar": {
         "addDates": "+ Dátumok",
@@ -2618,6 +2635,7 @@
       "fields": "Mezők:",
       "fieldsSelected": "{count, plural, one {# kiválasztva} other {# kiválasztva}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Csoportosítás:",
       "hideColumn": "Oszlop elrejtése",
@@ -2632,6 +2650,7 @@
         "timeline": "Idővonal"
       },
       "newView": "Új {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Mentés sablonként…",
       "selectProperty": "Tulajdonság kiválasztása",
       "templates": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -650,6 +650,7 @@
     "actions": "Veiksmai",
     "add": "Pridėti",
     "all": "Visi",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adresas",
       "bankAccountNumber": "Banko sąskaitos numeris",
@@ -778,6 +779,7 @@
     "open": "Atidaryti",
     "openInNewTab": "Atidaryti naujame skirtuke",
     "options": "Parinktys",
+    "or": "Or",
     "organization": "Organizacija",
     "organizationName": "Organizacijos pavadinimas",
     "pin": "Prisegti",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "apima",
+    "contains_all": "contains all of",
     "eq": "yra",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "yra tuščias",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "nėra"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Galimi dublikatai",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Pridėkite bent vieną įvesties savybę naudodami \"@\"",
       "addOption": "Pridėti parinktį",
       "addPromptForBetterResults": "Pridėkite užklausą geresniems rezultatams",
@@ -2478,6 +2487,7 @@
       "editColumn": "Redaguoti stulpelį",
       "editConditions": "Redaguoti sąlygas",
       "editConditionsDescription": "Nustatykite sąlygas, kada ši savybė turi būti generuojama.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Įveskite reikšmę",
       "extractEntityType": "Ištraukti subjekto tipą",
       "extractEntityTypeDescription": "Sukurkite AI pildomą lentelės stulpelį.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Naujas stulpelis",
       "newColumnDescription": "Pasirinkite, kaip šis lentelės stulpelis turi būti pildomas.",
       "newColumnName": "Stulpelio pavadinimas",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Dar nėra dokumentų peržiūrai.",
       "noPropertiesFound": "Savybių nerasta",
       "optionsHelp": "Apibrėžk reikšmes, iš kurių AI gali rinktis.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Naudokite visus failų stulpelius ir paleiskite bylą.",
       "searchOrAddOptions": "Ieškoti arba pridėti parinktis",
       "selectColor": "Pasirinkite spalvą",
+      "selectField": "Select field",
       "selectOperator": "Pasirinkite operatorių",
       "setPromptPlaceholder": "Nustatykite užklausą informacijos išgavimui",
       "singleSelect": "Vienas pasirinkimas",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Eksportuoti XLSX",
       "fields": "Laukai:",
       "fieldsSelected": "{count, plural, one {# pasirinktas} few {# pasirinkti} many {# pasirinktų} other {# pasirinktų}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Grupuoti pagal:",
       "hideColumn": "Slėpti stulpelį",
       "layouts": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2626,6 +2626,7 @@
         "year": "Metai"
       },
       "cannotDeleteRequired": "Reikalingas bent vienas šio tipo rodinys",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (kopija)",
       "deleteView": "Ištrinti rodinį",
       "exportCsv": "Eksportuoti CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Laiko juosta"
       },
       "newView": "Naujas {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Išsaugoti kaip šabloną…",
       "selectProperty": "Pasirinkti savybę",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "apima",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "yra",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "yra tuščias",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "nėra"
+    "neq": "nėra",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Priimti pakeitimą",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Išarchyvuoti",
     "uploadDocuments": "Įkelti dokumentus",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Pridėti laukus",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Sugeneruota AI",
       "calendar": {
         "addDates": "+ Datos",
@@ -2618,6 +2635,7 @@
       "fields": "Laukai:",
       "fieldsSelected": "{count, plural, one {# pasirinktas} few {# pasirinkti} many {# pasirinktų} other {# pasirinktų}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Grupuoti pagal:",
       "hideColumn": "Slėpti stulpelį",
@@ -2632,6 +2650,7 @@
         "timeline": "Laiko juosta"
       },
       "newView": "Naujas {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Išsaugoti kaip šabloną…",
       "selectProperty": "Pasirinkti savybę",
       "templates": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2626,6 +2626,7 @@
         "year": "Gads"
       },
       "cannotDeleteRequired": "Ir nepieciešams vismaz viens šāda veida skats",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (kopija)",
       "deleteView": "Dzēst skatu",
       "exportCsv": "Eksportēt CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Laika skala"
       },
       "newView": "Jauns {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Saglabāt kā veidni…",
       "selectProperty": "Izvēlieties rekvizītu",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "satur",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "ir",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "ir tukšs",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "nav"
+    "neq": "nav",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Pieņemt izmaiņu",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Atarhivēt",
     "uploadDocuments": "Augšupielādēt dokumentus",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Pievienot laukus",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "AI ģenerēts",
       "calendar": {
         "addDates": "+ Datumi",
@@ -2618,6 +2635,7 @@
       "fields": "Lauki:",
       "fieldsSelected": "{count, plural, zero {# atlasīti} one {# atlasīts} other {# atlasīti}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Grupēt pēc:",
       "hideColumn": "Slēpt kolonnu",
@@ -2632,6 +2650,7 @@
         "timeline": "Laika skala"
       },
       "newView": "Jauns {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Saglabāt kā veidni…",
       "selectProperty": "Izvēlieties rekvizītu",
       "templates": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -650,6 +650,7 @@
     "actions": "Darbības",
     "add": "Pievienot",
     "all": "Visi",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adrese",
       "bankAccountNumber": "Bankas konta numurs",
@@ -778,6 +779,7 @@
     "open": "Atvērt",
     "openInNewTab": "Atvērt jaunā cilnē",
     "options": "Iespējas",
+    "or": "Or",
     "organization": "Organizācija",
     "organizationName": "Organizācijas nosaukums",
     "pin": "Piespraust",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "satur",
+    "contains_all": "contains all of",
     "eq": "ir",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "ir tukšs",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "nav"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Iespējamie dublikāti",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Pievienojiet vismaz vienu ievades rekvizītu, izmantojot \"@\"",
       "addOption": "Pievienot opciju",
       "addPromptForBetterResults": "Pievienojiet uzvedni labākiem rezultātiem",
@@ -2478,6 +2487,7 @@
       "editColumn": "Rediģēt sleju",
       "editConditions": "Rediģēt nosacījumus",
       "editConditionsDescription": "Iestatiet nosacījumus, kad šis rekvizīts tiks ģenerēts.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Ievadiet vērtību",
       "extractEntityType": "Izvilkt entītijas tipu",
       "extractEntityTypeDescription": "Izveidojiet AI aizpildītu tabulas kolonnu.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Jauna kolonna",
       "newColumnDescription": "Izvēlieties, kā šī tabulas kolonna jāaizpilda.",
       "newColumnName": "Kolonnas nosaukums",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Vēl nav dokumentu priekšskatījumam.",
       "noPropertiesFound": "Rekvizīti nav atrasti",
       "optionsHelp": "Definē vērtības, no kurām AI var izvēlēties.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Izmantojiet visas failu kolonnas un palaidiet lietu.",
       "searchOrAddOptions": "Meklēt vai pievienot opcijas",
       "selectColor": "Izvēlieties krāsu",
+      "selectField": "Select field",
       "selectOperator": "Izvēlieties operatoru",
       "setPromptPlaceholder": "Iestatiet uzvedni informācijas ieguvei",
       "singleSelect": "Vienas izvēles",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Eksportēt XLSX",
       "fields": "Lauki:",
       "fieldsSelected": "{count, plural, zero {# atlasīti} one {# atlasīts} other {# atlasīti}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Grupēt pēc:",
       "hideColumn": "Slēpt kolonnu",
       "layouts": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2629,6 +2629,7 @@ type Messages = {
         "year": "Year";
       };
       "cannotDeleteRequired": "At least one view of this type is required";
+      "clearFilters": "Clear filters";
       "copySuffix": "{name} (copy)";
       "deleteView": "Delete view";
       "exportCsv": "Export CSV";
@@ -2653,6 +2654,8 @@ type Messages = {
         "timeline": "Timeline";
       };
       "newView": "New {layout}";
+      "noFilterResults": "No items match these filters";
+      "noFilterResultsHint": "They would show up here if you removed some filters.";
       "removeAdvancedFilter": "Remove advanced filter";
       "saveAsTemplate": "Save as template…";
       "selectProperty": "Select property";

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -653,6 +653,7 @@ type Messages = {
     "actions": "Actions";
     "add": "Add";
     "all": "All";
+    "and": "And";
     "anonymizationLabels": {
       "address": "Address";
       "bankAccountNumber": "Bank account number";
@@ -781,6 +782,7 @@ type Messages = {
     "open": "Open";
     "openInNewTab": "Open in new tab";
     "options": "Options";
+    "or": "Or";
     "organization": "Organization";
     "organizationName": "Organization name";
     "pin": "Pin";
@@ -1107,8 +1109,14 @@ type Messages = {
   };
   "filters": {
     "contains": "contains";
+    "contains_all": "contains all of";
     "eq": "is";
+    "gt": "is greater than";
+    "gte": "is greater than or equal to";
+    "in": "is any of";
     "is_empty": "is empty";
+    "lt": "is less than";
+    "lte": "is less than or equal to";
     "neq": "is not";
   };
   "folio": {
@@ -2440,6 +2448,7 @@ type Messages = {
     };
     "possibleDuplicates": "Possible duplicates";
     "properties": {
+      "addCondition": "Add condition";
       "addInputProperty": "Add at least one input property using \"@\"";
       "addOption": "Add option";
       "addPromptForBetterResults": "Add a prompt for better results";
@@ -2481,6 +2490,7 @@ type Messages = {
       "editColumn": "Edit column";
       "editConditions": "Edit conditions";
       "editConditionsDescription": "Set conditions for when this property should be generated.";
+      "editConditionsWhen": "Only run extraction when …";
       "enterAValue": "Enter a value";
       "extractEntityType": "Extract entity type";
       "extractEntityTypeDescription": "Create an AI-extracted table column.";
@@ -2505,6 +2515,7 @@ type Messages = {
       "newColumn": "New column";
       "newColumnDescription": "Choose how this table column should be filled.";
       "newColumnName": "Column name";
+      "noConditionFields": "No fields available to filter on.";
       "noFirstDocument": "No documents to preview yet.";
       "noPropertiesFound": "No properties found";
       "optionsHelp": "Define the values the AI may pick from.";
@@ -2527,6 +2538,7 @@ type Messages = {
       "scopeMatterDescription": "Use all file columns and run the matter.";
       "searchOrAddOptions": "Search or add options";
       "selectColor": "Select color";
+      "selectField": "Select field";
       "selectOperator": "Select operator";
       "setPromptPlaceholder": "Set a prompt to extract the information";
       "singleSelect": "Single Select";
@@ -2608,6 +2620,8 @@ type Messages = {
       "exportXlsx": "Export XLSX";
       "fields": "Fields:";
       "fieldsSelected": "{count, plural, one {# selected} other {# selected}}";
+      "filter": "Filter";
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}";
       "groupBy": "Group by:";
       "hideColumn": "Hide column";
       "layouts": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1110,14 +1110,28 @@ type Messages = {
   "filters": {
     "contains": "contains";
     "contains_all": "contains all of";
+    "dateAfter": "is after";
+    "dateBefore": "is before";
+    "dateOnOrAfter": "is on or after";
+    "dateOnOrBefore": "is on or before";
+    "ends_with": "ends with";
     "eq": "is";
     "gt": "is greater than";
     "gte": "is greater than or equal to";
     "in": "is any of";
     "is_empty": "is empty";
+    "is_not_empty": "is not empty";
     "lt": "is less than";
     "lte": "is less than or equal to";
     "neq": "is not";
+    "not_contains": "does not contain";
+    "numEq": "=";
+    "numGt": ">";
+    "numGte": "≥";
+    "numLt": "<";
+    "numLte": "≤";
+    "numNeq": "≠";
+    "starts_with": "starts with";
   };
   "folio": {
     "acceptChange": "Accept Change";
@@ -2595,7 +2609,10 @@ type Messages = {
     "unarchiveMatter": "Unarchive";
     "uploadDocuments": "Upload documents";
     "views": {
+      "addAdvancedFilter": "Add advanced filter";
       "addFields": "Add fields";
+      "advancedFilter": "Advanced";
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}";
       "aiGenerated": "AI-generated";
       "calendar": {
         "addDates": "+ Dates";
@@ -2621,6 +2638,7 @@ type Messages = {
       "fields": "Fields:";
       "fieldsSelected": "{count, plural, one {# selected} other {# selected}}";
       "filter": "Filter";
+      "filterByPlaceholder": "Filter by…";
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}";
       "groupBy": "Group by:";
       "hideColumn": "Hide column";
@@ -2635,6 +2653,7 @@ type Messages = {
         "timeline": "Timeline";
       };
       "newView": "New {layout}";
+      "removeAdvancedFilter": "Remove advanced filter";
       "saveAsTemplate": "Save as template…";
       "selectProperty": "Select property";
       "templates": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2626,6 +2626,7 @@
         "year": "Rok"
       },
       "cannotDeleteRequired": "Wymagany jest co najmniej jeden widok tego typu",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (kopia)",
       "deleteView": "Usuń widok",
       "exportCsv": "Eksportuj CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Oś czasu"
       },
       "newView": "Nowy {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Zapisz jako szablon…",
       "selectProperty": "Wybierz właściwość",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "zawiera",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "jest",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "jest puste",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "nie jest"
+    "neq": "nie jest",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Przyjmij zmianę",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Przywróć z archiwum",
     "uploadDocuments": "Prześlij dokumenty",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Dodaj pola",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Wygenerowane przez AI",
       "calendar": {
         "addDates": "+ Daty",
@@ -2618,6 +2635,7 @@
       "fields": "Pola:",
       "fieldsSelected": "{count, plural, one {# wybrany} few {# wybrane} many {# wybranych} other {# wybranych}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Grupuj według:",
       "hideColumn": "Ukryj kolumnę",
@@ -2632,6 +2650,7 @@
         "timeline": "Oś czasu"
       },
       "newView": "Nowy {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Zapisz jako szablon…",
       "selectProperty": "Wybierz właściwość",
       "templates": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -650,6 +650,7 @@
     "actions": "Akcje",
     "add": "Dodaj",
     "all": "Wszystkie",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adres",
       "bankAccountNumber": "Numer rachunku bankowego",
@@ -778,6 +779,7 @@
     "open": "Otwórz",
     "openInNewTab": "Otwórz w nowej karcie",
     "options": "Opcje",
+    "or": "Or",
     "organization": "Organizacja",
     "organizationName": "Nazwa organizacji",
     "pin": "Przypnij",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "zawiera",
+    "contains_all": "contains all of",
     "eq": "jest",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "jest puste",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "nie jest"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Możliwe duplikaty",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Dodaj co najmniej jedną właściwość wejściową za pomocą \"@\"",
       "addOption": "Dodaj opcję",
       "addPromptForBetterResults": "Dodaj prompt, aby uzyskać lepsze wyniki",
@@ -2478,6 +2487,7 @@
       "editColumn": "Edytuj kolumnę",
       "editConditions": "Edytuj warunki",
       "editConditionsDescription": "Ustaw warunki, kiedy ta właściwość ma być generowana.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Wprowadź wartość",
       "extractEntityType": "Wyodrębnij typ encji",
       "extractEntityTypeDescription": "Utwórz kolumnę tabeli wypełnianą przez AI.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Nowa kolumna",
       "newColumnDescription": "Wybierz, jak ta kolumna tabeli ma być wypełniana.",
       "newColumnName": "Nazwa kolumny",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Brak dokumentów do podglądu.",
       "noPropertiesFound": "Nie znaleziono właściwości",
       "optionsHelp": "Określ wartości, spośród których AI może wybierać.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Użyj wszystkich kolumn plików i uruchom sprawę.",
       "searchOrAddOptions": "Szukaj lub dodaj opcje",
       "selectColor": "Wybierz kolor",
+      "selectField": "Select field",
       "selectOperator": "Wybierz operator",
       "setPromptPlaceholder": "Ustaw prompt do wyodrębnienia informacji",
       "singleSelect": "Jednokrotny wybór",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Eksportuj XLSX",
       "fields": "Pola:",
       "fieldsSelected": "{count, plural, one {# wybrany} few {# wybrane} many {# wybranych} other {# wybranych}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Grupuj według:",
       "hideColumn": "Ukryj kolumnę",
       "layouts": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -650,6 +650,7 @@
     "actions": "Ações",
     "add": "Adicionar",
     "all": "Todos",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Endereço",
       "bankAccountNumber": "Número da conta bancária",
@@ -778,6 +779,7 @@
     "open": "Abrir",
     "openInNewTab": "Abrir em nova aba",
     "options": "Opções",
+    "or": "Or",
     "organization": "Organização",
     "organizationName": "Nome da organização",
     "pin": "Fixar",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "contém",
+    "contains_all": "contains all of",
     "eq": "é",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "está vazio",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "não é"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Possíveis duplicatas",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Adicione pelo menos uma propriedade de entrada usando \"@\"",
       "addOption": "Adicionar opção",
       "addPromptForBetterResults": "Adicione um prompt para obter melhores resultados",
@@ -2478,6 +2487,7 @@
       "editColumn": "Editar coluna",
       "editConditions": "Editar condições",
       "editConditionsDescription": "Defina condições para quando esta propriedade deve ser gerada.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Insira um valor",
       "extractEntityType": "Extrair tipo de entidade",
       "extractEntityTypeDescription": "Crie uma coluna de tabela extraída de IA.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Nova coluna",
       "newColumnDescription": "Escolha como esta coluna da tabela deve ser preenchida.",
       "newColumnName": "Nome da coluna",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Ainda não há documentos para visualizar.",
       "noPropertiesFound": "Nenhuma propriedade encontrada",
       "optionsHelp": "Defina os valores que a IA pode escolher.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Use todas as colunas de arquivo e execute o caso.",
       "searchOrAddOptions": "Pesquise ou adicione opções",
       "selectColor": "Selecione a cor",
+      "selectField": "Select field",
       "selectOperator": "Selecione o operador",
       "setPromptPlaceholder": "Defina um prompt para extrair as informações",
       "singleSelect": "Seleção única",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Exportar XLSX",
       "fields": "Campos:",
       "fieldsSelected": "{count, plural, one {# selecionado} many {# selecionados} other {# selecionados}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Agrupar por:",
       "hideColumn": "Ocultar coluna",
       "layouts": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "contém",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "é",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "está vazio",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "não é"
+    "neq": "não é",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Aceitar alteração",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Desarquivar",
     "uploadDocuments": "Carregar documentos",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Adicionar campos",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Gerado por IA",
       "calendar": {
         "addDates": "+ Datas",
@@ -2618,6 +2635,7 @@
       "fields": "Campos:",
       "fieldsSelected": "{count, plural, one {# selecionado} many {# selecionados} other {# selecionados}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Agrupar por:",
       "hideColumn": "Ocultar coluna",
@@ -2632,6 +2650,7 @@
         "timeline": "Linha do tempo"
       },
       "newView": "Novo {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Salvar como modelo…",
       "selectProperty": "Selecione a propriedade",
       "templates": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2626,6 +2626,7 @@
         "year": "Ano"
       },
       "cannotDeleteRequired": "É necessária pelo menos uma visualização deste tipo",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (cópia)",
       "deleteView": "Excluir visualização",
       "exportCsv": "Exportar CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Linha do tempo"
       },
       "newView": "Novo {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Salvar como modelo…",
       "selectProperty": "Selecione a propriedade",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2626,6 +2626,7 @@
         "year": "Rok"
       },
       "cannotDeleteRequired": "Je vyžadované aspoň jedno zobrazenie tohto typu",
+      "clearFilters": "Clear filters",
       "copySuffix": "{name} (kópia)",
       "deleteView": "Vymazať pohľad",
       "exportCsv": "Exportovať CSV",
@@ -2650,6 +2651,8 @@
         "timeline": "Časová os"
       },
       "newView": "Nový {layout}",
+      "noFilterResults": "No items match these filters",
+      "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Uložiť ako šablónu…",
       "selectProperty": "Vybrať vlastnosť",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1107,14 +1107,28 @@
   "filters": {
     "contains": "obsahuje",
     "contains_all": "contains all of",
+    "dateAfter": "is after",
+    "dateBefore": "is before",
+    "dateOnOrAfter": "is on or after",
+    "dateOnOrBefore": "is on or before",
+    "ends_with": "ends with",
     "eq": "je",
     "gt": "is greater than",
     "gte": "is greater than or equal to",
     "in": "is any of",
     "is_empty": "je prázdne",
+    "is_not_empty": "is not empty",
     "lt": "is less than",
     "lte": "is less than or equal to",
-    "neq": "nie je"
+    "neq": "nie je",
+    "not_contains": "does not contain",
+    "numEq": "=",
+    "numGt": ">",
+    "numGte": "≥",
+    "numLt": "<",
+    "numLte": "≤",
+    "numNeq": "≠",
+    "starts_with": "starts with"
   },
   "folio": {
     "acceptChange": "Prijať zmenu",
@@ -2592,7 +2606,10 @@
     "unarchiveMatter": "Obnoviť",
     "uploadDocuments": "Nahrať dokumenty",
     "views": {
+      "addAdvancedFilter": "Add advanced filter",
       "addFields": "Pridať polia",
+      "advancedFilter": "Advanced",
+      "advancedFilterCount": "{count, plural, =0 {Any} one {# rule} other {# rules}}",
       "aiGenerated": "Vygenerované AI",
       "calendar": {
         "addDates": "+ Dátumy",
@@ -2618,6 +2635,7 @@
       "fields": "Polia:",
       "fieldsSelected": "{count, plural, one {# vybraný} few {# vybrané} other {# vybraných}}",
       "filter": "Filter",
+      "filterByPlaceholder": "Filter by…",
       "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Zoskupiť podľa:",
       "hideColumn": "Skryť stĺpec",
@@ -2632,6 +2650,7 @@
         "timeline": "Časová os"
       },
       "newView": "Nový {layout}",
+      "removeAdvancedFilter": "Remove advanced filter",
       "saveAsTemplate": "Uložiť ako šablónu…",
       "selectProperty": "Vybrať vlastnosť",
       "templates": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -650,6 +650,7 @@
     "actions": "Akcie",
     "add": "Pridať",
     "all": "Všetko",
+    "and": "And",
     "anonymizationLabels": {
       "address": "Adresa",
       "bankAccountNumber": "Číslo bankového účtu",
@@ -778,6 +779,7 @@
     "open": "Otvoriť",
     "openInNewTab": "Otvoriť na novej karte",
     "options": "Možnosti",
+    "or": "Or",
     "organization": "Organizácia",
     "organizationName": "Názov organizácie",
     "pin": "Pripnúť",
@@ -1104,8 +1106,14 @@
   },
   "filters": {
     "contains": "obsahuje",
+    "contains_all": "contains all of",
     "eq": "je",
+    "gt": "is greater than",
+    "gte": "is greater than or equal to",
+    "in": "is any of",
     "is_empty": "je prázdne",
+    "lt": "is less than",
+    "lte": "is less than or equal to",
     "neq": "nie je"
   },
   "folio": {
@@ -2437,6 +2445,7 @@
     },
     "possibleDuplicates": "Možné duplicity",
     "properties": {
+      "addCondition": "Add condition",
       "addInputProperty": "Pridajte aspoň jednu vstupnú vlastnosť pomocou \"@\"",
       "addOption": "Pridať možnosť",
       "addPromptForBetterResults": "Pridajte prompt pre lepšie výsledky",
@@ -2478,6 +2487,7 @@
       "editColumn": "Upraviť stĺpec",
       "editConditions": "Upraviť podmienky",
       "editConditionsDescription": "Nastavte podmienky, kedy sa má táto vlastnosť generovať.",
+      "editConditionsWhen": "Only run extraction when …",
       "enterAValue": "Zadajte hodnotu",
       "extractEntityType": "Extrahovať typ entity",
       "extractEntityTypeDescription": "Vytvorte tabuľkový stĺpec vypĺňaný AI.",
@@ -2502,6 +2512,7 @@
       "newColumn": "Nový stĺpec",
       "newColumnDescription": "Vyberte, ako sa má tento stĺpec tabuľky vypĺňať.",
       "newColumnName": "Názov stĺpca",
+      "noConditionFields": "No fields available to filter on.",
       "noFirstDocument": "Zatiaľ žiadne dokumenty pre náhľad.",
       "noPropertiesFound": "Neboli nájdené žiadne vlastnosti",
       "optionsHelp": "Zadaj hodnoty, z ktorých si AI môže vybrať.",
@@ -2524,6 +2535,7 @@
       "scopeMatterDescription": "Použiť všetky stĺpce súborov a spustiť celý spis.",
       "searchOrAddOptions": "Hľadať alebo pridať možnosti",
       "selectColor": "Vyberte farbu",
+      "selectField": "Select field",
       "selectOperator": "Vyberte operátor",
       "setPromptPlaceholder": "Nastavte prompt na extrakciu informácií",
       "singleSelect": "Jednoduchý výber",
@@ -2605,6 +2617,8 @@
       "exportXlsx": "Exportovať XLSX",
       "fields": "Polia:",
       "fieldsSelected": "{count, plural, one {# vybraný} few {# vybrané} other {# vybraných}}",
+      "filter": "Filter",
+      "filtersWithCount": "{count, plural, one {# filter} other {# filters}}",
       "groupBy": "Zoskupiť podľa:",
       "hideColumn": "Skryť stĺpec",
       "layouts": {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -15,7 +15,7 @@ import type { FileRouteTypes } from "@/routeTree.gen";
 
 export type {
   EntityKind,
-  ViewFilterCondition,
+  ConditionNode,
   AgendaItemKind,
   AgendaItemSource,
   ViewLayout,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -2,9 +2,9 @@ import type {
   BoundingBox,
   AgendaItemKind,
   AgendaItemSource,
+  ConditionNode,
   EntityKind,
   OptionColor,
-  PropertyCondition,
   ViewLayout,
   ViewLayoutType,
 } from "@stll/api/types";
@@ -58,7 +58,7 @@ export const isFileDisplayable = (file: {
 
 export type PropertyDependency = {
   dependsOnPropertyId: string;
-  condition: PropertyCondition | null;
+  condition: ConditionNode | null;
 };
 
 type ManualInputTool = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic.ts
@@ -1,0 +1,313 @@
+import type {
+  CompareOp,
+  ConditionNode,
+  GroupNode,
+  PredicateOp,
+  RefOperand,
+} from "@stll/conditions";
+
+import type { TranslationKey } from "@/i18n/types";
+
+/**
+ * Context-agnostic description of one operand the builder may filter
+ * on. `valueType` drives both the operator set (`operatorsFor`) and
+ * the value editor; `options` supplies the choices for any select-like
+ * value type.
+ */
+export type FieldValueType =
+  | "text"
+  | "single-select"
+  | "multi-select"
+  | "date"
+  | "int"
+  | "kind"
+  | "status"
+  | "priority";
+
+export type FieldOptionChoice = {
+  value: string;
+  label: string;
+  color?: string;
+};
+
+export type FieldOption = {
+  operand: RefOperand;
+  label: string;
+  valueType: FieldValueType;
+  options?: FieldOptionChoice[];
+};
+
+/**
+ * The surface operators the builder exposes. A subset maps to
+ * `compare` nodes (binary comparisons against a literal); the rest map
+ * to `predicate` nodes. `operatorKind` is the single place that
+ * decides which AST node each operator builds.
+ */
+export const CONDITION_OPERATORS = [
+  "eq",
+  "neq",
+  "contains",
+  "contains_all",
+  "in",
+  "gt",
+  "lt",
+  "gte",
+  "lte",
+  "is_empty",
+] as const;
+
+export type ConditionOperator = (typeof CONDITION_OPERATORS)[number];
+
+const CONDITION_OPERATOR_SET: ReadonlySet<string> = new Set(
+  CONDITION_OPERATORS,
+);
+
+export const isConditionOperator = (
+  value: string,
+): value is ConditionOperator => CONDITION_OPERATOR_SET.has(value);
+
+const COMPARE_OPERATORS = ["eq", "neq", "gt", "lt", "gte", "lte"] as const;
+
+type CompareOperator = (typeof COMPARE_OPERATORS)[number];
+
+const isCompareOperator = (op: ConditionOperator): op is CompareOperator =>
+  op === "eq" ||
+  op === "neq" ||
+  op === "gt" ||
+  op === "lt" ||
+  op === "gte" ||
+  op === "lte";
+
+export const OPERATOR_LABEL_KEYS = {
+  eq: "filters.eq",
+  neq: "filters.neq",
+  contains: "filters.contains",
+  contains_all: "filters.contains_all",
+  in: "filters.in",
+  gt: "filters.gt",
+  lt: "filters.lt",
+  gte: "filters.gte",
+  lte: "filters.lte",
+  is_empty: "filters.is_empty",
+} as const satisfies Record<ConditionOperator, TranslationKey>;
+
+/**
+ * Single source of truth mapping a field's value type to the operators
+ * the builder offers for it. Order here is the order rendered in the
+ * operator Select.
+ */
+const OPERATORS_BY_VALUE_TYPE = {
+  text: ["eq", "neq", "contains", "is_empty"],
+  "single-select": ["eq", "neq", "contains", "is_empty"],
+  status: ["eq", "neq", "contains", "is_empty"],
+  priority: ["eq", "neq", "contains", "is_empty"],
+  "multi-select": ["contains_all", "is_empty"],
+  int: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty"],
+  date: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty"],
+  kind: ["in"],
+} as const satisfies Record<FieldValueType, readonly ConditionOperator[]>;
+
+export const operatorsFor = (
+  valueType: FieldValueType,
+): readonly ConditionOperator[] => OPERATORS_BY_VALUE_TYPE[valueType];
+
+/** How a value type renders its value editor. */
+export type ValueEditorKind = "none" | "text" | "int" | "date" | "select";
+
+export const valueEditorFor = (
+  valueType: FieldValueType,
+  operator: ConditionOperator,
+): ValueEditorKind => {
+  if (operator === "is_empty") {
+    return "none";
+  }
+  if (
+    valueType === "single-select" ||
+    valueType === "multi-select" ||
+    valueType === "status" ||
+    valueType === "priority" ||
+    valueType === "kind"
+  ) {
+    return "select";
+  }
+  if (valueType === "int") {
+    return "int";
+  }
+  if (valueType === "date") {
+    return "date";
+  }
+  return "text";
+};
+
+/** Whether the value editor accepts multiple selections. */
+export const isMultiValue = (operator: ConditionOperator): boolean =>
+  operator === "contains_all" || operator === "in";
+
+// ── Leaf identity ─────────────────────────────────────────
+
+/** Compares two ref operands for the field-matching needed by the row. */
+export const operandsEqual = (a: RefOperand, b: RefOperand): boolean => {
+  if (a.type !== b.type) {
+    return false;
+  }
+  if (a.type === "property" && b.type === "property") {
+    return a.propertyId === b.propertyId;
+  }
+  if (a.type === "builtin" && b.type === "builtin") {
+    return a.field === b.field;
+  }
+  // `kind` and `path` carry no further identity for `path`, but two
+  // distinct path operands never coexist in a single builder context.
+  return true;
+};
+
+/** Reads the ref operand a leaf node filters on, or null for a group. */
+export const leafOperand = (node: ConditionNode): RefOperand | null => {
+  if (node.type === "compare" && node.left.type !== "literal") {
+    return node.left;
+  }
+  if (node.type === "predicate" && node.operand.type !== "literal") {
+    return node.operand;
+  }
+  return null;
+};
+
+/** Reads the surface operator a leaf node represents. */
+export const leafOperator = (node: ConditionNode): ConditionOperator | null => {
+  if (node.type === "compare") {
+    return compareToOperator(node.op);
+  }
+  if (node.type === "predicate") {
+    return predicateToOperator(node.op);
+  }
+  return null;
+};
+
+const compareToOperator = (op: CompareOp): ConditionOperator => op;
+
+const predicateToOperator = (op: PredicateOp): ConditionOperator | null => {
+  if (
+    op === "contains" ||
+    op === "contains_all" ||
+    op === "in" ||
+    op === "is_empty"
+  ) {
+    return op;
+  }
+  return null;
+};
+
+/** Reads a leaf's value as a string (scalar editors). */
+export const leafValueString = (node: ConditionNode): string => {
+  if (node.type === "compare" && node.right.type === "literal") {
+    const { value } = node.right;
+    if (Array.isArray(value)) {
+      return value.join(", ");
+    }
+    return String(value);
+  }
+  if (node.type === "predicate" && typeof node.value === "string") {
+    return node.value;
+  }
+  return "";
+};
+
+/** Reads a leaf's value as a string list (multi editors). */
+export const leafValueList = (node: ConditionNode): string[] => {
+  if (node.type === "predicate" && Array.isArray(node.value)) {
+    return node.value;
+  }
+  if (node.type === "predicate" && typeof node.value === "string") {
+    return node.value === "" ? [] : [node.value];
+  }
+  return [];
+};
+
+// ── Leaf construction ─────────────────────────────────────
+
+type BuildLeafArgs = {
+  operand: RefOperand;
+  operator: ConditionOperator;
+  value: string | string[];
+};
+
+/**
+ * Rebuilds a leaf node from its editor state. `compare` operators
+ * produce a literal right operand; predicate operators carry their
+ * payload (or none, for `is_empty`).
+ */
+export const buildLeaf = ({
+  operand,
+  operator,
+  value,
+}: BuildLeafArgs): ConditionNode => {
+  if (isCompareOperator(operator)) {
+    const scalar = Array.isArray(value) ? (value.at(0) ?? "") : value;
+    return {
+      type: "compare",
+      left: operand,
+      op: operator,
+      right: { type: "literal", value: scalar },
+    };
+  }
+  if (operator === "is_empty") {
+    return { type: "predicate", operand, op: "is_empty" };
+  }
+  if (operator === "contains") {
+    const scalar = Array.isArray(value) ? (value.at(0) ?? "") : value;
+    return { type: "predicate", operand, op: "contains", value: scalar };
+  }
+  // contains_all | in — list payloads
+  return { type: "predicate", operand, op: operator, value: toList(value) };
+};
+
+const toList = (value: string | string[]): string[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value === "" ? [] : [value];
+};
+
+/** A fresh leaf for a newly added row, with the field's first operator. */
+export const leafFromField = (field: FieldOption): ConditionNode => {
+  const operator = operatorsFor(field.valueType).at(0) ?? "eq";
+  const value = isMultiValue(operator) ? [] : "";
+  return buildLeaf({ operand: field.operand, operator, value });
+};
+
+// ── Group helpers ─────────────────────────────────────────
+
+/** Normalizes the controlled `value` prop into a concrete group root. */
+export const asGroup = (value: ConditionNode | null): GroupNode => {
+  if (value && value.type === "group") {
+    return value;
+  }
+  if (value) {
+    return { type: "group", combinator: "and", children: [value] };
+  }
+  return { type: "group", combinator: "and", children: [] };
+};
+
+export const replaceChild = (
+  group: GroupNode,
+  index: number,
+  child: ConditionNode,
+): GroupNode => ({
+  ...group,
+  children: group.children.map((existing, i) =>
+    i === index ? child : existing,
+  ),
+});
+
+export const removeChild = (group: GroupNode, index: number): GroupNode => ({
+  ...group,
+  children: group.children.filter((_, i) => i !== index),
+});
+
+export const appendChild = (
+  group: GroupNode,
+  child: ConditionNode,
+): GroupNode => ({
+  ...group,
+  children: [...group.children, child],
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic.ts
@@ -1,3 +1,4 @@
+import type { PropertyContentType } from "@stll/api/types";
 import type {
   CompareOp,
   ConditionNode,
@@ -34,6 +35,8 @@ export type FieldOption = {
   operand: RefOperand;
   label: string;
   valueType: FieldValueType;
+  /** Drives the property-type icon shown in chips and the picker. */
+  type: PropertyContentType;
   options?: FieldOptionChoice[];
 };
 
@@ -47,6 +50,9 @@ export const CONDITION_OPERATORS = [
   "eq",
   "neq",
   "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
   "contains_all",
   "in",
   "gt",
@@ -54,6 +60,7 @@ export const CONDITION_OPERATORS = [
   "gte",
   "lte",
   "is_empty",
+  "is_not_empty",
 ] as const;
 
 export type ConditionOperator = (typeof CONDITION_OPERATORS)[number];
@@ -78,10 +85,18 @@ const isCompareOperator = (op: ConditionOperator): op is CompareOperator =>
   op === "gte" ||
   op === "lte";
 
+/**
+ * Default operator labels. A few value types override individual
+ * operators with type-aware wording (e.g. `int` shows `=`/`≠`, `date`
+ * shows `Is after`/`Is before`); see `OPERATOR_LABEL_OVERRIDES`.
+ */
 export const OPERATOR_LABEL_KEYS = {
   eq: "filters.eq",
   neq: "filters.neq",
   contains: "filters.contains",
+  not_contains: "filters.not_contains",
+  starts_with: "filters.starts_with",
+  ends_with: "filters.ends_with",
   contains_all: "filters.contains_all",
   in: "filters.in",
   gt: "filters.gt",
@@ -89,21 +104,80 @@ export const OPERATOR_LABEL_KEYS = {
   gte: "filters.gte",
   lte: "filters.lte",
   is_empty: "filters.is_empty",
+  is_not_empty: "filters.is_not_empty",
 } as const satisfies Record<ConditionOperator, TranslationKey>;
+
+/**
+ * Per-value-type label overrides. Notion renders numeric and date
+ * comparisons differently from the generic "is greater than" wording:
+ * numbers use math symbols, dates use temporal phrasing.
+ */
+const INT_OPERATOR_LABEL_KEYS = {
+  eq: "filters.numEq",
+  neq: "filters.numNeq",
+  gt: "filters.numGt",
+  lt: "filters.numLt",
+  gte: "filters.numGte",
+  lte: "filters.numLte",
+} as const satisfies Partial<Record<ConditionOperator, TranslationKey>>;
+
+const DATE_OPERATOR_LABEL_KEYS = {
+  gt: "filters.dateAfter",
+  lt: "filters.dateBefore",
+  gte: "filters.dateOnOrAfter",
+  lte: "filters.dateOnOrBefore",
+} as const satisfies Partial<Record<ConditionOperator, TranslationKey>>;
+
+/**
+ * The exact label keys an operator may resolve to, derived from the maps
+ * above — not the full `TranslationKey` nor every `filters.*` key (some of
+ * which carry ICU params), so `t()` accepts a single argument.
+ */
+type OperatorLabelKey =
+  | (typeof OPERATOR_LABEL_KEYS)[keyof typeof OPERATOR_LABEL_KEYS]
+  | (typeof INT_OPERATOR_LABEL_KEYS)[keyof typeof INT_OPERATOR_LABEL_KEYS]
+  | (typeof DATE_OPERATOR_LABEL_KEYS)[keyof typeof DATE_OPERATOR_LABEL_KEYS];
+
+const labelFrom = (
+  overrides: Partial<Record<ConditionOperator, OperatorLabelKey>>,
+  operator: ConditionOperator,
+): OperatorLabelKey => overrides[operator] ?? OPERATOR_LABEL_KEYS[operator];
+
+export const operatorLabelKey = (
+  valueType: FieldValueType,
+  operator: ConditionOperator,
+): OperatorLabelKey => {
+  if (valueType === "int") {
+    return labelFrom(INT_OPERATOR_LABEL_KEYS, operator);
+  }
+  if (valueType === "date") {
+    return labelFrom(DATE_OPERATOR_LABEL_KEYS, operator);
+  }
+  return OPERATOR_LABEL_KEYS[operator];
+};
 
 /**
  * Single source of truth mapping a field's value type to the operators
  * the builder offers for it. Order here is the order rendered in the
- * operator Select.
+ * operator Select, and the first entry is the field's default operator.
  */
 const OPERATORS_BY_VALUE_TYPE = {
-  text: ["eq", "neq", "contains", "is_empty"],
-  "single-select": ["eq", "neq", "contains", "is_empty"],
-  status: ["eq", "neq", "contains", "is_empty"],
-  priority: ["eq", "neq", "contains", "is_empty"],
-  "multi-select": ["contains_all", "is_empty"],
-  int: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty"],
-  date: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty"],
+  text: [
+    "eq",
+    "neq",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+  ],
+  "single-select": ["eq", "neq", "in", "is_empty", "is_not_empty"],
+  status: ["eq", "neq", "in", "is_empty", "is_not_empty"],
+  priority: ["eq", "neq", "in", "is_empty", "is_not_empty"],
+  "multi-select": ["contains", "not_contains", "is_empty", "is_not_empty"],
+  int: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty", "is_not_empty"],
+  date: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty", "is_not_empty"],
   kind: ["in"],
 } as const satisfies Record<FieldValueType, readonly ConditionOperator[]>;
 
@@ -118,7 +192,7 @@ export const valueEditorFor = (
   valueType: FieldValueType,
   operator: ConditionOperator,
 ): ValueEditorKind => {
-  if (operator === "is_empty") {
+  if (operator === "is_empty" || operator === "is_not_empty") {
     return "none";
   }
   if (
@@ -188,9 +262,13 @@ const compareToOperator = (op: CompareOp): ConditionOperator => op;
 const predicateToOperator = (op: PredicateOp): ConditionOperator | null => {
   if (
     op === "contains" ||
+    op === "not_contains" ||
+    op === "starts_with" ||
+    op === "ends_with" ||
     op === "contains_all" ||
     op === "in" ||
-    op === "is_empty"
+    op === "is_empty" ||
+    op === "is_not_empty"
   ) {
     return op;
   }
@@ -250,12 +328,17 @@ export const buildLeaf = ({
       right: { type: "literal", value: scalar },
     };
   }
-  if (operator === "is_empty") {
-    return { type: "predicate", operand, op: "is_empty" };
+  if (operator === "is_empty" || operator === "is_not_empty") {
+    return { type: "predicate", operand, op: operator };
   }
-  if (operator === "contains") {
+  if (
+    operator === "contains" ||
+    operator === "not_contains" ||
+    operator === "starts_with" ||
+    operator === "ends_with"
+  ) {
     const scalar = Array.isArray(value) ? (value.at(0) ?? "") : value;
-    return { type: "predicate", operand, op: "contains", value: scalar };
+    return { type: "predicate", operand, op: operator, value: scalar };
   }
   // contains_all | in — list payloads
   return { type: "predicate", operand, op: operator, value: toList(value) };
@@ -273,6 +356,18 @@ export const leafFromField = (field: FieldOption): ConditionNode => {
   const operator = operatorsFor(field.valueType).at(0) ?? "eq";
   const value = isMultiValue(operator) ? [] : "";
   return buildLeaf({ operand: field.operand, operator, value });
+};
+
+/** Finds the field a leaf node targets, or null when none matches. */
+export const fieldForNode = (
+  node: ConditionNode,
+  fields: FieldOption[],
+): FieldOption | null => {
+  const operand = leafOperand(node);
+  if (!operand) {
+    return null;
+  }
+  return fields.find((field) => operandsEqual(field.operand, operand)) ?? null;
 };
 
 // ── Group helpers ─────────────────────────────────────────

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
@@ -29,8 +29,8 @@ import {
   leafOperator,
   leafValueList,
   leafValueString,
-  OPERATOR_LABEL_KEYS,
   operandsEqual,
+  operatorLabelKey,
   operatorsFor,
   removeChild,
   replaceChild,
@@ -291,12 +291,14 @@ const LeafRow = ({ node, fields, onChange, onRemove }: LeafRowProps) => {
           className="h-7 min-h-0 w-auto min-w-24 text-xs"
           size="sm"
         >
-          <SelectValue>{() => t(OPERATOR_LABEL_KEYS[operator])}</SelectValue>
+          <SelectValue>
+            {() => t(operatorLabelKey(field.valueType, operator))}
+          </SelectValue>
         </SelectTrigger>
         <SelectPopup alignItemWithTrigger={false}>
           {operators.map((op) => (
             <SelectItem key={op} value={op}>
-              {t(OPERATOR_LABEL_KEYS[op])}
+              {t(operatorLabelKey(field.valueType, op))}
             </SelectItem>
           ))}
         </SelectPopup>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
@@ -1,0 +1,493 @@
+import { PlusIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import type { Combinator, ConditionNode, GroupNode } from "@stll/conditions";
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { cn } from "@stll/ui/lib/utils";
+
+import { DatePickerPopover } from "@/components/date-picker-popover";
+import type {
+  ConditionOperator,
+  FieldOption,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import {
+  appendChild,
+  asGroup,
+  buildLeaf,
+  isConditionOperator,
+  isMultiValue,
+  leafFromField,
+  leafOperand,
+  leafOperator,
+  leafValueList,
+  leafValueString,
+  OPERATOR_LABEL_KEYS,
+  operandsEqual,
+  operatorsFor,
+  removeChild,
+  replaceChild,
+  valueEditorFor,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";
+
+type ConditionBuilderProps = {
+  value: ConditionNode | null;
+  onChange: (next: GroupNode) => void;
+  fields: FieldOption[];
+  allowGroups?: boolean;
+};
+
+export const ConditionBuilder = ({
+  value,
+  onChange,
+  fields,
+  allowGroups = false,
+}: ConditionBuilderProps) => {
+  const t = useTranslations();
+  const group = asGroup(value);
+
+  if (fields.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        {t("workspaces.properties.noConditionFields")}
+      </p>
+    );
+  }
+
+  const firstField = fields.at(0);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {allowGroups && group.children.length > 1 && (
+        <CombinatorControl
+          combinator={group.combinator}
+          onChange={(combinator) => onChange({ ...group, combinator })}
+        />
+      )}
+
+      <div className="flex flex-col gap-2">
+        {group.children.map((child, index) => {
+          if (child.type === "group" && allowGroups) {
+            return (
+              <NestedGroupRow
+                fields={fields}
+                key={index}
+                onChange={(next) => onChange(replaceChild(group, index, next))}
+                onRemove={() => onChange(removeChild(group, index))}
+                value={child}
+              />
+            );
+          }
+          return (
+            <LeafRow
+              fields={fields}
+              key={index}
+              node={child}
+              onChange={(next) => onChange(replaceChild(group, index, next))}
+              onRemove={() => onChange(removeChild(group, index))}
+            />
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          className="justify-start"
+          disabled={!firstField}
+          onClick={() => {
+            if (firstField) {
+              onChange(appendChild(group, leafFromField(firstField)));
+            }
+          }}
+          size="xs"
+          type="button"
+          variant="ghost"
+        >
+          <PlusIcon />
+          {t("workspaces.properties.addCondition")}
+        </Button>
+        {allowGroups && (
+          <Button
+            className="justify-start"
+            onClick={() =>
+              onChange(
+                appendChild(group, {
+                  type: "group",
+                  combinator: "and",
+                  children: firstField ? [leafFromField(firstField)] : [],
+                }),
+              )
+            }
+            size="xs"
+            type="button"
+            variant="ghost"
+          >
+            <PlusIcon />
+            {t("common.add")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+type CombinatorControlProps = {
+  combinator: Combinator;
+  onChange: (combinator: Combinator) => void;
+};
+
+const COMBINATORS = ["and", "or"] as const;
+
+const COMBINATOR_LABEL_KEYS = {
+  and: "common.and",
+  or: "common.or",
+} as const;
+
+const CombinatorControl = ({
+  combinator,
+  onChange,
+}: CombinatorControlProps) => {
+  const t = useTranslations();
+
+  return (
+    <div className="border-border/70 bg-muted/30 inline-flex w-fit items-center gap-0.5 rounded-md border p-0.5">
+      {COMBINATORS.map((option) => {
+        const isActive = option === combinator;
+        return (
+          <Button
+            aria-pressed={isActive}
+            className={cn(
+              "text-muted-foreground h-6 min-h-0 rounded-[4px]",
+              isActive &&
+                "bg-muted text-foreground ring-border/80 shadow-xs ring-1",
+            )}
+            key={option}
+            onClick={() => onChange(option)}
+            size="xs"
+            type="button"
+            variant="ghost"
+          >
+            {t(COMBINATOR_LABEL_KEYS[option])}
+          </Button>
+        );
+      })}
+    </div>
+  );
+};
+
+type NestedGroupRowProps = {
+  value: GroupNode;
+  fields: FieldOption[];
+  onChange: (next: GroupNode) => void;
+  onRemove: () => void;
+};
+
+const NestedGroupRow = ({
+  value,
+  fields,
+  onChange,
+  onRemove,
+}: NestedGroupRowProps) => (
+  <div className="border-border/70 bg-muted/20 flex items-start gap-2 rounded-md border p-2">
+    <div className="flex-1">
+      <ConditionBuilder
+        allowGroups
+        fields={fields}
+        onChange={onChange}
+        value={value}
+      />
+    </div>
+    <Button onClick={onRemove} size="icon-xs" type="button" variant="ghost">
+      <XIcon />
+    </Button>
+  </div>
+);
+
+type LeafRowProps = {
+  node: ConditionNode;
+  fields: FieldOption[];
+  onChange: (next: ConditionNode) => void;
+  onRemove: () => void;
+};
+
+const LeafRow = ({ node, fields, onChange, onRemove }: LeafRowProps) => {
+  const t = useTranslations();
+  const operand = leafOperand(node);
+  const fieldIndex = operand
+    ? fields.findIndex((f) => operandsEqual(f.operand, operand))
+    : -1;
+  const field = fields[fieldIndex];
+
+  if (!field) {
+    return null;
+  }
+
+  const operator = leafOperator(node) ?? operatorsFor(field.valueType).at(0);
+
+  if (!operator) {
+    return null;
+  }
+
+  const operators = operatorsFor(field.valueType);
+  const editorKind = valueEditorFor(field.valueType, operator);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Select
+        onValueChange={(next) => {
+          if (next === null) {
+            return;
+          }
+          const nextField = fields[Number(next)];
+          if (nextField) {
+            onChange(leafFromField(nextField));
+          }
+        }}
+        value={String(fieldIndex)}
+      >
+        <SelectTrigger
+          className="h-7 min-h-0 w-auto min-w-32 text-xs"
+          size="sm"
+        >
+          <SelectValue placeholder={t("workspaces.properties.selectField")}>
+            {field.label}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectPopup alignItemWithTrigger={false}>
+          {fields.map((option, index) => (
+            <SelectItem key={index} value={String(index)}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+
+      <Select
+        onValueChange={(next) => {
+          if (next === null || !isConditionOperator(next)) {
+            return;
+          }
+          onChange(
+            buildLeaf({
+              operand: field.operand,
+              operator: next,
+              value: isMultiValue(next)
+                ? leafValueList(node)
+                : leafValueString(node),
+            }),
+          );
+        }}
+        value={operator}
+      >
+        <SelectTrigger
+          className="h-7 min-h-0 w-auto min-w-24 text-xs"
+          size="sm"
+        >
+          <SelectValue>{() => t(OPERATOR_LABEL_KEYS[operator])}</SelectValue>
+        </SelectTrigger>
+        <SelectPopup alignItemWithTrigger={false}>
+          {operators.map((op) => (
+            <SelectItem key={op} value={op}>
+              {t(OPERATOR_LABEL_KEYS[op])}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+
+      <LeafValueEditor
+        editorKind={editorKind}
+        field={field}
+        node={node}
+        onChange={onChange}
+        operator={operator}
+      />
+
+      <Button onClick={onRemove} size="icon-xs" type="button" variant="ghost">
+        <XIcon />
+      </Button>
+    </div>
+  );
+};
+
+type LeafValueEditorProps = {
+  editorKind: ReturnType<typeof valueEditorFor>;
+  field: FieldOption;
+  node: ConditionNode;
+  operator: ConditionOperator;
+  onChange: (next: ConditionNode) => void;
+};
+
+const LeafValueEditor = ({
+  editorKind,
+  field,
+  node,
+  operator,
+  onChange,
+}: LeafValueEditorProps) => {
+  const t = useTranslations();
+
+  if (editorKind === "none") {
+    return null;
+  }
+
+  const emit = (value: string | string[]) => {
+    onChange(buildLeaf({ operand: field.operand, operator, value }));
+  };
+
+  if (editorKind === "select") {
+    if (isMultiValue(operator)) {
+      return (
+        <MultiSelectValue
+          field={field}
+          onChange={emit}
+          value={leafValueList(node)}
+        />
+      );
+    }
+    return (
+      <SingleSelectValue
+        field={field}
+        onChange={emit}
+        value={leafValueString(node)}
+      />
+    );
+  }
+
+  if (editorKind === "int") {
+    return (
+      <Input
+        className="h-7! w-24 text-xs"
+        onChange={(e) => emit(e.currentTarget.value)}
+        size="sm"
+        type="number"
+        value={leafValueString(node)}
+      />
+    );
+  }
+
+  if (editorKind === "date") {
+    return (
+      <div className="border-input bg-background min-w-28 rounded-md border px-1">
+        <DatePickerPopover
+          onChange={(next) => emit(next ?? "")}
+          value={leafValueString(node) || null}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      className="h-7! w-32 text-xs"
+      onChange={(e) => emit(e.currentTarget.value)}
+      placeholder={t("workspaces.properties.enterAValue")}
+      size="sm"
+      value={leafValueString(node)}
+    />
+  );
+};
+
+type SelectValueEditorProps = {
+  field: FieldOption;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+const SingleSelectValue = ({
+  field,
+  value,
+  onChange,
+}: SelectValueEditorProps) => {
+  const t = useTranslations();
+  const options = field.options ?? [];
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <Select
+      onValueChange={(next) => {
+        if (next !== null) {
+          onChange(next);
+        }
+      }}
+      value={value}
+    >
+      <SelectTrigger className="h-7 min-h-0 w-auto min-w-28 text-xs" size="sm">
+        <SelectValue placeholder={t("workspaces.fields.selectAValue")}>
+          {() =>
+            selected ? (
+              <span className="flex items-center gap-1.5">
+                {selected.color !== undefined && (
+                  <SelectColorIcon color={selected.color} />
+                )}
+                {selected.label}
+              </span>
+            ) : (
+              t("workspaces.fields.selectAValue")
+            )
+          }
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup alignItemWithTrigger={false}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            <span className="flex items-center gap-1.5">
+              {option.color !== undefined && (
+                <SelectColorIcon color={option.color} />
+              )}
+              {option.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+};
+
+type MultiSelectValueProps = {
+  field: FieldOption;
+  value: string[];
+  onChange: (value: string[]) => void;
+};
+
+const MultiSelectValue = ({
+  field,
+  value,
+  onChange,
+}: MultiSelectValueProps) => {
+  const t = useTranslations();
+  const options = field.options ?? [];
+  const label =
+    value.length === 0
+      ? t("workspaces.fields.selectValues")
+      : value
+          .map((v) => options.find((option) => option.value === v)?.label ?? v)
+          .join(", ");
+
+  return (
+    <Select multiple onValueChange={(next) => onChange(next)} value={value}>
+      <SelectTrigger className="h-7 min-h-0 w-auto min-w-28 text-xs" size="sm">
+        <SelectValue>{() => label}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup alignItemWithTrigger={false}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            <span className="flex items-center gap-1.5">
+              {option.color !== undefined && (
+                <SelectColorIcon color={option.color} />
+              )}
+              {option.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
@@ -98,43 +98,21 @@ export const ConditionBuilder = ({
         })}
       </div>
 
-      <div className="flex items-center gap-2">
-        <Button
-          className="justify-start"
-          disabled={!firstField}
-          onClick={() => {
-            if (firstField) {
-              onChange(appendChild(group, leafFromField(firstField)));
-            }
-          }}
-          size="xs"
-          type="button"
-          variant="ghost"
-        >
-          <PlusIcon />
-          {t("workspaces.properties.addCondition")}
-        </Button>
-        {allowGroups && (
-          <Button
-            className="justify-start"
-            onClick={() =>
-              onChange(
-                appendChild(group, {
-                  type: "group",
-                  combinator: "and",
-                  children: firstField ? [leafFromField(firstField)] : [],
-                }),
-              )
-            }
-            size="xs"
-            type="button"
-            variant="ghost"
-          >
-            <PlusIcon />
-            {t("common.add")}
-          </Button>
-        )}
-      </div>
+      <Button
+        className="w-fit justify-start"
+        disabled={!firstField}
+        onClick={() => {
+          if (firstField) {
+            onChange(appendChild(group, leafFromField(firstField)));
+          }
+        }}
+        size="xs"
+        type="button"
+        variant="ghost"
+      >
+        <PlusIcon />
+        {t("workspaces.properties.addCondition")}
+      </Button>
     </div>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/empty-state.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/empty-state.tsx
@@ -1,8 +1,10 @@
 import { useRef } from "react";
 
-import { UploadIcon } from "lucide-react";
+import { FilterXIcon, UploadIcon } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import {
   EMPTY_SCREEN_MATTERS_VIDEO,
@@ -50,6 +52,35 @@ export const EmptyState = ({
             <p className="text-foreground-strong-muted mt-1 text-xs">{hint}</p>
           )}
         </div>
+      </div>
+    </div>
+  );
+};
+
+type FilteredEmptyStateProps = {
+  onClearFilters: () => void;
+};
+
+export const FilteredEmptyState = ({
+  onClearFilters,
+}: FilteredEmptyStateProps) => {
+  const t = useTranslations();
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        <FilterXIcon className="text-muted-foreground size-8" />
+        <div>
+          <p className="text-muted-foreground text-sm">
+            {t("workspaces.views.noFilterResults")}
+          </p>
+          <p className="text-foreground-strong-muted mt-1 text-xs">
+            {t("workspaces.views.noFilterResultsHint")}
+          </p>
+        </div>
+        <Button onClick={onClearFilters} size="sm" variant="secondary">
+          {t("workspaces.views.clearFilters")}
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
@@ -1,10 +1,11 @@
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { RouteIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import type { ConditionNode, GroupNode } from "@stll/conditions";
+import type { ConditionNode } from "@stll/conditions";
+import { pruneIncomplete } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -95,27 +96,13 @@ export const PropertyConditions = ({
                     </span>
                     <Separator />
                   </div>
-                  <div className="flex flex-col gap-3 rounded-md border p-3">
-                    <div className="flex items-center gap-x-1.5">
-                      <PropertyIcon type={property.content.type} />
-                      <span className="text-sm font-medium">
-                        {property.name}
-                      </span>
-                    </div>
-                    <p className="text-muted-foreground text-xs">
-                      {t("workspaces.properties.editConditionsWhen")}
-                    </p>
-                    <ConditionBuilder
-                      fields={[field]}
-                      onChange={(next) => {
-                        replaceValue(index, {
-                          dependsOnPropertyId: property.id,
-                          condition: collapseGroup(next),
-                        });
-                      }}
-                      value={dependency.condition}
-                    />
-                  </div>
+                  <DependencyConditionEditor
+                    dependency={dependency}
+                    field={field}
+                    index={index}
+                    onPersist={replaceValue}
+                    property={property}
+                  />
                 </Fragment>
               ),
             )}
@@ -126,16 +113,56 @@ export const PropertyConditions = ({
   );
 };
 
+type DependencyConditionEditorProps = {
+  dependency: PropertyDependency;
+  field: FieldOption;
+  index: number;
+  property: WorkspaceProperty;
+  onPersist: (index: number, value: PropertyDependency) => void;
+};
+
 /**
- * An empty group means "no gate"; the handler stores `null` for that.
- * Otherwise the group node is stored verbatim and the gating evaluator
- * walks it directly.
+ * Edits one dependency's gate. The builder is controlled and the parent
+ * persists on every change, so we hold the in-progress group locally
+ * (incomplete leaves and all) and persist only the pruned condition. A
+ * half-entered leaf would otherwise be saved as a live gate and then vanish
+ * from the editor on the next render. An all-incomplete group prunes to
+ * `null` ("no gate"), matching the gating evaluator and the SQL compiler.
  */
-const collapseGroup = (group: GroupNode): ConditionNode | null => {
-  if (group.children.length === 0) {
-    return null;
-  }
-  return group;
+const DependencyConditionEditor = ({
+  dependency,
+  field,
+  index,
+  property,
+  onPersist,
+}: DependencyConditionEditorProps) => {
+  const t = useTranslations();
+  const [draft, setDraft] = useState<ConditionNode | null>(
+    dependency.condition,
+  );
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border p-3">
+      <div className="flex items-center gap-x-1.5">
+        <PropertyIcon type={property.content.type} />
+        <span className="text-sm font-medium">{property.name}</span>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {t("workspaces.properties.editConditionsWhen")}
+      </p>
+      <ConditionBuilder
+        fields={[field]}
+        onChange={(next) => {
+          setDraft(next);
+          onPersist(index, {
+            dependsOnPropertyId: property.id,
+            condition: pruneIncomplete(next),
+          });
+        }}
+        value={draft}
+      />
+    </div>
+  );
 };
 
 /** Maps a gateable dependency property to a builder field, or null. */

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { RouteIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import type { PropertyCondition } from "@stll/api/types";
+import type { ConditionNode } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -35,26 +35,57 @@ import { FieldValueSelect } from "@/routes/_protected.workspaces/$workspaceId/-c
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
 
-type StringOperators = Extract<
-  PropertyCondition,
-  { type: "string" }
->["operator"];
-
-type StringArrayOperators = Extract<
-  PropertyCondition,
-  { type: "string-array" }
->["operator"];
+// Surface operators map onto canonical AST shapes:
+//  - "equals" (text/single-select) → compare/eq against a literal
+//  - "contains-every" (multi-select) → predicate/contains_all with a list
+const CONDITION_OPERATORS = ["equals", "contains-every"] as const;
+type ConditionOperator = (typeof CONDITION_OPERATORS)[number];
 
 type ConditionData = {
-  version: 1;
   operator: ConditionOperator;
   value: string | string[];
   options: WorkspacePropertyOption[] | undefined;
 };
 
-type ConditionOperator = PropertyCondition["operator"];
-
 type Condition = PropertyDependency["condition"];
+
+/**
+ * Reads a stored AST node back into the editor's flat
+ * `{ operator, value }` shape for the two surface operators this
+ * builder produces. Any other node shape (or null) yields the
+ * content-type default, so an unrecognized condition simply resets.
+ */
+const readCondition = (
+  condition: Condition,
+  propertyId: string,
+): { operator: ConditionOperator; value: string | string[] } | null => {
+  if (!condition) {
+    return null;
+  }
+
+  if (
+    condition.type === "compare" &&
+    condition.op === "eq" &&
+    condition.left.type === "property" &&
+    condition.left.propertyId === propertyId &&
+    condition.right.type === "literal" &&
+    typeof condition.right.value === "string"
+  ) {
+    return { operator: "equals", value: condition.right.value };
+  }
+
+  if (
+    condition.type === "predicate" &&
+    condition.op === "contains_all" &&
+    condition.operand.type === "property" &&
+    condition.operand.propertyId === propertyId &&
+    Array.isArray(condition.value)
+  ) {
+    return { operator: "contains-every", value: condition.value };
+  }
+
+  return null;
+};
 
 const getConditionData = (
   property: WorkspaceProperty | undefined,
@@ -64,14 +95,14 @@ const getConditionData = (
     return null;
   }
 
-  let defaultOperator: NonNullable<Condition>["operator"] | undefined;
-  let defaultValue: NonNullable<Condition>["value"] | undefined;
+  let defaultOperator: ConditionOperator | undefined;
+  let defaultValue: string | string[] | undefined;
 
   switch (property.content.type) {
     case "text":
     case "single-select":
       defaultValue = "";
-      defaultOperator = "eq";
+      defaultOperator = "equals";
       break;
     case "multi-select":
       defaultValue = [];
@@ -87,10 +118,11 @@ const getConditionData = (
     return null;
   }
 
+  const parsed = readCondition(condition, property.id);
+
   return {
-    version: 1,
-    operator: condition?.operator ?? defaultOperator,
-    value: condition?.value ?? defaultValue,
+    operator: parsed?.operator ?? defaultOperator,
+    value: parsed?.value ?? defaultValue,
     options:
       "options" in property.content ? property.content.options : undefined,
   };
@@ -199,13 +231,13 @@ export const PropertyConditions = ({
 const getOperatorLabels = (): Record<ConditionOperator, string> => {
   const t = getTranslator();
   return {
-    eq: t("workspaces.operators.equals"),
+    equals: t("workspaces.operators.equals"),
     "contains-every": t("workspaces.operators.containsEvery"),
   };
 };
 
-const STRING_OPERATORS: StringOperators[] = ["eq"];
-const STRING_ARRAY_OPERATORS: StringArrayOperators[] = ["contains-every"];
+const STRING_OPERATORS: ConditionOperator[] = ["equals"];
+const STRING_ARRAY_OPERATORS: ConditionOperator[] = ["contains-every"];
 
 const getOperatorOptions = (
   value: string | string[],
@@ -225,32 +257,35 @@ const getOperatorOptions = (
 };
 
 type BuildConditionArgs = {
+  propertyId: string;
   operator: ConditionOperator;
   value: string | string[] | null;
 };
 
 const buildCondition = ({
+  propertyId,
   operator,
   value,
-}: BuildConditionArgs): PropertyCondition | null => {
+}: BuildConditionArgs): ConditionNode | null => {
   if (Array.isArray(value) && operator === "contains-every") {
     return value.length > 0
       ? {
-          version: 1,
-          type: "string-array",
-          operator,
+          type: "predicate",
+          operand: { type: "property", propertyId },
+          op: "contains_all",
           value,
         }
       : null;
   }
 
-  if (typeof value === "string" && operator === "eq") {
-    return value.trim().length > 0
+  if (typeof value === "string" && operator === "equals") {
+    const trimmed = value.trim();
+    return trimmed.length > 0
       ? {
-          version: 1,
-          type: "string",
-          operator,
-          value: value.trim(),
+          type: "compare",
+          left: { type: "property", propertyId },
+          op: "eq",
+          right: { type: "literal", value: trimmed },
         }
       : null;
   }
@@ -260,8 +295,8 @@ const buildCondition = ({
 
 type ConditionRowProps = {
   property: WorkspaceProperty;
-  data: NonNullable<ReturnType<typeof getConditionData>>;
-  onConditionChange: (condition: PropertyCondition | null) => void;
+  data: ConditionData;
+  onConditionChange: (condition: ConditionNode | null) => void;
 };
 
 const ConditionRow = ({
@@ -285,7 +320,11 @@ const ConditionRow = ({
           onValueChange={(newValue) => {
             if (newValue) {
               onConditionChange(
-                buildCondition({ operator: newValue, value: data.value }),
+                buildCondition({
+                  propertyId: property.id,
+                  operator: newValue,
+                  value: data.value,
+                }),
               );
             }
           }}
@@ -312,6 +351,7 @@ const ConditionRow = ({
             onChange={(e) =>
               onConditionChange(
                 buildCondition({
+                  propertyId: property.id,
                   operator: data.operator,
                   value: e.target.value,
                 }),
@@ -325,7 +365,11 @@ const ConditionRow = ({
           <FieldValueSelect
             onChange={(value) => {
               onConditionChange(
-                buildCondition({ operator: data.operator, value }),
+                buildCondition({
+                  propertyId: property.id,
+                  operator: data.operator,
+                  value,
+                }),
               );
             }}
             options={data.options}
@@ -337,7 +381,11 @@ const ConditionRow = ({
           <FieldValueSelect
             onChange={(value) => {
               onConditionChange(
-                buildCondition({ operator: data.operator, value }),
+                buildCondition({
+                  propertyId: property.id,
+                  operator: data.operator,
+                  value,
+                }),
               );
             }}
             options={data.options}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
@@ -151,6 +151,7 @@ const fieldOptionFor = (property: WorkspaceProperty): FieldOption | null => {
       operand: { type: "property", propertyId: property.id },
       label: property.name,
       valueType: content.type,
+      type: content.type,
       options: content.options.map((option) => ({
         value: option.value,
         label: option.value,
@@ -163,5 +164,6 @@ const fieldOptionFor = (property: WorkspaceProperty): FieldOption | null => {
     operand: { type: "property", propertyId: property.id },
     label: property.name,
     valueType: content.type,
+    type: content.type,
   };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { RouteIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import type { ConditionNode } from "@stll/conditions";
+import type { ConditionNode, GroupNode } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -14,119 +14,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@stll/ui/components/dialog";
-import { Input } from "@stll/ui/components/input";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
 import { Separator } from "@stll/ui/components/separator";
 
-import { getTranslator } from "@/i18n/i18n-store";
-import type {
-  PropertyDependency,
-  WorkspaceProperty,
-  WorkspacePropertyOption,
-} from "@/lib/types";
-import { FieldValueSelect } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value-select";
+import type { PropertyDependency, WorkspaceProperty } from "@/lib/types";
+import { ConditionBuilder } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder";
+import type { FieldOption } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
-
-// Surface operators map onto canonical AST shapes:
-//  - "equals" (text/single-select) → compare/eq against a literal
-//  - "contains-every" (multi-select) → predicate/contains_all with a list
-const CONDITION_OPERATORS = ["equals", "contains-every"] as const;
-type ConditionOperator = (typeof CONDITION_OPERATORS)[number];
-
-type ConditionData = {
-  operator: ConditionOperator;
-  value: string | string[];
-  options: WorkspacePropertyOption[] | undefined;
-};
-
-type Condition = PropertyDependency["condition"];
-
-/**
- * Reads a stored AST node back into the editor's flat
- * `{ operator, value }` shape for the two surface operators this
- * builder produces. Any other node shape (or null) yields the
- * content-type default, so an unrecognized condition simply resets.
- */
-const readCondition = (
-  condition: Condition,
-  propertyId: string,
-): { operator: ConditionOperator; value: string | string[] } | null => {
-  if (!condition) {
-    return null;
-  }
-
-  if (
-    condition.type === "compare" &&
-    condition.op === "eq" &&
-    condition.left.type === "property" &&
-    condition.left.propertyId === propertyId &&
-    condition.right.type === "literal" &&
-    typeof condition.right.value === "string"
-  ) {
-    return { operator: "equals", value: condition.right.value };
-  }
-
-  if (
-    condition.type === "predicate" &&
-    condition.op === "contains_all" &&
-    condition.operand.type === "property" &&
-    condition.operand.propertyId === propertyId &&
-    Array.isArray(condition.value)
-  ) {
-    return { operator: "contains-every", value: condition.value };
-  }
-
-  return null;
-};
-
-const getConditionData = (
-  property: WorkspaceProperty | undefined,
-  condition: Condition,
-): ConditionData | null => {
-  if (!property) {
-    return null;
-  }
-
-  let defaultOperator: ConditionOperator | undefined;
-  let defaultValue: string | string[] | undefined;
-
-  switch (property.content.type) {
-    case "text":
-    case "single-select":
-      defaultValue = "";
-      defaultOperator = "equals";
-      break;
-    case "multi-select":
-      defaultValue = [];
-      defaultOperator = "contains-every";
-      break;
-    default:
-      defaultValue = undefined;
-      defaultOperator = undefined;
-      break;
-  }
-
-  if (defaultValue === undefined || defaultOperator === undefined) {
-    return null;
-  }
-
-  const parsed = readCondition(condition, property.id);
-
-  return {
-    operator: parsed?.operator ?? defaultOperator,
-    value: parsed?.value ?? defaultValue,
-    options:
-      "options" in property.content ? property.content.options : undefined,
-  };
-};
 
 type PropertyConditionsProps = {
   workspaceId: string;
@@ -142,29 +37,26 @@ export const PropertyConditions = ({
   const t = useTranslations();
   const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
 
-  const data = dependencies
-    .map((dependency) => {
+  const editableDependencies = dependencies
+    .map((dependency, index) => {
       const property = properties.find(
         (p) => p.id === dependency.dependsOnPropertyId,
       );
-      const conditionData = getConditionData(property, dependency.condition);
+      const field = property ? fieldOptionFor(property) : null;
 
-      if (!property || !conditionData) {
+      if (!property || !field) {
         return null;
       }
 
-      return { property, conditionData };
+      return { dependency, field, index, property };
     })
-    .filter(
-      (condition): condition is NonNullable<typeof condition> =>
-        condition !== null,
-    );
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 
   const conditionCount = dependencies.filter(
     (dependency) => dependency.condition !== null,
   ).length;
 
-  if (data.length === 0) {
+  if (editableDependencies.length === 0) {
     return null;
   }
 
@@ -193,34 +85,40 @@ export const PropertyConditions = ({
         </DialogHeader>
         <ScrollArea className="h-96">
           <DialogPanel>
-            {data.map(({ property, conditionData }) => (
-              <Fragment key={property.id}>
-                <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 py-2 first:hidden">
-                  <Separator />
-                  <span className="text-muted-foreground text-xs font-medium">
-                    {t("workspaces.properties.conditionSeparator")}
-                  </span>
-                  <Separator />
-                </div>
-                <ConditionRow
-                  data={conditionData}
-                  onConditionChange={(condition) => {
-                    const index = dependencies.findIndex(
-                      (d) => d.dependsOnPropertyId === property.id,
-                    );
-
-                    if (index === -1) {
-                      return;
-                    }
-                    replaceValue(index, {
-                      dependsOnPropertyId: property.id,
-                      condition,
-                    });
-                  }}
-                  property={property}
-                />
-              </Fragment>
-            ))}
+            {editableDependencies.map(
+              ({ dependency, field, index, property }) => (
+                <Fragment key={property.id}>
+                  <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 py-2 first:hidden">
+                    <Separator />
+                    <span className="text-muted-foreground text-xs font-medium">
+                      {t("workspaces.properties.conditionSeparator")}
+                    </span>
+                    <Separator />
+                  </div>
+                  <div className="flex flex-col gap-3 rounded-md border p-3">
+                    <div className="flex items-center gap-x-1.5">
+                      <PropertyIcon type={property.content.type} />
+                      <span className="text-sm font-medium">
+                        {property.name}
+                      </span>
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      {t("workspaces.properties.editConditionsWhen")}
+                    </p>
+                    <ConditionBuilder
+                      fields={[field]}
+                      onChange={(next) => {
+                        replaceValue(index, {
+                          dependsOnPropertyId: property.id,
+                          condition: collapseGroup(next),
+                        });
+                      }}
+                      value={dependency.condition}
+                    />
+                  </div>
+                </Fragment>
+              ),
+            )}
           </DialogPanel>
         </ScrollArea>
       </DialogPopup>
@@ -228,172 +126,42 @@ export const PropertyConditions = ({
   );
 };
 
-const getOperatorLabels = (): Record<ConditionOperator, string> => {
-  const t = getTranslator();
+/**
+ * An empty group means "no gate"; the handler stores `null` for that.
+ * Otherwise the group node is stored verbatim and the gating evaluator
+ * walks it directly.
+ */
+const collapseGroup = (group: GroupNode): ConditionNode | null => {
+  if (group.children.length === 0) {
+    return null;
+  }
+  return group;
+};
+
+/** Maps a gateable dependency property to a builder field, or null. */
+const fieldOptionFor = (property: WorkspaceProperty): FieldOption | null => {
+  const { content } = property;
+
+  if (content.type === "file") {
+    return null;
+  }
+
+  if (content.type === "single-select" || content.type === "multi-select") {
+    return {
+      operand: { type: "property", propertyId: property.id },
+      label: property.name,
+      valueType: content.type,
+      options: content.options.map((option) => ({
+        value: option.value,
+        label: option.value,
+        color: option.color,
+      })),
+    };
+  }
+
   return {
-    equals: t("workspaces.operators.equals"),
-    "contains-every": t("workspaces.operators.containsEvery"),
+    operand: { type: "property", propertyId: property.id },
+    label: property.name,
+    valueType: content.type,
   };
-};
-
-const STRING_OPERATORS: ConditionOperator[] = ["equals"];
-const STRING_ARRAY_OPERATORS: ConditionOperator[] = ["contains-every"];
-
-const getOperatorOptions = (
-  value: string | string[],
-  operatorLabels: Record<ConditionOperator, string>,
-) => {
-  let operatorKeys: ConditionOperator[] = [];
-  if (typeof value === "string") {
-    operatorKeys = STRING_OPERATORS;
-  } else if (Array.isArray(value)) {
-    operatorKeys = STRING_ARRAY_OPERATORS;
-  }
-
-  return operatorKeys.map((operator) => ({
-    value: operator,
-    label: operatorLabels[operator],
-  }));
-};
-
-type BuildConditionArgs = {
-  propertyId: string;
-  operator: ConditionOperator;
-  value: string | string[] | null;
-};
-
-const buildCondition = ({
-  propertyId,
-  operator,
-  value,
-}: BuildConditionArgs): ConditionNode | null => {
-  if (Array.isArray(value) && operator === "contains-every") {
-    return value.length > 0
-      ? {
-          type: "predicate",
-          operand: { type: "property", propertyId },
-          op: "contains_all",
-          value,
-        }
-      : null;
-  }
-
-  if (typeof value === "string" && operator === "equals") {
-    const trimmed = value.trim();
-    return trimmed.length > 0
-      ? {
-          type: "compare",
-          left: { type: "property", propertyId },
-          op: "eq",
-          right: { type: "literal", value: trimmed },
-        }
-      : null;
-  }
-
-  return null;
-};
-
-type ConditionRowProps = {
-  property: WorkspaceProperty;
-  data: ConditionData;
-  onConditionChange: (condition: ConditionNode | null) => void;
-};
-
-const ConditionRow = ({
-  property,
-  data,
-  onConditionChange,
-}: ConditionRowProps) => {
-  const t = useTranslations();
-  const operatorLabels = getOperatorLabels();
-  const operatorOptions = getOperatorOptions(data.value, operatorLabels);
-
-  return (
-    <div className="flex flex-col gap-3 rounded-md border p-3">
-      <div className="flex items-center gap-x-1.5">
-        <PropertyIcon type={property.content.type} />{" "}
-        <span className="text-sm font-medium">{property.name}</span>
-      </div>
-      <div className="grid grid-cols-2 gap-2">
-        <Select
-          items={operatorOptions}
-          onValueChange={(newValue) => {
-            if (newValue) {
-              onConditionChange(
-                buildCondition({
-                  propertyId: property.id,
-                  operator: newValue,
-                  value: data.value,
-                }),
-              );
-            }
-          }}
-          value={data.operator}
-        >
-          <SelectTrigger>
-            <SelectValue className="truncate">
-              {(selected) =>
-                operatorOptions.find((o) => o.value === selected)?.label ??
-                t("workspaces.properties.selectOperator")
-              }
-            </SelectValue>
-          </SelectTrigger>
-          <SelectPopup alignItemWithTrigger={false}>
-            {operatorOptions.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectPopup>
-        </Select>
-        {typeof data.value === "string" && !data.options && (
-          <Input
-            onChange={(e) =>
-              onConditionChange(
-                buildCondition({
-                  propertyId: property.id,
-                  operator: data.operator,
-                  value: e.target.value,
-                }),
-              )
-            }
-            placeholder={t("workspaces.properties.enterAValue")}
-            value={data.value}
-          />
-        )}
-        {data.options && typeof data.value === "string" && (
-          <FieldValueSelect
-            onChange={(value) => {
-              onConditionChange(
-                buildCondition({
-                  propertyId: property.id,
-                  operator: data.operator,
-                  value,
-                }),
-              );
-            }}
-            options={data.options}
-            type="single-select"
-            value={data.value}
-          />
-        )}
-        {data.options && Array.isArray(data.value) && (
-          <FieldValueSelect
-            onChange={(value) => {
-              onConditionChange(
-                buildCondition({
-                  propertyId: property.id,
-                  operator: data.operator,
-                  value,
-                }),
-              );
-            }}
-            options={data.options}
-            type="multi-select"
-            value={data.value}
-          />
-        )}
-      </div>
-    </div>
-  );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -24,8 +24,8 @@ import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 import type {
+  ConditionNode,
   PropertyDependency,
-  ViewFilterCondition,
   WorkspaceProperty,
 } from "@/lib/types";
 import { CreateProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/create-property";
@@ -45,7 +45,7 @@ import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queri
 type PropertyPopoverProps = {
   property: WorkspaceProperty;
   header: TableHeader;
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
 };
 
 type ReplaceAction = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 
 import type {
-  ViewFilterCondition,
+  ConditionNode,
   WorkspaceEntity,
   WorkspaceProperty,
 } from "@/lib/types";
@@ -26,7 +26,7 @@ import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-
 import { getFirstFile } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 type PropertyColumnOptions = {
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
 };
 
 export const getPropertyColumn = ({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -12,7 +12,10 @@ import { useTranslations } from "use-intl";
 
 import { useAIKeyGate } from "@/components/require-ai-key";
 import type { WorkspaceView } from "@/lib/types";
-import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
+import {
+  EmptyState,
+  FilteredEmptyState,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
 import {
   AuthorCell,
   LastUpdatedCell,
@@ -32,6 +35,7 @@ import { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-com
 import { useTableStore } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 import { useSyncJustificationChunks } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
 import { useTableState } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state";
+import { useUpdateView } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
 import {
   DEFAULT_ENTITY_WINDOW_SIZE,
   useEntitiesWindowOptions,
@@ -97,6 +101,7 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   const t = useTranslations();
   const { openIfAIUnavailable } = useAIKeyGate();
   const tableState = useTableState({ workspaceId, view });
+  const updateView = useUpdateView(workspaceId);
 
   const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
   const fieldIds = useMemo(
@@ -263,6 +268,18 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   });
 
   if (table.getRowModel().rows.length === 0) {
+    if (view.layout.filters.length > 0) {
+      return (
+        <FilteredEmptyState
+          onClearFilters={() =>
+            updateView.mutate({
+              viewId: view.id,
+              layout: { ...view.layout, filters: [] },
+            })
+          }
+        />
+      );
+    }
     return (
       <EmptyState
         icon={TableIcon}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -87,6 +87,15 @@ export const FilterChips = ({
     onUpdate([...filters, node]);
   };
 
+  // The backend rejects a second top-level kind filter, so drop "Kind" from
+  // the add picker once one already exists.
+  const hasKindFilter = filters.some(
+    (node) => node.type === "predicate" && node.operand.type === "kind",
+  );
+  const pickerFields = hasKindFilter
+    ? fields.filter((field) => field.operand.type !== "kind")
+    : fields;
+
   if (filters.length === 0) {
     return (
       <AddFilterPicker
@@ -128,7 +137,7 @@ export const FilterChips = ({
         );
       })}
       <AddFilterPicker
-        fields={fields}
+        fields={pickerFields}
         onAddAdvanced={() => append(emptyAdvancedGroup())}
         onAddField={(field) => append(leafFromField(field))}
         trigger={

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -1,43 +1,18 @@
-import type { PropsWithChildren, ReactNode } from "react";
-
-import type { LucideIcon } from "lucide-react";
-import {
-  CircleDotIcon,
-  FileTextIcon,
-  FilterIcon,
-  FolderIcon,
-  SignalIcon,
-  SquareCheckIcon,
-  XIcon,
-} from "lucide-react";
+import { FilterIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import type { BuiltinField, ConditionNode } from "@stll/conditions";
+import type { ConditionNode, GroupNode } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
-import { Input } from "@stll/ui/components/input";
 import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
+  Popover,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
 
 import type { TranslationKey } from "@/i18n/types";
 import type { WorkspaceProperty } from "@/lib/types";
-import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
-
-const KIND_ICONS: Record<string, LucideIcon> = {
-  document: FileTextIcon,
-  folder: FolderIcon,
-  task: SquareCheckIcon,
-};
+import { ConditionBuilder } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder";
+import type { FieldOption } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
 
 type FilterChipsProps = {
   filters: ConditionNode[];
@@ -50,315 +25,52 @@ export const FilterChips = ({
   properties,
   onUpdate,
 }: FilterChipsProps) => {
-  const handleChange = (index: number, updated: ConditionNode) => {
-    onUpdate(filters.map((node, i) => (i === index ? updated : node)));
-  };
-
-  const handleRemove = (index: number) => {
-    onUpdate(filters.filter((_, i) => i !== index));
-  };
-
-  const renderChip = (filter: ConditionNode, index: number) => {
-    const shared = {
-      onChange: (updated: ConditionNode) => handleChange(index, updated),
-      onRemove: () => handleRemove(index),
-    };
-
-    const kind = kindOf(filter);
-    switch (kind) {
-      case "kind":
-        return <KindFilterChip filter={filter} key={index} {...shared} />;
-      case "builtin":
-        return <BuiltinFilterChip filter={filter} key={index} {...shared} />;
-      case "property":
-        return (
-          <PropertyFilterChip
-            filter={filter}
-            key={index}
-            properties={properties}
-            {...shared}
-          />
-        );
-      default:
-        return null;
-    }
-  };
-
-  return (
-    <>
-      {filters.map(renderChip)}
-      <AddFilterButton
-        filters={filters}
-        onAdd={(filter) => onUpdate([...filters, filter])}
-        properties={properties}
-      />
-    </>
-  );
-};
-
-// -- Node shape helpers --
-
-type FilterKind = "kind" | "builtin" | "property" | null;
-
-/** Classifies a node by the operand its leaf references. */
-const kindOf = (node: ConditionNode): FilterKind => {
-  if (node.type === "predicate") {
-    return operandKind(node.operand.type);
-  }
-  if (node.type === "compare") {
-    return operandKind(node.left.type);
-  }
-  return null;
-};
-
-const operandKind = (type: string): FilterKind => {
-  if (type === "kind" || type === "builtin" || type === "property") {
-    return type;
-  }
-  return null;
-};
-
-const kindNode = (values: string[]): ConditionNode => ({
-  type: "predicate",
-  operand: { type: "kind" },
-  op: "in",
-  value: values,
-});
-
-const kindValues = (node: ConditionNode): string[] => {
-  if (node.type === "predicate" && Array.isArray(node.value)) {
-    return node.value;
-  }
-  return [];
-};
-
-type LeafOp = "eq" | "neq" | "contains" | "is_empty";
-
-/** The user-visible operator for a builtin/property leaf node. */
-const leafOp = (node: ConditionNode): LeafOp => {
-  if (node.type === "compare") {
-    return node.op === "neq" ? "neq" : "eq";
-  }
-  if (node.type === "predicate" && node.op === "contains") {
-    return "contains";
-  }
-  return "is_empty";
-};
-
-const leafValue = (node: ConditionNode): string => {
-  if (node.type === "compare" && node.right.type === "literal") {
-    return String(node.right.value);
-  }
-  if (node.type === "predicate" && typeof node.value === "string") {
-    return node.value;
-  }
-  return "";
-};
-
-type BuiltinOp = "eq" | "neq" | "is_empty";
-
-const builtinNode = (
-  field: BuiltinField,
-  op: BuiltinOp,
-  value: string,
-): ConditionNode => {
-  if (op === "is_empty") {
-    return { type: "predicate", operand: { type: "builtin", field }, op };
-  }
-  return {
-    type: "compare",
-    left: { type: "builtin", field },
-    op,
-    right: { type: "literal", value },
-  };
-};
-
-const builtinField = (node: ConditionNode): BuiltinField => {
-  if (node.type === "compare" && node.left.type === "builtin") {
-    return node.left.field;
-  }
-  if (node.type === "predicate" && node.operand.type === "builtin") {
-    return node.operand.field;
-  }
-  return "status";
-};
-
-const propertyNode = (
-  propertyId: string,
-  op: LeafOp,
-  value: string,
-): ConditionNode => {
-  if (op === "contains") {
-    return {
-      type: "predicate",
-      operand: { type: "property", propertyId },
-      op: "contains",
-      value,
-    };
-  }
-  if (op === "is_empty") {
-    return {
-      type: "predicate",
-      operand: { type: "property", propertyId },
-      op: "is_empty",
-    };
-  }
-  return {
-    type: "compare",
-    left: { type: "property", propertyId },
-    op,
-    right: { type: "literal", value },
-  };
-};
-
-const propertyId = (node: ConditionNode): string => {
-  if (node.type === "compare" && node.left.type === "property") {
-    return node.left.propertyId;
-  }
-  if (node.type === "predicate" && node.operand.type === "property") {
-    return node.operand.propertyId;
-  }
-  return "";
-};
-
-// -- Add filter --
-
-type AddFilterButtonProps = {
-  properties: WorkspaceProperty[];
-  filters: ConditionNode[];
-  onAdd: (filter: ConditionNode) => void;
-};
-
-const hasKindFilter = (filters: ConditionNode[]) =>
-  filters.some((node) => kindOf(node) === "kind");
-
-const hasBuiltinFilter = (filters: ConditionNode[], field: BuiltinField) =>
-  filters.some(
-    (node) => kindOf(node) === "builtin" && builtinField(node) === field,
-  );
-
-const AddFilterButton = ({
-  properties,
-  filters,
-  onAdd,
-}: AddFilterButtonProps) => {
   const t = useTranslations();
+  const fields = useFilterFields(properties);
+
+  // View filters persist as a flat `ConditionNode[]` evaluated with
+  // implicit AND, so the builder runs as a flat AND group and we write
+  // its children straight back to that array.
+  const group: GroupNode = {
+    type: "group",
+    combinator: "and",
+    children: filters,
+  };
+  const count = filters.length;
 
   return (
-    <Menu>
-      <MenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
-        <FilterIcon />
-      </MenuTrigger>
-      <MenuPopup>
-        <MenuItem
-          disabled={hasKindFilter(filters)}
-          onClick={() => onAdd(kindNode([]))}
-        >
-          <FilterIcon className="size-3.5" />
-          {t("common.kind")}
-        </MenuItem>
-        <MenuItem
-          disabled={hasBuiltinFilter(filters, "status")}
-          onClick={() => onAdd(builtinNode("status", "eq", ""))}
-        >
-          <CircleDotIcon className="size-3.5" />
-          {t("common.status")}
-        </MenuItem>
-        <MenuItem
-          disabled={hasBuiltinFilter(filters, "priority")}
-          onClick={() => onAdd(builtinNode("priority", "eq", ""))}
-        >
-          <SignalIcon className="size-3.5" />
-          {t("tasks.priority")}
-        </MenuItem>
-        {properties
-          .filter((p) => p.content.type !== "file")
-          .map((prop) => (
-            <MenuItem
-              key={prop.id}
-              onClick={() => onAdd(propertyNode(prop.id, "eq", ""))}
-            >
-              <PropertyIcon type={prop.content.type} />
-              {prop.name}
-            </MenuItem>
-          ))}
-      </MenuPopup>
-    </Menu>
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            className="gap-1.5"
+            size="xs"
+            variant={count > 0 ? "secondary" : "ghost"}
+          />
+        }
+      >
+        <FilterIcon className="size-3.5" />
+        {count > 0
+          ? t("workspaces.views.filtersWithCount", { count })
+          : t("workspaces.views.filter")}
+      </PopoverTrigger>
+      <PopoverPopup className="w-auto max-w-[min(36rem,90vw)] p-3">
+        <ConditionBuilder
+          fields={fields}
+          onChange={(next) => onUpdate(next.children)}
+          value={group}
+        />
+      </PopoverPopup>
+    </Popover>
   );
 };
 
 const ENTITY_KINDS = ["document", "task"] as const;
 
-type FilterChipWrapperProps = {
-  label: string;
-  onRemove: () => void;
-  children: ReactNode;
-};
-
-const FilterChipWrapper = ({
-  label,
-  onRemove,
-  children,
-}: FilterChipWrapperProps) => (
-  <div className="bg-muted/50 flex items-center gap-1 rounded-md border">
-    <span className="ps-2 text-xs font-medium">{label}</span>
-    {children}
-    <Button onClick={onRemove} size="icon-xs" variant="ghost">
-      <XIcon />
-    </Button>
-  </div>
-);
-
-type FilterChipProps = {
-  filter: ConditionNode;
-  onChange: (filter: ConditionNode) => void;
-  onRemove: () => void;
-};
-
-const useKindLabels = (): Record<string, string> => {
-  const t = useTranslations();
-  return {
-    document: t("search.kinds.document"),
-    folder: t("search.kinds.folder"),
-    task: t("search.kinds.task"),
-    message: t("search.kinds.message"),
-  };
-};
-
-const KindFilterChip = ({ filter, onChange, onRemove }: FilterChipProps) => {
-  const t = useTranslations();
-  const kindLabels = useKindLabels();
-  const values = kindValues(filter);
-  const label =
-    values.length === 0
-      ? t("common.all")
-      : values.map((k) => kindLabels[k] ?? k).join(", ");
-
-  return (
-    <FilterChipWrapper label={t("common.kind")} onRemove={onRemove}>
-      <Select
-        multiple
-        onValueChange={(kinds) => onChange(kindNode(kinds))}
-        value={values}
-      >
-        <FilterSelectTrigger>{label}</FilterSelectTrigger>
-        <SelectPopup alignItemWithTrigger={false}>
-          {ENTITY_KINDS.map((kind) => {
-            const Icon = KIND_ICONS[kind];
-            return (
-              <SelectItem key={kind} value={kind}>
-                {Icon && <Icon className="size-3.5" />}
-                {kindLabels[kind] ?? kind}
-              </SelectItem>
-            );
-          })}
-        </SelectPopup>
-      </Select>
-    </FilterChipWrapper>
-  );
-};
-
-// -- Builtin field filter (status, priority) --
+const KIND_LABEL_KEYS = {
+  document: "search.kinds.document",
+  task: "search.kinds.task",
+} as const satisfies Record<(typeof ENTITY_KINDS)[number], TranslationKey>;
 
 const STATUS_VALUES = [
   "open",
@@ -370,16 +82,13 @@ const STATUS_VALUES = [
 
 const PRIORITY_VALUES = ["none", "urgent", "high", "medium", "low"] as const;
 
-type StatusValue = (typeof STATUS_VALUES)[number];
-type PriorityValue = (typeof PRIORITY_VALUES)[number];
-
 const STATUS_VALUE_LABEL_KEYS = {
   open: "tasks.statusValues.open",
   in_progress: "tasks.statusValues.in_progress",
   in_review: "tasks.statusValues.in_review",
   done: "tasks.statusValues.done",
   cancelled: "tasks.statusValues.cancelled",
-} satisfies Record<StatusValue, TranslationKey>;
+} as const satisfies Record<(typeof STATUS_VALUES)[number], TranslationKey>;
 
 const PRIORITY_VALUE_LABEL_KEYS = {
   none: "tasks.priorityValues.none",
@@ -387,200 +96,68 @@ const PRIORITY_VALUE_LABEL_KEYS = {
   high: "tasks.priorityValues.high",
   medium: "tasks.priorityValues.medium",
   low: "tasks.priorityValues.low",
-} satisfies Record<PriorityValue, TranslationKey>;
+} as const satisfies Record<(typeof PRIORITY_VALUES)[number], TranslationKey>;
 
-const STATUS_VALUE_SET: ReadonlySet<string> = new Set(STATUS_VALUES);
-const PRIORITY_VALUE_SET: ReadonlySet<string> = new Set(PRIORITY_VALUES);
-
-const isStatusValue = (value: string): value is StatusValue =>
-  STATUS_VALUE_SET.has(value);
-
-const isPriorityValue = (value: string): value is PriorityValue =>
-  PRIORITY_VALUE_SET.has(value);
-
-const isLeafOp = (value: string): value is LeafOp =>
-  value === "eq" ||
-  value === "neq" ||
-  value === "contains" ||
-  value === "is_empty";
-
-const isBuiltinOp = (value: string): value is BuiltinOp =>
-  value === "eq" || value === "neq" || value === "is_empty";
-
-const BuiltinFilterChip = ({ filter, onChange, onRemove }: FilterChipProps) => {
+/** Builds the operands a view filter may target: kind, builtins, properties. */
+const useFilterFields = (properties: WorkspaceProperty[]): FieldOption[] => {
   const t = useTranslations();
-  const field = builtinField(filter);
-  const rawOp = leafOp(filter);
-  const op: BuiltinOp = isBuiltinOp(rawOp) ? rawOp : "eq";
-  const value = leafValue(filter);
-  const isStatus = field === "status";
-  const label = isStatus ? t("common.status") : t("tasks.priority");
-  const values = isStatus ? STATUS_VALUES : PRIORITY_VALUES;
 
-  const resolveLabel = (raw: string) => {
-    if (isStatus) {
-      return isStatusValue(raw) ? t(STATUS_VALUE_LABEL_KEYS[raw]) : raw;
+  const fields: FieldOption[] = [
+    {
+      operand: { type: "kind" },
+      label: t("common.kind"),
+      valueType: "kind",
+      options: ENTITY_KINDS.map((kind) => ({
+        value: kind,
+        label: t(KIND_LABEL_KEYS[kind]),
+      })),
+    },
+    {
+      operand: { type: "builtin", field: "status" },
+      label: t("common.status"),
+      valueType: "status",
+      options: STATUS_VALUES.map((value) => ({
+        value,
+        label: t(STATUS_VALUE_LABEL_KEYS[value]),
+      })),
+    },
+    {
+      operand: { type: "builtin", field: "priority" },
+      label: t("tasks.priority"),
+      valueType: "priority",
+      options: PRIORITY_VALUES.map((value) => ({
+        value,
+        label: t(PRIORITY_VALUE_LABEL_KEYS[value]),
+      })),
+    },
+  ];
+
+  for (const property of properties) {
+    if (property.content.type === "file") {
+      continue;
     }
-    return isPriorityValue(raw) ? t(PRIORITY_VALUE_LABEL_KEYS[raw]) : raw;
-  };
-
-  const opOptions = [
-    { value: "eq", label: t("filters.eq") },
-    { value: "neq", label: t("filters.neq") },
-    { value: "is_empty", label: t("filters.is_empty") },
-  ] as const;
-
-  return (
-    <FilterChipWrapper label={label} onRemove={onRemove}>
-      <Select
-        onValueChange={(nextOp) => {
-          if (nextOp && isBuiltinOp(nextOp)) {
-            onChange(builtinNode(field, nextOp, value));
-          }
-        }}
-        value={op}
-      >
-        <FilterSelectTrigger>
-          {opOptions.find((o) => o.value === op)?.label}
-        </FilterSelectTrigger>
-        <SelectPopup alignItemWithTrigger={false}>
-          {opOptions.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectPopup>
-      </Select>
-      {op !== "is_empty" && (
-        <Select
-          onValueChange={(val) => {
-            if (val !== null) {
-              onChange(builtinNode(field, op, val));
-            }
-          }}
-          value={value}
-        >
-          <FilterSelectTrigger>
-            {value !== "" ? resolveLabel(value) : "…"}
-          </FilterSelectTrigger>
-          <SelectPopup alignItemWithTrigger={false}>
-            {values.map((val) => (
-              <SelectItem key={val} value={val}>
-                {resolveLabel(val)}
-              </SelectItem>
-            ))}
-          </SelectPopup>
-        </Select>
-      )}
-    </FilterChipWrapper>
-  );
-};
-
-type PropertyFilterChipProps = FilterChipProps & {
-  properties: WorkspaceProperty[];
-};
-
-const PropertyFilterChip = ({
-  filter,
-  properties,
-  onChange,
-  onRemove,
-}: PropertyFilterChipProps) => {
-  const t = useTranslations();
-  const id = propertyId(filter);
-  const property = properties.find((p) => p.id === id);
-
-  if (!property) {
-    return null;
+    if (
+      property.content.type === "single-select" ||
+      property.content.type === "multi-select"
+    ) {
+      fields.push({
+        operand: { type: "property", propertyId: property.id },
+        label: property.name,
+        valueType: property.content.type,
+        options: property.content.options.map((option) => ({
+          value: option.value,
+          label: option.value,
+          color: option.color,
+        })),
+      });
+      continue;
+    }
+    fields.push({
+      operand: { type: "property", propertyId: property.id },
+      label: property.name,
+      valueType: property.content.type,
+    });
   }
 
-  const op = leafOp(filter);
-  const value = leafValue(filter);
-  const isSingleSelect =
-    property.content.type === "single-select" ||
-    property.content.type === "multi-select";
-
-  const selectOptions =
-    property.content.type === "single-select" ||
-    property.content.type === "multi-select"
-      ? property.content.options
-      : [];
-
-  // For single-select: simpler ops (is / is not / is empty)
-  const opOptions = isSingleSelect
-    ? ([
-        { value: "eq", label: t("filters.eq") },
-        { value: "neq", label: t("filters.neq") },
-        { value: "is_empty", label: t("filters.is_empty") },
-      ] as const)
-    : ([
-        { value: "eq", label: t("filters.eq") },
-        { value: "neq", label: t("filters.neq") },
-        { value: "contains", label: t("filters.contains") },
-        { value: "is_empty", label: t("filters.is_empty") },
-      ] as const);
-
-  return (
-    <FilterChipWrapper label={property.name} onRemove={onRemove}>
-      <Select
-        onValueChange={(nextOp) => {
-          if (nextOp && isLeafOp(nextOp)) {
-            onChange(propertyNode(id, nextOp, value));
-          }
-        }}
-        value={op}
-      >
-        <FilterSelectTrigger>
-          {opOptions.find((o) => o.value === op)?.label}
-        </FilterSelectTrigger>
-        <SelectPopup alignItemWithTrigger={false}>
-          {opOptions.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectPopup>
-      </Select>
-      {op !== "is_empty" &&
-        (isSingleSelect ? (
-          <Select
-            onValueChange={(val) => {
-              if (val !== null) {
-                onChange(propertyNode(id, op, val));
-              }
-            }}
-            value={value}
-          >
-            <FilterSelectTrigger>
-              {value !== "" ? value : "…"}
-            </FilterSelectTrigger>
-            <SelectPopup alignItemWithTrigger={false}>
-              {selectOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.value}
-                </SelectItem>
-              ))}
-            </SelectPopup>
-          </Select>
-        ) : (
-          <Input
-            className="h-6! w-24 border-0 bg-transparent px-1 text-xs shadow-none"
-            onChange={(e) =>
-              onChange(propertyNode(id, op, e.currentTarget.value))
-            }
-            size="sm"
-            value={value}
-          />
-        ))}
-    </FilterChipWrapper>
-  );
+  return fields;
 };
-
-const FilterSelectTrigger = ({ children }: PropsWithChildren) => (
-  <SelectTrigger
-    className="w-auto! min-w-min! gap-0.5 border-0 bg-transparent px-1 text-xs! shadow-none [&_svg]:size-3"
-    size="sm"
-  >
-    <SelectValue>{(): ReactNode => children}</SelectValue>
-  </SelectTrigger>
-);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -6,7 +6,6 @@ import {
   FlagIcon,
   LayersIcon,
   MoreHorizontalIcon,
-  PlusIcon,
   SlidersHorizontalIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -133,8 +132,9 @@ export const FilterChips = ({
         onAddAdvanced={() => append(emptyAdvancedGroup())}
         onAddField={(field) => append(leafFromField(field))}
         trigger={
-          <Button size="icon-xs" variant="ghost">
-            <PlusIcon />
+          <Button className="gap-1.5" size="xs" variant="ghost">
+            <FilterIcon className="size-3.5" />
+            {t("workspaces.views.filter")}
           </Button>
         }
       />
@@ -500,10 +500,7 @@ const AdvancedFilterChip = ({
           })}
         </span>
       </PopoverTrigger>
-      <PopoverPopup
-        align="start"
-        className="w-auto max-w-[min(36rem,90vw)] p-3"
-      >
+      <PopoverPopup align="start" className="w-[34rem] max-w-[90vw] p-3">
         <ConditionBuilder
           allowGroups
           fields={fields}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import type { BuiltinField, ConditionNode } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import {
@@ -29,7 +30,7 @@ import {
 } from "@stll/ui/components/select";
 
 import type { TranslationKey } from "@/i18n/types";
-import type { ViewFilterCondition, WorkspaceProperty } from "@/lib/types";
+import type { WorkspaceProperty } from "@/lib/types";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 
 const KIND_ICONS: Record<string, LucideIcon> = {
@@ -39,9 +40,9 @@ const KIND_ICONS: Record<string, LucideIcon> = {
 };
 
 type FilterChipsProps = {
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
   properties: WorkspaceProperty[];
-  onUpdate: (filters: ViewFilterCondition[]) => void;
+  onUpdate: (filters: ConditionNode[]) => void;
 };
 
 export const FilterChips = ({
@@ -49,33 +50,31 @@ export const FilterChips = ({
   properties,
   onUpdate,
 }: FilterChipsProps) => {
-  const handleChange = (id: string, updated: ViewFilterCondition) => {
-    onUpdate(filters.map((f) => (f.id === id ? updated : f)));
+  const handleChange = (index: number, updated: ConditionNode) => {
+    onUpdate(filters.map((node, i) => (i === index ? updated : node)));
   };
 
-  const handleRemove = (id: string) => {
-    onUpdate(filters.filter((f) => f.id !== id));
+  const handleRemove = (index: number) => {
+    onUpdate(filters.filter((_, i) => i !== index));
   };
 
-  const renderChip = (filter: ViewFilterCondition) => {
+  const renderChip = (filter: ConditionNode, index: number) => {
     const shared = {
-      onChange: (updated: ViewFilterCondition) =>
-        handleChange(filter.id, updated),
-      onRemove: () => handleRemove(filter.id),
+      onChange: (updated: ConditionNode) => handleChange(index, updated),
+      onRemove: () => handleRemove(index),
     };
 
-    switch (filter.field) {
+    const kind = kindOf(filter);
+    switch (kind) {
       case "kind":
-        return <KindFilterChip filter={filter} key={filter.id} {...shared} />;
+        return <KindFilterChip filter={filter} key={index} {...shared} />;
       case "builtin":
-        return (
-          <BuiltinFilterChip filter={filter} key={filter.id} {...shared} />
-        );
+        return <BuiltinFilterChip filter={filter} key={index} {...shared} />;
       case "property":
         return (
           <PropertyFilterChip
             filter={filter}
-            key={filter.id}
+            key={index}
             properties={properties}
             {...shared}
           />
@@ -97,22 +96,145 @@ export const FilterChips = ({
   );
 };
 
-type AddFilterButtonProps = {
-  properties: WorkspaceProperty[];
-  filters: ViewFilterCondition[];
-  onAdd: (filter: ViewFilterCondition) => void;
+// -- Node shape helpers --
+
+type FilterKind = "kind" | "builtin" | "property" | null;
+
+/** Classifies a node by the operand its leaf references. */
+const kindOf = (node: ConditionNode): FilterKind => {
+  if (node.type === "predicate") {
+    return operandKind(node.operand.type);
+  }
+  if (node.type === "compare") {
+    return operandKind(node.left.type);
+  }
+  return null;
 };
 
-const hasFilter = (
-  filters: ViewFilterCondition[],
-  field: string,
-  builtinField?: string,
-) =>
+const operandKind = (type: string): FilterKind => {
+  if (type === "kind" || type === "builtin" || type === "property") {
+    return type;
+  }
+  return null;
+};
+
+const kindNode = (values: string[]): ConditionNode => ({
+  type: "predicate",
+  operand: { type: "kind" },
+  op: "in",
+  value: values,
+});
+
+const kindValues = (node: ConditionNode): string[] => {
+  if (node.type === "predicate" && Array.isArray(node.value)) {
+    return node.value;
+  }
+  return [];
+};
+
+type LeafOp = "eq" | "neq" | "contains" | "is_empty";
+
+/** The user-visible operator for a builtin/property leaf node. */
+const leafOp = (node: ConditionNode): LeafOp => {
+  if (node.type === "compare") {
+    return node.op === "neq" ? "neq" : "eq";
+  }
+  if (node.type === "predicate" && node.op === "contains") {
+    return "contains";
+  }
+  return "is_empty";
+};
+
+const leafValue = (node: ConditionNode): string => {
+  if (node.type === "compare" && node.right.type === "literal") {
+    return String(node.right.value ?? "");
+  }
+  if (node.type === "predicate" && typeof node.value === "string") {
+    return node.value;
+  }
+  return "";
+};
+
+type BuiltinOp = "eq" | "neq" | "is_empty";
+
+const builtinNode = (
+  field: BuiltinField,
+  op: BuiltinOp,
+  value: string,
+): ConditionNode => {
+  if (op === "is_empty") {
+    return { type: "predicate", operand: { type: "builtin", field }, op };
+  }
+  return {
+    type: "compare",
+    left: { type: "builtin", field },
+    op,
+    right: { type: "literal", value },
+  };
+};
+
+const builtinField = (node: ConditionNode): BuiltinField => {
+  if (node.type === "compare" && node.left.type === "builtin") {
+    return node.left.field;
+  }
+  if (node.type === "predicate" && node.operand.type === "builtin") {
+    return node.operand.field;
+  }
+  return "status";
+};
+
+const propertyNode = (
+  propertyId: string,
+  op: LeafOp,
+  value: string,
+): ConditionNode => {
+  if (op === "contains") {
+    return {
+      type: "predicate",
+      operand: { type: "property", propertyId },
+      op: "contains",
+      value,
+    };
+  }
+  if (op === "is_empty") {
+    return {
+      type: "predicate",
+      operand: { type: "property", propertyId },
+      op: "is_empty",
+    };
+  }
+  return {
+    type: "compare",
+    left: { type: "property", propertyId },
+    op,
+    right: { type: "literal", value },
+  };
+};
+
+const propertyId = (node: ConditionNode): string => {
+  if (node.type === "compare" && node.left.type === "property") {
+    return node.left.propertyId;
+  }
+  if (node.type === "predicate" && node.operand.type === "property") {
+    return node.operand.propertyId;
+  }
+  return "";
+};
+
+// -- Add filter --
+
+type AddFilterButtonProps = {
+  properties: WorkspaceProperty[];
+  filters: ConditionNode[];
+  onAdd: (filter: ConditionNode) => void;
+};
+
+const hasKindFilter = (filters: ConditionNode[]) =>
+  filters.some((node) => kindOf(node) === "kind");
+
+const hasBuiltinFilter = (filters: ConditionNode[], field: BuiltinField) =>
   filters.some(
-    (f) =>
-      f.field === field &&
-      (builtinField === undefined ||
-        (f.field === "builtin" && f.builtinField === builtinField)),
+    (node) => kindOf(node) === "builtin" && builtinField(node) === field,
   );
 
 const AddFilterButton = ({
@@ -129,45 +251,22 @@ const AddFilterButton = ({
       </MenuTrigger>
       <MenuPopup>
         <MenuItem
-          disabled={hasFilter(filters, "kind")}
-          onClick={() =>
-            onAdd({
-              id: crypto.randomUUID(),
-              field: "kind",
-              op: "in",
-              value: [],
-            })
-          }
+          disabled={hasKindFilter(filters)}
+          onClick={() => onAdd(kindNode([]))}
         >
           <FilterIcon className="size-3.5" />
           {t("common.kind")}
         </MenuItem>
         <MenuItem
-          disabled={hasFilter(filters, "builtin", "status")}
-          onClick={() =>
-            onAdd({
-              id: crypto.randomUUID(),
-              field: "builtin",
-              builtinField: "status",
-              op: "eq",
-              value: "",
-            })
-          }
+          disabled={hasBuiltinFilter(filters, "status")}
+          onClick={() => onAdd(builtinNode("status", "eq", ""))}
         >
           <CircleDotIcon className="size-3.5" />
           {t("common.status")}
         </MenuItem>
         <MenuItem
-          disabled={hasFilter(filters, "builtin", "priority")}
-          onClick={() =>
-            onAdd({
-              id: crypto.randomUUID(),
-              field: "builtin",
-              builtinField: "priority",
-              op: "eq",
-              value: "",
-            })
-          }
+          disabled={hasBuiltinFilter(filters, "priority")}
+          onClick={() => onAdd(builtinNode("priority", "eq", ""))}
         >
           <SignalIcon className="size-3.5" />
           {t("tasks.priority")}
@@ -177,15 +276,7 @@ const AddFilterButton = ({
           .map((prop) => (
             <MenuItem
               key={prop.id}
-              onClick={() =>
-                onAdd({
-                  id: crypto.randomUUID(),
-                  field: "property",
-                  propertyId: prop.id,
-                  op: "eq",
-                  value: "",
-                })
-              }
+              onClick={() => onAdd(propertyNode(prop.id, "eq", ""))}
             >
               <PropertyIcon type={prop.content.type} />
               {prop.name}
@@ -218,9 +309,9 @@ const FilterChipWrapper = ({
   </div>
 );
 
-type KindFilterChipProps = {
-  filter: Extract<ViewFilterCondition, { field: "kind" }>;
-  onChange: (filter: ViewFilterCondition) => void;
+type FilterChipProps = {
+  filter: ConditionNode;
+  onChange: (filter: ConditionNode) => void;
   onRemove: () => void;
 };
 
@@ -234,24 +325,21 @@ const useKindLabels = (): Record<string, string> => {
   };
 };
 
-const KindFilterChip = ({
-  filter,
-  onChange,
-  onRemove,
-}: KindFilterChipProps) => {
+const KindFilterChip = ({ filter, onChange, onRemove }: FilterChipProps) => {
   const t = useTranslations();
   const kindLabels = useKindLabels();
+  const values = kindValues(filter);
   const label =
-    filter.value.length === 0
+    values.length === 0
       ? t("common.all")
-      : filter.value.map((k) => kindLabels[k] ?? k).join(", ");
+      : values.map((k) => kindLabels[k] ?? k).join(", ");
 
   return (
     <FilterChipWrapper label={t("common.kind")} onRemove={onRemove}>
       <Select
         multiple
-        onValueChange={(kinds) => onChange({ ...filter, value: kinds })}
-        value={filter.value}
+        onValueChange={(kinds) => onChange(kindNode(kinds))}
+        value={values}
       >
         <FilterSelectTrigger>{label}</FilterSelectTrigger>
         <SelectPopup alignItemWithTrigger={false}>
@@ -310,28 +398,30 @@ const isStatusValue = (value: string): value is StatusValue =>
 const isPriorityValue = (value: string): value is PriorityValue =>
   PRIORITY_VALUE_SET.has(value);
 
-type BuiltinFilterChipProps = {
-  filter: Extract<ViewFilterCondition, { field: "builtin" }>;
-  onChange: (filter: ViewFilterCondition) => void;
-  onRemove: () => void;
-};
+const isLeafOp = (value: string): value is LeafOp =>
+  value === "eq" ||
+  value === "neq" ||
+  value === "contains" ||
+  value === "is_empty";
 
-const BuiltinFilterChip = ({
-  filter,
-  onChange,
-  onRemove,
-}: BuiltinFilterChipProps) => {
+const isBuiltinOp = (value: string): value is BuiltinOp =>
+  value === "eq" || value === "neq" || value === "is_empty";
+
+const BuiltinFilterChip = ({ filter, onChange, onRemove }: FilterChipProps) => {
   const t = useTranslations();
-  const isStatus = filter.builtinField === "status";
+  const field = builtinField(filter);
+  const rawOp = leafOp(filter);
+  const op: BuiltinOp = isBuiltinOp(rawOp) ? rawOp : "eq";
+  const value = leafValue(filter);
+  const isStatus = field === "status";
   const label = isStatus ? t("common.status") : t("tasks.priority");
   const values = isStatus ? STATUS_VALUES : PRIORITY_VALUES;
 
-  const resolveLabel = (value: string) => {
+  const resolveLabel = (raw: string) => {
     if (isStatus) {
-      return isStatusValue(value) ? t(STATUS_VALUE_LABEL_KEYS[value]) : value;
+      return isStatusValue(raw) ? t(STATUS_VALUE_LABEL_KEYS[raw]) : raw;
     }
-
-    return isPriorityValue(value) ? t(PRIORITY_VALUE_LABEL_KEYS[value]) : value;
+    return isPriorityValue(raw) ? t(PRIORITY_VALUE_LABEL_KEYS[raw]) : raw;
   };
 
   const opOptions = [
@@ -343,35 +433,35 @@ const BuiltinFilterChip = ({
   return (
     <FilterChipWrapper label={label} onRemove={onRemove}>
       <Select
-        onValueChange={(op) => {
-          if (op) {
-            onChange({ ...filter, op });
+        onValueChange={(nextOp) => {
+          if (nextOp && isBuiltinOp(nextOp)) {
+            onChange(builtinNode(field, nextOp, value));
           }
         }}
-        value={filter.op}
+        value={op}
       >
         <FilterSelectTrigger>
-          {opOptions.find((o) => o.value === filter.op)?.label}
+          {opOptions.find((o) => o.value === op)?.label}
         </FilterSelectTrigger>
         <SelectPopup alignItemWithTrigger={false}>
-          {opOptions.map((op) => (
-            <SelectItem key={op.value} value={op.value}>
-              {op.label}
+          {opOptions.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
             </SelectItem>
           ))}
         </SelectPopup>
       </Select>
-      {filter.op !== "is_empty" && (
+      {op !== "is_empty" && (
         <Select
           onValueChange={(val) => {
             if (val !== null) {
-              onChange({ ...filter, value: val });
+              onChange(builtinNode(field, op, val));
             }
           }}
-          value={String(filter.value ?? "")}
+          value={value}
         >
           <FilterSelectTrigger>
-            {filter.value !== "" ? resolveLabel(String(filter.value)) : "…"}
+            {value !== "" ? resolveLabel(value) : "…"}
           </FilterSelectTrigger>
           <SelectPopup alignItemWithTrigger={false}>
             {values.map((val) => (
@@ -386,11 +476,8 @@ const BuiltinFilterChip = ({
   );
 };
 
-type PropertyFilterChipProps = {
-  filter: Extract<ViewFilterCondition, { field: "property" }>;
+type PropertyFilterChipProps = FilterChipProps & {
   properties: WorkspaceProperty[];
-  onChange: (filter: ViewFilterCondition) => void;
-  onRemove: () => void;
 };
 
 const PropertyFilterChip = ({
@@ -400,20 +487,22 @@ const PropertyFilterChip = ({
   onRemove,
 }: PropertyFilterChipProps) => {
   const t = useTranslations();
-  const property = properties.find((p) => p.id === filter.propertyId);
+  const id = propertyId(filter);
+  const property = properties.find((p) => p.id === id);
 
   if (!property) {
     return null;
   }
 
+  const op = leafOp(filter);
+  const value = leafValue(filter);
   const isSingleSelect =
     property.content.type === "single-select" ||
     property.content.type === "multi-select";
 
   const selectOptions =
-    isSingleSelect &&
-    (property.content.type === "single-select" ||
-      property.content.type === "multi-select")
+    property.content.type === "single-select" ||
+    property.content.type === "multi-select"
       ? property.content.options
       : [];
 
@@ -434,36 +523,36 @@ const PropertyFilterChip = ({
   return (
     <FilterChipWrapper label={property.name} onRemove={onRemove}>
       <Select
-        onValueChange={(op) => {
-          if (op) {
-            onChange({ ...filter, op });
+        onValueChange={(nextOp) => {
+          if (nextOp && isLeafOp(nextOp)) {
+            onChange(propertyNode(id, nextOp, value));
           }
         }}
-        value={filter.op}
+        value={op}
       >
         <FilterSelectTrigger>
-          {opOptions.find((o) => o.value === filter.op)?.label}
+          {opOptions.find((o) => o.value === op)?.label}
         </FilterSelectTrigger>
         <SelectPopup alignItemWithTrigger={false}>
-          {opOptions.map((op) => (
-            <SelectItem key={op.value} value={op.value}>
-              {op.label}
+          {opOptions.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
             </SelectItem>
           ))}
         </SelectPopup>
       </Select>
-      {filter.op !== "is_empty" &&
+      {op !== "is_empty" &&
         (isSingleSelect ? (
           <Select
             onValueChange={(val) => {
               if (val !== null) {
-                onChange({ ...filter, value: val });
+                onChange(propertyNode(id, op, val));
               }
             }}
-            value={String(filter.value ?? "")}
+            value={value}
           >
             <FilterSelectTrigger>
-              {filter.value !== "" ? String(filter.value) : "…"}
+              {value !== "" ? value : "…"}
             </FilterSelectTrigger>
             <SelectPopup alignItemWithTrigger={false}>
               {selectOptions.map((opt) => (
@@ -477,13 +566,10 @@ const PropertyFilterChip = ({
           <Input
             className="h-6! w-24 border-0 bg-transparent px-1 text-xs shadow-none"
             onChange={(e) =>
-              onChange({
-                ...filter,
-                value: e.currentTarget.value,
-              })
+              onChange(propertyNode(id, op, e.currentTarget.value))
             }
             size="sm"
-            value={String(filter.value ?? "")}
+            value={value}
           />
         ))}
     </FilterChipWrapper>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -1,18 +1,68 @@
-import { FilterIcon } from "lucide-react";
+import { useState } from "react";
+
+import {
+  CircleDotIcon,
+  FilterIcon,
+  FlagIcon,
+  LayersIcon,
+  MoreHorizontalIcon,
+  PlusIcon,
+  SlidersHorizontalIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import type { ConditionNode, GroupNode } from "@stll/conditions";
 import { Button } from "@stll/ui/components/button";
 import {
+  Command,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@stll/ui/components/command";
+import { Input } from "@stll/ui/components/input";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuSeparator,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import {
   Popover,
   PopoverPopup,
   PopoverTrigger,
 } from "@stll/ui/components/popover";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
 
+import { DatePickerPopover } from "@/components/date-picker-popover";
 import type { TranslationKey } from "@/i18n/types";
 import type { WorkspaceProperty } from "@/lib/types";
 import { ConditionBuilder } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder";
-import type { FieldOption } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import type {
+  ConditionOperator,
+  FieldOption,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import {
+  buildLeaf,
+  fieldForNode,
+  isMultiValue,
+  leafFromField,
+  leafOperator,
+  leafValueList,
+  leafValueString,
+  operatorLabelKey,
+  operatorsFor,
+  valueEditorFor,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";
+import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 
 type FilterChipsProps = {
   filters: ConditionNode[];
@@ -28,41 +78,602 @@ export const FilterChips = ({
   const t = useTranslations();
   const fields = useFilterFields(properties);
 
-  // View filters persist as a flat `ConditionNode[]` evaluated with
-  // implicit AND, so the builder runs as a flat AND group and we write
-  // its children straight back to that array.
-  const group: GroupNode = {
-    type: "group",
-    combinator: "and",
-    children: filters,
+  const replaceAt = (index: number, node: ConditionNode) => {
+    onUpdate(filters.map((existing, i) => (i === index ? node : existing)));
   };
-  const count = filters.length;
+  const removeAt = (index: number) => {
+    onUpdate(filters.filter((_, i) => i !== index));
+  };
+  const append = (node: ConditionNode) => {
+    onUpdate([...filters, node]);
+  };
+
+  if (filters.length === 0) {
+    return (
+      <AddFilterPicker
+        fields={fields}
+        onAddAdvanced={() => append(emptyAdvancedGroup())}
+        onAddField={(field) => append(leafFromField(field))}
+        trigger={
+          <Button className="gap-1.5" size="xs" variant="ghost">
+            <FilterIcon className="size-3.5" />
+            {t("workspaces.views.filter")}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      {filters.map((node, index) => {
+        if (node.type === "group") {
+          return (
+            <AdvancedFilterChip
+              fields={fields}
+              key={index}
+              node={node}
+              onChange={(next) => replaceAt(index, next)}
+              onRemove={() => removeAt(index)}
+            />
+          );
+        }
+        return (
+          <FilterChip
+            fields={fields}
+            key={index}
+            node={node}
+            onChange={(next) => replaceAt(index, next)}
+            onRemove={() => removeAt(index)}
+          />
+        );
+      })}
+      <AddFilterPicker
+        fields={fields}
+        onAddAdvanced={() => append(emptyAdvancedGroup())}
+        onAddField={(field) => append(leafFromField(field))}
+        trigger={
+          <Button size="icon-xs" variant="ghost">
+            <PlusIcon />
+          </Button>
+        }
+      />
+    </>
+  );
+};
+
+// ── Simple chip ───────────────────────────────────────────
+
+type FilterChipProps = {
+  node: ConditionNode;
+  fields: FieldOption[];
+  onChange: (next: ConditionNode) => void;
+  onRemove: () => void;
+};
+
+const FilterChip = ({ node, fields, onChange, onRemove }: FilterChipProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+  const field = fieldForNode(node, fields);
+  const operator = leafOperator(node);
+
+  if (!field || !operator) {
+    return null;
+  }
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger
+        render={
+          <Button
+            className="gap-1.5 font-normal"
+            size="xs"
+            variant="secondary"
+          />
+        }
+      >
+        <FieldTypeIcon field={field} />
+        <span className="text-foreground">{field.label}</span>
+        <span className="text-muted-foreground">
+          {chipSummary({
+            field,
+            node,
+            operator,
+            operatorLabel: t(operatorLabelKey(field.valueType, operator)),
+          })}
+        </span>
+      </PopoverTrigger>
+      <PopoverPopup align="start" className="w-72 p-0">
+        <FilterEditBody
+          field={field}
+          node={node}
+          onChange={onChange}
+          onRemove={() => {
+            onRemove();
+            setOpen(false);
+          }}
+          operator={operator}
+        />
+      </PopoverPopup>
+    </Popover>
+  );
+};
+
+type FilterEditBodyProps = {
+  field: FieldOption;
+  node: ConditionNode;
+  operator: ConditionOperator;
+  onChange: (next: ConditionNode) => void;
+  onRemove: () => void;
+};
+
+const FilterEditBody = ({
+  field,
+  node,
+  operator,
+  onChange,
+  onRemove,
+}: FilterEditBodyProps) => {
+  const t = useTranslations();
+  const operators = operatorsFor(field.valueType);
+  const editorKind = valueEditorFor(field.valueType, operator);
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-1.5 border-b px-2.5 py-2">
+        <FieldTypeIcon field={field} />
+        <span className="flex-1 truncate text-sm font-medium">
+          {field.label}
+        </span>
+        <Menu>
+          <MenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
+            <MoreHorizontalIcon />
+          </MenuTrigger>
+          <MenuPopup align="end">
+            <MenuItem onClick={() => onChange(leafFromField(field))}>
+              {t("common.duplicate")}
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem onClick={onRemove} variant="destructive">
+              {t("common.delete")}
+            </MenuItem>
+          </MenuPopup>
+        </Menu>
+      </div>
+
+      <div className="flex flex-col gap-2 p-2.5">
+        <Select
+          onValueChange={(next) => {
+            if (next === null) {
+              return;
+            }
+            onChange(
+              buildLeaf({
+                operand: field.operand,
+                operator: next,
+                value: isMultiValue(next)
+                  ? leafValueList(node)
+                  : leafValueString(node),
+              }),
+            );
+          }}
+          value={operator}
+        >
+          <SelectTrigger className="h-7 min-h-0 w-full text-xs" size="sm">
+            <SelectValue>
+              {() => t(operatorLabelKey(field.valueType, operator))}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectPopup alignItemWithTrigger={false}>
+            {operators.map((op) => (
+              <SelectItem key={op} value={op}>
+                {t(operatorLabelKey(field.valueType, op))}
+              </SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+
+        <ValueEditor
+          editorKind={editorKind}
+          field={field}
+          node={node}
+          onChange={onChange}
+          operator={operator}
+        />
+      </div>
+    </div>
+  );
+};
+
+type ValueEditorProps = {
+  editorKind: ReturnType<typeof valueEditorFor>;
+  field: FieldOption;
+  node: ConditionNode;
+  operator: ConditionOperator;
+  onChange: (next: ConditionNode) => void;
+};
+
+const ValueEditor = ({
+  editorKind,
+  field,
+  node,
+  operator,
+  onChange,
+}: ValueEditorProps) => {
+  const t = useTranslations();
+
+  if (editorKind === "none") {
+    return null;
+  }
+
+  const emit = (value: string | string[]) => {
+    onChange(buildLeaf({ operand: field.operand, operator, value }));
+  };
+
+  if (editorKind === "select") {
+    if (isMultiValue(operator)) {
+      return (
+        <MultiSelectValue
+          field={field}
+          onChange={emit}
+          value={leafValueList(node)}
+        />
+      );
+    }
+    return (
+      <SingleSelectValue
+        field={field}
+        onChange={emit}
+        value={leafValueString(node)}
+      />
+    );
+  }
+
+  if (editorKind === "int") {
+    return (
+      <Input
+        autoFocus
+        className="h-7! w-full text-xs"
+        onChange={(e) => emit(e.currentTarget.value)}
+        size="sm"
+        type="number"
+        value={leafValueString(node)}
+      />
+    );
+  }
+
+  if (editorKind === "date") {
+    return (
+      <div className="border-input bg-background rounded-md border px-1">
+        <DatePickerPopover
+          onChange={(next) => emit(next ?? "")}
+          value={leafValueString(node) || null}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      autoFocus
+      className="h-7! w-full text-xs"
+      onChange={(e) => emit(e.currentTarget.value)}
+      placeholder={t("workspaces.properties.enterAValue")}
+      size="sm"
+      value={leafValueString(node)}
+    />
+  );
+};
+
+type SingleSelectValueProps = {
+  field: FieldOption;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+const SingleSelectValue = ({
+  field,
+  value,
+  onChange,
+}: SingleSelectValueProps) => {
+  const t = useTranslations();
+  const options = field.options ?? [];
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <Select
+      onValueChange={(next) => {
+        if (next !== null) {
+          onChange(next);
+        }
+      }}
+      value={value}
+    >
+      <SelectTrigger className="h-7 min-h-0 w-full text-xs" size="sm">
+        <SelectValue placeholder={t("workspaces.fields.selectAValue")}>
+          {() =>
+            selected ? (
+              <span className="flex items-center gap-1.5">
+                {selected.color !== undefined && (
+                  <SelectColorIcon color={selected.color} />
+                )}
+                {selected.label}
+              </span>
+            ) : (
+              t("workspaces.fields.selectAValue")
+            )
+          }
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup alignItemWithTrigger={false}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            <span className="flex items-center gap-1.5">
+              {option.color !== undefined && (
+                <SelectColorIcon color={option.color} />
+              )}
+              {option.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+};
+
+type MultiSelectValueProps = {
+  field: FieldOption;
+  value: string[];
+  onChange: (value: string[]) => void;
+};
+
+const MultiSelectValue = ({
+  field,
+  value,
+  onChange,
+}: MultiSelectValueProps) => {
+  const t = useTranslations();
+  const options = field.options ?? [];
+  const label =
+    value.length === 0
+      ? t("workspaces.fields.selectValues")
+      : value
+          .map((v) => options.find((option) => option.value === v)?.label ?? v)
+          .join(", ");
+
+  return (
+    <Select multiple onValueChange={(next) => onChange(next)} value={value}>
+      <SelectTrigger className="h-7 min-h-0 w-full text-xs" size="sm">
+        <SelectValue>{() => label}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup alignItemWithTrigger={false}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            <span className="flex items-center gap-1.5">
+              {option.color !== undefined && (
+                <SelectColorIcon color={option.color} />
+              )}
+              {option.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+};
+
+// ── Advanced (AND/OR group) chip ──────────────────────────
+
+type AdvancedFilterChipProps = {
+  node: GroupNode;
+  fields: FieldOption[];
+  onChange: (next: GroupNode) => void;
+  onRemove: () => void;
+};
+
+const AdvancedFilterChip = ({
+  node,
+  fields,
+  onChange,
+  onRemove,
+}: AdvancedFilterChipProps) => {
+  const t = useTranslations();
 
   return (
     <Popover>
       <PopoverTrigger
         render={
           <Button
-            className="gap-1.5"
+            className="gap-1.5 font-normal"
             size="xs"
-            variant={count > 0 ? "secondary" : "ghost"}
+            variant="secondary"
           />
         }
       >
-        <FilterIcon className="size-3.5" />
-        {count > 0
-          ? t("workspaces.views.filtersWithCount", { count })
-          : t("workspaces.views.filter")}
+        <SlidersHorizontalIcon className="size-3.5" />
+        <span className="text-foreground">
+          {t("workspaces.views.advancedFilter")}
+        </span>
+        <span className="text-muted-foreground">
+          {t("workspaces.views.advancedFilterCount", {
+            count: node.children.length,
+          })}
+        </span>
       </PopoverTrigger>
-      <PopoverPopup className="w-auto max-w-[min(36rem,90vw)] p-3">
+      <PopoverPopup
+        align="start"
+        className="w-auto max-w-[min(36rem,90vw)] p-3"
+      >
         <ConditionBuilder
+          allowGroups
           fields={fields}
-          onChange={(next) => onUpdate(next.children)}
-          value={group}
+          onChange={onChange}
+          value={node}
         />
+        <div className="mt-2 border-t pt-2">
+          <Button
+            className="text-muted-foreground"
+            onClick={onRemove}
+            size="xs"
+            variant="ghost"
+          >
+            {t("workspaces.views.removeAdvancedFilter")}
+          </Button>
+        </div>
       </PopoverPopup>
     </Popover>
   );
+};
+
+// ── Add picker ────────────────────────────────────────────
+
+type AddFilterPickerProps = {
+  fields: FieldOption[];
+  trigger: React.ReactElement;
+  onAddField: (field: FieldOption) => void;
+  onAddAdvanced: () => void;
+};
+
+const AddFilterPicker = ({
+  fields,
+  trigger,
+  onAddField,
+  onAddAdvanced,
+}: AddFilterPickerProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const normalized = query.trim().toLowerCase();
+  const visible = normalized
+    ? fields.filter((field) => field.label.toLowerCase().includes(normalized))
+    : fields;
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger render={trigger} />
+      <PopoverPopup align="start" className="w-64 p-0">
+        <Command mode="none" onValueChange={setQuery} value={query}>
+          <div className="border-b px-2.5 py-2">
+            <CommandInput
+              autoFocus
+              placeholder={t("workspaces.views.filterByPlaceholder")}
+              size="sm"
+            />
+          </div>
+          <CommandList className="p-1">
+            {visible.length === 0 && (
+              <p className="text-muted-foreground px-2 py-1.5 text-sm">
+                {t("common.noResults")}
+              </p>
+            )}
+            {visible.map((field) => (
+              <CommandItem
+                key={fieldKey(field)}
+                onClick={() => {
+                  onAddField(field);
+                  close();
+                }}
+                value={field.label}
+              >
+                <FieldTypeIcon field={field} />
+                {field.label}
+              </CommandItem>
+            ))}
+            <CommandSeparator className="my-1" />
+            <CommandItem
+              onClick={() => {
+                onAddAdvanced();
+                close();
+              }}
+              value="__advanced__"
+            >
+              <SlidersHorizontalIcon className="text-muted-foreground" />
+              {t("workspaces.views.addAdvancedFilter")}
+            </CommandItem>
+          </CommandList>
+        </Command>
+      </PopoverPopup>
+    </Popover>
+  );
+};
+
+const FieldTypeIcon = ({ field }: { field: FieldOption }) => {
+  if (field.valueType === "kind") {
+    return <LayersIcon className="text-muted-foreground" />;
+  }
+  if (field.valueType === "status") {
+    return <CircleDotIcon className="text-muted-foreground" />;
+  }
+  if (field.valueType === "priority") {
+    return <FlagIcon className="text-muted-foreground" />;
+  }
+  return <PropertyIcon className="text-muted-foreground" type={field.type} />;
+};
+
+// ── Chip summary ──────────────────────────────────────────
+
+type ChipSummaryArgs = {
+  field: FieldOption;
+  node: ConditionNode;
+  operator: ConditionOperator;
+  operatorLabel: string;
+};
+
+const optionLabel = (field: FieldOption, value: string): string =>
+  field.options?.find((option) => option.value === value)?.label ?? value;
+
+const chipSummary = ({
+  field,
+  node,
+  operator,
+  operatorLabel,
+}: ChipSummaryArgs): string => {
+  const editorKind = valueEditorFor(field.valueType, operator);
+
+  if (editorKind === "none") {
+    return operatorLabel;
+  }
+
+  if (isMultiValue(operator)) {
+    const values = leafValueList(node).map((value) =>
+      optionLabel(field, value),
+    );
+    if (values.length === 0) {
+      return operatorLabel;
+    }
+    return `${operatorLabel} ${values.join(", ")}`;
+  }
+
+  const raw = leafValueString(node);
+  if (!raw) {
+    return operatorLabel;
+  }
+  const display = editorKind === "select" ? optionLabel(field, raw) : raw;
+  return `${operatorLabel} ${display}`;
+};
+
+// ── Field catalogue ───────────────────────────────────────
+
+const emptyAdvancedGroup = (): GroupNode => ({
+  type: "group",
+  combinator: "and",
+  children: [],
+});
+
+const fieldKey = (field: FieldOption): string => {
+  if (field.operand.type === "property") {
+    return `property:${field.operand.propertyId}`;
+  }
+  if (field.operand.type === "builtin") {
+    return `builtin:${field.operand.field}`;
+  }
+  return field.operand.type;
 };
 
 const ENTITY_KINDS = ["document", "task"] as const;
@@ -107,6 +718,7 @@ const useFilterFields = (properties: WorkspaceProperty[]): FieldOption[] => {
       operand: { type: "kind" },
       label: t("common.kind"),
       valueType: "kind",
+      type: "text",
       options: ENTITY_KINDS.map((kind) => ({
         value: kind,
         label: t(KIND_LABEL_KEYS[kind]),
@@ -116,6 +728,7 @@ const useFilterFields = (properties: WorkspaceProperty[]): FieldOption[] => {
       operand: { type: "builtin", field: "status" },
       label: t("common.status"),
       valueType: "status",
+      type: "single-select",
       options: STATUS_VALUES.map((value) => ({
         value,
         label: t(STATUS_VALUE_LABEL_KEYS[value]),
@@ -125,6 +738,7 @@ const useFilterFields = (properties: WorkspaceProperty[]): FieldOption[] => {
       operand: { type: "builtin", field: "priority" },
       label: t("tasks.priority"),
       valueType: "priority",
+      type: "single-select",
       options: PRIORITY_VALUES.map((value) => ({
         value,
         label: t(PRIORITY_VALUE_LABEL_KEYS[value]),
@@ -144,6 +758,7 @@ const useFilterFields = (properties: WorkspaceProperty[]): FieldOption[] => {
         operand: { type: "property", propertyId: property.id },
         label: property.name,
         valueType: property.content.type,
+        type: property.content.type,
         options: property.content.options.map((option) => ({
           value: option.value,
           label: option.value,
@@ -156,6 +771,7 @@ const useFilterFields = (properties: WorkspaceProperty[]): FieldOption[] => {
       operand: { type: "property", propertyId: property.id },
       label: property.name,
       valueType: property.content.type,
+      type: property.content.type,
     });
   }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -147,7 +147,7 @@ const leafOp = (node: ConditionNode): LeafOp => {
 
 const leafValue = (node: ConditionNode): string => {
   if (node.type === "compare" && node.right.type === "literal") {
-    return String(node.right.value ?? "");
+    return String(node.right.value);
   }
   if (node.type === "predicate" && typeof node.value === "string") {
     return node.value;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -99,7 +99,7 @@ export const FilterChips = ({
   if (filters.length === 0) {
     return (
       <AddFilterPicker
-        fields={fields}
+        fields={pickerFields}
         onAddAdvanced={() => append(emptyAdvancedGroup())}
         onAddField={(field) => append(leafFromField(field))}
         trigger={

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/calendar-tasks.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/calendar-tasks.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
-import type { ViewFilterCondition } from "@/lib/types";
+import type { ConditionNode } from "@/lib/types";
 import { normalizeVisibleFieldIds } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
 import type { ViewSort } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
 
@@ -12,7 +12,7 @@ type CalendarTasksKey = {
   dateTo: string;
   datePropertyIds: string[];
   endDatePropertyId?: string | undefined;
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
   sorts: ViewSort[];
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
@@ -1,8 +1,4 @@
-import type {
-  EntityKind,
-  ViewFilterCondition,
-  WorkspaceProperty,
-} from "@/lib/types";
+import type { ConditionNode, EntityKind, WorkspaceProperty } from "@/lib/types";
 
 export type ViewSort = {
   propertyId: string;
@@ -13,7 +9,7 @@ export type EntitiesFieldMode = "full" | "visible";
 
 export type EntitiesPageKey = {
   workspaceId: string;
-  filters: ViewFilterCondition[];
+  filters: ConditionNode[];
   sorts: ViewSort[];
   page: number;
   search?: string;

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "@stll/boe": "workspace:*",
         "@stll/business-registries": "workspace:*",
         "@stll/catalogue": "workspace:*",
+        "@stll/conditions": "workspace:*",
         "@stll/country-codes": "workspace:*",
         "@stll/docx-core": "workspace:*",
         "@stll/docx-utils": "workspace:*",
@@ -237,6 +238,7 @@
         "@stll/anonymize-wasm": "catalog:",
         "@stll/api": "workspace:*",
         "@stll/catalogue": "workspace:*",
+        "@stll/conditions": "workspace:*",
         "@stll/country-codes": "workspace:*",
         "@stll/errors": "workspace:*",
         "@stll/folio": "workspace:*",
@@ -383,6 +385,19 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/conditions": {
+      "name": "@stll/conditions",
+      "version": "0.0.0",
+      "dependencies": {
+        "valibot": "catalog:",
+      },
+      "devDependencies": {
+        "@stll/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
+        "fast-check": "catalog:",
         "typescript": "catalog:",
       },
     },
@@ -1624,6 +1639,8 @@
     "@stll/catalogue": ["@stll/catalogue@workspace:packages/catalogue"],
 
     "@stll/collab": ["@stll/collab@workspace:apps/collab"],
+
+    "@stll/conditions": ["@stll/conditions@workspace:packages/conditions"],
 
     "@stll/country-codes": ["@stll/country-codes@workspace:packages/country-codes"],
 

--- a/packages/conditions/package.json
+++ b/packages/conditions/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@stll/conditions",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo node_modules",
+    "test": "bun test src",
+    "typecheck": "tsgo --noEmit",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/conditions",
+    "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/conditions",
+    "format": "oxfmt ."
+  },
+  "dependencies": {
+    "valibot": "catalog:"
+  },
+  "devDependencies": {
+    "@stll/typescript-config": "workspace:*",
+    "@types/bun": "catalog:",
+    "fast-check": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/conditions/src/evaluate.property.test.ts
+++ b/packages/conditions/src/evaluate.property.test.ts
@@ -238,10 +238,12 @@ describe("evaluator invariants (property-based)", () => {
   // complement properties above all pass on a uniformly wrong-but-boolean
   // result (e.g. gt/lt always false for dates), so this is what actually pins
   // gt/lt/gte/lte semantics — and what would have caught the ISO-date bug.
-  test("ordered comparisons are reflexive for any literal value", () => {
+  test("ordered comparisons are reflexive for any non-blank literal value", () => {
     fc.assert(
       fc.property(
-        fc.oneof(fc.string(), fc.integer(), fc.boolean()),
+        // Exclude the empty string: a blank value is the "not comparable"
+        // sentinel and is intentionally excluded from ordered comparisons.
+        fc.oneof(fc.string({ minLength: 1 }), fc.integer(), fc.boolean()),
         (value) => {
           const resolve = makeResolver({});
           const cmp = (op: "gt" | "lt" | "gte" | "lte"): ConditionNode => ({
@@ -254,6 +256,27 @@ describe("evaluator invariants (property-based)", () => {
           expect(evaluateCondition(cmp("lte"), resolve)).toBe(true);
           expect(evaluateCondition(cmp("gt"), resolve)).toBe(false);
           expect(evaluateCondition(cmp("lt"), resolve)).toBe(false);
+        },
+      ),
+    );
+  });
+
+  // Another absolute oracle: an absent value (resolves to undefined) is not
+  // comparable, so no ordered operator may match it against a real literal.
+  // The lexicographic fallback would otherwise rank "" before every date.
+  test("an absent value never satisfies an ordered comparison", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom<"gt" | "lt" | "gte" | "lte">("gt", "lt", "gte", "lte"),
+        fc.oneof(fc.string({ minLength: 1 }), fc.integer()),
+        (op, literal) => {
+          const node: ConditionNode = {
+            type: "compare",
+            left: { type: "property", propertyId: "missing" },
+            op,
+            right: { type: "literal", value: literal },
+          };
+          expect(evaluateCondition(node, makeResolver({}))).toBe(false);
         },
       ),
     );

--- a/packages/conditions/src/evaluate.property.test.ts
+++ b/packages/conditions/src/evaluate.property.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import * as v from "valibot";
+
+import {
+  type ConditionValue,
+  evaluateCondition,
+  type OperandResolver,
+} from "./evaluate";
+import {
+  COMPARE_OPS,
+  type Combinator,
+  type ConditionNode,
+  conditionNodeSchema,
+  type Operand,
+  PREDICATE_OPS,
+  type RefOperand,
+} from "./schema";
+
+// A small fixed key space so generated resolvers actually hold values to
+// return (otherwise nearly every operand resolves to undefined).
+const KEYS = ["a", "b", "c", "status", "priority", "kind"] as const;
+
+const refOperandArb: fc.Arbitrary<RefOperand> = fc.oneof(
+  fc
+    .constantFrom("a", "b", "c")
+    .map((propertyId): RefOperand => ({ type: "property", propertyId })),
+  fc
+    .constantFrom("status", "priority")
+    .map((field): RefOperand => ({ type: "builtin", field })),
+  fc.constant<RefOperand>({ type: "kind" }),
+  fc
+    .constantFrom("a", "b", "c")
+    .map((path): RefOperand => ({ type: "path", path })),
+);
+
+const literalArb: fc.Arbitrary<Operand> = fc
+  .oneof(fc.string(), fc.integer(), fc.boolean(), fc.array(fc.string()))
+  .map((value): Operand => ({ type: "literal", value }));
+
+const operandArb: fc.Arbitrary<Operand> = fc.oneof(refOperandArb, literalArb);
+
+const leafArb: fc.Arbitrary<ConditionNode> = fc.oneof(
+  fc.tuple(operandArb, fc.constantFrom(...COMPARE_OPS), operandArb).map(
+    ([left, op, right]): ConditionNode => ({
+      type: "compare",
+      left,
+      op,
+      right,
+    }),
+  ),
+  fc
+    .tuple(
+      operandArb,
+      fc.constantFrom(...PREDICATE_OPS),
+      fc.oneof(fc.string(), fc.array(fc.string())),
+    )
+    .map(
+      ([operand, op, value]): ConditionNode => ({
+        type: "predicate",
+        operand,
+        op,
+        value,
+      }),
+    ),
+);
+
+const { node: nodeArb } = fc.letrec<{ node: ConditionNode }>((tie) => ({
+  node: fc.oneof(
+    { weight: 3, arbitrary: leafArb },
+    {
+      weight: 1,
+      arbitrary: fc
+        .tuple(
+          fc.constantFrom<Combinator>("and", "or"),
+          fc.boolean(),
+          fc.array(tie("node"), { maxLength: 3 }),
+        )
+        .map(
+          ([combinator, negated, children]): ConditionNode => ({
+            type: "group",
+            combinator,
+            negated,
+            children,
+          }),
+        ),
+    },
+  ),
+}));
+
+const valueArb: fc.Arbitrary<ConditionValue> = fc.oneof(
+  fc.string(),
+  fc.integer(),
+  fc.boolean(),
+  fc.array(fc.string()),
+);
+
+const dataArb = fc.dictionary(fc.constantFrom(...KEYS), valueArb);
+
+const makeResolver =
+  (data: Record<string, ConditionValue>): OperandResolver =>
+  (operand) => {
+    if (operand.type === "property") {
+      return data[operand.propertyId];
+    }
+    if (operand.type === "path") {
+      return data[operand.path];
+    }
+    if (operand.type === "kind") {
+      return data["kind"];
+    }
+    return data[operand.field];
+  };
+
+const negate = (child: ConditionNode): ConditionNode => ({
+  type: "group",
+  combinator: "and",
+  negated: true,
+  children: [child],
+});
+
+describe("evaluator invariants (property-based)", () => {
+  test("every generated node is schema-valid and evaluation is total", () => {
+    fc.assert(
+      fc.property(nodeArb, dataArb, (node, data) => {
+        expect(v.is(conditionNodeSchema, node)).toBe(true);
+        expect(typeof evaluateCondition(node, makeResolver(data))).toBe(
+          "boolean",
+        );
+      }),
+    );
+  });
+
+  test("a group combinator equals every/some over its children", () => {
+    fc.assert(
+      fc.property(
+        fc.array(nodeArb, { maxLength: 4 }),
+        fc.constantFrom<Combinator>("and", "or"),
+        dataArb,
+        (children, combinator, data) => {
+          const resolve = makeResolver(data);
+          const group: ConditionNode = { type: "group", combinator, children };
+          const expected =
+            combinator === "and"
+              ? children.every((c) => evaluateCondition(c, resolve))
+              : children.some((c) => evaluateCondition(c, resolve));
+          expect(evaluateCondition(group, resolve)).toBe(expected);
+        },
+      ),
+    );
+  });
+
+  test("double negation is identity", () => {
+    fc.assert(
+      fc.property(nodeArb, dataArb, (node, data) => {
+        const resolve = makeResolver(data);
+        expect(evaluateCondition(negate(negate(node)), resolve)).toBe(
+          evaluateCondition(node, resolve),
+        );
+      }),
+    );
+  });
+
+  test("neq is the negation of eq for the same operands", () => {
+    fc.assert(
+      fc.property(operandArb, operandArb, dataArb, (left, right, data) => {
+        const resolve = makeResolver(data);
+        const eqNode: ConditionNode = {
+          type: "compare",
+          left,
+          op: "eq",
+          right,
+        };
+        const neqNode: ConditionNode = {
+          type: "compare",
+          left,
+          op: "neq",
+          right,
+        };
+        expect(evaluateCondition(eqNode, resolve)).toBe(
+          !evaluateCondition(neqNode, resolve),
+        );
+      }),
+    );
+  });
+});

--- a/packages/conditions/src/evaluate.property.test.ts
+++ b/packages/conditions/src/evaluate.property.test.ts
@@ -232,4 +232,30 @@ describe("evaluator invariants (property-based)", () => {
       }),
     );
   });
+
+  // An absolute oracle for the ordered operators: any value compared to itself
+  // must satisfy gte/lte and fail gt/lt, whatever its type. The totality and
+  // complement properties above all pass on a uniformly wrong-but-boolean
+  // result (e.g. gt/lt always false for dates), so this is what actually pins
+  // gt/lt/gte/lte semantics — and what would have caught the ISO-date bug.
+  test("ordered comparisons are reflexive for any literal value", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.string(), fc.integer(), fc.boolean()),
+        (value) => {
+          const resolve = makeResolver({});
+          const cmp = (op: "gt" | "lt" | "gte" | "lte"): ConditionNode => ({
+            type: "compare",
+            left: { type: "literal", value },
+            op,
+            right: { type: "literal", value },
+          });
+          expect(evaluateCondition(cmp("gte"), resolve)).toBe(true);
+          expect(evaluateCondition(cmp("lte"), resolve)).toBe(true);
+          expect(evaluateCondition(cmp("gt"), resolve)).toBe(false);
+          expect(evaluateCondition(cmp("lt"), resolve)).toBe(false);
+        },
+      ),
+    );
+  });
 });

--- a/packages/conditions/src/evaluate.property.test.ts
+++ b/packages/conditions/src/evaluate.property.test.ts
@@ -183,4 +183,53 @@ describe("evaluator invariants (property-based)", () => {
       }),
     );
   });
+
+  test("not_contains is the negation of contains", () => {
+    fc.assert(
+      fc.property(
+        refOperandArb,
+        fc.string(),
+        dataArb,
+        (operand, value, data) => {
+          const resolve = makeResolver(data);
+          const contains: ConditionNode = {
+            type: "predicate",
+            operand,
+            op: "contains",
+            value,
+          };
+          const notContains: ConditionNode = {
+            type: "predicate",
+            operand,
+            op: "not_contains",
+            value,
+          };
+          expect(evaluateCondition(contains, resolve)).toBe(
+            !evaluateCondition(notContains, resolve),
+          );
+        },
+      ),
+    );
+  });
+
+  test("is_not_empty is the negation of is_empty", () => {
+    fc.assert(
+      fc.property(refOperandArb, dataArb, (operand, data) => {
+        const resolve = makeResolver(data);
+        const empty: ConditionNode = {
+          type: "predicate",
+          operand,
+          op: "is_empty",
+        };
+        const notEmpty: ConditionNode = {
+          type: "predicate",
+          operand,
+          op: "is_not_empty",
+        };
+        expect(evaluateCondition(empty, resolve)).toBe(
+          !evaluateCondition(notEmpty, resolve),
+        );
+      }),
+    );
+  });
 });

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -61,6 +61,32 @@ describe("compare operators", () => {
     expect(evaluateCondition(gt, resolverFor({ amount: "500" }))).toBe(false);
     expect(evaluateCondition(gt, resolverFor({ amount: "n/a" }))).toBe(false);
   });
+
+  test("non-numeric literals compare lexicographically (ISO dates order chronologically)", () => {
+    const after = compare(
+      { type: "property", propertyId: "due" },
+      "gt",
+      "2026-01-01",
+    );
+    expect(evaluateCondition(after, resolverFor({ due: "2026-06-01" }))).toBe(
+      true,
+    );
+    expect(evaluateCondition(after, resolverFor({ due: "2025-12-31" }))).toBe(
+      false,
+    );
+
+    const onOrBefore = compare(
+      { type: "property", propertyId: "due" },
+      "lte",
+      "2026-06-18",
+    );
+    expect(
+      evaluateCondition(onOrBefore, resolverFor({ due: "2026-06-18" })),
+    ).toBe(true);
+    expect(
+      evaluateCondition(onOrBefore, resolverFor({ due: "2026-07-01" })),
+    ).toBe(false);
+  });
 });
 
 describe("predicate operators", () => {

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
-import { type ConditionValue, evaluateCondition } from "./evaluate";
+import {
+  type ConditionValue,
+  evaluateCondition,
+  pruneIncomplete,
+} from "./evaluate";
 import {
   type CompareOp,
   type ConditionNode,
@@ -88,15 +92,50 @@ describe("compare operators", () => {
     ).toBe(false);
   });
 
-  test("an incomplete ordered comparison (empty literal) is a no-op", () => {
-    const gt = compare({ type: "property", propertyId: "amount" }, "gt", "");
-    expect(evaluateCondition(gt, resolverFor({ amount: 5 }))).toBe(true);
-    expect(evaluateCondition(gt, resolverFor({ amount: "" }))).toBe(true);
-
-    const lte = compare({ type: "property", propertyId: "due" }, "lte", "");
-    expect(evaluateCondition(lte, resolverFor({ due: "2026-06-01" }))).toBe(
-      true,
+  test("pruneIncomplete drops incomplete leaves and empty groups", () => {
+    const real = compare({ type: "property", propertyId: "x" }, "eq", "a");
+    const incompleteGt = compare(
+      { type: "property", propertyId: "x" },
+      "gt",
+      "",
     );
+    const incompleteContains: ConditionNode = {
+      type: "predicate",
+      operand: { type: "property", propertyId: "x" },
+      op: "contains",
+      value: "",
+    };
+    const eqEmpty = compare({ type: "property", propertyId: "x" }, "eq", "");
+    const isEmpty: ConditionNode = {
+      type: "predicate",
+      operand: { type: "property", propertyId: "x" },
+      op: "is_empty",
+    };
+
+    // Incomplete leaves prune away; complete ones (incl. `eq ""`, `is_empty`) stay.
+    expect(pruneIncomplete(incompleteGt)).toBeNull();
+    expect(pruneIncomplete(incompleteContains)).toBeNull();
+    expect(pruneIncomplete(real)).toEqual(real);
+    expect(pruneIncomplete(eqEmpty)).toEqual(eqEmpty);
+    expect(pruneIncomplete(isEmpty)).toEqual(isEmpty);
+
+    // A group keeps real children and drops incomplete ones...
+    expect(
+      pruneIncomplete({
+        type: "group",
+        combinator: "or",
+        children: [incompleteGt, real],
+      }),
+    ).toEqual({ type: "group", combinator: "or", children: [real] });
+
+    // ...and a group of only incomplete leaves prunes to null.
+    expect(
+      pruneIncomplete({
+        type: "group",
+        combinator: "and",
+        children: [incompleteGt, incompleteContains],
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -3,9 +3,11 @@ import * as v from "valibot";
 
 import { type ConditionValue, evaluateCondition } from "./evaluate";
 import {
+  type CompareOp,
   type ConditionNode,
   conditionNodeSchema,
   emptyCondition,
+  type LiteralValue,
   type RefOperand,
 } from "./schema";
 
@@ -19,24 +21,21 @@ const resolverFor =
     if (operand.type === "path") {
       return data[operand.path];
     }
-    if (operand.type === "builtin") {
-      return data[operand.field];
-    }
     if (operand.type === "kind") {
       return data["kind"];
     }
-    return undefined;
+    return data[operand.field];
   };
 
 const compare = (
   left: RefOperand,
-  op: "eq" | "neq" | "gt" | "lt" | "gte" | "lte",
-  literal: ConditionValue,
+  op: CompareOp,
+  literal: LiteralValue,
 ): ConditionNode => ({
   type: "compare",
   left,
   op,
-  right: { type: "literal", value: literal as never },
+  right: { type: "literal", value: literal },
 });
 
 describe("compare operators", () => {

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { type ConditionValue, evaluateCondition } from "./evaluate";
+import {
+  type ConditionNode,
+  conditionNodeSchema,
+  emptyCondition,
+  type RefOperand,
+} from "./schema";
+
+/** A simple record-backed resolver for `property`/`path` operands. */
+const resolverFor =
+  (data: Record<string, ConditionValue>) =>
+  (operand: RefOperand): ConditionValue => {
+    if (operand.type === "property") {
+      return data[operand.propertyId];
+    }
+    if (operand.type === "path") {
+      return data[operand.path];
+    }
+    if (operand.type === "builtin") {
+      return data[operand.field];
+    }
+    if (operand.type === "kind") {
+      return data["kind"];
+    }
+    return undefined;
+  };
+
+const compare = (
+  left: RefOperand,
+  op: "eq" | "neq" | "gt" | "lt" | "gte" | "lte",
+  literal: ConditionValue,
+): ConditionNode => ({
+  type: "compare",
+  left,
+  op,
+  right: { type: "literal", value: literal as never },
+});
+
+describe("compare operators", () => {
+  test("eq normalizes nullish and number/string across types", () => {
+    const node = compare(
+      { type: "property", propertyId: "type" },
+      "eq",
+      "Lease",
+    );
+    expect(evaluateCondition(node, resolverFor({ type: "Lease" }))).toBe(true);
+    expect(evaluateCondition(node, resolverFor({ type: "NDA" }))).toBe(false);
+    expect(evaluateCondition(node, resolverFor({}))).toBe(false);
+
+    const numNode = compare({ type: "path", path: "amount" }, "eq", 1000);
+    expect(evaluateCondition(numNode, resolverFor({ amount: "1000" }))).toBe(
+      true,
+    );
+  });
+
+  test("numeric comparisons coerce strings and fail on non-numbers", () => {
+    const gt = compare({ type: "path", path: "amount" }, "gt", 1000);
+    expect(evaluateCondition(gt, resolverFor({ amount: 1500 }))).toBe(true);
+    expect(evaluateCondition(gt, resolverFor({ amount: "500" }))).toBe(false);
+    expect(evaluateCondition(gt, resolverFor({ amount: "n/a" }))).toBe(false);
+  });
+});
+
+describe("predicate operators", () => {
+  const operand: RefOperand = { type: "property", propertyId: "tags" };
+
+  test("is_empty across scalar, array, and absent", () => {
+    const node: ConditionNode = { type: "predicate", operand, op: "is_empty" };
+    expect(evaluateCondition(node, resolverFor({}))).toBe(true);
+    expect(evaluateCondition(node, resolverFor({ tags: "" }))).toBe(true);
+    expect(evaluateCondition(node, resolverFor({ tags: [] }))).toBe(true);
+    expect(evaluateCondition(node, resolverFor({ tags: ["a"] }))).toBe(false);
+  });
+
+  test("contains_all mirrors the legacy contains-every multi-select gate", () => {
+    const node: ConditionNode = {
+      type: "predicate",
+      operand,
+      op: "contains_all",
+      value: ["a", "b"],
+    };
+    expect(
+      evaluateCondition(node, resolverFor({ tags: ["a", "b", "c"] })),
+    ).toBe(true);
+    expect(evaluateCondition(node, resolverFor({ tags: ["a"] }))).toBe(false);
+  });
+
+  test("contains is case-insensitive substring (scalar) or membership (array)", () => {
+    const scalar: ConditionNode = {
+      type: "predicate",
+      operand: { type: "property", propertyId: "title" },
+      op: "contains",
+      value: "lease",
+    };
+    expect(
+      evaluateCondition(scalar, resolverFor({ title: "Master LEASE v2" })),
+    ).toBe(true);
+  });
+
+  test("in tests membership of the resolved value in the payload set", () => {
+    const node: ConditionNode = {
+      type: "predicate",
+      operand: { type: "builtin", field: "status" },
+      op: "in",
+      value: ["open", "review"],
+    };
+    expect(evaluateCondition(node, resolverFor({ status: "review" }))).toBe(
+      true,
+    );
+    expect(evaluateCondition(node, resolverFor({ status: "done" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("groups", () => {
+  test("empty AND root matches everything; empty OR matches nothing", () => {
+    expect(evaluateCondition(emptyCondition(), resolverFor({}))).toBe(true);
+    expect(
+      evaluateCondition(
+        { type: "group", combinator: "or", children: [] },
+        resolverFor({}),
+      ),
+    ).toBe(false);
+  });
+
+  test("and/or combinators and negation compose", () => {
+    const isLease = compare(
+      { type: "property", propertyId: "type" },
+      "eq",
+      "Lease",
+    );
+    const bigAmount = compare({ type: "path", path: "amount" }, "gt", 1000);
+
+    const and: ConditionNode = {
+      type: "group",
+      combinator: "and",
+      children: [isLease, bigAmount],
+    };
+    expect(
+      evaluateCondition(and, resolverFor({ type: "Lease", amount: 2000 })),
+    ).toBe(true);
+    expect(
+      evaluateCondition(and, resolverFor({ type: "Lease", amount: 10 })),
+    ).toBe(false);
+
+    const negated: ConditionNode = {
+      type: "group",
+      combinator: "and",
+      negated: true,
+      children: [isLease],
+    };
+    expect(evaluateCondition(negated, resolverFor({ type: "NDA" }))).toBe(true);
+  });
+});
+
+describe("schema", () => {
+  test("validates a nested group round-trip", () => {
+    const node: ConditionNode = {
+      type: "group",
+      combinator: "or",
+      children: [
+        compare({ type: "property", propertyId: "type" }, "eq", "Lease"),
+        {
+          type: "group",
+          combinator: "and",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "property", propertyId: "tags" },
+              op: "contains_all",
+              value: ["x"],
+            },
+          ],
+        },
+      ],
+    };
+    expect(v.parse(conditionNodeSchema, node)).toEqual(node);
+  });
+
+  test("rejects unknown operators and extra keys", () => {
+    expect(() =>
+      v.parse(conditionNodeSchema, {
+        type: "compare",
+        left: { type: "kind" },
+        op: "bogus",
+        right: { type: "literal", value: "x" },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -87,6 +87,17 @@ describe("compare operators", () => {
       evaluateCondition(onOrBefore, resolverFor({ due: "2026-07-01" })),
     ).toBe(false);
   });
+
+  test("an incomplete ordered comparison (empty literal) is a no-op", () => {
+    const gt = compare({ type: "property", propertyId: "amount" }, "gt", "");
+    expect(evaluateCondition(gt, resolverFor({ amount: 5 }))).toBe(true);
+    expect(evaluateCondition(gt, resolverFor({ amount: "" }))).toBe(true);
+
+    const lte = compare({ type: "property", propertyId: "due" }, "lte", "");
+    expect(evaluateCondition(lte, resolverFor({ due: "2026-06-01" }))).toBe(
+      true,
+    );
+  });
 });
 
 describe("predicate operators", () => {

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -159,15 +159,22 @@ const evaluatePredicate = (
   switch (node.op) {
     case "is_empty":
       return asArray(actual).length === 0;
+    case "is_not_empty":
+      return asArray(actual).length > 0;
     case "is_truthy":
       return isTruthy(actual);
-    case "contains": {
-      const needle = String(node.value ?? "").toLowerCase();
-      if (Array.isArray(actual)) {
-        return actual.some((item) => item.toLowerCase() === needle);
-      }
-      return normScalar(actual).toLowerCase().includes(needle);
-    }
+    case "contains":
+      return matchesContains(actual, node.value);
+    case "not_contains":
+      return !matchesContains(actual, node.value);
+    case "starts_with":
+      return normScalar(actual)
+        .toLowerCase()
+        .startsWith(String(node.value ?? "").toLowerCase());
+    case "ends_with":
+      return normScalar(actual)
+        .toLowerCase()
+        .endsWith(String(node.value ?? "").toLowerCase());
     case "contains_all": {
       const present = asArray(actual);
       return asArray(node.value).every((want) => present.includes(want));
@@ -177,4 +184,16 @@ const evaluatePredicate = (
     default:
       return false;
   }
+};
+
+/** Substring match on a scalar, or membership on an array. */
+const matchesContains = (
+  actual: ConditionValue,
+  value: string | string[] | undefined,
+): boolean => {
+  const needle = String(value ?? "").toLowerCase();
+  if (Array.isArray(actual)) {
+    return actual.some((item) => item.toLowerCase() === needle);
+  }
+  return normScalar(actual).toLowerCase().includes(needle);
 };

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -103,23 +103,40 @@ const compareValues = (
     return normScalar(left) !== normScalar(right);
   }
 
-  const ln = toNumber(left);
+  // Numeric comparison when the right-hand value (the literal, in Table
+  // filters) is a number: a non-numeric left value is then excluded. When the
+  // right value is non-numeric — e.g. an ISO date string — compare
+  // lexicographically so dates order chronologically, matching the SQL side.
   const rn = toNumber(right);
-  if (ln === undefined || rn === undefined) {
-    return false;
-  }
-  switch (op) {
-    case "gt":
-      return ln > rn;
-    case "lt":
-      return ln < rn;
-    case "gte":
-      return ln >= rn;
-    case "lte":
-      return ln <= rn;
-    default:
+  if (rn !== undefined) {
+    const ln = toNumber(left);
+    if (ln === undefined) {
       return false;
+    }
+    if (op === "gt") {
+      return ln > rn;
+    }
+    if (op === "lt") {
+      return ln < rn;
+    }
+    if (op === "gte") {
+      return ln >= rn;
+    }
+    return ln <= rn;
   }
+
+  const ls = normScalar(left);
+  const rs = normScalar(right);
+  if (op === "gt") {
+    return ls > rs;
+  }
+  if (op === "lt") {
+    return ls < rs;
+  }
+  if (op === "gte") {
+    return ls >= rs;
+  }
+  return ls <= rs;
 };
 
 // ── Predicates ────────────────────────────────────────────

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -1,0 +1,180 @@
+/**
+ * The single in-memory evaluator for the condition AST. Domain
+ * code supplies a `resolve` adapter that turns a non-literal
+ * operand into a concrete value; everything else (operators,
+ * boolean combination, negation) lives here so semantics never
+ * drift between view filters, extraction gating, and templates.
+ */
+import type {
+  CompareNode,
+  CompareOp,
+  ConditionNode,
+  Operand,
+  PredicateNode,
+  RefOperand,
+} from "./schema";
+
+export type ConditionValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | null
+  | undefined;
+
+export type OperandResolver = (operand: RefOperand) => ConditionValue;
+
+export const evaluateCondition = (
+  node: ConditionNode,
+  resolve: OperandResolver,
+): boolean => {
+  switch (node.type) {
+    case "group": {
+      const evalChild = (child: ConditionNode) =>
+        evaluateCondition(child, resolve);
+      // Empty AND ⇒ true (matches all); empty OR ⇒ false.
+      const combined =
+        node.combinator === "and"
+          ? node.children.every(evalChild)
+          : node.children.some(evalChild);
+      return node.negated ? !combined : combined;
+    }
+    case "compare":
+      return evaluateCompare(node, resolve);
+    case "predicate":
+      return evaluatePredicate(node, resolve);
+    default:
+      return false;
+  }
+};
+
+const resolveOperand = (
+  operand: Operand,
+  resolve: OperandResolver,
+): ConditionValue => {
+  if (operand.type === "literal") {
+    return operand.value;
+  }
+  return resolve(operand);
+};
+
+// ── Comparisons ───────────────────────────────────────────
+
+const evaluateCompare = (
+  node: CompareNode,
+  resolve: OperandResolver,
+): boolean => {
+  const left = resolveOperand(node.left, resolve);
+  const right = resolveOperand(node.right, resolve);
+  return compareValues(left, node.op, right);
+};
+
+/** Normalize for equality: nullish ⇒ "", arrays ⇒ comma-joined. */
+const normScalar = (value: ConditionValue): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value.join(",");
+  }
+  return String(value);
+};
+
+const toNumber = (value: ConditionValue): number | undefined => {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+};
+
+const compareValues = (
+  left: ConditionValue,
+  op: CompareOp,
+  right: ConditionValue,
+): boolean => {
+  if (op === "eq") {
+    return normScalar(left) === normScalar(right);
+  }
+  if (op === "neq") {
+    return normScalar(left) !== normScalar(right);
+  }
+
+  const ln = toNumber(left);
+  const rn = toNumber(right);
+  if (ln === undefined || rn === undefined) {
+    return false;
+  }
+  switch (op) {
+    case "gt":
+      return ln > rn;
+    case "lt":
+      return ln < rn;
+    case "gte":
+      return ln >= rn;
+    case "lte":
+      return ln <= rn;
+    default:
+      return false;
+  }
+};
+
+// ── Predicates ────────────────────────────────────────────
+
+const isTruthy = (value: ConditionValue): boolean => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+  if (typeof value === "string") {
+    return value.length > 0;
+  }
+  return value.length > 0;
+};
+
+const asArray = (value: ConditionValue): string[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === null || value === undefined || value === "") {
+    return [];
+  }
+  return [String(value)];
+};
+
+const evaluatePredicate = (
+  node: PredicateNode,
+  resolve: OperandResolver,
+): boolean => {
+  const actual = resolveOperand(node.operand, resolve);
+
+  switch (node.op) {
+    case "is_empty":
+      return asArray(actual).length === 0;
+    case "is_truthy":
+      return isTruthy(actual);
+    case "contains": {
+      const needle = String(node.value ?? "").toLowerCase();
+      if (Array.isArray(actual)) {
+        return actual.some((item) => item.toLowerCase() === needle);
+      }
+      return normScalar(actual).toLowerCase().includes(needle);
+    }
+    case "contains_all": {
+      const present = asArray(actual);
+      return asArray(node.value).every((want) => present.includes(want));
+    }
+    case "in":
+      return asArray(node.value).includes(normScalar(actual));
+    default:
+      return false;
+  }
+};

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -127,6 +127,12 @@ const compareValues = (
 
   const ls = normScalar(left);
   const rs = normScalar(right);
+  // A blank/absent value is not comparable: exclude it from ordered
+  // comparisons (so "date is before X" never matches rows with no date),
+  // mirroring the numeric branch's exclusion of non-numeric values.
+  if (ls === "") {
+    return false;
+  }
   if (op === "gt") {
     return ls > rs;
   }

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -103,6 +103,13 @@ const compareValues = (
     return normScalar(left) !== normScalar(right);
   }
 
+  // An ordered comparison needs a comparison value. An empty one is an
+  // incomplete filter (operator chosen, value not yet entered) — treat it as a
+  // no-op (vacuously true) rather than matching every row.
+  if (normScalar(right) === "") {
+    return true;
+  }
+
   // Numeric comparison when the right-hand value (the literal, in Table
   // filters) is a number: a non-numeric left value is then excluded. When the
   // right value is non-numeric — e.g. an ISO date string — compare

--- a/packages/conditions/src/evaluate.ts
+++ b/packages/conditions/src/evaluate.ts
@@ -103,13 +103,6 @@ const compareValues = (
     return normScalar(left) !== normScalar(right);
   }
 
-  // An ordered comparison needs a comparison value. An empty one is an
-  // incomplete filter (operator chosen, value not yet entered) — treat it as a
-  // no-op (vacuously true) rather than matching every row.
-  if (normScalar(right) === "") {
-    return true;
-  }
-
   // Numeric comparison when the right-hand value (the literal, in Table
   // filters) is a number: a non-numeric left value is then excluded. When the
   // right value is non-numeric — e.g. an ISO date string — compare
@@ -226,4 +219,47 @@ const matchesContains = (
     return actual.some((item) => item.toLowerCase() === needle);
   }
   return normScalar(actual).toLowerCase().includes(needle);
+};
+
+/**
+ * Whether a leaf is an incomplete filter — an ordered comparison or a
+ * value-bearing predicate whose value has not been entered yet. `eq`/`neq`
+ * against `""` and `is_empty`/`is_not_empty`/`is_truthy` are complete.
+ */
+const isIncompleteLeaf = (node: CompareNode | PredicateNode): boolean => {
+  if (node.type === "compare") {
+    return (
+      node.op !== "eq" &&
+      node.op !== "neq" &&
+      node.right.type === "literal" &&
+      String(node.right.value) === ""
+    );
+  }
+  return (
+    node.op !== "is_empty" &&
+    node.op !== "is_not_empty" &&
+    node.op !== "is_truthy" &&
+    asArray(node.value).length === 0
+  );
+};
+
+/**
+ * Drops incomplete leaves and any group left empty, recursing into groups, so
+ * an in-progress filter contributes no constraint. The SQL compiler prunes the
+ * same way (a `null` op-condition is dropped from `and()`/`or()`); applying
+ * this before in-memory evaluation keeps the two implementations in agreement —
+ * crucially under `or`, where a leaf evaluated as vacuously-true would not match
+ * a dropped one. Returns `null` when the whole node is incomplete.
+ */
+export const pruneIncomplete = (node: ConditionNode): ConditionNode | null => {
+  if (node.type === "group") {
+    const children = node.children
+      .map(pruneIncomplete)
+      .filter((child): child is ConditionNode => child !== null);
+    if (children.length === 0) {
+      return null;
+    }
+    return { ...node, children };
+  }
+  return isIncompleteLeaf(node) ? null : node;
 };

--- a/packages/conditions/src/index.ts
+++ b/packages/conditions/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * `@stll/conditions` — the canonical structured-condition AST
+ * and its single evaluator. See `./schema` for the shape and
+ * `./evaluate` for semantics.
+ */
+export * from "./schema";
+export * from "./evaluate";

--- a/packages/conditions/src/schema.ts
+++ b/packages/conditions/src/schema.ts
@@ -18,18 +18,26 @@ import * as v from "valibot";
 export const COMPARE_OPS = ["eq", "neq", "gt", "lt", "gte", "lte"] as const;
 export type CompareOp = (typeof COMPARE_OPS)[number];
 
-/** Operand-plus-payload tests (membership, emptiness, truthiness). */
+/** Operand-plus-payload tests (membership, emptiness, truthiness, text). */
 export const PREDICATE_OPS = [
   "is_empty",
+  "is_not_empty",
   "is_truthy",
   "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
   "contains_all",
   "in",
 ] as const;
 export type PredicateOp = (typeof PREDICATE_OPS)[number];
 
 /** Predicate operators that carry no payload value. */
-export const NULLARY_PREDICATE_OPS = ["is_empty", "is_truthy"] as const;
+export const NULLARY_PREDICATE_OPS = [
+  "is_empty",
+  "is_not_empty",
+  "is_truthy",
+] as const;
 
 export const BUILTIN_FIELDS = ["status", "priority"] as const;
 export type BuiltinField = (typeof BUILTIN_FIELDS)[number];

--- a/packages/conditions/src/schema.ts
+++ b/packages/conditions/src/schema.ts
@@ -1,0 +1,143 @@
+/**
+ * Canonical structured-condition AST shared across the
+ * workspace: view filters, AI-extraction gating, playbook
+ * matching, and (via a string parser) DOCX template
+ * conditionals. One representation, one evaluator, one set of
+ * operators. Surface syntaxes (a visual builder, an inline
+ * `{{#if ...}}` string) parse into this AST; they are not
+ * competing models.
+ *
+ * Pure schema module: valibot only, no runtime side effects,
+ * usable on both backend (Bun) and frontend (browser).
+ */
+import * as v from "valibot";
+
+// ── Operators ─────────────────────────────────────────────
+
+/** Binary comparisons between two operands. */
+export const COMPARE_OPS = ["eq", "neq", "gt", "lt", "gte", "lte"] as const;
+export type CompareOp = (typeof COMPARE_OPS)[number];
+
+/** Operand-plus-payload tests (membership, emptiness, truthiness). */
+export const PREDICATE_OPS = [
+  "is_empty",
+  "is_truthy",
+  "contains",
+  "contains_all",
+  "in",
+] as const;
+export type PredicateOp = (typeof PREDICATE_OPS)[number];
+
+/** Predicate operators that carry no payload value. */
+export const NULLARY_PREDICATE_OPS = ["is_empty", "is_truthy"] as const;
+
+export const BUILTIN_FIELDS = ["status", "priority"] as const;
+export type BuiltinField = (typeof BUILTIN_FIELDS)[number];
+
+export const COMBINATORS = ["and", "or"] as const;
+export type Combinator = (typeof COMBINATORS)[number];
+
+// ── Operands ──────────────────────────────────────────────
+
+const literalValueSchema = v.union([
+  v.string(),
+  v.number(),
+  v.boolean(),
+  v.array(v.string()),
+]);
+
+export type LiteralValue = v.InferOutput<typeof literalValueSchema>;
+
+/**
+ * A value reference. Domain adapters resolve every operand
+ * except `literal` (which the evaluator resolves directly):
+ *  - `property`/`builtin`/`kind` are the Table domain.
+ *  - `path` is the DOCX template fill-bag surface.
+ */
+export const operandSchema = v.variant("type", [
+  v.strictObject({
+    type: v.literal("property"),
+    propertyId: v.pipe(v.string(), v.minLength(1)),
+  }),
+  v.strictObject({
+    type: v.literal("builtin"),
+    field: v.picklist(BUILTIN_FIELDS),
+  }),
+  v.strictObject({ type: v.literal("kind") }),
+  v.strictObject({
+    type: v.literal("path"),
+    path: v.pipe(v.string(), v.minLength(1)),
+  }),
+  v.strictObject({ type: v.literal("literal"), value: literalValueSchema }),
+]);
+
+export type Operand = v.InferOutput<typeof operandSchema>;
+/** Any operand the domain adapter must resolve (everything but a literal). */
+export type RefOperand = Exclude<Operand, { type: "literal" }>;
+
+// ── Nodes ─────────────────────────────────────────────────
+
+export type CompareNode = {
+  type: "compare";
+  left: Operand;
+  op: CompareOp;
+  right: Operand;
+};
+
+export type PredicateNode = {
+  type: "predicate";
+  operand: Operand;
+  op: PredicateOp;
+  /** Payload for `contains`/`contains_all`/`in`; omitted for nullary ops. */
+  value?: string | string[] | undefined;
+};
+
+export type GroupNode = {
+  type: "group";
+  combinator: Combinator;
+  negated?: boolean | undefined;
+  children: ConditionNode[];
+};
+
+export type ConditionNode = CompareNode | PredicateNode | GroupNode;
+
+// Leaf schemas stay concrete (not annotated as GenericSchema) so they
+// remain valid `v.variant` options; only the recursive reference is lazy.
+const compareSchema = v.strictObject({
+  type: v.literal("compare"),
+  left: operandSchema,
+  op: v.picklist(COMPARE_OPS),
+  right: operandSchema,
+});
+
+const predicateSchema = v.strictObject({
+  type: v.literal("predicate"),
+  operand: operandSchema,
+  op: v.picklist(PREDICATE_OPS),
+  value: v.optional(v.union([v.string(), v.array(v.string())])),
+});
+
+const groupSchema = v.strictObject({
+  type: v.literal("group"),
+  combinator: v.picklist(COMBINATORS),
+  negated: v.optional(v.boolean()),
+  children: v.array(
+    v.lazy((): v.GenericSchema<ConditionNode> => conditionNodeSchema),
+  ),
+});
+
+export const conditionNodeSchema: v.GenericSchema<ConditionNode> = v.variant(
+  "type",
+  [compareSchema, predicateSchema, groupSchema],
+);
+
+/** A top-level condition is always a group (the AND/OR root). */
+export const conditionSchema = groupSchema;
+export type Condition = GroupNode;
+
+/** An empty AND root: matches everything (the "no filter" identity). */
+export const emptyCondition = (): Condition => ({
+  type: "group",
+  combinator: "and",
+  children: [],
+});

--- a/packages/conditions/tsconfig.json
+++ b/packages/conditions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@stll/typescript-config/base.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "types": ["bun"]
+  },
+  "include": ["."],
+  "exclude": ["node_modules"]
+}

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -121,7 +121,10 @@ schema_file_has_migration_relevant_diff() {
         keptLines.push(line);
       }
 
-      return keptLines.join("\n");
+      // `$type<...>` is a TypeScript-only column annotation with no effect on
+      // the generated DDL (the column stays the same SQL type), so normalize
+      // its generic argument away — like type-only imports above.
+      return keptLines.join("\n").replace(/\.\$type<.*>/gu, ".$type<>");
     };
 
     const currentSource = fs.readFileSync(changedFile, "utf8");


### PR DESCRIPTION
## Summary

Replaces the three independent "condition" dialects in the codebase with one structured AST (`@stll/conditions`) and migrates the Table-view filter and AI-extraction-gating paths onto it.

## Core — `packages/conditions`
- A structured condition AST: `compare | predicate | group` nodes over `property | builtin | kind | path | literal` operands, designed as a superset that can also represent the inline template-condition language (a follow-up converges the DOCX string engine onto it via a parser).
- One pure evaluator parameterized by a per-domain `resolve(operand)` adapter, so semantics never diverge across domains.
- Operators: `eq, neq, gt, lt, gte, lte` (compare); `is_empty, is_not_empty, is_truthy, contains, not_contains, starts_with, ends_with, contains_all, in` (predicate).
- fast-check property tests assert the invariants examples can't: totality + schema-validity over arbitrary trees; group = every/some; double-negation identity; `neq = ¬eq`, `not_contains = ¬contains`, `is_not_empty = ¬is_empty`.

## Migrations onto the core
- **View filters**: `ViewLayout.filters` is now `ConditionNode[]`; `entity-filters.ts` compiles the AST to SQL (groups → and/or/not, property EXISTS subqueries, builtin columns, kind document→folder expansion) and evaluates in-memory via the shared evaluator. The bespoke `ViewFilterCondition` union is deleted.
- **AI-extraction gating**: `propertyDependencies.condition` is now a `ConditionNode`; the gating evaluator builds a resolver from a row's fields and delegates to the shared evaluator. The bespoke `PropertyCondition` is deleted.
- **No data migration**: stored filters validate leniently (a stray pre-AST row resets to empty); gating conditions read leniently (invalid → no gate). Rollout-safe, zero downtime.

## Filter builder UI
- One reusable condition builder shared by view filters and the extraction-column config (replacing two ad-hoc editors).
- Compact filter chips in the toolbar, a searchable property picker with type icons, an inline type-aware operator dropdown (text/number/date/select each get the right operator labels), a per-chip overflow menu, and AND/OR groups for advanced filters.
- A dedicated "no items match these filters" empty state (with Clear filters) when a view is empty due to filters, instead of the generic empty screen.

## API contract
- A TypeBox mirror of the AST for Elysia route bodies, with a compile-time guard that fails typecheck if it drifts from the canonical valibot schema.

## Notes
- `template-conditions` (the inline DOCX string engine) is intentionally left as-is; a follow-up makes it a parser/printer onto this AST.
- First of a stacked series; subsequent PRs add grouping, classification, faceting, playbooks, and the per-type display.
- Verified: `@stll/conditions` 16 tests / 723 assertions; api + web typecheck; entity-filters/views tests (41 tests / 2402 assertions); type-aware lint; i18n in sync.
