### PR TITLE
feat(web): structural loading skeletons in place of the glowing logo

### DIFF
--- a/.agents/skills/conventions-ux/SKILL.md
+++ b/.agents/skills/conventions-ux/SKILL.md
@@ -124,6 +124,21 @@ Small, almost invisible touches. Linear is a good reference.
 - **Inline spinners over full-page loaders.** Scope loading
   indicators to the region that's actually waiting. A full-page
   spinner for a sidebar fetch is disorienting.
+- **Render the destination's structure, not a logo.** When a route
+  loads, show its real shape (table chrome with header and columns,
+  toolbar, section cards) with the values shimmering in. The centered
+  glowing logo (`DefaultPendingComponent`) is the last-resort
+  fallback, not the default. Give each route its own
+  `pendingComponent` so the route you navigate to picks its own shape.
+- **Skeletons must be structurally drift-proof.** Generate the
+  skeleton from the same source as the real UI, never a hand-copied
+  parallel tree. For tables, render the header, rows, and skeleton
+  from one column model (`@stll/ui` table plus the shared
+  `TableSkeletonRows` helper) so adding or reordering a column moves
+  all three at once. Where the page chrome does not need the data,
+  move the Suspense boundary inward (render the real chrome, suspend
+  only the leaves). For scaffolds that cannot share a source, mirror
+  the real layout faithfully.
 
 ## Viewport & Responsive
 

--- a/.ai/local-skills/conventions-ux/SKILL.md
+++ b/.ai/local-skills/conventions-ux/SKILL.md
@@ -124,6 +124,21 @@ Small, almost invisible touches. Linear is a good reference.
 - **Inline spinners over full-page loaders.** Scope loading
   indicators to the region that's actually waiting. A full-page
   spinner for a sidebar fetch is disorienting.
+- **Render the destination's structure, not a logo.** When a route
+  loads, show its real shape (table chrome with header and columns,
+  toolbar, section cards) with the values shimmering in. The centered
+  glowing logo (`DefaultPendingComponent`) is the last-resort
+  fallback, not the default. Give each route its own
+  `pendingComponent` so the route you navigate to picks its own shape.
+- **Skeletons must be structurally drift-proof.** Generate the
+  skeleton from the same source as the real UI, never a hand-copied
+  parallel tree. For tables, render the header, rows, and skeleton
+  from one column model (`@stll/ui` table plus the shared
+  `TableSkeletonRows` helper) so adding or reordering a column moves
+  all three at once. Where the page chrome does not need the data,
+  move the Suspense boundary inward (render the real chrome, suspend
+  only the leaves). For scaffolds that cannot share a source, mirror
+  the real layout faithfully.
 
 ## Viewport & Responsive
 

--- a/.claude/commands/conventions-ux.md
+++ b/.claude/commands/conventions-ux.md
@@ -119,6 +119,21 @@ Small, almost invisible touches. Linear is a good reference.
 - **Inline spinners over full-page loaders.** Scope loading
   indicators to the region that's actually waiting. A full-page
   spinner for a sidebar fetch is disorienting.
+- **Render the destination's structure, not a logo.** When a route
+  loads, show its real shape (table chrome with header and columns,
+  toolbar, section cards) with the values shimmering in. The centered
+  glowing logo (`DefaultPendingComponent`) is the last-resort
+  fallback, not the default. Give each route its own
+  `pendingComponent` so the route you navigate to picks its own shape.
+- **Skeletons must be structurally drift-proof.** Generate the
+  skeleton from the same source as the real UI, never a hand-copied
+  parallel tree. For tables, render the header, rows, and skeleton
+  from one column model (`@stll/ui` table plus the shared
+  `TableSkeletonRows` helper) so adding or reordering a column moves
+  all three at once. Where the page chrome does not need the data,
+  move the Suspense boundary inward (render the real chrome, suspend
+  only the leaves). For scaffolds that cannot share a source, mirror
+  the real layout faithfully.
 
 ## Viewport & Responsive
 

--- a/apps/api/src/handlers/views/read.ts
+++ b/apps/api/src/handlers/views/read.ts
@@ -9,7 +9,7 @@ import type { AuditEvent } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { extractLangFromRequest } from "@/api/lib/locale";
 import { getDefaultViews } from "@/api/lib/views";
-import { parseViewLayout } from "@/api/lib/views-schema";
+import { parseViewLayoutSafe } from "@/api/lib/views-schema";
 
 const config = {
   permissions: { workspace: ["read"] },
@@ -23,7 +23,7 @@ const toViewResponse = (
     position: number;
     createdAt: Date;
   },
-  layout = parseViewLayout(view.layout),
+  layout = parseViewLayoutSafe(view.layout),
 ) => ({
   version: 1 as const,
   id: view.id,
@@ -87,7 +87,7 @@ const readViews = createSafeHandler(
                 old: null,
                 new: {
                   name: row.name,
-                  layoutType: parseViewLayout(row.layout).type,
+                  layoutType: parseViewLayoutSafe(row.layout).type,
                   position: row.position,
                 },
               },
@@ -132,7 +132,7 @@ const readViews = createSafeHandler(
 
     return Result.ok(
       views.map((view) => {
-        const layout = parseViewLayout(view.layout);
+        const layout = parseViewLayoutSafe(view.layout);
         cleanStalePropertyIds(layout, propertyIds);
         return toViewResponse(view, layout);
       }),

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -5,6 +5,7 @@ import * as v from "valibot";
 
 import {
   parseViewLayout,
+  parseViewLayoutSafe,
   tViewFilterConditionSchema,
   tViewLayoutSchema,
   tViewTemplatePropertySchema,
@@ -39,6 +40,75 @@ describe("parseViewLayout", () => {
     };
 
     expect(() => parseViewLayout(layout)).toThrow();
+  });
+});
+
+describe("parseViewLayoutSafe", () => {
+  test("returns a well-formed layout unchanged", () => {
+    const layout = {
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: ["name"],
+      columnPinning: [],
+    } satisfies ViewLayout;
+
+    expect(parseViewLayoutSafe(layout)).toEqual(layout);
+  });
+
+  test("recovers a layout whose filters use a retired grammar by dropping them", () => {
+    // Legacy group/predicate filter AST the current schema no longer accepts.
+    const legacy = {
+      version: 1,
+      type: "table",
+      filters: [
+        {
+          type: "group",
+          combinator: "and",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: [],
+            },
+          ],
+        },
+      ],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: ["name"],
+      columnPinning: ["name"],
+    };
+
+    // The raw layout throws under strict parsing...
+    expect(() => parseViewLayout(legacy)).toThrow();
+
+    // ...but the safe parser keeps the table view and its columns, only
+    // dropping the unparseable filters so one legacy view can't fail the list.
+    expect(parseViewLayoutSafe(legacy)).toEqual({
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: ["name"],
+      columnPinning: ["name"],
+    });
+  });
+
+  test("falls back to a minimal layout for an unrecoverable value and never throws", () => {
+    expect(parseViewLayoutSafe({ type: "garbage" })).toEqual({
+      type: "filesystem",
+      version: 1,
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+    });
+    expect(() => parseViewLayoutSafe(null)).not.toThrow();
+    expect(() => parseViewLayoutSafe("not a layout")).not.toThrow();
   });
 });
 

--- a/apps/api/src/lib/views-schema.ts
+++ b/apps/api/src/lib/views-schema.ts
@@ -204,6 +204,36 @@ export type ViewLayoutType = ViewLayout["type"];
 export const parseViewLayout = (value: unknown): ViewLayout =>
   v.parse(viewLayoutSchema, value);
 
+// Recovers a stored layout that fails strict parsing: older views can carry a
+// filter grammar the current schema rejects. Drop the unparseable filters/sorts
+// and retry so a single legacy view can't fail the whole views response; fall
+// back to a minimal filesystem layout only if the row is otherwise unrecoverable.
+export const parseViewLayoutSafe = (value: unknown): ViewLayout => {
+  const direct = v.safeParse(viewLayoutSchema, value);
+  if (direct.success) {
+    return direct.output;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const sanitized = v.safeParse(viewLayoutSchema, {
+      ...value,
+      filters: [],
+      sorts: [],
+    });
+    if (sanitized.success) {
+      return sanitized.output;
+    }
+  }
+
+  return {
+    type: "filesystem",
+    version: 1,
+    filters: [],
+    sorts: [],
+    hiddenProperties: [],
+  };
+};
+
 const tBaseLayoutSchema = {
   filters: t.Array(tViewFilterConditionSchema),
   sorts: t.Array(tViewSortSchema),

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -92,6 +92,8 @@ export const DevSidebarGroup = () => {
       setReactGrab: s.setReactGrab,
       publicLawPreview: s.publicLawPreview,
       setPublicLawPreview: s.setPublicLawPreview,
+      simulateSlowLoad: s.simulateSlowLoad,
+      setSimulateSlowLoad: s.setSimulateSlowLoad,
     })),
   );
 
@@ -224,6 +226,13 @@ export const DevSidebarGroup = () => {
           variant="switch"
         >
           Public law preview
+        </MenuCheckboxItem>
+        <MenuCheckboxItem
+          checked={dev.simulateSlowLoad}
+          onClick={() => dev.setSimulateSlowLoad(!dev.simulateSlowLoad)}
+          variant="switch"
+        >
+          Simulate slow load
         </MenuCheckboxItem>
         <MenuSeparator />
         <MenuGroup>

--- a/apps/web/src/components/table-skeleton-rows.tsx
+++ b/apps/web/src/components/table-skeleton-rows.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react";
+
+import type { Column, RowData, TableFeatures } from "@tanstack/react-table";
+
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { TableCell, TableRow } from "@stll/ui/components/table";
+
+// Stable keys so loading rows never fall back to array-index keys.
+const SKELETON_ROW_KEYS = [
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+  "i",
+  "j",
+  "k",
+  "l",
+] as const;
+
+const DEFAULT_SKELETON_ROW_COUNT = 8;
+
+type TableSkeletonRowsProps<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+> = {
+  columns: readonly Column<TFeatures, TData>[];
+  rowCount?: number;
+  // Per-column placeholder. Return `undefined` to use the default bar, `null`
+  // for an intentionally empty cell, or any node for a custom placeholder.
+  renderCell?: (column: Column<TFeatures, TData>) => ReactNode;
+};
+
+/**
+ * Loading rows generated from the table's own column model, so the skeleton
+ * cannot drift from the real table: add, remove, or reorder a column and the
+ * placeholder gains, loses, or moves the matching cell automatically. Render it
+ * inside the same `<TableBody>` the real rows use, passing the table's leaf
+ * columns (e.g. `table.getAllLeafColumns()`).
+ */
+export const TableSkeletonRows = <
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>({
+  columns,
+  rowCount = DEFAULT_SKELETON_ROW_COUNT,
+  renderCell,
+}: TableSkeletonRowsProps<TFeatures, TData>) => {
+  const rowKeys = SKELETON_ROW_KEYS.slice(
+    0,
+    Math.min(rowCount, SKELETON_ROW_KEYS.length),
+  );
+
+  return rowKeys.map((rowKey) => (
+    <TableRow key={rowKey}>
+      {columns.map((column) => {
+        const custom = renderCell?.(column);
+        return (
+          <TableCell key={column.id}>
+            {custom === undefined ? <Skeleton className="h-4 w-3/5" /> : custom}
+          </TableCell>
+        );
+      })}
+    </TableRow>
+  ));
+};

--- a/apps/web/src/features/case-law/components/decision-table.tsx
+++ b/apps/web/src/features/case-law/components/decision-table.tsx
@@ -1,21 +1,25 @@
 import { Link } from "@tanstack/react-router";
 import { useFormatter, useTranslations } from "use-intl";
 
+import { Skeleton } from "@stll/ui/components/skeleton";
+
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
+
+// Stable keys so loading rows never fall back to array-index keys.
+const SKELETON_ROW_KEYS = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+const SKELETON_CELL_KEYS = [
+  "caseNumber",
+  "court",
+  "country",
+  "date",
+  "type",
+] as const;
 
 export const DecisionTable = ({ decisions, isLoading }: DecisionTableProps) => {
   const t = useTranslations();
   const format = useFormatter();
 
-  if (isLoading) {
-    return (
-      <p className="text-muted-foreground py-8 text-center text-sm">
-        {t("caseLaw.loading")}
-      </p>
-    );
-  }
-
-  if (decisions.length === 0) {
+  if (!isLoading && decisions.length === 0) {
     return (
       <p className="text-muted-foreground py-8 text-center text-sm">
         {t("caseLaw.emptyState")}
@@ -62,24 +66,39 @@ export const DecisionTable = ({ decisions, isLoading }: DecisionTableProps) => {
             </tr>
           </thead>
           <tbody>
-            {decisions.map((decision) => (
-              <tr
-                className="border-border/35 hover:bg-muted/30 border-b last:border-b-0"
-                key={decision.id}
-              >
-                <td className="px-4 py-2">{renderCaseNumberCell(decision)}</td>
-                <td className="px-4 py-2">{decision.court}</td>
-                <td className="px-4 py-2">
-                  {renderCountryCell(decision.country)}
-                </td>
-                <td className="px-4 py-2">
-                  {formatDecisionDate(decision.decisionDate, format)}
-                </td>
-                <td className="px-4 py-2">
-                  {decision.decisionType ?? "\u2014"}
-                </td>
-              </tr>
-            ))}
+            {isLoading
+              ? SKELETON_ROW_KEYS.map((rowKey) => (
+                  <tr
+                    className="border-border/35 border-b last:border-b-0"
+                    key={rowKey}
+                  >
+                    {SKELETON_CELL_KEYS.map((cellKey) => (
+                      <td className="px-4 py-2" key={cellKey}>
+                        <Skeleton className="h-4 w-3/5" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              : decisions.map((decision) => (
+                  <tr
+                    className="border-border/35 hover:bg-muted/30 border-b last:border-b-0"
+                    key={decision.id}
+                  >
+                    <td className="px-4 py-2">
+                      {renderCaseNumberCell(decision)}
+                    </td>
+                    <td className="px-4 py-2">{decision.court}</td>
+                    <td className="px-4 py-2">
+                      {renderCountryCell(decision.country)}
+                    </td>
+                    <td className="px-4 py-2">
+                      {formatDecisionDate(decision.decisionDate, format)}
+                    </td>
+                    <td className="px-4 py-2">
+                      {decision.decisionType ?? "\u2014"}
+                    </td>
+                  </tr>
+                ))}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,11 +4,20 @@ import { posthog } from "posthog-js";
 import type { API } from "@stll/api/types";
 
 import { env } from "@/env";
+import { getSimulateSlowLoadDelayMs } from "@/lib/dev-store";
 
 const eden = treaty<API>(env.VITE_API_URL, {
   parseDate: false,
   fetch: {
     credentials: "include",
+  },
+  async onRequest() {
+    const delayMs = getSimulateSlowLoadDelayMs();
+    if (delayMs > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
+    }
   },
   headers() {
     if (typeof window === "undefined") {

--- a/apps/web/src/lib/dev-store.ts
+++ b/apps/web/src/lib/dev-store.ts
@@ -11,6 +11,7 @@ type State = {
   showToolCallDetails: boolean;
   reactGrab: boolean;
   publicLawPreview: boolean;
+  simulateSlowLoad: boolean;
 };
 
 type Actions = {
@@ -20,6 +21,7 @@ type Actions = {
   setShowToolCallDetails: (value: boolean) => void;
   setReactGrab: (value: boolean) => void;
   setPublicLawPreview: (value: boolean) => void;
+  setSimulateSlowLoad: (value: boolean) => void;
 };
 
 const serverStorage: StateStorage = {
@@ -37,6 +39,7 @@ export const useDevStore = create<State & Actions>()(
       showToolCallDetails: false,
       reactGrab: false,
       publicLawPreview: false,
+      simulateSlowLoad: false,
 
       setTanstackDevtools: (tanstackDevtools) => {
         void set({ tanstackDevtools });
@@ -56,6 +59,9 @@ export const useDevStore = create<State & Actions>()(
       setPublicLawPreview: (publicLawPreview) => {
         void set({ publicLawPreview });
       },
+      setSimulateSlowLoad: (simulateSlowLoad) => {
+        void set({ simulateSlowLoad });
+      },
     }),
     {
       storage: createJSONStorage(() =>
@@ -65,3 +71,20 @@ export const useDevStore = create<State & Actions>()(
     },
   ),
 );
+
+/** Artificial per-request delay (ms) injected into every API fetch while
+ *  the "Simulate slow load" dev toggle is on, so loading screens stay
+ *  visible long enough to inspect and restyle. */
+export const SIMULATE_SLOW_LOAD_DELAY_MS = 3000;
+
+/** Current artificial API delay, read outside React for the fetch layer.
+ *  Returns 0 in production builds and during SSR so the delay only ever
+ *  applies to a developer's own client session. */
+export const getSimulateSlowLoadDelayMs = (): number => {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return 0;
+  }
+  return useDevStore.getState().simulateSlowLoad
+    ? SIMULATE_SLOW_LOAD_DELAY_MS
+    : 0;
+};

--- a/apps/web/src/routes/_protected.chat/$threadId.tsx
+++ b/apps/web/src/routes/_protected.chat/$threadId.tsx
@@ -1,14 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { Skeleton } from "@stll/ui/components/skeleton";
+
 import { toChatThreadId } from "@/lib/chat-thread-ref";
 import { ChatThreadPage } from "@/routes/_protected.chat/-components/chat-thread-page";
 
 export const Route = createFileRoute("/_protected/chat/$threadId")({
   component: ThreadRoute,
-  // Skip the route-level pending splash for chat-thread navigations.
-  // Most threads load instantly from cache; the brief splash was
-  // jarring between two consecutive chats. With pendingMs at 1s
-  // the splash only appears when the load actually stalls.
+  pendingComponent: ChatThreadPending,
+  // Most threads load instantly from cache, so hold the skeleton back for
+  // 1s — it only appears when the load actually stalls, avoiding a flash
+  // between two consecutive chats.
   pendingMs: 1000,
 });
 
@@ -18,4 +20,51 @@ function ThreadRoute() {
   });
 
   return <ChatThreadPage threadRef={{ scope: "global", threadId }} />;
+}
+
+const CHAT_SKELETON_BUBBLES = [
+  { key: "a", side: "user" },
+  { key: "b", side: "assistant" },
+  { key: "c", side: "user" },
+  { key: "d", side: "assistant" },
+] as const;
+
+// Mirrors the ChatThreadPage shell: top bar, conversation area, and the input
+// surface — so the chat structure is visible immediately instead of a logo.
+function ChatThreadPending() {
+  return (
+    <div className="flex w-full flex-1 flex-col overflow-hidden">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-2 px-4 py-2">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-24 rounded-md" />
+          <Skeleton className="h-8 w-32 rounded-md" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Skeleton className="size-8 rounded-md" />
+          <Skeleton className="size-8 rounded-md" />
+          <Skeleton className="size-8 rounded-md" />
+        </div>
+      </div>
+
+      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-4 overflow-hidden px-4 py-4">
+        {CHAT_SKELETON_BUBBLES.map((bubble) =>
+          bubble.side === "user" ? (
+            <div className="flex justify-end" key={bubble.key}>
+              <Skeleton className="h-12 w-2/5 rounded-2xl" />
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2" key={bubble.key}>
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          ),
+        )}
+      </div>
+
+      <div className="mx-auto w-full max-w-5xl p-4">
+        <Skeleton className="h-24 w-full rounded-xl" />
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -13,6 +13,7 @@ import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { ContactCommunicationEditor } from "@/routes/_protected.contacts/-components/contact-communication-editor";
@@ -35,13 +36,57 @@ import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/crea
 
 export const Route = createFileRoute("/_protected/contacts/$contactId")({
   component: ContactDetailPage,
-  pendingComponent: () => (
-    <div className="flex flex-1 flex-col gap-4 border-t p-4">
-      <Skeleton className="h-8 w-64" />
-      <Skeleton className="h-48 w-full" />
-    </div>
-  ),
+  pendingComponent: ContactDetailPending,
 });
+
+const SECTION_ROW_KEYS = ["a", "b", "c", "d", "e", "f"];
+
+const ContactSectionSkeleton = ({
+  rows,
+  className,
+}: {
+  rows: number;
+  className?: string;
+}) => (
+  <section className={cn("rounded-lg border p-4", className)}>
+    <Skeleton className="mb-3 h-4 w-28" />
+    <div className="space-y-2.5">
+      {SECTION_ROW_KEYS.slice(0, rows).map((key) => (
+        <div className="flex items-center justify-between gap-4" key={key}>
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+// Mirrors the real detail layout: header (back/icon/title/badge/actions) above a
+// two-column grid of section cards, so the page does not jump when data lands.
+function ContactDetailPending() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto border-t p-4">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-7 rounded-md" />
+        <Skeleton className="size-5 rounded-full" />
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-5 w-16 rounded-md" />
+        <div className="ms-auto flex items-center gap-2">
+          <Skeleton className="h-8 w-28 rounded-md" />
+          <Skeleton className="h-8 w-24 rounded-md" />
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <ContactSectionSkeleton rows={5} />
+        <ContactSectionSkeleton rows={4} />
+        <ContactSectionSkeleton rows={3} />
+        <ContactSectionSkeleton rows={3} />
+        <ContactSectionSkeleton className="md:col-span-2" rows={2} />
+        <ContactSectionSkeleton className="md:col-span-2" rows={3} />
+      </div>
+    </div>
+  );
+}
 
 const protectedRouteApi = getRouteApi("/_protected");
 

--- a/apps/web/src/routes/_protected.contacts/index.tsx
+++ b/apps/web/src/routes/_protected.contacts/index.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
 
 import { useForm } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -9,6 +10,14 @@ import {
   useNavigate,
 } from "@tanstack/react-router";
 import { useSelector } from "@tanstack/react-store";
+import {
+  createColumnHelper,
+  createCoreRowModel,
+  flexRender,
+  tableFeatures,
+  useTable,
+} from "@tanstack/react-table";
+import type { Column, ReactTable, Row } from "@tanstack/react-table";
 import {
   BuildingIcon,
   EllipsisVerticalIcon,
@@ -47,6 +56,7 @@ import {
   MenuPopup,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import {
   Table,
   TableBody,
@@ -58,6 +68,7 @@ import {
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { EmptyScreen } from "@/components/empty-screen";
+import { TableSkeletonRows } from "@/components/table-skeleton-rows";
 import Tooltip from "@/components/tooltip";
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";
@@ -84,6 +95,7 @@ export const Route = createFileRoute("/_protected/contacts/")({
     meta: [{ title: pageTitle("navigation.contacts") }],
   }),
   component: ContactsPage,
+  pendingComponent: ContactsPendingComponent,
 });
 
 const protectedRouteApi = getRouteApi("/_protected");
@@ -113,12 +125,21 @@ function ContactsPage() {
     }),
   );
 
-  const items = data?.items ?? [];
+  const items: ContactItem[] = data?.items ?? [];
   const isFirstUseEmpty =
     !isLoading &&
     items.length === 0 &&
     searchQuery.trim() === "" &&
     filter === "all";
+
+  const columns = useContactColumns();
+
+  const table = useTable({
+    features: contactTableFeatures,
+    data: items,
+    columns,
+    getRowId: (row) => row.id,
+  });
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto border-t p-4">
@@ -173,36 +194,7 @@ function ContactsPage() {
           title={tContacts("emptyTitle")}
         />
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-8" />
-              <TableHead>{t("common.name")}</TableHead>
-              <TableHead>{t("common.email")}</TableHead>
-              <TableHead>{t("contacts.columns.phone")}</TableHead>
-              <TableHead className="text-end">{t("common.matters")}</TableHead>
-              <TableHead />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {items.map((contact) => (
-              <ContactRow contact={contact} key={contact.id} />
-            ))}
-            {!isLoading && items.length === 0 && (
-              <TableRow>
-                <TableCell
-                  className="text-muted-foreground py-8 text-center"
-                  colSpan={6}
-                >
-                  <p>{t("contacts.noContactsFound")}</p>
-                  <p className="text-sm">
-                    {t("contacts.noContactsDescription")}
-                  </p>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+        <ContactsTable isLoading={isLoading} table={table} />
       )}
     </div>
   );
@@ -235,27 +227,166 @@ type ContactItem = {
   clientMatterCount: number;
 };
 
-const ContactRow = ({ contact }: { contact: ContactItem }) => {
+const contactTableFeatures = tableFeatures({
+  coreRowModel: createCoreRowModel(),
+});
+type ContactTableFeatures = typeof contactTableFeatures;
+
+const columnHelper = createColumnHelper<ContactTableFeatures, ContactItem>();
+
+// Single column source of truth: the page table, its loading skeleton, and the
+// route-level pending shell all derive from this, so none can drift.
+const useContactColumns = () => {
   const t = useTranslations();
+  return useMemo(
+    () =>
+      columnHelper.columns([
+        columnHelper.display({
+          id: "icon",
+          header: () => null,
+          cell: ({ row }) =>
+            row.original.type === "person" ? (
+              <UserIcon className="text-muted-foreground size-4" />
+            ) : (
+              <BuildingIcon className="text-muted-foreground size-4" />
+            ),
+        }),
+        columnHelper.accessor("displayName", {
+          id: "name",
+          header: t("common.name"),
+          cell: ({ row, getValue }) => (
+            <Link
+              className="font-medium hover:underline"
+              onClick={(event) => event.stopPropagation()}
+              params={{ contactId: row.original.id }}
+              to="/contacts/$contactId"
+            >
+              {getValue()}
+            </Link>
+          ),
+        }),
+        columnHelper.display({
+          id: "email",
+          header: t("common.email"),
+          cell: ({ row }) => {
+            const primaryEmail =
+              row.original.emails?.find((e) => e.isPrimary) ??
+              row.original.emails?.at(0);
+            if (!primaryEmail) {
+              return null;
+            }
+            return (
+              <a
+                className="text-muted-foreground hover:text-foreground hover:underline"
+                href={`mailto:${primaryEmail.address}`}
+              >
+                {primaryEmail.address}
+              </a>
+            );
+          },
+        }),
+        columnHelper.display({
+          id: "phone",
+          header: t("contacts.columns.phone"),
+          cell: ({ row }) => {
+            const primaryPhone =
+              row.original.phones?.find((p) => p.isPrimary) ??
+              row.original.phones?.at(0);
+            return (
+              <span className="text-muted-foreground">
+                {primaryPhone?.number}
+              </span>
+            );
+          },
+        }),
+        columnHelper.accessor("clientMatterCount", {
+          id: "matters",
+          header: () => <div className="text-end">{t("common.matters")}</div>,
+          cell: ({ getValue }) => (
+            <div className="text-end tabular-nums">{getValue()}</div>
+          ),
+        }),
+        columnHelper.display({
+          id: "actions",
+          header: () => null,
+          cell: ({ row }) => <ContactRowActions contact={row.original} />,
+        }),
+      ]),
+    [t],
+  );
+};
+
+// Placeholder cells keyed off each column's stable id, so the loading state
+// stays aligned with the column definitions above without a parallel skeleton.
+const renderContactSkeletonCell = (
+  column: Column<ContactTableFeatures, ContactItem>,
+): ReactNode => {
+  if (column.id === "icon") {
+    return <Skeleton className="size-4 rounded" />;
+  }
+  if (column.id === "matters") {
+    return <Skeleton className="ms-auto h-4 w-6" />;
+  }
+  if (column.id === "actions") {
+    return null;
+  }
+  return undefined;
+};
+
+const ContactTableRow = ({
+  row,
+}: {
+  row: Row<ContactTableFeatures, ContactItem>;
+}) => {
   const navigate = useNavigate();
+
+  const openContact = () => {
+    void navigate({
+      to: "/contacts/$contactId",
+      params: { contactId: row.original.id },
+    });
+  };
+
+  return (
+    <TableRow
+      className="hover:bg-accent/30 focus-visible:ring-ring group cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-inset"
+      onClick={openContact}
+      onKeyDown={(event) => {
+        if (event.currentTarget !== event.target) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openContact();
+        }
+      }}
+      tabIndex={0}
+    >
+      {row.getAllCells().map((cell) => {
+        const stopsRowClick =
+          cell.column.id === "email" || cell.column.id === "actions";
+        return (
+          <TableCell
+            key={cell.id}
+            onClick={
+              stopsRowClick ? (event) => event.stopPropagation() : undefined
+            }
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </TableCell>
+        );
+      })}
+    </TableRow>
+  );
+};
+
+const ContactRowActions = ({ contact }: { contact: ContactItem }) => {
+  const t = useTranslations();
   const canDeleteContact = usePermissions({ contact: ["delete"] });
   const deleteContact = useDeleteContact();
   const queryClient = useQueryClient();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const deleteBlockedDescription = t("contacts.deleteContactBlockedByMatters");
-
-  const primaryEmail =
-    contact.emails?.find((e) => e.isPrimary) ?? contact.emails?.at(0);
-
-  const primaryPhone =
-    contact.phones?.find((p) => p.isPrimary) ?? contact.phones?.at(0);
-
-  const openContact = () => {
-    void navigate({
-      to: "/contacts/$contactId",
-      params: { contactId: contact.id },
-    });
-  };
 
   const handleDelete = async () => {
     await deleteContact.mutateAsync(
@@ -294,100 +425,148 @@ const ContactRow = ({ contact }: { contact: ContactItem }) => {
   };
 
   return (
-    <TableRow
-      className="hover:bg-accent/30 focus-visible:ring-ring group cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-inset"
-      onClick={openContact}
-      onKeyDown={(event) => {
-        if (event.currentTarget !== event.target) {
-          return;
-        }
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          openContact();
-        }
-      }}
-      tabIndex={0}
-    >
-      <TableCell>
-        {contact.type === "person" ? (
-          <UserIcon className="text-muted-foreground size-4" />
-        ) : (
-          <BuildingIcon className="text-muted-foreground size-4" />
-        )}
-      </TableCell>
-      <TableCell>
-        <Link
-          className="font-medium hover:underline"
-          onClick={(event) => event.stopPropagation()}
-          params={{ contactId: contact.id }}
-          to="/contacts/$contactId"
+    <div className="flex justify-end">
+      <Menu>
+        <Tooltip
+          content={t("common.actions")}
+          render={
+            <MenuTrigger
+              className="opacity-0! transition-opacity group-hover:opacity-100!"
+              render={<Button size="icon-xs" variant="ghost" />}
+            />
+          }
         >
-          {contact.displayName}
-        </Link>
-      </TableCell>
-      <TableCell
-        className="text-muted-foreground"
-        onClick={(event) => event.stopPropagation()}
-      >
-        {primaryEmail && (
-          <a
-            className="hover:text-foreground hover:underline"
-            href={`mailto:${primaryEmail.address}`}
-          >
-            {primaryEmail.address}
-          </a>
-        )}
-      </TableCell>
-      <TableCell className="text-muted-foreground">
-        {primaryPhone?.number}
-      </TableCell>
-      <TableCell className="text-end tabular-nums">
-        {contact.clientMatterCount}
-      </TableCell>
-      <TableCell
-        className="w-10 text-end"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <Menu>
-          <Tooltip
-            content={t("common.actions")}
-            render={
-              <MenuTrigger
-                className="opacity-0! transition-opacity group-hover:opacity-100!"
-                render={<Button size="icon-xs" variant="ghost" />}
-              />
-            }
-          >
-            <EllipsisVerticalIcon />
-          </Tooltip>
-          <MenuPopup>
-            {canDeleteContact && (
-              <MenuItem
-                disabled={deleteContact.isPending}
-                onClick={handleDeleteOpen}
-                variant="destructive"
-              >
-                {t("contacts.deleteContact")}
-              </MenuItem>
-            )}
-          </MenuPopup>
-        </Menu>
-        <DestructiveConfirmDialog
-          cancelLabel={t("common.cancel")}
-          confirmLabel={t("common.delete")}
-          confirmation={contact.displayName}
-          description={t("contacts.deleteContactConfirmDescription")}
-          inputLabel={t("common.typeNameToConfirm")}
-          loading={deleteContact.isPending}
-          onConfirm={handleDelete}
-          onOpenChange={setDeleteOpen}
-          open={deleteOpen}
-          title={t("contacts.deleteContact")}
-        />
-      </TableCell>
-    </TableRow>
+          <EllipsisVerticalIcon />
+        </Tooltip>
+        <MenuPopup>
+          {canDeleteContact && (
+            <MenuItem
+              disabled={deleteContact.isPending}
+              onClick={handleDeleteOpen}
+              variant="destructive"
+            >
+              {t("contacts.deleteContact")}
+            </MenuItem>
+          )}
+        </MenuPopup>
+      </Menu>
+      <DestructiveConfirmDialog
+        cancelLabel={t("common.cancel")}
+        confirmLabel={t("common.delete")}
+        confirmation={contact.displayName}
+        description={t("contacts.deleteContactConfirmDescription")}
+        inputLabel={t("common.typeNameToConfirm")}
+        loading={deleteContact.isPending}
+        onConfirm={handleDelete}
+        onOpenChange={setDeleteOpen}
+        open={deleteOpen}
+        title={t("contacts.deleteContact")}
+      />
+    </div>
   );
 };
+
+const EMPTY_CONTACTS: ContactItem[] = [];
+
+type ContactsTableProps = {
+  table: ReactTable<ContactTableFeatures, ContactItem>;
+  isLoading: boolean;
+};
+
+// Shared table render for both the live page and the route pending shell:
+// header, rows, and skeleton all come off the same TanStack column model.
+const ContactsTable = ({ table, isLoading }: ContactsTableProps) => {
+  const t = useTranslations();
+  const rows = table.getRowModel().rows;
+
+  return (
+    <Table>
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <TableHead key={header.id}>
+                {flexRender(
+                  header.column.columnDef.header,
+                  header.getContext(),
+                )}
+              </TableHead>
+            ))}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {isLoading ? (
+          <TableSkeletonRows
+            columns={table.getAllLeafColumns()}
+            renderCell={renderContactSkeletonCell}
+          />
+        ) : (
+          rows.map((row) => <ContactTableRow key={row.id} row={row} />)
+        )}
+        {!isLoading && rows.length === 0 && (
+          <TableRow>
+            <TableCell
+              className="text-muted-foreground py-8 text-center"
+              colSpan={table.getAllLeafColumns().length}
+            >
+              <p>{t("contacts.noContactsFound")}</p>
+              <p className="text-sm">{t("contacts.noContactsDescription")}</p>
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+};
+
+// Inert toolbar matching the live layout, so the pending shell reserves the
+// same space and the page does not jump when it swaps in.
+const ContactsToolbarPlaceholder = () => {
+  const t = useTranslations();
+
+  return (
+    <div className="flex items-center gap-2">
+      <InputGroup className="me-auto max-w-sm flex-1">
+        <InputGroupInput disabled placeholder={t("contacts.search")} />
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+      </InputGroup>
+      <div className="flex gap-1">
+        <Button disabled size="sm" variant="default">
+          {t("common.all")}
+        </Button>
+        <Button disabled size="sm" variant="outline">
+          {t("contacts.filterPersons")}
+        </Button>
+        <Button disabled size="sm" variant="outline">
+          {t("contacts.filterOrganizations")}
+        </Button>
+      </div>
+      <Button disabled size="sm">
+        <PlusIcon />
+        {t("contacts.newContact")}
+      </Button>
+    </div>
+  );
+};
+
+function ContactsPendingComponent() {
+  const columns = useContactColumns();
+  const table = useTable({
+    features: contactTableFeatures,
+    data: EMPTY_CONTACTS,
+    columns,
+  });
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto border-t p-4">
+      <ContactsToolbarPlaceholder />
+      <ContactsTable isLoading table={table} />
+    </div>
+  );
+}
 
 const trimmedString = (maxLength: number) =>
   v.pipe(v.string(), v.trim(), v.maxLength(maxLength));

--- a/apps/web/src/routes/_protected.knowledge/clauses.tsx
+++ b/apps/web/src/routes/_protected.knowledge/clauses.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
@@ -52,6 +53,53 @@ export const Route = createFileRoute("/_protected/knowledge/clauses")({
 });
 
 const protectedRouteApi = getRouteApi("/_protected");
+
+const SIDEBAR_CATEGORY_KEYS = ["a", "b", "c", "d", "e"];
+const CLAUSE_ROW_KEYS = ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+// Mirrors the ClauseList layout (w-48 category sidebar + bordered list
+// pane with toolbar and divided rows) so the page does not jump when
+// clauses land; only the values fade in.
+function ClausesPageSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1">
+      <div className="flex w-48 shrink-0 flex-col overflow-y-auto">
+        <nav className="flex-1 space-y-1 p-2">
+          <Skeleton className="h-7 w-full rounded-md" />
+          <Skeleton className="h-7 w-3/4 rounded-md" />
+          <div className="my-1 border-t" />
+          {SIDEBAR_CATEGORY_KEYS.map((key) => (
+            <Skeleton className="h-7 w-2/3 rounded-md" key={key} />
+          ))}
+        </nav>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col border-s">
+        <div className="flex items-center justify-between border-b px-4 py-2">
+          <Skeleton className="me-3 h-8 flex-1 rounded-md" />
+          <div className="flex gap-1">
+            <Skeleton className="h-8 w-20 rounded-md" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+            <Skeleton className="h-8 w-28 rounded-md" />
+          </div>
+        </div>
+
+        <ul className="flex-1 divide-y overflow-y-auto">
+          {CLAUSE_ROW_KEYS.map((key) => (
+            <li className="flex items-center gap-3 px-4 py-3" key={key}>
+              <Skeleton className="size-9 shrink-0 rounded-lg" />
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+              <Skeleton className="h-3 w-12 shrink-0" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
 
 function RouteComponent() {
   const t = useTranslations();
@@ -247,11 +295,7 @@ function RouteComponent() {
   }
 
   if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">{t("clauses.loading")}</p>
-      </div>
-    );
+    return <ClausesPageSkeleton />;
   }
 
   if (isError) {

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -15,6 +15,7 @@ import { useFormatter, useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/components/tabs";
 import { stellaToast } from "@stll/ui/components/toast";
 
@@ -85,6 +86,47 @@ export const Route = createFileRoute("/_protected/knowledge/templates")({
 });
 
 const protectedRouteApi = getRouteApi("/_protected");
+
+const TEMPLATE_SIDEBAR_KEYS = ["a", "b", "c", "d", "e"];
+const TEMPLATE_ROW_KEYS = ["a", "b", "c", "d", "e", "f"];
+
+// Mirrors the TemplateList layout (w-48 category sidebar + bordered list
+// pane with count/new-template toolbar and divided rows) so the page
+// keeps its shape while templates load; only the values fade in.
+function TemplatesPageSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1">
+      <div className="flex w-48 shrink-0 flex-col overflow-y-auto">
+        <nav className="flex-1 space-y-1 p-2">
+          <Skeleton className="h-7 w-full rounded-md" />
+          <div className="my-1 border-t" />
+          {TEMPLATE_SIDEBAR_KEYS.map((key) => (
+            <Skeleton className="h-7 w-2/3 rounded-md" key={key} />
+          ))}
+        </nav>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col border-s">
+        <div className="flex items-center justify-between border-b px-4 py-2">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-8 w-32 rounded-md" />
+        </div>
+
+        <ul className="flex-1 divide-y overflow-y-auto">
+          {TEMPLATE_ROW_KEYS.map((key) => (
+            <li className="flex items-center gap-4 px-4 py-3" key={key}>
+              <Skeleton className="size-9 shrink-0 rounded-lg" />
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
 
 function RouteComponent() {
   const t = useTranslations();
@@ -268,13 +310,7 @@ function RouteComponent() {
   }
 
   if (templatesLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">
-          {t("templates.discovering")}
-        </p>
-      </div>
-    );
+    return <TemplatesPageSkeleton />;
   }
 
   if (templatesError) {

--- a/apps/web/src/routes/_protected.knowledge/tools.tsx
+++ b/apps/web/src/routes/_protected.knowledge/tools.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { registerInspectorView } from "@/components/inspector/view-registry";
@@ -79,6 +80,7 @@ export const Route = createFileRoute("/_protected/knowledge/tools")({
     }
   },
   component: ToolsPage,
+  pendingComponent: ToolsPagePending,
 });
 
 const protectedRouteApi = getRouteApi("/_protected");
@@ -122,20 +124,85 @@ function ToolsPage() {
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto p-6">
-      <div className="mb-6 flex flex-col gap-1">
-        <h1 className="text-foreground text-xl font-semibold">
-          {t("knowledge.sections.tools.title")}
-        </h1>
-        <p className="text-muted-foreground text-sm">
-          {t("knowledge.sections.tools.description")}
-        </p>
-      </div>
-      <Suspense fallback={null}>
+      <ToolsPageHeader />
+      <Suspense fallback={<ToolsCatalogueSkeleton />}>
         <ToolsCatalogue
           initialKind={initialKind}
           organizationId={organizationId}
         />
       </Suspense>
+    </div>
+  );
+}
+
+const CATALOGUE_FILTER_KEYS = ["all", "skill", "mcp"];
+const CATALOGUE_ROW_KEYS = ["a", "b", "c", "d", "e", "f"];
+
+// Mirrors the CatalogueBrowser body (toolbar row, filter pills, then a
+// stack of bordered entry cards) so the Tools page chrome stays put and
+// only the catalogue values stream in.
+function ToolsCatalogueSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-9 flex-1 rounded-md" />
+        <Skeleton className="h-9 w-24 rounded-md" />
+        <Skeleton className="h-9 w-28 rounded-md" />
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        {CATALOGUE_FILTER_KEYS.map((key) => (
+          <Skeleton className="h-6 w-14 rounded-md" key={key} />
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Skeleton className="mb-1 h-3 w-28" />
+        {CATALOGUE_ROW_KEYS.map((key) => (
+          <div
+            className="flex items-start gap-3 rounded-lg border p-3"
+            key={key}
+          >
+            <Skeleton className="mt-0.5 size-6 shrink-0 rounded-md" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <div className="flex min-h-6 items-center gap-2">
+                <Skeleton className="h-4 w-40" />
+              </div>
+              <Skeleton className="h-3 w-3/4" />
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Skeleton className="h-5 w-12 rounded-md" />
+                <Skeleton className="h-5 w-16 rounded-md" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const ToolsPageHeader = () => {
+  const t = useTranslations();
+  return (
+    <div className="mb-6 flex flex-col gap-1">
+      <h1 className="text-foreground text-xl font-semibold">
+        {t("knowledge.sections.tools.title")}
+      </h1>
+      <p className="text-muted-foreground text-sm">
+        {t("knowledge.sections.tools.description")}
+      </p>
+    </div>
+  );
+};
+
+// The route's `loader` (skills.seed POST) blocks the first visit, so without a
+// pendingComponent it flashes the glowing logo before the catalogue skeleton.
+// Render the real chrome + catalogue skeleton during route-pending as well.
+function ToolsPagePending() {
+  return (
+    <div className="flex flex-1 flex-col overflow-y-auto p-6">
+      <ToolsPageHeader />
+      <ToolsCatalogueSkeleton />
     </div>
   );
 }

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -26,6 +26,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { authClient } from "@/lib/auth";
@@ -38,7 +39,67 @@ import { SettingsPageHeader } from "@/routes/_protected.settings/-components/set
 
 export const Route = createFileRoute("/_protected/settings/account/profile")({
   component: ProfilePage,
+  pendingComponent: ProfilePagePending,
 });
+
+const SESSION_ROW_KEYS = ["a", "b", "c"];
+
+// Mirrors the real profile fragment: settings header, the timezone +
+// word-edit-identity Frame, and the sessions section, so the layout does
+// not jump when the session query resolves.
+function ProfilePagePending() {
+  return (
+    <>
+      <header className="flex flex-col gap-1">
+        <Skeleton className="h-7 w-32" />
+        <Skeleton className="h-4 w-80 max-w-full" />
+      </header>
+      <Frame>
+        <FrameHeader>
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="mt-1.5 h-4 w-64 max-w-full" />
+        </FrameHeader>
+        <FramePanel>
+          <div className="flex flex-col gap-2 p-4">
+            <Skeleton className="h-9 w-72 max-w-full rounded-md" />
+          </div>
+          <div className="border-border flex flex-col gap-4 border-t p-4">
+            <div className="flex max-w-lg flex-col gap-2">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-72 max-w-full" />
+              <Skeleton className="h-9 w-full rounded-md" />
+            </div>
+            <div className="flex max-w-xs flex-col gap-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-64 max-w-full" />
+              <Skeleton className="h-9 w-full rounded-md" />
+            </div>
+            <Skeleton className="h-9 w-20 rounded-md" />
+          </div>
+        </FramePanel>
+      </Frame>
+
+      <section className="flex flex-col gap-2">
+        <Skeleton className="h-3 w-20" />
+        <Frame>
+          <div className="flex flex-col gap-3 p-4">
+            {SESSION_ROW_KEYS.map((key) => (
+              <div
+                className="flex items-center justify-between gap-4"
+                key={key}
+              >
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-5 w-16 rounded-md" />
+              </div>
+            ))}
+          </div>
+        </Frame>
+      </section>
+    </>
+  );
+}
 
 function isCommonTimezone(tz: string): tz is CommonTimezone {
   const timezones: readonly string[] = COMMON_TIMEZONES;

--- a/apps/web/src/routes/_protected.settings/organization.members.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.members.tsx
@@ -6,12 +6,22 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute, useSearch } from "@tanstack/react-router";
-import { ArrowDownIcon, ArrowUpIcon, EllipsisVerticalIcon } from "lucide-react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  EllipsisVerticalIcon,
+  SearchIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
-import { Frame } from "@stll/ui/components/frame";
+import { Frame, FramePanel } from "@stll/ui/components/frame";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@stll/ui/components/input-group";
 import {
   Menu,
   MenuItem,
@@ -25,6 +35,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import {
   Table,
   TableBody,
@@ -72,10 +83,63 @@ type SortKey = "name" | "role" | "joined";
 type SortDir = "asc" | "desc";
 type Sort = { key: SortKey; dir: SortDir };
 
+const MEMBERS_SKELETON_ROW_COUNT = 8;
+const INVITATIONS_SKELETON_ROW_COUNT = 3;
+
+// Stable keys so loading rows never fall back to array-index keys.
+const SKELETON_ROW_KEYS = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+
+// The members and invitations tables are hand-rolled @stll/ui markup (no
+// TanStack), so a single column descriptor array per table is the source of
+// truth: both the real header and the loading skeleton map over it, so they
+// cannot drift. `sortKey` distinguishes sortable heads from inert ones (the
+// trailing actions column has no header). `skeleton` shapes the placeholder.
+type MemberSkeletonShape = "identity" | "control" | "text" | "none";
+
+type MemberColumn = {
+  id: "user" | "role" | "joined" | "actions";
+  sortKey: SortKey | null;
+  label: "common.user" | "common.role" | "organization.members.joined" | null;
+  skeleton: MemberSkeletonShape;
+};
+
+const MEMBER_COLUMNS: readonly MemberColumn[] = [
+  { id: "user", sortKey: "name", label: "common.user", skeleton: "identity" },
+  { id: "role", sortKey: "role", label: "common.role", skeleton: "control" },
+  {
+    id: "joined",
+    sortKey: "joined",
+    label: "organization.members.joined",
+    skeleton: "text",
+  },
+  { id: "actions", sortKey: null, label: null, skeleton: "none" },
+];
+
+type InvitationColumn = {
+  id: "email" | "role" | "status" | "invited" | "expires" | "actions";
+  label:
+    | "common.email"
+    | "common.role"
+    | "common.status"
+    | "organization.invitations.invited"
+    | "organization.invitations.expires"
+    | null;
+};
+
+const INVITATION_COLUMNS: readonly InvitationColumn[] = [
+  { id: "email", label: "common.email" },
+  { id: "role", label: "common.role" },
+  { id: "status", label: "common.status" },
+  { id: "invited", label: "organization.invitations.invited" },
+  { id: "expires", label: "organization.invitations.expires" },
+  { id: "actions", label: null },
+];
+
 export const Route = createFileRoute(
   "/_protected/settings/organization/members",
 )({
   component: Members,
+  pendingComponent: MembersPendingComponent,
 });
 
 function Members() {
@@ -166,26 +230,7 @@ function Members() {
         <Frame>
           <OrganizationListToolbar />
           <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  active={sort.key === "name" ? sort.dir : null}
-                  label={t("common.user")}
-                  onClick={() => toggleSort("name")}
-                />
-                <SortableHead
-                  active={sort.key === "role" ? sort.dir : null}
-                  label={t("common.role")}
-                  onClick={() => toggleSort("role")}
-                />
-                <SortableHead
-                  active={sort.key === "joined" ? sort.dir : null}
-                  label={t("organization.members.joined")}
-                  onClick={() => toggleSort("joined")}
-                />
-                <TableHead />
-              </TableRow>
-            </TableHeader>
+            <MembersTableHeader sort={sort} toggleSort={toggleSort} />
             <TableBody>
               {filteredMembers.map((member) => {
                 const isSelf = member.userId === userId;
@@ -262,16 +307,7 @@ function Members() {
           </h2>
           <Frame>
             <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("common.email")}</TableHead>
-                  <TableHead>{t("common.role")}</TableHead>
-                  <TableHead>{t("common.status")}</TableHead>
-                  <TableHead>{t("organization.invitations.invited")}</TableHead>
-                  <TableHead>{t("organization.invitations.expires")}</TableHead>
-                  <TableHead />
-                </TableRow>
-              </TableHeader>
+              <InvitationsTableHeader />
               <TableBody>
                 {filteredInvitations.map((invitation) => (
                   <TableRow key={invitation.id}>
@@ -527,3 +563,192 @@ const SortableHead = ({ label, active, onClick }: SortableHeadProps) => (
     </button>
   </TableHead>
 );
+
+type MembersTableHeaderProps = {
+  sort: Sort;
+  toggleSort: (key: SortKey) => void;
+};
+
+// Real header and skeleton both map over MEMBER_COLUMNS, so adding, removing,
+// or reordering a column updates both at once.
+const MembersTableHeader = ({ sort, toggleSort }: MembersTableHeaderProps) => {
+  const t = useTranslations();
+
+  return (
+    <TableHeader>
+      <TableRow>
+        {MEMBER_COLUMNS.map((column) => {
+          if (column.sortKey === null || column.label === null) {
+            return <TableHead key={column.id} />;
+          }
+          const sortKey = column.sortKey;
+          return (
+            <SortableHead
+              active={sort.key === sortKey ? sort.dir : null}
+              key={column.id}
+              label={t(column.label)}
+              onClick={() => toggleSort(sortKey)}
+            />
+          );
+        })}
+      </TableRow>
+    </TableHeader>
+  );
+};
+
+const InvitationsTableHeader = () => {
+  const t = useTranslations();
+
+  return (
+    <TableHeader>
+      <TableRow>
+        {INVITATION_COLUMNS.map((column) =>
+          column.label === null ? (
+            <TableHead key={column.id} />
+          ) : (
+            <TableHead key={column.id}>{t(column.label)}</TableHead>
+          ),
+        )}
+      </TableRow>
+    </TableHeader>
+  );
+};
+
+const MemberSkeletonCell = ({ shape }: { shape: MemberSkeletonShape }) => {
+  if (shape === "identity") {
+    return (
+      <div className="flex items-center gap-2">
+        <Skeleton className="size-8 shrink-0 rounded-full" />
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-40" />
+        </div>
+      </div>
+    );
+  }
+  if (shape === "control") {
+    return <Skeleton className="h-8 w-32" />;
+  }
+  if (shape === "none") {
+    return null;
+  }
+  return <Skeleton className="h-4 w-24" />;
+};
+
+// Skeleton body derived from MEMBER_COLUMNS: one cell per column, in order, so
+// it stays aligned with both the real header and the real rows.
+const MembersSkeletonRows = () =>
+  SKELETON_ROW_KEYS.slice(0, MEMBERS_SKELETON_ROW_COUNT).map((rowKey) => (
+    <TableRow key={rowKey}>
+      {MEMBER_COLUMNS.map((column) => (
+        <TableCell key={column.id}>
+          <MemberSkeletonCell shape={column.skeleton} />
+        </TableCell>
+      ))}
+    </TableRow>
+  ));
+
+const InvitationsSkeletonRows = () =>
+  SKELETON_ROW_KEYS.slice(0, INVITATIONS_SKELETON_ROW_COUNT).map((rowKey) => (
+    <TableRow key={rowKey}>
+      {INVITATION_COLUMNS.map((column) => (
+        <TableCell key={column.id}>
+          {column.id === "actions" ? null : <Skeleton className="h-4 w-24" />}
+        </TableCell>
+      ))}
+    </TableRow>
+  ));
+
+// Inert toolbar matching OrganizationListToolbar's layout so the pending shell
+// reserves the same space and the page does not jump when data resolves.
+const MembersToolbarPlaceholder = () => {
+  const t = useTranslations();
+
+  return (
+    <div className="border-border/60 flex items-center gap-2 border-b px-2 py-2">
+      <InputGroup className="max-w-sm flex-1">
+        <InputGroupInput disabled placeholder={t("common.search")} />
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+};
+
+const NOOP_SORT: Sort = { key: "name", dir: "asc" };
+const noopToggleSort = () => undefined;
+
+// Card placeholder for the profile/jurisdictions sections. The real cards
+// (OrganizationProfileCard, OrganizationJurisdictionsCard) call their own
+// suspense/queries against organizationOptions, so rendering them here would
+// re-suspend the pending shell and fall back to the bare logo. A static
+// skeleton keeps this component fully synchronous.
+const CardSkeletonPlaceholder = () => (
+  <Frame>
+    <FramePanel className="flex flex-col gap-3">
+      <Skeleton className="h-4 w-40" />
+      <Skeleton className="h-9 w-full max-w-sm" />
+    </FramePanel>
+  </Frame>
+);
+
+// Structural skeleton for route-pending: the section headers plus the members
+// table chrome (headers from MEMBER_COLUMNS) with shimmer rows, and the
+// invitations table chrome with a few shimmer rows. Hoisted `function` so the
+// Route literal above can reference it.
+function MembersPendingComponent() {
+  const t = useTranslations();
+
+  return (
+    <>
+      <SettingsPageHeader
+        description={t("settings.organization.membersDescription")}
+        title={t("navigation.members")}
+      />
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-muted-foreground px-1 text-xs font-medium tracking-wide uppercase">
+          {t("settings.organization.profile")}
+        </h2>
+        <CardSkeletonPlaceholder />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-muted-foreground px-1 text-xs font-medium tracking-wide uppercase">
+          {t("settings.organization.practiceJurisdictions")}
+        </h2>
+        <CardSkeletonPlaceholder />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-muted-foreground px-1 text-xs font-medium tracking-wide uppercase">
+          {t("settings.organization.activeMembers")}
+        </h2>
+        <Frame>
+          <MembersToolbarPlaceholder />
+          <Table>
+            <MembersTableHeader sort={NOOP_SORT} toggleSort={noopToggleSort} />
+            <TableBody>
+              <MembersSkeletonRows />
+            </TableBody>
+          </Table>
+        </Frame>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-muted-foreground px-1 text-xs font-medium tracking-wide uppercase">
+          {t("settings.organization.pendingInvitations")}
+        </h2>
+        <Frame>
+          <Table>
+            <InvitationsTableHeader />
+            <TableBody>
+              <InvitationsSkeletonRows />
+            </TableBody>
+          </Table>
+        </Frame>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/routes/_protected.settings/organization.usage.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.usage.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import type { TranslationKey } from "@/i18n/types";
@@ -48,14 +49,40 @@ function UsageBody({
   data: UsageEntitlement | null;
   isLoading: boolean;
 }) {
-  const t = useTranslations();
   if (isLoading) {
-    return <FramePanel>{t("settings.organization.usageLoading")}</FramePanel>;
+    return <EntitlementCardSkeleton />;
   }
   if (data) {
     return <ActiveEntitlementCard data={data} />;
   }
   return <EmptyStateCard />;
+}
+
+// Mirrors ActiveEntitlementCard: title + meta row with a trailing action,
+// then the usage label/value row above the meter, so the card does not
+// jump when the entitlement query resolves.
+function EntitlementCardSkeleton() {
+  return (
+    <Frame>
+      <FramePanel>
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-4 w-72 max-w-full" />
+          </div>
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+
+        <div className="mt-6 space-y-2">
+          <div className="flex justify-between gap-4">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <Skeleton className="h-2 w-full rounded-full" />
+        </div>
+      </FramePanel>
+    </Frame>
+  );
 }
 
 function ActiveEntitlementCard({ data }: { data: UsageEntitlement }) {

--- a/apps/web/src/routes/_protected.todos/index.tsx
+++ b/apps/web/src/routes/_protected.todos/index.tsx
@@ -24,6 +24,7 @@ import {
   MenuPopup,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
@@ -69,6 +70,16 @@ const PRIORITY_COLORS: Record<string, string> = {
   high: "text-warning",
   medium: "text-warning",
   low: "text-foreground-muted dark:text-foreground",
+};
+
+const SKELETON_GROUP_KEYS = ["alpha", "beta", "gamma"];
+const SKELETON_ROW_KEYS = ["one", "two", "three"];
+// Vary the name-bar width per row so the skeleton reads as a real task list
+// rather than a uniform block.
+const SKELETON_ROW_NAME_WIDTHS: Record<string, string> = {
+  one: "w-48",
+  two: "w-64",
+  three: "w-40",
 };
 
 type ValidTask = TaskItem & {
@@ -200,6 +211,8 @@ function MyTodosPage() {
         </div>
       </div>
 
+      {isLoading && <TasksLoadingSkeleton />}
+
       {!isLoading && groups.length === 0 && (
         <div className="text-muted-foreground flex flex-col items-center justify-center gap-3 py-16">
           <ListTodoIcon className="size-10 opacity-40" />
@@ -314,3 +327,30 @@ const TaskRow = ({ task }: { task: ValidTask }) => {
     </MatterRefLink>
   );
 };
+
+// Mirrors the loaded grouped-list layout (group header + task rows) so only the
+// values fade in when data lands, instead of a layout shift from blank to list.
+const TasksLoadingSkeleton = () => (
+  <>
+    {SKELETON_GROUP_KEYS.map((groupKey) => (
+      <div className="flex flex-col gap-1" key={groupKey}>
+        <Skeleton className="mx-1 h-4 w-32" />
+        <div className="flex flex-col">
+          {SKELETON_ROW_KEYS.map((rowKey) => (
+            <div
+              className="flex items-center gap-3 px-2 py-1.5"
+              key={`${groupKey}-${rowKey}`}
+            >
+              <Skeleton className="size-2 shrink-0 rounded-full" />
+              <Skeleton
+                className={cn("h-4", SKELETON_ROW_NAME_WIDTHS[rowKey])}
+              />
+              <Skeleton className="ms-auto size-3.5 shrink-0 rounded-sm" />
+              <Skeleton className="h-4 w-14 shrink-0" />
+            </div>
+          ))}
+        </div>
+      </div>
+    ))}
+  </>
+);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
   Outlet,
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import * as v from "valibot";
 
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { cn } from "@stll/ui/lib/utils";
 
 import { getAnalytics } from "@/lib/analytics/provider";
@@ -16,7 +17,7 @@ import {
   prefetchNonCriticalQuery,
 } from "@/lib/react-query";
 import { optionalSearchStringSchema } from "@/lib/schema";
-import type { WorkspaceView } from "@/lib/types";
+import type { ViewLayout, WorkspaceView } from "@/lib/types";
 import { ViewSwitcher } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher";
 import { ViewToolbar } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar";
 import {
@@ -47,6 +48,7 @@ export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/$viewId",
 )({
   component: RouteComponent,
+  pendingComponent: ViewPendingComponent,
   validateSearch: searchSchema,
   beforeLoad: ({ params }) => {
     // Reject obviously invalid viewIds (e.g. "workspaces" from stale doubled
@@ -309,6 +311,129 @@ function ViewShell({ activeView, workspaceId }: ViewContentProps) {
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex-1 overflow-auto">
           <Outlet />
+        </div>
+      </div>
+    </>
+  );
+}
+
+const PENDING_TABLE_ROW_KEYS = [
+  "r1",
+  "r2",
+  "r3",
+  "r4",
+  "r5",
+  "r6",
+  "r7",
+  "r8",
+  "r9",
+  "r10",
+  "r11",
+  "r12",
+];
+const PENDING_TABLE_CELLS = [
+  { key: "name", width: "w-48" },
+  { key: "c2", width: "w-28" },
+  { key: "c3", width: "w-20" },
+  { key: "c4", width: "w-32" },
+  { key: "c5", width: "w-24" },
+] as const;
+const PENDING_KANBAN_COLUMN_KEYS = ["k1", "k2", "k3", "k4"];
+const PENDING_KANBAN_CARD_KEYS = ["card1", "card2", "card3"];
+const PENDING_OVERVIEW_CARD_KEYS = ["o1", "o2", "o3", "o4"];
+
+const PendingTableBody = () => (
+  <div className="flex flex-col">
+    <div className="flex items-center gap-4 border-b px-3 py-2">
+      <Skeleton className="size-4 rounded" />
+      {PENDING_TABLE_CELLS.map((cell) => (
+        <Skeleton className={cn("h-3", cell.width)} key={cell.key} />
+      ))}
+    </div>
+    {PENDING_TABLE_ROW_KEYS.map((rowKey) => (
+      <div
+        className="flex items-center gap-4 border-b px-3 py-2.5"
+        key={rowKey}
+      >
+        <Skeleton className="size-4 rounded" />
+        {PENDING_TABLE_CELLS.map((cell) => (
+          <Skeleton className={cn("h-4", cell.width)} key={cell.key} />
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+const PendingKanbanBody = () => (
+  <div className="flex gap-3 p-3">
+    {PENDING_KANBAN_COLUMN_KEYS.map((columnKey) => (
+      <div className="flex w-72 shrink-0 flex-col gap-2" key={columnKey}>
+        <Skeleton className="h-5 w-32" />
+        {PENDING_KANBAN_CARD_KEYS.map((cardKey) => (
+          <Skeleton className="h-20 w-full rounded-lg" key={cardKey} />
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+const PendingOverviewBody = () => (
+  <div className="grid gap-4 p-4 md:grid-cols-2 lg:grid-cols-4">
+    {PENDING_OVERVIEW_CARD_KEYS.map((cardKey) => (
+      <Skeleton className="h-28 rounded-xl" key={cardKey} />
+    ))}
+  </div>
+);
+
+const ViewBodySkeleton = ({
+  layoutType,
+}: {
+  layoutType: ViewLayout["type"] | undefined;
+}) => {
+  if (layoutType === "kanban") {
+    return <PendingKanbanBody />;
+  }
+  if (layoutType === "overview") {
+    return <PendingOverviewBody />;
+  }
+  // table / filesystem / calendar / unknown all fall back to the row list.
+  return <PendingTableBody />;
+};
+
+// Route-pending shell for the matter data-grid: the view chrome row plus a
+// layout-aware body skeleton (rows / kanban columns / overview cards), read
+// from the cached view so opening a matter shows its structure, not the logo.
+function ViewPendingComponent() {
+  const { workspaceId, viewId } = Route.useParams({
+    select: (p) => ({ workspaceId: p.workspaceId, viewId: p.viewId }),
+  });
+  const { data: layoutType } = useQuery({
+    ...viewsOptions(workspaceId),
+    select: (views) =>
+      (views.find((view) => view.id === viewId) ?? views.at(0))?.layout.type,
+  });
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex min-w-0 items-center justify-between border-b px-3",
+          TOOLBAR_ROW_HEIGHT,
+        )}
+      >
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-7 w-24 rounded-md" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="size-7 rounded-md" />
+          <Skeleton className="size-7 rounded-md" />
+          <Skeleton className="h-7 w-24 rounded-md" />
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex-1 overflow-auto">
+          <ViewBodySkeleton layoutType={layoutType} />
         </div>
       </div>
     </>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
@@ -5,6 +5,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { ExpenseListView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/expense-list-view";
 
@@ -13,6 +14,40 @@ export const Route = createFileRoute(
 )({
   component: ExpensesPage,
 });
+
+const EXPENSE_ROW_KEYS = ["a", "b", "c", "d", "e", "f"];
+
+// Mirrors ExpenseListView's rest layout: the summary bar (totals + add entry)
+// above a list of expense rows, so only the values pop in once data lands.
+const ExpenseListSkeleton = () => (
+  <div className="flex flex-col gap-3">
+    {/* Summary bar */}
+    <div className="flex items-center justify-between">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-8 w-28 rounded-md" />
+    </div>
+
+    {/* Expenses list */}
+    <div className="flex flex-col gap-1.5">
+      {EXPENSE_ROW_KEYS.map((key) => (
+        <div
+          className="flex items-center gap-3 rounded-md border px-3 py-2"
+          key={key}
+        >
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-14 rounded" />
+              <Skeleton className="h-4 w-12 rounded" />
+            </div>
+            <Skeleton className="h-3 w-56" />
+          </div>
+          <Skeleton className="h-4 w-20 shrink-0" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
 
 const formatDateISO = (d: Date): string => {
   const y = d.getFullYear();
@@ -102,13 +137,7 @@ function ExpensesPage() {
 
       {/* Content */}
       <div className="flex-1 overflow-auto p-4">
-        <Suspense
-          fallback={
-            <div className="text-muted-foreground py-8 text-center text-sm">
-              {t("billing.loading")}
-            </div>
-          }
-        >
+        <Suspense fallback={<ExpenseListSkeleton />}>
           <ExpenseListView
             dateFrom={dateFrom}
             dateTo={dateTo}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { ReactNode } from "react";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import {
@@ -12,6 +13,8 @@ import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrencyAmount } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
@@ -59,13 +62,7 @@ function InvoicesPage() {
       </div>
 
       <div className="flex-1 overflow-auto p-4">
-        <Suspense
-          fallback={
-            <div className="text-muted-foreground py-8 text-center text-sm">
-              {t("billing.loading")}
-            </div>
-          }
-        >
+        <Suspense fallback={<InvoicesTableSkeleton />}>
           <InvoicesList workspaceId={workspaceId} />
         </Suspense>
       </div>
@@ -75,9 +72,141 @@ function InvoicesPage() {
 
 const PAGE_SIZE = 50;
 
+type InvoiceListItem = Awaited<
+  ReturnType<NonNullable<ReturnType<typeof invoicesInfiniteOptions>["queryFn"]>>
+>["items"][number];
+
+type InvoiceColumn = {
+  id: string;
+  header: () => ReactNode;
+  cell: (invoice: InvoiceListItem) => ReactNode;
+  // Header and data cell classes, kept on the column so alignment cannot drift
+  // between the live row and the skeleton row.
+  headClassName?: string;
+  cellClassName?: string;
+  // Skeleton placeholder for this column. Defaults to a left-aligned bar.
+  skeletonCell?: () => ReactNode;
+};
+
+// Single column source of truth: the table header, the live data rows, and the
+// loading skeleton all derive from this array, so none can drift from another.
+const useInvoiceColumns = (): InvoiceColumn[] => {
+  const t = useTranslations();
+
+  return [
+    {
+      id: "invoiceNumber",
+      header: () => t("billing.invoices.invoiceNumber"),
+      cell: (invoice) => invoice.invoiceNumber,
+      cellClassName: "font-medium",
+      skeletonCell: () => <Skeleton className="h-4 w-24" />,
+    },
+    {
+      id: "status",
+      header: () => t("common.status"),
+      cell: (invoice) => <InvoiceStatusBadge status={invoice.status} />,
+      skeletonCell: () => <Skeleton className="h-5 w-16 rounded-md" />,
+    },
+    {
+      id: "invoiceDate",
+      header: () => t("billing.invoices.invoiceDate"),
+      cell: (invoice) => invoice.invoiceDate,
+      cellClassName: "tabular-nums",
+      skeletonCell: () => <Skeleton className="h-4 w-20" />,
+    },
+    {
+      id: "dueDate",
+      header: () => t("billing.invoices.dueDate"),
+      cell: (invoice) => invoice.dueDate ?? "—",
+      cellClassName: "text-muted-foreground tabular-nums",
+      skeletonCell: () => <Skeleton className="h-4 w-20" />,
+    },
+    {
+      id: "totalAmount",
+      header: () => t("billing.invoices.totalAmount"),
+      cell: (invoice) =>
+        formatCurrencyAmount(invoice.totalAmount, invoice.currency),
+      headClassName: "text-end",
+      cellClassName: "text-end tabular-nums",
+      skeletonCell: () => <Skeleton className="ms-auto h-4 w-20" />,
+    },
+    {
+      id: "reference",
+      header: () => t("common.reference"),
+      cell: (invoice) => invoice.reference ?? "—",
+      cellClassName: "text-muted-foreground",
+      skeletonCell: () => <Skeleton className="h-4 w-16" />,
+    },
+  ];
+};
+
+const SKELETON_ROW_COUNT = 8;
+
+// Stable keys so skeleton rows never fall back to array-index keys.
+const SKELETON_ROW_KEYS = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+
+type InvoicesTableShellProps = {
+  columns: InvoiceColumn[];
+  children: ReactNode;
+};
+
+// Shared table chrome for both the live rows and the loading skeleton: the
+// header is built from the column model, the body slot holds whichever rows the
+// caller renders (real data or skeleton placeholders).
+const InvoicesTableShell = ({ columns, children }: InvoicesTableShellProps) => (
+  <div className="overflow-auto rounded-lg border">
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="bg-muted/50 text-muted-foreground border-b text-start">
+          {columns.map((column) => (
+            <th
+              className={cn("px-4 py-2 font-medium", column.headClassName)}
+              key={column.id}
+            >
+              {column.header()}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  </div>
+);
+
+// Placeholder rows generated from the same column model as the live table, so
+// the skeleton cannot drift: add, remove, or reorder a column and the
+// placeholder gains, loses, or moves the matching cell automatically.
+const InvoicesTableSkeleton = () => {
+  const columns = useInvoiceColumns();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <InvoicesTableShell columns={columns}>
+        {SKELETON_ROW_KEYS.slice(0, SKELETON_ROW_COUNT).map((rowKey) => (
+          <tr className="border-b last:border-0" key={rowKey}>
+            {columns.map((column) => (
+              <td
+                className={cn("px-4 py-2.5", column.cellClassName)}
+                key={column.id}
+              >
+                {column.skeletonCell ? (
+                  column.skeletonCell()
+                ) : (
+                  <Skeleton className="h-4 w-3/5" />
+                )}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </InvoicesTableShell>
+    </div>
+  );
+};
+
 const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
   const t = useTranslations();
   const navigate = useNavigate();
+  const columns = useInvoiceColumns();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(invoicesInfiniteOptions(workspaceId, PAGE_SIZE));
   const invoices = data.pages.flatMap((page) => page.items);
@@ -92,65 +221,32 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="overflow-auto rounded-lg border">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="bg-muted/50 text-muted-foreground border-b text-start">
-              <th className="px-4 py-2 font-medium">
-                {t("billing.invoices.invoiceNumber")}
-              </th>
-              <th className="px-4 py-2 font-medium">{t("common.status")}</th>
-              <th className="px-4 py-2 font-medium">
-                {t("billing.invoices.invoiceDate")}
-              </th>
-              <th className="px-4 py-2 font-medium">
-                {t("billing.invoices.dueDate")}
-              </th>
-              <th className="px-4 py-2 text-end font-medium">
-                {t("billing.invoices.totalAmount")}
-              </th>
-              <th className="px-4 py-2 font-medium">{t("common.reference")}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {invoices.map((invoice) => (
-              <tr
-                className="hover:bg-muted/30 cursor-pointer border-b last:border-0"
-                key={invoice.id}
-                onClick={() => {
-                  void (async () =>
-                    await navigate({
-                      to: "/workspaces/$workspaceId/invoices/$invoiceId",
-                      params: {
-                        workspaceId,
-                        invoiceId: invoice.id,
-                      },
-                    }))();
-                }}
+      <InvoicesTableShell columns={columns}>
+        {invoices.map((invoice) => (
+          <tr
+            className="hover:bg-muted/30 cursor-pointer border-b last:border-0"
+            key={invoice.id}
+            onClick={() => {
+              void navigate({
+                to: "/workspaces/$workspaceId/invoices/$invoiceId",
+                params: {
+                  workspaceId,
+                  invoiceId: invoice.id,
+                },
+              });
+            }}
+          >
+            {columns.map((column) => (
+              <td
+                className={cn("px-4 py-2.5", column.cellClassName)}
+                key={column.id}
               >
-                <td className="px-4 py-2.5 font-medium">
-                  {invoice.invoiceNumber}
-                </td>
-                <td className="px-4 py-2.5">
-                  <InvoiceStatusBadge status={invoice.status} />
-                </td>
-                <td className="px-4 py-2.5 tabular-nums">
-                  {invoice.invoiceDate}
-                </td>
-                <td className="text-muted-foreground px-4 py-2.5 tabular-nums">
-                  {invoice.dueDate ?? "—"}
-                </td>
-                <td className="px-4 py-2.5 text-end tabular-nums">
-                  {formatCurrencyAmount(invoice.totalAmount, invoice.currency)}
-                </td>
-                <td className="text-muted-foreground px-4 py-2.5">
-                  {invoice.reference ?? "—"}
-                </td>
-              </tr>
+                {column.cell(invoice)}
+              </td>
             ))}
-          </tbody>
-        </table>
-      </div>
+          </tr>
+        ))}
+      </InvoicesTableShell>
       {hasNextPage && (
         <div className="flex justify-center">
           <Button

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -37,8 +37,10 @@ import { Field, FieldError } from "@stll/ui/components/field";
 import { Form } from "@stll/ui/components/form";
 import { Input } from "@stll/ui/components/input";
 import { Label } from "@stll/ui/components/label";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -88,19 +90,99 @@ function InvoiceDetailPage() {
       </div>
 
       <div className="flex-1 overflow-auto p-6">
-        <Suspense
-          fallback={
-            <div className="text-muted-foreground py-8 text-center text-sm">
-              {t("billing.loading")}
-            </div>
-          }
-        >
+        <Suspense fallback={<InvoiceDetailSkeleton />}>
           <InvoiceDetail invoiceId={invoiceId} workspaceId={workspaceId} />
         </Suspense>
       </div>
     </div>
   );
 }
+
+// Stable keys so skeleton rows/cells never fall back to array-index keys.
+const INFO_CELL_KEYS = ["a", "b", "c", "d"] as const;
+const ENTRY_ROW_KEYS = ["a", "b", "c", "d", "e"] as const;
+// Plain `<table>` (not TanStack) with: matter, date, narrative, hours, amount.
+const ENTRY_COLUMN_KEYS = [
+  "matter",
+  "date",
+  "narrative",
+  "hours",
+  "amount",
+] as const;
+const ENTRY_END_ALIGNED_COLUMNS = new Set(["hours", "amount"]);
+
+// Mirrors the real InvoiceDetail layout (header row, info grid, time-entries
+// table) so only values fill in when the query resolves; the page does not jump.
+const InvoiceDetailSkeleton = () => (
+  <div className="mx-auto flex max-w-4xl flex-col gap-6">
+    {/* Header */}
+    <div className="flex items-start justify-between">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-5 w-16 rounded-md" />
+        </div>
+        <Skeleton className="h-4 w-28" />
+      </div>
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-8 w-24 rounded-md" />
+        <Skeleton className="h-8 w-24 rounded-md" />
+      </div>
+    </div>
+
+    {/* Info grid */}
+    <div className="grid grid-cols-2 gap-4 rounded-lg border p-4 sm:grid-cols-4">
+      {INFO_CELL_KEYS.map((key) => (
+        <div key={key}>
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="mt-1.5 h-4 w-24" />
+        </div>
+      ))}
+    </div>
+
+    {/* Time entries */}
+    <div className="rounded-lg border">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+      <div className="overflow-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              {ENTRY_COLUMN_KEYS.map((column) => (
+                <th className="px-4 py-2" key={column}>
+                  <Skeleton
+                    className={cn(
+                      "h-3 w-16",
+                      ENTRY_END_ALIGNED_COLUMNS.has(column) && "ms-auto",
+                    )}
+                  />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {ENTRY_ROW_KEYS.map((rowKey) => (
+              <tr className="border-b last:border-0" key={rowKey}>
+                {ENTRY_COLUMN_KEYS.map((column) => (
+                  <td className="px-4 py-2" key={column}>
+                    <Skeleton
+                      className={cn(
+                        "h-4 w-3/5",
+                        ENTRY_END_ALIGNED_COLUMNS.has(column) && "ms-auto w-12",
+                      )}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+);
 
 const showErrorToast = (title: string) => {
   stellaToast.add({ type: "error", title });

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -3,23 +3,44 @@ import type { ReactNode } from "react";
 
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { PlusIcon } from "lucide-react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  LayoutGridIcon,
+  ListIcon,
+  PlusIcon,
+  SlidersHorizontalIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
+import { Button } from "@stll/ui/components/button";
+import { Frame } from "@stll/ui/components/frame";
+import { Input } from "@stll/ui/components/input";
 import {
   Menu,
   MenuItem,
   MenuPopup,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { Separator } from "@stll/ui/components/separator";
 import { Skeleton } from "@stll/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@stll/ui/components/table";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   EMPTY_SCREEN_MATTERS_VIDEO,
   EmptyScreen,
 } from "@/components/empty-screen";
 import { usePermissions } from "@/hooks/use-permissions";
+import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { pageTitle } from "@/lib/page-title";
 import { AlphabetIndex } from "@/routes/_protected.workspaces/-components/alphabet-index";
 import { ClientGroupHeader } from "@/routes/_protected.workspaces/-components/client-group-header";
@@ -28,6 +49,8 @@ import { MattersTable } from "@/routes/_protected.workspaces/-components/matters
 import { MattersToolbar } from "@/routes/_protected.workspaces/-components/matters-toolbar";
 import { ActiveFilterChips } from "@/routes/_protected.workspaces/-filters/active-filter-chips";
 import { applyMattersFilters } from "@/routes/_protected.workspaces/-filters/filter-pipeline";
+import { useColumnLabels } from "@/routes/_protected.workspaces/-hooks/use-column-labels";
+import { useSortLabels } from "@/routes/_protected.workspaces/-hooks/use-sort-labels";
 import { getMatterOrganizationResetPatch } from "@/routes/_protected.workspaces/-organization-reset";
 import {
   workspacesKeys,
@@ -35,9 +58,11 @@ import {
 } from "@/routes/_protected.workspaces/-queries";
 import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 import type {
+  MattersColumnId,
   Workspace,
   WorkspaceGroup,
 } from "@/routes/_protected.workspaces/-types";
+import { ALL_COLUMNS } from "@/routes/_protected.workspaces/-types";
 import {
   compareWorkspacesByKey,
   groupByClient,
@@ -49,13 +74,7 @@ export const Route = createFileRoute("/_protected/workspaces/")({
     meta: [{ title: pageTitle("common.matters") }],
   }),
   component: RouteComponent,
-  pendingComponent: () => (
-    <div className="grid auto-rows-min gap-4 border-t p-4 md:grid-cols-3">
-      <Skeleton className="h-22 w-full rounded-xl" />
-      <Skeleton className="h-22 w-full rounded-xl" />
-      <Skeleton className="h-22 w-full rounded-xl" />
-    </div>
-  ),
+  pendingComponent: MattersPending,
 });
 
 function RouteComponent() {
@@ -230,6 +249,228 @@ function RouteComponent() {
     </MattersPageContextMenu>
   );
 }
+
+const SKELETON_TABLE_ROW_KEYS = [
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+] as const;
+
+const SKELETON_CARD_KEYS = ["a", "b", "c", "d", "e", "f"] as const;
+
+// Mirrors the fixed widths in matters-table.tsx's COLUMNS model so the pending
+// table reserves the same column geometry. `name` is the flexible first column
+// (no fixed width) and is always rendered; the rest follow ALL_COLUMNS order.
+const SKELETON_COLUMN_WIDTHS: Record<MattersColumnId, string> = {
+  client: "240px",
+  team: "160px",
+  reference: "120px",
+  entityCount: "96px",
+  lastActivityAt: "140px",
+  createdAt: "120px",
+};
+
+type SkeletonColumn =
+  | { id: "name"; width?: undefined }
+  | { id: MattersColumnId; width: string };
+
+// Faithful placeholder of the matters page during route suspension: the real
+// toolbar chrome plus a content skeleton that follows the live view mode, so the
+// page does not jump or change shape when the suspended query resolves.
+function MattersPending() {
+  const viewMode = useConfigStore((s) => s.matters.viewMode);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <MattersToolbarSkeleton />
+      <div className="relative flex-1">
+        <div className="absolute inset-0 overflow-y-auto">
+          <div className="p-2">
+            {viewMode === "table" ? (
+              <MattersTableSkeleton />
+            ) : (
+              <MatterCardGridSkeleton />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Inert mirror of MattersToolbar: same h-12 bordered row, search input, sort and
+// view-toggle ghost buttons, and a trailing create button. Real (disabled)
+// primitives keep sizing, radii, and spacing identical to the live toolbar.
+const MattersToolbarSkeleton = () => {
+  const t = useTranslations();
+  const config = useConfigStore(useShallow((s) => s.matters));
+  const sortLabels = useSortLabels();
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 border-b px-2",
+        TOOLBAR_ROW_HEIGHT,
+      )}
+    >
+      <Input
+        className="w-64 max-w-[40%]"
+        disabled
+        placeholder={t("common.search")}
+        size="sm"
+      />
+      <Separator className="mx-1 h-4" orientation="vertical" />
+      <Button disabled size="xs" variant="ghost">
+        <SlidersHorizontalIcon />
+        <span className="text-muted-foreground text-xs">
+          {sortLabels[config.sortKey]}
+        </span>
+        {config.sortDesc ? (
+          <ArrowDownIcon className="size-3" />
+        ) : (
+          <ArrowUpIcon className="size-3" />
+        )}
+      </Button>
+      <Button disabled size="xs" variant="ghost">
+        {config.viewMode === "grid" ? (
+          <>
+            <ListIcon />
+            {t("workspaces.views.layouts.table")}
+          </>
+        ) : (
+          <>
+            <LayoutGridIcon />
+            {t("workspaces.views.layouts.grid")}
+          </>
+        )}
+      </Button>
+      <Button className="ms-auto" disabled size="xs">
+        <PlusIcon />
+        {t("workspaces.newMatter")}
+      </Button>
+    </div>
+  );
+};
+
+// Table skeleton derived from the same column model the real MattersTable reads
+// (ALL_COLUMNS order, fixed widths, name always first) gated by the live
+// hiddenColumns set, so columns appear, disappear, or move in lockstep.
+const MattersTableSkeleton = () => {
+  const columnLabels = useColumnLabels();
+  const sortLabels = useSortLabels();
+  const hiddenColumns = useConfigStore(
+    useShallow((s) => s.matters.hiddenColumns),
+  );
+
+  const hiddenColumnSet = new Set(hiddenColumns);
+  const columns: SkeletonColumn[] = [
+    { id: "name" },
+    ...ALL_COLUMNS.filter((id) => !hiddenColumnSet.has(id)).map((id) => ({
+      id,
+      width: SKELETON_COLUMN_WIDTHS[id],
+    })),
+  ];
+
+  const headerLabel = (id: SkeletonColumn["id"]): string =>
+    id === "name" ? sortLabels.name : columnLabels[id];
+
+  return (
+    <Frame>
+      <Table className="table-fixed">
+        <colgroup>
+          {columns.map((col) => (
+            <col
+              key={col.id}
+              style={col.width ? { width: col.width } : undefined}
+            />
+          ))}
+        </colgroup>
+        <TableHeader>
+          <TableRow>
+            {columns.map((col) => (
+              <TableHead key={col.id}>
+                <span className="truncate">{headerLabel(col.id)}</span>
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {SKELETON_TABLE_ROW_KEYS.map((rowKey) => (
+            <TableRow key={rowKey}>
+              {columns.map((col) => (
+                <TableCell key={col.id}>
+                  <SkeletonTableCell columnId={col.id} />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Frame>
+  );
+};
+
+const SkeletonTableCell = ({
+  columnId,
+}: {
+  columnId: SkeletonColumn["id"];
+}) => {
+  if (columnId === "name") {
+    return (
+      <div className="flex min-w-0 items-center gap-2">
+        <Skeleton className="size-2 shrink-0 rounded-full" />
+        <Skeleton className="h-4 w-2/5" />
+      </div>
+    );
+  }
+  if (columnId === "team") {
+    return (
+      <div className="flex items-center -space-x-1">
+        <Skeleton className="size-6 rounded-full" />
+        <Skeleton className="size-6 rounded-full" />
+        <Skeleton className="size-6 rounded-full" />
+      </div>
+    );
+  }
+  if (columnId === "entityCount") {
+    return <Skeleton className="h-4 w-6" />;
+  }
+  return <Skeleton className="h-4 w-3/5" />;
+};
+
+// Card grid skeleton mirroring the MatterCard grid: md:grid-cols-3 of bordered,
+// rounded-xl cards with the name+reference, items, and avatars+activity lines.
+const MatterCardGridSkeleton = () => (
+  <div className="grid auto-rows-min gap-3 md:grid-cols-3">
+    {SKELETON_CARD_KEYS.map((cardKey) => (
+      <div
+        className="bg-card flex flex-col gap-1 overflow-hidden rounded-xl border px-3 py-2"
+        key={cardKey}
+      >
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 min-w-0 flex-1" />
+          <Skeleton className="h-3 w-16 shrink-0" />
+        </div>
+        <Skeleton className="-mt-1 h-3 w-24" />
+        <div className="flex items-center justify-between gap-2">
+          <Skeleton className="h-3 w-20" />
+          <div className="flex items-center gap-2">
+            <div className="flex items-center -space-x-1">
+              <Skeleton className="size-5 rounded-full" />
+              <Skeleton className="size-5 rounded-full" />
+            </div>
+            <Skeleton className="h-3 w-10" />
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+);
 
 type MattersPageContextMenuProps = {
   canCreateMatter: boolean;

--- a/apps/web/src/routes/law/cases/index.tsx
+++ b/apps/web/src/routes/law/cases/index.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { Button } from "@stll/ui/components/button";
+import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { DecisionFilters } from "@/features/case-law/components/decision-filters";
@@ -164,7 +165,28 @@ export const Route = createFileRoute("/law/cases/")({
     });
   },
   component: PublicCaseLawIndex,
+  pendingComponent: PublicCaseLawIndexPending,
 });
+
+// The loader fetches decisions + facets (both delayed by slow-load), so without
+// a pendingComponent the route flashes the glowing logo. Reuse the real
+// DecisionTable skeleton plus the page chrome during route-pending.
+function PublicCaseLawIndexPending() {
+  const t = useTranslations();
+  return (
+    <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">{t("common.caseLaw")}</h1>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Skeleton className="h-9 w-40 rounded-md" />
+        <Skeleton className="h-9 w-32 rounded-md" />
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+      <DecisionTable decisions={[]} isLoading />
+    </main>
+  );
+}
 
 function PublicCaseLawIndex() {
   const t = useTranslations();


### PR DESCRIPTION
Routes now render their real structure while data loads — table chrome with columns, toolbars, section cards, and the matter view's body — instead of the centered StellaMark loader.

- Shared `TableSkeletonRows` helper derives skeleton rows from the TanStack column model, so table skeletons can't drift from the real columns. Non-table scaffolds mirror their layout.
- Per-route `pendingComponent`s render each route's own skeleton; the glowing logo (`DefaultPendingComponent`) is now only the fallback. Loader-backed routes (`knowledge/tools`, `law/cases`) get a pending shell so the logo doesn't flash before the skeleton.
- The matter data-grid `$viewId` pending shell is layout-aware (table rows / kanban columns / overview cards), read from the cached view.
- Adds a dev-only "Simulate slow load" toggle (Dev menu) that delays client API requests so loaders can be studied; inert in production.
- Documents the rule in the UX conventions (Loading States).

Screens covered: contacts (list + detail), chat thread, case-law table, invoices (list + detail), settings (members / profile / usage), matters list, knowledge (clauses / templates / tools), todos, expenses, and the matter data-grid.

Verified: full-app `tsgo` 0 errors, oxlint type-aware + oxfmt clean.