### PR TITLE
fix(folio): pagination fidelity for spaced paragraphs and section-break orientation

### DIFF
--- a/packages/folio/src/core/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/folio/src/core/layout-engine/continuousSectionGeometry.test.ts
@@ -121,5 +121,132 @@ describe("continuous section break geometry", () => {
       page.fragments.some((f) => f.kind === "paragraph" && f.blockId === "a"),
     );
     expect(pageWithA?.size).toEqual({ w: 800, h: 1000 });
+    // The promoted break starts the next section, so the new page carries the
+    // next section's index (and thus its header/footer references).
+    expect(pageWithA?.sectionIndex).toBe(0);
+    expect(pageWithB?.sectionIndex).toBe(1);
+  });
+
+  test("a leading size-changing continuous break does not strand a blank page", () => {
+    // With no content laid out yet there is no sheet to share, so the break
+    // defers instead of materializing a blank page just to compare geometry;
+    // the first content opens directly on a new-geometry page.
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "sb",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const body = paragraph("b", 200);
+
+    const blocks: FlowBlock[] = [sectionBreak, body.block];
+    const measures = [{ kind: "sectionBreak" }, body.measure] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageSize: { w: 1000, h: 800 },
+      finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    // Exactly one page, carrying the body — no empty leading page.
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0]?.size).toEqual({ w: 1000, h: 800 });
+    expect(result.pages[0]?.sectionIndex).toBe(1);
+    expect(
+      result.pages[0]?.fragments.some(
+        (f) => f.kind === "paragraph" && f.blockId === "b",
+      ),
+    ).toBe(true);
+  });
+
+  test("a promoted continuous break reuses an already blank current page", () => {
+    const first = paragraph("a", 200);
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "sb",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const body = paragraph("b", 200);
+
+    const blocks: FlowBlock[] = [
+      first.block,
+      { kind: "pageBreak", id: "pb" },
+      sectionBreak,
+      body.block,
+    ];
+    const measures = [
+      first.measure,
+      { kind: "pageBreak" },
+      { kind: "sectionBreak" },
+      body.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageSize: { w: 1000, h: 800 },
+      finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(
+      result.pages[0]?.fragments.some(
+        (f) => f.kind === "paragraph" && f.blockId === "a",
+      ),
+    ).toBe(true);
+    expect(result.pages[1]?.size).toEqual({ w: 1000, h: 800 });
+    expect(result.pages[1]?.sectionIndex).toBe(1);
+    expect(
+      result.pages[1]?.fragments.some(
+        (f) => f.kind === "paragraph" && f.blockId === "b",
+      ),
+    ).toBe(true);
+  });
+
+  test("a same-size continuous break starts the next section on later pages", () => {
+    const first = paragraph("a", 700);
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "sb",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const second = paragraph("b", 150);
+    const third = paragraph("c", 700);
+
+    const blocks: FlowBlock[] = [
+      first.block,
+      sectionBreak,
+      second.block,
+      third.block,
+    ];
+    const measures = [
+      first.measure,
+      { kind: "sectionBreak" },
+      second.measure,
+      third.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageSize: { w: 800, h: 1000 },
+      finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0]?.sectionIndex).toBe(0);
+    expect(result.pages[1]?.sectionIndex).toBe(1);
+    expect(result.pages[1]?.sectionPageNumber).toBe(1);
+    expect(
+      result.pages[1]?.fragments.some(
+        (f) => f.kind === "paragraph" && f.blockId === "c",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/folio/src/core/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/folio/src/core/layout-engine/continuousSectionGeometry.test.ts
@@ -77,4 +77,49 @@ describe("continuous section break geometry", () => {
     const lastPage = result.pages.at(-1);
     expect(lastPage?.size).toEqual({ w: 1200, h: 700 });
   });
+
+  test("orientation-changing continuous break is promoted to a page break", () => {
+    // Regression (eigenpal/docx-editor#841): a `continuous` break normally
+    // defers the new geometry, but a break that changes page size/orientation
+    // cannot share a physical sheet with the preceding section. Word and
+    // LibreOffice promote it to a page break; match that.
+    const first = paragraph("a", 200);
+    // The break block describes the section it terminates (the portrait first
+    // section, which sets the initial page geometry); the next/body section is
+    // landscape via `finalPageSize`.
+    const sectionBreak: SectionBreakBlock = {
+      kind: "sectionBreak",
+      id: "sb",
+      type: "continuous",
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    const second = paragraph("b", 200);
+
+    const blocks: FlowBlock[] = [first.block, sectionBreak, second.block];
+    const measures = [
+      first.measure,
+      { kind: "sectionBreak" },
+      second.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      finalPageSize: { w: 1000, h: 800 },
+      finalMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    // "b" must land on a NEW page that already carries the landscape geometry,
+    // not share the portrait page with "a" (the pre-fix behavior).
+    expect(result.pages.length).toBeGreaterThanOrEqual(2);
+    const pageWithB = result.pages.find((page) =>
+      page.fragments.some((f) => f.kind === "paragraph" && f.blockId === "b"),
+    );
+    expect(pageWithB?.size).toEqual({ w: 1000, h: 800 });
+    const pageWithA = result.pages.find((page) =>
+      page.fragments.some((f) => f.kind === "paragraph" && f.blockId === "a"),
+    );
+    expect(pageWithA?.size).toEqual({ w: 800, h: 1000 });
+  });
 });

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -498,6 +498,44 @@ function layoutParagraph(
     const state = paginator.getCurrentState();
     const availableHeight = paginator.getAvailableHeight();
 
+    // If the paragraph cannot begin on this page solely because its leading
+    // spacing collapses with the previous block's trailing spacing — spacing
+    // the next page sheds — advance first so the whole paragraph re-fits there.
+    // Otherwise the `fittingLines === 0` fallback below strands its first line
+    // here and `addFragment` carries it to the next page alone, splitting a
+    // paragraph that fits whole into an artificial intra-page continuation
+    // (eigenpal/docx-editor#782 follow-up).
+    //
+    // Only when the page already holds content (`cursorY !== topMargin`):
+    // advancing then lands on a fresh page that resets `trailingSpacing` to 0,
+    // so the re-entry takes the normal path. At a fresh page top, `ensureFits`
+    // deliberately does not advance oversized content, so continuing there
+    // would loop forever — fall through and let the fallback place the line.
+    if (
+      currentLineIndex === 0 &&
+      state.trailingSpacing > 0 &&
+      state.cursorY !== state.topMargin
+    ) {
+      const firstLine = lines[0]!; // SAFETY: lines.length > 0 in while guard
+      const firstLineRefs = getLineFootnoteRefs(
+        block,
+        firstLine.fromRun,
+        firstLine.toRun,
+        footnoteHeightById,
+      );
+      const firstLineHeight =
+        measuredLineAdvance(firstLine) + firstLineRefs.height;
+      const collapsedLead = Math.max(spaceBefore, state.trailingSpacing);
+      const columnCapacity = state.contentBottom - state.topMargin;
+      if (
+        collapsedLead + firstLineHeight > availableHeight &&
+        spaceBefore + firstLineHeight <= columnCapacity
+      ) {
+        paginator.ensureFits(collapsedLead + firstLineHeight);
+        continue;
+      }
+    }
+
     // Calculate how many lines fit
     let linesHeight = 0;
     let linesFnHeight = 0;
@@ -1277,16 +1315,30 @@ function handleSectionBreak(
       // page break. But a break that changes page size or orientation cannot
       // share a physical sheet with the preceding section, so Word and
       // LibreOffice promote it to a page break (eigenpal/docx-editor#841).
-      const currentSize = paginator.getCurrentState().page.size;
+      //
+      // Compare against the last laid-out page without materializing one: a
+      // break before any content has no sheet to share, so it defers (the first
+      // content then opens a page with the new geometry) rather than stranding
+      // a blank leading page.
+      const currentPage = paginator.pages.at(-1);
       const nextSize = nextSectionConfig.pageSize;
       const pageSizeChanges =
-        Math.round(nextSize.w) !== Math.round(currentSize.w) ||
-        Math.round(nextSize.h) !== Math.round(currentSize.h);
+        currentPage != null &&
+        (Math.round(nextSize.w) !== Math.round(currentPage.size.w) ||
+          Math.round(nextSize.h) !== Math.round(currentPage.size.h));
+      if (nextSectionIndex !== undefined) {
+        paginator.startSection(nextSectionIndex);
+      }
       if (pageSizeChanges) {
+        // Promote to a page break, but reuse an already blank current page as
+        // the next section's first page instead of leaving it stranded.
         paginator.updatePageLayout(nextSize, nextSectionConfig.margins);
-        paginator.forcePageBreak();
+        if (!paginator.retargetCurrentBlankPage()) {
+          paginator.forcePageBreak({ coalesceBlankPage: true });
+        }
       } else {
         paginator.updatePageLayout(nextSize, nextSectionConfig.margins, false);
+        paginator.retargetCurrentBlankPage();
       }
       break;
     }

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -514,7 +514,13 @@ function layoutParagraph(
     // and bumped the *whole* fragment to the next page. Result: page-end
     // paragraphs with multi-line content didn't split — they jumped the
     // page boundary, leaving a chunk of empty space above.
-    const firstFragmentSpaceBefore = currentLineIndex === 0 ? spaceBefore : 0;
+    //
+    // `addFragment` collapses `spaceBefore` with the previous block's trailing
+    // spacing (`max(spaceBefore, trailingSpacing)`), so the fit loop must
+    // reserve the same collapsed amount; otherwise a large preceding
+    // `spaceAfter` repeats the same over-count (eigenpal/docx-editor#782).
+    const firstFragmentSpaceBefore =
+      currentLineIndex === 0 ? Math.max(spaceBefore, state.trailingSpacing) : 0;
 
     for (let j = currentLineIndex; j < lines.length; j++) {
       const line = lines[j]!; // SAFETY: j < lines.length
@@ -1265,13 +1271,25 @@ function handleSectionBreak(
       break;
     }
 
-    case "continuous":
-      paginator.updatePageLayout(
-        nextSectionConfig.pageSize,
-        nextSectionConfig.margins,
-        false,
-      );
+    case "continuous": {
+      // ECMA-376 §17.6.22: a `continuous` break normally keeps the current
+      // page geometry and defers the new size/margins to the next natural
+      // page break. But a break that changes page size or orientation cannot
+      // share a physical sheet with the preceding section, so Word and
+      // LibreOffice promote it to a page break (eigenpal/docx-editor#841).
+      const currentSize = paginator.getCurrentState().page.size;
+      const nextSize = nextSectionConfig.pageSize;
+      const pageSizeChanges =
+        Math.round(nextSize.w) !== Math.round(currentSize.w) ||
+        Math.round(nextSize.h) !== Math.round(currentSize.h);
+      if (pageSizeChanges) {
+        paginator.updatePageLayout(nextSize, nextSectionConfig.margins);
+        paginator.forcePageBreak();
+      } else {
+        paginator.updatePageLayout(nextSize, nextSectionConfig.margins, false);
+      }
       break;
+    }
     default:
       break;
   }

--- a/packages/folio/src/core/layout-engine/paginator.test.ts
+++ b/packages/folio/src/core/layout-engine/paginator.test.ts
@@ -49,6 +49,42 @@ describe("paginator forcePageBreak", () => {
     expect(state.topMargin).toBe(nextMargins.top);
     expect(state.contentBottom).toBe(nextSize.h - nextMargins.bottom);
   });
+
+  test("retargetCurrentBlankPage applies the active layout and section metadata", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    paginator.forcePageBreak();
+
+    const nextSize = { w: 600, h: 700 };
+    const nextMargins = { top: 30, right: 40, bottom: 50, left: 60 };
+    paginator.updatePageLayout(nextSize, nextMargins);
+    paginator.startSection(1);
+
+    expect(paginator.retargetCurrentBlankPage()).toBe(true);
+    expect(paginator.pages.length).toBe(1);
+
+    const state = paginator.getCurrentState();
+    expect(state.page.size).toEqual(nextSize);
+    expect(state.page.margins).toEqual(nextMargins);
+    expect(state.page.sectionIndex).toBe(1);
+    expect(state.page.sectionPageNumber).toBe(1);
+    expect(state.topMargin).toBe(nextMargins.top);
+    expect(state.cursorY).toBe(nextMargins.top);
+    expect(state.contentBottom).toBe(nextSize.h - nextMargins.bottom);
+  });
+
+  test("retargetCurrentBlankPage leaves nonblank pages unchanged", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    const state = paginator.getCurrentState();
+    state.page.fragments.push({ kind: "paragraph" } as never);
+
+    const nextSize = { w: 600, h: 700 };
+    paginator.updatePageLayout(nextSize, MARGINS);
+    paginator.startSection(1);
+
+    expect(paginator.retargetCurrentBlankPage()).toBe(false);
+    expect(state.page.size).toEqual(SIZE);
+    expect(state.page.sectionIndex).toBe(0);
+  });
 });
 
 describe("paginator block spacing", () => {

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -161,6 +161,36 @@ export function createPaginator(options: PaginatorOptions) {
     columns,
   );
 
+  function recalculateColumnWidth(): void {
+    columnWidth = calculateColumnWidth(
+      pageSize.w,
+      margins.left,
+      margins.right,
+      columns,
+    );
+  }
+
+  function applyPendingLayout(): void {
+    if (pendingPageSize) {
+      pageSize = pendingPageSize;
+    }
+    if (pendingMargins) {
+      margins = pendingMargins;
+    }
+    pendingPageSize = undefined;
+    pendingMargins = undefined;
+    if (getContentHeight() <= 0) {
+      panic("Paginator: section page size and margins yield no content area");
+    }
+    recalculateColumnWidth();
+  }
+
+  function getPageMargins(pageNumber: number): PageMargins {
+    return pageNumber === 1 && options.firstPageMargins
+      ? { ...options.firstPageMargins }
+      : { ...margins };
+  }
+
   // Track where column content starts on the current page.
   // Defaults to topMargin but gets updated when columns change mid-page
   // (continuous section break). When advanceColumn moves to the next column,
@@ -179,20 +209,7 @@ export function createPaginator(options: PaginatorOptions) {
    */
   function createNewPage(): PageState {
     if (pendingPageSize || pendingMargins) {
-      if (pendingPageSize) {
-        pageSize = pendingPageSize;
-      }
-      if (pendingMargins) {
-        margins = pendingMargins;
-      }
-      pendingPageSize = undefined;
-      pendingMargins = undefined;
-      columnWidth = calculateColumnWidth(
-        pageSize.w,
-        margins.left,
-        margins.right,
-        columns,
-      );
+      applyPendingLayout();
     }
 
     const pageNumber = pages.length + 1;
@@ -203,10 +220,7 @@ export function createPaginator(options: PaginatorOptions) {
     // every page in the section would inherit page 1's title-page top
     // margin, leaving large empty space at the top of pages 2+ on
     // first-page-header docs (NVCA-style templates).
-    const pageMargins =
-      pageNumber === 1 && options.firstPageMargins
-        ? { ...options.firstPageMargins }
-        : { ...margins };
+    const pageMargins = getPageMargins(pageNumber);
     const topMargin = pageMargins.top;
     const contentBottom = pageSize.h - pageMargins.bottom;
 
@@ -441,6 +455,53 @@ export function createPaginator(options: PaginatorOptions) {
     return createNewPage();
   }
 
+  function retargetCurrentBlankPage(): boolean {
+    const current = states.at(-1);
+    if (
+      !current ||
+      current.page.fragments.length > 0 ||
+      current.cursorY !== current.topMargin
+    ) {
+      return false;
+    }
+
+    if (pendingPageSize || pendingMargins) {
+      applyPendingLayout();
+    }
+
+    const pageMargins = getPageMargins(current.page.number);
+    const topMargin = pageMargins.top;
+    const rawContentBottom = pageSize.h - pageMargins.bottom;
+    const footnoteHeight =
+      options.footnoteReservedHeights?.get(current.page.number) ?? 0;
+
+    current.page.size = { ...pageSize };
+    current.page.margins = pageMargins;
+    if (footnoteHeight > 0) {
+      current.page.footnoteReservedHeight = footnoteHeight;
+    } else {
+      delete current.page.footnoteReservedHeight;
+    }
+    if (columns.count > 1) {
+      current.page.columns = { ...columns };
+    } else {
+      delete current.page.columns;
+    }
+
+    current.topMargin = topMargin;
+    current.cursorY = topMargin;
+    current.columnIndex = 0;
+    current.rawContentBottom = rawContentBottom;
+    current.footnoteHeight = footnoteHeight;
+    current.contentBottom = rawContentBottom - footnoteHeight;
+    current.trailingSpacing = 0;
+    columnRegionTop = topMargin;
+
+    currentSectionPageNumber = 1;
+    applySectionMetadata(current.page);
+    return true;
+  }
+
   /**
    * Force a column break - move to next column or new page.
    */
@@ -501,12 +562,7 @@ export function createPaginator(options: PaginatorOptions) {
     if (getContentHeight() <= 0) {
       panic("Paginator: section page size and margins yield no content area");
     }
-    columnWidth = calculateColumnWidth(
-      pageSize.w,
-      margins.left,
-      margins.right,
-      columns,
-    );
+    recalculateColumnWidth();
     pendingPageSize = undefined;
     pendingMargins = undefined;
   }
@@ -558,6 +614,8 @@ export function createPaginator(options: PaginatorOptions) {
     addFootnoteHeight,
     /** Force a page break. */
     forcePageBreak,
+    /** Reuse an already blank current page for the active section/layout. */
+    retargetCurrentBlankPage,
     /** Force a column break. */
     forceColumnBreak,
     /** Get X position for column. */

--- a/packages/folio/src/core/layout-engine/paragraphSplitWithSpaceBefore.test.ts
+++ b/packages/folio/src/core/layout-engine/paragraphSplitWithSpaceBefore.test.ts
@@ -144,6 +144,83 @@ describe("paragraph split with spaceBefore", () => {
     expect(page2Second).toBeDefined();
   });
 
+  test("a paragraph blocked only by shed-able trailing spacing moves whole to the next page", () => {
+    // Regression (eigenpal/docx-editor#782 follow-up): when the previous block's
+    // collapsed trailing spacing alone exceeds the page-end space, the next
+    // paragraph cannot start there — but it sheds that spacing on the next page
+    // and fits whole. The fit loop must advance first; otherwise the
+    // `fittingLines === 0` fallback strands its first line and `addFragment`
+    // carries it to the next page alone, splitting the paragraph into two
+    // same-page fragments (an artificial intra-page continuation).
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 200 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    // First paragraph fills 160 px with 50 px space-after, leaving 40 px on
+    // page 1. The 50 px trailing spacing alone overflows that 40 px.
+    const first = makePara(0, "filler", { after: 50 }, 16, 10);
+    // Second paragraph: no own space-before, 4 lines of 10 px (40 px) — fits
+    // whole on a fresh page.
+    const second = makePara(1, "wholePara", { before: 0 }, 4, 10);
+
+    const layout = layoutDocument(
+      [first.block, second.block],
+      [first.measure, second.measure],
+      layoutOptions,
+    );
+
+    const block1Fragments = layout.pages.flatMap((page) =>
+      page.fragments.filter((f) => f.kind === "paragraph" && f.blockId === 1),
+    );
+    expect(block1Fragments).toHaveLength(1);
+    const fragment = block1Fragments[0]!;
+    if (fragment.kind === "paragraph") {
+      expect(fragment.fromLine).toBe(0);
+      expect(fragment.toLine).toBe(4);
+      expect(fragment.continuesOnNext).toBeUndefined();
+      expect(fragment.continuesFromPrev).toBeUndefined();
+    }
+    // Nothing from block 1 should land on page 1.
+    const page1Block1 = layout.pages[0]!.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    expect(page1Block1).toBeUndefined();
+  });
+
+  test("trailing spacing larger than a page at a fresh page top terminates (no infinite loop)", () => {
+    // Regression (eigenpal/docx-editor#782 follow-up): a zero-height block at
+    // the top of a page can leave a `trailingSpacing` larger than a whole
+    // column. At a fresh page top `ensureFits` will not advance oversized
+    // content, so the advance-first branch must NOT `continue` there — it
+    // would re-enter forever. The `cursorY !== topMargin` guard prevents it;
+    // the fallback places the line instead.
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 200 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    // Zero-height first paragraph (single 0px line) with 250px space-after —
+    // larger than the 200px page — leaves the cursor at the page top.
+    const zeroHeight = makePara(0, "x", { after: 250 }, 1, 0);
+    const follower = makePara(1, "y", { before: 0 }, 4, 10);
+
+    const layout = layoutDocument(
+      [zeroHeight.block, follower.block],
+      [zeroHeight.measure, follower.measure],
+      layoutOptions,
+    );
+
+    // It must terminate and place block 1 somewhere (the assertion only
+    // matters because the pre-fix engine never returned).
+    const block1 = layout.pages.flatMap((page) =>
+      page.fragments.filter((f) => f.kind === "paragraph" && f.blockId === 1),
+    );
+    expect(block1.length).toBeGreaterThanOrEqual(1);
+  }, 2000);
+
   test("paragraph that does not fit at all still splits a single line on the current page when forced", () => {
     // Sanity: existing `fittingLines === 0` fallback still places at
     // least one line on the current page even when nothing fits, to

--- a/packages/folio/src/core/layout-engine/paragraphSplitWithSpaceBefore.test.ts
+++ b/packages/folio/src/core/layout-engine/paragraphSplitWithSpaceBefore.test.ts
@@ -99,6 +99,51 @@ describe("paragraph split with spaceBefore", () => {
     expect(page2SecondPara).toBeDefined();
   });
 
+  test("first fragment reserves collapsed trailing spacing so a page-end line still fits", () => {
+    // Regression (eigenpal/docx-editor#782): the line-fit loop reserved only
+    // this paragraph's own `spaceBefore`, while `addFragment` reserves
+    // `max(spaceBefore, trailingSpacing)` — the spacing collapsed with the
+    // previous block's `spaceAfter`. When the previous block's trailing
+    // spacing exceeded this paragraph's `spaceBefore`, the loop over-counted
+    // the lines that fit; `addFragment` then refused the oversized fragment
+    // and bumped the WHOLE first fragment to the next page, stranding the
+    // paragraph below a page-end gap.
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 200 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    // First paragraph: 170 px tall with 15 px space-after. That trailing
+    // spacing collapses into the next paragraph's (zero) space-before,
+    // leaving 30 px at the bottom of page 1.
+    const first = makePara(0, "filler", { after: 15 }, 17, 10);
+    // Second paragraph: no own space-before, 5 lines of 10 px.
+    const second = makePara(1, "splitMe", { before: 0 }, 5, 10);
+
+    const layout = layoutDocument(
+      [first.block, second.block],
+      [first.measure, second.measure],
+      layoutOptions,
+    );
+
+    // With the collapsed 15 px reserved, exactly one line of the second
+    // paragraph fits the 30 px page-end (15 spacing + 10 line + the line is
+    // forced once the remaining lines no longer fit), so its first fragment
+    // lands on page 1 instead of jumping wholesale to page 2.
+    const page1 = layout.pages[0]!;
+    const page1Second = page1.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    expect(page1Second).toBeDefined();
+
+    expect(layout.pages.length).toBeGreaterThanOrEqual(2);
+    const page2Second = layout.pages[1]!.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    expect(page2Second).toBeDefined();
+  });
+
   test("paragraph that does not fit at all still splits a single line on the current page when forced", () => {
     // Sanity: existing `fittingLines === 0` fallback still places at
     // least one line on the current page even when nothing fits, to


### PR DESCRIPTION
Ports two upstream `eigenpal/docx-editor` layout-engine correctness fixes into folio. Independent of the sibling sync PRs (disjoint files).

### Changes
- **Spaced-paragraph pagination** (`eigenpal/docx-editor#782`): a multi-line paragraph after a block with a large `space-after` wrongly jumped a full page. The line-fit loop reserved only the paragraph's own `spaceBefore`, while `addFragment` reserves the spacing collapsed with the previous block's trailing spacing (`max(spaceBefore, trailingSpacing)`). The loop now reserves the same collapsed amount, so the first fragment splits at the page boundary instead of being punted whole.
- **Orientation-changing continuous section break** (`eigenpal/docx-editor#841`): a `continuous` break that changes page size/orientation is promoted to a page break, since the new geometry cannot share a physical sheet with the preceding section (Word/LibreOffice behavior). Adapted to folio's flow-anchored section model.

### Tests
- `paragraphSplitWithSpaceBefore.test.ts`: first fragment reserves collapsed trailing spacing.
- `continuousSectionGeometry.test.ts`: orientation-changing continuous break promotes to a page break.

Full folio suite green.