### PR TITLE
fix(folio): painter rendering fidelity (superscript, justify, anchored images, HF overlay, empty-line selection)

### DIFF
--- a/packages/folio/src/core/layout-bridge/selectionRects.test.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.test.ts
@@ -552,6 +552,149 @@ describe("selection rect geometry", () => {
     expect(rects.every((rect) => rect.y >= 0 && rect.y < 40)).toBe(true);
   });
 
+  test("paints a fixed-width sliver for an empty paragraph the selection spans (#836)", () => {
+    // A genuinely empty paragraph has a zero-length line (pmStart === pmEnd),
+    // so the run-span overlap (sliceFrom >= sliceTo) produced no rect and
+    // dragging across blank lines showed no highlight. Emit a caret-height
+    // sliver instead.
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "empty",
+      pmStart: 10,
+      pmEnd: 12,
+      runs: [{ kind: "text", text: "" }],
+    };
+    const measures: Measure[] = [
+      {
+        kind: "paragraph",
+        lines: [
+          {
+            fromRun: 0,
+            toRun: 0,
+            fromChar: 0,
+            toChar: 0,
+            width: 0,
+            ascent: 12,
+            descent: 4,
+            lineHeight: 16,
+          },
+        ],
+        totalHeight: 16,
+      },
+    ];
+    const layout: Layout = {
+      pageGap: 0,
+      pages: [
+        {
+          number: 1,
+          size: { w: 600, h: 800 },
+          margins: { top: 0, right: 0, bottom: 0, left: 0 },
+          fragments: [
+            {
+              kind: "paragraph",
+              blockId: "empty",
+              x: 0,
+              y: 0,
+              width: 500,
+              height: 16,
+              fromLine: 0,
+              toLine: 1,
+            },
+          ],
+        },
+      ],
+    };
+
+    // Selection strictly contains the empty paragraph's pm position (11).
+    const rects = selectionToRects(layout, [block], measures, 10, 12);
+
+    expect(rects).toHaveLength(1);
+    expect(rects[0]?.width).toBe(4);
+    expect(rects[0]?.height).toBe(16);
+
+    // A drag that ENDS exactly at the empty paragraph (to === 11) still slivers
+    // it — the zero-length line overlaps inclusive of the endpoint (#836).
+    const endpointRects = selectionToRects(layout, [block], measures, 10, 11);
+    expect(endpointRects).toHaveLength(1);
+    expect(endpointRects[0]?.width).toBe(4);
+
+    // A collapsed selection (caret) draws no sliver.
+    expect(selectionToRects(layout, [block], measures, 11, 11)).toHaveLength(0);
+  });
+
+  test("does not sliver the blank row a trailing hard break leaves (#836)", () => {
+    // A paragraph that ends with a hard break has a trailing blank row whose
+    // `fromRun` is past the last run; `computeLinePmRange` resolves it to the
+    // paragraph start, so a selection entering the paragraph from before it
+    // must NOT draw a sliver for that row — only the real content highlights.
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p",
+      pmStart: 10,
+      pmEnd: 15,
+      runs: [{ kind: "text", text: "abc" }],
+    };
+    const measures: Measure[] = [
+      {
+        kind: "paragraph",
+        lines: [
+          {
+            fromRun: 0,
+            toRun: 0,
+            fromChar: 0,
+            toChar: 3,
+            width: 21,
+            ascent: 12,
+            descent: 4,
+            lineHeight: 16,
+          },
+          // Trailing blank row left by the hard break: fromRun === runs.length.
+          {
+            fromRun: 1,
+            toRun: 1,
+            fromChar: 0,
+            toChar: 0,
+            width: 0,
+            ascent: 12,
+            descent: 4,
+            lineHeight: 16,
+          },
+        ],
+        totalHeight: 32,
+      },
+    ];
+    const layout: Layout = {
+      pageGap: 0,
+      pages: [
+        {
+          number: 1,
+          size: { w: 600, h: 800 },
+          margins: { top: 0, right: 0, bottom: 0, left: 0 },
+          fragments: [
+            {
+              kind: "paragraph",
+              blockId: "p",
+              x: 0,
+              y: 0,
+              width: 500,
+              height: 32,
+              fromLine: 0,
+              toLine: 2,
+            },
+          ],
+        },
+      ],
+    };
+
+    // Enter the paragraph from before its content (10) into "a" (12): the
+    // trailing blank row (resolved to pos 11) would be spuriously slivered
+    // pre-fix. Only the content line should highlight.
+    const rects = selectionToRects(layout, [block], measures, 10, 12);
+
+    expect(rects).toHaveLength(1);
+    expect(rects[0]?.width).not.toBe(4);
+  });
+
   test("table hit testing maps clipped continuations to row-local coordinates", () => {
     const { layout, block, measure } = clippedTableFixture();
     const page = layout.pages[0]!;

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -39,6 +39,14 @@ import type {
 import { inlineImageBoundingBox } from "../utils/rotationBoundingBox";
 import { getPageTop } from "./hitTest";
 
+/**
+ * Width (px) of the highlight sliver painted for an empty paragraph the
+ * selection spans. A genuinely empty paragraph has a zero-length line, so the
+ * normal run-span overlap produces no rect; a fixed sliver keeps drag-selection
+ * across blank lines visible (eigenpal/docx-editor#836).
+ */
+const EMPTY_PARAGRAPH_SLIVER_WIDTH = 4;
+
 // =============================================================================
 // TYPES
 // =============================================================================
@@ -246,8 +254,15 @@ function findLinesInRange(
       continue;
     }
 
-    // Check if line overlaps with selection
-    if (range.pmEnd > from && range.pmStart < to) {
+    // A zero-length line (an empty paragraph) overlaps the selection when its
+    // caret position is anywhere within it, INCLUSIVE of the endpoints, so a
+    // drag that starts or ends exactly there still selects it. A non-empty line
+    // uses the strict overlap test (eigenpal/docx-editor#836).
+    const overlaps =
+      range.pmStart === range.pmEnd
+        ? from < to && range.pmStart >= from && range.pmStart <= to
+        : range.pmEnd > from && range.pmStart < to;
+    if (overlaps) {
       result.push({ line, index: i });
     }
   }
@@ -456,10 +471,21 @@ export function selectionToRects(
             continue;
           }
 
-          // Calculate overlap with selection
+          // Calculate overlap with selection. A zero-length line is either a
+          // genuinely empty paragraph (a caret-only line) or the blank row a
+          // trailing hard break leaves behind. The latter starts past the last
+          // run and `computeLinePmRange` resolves it to the paragraph START, so
+          // only a true empty paragraph draws a sliver — never the trailing
+          // break row, which would otherwise highlight whenever the selection
+          // merely crosses the paragraph start (eigenpal/docx-editor#836).
+          const isTrailingBreakRow =
+            paragraphBlock.runs.length > 0 &&
+            line.fromRun >= paragraphBlock.runs.length;
+          const isEmptyLine =
+            range.pmStart === range.pmEnd && !isTrailingBreakRow;
           const sliceFrom = Math.max(range.pmStart, selFrom);
           const sliceTo = Math.min(range.pmEnd, selTo);
-          if (sliceFrom >= sliceTo) {
+          if (!isEmptyLine && sliceFrom >= sliceTo) {
             continue;
           }
 
@@ -513,7 +539,9 @@ export function selectionToRects(
           // Create selection rectangle
           const rectX =
             fragment.x + indentLeft + alignmentOffset + Math.min(startX, endX);
-          const rectWidth = Math.max(1, Math.abs(endX - startX));
+          const rectWidth = isEmptyLine
+            ? EMPTY_PARAGRAPH_SLIVER_WIDTH
+            : Math.max(1, Math.abs(endX - startX));
           const rectY = fragment.y + lineOffset;
 
           rects.push({
@@ -635,9 +663,16 @@ export function selectionToRects(
                   continue;
                 }
 
+                // Only a true empty paragraph draws a sliver — not the blank row
+                // a trailing hard break leaves behind (eigenpal/docx-editor#836).
+                const isTrailingBreakRow =
+                  paragraphBlock.runs.length > 0 &&
+                  line.fromRun >= paragraphBlock.runs.length;
+                const isEmptyLine =
+                  range.pmStart === range.pmEnd && !isTrailingBreakRow;
                 const sliceFrom = Math.max(range.pmStart, selFrom);
                 const sliceTo = Math.min(range.pmEnd, selTo);
-                if (sliceFrom >= sliceTo) {
+                if (!isEmptyLine && sliceFrom >= sliceTo) {
                   continue;
                 }
 
@@ -685,7 +720,9 @@ export function selectionToRects(
                     contentOffsetX +
                     Math.min(startX, endX),
                   y: tableFragment.y + rowY + clippedLineY - clipTop + pageTopY,
-                  width: Math.max(1, Math.abs(endX - startX)),
+                  width: isEmptyLine
+                    ? EMPTY_PARAGRAPH_SLIVER_WIDTH
+                    : Math.max(1, Math.abs(endX - startX)),
                   height: line.lineHeight,
                   pageIndex,
                 });

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -639,6 +639,99 @@ describe("header and footer rendering", () => {
     expect(afterParagraph?.style.top).toBe("40px");
   });
 
+  test("interactive header/footer box tracks the flow band, not a floating shape's extent (#869)", () => {
+    const para = (id: string): ParagraphBlock => ({
+      kind: "paragraph",
+      id,
+      runs: [{ kind: "text", text: "x" }],
+    });
+    const measure = { kind: "paragraph" as const, lines: [], totalHeight: 30 };
+
+    // Header with a page-anchored shape whose visualBottom extends far below the
+    // 30px flow band: the interactive box must stay 30px (not 600px), or it
+    // would sit over the body and swallow its clicks.
+    const headerPage = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        headerContent: {
+          blocks: [para("h")],
+          measures: [measure],
+          height: 30,
+          visualTop: 0,
+          visualBottom: 600,
+        },
+      },
+    );
+    expect(
+      findByClass(headerPage as unknown as FakeElement, "layout-page-header")
+        ?.style.height,
+    ).toBe("30px");
+
+    // Footer with a shape anchored ABOVE the footer line (very negative
+    // visualTop): the box must not grow upward into the body.
+    const renderFooter = (visualTop: number, visualBottom: number) =>
+      renderPage(
+        { ...page, fragments: [] },
+        { pageNumber: 1, totalPages: 1, section: "body" },
+        {
+          document: fakeDocument,
+          footerContent: {
+            blocks: [para("f")],
+            measures: [measure],
+            height: 30,
+            visualTop,
+            visualBottom,
+          },
+        },
+      );
+    const plainFooter = findByClass(
+      renderFooter(0, 30) as unknown as FakeElement,
+      "layout-page-footer",
+    );
+    const shapedFooter = findByClass(
+      renderFooter(-500, 30) as unknown as FakeElement,
+      "layout-page-footer",
+    );
+    // Height pins to the 30px flow band regardless of the above-flow shape...
+    expect(shapedFooter?.style.height).toBe("30px");
+    // ...and the box top does not move up with the shape (no body coverage).
+    expect(shapedFooter?.style.top).toBe(plainFooter?.style.top);
+  });
+
+  test("does not clip header content overflowing the flow band within the margin (#869)", () => {
+    // A non-image floating object (e.g. a positioned text box) extends past the
+    // 30px flow band but stays within the page margin. After the box shrank to
+    // the flow band, clipping it to the box would cut the object off; it must
+    // stay visible.
+    const headerPage = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        headerContent: {
+          blocks: [
+            {
+              kind: "paragraph",
+              id: "h",
+              runs: [{ kind: "text", text: "x" }],
+            } as ParagraphBlock,
+          ],
+          measures: [{ kind: "paragraph", lines: [], totalHeight: 30 }],
+          height: 30,
+          visualTop: 0,
+          visualBottom: 45,
+        },
+      },
+    );
+    const header = findByClass(
+      headerPage as unknown as FakeElement,
+      "layout-page-header",
+    );
+    expect(header?.style.overflow).not.toBe("hidden");
+  });
+
   test("preserves footer content offset when moving behind images to the page layer", () => {
     const footerNaturalTop = page.size.h - 48;
     const footerImageBlock: ParagraphBlock = {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2216,13 +2216,25 @@ export function renderPage(
     const headerVisualTop = options.headerContent?.visualTop ?? 0;
     const headerVisualBottom =
       options.headerContent?.visualBottom ?? options.headerContent?.height ?? 0;
-    const actualHeaderHeight = Math.max(
-      headerVisualBottom - headerVisualTop,
+    // The interactive box height tracks the in-flow band (`height`), NOT the
+    // float-inclusive `visualBottom`. A page/margin-anchored shape (e.g. a
+    // full-page letterhead in a header) overflows the band visually but must
+    // not inflate the box, which would then sit over the body and intercept its
+    // clicks. The floating content still paints (overflow stays visible below)
+    // and is made non-interactive in normal mode via CSS (eigenpal/docx-editor#869).
+    // Normal headers (visualBottom === height, visualTop === 0) are unaffected.
+    const headerFlowHeight = options.headerContent?.height ?? 0;
+    const interactiveHeaderHeight = Math.max(
+      headerFlowHeight - Math.min(0, headerVisualTop),
       24,
     );
-    // If header content fits in the original space, clip overflow; otherwise
-    // margins.top was already expanded so let content show fully.
+    // Clip overflow only when the content fits both the page margin AND the
+    // (shrunk) interactive box. Content that extends past the flow band — a
+    // floating table, positioned text box, or image — must stay visible rather
+    // than be cut off by the smaller box (eigenpal/docx-editor#869).
     const headerOverflows = headerVisualBottom > availableHeaderHeight;
+    const headerContentFitsBox =
+      headerVisualBottom - headerVisualTop <= interactiveHeaderHeight;
 
     const headerEl = doc.createElement("div");
     headerEl.className = PAGE_CLASS_NAMES.header;
@@ -2234,11 +2246,11 @@ export function renderPage(
     headerEl.style.left = `${page.margins.left}px`;
     headerEl.style.right = `${page.margins.right}px`;
     headerEl.style.width = `${headerContentWidth}px`;
-    headerEl.style.height = `${actualHeaderHeight}px`;
-    headerEl.style.minHeight = `${actualHeaderHeight}px`;
+    headerEl.style.height = `${interactiveHeaderHeight}px`;
+    headerEl.style.minHeight = `${interactiveHeaderHeight}px`;
     headerEl.style.opacity = "0.62";
 
-    let shouldClipHeader = !headerOverflows;
+    let shouldClipHeader = !headerOverflows && headerContentFitsBox;
     if (options.headerContent && options.headerContent.blocks.length > 0) {
       const headerContentEl = renderHeaderFooterContent(
         options.headerContent,
@@ -2295,31 +2307,42 @@ export function renderPage(
       24,
     );
     const footerOverflows = actualFooterHeight > availableFooterHeight;
+    // Like the header, the interactive box tracks the in-flow band, not a
+    // floating shape's extent — otherwise a footer object anchored above the
+    // footer line would cover the body and swallow its clicks. Folio anchors
+    // the footer at the flow origin (not bottom-pinned like upstream), so the
+    // box covers exactly [footerNaturalTop, footerNaturalTop + flow band]; the
+    // content offset is zeroed so in-flow content still paints at the flow
+    // origin (a no-op for a normal footer, where visualTop === 0). Overflowing
+    // content renders outside the box (visible) and is made non-interactive in
+    // normal mode via CSS (eigenpal/docx-editor#869).
+    const interactiveFooterHeight = Math.max(footerFlowHeight, 24);
 
-    // Anchor the footer container at the *flow* origin, then let it stretch
-    // upward (above-flow image overflow via negative visualTop) and downward
-    // (below-flow floating-table overflow via visualBottom > flowHeight).
-    // Anchoring at the flow origin keeps in-flow content rendered at the
-    // natural footer line (page.h - footerDistance - flowHeight) and keeps
-    // the resolver's `flowTop` consistent with where the in-flow first
-    // paragraph actually paints.
+    // Anchor the footer container at the *flow* origin. In-flow content renders
+    // at the natural footer line (page.h - footerDistance - flowHeight) and the
+    // resolver's `flowTop` stays consistent with where the in-flow first
+    // paragraph actually paints; floating content overflows the box (visible).
     const footerNaturalTop = page.size.h - footerDistance - footerFlowHeight;
-    const footerContainerTop = footerNaturalTop + footerVisualTop;
     const footerEl = doc.createElement("div");
     footerEl.className = PAGE_CLASS_NAMES.footer;
     if (options.footerContent?.rId) {
       footerEl.dataset["rid"] = options.footerContent.rId;
     }
     footerEl.style.position = "absolute";
-    footerEl.style.top = `${footerContainerTop}px`;
+    footerEl.style.top = `${footerNaturalTop}px`;
     footerEl.style.left = `${page.margins.left}px`;
     footerEl.style.right = `${page.margins.right}px`;
     footerEl.style.width = `${footerContentWidth}px`;
-    footerEl.style.height = `${actualFooterHeight}px`;
-    footerEl.style.minHeight = `${actualFooterHeight}px`;
+    footerEl.style.height = `${interactiveFooterHeight}px`;
+    footerEl.style.minHeight = `${interactiveFooterHeight}px`;
     footerEl.style.opacity = "0.62";
 
-    let shouldClipFooter = !footerOverflows;
+    // As with the header, only clip when the content fits the shrunk box; a
+    // floating object extending past the flow band must stay visible
+    // (eigenpal/docx-editor#869).
+    const footerContentFitsBox =
+      footerVisualBottom - footerVisualTop <= interactiveFooterHeight;
+    let shouldClipFooter = !footerOverflows && footerContentFitsBox;
     if (options.footerContent && options.footerContent.blocks.length > 0) {
       const footerContentEl = renderHeaderFooterContent(
         options.footerContent,
@@ -2334,7 +2357,11 @@ export function renderPage(
           margins: page.margins,
         },
       );
-      footerContentEl.style.top = `${-footerVisualTop}px`;
+      // The box top moved from `footerNaturalTop + footerVisualTop` to
+      // `footerNaturalTop`, so zero the content offset to keep in-flow content
+      // painted at the flow origin (a no-op for a normal footer, where
+      // visualTop === 0). Above-flow content overflows the box upward.
+      footerContentEl.style.top = "0px";
       if (footerContentEl.querySelector("img")) {
         shouldClipFooter = false;
       }

--- a/packages/folio/src/core/layout-painter/renderParagraph-justify-first-line-indent.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-justify-first-line-indent.test.ts
@@ -1,0 +1,155 @@
+// eigenpal/docx-editor#868 — a justified paragraph with a first-line indent
+// must justify its first line to the FULL content width. The first-line shift
+// is realized purely by `text-indent`; narrowing the justify box by `firstLine`
+// as well double-counted the indent, leaving the first line's right edge short
+// of the right margin while body lines reached it.
+
+import { describe, expect, test } from "bun:test";
+
+import { clearTextWidthCache } from "../layout-engine/measure/cache";
+import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
+import type {
+  ParagraphBlock,
+  ParagraphFragment,
+  ParagraphMeasure,
+} from "../layout-engine/types";
+import { renderParagraphFragment } from "./renderParagraph";
+
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      if (prop === "getPropertyValue") {
+        return (key: string) => target[key] ?? "";
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  dir = "";
+  style: Record<string, string> = createFakeStyle();
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+  prepend(...children: FakeElement[]): void {
+    this.children.unshift(...children);
+  }
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return { font: "", measureText: (t: string) => ({ width: t.length * 7 }) };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function renderJustifiedFirstLine(firstLine: number): {
+  firstLineEl: HTMLElement;
+} {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p1",
+    runs: [{ kind: "text", text: "first second third fourth fifth sixth" }],
+    attrs: { alignment: "justify", indent: { firstLine } },
+  };
+  const line = (toChar: number, fromChar: number) => ({
+    fromRun: 0,
+    fromChar,
+    toRun: 0,
+    toChar,
+    width: 380,
+    ascent: 10,
+    descent: 3,
+    lineHeight: 14,
+  });
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    // Two lines: the first is justified, the second is the (left-aligned) last.
+    lines: [line(18, 0), line(36, 18)],
+    totalHeight: 28,
+  };
+  const fragment: ParagraphFragment = {
+    kind: "paragraph",
+    blockId: "p1",
+    x: 0,
+    y: 0,
+    width: 400, // no left/right indent → availableWidth === 400
+    height: 28,
+    fromLine: 0,
+    toLine: 2,
+  };
+
+  const originalDocument = globalThis.document;
+  Object.defineProperty(globalThis, "document", {
+    value: fakeDocument,
+    configurable: true,
+  });
+  clearTextWidthCache();
+  resetCanvasContext();
+  try {
+    const fragmentEl = renderParagraphFragment(
+      fragment,
+      block,
+      measure,
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument },
+    );
+    return { firstLineEl: fragmentEl.children[0] as HTMLElement };
+  } finally {
+    clearTextWidthCache();
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      value: originalDocument,
+      configurable: true,
+    });
+  }
+}
+
+describe("Issue #868 — justify first line to full content width on indented paragraphs", () => {
+  test("first line justify box is the full content width, not narrowed by firstLine", () => {
+    const { firstLineEl } = renderJustifiedFirstLine(30);
+    // availableWidth is the full 400px content width; the first-line shift is
+    // applied via text-indent, NOT by shrinking the justify box to 370px.
+    expect(firstLineEl.style.width).toBe("400px");
+    expect(firstLineEl.style.textIndent).toBe("30px");
+    expect(firstLineEl.style.textAlign).toBe("justify");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-line-box.test.ts
@@ -161,7 +161,11 @@ describe("renderLine box model", () => {
     }) as unknown as FakeElement;
     const noteMarker = lineEl.children.at(0);
 
-    expect(noteMarker?.style["verticalAlign"]).toBe("super");
+    // eigenpal/docx-editor#846: raised via a paint-only `position`/`top`
+    // offset, never `vertical-align` (which would inflate the line box).
+    expect(noteMarker?.style["verticalAlign"]).not.toBe("super");
+    expect(noteMarker?.style["position"]).toBe("relative");
+    expect(noteMarker?.style["top"]).toBe("-0.4em");
     expect(noteMarker?.style["textDecorationLine"]).toBeUndefined();
   });
 
@@ -199,7 +203,11 @@ describe("renderLine box model", () => {
     }) as unknown as FakeElement;
     const noteMarker = lineEl.children.at(0);
 
-    expect(noteMarker?.style["verticalAlign"]).toBe("super");
+    // eigenpal/docx-editor#846: paint-only offset, font size still derived
+    // from the run (folio keeps `getRaisedRunFontSize`, not a hardcoded ratio).
+    expect(noteMarker?.style["verticalAlign"]).not.toBe("super");
+    expect(noteMarker?.style["position"]).toBe("relative");
+    expect(noteMarker?.style["top"]).toBe("-0.4em");
     expect(noteMarker?.style["fontFamily"]).toContain("Times New Roman");
     expect(noteMarker?.style["fontSize"]).toBe("10px");
   });

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -46,7 +46,7 @@ import {
   hasImageVisualAttrs,
   wrapImageWithCrop,
 } from "./renderImage";
-import { isFloatingImageRun } from "./renderUtils";
+import { isFloatingImageRun, resolveImageLineAlign } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
 import { applySdtDataAttrs } from "./sdtBoundary";
 
@@ -459,13 +459,22 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     element.style.textDecorationLine = decorations.join(" ");
   }
 
-  // Superscript/subscript
+  // Superscript/subscript. Raise/lower the glyph with a paint-only
+  // `position: relative` offset rather than `vertical-align: super/sub`. CSS
+  // grows the line box to contain a vertical-align shift, so `super`/`sub`
+  // inflated the height of any line carrying a superscript (e.g. a footnote
+  // anchor) past the base-font height the measurer reserved. A relative offset
+  // moves only where the glyph paints, leaving the line box intact
+  // (eigenpal/docx-editor#846). The reduced `fontSize` from
+  // `getRaisedRunFontSize` already keeps the glyph shorter than the line.
   if (run.superscript) {
-    element.style.verticalAlign = "super";
+    element.style.position = "relative";
+    element.style.top = "-0.4em";
     element.style.fontSize = getRaisedRunFontSize(run);
   }
   if (run.subscript) {
-    element.style.verticalAlign = "sub";
+    element.style.position = "relative";
+    element.style.top = "0.2em";
     element.style.fontSize = getRaisedRunFontSize(run);
   }
 }
@@ -1490,12 +1499,15 @@ export function renderLine(
     lineEl.style.alignItems = "center";
     // Flex defaults to flex-start regardless of the parent's text-align, so
     // an image-only line in a centred / right-aligned paragraph would
-    // left-align after the flex switch. Mirror the paragraph alignment onto
-    // justify-content so logo-only header lines stay centred / right-aligned
-    // like Word.
-    if (alignment === "center") {
+    // left-align after the flex switch. An ANCHORED image is positioned by its
+    // own `wp:positionH` (defaulting to left like Word); an inline image
+    // follows the paragraph alignment. Mirror the resolved alignment onto
+    // justify-content so logo-only header lines stay placed like Word
+    // (eigenpal/docx-editor#787).
+    const imageAlign = resolveImageLineAlign(runsForLine[0]!, alignment);
+    if (imageAlign === "center") {
       lineEl.style.justifyContent = "center";
-    } else if (alignment === "right") {
+    } else if (imageAlign === "right") {
       lineEl.style.justifyContent = "flex-end";
     }
   } else if (runsForLine.some((r) => isImageRun(r) && !isFloatingImageRun(r))) {
@@ -2309,19 +2321,16 @@ export function renderParagraphFragment(
     const lineLeftOffset = line.leftOffset ?? 0;
     const lineRightOffset = line.rightOffset ?? 0;
 
-    // For first line, adjust available width for hanging/firstLine indent
-    // Measurement uses: baseFirstLineWidth = bodyContentWidth - (firstLine - hanging)
-    // So hanging gives MORE width, firstLine gives LESS width
-    let lineAvailableWidth = availableWidth;
-    if (isFirstLine) {
-      const hasHangingIndent = indent?.hanging && indent.hanging > 0;
-      const hasFirstLineIndent = indent?.firstLine && indent.firstLine > 0;
-      if (hasHangingIndent && indent.hanging) {
-        lineAvailableWidth = availableWidth + indent.hanging;
-      } else if (hasFirstLineIndent && indent.firstLine) {
-        lineAvailableWidth = availableWidth - indent.firstLine;
-      }
-    }
+    // The justify box width (and the floating-image width constraint below) is
+    // the full content width on every line, including the first. The first
+    // line's hanging/firstLine shift is realized purely by `text-indent` /
+    // padding further down: the shift moves where the line STARTS, but justify
+    // still stretches to the content box's right edge. Narrowing the box by
+    // `firstLine` (or widening it by `hanging`) here as well double-counted the
+    // indent, so the first line's right edge fell short of (or past) the margin
+    // while body lines reached it. Measurement separately accounts for the
+    // indent when deciding how much text fits the first line (eigenpal/docx-editor#868).
+    const lineAvailableWidth = availableWidth;
 
     const lineEl = renderLine(block, line, effectiveAlignment, doc, {
       availableWidth: lineAvailableWidth - lineLeftOffset - lineRightOffset,

--- a/packages/folio/src/core/layout-painter/renderUtils-image-line-align.test.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils-image-line-align.test.ts
@@ -1,0 +1,53 @@
+// eigenpal/docx-editor#787 (issue #777) — an anchored image alone on a line is
+// positioned by its own `wp:positionH` alignment, defaulting to LEFT like Word,
+// not by the paragraph's `jc`. An inline image (no anchor) follows the
+// paragraph alignment. Word's `inside`/`outside` collapse to left/right.
+
+import { describe, expect, test } from "bun:test";
+
+import type { ImageRun, ImageRunPosition } from "../layout-engine/types";
+import { resolveImageLineAlign } from "./renderUtils";
+
+function img(horizontal?: ImageRunPosition["horizontal"]): ImageRun {
+  return {
+    kind: "image",
+    src: "logo.png",
+    width: 100,
+    height: 50,
+    ...(horizontal ? { position: { horizontal } } : {}),
+  };
+}
+
+describe("resolveImageLineAlign", () => {
+  test("anchored image keeps its explicit alignment, ignoring the paragraph jc", () => {
+    expect(resolveImageLineAlign(img({ align: "left" }), "center")).toBe(
+      "left",
+    );
+    expect(resolveImageLineAlign(img({ align: "right" }), "center")).toBe(
+      "right",
+    );
+    expect(resolveImageLineAlign(img({ align: "center" }), "left")).toBe(
+      "center",
+    );
+  });
+
+  test("anchored image maps inside/outside to left/right", () => {
+    expect(resolveImageLineAlign(img({ align: "inside" }), "center")).toBe(
+      "left",
+    );
+    expect(resolveImageLineAlign(img({ align: "outside" }), "left")).toBe(
+      "right",
+    );
+  });
+
+  test("anchored image with no explicit alignment defaults to left, NOT the paragraph jc", () => {
+    expect(resolveImageLineAlign(img({}), "center")).toBe("left");
+    expect(resolveImageLineAlign(img({}), "right")).toBe("left");
+  });
+
+  test("inline image (no anchor) follows the paragraph alignment", () => {
+    expect(resolveImageLineAlign(img(undefined), "center")).toBe("center");
+    expect(resolveImageLineAlign(img(undefined), "right")).toBe("right");
+    expect(resolveImageLineAlign(img(undefined), undefined)).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -3,6 +3,8 @@
  * Extracted to break import cycles between renderPage, renderParagraph, renderTable, etc.
  */
 
+import type { ImageRun } from "../layout-engine/types";
+
 // `isFloatingImageRun` and `isTextWrappingFloatingImageRun` are pure
 // predicates over `ImageRun` and now live in `layout-engine/types` so the
 // bridge can call them without importing across the layer boundary. They
@@ -11,6 +13,35 @@ export {
   isFloatingImageRun,
   isTextWrappingFloatingImageRun,
 } from "../layout-engine/types";
+
+/**
+ * Horizontal alignment for an image alone on a line. An anchored image
+ * (`wp:positionH`, i.e. `position.horizontal` present) is positioned by its
+ * OWN alignment, independent of the paragraph's `jc` — and defaults to LEFT
+ * like Word, NOT the paragraph alignment (which would wrongly centre a
+ * left-anchored header logo in a centred paragraph). An inline image (no
+ * anchor) follows the paragraph alignment. Word's `inside`/`outside` collapse
+ * to left/right (eigenpal/docx-editor#787, issue #777).
+ */
+export function resolveImageLineAlign(
+  imageRun: ImageRun,
+  paragraphAlignment: "left" | "center" | "right" | "justify" | undefined,
+): "left" | "center" | "right" | "justify" | undefined {
+  const horizontal = imageRun.position?.horizontal;
+  if (!horizontal) {
+    return paragraphAlignment;
+  }
+  switch (horizontal.align) {
+    case "center":
+      return "center";
+    case "right":
+    case "outside":
+      return "right";
+    default:
+      // left, inside, or unspecified — Word's anchored default is left.
+      return "left";
+  }
+}
 
 /**
  * Context passed to fragment renderers

--- a/packages/folio/src/core/prosemirror/editor.css
+++ b/packages/folio/src/core/prosemirror/editor.css
@@ -663,6 +663,24 @@
   padding: 4px 0;
 }
 
+/* Header/footer CONTENT is non-interactive in normal mode: a single click on a
+   header/footer is already a no-op (Word parity), and — crucially — a page- or
+   margin-anchored shape (e.g. a full-page letterhead in a header) that
+   overflows the band must not sit on top of the body and swallow clicks meant
+   for the document text. The band element itself keeps pointer events so it
+   stays the double-click-to-edit target; only its content is passed through.
+   See eigenpal/docx-editor#869. */
+.layout-page-header > *,
+.layout-page-footer > * {
+  pointer-events: none;
+}
+/* While editing a region, its content is hittable again so clicks map to
+   header/footer caret positions. */
+.paged-editor--editing-header .layout-page-header > *,
+.paged-editor--editing-footer .layout-page-footer > * {
+  pointer-events: auto;
+}
+
 /* Header/footer editor ProseMirror styles */
 .hf-editor-pm.prosemirror-editor {
   width: 100%;


### PR DESCRIPTION
Ports five upstream `eigenpal/docx-editor` painter fixes into folio. Independent of the sibling sync PRs (disjoint files).

### Changes
- **Superscript line height** (`eigenpal/docx-editor#846`): super/subscript now raise via a paint-only `position: relative` offset instead of `vertical-align`, which grew the CSS line box. A line carrying a footnote anchor no longer exceeds the measurer-reserved height. Folio keeps its run-derived raised font size (better than upstream's hardcoded ratio).
- **Justify + first-line indent** (`eigenpal/docx-editor#868`): the justify box is the full content width on every line; the first-line shift rides on `text-indent` only. Previously the box was also narrowed by `firstLine`, double-counting the indent so the first line fell short of the right margin.
- **Anchored-image alignment** (`eigenpal/docx-editor#787`, issue #777): an image alone on a line uses its own `wp:positionH` alignment (defaulting to left like Word), not the paragraph `jc`. `inside`/`outside` map to left/right.
- **Header/footer shape overlay** (`eigenpal/docx-editor#869`, #856): a page/margin-anchored shape (full-page letterhead) no longer inflates the header/footer interactive box over the body. The box tracks the in-flow band; header/footer content is `pointer-events: none` in normal mode and re-enabled while editing. Adapted to folio's flow-anchored footer.
- **Empty-paragraph selection sliver** (`eigenpal/docx-editor#836`, #776): drag-selecting across a blank line paints a fixed-width caret-height sliver. Fixed in folio's model-based `selectionToRects` (body + table-cell loops), where a zero-length line produced no rect.

### Tests
- `renderParagraph-line-box.test.ts`, `renderParagraph-justify-first-line-indent.test.ts`, `renderUtils-image-line-align.test.ts`, `renderPage.test.ts`, `selectionRects.test.ts`.

Full folio suite green.