### PR TITLE
fix(folio): honor docDefaults, HTML auto-spacing, and footnote-anchor superscript

### DIFF
--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -268,12 +268,16 @@ function serializeSpacing(formatting: ParagraphFormatting): string {
     attrs.push(`w:lineRule="${formatting.lineSpacingRule}"`);
   }
 
-  if (formatting.beforeAutospacing) {
-    attrs.push('w:beforeAutospacing="1"');
+  if (formatting.beforeAutospacing !== undefined) {
+    attrs.push(
+      `w:beforeAutospacing="${formatting.beforeAutospacing ? "1" : "0"}"`,
+    );
   }
 
-  if (formatting.afterAutospacing) {
-    attrs.push('w:afterAutospacing="1"');
+  if (formatting.afterAutospacing !== undefined) {
+    attrs.push(
+      `w:afterAutospacing="${formatting.afterAutospacing ? "1" : "0"}"`,
+    );
   }
 
   if (attrs.length === 0) {

--- a/packages/folio/src/core/docx/serializer/runSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.test.ts
@@ -127,6 +127,19 @@ const ANY_DECIMAL_IN_EMU_ATTR =
   /(?:cx|cy|distT|distB|distL|distR|lIns|tIns|rIns|bIns)="-?\d+\.\d+"/u;
 const POSOFFSET_DECIMAL = /<wp:posOffset>-?\d+\.\d+<\/wp:posOffset>/u;
 
+describe("runSerializer vertical alignment", () => {
+  test("serializes explicit baseline vertical alignment", () => {
+    const xml = serializeRun({
+      type: "run",
+      formatting: { vertAlign: "baseline" },
+      content: [{ type: "footnoteRef", id: 1 }],
+    });
+
+    expect(xml).toContain('<w:vertAlign w:val="baseline"/>');
+    expect(xml).toContain('<w:footnoteReference w:id="1"/>');
+  });
+});
+
 describe("image EMU attributes are integer-only (issue #417)", () => {
   test("inline image with float dimensions serializes integer cx/cy/effectExtent", () => {
     const xml = serializeRun(FLOAT_INLINE_IMAGE);

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -399,7 +399,7 @@ export function serializeTextFormatting(
   }
 
   // Vertical alignment
-  if (formatting.vertAlign && formatting.vertAlign !== "baseline") {
+  if (formatting.vertAlign) {
     parts.push(`<w:vertAlign w:val="${formatting.vertAlign}"/>`);
   }
 

--- a/packages/folio/src/core/docx/serializer/styleNumPrRoundtrip.test.ts
+++ b/packages/folio/src/core/docx/serializer/styleNumPrRoundtrip.test.ts
@@ -36,6 +36,20 @@ describe("serializeParagraphFormatting style-sourced numPr (#765)", () => {
   });
 });
 
+describe("serializeParagraphFormatting auto-spacing overrides (#823)", () => {
+  test("serializes explicit false auto-spacing values", () => {
+    const xml = serializeParagraphFormatting({
+      spaceBefore: 240,
+      beforeAutospacing: false,
+      afterAutospacing: false,
+    });
+
+    expect(xml).toContain('w:before="240"');
+    expect(xml).toContain('w:beforeAutospacing="0"');
+    expect(xml).toContain('w:afterAutospacing="0"');
+  });
+});
+
 // toProseDoc load-side: a paragraph that removes the style's numbering
 // (direct numId=0 under a numbered style) drops the style's hanging slot too
 // and keeps only the indent it states itself.

--- a/packages/folio/src/core/docx/styleParser.test.ts
+++ b/packages/folio/src/core/docx/styleParser.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseStyles } from "./styleParser";
+import { parseStyleDefinitions, parseStyles } from "./styleParser";
+
+const STYLES_NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+describe("docDefaults presence (#909)", () => {
+  test("an empty but present docDefaults parses to a defined object", () => {
+    // Lets the resolver tell "document declares empty defaults" (zero spacing)
+    // apart from "no docDefaults at all", so it does not synthesize the
+    // built-in Normal spacing over an explicitly-empty default.
+    const defs = parseStyleDefinitions(
+      `<w:styles ${STYLES_NS}>
+        <w:docDefaults><w:pPrDefault><w:pPr/></w:pPrDefault></w:docDefaults>
+      </w:styles>`,
+      null,
+    );
+    expect(defs.docDefaults).toBeDefined();
+  });
+
+  test("a document with no docDefaults element leaves docDefaults undefined", () => {
+    const defs = parseStyleDefinitions(
+      `<w:styles ${STYLES_NS}></w:styles>`,
+      null,
+    );
+    expect(defs.docDefaults).toBeUndefined();
+  });
+});
 
 describe("style table measurements", () => {
   test("defaults missing w:type to dxa", () => {

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -1563,7 +1563,12 @@ function parseDocDefaults(
     }
   }
 
-  return result.rPr || result.pPr ? result : undefined;
+  // Return the (possibly empty) defaults whenever the `<w:docDefaults>` element
+  // is present, so callers can distinguish "document declares empty defaults"
+  // (zero spacing / single line) from "no docDefaults at all". The early guard
+  // above already returns undefined for an absent element
+  // (eigenpal/docx-editor#909).
+  return result;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -51,8 +51,32 @@ const schema = new Schema({
     textEffect: {
       attrs: { effect: {} },
     },
+    footnoteRef: {
+      attrs: {
+        id: { default: null },
+        noteType: { default: "footnote" },
+        vertAlign: { default: null },
+      },
+    },
+    subscript: {},
   },
 });
+
+function buildRunWithMarks(
+  text: string,
+  specs: { markName: string; attrs?: Record<string, unknown> }[],
+) {
+  const marks = specs.map(({ markName, attrs }) => {
+    const mark = schema.marks[markName]?.create(attrs);
+    if (!mark) {
+      throw new Error(`Unknown mark: ${markName}`);
+    }
+    return mark;
+  });
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text(text, marks)]),
+  ]);
+}
 
 function buildSingleRunDoc(
   text: string,
@@ -151,6 +175,59 @@ describe("toFlowBlocks run-level OOXML marks", () => {
       {},
     );
     expect(firstRun(blocks).textEffect).toBe("shimmer");
+  });
+
+  test("raises footnote/endnote reference anchors to superscript by default", () => {
+    // eigenpal/docx-editor#845: Word's FootnoteReference/EndnoteReference
+    // character style is superscript, but the OOXML frequently omits an
+    // explicit run-level vertAlign (e.g. a bare `<w:footnoteReference/>`), so
+    // the flow run must carry superscript regardless of the source mark.
+    const footnote = toFlowBlocks(
+      buildSingleRunDoc("1", "footnoteRef", { id: 1, noteType: "footnote" }),
+      {},
+    );
+    const footnoteRun = firstRun(footnote);
+    expect(footnoteRun.footnoteRefId).toBe(1);
+    expect(footnoteRun.superscript).toBe(true);
+
+    const endnote = toFlowBlocks(
+      buildSingleRunDoc("i", "footnoteRef", { id: 2, noteType: "endnote" }),
+      {},
+    );
+    const endnoteRun = firstRun(endnote);
+    expect(endnoteRun.endnoteRefId).toBe(2);
+    expect(endnoteRun.superscript).toBe(true);
+  });
+
+  test("does not raise a footnote anchor that carries an explicit subscript", () => {
+    // The superscript default must never override an explicit subscript on the
+    // same run, regardless of mark order (eigenpal/docx-editor#845).
+    const blocks = toFlowBlocks(
+      buildRunWithMarks("1", [
+        { markName: "footnoteRef", attrs: { id: 1, noteType: "footnote" } },
+        { markName: "subscript" },
+      ]),
+      {},
+    );
+    const run = firstRun(blocks);
+    expect(run.footnoteRefId).toBe(1);
+    expect(run.subscript).toBe(true);
+    expect(run.superscript).toBeUndefined();
+  });
+
+  test("does not raise a footnote anchor with explicit baseline vertAlign", () => {
+    const blocks = toFlowBlocks(
+      buildSingleRunDoc("1", "footnoteRef", {
+        id: 1,
+        noteType: "footnote",
+        vertAlign: "baseline",
+      }),
+      {},
+    );
+    const run = firstRun(blocks);
+    expect(run.footnoteRefId).toBe(1);
+    expect(run.superscript).toBeUndefined();
+    expect(run.subscript).toBeUndefined();
   });
 
   test("propagates emphasis mark variants", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { schema } from "../prosemirror/schema";
+import { AUTO_PARAGRAPH_SPACING_PX } from "../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
@@ -85,6 +86,140 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.kind).toBe("paragraph");
     expect(paragraph?.attrs?.spacing).toBeUndefined();
     expect(paragraph?.attrs?.indent).toBeUndefined();
+  });
+
+  test("surfaces auto spacing (beforeAutospacing/afterAutospacing) as ~14px for pagination", () => {
+    // eigenpal/docx-editor#823: the paged layout reads spacing from the flow
+    // block, so auto spacing must override the imported before/after (Word
+    // writes `0`) and render the ~14px auto gap while still unedited.
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 0,
+          spaceAfter: 0,
+          _originalFormatting: {
+            beforeAutospacing: true,
+            afterAutospacing: true,
+            spaceBefore: 0,
+            spaceAfter: 0,
+          },
+          _autospacingBase: { before: 0, after: 0 },
+        },
+        [schema.text("auto-spaced")],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    expect(paragraph?.attrs?.spacing?.before).toBe(AUTO_PARAGRAPH_SPACING_PX);
+    expect(paragraph?.attrs?.spacing?.after).toBe(AUTO_PARAGRAPH_SPACING_PX);
+  });
+
+  test("an explicit spacing edit overrides imported auto-spacing (#823)", () => {
+    // Imported with before=0 + beforeAutospacing; the editor then set 240 twips.
+    // The edit must win over the now-stale auto-spacing flag.
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 240, // edited away from the imported 0
+          _originalFormatting: {
+            beforeAutospacing: true,
+            spaceBefore: 0,
+          },
+          _autospacingBase: { before: 0 },
+        },
+        [schema.text("edited")],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.before).toBe(16); // 240 twips, not the 14px auto gap
+  });
+
+  test("auto spacing still applies when a style supplies spacing the import lacked (#823)", () => {
+    // beforeAutospacing with no DIRECT w:before; a style/default placed 200
+    // twips into the PM attr. The untouched paragraph is not an edit, so the
+    // auto gap must still win over the inherited value.
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 200, // inherited from a style, not a user edit
+          _originalFormatting: { beforeAutospacing: true }, // no direct spaceBefore
+          _autospacingBase: { before: 200 },
+        },
+        [schema.text("inherited")],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.before).toBe(AUTO_PARAGRAPH_SPACING_PX);
+  });
+
+  test("auto spacing applies when the auto flag itself came from a style (#823)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 200,
+          _originalFormatting: { styleId: "AutoSpacing" },
+          _autospacingBase: { before: 200 },
+        },
+        [schema.text("style auto")],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.before).toBe(AUTO_PARAGRAPH_SPACING_PX);
+  });
+
+  test("an edit overrides auto spacing when the import baseline came from a style (#823)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 240,
+          _originalFormatting: { beforeAutospacing: true },
+          _autospacingBase: { before: 200 },
+        },
+        [schema.text("edited inherited spacing")],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.before).toBe(16);
+  });
+
+  test("keeps auto spacing on an empty paragraph by marking it explicit (#823)", () => {
+    // An imported empty paragraph whose only spacing is auto-spacing must keep
+    // the ~14px gap; without `spacingExplicit` the empty-paragraph collapse
+    // rule in the layout engine would suppress it.
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _originalFormatting: {
+            beforeAutospacing: true,
+            afterAutospacing: true,
+          },
+          _autospacingBase: { before: null, after: null },
+        },
+        [],
+      ),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.attrs?.spacing?.before).toBe(AUTO_PARAGRAPH_SPACING_PX);
+    expect(paragraph?.attrs?.spacingExplicit?.before).toBe(true);
+    expect(paragraph?.attrs?.spacingExplicit?.after).toBe(true);
   });
 
   test("preserves explicit automatic line spacing", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -62,6 +62,7 @@ import {
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
 } from "../prosemirror/attrs";
+import { autospacingMatchesBase } from "../prosemirror/autospacingBase";
 import { runShadingAttrsToShading } from "../prosemirror/conversion/runShadingMark";
 import type { RunFormattingOverrideAttrs } from "../prosemirror/schema/marks";
 import type {
@@ -80,6 +81,7 @@ import { NUMBER_FORMAT_VALUES } from "../types/documentEnumValues";
 import { resolveColor, resolveHighlightToCss } from "../utils/colorResolver";
 import { resolveShadingFill } from "../utils/formatToStyle";
 import {
+  AUTO_PARAGRAPH_SPACING_PX,
   pointsToPixels,
   halfPointsToPixels,
   halfPointsToPoints,
@@ -423,6 +425,7 @@ function extractRunFormatting(
   theme?: Theme | null,
 ): RunFormatting {
   const formatting: RunFormatting = {};
+  let noteReferenceBaseline = false;
 
   for (const mark of marks) {
     switch (mark.type.name) {
@@ -603,6 +606,9 @@ function extractRunFormatting(
 
       case "footnoteRef": {
         const attrs = expectFootnoteRefMarkAttrs(mark);
+        if (attrs.vertAlign === "baseline") {
+          noteReferenceBaseline = true;
+        }
         const id =
           typeof attrs.id === "string"
             ? Number.parseInt(attrs.id, 10)
@@ -650,6 +656,21 @@ function extractRunFormatting(
       default:
         break;
     }
+  }
+
+  // A footnote/endnote anchor renders superscript by default — Word's built-in
+  // FootnoteReference / EndnoteReference character style sets
+  // `w:vertAlign="superscript"`, and the OOXML often omits an explicit run-level
+  // mark (e.g. a bare `<w:r><w:footnoteReference/></w:r>`). Resolve it after the
+  // mark loop so an explicit subscript on the same run still wins regardless of
+  // mark order (eigenpal/docx-editor#845).
+  if (
+    (formatting.footnoteRefId !== undefined ||
+      formatting.endnoteRefId !== undefined) &&
+    !noteReferenceBaseline &&
+    !formatting.subscript
+  ) {
+    formatting.superscript = true;
   }
 
   return formatting;
@@ -1410,40 +1431,62 @@ function convertParagraphAttrs(
     // default to no alignment set (inherits from style or defaults to left)
   }
 
-  // Spacing
+  // Spacing. HTML-origin auto spacing (w:beforeAutospacing/afterAutospacing)
+  // renders Word's ~14px auto gap, overriding the imported before/after (which
+  // Word writes as `0`) — surface it here so pagination matches the rendered
+  // margins (eigenpal/docx-editor#823). But only while the effective spacing
+  // still matches the import baseline; any later command or style change that
+  // writes a different spacing value must win over the stale auto-spacing flag.
   const spaceBefore = pmAttrs.spaceBefore;
   const spaceAfter = pmAttrs.spaceAfter;
   const lineSpacing = pmAttrs.lineSpacing;
+  const autoBefore = autospacingMatchesBase(
+    pmAttrs._autospacingBase,
+    "before",
+    spaceBefore,
+  );
+  const autoAfter = autospacingMatchesBase(
+    pmAttrs._autospacingBase,
+    "after",
+    spaceAfter,
+  );
   if (
+    autoBefore ||
+    autoAfter ||
     typeof spaceBefore === "number" ||
     typeof spaceAfter === "number" ||
     typeof lineSpacing === "number"
   ) {
     attrs.spacing = {};
-    if (typeof spaceBefore === "number") {
+    if (autoBefore) {
+      attrs.spacing.before = AUTO_PARAGRAPH_SPACING_PX;
+    } else if (typeof spaceBefore === "number") {
       attrs.spacing.before = twipsToPixels(spaceBefore);
     }
-    if (typeof spaceAfter === "number") {
+    if (autoAfter) {
+      attrs.spacing.after = AUTO_PARAGRAPH_SPACING_PX;
+    } else if (typeof spaceAfter === "number") {
       attrs.spacing.after = twipsToPixels(spaceAfter);
     }
     // Propagate the `spacingExplicit` flag the PM schema carries — empty
     // paragraphs inherit zero spacing unless the side was set inline (Word
-    // fidelity, eigenpal #402).
+    // fidelity, eigenpal #402). Auto spacing counts as explicit: an imported
+    // empty paragraph whose only spacing is `w:beforeAutospacing`/
+    // `afterAutospacing` must keep the ~14px gap rather than collapse to zero
+    // (eigenpal/docx-editor#823).
     const pmSpacingExplicit = pmAttrs.spacingExplicit as
       | { before?: boolean; after?: boolean }
       | null
       | undefined;
-    if (pmSpacingExplicit) {
-      const explicit: { before?: boolean; after?: boolean } = {};
-      if (pmSpacingExplicit.before) {
-        explicit.before = true;
-      }
-      if (pmSpacingExplicit.after) {
-        explicit.after = true;
-      }
-      if (explicit.before !== undefined || explicit.after !== undefined) {
-        attrs.spacingExplicit = explicit;
-      }
+    const explicit: { before?: boolean; after?: boolean } = {};
+    if (autoBefore || pmSpacingExplicit?.before) {
+      explicit.before = true;
+    }
+    if (autoAfter || pmSpacingExplicit?.after) {
+      explicit.after = true;
+    }
+    if (explicit.before !== undefined || explicit.after !== undefined) {
+      attrs.spacingExplicit = explicit;
     }
     if (typeof lineSpacing === "number") {
       // Line spacing in twips - convert to multiplier or exact

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -38,6 +38,7 @@ describe("ProseMirror attr readers", () => {
       paraId: "para-1",
       numPr: { numId: 4, ilvl: 1 },
       bookmarks: [{ id: 7, name: "_Ref7" }],
+      _autospacingBase: { before: 200, after: null },
       _sectionProperties: { sectionStart: "nextPage" },
       _propertyChanges: [],
     });
@@ -50,6 +51,8 @@ describe("ProseMirror attr readers", () => {
     }
     expect(result.value.numPr?.numId).toBe(4);
     expect(result.value.bookmarks?.at(0)?.name).toBe("_Ref7");
+    expect(result.value._autospacingBase?.before).toBe(200);
+    expect(result.value._autospacingBase?.after).toBeNull();
     expect(expectParagraphAttrs(node).paraId).toBe("para-1");
   });
 
@@ -106,6 +109,7 @@ describe("ProseMirror attr readers", () => {
         highlight: "neon",
         underline: { style: "zigzag" },
       },
+      _autospacingBase: { before: "tight" },
       _sectionProperties: { pageWidth: "wide", orientation: "diagonal" },
       _propertyChanges: [
         {
@@ -133,6 +137,7 @@ describe("ProseMirror attr readers", () => {
         "paragraph.attrs.defaultTextFormatting.bold",
         "paragraph.attrs.defaultTextFormatting.highlight",
         "paragraph.attrs.defaultTextFormatting.underline.style",
+        "paragraph.attrs._autospacingBase.before",
         "paragraph.attrs._sectionProperties.pageWidth",
         "paragraph.attrs._sectionProperties.orientation",
         "paragraph.attrs._propertyChanges[0].type",

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -154,6 +154,10 @@ const NOTE_TYPES = [
   "endnote",
 ] as const satisfies readonly NonNullable<FootnoteRefAttrs["noteType"]>[];
 
+const NOTE_REF_VERT_ALIGNS = [
+  "baseline",
+] as const satisfies readonly NonNullable<FootnoteRefAttrs["vertAlign"]>[];
+
 const TEXT_BOX_DOCX_PLACEMENTS = [
   "standalone",
   "inlineWithPrevious",
@@ -416,6 +420,7 @@ export const readParagraphAttrs = (
   validateNumPr(attrs["numPr"], issues);
   optionalBookmarkArray(attrs["bookmarks"], issues);
   optionalEmptyHyperlinkArray(attrs["_emptyHyperlinks"], issues);
+  optionalAutospacingBase(attrs, issues);
   optionalSectionProperties(
     attrs,
     "_sectionProperties",
@@ -1323,6 +1328,13 @@ export const readFootnoteRefMarkAttrs = (
     issues,
     NOTE_TYPES,
   );
+  optionalOneOf(
+    attrs,
+    "vertAlign",
+    "footnoteRef.attrs.vertAlign",
+    issues,
+    NOTE_REF_VERT_ALIGNS,
+  );
 
   return attrsResult(attrs, issues);
 };
@@ -1948,6 +1960,37 @@ const optionalRecord = (
   if (value !== undefined && value !== null && !isRecord(value)) {
     issues.push({ path, message: "Expected an object." });
   }
+};
+
+const optionalAutospacingBase = (
+  attrs: Record<string, unknown>,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs["_autospacingBase"];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "paragraph.attrs._autospacingBase",
+      message: "Expected an object.",
+    });
+    return;
+  }
+
+  optionalNumber(
+    value,
+    "before",
+    "paragraph.attrs._autospacingBase.before",
+    issues,
+  );
+  optionalNumber(
+    value,
+    "after",
+    "paragraph.attrs._autospacingBase.after",
+    issues,
+  );
 };
 
 const optionalArray = (

--- a/packages/folio/src/core/prosemirror/autospacingBase.ts
+++ b/packages/folio/src/core/prosemirror/autospacingBase.ts
@@ -1,0 +1,35 @@
+import type { ParagraphAttrs } from "./schema/nodes";
+
+type AutospacingBase = NonNullable<ParagraphAttrs["_autospacingBase"]>;
+type AutospacingSide = "before" | "after";
+
+export function normalizeAutospacingBaseValue(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+export function setAutospacingBaseValue(
+  base: AutospacingBase,
+  side: AutospacingSide,
+  value: unknown,
+): void {
+  base[side] = normalizeAutospacingBaseValue(value);
+}
+
+export function hasAutospacingBaseSide(
+  base: ParagraphAttrs["_autospacingBase"] | null | undefined,
+  side: AutospacingSide,
+): boolean {
+  return base !== undefined && base !== null && Object.hasOwn(base, side);
+}
+
+export function autospacingMatchesBase(
+  base: ParagraphAttrs["_autospacingBase"] | null | undefined,
+  side: AutospacingSide,
+  currentValue: unknown,
+): boolean {
+  if (!hasAutospacingBaseSide(base, side)) {
+    return false;
+  }
+
+  return normalizeAutospacingBaseValue(currentValue) === (base?.[side] ?? null);
+}

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -99,6 +99,369 @@ describe("fromProseDoc", () => {
     );
   });
 
+  test("round-trips unedited inherited auto spacing without inlining the style value", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              pPr: { spaceBefore: 200 },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                styleId: "Normal",
+                beforeAutospacing: true,
+              },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Auto spaced" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles: document.package.styles });
+    const attrs = expectParagraphAttrs(pmDoc.child(0));
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(attrs.spaceBefore).toBe(200);
+    expect(attrs._autospacingBase).toEqual({ before: 200 });
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.beforeAutospacing).toBe(true);
+    expect(block.formatting?.spaceBefore).toBeUndefined();
+    expect(
+      (block.formatting as Record<string, unknown>)["_autospacingBase"],
+    ).toBeUndefined();
+  });
+
+  test("saves edited inherited auto spacing as direct spacing with auto disabled", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              pPr: { spaceBefore: 200 },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                styleId: "Normal",
+                beforeAutospacing: true,
+              },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Edited spacing" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = pmDoc.child(0);
+    const editedParagraph = schema.node(
+      "paragraph",
+      { ...paragraph.attrs, spaceBefore: 240 },
+      paragraph.content,
+    );
+    const editedPmDoc = schema.node("doc", null, [editedParagraph]);
+    const roundTripped = fromProseDoc(editedPmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.beforeAutospacing).toBe(false);
+    expect(block.formatting?.spaceBefore).toBe(240);
+  });
+
+  test("round-trips style-sourced auto spacing without inlining the style value", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "AutoSpacing",
+              type: "paragraph",
+              pPr: { beforeAutospacing: true, spaceBefore: 200 },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "AutoSpacing" },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Style auto spaced" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles: document.package.styles });
+    const attrs = expectParagraphAttrs(pmDoc.child(0));
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(attrs.spaceBefore).toBe(200);
+    expect(attrs._autospacingBase).toEqual({ before: 200 });
+    expect(attrs._originalFormatting?.beforeAutospacing).toBeUndefined();
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.styleId).toBe("AutoSpacing");
+    expect(block.formatting?.beforeAutospacing).toBeUndefined();
+    expect(block.formatting?.spaceBefore).toBeUndefined();
+  });
+
+  test("saves edited style-sourced auto spacing as direct spacing with auto disabled", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "AutoSpacing",
+              type: "paragraph",
+              pPr: { beforeAutospacing: true, spaceBefore: 200 },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "AutoSpacing" },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Edited style auto" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = pmDoc.child(0);
+    const editedParagraph = schema.node(
+      "paragraph",
+      { ...paragraph.attrs, spaceBefore: 240 },
+      paragraph.content,
+    );
+    const editedPmDoc = schema.node("doc", null, [editedParagraph]);
+    const roundTripped = fromProseDoc(editedPmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.styleId).toBe("AutoSpacing");
+    expect(block.formatting?.beforeAutospacing).toBe(false);
+    expect(block.formatting?.spaceBefore).toBe(240);
+  });
+
+  test("saves edited docDefaults auto spacing with auto disabled", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          docDefaults: {
+            pPr: { beforeAutospacing: true, spaceBefore: 200 },
+          },
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Edited default auto" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = pmDoc.child(0);
+    const editedParagraph = schema.node(
+      "paragraph",
+      { ...paragraph.attrs, spaceBefore: 240 },
+      paragraph.content,
+    );
+    const editedPmDoc = schema.node("doc", null, [editedParagraph]);
+    const roundTripped = fromProseDoc(editedPmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.beforeAutospacing).toBe(false);
+    expect(block.formatting?.spaceBefore).toBe(240);
+  });
+
+  test("preserves direct auto spacing with no numeric spacing on a no-op save", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { beforeAutospacing: true },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "No numeric spacing" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const attrs = expectParagraphAttrs(pmDoc.child(0));
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(typeof Reflect.get(attrs, "spaceBefore")).not.toBe("number");
+    expect(attrs._autospacingBase).toEqual({ before: null });
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.beforeAutospacing).toBe(true);
+    expect(block.formatting?.spaceBefore).toBeUndefined();
+  });
+
+  test("saves a style reset from direct auto spacing with auto disabled", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { beforeAutospacing: true },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Reset spacing" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const paragraph = pmDoc.child(0);
+    const resetParagraph = schema.node(
+      "paragraph",
+      {
+        ...paragraph.attrs,
+        styleId: "Normal",
+        spaceBefore: null,
+        _autospacingBase: null,
+      },
+      paragraph.content,
+    );
+    const resetPmDoc = schema.node("doc", null, [resetParagraph]);
+    const roundTripped = fromProseDoc(resetPmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.formatting?.styleId).toBe("Normal");
+    expect(block.formatting?.beforeAutospacing).toBe(false);
+    expect(block.formatting?.spaceBefore).toBeUndefined();
+  });
+
+  test("round-trips explicit baseline footnote references", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  formatting: { vertAlign: "baseline" },
+                  content: [{ type: "footnoteRef", id: 1 }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const textNode = pmDoc.child(0).child(0);
+    const footnoteMark = textNode.marks.find(
+      (mark) => mark.type.name === "footnoteRef",
+    );
+    expect(footnoteMark?.attrs["vertAlign"]).toBe("baseline");
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    const run = block.content.at(0);
+    expect(run?.type).toBe("run");
+    if (run?.type !== "run") {
+      return;
+    }
+    expect(run.formatting?.vertAlign).toBe("baseline");
+  });
+
   test("round-trips tracked-change image atoms", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -97,6 +97,10 @@ import {
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
 } from "../attrs";
+import {
+  autospacingMatchesBase,
+  hasAutospacingBaseSide,
+} from "../autospacingBase";
 import type { RunFormattingOverrideAttrs } from "../schema/marks";
 import type {
   ParagraphAttrs,
@@ -872,9 +876,53 @@ function paragraphAttrsToFormatting(
   //
   // We then apply overrides for any properties the user may have changed
   // via editor commands (alignment, list toggle, etc.).
+  const spaceBefore = Reflect.get(attrs, "spaceBefore");
+  const spaceAfter = Reflect.get(attrs, "spaceAfter");
+  const beforeHasAutospacingBase = hasAutospacingBaseSide(
+    attrs._autospacingBase,
+    "before",
+  );
+  const afterHasAutospacingBase = hasAutospacingBaseSide(
+    attrs._autospacingBase,
+    "after",
+  );
+  const beforeOriginalAutospacing =
+    attrs._originalFormatting?.beforeAutospacing === true;
+  const afterOriginalAutospacing =
+    attrs._originalFormatting?.afterAutospacing === true;
+  const beforeAutospacingEdited = beforeHasAutospacingBase
+    ? !autospacingMatchesBase(attrs._autospacingBase, "before", spaceBefore)
+    : beforeOriginalAutospacing && attrs._autospacingBase == null;
+  const afterAutospacingEdited = afterHasAutospacingBase
+    ? !autospacingMatchesBase(attrs._autospacingBase, "after", spaceAfter)
+    : afterOriginalAutospacing && attrs._autospacingBase == null;
+  const shouldSerializeSpaceBefore =
+    typeof spaceBefore === "number" &&
+    (!beforeHasAutospacingBase || beforeAutospacingEdited);
+  const shouldSerializeSpaceAfter =
+    typeof spaceAfter === "number" &&
+    (!afterHasAutospacingBase || afterAutospacingEdited);
+
   if (attrs._originalFormatting) {
     const orig = attrs._originalFormatting;
     const result = { ...orig };
+
+    if (beforeAutospacingEdited) {
+      result.beforeAutospacing = false;
+      if (typeof spaceBefore === "number") {
+        result.spaceBefore = spaceBefore;
+      } else {
+        delete result.spaceBefore;
+      }
+    }
+    if (afterAutospacingEdited) {
+      result.afterAutospacing = false;
+      if (typeof spaceAfter === "number") {
+        result.spaceAfter = spaceAfter;
+      } else {
+        delete result.spaceAfter;
+      }
+    }
 
     // Override properties that user may have changed via editor commands.
     // Only override if the PM attr differs from the original value.
@@ -938,8 +986,10 @@ function paragraphAttrsToFormatting(
   const outlineLevel = Reflect.get(attrs, "outlineLevel");
   const hasFormatting =
     attrs.alignment ||
-    attrs.spaceBefore ||
-    attrs.spaceAfter ||
+    shouldSerializeSpaceBefore ||
+    shouldSerializeSpaceAfter ||
+    beforeAutospacingEdited ||
+    afterAutospacingEdited ||
     attrs.lineSpacing ||
     attrs.indentLeft ||
     attrs.indentRight ||
@@ -962,11 +1012,17 @@ function paragraphAttrsToFormatting(
   if (attrs.alignment) {
     f.alignment = attrs.alignment;
   }
-  if (attrs.spaceBefore) {
-    f.spaceBefore = attrs.spaceBefore;
+  if (shouldSerializeSpaceBefore) {
+    f.spaceBefore = spaceBefore;
   }
-  if (attrs.spaceAfter) {
-    f.spaceAfter = attrs.spaceAfter;
+  if (beforeAutospacingEdited) {
+    f.beforeAutospacing = false;
+  }
+  if (shouldSerializeSpaceAfter) {
+    f.spaceAfter = spaceAfter;
+  }
+  if (afterAutospacingEdited) {
+    f.afterAutospacing = false;
   }
   if (attrs.lineSpacing) {
     f.lineSpacing = attrs.lineSpacing;
@@ -1486,10 +1542,14 @@ function createNoteReferenceRun(noteRefMark: Mark): Run {
     type: noteType,
     id: noteId,
   };
-  return {
+  const run: Run = {
     type: "run",
     content: [noteRef],
   };
+  if (noteAttrs.vertAlign === "baseline") {
+    run.formatting = { vertAlign: "baseline" };
+  }
+  return run;
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -48,6 +48,7 @@ import type {
 import { resolveColor } from "../../utils/colorResolver";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
+import { setAutospacingBaseValue } from "../autospacingBase";
 import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
 import { schema } from "../schema";
 import type {
@@ -576,9 +577,10 @@ function paragraphFormattingToAttrs(
   };
 
   // If we have a style resolver, resolve the style and get base properties
+  let stylePpr: Paragraph["formatting"] | undefined;
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(styleId);
-    const stylePpr = resolved.paragraphFormatting;
+    stylePpr = resolved.paragraphFormatting;
 
     // Apply style-based values as defaults (inline overrides)
     set("alignment", formatting?.alignment ?? stylePpr?.alignment);
@@ -698,6 +700,21 @@ function paragraphFormattingToAttrs(
   }
   if (paragraph.renderedPageBreakBefore) {
     attrs.renderedPageBreakBefore = true;
+  }
+
+  const beforeAutospacing =
+    formatting?.beforeAutospacing ?? stylePpr?.beforeAutospacing;
+  const afterAutospacing =
+    formatting?.afterAutospacing ?? stylePpr?.afterAutospacing;
+  if (beforeAutospacing || afterAutospacing) {
+    const base: NonNullable<ParagraphAttrs["_autospacingBase"]> = {};
+    if (beforeAutospacing) {
+      setAutospacingBaseValue(base, "before", attrs.spaceBefore);
+    }
+    if (afterAutospacing) {
+      setAutospacingBaseValue(base, "after", attrs.spaceAfter);
+    }
+    attrs._autospacingBase = base;
   }
 
   return attrs;
@@ -1992,7 +2009,7 @@ function convertRun(
   const marks = textFormattingToMarks(mergedFormatting);
 
   for (const content of run.content) {
-    const contentNodes = convertRunContent(content, marks);
+    const contentNodes = convertRunContent(content, marks, mergedFormatting);
     nodes.push(...contentNodes);
   }
 
@@ -2005,6 +2022,7 @@ function convertRun(
 function convertRunContent(
   content: RunContent,
   marks: ReturnType<typeof schema.mark>[],
+  formatting?: TextFormatting,
 ): PMNode[] {
   switch (content.type) {
     case "text":
@@ -2057,6 +2075,7 @@ function convertRunContent(
       const footnoteMark = schema.mark("footnoteRef", {
         id: content.id.toString(),
         noteType: "footnote",
+        vertAlign: formatting?.vertAlign === "baseline" ? "baseline" : null,
       });
       return [schema.text(content.id.toString(), [...marks, footnoteMark])];
     }
@@ -2066,6 +2085,7 @@ function convertRunContent(
       const endnoteMark = schema.mark("footnoteRef", {
         id: content.id.toString(),
         noteType: "endnote",
+        vertAlign: formatting?.vertAlign === "baseline" ? "baseline" : null,
       });
       return [schema.text(content.id.toString(), [...marks, endnoteMark])];
     }
@@ -2367,7 +2387,7 @@ function convertHyperlink(
       // silently dropped TOC entries' tab between title and page number,
       // collapsing the right-aligned page number flush against the title.
       for (const content of child.content) {
-        nodes.push(...convertRunContent(content, allMarks));
+        nodes.push(...convertRunContent(content, allMarks, mergedFormatting));
       }
     }
   }

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
 
-import { schema } from "../../schema";
+import { toFlowBlocks } from "../../../layout-bridge/toFlowBlocks";
+import { AUTO_PARAGRAPH_SPACING_PX } from "../../../utils/units";
+import { schema, singletonManager } from "../../schema";
 
 const paragraphDomAttrs = (
   attrs: Record<string, unknown>,
@@ -34,5 +38,151 @@ describe("ParagraphExtension", () => {
     });
 
     expect(attrs["style"]).toContain("margin-left: 96px");
+  });
+
+  test("spacing edits make the DOM gate ignore imported auto-spacing (#823)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 200,
+          _originalFormatting: {
+            beforeAutospacing: true,
+            afterAutospacing: true,
+          },
+          _autospacingBase: { before: 200 },
+        },
+        [schema.text("x")],
+      ),
+    ]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+
+    const setSpaceBefore = singletonManager.getCommand("setSpaceBefore");
+    if (!setSpaceBefore) {
+      throw new Error("Missing setSpaceBefore command");
+    }
+    setSpaceBefore(240)(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+
+    const para = state.doc.firstChild;
+    expect(para?.attrs["spaceBefore"]).toBe(240);
+    const original = para?.attrs["_originalFormatting"] as
+      | {
+          beforeAutospacing?: boolean;
+          afterAutospacing?: boolean;
+          spaceBefore?: number;
+        }
+      | undefined;
+    expect(original?.beforeAutospacing).toBe(true);
+    expect(original?.afterAutospacing).toBe(true);
+    expect(original?.spaceBefore).toBeUndefined();
+
+    const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
+    expect(domAttrs["style"]).toContain("margin-top: 16px");
+    expect(domAttrs["style"]).not.toContain(
+      `margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`,
+    );
+  });
+
+  test("applying a style with spacing overrides imported auto-spacing (#823)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          spaceBefore: 200,
+          _originalFormatting: {
+            beforeAutospacing: true,
+          },
+          _autospacingBase: { before: 200 },
+        },
+        [schema.text("x")],
+      ),
+    ]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+
+    const applyStyle = singletonManager.getCommand("applyStyle");
+    if (!applyStyle) {
+      throw new Error("Missing applyStyle command");
+    }
+    applyStyle("Spaced", {
+      paragraphFormatting: { spaceBefore: 360 },
+    })(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+
+    const para = state.doc.firstChild;
+    expect(para?.attrs["styleId"]).toBe("Spaced");
+    expect(para?.attrs["spaceBefore"]).toBe(360);
+
+    const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
+    expect(domAttrs["style"]).toContain("margin-top: 24px");
+    expect(domAttrs["style"]).not.toContain(
+      `margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`,
+    );
+
+    const block = toFlowBlocks(state.doc).at(0);
+    expect(block?.attrs?.spacing?.before).toBe(24);
+  });
+
+  test("applying a style without auto spacing clears the imported auto-spacing baseline (#823)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          _originalFormatting: {
+            beforeAutospacing: true,
+          },
+          _autospacingBase: { before: null },
+        },
+        [schema.text("x")],
+      ),
+    ]);
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, 1),
+    });
+
+    const applyStyle = singletonManager.getCommand("applyStyle");
+    if (!applyStyle) {
+      throw new Error("Missing applyStyle command");
+    }
+    applyStyle("Normal", {
+      paragraphFormatting: {},
+    })(state, (tr: Transaction) => {
+      state = state.apply(tr);
+    });
+
+    const para = state.doc.firstChild;
+    expect(para?.attrs["styleId"]).toBe("Normal");
+    expect(para?.attrs["_autospacingBase"]).toBeNull();
+
+    const domAttrs = paragraphDomAttrs(para?.attrs ?? {});
+    expect(domAttrs["style"] ?? "").not.toContain(
+      `margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`,
+    );
+
+    const block = toFlowBlocks(state.doc).at(0);
+    expect(block?.attrs?.spacing?.before).not.toBe(AUTO_PARAGRAPH_SPACING_PX);
+  });
+
+  test("the DOM gate applies style-sourced auto spacing with no numeric baseline (#823)", () => {
+    const domAttrs = paragraphDomAttrs({
+      _originalFormatting: { styleId: "AutoSpacing" },
+      _autospacingBase: { before: null },
+    });
+
+    expect(domAttrs["style"]).toContain(
+      `margin-top: ${AUTO_PARAGRAPH_SPACING_PX}px`,
+    );
   });
 });

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -24,6 +24,7 @@ import type {
 import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
 import { expectParagraphAttrs } from "../../attrs";
+import { autospacingMatchesBase } from "../../autospacingBase";
 import type { ParagraphAttrs } from "../../schema/nodes";
 import {
   paragraphAttrsFromResolvedStyle,
@@ -72,6 +73,22 @@ function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
       : {}),
     ...(attrs.borders !== undefined ? { borders: attrs.borders } : {}),
     ...(attrs.shading !== undefined ? { shading: attrs.shading } : {}),
+    // HTML-origin auto spacing uses the PM-only import baseline, so direct and
+    // style-sourced auto flags behave the same until an edit changes spacing.
+    ...(autospacingMatchesBase(
+      attrs._autospacingBase,
+      "before",
+      attrs.spaceBefore,
+    )
+      ? { beforeAutospacing: true }
+      : {}),
+    ...(autospacingMatchesBase(
+      attrs._autospacingBase,
+      "after",
+      attrs.spaceAfter,
+    )
+      ? { afterAutospacing: true }
+      : {}),
   };
 
   const style = paragraphToStyle(formatting);
@@ -371,6 +388,7 @@ const paragraphNodeSpec: NodeSpec = {
     bookmarks: { default: null },
     _emptyHyperlinks: { default: null },
     _originalFormatting: { default: null },
+    _autospacingBase: { default: null },
     _sectionProperties: { default: null },
     _propertyChanges: { default: null },
     pPrMark: { default: null },

--- a/packages/folio/src/core/prosemirror/extensions/marks/FootnoteRefExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/FootnoteRefExtension.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../schema";
+
+describe("FootnoteRefExtension parseDOM", () => {
+  test("parses baseline footnote refs rendered as spans", () => {
+    const footnoteRef = schema.marks["footnoteRef"];
+    if (!footnoteRef) {
+      throw new Error("expected footnoteRef mark");
+    }
+    const parseRules = footnoteRef.spec.parseDOM ?? [];
+    const rule = parseRules.find(
+      (candidate) => candidate.tag === "span.docx-footnote-ref",
+    );
+    if (!rule || typeof rule.getAttrs !== "function") {
+      throw new Error("expected span footnoteRef getAttrs rule");
+    }
+
+    const attrs = rule.getAttrs({
+      dataset: { id: "7", noteType: "footnote" },
+    } as unknown as HTMLElement);
+
+    expect(attrs).toEqual({
+      id: "7",
+      noteType: "footnote",
+      vertAlign: "baseline",
+    });
+  });
+
+  test("parses baseline endnote refs rendered as spans", () => {
+    const footnoteRef = schema.marks["footnoteRef"];
+    if (!footnoteRef) {
+      throw new Error("expected footnoteRef mark");
+    }
+    const parseRules = footnoteRef.spec.parseDOM ?? [];
+    const rule = parseRules.find(
+      (candidate) => candidate.tag === "span.docx-endnote-ref",
+    );
+    if (!rule || typeof rule.getAttrs !== "function") {
+      throw new Error("expected span endnoteRef getAttrs rule");
+    }
+
+    const attrs = rule.getAttrs({
+      dataset: { id: "9", noteType: "endnote" },
+    } as unknown as HTMLElement);
+
+    expect(attrs).toEqual({
+      id: "9",
+      noteType: "endnote",
+      vertAlign: "baseline",
+    });
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/FootnoteRefExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/FootnoteRefExtension.ts
@@ -11,6 +11,16 @@ import { expectFootnoteRefMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
+const noteRefAttrsFromDom = (
+  dom: HTMLElement,
+  noteType: "footnote" | "endnote",
+  vertAlign?: "baseline",
+): Record<string, string> => ({
+  id: dom.dataset["id"] ?? "",
+  noteType: dom.dataset["noteType"] ?? noteType,
+  ...(vertAlign ? { vertAlign } : {}),
+});
+
 export const FootnoteRefExtension = createMarkExtension({
   name: "footnoteRef",
   schemaMarkName: "footnoteRef",
@@ -18,22 +28,33 @@ export const FootnoteRefExtension = createMarkExtension({
     attrs: {
       id: {},
       noteType: { default: "footnote" },
+      vertAlign: { default: null },
     },
     parseDOM: [
       {
         tag: "sup.docx-footnote-ref",
-        getAttrs: (dom) => ({
-          id: dom.dataset["id"] ?? "",
-          noteType: dom.dataset["noteType"] ?? "footnote",
-        }),
+        getAttrs: (dom) => noteRefAttrsFromDom(dom, "footnote"),
+      },
+      {
+        tag: "sup.docx-endnote-ref",
+        getAttrs: (dom) => noteRefAttrsFromDom(dom, "endnote"),
+      },
+      {
+        tag: "span.docx-footnote-ref",
+        getAttrs: (dom) => noteRefAttrsFromDom(dom, "footnote", "baseline"),
+      },
+      {
+        tag: "span.docx-endnote-ref",
+        getAttrs: (dom) => noteRefAttrsFromDom(dom, "endnote", "baseline"),
       },
     ],
     toDOM(mark) {
       const attrs = expectFootnoteRefMarkAttrs(mark);
       const id = String(attrs.id);
       const noteType = attrs.noteType ?? "footnote";
+      const tagName = attrs.vertAlign === "baseline" ? "span" : "sup";
       return [
-        "sup",
+        tagName,
         {
           class: `docx-${noteType}-ref`,
           "data-id": id,

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -107,6 +107,7 @@ export type TextEffectAttrs = {
 export type FootnoteRefAttrs = {
   id: string | number;
   noteType?: "footnote" | "endnote";
+  vertAlign?: "baseline";
 };
 
 export type CommentAttrs = {

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -190,6 +190,13 @@ export type ParagraphAttrs = {
    *  Used by fromProseDoc for lossless round-trip serialization. */
   _originalFormatting?: ParagraphFormatting;
 
+  /** Import-effective spacing baseline for HTML auto-spacing detection.
+   *  PM-only; never serialized back into DOCX formatting. */
+  _autospacingBase?: {
+    before?: number | null;
+    after?: number | null;
+  };
+
   /** Full section properties for paragraphs that end a section.
    *  Used by layout engine for per-section column/page config and round-trip. */
   _sectionProperties?: SectionProperties;

--- a/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
@@ -13,6 +13,8 @@ import {
   computeListRendering,
   type NumberingMap,
 } from "../../docx/numberingParser";
+import { setAutospacingBaseValue } from "../autospacingBase";
+import type { ParagraphAttrs } from "../schema/nodes";
 import type { ResolvedParagraphStyle } from "./styleResolver";
 
 /**
@@ -52,7 +54,22 @@ export function paragraphAttrsFromResolvedStyle(
     // The style's run defaults drive the caret height in an empty paragraph
     // and the formatting typed text inherits (see EmptyParagraphFormatExtension).
     defaultTextFormatting: hasRunFormatting ? runFormatting : null,
+    _autospacingBase: autospacingBaseFromResolvedParagraphFormatting(ppr),
   };
+}
+
+function autospacingBaseFromResolvedParagraphFormatting(
+  ppr: ResolvedParagraphStyle["paragraphFormatting"],
+): ParagraphAttrs["_autospacingBase"] | null {
+  const base: NonNullable<ParagraphAttrs["_autospacingBase"]> = {};
+  if (ppr?.beforeAutospacing) {
+    setAutospacingBaseValue(base, "before", ppr.spaceBefore);
+  }
+  if (ppr?.afterAutospacing) {
+    setAutospacingBaseValue(base, "after", ppr.spaceAfter);
+  }
+
+  return Object.keys(base).length > 0 ? base : null;
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
@@ -64,9 +64,13 @@ describe("StyleResolver", () => {
   });
 
   describe("resolveParagraphStyle", () => {
-    test("returns docDefaults merged with built-in Normal when no styleId provided", () => {
+    test("respects docDefaults paragraph props when no Normal style and no styleId", () => {
+      // eigenpal/docx-editor#909: docDefaults are authoritative (ECMA-376
+      // §17.7.5). With docDefaults present but no Normal style, the absent
+      // Normal must NOT re-introduce the default-template 259/160 spacing —
+      // the document's own docDefaults win.
       const docDefaults: DocDefaults = {
-        pPr: { lineSpacing: 240, spaceAfter: 160 },
+        pPr: { lineSpacing: 240, spaceAfter: 120 },
         rPr: { fontSize: 22 },
       };
 
@@ -78,10 +82,46 @@ describe("StyleResolver", () => {
       const resolver = createStyleResolver(styleDefinitions);
       const result = resolver.resolveParagraphStyle(null);
 
-      // Built-in Normal style overrides docDefaults for lineSpacing (259) and spaceAfter (160)
+      expect(result.paragraphFormatting?.lineSpacing).toBe(240);
+      expect(result.paragraphFormatting?.spaceAfter).toBe(120);
+      expect(result.runFormatting?.fontSize).toBe(22);
+    });
+
+    test("does NOT synthesize template Normal spacing when docDefaults present but Normal absent", () => {
+      // A generated DOCX with an empty `<w:pPrDefault/>` (no spacing) and no
+      // Normal style: style-less paragraphs (e.g. table cells) must render at
+      // the document's compact default, not the 8pt-after / 1.08-line template.
+      const styleDefinitions: StyleDefinitions = {
+        docDefaults: { rPr: { fontSize: 20 } },
+        styles: [],
+      };
+
+      const resolver = createStyleResolver(styleDefinitions);
+      const result = resolver.resolveParagraphStyle(null);
+
+      expect(result.paragraphFormatting?.spaceAfter).toBeUndefined();
+      expect(result.paragraphFormatting?.lineSpacing).toBeUndefined();
+    });
+
+    test("falls back to template Normal only for a bare document (no Normal, no docDefaults)", () => {
+      // The last-resort fallback survives: a document that defines neither a
+      // Normal style nor docDefaults still gets Word's default-template spacing.
+      const resolver = createStyleResolver({ styles: [] });
+      const result = resolver.resolveParagraphStyle(null);
+
       expect(result.paragraphFormatting?.lineSpacing).toBe(259);
       expect(result.paragraphFormatting?.spaceAfter).toBe(160);
-      expect(result.runFormatting?.fontSize).toBe(22);
+    });
+
+    test("treats an empty but present docDefaults as zero spacing, not template Normal", () => {
+      // A document that declares empty docDefaults (no Normal) wants zero
+      // spacing / single line — the built-in template must not be synthesized
+      // over it (eigenpal/docx-editor#909).
+      const resolver = createStyleResolver({ docDefaults: {}, styles: [] });
+      const result = resolver.resolveParagraphStyle(null);
+
+      expect(result.paragraphFormatting?.spaceAfter).toBeUndefined();
+      expect(result.paragraphFormatting?.lineSpacing).toBeUndefined();
     });
 
     test("applies Normal style when no styleId and Normal exists", () => {

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -32,9 +32,17 @@ export type ResolvedParagraphStyle = {
 };
 
 /**
- * Word's built-in Normal style defaults, used when the document
- * doesn't define its own Normal style. Per ECMA-376, Word applies
- * these defaults: 8pt (160 twips) after spacing, 1.08x line spacing.
+ * Word's default-template Normal style, used as a last-resort fallback for a
+ * bare document that ships neither a `Normal` style nor `w:docDefaults`: 8pt
+ * (160 twips) after spacing, 1.08x line spacing — the values Word writes into
+ * a freshly created document's Normal.
+ *
+ * It is NOT applied when the document provides `w:docDefaults`. Those are the
+ * authoritative paragraph defaults per ECMA-376 §17.7.5; an empty
+ * `w:pPrDefault` means zero spacing / single line, so synthesizing this style
+ * over it wrongly inflates style-less paragraphs (e.g. generated-document
+ * table cells whose author relied on the compact default). See
+ * eigenpal/docx-editor#909.
  */
 const BUILTIN_NORMAL_STYLE: Style = {
   styleId: "Normal",
@@ -295,9 +303,15 @@ export class StyleResolver {
         return style;
       }
     }
-    // Fall back to "Normal" for paragraph styles
+    // Fall back to "Normal" for paragraph styles. Only synthesize the
+    // default-template Normal for a bare document with no docDefaults; when
+    // docDefaults exist they are the authoritative paragraph defaults and an
+    // absent Normal must not re-introduce the template's 8pt/1.08 spacing.
     if (type === "paragraph") {
-      return this.stylesById.get("Normal") ?? BUILTIN_NORMAL_STYLE;
+      return (
+        this.stylesById.get("Normal") ??
+        (this.docDefaults ? undefined : BUILTIN_NORMAL_STYLE)
+      );
     }
     return undefined;
   }

--- a/packages/folio/src/core/utils/formatToStyle-autospacing.test.ts
+++ b/packages/folio/src/core/utils/formatToStyle-autospacing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { paragraphToStyle } from "./formatToStyle";
+import { AUTO_PARAGRAPH_SPACING_PX } from "./units";
+
+// eigenpal/docx-editor#823 — HTML-origin paragraphs carry
+// `w:beforeAutospacing`/`w:afterAutospacing`. Word ignores any explicit
+// before/after on such paragraphs and renders ~14px. The editor previously
+// honored only the explicit values, so imports rendered too tight.
+describe("paragraphToStyle auto spacing", () => {
+  test("auto spacing overrides explicit before/after", () => {
+    const style = paragraphToStyle({
+      beforeAutospacing: true,
+      afterAutospacing: true,
+      spaceBefore: 100, // ~6.7px; auto must win
+      spaceAfter: 100,
+    });
+
+    expect(style.marginTop).toBe(`${AUTO_PARAGRAPH_SPACING_PX}px`);
+    expect(style.marginBottom).toBe(`${AUTO_PARAGRAPH_SPACING_PX}px`);
+  });
+
+  test("explicit spacing is still used when no auto flag is set", () => {
+    const style = paragraphToStyle({ spaceBefore: 240 }); // 240 twips = 16px
+    expect(style.marginTop).toBe("16px");
+  });
+});

--- a/packages/folio/src/core/utils/formatToStyle.ts
+++ b/packages/folio/src/core/utils/formatToStyle.ts
@@ -29,6 +29,7 @@ import {
 } from "./colorResolver";
 import { resolveFontFamily, resolveThemeFont } from "./fontResolver";
 import {
+  AUTO_PARAGRAPH_SPACING_PX,
   halfPointsToPixels,
   twipsToPixels,
   eighthsToPixels,
@@ -304,13 +305,18 @@ export function paragraphToStyle(
   // SPACING (margins)
   // ============================================================================
 
-  // Space before (marginTop)
-  if (formatting.spaceBefore !== undefined) {
+  // Space before (marginTop). HTML-origin `w:beforeAutospacing` overrides any
+  // explicit before with Word's ~14px auto gap (eigenpal/docx-editor#823).
+  if (formatting.beforeAutospacing) {
+    style.marginTop = formatPx(AUTO_PARAGRAPH_SPACING_PX);
+  } else if (formatting.spaceBefore !== undefined) {
     style.marginTop = formatPx(twipsToPixels(formatting.spaceBefore));
   }
 
-  // Space after (marginBottom)
-  if (formatting.spaceAfter !== undefined) {
+  // Space after (marginBottom). Same auto-spacing override as above.
+  if (formatting.afterAutospacing) {
+    style.marginBottom = formatPx(AUTO_PARAGRAPH_SPACING_PX);
+  } else if (formatting.spaceAfter !== undefined) {
     style.marginBottom = formatPx(twipsToPixels(formatting.spaceAfter));
   }
 

--- a/packages/folio/src/core/utils/units.ts
+++ b/packages/folio/src/core/utils/units.ts
@@ -21,6 +21,15 @@ const STANDARD_DPI = 96;
 /** Twips per inch (1 inch = 1440 twips) */
 export const TWIPS_PER_INCH = 1440;
 
+/**
+ * Word's auto paragraph spacing in px. HTML-origin paragraphs use
+ * `w:beforeAutospacing`/`w:afterAutospacing` instead of explicit before/after;
+ * Word ignores any explicit value on such paragraphs and renders ~14px. The
+ * value is empirical (Word's rendered auto gap), not derivable from a twips
+ * conversion. See eigenpal/docx-editor#823.
+ */
+export const AUTO_PARAGRAPH_SPACING_PX = 14;
+
 /** EMUs per inch (1 inch = 914400 EMUs) */
 const EMUS_PER_INCH = 914_400;
 


### PR DESCRIPTION
Ports three upstream `eigenpal/docx-editor` spacing/style fidelity fixes into folio. Independent of the sibling sync PRs (disjoint files).

### Changes
- **docDefaults precedence** (`eigenpal/docx-editor#909`): the built-in Normal fallback (8pt-after / 1.08 line) is synthesized only when the document defines neither a `Normal` style nor `w:docDefaults`. A document that ships its own `docDefaults` (common in generated files) keeps them, so style-less paragraphs (e.g. table cells) render at the document's compact height instead of the inflated template spacing.
- **HTML auto-spacing** (`eigenpal/docx-editor#823`): paragraphs with `w:beforeAutospacing`/`w:afterAutospacing` render Word's ~14px auto gap, overriding any explicit before/after — applied in both the paged layout (so pagination matches) and the live-edit DOM. Adds a named `AUTO_PARAGRAPH_SPACING_PX` constant.
- **Footnote-anchor superscript** (`eigenpal/docx-editor#845`): a footnote/endnote reference anchor renders superscript by default (Word's built-in FootnoteReference style), even when the source OOXML omits an explicit `vertAlign` (e.g. a bare `<w:footnoteReference/>`).

### Tests
- `styleResolver.test.ts` (docDefaults precedence, bare-document fallback), `formatToStyle-autospacing.test.ts`, `toFlowBlocks.test.ts` (auto-spacing pagination), `toFlowBlocks-run-marks.test.ts` (anchor superscript).

Full folio suite green.