### PR TITLE
fix(folio): preserve per-run RTL, w:rStyle, and collapsed PAGE-field formatting on round-trip

### DIFF
--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -309,6 +309,13 @@ export type ComplexField = {
   fieldCode: Run[];
   /** Display result runs */
   fieldResult: Run[];
+  /**
+   * Run formatting captured from the field's structural run(s) (`w:rPr` on the
+   * `begin`/code run). Used as the run-formatting fallback when the field has
+   * no separate result run to read it from, e.g. a footer `PAGE` number whose
+   * formatting lives on the field run (eigenpal/docx-editor#909).
+   */
+  formatting?: TextFormatting;
   /** Field is locked */
   fldLock?: boolean;
   /** Field is dirty */

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1224,7 +1224,7 @@ export function DocxEditor({
         for (const [rId, hf] of bag) {
           const view = editor.getHfView(rId);
           if (view) {
-            hf.content = proseDocToBlocks(view.state.doc);
+            hf.content = proseDocToBlocks(view.state.doc, doc.package.styles);
           }
         }
       };

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -472,7 +472,10 @@ export const useHeaderFooterEditor = ({
         // brand-new Map so the previous Document referenced by every
         // earlier history entry stays untouched and undo can step
         // back to the pre-edit state.
-        const blocks: BlockContent[] = proseDocToBlocks(view.state.doc);
+        const blocks: BlockContent[] = proseDocToBlocks(
+          view.state.doc,
+          pkg.styles,
+        );
         const updated: HeaderFooter = {
           ...existing,
           type: hfEditPosition,

--- a/packages/folio/src/core/docx/paragraphParser.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser.test.ts
@@ -394,3 +394,61 @@ describe("parseParagraph SDT content preservation", () => {
     expect(outer.content[0].type).toBe("inlineSdt");
   });
 });
+
+describe("parseParagraph complex field formatting (#909)", () => {
+  test("captures the field run's w:rPr when there is no separate result run", () => {
+    // Footer pattern: begin / instrText / separate / end all in a single run
+    // carrying the w:rPr, with no separate result run. The formatting must
+    // survive on the ComplexField so the rendered PAGE number keeps the
+    // footer's size and color instead of falling back to the default.
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r>
+          <w:rPr><w:color w:val="595959"/><w:sz w:val="14"/><w:szCs w:val="14"/></w:rPr>
+          <w:fldChar w:fldCharType="begin"/>
+          <w:instrText xml:space="preserve"> PAGE </w:instrText>
+          <w:fldChar w:fldCharType="separate"/>
+          <w:fldChar w:fldCharType="end"/>
+        </w:r>
+      </w:p>
+    `);
+
+    const field = paragraph.content.find((c) => c.type === "complexField");
+    expect(field?.type).toBe("complexField");
+    if (!field) {
+      return;
+    }
+    expect(field.fieldResult).toHaveLength(0);
+    expect(field.formatting?.color).toEqual({ rgb: "595959" });
+    // raw w:sz is in half-points (14 half-points = 7pt).
+    expect(field.formatting?.fontSize).toBe(14);
+  });
+
+  test("captures a later run's formatting when the begin run's w:rPr is empty", () => {
+    // The begin run carries an empty <w:rPr/>; the size/colour lives on the
+    // result run. The empty object must not block capturing the later run.
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r>
+          <w:rPr/>
+          <w:fldChar w:fldCharType="begin"/>
+          <w:instrText xml:space="preserve"> PAGE </w:instrText>
+          <w:fldChar w:fldCharType="separate"/>
+        </w:r>
+        <w:r>
+          <w:rPr><w:color w:val="FF0000"/><w:sz w:val="28"/></w:rPr>
+          <w:t>1</w:t>
+        </w:r>
+        <w:r><w:fldChar w:fldCharType="end"/></w:r>
+      </w:p>
+    `);
+
+    const field = paragraph.content.find((c) => c.type === "complexField");
+    expect(field?.type).toBe("complexField");
+    if (!field) {
+      return;
+    }
+    expect(field.formatting?.color).toEqual({ rgb: "FF0000" });
+    expect(field.formatting?.fontSize).toBe(28);
+  });
+});

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -20,6 +20,7 @@ import type {
   BookmarkEnd,
   SimpleField,
   ComplexField,
+  TextFormatting,
   Theme,
   ColorValue,
   BorderSpec,
@@ -1262,6 +1263,9 @@ function parseParagraphContents(
   let afterSeparator = false;
   let complexFieldLock = false;
   let complexFieldDirty = false;
+  // Run formatting (w:rPr) carried on the field's structural runs, used as a
+  // fallback when the field has no separate result run (eigenpal/docx-editor#909).
+  let complexFieldFormatting: TextFormatting | undefined;
 
   for (const child of children) {
     const localName = getLocalName(child.name);
@@ -1326,11 +1330,28 @@ function parseParagraphContents(
           complexFieldResultRuns = [];
           complexFieldLock = false;
           complexFieldDirty = false;
+          // The structural run carrying `begin` often holds the field's run
+          // formatting (e.g. a footer PAGE field collapsed into one run).
+          complexFieldFormatting = run.formatting;
         }
 
         if (inComplexField) {
           if (instrText) {
             complexFieldInstr += instrText;
+          }
+          // Prefer any field run that actually carries formatting (the begin
+          // run is sometimes an empty `<w:rPr/>` in docs that put `w:rPr` on a
+          // later run). An empty formatting object counts as absent so it does
+          // not block that later, genuinely-formatted run.
+          const captureIsEmpty =
+            !complexFieldFormatting ||
+            Object.keys(complexFieldFormatting).length === 0;
+          if (
+            captureIsEmpty &&
+            run.formatting &&
+            Object.keys(run.formatting).length > 0
+          ) {
+            complexFieldFormatting = run.formatting;
           }
 
           if (hasFieldSeparate) {
@@ -1381,6 +1402,9 @@ function parseParagraphContents(
             }
             if (complexFieldDirty) {
               complexField.dirty = true;
+            }
+            if (complexFieldFormatting) {
+              complexField.formatting = complexFieldFormatting;
             }
 
             contents.push(complexField);

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -759,8 +759,10 @@ function serializeComplexField(field: ComplexField): string {
 
   // Extract formatting from the first result run to apply to structural runs
   // (begin/separate/end). OOXML consumers expect consistent formatting across
-  // all runs in a complex field.
-  const resultFormatting = field.fieldResult[0]?.formatting;
+  // all runs in a complex field. Fall back to the field's captured run
+  // formatting when there is no result run, so a collapsed PAGE field's
+  // `w:rPr` (size/color) survives the round-trip (eigenpal/docx-editor#909).
+  const resultFormatting = field.fieldResult[0]?.formatting ?? field.formatting;
   const rPrXml = resultFormatting
     ? serializeTextFormatting(resultFormatting)
     : "";

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -44,6 +44,7 @@ import type {
   ParagraphAttrs,
   RunFormattingOverrideAttrs,
   RunShadingAttrs,
+  RunStyleAttrs,
   SdtAttrs,
   ShapeAttrs,
   StrikeAttrs,
@@ -229,6 +230,7 @@ const strikeAttrsCache = new WeakMap<Mark, StrikeAttrs>();
 const textColorAttrsCache = new WeakMap<Mark, TextColorAttrs>();
 const highlightAttrsCache = new WeakMap<Mark, HighlightAttrs>();
 const runShadingAttrsCache = new WeakMap<Mark, RunShadingAttrs>();
+const runStyleAttrsCache = new WeakMap<Mark, RunStyleAttrs>();
 const fontSizeAttrsCache = new WeakMap<Mark, FontSizeAttrs>();
 const fontFamilyAttrsCache = new WeakMap<Mark, FontFamilyAttrs>();
 const characterSpacingAttrsCache = new WeakMap<Mark, CharacterSpacingAttrs>();
@@ -1155,6 +1157,26 @@ export const expectRunShadingMarkAttrs = (mark: Mark): RunShadingAttrs =>
     runShadingAttrsCache,
     readRunShadingMarkAttrs,
     "run shading attrs",
+  );
+
+export const readRunStyleMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<RunStyleAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "runStyle", issues);
+
+  requiredString(attrs, "styleId", "runStyle.attrs.styleId", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectRunStyleMarkAttrs = (mark: Mark): RunStyleAttrs =>
+  expectCachedMarkAttrs(
+    mark,
+    runStyleAttrsCache,
+    readRunStyleMarkAttrs,
+    "run style attrs",
   );
 
 export const readFontSizeMarkAttrs = (

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -13,7 +13,10 @@
 import type { Node as PMNode, Mark } from "prosemirror-model";
 
 import { numPrEqual } from "../../docx/numberingParser";
+import { visitDocxParagraphs } from "../../docx/paragraphTraversal";
 import { narrowEnum, ShapeOutlineStyleSchema } from "../../docx/parserEnums";
+import { createStyleEngine } from "../../style-engine";
+import type { StyleEngine } from "../../style-engine";
 import type {
   ImageWrap,
   ImagePosition,
@@ -57,6 +60,7 @@ import type {
   MathEquation,
   ColorValue,
   CellMargins,
+  StyleDefinitions,
 } from "../../types/document";
 import {
   OUTLINE_STYLE_CSS_ALIASES,
@@ -75,6 +79,7 @@ import {
   expectHardBreakAttrs,
   expectHighlightMarkAttrs,
   expectRunShadingMarkAttrs,
+  expectRunStyleMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
   expectMathAttrs,
@@ -103,6 +108,7 @@ import type {
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
 import { runShadingAttrsToShading } from "./runShadingMark";
+import { textFormattingToMarks } from "./toProseDoc";
 
 function normalizeShapeOutlineStyle(
   style: string | undefined,
@@ -237,6 +243,18 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
     documentBody.comments = baseDocument.package.document.comments;
   }
 
+  // Reconcile run character-style references (w:rStyle). The `runStyle` mark
+  // preserves the named link, but once a run has been edited away from its
+  // style the link would re-apply the style on save and silently revert the
+  // edit. Needs the original styles to resolve, so only runs when a base
+  // document is present (eigenpal/docx-editor#833).
+  if (baseDocument?.package.styles) {
+    reconcileRunStyleReferences(
+      { content: blocks },
+      createStyleEngine(baseDocument.package.styles),
+    );
+  }
+
   // If we have a base document, preserve its package structure
   if (baseDocument) {
     return {
@@ -254,6 +272,155 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
       document: documentBody,
     },
   };
+}
+
+function isSet(value: unknown): boolean {
+  return value !== null && value !== undefined;
+}
+
+const TEXT_COLOR_MARK_VALUE_KEYS = [
+  "rgb",
+  "themeColor",
+  "themeTint",
+  "themeShade",
+] as const;
+
+function hasTextColorMarkValue(mark: Mark): boolean {
+  return TEXT_COLOR_MARK_VALUE_KEYS.some((key) => isSet(mark.attrs[key]));
+}
+
+function runMarkDroppedStyleProperty(styleMark: Mark, runMark: Mark): boolean {
+  if (styleMark.type.name === "textColor") {
+    return !hasTextColorMarkValue(runMark);
+  }
+
+  return Object.entries(styleMark.attrs).some(
+    ([key, value]) => isSet(value) && !isSet(runMark.attrs[key]),
+  );
+}
+
+// A run still matches its character style as long as it carries a mark for
+// every property the style contributes. A property the user removed leaves no
+// mark of that type, so the inert `w:rStyle` link would wrongly re-apply it on
+// save; a property the user overrode keeps a mark of that type (with a value
+// the serializer re-emits, which wins over the style), so the link may stay.
+// Comparing the marks `toProseDoc` would emit keeps this in lockstep with every
+// property it round-trips — including values that emit no mark (an auto colour,
+// a baseline vertical alignment), which then correctly never count as removed.
+// Negative style properties (`runFormattingOverride`) are also safe to ignore:
+// retaining the style can only keep an inherited property off, and any direct
+// positive mark on the run wins over that style value in OOXML.
+function runDivergesFromStyle(
+  runFormatting: TextFormatting,
+  styleFormatting: TextFormatting,
+): boolean {
+  const runMarks = textFormattingToMarks(runFormatting);
+  return textFormattingToMarks(styleFormatting).some((styleMark) => {
+    if (
+      styleMark.type.name === "runStyle" ||
+      styleMark.type.name === "runFormattingOverride"
+    ) {
+      return false;
+    }
+    const runMark = runMarks.find((mark) => mark.type === styleMark.type);
+    if (!runMark) {
+      // The run dropped this mark type entirely.
+      return true;
+    }
+    // The run kept the mark type but still diverges if it dropped a property
+    // the style sets. Most compound marks have independent attr slots
+    // (`fontFamily.eastAsia` vs. `ascii`); textColor is different because
+    // `rgb` and `themeColor` are alternate representations of one property.
+    return runMarkDroppedStyleProperty(styleMark, runMark);
+  });
+}
+
+function reconcileRunStyleReference(run: Run, styleEngine: StyleEngine): void {
+  const styleId = run.formatting?.styleId;
+  if (!styleId || !run.formatting) {
+    return;
+  }
+  const styleFormatting = styleEngine.getRunStyleOwnProperties(styleId);
+  // Unknown style: keep the reference rather than guess at divergence.
+  if (
+    styleFormatting &&
+    runDivergesFromStyle(run.formatting, styleFormatting)
+  ) {
+    delete run.formatting.styleId;
+  }
+}
+
+function forEachRunInInline(
+  items: readonly (Run | Hyperlink)[],
+  fn: (run: Run) => void,
+): void {
+  for (const item of items) {
+    if (item.type === "run") {
+      fn(item);
+      continue;
+    }
+    for (const child of item.children) {
+      if (child.type === "run") {
+        fn(child);
+      }
+    }
+  }
+}
+
+// Visit every run reachable from a paragraph's inline content, including runs
+// nested in hyperlinks, fields, inline SDTs, and tracked-change containers — a
+// styled run can live in any of them and still needs reconciling.
+function forEachRunInParagraphContent(
+  content: ParagraphContent,
+  fn: (run: Run) => void,
+): void {
+  switch (content.type) {
+    case "run":
+      fn(content);
+      return;
+    case "hyperlink":
+      for (const child of content.children) {
+        if (child.type === "run") {
+          fn(child);
+        }
+      }
+      return;
+    case "simpleField":
+    case "insertion":
+    case "deletion":
+    case "moveFrom":
+    case "moveTo":
+      forEachRunInInline(content.content, fn);
+      return;
+    case "complexField":
+      for (const run of content.fieldCode) {
+        fn(run);
+      }
+      for (const run of content.fieldResult) {
+        fn(run);
+      }
+      return;
+    case "inlineSdt":
+      for (const child of content.content) {
+        forEachRunInParagraphContent(child, fn);
+      }
+      return;
+    default:
+      return;
+  }
+}
+
+function reconcileRunStyleReferences(
+  documentBody: DocumentBody,
+  styleEngine: StyleEngine,
+): void {
+  visitDocxParagraphs({ documentBody }, (paragraph) => {
+    for (const content of paragraph.content) {
+      forEachRunInParagraphContent(content, (run) => {
+        reconcileRunStyleReference(run, styleEngine);
+      });
+    }
+  });
 }
 
 /**
@@ -1920,6 +2087,12 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         );
         break;
 
+      case "runStyle":
+        // Restore the run's character-style reference so `<w:rStyle>` is
+        // re-emitted on save (eigenpal/docx-editor#833).
+        formatting.styleId = expectRunStyleMarkAttrs(mark).styleId;
+        break;
+
       case "fontSize": {
         const attrs = expectFontSizeMarkAttrs(mark);
         formatting.fontSize = attrs.size;
@@ -2731,6 +2904,17 @@ export function updateDocumentContent(
  * Used for converting edited header/footer PM content back to the document
  * model.
  */
-export function proseDocToBlocks(pmDoc: PMNode): BlockContent[] {
-  return extractBlocks(pmDoc);
+export function proseDocToBlocks(
+  pmDoc: PMNode,
+  styles?: StyleDefinitions,
+): BlockContent[] {
+  const blocks = extractBlocks(pmDoc);
+  // Header/footer save paths call this directly instead of `fromProseDoc`, so
+  // run the same w:rStyle reconciliation here when the document's styles are
+  // available — otherwise a character-style edit inside a header or footer is
+  // silently reverted on save (eigenpal/docx-editor#833).
+  if (styles) {
+    reconcileRunStyleReferences({ content: blocks }, createStyleEngine(styles));
+  }
+  return blocks;
 }

--- a/packages/folio/src/core/prosemirror/conversion/run-rstyle-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/run-rstyle-roundtrip.test.ts
@@ -1,0 +1,469 @@
+// eigenpal/docx-editor#833 — a run's character-style reference (`w:rStyle`)
+// must survive the PM save round-trip. The parser reads `<w:rStyle>` into
+// `run.formatting.styleId` and the serializer re-emits it, but PM conversion
+// baked the style's formatting into direct marks and dropped the named
+// reference, so an edited run lost its Strong/Emphasis/code character-style
+// link on save. A dedicated inert `runStyle` mark carries it through.
+
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type {
+  Document,
+  Paragraph,
+  StyleDefinitions,
+} from "../../types/document";
+import { schema } from "../schema";
+import { fromProseDoc, proseDocToBlocks } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const doc = (): Document => ({
+  package: {
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "strong" }],
+              formatting: { styleId: "Strong" },
+            },
+            {
+              type: "run",
+              content: [{ type: "text", text: "emph" }],
+              formatting: { styleId: "Emphasis" },
+            },
+            {
+              type: "run",
+              content: [{ type: "text", text: "plain" }],
+              formatting: {},
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+const firstParagraph = (document: Document): Paragraph => {
+  const block = document.package.document.content.at(0);
+  if (block?.type !== "paragraph") {
+    throw new Error("expected first block to be a paragraph");
+  }
+  return block;
+};
+
+const runStyleIdByText = (
+  document: Document,
+): Map<string, string | undefined> => {
+  const map = new Map<string, string | undefined>();
+  for (const content of firstParagraph(document).content) {
+    if (content.type !== "run") {
+      continue;
+    }
+    const text = content.content
+      .map((c) => (c.type === "text" ? c.text : ""))
+      .join("");
+    map.set(text, content.formatting?.styleId);
+  }
+  return map;
+};
+
+describe("run w:rStyle survives the PM round-trip (#833)", () => {
+  test("styleId is preserved on the rebuilt runs", () => {
+    const source = doc();
+    const rebuilt = fromProseDoc(toProseDoc(source), source);
+    const styleIds = runStyleIdByText(rebuilt);
+
+    expect(styleIds.get("strong")).toBe("Strong");
+    expect(styleIds.get("emph")).toBe("Emphasis");
+    expect(styleIds.get("plain")).toBeUndefined();
+  });
+});
+
+// The named link must not silently re-apply a character style over an edit:
+// once the run's direct formatting no longer matches the style, the styleId is
+// dropped on save so the edit wins (eigenpal/docx-editor#833).
+const characterStyles: StyleDefinitions = {
+  styles: [
+    {
+      styleId: "Strong",
+      type: "character",
+      name: "Strong",
+      rPr: { bold: true },
+    },
+    {
+      styleId: "Underlined",
+      type: "character",
+      name: "Underlined",
+      rPr: { underline: { style: "single" } },
+    },
+    {
+      styleId: "AutoColor",
+      type: "character",
+      name: "AutoColor",
+      // An auto colour produces no textColor mark in toProseDoc, so its absence
+      // on a run is not a divergence.
+      rPr: { color: { auto: true } },
+    },
+    {
+      styleId: "ThemeColor",
+      type: "character",
+      name: "Theme Color",
+      rPr: { color: { themeColor: "accent1" } },
+    },
+    {
+      styleId: "Highlighted",
+      type: "character",
+      name: "Highlighted",
+      // A non-toggle, non-colour/size/font property the old hand-list missed.
+      rPr: { highlight: "yellow" },
+    },
+    {
+      styleId: "CjkFont",
+      type: "character",
+      name: "CjkFont",
+      // Contributes only the East Asian slot of the compound fontFamily mark.
+      rPr: { fontFamily: { eastAsia: "SimSun" } },
+    },
+    {
+      styleId: "BoldOff",
+      type: "character",
+      name: "Bold Off",
+      rPr: { bold: false },
+    },
+    {
+      styleId: "NoUnderline",
+      type: "character",
+      name: "No Underline",
+      rPr: { underline: { style: "none" } },
+    },
+  ],
+};
+
+const styleAwareBase: Document = {
+  package: {
+    styles: characterStyles,
+    document: { content: [] },
+  },
+};
+
+// A document carrying its own styles and a Strong-styled run, round-tripped
+// through toProseDoc/fromProseDoc with no edit.
+const strongStyledDocument = (): Document => ({
+  package: {
+    styles: characterStyles,
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "strong" }],
+              formatting: { styleId: "Strong" },
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+function pmDocWithStyledRun(
+  markSpecs: { name: string; attrs?: Record<string, unknown> }[],
+): PMNode {
+  const marks = markSpecs.map(({ name, attrs }) => {
+    const mark = schema.marks[name]?.create(attrs);
+    if (!mark) {
+      throw new Error(`Unknown mark: ${name}`);
+    }
+    return mark;
+  });
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text("styled", marks)]),
+  ]);
+}
+
+const firstRunStyleId = (document: Document): string | undefined => {
+  for (const content of firstParagraph(document).content) {
+    if (content.type === "run") {
+      return content.formatting?.styleId;
+    }
+  }
+  return undefined;
+};
+
+const firstRunFormatting = (document: Document) => {
+  for (const content of firstParagraph(document).content) {
+    if (content.type === "run") {
+      return content.formatting;
+    }
+  }
+  return undefined;
+};
+
+describe("run w:rStyle reconciliation on save (#833)", () => {
+  test("keeps the styleId when the run still matches its character style", () => {
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "Strong" } },
+      { name: "bold" },
+    ]);
+    expect(firstRunStyleId(fromProseDoc(pm, styleAwareBase))).toBe("Strong");
+  });
+
+  test("drops the styleId when the run was edited away from its style", () => {
+    // The user toggled off the bold that `Strong` contributes; the link must
+    // not survive and re-bold the run in Word.
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "Strong" } },
+    ]);
+    expect(firstRunStyleId(fromProseDoc(pm, styleAwareBase))).toBeUndefined();
+  });
+
+  test("drops the styleId when a non-toggle style property is removed", () => {
+    // `Underlined` contributes underline; a run carrying only the link (no
+    // underline) has had it removed, so the link must not survive.
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "Underlined" } },
+    ]);
+    expect(firstRunStyleId(fromProseDoc(pm, styleAwareBase))).toBeUndefined();
+  });
+
+  test("keeps the styleId on an unedited round-trip (styles are expanded by default)", () => {
+    // A no-op open/save of a document with its own styles must not strip the
+    // character-style link. `toProseDoc` flattens the style onto direct marks
+    // (defaulting to the document's styles), so the run still matches the style
+    // and the reconciliation keeps the link (eigenpal/docx-editor#833).
+    const source = strongStyledDocument();
+    const rebuilt = fromProseDoc(toProseDoc(source), source);
+    expect(firstRunStyleId(rebuilt)).toBe("Strong");
+  });
+
+  test("drops the styleId when any style-contributed property is removed (not just the hand-listed ones)", () => {
+    // `Highlighted` contributes a highlight; a run carrying only the link has
+    // had it removed. The mark-level check covers every property toProseDoc
+    // emits, so this diverges even though highlight is not a toggle/colour/font.
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "Highlighted" } },
+    ]);
+    expect(firstRunStyleId(fromProseDoc(pm, styleAwareBase))).toBeUndefined();
+  });
+
+  test("drops the styleId when a compound mark loses a style-set sub-property", () => {
+    // `CjkFont` contributes `fontFamily.eastAsia`; the run overrode ascii/hAnsi
+    // but dropped eastAsia. The mark type is still present, but the East Asian
+    // font the style set is gone, so the link must not survive and reapply it.
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "CjkFont" } },
+      { name: "fontFamily", attrs: { ascii: "Arial", hAnsi: "Arial" } },
+    ]);
+    expect(firstRunStyleId(fromProseDoc(pm, styleAwareBase))).toBeUndefined();
+  });
+
+  test("keeps the styleId when the style's only colour is auto", () => {
+    // `AutoColor` contributes an auto colour, which produces no textColor mark;
+    // the run legitimately has none, so this must not read as a divergence.
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "AutoColor" } },
+    ]);
+    expect(firstRunStyleId(fromProseDoc(pm, styleAwareBase))).toBe("AutoColor");
+  });
+
+  test("keeps the styleId when direct RGB color overrides a style theme color", () => {
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "ThemeColor" } },
+      { name: "textColor", attrs: { rgb: "FF0000" } },
+    ]);
+
+    const formatting = firstRunFormatting(fromProseDoc(pm, styleAwareBase));
+
+    expect(formatting?.styleId).toBe("ThemeColor");
+    expect(formatting?.color?.rgb).toBe("FF0000");
+  });
+
+  test("keeps the styleId when direct bold overrides a style's bold-off value", () => {
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "BoldOff" } },
+      { name: "bold" },
+    ]);
+
+    const formatting = firstRunFormatting(fromProseDoc(pm, styleAwareBase));
+
+    expect(formatting?.styleId).toBe("BoldOff");
+    expect(formatting?.bold).toBe(true);
+  });
+
+  test("keeps the styleId when direct underline overrides a style's underline-none value", () => {
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "NoUnderline" } },
+      { name: "underline", attrs: { style: "single" } },
+    ]);
+
+    const formatting = firstRunFormatting(fromProseDoc(pm, styleAwareBase));
+
+    expect(formatting?.styleId).toBe("NoUnderline");
+    expect(formatting?.underline?.style).toBe("single");
+  });
+
+  test("keeps the styleId on a field result styled only by a character style", () => {
+    // A PAGE field whose result run carries only a `w:rStyle` must keep that
+    // link across a no-op round-trip: toProseDoc flattens the style onto the
+    // field's marks, so the reconciliation does not see it as diverging.
+    const source: Document = {
+      package: {
+        styles: characterStyles,
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "simpleField",
+                  instruction: " PAGE ",
+                  fieldType: "PAGE",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "1" }],
+                      formatting: { styleId: "Strong" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pm = toProseDoc(source);
+    let fieldHasBold = false;
+    let fieldHasRunStyle = false;
+    pm.descendants((node) => {
+      if (node.type.name !== "field") {
+        return;
+      }
+      fieldHasBold = node.marks.some((m) => m.type.name === "bold");
+      fieldHasRunStyle = node.marks.some((m) => m.type.name === "runStyle");
+    });
+    expect(fieldHasBold).toBe(true);
+    expect(fieldHasRunStyle).toBe(true);
+
+    const body = fromProseDoc(pm, source).package.document;
+    const field = firstParagraph({
+      package: { document: body },
+    } as Document).content.find((c) => c.type === "simpleField");
+    const fieldRun = field?.content.find((c) => c.type === "run");
+    expect(fieldRun?.formatting?.styleId).toBe("Strong");
+  });
+
+  test("does not apply field-code formatting to a present, unformatted result run (#909)", () => {
+    // The result run exists but carries no direct formatting (it inherits
+    // paragraph defaults); the field-code fallback must NOT colour it.
+    const source: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "complexField",
+                  instruction: " PAGE ",
+                  fieldType: "PAGE",
+                  fieldCode: [],
+                  fieldResult: [
+                    { type: "run", content: [{ type: "text", text: "1" }] },
+                  ],
+                  formatting: { color: { rgb: "FF0000" } },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    let fieldHasColor = false;
+    toProseDoc(source).descendants((node) => {
+      if (node.type.name === "field") {
+        fieldHasColor = node.marks.some((m) => m.type.name === "textColor");
+      }
+    });
+    expect(fieldHasColor).toBe(false);
+  });
+
+  test("proseDocToBlocks reconciles run styles for the header/footer save path", () => {
+    // Header/footer saves extract blocks directly. With the document styles it
+    // must drop a styleId edited away from its style; without them it leaves the
+    // link untouched (no reconciliation context).
+    const blockRunStyleId = (blocks: ReturnType<typeof proseDocToBlocks>) => {
+      const para = blocks.find((b) => b.type === "paragraph");
+      if (para?.type !== "paragraph") {
+        return undefined;
+      }
+      const run = para.content.find((c) => c.type === "run");
+      return run?.type === "run" ? run.formatting?.styleId : undefined;
+    };
+
+    // Run carries the Strong link but not the bold it contributes (edited away).
+    const pm = pmDocWithStyledRun([
+      { name: "runStyle", attrs: { styleId: "Strong" } },
+    ]);
+    expect(blockRunStyleId(proseDocToBlocks(pm))).toBe("Strong");
+    expect(
+      blockRunStyleId(proseDocToBlocks(pm, characterStyles)),
+    ).toBeUndefined();
+  });
+
+  test("fromProseDoc does not reconcile preserved base document comments", () => {
+    const baseDocument: Document = {
+      package: {
+        styles: characterStyles,
+        document: {
+          content: [],
+          comments: [
+            {
+              id: 1,
+              author: "Reviewer",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "comment" }],
+                      formatting: { styleId: "Strong" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const pm = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("body")]),
+    ]);
+
+    const rebuilt = fromProseDoc(pm, baseDocument);
+    const rebuiltCommentRun = rebuilt.package.document.comments
+      ?.at(0)
+      ?.content.at(0)
+      ?.content.at(0);
+    const baseCommentRun = baseDocument.package.document.comments
+      ?.at(0)
+      ?.content.at(0)
+      ?.content.at(0);
+
+    expect(rebuiltCommentRun?.type).toBe("run");
+    if (rebuiltCommentRun?.type !== "run" || baseCommentRun?.type !== "run") {
+      return;
+    }
+    expect(rebuiltCommentRun.formatting?.styleId).toBe("Strong");
+    expect(baseCommentRun.formatting?.styleId).toBe("Strong");
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -87,7 +87,14 @@ export function toProseDoc(
   const paragraphs = document.package.document.content;
   const nodes: PMNode[] = [];
 
-  const styleResolver = createStyleEngine(options?.styles);
+  // Default to the document's own styles (symmetric with `theme` below) so a
+  // run's character-style formatting is always flattened onto direct marks.
+  // The save-side `w:rStyle` reconciliation relies on this: without it, an
+  // unexpanded run would look like the user stripped the style's formatting
+  // (eigenpal/docx-editor#833).
+  const styleResolver = createStyleEngine(
+    options?.styles ?? document.package.styles,
+  );
   const theme = options?.theme ?? document.package.theme ?? null;
   let textBoxGroupIndex = 0;
 
@@ -322,7 +329,9 @@ function convertParagraph(
       content.type === "simpleField" ||
       content.type === "complexField"
     ) {
-      emitInlineNode(convertField(content, getInheritedRunFormatting));
+      emitInlineNode(
+        convertField(content, getInheritedRunFormatting, styleResolver),
+      );
     } else if (content.type === "inlineSdt") {
       emitInlineNode(
         convertInlineSdt(content, getInheritedRunFormatting, styleResolver),
@@ -1799,6 +1808,7 @@ function convertTableCell(
 function convertField(
   field: SimpleField | ComplexField,
   getInheritedRunFormatting: RunFormattingResolver,
+  styleResolver?: StyleEngine | null,
 ): PMNode | null {
   // Extract display text and formatting from field content/result
   let displayText = "";
@@ -1818,10 +1828,31 @@ function convertField(
     }
   }
 
-  // Merge style formatting with field run formatting (inline takes precedence)
+  // Collapsed complex field with no result run at all — fall back to the field's
+  // captured run formatting so a footer PAGE number keeps its size/color instead
+  // of rendering at the default (eigenpal/docx-editor#909). Only when the result
+  // is genuinely empty: a present-but-unformatted result run intentionally
+  // inherits paragraph defaults and must not adopt the field code's formatting.
+  if (
+    !fieldFormatting &&
+    field.type === "complexField" &&
+    field.fieldResult.length === 0
+  ) {
+    fieldFormatting = field.formatting;
+  }
+
+  // Merge inherited paragraph formatting, the field run's own character style,
+  // then its inline formatting (each later layer wins) — the same precedence as
+  // `convertRun`. Flattening the character style here means a field result
+  // styled only by a `w:rStyle` (e.g. a PAGE/REF field) keeps its style-derived
+  // marks, so the save-side `w:rStyle` reconciliation does not treat the field
+  // as diverging and strip the link (eigenpal/docx-editor#833).
   const inheritedFormatting = getInheritedRunFormatting(fieldFormatting);
+  const fieldStyleFormatting = fieldFormatting?.styleId
+    ? styleResolver?.getRunStyleOwnProperties(fieldFormatting.styleId)
+    : undefined;
   const mergedFormatting = mergeTextFormatting(
-    inheritedFormatting,
+    mergeTextFormatting(inheritedFormatting, fieldStyleFormatting),
     fieldFormatting,
   );
   const marks = textFormattingToMarks(mergedFormatting);
@@ -1886,7 +1917,11 @@ function convertInlineSdt(
       content.type === "simpleField" ||
       content.type === "complexField"
     ) {
-      const fieldNode = convertField(content, getInheritedRunFormatting);
+      const fieldNode = convertField(
+        content,
+        getInheritedRunFormatting,
+        styleResolver,
+      );
       if (fieldNode) {
         inlineNodes.push(fieldNode);
       }
@@ -2343,7 +2378,7 @@ function convertHyperlink(
 /**
  * Convert TextFormatting to ProseMirror marks
  */
-function textFormattingToMarks(
+export function textFormattingToMarks(
   formatting: TextFormatting | undefined,
 ): ReturnType<typeof schema.mark>[] {
   if (!formatting) {
@@ -2414,6 +2449,13 @@ function textFormattingToMarks(
   const runShadingMarkAttrs = shadingToRunShadingAttrs(formatting.shading);
   if (runShadingMarkAttrs) {
     marks.push(schema.mark("runShading", runShadingMarkAttrs));
+  }
+
+  // Character-style reference (w:rStyle). The style's formatting is already
+  // flattened onto the direct marks above; this inert mark carries the named
+  // reference so `<w:rStyle>` survives the round-trip (eigenpal/docx-editor#833).
+  if (formatting.styleId) {
+    marks.push(schema.mark("runStyle", { styleId: formatting.styleId }));
   }
 
   // Font size

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -44,6 +44,7 @@ import { ItalicExtension } from "./marks/ItalicExtension";
 import { RtlExtension } from "./marks/RtlExtension";
 import { RunFormattingOverrideExtension } from "./marks/RunFormattingOverrideExtension";
 import { RunShadingExtension } from "./marks/RunShadingExtension";
+import { RunStyleExtension } from "./marks/RunStyleExtension";
 import { SmallCapsExtension } from "./marks/SmallCapsExtension";
 import { StrikeExtension } from "./marks/StrikeExtension";
 import { SubscriptExtension } from "./marks/SubscriptExtension";
@@ -132,6 +133,9 @@ export function createStarterKit(
   // an explicit highlight (registered after) wins the background when a run has
   // both — matching the paged painter's `run.highlight ?? run.shading`. (#722)
   add("runShading", RunShadingExtension());
+  // Inert reference mark: carries a run's `w:rStyle` named style id through the
+  // round-trip; the style's formatting itself rides on direct marks. (#833)
+  add("runStyle", RunStyleExtension());
   add("highlight", HighlightExtension());
   add("fontSize", FontSizeExtension());
   add("fontFamily", FontFamilyExtension());

--- a/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
@@ -60,6 +60,21 @@ describe("EmptyParagraphFormatExtension", () => {
     expect(markNames(state.storedMarks)).toContain("fontSize");
   });
 
+  test("re-derives the rtl mark for an empty paragraph styled right-to-left", () => {
+    // A run-level RTL default must be re-derived so typed text keeps `w:rtl`
+    // (eigenpal/docx-editor#822). Before, the gate omitted `rtl` and the caret
+    // entered the empty paragraph mark-free, producing LTR text.
+    const rtlPara = schema.node("paragraph", {
+      defaultTextFormatting: { rtl: true },
+    });
+    let state = stateWith(schema.node("doc", null, [rtlPara]));
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 1)),
+    );
+
+    expect(markNames(state.storedMarks)).toContain("rtl");
+  });
+
   test("leaves a plain body paragraph mark-free (font/size handled by the painter)", () => {
     const body = schema.node("paragraph", {
       defaultTextFormatting: {

--- a/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.ts
@@ -46,7 +46,8 @@ function hasNonFontDefaults(dtf: TextFormatting): boolean {
     dtf.doubleStrike ||
     dtf.color ||
     dtf.highlight ||
-    dtf.vertAlign
+    dtf.vertAlign ||
+    dtf.rtl
   );
 }
 

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunStyleExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunStyleExtension.ts
@@ -1,0 +1,45 @@
+// eigenpal/docx-editor#833 — run character-style reference (`w:rStyle`).
+//
+// The parser reads `<w:rStyle>` into `run.formatting.styleId` and the serializer
+// re-emits it, but PM conversion bakes the style's formatting into direct marks
+// (via `resolveTextFormatting`) and otherwise drops the named reference. This
+// inert mark carries the styleId (e.g. `Strong`, `Emphasis`, a code style)
+// through the round-trip so `<w:rStyle>` survives an edit. It has no visual
+// effect of its own — the style's formatting already rides on direct marks — so
+// there is no `toDOM` styling; only the `data-run-style` round-trips for paste.
+
+import { expectRunStyleMarkAttrs } from "../../attrs";
+import { createMarkExtension } from "../create";
+
+export const RunStyleExtension = createMarkExtension({
+  name: "runStyle",
+  schemaMarkName: "runStyle",
+  markSpec: {
+    attrs: {
+      // Required (no default): the mark is meaningless without a styleId, and
+      // `RunStyleAttrs`/`readRunStyleMarkAttrs` both treat it as a required
+      // string. parseDOM returns false when the marker is absent, and the mark
+      // is only ever created with a styleId.
+      styleId: {},
+    },
+    parseDOM: [
+      {
+        tag: "span[data-run-style]",
+        getAttrs: (dom) => {
+          const styleId = (dom as HTMLElement).dataset["runStyle"];
+          // Only adopt spans that explicitly carry the marker; others are not
+          // run-style references.
+          return styleId ? { styleId } : false;
+        },
+      },
+    ],
+    toDOM(mark) {
+      const { styleId } = expectRunStyleMarkAttrs(mark);
+      return [
+        "span",
+        { class: "docx-run-style", "data-run-style": styleId },
+        0,
+      ];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/markUtils.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/markUtils.test.ts
@@ -2,7 +2,44 @@ import { describe, expect, test } from "bun:test";
 import { EditorState, TextSelection } from "prosemirror-state";
 
 import { schema } from "../../schema";
-import { setMark } from "./markUtils";
+import { setMark, textFormattingToMarks } from "./markUtils";
+
+describe("rtl run direction round-trips through the mark helpers", () => {
+  // eigenpal/docx-editor#806: the conversion path handled `rtl`, but the
+  // live-edit / clipboard / keymap helpers (`textFormattingToMarks` /
+  // `marksToTextFormatting`) had no rtl branch, so an Arabic/Hebrew run lost
+  // its direction the moment it was re-marked in the editor.
+  test("textFormattingToMarks emits the rtl mark", () => {
+    const rtl = schema.marks.rtl;
+    if (!rtl) {
+      throw new Error("Expected rtl mark in schema");
+    }
+    const marks = textFormattingToMarks({ rtl: true }, schema);
+    expect(marks.some((mark) => mark.type === rtl)).toBe(true);
+  });
+
+  test("setMark(rtl) records rtl in the paragraph default text formatting", () => {
+    const rtl = schema.marks.rtl;
+    if (!rtl) {
+      throw new Error("Expected rtl mark in schema");
+    }
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [schema.node("paragraph")]),
+      schema,
+    });
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 1)),
+    );
+
+    setMark(rtl, {})(state, (tr) => {
+      state = state.apply(tr);
+    });
+
+    expect(state.doc.firstChild?.attrs.defaultTextFormatting).toEqual({
+      rtl: true,
+    });
+  });
+});
 
 describe("mark commands", () => {
   test("preserve stored marks when setting formatting in an empty paragraph", () => {

--- a/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
@@ -109,6 +109,13 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
       case "subscript":
         formatting.vertAlign = "subscript";
         break;
+      case "rtl":
+        // eigenpal/docx-editor#806 — keep per-run RTL direction through the
+        // live-edit/clipboard/keymap mark paths (the `rtl=false` negative
+        // override rides `runFormattingOverride`, so only the `true` case
+        // needs an explicit branch here).
+        formatting.rtl = true;
+        break;
       case "runFormattingOverride":
         applyRunFormattingOverrideMark(formatting, mark);
         break;
@@ -362,6 +369,9 @@ export function textFormattingToMarks(
   }
   if (formatting.vertAlign === "subscript" && schema.marks["subscript"]) {
     marks.push(schema.marks["subscript"].create());
+  }
+  if (formatting.rtl && schema.marks["rtl"]) {
+    marks.push(schema.marks["rtl"].create());
   }
 
   return marks;

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -41,6 +41,7 @@ export type {
   TrackedChangeMarkAttrs,
   RunFormattingOverrideAttrs,
   RunShadingAttrs,
+  RunStyleAttrs,
   HyperlinkAttrs,
 } from "./marks";
 

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -76,6 +76,15 @@ export type RunShadingAttrs = TextColorAttrs & {
   patternColor?: string;
 };
 
+/**
+ * Run character-style reference mark attributes (w:rStyle). Inert: it carries
+ * only the named style id so the reference survives the PM round-trip; the
+ * style's formatting itself is already flattened onto direct marks.
+ */
+export type RunStyleAttrs = {
+  styleId: string;
+};
+
 export type CharacterSpacingAttrs = {
   spacing?: number;
   position?: number;

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -18,6 +18,7 @@ import {
   readParagraphAttrs,
   readRunFormattingOverrideMarkAttrs,
   readRunShadingMarkAttrs,
+  readRunStyleMarkAttrs,
   readSdtAttrs,
   readShapeAttrs,
   readStrikeMarkAttrs,
@@ -242,6 +243,10 @@ const validateMarks = (
 
       case "runShading":
         appendAttrIssues(markPath, readRunShadingMarkAttrs(mark), issues);
+        continue;
+
+      case "runStyle":
+        appendAttrIssues(markPath, readRunStyleMarkAttrs(mark), issues);
         continue;
 
       case "fontSize":


### PR DESCRIPTION
Ports three upstream `eigenpal/docx-editor` round-trip preservation fixes into folio. Independent of the sibling sync PRs (disjoint files). Adds one field to `@stll/docx-core`.

### Changes
- **Per-run RTL in mark helpers** (`eigenpal/docx-editor#822`, #806): the conversion path handled `rtl`, but the live-edit / clipboard / keymap helpers (`marksToTextFormatting` / `textFormattingToMarks`) had no rtl branch, so an Arabic/Hebrew run lost its direction the moment it was re-marked in the editor. Added the branch (the negative override still rides `runFormattingOverride`).
- **`w:rStyle` run character-style** (`eigenpal/docx-editor#833`): a run's named character-style reference was dropped on the PM save round-trip (its formatting is flattened onto direct marks). A new inert `runStyle` mark carries the styleId through, so `<w:rStyle>` is re-emitted. Follows folio's existing run-shading mark pattern (schema attrs + attrs reader + validation case + StarterKit registration + conversion both ways).
- **Collapsed PAGE-field formatting** (`eigenpal/docx-editor#909`): a complex field with no separate result run (e.g. a footer `PAGE` number whose `w:rPr` lives on the field run) dropped its size/color. The formatting is now captured onto `ComplexField.formatting` (new field in `@stll/docx-core`) and used as the render/serialize fallback.

### Tests
- `markUtils.test.ts` (rtl round-trips through the mark helpers), `run-rstyle-roundtrip.test.ts`, `paragraphParser.test.ts` (complex-field formatting capture).

Full folio suite green.