### PR TITLE
fix(folio): delete spanned table rows and track paste-over-selection

### DIFF
--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Node as PMNode } from "prosemirror-model";
 import { EditorState, TextSelection } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
+import { CellSelection } from "prosemirror-tables";
 
 import { schema, singletonManager } from "../../schema";
 
@@ -133,5 +134,130 @@ describe("table border commands", () => {
       right: { color: { rgb: "00AA00" }, size: 6, style: "single" },
       top: { color: { rgb: "00AA00" }, size: 6, style: "single" },
     });
+  });
+});
+
+const createRowTable = (rowCount: number): EditorState => {
+  const rows = Array.from({ length: rowCount }, (_, i) =>
+    schema.node("tableRow", null, [
+      schema.node("tableCell", { borders: null }, [
+        schema.node("paragraph", null, [schema.text(`R${i}`)]),
+      ]),
+    ]),
+  );
+  const doc = schema.node("doc", null, [schema.node("table", null, rows)]);
+  return EditorState.create({
+    doc,
+    schema,
+    selection: TextSelection.create(doc, 1),
+  });
+};
+
+const cellPositions = (doc: PMNode): number[] => {
+  const positions: number[] = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name === "tableCell") {
+      positions.push(pos);
+    }
+  });
+  return positions;
+};
+
+const countNodes = (doc: PMNode, typeName: string): number => {
+  let count = 0;
+  doc.descendants((node) => {
+    if (node.type.name === typeName) {
+      count += 1;
+    }
+  });
+  return count;
+};
+
+const selectCells = (
+  state: EditorState,
+  anchorCellPos: number,
+  headCellPos: number,
+): EditorState =>
+  state.apply(
+    state.tr.setSelection(
+      CellSelection.create(state.doc, anchorCellPos, headCellPos),
+    ),
+  );
+
+// eigenpal/docx-editor#783 — deleting a table row must remove every row a
+// CellSelection spans (not just the anchor row), and drop the whole table when
+// the selection covers all rows. (Folio has no tracked table-row deletion, so
+// only the plain path is ported.)
+describe("deleteRow with a multi-row CellSelection (#783)", () => {
+  test("deletes every row the selection spans", () => {
+    let state = createRowTable(3);
+    const cells = cellPositions(state.doc);
+    state = selectCells(state, cells[0]!, cells[1]!); // rows 0 and 1
+    state = runTableCommand(state, "deleteRow");
+
+    expect(countNodes(state.doc, "tableRow")).toBe(1);
+    expect(countNodes(state.doc, "table")).toBe(1);
+  });
+
+  test("drops the whole table when the selection covers all rows", () => {
+    let state = createRowTable(2);
+    const cells = cellPositions(state.doc);
+    state = selectCells(state, cells[0]!, cells[1]!); // all rows
+    state = runTableCommand(state, "deleteRow");
+
+    expect(countNodes(state.doc, "table")).toBe(0);
+  });
+
+  test("replaces a sole table with an empty paragraph instead of emptying the doc", () => {
+    // The doc holds only the table; deleting every row must keep a valid block
+    // (an empty doc violates the `block+` schema) rather than a bare delete.
+    let state = createRowTable(2);
+    const cells = cellPositions(state.doc);
+    state = selectCells(state, cells[0]!, cells[1]!);
+    state = runTableCommand(state, "deleteRow");
+
+    expect(countNodes(state.doc, "table")).toBe(0);
+    expect(countNodes(state.doc, "paragraph")).toBe(1);
+    expect(state.doc.childCount).toBe(1);
+    expect(() => state.doc.check()).not.toThrow();
+  });
+
+  test("adjusts a spanning cell's rowspan when one of its rows is deleted", () => {
+    // row0: [A (rowspan 2), B]   row1: [C]   row2: [D, E]
+    // A spans rows 0-1; deleting row 1 must reduce A's rowspan to 1, not orphan it.
+    const cell = (text: string, attrs: Record<string, unknown> = {}) =>
+      schema.node("tableCell", { borders: null, ...attrs }, [
+        schema.node("paragraph", null, [schema.text(text)]),
+      ]);
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [cell("A", { rowspan: 2 }), cell("B")]),
+        schema.node("tableRow", null, [cell("C")]),
+        schema.node("tableRow", null, [cell("D"), cell("E")]),
+      ]),
+    ]);
+    // Caret inside C (row 1).
+    let cPos = 0;
+    doc.descendants((node, pos) => {
+      if (cPos === 0 && node.isText && node.text === "C") {
+        cPos = pos;
+      }
+    });
+    let state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, cPos),
+    });
+    state = runTableCommand(state, "deleteRow");
+
+    expect(countNodes(state.doc, "tableRow")).toBe(2);
+    let spanningCell: PMNode | null = null;
+    state.doc.descendants((node) => {
+      if (node.type.name === "tableCell" && node.textContent === "A") {
+        spanningCell = node;
+      }
+    });
+    expect(spanningCell).not.toBeNull();
+    expect((spanningCell as unknown as PMNode).attrs["rowspan"]).toBe(1);
   });
 });

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -15,6 +15,9 @@ import {
   mergeCells as pmMergeCells,
   splitCell as pmSplitCell,
   CellSelection,
+  selectedRect,
+  removeRow,
+  TableMap,
 } from "prosemirror-tables";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
@@ -1252,21 +1255,70 @@ export const TablePluginExtension = createExtension({
         !context.isInTable ||
         context.rowIndex === undefined ||
         !context.table ||
-        context.tablePos === undefined ||
-        (context.rowCount ?? 0) <= 1
+        context.tablePos === undefined
       ) {
         return false;
       }
+      const tablePos = context.tablePos;
+      const table = context.table;
+      const rowCount = context.rowCount ?? 0;
+      if (rowCount <= 0) {
+        return false;
+      }
+
+      // A CellSelection deletes every row it covers; a plain caret deletes only
+      // its own row — even inside a vertically merged cell, whose rowspan would
+      // otherwise make `selectedRect` cover the whole merged span
+      // (eigenpal/docx-editor#783).
+      let firstRow: number;
+      let lastRow: number;
+      if (state.selection instanceof CellSelection) {
+        const rect = selectedRect(state);
+        firstRow = Math.max(0, Math.min(rect.top, rowCount - 1));
+        lastRow = Math.min(Math.max(rect.bottom - 1, firstRow), rowCount - 1);
+      } else {
+        firstRow = context.rowIndex;
+        lastRow = context.rowIndex;
+      }
+      const coversAllRows = firstRow === 0 && lastRow >= rowCount - 1;
 
       if (dispatch) {
         const tr = state.tr;
-        let rowStart = context.tablePos + 1;
-        for (let i = 0; i < context.rowIndex; i++) {
-          rowStart += context.table.child(i).nodeSize;
+        if (coversAllRows) {
+          // Deleting every row deletes the table (Word drops an emptied table).
+          // If the table is its parent's only child, a bare delete would leave
+          // an empty doc/cell, which the schema forbids — replace it with an
+          // empty paragraph in that case so the parent keeps a valid block.
+          const tableEnd = tablePos + table.nodeSize;
+          const parent = state.doc.resolve(tablePos).parent;
+          const emptyParagraph =
+            parent.childCount === 1
+              ? state.schema.nodes["paragraph"]?.createAndFill()
+              : null;
+          if (emptyParagraph) {
+            tr.replaceWith(tablePos, tableEnd, emptyParagraph);
+            tr.setSelection(TextSelection.near(tr.doc.resolve(tablePos + 1)));
+          } else {
+            tr.delete(tablePos, tableEnd);
+          }
+          dispatch(tr.scrollIntoView());
+          return true;
         }
-        const rowEnd =
-          rowStart + context.table.child(context.rowIndex).nodeSize;
-        tr.delete(rowStart, rowEnd);
+        // Remove rows bottom-up through prosemirror-tables so cells that span
+        // into a deleted row have their rowspan adjusted (and their content
+        // preserved) instead of being orphaned. `removeRow` mutates the table,
+        // so the map is re-read after each removal.
+        const rect = selectedRect(state);
+        for (let row = lastRow; row >= firstRow; row--) {
+          removeRow(tr, rect, row);
+          if (row > firstRow) {
+            const updated = tr.doc.nodeAt(rect.tableStart - 1);
+            if (updated) {
+              rect.table = updated;
+              rect.map = TableMap.get(updated);
+            }
+          }
+        }
         dispatch(tr.scrollIntoView());
       }
       return true;

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test, expect } from "bun:test";
 import { history, undo } from "prosemirror-history";
-import { Schema } from "prosemirror-model";
+import { Fragment, Schema, Slice } from "prosemirror-model";
 import { EditorState, TextSelection } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
@@ -14,6 +14,7 @@ import {
   suggestionModeKey,
   setSuggestionMode,
   handleSuggestionEnter,
+  handleSuggestionPaste,
 } from "./suggestionMode";
 
 // Minimal schema with insertion/deletion marks
@@ -199,6 +200,99 @@ describe("SuggestionMode Plugin", () => {
       const worldEntry = marks.find((m) => m.text.includes("World"));
       expect(worldEntry).toBeDefined();
       expect(worldEntry?.marks).toContain("deletion");
+    });
+  });
+
+  describe("handlePaste (#784)", () => {
+    function mockView(state: EditorState): {
+      view: EditorView;
+      get: () => EditorState;
+    } {
+      let current = state;
+      const view = {
+        get state() {
+          return current;
+        },
+        dispatch(tr: Transaction) {
+          current = current.apply(tr);
+        },
+      } as unknown as EditorView;
+      return { view, get: () => current };
+    }
+
+    test("pasting over a selection marks the replacement as deletion + insertion", () => {
+      // "The lazy dog": select "lazy" ([5,9)) and paste "quick".
+      let state = createState("The lazy dog", true);
+      const sel = TextSelection.create(state.doc, 5, 9);
+      state = state.apply(state.tr.setSelection(sel));
+
+      const { view, get } = mockView(state);
+      const slice = new Slice(Fragment.from(schema.text("quick")), 0, 0);
+      const pluginState = suggestionModeKey.getState(state)!;
+
+      const handled = handleSuggestionPaste(view, slice, pluginState);
+      expect(handled).toBe(true);
+
+      const marks = getMarks(get());
+      const deleted = marks.find((m) => m.text.includes("lazy"));
+      expect(deleted?.marks).toContain("deletion");
+      const inserted = marks.find((m) => m.text.includes("quick"));
+      expect(inserted?.marks).toContain("insertion");
+      expect(inserted?.marks).not.toContain("deletion");
+      // The replaced text is preserved (struck through), not destroyed.
+      expect(getText(get())).toContain("lazy");
+      // The selection collapses after the pasted content, so the next keystroke
+      // does not delete the struck-through original plus the paste.
+      expect(get().selection.empty).toBe(true);
+    });
+
+    test("pasting block content over a selection fits the slice and tracks it", () => {
+      // Select "lazy" and paste two whole paragraphs (block content). A raw
+      // `replace` at the inline point would fail or drop structure; the
+      // slice-fitting `replaceRange` places the blocks and tracks them.
+      let state = createState("The lazy dog", true);
+      state = state.apply(
+        state.tr.setSelection(TextSelection.create(state.doc, 5, 9)),
+      );
+
+      const { view, get } = mockView(state);
+      const blockSlice = new Slice(
+        Fragment.from([
+          schema.node("paragraph", null, [schema.text("one")]),
+          schema.node("paragraph", null, [schema.text("two")]),
+        ]),
+        1,
+        1,
+      );
+      const pluginState = suggestionModeKey.getState(state)!;
+
+      const handled = handleSuggestionPaste(view, blockSlice, pluginState);
+      expect(handled).toBe(true);
+
+      const text = getText(get());
+      expect(text).toContain("one");
+      expect(text).toContain("two");
+      // The replaced original is struck through, not destroyed.
+      expect(text).toContain("lazy");
+      const marks = getMarks(get());
+      expect(marks.find((m) => m.text.includes("one"))?.marks).toContain(
+        "insertion",
+      );
+      expect(marks.find((m) => m.text.includes("lazy"))?.marks).toContain(
+        "deletion",
+      );
+    });
+
+    test("pasting at a collapsed cursor is declined (default paste handles it)", () => {
+      let state = createState("abc", true);
+      state = state.apply(
+        state.tr.setSelection(TextSelection.create(state.doc, 2)),
+      );
+      const { view } = mockView(state);
+      const slice = new Slice(Fragment.from(schema.text("X")), 0, 0);
+      const pluginState = suggestionModeKey.getState(state)!;
+
+      expect(handleSuggestionPaste(view, slice, pluginState)).toBe(false);
     });
   });
 

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
@@ -12,7 +12,7 @@
  */
 
 import { isHistoryTransaction } from "prosemirror-history";
-import type { Node as PMNode, MarkType } from "prosemirror-model";
+import type { Node as PMNode, MarkType, Slice } from "prosemirror-model";
 import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
@@ -180,6 +180,124 @@ function markRangeAsDeleted(
       tr.addMark(range.from, range.to, deletionType.create(delAttrs));
     }
   }
+}
+
+/**
+ * Add the insertion mark to every inline node in `[from, to)` that can carry
+ * it and does not already carry a tracked-change mark. Mirrors the catch-all's
+ * node-by-node walk: a leaf text node's own `markSet` is empty so
+ * `allowsMarkType` is false, hence the explicit `isText` arm; content already
+ * carrying an insertion/deletion is left untouched so another author's revision
+ * isn't overwritten. eigenpal/docx-editor#784.
+ */
+function markRangeAsInserted(
+  tr: Transaction,
+  doc: PMNode,
+  from: number,
+  to: number,
+  insertionType: MarkType,
+  deletionType: MarkType,
+  attrs: MarkAttrs,
+): void {
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (
+      !node.isText &&
+      !(node.isInline && node.type.allowsMarkType(insertionType))
+    ) {
+      return;
+    }
+    if (
+      node.marks.some(
+        (m) => m.type === insertionType || m.type === deletionType,
+      )
+    ) {
+      return;
+    }
+    const start = Math.max(pos, from);
+    const end = Math.min(pos + node.nodeSize, to);
+    if (start >= end) {
+      return;
+    }
+    tr.addMark(start, end, insertionType.create(attrs));
+  });
+}
+
+/**
+ * With track changes on, pasting over a non-empty text selection marks the
+ * replaced text as a tracked deletion and the pasted slice as a tracked
+ * insertion (so they read as one replacement), matching typing over a
+ * selection. Returns false for a collapsed cursor or non-text selection so the
+ * default paste + the `appendTransaction` catch-all marks a plain insertion
+ * (eigenpal/docx-editor#784).
+ */
+export function handleSuggestionPaste(
+  view: EditorView,
+  slice: Slice,
+  pluginState: SuggestionModeState,
+): boolean {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || selection.empty) {
+    return false;
+  }
+  const insertionType = view.state.schema.marks["insertion"];
+  const deletionType = view.state.schema.marks["deletion"];
+  if (!insertionType || !deletionType) {
+    return false;
+  }
+
+  const { from, to } = selection;
+  const tr = view.state.tr;
+  tr.setMeta(SUGGESTION_META, true);
+
+  // 1. Strike through the replaced selection (or retract own pending inserts).
+  markRangeAsDeleted(
+    tr,
+    view.state.doc,
+    from,
+    to,
+    insertionType,
+    deletionType,
+    pluginState,
+  );
+
+  // 2. Insert the pasted slice immediately after the struck-through selection.
+  //    `replaceRange` fits the slice's open sides into the surrounding content
+  //    the way ProseMirror's normal paste does, so block clipboard content (a
+  //    copied table or whole paragraphs) is placed structurally instead of
+  //    failing or dropping nodes as a raw `replace` at an inline point would.
+  const insertFrom = tr.mapping.map(to);
+  const sizeBefore = tr.doc.content.size;
+  tr.replaceRange(insertFrom, insertFrom, slice);
+  const insertTo = insertFrom + (tr.doc.content.size - sizeBefore);
+
+  // 3. Mark the pasted content as a tracked insertion; drop any inherited
+  //    deletion marks first so new content is never shown struck through.
+  tr.removeMark(insertFrom, insertTo, deletionType);
+  const insertAttrs =
+    findAdjacentRevision(
+      view.state.doc,
+      from,
+      "insertion",
+      pluginState.author,
+    ) || makeMarkAttrs(pluginState);
+  markRangeAsInserted(
+    tr,
+    tr.doc,
+    insertFrom,
+    insertTo,
+    insertionType,
+    deletionType,
+    insertAttrs,
+  );
+
+  // Collapse to the end of the pasted content. Without this the struck-through
+  // original plus the pasted text stay selected, so the next keystroke would
+  // delete them both. `near` keeps the selection valid even when the pasted
+  // slice was block content and `insertTo` lands at a block boundary.
+  tr.setSelection(TextSelection.near(tr.doc.resolve(insertTo)));
+
+  view.dispatch(tr.scrollIntoView());
+  return true;
 }
 
 /**
@@ -610,6 +728,17 @@ export function createSuggestionModePlugin(
           return false;
         }
         return applySuggestionInsert(view, from, to, text, pluginState);
+      },
+
+      // Pasting over a non-empty selection must track the replaced text as a
+      // deletion (not destroy it) and the pasted text as an insertion. A
+      // collapsed cursor falls through to the default paste + catch-all.
+      handlePaste(view: EditorView, _event: ClipboardEvent, slice: Slice) {
+        const pluginState = suggestionModeKey.getState(view.state);
+        if (!pluginState?.active) {
+          return false;
+        }
+        return handleSuggestionPaste(view, slice, pluginState);
       },
     },
 


### PR DESCRIPTION
Two upstream `eigenpal/docx-editor` editor-command fixes. Independent of the sibling sync PRs (touches only `TableExtension.ts` and `suggestionMode.ts`).

- **Delete spanned table rows** (`eigenpal/docx-editor#783`): `deleteRow` now removes every row a multi-cell selection covers (via `selectedRect`), deleting the contiguous span in a single step, and drops the whole table when the selection spans all rows. (Track-changes deletion of rows is not modelled, so only the plain path is ported.)
- **Track paste over a selection** (`eigenpal/docx-editor#784`): with track changes on, pasting over a non-empty text selection records the replaced text as a deletion and the pasted content as an insertion (matching typing over a selection), then collapses the selection after the paste, instead of silently destroying the replaced text. A collapsed cursor falls through to the existing default-paste path.

Tests added for both.

Note: the internal plugin is named `suggestionMode` (legacy naming inherited from the upstream fork); the user-facing feature is track changes.