### PR TITLE
refactor(lint): enforce prefer-named-capture-group

### DIFF
--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -81,7 +81,7 @@ import {
 
 // ─── Mock file generators ───────────────────────────────
 
-const fileExtRe = /\.(pdf|docx)$/u;
+const fileExtRe = /\.(?:pdf|docx)$/u;
 
 const PDF_MIME = "application/pdf" as const;
 const DOCX_MIME =

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -116,17 +116,18 @@ const entryField = (
 /** Metadata label patterns on detail pages. */
 const LABEL_PATTERNS: Record<string, RegExp> = {
   decisionDate:
-    /Datum rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>([\s\S]*?)<\/font>/iu,
-  ecli: /ECLI:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>([\s\S]*?)<\/font>/iu,
+    /Datum rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
+  ecli: /ECLI:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
   decisionType:
-    /Typ rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>([\s\S]*?)<\/font>/iu,
+    /Typ rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
   keywords:
-    /Heslo:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>([\s\S]*?)<\/font>/iu,
+    /Heslo:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
   statutes:
-    /Dotčené předpisy:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>([\s\S]*?)<\/font>/iu,
+    /Dotčené předpisy:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
   category:
-    /Kategorie rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>([\s\S]*?)<\/font>/iu,
-  legalSentence: /Právní věta:<\/font><\/b><\/td><td[^>]*>([\s\S]*?)<\/td>/iu,
+    /Kategorie rozhodnutí:<\/font><\/b><\/td><td[^>]*><b><font[^>]*>(?<value>[\s\S]*?)<\/font>/iu,
+  legalSentence:
+    /Právní věta:<\/font><\/b><\/td><td[^>]*>(?<value>[\s\S]*?)<\/td>/iu,
 };
 
 /**
@@ -161,7 +162,7 @@ const BODY_END_MARKER = "Citace rozhodnutí";
 const extractFulltext = (html: string): string | undefined => {
   // Decision text is in <font face="Times New Roman"> tags
   const parts = html.match(
-    /<font[^>]*face="Times New Roman"[^>]*>([\s\S]*?)<\/font>/giu,
+    /<font[^>]*face="Times New Roman"[^>]*>(?:[\s\S]*?)<\/font>/giu,
   );
   if (!parts || parts.length === 0) {
     return undefined;
@@ -193,8 +194,8 @@ const parseDetailPage = (html: string): Record<string, string | undefined> => {
 
   for (const [key, pattern] of Object.entries(LABEL_PATTERNS)) {
     const match = html.match(pattern);
-    if (match?.[1]) {
-      const text = stripHtml(match[1]).trim();
+    if (match?.groups?.["value"]) {
+      const text = stripHtml(match.groups["value"]).trim();
       if (text) {
         result[key] = text;
       }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -29,36 +29,37 @@ const BASE_URL = "https://vyhledavac.nssoud.cz";
 const parseResultRows = (html: string): ParsedRow[] => {
   const rows: ParsedRow[] = [];
 
-  const tbodyPattern = /<tbody>([\s\S]*?)<\/tbody>/giu;
+  const tbodyPattern = /<tbody>(?<block>[\s\S]*?)<\/tbody>/giu;
   let tbodyMatch: RegExpExecArray | null;
 
   while ((tbodyMatch = tbodyPattern.exec(html)) !== null) {
-    const block = tbodyMatch[1];
+    const block = tbodyMatch.groups?.["block"];
     if (!block?.includes("Citace")) {
       continue;
     }
 
     const citMatch =
       // oxlint-disable-next-line sonarjs/slow-regex -- test fixture rows are bounded representative NSS HTML snippets
-      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.)[\s]*([^"]+?)(?:-\d+)?"/iu.exec(
+      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.)[\s]*(?<caseNumber>[^"]+?)(?:-\d+)?"/iu.exec(
         block,
       );
-    const caseNumber = citMatch?.[1]?.trim();
+    const caseNumber = citMatch?.groups?.["caseNumber"]?.trim();
     if (!caseNumber) {
       continue;
     }
 
-    const detailMatch = /href="(\/DokumentDetail\/Index\/\d+)"/u.exec(block);
-    const documentUrl = detailMatch?.[1]
-      ? `${BASE_URL}${detailMatch[1]}`
-      : undefined;
+    const detailMatch =
+      /href="(?<documentPath>\/DokumentDetail\/Index\/\d+)"/u.exec(block);
+    const documentPath = detailMatch?.groups?.["documentPath"];
+    const documentUrl = documentPath ? `${BASE_URL}${documentPath}` : undefined;
 
     const cells: string[] = [];
-    const cellPattern = /<td[^>]*>([\s\S]*?)<\/td>/giu;
+    const cellPattern = /<td[^>]*>(?<cell>[\s\S]*?)<\/td>/giu;
     let cellMatch: RegExpExecArray | null;
     while ((cellMatch = cellPattern.exec(block)) !== null) {
-      if (cellMatch[1]) {
-        cells.push(stripHtml(cellMatch[1]).trim());
+      const cell = cellMatch.groups?.["cell"];
+      if (cell) {
+        cells.push(stripHtml(cell).trim());
       }
     }
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -65,29 +65,32 @@ const extractFormFields = (html: string): Map<string, string> => {
 
   // Hidden inputs (token, FormularCiselnik, etc.)
   const hiddenPattern =
-    /<input\b(?=[^>]*\btype=["']hidden["'])(?=[^>]*\bname=["']([^"']*)["'])(?=[^>]*\bvalue=["']([^"']*)["'])[^>]*>/giu;
+    /<input\b(?=[^>]*\btype=["']hidden["'])(?=[^>]*\bname=["'](?<name>[^"']*)["'])(?=[^>]*\bvalue=["'](?<value>[^"']*)["'])[^>]*>/giu;
   let match: RegExpExecArray | null;
   while ((match = hiddenPattern.exec(html)) !== null) {
-    if (match[1] !== undefined && match[2] !== undefined) {
-      fields.set(match[1], match[2]);
+    const { name, value } = match.groups ?? {};
+    if (name !== undefined && value !== undefined) {
+      fields.set(name, value);
     }
   }
 
   // Text inputs (date fields in vyhledavaciSekce)
   const textPattern =
-    /<input[^>]*\btype=["']text["'][^>]*\bname=["']([^"']*)["'][^>]*>/giu;
+    /<input[^>]*\btype=["']text["'][^>]*\bname=["'](?<name>[^"']*)["'][^>]*>/giu;
   while ((match = textPattern.exec(html)) !== null) {
-    if (match[1] && !fields.has(match[1])) {
-      fields.set(match[1], "");
+    const name = match.groups?.["name"];
+    if (name && !fields.has(name)) {
+      fields.set(name, "");
     }
   }
 
   // Also try reversed order (name before type)
   const textPattern2 =
-    /<input[^>]*\bname=["']([^"']*)["'][^>]*\btype=["']text["'][^>]*>/giu;
+    /<input[^>]*\bname=["'](?<name>[^"']*)["'][^>]*\btype=["']text["'][^>]*>/giu;
   while ((match = textPattern2.exec(html)) !== null) {
-    if (match[1] && !fields.has(match[1])) {
-      fields.set(match[1], "");
+    const name = match.groups?.["name"];
+    if (name && !fields.has(name)) {
+      fields.set(name, "");
     }
   }
 
@@ -105,12 +108,12 @@ const extractAntiforgeryToken = (html: string): string | undefined =>
  */
 const extractCurrParams = (html: string): string | undefined => {
   // currParams is passed to the JavaScript pagination function
-  const match = /currParams\s*[:=]\s*["']([^"']+)["']/u.exec(html);
-  if (match?.[1]) {
+  const match = /currParams\s*[:=]\s*["'](?<value>[^"']+)["']/u.exec(html);
+  if (match?.groups?.["value"]) {
     try {
-      return decodeURIComponent(match[1]);
+      return decodeURIComponent(match.groups["value"]);
     } catch {
-      return match[1];
+      return match.groups["value"];
     }
   }
 
@@ -212,11 +215,11 @@ type ParsedRow = {
 const parseResultRows = (html: string): ParsedRow[] => {
   const rows: ParsedRow[] = [];
 
-  const tbodyPattern = /<tbody>([\s\S]*?)<\/tbody>/giu;
+  const tbodyPattern = /<tbody>(?<block>[\s\S]*?)<\/tbody>/giu;
   let tbodyMatch: RegExpExecArray | null;
 
   while ((tbodyMatch = tbodyPattern.exec(html)) !== null) {
-    const block = tbodyMatch[1];
+    const block = tbodyMatch.groups?.["block"];
     if (!block?.includes("Citace")) {
       continue;
     }
@@ -225,10 +228,10 @@ const parseResultRows = (html: string): ParsedRow[] => {
     // Stop at comma to exclude publication reference (e.g. ", č. 421/2004 Sb. NSS")
     const citMatch =
       // oxlint-disable-next-line sonarjs/slow-regex -- tbody blocks are bounded search-result rows from NSS
-      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.|&#x10[dD];j\.|&#26[89];j\.)[\s]*([^",]+?)(?:-\d+)?[",]/iu.exec(
+      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.|&#x10[dD];j\.|&#26[89];j\.)[\s]*(?<caseNumber>[^",]+?)(?:-\d+)?[",]/iu.exec(
         block,
       );
-    const caseNumber = citMatch?.[1]?.trim();
+    const caseNumber = citMatch?.groups?.["caseNumber"]?.trim();
     if (!caseNumber || caseNumber.length > 100) {
       // Skip malformed or overly long case numbers
       if (caseNumber) {
@@ -241,18 +244,20 @@ const parseResultRows = (html: string): ParsedRow[] => {
       continue;
     }
 
-    const detailMatch = /href="\/DokumentDetail\/Index\/(\d+)"/u.exec(block);
-    const documentId = detailMatch?.[1];
+    const detailMatch =
+      /href="\/DokumentDetail\/Index\/(?<documentId>\d+)"/u.exec(block);
+    const documentId = detailMatch?.groups?.["documentId"];
     const documentUrl = documentId
       ? `${BASE_URL}/DokumentDetail/Index/${documentId}`
       : undefined;
 
     const cells: string[] = [];
-    const cellPattern = /<td[^>]*>([\s\S]*?)<\/td>/giu;
+    const cellPattern = /<td[^>]*>(?<cell>[\s\S]*?)<\/td>/giu;
     let cellMatch: RegExpExecArray | null;
     while ((cellMatch = cellPattern.exec(block)) !== null) {
-      if (cellMatch[1]) {
-        cells.push(stripHtml(cellMatch[1]).trim());
+      const cell = cellMatch.groups?.["cell"];
+      if (cell) {
+        cells.push(stripHtml(cell).trim());
       }
     }
 
@@ -414,11 +419,12 @@ const extractDivText = (html: string, divId: string): string | undefined => {
 
   // Structure: <span class="det-textitle">Label:</span>
   //            <span class="det-textval" title="Value">Value</span>
-  const valPattern = /class="det-textval[^"]*"[^>]*>([\s\S]*?)<\/span>/giu;
+  const valPattern =
+    /class="det-textval[^"]*"[^>]*>(?<value>[\s\S]*?)<\/span>/giu;
   let valMatch: RegExpExecArray | null;
   const texts: string[] = [];
   while ((valMatch = valPattern.exec(match[1])) !== null) {
-    const text = stripHtml(valMatch[1] ?? "").trim();
+    const text = stripHtml(valMatch.groups?.["value"] ?? "").trim();
     if (text) {
       texts.push(text);
     }
@@ -802,20 +808,20 @@ export const czNssAdapter: SourceAdapter = {
 
       const countPatterns = [
         // oxlint-disable-next-line sonarjs/slow-regex -- count labels are matched once against one NSS result page
-        /Nalezeno\s+(\d[\d\s]*)\s+záznam/iu,
+        /Nalezeno\s+(?<count>\d[\d\s]*)\s+záznam/iu,
         // oxlint-disable-next-line sonarjs/slow-regex -- count labels are matched once against one NSS result page
-        /Celkem\s+(\d[\d\s]*)\s+záznam/iu,
+        /Celkem\s+(?<count>\d[\d\s]*)\s+záznam/iu,
         // oxlint-disable-next-line sonarjs/slow-regex -- count labels are matched once against one NSS result page
-        /(\d[\d\s]*)\s+výsledk/iu,
-        /resCount[^>]*>(\d[\d\s]*)</iu,
-        /myResCount[^>]*>(\d[\d\s]*)</iu,
-        /pocetZaznamu[^>]*>(\d[\d\s]*)</iu,
+        /(?<count>\d[\d\s]*)\s+výsledk/iu,
+        /resCount[^>]*>(?<count>\d[\d\s]*)</iu,
+        /myResCount[^>]*>(?<count>\d[\d\s]*)</iu,
+        /pocetZaznamu[^>]*>(?<count>\d[\d\s]*)</iu,
       ];
 
       for (const pattern of countPatterns) {
         const match = html.match(pattern);
-        if (match?.[1]) {
-          const cleaned = match[1].replace(/\s/gu, "");
+        if (match?.groups?.["count"]) {
+          const cleaned = match.groups["count"].replace(/\s/gu, "");
           const parsed = Number.parseInt(cleaned, 10);
           if (!Number.isNaN(parsed) && parsed > 0) {
             return parsed;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -109,11 +109,12 @@ const extractAntiforgeryToken = (html: string): string | undefined =>
 const extractCurrParams = (html: string): string | undefined => {
   // currParams is passed to the JavaScript pagination function
   const match = /currParams\s*[:=]\s*["'](?<value>[^"']+)["']/u.exec(html);
-  if (match?.groups?.["value"]) {
+  const value = match?.groups?.["value"];
+  if (value) {
     try {
-      return decodeURIComponent(match.groups["value"]);
+      return decodeURIComponent(value);
     } catch {
-      return match.groups["value"];
+      return value;
     }
   }
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
@@ -73,9 +73,9 @@ describe("czUsAdapter.fetchPage", () => {
         if (url.includes("GetAbstract")) {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
-        const match = /sz=I-(\d+)-(\d+)_1/u.exec(url);
-        const n = match ? Number(match[1]) : 0;
-        const yr = match ? Number(match[2]) : 0;
+        const match = /sz=I-(?<n>\d+)-(?<yr>\d+)_1/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
+        const yr = match ? Number(match.groups?.["yr"]) : 0;
 
         if (yr === Number(curYr) && n === 1) {
           return Promise.resolve(
@@ -120,9 +120,9 @@ describe("czUsAdapter.fetchPage", () => {
         if (url.includes("GetAbstract")) {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
-        const match = /sz=I-(\d+)-(\d+)_1/u.exec(url);
-        const n = match ? Number(match[1]) : 0;
-        const yr = match ? Number(match[2]) : 0;
+        const match = /sz=I-(?<n>\d+)-(?<yr>\d+)_1/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
+        const yr = match ? Number(match.groups?.["yr"]) : 0;
         const body =
           yr === 25 && hitNumbers.has(n)
             ? makeTextPage(`II.ÚS ${n}/25`, "1. 1. 2025")
@@ -154,13 +154,13 @@ describe("czUsAdapter.fetchPage", () => {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
 
-        const yearMatch = /sz=I-(\d+)-(\d+)_1/u.exec(url);
+        const yearMatch = /sz=I-(?<n>\d+)-(?<yr>\d+)_1/u.exec(url);
         if (!yearMatch) {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
 
-        const n = Number(yearMatch[1]);
-        const yr = Number(yearMatch[2]);
+        const n = Number(yearMatch.groups?.["n"]);
+        const yr = Number(yearMatch.groups?.["yr"]);
 
         if (yr === 25 && n === 1) {
           return Promise.resolve(
@@ -203,8 +203,8 @@ describe("czUsAdapter.fetchPage", () => {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
 
-        const match = /sz=I-(\d+)-93_1/u.exec(url);
-        if (match && Number(match[1]) === 1) {
+        const match = /sz=I-(?<n>\d+)-93_1/u.exec(url);
+        if (match && Number(match.groups?.["n"]) === 1) {
           return Promise.resolve(
             new Response(makeTextPage("I.ÚS 1/93", "11. 11. 1993")),
           );
@@ -235,8 +235,8 @@ describe("czUsAdapter.fetchPage", () => {
         if (url.includes("GetAbstract")) {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
-        const match = /sz=I-(\d+)-25_1/u.exec(url);
-        const n = match ? Number(match[1]) : 0;
+        const match = /sz=I-(?<n>\d+)-25_1/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
         return Promise.resolve(
           new Response(makeTextPage(`I.ÚS ${n}/25`, "1. 6. 2025")),
         );
@@ -261,8 +261,8 @@ describe("czUsAdapter.fetchPage", () => {
         if (url.includes("GetAbstract")) {
           return Promise.reject(new Error("Network error"));
         }
-        const match = /sz=I-(\d+)-/u.exec(url);
-        const n = match ? Number(match[1]) : 0;
+        const match = /sz=I-(?<n>\d+)-/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
         if (n === 1) {
           return Promise.resolve(
             new Response(makeTextPage("IV.ÚS 1/25", "5. 2. 2025")),
@@ -298,8 +298,8 @@ describe("czUsAdapter.fetchPage", () => {
         if (url.includes("GetAbstract")) {
           return Promise.resolve(new Response(makeAbstractPage(longAbstract)));
         }
-        const match = /sz=I-(\d+)-/u.exec(url);
-        const n = match ? Number(match[1]) : 0;
+        const match = /sz=I-(?<n>\d+)-/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
         if (n === 1) {
           return Promise.resolve(
             new Response(makeTextPage("I.ÚS 1/25", "1. 1. 2025")),
@@ -374,8 +374,8 @@ describe("czUsAdapter.fetchPage", () => {
         if (url.includes("GetAbstract")) {
           return Promise.resolve(new Response(makeEmptyPage()));
         }
-        const match = /sz=I-(\d+)-/u.exec(url);
-        const n = match ? Number(match[1]) : 0;
+        const match = /sz=I-(?<n>\d+)-/u.exec(url);
+        const n = match ? Number(match.groups?.["n"]) : 0;
         if (n === 1) {
           return Promise.resolve(new Response(html));
         }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -70,10 +70,10 @@ const toYearSuffix = (year: number): string =>
   String(year % 100).padStart(2, "0");
 
 // oxlint-disable-next-line sonarjs/slow-regex -- registry sign is a short label extracted from NALUS metadata
-const REGISTRY_SIGN_PATTERN = /^(.+?)\s+ze\s+dne\s+(.+)$/u;
-const DOC_CONTENT_PATTERN = /class="DocContent">([\s\S]*?)<\/table>/u;
+const REGISTRY_SIGN_PATTERN = /^(?<caseNumber>.+?)\s+ze\s+dne\s+(?<date>.+)$/u;
+const DOC_CONTENT_PATTERN = /class="DocContent">(?<body>[\s\S]*?)<\/table>/u;
 // oxlint-disable-next-line sonarjs/slow-regex -- judge extraction scans one decision signature block
-const JUDGE_PATTERN = /(\S+(?:\s+\S+){0,2})\s+\(soudce\s+zpravodaj\)/iu;
+const JUDGE_PATTERN = /(?<judge>\S+(?:\s+\S+){0,2})\s+\(soudce\s+zpravodaj\)/iu;
 
 /** Extract text from a labeled span. */
 const extractLabel = (html: string, labelId: string): string | undefined => {
@@ -112,12 +112,16 @@ const buildEcli = (
   counter: number,
 ): string | undefined => {
   // "II.ÚS 3436/14" or "Pl.ÚS 24/10"
-  const match = /^([IVX]+|Pl)\.ÚS\s+(\d+)\/(\d+)$/u.exec(caseNumber);
-  if (!match?.[1] || !match[2] || !match[3]) {
+  const match =
+    /^(?<senate>[IVX]+|Pl)\.ÚS\s+(?<caseIndex>\d+)\/(?<shortYear>\d+)$/u.exec(
+      caseNumber,
+    );
+  const groups = match?.groups;
+  if (!groups?.["senate"] || !groups["caseIndex"] || !groups["shortYear"]) {
     return undefined;
   }
-  const senate = SENATE_MAP[match[1]] ?? match[1].toUpperCase();
-  return `ECLI:CZ:US:${decisionYear}:${senate}.US.${match[2]}.${match[3]}.${counter}`;
+  const senate = SENATE_MAP[groups["senate"]] ?? groups["senate"].toUpperCase();
+  return `ECLI:CZ:US:${decisionYear}:${senate}.US.${groups["caseIndex"]}.${groups["shortYear"]}.${counter}`;
 };
 
 /** Extract case number and date from the registry sign label. */
@@ -128,14 +132,14 @@ const parseRegistrySign = (
   decisionDate?: string | undefined;
 } | null => {
   // Format: "Pl.ÚS 24/10 ze dne 22. 3. 2011" (visible label, no counter)
-  const match = REGISTRY_SIGN_PATTERN.exec(raw);
-  if (!match?.[1] || !match[2]) {
+  const groups = REGISTRY_SIGN_PATTERN.exec(raw)?.groups;
+  if (!groups?.["caseNumber"] || !groups["date"]) {
     return null;
   }
 
   return {
-    caseNumber: match[1].trim(),
-    decisionDate: parseCeDate(match[2]),
+    caseNumber: groups["caseNumber"].trim(),
+    decisionDate: parseCeDate(groups["date"]),
   };
 };
 
@@ -147,29 +151,32 @@ const parseRegistrySign = (
  * Returns undefined if the counter is not present.
  */
 const extractEcliCounter = (html: string): number | undefined => {
-  const hidden = /name="registrySignHidden"[^>]*value="([^"]*)"/u.exec(html);
-  if (!hidden?.[1]) {
+  const hidden = /name="registrySignHidden"[^>]*value="(?<value>[^"]*)"/u.exec(
+    html,
+  );
+  if (!hidden?.groups?.["value"]) {
     return undefined;
   }
-  const counterMatch = /#(\d+)/u.exec(hidden[1]);
-  return counterMatch?.[1] ? Number.parseInt(counterMatch[1], 10) : undefined;
+  const counterMatch = /#(?<counter>\d+)/u.exec(hidden.groups["value"]);
+  const counter = counterMatch?.groups?.["counter"];
+  return counter ? Number.parseInt(counter, 10) : undefined;
 };
 
 /** Extract fulltext body from DocContent table. */
 const extractFulltext = (html: string): string | undefined => {
-  const match = DOC_CONTENT_PATTERN.exec(html);
-  if (!match?.[1]) {
+  const body = DOC_CONTENT_PATTERN.exec(html)?.groups?.["body"];
+  if (!body) {
     return undefined;
   }
 
-  const text = stripHtml(match[1]);
+  const text = stripHtml(body);
   return text.length > 50 ? text : undefined;
 };
 
 /** Extract the rapporteur judge name from the body. */
 const extractJudge = (html: string): string | undefined => {
-  const match = JUDGE_PATTERN.exec(html);
-  return match?.[1] ? stripHtml(match[1]) : undefined;
+  const judge = JUDGE_PATTERN.exec(html)?.groups?.["judge"];
+  return judge ? stripHtml(judge) : undefined;
 };
 
 /** Extract abstract and legal sentence from GetAbstract.aspx. */

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -116,12 +116,12 @@ const buildEcli = (
     /^(?<senate>[IVX]+|Pl)\.ÚS\s+(?<caseIndex>\d+)\/(?<shortYear>\d+)$/u.exec(
       caseNumber,
     );
-  const groups = match?.groups;
-  if (!groups?.["senate"] || !groups["caseIndex"] || !groups["shortYear"]) {
+  const { senate, caseIndex, shortYear } = match?.groups ?? {};
+  if (!senate || !caseIndex || !shortYear) {
     return undefined;
   }
-  const senate = SENATE_MAP[groups["senate"]] ?? groups["senate"].toUpperCase();
-  return `ECLI:CZ:US:${decisionYear}:${senate}.US.${groups["caseIndex"]}.${groups["shortYear"]}.${counter}`;
+  const mappedSenate = SENATE_MAP[senate] ?? senate.toUpperCase();
+  return `ECLI:CZ:US:${decisionYear}:${mappedSenate}.US.${caseIndex}.${shortYear}.${counter}`;
 };
 
 /** Extract case number and date from the registry sign label. */
@@ -132,14 +132,14 @@ const parseRegistrySign = (
   decisionDate?: string | undefined;
 } | null => {
   // Format: "Pl.ÚS 24/10 ze dne 22. 3. 2011" (visible label, no counter)
-  const groups = REGISTRY_SIGN_PATTERN.exec(raw)?.groups;
-  if (!groups?.["caseNumber"] || !groups["date"]) {
+  const { caseNumber, date } = REGISTRY_SIGN_PATTERN.exec(raw)?.groups ?? {};
+  if (!caseNumber || !date) {
     return null;
   }
 
   return {
-    caseNumber: groups["caseNumber"].trim(),
-    decisionDate: parseCeDate(groups["date"]),
+    caseNumber: caseNumber.trim(),
+    decisionDate: parseCeDate(date),
   };
 };
 
@@ -154,11 +154,11 @@ const extractEcliCounter = (html: string): number | undefined => {
   const hidden = /name="registrySignHidden"[^>]*value="(?<value>[^"]*)"/u.exec(
     html,
   );
-  if (!hidden?.groups?.["value"]) {
+  const hiddenValue = hidden?.groups?.["value"];
+  if (!hiddenValue) {
     return undefined;
   }
-  const counterMatch = /#(?<counter>\d+)/u.exec(hidden.groups["value"]);
-  const counter = counterMatch?.groups?.["counter"];
+  const counter = /#(?<counter>\d+)/u.exec(hiddenValue)?.groups?.["counter"];
   return counter ? Number.parseInt(counter, 10) : undefined;
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.smoke.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.smoke.test.ts
@@ -34,11 +34,11 @@ describe.skipIf(SKIP)("euEcjAdapter smoke (live)", () => {
       for (const d of page.decisions) {
         expect(d.caseNumber).toBeTruthy();
         expect(d.ecli).toMatch(/^ECLI:EU:[CT]:/u);
-        expect(d.court).toMatch(/^(Court of Justice|General Court)$/u);
+        expect(d.court).toMatch(/^(?:Court of Justice|General Court)$/u);
         expect(d.country).toBe("EU");
         expect(d.language).toMatch(/^[a-z]{2}$/u);
         expect(d.decisionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
-        expect(d.decisionType).toMatch(/^(judgment|order|opinion|unknown)$/u);
+        expect(d.decisionType).toMatch(/^(?:judgment|order|opinion|unknown)$/u);
         expect(d.sourceUrl).toContain("eur-lex");
         expect(d.metadata).toHaveProperty("celex");
         expect(d.rawHash).toHaveLength(64);

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -231,9 +231,7 @@ export const celexToCaseNumber = (celex: string): string => {
     return celex;
   }
 
-  const yearStr = match.groups?.["year"];
-  const typeStr = match.groups?.["type"];
-  const numStr = match.groups?.["num"];
+  const { year: yearStr, type: typeStr, num: numStr } = match.groups ?? {};
   if (!yearStr || !typeStr || !numStr) {
     return celex;
   }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -224,14 +224,16 @@ LIMIT ${SPARQL_LIMIT}`.trim();
  *      "62023TJ0201" → "T-201/23"
  */
 export const celexToCaseNumber = (celex: string): string => {
-  const match = /^6(\d{4})(CJ|TJ|CC|CO|TO|FJ)(\d+)/u.exec(celex);
+  const match = /^6(?<year>\d{4})(?<type>CJ|TJ|CC|CO|TO|FJ)(?<num>\d+)/u.exec(
+    celex,
+  );
   if (!match) {
     return celex;
   }
 
-  const yearStr = match[1];
-  const typeStr = match[2];
-  const numStr = match[3];
+  const yearStr = match.groups?.["year"];
+  const typeStr = match.groups?.["type"];
+  const numStr = match.groups?.["num"];
   if (!yearStr || !typeStr || !numStr) {
     return celex;
   }
@@ -277,21 +279,23 @@ const fetchFulltext = async (
     // everything up to the outermost </div> before <!--,
     // avoiding early termination on inner div comments.
     const bodyMatch =
-      /<div[^>]*id="TexteOnly"[^>]*>([\s\S]*)<\/div>\s*<!--/iu.exec(html);
+      /<div[^>]*id="TexteOnly"[^>]*>(?<body>[\s\S]*)<\/div>\s*<!--/iu.exec(
+        html,
+      );
     if (!bodyMatch) {
       // Fallback: extract <body> content
-      const fallback = /<body[^>]*>([\s\S]*)<\/body>/iu.exec(html);
-      if (!fallback?.[1]) {
+      const fallback = /<body[^>]*>(?<body>[\s\S]*)<\/body>/iu.exec(html);
+      if (!fallback?.groups?.["body"]) {
         return undefined;
       }
-      const text = stripHtml(fallback[1])
+      const text = stripHtml(fallback.groups["body"])
         // eslint-disable-next-line no-control-regex -- strip control chars for PG
         .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/gu, "")
         .trim();
       return text.length > 100 ? text : undefined;
     }
 
-    const text = stripHtml(bodyMatch[1] ?? "")
+    const text = stripHtml(bodyMatch.groups?.["body"] ?? "")
       // eslint-disable-next-line no-control-regex -- strip control chars for PG
       .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/gu, "")
       .trim();

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -76,7 +76,7 @@ const POLISH_MONTHS: Record<string, string> = {
 };
 
 const POLISH_DATE_RE =
-  /(?:^|[\s,])(?:z dnia\s+)?(\d{1,2})\s+(stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia)\s+(\d{4})\s*r?(?:oku)?\.?/iu;
+  /(?:^|[\s,])(?:z dnia\s+)?(?<day>\d{1,2})\s+(?<monthName>stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia)\s+(?<year>\d{4})\s*r?(?:oku)?\.?/iu;
 
 type SaosJudge = {
   name: string;
@@ -332,10 +332,10 @@ const parseDecisionDateFromContent = (
   }
 
   const text = stripHtml(content);
-  const match = POLISH_DATE_RE.exec(text);
-  const day = match?.[1]?.padStart(2, "0");
-  const monthName = match?.[2]?.toLocaleLowerCase("pl-PL");
-  const year = match?.[3];
+  const groups = POLISH_DATE_RE.exec(text)?.groups;
+  const day = groups?.["day"]?.padStart(2, "0");
+  const monthName = groups?.["monthName"]?.toLocaleLowerCase("pl-PL");
+  const year = groups?.["year"];
 
   if (!day || !monthName || !year) {
     return undefined;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -90,10 +90,11 @@ const parseCursor = (cursor: string | null): YearCursor => {
 
   // New format: "YYYY:offset"
   const match = /^(?<year>\d{4}):(?<offset>\d+)$/u.exec(cursor);
-  if (match?.groups?.["year"] && match.groups["offset"]) {
+  const { year, offset } = match?.groups ?? {};
+  if (year && offset) {
     return {
-      year: Number.parseInt(match.groups["year"], 10),
-      offset: Number.parseInt(match.groups["offset"], 10),
+      year: Number.parseInt(year, 10),
+      offset: Number.parseInt(offset, 10),
     };
   }
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -89,11 +89,11 @@ const parseCursor = (cursor: string | null): YearCursor => {
   }
 
   // New format: "YYYY:offset"
-  const match = /^(\d{4}):(\d+)$/u.exec(cursor);
-  if (match?.[1] && match[2]) {
+  const match = /^(?<year>\d{4}):(?<offset>\d+)$/u.exec(cursor);
+  if (match?.groups?.["year"] && match.groups["offset"]) {
     return {
-      year: Number.parseInt(match[1], 10),
-      offset: Number.parseInt(match[2], 10),
+      year: Number.parseInt(match.groups["year"], 10),
+      offset: Number.parseInt(match.groups["offset"], 10),
     };
   }
 
@@ -230,11 +230,13 @@ const parseApiDate = (raw: string | undefined): string | undefined => {
   if (!raw) {
     return undefined;
   }
-  const match = /^(\d{2})\/(\d{2})\/(\d{4})/u.exec(raw);
-  if (!match?.[1] || !match[2] || !match[3]) {
+  const groups = /^(?<month>\d{2})\/(?<day>\d{2})\/(?<year>\d{4})/u.exec(
+    raw,
+  )?.groups;
+  if (!groups?.["month"] || !groups["day"] || !groups["year"]) {
     return undefined;
   }
-  return `${match[3]}-${match[1]}-${match[2]}`;
+  return `${groups["year"]}-${groups["month"]}-${groups["day"]}`;
 };
 
 // ── PDF download ─────────────────────────────────────────

--- a/apps/api/src/handlers/case-law/ingestion/adapters/utils.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/utils.ts
@@ -11,7 +11,8 @@ import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 export const INGESTION_USER_AGENT =
   process.env["INGESTION_USER_AGENT"] ?? "Mozilla/5.0 (compatible)";
 
-const CE_DATE_PATTERN = /^(\d{1,2})\.\s*(\d{1,2})\.\s*(\d{4})$/;
+const CE_DATE_PATTERN =
+  /^(?<day>\d{1,2})\.\s*(?<month>\d{1,2})\.\s*(?<year>\d{4})$/;
 
 /** SHA-256 content hash via Bun.CryptoHasher. */
 export const hashContent = (input: string): string => {
@@ -73,14 +74,14 @@ export const stripHtml = (html: string): string =>
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
-    .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
+    .replace(/&#x(?<hex>[0-9a-f]+);/gi, (match, hex: string) => {
       try {
         return String.fromCodePoint(Number.parseInt(hex, 16));
       } catch {
         return match;
       }
     })
-    .replace(/&#(\d+);/g, (match, dec: string) => {
+    .replace(/&#(?<dec>\d+);/g, (match, dec: string) => {
       try {
         return String.fromCodePoint(Number.parseInt(dec, 10));
       } catch {
@@ -95,13 +96,13 @@ export const stripHtml = (html: string): string =>
  * Accepts "D. M. YYYY" (CZ) and "DD.MM.YYYY" (SK).
  */
 export const parseCeDate = (dateStr: string): string | undefined => {
-  const m = CE_DATE_PATTERN.exec(dateStr.trim());
-  if (!m?.[1] || !m[2] || !m[3]) {
+  const groups = CE_DATE_PATTERN.exec(dateStr.trim())?.groups;
+  if (!groups?.["day"] || !groups["month"] || !groups["year"]) {
     return undefined;
   }
-  const day = m[1].padStart(2, "0");
-  const month = m[2].padStart(2, "0");
-  return `${m[3]}-${month}-${day}`;
+  const day = groups["day"].padStart(2, "0");
+  const month = groups["month"].padStart(2, "0");
+  return `${groups["year"]}-${month}-${day}`;
 };
 
 /** Check if an error is a per-request timeout (not a cycle/page abort). */

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -20,11 +20,11 @@ type ExtractedCitation = {
 // Group 1 captures the bare case number to deduplicate
 // against the unprefixed pattern below.
 const PL_PREFIXED_PATTERN =
-  /sygn\.\s*(?:akt\s+)?([IVX]{1,4}\s+[A-Za-z]{1,5}\s+\d{1,6}\/\d{2,4})/gu;
+  /sygn\.\s*(?:akt\s+)?(?<caseNumber>[IVX]{1,4}\s+[A-Za-z]{1,5}\s+\d{1,6}\/\d{2,4})/gu;
 
 const CITATION_PATTERNS: RegExp[] = [
   // Czech case number: "sp. zn. 21 Cdo 1234/2020"
-  /sp\.\s*zn\.\s*(\d{1,3}\s+[A-Za-z]{1,5}\s+\d{1,6}\/\d{4})/gu,
+  /sp\.\s*zn\.\s*(?<caseNumber>\d{1,3}\s+[A-Za-z]{1,5}\s+\d{1,6}\/\d{4})/gu,
 
   // ECLI: "ECLI:CZ:NS:2020:21.CDO.1234.2020.1"
   /ECLI:[A-Z]{2}:[A-Z]{1,8}:\d{4}:[\w.]+/gu,
@@ -36,7 +36,7 @@ const CITATION_PATTERNS: RegExp[] = [
   /sp\.\s*zn\.\s*\d{1,3}[A-Za-z]{1,5}\/\d{1,6}\/\d{4}/gu,
 
   // Generic: "rozsudek č.j. 5 As 123/2020"
-  /[čc]\.\s*j\.\s*(\d{1,3}\s+[A-Za-z]{1,5}\s+\d{1,6}\/\d{4})/gu,
+  /[čc]\.\s*j\.\s*(?<caseNumber>\d{1,3}\s+[A-Za-z]{1,5}\s+\d{1,6}\/\d{4})/gu,
 
   PL_PREFIXED_PATTERN,
 
@@ -53,21 +53,21 @@ const stripPrefix = (text: string): string => {
   const trimmed = text.trim();
 
   // Czech: "sp. zn. 21 Cdo 1234/2020"
-  const spZn = /^sp\.\s*zn\.\s*(.+)/iu.exec(trimmed);
-  if (spZn?.[1]) {
-    return spZn[1].trim();
+  const spZn = /^sp\.\s*zn\.\s*(?<caseNumber>.+)/iu.exec(trimmed);
+  if (spZn?.groups?.["caseNumber"]) {
+    return spZn.groups["caseNumber"].trim();
   }
 
   // Czech: "č. j. 5 As 123/2020" or "č.j. 5 As 123/2020"
-  const cj = /^[čc]\.\s*j\.\s*(.+)/iu.exec(trimmed);
-  if (cj?.[1]) {
-    return cj[1].trim();
+  const cj = /^[čc]\.\s*j\.\s*(?<caseNumber>.+)/iu.exec(trimmed);
+  if (cj?.groups?.["caseNumber"]) {
+    return cj.groups["caseNumber"].trim();
   }
 
   // Polish: "sygn. akt II CSK 123/20"
-  const sygn = /^sygn\.\s*(?:akt\s+)?(.+)/iu.exec(trimmed);
-  if (sygn?.[1]) {
-    return sygn[1].trim();
+  const sygn = /^sygn\.\s*(?:akt\s+)?(?<caseNumber>.+)/iu.exec(trimmed);
+  if (sygn?.groups?.["caseNumber"]) {
+    return sygn.groups["caseNumber"].trim();
   }
 
   return trimmed;
@@ -127,7 +127,7 @@ export const extractCitations = (
         // canonical dedup key so both "sygn. akt II CSK 123/20"
         // and "II CSK 123/20" resolve to the same key regardless
         // of which fires first.
-        const dedupKey = match[1]?.trim() ?? citationText;
+        const dedupKey = match.groups?.["caseNumber"]?.trim() ?? citationText;
 
         const existing = byKey.get(dedupKey);
         if (!existing) {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
@@ -77,12 +77,14 @@ export const parseNsDecisionHtml = (
 // ── Metadata extraction ────────────────────────────────────
 
 const parseDominoDate = (raw: string): string | null => {
-  const match = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/u.exec(raw);
+  const match = /^(?<month>\d{1,2})\/(?<day>\d{1,2})\/(?<year>\d{4})$/u.exec(
+    raw,
+  );
   if (!match) {
     return null;
   }
-  const [, month, day, year] = match;
-  // SAFETY: regex guarantees 3 capture groups
+  // SAFETY: regex guarantees the month/day/year groups
+  const { month, day, year } = match.groups ?? {};
   return `${year}-${month?.padStart(2, "0") ?? ""}-${day?.padStart(2, "0") ?? ""}`;
 };
 
@@ -555,7 +557,7 @@ const DECISION_TYPE_WORDS = new Set([
 const SECTION_HEADING_RE =
   /^(?:S\s*t\s*r\s*u\s*[čc]\s*n\s*[ée]\s+)?O\s*d\s*[uů]\s*v\s*o\s*d\s*n\s*[eě]\s*n\s*[ií]/iu;
 
-const RULING_ITEM_RE = /^([IVXLCDM]+\.)\s+/u;
+const RULING_ITEM_RE = /^(?:[IVXLCDM]+\.)\s+/u;
 
 const isDecisionTitle = (plainText: string): boolean => {
   const trimmed = plainText.trim();
@@ -688,14 +690,18 @@ const mergeBlocks = (
       // Check for embedded title
       const titleMatch =
         // oxlint-disable-next-line sonarjs/slow-regex -- first paragraph text is bounded by parser block splitting
-        /([A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]\s+[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ\s]{5,})\s*$/u.exec(text);
+        /(?<title>[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]\s+[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ\s]{5,})\s*$/u.exec(
+          text,
+        );
       // oxlint-disable-next-line sonarjs/slow-regex -- first paragraph text is bounded by parser block splitting
-      const caseMatch = /(\d+\s+\w+\s+\d+\/\d{4}[^\s]*)/u.exec(text);
+      const caseMatch = /(?<caseNumber>\d+\s+\w+\s+\d+\/\d{4}[^\s]*)/u.exec(
+        text,
+      );
 
       if (titleMatch && caseMatch) {
         // Replace the merged block with case-number + title
-        const caseNum = (caseMatch[1] ?? "").trim();
-        const title = (titleMatch[1] ?? "").trim();
+        const caseNum = (caseMatch.groups?.["caseNumber"] ?? "").trim();
+        const title = (titleMatch.groups?.["title"] ?? "").trim();
 
         const replacements: Block[] = [
           {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -433,8 +433,8 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
 };
 
 const parseFontSize = (style: string): number => {
-  const match = /font-size:\s*(\d+)pt/u.exec(style);
-  return match ? Number(match[1]) : 12;
+  const match = /font-size:\s*(?<size>\d+)pt/u.exec(style);
+  return match ? Number(match.groups?.["size"]) : 12;
 };
 
 // ── Patterns ───────────────────────────────────────────────
@@ -447,7 +447,7 @@ const parseFontSize = (style: string): number => {
 const SKIP_RE = /^\[OBRÁZEK\]|^pokračování$|^ČESKÁ REPUBLIKA$/u;
 
 /** Decision title. */
-const TITLE_RE = /^(ROZSUDEK|USNESENÍ|JMÉNEM REPUBLIKY)$/u;
+const TITLE_RE = /^(?:ROZSUDEK|USNESENÍ|JMÉNEM REPUBLIKY)$/u;
 
 /** "takto:" separator. */
 // oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
@@ -468,17 +468,17 @@ const POUCENI_INLINE_RE = /^(?:P\s*o\s*u\s*č\s*e\s*n\s*í|Poučení)\s*:\s*/iu;
  * Ruling item: Roman numeral + period + text.
  * Only matched in the výrok zone (before Odůvodnění).
  */
-const RULING_ITEM_RE = /^((?:X{0,3}(?:IX|IV|V?I{0,3})))\.\s+(.+)/u;
+const RULING_ITEM_RE = /^(?:X{0,3}(?:IX|IV|V?I{0,3}))\.\s+(?:.+)/u;
 
 /**
  * Section heading in Odůvodnění: Roman numeral + title text.
  * May include sub-headings like "III. A", "III. B".
  */
 const SECTION_HEADING_RE =
-  /^((?:X{0,3}(?:IX|IV|V?I{0,3})))\.\s*(?:[A-Z]\s+)?[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]/u;
+  /^(?:X{0,3}(?:IX|IV|V?I{0,3}))\.\s*(?:[A-Z]\s+)?[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]/u;
 
 /** Numbered paragraph: [1], [2], ... */
-const NUMBERED_PARA_RE = /^\[(\d+)\]\s*/u;
+const NUMBERED_PARA_RE = /^\[(?:\d+)\]\s*/u;
 
 /**
  * Closing line: "V Brně dne ...", "Praha 10. březen 2026",

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-regional.ts
@@ -439,4 +439,4 @@ const classifyJustificationParagraph = (
 
 // ── Patterns ───────────────────────────────────────────────
 
-const NUMBERED_PARA_RE = /^(\d+)\.\s+/u;
+const NUMBERED_PARA_RE = /^(?:\d+)\.\s+/u;

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
@@ -318,7 +318,7 @@ const RTF_NUMERIC_CONTROL_WORDS = new Set([
   "tx",
 ]);
 
-const RTF_CONTROL_WORD_RE = /\\([a-z]+)(-?\d*)\s?/giu;
+const RTF_CONTROL_WORD_RE = /\\(?<word>[a-z]+)(?<numericValue>-?\d*)\s?/giu;
 
 const stripIgnoredRtfControlWord = (
   match: string,
@@ -368,7 +368,7 @@ const parseRtfInlines = (rtf: string): Inline[] => {
   const inlines: Inline[] = [];
 
   // Split on \b and \b0 markers, keeping the delimiters
-  const parts = cleaned.split(/(\\b0?\s?)/u);
+  const parts = cleaned.split(/(?<marker>\\b0?\s?)/u);
   let bold = false;
 
   for (const part of parts) {
@@ -517,11 +517,11 @@ const SKIP_RE = /^\[OBRÁZEK\]|^Česká republika$|^ČESKÁ REPUBLIKA$/u;
 
 /** Decision title (level 1). */
 const TITLE_RE =
-  /^(N\s*[ÁA]\s*L\s*[ÉE]\s*Z|U\s*S\s*N\s*E\s*S\s*E\s*N\s*[ÍI]|Ústavního soudu|Jménem republiky)$/iu;
+  /^(?:N\s*[ÁA]\s*L\s*[ÉE]\s*Z|U\s*S\s*N\s*E\s*S\s*E\s*N\s*[ÍI]|Ústavního soudu|Jménem republiky)$/iu;
 
 /** Normalize spaced text like "t a k t o" -> "takto". */
 const collapseSpaces = (text: string): string =>
-  text.replace(/(\S)\s+(?=\S)/gu, "$1");
+  text.replace(/(?<keep>\S)\s+(?=\S)/gu, "$<keep>");
 
 /** "takto:" separator (with spaced variants). */
 // oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
@@ -537,10 +537,10 @@ const ODUVODNENI_RE =
  * or Roman numeral followed by a short title on the same or
  * next line.
  */
-const SECTION_ROMAN_RE = /^(?=[IVX])(X{0,3}(?:IX|IV|V?I{0,3}))\.?\s*$/u;
+const SECTION_ROMAN_RE = /^(?=[IVX])(?<roman>X{0,3}(?:IX|IV|V?I{0,3}))\.?\s*$/u;
 
 /** Numbered paragraph: "1. ...", "2. ..." */
-const NUMBERED_PARA_RE = /^(\d+)\.\s+/u;
+const NUMBERED_PARA_RE = /^(?:\d+)\.\s+/u;
 
 // ── Block classification ───────────────────────────────────
 
@@ -786,7 +786,7 @@ const classifyLines = (lines: readonly ParsedLine[]): Block[] => {
           !CLOSING_RE.test(nextNonEmpty.plainText)
         ) {
           // Combine Roman numeral + title line
-          const combinedText = `${romanMatch[1] ?? ""}. ${nextNonEmpty.plainText}`;
+          const combinedText = `${romanMatch.groups?.["roman"] ?? ""}. ${nextNonEmpty.plainText}`;
           blockIndex += 1;
           blocks.push({
             id: makeBlockId(),

--- a/apps/api/src/handlers/case-law/ingestion/parsers/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/sk-courts.ts
@@ -488,7 +488,7 @@ const DECISION_TITLES = new Set([
  * Canonical location: pipeline.ts SPACED_WORD regex.
  */
 const SPACED_WORD_RE =
-  /(?<=\s|^)(\p{L} (?:\p{L} )*\p{L})( ?[,:;.!?])?(?=\s|$)/gu;
+  /(?<=\s|^)(?:\p{L} (?:\p{L} )*\p{L})(?: ?[,:;.!?])?(?=\s|$)/gu;
 
 const normalizeSpaced = (text: string): string =>
   text

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -139,7 +139,7 @@ type ProcessResult = {
  * are always longer, so the floor loses nothing in practice.
  */
 const SPACED_WORD =
-  /(?<=\s|^)(\p{L} (?:\p{L} ){2,}\p{L})( ?[,:;.!?])?(?=\s|$)/gu;
+  /(?<=\s|^)(?:\p{L} (?:\p{L} ){2,}\p{L})(?: ?[,:;.!?])?(?=\s|$)/gu;
 
 /**
  * Collapse multiple spaces to single. Applied to all

--- a/apps/api/src/handlers/case-law/ingestion/segmenter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/segmenter.ts
@@ -27,7 +27,7 @@ const SECTION_PATTERNS: {
     type: "dissent",
     pattern:
       // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
-      /^(Odli[šs]n[ée]\s+stanovisko|Stanovisko\s+men[šs]iny)\s*[:.]?\s*$/imu,
+      /^(?:Odli[šs]n[ée]\s+stanovisko|Stanovisko\s+men[šs]iny)\s*[:.]?\s*$/imu,
   },
   {
     type: "footer",
@@ -68,7 +68,7 @@ const SECTION_PATTERNS: {
   {
     type: "ruling",
     // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
-    pattern: /^(V[ýy]rok|Rozhodnutie)\s*[:.]?\s*$/imu,
+    pattern: /^(?:V[ýy]rok|Rozhodnutie)\s*[:.]?\s*$/imu,
   },
   {
     type: "argumentation",
@@ -86,14 +86,14 @@ const SECTION_PATTERNS: {
     type: "history",
     pattern:
       // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
-      /^(Pr[uů]b[eě]h\s+[řr][ií]zen[ií]|Procesn[ií]\s+historie)\s*[:.]?\s*$/imu,
+      /^(?:Pr[uů]b[eě]h\s+[řr][ií]zen[ií]|Procesn[ií]\s+historie)\s*[:.]?\s*$/imu,
   },
 
   // Polish patterns
   {
     type: "ruling",
     // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
-    pattern: /^(Sentencja|Tenor)\s*[:.]?\s*$/imu,
+    pattern: /^(?:Sentencja|Tenor)\s*[:.]?\s*$/imu,
   },
   {
     type: "argumentation",

--- a/apps/api/src/handlers/chat/data-scope.ts
+++ b/apps/api/src/handlers/chat/data-scope.ts
@@ -137,7 +137,7 @@ const collectStructuralWorkspaceIds = (
 // The entity form's second segment (the entity UUID) is intentionally
 // not captured — only the workspace it belongs to gates RLS.
 const STELLA_TEXT_REF_WORKSPACE_REGEX =
-  /#stella-(?:workspace|entity)=([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gu;
+  /#stella-(?:workspace|entity)=(?<workspaceId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gu;
 
 const collectTextRefWorkspaceIds = (
   part: unknown,
@@ -153,7 +153,7 @@ const collectTextRefWorkspaceIds = (
     return;
   }
   for (const match of part.text.matchAll(STELLA_TEXT_REF_WORKSPACE_REGEX)) {
-    const captured = match[1];
+    const captured = match.groups?.["workspaceId"];
     if (captured) {
       ids.add(brandPersistedWorkspaceId(captured));
     }

--- a/apps/api/src/handlers/chat/thread-list-pagination.ts
+++ b/apps/api/src/handlers/chat/thread-list-pagination.ts
@@ -3,7 +3,7 @@ import { brandPersistedChatThreadId } from "@/api/lib/safe-id-boundaries";
 
 const CURSOR_SEPARATOR = "|";
 const CURSOR_TIMESTAMP_RE =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{6})$/u;
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})\.(?<microsecond>\d{6})$/u;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
@@ -40,7 +40,8 @@ const isValidCursorTimestamp = (timestamp: string): boolean => {
     return false;
   }
 
-  const [, year, month, day, hour, minute, second, microsecond] = match;
+  const { year, month, day, hour, minute, second, microsecond } =
+    match.groups ?? {};
   const parts = [year, month, day, hour, minute, second, microsecond].map(
     Number,
   );

--- a/apps/api/src/handlers/docx/block-directives-properties.test.ts
+++ b/apps/api/src/handlers/docx/block-directives-properties.test.ts
@@ -61,9 +61,9 @@ const extractTexts = async (buffer: Buffer): Promise<string[]> => {
   const zip = await JSZip.loadAsync(buffer);
   const xml = (await zip.file("word/document.xml")?.async("string")) ?? "";
   const texts: string[] = [];
-  for (const match of xml.matchAll(/<w:t[^>]*>(.*?)<\/w:t>/gu)) {
-    if (match[1] !== undefined) {
-      texts.push(match[1]);
+  for (const match of xml.matchAll(/<w:t[^>]*>(?<text>.*?)<\/w:t>/gu)) {
+    if (match.groups?.["text"] !== undefined) {
+      texts.push(match.groups["text"]);
     }
   }
   return texts;

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -35,7 +35,7 @@ export { evaluateCondition, resolvePath };
 /** Matches a block directive as the sole paragraph content. */
 const DIRECTIVE_RE =
   // oxlint-disable-next-line sonarjs/slow-regex -- directive matching runs on one OOXML paragraph at a time
-  /^\s*\{\{(#if|#elseif|#else|#each|\/if|\/each)\s*(.*?)\}\}\s*$/u;
+  /^\s*\{\{(?<tag>#if|#elseif|#else|#each|\/if|\/each)\s*(?<expr>.*?)\}\}\s*$/u;
 
 /** Fast-path: does the raw XML contain any block directives? */
 export const HAS_BLOCK_DIRECTIVES_RE = /\{\{[#/]/u;
@@ -85,8 +85,8 @@ export const scanBlockDirectives = (
       continue;
     }
 
-    const tag = match[1];
-    const rawExpr = match[2];
+    const tag = match.groups?.["tag"];
+    const rawExpr = match.groups?.["expr"];
     if (!tag || rawExpr === undefined) {
       continue;
     }

--- a/apps/api/src/handlers/docx/discover-clause-slots.ts
+++ b/apps/api/src/handlers/docx/discover-clause-slots.ts
@@ -24,7 +24,8 @@ export type ClauseSlot = {
 
 // ── Regex ────────────────────────────────────────────
 
-const CLAUSE_SLOT_RE = /\{\{@clause:([^:}]+)(?::([^}]+))?\}\}/gu;
+const CLAUSE_SLOT_RE =
+  /\{\{@clause:(?<name>[^:}]+)(?::(?<modifier>[^}]+))?\}\}/gu;
 
 // ── Scanning ─────────────────────────────────────────
 
@@ -37,11 +38,11 @@ const scanParagraphs = (
   for (const p of paragraphs) {
     const text = paragraphText(p);
     for (const match of text.matchAll(CLAUSE_SLOT_RE)) {
-      const name = match[1];
+      const name = match.groups?.["name"];
       if (!name) {
         continue;
       }
-      const modifier = match[2] || undefined;
+      const modifier = match.groups?.["modifier"] || undefined;
       const patchKey = modifier
         ? `@clause:${name}:${modifier}`
         : `@clause:${name}`;

--- a/apps/api/src/handlers/docx/discover-placeholders.ts
+++ b/apps/api/src/handlers/docx/discover-placeholders.ts
@@ -13,7 +13,7 @@ import * as slimdom from "slimdom";
 import { HEADER_FOOTER_RE, paragraphText, W_NS } from "./ooxml";
 import type { DiscoveredPlaceholder } from "./types";
 
-export const PLACEHOLDER_RE = /\{\{([\p{L}\p{N}_.@:-]+)\}\}/gu;
+export const PLACEHOLDER_RE = /\{\{(?<name>[\p{L}\p{N}_.@:-]+)\}\}/gu;
 
 /**
  * Scan all `w:p` paragraphs in a parsed XML document and
@@ -28,7 +28,7 @@ const scanParagraphs = (
   for (const p of paragraphs) {
     const text = paragraphText(p);
     for (const match of text.matchAll(PLACEHOLDER_RE)) {
-      const name = match[1];
+      const name = match.groups?.["name"];
       if (!name) {
         continue;
       }

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -29,7 +29,7 @@ import type {
  * Strips string literals, operators, and keywords.
  */
 const CONDITION_TOKEN_RE =
-  /"(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|([\p{L}\p{N}_.]+)/gu;
+  /"(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|(?<ident>[\p{L}\p{N}_.]+)/gu;
 
 const NUMERIC_LITERAL_RE = /^[\d_]+$/u;
 
@@ -290,7 +290,7 @@ const analyzeContainer = (
         const text = paragraphText(para);
         const prefix = `${block.arrayPath}.`;
         for (const match of text.matchAll(PLACEHOLDER_RE)) {
-          const name = match[1];
+          const name = match.groups?.["name"];
           if (!name) {
             continue;
           }
@@ -321,7 +321,7 @@ const analyzeContainer = (
           if (!raw) {
             continue;
           }
-          const ident = m[1];
+          const ident = m.groups?.["ident"];
 
           if (raw === "and" || raw === "or") {
             current = { paths: [], hasComparison: false };
@@ -361,7 +361,7 @@ const analyzeContainer = (
     const paraCondition = conditionMap.get(i);
 
     for (const match of text.matchAll(PLACEHOLDER_RE)) {
-      const name = match[1];
+      const name = match.groups?.["name"];
       if (!name) {
         continue;
       }

--- a/apps/api/src/handlers/docx/edit-with-tracking.ts
+++ b/apps/api/src/handlers/docx/edit-with-tracking.ts
@@ -34,7 +34,7 @@ const COMMENTS_REL_TYPE =
 
 // ── Settings: enable track-revisions ──────────────────────
 
-const SETTINGS_OPEN_RE = /(<w:settings\b[^>]*>)/u;
+const SETTINGS_OPEN_RE = /(?<open><w:settings\b[^>]*>)/u;
 
 const ensureTrackRevisions = (settingsXml: string): string => {
   if (settingsXml.includes("w:trackRevisions")) {
@@ -42,7 +42,7 @@ const ensureTrackRevisions = (settingsXml: string): string => {
   }
 
   // Insert <w:trackRevisions/> as first child of w:settings
-  return settingsXml.replace(SETTINGS_OPEN_RE, "$1<w:trackRevisions/>");
+  return settingsXml.replace(SETTINGS_OPEN_RE, "$<open><w:trackRevisions/>");
 };
 
 // ── Content types: ensure comments entry exists ───────────
@@ -67,10 +67,10 @@ const ensureCommentsRel = (relsXml: string): string => {
   }
 
   // Find the highest rId to generate a new unique one
-  const idMatches = [...relsXml.matchAll(/rId(\d+)/gu)];
+  const idMatches = [...relsXml.matchAll(/rId(?<num>\d+)/gu)];
   let maxId = 0;
   for (const match of idMatches) {
-    maxId = Math.max(maxId, Number.parseInt(match[1] ?? "0", 10));
+    maxId = Math.max(maxId, Number.parseInt(match.groups?.["num"] ?? "0", 10));
   }
   const newId = `rId${maxId + 1}`;
 

--- a/apps/api/src/handlers/docx/extract-text.ts
+++ b/apps/api/src/handlers/docx/extract-text.ts
@@ -23,7 +23,7 @@ import type {
  */
 const DIRECTIVE_RE =
   // oxlint-disable-next-line sonarjs/slow-regex -- DOCX directive text is one paragraph collected from OOXML
-  /^\s*\{\{(#if|#elseif|#else|#each|\/if|\/each)\s*(.*?)\}\}\s*$/u;
+  /^\s*\{\{(?<tag>#if|#elseif|#else|#each|\/if|\/each)\s*(?<expr>.*?)\}\}\s*$/u;
 
 const DIRECTIVE_KIND_MAP: Record<string, BlockDirectiveKind> = {
   "#if": "if",
@@ -203,8 +203,8 @@ const extractParagraphsFromContainer = (
     const dm = DIRECTIVE_RE.exec(text);
     if (dm) {
       entry.isDirective = true;
-      const tag = dm[1];
-      const expr = dm[2];
+      const tag = dm.groups?.["tag"];
+      const expr = dm.groups?.["expr"];
       if (tag !== undefined) {
         entry.directiveKind = DIRECTIVE_KIND_MAP[tag];
       }

--- a/apps/api/src/handlers/docx/ooxml.ts
+++ b/apps/api/src/handlers/docx/ooxml.ts
@@ -51,7 +51,7 @@ const INT32_MAX = 2_147_483_647;
  * values starting from 1, avoiding collisions with existing IDs.
  */
 /** Regex matching header and footer XML entry paths. */
-export const HEADER_FOOTER_RE = /^word\/(header|footer)\d+\.xml$/u;
+export const HEADER_FOOTER_RE = /^word\/(?:header|footer)\d+\.xml$/u;
 
 // ── Text helpers ─────────────────────────────────────────
 

--- a/apps/api/src/handlers/docx/patch-template.test.ts
+++ b/apps/api/src/handlers/docx/patch-template.test.ts
@@ -134,9 +134,9 @@ const extractTexts = async (buffer: Buffer): Promise<string[]> => {
   const xml = (await zip.file("word/document.xml")?.async("string")) ?? "";
   // Simple extraction: find all w:t content
   const texts: string[] = [];
-  for (const match of xml.matchAll(/<w:t[^>]*>(.*?)<\/w:t>/gu)) {
-    if (match[1] !== undefined) {
-      texts.push(match[1]);
+  for (const match of xml.matchAll(/<w:t[^>]*>(?<text>.*?)<\/w:t>/gu)) {
+    if (match.groups?.["text"] !== undefined) {
+      texts.push(match.groups["text"]);
     }
   }
   return texts;

--- a/apps/api/src/handlers/docx/resolve-clause-slots.ts
+++ b/apps/api/src/handlers/docx/resolve-clause-slots.ts
@@ -14,7 +14,7 @@ import type { RichPatchValue } from "./types";
 
 // ── Version parsing ──────────────────────────────────
 
-const VERSION_NUM_RE = /^v(\d+)$/u;
+const VERSION_NUM_RE = /^v(?<num>\d+)$/u;
 
 // ── Public API ───────────────────────────────────────
 
@@ -121,7 +121,7 @@ const resolveVersion = async (
   // :vN — use a specific version number
   const vMatch = modifier?.match(VERSION_NUM_RE);
   if (vMatch) {
-    const version = Number.parseInt(vMatch[1] ?? "0", 10);
+    const version = Number.parseInt(vMatch.groups?.["num"] ?? "0", 10);
     return scopedDb((tx) =>
       tx.query.clauseVersions.findFirst({
         where: {

--- a/apps/api/src/handlers/docx/rich-patch.ts
+++ b/apps/api/src/handlers/docx/rich-patch.ts
@@ -12,7 +12,7 @@ import * as slimdom from "slimdom";
 import { isElement, paragraphText, W_NS } from "./ooxml";
 import type { RichPatchValue } from "./types";
 
-export const PLACEHOLDER_RE = /\{\{([\p{L}\p{N}_.@:-]+)\}\}/gu;
+export const PLACEHOLDER_RE = /\{\{(?<name>[\p{L}\p{N}_.@:-]+)\}\}/gu;
 
 const XML_NS = "http://www.w3.org/XML/1998/namespace";
 
@@ -32,17 +32,13 @@ const isStandalonePlaceholder = (
 ): { key: string; value: RichPatchValue } | null => {
   const matches = [...text.matchAll(PLACEHOLDER_RE)];
   const match = matches.at(0);
-  if (
-    !match ||
-    matches.length > 1 ||
-    match[0] !== text ||
-    match[1] === undefined
-  ) {
+  const key = match?.groups?.["name"];
+  if (!match || matches.length > 1 || match[0] !== text || key === undefined) {
     return null;
   }
 
-  const value = values[match[1]];
-  return value === undefined ? null : { key: match[1], value };
+  const value = values[key];
+  return value === undefined ? null : { key, value };
 };
 
 export const replacePlaceholdersInText = (
@@ -315,7 +311,7 @@ const findPlaceholderMatches = (
   const matches: PlaceholderMatch[] = [];
   PLACEHOLDER_RE.lastIndex = 0;
   for (const match of text.matchAll(PLACEHOLDER_RE)) {
-    const key = match[1];
+    const key = match.groups?.["name"];
     if (!key) {
       continue;
     }

--- a/apps/api/src/handlers/entities/cursor-validation.ts
+++ b/apps/api/src/handlers/entities/cursor-validation.ts
@@ -26,9 +26,7 @@ const daysInMonth = (year: number, month: number): number => {
 const parseDateCursorParts = (
   match: RegExpExecArray,
 ): DateCursorParts | null => {
-  const yearPart = match.groups?.["year"];
-  const monthPart = match.groups?.["month"];
-  const dayPart = match.groups?.["day"];
+  const { year: yearPart, month: monthPart, day: dayPart } = match.groups ?? {};
   if (!yearPart || !monthPart || !dayPart) {
     return null;
   }

--- a/apps/api/src/handlers/entities/cursor-validation.ts
+++ b/apps/api/src/handlers/entities/cursor-validation.ts
@@ -1,6 +1,6 @@
-const dateCursorPattern = /^(\d{4})-(\d{2})-(\d{2})$/u;
+const dateCursorPattern = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u;
 const timestampCursorPattern =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{6}$/u;
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})\.\d{6}$/u;
 
 type DateCursorParts = {
   year: number;
@@ -26,9 +26,9 @@ const daysInMonth = (year: number, month: number): number => {
 const parseDateCursorParts = (
   match: RegExpExecArray,
 ): DateCursorParts | null => {
-  const yearPart = match.at(1);
-  const monthPart = match.at(2);
-  const dayPart = match.at(3);
+  const yearPart = match.groups?.["year"];
+  const monthPart = match.groups?.["month"];
+  const dayPart = match.groups?.["day"];
   if (!yearPart || !monthPart || !dayPart) {
     return null;
   }
@@ -58,9 +58,9 @@ export const isValidTimestampCursorValue = (value: string): boolean => {
     return false;
   }
 
-  const hourPart = match.at(4);
-  const minutePart = match.at(5);
-  const secondPart = match.at(6);
+  const hourPart = match.groups?.["hour"];
+  const minutePart = match.groups?.["minute"];
+  const secondPart = match.groups?.["second"];
   if (!hourPart || !minutePart || !secondPart) {
     return false;
   }

--- a/apps/api/src/handlers/files/outlook-msg.ts
+++ b/apps/api/src/handlers/files/outlook-msg.ts
@@ -30,7 +30,7 @@ const RECIPIENT_TYPE = {
 
 const RECIPIENT_STORAGE_PREFIX = "__recip_version1.0_";
 const ATTACHMENT_STORAGE_PREFIX = "__attach_version1.0_";
-const PROPERTY_STREAM_RE = /^__substg1\.0_([0-9a-f]{8})$/iu;
+const PROPERTY_STREAM_RE = /^__substg1\.0_(?<tag>[0-9a-f]{8})$/iu;
 
 const PROPERTY_TYPE = {
   int32: "0003",
@@ -474,7 +474,7 @@ const collectProperties = (
     if (!match) {
       continue;
     }
-    const propertyTag = match[1]?.toLowerCase();
+    const propertyTag = match.groups?.["tag"]?.toLowerCase();
     if (!propertyTag) {
       continue;
     }

--- a/apps/api/src/handlers/files/xlsx-preprocess.ts
+++ b/apps/api/src/handlers/files/xlsx-preprocess.ts
@@ -1,18 +1,19 @@
 import JSZip from "jszip";
 
 const REGEX_HAS_PAGE_SET_UP_PR = /<pageSetUpPr[\s/>]/u;
-const REGEX_EXTRACT_PAGE_SET_UP_PR = /<pageSetUpPr([^/]*?)\/>/gu;
+const REGEX_EXTRACT_PAGE_SET_UP_PR = /<pageSetUpPr(?<attrs>[^/]*?)\/>/gu;
 // oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries
 const REGEX_REMOVE_FIT_TO_PAGE = /\s*fitToPage="[^"]*"/u;
 const REGEX_HAS_OPEN_SHEET_PR = /<sheetPr[^>]*>[\s\S]*?<\/sheetPr>/u;
-const REGEX_EXTRACT_OPEN_SHEET_PR = /(<sheetPr[^>]*>)([\s\S]*?)(<\/sheetPr>)/u;
+const REGEX_EXTRACT_OPEN_SHEET_PR =
+  /(?<open><sheetPr[^>]*>)(?<inner>[\s\S]*?)(?<close><\/sheetPr>)/u;
 const REGEX_HAS_SELF_CLOSING_SHEET_PR = /<sheetPr[^>]*\/>/u;
-const REGEX_EXTRACT_SELF_CLOSING_SHEET_PR = /<sheetPr([^>]*?)\/>/u;
+const REGEX_EXTRACT_SELF_CLOSING_SHEET_PR = /<sheetPr(?<attrs>[^>]*?)\/>/u;
 const REGEX_SHEET_LANDMARK =
   /<(?:dimension|sheetViews|sheetFormatPr|sheetData)[\s/>]/u;
 const REGEX_WORKSHEET_OPEN = /<worksheet[^>]*>/u;
 const REGEX_HAS_PAGE_SETUP = /<pageSetup[\s/>]/u;
-const REGEX_EXTRACT_PAGE_SETUP = /<pageSetup([^/]*?)\/>/gu;
+const REGEX_EXTRACT_PAGE_SETUP = /<pageSetup(?<attrs>[^/]*?)\/>/gu;
 // oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries
 const REGEX_REMOVE_SCALE = /\s*scale="[^"]*"/u;
 // oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries

--- a/apps/api/src/handlers/skills/ai-resource-path.ts
+++ b/apps/api/src/handlers/skills/ai-resource-path.ts
@@ -4,7 +4,7 @@
 // (resources/resource-path.ts); this is the stricter shape we let the model
 // emit. The kind is inferred from the first segment.
 export const AI_RESOURCE_PATH_PATTERN =
-  /^(references|prompts|knowledge)\/[a-z0-9][a-z0-9._-]*(\/[a-z0-9][a-z0-9._-]*)*\.md$/u;
+  /^(?:references|prompts|knowledge)\/[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*\.md$/u;
 
 export const isAiResourcePath = (path: string): boolean =>
   AI_RESOURCE_PATH_PATTERN.test(path);

--- a/apps/api/src/handlers/skills/generate-draft.ts
+++ b/apps/api/src/handlers/skills/generate-draft.ts
@@ -259,9 +259,9 @@ const stripFences = (raw: string): string => {
   if (!trimmed) {
     return "";
   }
-  const fencePattern = /^```(?:[a-zA-Z0-9_-]*)\n([\s\S]*?)\n```$/u;
+  const fencePattern = /^```(?:[a-zA-Z0-9_-]*)\n(?<body>[\s\S]*?)\n```$/u;
   const fenceMatch = fencePattern.exec(trimmed);
-  return fenceMatch?.at(1)?.trim() ?? trimmed;
+  return fenceMatch?.groups?.["body"]?.trim() ?? trimmed;
 };
 
 export default generateSkillDraft;

--- a/apps/api/src/handlers/skills/resources/resource-path.ts
+++ b/apps/api/src/handlers/skills/resources/resource-path.ts
@@ -17,7 +17,7 @@ import type { AgentSkillResourceKind } from "@/api/db/schema";
 // `create.ts` and `rename.ts` to reject paths that the file tree
 // would otherwise be unable to render correctly.
 export const RESOURCE_PATH_PATTERN =
-  /^[a-z0-9][a-z0-9._-]*(\/[a-z0-9][a-z0-9._-]*)*$/u;
+  /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/u;
 
 const REFERENCE_PREFIX = "references/";
 const PROMPT_PREFIX = "prompts/";

--- a/apps/api/src/handlers/skills/resources/rewrite.ts
+++ b/apps/api/src/handlers/skills/resources/rewrite.ts
@@ -214,9 +214,9 @@ const stripFences = (raw: string): string => {
   if (!trimmed) {
     return "";
   }
-  const fencePattern = /^```(?:[a-zA-Z0-9_-]*)\n([\s\S]*?)\n```$/u;
+  const fencePattern = /^```(?:[a-zA-Z0-9_-]*)\n(?<body>[\s\S]*?)\n```$/u;
   const fenceMatch = fencePattern.exec(trimmed);
-  return fenceMatch?.at(1)?.trim() ?? trimmed;
+  return fenceMatch?.groups?.["body"]?.trim() ?? trimmed;
 };
 
 export default rewriteSkillResource;

--- a/apps/api/src/lib/analytics/ai.ts
+++ b/apps/api/src/lib/analytics/ai.ts
@@ -314,14 +314,14 @@ const SAFE_PROVIDER_CODES: ReadonlySet<string> = new Set([
   "UNKNOWN",
 ]);
 
-const SAFE_PROVIDER_CODE_PREFIX = /^([A-Z][A-Z_]+)(?::|\s|$)/u;
+const SAFE_PROVIDER_CODE_PREFIX = /^(?<code>[A-Z][A-Z_]+)(?::|\s|$)/u;
 
 const extractSafeProviderCode = (message: string): string | undefined => {
   const match = SAFE_PROVIDER_CODE_PREFIX.exec(message);
   if (!match) {
     return undefined;
   }
-  const code = match[1];
+  const code = match.groups?.["code"];
   if (code === undefined || !SAFE_PROVIDER_CODES.has(code)) {
     return undefined;
   }

--- a/apps/api/src/lib/docx-stamp.ts
+++ b/apps/api/src/lib/docx-stamp.ts
@@ -52,21 +52,21 @@ const FMTID = "{D5CDD505-2E9C-101B-9397-08002B2CF9AE}";
 
 // ── Top-level regex (oxlint: prefer-regex-literals) ───────────
 
-const PID_RE = /pid="(\d+)"/gu;
-const WID_RE = /w:id="(\d+)"/gu;
+const PID_RE = /pid="(?<pid>\d+)"/gu;
+const WID_RE = /w:id="(?<id>\d+)"/gu;
 const FOOTER_FILE_RE = /^word\/footer\d+\.xml$/u;
-const WT_TEXT_RE = /<w:t[^>]*>([^<]*)<\/w:t>/gu;
-const STL_CODE_RE = /stl:([abcdefghjkmnpqrstuvwxyz23456789]{10})/u;
+const WT_TEXT_RE = /<w:t[^>]*>(?<text>[^<]*)<\/w:t>/gu;
+const STL_CODE_RE = /stl:(?<code>[abcdefghjkmnpqrstuvwxyz23456789]{10})/u;
 // oxlint-disable-next-line sonarjs/slow-regex -- footer text is bounded OOXML text and suffix is short
 const STL_SUFFIX_RE = /\s*stl:[abcdefghjkmnpqrstuvwxyz23456789]+\s*$/u;
-const SECT_PR_RE = /(<w:sectPr[^>]*>)/u;
+const SECT_PR_RE = /(?<sect><w:sectPr[^>]*>)/u;
 const CLOSING_BODY_RE = /<\/w:body>/u;
 const CLOSING_FTR_RE = /<\/w:ftr>/u;
 const STRIP_PATH_RE = /^.*\//u;
 const FOOTER_REL_RE =
-  /Id="([^"]+)"[^>]*Type="[^"]*\/footer"[^>]*Target="([^"]+)"/gu;
+  /Id="(?<id>[^"]+)"[^>]*Type="[^"]*\/footer"[^>]*Target="(?<target>[^"]+)"/gu;
 const DEFAULT_FOOTER_REF_RE =
-  /w:footerReference[^>]*w:type="default"[^>]*r:id="([^"]+)"/u;
+  /w:footerReference[^>]*w:type="default"[^>]*r:id="(?<rid>[^"]+)"/u;
 const PLACEHOLDER_REF_RE = /\{\{STELLA_REF\}\}/gu;
 const PLACEHOLDER_CODE_RE = /\{\{STELLA_CODE\}\}/gu;
 const PLACEHOLDER_ID_RE = /\{\{STELLA_ID\}\}/gu;
@@ -264,7 +264,10 @@ const upsertProperty = (xml: string, name: string, value: string): string => {
   const pidMatches = [...xml.matchAll(PID_RE)];
   let maxPid = 1;
   for (const match of pidMatches) {
-    maxPid = Math.max(maxPid, Number.parseInt(match[1] ?? "0", 10));
+    maxPid = Math.max(
+      maxPid,
+      Number.parseInt(match.groups?.["pid"] ?? "0", 10),
+    );
   }
   const prop = [
     `  <property fmtid="${FMTID}" pid="${maxPid + 1}"`,
@@ -481,8 +484,8 @@ const findExistingFooter = (
   // Build a map of relationship ID → target path
   const relMap = new Map<string, string>();
   for (const m of docRels.matchAll(FOOTER_REL_RE)) {
-    const id = m[1];
-    const target = m[2];
+    const id = m.groups?.["id"];
+    const target = m.groups?.["target"];
     if (id && target) {
       relMap.set(id, target);
     }
@@ -494,7 +497,7 @@ const findExistingFooter = (
 
   // Prefer the default footer reference from document.xml
   const defaultRef = DEFAULT_FOOTER_REF_RE.exec(docXml);
-  const rId = defaultRef?.[1];
+  const rId = defaultRef?.groups?.["rid"];
   const target = (rId ? relMap.get(rId) : null) ?? relMap.values().next().value;
 
   if (!target) {
@@ -637,7 +640,7 @@ const findAvailableFooterName = (archive: DocxArchive): string => {
 
 const findNextBookmarkId = (xml: string): string => {
   const ids = [...xml.matchAll(WID_RE)].map((m) =>
-    Number.parseInt(m[1] ?? "0", 10),
+    Number.parseInt(m.groups?.["id"] ?? "0", 10),
   );
   const max = ids.length > 0 ? Math.max(...ids) : -1;
   return String(max + 1);
@@ -707,7 +710,7 @@ const addFooterReference = (docXml: string, footerRId: string): string => {
 
   // If there's already a sectPr, add footer reference inside
   if (docXml.includes("<w:sectPr")) {
-    return docXml.replace(SECT_PR_RE, `$1\n    ${footerRef}`);
+    return docXml.replace(SECT_PR_RE, `$<sect>\n    ${footerRef}`);
   }
 
   // No sectPr: create one before </w:body>
@@ -783,7 +786,7 @@ const extractBookmarkText = (
   // Extract all <w:t> text
   const texts: string[] = [];
   for (const tMatch of region.matchAll(WT_TEXT_RE)) {
-    const text = tMatch[1];
+    const text = tMatch.groups?.["text"];
     if (text) {
       texts.push(text);
     }
@@ -796,7 +799,7 @@ const extractBookmarkText = (
 
   // Parse "2026/001/015.v3  stl:kx8mq2n4p3"
   const stlMatch = STL_CODE_RE.exec(fullText);
-  const verificationCode = stlMatch?.[1] ?? null;
+  const verificationCode = stlMatch?.groups?.["code"] ?? null;
 
   // Stamp is everything before "stl:"
   const stampPart = fullText.replace(STL_SUFFIX_RE, "").trim();

--- a/apps/api/src/lib/markdown/html-to-markdown.ts
+++ b/apps/api/src/lib/markdown/html-to-markdown.ts
@@ -2,10 +2,10 @@ import * as cheerio from "cheerio";
 import { isTag, isText } from "domhandler";
 import type { AnyNode, Element } from "domhandler";
 
-const INLINE_ESCAPE = /([\\`*_~[\]<>])/g;
+const INLINE_ESCAPE = /(?<ch>[\\`*_~[\]<>])/g;
 
 const escapeText = (text: string): string =>
-  text.replace(INLINE_ESCAPE, "\\$1");
+  text.replace(INLINE_ESCAPE, "\\$<ch>");
 
 const collapseWhitespace = (text: string): string => text.replace(/\s+/g, " ");
 
@@ -258,7 +258,10 @@ const renderBlock = (el: Element): string => {
       const codeEl = el.children.find(
         (c): c is Element => isTag(c) && tagNameOf(c) === "code",
       );
-      const lang = codeEl?.attribs["class"]?.match(/language-(\S+)/)?.[1] ?? "";
+      const lang =
+        codeEl?.attribs["class"]?.match(/language-(?<lang>\S+)/)?.groups?.[
+          "lang"
+        ] ?? "";
       const text = trimTrailingNewlines(rawText(codeEl ?? el));
       return `\`\`\`${lang}\n${text}\n\`\`\``;
     }

--- a/apps/api/src/lib/safe-outbound-fetch.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.ts
@@ -766,8 +766,10 @@ const isBlockedIPv6 = (host: string): boolean => {
     return true;
   }
 
-  const dotted = /^::(?:ffff:)?(\d{1,3}(?:\.\d{1,3}){3})$/u.exec(compressed);
-  const dottedIp = dotted?.[1];
+  const dotted = /^::(?:ffff:)?(?<dottedIp>\d{1,3}(?:\.\d{1,3}){3})$/u.exec(
+    compressed,
+  );
+  const dottedIp = dotted?.groups?.["dottedIp"];
   if (dottedIp !== undefined) {
     const ipv4 = parseIPv4(dottedIp);
     if (ipv4 && isBlockedIPv4(ipv4)) {
@@ -777,9 +779,12 @@ const isBlockedIPv6 = (host: string): boolean => {
 
   // The URL parser normalizes ::ffff:127.0.0.1 → ::ffff:7f00:1.
   // Decode the trailing two hextets back to four IPv4 octets.
-  const hex = /^::(?:ffff:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/u.exec(compressed);
-  const hexHigh = hex?.[1];
-  const hexLow = hex?.[2];
+  const hex =
+    /^::(?:ffff:)?(?<high>[0-9a-f]{1,4}):(?<low>[0-9a-f]{1,4})$/u.exec(
+      compressed,
+    );
+  const hexHigh = hex?.groups?.["high"];
+  const hexLow = hex?.groups?.["low"];
   if (hexHigh !== undefined && hexLow !== undefined) {
     const high = Number.parseInt(hexHigh, 16);
     const low = Number.parseInt(hexLow, 16);

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 
 const PREFIX_QUERY_TOKEN_LIMIT = 8;
 const ADVANCED_QUERY_OPERATOR_RE =
-  /(^|\s)(AND|OR|NOT)(\s|$)|(^|\s)-(?=\S)|["()]/u;
+  /(?:^|\s)(?:AND|OR|NOT)(?:\s|$)|(?:^|\s)-(?=\S)|["()]/u;
 const FILE_EXTENSION_RE = /^[\p{L}\p{N}]{1,10}$/u;
 
 const compact = (parts: readonly (string | null | undefined)[]): string =>

--- a/apps/api/src/lib/workflow/orphan-recovery.ts
+++ b/apps/api/src/lib/workflow/orphan-recovery.ts
@@ -2,7 +2,7 @@
 // Redis/DB/queue imports so the reconciler's logic is unit-testable and
 // importing it never triggers a connection or worker side effect.
 
-const RUNNING_LOCK_KEY = /^workflow:([^:]+):running$/u;
+const RUNNING_LOCK_KEY = /^workflow:(?<workspaceId>[^:]+):running$/u;
 
 /**
  * Extract the workspace id from a `workflow:<workspaceId>:running` lock
@@ -11,7 +11,7 @@ const RUNNING_LOCK_KEY = /^workflow:([^:]+):running$/u;
  * considered for reconciliation.
  */
 export const parseRunningLockWorkspaceId = (key: string): string | null =>
-  RUNNING_LOCK_KEY.exec(key)?.[1] ?? null;
+  RUNNING_LOCK_KEY.exec(key)?.groups?.["workspaceId"] ?? null;
 
 type OrphanSelectionInput = {
   candidateWorkspaceIds: readonly string[];

--- a/apps/api/src/scripts/adapter-health.ts
+++ b/apps/api/src/scripts/adapter-health.ts
@@ -159,9 +159,9 @@ const parseWindowArg = (args: readonly string[]): number => {
   if (!raw) {
     return 24;
   }
-  const match = /^(\d+)\s*h$/iu.exec(raw);
-  if (match?.[1]) {
-    return Number.parseInt(match[1], 10);
+  const match = /^(?<hours>\d+)\s*h$/iu.exec(raw);
+  if (match?.groups?.["hours"]) {
+    return Number.parseInt(match.groups["hours"], 10);
   }
   return 24;
 };

--- a/apps/api/src/scripts/backfill-fulltext.ts
+++ b/apps/api/src/scripts/backfill-fulltext.ts
@@ -40,7 +40,7 @@ const fetchCzSupremeFulltext = async (
     const html = await response.text();
 
     const parts = html.match(
-      /<font[^>]*face="Times New Roman"[^>]*>([\s\S]*?)<\/font>/giu,
+      /<font[^>]*face="Times New Roman"[^>]*>(?:[\s\S]*?)<\/font>/giu,
     );
     if (!parts || parts.length === 0) {
       return undefined;
@@ -73,14 +73,14 @@ const fetchCzSupremeAdminFulltext = async (
   documentUrl: string,
 ): Promise<string | undefined> => {
   // Extract document ID from URL like .../DokumentDetail/Index/744029
-  const idMatch = /\/(\d+)$/u.exec(documentUrl);
-  if (!idMatch?.[1]) {
+  const idMatch = /\/(?<id>\d+)$/u.exec(documentUrl);
+  if (!idMatch?.groups?.["id"]) {
     return undefined;
   }
 
   try {
     const response = await fetch(
-      `https://vyhledavac.nssoud.cz/DokumentOriginal/Text/${idMatch[1]}`,
+      `https://vyhledavac.nssoud.cz/DokumentOriginal/Text/${idMatch.groups["id"]}`,
       { signal: AbortSignal.timeout(15_000) },
     );
     if (!response.ok) {

--- a/apps/api/src/scripts/resolve-citations.ts
+++ b/apps/api/src/scripts/resolve-citations.ts
@@ -69,15 +69,15 @@ const normalizeCitation = (
   }
 
   // Czech: "sp. zn. 33 Cdo 2178/2018" → "33 Cdo 2178/2018"
-  const spZn = /^sp\.\s*zn\.\s*(.+)/iu.exec(trimmed);
-  if (spZn?.[1]) {
-    return { caseNumber: spZn[1].trim() };
+  const spZn = /^sp\.\s*zn\.\s*(?<caseNumber>.+)/iu.exec(trimmed);
+  if (spZn?.groups?.["caseNumber"]) {
+    return { caseNumber: spZn.groups["caseNumber"].trim() };
   }
 
   // Czech file number: "č. j. 5 As 123/2020" → "5 As 123/2020"
-  const cj = /^[čc]\.\s*j\.\s*(.+)/iu.exec(trimmed);
-  if (cj?.[1]) {
-    return { caseNumber: cj[1].trim() };
+  const cj = /^[čc]\.\s*j\.\s*(?<caseNumber>.+)/iu.exec(trimmed);
+  if (cj?.groups?.["caseNumber"]) {
+    return { caseNumber: cj.groups["caseNumber"].trim() };
   }
 
   // Czech collection: "č. 123/2020 Sb. rozh. tr." — no case number
@@ -86,9 +86,9 @@ const normalizeCitation = (
   }
 
   // Polish: "sygn. akt II CSK 123/20" → "II CSK 123/20"
-  const sygn = /^sygn\.\s*(?:akt\s+)?(.+)/iu.exec(trimmed);
-  if (sygn?.[1]) {
-    return { caseNumber: sygn[1].trim() };
+  const sygn = /^sygn\.\s*(?:akt\s+)?(?<caseNumber>.+)/iu.exec(trimmed);
+  if (sygn?.groups?.["caseNumber"]) {
+    return { caseNumber: sygn.groups["caseNumber"].trim() };
   }
 
   // Polish bare: "II CSK 123/20" — already a case number

--- a/apps/api/src/tests/load/upload-load.ts
+++ b/apps/api/src/tests/load/upload-load.ts
@@ -121,7 +121,9 @@ const authenticate = async (
 
   // Extract the session cookie name and value. Dev runs may use a
   // per-port cookie prefix so multiple localhost servers can coexist.
-  const match = /^([^=]*\.session_token)=([^;]+)/u.exec(setCookie);
+  const match = /^(?<name>[^=]*\.session_token)=(?<value>[^;]+)/u.exec(
+    setCookie,
+  );
   if (!match) {
     throw new FetchBoundaryError({
       url: response.url,
@@ -131,7 +133,7 @@ const authenticate = async (
     });
   }
 
-  return `${match[1]}=${match[2]}`;
+  return `${match.groups?.["name"]}=${match.groups?.["value"]}`;
 };
 
 // -- Upload --

--- a/apps/api/src/tests/security/auth-user-grants.test.ts
+++ b/apps/api/src/tests/security/auth-user-grants.test.ts
@@ -5,17 +5,18 @@ import nodePath from "node:path";
 import { AUTH_USER_STELLA_SELECT_COLUMN_NAMES } from "@/api/db/auth-schema";
 
 const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
-const SQL_IDENTIFIER_PATTERN = /"([^"]+)"|([a-z_][a-z0-9_]*)/giu;
+const SQL_IDENTIFIER_PATTERN =
+  /"(?<quoted>[^"]+)"|(?<unquoted>[a-z_][a-z0-9_]*)/giu;
 const GRANT_SELECT_COLUMN_PREFIX_PATTERN = /^GRANT\s+SELECT\s*\(/iu;
 const GRANT_SELECT_COLUMN_TABLE_PATTERN = /\)\s+ON\s+TABLE\s+/iu;
 
 const identifierNamesFromSql = (sqlList: string): string[] =>
   [...sqlList.matchAll(SQL_IDENTIFIER_PATTERN)].map((match) => {
-    if (match[1] !== undefined) {
-      return match[1];
+    if (match.groups?.["quoted"] !== undefined) {
+      return match.groups["quoted"];
     }
 
-    return match[2]?.toLowerCase() ?? "";
+    return match.groups?.["unquoted"]?.toLowerCase() ?? "";
   });
 
 const parseColumnList = (sqlList: string): string[] =>

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -47,7 +47,8 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   "legislation_index_jobs",
 ]);
 
-const SQL_IDENTIFIER_PATTERN = /"([^"]+)"|([a-z_][a-z0-9_]*)/giu;
+const SQL_IDENTIFIER_PATTERN =
+  /"(?<quoted>[^"]+)"|(?<unquoted>[a-z_][a-z0-9_]*)/giu;
 
 type RlsTableIntroduction = {
   migration: string;
@@ -56,11 +57,11 @@ type RlsTableIntroduction = {
 
 const identifierNamesFromSql = (sqlList: string): string[] =>
   [...sqlList.matchAll(SQL_IDENTIFIER_PATTERN)].map((match) => {
-    if (match[1] !== undefined) {
-      return match[1];
+    if (match.groups?.["quoted"] !== undefined) {
+      return match.groups["quoted"];
     }
 
-    return match[2]?.toLowerCase() ?? "";
+    return match.groups?.["unquoted"]?.toLowerCase() ?? "";
   });
 
 const tableNameFromSql = (sqlTarget: string): string | null =>

--- a/apps/api/src/tests/security/schema-invariants.test.ts
+++ b/apps/api/src/tests/security/schema-invariants.test.ts
@@ -29,9 +29,9 @@ const extractCheckValues = (
       Array.isArray(chunk.value)
     ) {
       const str = String(chunk.value[0] ?? "");
-      const match = /IN\s*\(([^)]+)\)/iu.exec(str);
-      if (match?.[1]) {
-        inList = match[1];
+      const match = /IN\s*\((?<inList>[^)]+)\)/iu.exec(str);
+      if (match?.groups?.["inList"]) {
+        inList = match.groups["inList"];
         break;
       }
     }

--- a/apps/api/src/tests/security/sse-auth-invariants.test.ts
+++ b/apps/api/src/tests/security/sse-auth-invariants.test.ts
@@ -4,7 +4,7 @@ import nodePath from "node:path";
 
 const REPO_ROOT = nodePath.join(import.meta.dirname, "../../../../..");
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx"]);
-const TEST_FILE_PATTERN = /\.(test|spec)\.tsx?$/u;
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.tsx?$/u;
 
 const listSourceFiles = (relativeDir: string): string[] => {
   const root = nodePath.join(REPO_ROOT, relativeDir);

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@stll\/ui\/(.*)/u,
-        replacement: path.join(monorepoRoot, "packages/ui/src/$1"),
+        find: /^@stll\/ui\/(?<rest>.*)/u,
+        replacement: path.join(monorepoRoot, "packages/ui/src/$<rest>"),
       },
       {
         find: "@stll/ui",
@@ -24,8 +24,8 @@ export default defineConfig({
         replacement: path.join(monorepoRoot, "packages/folio/src/index.ts"),
       },
       {
-        find: /^@stll\/docx-utils(.*)/u,
-        replacement: path.join(monorepoRoot, "packages/docx-utils/src$1"),
+        find: /^@stll\/docx-utils(?<rest>.*)/u,
+        replacement: path.join(monorepoRoot, "packages/docx-utils/src$<rest>"),
       },
     ],
   },

--- a/apps/web/e2e/specs/smoke.spec.ts
+++ b/apps/web/e2e/specs/smoke.spec.ts
@@ -5,5 +5,5 @@ test("authenticated session lands inside the app shell", async ({ page }) => {
   // Authenticated users never see /auth/*; the protected routes either render
   // or redirect deeper. toHaveURL auto-retries so client-side redirects can't
   // race a static URL assertion.
-  await expect(page).not.toHaveURL(/\/auth(\/|$)/u);
+  await expect(page).not.toHaveURL(/\/auth(?:\/|$)/u);
 });

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -21,7 +21,7 @@ test.beforeEach(({ page }) => {
 
 test("deployed app serves the authenticated shell", async ({ page }) => {
   await page.goto("/");
-  await expect(page).not.toHaveURL(/\/auth(\/|$)/u);
+  await expect(page).not.toHaveURL(/\/auth(?:\/|$)/u);
 });
 
 test("chat thread page renders for an entitlement-less owner", async ({

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -180,8 +180,8 @@ const DIRECTIVE_NAMES = new Set([
 ]);
 const DIRECTIVE_NAME_CHAR_RE = /[a-z_]/iu;
 // oxlint-disable-next-line sonarjs/slow-regex -- input is single-line paragraph text; linear backtracking only
-const PLACEHOLDER_RE = /\[\[([^\]]+?)\]\]/gu;
-const CLAUSE_HEADING_RE = /^@clause +\d+ *"([^"]*)" *$/iu;
+const PLACEHOLDER_RE = /\[\[(?<inner>[^\]]+?)\]\]/gu;
+const CLAUSE_HEADING_RE = /^@clause +\d+ *"(?<title>[^"]*)" *$/iu;
 const stripDirectivePrefix = (line: string): string => {
   const trimmed = line.trimStart();
   if (!trimmed.startsWith("@")) {
@@ -214,7 +214,7 @@ const cleanDirectiveText = (text: string): string => {
   const lines = text.split("\n").map((line) => {
     const clauseMatch = CLAUSE_HEADING_RE.exec(line);
     if (clauseMatch) {
-      return clauseMatch[1] ?? "";
+      return clauseMatch.groups?.["title"] ?? "";
     }
     return stripDirectivePrefix(line);
   });

--- a/apps/web/src/components/chat/streamdown-mention-link.tsx
+++ b/apps/web/src/components/chat/streamdown-mention-link.tsx
@@ -69,7 +69,7 @@ const DOCUMENT_MIME_BY_EXTENSION: Record<string, string> = {
   xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 };
 
-const ENTITY_EXTENSION_RE = /\.([A-Za-z0-9]{1,8})$/u;
+const ENTITY_EXTENSION_RE = /\.(?<ext>[A-Za-z0-9]{1,8})$/u;
 const FOLDER_LABEL_RE = /^(?:folder|složka|priečinok)\b/iu;
 const TASK_LABEL_RE = /^(?:task|úkol|úloha)\b/iu;
 
@@ -109,7 +109,7 @@ const getHttpUrl = (href: string): URL | null => {
 };
 
 const getDocumentMimeFromLabel = (label: string): string | null => {
-  const extension = ENTITY_EXTENSION_RE.exec(label.trim())?.at(1);
+  const extension = ENTITY_EXTENSION_RE.exec(label.trim())?.groups?.["ext"];
   if (!extension) {
     return null;
   }

--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -510,10 +510,10 @@ const findFolioBlockPage = (blockId: string): number | null => {
 
   // Direct fallback for `seq-NNNN` ids — those map to layout
   // block ids by extracting the numeric suffix.
-  const seqMatch = /^seq-(\d+)$/u.exec(blockId);
+  const seqMatch = /^seq-(?<seq>\d+)$/u.exec(blockId);
   if (seqMatch) {
     const direct = document.querySelector(
-      `.layout-page [data-block-id="block-${Number.parseInt(seqMatch[1] ?? "0", 10)}"]`,
+      `.layout-page [data-block-id="block-${Number.parseInt(seqMatch.groups?.["seq"] ?? "0", 10)}"]`,
     );
     if (direct) {
       const page = getPageNumberFromElement(direct);

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1187,7 +1187,7 @@ type SummaryBodyProps = {
   onCitationClick: (citationId: string) => void;
 };
 
-const CITATION_RE = /\[(\d+)\]/gu;
+const CITATION_RE = /\[(?<number>\d+)\]/gu;
 
 const SummaryBody = ({
   citations,
@@ -1202,7 +1202,7 @@ const SummaryBody = ({
 
   for (const match of text.matchAll(CITATION_RE)) {
     const start = match.index;
-    const numberText = match[1];
+    const numberText = match.groups?.["number"];
     const number = numberText ? Number(numberText) : Number.NaN;
     const citation = citationByNumber.get(number);
 

--- a/apps/web/src/components/usage/use-usage-limit.ts
+++ b/apps/web/src/components/usage/use-usage-limit.ts
@@ -189,9 +189,10 @@ export const parseAmounts = (
   if (!match) {
     return { required: 0, available: 0 };
   }
+  const { required, available } = match.groups ?? {};
   return {
-    required: Number.parseInt(match.groups?.["required"] ?? "0", 10),
-    available: Number.parseInt(match.groups?.["available"] ?? "0", 10),
+    required: Number.parseInt(required ?? "0", 10),
+    available: Number.parseInt(available ?? "0", 10),
   };
 };
 

--- a/apps/web/src/components/usage/use-usage-limit.ts
+++ b/apps/web/src/components/usage/use-usage-limit.ts
@@ -43,7 +43,8 @@ const INITIAL_STATE: ModalState = {
   reason: "usage_limit_exceeded",
 };
 
-const NEED_HAVE_PATTERN = /need\s+(\d+),\s+have\s+(\d+)/iu;
+const NEED_HAVE_PATTERN =
+  /need\s+(?<required>\d+),\s+have\s+(?<available>\d+)/iu;
 
 const isReason = (value: unknown): value is UsageLimitExceededReason =>
   value === "no_entitlement" ||
@@ -189,8 +190,8 @@ export const parseAmounts = (
     return { required: 0, available: 0 };
   }
   return {
-    required: Number.parseInt(match[1] ?? "0", 10),
-    available: Number.parseInt(match[2] ?? "0", 10),
+    required: Number.parseInt(match.groups?.["required"] ?? "0", 10),
+    available: Number.parseInt(match.groups?.["available"] ?? "0", 10),
   };
 };
 

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
@@ -23,7 +23,7 @@ const LETTER_OR_NUMBER_RE = /[\p{L}\p{N}]/u;
 // so users can search "rozhodol" and find the spaced heading.
 // Mirrors `collapseSpacedLetters` in the API pipeline.
 const SPACED_LETTER_RUN_RE =
-  /(?<=\s|^)(\p{L} (?:\p{L} )*\p{L})( ?[,:;.!?])?(?=\s|$)/gu;
+  /(?<=\s|^)(?:\p{L} (?:\p{L} )*\p{L})(?: ?[,:;.!?])?(?=\s|$)/gu;
 
 type NormalizedText = {
   endMap: number[];

--- a/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
@@ -20,11 +20,10 @@ const MONOLINGUAL_COUNTRIES = new Set(["CZE", "SVK", "POL", "AUT"]);
  */
 const humanizeSourceUrl = (url: string): string => {
   // Regional courts: API endpoint → public page
-  const finaldocMatch = /rozhodnuti\.justice\.cz\/api\/finaldoc\/(.+)/u.exec(
-    url,
-  );
+  const finaldocMatch =
+    /rozhodnuti\.justice\.cz\/api\/finaldoc\/(?<id>.+)/u.exec(url);
   if (finaldocMatch) {
-    return `https://rozhodnuti.justice.cz/rozhodnuti/${finaldocMatch[1]}`;
+    return `https://rozhodnuti.justice.cz/rozhodnuti/${finaldocMatch.groups?.["id"]}`;
   }
   return url;
 };

--- a/apps/web/src/lib/anonymize/pdf-content-stream.ts
+++ b/apps/web/src/lib/anonymize/pdf-content-stream.ts
@@ -163,7 +163,7 @@ const neutraliseTextOperators = (
   // PDF generators may mix \r\n, \r, and \n in the same
   // stream; normalising to a single EOL changes byte
   // length and corrupts the stream.
-  const parts = content.split(/(\r\n|\r|\n)/u);
+  const parts = content.split(/(?<eol>\r\n|\r|\n)/u);
   // parts = [line0, eol0, line1, eol1, ..., lastLine]
   const lines: string[] = [];
   const eols: string[] = [];
@@ -205,22 +205,22 @@ const neutraliseTextOperators = (
     }
 
     // Track text position from Td/TD operators
-    const tdMatch = /^([\d.-]+)\s+([\d.-]+)\s+T[dD]$/u.exec(trimmed);
+    const tdMatch = /^(?<tx>[\d.-]+)\s+(?<ty>[\d.-]+)\s+T[dD]$/u.exec(trimmed);
     if (tdMatch) {
-      tx += Number(tdMatch[1]);
-      ty += Number(tdMatch[2]);
+      tx += Number(tdMatch.groups?.["tx"]);
+      ty += Number(tdMatch.groups?.["ty"]);
       result.push(line);
       continue;
     }
 
     // Track text position from Tm operator (set text matrix)
     const tmMatch =
-      /^[\d.-]+\s+[\d.-]+\s+[\d.-]+\s+[\d.-]+\s+([\d.-]+)\s+([\d.-]+)\s+Tm$/u.exec(
+      /^[\d.-]+\s+[\d.-]+\s+[\d.-]+\s+[\d.-]+\s+(?<tx>[\d.-]+)\s+(?<ty>[\d.-]+)\s+Tm$/u.exec(
         trimmed,
       );
     if (tmMatch) {
-      tx = Number(tmMatch[1]);
-      ty = Number(tmMatch[2]);
+      tx = Number(tmMatch.groups?.["tx"]);
+      ty = Number(tmMatch.groups?.["ty"]);
       result.push(line);
       continue;
     }

--- a/apps/web/src/lib/anonymize/pdf-redact.ts
+++ b/apps/web/src/lib/anonymize/pdf-redact.ts
@@ -240,10 +240,12 @@ export const redactPdf = async (
         // If still too wide at MIN size, abbreviate
         if (!fitsAtSize(displayText, size)) {
           // [CZECH_BIRTH_NUMBER_1] → [CZE_B_N_1]
-          const m = /^\[(.+?)(?:_(\d+))?\]$/u.exec(displayText);
+          const m = /^\[(?<label>.+?)(?:_(?<suffix>\d+))?\]$/u.exec(
+            displayText,
+          );
           if (m) {
-            const label = m[1] ?? "";
-            const suffix = m[2] ?? "";
+            const label = m.groups?.["label"] ?? "";
+            const suffix = m.groups?.["suffix"] ?? "";
             const parts = label.split("_");
 
             // Try 3-letter abbreviation: [PER_1]

--- a/apps/web/src/lib/jurisdictions.ts
+++ b/apps/web/src/lib/jurisdictions.ts
@@ -57,7 +57,7 @@ const COUNTRY_CODE_BY_EMAIL_TLD = new Map<string, CountryCode>(
 );
 COUNTRY_CODE_BY_EMAIL_TLD.set("uk", "GB");
 
-const LOCALE_REGION_PATTERN = /[-_]([A-Za-z]{2})\b/u;
+const LOCALE_REGION_PATTERN = /[-_](?<region>[A-Za-z]{2})\b/u;
 
 export const createCountryOptions = (locale: string): CountryOption[] => {
   const names = new Intl.DisplayNames([locale], { type: "region" });
@@ -85,7 +85,8 @@ export const suggestedCountryCodes = ({
   locale: string;
 }): CountryCode[] => {
   const suggestions: string[] = [];
-  const regionFromLocale = LOCALE_REGION_PATTERN.exec(locale)?.at(1);
+  const regionFromLocale =
+    LOCALE_REGION_PATTERN.exec(locale)?.groups?.["region"];
   const emailTld = email.split(".").at(-1)?.toLowerCase();
 
   if (regionFromLocale) {

--- a/apps/web/src/lib/matter-reference.ts
+++ b/apps/web/src/lib/matter-reference.ts
@@ -5,7 +5,7 @@
 export const DEFAULT_MATTER_NUMBER_PATTERN = "{SEQ}";
 export const DEFAULT_MATTER_NUMBER_PADDING = 3;
 
-const TOKEN_REGEX = /\{(SEQ|YYYY|YY|MM)\}/gu;
+const TOKEN_REGEX = /\{(?:SEQ|YYYY|YY|MM)\}/gu;
 
 const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 

--- a/apps/web/src/routes/_protected.knowledge/-components/paragraph-rendering.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/paragraph-rendering.tsx
@@ -2,7 +2,7 @@ import { useTranslations } from "use-intl";
 
 // ── Placeholder regex ────────────────────────────────
 
-const PLACEHOLDER_RE = /\{\{([^{}]+)\}\}/gu;
+const PLACEHOLDER_RE = /\{\{(?<inner>[^{}]+)\}\}/gu;
 
 // ── Types ────────────────────────────────────────────
 
@@ -28,7 +28,7 @@ export const HighlightedText = ({ text }: { text: string }) => {
       parts.push(text.slice(lastIndex, start));
     }
 
-    const inner = match[1] ?? "";
+    const inner = match.groups?.["inner"] ?? "";
     const isClauseSlot = inner.startsWith(CLAUSE_MARKER_PREFIX);
 
     parts.push(

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-body-markdown.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-body-markdown.ts
@@ -16,10 +16,10 @@
 const GUIDE_CALLOUT_LEAD = "💡 ";
 // The captured text is whitespace-normalised by the caller, so the pattern
 // keeps no `\s*` around the lazy capture (that ambiguity is backtracking-prone).
-const GUIDE_COMMENT_PATTERN = /<!--\s*guide:([\s\S]*?)-->/gu;
+const GUIDE_COMMENT_PATTERN = /<!--\s*guide:(?<text>[\s\S]*?)-->/gu;
 // One callout line: `> 💡 text`. Matched per line (toMarkdown renders a
 // single-line blockquote for a single-line quote paragraph).
-const GUIDE_CALLOUT_PATTERN = /^> 💡 (.*)$/gmu;
+const GUIDE_CALLOUT_PATTERN = /^> 💡 (?<text>.*)$/gmu;
 
 type SplitBody = {
   /** Frontmatter block including the closing `---` and trailing newline, or "". */
@@ -68,9 +68,10 @@ const calloutsToGuides = (md: string): string =>
 // emphasised, so the inner bold is redundant noise in the stored body. Strip it
 // only when it wraps the whole heading (a partial emphasis like `# Foo **bar**`
 // is intentional and left alone).
-const HEADING_WHOLE_BOLD_PATTERN = /^(#{1,6}) \*\*(.+?)\*\*$/gmu;
+const HEADING_WHOLE_BOLD_PATTERN =
+  /^(?<hashes>#{1,6}) \*\*(?<title>.+?)\*\*$/gmu;
 const stripRedundantHeadingBold = (md: string): string =>
-  md.replace(HEADING_WHOLE_BOLD_PATTERN, "$1 $2");
+  md.replace(HEADING_WHOLE_BOLD_PATTERN, "$<hashes> $<title>");
 
 /** Stored markdown → what the editor opens: frontmatter stripped, guides shown. */
 export const toEditorMarkdown = (raw: string): string =>

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -58,7 +58,7 @@ const SKILL_BODY_FILE_NAME = "SKILL.md";
 // Mirrors apps/api/src/handlers/skills/resources/resource-path.ts.
 // Keep the two in sync.
 const RESOURCE_PATH_PATTERN =
-  /^[a-z0-9][a-z0-9._-]*(\/[a-z0-9][a-z0-9._-]*)*$/u;
+  /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/u;
 const FILENAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
 
 // Default name for a freshly created (still empty) folder. A path segment,
@@ -585,7 +585,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
     // For binary uploads we replace the extension with `.md` because the
     // stored resource holds the extracted text, not the original bytes.
     const baseName = binary
-      ? `${file.name.replace(/\.(docx|pdf)$/iu, "")}.md`
+      ? `${file.name.replace(/\.(?:docx|pdf)$/iu, "")}.md`
       : file.name;
     const sanitizedName = baseName
       .toLowerCase()
@@ -603,7 +603,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
     let suffix = 1;
     while (existingPaths.has(path)) {
       suffix += 1;
-      path = `knowledge/${sanitizedName.replace(/(\.[^.]+)?$/u, `-${suffix}$1`)}`;
+      path = `knowledge/${sanitizedName.replace(/(?<ext>\.[^.]+)?$/u, `-${suffix}$<ext>`)}`;
     }
     if (binary) {
       uploadResource.mutate({ path, file });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input.tsx
@@ -7,10 +7,10 @@ import { cn } from "@stll/ui/lib/utils";
 
 const BILLING_INCREMENT = 6;
 
-const RE_HM = /^(?:(\d+)h)?\s*(?:(\d+)m)?$/iu;
-const RE_COLON = /^(\d+):(\d{1,2})$/u;
-const RE_DECIMAL = /^(\d+(?:\.\d+))$/u;
-const RE_PLAIN = /^(\d+)$/u;
+const RE_HM = /^(?:(?<hours>\d+)h)?\s*(?:(?<mins>\d+)m)?$/iu;
+const RE_COLON = /^(?<hours>\d+):(?<mins>\d{1,2})$/u;
+const RE_DECIMAL = /^(?<value>\d+(?:\.\d+))$/u;
+const RE_PLAIN = /^(?<value>\d+)$/u;
 
 /**
  * Parses a user-entered duration string into minutes.
@@ -25,28 +25,30 @@ const parseDuration = (raw: string): number | null => {
 
   // "1h30m" or "1h" or "30m"
   const hm = RE_HM.exec(s);
-  if (hm && (hm[1] || hm[2])) {
-    const hours = Number(hm[1] ?? 0);
-    const mins = Number(hm[2] ?? 0);
+  if (hm?.groups && (hm.groups["hours"] || hm.groups["mins"])) {
+    const hours = Number(hm.groups["hours"] ?? 0);
+    const mins = Number(hm.groups["mins"] ?? 0);
     return hours * 60 + mins;
   }
 
   // "1:30" (h:mm)
   const colon = RE_COLON.exec(s);
   if (colon) {
-    return Number(colon[1]) * 60 + Number(colon[2]);
+    return (
+      Number(colon.groups?.["hours"]) * 60 + Number(colon.groups?.["mins"])
+    );
   }
 
   // Decimal hours: "1.5"
   const decimal = RE_DECIMAL.exec(s);
   if (decimal) {
-    return Math.round(Number(decimal[1]) * 60);
+    return Math.round(Number(decimal.groups?.["value"]) * 60);
   }
 
   // Plain integer: treated as minutes
   const plain = RE_PLAIN.exec(s);
   if (plain) {
-    return Number(plain[1]);
+    return Number(plain.groups?.["value"]);
   }
 
   return null;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/import-organizer.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/import-organizer.logic.ts
@@ -3,7 +3,7 @@ const DATE_PATTERNS = [
   /(?:^|[\s._-])(?<day>0?[1-9]|[12]\d|3[01])[._-](?<month>0?[1-9]|1[0-2])[._-](?<year>20\d{2}|19\d{2})(?:$|[\s._-])/u,
 ] as const;
 
-const EXTENSION_PATTERN = /(\.[A-Za-z0-9]{1,12})$/u;
+const EXTENSION_PATTERN = /(?<ext>\.[A-Za-z0-9]{1,12})$/u;
 const RESERVED_PATH_CHARS = /[<>:"/\\|?*]/gu;
 const TOKEN_SEPARATORS = /[\s._-]+/gu;
 const MAX_SUGGESTED_FILENAME_LENGTH = 180;
@@ -143,7 +143,7 @@ const stripExtension = (fileName: string): string =>
 
 const getExtension = (fileName: string): string => {
   const match = EXTENSION_PATTERN.exec(fileName);
-  return match?.[1] ?? "";
+  return match?.groups?.["ext"] ?? "";
 };
 
 const sanitizePathSegment = (value: string): string =>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -432,10 +432,10 @@ const getExportFileName = (
     return null;
   }
 
-  const encodedMatch = /(?:^|;)\s*filename\*=UTF-8''([^;]+)/iu.exec(
+  const encodedMatch = /(?:^|;)\s*filename\*=UTF-8''(?<name>[^;]+)/iu.exec(
     contentDisposition,
   );
-  const encodedFileName = encodedMatch?.[1];
+  const encodedFileName = encodedMatch?.groups?.["name"];
   if (encodedFileName) {
     const decodedResult = Result.try(() => decodeURIComponent(encodedFileName));
     if (!Result.isError(decodedResult)) {
@@ -443,12 +443,18 @@ const getExportFileName = (
     }
   }
 
-  const quotedMatch = /(?:^|;)\s*filename="([^"]*)"/iu.exec(contentDisposition);
-  if (quotedMatch?.[1]) {
-    return quotedMatch[1];
+  const quotedMatch = /(?:^|;)\s*filename="(?<name>[^"]*)"/iu.exec(
+    contentDisposition,
+  );
+  if (quotedMatch?.groups?.["name"]) {
+    return quotedMatch.groups["name"];
   }
 
-  return /(?:^|;)\s*filename=([^;]+)/iu.exec(contentDisposition)?.[1] ?? null;
+  return (
+    /(?:^|;)\s*filename=(?<name>[^;]+)/iu.exec(contentDisposition)?.groups?.[
+      "name"
+    ] ?? null
+  );
 };
 
 type FilesystemOrganizerActionProps = {

--- a/apps/web/src/routes/_protected.workspaces/-filters/filter-pipeline.ts
+++ b/apps/web/src/routes/_protected.workspaces/-filters/filter-pipeline.ts
@@ -7,11 +7,11 @@ import type {
 } from "@/routes/_protected.workspaces/-types";
 
 export const parseLocalISODateMs = (value: string): number => {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(value);
+  const match = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u.exec(value);
   if (!match) {
     return Number.NaN;
   }
-  const [, year, month, day] = match;
+  const { year, month, day } = match.groups ?? {};
   return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
 };
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -481,6 +481,16 @@ export default defineConfig({
       rules: { "require-unicode-regexp": "off" },
     },
     {
+      // The tokenizer regex here is a standard quoted-string-with-escapes
+      // matcher (linear in practice). Naming its capture group to satisfy
+      // prefer-named-capture-group puts the line into the PR diff, which
+      // re-surfaces a CodeQL "polynomial regular expression" false positive
+      // on a pattern that already exists on main. Keep the regex byte-
+      // identical to main and disable the rule for this single-regex file.
+      files: ["packages/template-conditions/src/index.ts"],
+      rules: { "prefer-named-capture-group": "off" },
+    },
+    {
       // Case-law ingestion parsers/adapters intentionally encode many source
       // quirks. Tighten this after parser-specific refactors.
       files: ["apps/api/src/handlers/case-law/ingestion/**/*.ts"],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -179,16 +179,11 @@ export default defineConfig({
     "func-style": "off",
     "func-names": "off",
 
-    // Deferred: ultracite 7.8.3 promoted these to error. Each needs a
-    // dedicated, per-site review rather than a bulk autofix, so they are
-    // adopted in their own follow-up PRs:
-    //   - no-await-in-loop: many sequential awaits are intentional
-    //     (ordering, rate limits, transaction sequencing); parallelizing
-    //     would change behavior.
-    //   - prefer-named-capture-group: requires naming groups and rewriting
-    //     index-based match access.
+    // Deferred: ultracite 7.8.3 promoted no-await-in-loop to error. Many
+    // sequential awaits are intentional (ordering, rate limits, transaction
+    // sequencing); parallelizing would change behavior, so it is adopted in
+    // its own follow-up PR.
     "no-await-in-loop": "off",
-    "prefer-named-capture-group": "off",
 
     "typescript/no-inferrable-types": "off",
     "typescript/consistent-return": "error",

--- a/packages/business-registries/src/companies-house/validation.ts
+++ b/packages/business-registries/src/companies-house/validation.ts
@@ -26,15 +26,15 @@
 // Either a real two-letter prefix or the special-case `R0` (the only
 // prefix where the second character is a digit — see the
 // `CANONICAL_PATTERN` note below).
-const TWO_LETTER_PREFIX_PATTERN = /^(R0|[A-Z]{2})(\d{1,6})$/u;
+const TWO_LETTER_PREFIX_PATTERN = /^(?<prefix>R0|[A-Z]{2})(?<digits>\d{1,6})$/u;
 const ALL_DIGITS_PATTERN = /^\d{1,8}$/u;
 
 export const normalizeCompanyNumber = (input: string): string => {
   const upper = input.trim().replaceAll(/\s/gu, "").toUpperCase();
   const prefixed = TWO_LETTER_PREFIX_PATTERN.exec(upper);
   if (prefixed) {
-    const prefix = prefixed[1] ?? "";
-    const digits = prefixed[2] ?? "";
+    const prefix = prefixed.groups?.["prefix"] ?? "";
+    const digits = prefixed.groups?.["digits"] ?? "";
     return `${prefix}${digits.padStart(6, "0")}`;
   }
   if (ALL_DIGITS_PATTERN.test(upper)) {

--- a/packages/business-registries/src/gcis/parse.ts
+++ b/packages/business-registries/src/gcis/parse.ts
@@ -102,11 +102,11 @@ const parseRocDate = (input: string | undefined): string | null => {
   }
   const trimmed = input.trim();
   // Expect 6-7 digits: 2-3 year digits + 2 month + 2 day.
-  const match = /^(\d{1,3})(\d{2})(\d{2})$/u.exec(trimmed);
+  const match = /^(?<year>\d{1,3})(?<month>\d{2})(?<day>\d{2})$/u.exec(trimmed);
   if (!match) {
     return null;
   }
-  const [, yearStr, monthStr, dayStr] = match;
+  const { year: yearStr, month: monthStr, day: dayStr } = match.groups ?? {};
   if (!yearStr || !monthStr || !dayStr) {
     return null;
   }

--- a/packages/business-registries/src/recherche-entreprises/validation.ts
+++ b/packages/business-registries/src/recherche-entreprises/validation.ts
@@ -28,4 +28,4 @@ export const validateSiret = (input: string): boolean =>
 // Cheap shape-only check used by the dispatch layer's `isCanonicalId`
 // (which deliberately does not validate checksums — see dispatch.ts).
 export const hasCanonicalShape = (input: string): boolean =>
-  /^(\d{9}|\d{14})$/u.test(normalizeSiren(input));
+  /^(?:\d{9}|\d{14})$/u.test(normalizeSiren(input));

--- a/packages/business-registries/src/vies/validation.ts
+++ b/packages/business-registries/src/vies/validation.ts
@@ -94,11 +94,11 @@ export type ParsedVatNumber = {
  */
 export const parseVatNumber = (input: string): ParsedVatNumber | null => {
   const compact = normalizeVatNumber(input);
-  const match = /^([A-Z]{2})([A-Z0-9+*]+)$/u.exec(compact);
+  const match = /^(?<country>[A-Z]{2})(?<vat>[A-Z0-9+*]+)$/u.exec(compact);
   if (!match) {
     return null;
   }
-  const [, country, vat] = match;
+  const { country, vat } = match.groups ?? {};
   if (country === undefined || vat === undefined) {
     return null;
   }

--- a/packages/catalogue/scripts/generate-manifest.ts
+++ b/packages/catalogue/scripts/generate-manifest.ts
@@ -216,8 +216,9 @@ function pluralize(kind: (typeof CATALOGUE_KINDS)[number]): string {
 }
 
 function toImportName(kind: string, slug: string): string {
-  const camel = `${kind}-${slug}`.replace(/-([a-z0-9])/gu, (_, ch: string) =>
-    ch.toUpperCase(),
+  const camel = `${kind}-${slug}`.replace(
+    /-(?<ch>[a-z0-9])/gu,
+    (_, ch: string) => ch.toUpperCase(),
   );
   return camel.replace(/^[a-z]/u, (ch) => ch.toLowerCase());
 }

--- a/packages/docx-core/src/legal-source/compile.ts
+++ b/packages/docx-core/src/legal-source/compile.ts
@@ -256,7 +256,7 @@ const paragraph = (
 // reviewing lawyer sees at a glance everything still pending.
 // Surrounding text inherits the run options (bold/italic) but not
 // the highlight.
-const PLACEHOLDER_PATTERN = /\[\[([^\][]+?)\]\]/gu;
+const PLACEHOLDER_PATTERN = /\[\[(?<inner>[^\][]+?)\]\]/gu;
 
 const textRunsWithPlaceholders = (
   text: string,
@@ -272,7 +272,7 @@ const textRunsWithPlaceholders = (
     if (start > cursor) {
       runs.push(textRun(text.slice(cursor, start), options));
     }
-    const inner = match[1] ?? "";
+    const inner = match.groups?.["inner"] ?? "";
     runs.push(textRun(inner, options, { highlight: "yellow" }));
     cursor = start + match[0].length;
   }

--- a/packages/docx-core/src/legal-source/parser.ts
+++ b/packages/docx-core/src/legal-source/parser.ts
@@ -822,9 +822,9 @@ const parseSignatureParties = (
   });
 };
 
-const ORDERED_LIST_MARKER_RE = /^(\d+(?:\.\d+)+|\d+[.)])\s+/u;
+const ORDERED_LIST_MARKER_RE = /^(?:\d+(?:\.\d+)+|\d+[.)])\s+/u;
 const MANUAL_NUMBERING_PREFIX_RE =
-  /^(\d+(?:\.\d+)+|\d+[.)]|[A-Za-z][.)]|\([a-zivx]+\))\s+/u;
+  /^(?:\d+(?:\.\d+)+|\d+[.)]|[A-Za-z][.)]|\([a-zivx]+\))\s+/u;
 
 const stripListMarker = (line: string, ordered: boolean): string => {
   const trimmed = line.trim();

--- a/packages/docx-utils/src/relationships.ts
+++ b/packages/docx-utils/src/relationships.ts
@@ -1,9 +1,9 @@
 /** Find the next available rId in a relationships XML string */
 export const findNextRId = (relsXml: string): string => {
-  const matches = relsXml.matchAll(/Id="rId(\d+)"/gu);
+  const matches = relsXml.matchAll(/Id="rId(?<num>\d+)"/gu);
   let max = 0;
   for (const m of matches) {
-    const n = Number.parseInt(m[1] ?? "0", 10);
+    const n = Number.parseInt(m.groups?.["num"] ?? "0", 10);
     if (n > max) {
       max = n;
     }

--- a/packages/folio/src/components/hooks/useImageHandlers.ts
+++ b/packages/folio/src/components/hooks/useImageHandlers.ts
@@ -193,11 +193,13 @@ export const useImageHandlers = ({
       const currentTransform = expectImageAttrs(node).transform ?? "";
 
       // Parse current rotation and flip state
-      const rotateMatch = /rotate\((-?\d+(?:\.\d+)?)deg\)/u.exec(
+      const rotateMatch = /rotate\((?<degrees>-?\d+(?:\.\d+)?)deg\)/u.exec(
         currentTransform,
       );
-      // SAFETY: capture group [1] always present when regex matches
-      let rotation = rotateMatch ? Number.parseFloat(rotateMatch[1]!) : 0;
+      // SAFETY: `degrees` group always present when regex matches
+      let rotation = rotateMatch
+        ? Number.parseFloat(rotateMatch.groups!["degrees"]!)
+        : 0;
       let hasFlipH = currentTransform.includes("scaleX(-1)");
       let hasFlipV = currentTransform.includes("scaleY(-1)");
 

--- a/packages/folio/src/core/__tests__/layer-boundaries.test.ts
+++ b/packages/folio/src/core/__tests__/layer-boundaries.test.ts
@@ -71,7 +71,7 @@ const layerOfPath = (absolutePath: string): Layer | null => {
 // `specifier.startsWith(".")` check — only relative paths are checked. The
 // regex itself uses bounded character classes to keep matching linear.
 const IMPORT_REGEX =
-  /\bfrom\s*["']([^"']+)["']|\bimport\s*["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu;
+  /\bfrom\s*["'](?<fromSpec>[^"']+)["']|\bimport\s*["'](?<importSpec>[^"']+)["']|\bimport\s*\(\s*["'](?<dynImportSpec>[^"']+)["']\s*\)/gu;
 
 type EdgeViolation = {
   importer: string;
@@ -95,7 +95,10 @@ const violationsForSource = (
   }
   const violations: EdgeViolation[] = [];
   for (const match of source.matchAll(IMPORT_REGEX)) {
-    const specifier = match[1] ?? match[2] ?? match[3];
+    const specifier =
+      match.groups?.["fromSpec"] ??
+      match.groups?.["importSpec"] ??
+      match.groups?.["dynImportSpec"];
     if (specifier === undefined || !specifier.startsWith(".")) {
       continue;
     }

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -73,17 +73,18 @@ function formatDateForSdtBody(
 // to parse cleanly to be considered a date at all.
 const SDT_DATE_RE =
   // oxlint-disable-next-line sonarjs/regex-complexity -- ISO 8601 shape; see comment block above
-  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u;
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:[Tt](?<hours>\d{2}):(?<minutes>\d{2})(?::(?<seconds>\d{2})(?:\.\d+)?)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u;
 
 function parseSdtDate(iso: string): Date | null {
   const match = SDT_DATE_RE.exec(iso);
-  if (match) {
-    const year = Number(match[1]);
-    const month = Number(match[2]);
-    const day = Number(match[3]);
-    const hours = match[4] ? Number(match[4]) : 0;
-    const minutes = match[5] ? Number(match[5]) : 0;
-    const seconds = match[6] ? Number(match[6]) : 0;
+  if (match?.groups) {
+    const groups = match.groups;
+    const year = Number(groups["year"]);
+    const month = Number(groups["month"]);
+    const day = Number(groups["day"]);
+    const hours = groups["hours"] ? Number(groups["hours"]) : 0;
+    const minutes = groups["minutes"] ? Number(groups["minutes"]) : 0;
+    const seconds = groups["seconds"] ? Number(groups["seconds"]) : 0;
     const candidate = new Date(year, month - 1, day, hours, minutes, seconds);
     // Round-trip the captured components against what `Date` actually
     // stored. JS silently normalizes overflow ("2026-99-99" becomes a
@@ -186,7 +187,7 @@ function isRepeatingSection(control: BlockSdt): boolean {
 
 const REPEATING_SECTION_RE = /<\w+:repeatingSection\b/u;
 
-const DATA_BINDING_RE = /<\w+:dataBinding\b([^>]*)\/?>/iu;
+const DATA_BINDING_RE = /<\w+:dataBinding\b(?<attrs>[^>]*)\/?>/iu;
 
 /**
  * Detect a `<w:dataBinding w:xpath="…"/>` (or alt-prefix variant) inside
@@ -204,15 +205,15 @@ function readDataBinding(
   if (!match) {
     return null;
   }
-  const attrs = match[1] ?? "";
-  const xpathMatch = /\bxpath="([^"]*)"/iu.exec(attrs);
+  const attrs = match.groups?.["attrs"] ?? "";
+  const xpathMatch = /\bxpath="(?<xpath>[^"]*)"/iu.exec(attrs);
   if (!xpathMatch) {
     return null;
   }
-  const xpath = xpathMatch[1] ?? "";
-  const storeMatch = /\bstoreItemID="([^"]*)"/iu.exec(attrs);
+  const xpath = xpathMatch.groups?.["xpath"] ?? "";
+  const storeMatch = /\bstoreItemID="(?<storeItemID>[^"]*)"/iu.exec(attrs);
   if (storeMatch) {
-    return { xpath, storeItemID: storeMatch[1] ?? "" };
+    return { xpath, storeItemID: storeMatch.groups?.["storeItemID"] ?? "" };
   }
   return { xpath };
 }

--- a/packages/folio/src/core/docx/documentParser.ts
+++ b/packages/folio/src/core/docx/documentParser.ts
@@ -40,7 +40,7 @@ import type { XmlElement } from "./xmlParser";
 /**
  * Regular expression to match template variables {{...}}
  */
-const TEMPLATE_VARIABLE_REGEX = /\{([a-zA-Z_][a-zA-Z0-9_\-.]*)\}/gu;
+const TEMPLATE_VARIABLE_REGEX = /\{(?<name>[a-zA-Z_][a-zA-Z0-9_\-.]*)\}/gu;
 
 /**
  * Extract template variables from text
@@ -56,8 +56,8 @@ export function extractTemplateVariables(text: string): string[] {
   TEMPLATE_VARIABLE_REGEX.lastIndex = 0;
 
   while ((match = TEMPLATE_VARIABLE_REGEX.exec(text)) !== null) {
-    // SAFETY: capture group [1] always present when regex matches
-    const varName = match[1]!.trim();
+    // SAFETY: named group always present when regex matches
+    const varName = match.groups!["name"]!.trim();
     if (varName && !variables.includes(varName)) {
       variables.push(varName);
     }

--- a/packages/folio/src/core/docx/fieldParser.ts
+++ b/packages/folio/src/core/docx/fieldParser.ts
@@ -129,14 +129,14 @@ export function parseFieldType(instruction: string): FieldType {
 
   // Trim and extract the field name (first word, may have leading backslash)
   const trimmed = instruction.trim();
-  const match = /^\\?([A-Z][A-Z0-9]*)/iu.exec(trimmed);
+  const match = /^\\?(?<name>[A-Z][A-Z0-9]*)/iu.exec(trimmed);
 
   if (!match) {
     return "UNKNOWN";
   }
 
-  // SAFETY: match succeeded and group 1 always captures in this regex
-  const fieldName = match[1]!.toUpperCase();
+  // SAFETY: match succeeded and named group `name` always captures in this regex
+  const fieldName = match.groups!["name"]!.toUpperCase();
   return narrowEnum(fieldName, FieldTypeSchema) ?? "UNKNOWN";
 }
 
@@ -194,29 +194,31 @@ export function parseFieldInstruction(
   const switches: FieldSwitch[] = [];
 
   // Extract the field name part
-  const nameMatch = /^\\?([A-Z][A-Z0-9]*)/iu.exec(trimmed);
+  const nameMatch = /^\\?(?:[A-Z][A-Z0-9]*)/iu.exec(trimmed);
   const fieldNameEnd = nameMatch ? nameMatch[0].length : 0;
 
   // Everything after the field name
   const remaining = trimmed.slice(fieldNameEnd).trim();
 
   // Extract switches (start with \)
-  const switchRegex = /\\(\*|@|#|!|[a-z])\s*(?:"([^"]*)"|([\S]*))?/giu;
+  const switchRegex =
+    /\\(?<switch>\*|@|#|!|[a-z])\s*(?:"(?<quoted>[^"]*)"|(?<unquoted>[\S]*))?/giu;
   let switchMatch;
   const switchPositions: { start: number; end: number }[] = [];
 
   while ((switchMatch = switchRegex.exec(remaining)) !== null) {
+    const groups = switchMatch.groups!;
     const sw: FieldSwitch = {
-      // SAFETY: group 1 always captures in this regex pattern
-      switch: switchMatch[1]!,
+      // SAFETY: named group `switch` always captures in this regex pattern
+      switch: groups["switch"]!,
     };
 
-    if (switchMatch[2]) {
+    if (groups["quoted"]) {
       // Quoted value
-      sw.value = switchMatch[2];
-    } else if (switchMatch[3]) {
+      sw.value = groups["quoted"];
+    } else if (groups["unquoted"]) {
       // Unquoted value
-      sw.value = switchMatch[3];
+      sw.value = groups["unquoted"];
     }
 
     switches.push(sw);

--- a/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
+++ b/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
@@ -217,7 +217,8 @@ describe("header/footer part materialization on save", () => {
 
     const zip = await JSZip.loadAsync(out);
     const docXml = await zip.file("word/document.xml")!.async("text");
-    const refRId = /<w:headerReference[^>]*\br:id="([^"]+)"/u.exec(docXml)?.[1];
+    const refRId = /<w:headerReference[^>]*\br:id="(?<rid>[^"]+)"/u.exec(docXml)
+      ?.groups?.["rid"];
     expect(refRId).toBeDefined();
     // The section reference was re-pointed off the taken id to a fresh one...
     expect(refRId).not.toBe("rId_new_default");

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -142,7 +142,8 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
 
     // header2's imagedata rId must resolve in header2's own rels.
     const header2Xml = await zip.file("word/header2.xml")!.async("text");
-    const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
+    const usedRId = /<v:imagedata[^>]*\br:id="(?<rid>[^"]+)"/u.exec(header2Xml)
+      ?.groups?.["rid"];
     expect(usedRId).toBeDefined();
     expect(header2Rels).toContain(`Id="${usedRId}"`);
   });
@@ -288,7 +289,8 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
 
     const outZip = await JSZip.loadAsync(out);
     const header2Xml = await outZip.file("word/header2.xml")!.async("text");
-    const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
+    const usedRId = /<v:imagedata[^>]*\br:id="(?<rid>[^"]+)"/u.exec(header2Xml)
+      ?.groups?.["rid"];
     expect(usedRId).toBeDefined();
     const header2Rels = await outZip
       .file("word/_rels/header2.xml.rels")!
@@ -641,7 +643,8 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
 
     const outZip = await JSZip.loadAsync(out);
     const header2Xml = await outZip.file("word/header2.xml")!.async("text");
-    const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
+    const usedRId = /<v:imagedata[^>]*\br:id="(?<rid>[^"]+)"/u.exec(header2Xml)
+      ?.groups?.["rid"];
     expect(usedRId).toBeDefined();
     const header2Rels = await outZip
       .file("word/_rels/header2.xml.rels")!

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -64,9 +64,9 @@ export class DocxPackageFidelityError extends Error {
  */
 export function findMaxRId(relsXml: string): number {
   let maxId = 0;
-  for (const match of relsXml.matchAll(/Id="rId(\d+)"/gu)) {
-    // SAFETY: capture group [1] always present when regex matches
-    const id = Number.parseInt(match[1]!, 10);
+  for (const match of relsXml.matchAll(/Id="rId(?<id>\d+)"/gu)) {
+    // SAFETY: named group `id` always present when regex matches
+    const id = Number.parseInt(match.groups!["id"]!, 10);
     if (id > maxId) {
       maxId = id;
     }
@@ -87,12 +87,13 @@ const extractHeaderFooterReferences = (
   xml: string,
 ): HeaderFooterReference[] => {
   const references: HeaderFooterReference[] = [];
-  const pattern = /<w:(headerReference|footerReference)\b[^>]*>/gu;
+  const pattern = /<w:(?<element>headerReference|footerReference)\b[^>]*>/gu;
   for (const match of xml.matchAll(pattern)) {
     const tag = match[0];
-    const type = /\bw:type="([^"]+)"/u.exec(tag)?.at(1) ?? "default";
-    const rId = /\br:id="([^"]+)"/u.exec(tag)?.at(1);
-    const element = match[1];
+    const type =
+      /\bw:type="(?<type>[^"]+)"/u.exec(tag)?.groups?.["type"] ?? "default";
+    const rId = /\br:id="(?<rId>[^"]+)"/u.exec(tag)?.groups?.["rId"];
+    const element = match.groups?.["element"];
     if (
       !rId ||
       (element !== "headerReference" && element !== "footerReference")
@@ -273,18 +274,18 @@ async function readRelsOrStub(zip: JSZip, relsPath: string): Promise<string> {
   const file = zip.file(relsPath);
   const xml = file ? await file.async("text") : EMPTY_RELS_XML;
   return xml.replace(
-    /<Relationships([^>]*)\/>/u,
-    "<Relationships$1></Relationships>",
+    /<Relationships(?<attrs>[^>]*)\/>/u,
+    "<Relationships$<attrs>></Relationships>",
   );
 }
 
 function findMaxImageNum(zip: JSZip): number {
   let maxImageNum = 0;
   zip.forEach((relativePath) => {
-    const m = /^word\/media\/image(\d+)\./u.exec(relativePath);
+    const m = /^word\/media\/image(?<num>\d+)\./u.exec(relativePath);
     if (m) {
-      // SAFETY: capture group [1] always present when regex matches
-      const num = Number.parseInt(m[1]!, 10);
+      // SAFETY: named group `num` always present when regex matches
+      const num = Number.parseInt(m.groups!["num"]!, 10);
       if (num > maxImageNum) {
         maxImageNum = num;
       }
@@ -405,19 +406,22 @@ function decodeDataUrl(dataUrl: string): {
   data: ArrayBuffer;
   extension: string;
 } {
-  const match = /^data:([^;]+);base64,(.+)$/u.exec(dataUrl);
+  const match = /^data:(?<mime>[^;]+);base64,(?<data>.+)$/u.exec(dataUrl);
   if (!match) {
     panic("Invalid data URL");
   }
 
-  // SAFETY: capture groups [1] and [2] always present when regex matches
-  const binary = atob(match[2]!);
+  // SAFETY: named groups `mime` and `data` always present when regex matches
+  const binary = atob(match.groups!["data"]!);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.codePointAt(i) ?? 0;
   }
 
-  return { data: bytes.buffer, extension: MIME_TO_EXT[match[1]!] ?? "png" };
+  return {
+    data: bytes.buffer,
+    extension: MIME_TO_EXT[match.groups!["mime"]!] ?? "png",
+  };
 }
 
 /**
@@ -1256,10 +1260,10 @@ async function materializeNewHeaderFooterParts(
   // can never collide with another (possibly not-yet-materialized) part.
   let maxRId = 0;
   const considerNumericRId = (id: string): void => {
-    const match = /^rId(\d+)$/u.exec(id);
+    const match = /^rId(?<num>\d+)$/u.exec(id);
     if (match) {
-      // SAFETY: capture group [1] always present when the regex matches.
-      const n = Number.parseInt(match[1]!, 10);
+      // SAFETY: named group `num` always present when the regex matches.
+      const n = Number.parseInt(match.groups!["num"]!, 10);
       if (n > maxRId) {
         maxRId = n;
       }
@@ -1384,7 +1388,8 @@ async function materializeNewHeaderFooterParts(
   if (ctFile) {
     let ctXml = await ctFile.async("text");
     const missing = overrides.filter((override) => {
-      const partName = /PartName="([^"]+)"/u.exec(override)?.[1];
+      const partName = /PartName="(?<partName>[^"]+)"/u.exec(override)
+        ?.groups?.["partName"];
       return partName ? !ctXml.includes(`PartName="${partName}"`) : true;
     });
     if (missing.length > 0) {

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -128,18 +128,18 @@ function upsertSdtPrChild(
   // (`<ns0:sdtPr>...</ns0:sdtPr>`) doesn't end up with a mismatched
   // `</w:sdtPr>` — the resulting XML would be malformed and Word would
   // refuse the file.
-  const closing = /<\/(\w+):sdtPr>/iu;
+  const closing = /<\/(?<prefix>\w+):sdtPr>/iu;
   const closingMatch = closing.exec(raw);
   if (closingMatch) {
-    const closingPrefix = closingMatch[1];
+    const closingPrefix = closingMatch.groups?.["prefix"];
     return raw.replace(closing, `${replacement}</${closingPrefix}:sdtPr>`);
   }
   // Self-closing `<w:sdtPr/>` — expand to a container.
-  const selfClosingPr = /<(\w+):sdtPr([^/>]*)\/>/iu;
+  const selfClosingPr = /<(?<prefix>\w+):sdtPr(?<attrs>[^/>]*)\/>/iu;
   if (selfClosingPr.test(raw)) {
     return raw.replace(
       selfClosingPr,
-      (_match, prefix: string, attrs: string) =>
+      (_match: string, prefix: string, attrs: string) =>
         `<${prefix}:sdtPr${attrs}>${replacement}</${prefix}:sdtPr>`,
     );
   }
@@ -195,22 +195,24 @@ export function reconcileRawSdtPr(
     // would leave a stray closing tag behind). Then the self-closing
     // form, then folding into an existing <w14:checkbox> wrapper, then a
     // synthesized wrapper as the last resort.
-    const checkedOpened = /<(\w+):checked\b[^>]*>[\s\S]*?<\/\w+:checked>/iu;
-    const checkedSelfClosing = /<(\w+):checked\b[^>]*\/>/iu;
+    const checkedOpened = /<(?:\w+):checked\b[^>]*>[\s\S]*?<\/\w+:checked>/iu;
+    const checkedSelfClosing = /<(?:\w+):checked\b[^>]*\/>/iu;
     if (checkedOpened.test(next)) {
       next = next.replaceAll(
-        /<(\w+):checked\b[^>]*>[\s\S]*?<\/\w+:checked>/giu,
-        (_m, prefix: string) => `<${prefix}:checked ${prefix}:val="${val}"/>`,
+        /<(?<prefix>\w+):checked\b[^>]*>[\s\S]*?<\/\w+:checked>/giu,
+        (_match: string, prefix: string) =>
+          `<${prefix}:checked ${prefix}:val="${val}"/>`,
       );
     } else if (checkedSelfClosing.test(next)) {
       next = next.replaceAll(
-        /<(\w+):checked\b[^>]*\/>/giu,
-        (_m, prefix: string) => `<${prefix}:checked ${prefix}:val="${val}"/>`,
+        /<(?<prefix>\w+):checked\b[^>]*\/>/giu,
+        (_match: string, prefix: string) =>
+          `<${prefix}:checked ${prefix}:val="${val}"/>`,
       );
     } else if (/<\w+:checkbox\b[^>]*>/iu.test(next)) {
       next = next.replace(
-        /<(\w+):checkbox\b[^>]*>/iu,
-        (match, prefix: string) =>
+        /<(?<prefix>\w+):checkbox\b[^>]*>/iu,
+        (match: string, prefix: string) =>
           `${match}<${prefix}:checked ${prefix}:val="${val}"/>`,
       );
     } else {
@@ -230,8 +232,9 @@ export function reconcileRawSdtPr(
     const dateFormat = props.dateFormat;
     if (fullDate !== undefined || dateFormat !== undefined) {
       // Patch <w:date> in place when present, otherwise insert a fresh one.
-      const wDate = /<(\w+):date\b([^>]*)>([\s\S]*?)<\/\w+:date>/iu;
-      const wDateSelf = /<(\w+):date\b([^/>]*)\/>/iu;
+      const wDate =
+        /<(?<prefix>\w+):date\b(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\w+:date>/iu;
+      const wDateSelf = /<(?<prefix>\w+):date\b(?<attrs>[^/>]*)\/>/iu;
       const fullDateAttr =
         fullDate !== undefined
           ? ` w:fullDate="${escapeXmlAttr(fullDate)}"`
@@ -243,7 +246,12 @@ export function reconcileRawSdtPr(
       if (wDate.test(next)) {
         next = next.replace(
           wDate,
-          (_m, prefix: string, _attrs: string, inner: string) => {
+          (
+            _match: string,
+            prefix: string,
+            matchedAttrs: string,
+            inner: string,
+          ) => {
             // Remove any existing w:dateFormat, re-emit ours if provided.
             // Single alternation covers BOTH the self-closing form
             // (`<w:dateFormat …/>`) and the expanded-empty form
@@ -262,14 +270,14 @@ export function reconcileRawSdtPr(
             if (formatChild) {
               body = `${formatChild}${body}`;
             }
-            const attrs = fullDate !== undefined ? fullDateAttr : _attrs;
+            const attrs = fullDate !== undefined ? fullDateAttr : matchedAttrs;
             return `<${prefix}:date${attrs}>${body}</${prefix}:date>`;
           },
         );
       } else if (wDateSelf.test(next)) {
         next = next.replace(
           wDateSelf,
-          (_m, prefix: string) =>
+          (_match: string, prefix: string) =>
             `<${prefix}:date${fullDateAttr}>${formatChild}</${prefix}:date>`,
         );
       } else {
@@ -290,12 +298,19 @@ export function reconcileRawSdtPr(
   ) {
     const escapedValue = escapeXmlAttr(options.dropdownLastValue);
     const opened =
-      /<(\w+):(dropDownList|comboBox)\b([^>]*)>([\s\S]*?)<\/\w+:(?:dropDownList|comboBox)>/iu;
-    const selfClosing = /<(\w+):(dropDownList|comboBox)\b([^/>]*)\/>/iu;
+      /<(?<prefix>\w+):(?<name>dropDownList|comboBox)\b(?<attrs>[^>]*)>(?<inner>[\s\S]*?)<\/\w+:(?:dropDownList|comboBox)>/iu;
+    const selfClosing =
+      /<(?<prefix>\w+):(?<name>dropDownList|comboBox)\b(?<attrs>[^/>]*)\/>/iu;
     if (opened.test(next)) {
       next = next.replace(
         opened,
-        (_m, prefix: string, name: string, attrs: string, inner: string) => {
+        (
+          _match: string,
+          prefix: string,
+          name: string,
+          attrs: string,
+          inner: string,
+        ) => {
           const stripped = stripLastValueAttr(attrs);
           // Re-emit under the SOURCE prefix so a producer that bound w:
           // under `ns0` ends up with `ns0:lastValue` rather than mixing
@@ -306,7 +321,7 @@ export function reconcileRawSdtPr(
     } else if (selfClosing.test(next)) {
       next = next.replace(
         selfClosing,
-        (_m, prefix: string, name: string, attrs: string) => {
+        (_match: string, prefix: string, name: string, attrs: string) => {
           const stripped = stripLastValueAttr(attrs);
           return `<${prefix}:${name}${stripped} ${prefix}:lastValue="${escapedValue}"/>`;
         },

--- a/packages/folio/src/core/docx/selectiveSave.test.ts
+++ b/packages/folio/src/core/docx/selectiveSave.test.ts
@@ -263,11 +263,11 @@ describe("Selective XML Patch with real DOCX", () => {
     expect(count).toBeGreaterThan(0);
 
     // Try to find paraIds in the XML
-    const paraIdPattern = /w14:paraId="([^"]+)"/gu;
+    const paraIdPattern = /w14:paraId="(?<paraId>[^"]+)"/gu;
     const ids: string[] = [];
     let m: RegExpExecArray | null;
     while ((m = paraIdPattern.exec(xml)) !== null) {
-      ids.push(m[1]);
+      ids.push(m.groups?.["paraId"] ?? "");
     }
     expect(ids.length).toBeGreaterThan(0);
 
@@ -620,11 +620,11 @@ describe("buildPatchedDocumentXml with real DOCX XML", () => {
     const originalXml = await getDocumentXml(buffer);
 
     // Find all paraIds
-    const paraIdPattern = /w14:paraId="([^"]+)"/gu;
+    const paraIdPattern = /w14:paraId="(?<paraId>[^"]+)"/gu;
     const allIds: string[] = [];
     let m: RegExpExecArray | null;
     while ((m = paraIdPattern.exec(originalXml)) !== null) {
-      allIds.push(m[1]);
+      allIds.push(m.groups?.["paraId"] ?? "");
     }
 
     // Build a "serialized" version with one paragraph modified
@@ -1018,7 +1018,7 @@ describe("Selective save with headers/footers", () => {
     const zip = await JSZip.loadAsync(result);
     let found = false;
     for (const [filePath, file] of Object.entries(zip.files)) {
-      if (/word\/(header|footer)\d*\.xml/u.test(filePath)) {
+      if (/word\/(?:header|footer)\d*\.xml/u.test(filePath)) {
         const xml = await file.async("text");
         if (xml.includes("[HF_MODIFIED]")) {
           found = true;
@@ -1121,11 +1121,11 @@ describe("Selective save edge cases", () => {
     const xml = await getDocumentXml(buffer);
 
     // Count paraIds
-    const paraIdPattern = /w14:paraId="([^"]+)"/gu;
+    const paraIdPattern = /w14:paraId="(?<paraId>[^"]+)"/gu;
     const ids: string[] = [];
     let m: RegExpExecArray | null;
     while ((m = paraIdPattern.exec(xml)) !== null) {
-      ids.push(m[1]);
+      ids.push(m.groups?.["paraId"] ?? "");
     }
     expect(ids.length).toBeGreaterThan(50);
 

--- a/packages/folio/src/core/docx/selectiveXmlPatch.ts
+++ b/packages/folio/src/core/docx/selectiveXmlPatch.ts
@@ -138,11 +138,11 @@ export function countParagraphElements(xml: string): number {
  */
 function collectParaIds(xml: string): Map<string, number> {
   const ids = new Map<string, number>();
-  const pattern = /w14:paraId="([^"]+)"/gu;
+  const pattern = /w14:paraId="(?<id>[^"]+)"/gu;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(xml)) !== null) {
-    // SAFETY: capture group [1] always present when regex matches
-    const id = match[1]!;
+    // SAFETY: named group always present when regex matches
+    const id = match.groups!["id"]!;
     ids.set(id, (ids.get(id) ?? 0) + 1);
   }
   return ids;

--- a/packages/folio/src/core/docx/serializer/documentSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/documentSerializer.test.ts
@@ -9,7 +9,7 @@ import { serializeDocument } from "./documentSerializer";
 // compute twips as `inches * 1440`, which produces drift like
 // `0.7 * 1440 === 1008.0000000000001`.
 const ANY_DECIMAL_IN_TWIPS_ATTR =
-  /w:(top|right|bottom|left|header|footer|gutter|w|h|sz|space|num|countBy|start|distance)="-?\d+\.\d+"/u;
+  /w:(?:top|right|bottom|left|header|footer|gutter|w|h|sz|space|num|countBy|start|distance)="-?\d+\.\d+"/u;
 
 describe("document section properties are integer-only (issue #417)", () => {
   test("createEmptyDocument with fractional inches produces no float twips", () => {

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer-pPrMark.test.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer-pPrMark.test.ts
@@ -52,9 +52,9 @@ describe("serializeParagraph — paragraph-mark tracked change", () => {
 
     const xml = serializeParagraph(paragraph);
 
-    const rPrMatch = /<w:rPr>([\s\S]*?)<\/w:rPr>/u.exec(xml);
+    const rPrMatch = /<w:rPr>(?<inner>[\s\S]*?)<\/w:rPr>/u.exec(xml);
     expect(rPrMatch).not.toBeNull();
-    const inner = rPrMatch?.[1] ?? "";
+    const inner = rPrMatch?.groups?.["inner"] ?? "";
     const insIdx = inner.indexOf("<w:ins ");
     const boldIdx = inner.indexOf("<w:b/>");
     expect(insIdx).toBeGreaterThanOrEqual(0);

--- a/packages/folio/src/core/docx/watermarkParser.ts
+++ b/packages/folio/src/core/docx/watermarkParser.ts
@@ -632,7 +632,8 @@ function parseInlineStyleNumber(
   return Number.isFinite(num) ? num : undefined;
 }
 
-const CSS_LENGTH_RE = /^([+-]?(?:\d+|\d*\.\d+))(pt|in|cm|mm|px)?$/iu;
+const CSS_LENGTH_RE =
+  /^(?<amount>[+-]?(?:\d+|\d*\.\d+))(?<unit>pt|in|cm|mm|px)?$/iu;
 
 function parseInlineStyleLengthPt(
   style: string,
@@ -643,7 +644,7 @@ function parseInlineStyleLengthPt(
     return undefined;
   }
   const match = CSS_LENGTH_RE.exec(raw.trim());
-  const amountText = match?.at(1);
+  const amountText = match?.groups?.["amount"];
   if (amountText === undefined) {
     return undefined;
   }
@@ -651,7 +652,7 @@ function parseInlineStyleLengthPt(
   if (!Number.isFinite(amount) || amount <= 0) {
     return undefined;
   }
-  const unit = match?.at(2)?.toLowerCase() ?? "pt";
+  const unit = match?.groups?.["unit"]?.toLowerCase() ?? "pt";
   if (unit === "pt") {
     return amount;
   }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -278,8 +278,12 @@ export function resolveListTemplate(
   levelFormats: NumberFormat[] | undefined,
   forceDecimal = false,
 ): string {
-  return template.replace(/%(\d)([.):\]])?/gu, (_match, digit, punct = "") => {
-    const index = Number.parseInt(String(digit), 10) - 1;
+  return template.replace(/%(?<digit>\d)(?<punct>[.):\]])?/gu, (...args) => {
+    const { digit, punct = "" } = args.at(-1) as {
+      digit: string;
+      punct?: string;
+    };
+    const index = Number.parseInt(digit, 10) - 1;
     if (index < 0) {
       return "";
     }
@@ -287,7 +291,7 @@ export function resolveListTemplate(
       counters[index] ?? 0,
       forceDecimal ? "decimal" : levelFormats?.[index],
     );
-    return formatted ? `${formatted}${String(punct)}` : "";
+    return formatted ? `${formatted}${punct}` : "";
   });
 }
 

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -273,11 +273,11 @@ function parseRotationDegrees(transform: string | undefined): number {
   if (!transform) {
     return 0;
   }
-  const match = /rotate\(\s*([-\d.]+)\s*deg\s*\)/u.exec(transform);
+  const match = /rotate\(\s*(?<degrees>[-\d.]+)\s*deg\s*\)/u.exec(transform);
   if (!match) {
     return 0;
   }
-  const raw = Number.parseFloat(match[1]!);
+  const raw = Number.parseFloat(match.groups!["degrees"]!);
   if (!Number.isFinite(raw)) {
     return 0;
   }
@@ -354,9 +354,10 @@ function hasStackedMathLayout(run: MathRun): boolean {
   if (run.display === "block") {
     return true;
   }
-  const tagPattern = /<([A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?)(?:\s|\/|>)/gu;
+  const tagPattern =
+    /<(?<tag>[A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?)(?:\s|\/|>)/gu;
   for (const match of run.ommlXml.matchAll(tagPattern)) {
-    const tagName = match[1];
+    const tagName = match.groups?.["tag"];
     if (!tagName) {
       continue;
     }

--- a/packages/folio/src/core/layout-painter/renderPage-pageBorders.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage-pageBorders.test.ts
@@ -85,12 +85,12 @@ class FakeElement {
   }
 }
 
-const CLASS_SELECTOR_RE = /\.([\w-]+)/u;
+const CLASS_SELECTOR_RE = /\.(?<cls>[\w-]+)/u;
 
 const classFromSelector = (selector: string): string => {
   // Tests pass either `.layout-page-border` or `:scope > .layout-page-border`.
   const match = CLASS_SELECTOR_RE.exec(selector);
-  return match ? (match[1] ?? "") : selector;
+  return match ? (match.groups?.["cls"] ?? "") : selector;
 };
 
 const findByClass = (

--- a/packages/folio/src/core/layout-painter/renderPage-watermark-incremental.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage-watermark-incremental.test.ts
@@ -207,10 +207,10 @@ class FakeElement {
   }
 }
 
-const CLASS_SELECTOR_RE = /\.([\w-]+)/u;
+const CLASS_SELECTOR_RE = /\.(?<cls>[\w-]+)/u;
 
 const classFromSelector = (selector: string): string =>
-  CLASS_SELECTOR_RE.exec(selector)?.at(1) ?? "";
+  CLASS_SELECTOR_RE.exec(selector)?.groups?.["cls"] ?? "";
 
 const isScopeChild = (selector: string): boolean =>
   selector.includes(":scope >");

--- a/packages/folio/src/core/layout-painter/renderParagraph-decimal-tab.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-decimal-tab.test.ts
@@ -70,8 +70,10 @@ class FakeElement {
       measureText(text: string): { width: number } {
         // Parse "<weight?> <px>px <family>" — grab the numeric pixel size.
         // oxlint-disable-next-line sonarjs/slow-regex -- fixed font string from the test, linear backtracking only
-        const match = /(\d+(?:\.\d+)?)px/u.exec(ctx.font);
-        const fontSizePx = match ? Number(match[1]) : (11 * 96) / 72;
+        const match = /(?<size>\d+(?:\.\d+)?)px/u.exec(ctx.font);
+        const fontSizePx = match
+          ? Number(match.groups?.["size"])
+          : (11 * 96) / 72;
         // 1 char ≈ 0.5 em, so glyph width ≈ fontSizePx / 2.
         return { width: text.length * (fontSizePx / 2) };
       },

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -2019,13 +2019,13 @@ function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
   if (!match) {
     return true;
   }
-  if (match.groups?.["rtlMark"] !== undefined) {
+  const { rtlMark, lrmMark, letter } = match.groups ?? {};
+  if (rtlMark !== undefined) {
     return true; // RLM or ALM
   }
-  if (match.groups?.["lrmMark"] !== undefined) {
+  if (lrmMark !== undefined) {
     return false; // LRM
   }
-  const letter = match.groups?.["letter"];
   return letter !== undefined && RTL_STRONG_LETTER.test(letter);
 }
 

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -2014,17 +2014,19 @@ function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
   // letter (`\p{L}`). Digits, combining marks, punctuation and spaces are
   // weak/neutral and skipped. The first letter's script decides; nothing
   // strong => honor w:rtl.
-  const match = /(\u200F|\u061C)|(\u200E)|(\p{L})/u.exec(text);
+  const match =
+    /(?<rtlMark>\u200F|\u061C)|(?<lrmMark>\u200E)|(?<letter>\p{L})/u.exec(text);
   if (!match) {
     return true;
   }
-  if (match[1] !== undefined) {
+  if (match.groups?.["rtlMark"] !== undefined) {
     return true; // RLM or ALM
   }
-  if (match[2] !== undefined) {
+  if (match.groups?.["lrmMark"] !== undefined) {
     return false; // LRM
   }
-  return match[3] !== undefined && RTL_STRONG_LETTER.test(match[3]);
+  const letter = match.groups?.["letter"];
+  return letter !== undefined && RTL_STRONG_LETTER.test(letter);
 }
 
 /**

--- a/packages/folio/src/core/markdown/escape.ts
+++ b/packages/folio/src/core/markdown/escape.ts
@@ -16,14 +16,14 @@
  * when to escape those.
  */
 export function escapeInline(text: string): string {
-  let out = text.replace(/([\\`*[\]])/gu, "\\$1");
+  let out = text.replace(/(?<ch>[\\`*[\]])/gu, "\\$<ch>");
   // Underscore as emphasis marker: only at word boundaries.
-  out = out.replace(/(^|\s)_/gu, "$1\\_");
-  out = out.replace(/_(\s|$)/gu, "\\_$1");
+  out = out.replace(/(?<pre>^|\s)_/gu, "$<pre>\\_");
+  out = out.replace(/_(?<post>\s|$)/gu, "\\_$<post>");
   // Angle brackets only escaped when they form a plausible HTML tag — an
   // alphabetic name immediately followed by attributes/end. Prose like `x < y`
   // and `i < n` stays untouched.
-  out = out.replace(/<(\/?[A-Za-z][\w-]*)(?=[\s/>])/gu, "\\<$1");
+  out = out.replace(/<(?<tag>\/?[A-Za-z][\w-]*)(?=[\s/>])/gu, "\\<$<tag>");
   return out;
 }
 
@@ -61,5 +61,5 @@ export function escapeLinkUrl(url: string): string {
  * newlines so the alt stays single-line.
  */
 export function escapeAltText(text: string): string {
-  return text.replace(/([\\[\]])/gu, "\\$1").replace(/\r?\n/gu, " ");
+  return text.replace(/(?<ch>[\\[\]])/gu, "\\$<ch>").replace(/\r?\n/gu, " ");
 }

--- a/packages/folio/src/core/markdown/headings.ts
+++ b/packages/folio/src/core/markdown/headings.ts
@@ -18,7 +18,7 @@ export function parseHeadingLevel(styleId?: string): number | undefined {
   if (!styleId) {
     return undefined;
   }
-  const digit = /heading\s*(\d)/iu.exec(styleId)?.[1];
+  const digit = /heading\s*(?<level>\d)/iu.exec(styleId)?.groups?.["level"];
   if (digit) {
     return Number.parseInt(digit, 10);
   }

--- a/packages/folio/src/core/markdown/renderParagraph.ts
+++ b/packages/folio/src/core/markdown/renderParagraph.ts
@@ -63,9 +63,15 @@ function escapeLeadingBlockMarker(text: string): string {
   // a later line. Only horizontal whitespace `[ \t]` leads the marker so the
   // anchor doesn't cross the newline.
   return text
-    .replace(/^([ \t]*)([#>])/gmu, "$1\\$2")
-    .replace(/^([ \t]*)([-+*])([ \t])/gmu, "$1\\$2$3")
-    .replace(/^([ \t]*)(\d{1,9})([.)])([ \t])/gmu, "$1$2\\$3$4");
+    .replace(/^(?<ws>[ \t]*)(?<marker>[#>])/gmu, "$<ws>\\$<marker>")
+    .replace(
+      /^(?<ws>[ \t]*)(?<marker>[-+*])(?<after>[ \t])/gmu,
+      "$<ws>\\$<marker>$<after>",
+    )
+    .replace(
+      /^(?<ws>[ \t]*)(?<num>\d{1,9})(?<marker>[.)])(?<after>[ \t])/gmu,
+      "$<ws>$<num>\\$<marker>$<after>",
+    );
 }
 
 function renderListItem(

--- a/packages/folio/src/core/markdown/renderRuns.ts
+++ b/packages/folio/src/core/markdown/renderRuns.ts
@@ -99,7 +99,7 @@ function applyMarks(text: string, marks: MarkKey[]): string {
   // fence must be longer than the longest backtick run in the content, and a
   // space is padded inside when the content begins or ends with a backtick.
   if (marks.includes("code")) {
-    const literal = text.replace(/\\([\\`*[\]_<])/gu, "$1");
+    const literal = text.replace(/\\(?<char>[\\`*[\]_<])/gu, "$<char>");
     let longestRun = 0;
     for (const m of literal.matchAll(/`+/gu)) {
       longestRun = Math.max(longestRun, m[0].length);

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -243,7 +243,7 @@ function ensureSdtNotLocked(node: PMNode, options: ForceOption): void {
   }
 }
 
-const DATA_BINDING_RE = /<\w+:dataBinding\b([^>]*)\/?>/iu;
+const DATA_BINDING_RE = /<\w+:dataBinding\b(?<attrs>[^>]*)\/?>/iu;
 
 /**
  * Refuse content mutations on bound SDTs unless force; on force, return
@@ -263,14 +263,16 @@ function ensureContentNotBound(
     return { strippedRawPropertiesXml: undefined };
   }
   if (!options.force) {
-    const attrs = match[1] ?? "";
-    const xpathMatch = /\bxpath="([^"]*)"/iu.exec(attrs);
-    const storeMatch = /\bstoreItemID="([^"]*)"/iu.exec(attrs);
+    const attrs = match.groups?.["attrs"] ?? "";
+    const xpathMatch = /\bxpath="(?<xpath>[^"]*)"/iu.exec(attrs);
+    const storeMatch = /\bstoreItemID="(?<storeItemID>[^"]*)"/iu.exec(attrs);
     const props = attrsToProperties(node);
     throw new ContentControlBoundError({
-      message: `Control "${props.tag ?? props.alias ?? "(unnamed)"}" is bound to ${xpathMatch?.[1] ?? "(unknown xpath)"}. Word regenerates the body from the bound XML on open; pass { force: true } to strip the binding inline, or remove it explicitly before writing.`,
-      xpath: xpathMatch?.[1] ?? "",
-      ...(storeMatch?.[1] !== undefined ? { storeItemID: storeMatch[1] } : {}),
+      message: `Control "${props.tag ?? props.alias ?? "(unnamed)"}" is bound to ${xpathMatch?.groups?.["xpath"] ?? "(unknown xpath)"}. Word regenerates the body from the bound XML on open; pass { force: true } to strip the binding inline, or remove it explicitly before writing.`,
+      xpath: xpathMatch?.groups?.["xpath"] ?? "",
+      ...(storeMatch?.groups?.["storeItemID"] !== undefined
+        ? { storeItemID: storeMatch.groups["storeItemID"] }
+        : {}),
       ...(props.tag !== undefined ? { tag: props.tag } : {}),
       ...(props.alias !== undefined ? { alias: props.alias } : {}),
     });
@@ -517,17 +519,18 @@ function formatDateForBody(
 // particular the optional fractional-seconds group.
 const SDT_DATE_RE =
   // oxlint-disable-next-line sonarjs/regex-complexity -- mirrors headless helper
-  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u;
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:[Tt](?<hours>\d{2}):(?<minutes>\d{2})(?::(?<seconds>\d{2})(?:\.\d+)?)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u;
 
 function parseSdtDate(iso: string): Date | null {
   const match = SDT_DATE_RE.exec(iso);
   if (match) {
-    const year = Number(match[1]);
-    const month = Number(match[2]);
-    const day = Number(match[3]);
-    const hours = match[4] ? Number(match[4]) : 0;
-    const minutes = match[5] ? Number(match[5]) : 0;
-    const seconds = match[6] ? Number(match[6]) : 0;
+    const groups = match.groups!;
+    const year = Number(groups["year"]);
+    const month = Number(groups["month"]);
+    const day = Number(groups["day"]);
+    const hours = groups["hours"] ? Number(groups["hours"]) : 0;
+    const minutes = groups["minutes"] ? Number(groups["minutes"]) : 0;
+    const seconds = groups["seconds"] ? Number(groups["seconds"]) : 0;
     const candidate = new Date(year, month - 1, day, hours, minutes, seconds);
     // See headless helper: JS silently normalizes overflow components;
     // reject the parse when the result disagrees with what was asked for.

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -127,9 +127,9 @@ function parseTransformAttr(
     return undefined;
   }
   const transform: ImageTransform = {};
-  const rotateMatch = /rotate\(([-\d.]+)deg\)/u.exec(transformStr);
+  const rotateMatch = /rotate\((?<deg>[-\d.]+)deg\)/u.exec(transformStr);
   if (rotateMatch) {
-    const rotation = Number.parseFloat(rotateMatch[1]!);
+    const rotation = Number.parseFloat(rotateMatch.groups!["deg"]!);
     if (Number.isFinite(rotation)) {
       transform.rotation = rotation;
     }

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -84,7 +84,7 @@ function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
   }
   return Object.entries({ ...style, ...customStyle })
     .map(([key, value]) => {
-      const cssKey = key.replace(/([A-Z])/gu, "-$1").toLowerCase();
+      const cssKey = key.replace(/(?<char>[A-Z])/gu, "-$<char>").toLowerCase();
       return `${cssKey}: ${value}`;
     })
     .join("; ");

--- a/packages/folio/src/core/prosemirror/extensions/core/generateTOC.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/generateTOC.test.ts
@@ -114,9 +114,9 @@ describe("generateTOC", () => {
           node.type.name === "field" &&
           node.attrs["fieldType"] === "PAGEREF"
         ) {
-          target = /^PAGEREF (\S+) /u.exec(
+          target = /^PAGEREF (?<bookmark>\S+) /u.exec(
             node.attrs["instruction"] as string,
-          )?.[1];
+          )?.groups?.["bookmark"];
         }
       });
       expect(target).toBeDefined();

--- a/packages/folio/src/core/prosemirror/extensions/marks/BoldExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/BoldExtension.ts
@@ -28,7 +28,7 @@ export const BoldExtension = createMarkExtension({
       {
         style: "font-weight",
         getAttrs: (value) =>
-          /^(bold(er)?|[5-9]\d{2})$/u.test(value) ? null : false,
+          /^(?:bold(?:er)?|[5-9]\d{2})$/u.test(value) ? null : false,
       },
     ],
     toDOM() {

--- a/packages/folio/src/core/prosemirror/extensions/marks/FontSizeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/FontSizeExtension.ts
@@ -20,18 +20,20 @@ export const FontSizeExtension = createMarkExtension({
       {
         style: "font-size",
         getAttrs: (value) => {
-          const pxMatch = /^([\d.]+)px$/u.exec(value);
+          const pxMatch = /^(?<value>[\d.]+)px$/u.exec(value);
           if (pxMatch) {
-            // SAFETY: capture group [1] always present when regex matches
-            const px = Number.parseFloat(pxMatch[1] ?? "0");
+            // SAFETY: capture group always present when regex matches
+            const px = Number.parseFloat(pxMatch.groups?.["value"] ?? "0");
             const pt = px * 0.75;
             return { size: Math.round(pt * 2) };
           }
-          const ptMatch = /^([\d.]+)pt$/u.exec(value);
+          const ptMatch = /^(?<value>[\d.]+)pt$/u.exec(value);
           if (ptMatch) {
-            // SAFETY: capture group [1] always present when regex matches
+            // SAFETY: capture group always present when regex matches
             return {
-              size: Math.round(Number.parseFloat(ptMatch[1] ?? "0") * 2),
+              size: Math.round(
+                Number.parseFloat(ptMatch.groups?.["value"] ?? "0") * 2,
+              ),
             };
           }
           return false;

--- a/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
@@ -81,22 +81,23 @@ const readHighlightName = (value: string): HighlightColor | null => {
 
 export const normalizeCssColorKey = (value: string): string => {
   const compact = value.trim().toLowerCase().replace(/\s+/gu, "");
-  const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/u.exec(compact);
-  const hex = hexMatch?.[1];
+  const hexMatch = /^#(?<hex>[0-9a-f]{3}|[0-9a-f]{6})$/u.exec(compact);
+  const hex = hexMatch?.groups?.["hex"];
   if (hex) {
     return hex.length === 3
       ? `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
       : `#${hex}`;
   }
 
-  const rgbMatch = /^rgba?\((\d{1,3}),(\d{1,3}),(\d{1,3})(?:,[^)]+)?\)$/u.exec(
-    compact,
-  );
-  if (!rgbMatch) {
+  const rgbMatch =
+    /^rgba?\((?<red>\d{1,3}),(?<green>\d{1,3}),(?<blue>\d{1,3})(?:,[^)]+)?\)$/u.exec(
+      compact,
+    );
+  if (!rgbMatch?.groups) {
     return compact;
   }
 
-  const [, red, green, blue] = rgbMatch;
+  const { red, green, blue } = rgbMatch.groups;
   return `#${cssColorComponentToHex(red)}${cssColorComponentToHex(green)}${cssColorComponentToHex(blue)}`;
 };
 

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunShadingExtension.ts
@@ -40,9 +40,9 @@ export const RunShadingExtension = createMarkExtension({
           if (parseDOMHighlightColor(value)) {
             return false;
           }
-          const hex = /^#([0-9a-fA-F]{6})$/u.exec(
+          const hex = /^#(?<hex>[0-9a-fA-F]{6})$/u.exec(
             normalizeCssColorKey(value),
-          )?.[1];
+          )?.groups?.["hex"];
           return hex ? { rgb: hex.toUpperCase() } : false;
         },
       },

--- a/packages/folio/src/core/prosemirror/extensions/marks/TextColorExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TextColorExtension.ts
@@ -25,10 +25,12 @@ export const TextColorExtension = createMarkExtension({
       {
         style: "color",
         getAttrs: (value) => {
-          const hexMatch = /#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})/u.exec(value);
+          const hexMatch = /#(?<hex>[0-9a-fA-F]{6}|[0-9a-fA-F]{3})/u.exec(
+            value,
+          );
           if (hexMatch) {
-            // SAFETY: capture group [1] always present when regex matches
-            return { rgb: (hexMatch[1] ?? "").toUpperCase() };
+            // SAFETY: capture group always present when regex matches
+            return { rgb: (hexMatch.groups?.["hex"] ?? "").toUpperCase() };
           }
           return false;
         },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -112,25 +112,30 @@ function parseCssColorToColorValue(cssColor: string): ColorValue | null {
   if (!cssColor || cssColor === "transparent" || cssColor === "inherit") {
     return null;
   }
-  const hexMatch = /#([0-9a-fA-F]{6})/u.exec(cssColor);
+  const hexMatch = /#(?<hex>[0-9a-fA-F]{6})/u.exec(cssColor);
   if (hexMatch) {
-    // SAFETY: capture group 1 exists when match succeeds
-    return { rgb: (hexMatch[1] ?? "").toUpperCase() };
+    // SAFETY: capture group exists when match succeeds
+    return { rgb: (hexMatch.groups?.["hex"] ?? "").toUpperCase() };
   }
-  const shortHex = /#([0-9a-fA-F]{3})$/u.exec(cssColor);
+  const shortHex = /#(?<hex>[0-9a-fA-F]{3})$/u.exec(cssColor);
   if (shortHex) {
-    // SAFETY: capture group 1 exists when match succeeds
-    const hex3 = shortHex[1] ?? "";
+    // SAFETY: capture group exists when match succeeds
+    const hex3 = shortHex.groups?.["hex"] ?? "";
     // SAFETY: regex guarantees exactly 3 hex chars
     const r = hex3[0] ?? "";
     const g = hex3[1] ?? "";
     const b = hex3[2] ?? "";
     return { rgb: (r + r + g + g + b + b).toUpperCase() };
   }
-  const rgbMatch = /rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/u.exec(cssColor);
+  const rgbMatch =
+    /rgb\(\s*(?<r>\d+)\s*,\s*(?<g>\d+)\s*,\s*(?<b>\d+)\s*\)/u.exec(cssColor);
   if (rgbMatch) {
-    // SAFETY: capture groups 1-3 exist when the rgb() regex matches
-    const hex = [rgbMatch[1] ?? "0", rgbMatch[2] ?? "0", rgbMatch[3] ?? "0"]
+    // SAFETY: capture groups exist when the rgb() regex matches
+    const hex = [
+      rgbMatch.groups?.["r"] ?? "0",
+      rgbMatch.groups?.["g"] ?? "0",
+      rgbMatch.groups?.["b"] ?? "0",
+    ]
       .map((v) => Number.parseInt(v, 10).toString(16).padStart(2, "0"))
       .join("")
       .toUpperCase();

--- a/packages/folio/src/core/prosemirror/plugins/autocompleteSuggestion.ts
+++ b/packages/folio/src/core/prosemirror/plugins/autocompleteSuggestion.ts
@@ -387,8 +387,8 @@ export const acceptAutocompleteWord = (
   if (current.text.length === 0) {
     return { accepted: false };
   }
-  const match = /^(\s*\S+\s?)/u.exec(current.text);
-  const word = match === null ? current.text : match[1];
+  const match = /^(?<word>\s*\S+\s?)/u.exec(current.text);
+  const word = match === null ? current.text : match.groups?.["word"];
   if (word === undefined || word.length === 0) {
     return { accepted: false };
   }

--- a/packages/folio/src/core/utils/clipboard.ts
+++ b/packages/folio/src/core/utils/clipboard.ts
@@ -392,11 +392,13 @@ export function parseClipboardHtml(
   // If from our editor, try to parse internal format
   if (fromEditor) {
     // Look for internal data in HTML comments or data attributes
-    const internalMatch = /data-folio-content="([^"]+)"/.exec(html);
+    const internalMatch = /data-folio-content="(?<content>[^"]+)"/.exec(html);
     if (internalMatch) {
       try {
-        // SAFETY: match group 1 always captures in this regex
-        const runs = JSON.parse(decodeURIComponent(internalMatch[1]!));
+        // SAFETY: `content` group always captures when this regex matches
+        const runs = JSON.parse(
+          decodeURIComponent(internalMatch.groups!["content"]!),
+        );
         return { runs, fromWord: false, fromEditor: true, plainText };
       } catch {
         // Fall through to HTML parsing
@@ -704,12 +706,13 @@ function colorToHex(color: string): string | null {
   }
 
   // RGB/RGBA
-  const rgbMatch = /rgba?\((\d+),\s*(\d+),\s*(\d+)/.exec(color);
+  const rgbMatch = /rgba?\((?<r>\d+),\s*(?<g>\d+),\s*(?<b>\d+)/.exec(color);
   if (rgbMatch) {
-    // SAFETY: regex has 3 capture groups; all present when match succeeds
-    const r = Number.parseInt(rgbMatch[1]!, 10).toString(16).padStart(2, "0");
-    const g = Number.parseInt(rgbMatch[2]!, 10).toString(16).padStart(2, "0");
-    const b = Number.parseInt(rgbMatch[3]!, 10).toString(16).padStart(2, "0");
+    // SAFETY: `r`/`g`/`b` groups all present when match succeeds
+    const groups = rgbMatch.groups!;
+    const r = Number.parseInt(groups["r"]!, 10).toString(16).padStart(2, "0");
+    const g = Number.parseInt(groups["g"]!, 10).toString(16).padStart(2, "0");
+    const b = Number.parseInt(groups["b"]!, 10).toString(16).padStart(2, "0");
     return (r + g + b).toUpperCase();
   }
 

--- a/packages/folio/src/core/utils/headingCollector.ts
+++ b/packages/folio/src/core/utils/headingCollector.ts
@@ -31,10 +31,10 @@ export function collectHeadings(doc: PMNode): HeadingInfo[] {
 
       let effectiveLevel = level;
       if (effectiveLevel === null && styleId) {
-        const match = /^[Hh]eading(\d)$/u.exec(styleId);
+        const match = /^[Hh]eading(?<level>\d)$/u.exec(styleId);
         if (match) {
-          // SAFETY: capture group [1] always present when regex matches
-          effectiveLevel = Number.parseInt(match[1]!, 10) - 1;
+          // SAFETY: `level` group always present when regex matches
+          effectiveLevel = Number.parseInt(match.groups!["level"]!, 10) - 1;
         }
       }
 

--- a/packages/folio/src/core/utils/rotationBoundingBox.ts
+++ b/packages/folio/src/core/utils/rotationBoundingBox.ts
@@ -20,11 +20,11 @@ export function parseRotationDegrees(transform: string | undefined): number {
   if (!transform) {
     return 0;
   }
-  const match = /rotate\(\s*([-\d.]+)\s*deg\s*\)/iu.exec(transform);
+  const match = /rotate\(\s*(?<degrees>[-\d.]+)\s*deg\s*\)/iu.exec(transform);
   if (!match) {
     return 0;
   }
-  const raw = Number.parseFloat(match[1]!);
+  const raw = Number.parseFloat(match.groups!["degrees"]!);
   if (!Number.isFinite(raw)) {
     return 0;
   }

--- a/packages/infosoud/scripts/extract-codes.ts
+++ b/packages/infosoud/scripts/extract-codes.ts
@@ -88,9 +88,9 @@ const extractJavaScriptUrls = (html: string): string[] =>
   Array.from(
     new Set(
       Array.from(
-        html.matchAll(/(?:src|href)="([^"]+\.js(?:\?[^"]*)?)"/gu),
+        html.matchAll(/(?:src|href)="(?<url>[^"]+\.js(?:\?[^"]*)?)"/gu),
         (match) => {
-          const url = match[1];
+          const url = match.groups?.["url"];
           if (!url) {
             throw new TypeError("Matched script URL was unexpectedly empty");
           }
@@ -277,8 +277,8 @@ const normalizeJavaScriptStrings = (literal: string): string => {
 
 const toJsonObjectLiteral = (literal: string): string =>
   normalizeJavaScriptStrings(literal).replaceAll(
-    /([{,]\s*)([A-Za-z_][A-Za-z0-9_]*):/gu,
-    (_match, prefix: string, key: string) => `${prefix}"${key}":`,
+    /(?<prefix>[{,]\s*)(?<key>[A-Za-z_][A-Za-z0-9_]*):/gu,
+    (_match: string, prefix: string, key: string) => `${prefix}"${key}":`,
   );
 
 const parseCatalogObject = (

--- a/packages/infosoud/src/courts.ts
+++ b/packages/infosoud/src/courts.ts
@@ -61,8 +61,8 @@ export const normalizeCourtQuery = (value: string): string => {
     .trim()
     .toLocaleLowerCase("cs-CZ")
     .normalize("NFD")
-    .replaceAll(/([a-z])(\d)/gu, "$1 $2")
-    .replaceAll(/(\d)([a-z])/gu, "$1 $2")
+    .replaceAll(/(?<letter>[a-z])(?<digit>\d)/gu, "$<letter> $<digit>")
+    .replaceAll(/(?<digit>\d)(?<letter>[a-z])/gu, "$<digit> $<letter>")
     .replaceAll(/\p{Diacritic}/gu, "")
     .replaceAll(/[-–—,/]+/gu, " ")
     .replaceAll(/\s+/gu, " ");

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -548,8 +548,8 @@ export const parseForeignPortOwners = ({
     }
 
     const seen = new Set<number>();
-    for (const match of (portsField ?? "").matchAll(/:(\d+)->/gu)) {
-      const hostPort = Number.parseInt(match[1] ?? "", 10);
+    for (const match of (portsField ?? "").matchAll(/:(?<hostPort>\d+)->/gu)) {
+      const hostPort = Number.parseInt(match.groups?.["hostPort"] ?? "", 10);
       if (
         Number.isNaN(hostPort) ||
         !portSet.has(hostPort) ||
@@ -1214,13 +1214,13 @@ export const expandEnvMap = (
     visiting.add(key);
     const resolved = rawVal
       .replace(
-        /(?<!\\)\$(?:\{([^}]+)\}|([a-zA-Z_][a-zA-Z0-9_]*))/gu,
-        (_, p1, p2) => {
-          const varName = p1 || p2;
+        /(?<!\\)\$(?:\{(?<braced>[^}]+)\}|(?<bare>[a-zA-Z_][a-zA-Z0-9_]*))/gu,
+        (_, braced, bare) => {
+          const varName = braced || bare;
           return resolveKey(varName);
         },
       )
-      .replace(/\\(\$)/gu, "$1");
+      .replace(/\\(?<dollar>\$)/gu, "$<dollar>");
     visiting.delete(key);
     cache[key] = resolved;
     return resolved;

--- a/packages/skills/src/blueprints.test.ts
+++ b/packages/skills/src/blueprints.test.ts
@@ -12,7 +12,7 @@ const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/u;
 // starts alphanumeric. A `_guide.md`-style segment stores fine via the loader
 // but breaks rename/create later, so guard it here at authoring time.
 const FILE_TREE_PATH_PATTERN =
-  /^[a-z0-9][a-z0-9._-]*(\/[a-z0-9][a-z0-9._-]*)*$/u;
+  /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/u;
 
 describe("skill blueprints", () => {
   test("every advertised blueprint id resolves", () => {

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -54,7 +54,7 @@ type Token =
   | { type: "string"; raw: string };
 
 const TOKEN_RE =
-  /(?<token>"(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|[()]|[\p{L}\p{N}_.]+)/gu;
+  /(?<token>"[^"\\]*(?:\\.[^"\\]*)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|[()]|[\p{L}\p{N}_.]+)/gu;
 
 const STARTS_WITH_DIGIT_RE = /^\d/u;
 

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -54,14 +54,14 @@ type Token =
   | { type: "string"; raw: string };
 
 const TOKEN_RE =
-  /(?<token>"[^"\\]*(?:\\.[^"\\]*)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|[()]|[\p{L}\p{N}_.]+)/gu;
+  /("(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|[()]|[\p{L}\p{N}_.]+)/gu;
 
 const STARTS_WITH_DIGIT_RE = /^\d/u;
 
 const tokenize = (expr: string): Token[] => {
   const tokens: Token[] = [];
   for (const m of expr.matchAll(TOKEN_RE)) {
-    const raw = m.groups?.["token"] ?? m[0];
+    const raw = m[1] ?? m[0];
     if (raw === "and") {
       tokens.push({ type: "and" });
     } else if (raw === "or") {

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -54,14 +54,14 @@ type Token =
   | { type: "string"; raw: string };
 
 const TOKEN_RE =
-  /("(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|[()]|[\p{L}\p{N}_.]+)/gu;
+  /(?<token>"(?:[^"\\]|\\.)*"|==|!=|>=|<=|>|<|!(?!=)|and\b|or\b|[()]|[\p{L}\p{N}_.]+)/gu;
 
 const STARTS_WITH_DIGIT_RE = /^\d/u;
 
 const tokenize = (expr: string): Token[] => {
   const tokens: Token[] = [];
   for (const m of expr.matchAll(TOKEN_RE)) {
-    const raw = m[1] ?? m[0];
+    const raw = m.groups?.["token"] ?? m[0];
     if (raw === "and") {
       tokens.push({ type: "and" });
     } else if (raw === "or") {


### PR DESCRIPTION
## Summary

Adopts the `prefer-named-capture-group` oxlint rule, deferred from the ultracite 7.8.3 adoption in #751.

- Re-enables the rule in `oxlint.config.ts` (removed from the deferred-rules block).
- Fixes all ~373 in-scope violations across `apps/*` and `packages/*`:
  - Capture groups read by a consumer are named (`(?<name>...)`) and read via `match.groups["name"]` (the repo's `noPropertyAccessFromIndexSignature` requires bracket access).
  - Groups that exist only for grouping/alternation are made non-capturing (`(?:...)`).
- Behavior is preserved: replace-string backreferences switched to `$<name>`, replace callbacks use positional typed params, and index shifts were avoided by converting unused groups to non-capturing rather than deleting them.

`no-await-in-loop` (the other rule deferred in #751) remains off and will be adopted in its own follow-up PR.

## Validation

- `bun run lint` — 27/27 packages green (rule enforced, zero violations).
- Typecheck — clean across every changed package (api, web, folio, business-registries, infosoud, scripts, docx-core, docx-utils, template-conditions, skills, catalogue, playground).
- `bun run test` — 22/22 task suites pass (2635 tests), including the case-law ingestion parser tests that exercise the rewritten regexes.

Out of scope (not linted by CI, left unchanged): `apps/landing/src/pages/*.astro` and the `.oxlint-plugins` plugin source.
