### PR TITLE
fix(chat): keep system-prompt prefix cacheable across requests

### DIFF
--- a/apps/api/src/handlers/chat/chat-prompt.test.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.test.ts
@@ -102,7 +102,10 @@ describe("chat prompt builders", () => {
 
     expect(prompt).toContain("User registered as: Jan Kubica");
     expect(prompt).toContain("User UI language (BCP-47): cs");
-    expect(prompt).toContain("Current date/time:");
+    // Day granularity only: a minute-precise timestamp would change
+    // the prompt on every request and defeat prompt caching.
+    expect(prompt).toContain("Current date:");
+    expect(prompt).not.toMatch(/Current date:[^\n]*\d{1,2}:\d{2}/u);
   });
 
   test("keeps the cache-stable prefix independent from volatile user context", () => {
@@ -126,7 +129,7 @@ describe("chat prompt builders", () => {
     expect(first.cacheStablePrefix).toBe(second.cacheStablePrefix);
     expect(first.cacheStablePrefix).toContain("legal-interpretation");
     expect(first.cacheStablePrefix).not.toContain("First User");
-    expect(first.cacheStablePrefix).not.toContain("Current date/time");
+    expect(first.cacheStablePrefix).not.toContain("Current date");
     expect(first.fullPrompt).not.toBe(second.fullPrompt);
     expect(buildChatPromptCacheKey(first.cacheStablePrefix)).toBe(
       buildChatPromptCacheKey(second.cacheStablePrefix),

--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -39,7 +39,7 @@ import { readonlyWorkspaceFunctionContracts } from "@/api/handlers/chat/tools/ex
 import { CHAT_REFERENCE_HREF_PREFIXES } from "@/api/handlers/chat/types";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import type { SafeId } from "@/api/lib/branded-types";
-import { formatDateTimeInTimeZone } from "@/api/lib/date-format";
+import { formatDateInTimeZone } from "@/api/lib/date-format";
 import { DOCX_REVIEW_MARKUP_EXAMPLES } from "@/api/lib/docx-review-markup";
 import type { HandlerError } from "@/api/lib/errors/tagged-errors";
 
@@ -1242,7 +1242,7 @@ export const buildUserContextBlock = (userContext: UserContext | null) => {
 
   if (userContext.timezone) {
     lines.push(
-      `Current date/time: ${formatDateTimeInTimeZone({
+      `Current date: ${formatDateInTimeZone({
         timezone: userContext.timezone,
       })} (${userContext.timezone})`,
     );

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -48,6 +48,7 @@ import { repairActiveDocxEditToolCall } from "@/api/handlers/chat/tools/active-d
 import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import { hydrateFilePart } from "@/api/handlers/chat/upload-files";
+import { composeSystemWithCacheBoundary } from "@/api/lib/ai-caching";
 import { classifyAIError } from "@/api/lib/ai-error";
 import type { OrgAIConfig, ResolvedModelInfo } from "@/api/lib/ai-models";
 import {
@@ -420,10 +421,16 @@ export const streamChat = async ({
       },
     );
   }
-  const system =
-    preparedUntrusted.value.length > 0
-      ? `${systemSafe}${preparedUntrusted.value.startsWith("\n") ? "" : "\n\n"}${preparedUntrusted.value}`
-      : systemSafe;
+  // Keep the stable scaffold and the dynamic tail separable for the
+  // caching layer: the marker lets the middleware place the Anthropic
+  // cache breakpoint at the prefix boundary (so the volatile tail —
+  // user name, current date, matter / active-file context — does not
+  // invalidate the cached scaffold). Stripped to a plain concatenation
+  // for every other provider and when caching is off.
+  const system = composeSystemWithCacheBoundary({
+    cacheablePrefix: systemSafe,
+    dynamicTail: preparedUntrusted.value,
+  });
 
   const preparedMessages = await prepareMessagesForThirdParty({
     boundary: thirdPartyBoundary,

--- a/apps/api/src/lib/ai-caching.ts
+++ b/apps/api/src/lib/ai-caching.ts
@@ -46,3 +46,65 @@ export const markCacheBreakpoint = <P extends CacheablePart>(
     },
   };
 };
+
+/**
+ * In-band marker separating the cacheable system prefix from the
+ * dynamic, per-request system tail in the chat system prompt. The
+ * caching middleware in `ai-models.ts` consumes it before the payload
+ * reaches any provider: for Anthropic it splits the system into two
+ * consecutive system blocks (the stable prefix carries the cache
+ * breakpoint, the volatile tail — user name, current date, matter /
+ * active-file context — stays unmarked); for every other provider and
+ * whenever caching is off it is stripped, leaving a single system
+ * string byte-identical to a plain concatenation.
+ *
+ * Uses a private-use codepoint plus a literal tag so it cannot collide
+ * with real prompt text, and is visibly traceable if it ever leaks.
+ */
+export const SYSTEM_CACHE_BOUNDARY = "__stella_system_cache_boundary__";
+
+type SystemCacheParts = {
+  cacheablePrefix: string;
+  dynamicTail: string;
+};
+
+/**
+ * Join the cacheable system prefix and the dynamic system tail with
+ * the cache boundary marker. An empty tail yields just the prefix (no
+ * marker), matching the previous plain-concatenation behaviour.
+ */
+export const composeSystemWithCacheBoundary = ({
+  cacheablePrefix,
+  dynamicTail,
+}: SystemCacheParts): string => {
+  if (dynamicTail.length === 0) {
+    return cacheablePrefix;
+  }
+  const separator = dynamicTail.startsWith("\n") ? "" : "\n\n";
+  return `${cacheablePrefix}${SYSTEM_CACHE_BOUNDARY}${separator}${dynamicTail}`;
+};
+
+/**
+ * Split a composed system string back into its prefix and tail. When
+ * the marker is absent the whole string is the prefix and the tail is
+ * empty.
+ */
+export const splitSystemCacheBoundary = (system: string): SystemCacheParts => {
+  const index = system.indexOf(SYSTEM_CACHE_BOUNDARY);
+  if (index === -1) {
+    return { cacheablePrefix: system, dynamicTail: "" };
+  }
+  return {
+    cacheablePrefix: system.slice(0, index),
+    dynamicTail: system.slice(index + SYSTEM_CACHE_BOUNDARY.length),
+  };
+};
+
+/**
+ * Remove the boundary marker, yielding the plain concatenation
+ * (`cacheablePrefix` + separator + `dynamicTail`).
+ */
+export const stripSystemCacheBoundary = (system: string): string =>
+  system.includes(SYSTEM_CACHE_BOUNDARY)
+    ? system.split(SYSTEM_CACHE_BOUNDARY).join("")
+    : system;

--- a/apps/api/src/lib/ai-caching.ts
+++ b/apps/api/src/lib/ai-caching.ts
@@ -70,14 +70,18 @@ type SystemCacheParts = {
 
 /**
  * Join the cacheable system prefix and the dynamic system tail with
- * the cache boundary marker. An empty tail yields just the prefix (no
- * marker), matching the previous plain-concatenation behaviour.
+ * the cache boundary marker. An empty (or whitespace-only) tail yields
+ * just the prefix with no marker, matching the previous
+ * plain-concatenation behaviour.
  */
 export const composeSystemWithCacheBoundary = ({
   cacheablePrefix,
   dynamicTail,
 }: SystemCacheParts): string => {
-  if (dynamicTail.length === 0) {
+  // Whitespace-only tails (e.g. a global chat with no user context or
+  // installed skills) carry no content; treat them as empty so the
+  // split never emits a blank second system block.
+  if (dynamicTail.trim().length === 0) {
     return cacheablePrefix;
   }
   const separator = dynamicTail.startsWith("\n") ? "" : "\n\n";

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -1141,4 +1141,26 @@ describe("computeCachingParams system cache boundary", () => {
       systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
     ).toBeUndefined();
   });
+
+  test("a whitespace-only tail adds no boundary and yields one marked block", () => {
+    const whitespaceOnly = composeSystemWithCacheBoundary({
+      cacheablePrefix: "STABLE_SCAFFOLD",
+      dynamicTail: "\n\n",
+    });
+    expect(whitespaceOnly).toBe("STABLE_SCAFFOLD");
+
+    const result = computeCachingParams(
+      paramsWithSystem(whitespaceOnly),
+      "anthropic",
+      enabled,
+      "claude-sonnet-4-6",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(1);
+    expect(systems[0]?.content).toBe("STABLE_SCAFFOLD");
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toEqual({ type: "ephemeral" });
+  });
 });

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -9,6 +9,10 @@ import type {
 import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
+import {
+  composeSystemWithCacheBoundary,
+  SYSTEM_CACHE_BOUNDARY,
+} from "@/api/lib/ai-caching";
 import type { AIProvider, ModelRole, OrgAIConfig } from "@/api/lib/ai-models";
 import { type SafeId, toSafeId } from "@/api/lib/branded-types";
 
@@ -27,6 +31,7 @@ const {
   FALLBACK_FROM_SERVICE_TIER_PROVIDER_METADATA_KEY,
   SERVICE_TIER_PROVIDER_METADATA_KEY,
   STELLA_PROVIDER_METADATA_KEY,
+  computeCachingParams,
   createServiceTierMiddleware,
   defaultsForRole,
   getModelForRole,
@@ -992,5 +997,148 @@ describe("defaultsForRole", () => {
       const settings = settingsForRole(role, "openai");
       expect(settings.providerOptions).toBeUndefined();
     }
+  });
+});
+
+describe("computeCachingParams system cache boundary", () => {
+  const enabled = resolveCaching({
+    promptCachingEnabled: true,
+    role: "chat",
+    scopeKey: "thread-1",
+  });
+  const disabled = resolveCaching({
+    promptCachingEnabled: false,
+    role: "chat",
+    scopeKey: "thread-1",
+  });
+  const composed = composeSystemWithCacheBoundary({
+    cacheablePrefix: "STABLE_SCAFFOLD",
+    dynamicTail: "VOLATILE_TAIL",
+  });
+  const paramsWithSystem = (system: string): LanguageModelV3CallOptions => ({
+    prompt: [
+      { role: "system", content: system },
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ],
+  });
+  const systemMessages = (params: LanguageModelV3CallOptions) =>
+    params.prompt.filter((message) => message.role === "system");
+
+  test("anthropic splits the system at the boundary, marking only the prefix", () => {
+    const result = computeCachingParams(
+      paramsWithSystem(composed),
+      "anthropic",
+      enabled,
+      "claude-sonnet-4-6",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(2);
+    expect(systems[0]?.content).toBe("STABLE_SCAFFOLD");
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toEqual({ type: "ephemeral" });
+    expect(systems[1]?.content).toBe("\n\nVOLATILE_TAIL");
+    expect(
+      systems[1]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toBeUndefined();
+    for (const message of systems) {
+      expect(message.content).not.toContain(SYSTEM_CACHE_BOUNDARY);
+    }
+  });
+
+  test("anthropic without a boundary marks the single system block (back-compat)", () => {
+    const result = computeCachingParams(
+      paramsWithSystem("PLAIN_SYSTEM"),
+      "anthropic",
+      enabled,
+      "claude-sonnet-4-6",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(1);
+    expect(systems[0]?.content).toBe("PLAIN_SYSTEM");
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toEqual({ type: "ephemeral" });
+  });
+
+  test("non-anthropic providers strip the boundary to one clean block", () => {
+    const result = computeCachingParams(
+      paramsWithSystem(composed),
+      "openai",
+      enabled,
+      "gpt-5.4",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(1);
+    expect(systems[0]?.content).toBe("STABLE_SCAFFOLD\n\nVOLATILE_TAIL");
+    expect(systems[0]?.content).not.toContain(SYSTEM_CACHE_BOUNDARY);
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toBeUndefined();
+    expect(result.providerOptions?.["openai"]?.["promptCacheKey"]).toBeTypeOf(
+      "string",
+    );
+  });
+
+  test("caching off strips the boundary and all cache markers", () => {
+    const result = computeCachingParams(
+      paramsWithSystem(composed),
+      "anthropic",
+      disabled,
+      "claude-sonnet-4-6",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(1);
+    expect(systems[0]?.content).toBe("STABLE_SCAFFOLD\n\nVOLATILE_TAIL");
+    expect(systems[0]?.content).not.toContain(SYSTEM_CACHE_BOUNDARY);
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toBeUndefined();
+  });
+
+  test("openrouter splits the system for anthropic-family models", () => {
+    const result = computeCachingParams(
+      paramsWithSystem(composed),
+      "openrouter",
+      enabled,
+      "anthropic/claude-opus-4.8",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(2);
+    expect(systems[0]?.content).toBe("STABLE_SCAFFOLD");
+    // OpenRouter's converter reads `providerOptions.anthropic.cacheControl`
+    // for its Anthropic upstreams, so the native marker carries through.
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toEqual({ type: "ephemeral" });
+    expect(systems[1]?.content).toBe("\n\nVOLATILE_TAIL");
+    expect(
+      systems[1]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toBeUndefined();
+    for (const message of systems) {
+      expect(message.content).not.toContain(SYSTEM_CACHE_BOUNDARY);
+    }
+  });
+
+  test("openrouter strips the boundary for non-anthropic models", () => {
+    const result = computeCachingParams(
+      paramsWithSystem(composed),
+      "openrouter",
+      enabled,
+      "google/gemini-3.5-flash",
+    );
+    const systems = systemMessages(result);
+
+    expect(systems).toHaveLength(1);
+    expect(systems[0]?.content).toBe("STABLE_SCAFFOLD\n\nVOLATILE_TAIL");
+    expect(systems[0]?.content).not.toContain(SYSTEM_CACHE_BOUNDARY);
+    expect(
+      systems[0]?.providerOptions?.["anthropic"]?.["cacheControl"],
+    ).toBeUndefined();
   });
 });

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -828,7 +828,7 @@ const markAnthropicSystem = (
   prompt: CallOptions["prompt"],
 ): CallOptions["prompt"] =>
   prompt.flatMap((message): CallOptions["prompt"] => {
-    if (message.role !== "system") {
+    if (message.role !== "system" || typeof message.content !== "string") {
       return [message];
     }
     const { cacheablePrefix, dynamicTail } = splitSystemCacheBoundary(
@@ -864,7 +864,7 @@ const stripSystemCacheBoundaryFromPrompt = (
   prompt: CallOptions["prompt"],
 ): CallOptions["prompt"] =>
   prompt.map((message): PromptMessage => {
-    if (message.role !== "system") {
+    if (message.role !== "system" || typeof message.content !== "string") {
       return message;
     }
     const stripped = stripSystemCacheBoundary(message.content);

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -56,6 +56,10 @@ import type { AIProvider, BYOKProvider, ModelRole } from "@stll/ai-catalog";
 import type { UsageServiceTier } from "@/api/db/schema";
 import { env } from "@/api/env";
 import {
+  splitSystemCacheBoundary,
+  stripSystemCacheBoundary,
+} from "@/api/lib/ai-caching";
+import {
   AZURE_FOUNDRY_DEFAULT_API_VERSION,
   normalizeAzureFoundryBaseURL,
 } from "@/api/lib/azure-foundry";
@@ -810,20 +814,31 @@ const stripCacheMarkersFromPrompt = (
     };
   });
 
-const markAnthropicSystemEphemeral = (
+// Anthropic prompt caching, boundary-aware. A chat system prompt
+// carries `SYSTEM_CACHE_BOUNDARY` between its stable scaffold and its
+// volatile tail (user name, current date, matter / active-file
+// context). The provider groups consecutive system messages into the
+// top-level system array as one text block each, preserving per-block
+// cache_control — so emitting two system messages places the cache
+// breakpoint at the prefix boundary: the stable scaffold is cached
+// and the volatile tail no longer invalidates it. System prompts
+// without the marker (title generation, compaction, chat with no
+// dynamic tail) keep the previous single-block behaviour.
+const markAnthropicSystem = (
   prompt: CallOptions["prompt"],
 ): CallOptions["prompt"] =>
-  prompt.map((message) => {
+  prompt.flatMap((message): CallOptions["prompt"] => {
     if (message.role !== "system") {
-      return message;
+      return [message];
     }
+    const { cacheablePrefix, dynamicTail } = splitSystemCacheBoundary(
+      message.content,
+    );
     const existingMessageOptions = message.providerOptions ?? {};
     const existingAnthropic = existingMessageOptions["anthropic"] ?? {};
-    if (existingAnthropic["cacheControl"] !== undefined) {
-      return message;
-    }
-    return {
+    const markedPrefix = {
       ...message,
+      content: cacheablePrefix,
       providerOptions: {
         ...existingMessageOptions,
         anthropic: {
@@ -832,17 +847,60 @@ const markAnthropicSystemEphemeral = (
         },
       },
     };
+    if (dynamicTail.length > 0) {
+      return [markedPrefix, { ...message, content: dynamicTail }];
+    }
+    if (existingAnthropic["cacheControl"] !== undefined) {
+      return [message];
+    }
+    return [markedPrefix];
   });
 
-const computeCachingParams = (
+// Drop the boundary marker, collapsing the system back to a single
+// clean block (used for every non-Anthropic provider and whenever
+// caching is off). Yields a string byte-identical to a plain
+// scaffold + tail concatenation.
+const stripSystemCacheBoundaryFromPrompt = (
+  prompt: CallOptions["prompt"],
+): CallOptions["prompt"] =>
+  prompt.map((message): PromptMessage => {
+    if (message.role !== "system") {
+      return message;
+    }
+    const stripped = stripSystemCacheBoundary(message.content);
+    return stripped === message.content
+      ? message
+      : { ...message, content: stripped };
+  });
+
+// Providers whose system `cache_control` breakpoint we place
+// explicitly. Native Anthropic always honours it. OpenRouter forwards
+// `providerOptions.anthropic.cacheControl` to its upstreams (its
+// message converter falls back to the anthropic provider key), so
+// Anthropic-routed OpenRouter models (`anthropic/...`) get the same
+// prefix-boundary breakpoint. Other OpenRouter upstreams and every
+// other provider fall through to the strip path.
+const usesAnthropicSystemCaching = (
+  provider: AIProvider,
+  modelId: string,
+): boolean =>
+  provider === "anthropic" ||
+  (provider === "openrouter" && modelId.startsWith("anthropic/"));
+
+export const computeCachingParams = (
   params: CallOptions,
   provider: AIProvider,
   decision: CachingDecision,
+  modelId: string,
 ): CallOptions => {
   // OFF: strip every cache marker the caller may have set so the
   // wire payload carries no caching state regardless of provider.
+  // The system cache boundary marker is internal plumbing, so it is
+  // removed here too.
   if (!decision.enabled) {
-    const strippedPrompt = stripCacheMarkersFromPrompt(params.prompt);
+    const strippedPrompt = stripCacheMarkersFromPrompt(
+      stripSystemCacheBoundaryFromPrompt(params.prompt),
+    );
     const strippedProviderOptions = stripCacheMarkersFromProviderOptions(
       params.providerOptions,
     );
@@ -858,13 +916,14 @@ const computeCachingParams = (
   // ON: preserve caller-placed breakpoints (e.g. `markCacheBreakpoint`
   // on the document content in workflow extraction) and only add
   // baseline markers — Anthropic system cacheControl if absent,
-  // OpenAI promptCacheKey derived from scopeKey.
-  let nextPrompt = params.prompt;
+  // OpenAI promptCacheKey derived from scopeKey. The boundary marker
+  // splits the system into a cached prefix + unmarked tail for
+  // Anthropic-family models (native or via OpenRouter); every other
+  // provider/model gets it stripped so no marker reaches the wire.
   let nextProviderOptions = params.providerOptions;
-
-  if (provider === "anthropic") {
-    nextPrompt = markAnthropicSystemEphemeral(params.prompt);
-  }
+  const nextPrompt = usesAnthropicSystemCaching(provider, modelId)
+    ? markAnthropicSystem(params.prompt)
+    : stripSystemCacheBoundaryFromPrompt(params.prompt);
 
   if (
     (provider === "openai" || provider === "azure_foundry") &&
@@ -892,10 +951,13 @@ const computeCachingParams = (
 const cachingMiddleware = (
   provider: AIProvider,
   decision: CachingDecision,
+  modelId: string,
 ): SingleMiddleware => ({
   specificationVersion: "v3",
   transformParams: async ({ params }) =>
-    await Promise.resolve(computeCachingParams(params, provider, decision)),
+    await Promise.resolve(
+      computeCachingParams(params, provider, decision, modelId),
+    ),
 });
 
 // -- Provider service tier routing ------------------------------
@@ -1453,7 +1515,7 @@ const withInstrumentation = (
     middlewares.push(fixedSamplingMiddleware);
   }
   middlewares.push(
-    cachingMiddleware(ctx.provider, ctx.decision),
+    cachingMiddleware(ctx.provider, ctx.decision, ctx.modelId),
     createServiceTierMiddleware(ctx.serviceTierTarget, ctx.serviceTier, {
       allowFallbackToStandard: ctx.allowServiceTierFallback,
     }),

--- a/apps/api/src/lib/date-format.ts
+++ b/apps/api/src/lib/date-format.ts
@@ -23,6 +23,29 @@ export const formatDateTimeInTimeZone = ({
   }
 };
 
+/**
+ * Day-granularity variant of {@link formatDateTimeInTimeZone}. Used
+ * where the value lands in a cacheable prompt: a minute-precise
+ * timestamp would change the text on every request and defeat prompt
+ * caching, while the calendar date is all the model needs.
+ */
+export const formatDateInTimeZone = ({
+  date = new Date(),
+  timezone,
+}: FormatDateTimeInTimeZoneProps) => {
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(date);
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+};
+
 type FormatIsoDateForDisplayProps = {
   isoDate: string;
 };


### PR DESCRIPTION
The chat system prompt concatenated its stable scaffold and a dynamic tail (user context, current date, matter / active-file context) into a single block and placed the Anthropic cache breakpoint at the end, so any change in the tail invalidated the cached scaffold on every request.

- Split the system into a cacheable prefix + dynamic tail via an internal boundary marker. The caching middleware emits two Anthropic system blocks (prefix marked, tail unmarked) for Anthropic-family models (native and Anthropic-routed OpenRouter), and strips the marker to a single clean block — byte-identical to the previous concatenation — for every other provider and when caching is off.
- Reduce the date in the user-context block to day granularity so the tail no longer changes every minute.

Covered by unit tests in `ai-models.test.ts` (anthropic split, no-boundary back-compat, openrouter anthropic-family vs non-anthropic, openai strip, caching-off strip) and `chat-prompt.test.ts` (day-granularity).