### PR TITLE
refactor(lint): enforce no-await-in-loop

### DIFF
--- a/apps/api/scripts/backfill-image-thumbnails.ts
+++ b/apps/api/scripts/backfill-image-thumbnails.ts
@@ -71,6 +71,7 @@ const backfillEntityFields = async (): Promise<number> => {
   let enqueued = 0;
 
   for (;;) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: next page cursor depends on this batch
     const batch = await rootDb.execute<EntityFieldRow>(sql`
       SELECT
         f.id AS field_id,
@@ -104,6 +105,7 @@ const backfillEntityFields = async (): Promise<number> => {
         organizationId: row.organization_id,
         workspaceId: row.workspace_id,
       });
+      // oxlint-disable-next-line no-await-in-loop -- enqueue one job per row; jobId dedupe relies on processing rows in order
       await enqueueImageThumbnailOrMarkFailed({
         encrypted: row.encrypted,
         entityId: brandPersistedEntityId(row.entity_id),
@@ -132,6 +134,7 @@ const backfillChatFiles = async (): Promise<number> => {
   let generated = 0;
 
   for (;;) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: next page cursor depends on this batch
     const rows = await rootDb
       .select({
         id: userFiles.id,
@@ -155,6 +158,7 @@ const backfillChatFiles = async (): Promise<number> => {
     }
 
     for (const row of rows) {
+      // oxlint-disable-next-line no-await-in-loop -- bounded memory: read one source image from S3 at a time per row
       const source = await Result.tryPromise({
         try: async () => await getS3().file(row.s3Key).bytes(),
         catch: (cause) => cause,
@@ -164,6 +168,7 @@ const backfillChatFiles = async (): Promise<number> => {
         continue;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- bounded memory: resize one source image at a time per row
       const thumbnail = await generateImageThumbnail(source.value);
       if (Result.isError(thumbnail)) {
         console.warn(`  chat: skip ${row.id} (generate failed)`);
@@ -176,7 +181,9 @@ const backfillChatFiles = async (): Promise<number> => {
         mimeType: THUMBNAIL_MIME_TYPE,
         userId: row.userId,
       });
+      // oxlint-disable-next-line no-await-in-loop -- writes one thumbnail per row before patching the row; sequential keeps S3 write and DB update paired
       await getS3().write(thumbnailKey, thumbnail.value.webp);
+      // oxlint-disable-next-line no-await-in-loop -- compare-and-set row update depends on the just-written thumbnail object
       const updatedRows = await Result.tryPromise({
         try: async () =>
           await rootDb
@@ -189,10 +196,12 @@ const backfillChatFiles = async (): Promise<number> => {
         catch: (cause) => cause,
       });
       if (Result.isError(updatedRows)) {
+        // oxlint-disable-next-line no-await-in-loop -- best-effort S3 cleanup for this row before rethrowing
         await deleteThumbnailBestEffort(thumbnailKey);
         throw updatedRows.error;
       }
       if (updatedRows.value.length === 0) {
+        // oxlint-disable-next-line no-await-in-loop -- best-effort S3 cleanup for this row before continuing
         await deleteThumbnailBestEffort(thumbnailKey);
         continue;
       }

--- a/apps/api/scripts/benchmark-chat-read-surface.ts
+++ b/apps/api/scripts/benchmark-chat-read-surface.ts
@@ -1010,6 +1010,7 @@ const main = async () => {
     for (const surface of selectedSurfaces(args.surface)) {
       for (const task of tasks) {
         runs.push(
+          // oxlint-disable-next-line no-await-in-loop -- sequential benchmark runs; parallelism would distort per-task timings
           await runBenchTask({
             model: benchModel.model,
             repeat,

--- a/apps/api/scripts/classify-citations.ts
+++ b/apps/api/scripts/classify-citations.ts
@@ -78,6 +78,7 @@ const seedRules = async () => {
   console.log(`Seeding ${SEED_RULES.length} polarity rules...`);
 
   for (const rule of SEED_RULES) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order across rules
     await rootDb
       .insert(caseLawPolarityRules)
       .values({
@@ -162,6 +163,7 @@ const main = async () => {
     }
 
     try {
+      // oxlint-disable-next-line no-await-in-loop -- ordered, rate-limited backfill: classifies one citation at a time
       const result = await classifyCitation(
         context,
         citation.citationText,
@@ -179,11 +181,13 @@ const main = async () => {
       }
 
       if (!args.dryRun && result.source !== "fallback") {
+        // oxlint-disable-next-line no-await-in-loop -- ordered, rate-limited backfill: persists one citation's result at a time
         await persistPolarity(citation.id, result, scopedDb);
       }
 
       // Rate limit LLM calls
       if (result.source === "llm") {
+        // oxlint-disable-next-line no-await-in-loop -- ordered, rate-limited backfill: throttles sequential LLM calls
         await Bun.sleep(200);
       }
     } catch (error) {

--- a/apps/api/scripts/classify-local.ts
+++ b/apps/api/scripts/classify-local.ts
@@ -202,6 +202,7 @@ const readInput = async (args: Args): Promise<string> => {
     const decoder = new TextDecoder();
 
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential stream reads: each chunk depends on the previous read advancing the stdin reader
       const { done, value } = await reader.read();
       if (done) {
         break;

--- a/apps/api/scripts/ingestion-status.ts
+++ b/apps/api/scripts/ingestion-status.ts
@@ -43,12 +43,14 @@ console.log("\n=== Case Law Ingestion Status ===\n");
 
 for (const source of sources) {
   // Total decisions for this source
+  // oxlint-disable-next-line no-await-in-loop -- sequential status check; output is printed in order per source
   const [totalRow] = await rootDb
     .select({ total: count() })
     .from(caseLawDecisions)
     .where(eq(caseLawDecisions.sourceId, source.id));
 
   // Decisions inserted in last hour
+  // oxlint-disable-next-line no-await-in-loop -- sequential status check; output is printed in order per source
   const [hourRow] = await rootDb
     .select({
       inserted: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)`,
@@ -60,6 +62,7 @@ for (const source of sources) {
     );
 
   // Decisions inserted in last 24h
+  // oxlint-disable-next-line no-await-in-loop -- sequential status check; output is printed in order per source
   const [dayRow] = await rootDb
     .select({
       inserted: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)`,
@@ -71,6 +74,7 @@ for (const source of sources) {
     );
 
   // Recent failures count
+  // oxlint-disable-next-line no-await-in-loop -- sequential status check; output is printed in order per source
   const [failRow] = await rootDb
     .select({ total: count() })
     .from(caseLawIngestionFailures)
@@ -80,6 +84,7 @@ for (const source of sources) {
     );
 
   // Last event
+  // oxlint-disable-next-line no-await-in-loop -- sequential status check; output is printed in order per source
   const [lastEvent] = await rootDb
     .select({
       status: caseLawIngestionEvents.status,
@@ -95,6 +100,7 @@ for (const source of sources) {
     .limit(1);
 
   // Top failure types (last 24h)
+  // oxlint-disable-next-line no-await-in-loop -- sequential status check; output is printed in order per source
   const topFailures = await rootDb
     .select({
       errorType: caseLawIngestionFailures.errorType,

--- a/apps/api/scripts/seed-case-law.ts
+++ b/apps/api/scripts/seed-case-law.ts
@@ -108,6 +108,7 @@ const loadFixtures = async (): Promise<CaseLawFixture[]> => {
       continue;
     }
     const file = Bun.file(path.join(FIXTURES_DIR, entry));
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: read and parse one fixture file at a time
     const raw = v.parse(fixtureSchema, await file.json());
     // SAFETY: structural fields validated by fixtureSchema; deep JSON
     // (sections, document_ast, analysis) is checked into the repo
@@ -179,9 +180,11 @@ export async function seedCaseLaw() {
         columns: { id: true },
       });
 
+    // oxlint-disable-next-line no-await-in-loop -- per-fixture lookup decides whether to reuse or create the source
     const existingSource = await findSourceId();
     let sourceId = existingSource?.id;
     if (!sourceId) {
+      // oxlint-disable-next-line no-await-in-loop -- each fixture's source must exist before its decisions are inserted
       const inserted = await rootDb
         .insert(caseLawSources)
         .values({
@@ -199,6 +202,7 @@ export async function seedCaseLaw() {
       // it returns no rows and the actual source id is whatever
       // that writer set. Re-read so we don't FK-violate against a
       // deterministic id that does not match what's on disk.
+      // oxlint-disable-next-line no-await-in-loop -- conflict-recovery re-read when the insert raced and returned no rows
       sourceId = inserted.at(0)?.id ?? (await findSourceId())?.id;
       if (!sourceId) {
         panic(`Could not resolve source id for ${adapterKey}`);
@@ -211,6 +215,7 @@ export async function seedCaseLaw() {
       const fulltext =
         d.fulltext ?? d.sections?.map((s) => s.text).join("\n\n") ?? "";
 
+      // oxlint-disable-next-line no-await-in-loop -- FK dependency: each decision references the source resolved above
       const result = await rootDb
         .insert(caseLawDecisions)
         .values({
@@ -247,6 +252,7 @@ export async function seedCaseLaw() {
       // the actual row.
       let decisionId = result.at(0)?.id;
       if (!decisionId) {
+        // oxlint-disable-next-line no-await-in-loop -- conflict-recovery re-read for this decision's actual row id
         const existing = await rootDb
           .select({ id: caseLawDecisions.id })
           .from(caseLawDecisions)
@@ -266,6 +272,7 @@ export async function seedCaseLaw() {
         );
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- depends on the decision id resolved earlier this iteration
       await indexDecision(decisionId, scopedDb);
 
       if (result.length > 0) {

--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -3861,6 +3861,7 @@ export async function seed(organizationId?: string, userId?: string) {
   // 1. Contacts (original orgs + people)
   const coreContacts = [...orgContacts, ...personContacts];
   for (const c of coreContacts) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
     await rootDb
       .insert(contacts)
       .values({
@@ -3895,6 +3896,7 @@ export async function seed(organizationId?: string, userId?: string) {
   }
   // 1b. Additional org contacts for overview stress-testing
   for (const c of moreOrgContacts) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
     await rootDb
       .insert(contacts)
       .values({
@@ -3924,6 +3926,7 @@ export async function seed(organizationId?: string, userId?: string) {
 
   // 2. Workspaces
   for (const ws of seedWorkspaces) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(workspaces)
       .values({
@@ -3942,6 +3945,7 @@ export async function seed(organizationId?: string, userId?: string) {
   for (const mw of MORE_WORKSPACES) {
     const clientId = seedId(mw.clientLabel);
     const wsId = seedId(`extra-ws-${mw.reference}`);
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(workspaces)
       .values({
@@ -3966,6 +3970,7 @@ export async function seed(organizationId?: string, userId?: string) {
   ];
   for (const wsId of allWsIds) {
     for (const uid of seedUserIds) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
       await rootDb
         .insert(workspaceMembers)
         .values({
@@ -3993,6 +3998,7 @@ export async function seed(organizationId?: string, userId?: string) {
     allProperties.push(...buildProperties(wsId, label));
   }
   for (const prop of allProperties) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(properties)
       .values({
@@ -4030,6 +4036,7 @@ export async function seed(organizationId?: string, userId?: string) {
     allEntities.push(...buildEntities(wsId, label));
   }
   for (const [ei, e] of allEntities.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- entity row must exist before its version + currentVersion link below
     await rootDb
       .insert(entities)
       .values({
@@ -4043,6 +4050,7 @@ export async function seed(organizationId?: string, userId?: string) {
       })
       .onConflictDoNothing();
 
+    // oxlint-disable-next-line no-await-in-loop -- version row depends on the entity inserted just above
     await rootDb
       .insert(entityVersions)
       .values({
@@ -4053,9 +4061,11 @@ export async function seed(organizationId?: string, userId?: string) {
       .onConflictDoNothing();
 
     // Link currentVersionId
+    // oxlint-disable-next-line no-await-in-loop -- links the entity row to the version inserted in this same iteration
     await rootDb
       .update(entities)
       .set({ currentVersionId: e.versionId })
+      // oxlint-disable-next-line no-await-in-loop -- dynamic import of drizzle-orm eq() inside the where clause
       .where((await import("drizzle-orm")).eq(entities.id, e.entityId));
   }
   console.log(
@@ -4102,7 +4112,8 @@ export async function seed(organizationId?: string, userId?: string) {
 
       // ── S3 file ──
       const content = isDocx
-        ? await createMockDocx(title, docText)
+        ? // oxlint-disable-next-line no-await-in-loop -- bounded memory: build one document's bytes at a time
+          await createMockDocx(title, docText)
         : createMockPdf(title, docText);
 
       const sha256Hex = new Bun.CryptoHasher("sha256")
@@ -4111,6 +4122,7 @@ export async function seed(organizationId?: string, userId?: string) {
 
       const fileId = seedId(`${wsLabel}-file-${j}`);
       const s3Key = `${ORG_ID}/${wsId}/${fileId}.${ext}`;
+      // oxlint-disable-next-line no-await-in-loop -- bounded memory: upload one document's bytes to S3 at a time
       await getS3().write(s3Key, new Uint8Array(content));
 
       // DOCX files are rendered natively via Folio — no PDF twin needed.
@@ -4118,6 +4130,7 @@ export async function seed(organizationId?: string, userId?: string) {
       const pdfFileId: UserFileId | null = null;
 
       // ── File field ──
+      // oxlint-disable-next-line no-await-in-loop -- references the fileId/sha256 produced by the S3 write above
       await rootDb
         .insert(fields)
         .values({
@@ -4146,12 +4159,14 @@ export async function seed(organizationId?: string, userId?: string) {
       // (workspaces may belong to an org created before
       // the seed ran, e.g. via manual signup).
       if (docText) {
+        // oxlint-disable-next-line no-await-in-loop -- per-document org lookup feeds the extracted-content insert that follows
         const ws = await rootDb.query.workspaces.findFirst({
           where: { id: { eq: toWs(wsId) } },
           columns: { organizationId: true },
         });
         const ecOrgId = ws?.organizationId ?? ORG_ID;
 
+        // oxlint-disable-next-line no-await-in-loop -- depends on the org resolved from the workspace query above
         await rootDb
           .insert(extractedContent)
           .values({
@@ -4203,6 +4218,7 @@ export async function seed(organizationId?: string, userId?: string) {
   }
 
   for (const plan of docPlans) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory and S3 throughput: process one workspace's documents at a time
     await seedDocumentsForWorkspace(plan.wsId, plan.wsLabel, plan.docNames);
   }
 
@@ -4218,6 +4234,7 @@ export async function seed(organizationId?: string, userId?: string) {
     allFields.push(...buildFields(plan.wsLabel, wsEntities));
   }
   for (const f of allFields) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(fields)
       .values({
@@ -4239,6 +4256,7 @@ export async function seed(organizationId?: string, userId?: string) {
     );
   }
   for (const justification of allJustifications) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(justifications)
       .values({
@@ -4298,6 +4316,7 @@ export async function seed(organizationId?: string, userId?: string) {
   // 7c. Search index (depends on fields + extracted content)
   let searchCount = 0;
   for (const e of allEntities) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential indexing keeps memory bounded and avoids overwhelming the DB
     await upsertSearchDocument(e.entityId);
     searchCount++;
   }
@@ -4305,6 +4324,7 @@ export async function seed(organizationId?: string, userId?: string) {
 
   // 8. Workspace contacts (parties)
   for (const party of seedParties) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(workspaceContacts)
       .values({
@@ -4321,6 +4341,7 @@ export async function seed(organizationId?: string, userId?: string) {
   // 9. Billing codes
   const billingCodeSeeds = buildBillingCodes();
   for (const bc of billingCodeSeeds) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
     await rootDb
       .insert(billingCodes)
       .values({
@@ -4342,6 +4363,7 @@ export async function seed(organizationId?: string, userId?: string) {
     userRates: seedUserRates,
   });
   for (const rt of rateTableSeeds) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order / FK dependencies
     await rootDb
       .insert(rateTables)
       .values({
@@ -4355,6 +4377,7 @@ export async function seed(organizationId?: string, userId?: string) {
       .onConflictDoNothing();
   }
   for (const re of rateEntrySeeds) {
+    // oxlint-disable-next-line no-await-in-loop -- rate entries depend on rate tables seeded above; sequential preserves FK dependencies
     await rootDb
       .insert(rateEntries)
       .values({
@@ -4375,6 +4398,7 @@ export async function seed(organizationId?: string, userId?: string) {
   // that reference them)
   const invoiceSeeds = buildInvoices();
   for (const inv of invoiceSeeds) {
+    // oxlint-disable-next-line no-await-in-loop -- invoices must be inserted before time entries that reference them
     await rootDb
       .insert(invoices)
       .values({
@@ -4400,6 +4424,7 @@ export async function seed(organizationId?: string, userId?: string) {
     seedUserRates,
   );
   for (const te of extTimeEntries) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
     await rootDb
       .insert(timeEntries)
       .values({
@@ -4428,6 +4453,7 @@ export async function seed(organizationId?: string, userId?: string) {
   // 13. Expenses (~50)
   const expenseSeeds = buildExpenses(seedUserIds);
   for (const exp of expenseSeeds) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
     await rootDb
       .insert(expenses)
       .values({

--- a/apps/api/scripts/seed-templates.ts
+++ b/apps/api/scripts/seed-templates.ts
@@ -2193,6 +2193,7 @@ export async function seedTemplates(
 
   // ── 1. Clause categories ────────────────────────────
   for (const cat of CLAUSE_CATS) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves clause-category insert order
     await rootDb
       .insert(clauseCategories)
       .values({
@@ -2212,6 +2213,7 @@ export async function seedTemplates(
     const clauseId = scopedSeedId(c.label);
     const versionId = scopedSeedId(`${c.label}-v1`);
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves clause insert order / FK dependencies
     await rootDb
       .insert(clauses)
       .values({
@@ -2228,6 +2230,7 @@ export async function seedTemplates(
       })
       .onConflictDoNothing();
 
+    // oxlint-disable-next-line no-await-in-loop -- FK dependency: clause version references the clause inserted just above
     await rootDb
       .insert(clauseVersions)
       .values({
@@ -2242,6 +2245,7 @@ export async function seedTemplates(
     // 3. Clause variants
     if (c.variants) {
       for (const [vi, v] of c.variants.entries()) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves clause-variant insert order under the parent clause
         await rootDb
           .insert(clauseVariants)
           .values({
@@ -2261,6 +2265,7 @@ export async function seedTemplates(
 
   // ── 4. Template categories ──────────────────────────
   for (const cat of TEMPLATE_CATS) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves template-category insert order
     await rootDb
       .insert(templateCategories)
       .values({
@@ -2287,18 +2292,22 @@ export async function seedTemplates(
     };
 
     // Generate DOCX with body content
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: generate one template's DOCX at a time
     let docxBuffer = await createTemplateDocx(t.name, t.bodyXml);
 
     // Embed manifest into DOCX
+    // oxlint-disable-next-line no-await-in-loop -- depends on the DOCX buffer generated in the line above
     docxBuffer = await writeManifest(docxBuffer, manifest);
 
     const sizeBytes = docxBuffer.length;
 
     // Upload to S3
     const s3Key = `${ORG_ID}/templates/${templateId}.docx`;
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: write one template's DOCX buffer to S3 at a time
     await getS3().write(s3Key, new Uint8Array(docxBuffer));
 
     // Insert template
+    // oxlint-disable-next-line no-await-in-loop -- depends on the template DOCX uploaded to S3 just above this iteration
     await rootDb
       .insert(templates)
       .values({
@@ -2318,8 +2327,10 @@ export async function seedTemplates(
 
     // Insert version v1
     const versionS3Key = `${ORG_ID}/templates/${templateId}/v1.docx`;
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: write one template's DOCX buffer to S3 at a time
     await getS3().write(versionS3Key, new Uint8Array(docxBuffer));
 
+    // oxlint-disable-next-line no-await-in-loop -- depends on the template version's DOCX buffer written to S3 just above this iteration
     await rootDb
       .insert(templateVersions)
       .values({
@@ -2355,6 +2366,7 @@ export async function seedTemplates(
       }
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves template-clause link insert order
     await rootDb
       .insert(templateClauses)
       .values({

--- a/apps/api/scripts/seed-test-user.ts
+++ b/apps/api/scripts/seed-test-user.ts
@@ -172,6 +172,7 @@ export async function ensureSeedColleagueUsers({
   colleagueCount?: number;
 } = {}) {
   for (const colleague of getSeedColleagues(colleagueCount)) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order across colleague users
     await ensureUserExists(colleague);
   }
 }
@@ -186,6 +187,7 @@ export async function ensureSeedColleaguesInOrganization({
   await ensureSeedColleagueUsers({ colleagueCount });
 
   for (const colleague of getSeedColleagues(colleagueCount)) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves FK dependencies (memberships need users to exist)
     await ensureMembershipExists({
       organizationId,
       userId: colleague.id,
@@ -239,6 +241,7 @@ export async function ensureTestUsers(organizationId: string = TEST_ORG.id) {
   await ensureSeedColleagueUsers();
 
   for (const colleague of COLLEAGUES) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves FK dependencies (memberships need users to exist)
     await ensureMembershipExists({
       organizationId,
       userId: colleague.id,

--- a/apps/api/scripts/seed-usage-policies.ts
+++ b/apps/api/scripts/seed-usage-policies.ts
@@ -39,6 +39,7 @@ const seed = async (): Promise<void> => {
     // Upsert by policyKey so edits to the config (display name, units,
     // or a newly created hostedPolicyRef) propagate to the existing row
     // instead of being skipped.
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves upsert order across policies
     await rootDb
       .insert(usagePolicies)
       .values({

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -41,6 +41,7 @@ beforeAll(async () => {
   await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
   const { sqlStatements } = await pushSchema(allSchema, db);
   for (const statement of sqlStatements) {
+    // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)
     await db.execute(sql.raw(statement));
   }
 

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -211,6 +211,7 @@ export const backfillCorpusIndex = async (
   const docs: { row: IndexableRow; doc: Record<string, unknown> }[] = [];
   for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
     const chunk = rows.slice(i, i + INDEX_CONCURRENCY);
+    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
     const built = await Promise.all(
       chunk.map(async (row) => ({
         row,
@@ -255,6 +256,7 @@ export const backfillCorpusIndex = async (
     );
     let staleError: CorpusIndexError | null = null;
     for (const entry of moved) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
       const removed = await removeDecisionFromCorpusIndex(
         entry.id,
         scopedDb,
@@ -270,16 +272,19 @@ export const backfillCorpusIndex = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
     const ensured = await ensureIndex(indexId);
     const ingest = ensured.isErr()
       ? ensured
-      : await getCorpusIndexClient().ingestBatch(
+      : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
+        await getCorpusIndexClient().ingestBatch(
           indexId,
           group.map(({ doc }) => JSON.stringify(doc)).join("\n"),
         );
 
     if (ingest.isErr()) {
       firstError ??= ingest.error;
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
       await recordJobs(
         scopedDb,
         group.map(({ row }) => ({
@@ -295,6 +300,7 @@ export const backfillCorpusIndex = async (
     }
 
     const casMissed: SafeId<"caseLawDecision">[] = [];
+    // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per group; sequential to keep index writes and audit rows consistent
     await scopedDb(async (tx) => {
       // audit: skip — search index maintenance; rebuilds derived state
       for (const { row } of group) {
@@ -303,6 +309,7 @@ export const backfillCorpusIndex = async (
         // when the row was already pending) and bumps updatedAt, and an
         // unconditional write would mask that refresh so the stale index
         // document would never be retried.
+        // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
         const marked = await tx
           .update(caseLawDecisions)
           .set({
@@ -340,6 +347,7 @@ export const backfillCorpusIndex = async (
     // so delete the unrecorded copy now; the refreshed row is re-indexed
     // by a later cycle.
     for (const missedId of casMissed) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies
       const removed = await removeDecisionFromCorpusIndex(
         missedId,
         scopedDb,

--- a/apps/api/src/handlers/case-law/decisions/sitemap.ts
+++ b/apps/api/src/handlers/case-law/decisions/sitemap.ts
@@ -306,6 +306,7 @@ export const listSitemapShardDecisionsHandler = async (
       languageGroupKeys,
       SITEMAP_LANGUAGE_ALTERNATE_GROUP_BATCH_SIZE,
     )) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential reads on the same transaction connection (one in-flight query per tx)
       const batchRows = await tx
         .select({
           id: caseLawDecisions.id,

--- a/apps/api/src/handlers/case-law/erasure.ts
+++ b/apps/api/src/handlers/case-law/erasure.ts
@@ -135,6 +135,7 @@ export const redactCaseLawDecision = async ({
     // transient error) must not leave copies in the others undeleted.
     let firstError: CorpusIndexError | null = null;
     for (const indexId of targets) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential GDPR erasure across index targets for deterministic audit ordering
       const removed = await removeDecisionFromCorpusIndex(
         decisionId,
         scopedDb,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -310,6 +310,7 @@ export const czNsAdapter: SourceAdapter = {
                 ])
               : AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST);
 
+            // oxlint-disable-next-line no-await-in-loop -- polite sequential crawl of one court detail page per entry, rate-limited via Bun.sleep below
             const [detailResponse, printResponse] = await Promise.all([
               fetch(webUrl, { signal: requestSignal, headers: COMMON_HEADERS }),
               fetch(printUrl, {
@@ -319,10 +320,13 @@ export const czNsAdapter: SourceAdapter = {
             ]);
 
             if (detailResponse.ok) {
+              // oxlint-disable-next-line no-await-in-loop -- reads the body of the per-entry detail fetch in this sequential crawl loop
               const webHtml = await detailResponse.text();
-              const printHtml = printResponse.ok
-                ? await printResponse.text()
-                : "";
+              let printHtml = "";
+              if (printResponse.ok) {
+                // oxlint-disable-next-line no-await-in-loop -- reads the body of the per-entry print fetch in this sequential crawl loop
+                printHtml = await printResponse.text();
+              }
 
               const meta = parseDetailPage(webHtml);
               const raw = `${caseNumber}|${meta["ecli"] ?? ""}|${meta["decisionDate"] ?? ""}`;
@@ -425,6 +429,7 @@ export const czNsAdapter: SourceAdapter = {
 
           // Rate limit between detail fetches (skip for last entry)
           if (i < entries.length - 1) {
+            // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between sequential court detail fetches
             await Bun.sleep(50);
           }
         }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -899,6 +899,7 @@ export const czNssAdapter: SourceAdapter = {
 
           if (row.documentId) {
             // Fetch detail metadata first (needed by parser)
+            // oxlint-disable-next-line no-await-in-loop -- sequential per-row crawl against one court session; content fetch below depends on this detail
             detail = await fetchDetailMetadata(
               row.documentId,
               session,
@@ -913,6 +914,7 @@ export const czNssAdapter: SourceAdapter = {
           };
 
           if (row.documentId) {
+            // oxlint-disable-next-line no-await-in-loop -- sequential per-row crawl; consumes detail fetched above and shares one court session
             content = await fetchDecisionContent(
               row.documentId,
               row,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -545,6 +545,7 @@ export const czRegionalAdapter: SourceAdapter = {
           }
 
           try {
+            // oxlint-disable-next-line no-await-in-loop -- sequential retry loop; each attempt awaits the previous attempt's outcome before retrying
             response = await fetch(url, {
               signal: signal
                 ? AbortSignal.any([
@@ -569,6 +570,7 @@ export const czRegionalAdapter: SourceAdapter = {
                   maxRetries: LIST_FETCH_RETRIES,
                   retryDelayMs: delayMs,
                 });
+                // oxlint-disable-next-line no-await-in-loop -- exponential backoff delay between sequential retry attempts
                 await Bun.sleep(delayMs);
                 continue;
               }
@@ -595,6 +597,7 @@ export const czRegionalAdapter: SourceAdapter = {
               retry: attempt + 1,
               maxRetries: LIST_FETCH_RETRIES,
             });
+            // oxlint-disable-next-line no-await-in-loop -- backoff delay between sequential server-error retry attempts
             await Bun.sleep(LIST_FETCH_RETRY_DELAY_MS);
           }
         }
@@ -685,8 +688,10 @@ export const czRegionalAdapter: SourceAdapter = {
 
         for (let i = 0; i < decisions.length; i += FINALDOC_CONCURRENCY) {
           if (i > 0) {
+            // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between sequential enrichment batches against the court server
             await Bun.sleep(FINALDOC_BATCH_DELAY_MS);
           }
+          // oxlint-disable-next-line no-await-in-loop -- batches must run sequentially with delays between them to respect the court server; parallelism is bounded within each batch
           await Promise.all(
             decisions.slice(i, i + FINALDOC_CONCURRENCY).map(enrichDecision),
           );

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -348,6 +348,7 @@ export const czUsAdapter: SourceAdapter = {
           // by ~5x without meaningful server load increase.
           const yearSuffix = toYearSuffix(state.year);
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential probe batches; each batch advances the cursor based on the previous batch's results and consecutive-miss count
           const probeResults = await Promise.allSettled(
             Array.from({ length: PROBE_CONCURRENCY }, async (_, i) => {
               const num = state.number + i;
@@ -436,11 +437,13 @@ export const czUsAdapter: SourceAdapter = {
                     AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST),
                   ])
                 : AbortSignal.timeout(ADAPTER_TIMEOUT.REQUEST);
+              // oxlint-disable-next-line no-await-in-loop -- sequential per-decision abstract fetch within the ordered result-processing loop
               const absResp = await fetch(`${ABSTRACT_URL}?sz=${szParam}`, {
                 headers: COMMON_HEADERS,
                 signal: absSignal,
               });
               if (absResp.ok) {
+                // oxlint-disable-next-line no-await-in-loop -- reads the body of the per-decision abstract fetch in this ordered loop
                 const absHtml = await absResp.text();
                 const { abstract, legalSentence } = extractAbstract(absHtml);
                 if (abstract) {
@@ -467,6 +470,7 @@ export const czUsAdapter: SourceAdapter = {
           if (!rateLimited) {
             state.number += PROBE_CONCURRENCY;
           } else {
+            // oxlint-disable-next-line no-await-in-loop -- rate-limit backoff between probe batches after a 429 from the court server
             await Bun.sleep(backoffMs(0, 2000));
           }
 
@@ -485,6 +489,7 @@ export const czUsAdapter: SourceAdapter = {
           }
 
           // Rate limit between batches
+          // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between sequential probe batches against the court server
           await Bun.sleep(100);
         }
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -372,6 +372,7 @@ export const euEcjAdapter: SourceAdapter = {
 
           // 3. Fetch fulltext in each language
           for (const lang of ECJ_LANGUAGES) {
+            // oxlint-disable-next-line no-await-in-loop -- polite sequential fulltext fetch per language against EUR-Lex
             const fulltext = await fetchFulltext(
               celex,
               lang,
@@ -412,6 +413,7 @@ export const euEcjAdapter: SourceAdapter = {
           // Rate-limit per decision (not per language) to
           // keep total sleep within the page timeout budget.
           if (!abortSignal.aborted) {
+            // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between sequential per-decision fetches against EUR-Lex
             await Bun.sleep(500);
           }
         }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
@@ -34,6 +34,7 @@ const loadAllAdapters = async (): Promise<LoadResult[]> => {
   const results: LoadResult[] = [];
   for (const key of Object.keys(ADAPTER_MODULES)) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- sequential adapter module loads preserve deterministic result ordering
       const adapter = await loadAdapterByKey(key);
       if (adapter) {
         results.push({ adapter, key });
@@ -222,6 +223,7 @@ export const checkAllAdapters = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential health probes avoid hammering multiple court servers concurrently
     const result = await checkAdapterHealth(entry.adapter, timeoutMs);
     results.push(result);
   }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.test.ts
@@ -256,6 +256,7 @@ describe("createPagePaginatedFetch", () => {
 
     let cursor: string | null = null;
     for (let i = 0; i < 3; i++) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential paginated fetch (each page's cursor depends on the previous page)
       const result = await fetchAtPageSize20(cursor, {});
       const page = result.unwrap();
       cursor = page.nextCursor;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -299,6 +299,7 @@ export const createPagePaginatedFetch = <TResponse>(
             break;
           }
           const chunk = items.slice(i, i + chunkSize);
+          // oxlint-disable-next-line no-await-in-loop -- sequential chunk processing: abort/rewind bookkeeping depends on prior chunk completing
           const results = await Promise.allSettled(
             chunk.map(async (item) => await opts.parseItem(item, signal)),
           );

--- a/apps/api/src/handlers/case-law/ingestion/adapters/retry.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/retry.ts
@@ -93,6 +93,7 @@ export const fetchWithRetry = async (
     }
 
     try {
+      // oxlint-disable-next-line no-await-in-loop -- retry-with-backoff: each attempt must await the previous attempt's outcome
       const response = await fetch(url, {
         ...init,
         headers,
@@ -121,6 +122,7 @@ export const fetchWithRetry = async (
           delayMs: Math.round(delay),
         });
       }
+      // oxlint-disable-next-line no-await-in-loop -- sequential backoff delay before the next retry attempt
       await Bun.sleep(delay);
     } catch (error) {
       // Parent signal aborted: propagate immediately
@@ -140,6 +142,7 @@ export const fetchWithRetry = async (
             delayMs: Math.round(delay),
           });
         }
+        // oxlint-disable-next-line no-await-in-loop -- sequential backoff delay before retrying after a timeout
         await Bun.sleep(delay);
         continue;
       }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -488,6 +488,7 @@ export const skUsAdapter: SourceAdapter = {
 
         for (const doc of data.documents) {
           try {
+            // oxlint-disable-next-line no-await-in-loop -- sequential per-document PDF download/parse, rate-limited via Bun.sleep below
             const result = await parseDocument(doc, signal);
             if (result) {
               decisions.push(result);
@@ -500,6 +501,7 @@ export const skUsAdapter: SourceAdapter = {
           }
 
           // Rate limit between PDF downloads
+          // oxlint-disable-next-line no-await-in-loop -- deliberate crawl delay between sequential PDF downloads from the court server
           await Bun.sleep(300);
         }
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/update-fixtures.ts
@@ -125,6 +125,7 @@ if (import.meta.main) {
   let failures = 0;
   for (const [i, key] of keysToUpdate.entries()) {
     process.stdout.write(`  ${key}... `);
+    // oxlint-disable-next-line no-await-in-loop -- sequential per-adapter recording with rate-limit delay between adapters
     const result = await updateAdapter(key);
 
     if ("error" in result) {
@@ -136,6 +137,7 @@ if (import.meta.main) {
 
     // Rate limit between adapters
     if (i < keysToUpdate.length - 1) {
+      // oxlint-disable-next-line no-await-in-loop -- polite rate-limit delay between adapter fixture recordings
       await Bun.sleep(2000);
     }
   }

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -620,6 +620,7 @@ export const runIngestionPipeline = async ({
       ? AbortSignal.any([signal, AbortSignal.timeout(pageTimeout)])
       : AbortSignal.timeout(pageTimeout);
     recentCursors.add(cursor);
+    // oxlint-disable-next-line no-await-in-loop -- sequential paginated crawl (each page's cursor depends on the previous page)
     const pageResult = await adapter.fetchPage(
       cursor,
       source.config ?? {},
@@ -651,6 +652,7 @@ export const runIngestionPipeline = async ({
     // unexpected exceptions.
     if (dbSlot) {
       try {
+        // oxlint-disable-next-line no-await-in-loop -- sequential per-page DB-slot acquisition bounds concurrent DB pressure
         await dbSlot.acquire(signal);
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
@@ -673,6 +675,7 @@ export const runIngestionPipeline = async ({
           break;
         }
         try {
+          // oxlint-disable-next-line no-await-in-loop -- sequential decision inserts: consecutive-failure halting and per-page counters depend on ordering
           const outcome = await processDecision(result, source.id, scopedDb);
 
           if (outcome.inserted) {
@@ -712,6 +715,7 @@ export const runIngestionPipeline = async ({
 
           // Persist failure for later analysis
           try {
+            // oxlint-disable-next-line no-await-in-loop -- failure logged inline within the sequential decision loop
             await logIngestionFailure(scopedDb, {
               sourceId: source.id,
               caseNumber: result.caseNumber,
@@ -787,6 +791,7 @@ export const runIngestionPipeline = async ({
     }
 
     if (adapter.minRequestIntervalMs > 0) {
+      // oxlint-disable-next-line no-await-in-loop -- polite crawl delay between page fetches
       await Bun.sleep(adapter.minRequestIntervalMs);
     }
   }

--- a/apps/api/src/handlers/case-law/ingestion/status.ts
+++ b/apps/api/src/handlers/case-law/ingestion/status.ts
@@ -56,11 +56,13 @@ export const getIngestionStatus = async (
     const sourceStatuses: SourceStatus[] = [];
 
     for (const source of sources) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const [totalRow] = await db
         .select({ total: count() })
         .from(caseLawDecisions)
         .where(sql`${caseLawDecisions.sourceId} = ${source.id}`);
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const [hourRow] = await db
         .select({
           inserted: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)`,
@@ -71,6 +73,7 @@ export const getIngestionStatus = async (
             AND ${caseLawIngestionEvents.finishedAt} >= ${oneHourAgo}`,
         );
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const [dayRow] = await db
         .select({
           inserted: sql<number>`coalesce(sum(${caseLawIngestionEvents.inserted}), 0)`,
@@ -81,6 +84,7 @@ export const getIngestionStatus = async (
             AND ${caseLawIngestionEvents.finishedAt} >= ${oneDayAgo}`,
         );
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const [failRow] = await db
         .select({ total: count() })
         .from(caseLawIngestionFailures)
@@ -89,6 +93,7 @@ export const getIngestionStatus = async (
             AND ${caseLawIngestionFailures.createdAt} >= ${oneDayAgo}`,
         );
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const [lastEvent] = await db
         .select({
           status: caseLawIngestionEvents.status,
@@ -103,6 +108,7 @@ export const getIngestionStatus = async (
         .orderBy(desc(caseLawIngestionEvents.finishedAt))
         .limit(1);
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const topFailures = await db
         .select({
           errorType: caseLawIngestionFailures.errorType,

--- a/apps/api/src/handlers/case-law/search-index.ts
+++ b/apps/api/src/handlers/case-law/search-index.ts
@@ -215,6 +215,7 @@ export const backfillSearchIndex = async (
   let indexed = 0;
   for (let i = 0; i < rows.length; i += SEARCH_INDEX_CONCURRENCY) {
     const chunk = rows.slice(i, i + SEARCH_INDEX_CONCURRENCY);
+    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: each SEARCH_INDEX_CONCURRENCY chunk drains before the next so tsvector upserts don't overwhelm Postgres
     const results = await Promise.all(chunk.map(indexRow));
     for (const result of results) {
       indexed += result;

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1909,6 +1909,7 @@ const runPersistMessage = async ({
           );
 
         for (const deletedMessageId of deleteMessageIds) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential audit writes on the same transaction connection (one in-flight query per tx)
           await recordAuditEvent(tx, {
             action: AUDIT_ACTION.DELETE,
             resourceType: AUDIT_RESOURCE_TYPE.CHAT_MESSAGE,

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -66,6 +66,7 @@ const waitForCondition = async ({
     if (Date.now() > deadline) {
       throw new Error("Condition was not met before timeout.");
     }
+    // oxlint-disable-next-line no-await-in-loop -- polling loop: each tick must wait before re-checking the condition
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 5);
     });

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
@@ -843,6 +843,7 @@ const driveVmUntilSettled = async ({
     }
 
     if (state.pendingHostWork.size > 0) {
+      // oxlint-disable-next-line no-await-in-loop -- VM event loop: must wait for host progress before pumping the next VM step
       const waitResult = await waitForHostProgress({
         pendingHostWork: state.pendingHostWork,
         deadline,
@@ -860,6 +861,7 @@ const driveVmUntilSettled = async ({
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- VM event loop: yields the microtask queue before pumping the next VM step
     await Promise.resolve();
   }
 };

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -44,6 +44,7 @@ export const loadExternalMcpToolsForUser = async ({
   });
 
   for (const row of rows) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential per-connector load; mutates shared clients/connectors/loadedTools and avoids fanning out concurrent external MCP connections
     await loadConnectorTools({
       clients,
       connectors,

--- a/apps/api/src/handlers/chat/upload-files.ts
+++ b/apps/api/src/handlers/chat/upload-files.ts
@@ -121,9 +121,11 @@ export const uploadMessageFiles = async ({
 
     const parsedPart = parseMessageFileDataUrl({ part });
     if (Result.isError(parsedPart)) {
+      // oxlint-disable-next-line no-await-in-loop -- early-exit on first parse failure; awaits rollback of already-uploaded files
       return await fail(parsedPart.error);
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential per-file upload + DB write preserving parts order, with rollback on error
     const uploadedFile = await uploadUserFile({
       file: parsedPart.value,
       recordAuditEvent,
@@ -133,6 +135,7 @@ export const uploadMessageFiles = async ({
       workspaceId,
     });
     if (Result.isError(uploadedFile)) {
+      // oxlint-disable-next-line no-await-in-loop -- early-exit on first upload failure; awaits rollback of already-uploaded files
       return await fail(uploadedFile.error);
     }
 

--- a/apps/api/src/handlers/clauses/import.ts
+++ b/apps/api/src/handlers/clauses/import.ts
@@ -157,9 +157,11 @@ const importHandler = async function* ({
 
         let categoryId: SafeId<"clauseCategory"> | null = null;
         if (item.categoryName) {
+          // oxlint-disable-next-line no-await-in-loop -- dedups via shared categoryByName map; must run sequentially to avoid duplicate category inserts
           categoryId = await findOrCreateCategory(tx, item.categoryName);
         }
 
+        // oxlint-disable-next-line no-await-in-loop -- sequential clause inserts in one transaction preserve insertion order
         await tx.insert(clauses).values({
           id: clauseId,
           organizationId,
@@ -174,6 +176,7 @@ const importHandler = async function* ({
           createdBy: userId,
         });
 
+        // oxlint-disable-next-line no-await-in-loop -- sequential version inserts in one transaction preserve insertion order
         await tx.insert(clauseVersions).values({
           id: versionId,
           organizationId,

--- a/apps/api/src/handlers/contacts/create.ts
+++ b/apps/api/src/handlers/contacts/create.ts
@@ -87,6 +87,7 @@ const createContact = createSafeRootHandler(
       const hasInvalidAttorney = yield* Result.await(
         safeDb(async (tx) => {
           for (const attorneyId of uniqueAttorneyIds) {
+            // oxlint-disable-next-line no-await-in-loop -- early-exits on first invalid attorney; at most two ids
             const validAttorneyId = await validateOrgUserId(
               tx,
               brandPersistedUserId(attorneyId),

--- a/apps/api/src/handlers/contacts/update-by-id.ts
+++ b/apps/api/src/handlers/contacts/update-by-id.ts
@@ -83,6 +83,7 @@ const updateContactById = createSafeRootHandler(
       const hasInvalidAttorney = yield* Result.await(
         safeDb(async (tx) => {
           for (const attorneyId of uniqueAttorneyIds) {
+            // oxlint-disable-next-line no-await-in-loop -- early-exits on first invalid attorney; at most two ids
             const validAttorneyId = await validateOrgUserId(
               tx,
               brandPersistedUserId(attorneyId),

--- a/apps/api/src/handlers/docx/discover-clause-slots.ts
+++ b/apps/api/src/handlers/docx/discover-clause-slots.ts
@@ -88,6 +88,7 @@ export const discoverClauseSlots = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory while streaming docx parts; accumulates into shared slots map
     const xml = await entry.async("string");
     scanParagraphs(slimdom.parseXmlDocument(xml), slots);
   }

--- a/apps/api/src/handlers/docx/discover-placeholders.ts
+++ b/apps/api/src/handlers/docx/discover-placeholders.ts
@@ -73,6 +73,7 @@ export const discoverPlaceholders = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory while streaming docx parts; accumulates into shared counts map
     const xml = await entry.async("string");
     scanParagraphs(slimdom.parseXmlDocument(xml), counts);
   }

--- a/apps/api/src/handlers/docx/discover-template.ts
+++ b/apps/api/src/handlers/docx/discover-template.ts
@@ -499,6 +499,7 @@ const analyzeHeadersAndFooters = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential to keep running paragraph offsets correct across parts
     const xml = await entry.async("string");
     const doc = slimdom.parseXmlDocument(xml);
 

--- a/apps/api/src/handlers/docx/extract-text.ts
+++ b/apps/api/src/handlers/docx/extract-text.ts
@@ -241,6 +241,7 @@ const extractHeaderFooterParagraphs = async (
     .toSorted();
 
   for (const path of entries) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential to keep running paragraph index contiguous across parts
     const xml = await archive.readEntryString(path);
     if (xml === null) {
       continue;

--- a/apps/api/src/handlers/docx/patch-template.ts
+++ b/apps/api/src/handlers/docx/patch-template.ts
@@ -51,6 +51,7 @@ const fillTemplateWithValues = async (
     if (!entry) {
       continue;
     }
+    // oxlint-disable-next-line no-await-in-loop -- mutates the shared zip in place; bounded memory while streaming docx parts
     const xml = await entry.async("string");
     const patched = patchXmlPart(xml, values);
     if (patched.changed) {

--- a/apps/api/src/handlers/docx/resolve-clause-slots.ts
+++ b/apps/api/src/handlers/docx/resolve-clause-slots.ts
@@ -41,6 +41,7 @@ export const resolveClauseSlots = async (
   const patches: Record<string, RichPatchValue> = {};
 
   for (const slot of slots) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential clause resolution accumulating into shared patches map
     const link = await scopedDb((tx) =>
       tx.query.templateClauses.findFirst({
         where: {
@@ -59,6 +60,7 @@ export const resolveClauseSlots = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- consumes the link resolved in this iteration; sequential per slot
     const versionRow = await resolveVersion(
       link.clauseId,
       link.clauseVersionId,

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -388,6 +388,7 @@ const copyToWorkspaceHandler = async function* ({
       // Delete in reverse order (children first) to respect FK constraints.
       // The cascade will handle versions and fields.
       for (const id of sourceEntityIds.toReversed()) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential deletes in reverse (children-first) order respect FK constraints within the transaction
         await tx.delete(entities).where(eq(entities.id, id));
       }
 

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -563,7 +563,8 @@ export const copyEntities = async ({
 
     const copyName =
       source.id === sourceEntityId
-        ? await resolveEntityName({
+        ? // oxlint-disable-next-line no-await-in-loop -- copy steps depend on prior-created parent IDs in idMap; iterations must run sequentially in order
+          await resolveEntityName({
             tx,
             workspaceId: targetWorkspaceId,
             parentId: newParentId ?? null,
@@ -581,9 +582,11 @@ export const copyEntities = async ({
 
     const entityStamp =
       source.kind === "document"
-        ? await allocateEntityStamp(tx, targetWorkspaceId)
+        ? // oxlint-disable-next-line no-await-in-loop -- stamp allocation is a sequential per-workspace counter; must run in order within the transaction
+          await allocateEntityStamp(tx, targetWorkspaceId)
         : null;
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential inserts; children reference parent IDs created in earlier iterations
     await tx.insert(entities).values({
       id: newEntityId,
       workspaceId: targetWorkspaceId,
@@ -594,6 +597,7 @@ export const copyEntities = async ({
       docSequence: entityStamp?.docSequence ?? null,
     });
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential version insert depends on the entity row created just above in this iteration
     await tx.insert(entityVersions).values({
       id: newVersionId,
       workspaceId: targetWorkspaceId,
@@ -603,6 +607,7 @@ export const copyEntities = async ({
       verificationCode: entityStamp?.verificationCode ?? null,
     });
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential update sets currentVersionId on the just-created entity/version pair
     await tx
       .update(entities)
       .set({ currentVersionId: newVersionId })
@@ -632,6 +637,7 @@ export const copyEntities = async ({
         };
       });
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential field insert depends on the version created in this iteration
       await tx.insert(fields).values(fieldInserts);
     }
 

--- a/apps/api/src/handlers/entities/zip-archive.ts
+++ b/apps/api/src/handlers/entities/zip-archive.ts
@@ -167,6 +167,7 @@ export const mapOrderedConcurrent = async function* <T, R>(
     if (head === undefined) {
       break;
     }
+    // oxlint-disable-next-line no-await-in-loop -- bounded-concurrency drain: await the in-flight head before refilling the window and yielding
     const result = await head;
     startNext();
     yield result;

--- a/apps/api/src/handlers/external-preview/preview.ts
+++ b/apps/api/src/handlers/external-preview/preview.ts
@@ -396,6 +396,7 @@ const fetchPreviewUrl = async (
       let currentTarget = target;
 
       for (let redirects = 0; redirects <= MAX_PREVIEW_REDIRECTS; redirects++) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential redirect chain: each fetch targets the location resolved from the previous response
         const response = await fetchWithResolvedAddress({
           addresses: currentTarget.addresses,
           headers: {
@@ -428,6 +429,7 @@ const fetchPreviewUrl = async (
             });
           }
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential redirect chain: validate the next hop derived from this response's location before continuing
           const nextTarget = await validatePreviewUrl(
             new URL(location, currentTarget.url).toString(),
           );

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -148,6 +148,7 @@ const processColumnFlagBatch = async ({
     }
 
     for (const target of targets) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential lock acquisition in a deterministic order avoids deadlocks within the transaction
       await acquireCellLock({
         tx,
         entityVersionId: target.entityVersionId,

--- a/apps/api/src/handlers/files/utils.ts
+++ b/apps/api/src/handlers/files/utils.ts
@@ -156,6 +156,7 @@ export const deleteS3Keys = async (
   for (let i = 0; i < dedupedKeys.length; i += S3_DELETE_CONCURRENCY) {
     const chunk = dedupedKeys.slice(i, i + S3_DELETE_CONCURRENCY);
 
+    // oxlint-disable-next-line no-await-in-loop -- chunks run sequentially for bounded S3 concurrency and early return on the first failed chunk
     const result = await Result.tryPromise(
       async () =>
         await Promise.all(chunk.map(async (key) => await getS3().delete(key))),

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -202,6 +202,7 @@ export const backfillLegislationCorpusIndex = async (
   const docs: { row: IndexableRow; doc: Record<string, unknown> }[] = [];
   for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
     const chunk = rows.slice(i, i + INDEX_CONCURRENCY);
+    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
     const built = await Promise.all(
       chunk.map(async (row) => ({
         row,
@@ -242,6 +243,7 @@ export const backfillLegislationCorpusIndex = async (
     );
     let staleError: CorpusIndexError | null = null;
     for (const entry of moved) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
       const removed = await removeLegislationFromCorpusIndex(
         entry.id,
         scopedDb,
@@ -257,16 +259,19 @@ export const backfillLegislationCorpusIndex = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
     const ensured = await ensureIndex(indexId);
     const ingest = ensured.isErr()
       ? ensured
-      : await getCorpusIndexClient().ingestBatch(
+      : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
+        await getCorpusIndexClient().ingestBatch(
           indexId,
           group.map(({ doc }) => JSON.stringify(doc)).join("\n"),
         );
 
     if (ingest.isErr()) {
       firstError ??= ingest.error;
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
       await recordJobs(
         scopedDb,
         group.map(({ row }) => ({
@@ -282,6 +287,7 @@ export const backfillLegislationCorpusIndex = async (
     }
 
     const casMissed: SafeId<"legislationDocument">[] = [];
+    // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per group; sequential to keep index writes and audit rows consistent
     await scopedDb(async (tx) => {
       // audit: skip — search index maintenance; rebuilds derived state
       for (const { row } of group) {
@@ -290,6 +296,7 @@ export const backfillLegislationCorpusIndex = async (
         // when the row was already pending) and bumps updatedAt, and an
         // unconditional write would mask that refresh so the stale index
         // document would never be retried.
+        // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
         const marked = await tx
           .update(legislationDocuments)
           .set({
@@ -327,6 +334,7 @@ export const backfillLegislationCorpusIndex = async (
     // so delete the unrecorded copy now; the refreshed row is re-indexed
     // by a later cycle.
     for (const missedId of casMissed) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies
       const removed = await removeLegislationFromCorpusIndex(
         missedId,
         scopedDb,

--- a/apps/api/src/handlers/legislation/ingestion.test.ts
+++ b/apps/api/src/handlers/legislation/ingestion.test.ts
@@ -30,6 +30,7 @@ beforeAll(async () => {
   await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
   const { sqlStatements } = await pushSchema(allSchema, db);
   for (const statement of sqlStatements) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential DDL: schema statements must apply in emitted order
     await db.execute(sql.raw(statement));
   }
 

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -330,9 +330,11 @@ export const runLegislationIngestion = async ({
     if (signal.aborted) {
       break;
     }
+    // oxlint-disable-next-line no-await-in-loop -- cursor pagination: each page consumes the cursor returned by the prior page
     const { documents, nextCursor } = await adapter.fetchPage(cursor, signal);
     let corpusWriteFailures = 0;
     for (const doc of documents) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential ingestion: ordered counters and per-page cursor hold on corpus-write failure
       const result = await processLegislationDocument(doc, scopedDb);
       if (result.skipped) {
         skipped += 1;

--- a/apps/api/src/handlers/legislation/search-index.ts
+++ b/apps/api/src/handlers/legislation/search-index.ts
@@ -186,6 +186,7 @@ export const backfillLegislationSearchIndex = async (
   let indexed = 0;
   for (let i = 0; i < rows.length; i += SEARCH_INDEX_CONCURRENCY) {
     const chunk = rows.slice(i, i + SEARCH_INDEX_CONCURRENCY);
+    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: each SEARCH_INDEX_CONCURRENCY chunk drains before the next so tsvector upserts don't overwhelm Postgres
     const results = await Promise.all(chunk.map(indexRow));
     for (const result of results) {
       indexed += result;

--- a/apps/api/src/handlers/mcp-connectors/create-connector.ts
+++ b/apps/api/src/handlers/mcp-connectors/create-connector.ts
@@ -192,6 +192,7 @@ const nextSlug = async ({
 }) => {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const slug = attempt === 0 ? base : `${base}-${attempt + 1}`;
+    // oxlint-disable-next-line no-await-in-loop -- sequential slug-collision probe: each attempt depends on the prior slug being taken
     const existing = await safeDb((tx) =>
       tx
         .select({ id: mcpConnectors.id })

--- a/apps/api/src/handlers/mcp-connectors/oauth.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth.ts
@@ -173,6 +173,7 @@ export const discoverOAuthMetadata = async (
 
   let protectedResource: ProtectedResourceMetadata | null = null;
   for (const metadataUrl of mcpWellKnownProtectedResourceUrls(parsedUrl)) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered metadata discovery: probe well-known URLs in priority order, stop at first hit
     const result = await fetchJson({
       schema: protectedResourceMetadataSchema,
       url: metadataUrl,
@@ -199,11 +200,13 @@ export const discoverOAuthMetadata = async (
   for (const metadataUrl of authorizationServerMetadataUrls(
     authorizationServerUrl,
   )) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered metadata discovery: probe well-known URLs in priority order, stop at first hit
     const result = await fetchJson({
       schema: authorizationServerMetadataSchema,
       url: metadataUrl,
     });
     if (Result.isOk(result)) {
+      // oxlint-disable-next-line no-await-in-loop -- runs only on the first successful probe before breaking out of the discovery loop
       const safeMetadata = await validateAuthorizationServerMetadata(
         result.value,
       );
@@ -514,11 +517,13 @@ const discoverAuthorizationServer = async (
   for (const metadataUrl of authorizationServerMetadataUrls(
     new URL(authorizationServerUrl),
   )) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered metadata discovery: probe well-known URLs in priority order, stop at first hit
     const result = await fetchJson({
       schema: authorizationServerMetadataSchema,
       url: metadataUrl,
     });
     if (Result.isOk(result)) {
+      // oxlint-disable-next-line no-await-in-loop -- runs only on the first successful probe before returning out of the discovery loop
       const safeMetadata = await validateAuthorizationServerMetadata(
         result.value,
       );
@@ -548,6 +553,7 @@ const validateAuthorizationServerMetadata = async (
   ].filter((url) => url !== undefined);
 
   for (const url of urls) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential SSRF safety check: bail on the first unsafe metadata URL
     const safe = await validateOutboundFetchTarget(url);
     if (Result.isError(safe)) {
       return Result.err(

--- a/apps/api/src/handlers/mcp/routes.test.ts
+++ b/apps/api/src/handlers/mcp/routes.test.ts
@@ -71,6 +71,7 @@ describe("MCP protected resource discovery routes", () => {
     });
 
     for (const method of ["OPTIONS", "GET", "POST", "DELETE"]) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential test setup: asserts the recorded call order below
       const response = await route.handle(
         new Request(`http://localhost${MCP_HTTP_PATH}`, { method }),
       );
@@ -95,6 +96,7 @@ describe("MCP protected resource discovery routes", () => {
     });
 
     for (const method of ["OPTIONS", "GET", "POST", "DELETE"]) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential test setup: asserts the recorded call order below
       const response = await route.handle(
         new Request(`http://localhost${MCP_ANONYMIZED_HTTP_PATH}`, { method }),
       );
@@ -120,6 +122,7 @@ describe("MCP protected resource discovery routes", () => {
 
     for (const path of [MCP_HTTP_PATH, MCP_ANONYMIZED_HTTP_PATH]) {
       for (const method of ["PATCH", "PUT"]) {
+        // oxlint-disable-next-line no-await-in-loop -- deterministic sequential test setup over a small fixed method list
         const response = await route.handle(
           new Request(`http://localhost${path}`, { method }),
         );

--- a/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
@@ -103,6 +103,7 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
           );
 
           if (existing) {
+            // oxlint-disable-next-line no-await-in-loop -- sequential blacklist upserts inside one transaction
             await tx
               .update(anonymizationBlacklistEntries)
               .set({
@@ -126,6 +127,7 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
             continue;
           }
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential blacklist upserts inside one transaction
           await tx.insert(anonymizationBlacklistEntries).values({
             id: createSafeId<"anonymizationBlacklistEntry">(),
             organizationId: session.activeOrganizationId,

--- a/apps/api/src/handlers/properties/create-batch.ts
+++ b/apps/api/src/handlers/properties/create-batch.ts
@@ -91,6 +91,7 @@ const createPropertiesBatch = createSafeHandler(
           const { content, tool, dependencies } = built;
           const initialStatus = tool.type === "ai-model" ? "stale" : "fresh";
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential property inserts in one transaction; each row's id feeds its dependency rows and audit event
           const [inserted] = await tx
             .insert(properties)
             .values({
@@ -111,6 +112,7 @@ const createPropertiesBatch = createSafeHandler(
           }
 
           if (dependencies.length > 0) {
+            // oxlint-disable-next-line no-await-in-loop -- dependency rows reference the property id just inserted above in this iteration
             await tx.insert(propertyDependencies).values(
               dependencies.map(({ dependsOnPropertyId, condition }) => ({
                 workspaceId,
@@ -121,6 +123,7 @@ const createPropertiesBatch = createSafeHandler(
             );
           }
 
+          // oxlint-disable-next-line no-await-in-loop -- ordered audit trail: one event per inserted property in this transaction
           await recordAuditEvent(tx, {
             action: AUDIT_ACTION.CREATE,
             resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -338,6 +338,7 @@ export const refineSearchQuery = async ({
   let lastValidationError: string | null = null;
 
   for (let attempt = 1; attempt <= SEARCH_REFINE_MAX_ATTEMPTS; attempt++) {
+    // oxlint-disable-next-line no-await-in-loop -- retry loop: each attempt consumes the validation error from the previous attempt
     const result = await generateRefinedSearchQuery({
       attempt,
       body,
@@ -378,6 +379,7 @@ export const refineSearchQuery = async ({
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- retry loop: only validates the candidate query produced by this attempt; returns on success
     const postgresValidation = await validateSearchQueryWithPostgres({
       query: refinedQuery,
       scopedDb,
@@ -897,6 +899,7 @@ const buildSearchResultContexts = async ({
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- ordered char budget: each hit consumes remainingChars and assigns the next context number; stops when budget is exhausted
     const content = await loadSearchHitContent({
       hit,
       organizationId,

--- a/apps/api/src/handlers/skills/skill-package.test.ts
+++ b/apps/api/src/handlers/skills/skill-package.test.ts
@@ -185,6 +185,7 @@ Instructions.`,
     ];
 
     for (const url of unsafeUrls) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential test assertions over a fixed input list
       const result = await fetchSkillPackageFromUrl(url);
       expect(Result.isError(result)).toBe(true);
     }

--- a/apps/api/src/handlers/skills/skill-package.ts
+++ b/apps/api/src/handlers/skills/skill-package.ts
@@ -175,6 +175,7 @@ const parseZipSkillPackage = async (
       assertZipUncompressedLimit(totalUncompressedBytes + declaredSize);
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential unzip enforces a running cumulative-byte limit
     const bytes = await file.async("uint8array");
     totalUncompressedBytes += bytes.byteLength;
     assertZipUncompressedLimit(totalUncompressedBytes);
@@ -429,6 +430,7 @@ const fetchGithubSkillFiles = async (
       break;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- breadth-first GitHub traversal: each directory's contents enqueue the next
     const contents = await fetchGithubContents({ target, path: directory });
     for (const item of contents) {
       const relativePath = relativeGithubSkillPath({
@@ -477,6 +479,7 @@ const fetchGithubSkillFiles = async (
         assertGithubTotalFileBytes(totalFileBytes + item.size);
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential fetch enforces a running cumulative-byte limit across files
       const raw = await fetchSafeBytes(
         githubRawUrl({
           owner: target.owner,
@@ -815,6 +818,7 @@ export const resolveGithubRefAndPath = async ({
     const ref = parts.slice(0, refPartCount).join("/");
     if (
       !GITHUB_COMMIT_SHA_PATTERN.test(ref) &&
+      // oxlint-disable-next-line no-await-in-loop -- ordered ref-candidate probe: longest match wins, returns on first hit
       !(await refExists({ owner, ref, repo }))
     ) {
       continue;

--- a/apps/api/src/handlers/tasks/create.test.ts
+++ b/apps/api/src/handlers/tasks/create.test.ts
@@ -147,6 +147,7 @@ describe("createTaskHandler validation", () => {
     for (const taskStatus of validStatuses) {
       const scopedDb = resolvingScopedDb();
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential test setup: each iteration asserts on its own mock
       await createTaskHandler(
         createHandlerContext({
           body: { name: "Test task", status: taskStatus },
@@ -165,6 +166,7 @@ describe("createTaskHandler validation", () => {
     for (const priority of validPriorities) {
       const scopedDb = resolvingScopedDb();
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential test setup: each iteration asserts on its own mock
       await createTaskHandler(
         createHandlerContext({
           body: { name: "Test task", priority },

--- a/apps/api/src/handlers/templates/categories.ts
+++ b/apps/api/src/handlers/templates/categories.ts
@@ -212,15 +212,17 @@ export const updateTemplateCategoryHandler = async ({
       const currentId: SafeId<"templateCategory"> = checkId;
       const ancestor:
         | { parentId: SafeId<"templateCategory"> | null }
-        | undefined = await scopedDb((tx) =>
-        tx.query.templateCategories.findFirst({
-          where: {
-            id: { eq: currentId },
-            organizationId: { eq: organizationId },
-          },
-          columns: { parentId: true },
-        }),
-      );
+        | undefined =
+        // oxlint-disable-next-line no-await-in-loop -- ancestor-chain walk: each lookup depends on the prior row's parentId
+        await scopedDb((tx) =>
+          tx.query.templateCategories.findFirst({
+            where: {
+              id: { eq: currentId },
+              organizationId: { eq: organizationId },
+            },
+            columns: { parentId: true },
+          }),
+        );
       checkId = ancestor?.parentId ?? null;
     }
   }

--- a/apps/api/src/handlers/time-entries/split.ts
+++ b/apps/api/src/handlers/time-entries/split.ts
@@ -162,6 +162,7 @@ const splitEntry = createSafeHandler(
           }
           const billedMinutes = roundToIncrement(durationMinutes);
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential inserts create ordered successor rows for the split entry
           const [entry] = await tx
             .insert(timeEntries)
             .values({

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -141,6 +141,7 @@ const abortUpload = createSafeHandler(
       uploadId,
       workspaceId,
     })) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential S3 tmp-object cleanup after multipart abort
       await getS3()
         .delete(key)
         .catch((error: unknown) =>

--- a/apps/api/src/handlers/uploads/entity-create-tree.ts
+++ b/apps/api/src/handlers/uploads/entity-create-tree.ts
@@ -314,6 +314,7 @@ const prepareSignedFiles = async ({
       uploadId,
       workspaceId,
     });
+    // oxlint-disable-next-line no-await-in-loop -- sequential presign issuance; bails on first failure to avoid orphaned URLs
     const presign = await presignUploadUrl({
       key: tmpKey,
       expiresIn: PRESIGN_URL_EXPIRY_SECONDS,
@@ -390,6 +391,7 @@ const createDirectoryRows = async ({
     const entityId = createSafeId<"entity">();
     const entityVersionId = createSafeId<"entityVersion">();
 
+    // oxlint-disable-next-line no-await-in-loop -- tree creation: child folders depend on parent IDs from earlier iterations
     await tx.insert(entities).values({
       id: entityId,
       workspaceId,
@@ -398,17 +400,20 @@ const createDirectoryRows = async ({
       name: directory.name,
       createdBy: userId,
     });
+    // oxlint-disable-next-line no-await-in-loop -- tree creation: child folders depend on parent IDs from earlier iterations
     await tx.insert(entityVersions).values({
       id: entityVersionId,
       workspaceId,
       entityId,
       versionNumber: 1,
     });
+    // oxlint-disable-next-line no-await-in-loop -- tree creation: child folders depend on parent IDs from earlier iterations
     await tx
       .update(entities)
       .set({ currentVersionId: entityVersionId })
       .where(eq(entities.id, entityId));
 
+    // oxlint-disable-next-line no-await-in-loop -- tree creation: child folders depend on parent IDs from earlier iterations
     await recordAuditEvent(tx, {
       action: AUDIT_ACTION.CREATE,
       resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
@@ -476,6 +481,7 @@ const createPendingRows = async ({
     };
 
     // audit: skip — presigned URL bookkeeping; entity audit lands on finalize.
+    // oxlint-disable-next-line no-await-in-loop -- sequential inserts in the tree-creation transaction; parents resolved earlier
     await tx.insert(pendingUploads).values({
       id: file.uploadId,
       organizationId,

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -330,6 +330,7 @@ const deleteStagedUploadObjects = async ({
   workspaceId,
 }: StagedUploadKeyProps & { stage: string }) => {
   for (const key of tmpUploadKeys({ organizationId, uploadId, workspaceId })) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential S3 tmp-object cleanup after multipart finalize
     await getS3()
       .delete(key)
       .catch((deleteError: unknown) =>

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -226,6 +226,7 @@ export const resolveTemplateProperties = async ({
   }
 
   for (const templateProperty of templatePropertiesToCreate) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential inserts preserve column order and feed the source-id mapping
     const [inserted] = await tx
       .insert(properties)
       .values({
@@ -248,6 +249,7 @@ export const resolveTemplateProperties = async ({
     propertyIdBySourceId.set(templateProperty.sourceId, inserted.id);
     nextPropertyIds.push(inserted.id);
 
+    // oxlint-disable-next-line no-await-in-loop -- audit row depends on the property id inserted in this same iteration
     await recordAuditEvent(tx, {
       action: AUDIT_ACTION.CREATE,
       resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,

--- a/apps/api/src/handlers/views/table-export.test.ts
+++ b/apps/api/src/handlers/views/table-export.test.ts
@@ -411,6 +411,7 @@ describe("table export", () => {
       Object.keys(zip.files).some((path) => path.includes("externalLink")),
     ).toBe(false);
     for (const relFile of relFiles) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential test assertions over the archive's .rels entries
       const relXml = await zip.file(relFile)?.async("text");
       expect(relXml).not.toContain('TargetMode="External"');
       expect(relXml).not.toContain("hyperlink");

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -308,6 +308,7 @@ const copyWorkspaceFiles = async ({
         return;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- worker drains the shared queue sequentially; bounded concurrency comes from running multiple copyNext workers
       const key = await copyWorkspaceFile({
         copy,
         organizationId,
@@ -705,12 +706,14 @@ const duplicateWorkspace = createSafeHandler(
           const newVersionId = createSafeId<"entityVersion">();
           const entityStamp =
             source.kind === "document"
-              ? await allocateEntityStamp(tx, targetWorkspaceId)
+              ? // oxlint-disable-next-line no-await-in-loop -- stamp allocation is a sequential per-workspace counter; must run in order within the transaction
+                await allocateEntityStamp(tx, targetWorkspaceId)
               : null;
           const newParentId = source.parentId
             ? (entityIdMap.get(source.parentId) ?? null)
             : null;
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential inserts; children reference parent IDs created in earlier iterations via entityIdMap
           await tx.insert(entities).values({
             id: newEntityId,
             workspaceId: targetWorkspaceId,
@@ -748,6 +751,7 @@ const duplicateWorkspace = createSafeHandler(
             metadata: source.metadata,
           });
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential version insert depends on the entity row created just above in this iteration
           await tx.insert(entityVersions).values({
             id: newVersionId,
             workspaceId: targetWorkspaceId,
@@ -758,6 +762,7 @@ const duplicateWorkspace = createSafeHandler(
             createdBy: user.id,
           });
 
+          // oxlint-disable-next-line no-await-in-loop -- sequential update sets currentVersionId on the just-created entity/version pair
           await tx
             .update(entities)
             .set({ currentVersionId: newVersionId })
@@ -778,6 +783,7 @@ const duplicateWorkspace = createSafeHandler(
             ];
           });
           if (newFields.length > 0) {
+            // oxlint-disable-next-line no-await-in-loop -- sequential field insert depends on the version created in this iteration
             await tx.insert(fields).values(newFields);
           }
 

--- a/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
+++ b/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
@@ -57,6 +57,7 @@ const generateBoundingBoxes = createSafeHandler(
     const boxes: BoundingBox[] = [];
 
     for (const pageNumber of preparedData.pageNumbers) {
+      // oxlint-disable-next-line no-await-in-loop -- pages processed sequentially to bound concurrent AI calls and accumulate boxes in page order
       const pageBoxesResult = await generateFn({
         abortSignal: AbortSignal.timeout(60_000),
         justificationId,

--- a/apps/api/src/lib/cell-lock.ts
+++ b/apps/api/src/lib/cell-lock.ts
@@ -54,6 +54,7 @@ export const acquireCellLocks = async ({
   // can deadlock.
   const sorted = [...propertyIds].sort();
   for (const propertyId of sorted) {
+    // oxlint-disable-next-line no-await-in-loop -- locks acquired in sorted order within one tx to avoid deadlock
     await acquireCellLock({ tx, entityVersionId, propertyId });
   }
 };

--- a/apps/api/src/lib/deepl/client.ts
+++ b/apps/api/src/lib/deepl/client.ts
@@ -393,12 +393,14 @@ export const translateDocument = async (
       });
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: each delay precedes the next status check
     await delay(pollDelay);
     pollDelay = Math.min(
       Math.round(pollDelay * POLL_BACKOFF_FACTOR),
       POLL_MAX_DELAY_MS,
     );
 
+    // oxlint-disable-next-line no-await-in-loop -- polling loop: status is fetched once per interval until DeepL is done
     const status = await fetchStatus(input.apiKey, handle);
 
     if (status.status === "error") {
@@ -409,6 +411,7 @@ export const translateDocument = async (
     }
 
     if (status.status === "done") {
+      // oxlint-disable-next-line no-await-in-loop -- terminal download runs once when polling completes, then returns
       const bytes = await downloadResult(input.apiKey, handle);
       return {
         bytes,

--- a/apps/api/src/lib/docx-stamp.ts
+++ b/apps/api/src/lib/docx-stamp.ts
@@ -352,6 +352,7 @@ const replacePlaceholders = async (
   let replaced = false;
 
   for (const path of xmlPaths) {
+    // oxlint-disable-next-line no-await-in-loop -- read-modify-write against the shared mutable JSZip archive
     const xml = await archive.readEntryString(path);
     if (!xml) {
       continue;
@@ -751,6 +752,7 @@ const parseFooterStamp = async (
   );
 
   for (const path of footerFiles) {
+    // oxlint-disable-next-line no-await-in-loop -- scans footers in order and returns on the first match
     const xml = await archive.readEntryString(path);
     if (!xml || !xml.includes(STAMP_BOOKMARK)) {
       continue;

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -107,6 +107,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
     // Sort by BM25 explicitly: without it the engine returns hits in
     // document-id order and the rank-based lexical score below would be
     // meaningless.
+    // oxlint-disable-next-line no-await-in-loop -- offset pagination: each scan depends on the previous startOffset
     const result = await getCorpusIndexClient().search({
       indexId,
       query,
@@ -145,6 +146,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
     }
 
     startOffset += hits.length;
+    // oxlint-disable-next-line no-await-in-loop -- ranks the accumulated candidates each round to decide whether to stop early
     ranking = await rankCandidates(candidates);
     windowed = windowAfterCursor(ranking.ranked, parsedCursor);
     if (windowed.length > limit) {

--- a/apps/api/src/lib/mcp-upstream/connections.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.ts
@@ -233,14 +233,14 @@ const normalizeConnectionRows = async ({
   rows: RawConnectionRow[];
   safeDb: SafeDb;
 }): Promise<LoadedMcpConnection[]> => {
-  const normalized: LoadedMcpConnection[] = [];
-  for (const rawRow of rows) {
-    const row = await normalizeMcpConnectionRow({ rawRow, safeDb });
-    if (row) {
-      normalized.push(row);
-    }
-  }
-  return normalized;
+  const normalizedRows = await Promise.all(
+    rows.map(
+      async (rawRow) => await normalizeMcpConnectionRow({ rawRow, safeDb }),
+    ),
+  );
+  return normalizedRows.filter(
+    (row): row is LoadedMcpConnection => row !== null,
+  );
 };
 
 export const createMcpClientForConnection = async ({

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -75,6 +75,7 @@ export const runSchedulerOnce = async ({
     for (const [index, job] of jobs.entries()) {
       if (signal?.aborted) {
         const unstartedJobs = jobs.slice(index);
+        // oxlint-disable-next-line no-await-in-loop -- runs once before the break on abort; jobs are drained sequentially
         await releaseUnstartedJobs({
           jobs: unstartedJobs,
           runnerId,
@@ -83,6 +84,7 @@ export const runSchedulerOnce = async ({
         break;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- jobs run sequentially; lease renewal must precede this job's run
       const leasedJob = await renewJobLeaseBeforeStart({
         job,
         leaseMs,
@@ -94,6 +96,7 @@ export const runSchedulerOnce = async ({
         continue;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- scheduler runs leased jobs one at a time, in order, honouring the abort signal
       const status = await runJob({
         job: leasedJob,
         leaseMs,
@@ -234,6 +237,7 @@ const acquireDueJobs = async ({
   const acquired: SchedulerJob[] = [];
 
   for (const candidate of candidates) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential conditional locking preserves due-order acquisition
     const [job] = await rootDb
       .update(schedulerJobs)
       .set({

--- a/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry-notifications.ts
+++ b/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry-notifications.ts
@@ -67,12 +67,14 @@ export const publishDesktopEditSessionExpiryNotificationsWithRetry = async ({
 }): Promise<void> => {
   for (const retryDelayMs of retryDelaysMs) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- sequential retry: each attempt must complete before the next backoff
       await publishDesktopEditSessionExpiryNotifications({
         publisher,
         sessions,
       });
       return;
     } catch {
+      // oxlint-disable-next-line no-await-in-loop -- sequential backoff delay between retry attempts
       await sleep(retryDelayMs);
     }
   }

--- a/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.ts
+++ b/apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.ts
@@ -38,6 +38,7 @@ export const expireDesktopEditSessions: SchedulerTask = async ({
   let expired = 0;
 
   while (!signal.aborted) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential sweep: each bounded batch is processed before fetching the next
     const unnotifiedExpiredSessions = await rootDb
       .select({
         id: desktopEditSessions.id,
@@ -53,6 +54,7 @@ export const expireDesktopEditSessions: SchedulerTask = async ({
       .orderBy(asc(desktopEditSessions.closedAt))
       .limit(EXPIRE_SWEEP_BATCH_SIZE);
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential sweep: notify this batch before continuing the drain
     await publishAndMarkExpiryNotifications(unnotifiedExpiredSessions);
 
     if (unnotifiedExpiredSessions.length === EXPIRE_SWEEP_BATCH_SIZE) {
@@ -62,6 +64,7 @@ export const expireDesktopEditSessions: SchedulerTask = async ({
     // Mirror authorizeDesktopEditSession's liveness check: a session past
     // tokenExpiresAt has no connected desktop stream refreshing it.
     const now = new Date();
+    // oxlint-disable-next-line no-await-in-loop -- sequential sweep: each bounded batch is processed before fetching the next
     const batch = await rootDb
       .select({
         id: desktopEditSessions.id,
@@ -86,6 +89,7 @@ export const expireDesktopEditSessions: SchedulerTask = async ({
 
     const batchIds = batch.map((session) => session.id);
 
+    // oxlint-disable-next-line no-await-in-loop -- per-batch transition transaction; each batch commits before the next iteration
     const expiredSessions = await rootDb.transaction(async (tx) => {
       const transitioned = await tx
         .update(desktopEditSessions)
@@ -116,6 +120,7 @@ export const expireDesktopEditSessions: SchedulerTask = async ({
     });
 
     expired += expiredSessions.length;
+    // oxlint-disable-next-line no-await-in-loop -- sequential sweep: notify this batch before continuing the drain
     await publishAndMarkExpiryNotifications(expiredSessions);
 
     if (batch.length < EXPIRE_SWEEP_BATCH_SIZE) {

--- a/apps/api/src/lib/scheduler/tasks/infosoud.ts
+++ b/apps/api/src/lib/scheduler/tasks/infosoud.ts
@@ -27,6 +27,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
   let total = 0;
 
   while (!signal.aborted) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential sweep: each batch is processed before loading the next
     const trackedCases = await loadNextTrackedCaseBatch(syncStartedAt);
     if (trackedCases.length === 0) {
       break;
@@ -41,6 +42,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
       }
 
       try {
+        // oxlint-disable-next-line no-await-in-loop -- rate-limited external court lookups must run one at a time
         const lookupResult = await client.searchCaseWithHearings({
           courtCode: trackedCase.courtCode,
           signal,
@@ -57,6 +59,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
         }
 
         if (agendaItems.length > LIMITS.infoSoudAgendaImportItemsMax) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential per-case sweep with abort checks and ordered counters
           await markTrackedCaseFailed({
             error: "InfoSoudAgendaImportLimit",
             trackedCaseId: trackedCase.id,
@@ -65,6 +68,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
           continue;
         }
 
+        // oxlint-disable-next-line no-await-in-loop -- per-case import transaction commits before the next case is processed
         const importResult = await rootDb.transaction(async (tx) => {
           const result = await importInfoSoudAgendaItems({
             actorUserId: trackedCase.createdBy,
@@ -86,6 +90,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
         });
 
         if (!importResult.ok) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential per-case sweep with abort checks and ordered counters
           await markTrackedCaseFailed({
             error: "InfoSoudAgendaImportFailed",
             trackedCaseId: trackedCase.id,
@@ -101,6 +106,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
           break;
         }
 
+        // oxlint-disable-next-line no-await-in-loop -- sequential per-case sweep with abort checks and ordered counters
         await markTrackedCaseFailed({
           error: errorTag(error),
           trackedCaseId: trackedCase.id,

--- a/apps/api/src/lib/search/extraction-worker.ts
+++ b/apps/api/src/lib/search/extraction-worker.ts
@@ -126,6 +126,7 @@ const extractEmailPlaintext = async ({
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential recursive extraction preserves attachment order and bounds memory
     const text = await extractAttachmentPlaintext({
       bytes: attachment.bytes,
       maxChars,

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -198,6 +198,7 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
   let total = 0;
 
   for (;;) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset pagination: each batch depends on the previous cursor
     const batch = await rootDb.execute<{ id: SafeId<"chatThread"> }>(sql`
       SELECT t.id
       FROM chat_threads t
@@ -225,6 +226,7 @@ export const backfillChatThreadSearchIndex = async (): Promise<number> => {
 
     for (const row of batch) {
       try {
+        // oxlint-disable-next-line no-await-in-loop -- sequential per-thread backfill writes bound DB load
         await upsertChatThreadSearchDocument(row.id);
       } catch (error) {
         captureError(error, {

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -1477,6 +1477,7 @@ export const upsertWorkspaceSearchDocuments = async (
           if (!workspaceId) {
             return;
           }
+          // oxlint-disable-next-line no-await-in-loop -- bounded-concurrency worker draining a shared queue; the pool itself runs in parallel
           await upsertWorkspaceSearchDocument(workspaceId);
         }
       })(),
@@ -1526,6 +1527,7 @@ export const rebuildSupplementalSearchIndex = async (
   let hasMoreContacts = true;
 
   while (hasMoreContacts) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset pagination: each batch depends on the previous lastContactId cursor
     const batch = await rootDb
       .select({ id: contacts.id })
       .from(contacts)
@@ -1541,6 +1543,7 @@ export const rebuildSupplementalSearchIndex = async (
       .limit(REINDEX_BATCH_SIZE);
 
     for (const contact of batch) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-contact reindex writes bound DB load during rebuild
       await upsertContactSearchDocument(contact.id);
     }
 
@@ -1552,6 +1555,7 @@ export const rebuildSupplementalSearchIndex = async (
   let hasMoreWorkspaces = true;
 
   while (hasMoreWorkspaces) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset pagination: each batch depends on the previous lastWorkspaceId cursor
     const batch = await rootDb
       .select({ id: workspaces.id })
       .from(workspaces)
@@ -1567,6 +1571,7 @@ export const rebuildSupplementalSearchIndex = async (
       .limit(REINDEX_BATCH_SIZE);
 
     for (const workspace of batch) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-workspace reindex writes bound DB load during rebuild
       await upsertWorkspaceSearchDocument(workspace.id);
     }
 

--- a/apps/api/src/lib/search/pg-fts-provider.ts
+++ b/apps/api/src/lib/search/pg-fts-provider.ts
@@ -288,6 +288,7 @@ const rebuildIndex = async (orgId: SafeId<"organization">): Promise<void> => {
     let hasMore = true;
     while (hasMore) {
       // Keyset pagination: O(1) per batch vs O(N) for offset
+      // oxlint-disable-next-line no-await-in-loop -- keyset pagination: each batch depends on the previous lastId cursor
       const batch = await rootDb
         .select({ id: entities.id })
         .from(entities)
@@ -300,6 +301,7 @@ const rebuildIndex = async (orgId: SafeId<"organization">): Promise<void> => {
         .limit(REINDEX_BATCH_SIZE);
 
       for (const entity of batch) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential per-entity reindex writes bound DB load during rebuild
         await indexEntity(entity.id);
       }
 

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -345,6 +345,7 @@ const removeQueuedWorkflowJobs = async (
   jobIds: readonly string[],
 ): Promise<void> => {
   for (const chunk of chunkItems(jobIds, LIMITS.workflowEntityBatchSize)) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential chunk drain bounds the per-batch Promise.all concurrency
     await Promise.all(
       chunk.map(async (jobId) => {
         try {
@@ -554,6 +555,7 @@ export const startWorkflow = async ({
           workflowEntityJobId({ entityId, requestId }),
         );
         queuedJobIds.push(...chunkJobIds);
+        // oxlint-disable-next-line no-await-in-loop -- sequential chunk enqueue bounds queue write batch size and preserves job ordering
         await enqueueEntityJobs({
           entityIds: chunk,
           executionPlan,
@@ -643,6 +645,7 @@ const scanRunningLockWorkspaceIds = async (
     // Bun's RedisClient exposes raw commands via `send`; SCAN returns
     // [nextCursor, keys]. Iterating the cursor keeps a large keyspace off
     // a single blocking pass (unlike KEYS).
+    // oxlint-disable-next-line no-await-in-loop -- SCAN cursor iteration: each call depends on the previous cursor
     const reply: unknown = await redis.send("SCAN", [
       cursor,
       "MATCH",
@@ -693,6 +696,7 @@ const selectWorkspacesWithPendingCells = async (
             fields.workspaceId,
             workspaceIdBatch.map((id) => brandPersistedWorkspaceId(id)),
           );
+    // oxlint-disable-next-line no-await-in-loop -- sequential batched DB scan bounds the IN-list size per query
     const rows = await rootDb
       .selectDistinct({ workspaceId: fields.workspaceId })
       .from(fields)
@@ -733,6 +737,7 @@ const readWorkflowRequestIds = async (
     workspaceIds,
     LIMITS.workflowEntityBatchSize,
   )) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential batch drain bounds the per-batch Promise.all concurrency against Redis
     await Promise.all(
       workspaceIdBatch.map(async (id) => {
         const requestId = await redis.get(
@@ -754,6 +759,7 @@ const readWorkflowRunningValues = async (
     workspaceIds,
     LIMITS.workflowEntityBatchSize,
   )) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential batch drain bounds the per-batch Promise.all concurrency against Redis
     await Promise.all(
       workspaceIdBatch.map(async (id) => {
         const runningValue = await redis.get(
@@ -991,6 +997,7 @@ export const reconcileOrphanedWorkflows = async ({
   });
 
   for (const workspaceId of recoverableOrphans) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential recovery serialises lock contention across orphaned workflows
     await recoverOrphanedWorkflow({
       expectedRequestId: currentRequestIds.get(workspaceId) ?? null,
       workspaceId: brandPersistedWorkspaceId(workspaceId),
@@ -1254,6 +1261,7 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
   });
 
   for (let level = 0; level < executionPlan.length; level++) {
+    // oxlint-disable-next-line no-await-in-loop -- levels run in dependency order; recheck current request before each level
     const isStillCurrentRequest = await isCurrentWorkflowRequest({
       requestId,
       workspaceId: branded.workspaceId,
@@ -1273,6 +1281,7 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
 
     // Process all batches at this level in parallel
     // (same level = independent dependencies)
+    // oxlint-disable-next-line no-await-in-loop -- levels run in dependency order; a level must finish before the next starts
     await Promise.all(
       batches.map(
         async (batch) =>

--- a/apps/api/src/lib/workflow-target-queries.ts
+++ b/apps/api/src/lib/workflow-target-queries.ts
@@ -40,6 +40,7 @@ export const fetchExplicitWorkflowTargetRows = async ({
 }): Promise<WorkflowTargetEntityRow[]> => {
   const entityRows: WorkflowTargetEntityRow[] = [];
   for (const chunk of chunkEntityIds(inputEntityIds)) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential batched DB scan bounds the IN-list size per query
     const rows = await scopedDb((tx) =>
       tx
         .select({ id: entities.id, kind: entities.kind })
@@ -130,6 +131,7 @@ export const collectFullWorkflowTargetIds = async ({
   let lastCursor: FullWorkflowTargetCursor | null = null;
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- keyset pagination: each batch depends on the previous lastCursor
     const rows = await fetchFullWorkflowTargetBatch({
       createdAtCutoff,
       lastCursor,

--- a/apps/api/src/lib/workflow/docx-blocks.ts
+++ b/apps/api/src/lib/workflow/docx-blocks.ts
@@ -900,6 +900,7 @@ export const extractFolioBlockTextFromDocxBuffer = async (
   let blockIndex = 0;
 
   for (const path of sortedDocxPartPaths(zip, DOCX_HEADER_RE)) {
+    // oxlint-disable-next-line no-await-in-loop -- each part consumes the running blockIndex and shared `taken` set from the previous iteration
     const result = await extractBlocksFromZipEntry({
       comments,
       path,
@@ -923,6 +924,7 @@ export const extractFolioBlockTextFromDocxBuffer = async (
   blockIndex = bodyResult.nextBlockIndex;
 
   for (const path of sortedDocxPartPaths(zip, DOCX_FOOTER_RE)) {
+    // oxlint-disable-next-line no-await-in-loop -- each part consumes the running blockIndex and shared `taken` set from the previous iteration
     const result = await extractBlocksFromZipEntry({
       comments,
       path,

--- a/apps/api/src/lib/workflow/generate-batch-mock.ts
+++ b/apps/api/src/lib/workflow/generate-batch-mock.ts
@@ -115,6 +115,7 @@ export const generateBatchMock = async ({
       switch (content.type) {
         case "text": {
           const value = `${inputFieldValue} + ${faker.lorem.word()}`;
+          // oxlint-disable-next-line no-await-in-loop -- mock emits partial answers sequentially to mirror streaming order
           await onPartialAnswer?.({ propertyId: property.id, answer: value });
           aiResults.push({
             fieldId,
@@ -131,6 +132,7 @@ export const generateBatchMock = async ({
         case "single-select": {
           const possibleValues = content.options.map((option) => option.value);
           const value = faker.helpers.arrayElement(possibleValues);
+          // oxlint-disable-next-line no-await-in-loop -- mock emits partial answers sequentially to mirror streaming order
           await onPartialAnswer?.({ propertyId: property.id, answer: value });
           aiResults.push({
             fieldId,
@@ -150,6 +152,7 @@ export const generateBatchMock = async ({
             min: 1,
             max: possibleValues.length,
           });
+          // oxlint-disable-next-line no-await-in-loop -- mock emits partial answers sequentially to mirror streaming order
           await onPartialAnswer?.({
             propertyId: property.id,
             answer: value.join(", "),
@@ -170,6 +173,7 @@ export const generateBatchMock = async ({
         case "date": {
           const value =
             faker.date.past().toISOString().split("T")[0] ?? "1970-01-01";
+          // oxlint-disable-next-line no-await-in-loop -- mock emits partial answers sequentially to mirror streaming order
           await onPartialAnswer?.({ propertyId: property.id, answer: value });
           aiResults.push({
             fieldId,
@@ -187,6 +191,7 @@ export const generateBatchMock = async ({
           const currencies = ["USD", "EUR", "CZK", null];
           const value = faker.number.int({ min: 0, max: 1_000_000 });
           const currency = faker.helpers.arrayElement(currencies);
+          // oxlint-disable-next-line no-await-in-loop -- mock emits partial answers sequentially to mirror streaming order
           await onPartialAnswer?.({
             propertyId: property.id,
             answer: currency ? `${value} ${currency}` : String(value),

--- a/apps/api/src/lib/workflow/run-logic.ts
+++ b/apps/api/src/lib/workflow/run-logic.ts
@@ -121,6 +121,7 @@ export const runWorkflowBatchGenerationWithRetry = async <TValue>({
   let attempt = 1;
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- retry loop: each attempt must complete before deciding to retry
     const batchResult = await generate();
 
     if (!Result.isError(batchResult)) {
@@ -138,6 +139,7 @@ export const runWorkflowBatchGenerationWithRetry = async <TValue>({
 
     onRetryError(batchResult.error, attempt);
     throwIfAborted();
+    // oxlint-disable-next-line no-await-in-loop -- sequential backoff delay between retry attempts
     await sleep(WORKFLOW_INTEGRATION_ERROR_RETRY_DELAY_MS);
     throwIfAborted();
     attempt++;

--- a/apps/api/src/lib/workflow/streaming-answer.ts
+++ b/apps/api/src/lib/workflow/streaming-answer.ts
@@ -87,6 +87,7 @@ export const consumePartialAnswers = async ({
         continue;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- partial answers must be emitted in stream arrival order
       await onPartialAnswer({ propertyId, answer });
     }
   }

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -144,6 +144,7 @@ const anonymizeCompatSearchResults = async ({
     Array.from({ length: results.length });
 
   for (const [workspaceId, group] of byWorkspace) {
+    // oxlint-disable-next-line no-await-in-loop -- per-workspace anonymization bounds gazetteer/DB load across tenants
     const anonymized = await anonymizeTextFields({
       fields: group.titles,
       gazetteerEntries,

--- a/apps/api/src/mcp/gateway/rate-limit.test.ts
+++ b/apps/api/src/mcp/gateway/rate-limit.test.ts
@@ -47,6 +47,7 @@ describe("MCP gateway rate limiter", () => {
 
     for (let index = 0; index < LIMITS.mcpGatewayRateLimitMax; index += 1) {
       expect(
+        // oxlint-disable-next-line no-await-in-loop -- each consume mutates the limiter budget; order under test
         await limiter.consume({ connectorSlug: "registry", userId: "user_1" }),
       ).toBe(true);
     }
@@ -80,6 +81,7 @@ describe("MCP gateway rate limiter", () => {
 
     for (let index = 0; index < LIMITS.mcpGatewayRateLimitMax; index += 1) {
       expect(
+        // oxlint-disable-next-line no-await-in-loop -- each consume mutates the limiter budget; order under test
         await limiter.consume({ connectorSlug: "registry", userId: "user_1" }),
       ).toBe(true);
     }

--- a/apps/api/src/scripts/backfill-corpus-storage.ts
+++ b/apps/api/src/scripts/backfill-corpus-storage.ts
@@ -91,6 +91,7 @@ while (true) {
     ? and(isNull(caseLawDecisions.textS3Key), idFilter)
     : isNull(caseLawDecisions.textS3Key);
 
+  // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: next page cursor (lastId) depends on this query
   const rows: BackfillRow[] = await ingestionDb((tx) =>
     tx
       .select({
@@ -112,6 +113,7 @@ while (true) {
   }
 
   for (let i = 0; i < rows.length; i += CONCURRENCY) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one CONCURRENCY-sized chunk before starting the next
     await Promise.all(rows.slice(i, i + CONCURRENCY).map(backfillRow));
   }
 

--- a/apps/api/src/scripts/backfill-fulltext.ts
+++ b/apps/api/src/scripts/backfill-fulltext.ts
@@ -153,6 +153,7 @@ const backfillAdapter = async (config: BackfillConfig) => {
   let failed = 0;
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: fetch one batch of missing-fulltext rows at a time
     const batch = await rootDb
       .select({
         id: caseLawDecisions.id,
@@ -177,6 +178,7 @@ const backfillAdapter = async (config: BackfillConfig) => {
 
       if (!url) {
         // No URL available — mark as empty to prevent re-query
+        // oxlint-disable-next-line no-await-in-loop -- mark this row empty before continuing; keeps progress per row
         await rootDb
           .update(caseLawDecisions)
           .set({ fulltext: "" })
@@ -186,11 +188,13 @@ const backfillAdapter = async (config: BackfillConfig) => {
         continue;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- rate-limited source fetch, one row at a time
       const fulltext = await config.fetchFulltext(url);
 
       // Always update the row — set empty string on failure so
       // the NULL check no longer matches and we don't re-query
       // this row forever.
+      // oxlint-disable-next-line no-await-in-loop -- update this row's fulltext after its sequential, rate-limited fetch
       await rootDb
         .update(caseLawDecisions)
         .set({ fulltext: fulltext ?? "" })
@@ -211,6 +215,7 @@ const backfillAdapter = async (config: BackfillConfig) => {
         );
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- per-row delay enforces the source rate limit between fetches
       await Bun.sleep(config.delayMs);
     }
   }
@@ -224,6 +229,7 @@ const backfillAdapter = async (config: BackfillConfig) => {
 console.log("Starting fulltext backfill...\n");
 
 for (const config of CONFIGS) {
+  // oxlint-disable-next-line no-await-in-loop -- run adapters one at a time; each is independently rate-limited
   await backfillAdapter(config);
   console.log();
 }

--- a/apps/api/src/scripts/build-corpus-index.ts
+++ b/apps/api/src/scripts/build-corpus-index.ts
@@ -29,6 +29,7 @@ console.log(`=== BUILD CORPUS INDEX: generation ${generation} ===`);
 
 let total = 0;
 while (true) {
+  // oxlint-disable-next-line no-await-in-loop -- drives backfill to completion one batch at a time until none remain
   const indexed = await backfillCorpusIndex(
     ingestionDb,
     LIMITS.corpusIndexBatchSize,

--- a/apps/api/src/scripts/repair-case-law-jsonb.ts
+++ b/apps/api/src/scripts/repair-case-law-jsonb.ts
@@ -146,6 +146,7 @@ const main = async () => {
 
   while (true) {
     const batchStart = performance.now();
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: next cursor depends on this batch's result
     const result = await repairBatch(cursor);
 
     if (!result || result.scanned === 0) {

--- a/apps/api/src/scripts/resolve-citations.ts
+++ b/apps/api/src/scripts/resolve-citations.ts
@@ -111,6 +111,7 @@ const seedRules = async () => {
 
   let upserted = 0;
   for (const rule of SEED_RULES) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves upsert order across rules
     await rootDb
       .insert(caseLawPolarityRules)
       .values({
@@ -238,6 +239,7 @@ const resolveCitations = async (): Promise<ResolveStats> => {
   let offset = 0;
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: process one batch at a time
     const batch = await rootDb
       .select({
         id: caseLawCitations.id,
@@ -309,6 +311,7 @@ const resolveCitations = async (): Promise<ResolveStats> => {
       }
 
       if (validId && !DRY_RUN) {
+        // oxlint-disable-next-line no-await-in-loop -- bounded memory: resolve one batch row at a time
         await rootDb
           .update(caseLawCitations)
           .set({ citedDecisionId: validId })
@@ -386,6 +389,7 @@ const classifyWithRules = async () => {
   let noMatch = 0;
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded memory: process one batch at a time
     const batch = await rootDb
       .select({
         id: caseLawCitations.id,
@@ -406,6 +410,7 @@ const classifyWithRules = async () => {
 
     for (const row of batch) {
       // Get the citing decision's sections for context
+      // oxlint-disable-next-line no-await-in-loop -- bounded memory: load decision context for one batch row at a time
       const [decision] = await rootDb
         .select({ sections: caseLawDecisions.sections })
         .from(caseLawDecisions)
@@ -427,6 +432,7 @@ const classifyWithRules = async () => {
       for (const rule of compiled) {
         if (context && rule.pattern.test(context)) {
           if (!DRY_RUN && !REPORT_ONLY) {
+            // oxlint-disable-next-line no-await-in-loop -- bounded memory: classify one batch row at a time
             await rootDb
               .update(caseLawCitations)
               .set({
@@ -444,6 +450,7 @@ const classifyWithRules = async () => {
       if (!matched) {
         // Set as "unknown" so we don't re-process
         if (!DRY_RUN && !REPORT_ONLY) {
+          // oxlint-disable-next-line no-await-in-loop -- bounded memory: classify one batch row at a time
           await rootDb
             .update(caseLawCitations)
             .set({ polarity: "unknown" })
@@ -571,6 +578,7 @@ const printReport = async () => {
     "negative",
     "neutral",
   ] as const) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential status check; sample output is printed in order per polarity
     const examples = await rootDb.execute(sql`
       SELECT
         c.citation_text,

--- a/apps/api/src/tests/load/upload-load.ts
+++ b/apps/api/src/tests/load/upload-load.ts
@@ -201,6 +201,7 @@ const runPool = async <T>(
       if (!task) {
         continue;
       }
+      // oxlint-disable-next-line no-await-in-loop -- bounded-concurrency worker draining a shared task queue; the pool runs in parallel
       results[taskIndex] = await task();
     }
   };

--- a/apps/api/src/tests/security/case-law-slug-migration.test.ts
+++ b/apps/api/src/tests/security/case-law-slug-migration.test.ts
@@ -69,6 +69,7 @@ const runSlugMigration = async ({
     if (!statement.trim()) {
       continue;
     }
+    // oxlint-disable-next-line no-await-in-loop -- ordered migration statements run sequentially on one test DB connection
     await testDb.execute(sql.raw(statement));
   }
 };

--- a/apps/api/src/tests/security/file-upload-limits.test.ts
+++ b/apps/api/src/tests/security/file-upload-limits.test.ts
@@ -12,6 +12,7 @@ const listTypeScriptFiles = async (dir: string): Promise<string[]> => {
   for (const entry of entries) {
     const path = nodePath.join(dir, entry.name);
     if (entry.isDirectory()) {
+      // oxlint-disable-next-line no-await-in-loop -- recursive depth-first traversal accumulates files in directory order
       files.push(...(await listTypeScriptFiles(path)));
       continue;
     }
@@ -34,6 +35,7 @@ describe("file upload limits", () => {
         continue;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential reads keep offender ordering deterministic for the assertion
       const source = await readFile(file, "utf-8");
       for (const args of extractFileSchemaArgs(source)) {
         if (!args.includes("maxSize")) {

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -66,6 +66,7 @@ const createTestDb = async (): Promise<TestDatabase> => {
 
   const { sqlStatements } = await pushSchema(allSchema, pushSchemaDb);
   for (const statement of sqlStatements) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered DDL statements run sequentially on one test DB connection
     await testDb.execute(sql.raw(statement));
   }
 

--- a/apps/collab/src/server.test.ts
+++ b/apps/collab/src/server.test.ts
@@ -41,6 +41,7 @@ const waitFor = async (
       return;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- polling delay between predicate checks until the condition is met
     await Bun.sleep(10);
   }
 

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -247,6 +247,7 @@ const backfillCaseLaw = async (
     if (batchSize === 0) {
       break;
     }
+    // oxlint-disable-next-line no-await-in-loop -- credential refresh must complete before the next batch's S3 writes; sequential by design
     await refreshStaleS3();
 
     const idFilter: SQL | undefined =
@@ -255,6 +256,7 @@ const backfillCaseLaw = async (
       ? and(isNull(caseLawDecisions.textS3Key), idFilter)
       : isNull(caseLawDecisions.textS3Key);
 
+    // oxlint-disable-next-line no-await-in-loop -- cursor-paged select; each page depends on the prior page's lastId, so batches must run sequentially
     const rows: BackfillRow[] = await ingestionDb((tx) =>
       tx
         .select({
@@ -276,6 +278,7 @@ const backfillCaseLaw = async (
     }
 
     for (let i = 0; i < rows.length; i += CONCURRENCY) {
+      // oxlint-disable-next-line no-await-in-loop -- bounded chunked writes: each CONCURRENCY-sized chunk must settle before the next to cap in-flight S3/DB pressure
       const outcomes = await Promise.all(
         rows.slice(i, i + CONCURRENCY).map(backfillRow),
       );
@@ -307,6 +310,7 @@ const backfillLegislation = async (
     if (batchSize === 0) {
       break;
     }
+    // oxlint-disable-next-line no-await-in-loop -- credential refresh must complete before the next batch's S3 writes; sequential by design
     await refreshStaleS3();
 
     const idFilter: SQL | undefined =
@@ -315,6 +319,7 @@ const backfillLegislation = async (
       ? and(isNull(legislationDocuments.textS3Key), idFilter)
       : isNull(legislationDocuments.textS3Key);
 
+    // oxlint-disable-next-line no-await-in-loop -- cursor-paged select; each page depends on the prior page's lastId, so batches must run sequentially
     const rows: LegislationBackfillRow[] = await ingestionDb((tx) =>
       tx
         .select({
@@ -336,6 +341,7 @@ const backfillLegislation = async (
     }
 
     for (let i = 0; i < rows.length; i += CONCURRENCY) {
+      // oxlint-disable-next-line no-await-in-loop -- bounded chunked writes: each CONCURRENCY-sized chunk must settle before the next to cap in-flight S3/DB pressure
       const outcomes = await Promise.all(
         rows.slice(i, i + CONCURRENCY).map(backfillLegislationRow),
       );
@@ -370,8 +376,10 @@ const backfillCaseLawIndex = async (
     if (batchSize === 0) {
       break;
     }
+    // oxlint-disable-next-line no-await-in-loop -- credential refresh must complete before the next batch's S3 reads; sequential by design
     await refreshStaleS3();
 
+    // oxlint-disable-next-line no-await-in-loop -- batches drain a queue sequentially; the next iteration only proceeds once this batch's count is known
     const count = await backfillCorpusIndex(ingestionDb, batchSize, generation);
     if (count === 0) {
       break;
@@ -395,8 +403,10 @@ const backfillLegislationIndex = async (
     if (batchSize === 0) {
       break;
     }
+    // oxlint-disable-next-line no-await-in-loop -- credential refresh must complete before the next batch's S3 reads; sequential by design
     await refreshStaleS3();
 
+    // oxlint-disable-next-line no-await-in-loop -- batches drain a queue sequentially; the next iteration only proceeds once this batch's count is known
     const count = await backfillLegislationCorpusIndex(
       ingestionDb,
       batchSize,

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -412,6 +412,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
 
   while (true) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- continuous daemon: each adapter cycle must finish before the next so the persisted cursor advances in order
       const { outcome, inserted } = await runOneCycle(adapterKey, name);
 
       if (outcome === "failed") {
@@ -471,6 +472,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
     } else {
       delayMs = CYCLE_DELAY_MS;
     }
+    // oxlint-disable-next-line no-await-in-loop -- inter-cycle backoff/idle delay; the loop must pause before the next cycle, so this await is intentionally sequential
     await Bun.sleep(delayMs);
   }
 };
@@ -569,13 +571,16 @@ export const runCaseLawIngest = async (
   // Health loop: heartbeat + S3 credential refresh.
   const healthLoop = (async () => {
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval health poll; the loop must wait HEALTH_INTERVAL_MS between heartbeats, so this await is intentionally sequential
       await Bun.sleep(HEALTH_INTERVAL_MS);
       writeHeartbeat();
       try {
         if (isS3Stale()) {
+          // oxlint-disable-next-line no-await-in-loop -- credential refresh per poll cycle; must complete before the loop sleeps and re-checks staleness
           await refreshS3();
         }
         if (isCorpusS3Stale()) {
+          // oxlint-disable-next-line no-await-in-loop -- credential refresh per poll cycle; must complete before the loop sleeps and re-checks staleness
           await refreshCorpusS3();
         }
       } catch (error) {
@@ -591,8 +596,10 @@ export const runCaseLawIngest = async (
   // timeout so long texts don't block other work.
   const searchIndexLoop = (async () => {
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait SEARCH_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
       try {
+        // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await backfillSearchIndex(
           ingestionDb,
           SEARCH_INDEX_BATCH_SIZE,
@@ -616,8 +623,10 @@ export const runCaseLawIngest = async (
   // continuous daemon). Runs via the ingestion role outside the DB slot.
   const citationAuthorityLoop = (async () => {
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval recompute poll; the loop must wait CITATION_AUTHORITY_INTERVAL_MS between recomputes, so this await is intentionally sequential
       await Bun.sleep(CITATION_AUTHORITY_INTERVAL_MS);
       try {
+        // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const updated = await ingestionDb(async (tx) => {
           const count = await recomputeCitationAuthorityForAll(tx);
           return count;
@@ -646,8 +655,10 @@ export const runCaseLawIngest = async (
     const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
     logInfo(`[corpus-index] Enabled for generation ${generation}`);
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
       try {
+        // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await backfillCorpusIndex(
           ingestionDb,
           LIMITS.corpusIndexBatchSize,
@@ -671,8 +682,10 @@ export const runCaseLawIngest = async (
   // corpus daemon maintains both families' search projections.
   const legislationSearchIndexLoop = (async () => {
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait SEARCH_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
       try {
+        // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await backfillLegislationSearchIndex(
           ingestionDb,
           SEARCH_INDEX_BATCH_SIZE,
@@ -701,8 +714,10 @@ export const runCaseLawIngest = async (
     const generation = corpusGeneration("legislation");
     logInfo(`[legislation-corpus-index] Enabled for generation ${generation}`);
     while (true) {
+      // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
       await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
       try {
+        // oxlint-disable-next-line no-await-in-loop -- one bounded backfill batch per interval; the next poll only runs after this batch completes
         const indexed = await backfillLegislationCorpusIndex(
           ingestionDb,
           LIMITS.corpusIndexBatchSize,

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -87,6 +87,7 @@ const waitForDeployedRevision = async (): Promise<void> => {
   let consecutive = 0;
 
   while (Date.now() < deadline) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential readiness sampling: each sample must follow the prior interval to build a streak
     const readiness = await Promise.all(
       ORIGINS.map(async (origin) => await origin.isReady(expectedCommit)),
     );
@@ -94,6 +95,7 @@ const waitForDeployedRevision = async (): Promise<void> => {
     if (consecutive >= READINESS_STABLE_SAMPLES) {
       return;
     }
+    // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: wait between readiness samples
     await sleep(READINESS_INTERVAL_MS);
   }
 

--- a/apps/web/scripts/assert-start-runtime-build.ts
+++ b/apps/web/scripts/assert-start-runtime-build.ts
@@ -8,14 +8,14 @@ const requiredFiles = [
   "dist/client/dark-mode-init.js",
 ] as const;
 
-const missingPaths: string[] = [];
-for (const path of requiredFiles) {
-  if (await Bun.file(new URL(path, WEB_ROOT_URL)).exists()) {
-    continue;
-  }
-
-  missingPaths.push(path);
-}
+const requiredFileExistence = await Promise.all(
+  requiredFiles.map(
+    async (path) => await Bun.file(new URL(path, WEB_ROOT_URL)).exists(),
+  ),
+);
+const missingPaths: string[] = requiredFiles.filter(
+  (_, index) => !requiredFileExistence[index],
+);
 
 const clientAssetGlob = new Bun.Glob("dist/client/assets/*");
 let hasClientAsset = false;

--- a/apps/web/src/components/autocomplete/use-autocomplete-stream.ts
+++ b/apps/web/src/components/autocomplete/use-autocomplete-stream.ts
@@ -96,6 +96,7 @@ const consumeAutocompleteStream = async (
   const decoder = new TextDecoder();
   let buffer = "";
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential stream read: each chunk must be decoded before the next
     const chunk = await reader.read();
     if (chunk.done) {
       cb.onDone();

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -260,24 +260,27 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   const searchMentionItems = useCallback(async (query: string) => {
     const items: ChatMentionOption[] = [];
 
-    for (const { registration } of registrationsRef.current.values()) {
-      if (!registration.mentionSources) {
+    // Mention sources are independent; query them in parallel and append
+    // results in registration/source order (preserved by Promise.all).
+    const sources = Array.from(registrationsRef.current.values()).flatMap(
+      ({ registration }) => registration.mentionSources ?? [],
+    );
+    const results = await Promise.all(
+      sources.map(
+        async (source) =>
+          await Result.tryPromise(
+            async () => await source.searchItems?.(query),
+          ),
+      ),
+    );
+
+    for (const result of results) {
+      if (Result.isError(result)) {
+        getAnalytics().captureError(result.error);
         continue;
       }
-
-      for (const source of registration.mentionSources) {
-        const nextItemsResult = await Result.tryPromise(
-          async () => await source.searchItems?.(query),
-        );
-        if (Result.isError(nextItemsResult)) {
-          getAnalytics().captureError(nextItemsResult.error);
-          continue;
-        }
-
-        const nextItems = nextItemsResult.value;
-        if (nextItems !== undefined) {
-          items.push(...nextItems);
-        }
+      if (result.value !== undefined) {
+        items.push(...result.value);
       }
     }
 

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -107,6 +107,7 @@ export const DevSidebarGroup = () => {
     }
 
     for (let i = 0; i < SEED_STATUS_MAX_POLLS; i++) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential status poll: each probe reflects progress after the prior interval
       const status = await api.dev.seed.get();
       if (status.error) {
         setSeeding(false);
@@ -126,6 +127,7 @@ export const DevSidebarGroup = () => {
 
       if (status.data.status === "succeeded") {
         setSeeding(false);
+        // oxlint-disable-next-line no-await-in-loop -- terminal poll branch: returns right after, runs at most once
         await queryClient.invalidateQueries();
         stellaToast.add({
           title: "Dev data seeded",
@@ -134,6 +136,7 @@ export const DevSidebarGroup = () => {
         return;
       }
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: wait between seed status probes
       await sleep(SEED_STATUS_POLL_INTERVAL_MS);
     }
 

--- a/apps/web/src/components/inspector/skill-resource-panel.tsx
+++ b/apps/web/src/components/inspector/skill-resource-panel.tsx
@@ -155,8 +155,10 @@ export const SkillResourcePanel = ({
       const stored = toStoredMarkdown(next, content);
       const response =
         target === "body"
-          ? await skill.patch({ body: stored, queryKey: ["skills"] })
-          : await skill.resources.patch({
+          ? // oxlint-disable-next-line no-await-in-loop -- sequential save queue: each write must land before retrying with newer markdown
+            await skill.patch({ body: stored, queryKey: ["skills"] })
+          : // oxlint-disable-next-line no-await-in-loop -- sequential save queue: each write must land before retrying with newer markdown
+            await skill.resources.patch({
               path: resourcePath,
               content: stored,
               queryKey: ["skills"],

--- a/apps/web/src/hooks/external-file-drop.logic.ts
+++ b/apps/web/src/hooks/external-file-drop.logic.ts
@@ -105,6 +105,7 @@ const readAllDirectoryEntries = async (
   const entries: unknown[] = [];
 
   while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- paged reader: each readEntries call drains the next batch from the same cursor
     const batch = await readDirectoryEntriesBatch(reader);
     if (batch.length === 0) {
       return entries;
@@ -129,6 +130,7 @@ const collectDirectory = async ({
   const entries = await readAllDirectoryEntries(entry);
   for (const child of entries) {
     if (isDirectoryEntry(child)) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered traversal: children append to a shared tree in deterministic order
       await collectDirectory({
         entry: child,
         path: pathWithSegment(path, child.name),
@@ -141,6 +143,7 @@ const collectDirectory = async ({
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- ordered traversal: files append to a shared tree in deterministic order
     const file = await readFileEntry(child);
     tree.files.push({
       file,
@@ -164,6 +167,7 @@ export const collectDroppedFileTree = async ({
 
     const entry = item.webkitGetAsEntry?.();
     if (isDirectoryEntry(entry)) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered traversal: dropped items append to a shared tree in deterministic order
       await collectDirectory({
         entry,
         path: pathWithSegment([], entry.name),
@@ -173,6 +177,7 @@ export const collectDroppedFileTree = async ({
     }
 
     if (isFileEntry(entry)) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered traversal: dropped files append to a shared tree in deterministic order
       const file = await readFileEntry(entry);
       tree.files.push({
         file,

--- a/apps/web/src/lib/desktop-bridge.ts
+++ b/apps/web/src/lib/desktop-bridge.ts
@@ -137,10 +137,12 @@ const wakeDesktopAndReadBridgeHealth =
 
     const deadline = Date.now() + DESKTOP_BRIDGE_START_TIMEOUT_MS;
     while (Date.now() < deadline) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: must wait before re-checking the bridge
       await wait(
         Math.min(DESKTOP_BRIDGE_START_POLL_INTERVAL_MS, deadline - Date.now()),
       );
 
+      // oxlint-disable-next-line no-await-in-loop -- sequential health poll: each probe depends on the prior wait elapsing
       const health = await readBridgeHealth(1000);
       if (health) {
         return health;
@@ -245,6 +247,7 @@ const waitForDesktopEditHandoffOpened = async ({
     : Date.now() + 30_000;
 
   while (Date.now() < deadline) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential status poll: deadline may extend per status response, so probes must be ordered
     const handoffStatus = await readDesktopEditHandoffStatus({
       handoffId,
       workspaceId,
@@ -263,6 +266,7 @@ const waitForDesktopEditHandoffOpened = async ({
       deadline = nextDeadline;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: must wait between handoff status probes
     await wait(
       Math.max(
         0,

--- a/apps/web/src/lib/pdf/pdf-loader.ts
+++ b/apps/web/src/lib/pdf/pdf-loader.ts
@@ -90,6 +90,7 @@ const loadPortfolioPages = async (
       enableXfa: true,
     });
     attachmentLoadingTasks.push(attLoadingTask);
+    // oxlint-disable-next-line no-await-in-loop -- ordered: page IDs use a running pageCounter that advances per attachment
     const attDoc = await attLoadingTask.promise;
 
     const firstPageId = getPageId(instanceId, pageCounter);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
@@ -82,6 +82,7 @@ export const CopyToMatterDialog = ({
     let failedCount = 0;
     let firstErrorMessage: string | null = null;
     for (const { entityId } of transferEntities) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential copy/move mutations share query-key cache invalidation and move semantics (deleteSource); concurrent mutations would race and risk rate limits
       const result = await Result.tryPromise(
         async () =>
           await api

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -472,6 +472,7 @@ export const ExistingFileOrganizerDialog = ({
         );
 
         if (row.parentId !== targetParentId) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential entity moves share the same query-key cache invalidation and report progress on one toast; concurrent mutations would race and risk rate limits
           const moveResponse = await api
             .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
             .move.patch({
@@ -489,6 +490,7 @@ export const ExistingFileOrganizerDialog = ({
         }
 
         if (targetName !== row.originalName) {
+          // oxlint-disable-next-line no-await-in-loop -- sequential entity renames share the same query-key cache invalidation and report progress on one toast; concurrent mutations would race and risk rate limits
           const renameResponse = await api
             .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
             .rename.patch({
@@ -1446,6 +1448,7 @@ const ensureFolders = async ({
 
       const parentSafeId =
         currentParentId === null ? null : toSafeId<"entity">(currentParentId);
+      // oxlint-disable-next-line no-await-in-loop -- each created folder's id becomes the next segment's parentId, so nested-path creation is strictly order-dependent
       const response = await api
         .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .put({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -221,6 +221,7 @@ export const RowActions = ({
   const handleZipDownload = async () => {
     if (isBulk) {
       for (const e of selectedEntities) {
+        // oxlint-disable-next-line no-await-in-loop -- each iteration triggers a browser download; parallelizing would fire many concurrent downloads and lose ordering
         await downloadEntityAsZip(workspaceId, e, msg);
       }
       return;
@@ -234,6 +235,7 @@ export const RowActions = ({
       for (const e of selectedEntities) {
         const f = getFirstFile(e);
         if (f) {
+          // oxlint-disable-next-line no-await-in-loop -- each iteration triggers a browser download; parallelizing would fire many concurrent downloads and lose ordering
           await downloadSingleFile(workspaceId, f, asPdf, msg);
         }
       }
@@ -438,6 +440,7 @@ export const RowActions = ({
 
     let failedCount = 0;
     for (const e of targets) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential duplicate mutations share the same query-key cache invalidation and risk rate limits if fired concurrently
       const result = await Result.tryPromise(
         async () =>
           await api

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -103,6 +103,7 @@ const prepareFolderTreeUpload = async ({
       name: placement.file.name,
       mimeType: placement.file.type || "application/octet-stream",
       size: placement.file.size,
+      // oxlint-disable-next-line no-await-in-loop -- hashing files one at a time bounds peak memory; reading every dropped file into memory concurrently could exhaust it for large folder trees
       sha256Hex: await hashFileSha256Hex(placement.file),
     });
   }
@@ -200,6 +201,7 @@ const abortPreparedUploadsForFiles = async ({
   for (const file of files) {
     const preparedUpload = preparedUploadForFile(file);
     if (preparedUpload) {
+      // oxlint-disable-next-line no-await-in-loop -- best-effort sequential cleanup of presigned uploads; keeps abort load bounded and avoids a concurrent burst against the API during failure handling
       await abortUpload(workspaceId, preparedUpload.uploadId);
     }
   }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -342,6 +342,7 @@ const fetchAllWorkspaceFolders = async ({
   const folders: WorkspaceFolder[] = [];
   let cursor: string | undefined;
   do {
+    // oxlint-disable-next-line no-await-in-loop -- cursor pagination: each page depends on the previous response's nextCursor, so requests are strictly sequential
     const response = await api
       .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
       .folders.get({
@@ -397,6 +398,7 @@ const fetchAllWorkspaceFiles = async ({
   const files: WorkspaceFile[] = [];
   let cursor: string | undefined;
   do {
+    // oxlint-disable-next-line no-await-in-loop -- cursor pagination: each page depends on the previous response's nextCursor, so requests are strictly sequential
     const response = await api
       .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
       .files.get({

--- a/apps/web/src/routes/dev/-components/autocomplete-playground.tsx
+++ b/apps/web/src/routes/dev/-components/autocomplete-playground.tsx
@@ -152,6 +152,7 @@ const consumeStream = async (
   let buffer = "";
   let done = false;
   while (!done) {
+    // oxlint-disable-next-line no-await-in-loop -- streaming reader: each read advances the same ReadableStream and must complete before the next, so reads are inherently sequential
     const chunk = await reader.read();
     if (chunk.done) {
       break;

--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -41,9 +41,11 @@ const collectNamedPlugins = async (
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- ordered: plugins are collected in declaration order into a shared array
     const resolved = await option;
 
     if (Array.isArray(resolved)) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered: nested plugins are collected in declaration order into a shared array
       plugins.push(...(await collectNamedPlugins(resolved)));
       continue;
     }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -179,12 +179,6 @@ export default defineConfig({
     "func-style": "off",
     "func-names": "off",
 
-    // Deferred: ultracite 7.8.3 promoted no-await-in-loop to error. Many
-    // sequential awaits are intentional (ordering, rate limits, transaction
-    // sequencing); parallelizing would change behavior, so it is adopted in
-    // its own follow-up PR.
-    "no-await-in-loop": "off",
-
     "typescript/no-inferrable-types": "off",
     "typescript/consistent-return": "error",
     "typescript/dot-notation": "error",

--- a/packages/business-registries/src/companies-house/client.ts
+++ b/packages/business-registries/src/companies-house/client.ts
@@ -374,6 +374,7 @@ export const lookupOfficersByCompanyNumber = async (
       start_index: String(page * OFFICERS_PAGE_SIZE),
     });
     const url = `${COMPANIES_HOUSE_BASE}/company/${encodeURIComponent(normalized)}/officers?${params.toString()}`;
+    // oxlint-disable-next-line no-await-in-loop -- paged cursor crawl; each page's start_index and termination depend on the prior page
     const raw = await companiesHouseGet<CompaniesHouseRawOfficersResponse>(
       url,
       config.apiKey,

--- a/packages/business-registries/src/krs/client.ts
+++ b/packages/business-registries/src/krs/client.ts
@@ -156,6 +156,7 @@ export const lookupByKrsNumber = async (
   const registers =
     options?.register === undefined ? REGISTER_PROBE_ORDER : [options.register];
   for (const register of registers) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential sub-register probe, return on first hit, fall through on 404
     const { status, body } = await krsGet(buildLookupUrl(normalized, register));
     if (status === 404 || !body?.odpis) {
       continue;

--- a/packages/folio/scripts/build-corpus-fixtures.ts
+++ b/packages/folio/scripts/build-corpus-fixtures.ts
@@ -15,7 +15,7 @@
  */
 
 import JSZip from "jszip";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 
 const FIXTURES_DIR = path.join(
@@ -632,12 +632,14 @@ async function buildFixture(fixture: Fixture): Promise<ArrayBuffer> {
 
 async function main(): Promise<void> {
   mkdirSync(FIXTURES_DIR, { recursive: true });
-  for (const fixture of FIXTURES) {
-    const buf = await buildFixture(fixture);
-    const outPath = path.join(FIXTURES_DIR, fixture.filename);
-    writeFileSync(outPath, Buffer.from(buf));
-    console.log(`wrote ${outPath} (${buf.byteLength} bytes)`);
-  }
+  await Promise.all(
+    FIXTURES.map(async (fixture) => {
+      const buf = await buildFixture(fixture);
+      const outPath = path.join(FIXTURES_DIR, fixture.filename);
+      await Bun.write(outPath, buf);
+      console.log(`wrote ${outPath} (${buf.byteLength} bytes)`);
+    }),
+  );
 }
 
 await main();

--- a/packages/folio/scripts/profile-editor.ts
+++ b/packages/folio/scripts/profile-editor.ts
@@ -146,6 +146,7 @@ async function waitForServer(url: string): Promise<void> {
   const startedAt = performance.now();
   while (performance.now() - startedAt < 15_000) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- sequential readiness polling: each probe must wait for the previous to resolve before retrying
       const response = await fetch(url);
       if (response.ok) {
         return;
@@ -153,6 +154,7 @@ async function waitForServer(url: string): Promise<void> {
     } catch {
       // Server not ready yet.
     }
+    // oxlint-disable-next-line no-await-in-loop -- fixed back-off delay between sequential readiness probes
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 100);
     });
@@ -174,6 +176,7 @@ async function profileScenarios(): Promise<PerfResult[]> {
 
     for (const fixtureName of fixtureNames) {
       results.push(
+        // oxlint-disable-next-line no-await-in-loop -- performance scenarios must run sequentially so concurrent loads do not skew timing measurements
         await profileLoad(
           context,
           `load ${fixtureName}`,

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2313,9 +2313,11 @@ export function DocxEditor({
             let text = "";
             for (const item of items) {
               if (item.types.includes("text/html")) {
+                // oxlint-disable-next-line no-await-in-loop -- sequential reads from a shared clipboard item; html accumulates into one outer variable
                 html = await (await item.getType("text/html")).text();
               }
               if (item.types.includes("text/plain")) {
+                // oxlint-disable-next-line no-await-in-loop -- sequential reads from a shared clipboard item; text accumulates into one outer variable
                 text = await (await item.getType("text/plain")).text();
               }
             }

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -456,6 +456,7 @@ async function buildMediaMap(
     // with the original TIFF data — the round-trip survives even if the
     // in-browser preview is broken.
     if (isTiffMimeType(mimeType)) {
+      // oxlint-disable-next-line no-await-in-loop -- TIFF decode uses a shared Canvas; conversions must stay serialized to avoid contention
       const converted = await convertTiffToPngDataUrl(data);
       if (converted) {
         const mediaFile: MediaFile = {

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -445,6 +445,7 @@ async function processNewImages(
       continue;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- each part's rels feed shared maxImageNum/maxId counters that must advance sequentially
     const relsXml = await readRelsOrStub(zip, relsPath);
     let maxId = findMaxRId(relsXml);
     const relEntries: string[] = [];
@@ -644,6 +645,7 @@ export async function repackDocx(
     }
 
     // Get original file content
+    // oxlint-disable-next-line no-await-in-loop -- entries are decoded and written into the shared newZip in original order to keep deterministic output
     const content = await file.async("arraybuffer");
 
     // Add to new ZIP (we'll update specific files below)
@@ -775,6 +777,7 @@ export async function repackDocxFromRaw(
     }
 
     // Get original file content
+    // oxlint-disable-next-line no-await-in-loop -- entries are decoded and written into the shared newZip in original order to keep deterministic output
     const content = await file.async("arraybuffer");
 
     // Add to new ZIP
@@ -1482,6 +1485,7 @@ async function rebindWatermarkRelIds(
     }
   }
   for (const relsPath of headerRelsPaths) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential rels reads populate the shared relsXmlByPath map keyed by path
     relsXmlByPath.set(relsPath, await readRelsOrStub(zip, relsPath));
   }
 

--- a/packages/folio/src/core/docx/selectiveSave.test.ts
+++ b/packages/folio/src/core/docx/selectiveSave.test.ts
@@ -1019,6 +1019,7 @@ describe("Selective save with headers/footers", () => {
     let found = false;
     for (const [filePath, file] of Object.entries(zip.files)) {
       if (/word\/(?:header|footer)\d*\.xml/u.test(filePath)) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential test scan that breaks on the first matching entry
         const xml = await file.async("text");
         if (xml.includes("[HF_MODIFIED]")) {
           found = true;

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -249,6 +249,7 @@ export async function unzipDocx(
     // Determine file type and extract
     if (lowerPath.endsWith(".xml") || lowerPath.endsWith(".rels")) {
       assertEntrySize(path, declaredSize, limits.maxXmlBytes);
+      // oxlint-disable-next-line no-await-in-loop -- entries share a running totalUncompressedBytes budget and write into ordered content maps
       const xmlContent = await file.async("text");
       assertExtractedSize(path, xmlContent.length, limits.maxXmlBytes);
       content.allXml.set(path, xmlContent);
@@ -309,6 +310,7 @@ export async function unzipDocx(
         );
         continue;
       }
+      // oxlint-disable-next-line no-await-in-loop -- entries share a running totalUncompressedBytes budget and write into ordered content maps
       const binaryContent = await file.async("arraybuffer");
       if (binaryContent.byteLength > limits.maxMediaBytes) {
         content.warnings.push(
@@ -326,6 +328,7 @@ export async function unzipDocx(
       if (isEntryTooLarge(declaredSize, limits.maxFontBytes)) {
         continue;
       }
+      // oxlint-disable-next-line no-await-in-loop -- entries share a running totalUncompressedBytes budget and write into ordered content maps
       const binaryContent = await file.async("arraybuffer");
       if (binaryContent.byteLength > limits.maxFontBytes) {
         continue;

--- a/packages/folio/src/core/docx/watermarkCoverage.test.ts
+++ b/packages/folio/src/core/docx/watermarkCoverage.test.ts
@@ -45,6 +45,7 @@ describe("watermark header coverage on save (eigenpal #684)", () => {
     // Default header + the coverage-created first-page header.
     expect(headerFiles).toHaveLength(2);
     for (const path of headerFiles) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential test assertion over each extracted header entry
       expect(await zip.file(path)!.async("text")).toContain("CONFIDENTIAL");
     }
 

--- a/packages/folio/src/core/prosemirror/adapterBoundary.test.ts
+++ b/packages/folio/src/core/prosemirror/adapterBoundary.test.ts
@@ -28,6 +28,7 @@ describe("ProseMirror adapter attr boundaries", () => {
     const violations: string[] = [];
 
     for (const file of ADAPTER_BOUNDARY_FILES) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential test scan that accumulates violations in source order for a stable assertion
       const source = await Bun.file(file).text();
       const lines = source.split("\n");
 

--- a/packages/folio/src/core/prosemirror/extensions/features/ImagePasteExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ImagePasteExtension.ts
@@ -56,12 +56,14 @@ async function insertImageFiles(
   let insertPos = view.state.selection.from;
 
   for (const file of files) {
+    // oxlint-disable-next-line no-await-in-loop -- images insert sequentially at the moving insertPos cursor; ordering must be preserved
     if (!(await isSafeImageFile(file))) {
       continue;
     }
 
     let dataUrl: string;
     try {
+      // oxlint-disable-next-line no-await-in-loop -- images insert sequentially at the moving insertPos cursor; ordering must be preserved
       dataUrl = await readFileAsDataUrl(file);
     } catch {
       continue;
@@ -70,8 +72,10 @@ async function insertImageFiles(
     let naturalWidth: number;
     let naturalHeight: number;
     try {
-      ({ width: naturalWidth, height: naturalHeight } =
-        await loadImageSize(dataUrl));
+      // oxlint-disable-next-line no-await-in-loop -- images insert sequentially at the moving insertPos cursor; ordering must be preserved
+      const size = await loadImageSize(dataUrl);
+      naturalWidth = size.width;
+      naturalHeight = size.height;
     } catch {
       // Fall back to a safe minimal size if the image can't be decoded
       naturalWidth = 1;

--- a/packages/folio/src/core/utils/clipboard.ts
+++ b/packages/folio/src/core/utils/clipboard.ts
@@ -344,13 +344,17 @@ async function parseClipboardItems(
   for (const item of items) {
     // Get HTML content
     if (item.types.includes(CLIPBOARD_TYPES.HTML)) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential reads from a shared clipboard item; html accumulates into one outer variable
       const blob = await item.getType(CLIPBOARD_TYPES.HTML);
+      // oxlint-disable-next-line no-await-in-loop -- sequential reads from a shared clipboard item; html accumulates into one outer variable
       html = await blob.text();
     }
 
     // Get plain text
     if (item.types.includes(CLIPBOARD_TYPES.PLAIN)) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential reads from a shared clipboard item; plainText accumulates into one outer variable
       const blob = await item.getType(CLIPBOARD_TYPES.PLAIN);
+      // oxlint-disable-next-line no-await-in-loop -- sequential reads from a shared clipboard item; plainText accumulates into one outer variable
       plainText = await blob.text();
     }
   }

--- a/packages/infosoud/scripts/extract-codes.ts
+++ b/packages/infosoud/scripts/extract-codes.ts
@@ -126,6 +126,7 @@ const discoverCatalogBundleUrl = async (): Promise<string> => {
       break;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential BFS crawl; each fetch enqueues the next chunk URLs to discover
     const scriptText = await fetchText(candidate);
     if (
       scriptText.includes("udalost:{") &&

--- a/packages/infosoud/src/client.ts
+++ b/packages/infosoud/src/client.ts
@@ -659,6 +659,7 @@ export class InfoSoudClient {
 
       if (allowedEventTypes.has(event.udalost)) {
         try {
+          // oxlint-disable-next-line no-await-in-loop -- sequential per-event external-registry detail fetches, preserve polite request pacing
           detail = await this.getCaseEventDetail({
             courtCode: event.znackaId.organizace,
             event,
@@ -791,6 +792,7 @@ export class InfoSoudClient {
       };
 
       try {
+        // oxlint-disable-next-line no-await-in-loop -- sequential probe across Prague districts, return on first match
         return await this.#request({
           body: requestBody,
           cacheKey: this.#buildRequestCacheKey({

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -412,6 +412,7 @@ export const checkPortAvailabilityOnHosts = async (
   checkPort = canListenOnHost,
 ) => {
   for (const host of hosts) {
+    // oxlint-disable-next-line no-await-in-loop -- early return on first unavailable host; probes must run sequentially to short-circuit
     if (!(await checkPort(port, host))) {
       return false;
     }
@@ -773,6 +774,7 @@ const waitForSharedDockerServices = async ({
       return;
     }
     lastFailure = failure;
+    // oxlint-disable-next-line no-await-in-loop -- sequential poll: sleep between status reads until services are ready or timeout
     await Bun.sleep(DOCKER_SERVICES_POLL_INTERVAL_MS);
   }
 
@@ -868,6 +870,7 @@ export const findFirstAvailableOffset = async ({
     offset++
   ) {
     const ports = portsForOffset(offset);
+    // oxlint-disable-next-line no-await-in-loop -- sequential offset search: must check offsets in order and return the first free one
     const availability = await Promise.all(
       requiredPortsForMode(mode, ports, { aiDevtoolsEnabled }).map(
         async (port) => await checkPortAvailability(port),
@@ -875,7 +878,9 @@ export const findFirstAvailableOffset = async ({
     );
     if (availability.every(Boolean)) {
       if (mode === "dev:web") {
+        // oxlint-disable-next-line no-await-in-loop -- only reached for the first free offset; continues the offset search if the api port is taken
         const apiPortIsFree = await checkPortAvailability(ports.api);
+        // oxlint-disable-next-line no-await-in-loop -- short-circuits to continue the sequential offset search when the api port cannot be reused
         if (!apiPortIsFree && !(await checkReusableApiPort(ports.api))) {
           continue;
         }
@@ -1322,11 +1327,14 @@ const waitForHttpReadiness = async ({
 
   while (Date.now() - startedAt < timeoutMs) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- sequential readiness poll: probe the URL once per retry until it responds or timeout
       const response = await fetch(url, {
         method: "GET",
         signal: AbortSignal.timeout(DEFAULT_HTTP_PROBE_TIMEOUT_MS),
       });
+      // oxlint-disable-next-line no-await-in-loop -- reads the body of this poll's response before validating it
       const bodyText = await response.text();
+      // oxlint-disable-next-line no-await-in-loop -- validates this poll's response and returns early once it passes
       const validationFailure = await validate(response, bodyText);
 
       if (!validationFailure) {
@@ -1338,6 +1346,7 @@ const waitForHttpReadiness = async ({
       lastFailure = error instanceof Error ? error.message : String(error);
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential poll: back off between readiness probes until the service is up or timeout
     await Bun.sleep(300);
   }
 
@@ -1920,12 +1929,14 @@ const main = async () => {
     startSteps(persistentSteps.primary);
 
     for (const readinessCheck of readinessChecks.primary) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered startup: each primary service must be ready before the next is awaited
       await waitForHttpReadiness(readinessCheck);
     }
 
     startSteps(persistentSteps.secondary);
 
     for (const readinessCheck of readinessChecks.secondary) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered startup: each secondary service must be ready before the next is awaited
       await waitForHttpReadiness(readinessCheck);
     }
 

--- a/packages/scripts/src/i18n-check.ts
+++ b/packages/scripts/src/i18n-check.ts
@@ -372,6 +372,7 @@ if (import.meta.main) {
     const identicalToSource: Record<string, string[]> = {};
     for (const file of localeFiles) {
       const locale = file.replace(/\.json$/u, "");
+      // oxlint-disable-next-line no-await-in-loop -- locales must be processed in sorted order so identicalToSource accumulates deterministically
       const messages = await readLang(file);
       for (const key of findUntranslated(
         enMessages,
@@ -438,6 +439,7 @@ if (import.meta.main) {
 
   for (const file of localeFiles) {
     const locale = file.replace(/\.json$/u, "");
+    // oxlint-disable-next-line no-await-in-loop -- locales reported in sorted order; console output and sync writes must stay deterministic per file
     const messages = await readLang(file);
     const langKeys = new Set(flattenKeys(messages));
 
@@ -479,6 +481,7 @@ if (import.meta.main) {
 
     if (shouldSync) {
       const synced = syncMessages(enMessages, messages);
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-locale file write paired with ordered console output
       await Bun.write(filePath, `${JSON.stringify(synced, null, 2)}\n`);
       console.log("  ✓ synced");
     }


### PR DESCRIPTION
## Summary

Adopts the `no-await-in-loop` oxlint rule, the last rule deferred from the ultracite 7.8.3 adoption in #751.

- Re-enables the rule in `oxlint.config.ts`.
- Resolves all ~401 in-scope violations with a **behavior-preserving** strategy (per the deliberate sequential style of much of this codebase):
  - **Parallelized** the few loops whose iterations are provably independent (no ordering, no sequential DB writes, no rate-limited/paged external calls, no order-dependent accumulation) to `await Promise.all(...)`.
  - **Suppressed** (~394) the intentional sequential awaits with a specific justification each: `// oxlint-disable-next-line no-await-in-loop -- <reason>`. These are seed/backfill scripts (ordered inserts, FK deps), paged & rate-limited case-law ingestion crawls, ordered DB writes/transactions, retry/poll/backoff loops, and bounded-concurrency drains.

No behavior changes: the suppressions document existing intent, and the parallelizations are limited to independent-iteration loops.

## Validation

- `bun run lint` — 27/27 packages green (rule enforced; every suppression carries a description, no unused-directive errors).
- Typecheck — clean across all changed packages (api, web, folio, legal-atlas-runner, scripts, collab, …).
- `bun run test` — 22/22 task suites pass (2635 tests).

Out of scope (not linted by CI), left unchanged: `apps/landing/src/pages/*.astro`.

With this merged, both rules deferred in #751 (`prefer-named-capture-group` in #758, `no-await-in-loop` here) are adopted.
