### PR TITLE
fix: install Docker deps from root Bun lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,25 +623,14 @@ jobs:
             /tmp/web.log
           retention-days: 7
 
-  # Pruned-subset lockfile + prod-deps guard. The staging API image
-  # is built via `turbo prune @stll/api --docker` followed by
-  # `bun install --frozen-lockfile` against the pruned bun.lock.
-  # The other CI jobs all install against the full repo lockfile,
-  # so a workspace dep that resolves transitively from outside
-  # @stll/api's tree (e.g. via apps/web) can be missing from the
-  # relevant workspace block and still satisfy the full install —
-  # only to fail at deploy time when the prune drops the masking
-  # workspace. Mirror the Dockerfile's install path here so that
-  # class of drift fails the PR instead of the deploy.
+  # Image dependency guard. The API and legal-atlas-runner Dockerfiles use
+  # Turbo only for pruned source overlays; dependency installs come from the
+  # committed root bun.lock plus every workspace package.json so Bun remains
+  # the lockfile source of truth. Mirror that install path here so deploy-time
+  # lockfile drift fails the PR instead of the deploy.
   #
-  # The job then re-runs the install with `--production` (no
-  # devDependencies) and compiles + smokes the API entrypoints
-  # against that tree. This catches the second class of deploy-time
-  # failure: prod code (apps/api/src/** or apps/api/scripts/**) that
-  # imports a devDependency, or a `@stll/*` workspace package whose
-  # runtime imports are mis-classified as devDependencies. Without
-  # this gate, flipping the Dockerfile to `--production` would only
-  # fail at deploy time.
+  # The job then compiles the API entrypoints and runs the legal atlas runner
+  # production smoke against those Docker-style dependency trees.
   api-image-deps:
     needs: trust-check
     if: >-
@@ -682,7 +671,7 @@ jobs:
           done
           echo "run=$run" >> "$GITHUB_OUTPUT"
           if [[ "$run" != "true" ]]; then
-            echo "::notice::No API/runner-image-affecting paths changed; skipping pruned-lockfile guard."
+            echo "::notice::No API/runner-image-affecting paths changed; skipping image dependency guard."
           fi
 
       - name: Setup Bun
@@ -693,45 +682,44 @@ jobs:
 
       - name: Install turbo
         if: steps.changed.outputs.run == 'true'
-        # Match apps/api/Dockerfile: a global turbo install, no
-        # workspace dependency resolution beforehand.
-        run: bun install -g turbo@^2
+        # Match the Dockerfiles: Turbo is only used for pruned source overlays.
+        run: bun install -g turbo@2.9.18
 
-      - name: Prune monorepo for @stll/api
+      - name: Prepare Docker install inputs
         if: steps.changed.outputs.run == 'true'
-        run: turbo prune @stll/api --docker
-
-      - name: Install pruned deps with frozen lockfile
-        if: steps.changed.outputs.run == 'true'
-        # This is the exact command the Docker build runs against
-        # the pruned bun.lock in `apps/api/Dockerfile`. It is the
-        # only place that catches workspace-block drift in the
-        # repo lockfile, because the full-repo `bun ci` other jobs
-        # use accepts a stale workspace block as long as the
-        # package resolves transitively somewhere in the graph.
         run: |
-          cd out/json
-          bun install --frozen-lockfile --ignore-scripts
+          set -euo pipefail
+          rm -rf install-json
+          mkdir -p install-json
+          cp bun.lock bunfig.toml .npmrc package.json install-json/
+          find apps packages -mindepth 2 -maxdepth 2 -name package.json \
+            -not -path '*/node_modules/*' \
+            -exec cp --parents {} install-json/ \;
+
+      - name: Prune monorepo for API image source
+        if: steps.changed.outputs.run == 'true'
+        run: turbo prune @stll/api @stll/legal-atlas-runner --docker
+
+      - name: Install API image deps with frozen root lockfile
+        if: steps.changed.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          rm -rf api-install
+          cp -a install-json api-install
+          cd api-install
+          bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts
         env:
           NPM_TOKEN: ""
 
-      - name: Prod-deps API compile smoke
+      - name: API image compile smoke
         if: steps.changed.outputs.run == 'true'
-        # Empirically prove the pruned API tree builds and its
-        # runtime worker entrypoints resolve with devDependencies
-        # stripped. Runs a fresh `bun install --production` in a
-        # parallel dir (so the lockfile-drift install above stays
-        # unchanged), overlays the full pruned source via
-        # `cp -a ../full/. .` (mirrors `COPY --from=pruner
-        # /app/out/full/ .` in `apps/api/Dockerfile`), and compiles the
-        # API binary plus runtime workers.
+        # Overlay pruned source the same way apps/api/Dockerfile copies
+        # /app/out/full/ onto the dependency layer, then compile the API
+        # binary and runtime workers.
         run: |
           set -euo pipefail
-          rm -rf out-prod
-          cp -a out out-prod
-          cd out-prod/json
-          bun install --production --frozen-lockfile --ignore-scripts
-          cp -a ../full/. .
+          cd api-install
+          cp -a ../out/full/. .
           export NODE_ENV=production
           bun build \
             --compile \
@@ -758,9 +746,11 @@ jobs:
           set -euo pipefail
           rm -rf out-runner
           turbo prune @stll/legal-atlas-runner --docker --out-dir out-runner
-          cd out-runner/json
-          bun install --production --frozen-lockfile --ignore-scripts
-          cp -a ../full/. .
+          rm -rf runner-install
+          cp -a install-json runner-install
+          cd runner-install
+          bun install --filter @stll/legal-atlas-runner --production --frozen-lockfile --ignore-scripts
+          cp -a ../out-runner/full/. .
           bun --filter @stll/legal-atlas-runner build
           bun apps/legal-atlas-runner/dist/index.js smoke
           set +e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,10 +691,11 @@ jobs:
           set -euo pipefail
           rm -rf install-json
           mkdir -p install-json
-          cp bun.lock bunfig.toml .npmrc package.json install-json/
+          cp bun.lock package.json install-json/
+          for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" install-json/; done
           find apps packages -mindepth 2 -maxdepth 2 -name package.json \
             -not -path '*/node_modules/*' \
-            -exec cp --parents {} install-json/ \;
+            -exec cp --parents -t install-json/ {} +
 
       - name: Prune monorepo for API image source
         if: steps.changed.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/web/*|packages/*|VERSION|bun.lock|package.json|.github/workflows/ci.yml)
+              apps/web/*|packages/*|VERSION|bun.lock|bunfig.toml|package.json|.npmrc|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;
@@ -663,7 +663,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/api/*|apps/legal-atlas-runner/*|packages/*|bun.lock|package.json|turbo.json|.github/workflows/ci.yml)
+              apps/api/*|apps/legal-atlas-runner/*|packages/*|bun.lock|bunfig.toml|package.json|.npmrc|turbo.json|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -8,10 +8,11 @@ FROM base AS install-inputs
 # Bun's catalog/resolution semantics.
 COPY . .
 RUN mkdir -p /json && \
-    cp bun.lock bunfig.toml .npmrc package.json /json/ && \
+    cp bun.lock package.json /json/ && \
+    for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" /json/; done && \
     find apps packages -mindepth 2 -maxdepth 2 -name package.json \
       -not -path '*/node_modules/*' \
-      -exec cp --parents {} /json/ \;
+      -exec cp --parents -t /json/ {} +
 
 # Prune the monorepo for the API
 FROM base AS pruner

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,18 +2,28 @@
 FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS base
 WORKDIR /app
 
+FROM base AS install-inputs
+# Preserve Bun's committed root lockfile and full workspace manifest map.
+# Turbo's pruned bun.lock is a generated approximation and can drift from
+# Bun's catalog/resolution semantics.
+COPY . .
+RUN mkdir -p /json && \
+    cp bun.lock bunfig.toml .npmrc package.json /json/ && \
+    find apps packages -mindepth 2 -maxdepth 2 -name package.json \
+      -not -path '*/node_modules/*' \
+      -exec cp --parents {} /json/ \;
+
 # Prune the monorepo for the API
 FROM base AS pruner
-# Keep in sync with the turbo version in the root package.json; an unpinned
-# major lets a new turbo release change `turbo prune` lockfile output mid-flight.
+# Keep in sync with the turbo version in the root package.json.
 RUN bun install -g turbo@2.9.18
 COPY . .
 RUN turbo prune @stll/api @stll/legal-atlas-runner --docker
 
 # Install dependencies using only package manifests (cached layer)
 FROM base AS deps
-COPY --from=pruner /app/out/json/ .
-RUN bun install --frozen-lockfile --ignore-scripts
+COPY --from=install-inputs /json/ .
+RUN bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 # Copy source code and compile the API to a Bun binary.
 #

--- a/apps/legal-atlas-runner/Dockerfile
+++ b/apps/legal-atlas-runner/Dockerfile
@@ -2,15 +2,25 @@
 FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS base
 WORKDIR /app
 
+FROM base AS install-inputs
+# Preserve Bun's committed root lockfile and full workspace manifest map.
+# Turbo's pruned bun.lock is a generated approximation and can drift from
+# Bun's catalog/resolution semantics.
+COPY . .
+RUN mkdir -p /json && \
+    cp bun.lock bunfig.toml .npmrc package.json /json/ && \
+    find apps packages -mindepth 2 -maxdepth 2 -name package.json \
+      -not -path '*/node_modules/*' \
+      -exec cp --parents {} /json/ \;
+
 FROM base AS pruner
-# Keep in sync with the turbo version in the root package.json; an unpinned
-# major lets a new turbo release change `turbo prune` lockfile output mid-flight.
+# Keep in sync with the turbo version in the root package.json.
 RUN bun install -g turbo@2.9.18
 COPY . .
 RUN turbo prune @stll/legal-atlas-runner --docker
 
 FROM base AS deps
-COPY --from=pruner /app/out/json/ .
+COPY --from=install-inputs /json/ .
 RUN bun install --filter @stll/legal-atlas-runner --production --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 FROM deps AS builder

--- a/apps/legal-atlas-runner/Dockerfile
+++ b/apps/legal-atlas-runner/Dockerfile
@@ -8,10 +8,11 @@ FROM base AS install-inputs
 # Bun's catalog/resolution semantics.
 COPY . .
 RUN mkdir -p /json && \
-    cp bun.lock bunfig.toml .npmrc package.json /json/ && \
+    cp bun.lock package.json /json/ && \
+    for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" /json/; done && \
     find apps packages -mindepth 2 -maxdepth 2 -name package.json \
       -not -path '*/node_modules/*' \
-      -exec cp --parents {} /json/ \;
+      -exec cp --parents -t /json/ {} +
 
 FROM base AS pruner
 # Keep in sync with the turbo version in the root package.json.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,22 +2,32 @@
 FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS base
 WORKDIR /app
 
+FROM base AS install-inputs
+# Preserve Bun's committed root lockfile and full workspace manifest map.
+# Turbo's pruned bun.lock is a generated approximation and can drift from
+# Bun's catalog/resolution semantics.
+COPY . .
+RUN mkdir -p /json && \
+    cp bun.lock bunfig.toml .npmrc package.json /json/ && \
+    find apps packages -mindepth 2 -maxdepth 2 -name package.json \
+      -not -path '*/node_modules/*' \
+      -exec cp --parents {} /json/ \;
+
 FROM base AS pruner
-# Keep in sync with the turbo version in the root package.json; an unpinned
-# major lets a new turbo release change `turbo prune` lockfile output mid-flight.
+# Keep in sync with the turbo version in the root package.json.
 RUN bun install -g turbo@2.9.18
 COPY . .
 RUN turbo prune @stll/web --docker
 
 FROM base AS deps
-COPY --from=pruner /app/out/json/ .
+COPY --from=install-inputs /json/ .
 RUN bun install --filter @stll/web --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 # Runtime install: the SSR server bundle (dist/server/server.js) externalises
 # its imports, so they must resolve from `dependencies` alone with
 # devDependencies stripped. The web-build CI job boot-smokes this same install.
 FROM base AS deps-prod
-COPY --from=pruner /app/out/json/ .
+COPY --from=install-inputs /json/ .
 RUN bun install --filter @stll/web --production --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 FROM deps AS builder

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -8,10 +8,11 @@ FROM base AS install-inputs
 # Bun's catalog/resolution semantics.
 COPY . .
 RUN mkdir -p /json && \
-    cp bun.lock bunfig.toml .npmrc package.json /json/ && \
+    cp bun.lock package.json /json/ && \
+    for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" /json/; done && \
     find apps packages -mindepth 2 -maxdepth 2 -name package.json \
       -not -path '*/node_modules/*' \
-      -exec cp --parents {} /json/ \;
+      -exec cp --parents -t /json/ {} +
 
 FROM base AS pruner
 # Keep in sync with the turbo version in the root package.json.


### PR DESCRIPTION
Installs Docker image dependencies from the committed root Bun lockfile and workspace manifests, while keeping Turbo only for source pruning. Updates the API/runner image dependency guard to match.