### PR TITLE
feat(update-deps): teach the local skill to bump prerelease-pinned deps

### DIFF
--- a/.agents/skills/update-deps/SKILL.md
+++ b/.agents/skills/update-deps/SKILL.md
@@ -67,6 +67,17 @@ If the request is vague, default to:
      from source, several minutes). As a fallback, use
      `cargo update --dry-run` plus targeted `cargo search` /
      `cargo info` checks
+   - flag prerelease-pinned deps separately: `bun outdated`
+     and `bun update` resolve the npm `latest` dist-tag, so a
+     dependency intentionally pinned to a prerelease channel
+     (`alpha`, `beta`, `rc`, `next`, `canary`, `dev`) never
+     shows up as outdated and never moves, even when newer
+     prereleases exist on its own channel. Grep the manifests
+     and catalog for prerelease specifiers, then compare each
+     pin against its real channel with `npm view <pkg>
+     dist-tags`. A `bunfig.toml` `minimumReleaseAgeExcludes`
+     entry is a strong hint that a package is deliberately
+     tracked ahead of stable.
    - inspect open dependency PRs if the request is about
      triage rather than local edits
    - include GitHub Actions only when the request covers them
@@ -86,6 +97,10 @@ If the request is vague, default to:
    - minor: check new features and silent behavior changes
    - major: assume migration work
    - `0.x` minor: treat as potentially breaking
+   - prerelease (`beta`, `rc`, etc.): unstable channel; assume
+     breaking changes can land between any two prerelease
+     builds, so read the diff and validate even for a "small"
+     bump
 
 5. **Read official upgrade sources**:
    - changelog or release notes
@@ -146,6 +161,10 @@ If the request is vague, default to:
    - for Cargo, prefer `cargo update -p <crate>` when the
      existing semver range already covers the new version;
      edit `Cargo.toml` only when bumping past the range
+   - prerelease-pinned deps are usually exact-pinned to a
+     non-`latest` dist-tag, so neither `bun update` nor `bun
+     update --latest` will move them; edit the pin by hand to
+     the target prerelease version and run `bun install`
    - after each batch passes validation, commit that batch
      before moving to the next one
 

--- a/.ai/local-skills/update-deps/SKILL.md
+++ b/.ai/local-skills/update-deps/SKILL.md
@@ -67,6 +67,17 @@ If the request is vague, default to:
      from source, several minutes). As a fallback, use
      `cargo update --dry-run` plus targeted `cargo search` /
      `cargo info` checks
+   - flag prerelease-pinned deps separately: `bun outdated`
+     and `bun update` resolve the npm `latest` dist-tag, so a
+     dependency intentionally pinned to a prerelease channel
+     (`alpha`, `beta`, `rc`, `next`, `canary`, `dev`) never
+     shows up as outdated and never moves, even when newer
+     prereleases exist on its own channel. Grep the manifests
+     and catalog for prerelease specifiers, then compare each
+     pin against its real channel with `npm view <pkg>
+     dist-tags`. A `bunfig.toml` `minimumReleaseAgeExcludes`
+     entry is a strong hint that a package is deliberately
+     tracked ahead of stable.
    - inspect open dependency PRs if the request is about
      triage rather than local edits
    - include GitHub Actions only when the request covers them
@@ -86,6 +97,10 @@ If the request is vague, default to:
    - minor: check new features and silent behavior changes
    - major: assume migration work
    - `0.x` minor: treat as potentially breaking
+   - prerelease (`beta`, `rc`, etc.): unstable channel; assume
+     breaking changes can land between any two prerelease
+     builds, so read the diff and validate even for a "small"
+     bump
 
 5. **Read official upgrade sources**:
    - changelog or release notes
@@ -146,6 +161,10 @@ If the request is vague, default to:
    - for Cargo, prefer `cargo update -p <crate>` when the
      existing semver range already covers the new version;
      edit `Cargo.toml` only when bumping past the range
+   - prerelease-pinned deps are usually exact-pinned to a
+     non-`latest` dist-tag, so neither `bun update` nor `bun
+     update --latest` will move them; edit the pin by hand to
+     the target prerelease version and run `bun install`
    - after each batch passes validation, commit that batch
      before moving to the next one
 

--- a/.claude/commands/update-deps.md
+++ b/.claude/commands/update-deps.md
@@ -62,6 +62,17 @@ If the request is vague, default to:
      from source, several minutes). As a fallback, use
      `cargo update --dry-run` plus targeted `cargo search` /
      `cargo info` checks
+   - flag prerelease-pinned deps separately: `bun outdated`
+     and `bun update` resolve the npm `latest` dist-tag, so a
+     dependency intentionally pinned to a prerelease channel
+     (`alpha`, `beta`, `rc`, `next`, `canary`, `dev`) never
+     shows up as outdated and never moves, even when newer
+     prereleases exist on its own channel. Grep the manifests
+     and catalog for prerelease specifiers, then compare each
+     pin against its real channel with `npm view <pkg>
+     dist-tags`. A `bunfig.toml` `minimumReleaseAgeExcludes`
+     entry is a strong hint that a package is deliberately
+     tracked ahead of stable.
    - inspect open dependency PRs if the request is about
      triage rather than local edits
    - include GitHub Actions only when the request covers them
@@ -81,6 +92,10 @@ If the request is vague, default to:
    - minor: check new features and silent behavior changes
    - major: assume migration work
    - `0.x` minor: treat as potentially breaking
+   - prerelease (`beta`, `rc`, etc.): unstable channel; assume
+     breaking changes can land between any two prerelease
+     builds, so read the diff and validate even for a "small"
+     bump
 
 5. **Read official upgrade sources**:
    - changelog or release notes
@@ -141,6 +156,10 @@ If the request is vague, default to:
    - for Cargo, prefer `cargo update -p <crate>` when the
      existing semver range already covers the new version;
      edit `Cargo.toml` only when bumping past the range
+   - prerelease-pinned deps are usually exact-pinned to a
+     non-`latest` dist-tag, so neither `bun update` nor `bun
+     update --latest` will move them; edit the pin by hand to
+     the target prerelease version and run `bun install`
    - after each batch passes validation, commit that batch
      before moving to the next one
 


### PR DESCRIPTION
stella's `update-deps` skill is a local override (`.ai/local-skills/update-deps`) that shadows the shared one, so the shared update did not reach it. This mirrors the prerelease handling into the local skill and regenerates the consumer copies.

`bun outdated` and `bun update` resolve the npm `latest` dist-tag, so a dependency intentionally pinned to a prerelease channel (`alpha`, `beta`, `rc`, `next`, `canary`, `dev`) never shows up as outdated and never moves, even when newer prereleases exist on its own channel.

Adds prerelease handling in three spots:

- **Inventory**: grep manifests/catalog for prerelease specifiers and check each pin's real channel with `npm view <pkg> dist-tags`; a `bunfig.toml` `minimumReleaseAgeExcludes` entry is a strong signal a package is deliberately tracked ahead of stable.
- **Risk**: treat prerelease→prerelease as breaking-capable, so validate even "small" bumps.
- **Apply**: these are usually exact pins on a non-`latest` tag, so neither `bun update` nor `bun update --latest` moves them; edit the pin by hand and run `bun install`.

The `.agents/skills/update-deps/SKILL.md` and `.claude/commands/update-deps.md` copies are regenerated via `bun run sync-ai`. No submodule bump and no unrelated doc drift.