### PR TITLE
fix(folio): sync upstream fixes — comment ranges, CJK IME, RTL tables, zoom button

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-table-bidi.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-table-bidi.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type { TableBlock } from "../layout-engine/types";
+import { schema } from "../prosemirror/schema";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+const cell = (text: string): PMNode =>
+  schema.node("tableCell", { borders: null }, [
+    schema.node("paragraph", null, [schema.text(text)]),
+  ]);
+
+const tableDoc = (originalFormatting: unknown): PMNode =>
+  schema.node("doc", null, [
+    schema.node(
+      "table",
+      { columnWidths: [2000, 3000], _originalFormatting: originalFormatting },
+      [schema.node("tableRow", null, [cell("A"), cell("B")])],
+    ),
+  ]);
+
+const firstTable = (doc: PMNode): TableBlock => {
+  const block = toFlowBlocks(doc).find((b) => b.kind === "table");
+  if (!block) {
+    throw new Error("Expected a table block");
+  }
+  return block;
+};
+
+describe("toFlowBlocks table bidiVisual", () => {
+  test("carries w:bidiVisual onto the table block (eigenpal/docx-editor#940)", () => {
+    expect(firstTable(tableDoc({ bidi: true })).bidi).toBe(true);
+  });
+
+  test("leaves bidi unset for an ordinary LTR table", () => {
+    expect(firstTable(tableDoc(null)).bidi).toBeUndefined();
+    expect(firstTable(tableDoc({})).bidi).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2169,9 +2169,12 @@ function convertTable(
   // Extract justification
   const justification = attrs.justification;
 
-  // Extract table indent from _originalFormatting (w:tblInd)
+  // Extract table indent + RTL column order from _originalFormatting
+  // (w:tblInd, w:bidiVisual). bidiVisual is import-only — folio has no UI to
+  // toggle it — so reading the preserved formatting is sufficient
+  // (eigenpal/docx-editor#940).
   const originalFormatting = attrs._originalFormatting as
-    | { indent?: { value: number; type: string } }
+    | { indent?: { value: number; type: string }; bidi?: boolean }
     | undefined;
   const indentPx =
     originalFormatting?.indent?.value &&
@@ -2260,6 +2263,9 @@ function convertTable(
   }
   if (floatingPx) {
     tableBlock.floating = floatingPx;
+  }
+  if (originalFormatting?.bidi) {
+    tableBlock.bidi = true;
   }
   return tableBlock;
 }

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -554,6 +554,8 @@ export type TableBlock = {
   justification?: "left" | "center" | "right";
   /** Table indent from left margin (in pixels, from w:tblInd) */
   indent?: number;
+  /** Right-to-left column order (w:bidiVisual): logical column 0 paints on the right. */
+  bidi?: boolean;
   /** Floating table properties (pixel values). */
   floating?: FloatingTablePosition;
   pmStart?: number;

--- a/packages/folio/src/core/layout-painter/renderTable-bidi.test.ts
+++ b/packages/folio/src/core/layout-painter/renderTable-bidi.test.ts
@@ -219,5 +219,33 @@ describe("renderTableFragment RTL column order (w:bidiVisual)", () => {
     );
     // Boundary after logical column 0 is at x=100; mirrored to 250-100=150, less the 3px grab offset.
     expect(handle?.style["left"]).toBe("147px");
+    // Tagged bidi so the resize path inverts the drag delta.
+    expect(handle?.dataset["bidi"]).toBe("true");
+  });
+
+  test("bidiVisual edge handle resizes logical column 0 (the visual right edge)", () => {
+    const renderTable = (bidi: boolean): FakeElement => {
+      const { fragment, block, measure } = buildTwoColumnTable(bidi);
+      return renderTableFragment(fragment, block, measure, renderContext, {
+        document: fakeDocument,
+      }) as unknown as FakeElement;
+    };
+    const ltr = renderTable(false);
+    const rtl = renderTable(true);
+
+    const edgeOf = (el: FakeElement): FakeElement | undefined =>
+      el.children.find(
+        (child) => child.className === TABLE_CLASS_NAMES.tableEdgeHandleRight,
+      );
+
+    // LTR: the right edge resizes the last logical column.
+    expect(edgeOf(ltr)?.dataset["columnIndex"]).toBe("1");
+    expect(edgeOf(ltr)?.dataset["bidi"]).toBeUndefined();
+    // RTL: the visual right edge is logical column 0; internal handle is bidi-tagged.
+    expect(edgeOf(rtl)?.dataset["columnIndex"]).toBe("0");
+    const internal = rtl.children.find(
+      (child) => child.className === TABLE_CLASS_NAMES.resizeHandle,
+    );
+    expect(internal?.dataset["bidi"]).toBe("true");
   });
 });

--- a/packages/folio/src/core/layout-painter/renderTable-bidi.test.ts
+++ b/packages/folio/src/core/layout-painter/renderTable-bidi.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  TableBlock,
+  TableFragment,
+  TableMeasure,
+} from "../layout-engine/types";
+import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
+import type { RenderContext } from "./renderUtils";
+
+// Minimal DOM stand-in (mirrors renderTableFragment.test.ts) so the painter can
+// run under bun without a real document.
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): null {
+    return null;
+  }
+
+  querySelectorAll(): FakeElement[] {
+    return [];
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+  createTextNode(text: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.dataset["text"] = text;
+    return node;
+  },
+} as unknown as Document;
+
+const renderContext: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+const COLUMN_WIDTHS = [100, 150];
+const TABLE_WIDTH = 250;
+
+const solidBorder = { width: 1, style: "solid", color: "var(--doc-border)" };
+const allBorders = {
+  top: solidBorder,
+  right: solidBorder,
+  bottom: solidBorder,
+  left: solidBorder,
+};
+
+function buildTwoColumnTable(bidi: boolean): {
+  fragment: TableFragment;
+  block: TableBlock;
+  measure: TableMeasure;
+} {
+  const block: TableBlock = {
+    kind: "table",
+    id: "tbl",
+    rows: [
+      {
+        id: "row",
+        cells: [
+          {
+            id: "cell-0",
+            borders: allBorders,
+            blocks: [
+              {
+                kind: "paragraph",
+                id: "p0",
+                runs: [{ kind: "text", text: "A" }],
+              },
+            ],
+          },
+          {
+            id: "cell-1",
+            borders: allBorders,
+            blocks: [
+              {
+                kind: "paragraph",
+                id: "p1",
+                runs: [{ kind: "text", text: "B" }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    columnWidths: COLUMN_WIDTHS,
+  };
+  if (bidi) {
+    block.bidi = true;
+  }
+
+  const measure: TableMeasure = {
+    kind: "table",
+    rows: [
+      {
+        cells: [
+          {
+            blocks: [{ kind: "paragraph", lines: [], totalHeight: 20 }],
+            width: 100,
+            height: 20,
+          },
+          {
+            blocks: [{ kind: "paragraph", lines: [], totalHeight: 20 }],
+            width: 150,
+            height: 20,
+          },
+        ],
+        height: 20,
+      },
+    ],
+    columnWidths: COLUMN_WIDTHS,
+    totalWidth: TABLE_WIDTH,
+    totalHeight: 20,
+  };
+
+  const fragment: TableFragment = {
+    kind: "table",
+    blockId: "tbl",
+    x: 0,
+    y: 0,
+    width: TABLE_WIDTH,
+    height: 20,
+    fromRow: 0,
+    toRow: 1,
+  };
+
+  return { fragment, block, measure };
+}
+
+function findCells(element: FakeElement): FakeElement[] {
+  const matches: FakeElement[] = [];
+  if (element.className.split(" ").includes(TABLE_CLASS_NAMES.cell)) {
+    matches.push(element);
+  }
+  for (const child of element.children) {
+    matches.push(...findCells(child));
+  }
+  return matches;
+}
+
+function cellByColumn(cells: FakeElement[], columnIndex: string): FakeElement {
+  const cell = cells.find((c) => c.dataset["columnIndex"] === columnIndex);
+  if (!cell) {
+    throw new Error(`Expected a cell for column ${columnIndex}`);
+  }
+  return cell;
+}
+
+function render(bidi: boolean): FakeElement[] {
+  const { fragment, block, measure } = buildTwoColumnTable(bidi);
+  const tableEl = renderTableFragment(fragment, block, measure, renderContext, {
+    document: fakeDocument,
+  }) as unknown as FakeElement;
+  return findCells(tableEl);
+}
+
+describe("renderTableFragment RTL column order (w:bidiVisual)", () => {
+  test("LTR paints logical column 0 on the left", () => {
+    const cells = render(false);
+    expect(cellByColumn(cells, "0").style["left"]).toBe("0px");
+    expect(cellByColumn(cells, "1").style["left"]).toBe("100px");
+    // Outer left border lives on the leftmost cell (logical column 0).
+    expect(cellByColumn(cells, "0").style["borderLeft"]).toBe(
+      "1px solid var(--doc-border)",
+    );
+    expect(cellByColumn(cells, "1").style["borderLeft"]).toBeUndefined();
+  });
+
+  test("bidiVisual mirrors columns: logical column 0 paints on the right", () => {
+    const cells = render(true);
+    // tableWidth(250) - x - cellWidth: col0 -> 250-0-100=150, col1 -> 250-100-150=0
+    expect(cellByColumn(cells, "0").style["left"]).toBe("150px");
+    expect(cellByColumn(cells, "1").style["left"]).toBe("0px");
+    // Logical indices are preserved for selection/editing.
+    expect(cellByColumn(cells, "0").dataset["columnIndex"]).toBe("0");
+    expect(cellByColumn(cells, "1").dataset["columnIndex"]).toBe("1");
+    // The visual-leftmost cell (logical last column) now draws the left border.
+    expect(cellByColumn(cells, "1").style["borderLeft"]).toBe(
+      "1px solid var(--doc-border)",
+    );
+    expect(cellByColumn(cells, "0").style["borderLeft"]).toBeUndefined();
+  });
+
+  test("bidiVisual mirrors the internal column resize handle", () => {
+    const { fragment, block, measure } = buildTwoColumnTable(true);
+    const tableEl = renderTableFragment(
+      fragment,
+      block,
+      measure,
+      renderContext,
+      { document: fakeDocument },
+    ) as unknown as FakeElement;
+
+    const handle = tableEl.children.find(
+      (child) =>
+        child.className === TABLE_CLASS_NAMES.resizeHandle &&
+        child.dataset["columnIndex"] === "0",
+    );
+    // Boundary after logical column 0 is at x=100; mirrored to 250-100=150, less the 3px grab offset.
+    expect(handle?.style["left"]).toBe("147px");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -262,6 +262,8 @@ function renderNestedTable(
       doc,
       spanningCells,
       rowYPositions,
+      undefined,
+      block.bidi,
     );
     tableEl.append(rowEl);
     y += rowMeasure.height;
@@ -448,9 +450,17 @@ function renderTableRow(
   spanningCells?: Map<string, SpanningCell>,
   rowYPositions?: number[],
   isFirstRowInFragment?: boolean,
+  bidi = false,
 ): HTMLElement {
   const rowEl = doc.createElement("div");
   rowEl.className = TABLE_CLASS_NAMES.row;
+
+  // RTL tables (w:bidiVisual) mirror columns: logical column 0 paints on the
+  // right. Geometry-only — cell content and saved DOCX are unchanged
+  // (eigenpal/docx-editor#940).
+  const tableWidth = bidi
+    ? columnWidths.reduce((sum, columnWidth) => sum + columnWidth, 0)
+    : 0;
 
   // Positioning
   rowEl.style.position = "absolute";
@@ -518,15 +528,25 @@ function renderTableRow(
       }
     }
 
+    let cellWidth = 0;
+    for (let c = 0; c < colSpan && columnIndex + c < columnWidths.length; c++) {
+      cellWidth += columnWidths[columnIndex + c] ?? 0;
+    }
+    const cellLeft = bidi ? tableWidth - x - cellWidth : x;
+
     const isFirstRow = rowIndex === 0 || isFirstRowInFragment === true;
     const isLastRow = rowIndex + rowSpan >= totalRows;
-    const isFirstCol = columnIndex === 0;
-    const isLastCol = columnIndex + colSpan >= columnWidths.length;
+    // Outer-border sides are visual: in RTL the logical last column is the
+    // visual first (leftmost), so swap which cell draws the left/right border.
+    const atLogicalStart = columnIndex === 0;
+    const atLogicalEnd = columnIndex + colSpan >= columnWidths.length;
+    const isFirstCol = bidi ? atLogicalEnd : atLogicalStart;
+    const isLastCol = bidi ? atLogicalStart : atLogicalEnd;
 
     const cellEl = renderTableCell(
       cell,
       cellMeasure,
-      x,
+      cellLeft,
       cellHeight,
       { isFirstRow, isLastRow, isFirstCol, isLastCol },
       context,
@@ -552,15 +572,13 @@ function renderTableRow(
         startRow: rowIndex,
         rowSpan,
         colSpan,
-        x,
+        x: cellLeft,
         totalHeight: cellHeight,
       });
     }
 
-    // Move x by the width of columns this cell spans
-    for (let c = 0; c < colSpan && columnIndex + c < columnWidths.length; c++) {
-      x += columnWidths[columnIndex + c] ?? 0;
-    }
+    // Advance the logical running offset by the columns this cell spans
+    x += cellWidth;
 
     // Advance column index by colSpan
     columnIndex += colSpan;
@@ -615,14 +633,20 @@ export function renderTableFragment(
     tableEl.dataset["pmEnd"] = String(fragment.pmEnd);
   }
 
-  // Add column resize handles at each column boundary
+  // Add column resize handles at each column boundary. For RTL tables the
+  // boundary at the running left offset maps to the mirrored visual position
+  // so handles stay on the visible column edges (eigenpal/docx-editor#940).
+  const tableColumnsWidth = block.bidi
+    ? measure.columnWidths.reduce((sum, columnWidth) => sum + columnWidth, 0)
+    : 0;
   let handleX = 0;
   for (let col = 0; col < measure.columnWidths.length - 1; col++) {
     handleX += measure.columnWidths[col] ?? 0;
+    const handleLeft = block.bidi ? tableColumnsWidth - handleX : handleX;
     const handle = doc.createElement("div");
     handle.className = TABLE_CLASS_NAMES.resizeHandle;
     handle.style.position = "absolute";
-    handle.style.left = `${handleX - 3}px`;
+    handle.style.left = `${handleLeft - 3}px`;
     handle.style.top = "0";
     handle.style.width = "6px";
     handle.style.height = "100%";
@@ -673,6 +697,7 @@ export function renderTableFragment(
         spanningCells,
         rowYPositions,
         hdrIdx === 0, // first header row draws top border
+        block.bidi,
       );
       rowEl.dataset["repeatedHeader"] = "true";
       tableEl.append(rowEl);
@@ -724,6 +749,7 @@ export function renderTableFragment(
       spanningCells,
       rowYPositions,
       isFirstRowInFragment,
+      block.bidi,
     );
 
     contentParent.append(rowEl);

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -654,6 +654,11 @@ export function renderTableFragment(
     handle.style.zIndex = "10";
     handle.dataset["columnIndex"] = String(col);
     handle.dataset["tableBlockId"] = String(fragment.blockId);
+    // RTL boundary: the two columns are visually mirrored, so the resize path
+    // must invert the drag delta (eigenpal/docx-editor#940).
+    if (block.bidi) {
+      handle.dataset["bidi"] = "true";
+    }
     if (fragment.pmStart !== undefined) {
       handle.dataset["tablePmStart"] = String(fragment.pmStart);
     }
@@ -813,8 +818,11 @@ export function renderTableFragment(
     rightHandle.style.height = "100%";
     rightHandle.style.cursor = "col-resize";
     rightHandle.style.zIndex = "10";
+    // The visual right edge belongs to logical column 0 in an RTL table, so the
+    // edge handle resizes that column instead of the last one
+    // (eigenpal/docx-editor#940).
     rightHandle.dataset["columnIndex"] = String(
-      measure.columnWidths.length - 1,
+      block.bidi ? 0 : measure.columnWidths.length - 1,
     );
     rightHandle.dataset["tableBlockId"] = String(fragment.blockId);
     rightHandle.dataset["isEdge"] = "right";

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -1499,6 +1499,51 @@ describe("fromProseDoc", () => {
     expect(comment?.attrs.commentId).toBe(123);
   });
 
+  test("keeps one comment range across an interrupting tracked-change run (eigenpal/docx-editor#927)", () => {
+    const commentMark = schema.mark("comment", { commentId: 17 });
+    const insertionMark = schema.mark("insertion", {
+      revisionId: 1,
+      author: "Reviewer",
+      date: "2026-06-20T00:00:00Z",
+    });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("hello", [commentMark]),
+        schema.text("XXX", [insertionMark]),
+        schema.text("world", [commentMark]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const paragraph = document.package.document.content[0];
+
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+
+    // A single comment id must yield exactly one range; the tracked-change run
+    // that drops the comment mark sits inside it, not between two ranges.
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "commentRangeStart",
+      "run",
+      "insertion",
+      "run",
+      "commentRangeEnd",
+    ]);
+
+    const starts = paragraph.content.filter(
+      (content) => content.type === "commentRangeStart",
+    );
+    const ends = paragraph.content.filter(
+      (content) => content.type === "commentRangeEnd",
+    );
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(starts[0]?.id).toBe(17);
+    expect(ends[0]?.id).toBe(17);
+  });
+
   test("preserves comment ranges across multiple paragraphs", () => {
     const commentMark = schema.mark("comment", { commentId: 456 });
     const pmDoc = schema.node("doc", null, [

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1103,6 +1103,20 @@ function extractParagraphContent(
   let currentHyperlinkKey: string | null = null;
   const openedComments = new Set<number>();
 
+  // A single comment id must round-trip to a single contiguous comment range.
+  // Pre-compute the last offset at which each comment appears so the range
+  // spans any interrupting node that drops the mark (a tracked-change run, or
+  // an atom whose node spec can't carry the comment mark) instead of being
+  // split into several ranges for one id — invalid OOXML that Word rejects as
+  // unreadable content (eigenpal/docx-editor#927).
+  const commentLastOffset = new Map<number, number>();
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  paragraph.forEach((node, offset) => {
+    for (const commentId of getCommentMarkIds(node.marks)) {
+      commentLastOffset.set(commentId, offset);
+    }
+  });
+
   const flushCurrentInline = () => {
     if (currentRun) {
       content.push(currentRun);
@@ -1116,41 +1130,41 @@ function extractParagraphContent(
     }
   };
 
-  const syncCommentRanges = (node: PMNode) => {
+  const syncCommentRanges = (node: PMNode, offset: number) => {
     const nodeCommentIds = getCommentMarkIds(node.marks);
-    let changed = false;
+
+    // Close an open range only once this node is past the comment's last
+    // occurrence; a comment that reappears later stays open so the range spans
+    // the gap (eigenpal/docx-editor#927).
+    const toClose: number[] = [];
     for (const commentId of openedComments) {
-      if (!nodeCommentIds.has(commentId)) {
-        changed = true;
-        break;
+      const lastOffset = commentLastOffset.get(commentId) ?? offset;
+      if (!nodeCommentIds.has(commentId) && lastOffset <= offset) {
+        toClose.push(commentId);
       }
     }
-    if (!changed) {
-      for (const commentId of nodeCommentIds) {
-        if (!openedComments.has(commentId)) {
-          changed = true;
-          break;
-        }
+
+    const toOpen: number[] = [];
+    for (const commentId of nodeCommentIds) {
+      if (!openedComments.has(commentId)) {
+        toOpen.push(commentId);
       }
     }
-    if (!changed) {
+
+    if (toClose.length === 0 && toOpen.length === 0) {
       return;
     }
 
     flushCurrentInline();
 
-    for (const commentId of [...openedComments]) {
-      if (!nodeCommentIds.has(commentId)) {
-        content.push({ type: "commentRangeEnd", id: commentId });
-        openedComments.delete(commentId);
-      }
+    // Stable id ordering keeps shared-boundary emission deterministic.
+    for (const commentId of toClose.toSorted((a, b) => a - b)) {
+      content.push({ type: "commentRangeEnd", id: commentId });
+      openedComments.delete(commentId);
     }
-
-    for (const commentId of nodeCommentIds) {
-      if (!openedComments.has(commentId)) {
-        content.push({ type: "commentRangeStart", id: commentId });
-        openedComments.add(commentId);
-      }
+    for (const commentId of toOpen.toSorted((a, b) => a - b)) {
+      content.push({ type: "commentRangeStart", id: commentId });
+      openedComments.add(commentId);
     }
   };
 
@@ -1166,8 +1180,8 @@ function extractParagraphContent(
     }
   };
 
-  const processInlineNode = (node: PMNode): void => {
-    syncCommentRanges(node);
+  const processInlineNode = (node: PMNode, offset: number): void => {
+    syncCommentRanges(node, offset);
     const linkMark = node.marks.find((m) => m.type.name === "hyperlink");
 
     // Check for footnote/endnote reference mark
@@ -1315,7 +1329,7 @@ function extractParagraphContent(
         const splitOffset = Math.max(item.attrs.offset - offset, consumed);
         const segment = node.text.slice(consumed, splitOffset);
         if (segment) {
-          processInlineNode(node.type.schema.text(segment, node.marks));
+          processInlineNode(node.type.schema.text(segment, node.marks), offset);
         }
         flushCurrentInline();
         content.push(createEmptyHyperlink(item.attrs));
@@ -1325,12 +1339,12 @@ function extractParagraphContent(
 
       const remainder = node.text.slice(consumed);
       if (remainder) {
-        processInlineNode(node.type.schema.text(remainder, node.marks));
+        processInlineNode(node.type.schema.text(remainder, node.marks), offset);
       }
       return;
     }
 
-    processInlineNode(node);
+    processInlineNode(node, offset);
   });
 
   flushEmptyHyperlinksThroughOffset(Number.POSITIVE_INFINITY);

--- a/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
@@ -244,20 +244,16 @@ describe("semantic ProseMirror round-trip fixture", () => {
     const paragraph = firstParagraph(roundtripped);
 
     expect(pmValidation.valid).toBe(true);
-    // The shape now carries marks (eigenpal #641 — `Shape.nodeSpec.marks = "_"`
-    // so a tracked or commented shape survives the round-trip), so the
-    // comment range correctly re-opens around the shape-bearing run too. The
-    // mid-paragraph atom inserts split it from `mathEquation`.
+    // One comment id round-trips to one contiguous range (eigenpal/docx-editor
+    // #927): the range spans the `simpleField` and `mathEquation` atoms whose
+    // node specs drop the comment mark, instead of splitting into three ranges
+    // (the shape carries marks via eigenpal #641 `Shape.nodeSpec.marks = "_"`).
     expect(paragraph.content.map((content) => content.type)).toEqual([
       "commentRangeStart",
       "run",
-      "commentRangeEnd",
       "simpleField",
-      "commentRangeStart",
       "inlineSdt",
-      "commentRangeEnd",
       "mathEquation",
-      "commentRangeStart",
       "run",
       "commentRangeEnd",
     ]);

--- a/packages/folio/src/core/prosemirror/plugins/imeComposition.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/imeComposition.test.ts
@@ -1,0 +1,215 @@
+/**
+ * IME composition handling in suggestion mode.
+ *
+ * Regression coverage for Japanese / CJK input garbling: while an IME
+ * composition is in flight the plugin must NOT mark the composed text (the
+ * `appendTransaction` catch-all is suppressed), and the committed text must be
+ * marked as a tracked insertion once, on compositionend. See
+ * `createSuggestionModePlugin`'s IME guards and eigenpal/docx-editor#938.
+ *
+ * The composition handling lives in view-level DOM handlers, so these tests
+ * drive `props.handleDOMEvents` against a minimal mock view whose `dispatch`
+ * runs the real `EditorState.apply` pipeline (so the plugin's
+ * `appendTransaction` runs exactly as it would in the browser).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { Schema } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import {
+  createSuggestionModePlugin,
+  suggestionModeKey,
+} from "./suggestionMode";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*", toDOM: () => ["p", 0] },
+    text: { group: "inline" },
+  },
+  marks: {
+    insertion: {
+      attrs: {
+        revisionId: { default: 0 },
+        author: { default: "" },
+        date: { default: "" },
+      },
+      toDOM: () => ["ins", 0],
+    },
+    deletion: {
+      attrs: {
+        revisionId: { default: 0 },
+        author: { default: "" },
+        date: { default: "" },
+      },
+      toDOM: () => ["del", 0],
+    },
+  },
+});
+
+type MockView = {
+  state: EditorState;
+  composing: boolean;
+  dispatch: (tr: Transaction) => void;
+};
+
+function makeMockView(state: EditorState): MockView {
+  const view: MockView = {
+    state,
+    composing: false,
+    dispatch(tr: Transaction) {
+      view.state = view.state.apply(tr);
+    },
+  };
+  return view;
+}
+
+function insertionText(state: EditorState): string[] {
+  const out: string[] = [];
+  state.doc.descendants((node) => {
+    if (node.isText && node.marks.some((m) => m.type.name === "insertion")) {
+      out.push(node.text ?? "");
+    }
+  });
+  return out;
+}
+
+function deletionText(state: EditorState): string[] {
+  const out: string[] = [];
+  state.doc.descendants((node) => {
+    if (node.isText && node.marks.some((m) => m.type.name === "deletion")) {
+      out.push(node.text ?? "");
+    }
+  });
+  return out;
+}
+
+type DomEvents = Record<string, (view: unknown, event?: unknown) => boolean>;
+
+/** Build an active suggestion-mode editor with the cursor at the end of `text`. */
+function setup(text: string): {
+  view: MockView;
+  domEvents: DomEvents;
+  handleTextInput: (
+    v: unknown,
+    from: number,
+    to: number,
+    text: string,
+  ) => boolean;
+} {
+  const plugin = createSuggestionModePlugin(true, "TestUser");
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text(text)]),
+  ]);
+  const state = EditorState.create({ doc, plugins: [plugin] });
+  const view = makeMockView(
+    state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, text.length + 1)),
+    ),
+  );
+  // SAFETY: handleDOMEvents and handleTextInput are present on this plugin.
+  const props = plugin.props as {
+    handleDOMEvents: DomEvents;
+    handleTextInput: (
+      v: unknown,
+      from: number,
+      to: number,
+      text: string,
+    ) => boolean;
+  };
+  return {
+    view,
+    domEvents: props.handleDOMEvents,
+    handleTextInput: props.handleTextInput,
+  };
+}
+
+describe("SuggestionMode IME composition", () => {
+  test("composed text is NOT marked while a composition is in flight", () => {
+    const { view, domEvents } = setup("Hello");
+
+    domEvents.compositionstart(view);
+    // PM commits composed text as a plain (non-suggestion) transaction.
+    view.dispatch(view.state.tr.insertText("日本語", 6, 6));
+
+    // The catch-all must stay out of the way mid-composition.
+    expect(insertionText(view.state)).toEqual([]);
+    expect(view.state.doc.textContent).toBe("Hello日本語");
+    // The surrounding text must not be struck through as a tracked deletion.
+    expect(deletionText(view.state)).toEqual([]);
+  });
+
+  test("compositionend marks the committed range as a tracked insertion", async () => {
+    const { view, domEvents } = setup("Hello");
+
+    domEvents.compositionstart(view);
+    view.dispatch(view.state.tr.insertText("日本語", 6, 6));
+    domEvents.compositionend(view);
+    // Marking is deferred one microtask so it lands after the composition settles.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(insertionText(view.state)).toEqual(["日本語"]);
+    // The preceding text is NOT marked as a deletion (the garbling assertion).
+    expect(deletionText(view.state)).toEqual([]);
+    // The caret stays collapsed right after the committed text (not before it).
+    expect(view.state.selection.empty).toBe(true);
+    expect(view.state.selection.from).toBe(9); // 'Hello'(5) + '日本語'(3) + 1 doc offset
+  });
+
+  test("handleTextInput does NOT re-insert composed text while composing", () => {
+    // PM commits composed text from the DOM and then calls handleTextInput with
+    // it. Re-inserting there duplicates the text (the reported garbling), so the
+    // handler must decline while a composition is in flight.
+    const { view, domEvents, handleTextInput } = setup("Hello");
+
+    domEvents.compositionstart(view);
+    const handled = handleTextInput(view, 6, 6, "あ");
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.textContent).toBe("Hello"); // nothing re-inserted
+  });
+
+  test("handleTextInput still tracks plain input when not composing", () => {
+    const { view, handleTextInput } = setup("Hello");
+
+    const handled = handleTextInput(view, 6, 6, "Z");
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.textContent).toBe("HelloZ");
+    expect(insertionText(view.state)).toContain("Z");
+  });
+
+  test("composed text is left unmarked if suggestion mode is toggled off before compositionend settles", async () => {
+    const { view, domEvents } = setup("Hello");
+
+    domEvents.compositionstart(view);
+    view.dispatch(view.state.tr.insertText("日本語", 6, 6));
+    // Toggle suggestion mode OFF before the deferred marking runs.
+    view.dispatch(view.state.tr.setMeta(suggestionModeKey, { active: false }));
+    domEvents.compositionend(view);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Tracking is off now, so the composed text must NOT be marked.
+    expect(insertionText(view.state)).toEqual([]);
+    expect(view.state.doc.textContent).toBe("Hello日本語");
+  });
+
+  test("the catch-all resumes for non-composition input after composing ends", async () => {
+    const { view, domEvents } = setup("Hello");
+
+    domEvents.compositionstart(view);
+    view.dispatch(view.state.tr.insertText("あ", 6, 6));
+    domEvents.compositionend(view);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A later plain insertion (paste-like), away from the composed run so it
+    // can't merely inherit the adjacent mark, is tracked by the catch-all.
+    view.dispatch(view.state.tr.insertText("X", 1, 1));
+    expect(insertionText(view.state)).toContain("X");
+  });
+});

--- a/packages/folio/src/core/prosemirror/plugins/imeComposition.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/imeComposition.test.ts
@@ -30,12 +30,15 @@ const schema = new Schema({
     text: { group: "inline" },
   },
   marks: {
+    // Mirror the production tracked-change marks (TrackedChangeExtensions):
+    // inclusive: false so text typed at a revision boundary does not inherit it.
     insertion: {
       attrs: {
         revisionId: { default: 0 },
         author: { default: "" },
         date: { default: "" },
       },
+      inclusive: false,
       toDOM: () => ["ins", 0],
     },
     deletion: {
@@ -44,6 +47,7 @@ const schema = new Schema({
         author: { default: "" },
         date: { default: "" },
       },
+      inclusive: false,
       toDOM: () => ["del", 0],
     },
   },
@@ -196,6 +200,28 @@ describe("SuggestionMode IME composition", () => {
     // Tracking is off now, so the composed text must NOT be marked.
     expect(insertionText(view.state)).toEqual([]);
     expect(view.state.doc.textContent).toBe("Hello日本語");
+  });
+
+  test("composing over a selection records the replaced text as a tracked deletion (eigenpal/docx-editor#938)", async () => {
+    const { view, domEvents } = setup("Hello World");
+    // Select "World" (positions 7..12) and start composing over it.
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.create(view.state.doc, 7, 12)),
+    );
+
+    domEvents.compositionstart(view);
+    // compositionstart struck the selection and collapsed the caret after it;
+    // PM then commits the composed text at the caret.
+    const caret = view.state.selection.from;
+    view.dispatch(view.state.tr.insertText("世界", caret, caret));
+    domEvents.compositionend(view);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Redline preserved: the replaced selection is struck, the composed text inserted.
+    expect(deletionText(view.state)).toEqual(["World"]);
+    expect(insertionText(view.state)).toEqual(["世界"]);
+    expect(view.state.doc.textContent).toBe("Hello World世界");
   });
 
   test("the catch-all resumes for non-composition input after composing ends", async () => {

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
@@ -640,6 +640,66 @@ function handleSuggestionDelete(
 }
 
 /**
+ * Mark the text committed by an IME composition as a tracked insertion.
+ *
+ * Invoked from `compositionend` (deferred to a microtask) rather than from the
+ * `appendTransaction` catch-all. ProseMirror commits composed text as part of
+ * its own composition-end flush; adding the insertion mark *synchronously*
+ * during that flush re-wraps the very text node the IME just finalized, which
+ * corrupts CJK (Japanese / Chinese / Korean) input — characters duplicate or
+ * garble. Running one tick later, after the composition has settled, wraps the
+ * committed range safely. `markRangeAsInserted` skips nodes that already carry a
+ * tracked-change mark, so this is idempotent. eigenpal/docx-editor#938.
+ */
+function markComposedAsInsertion(
+  view: EditorView,
+  from: number,
+  pluginState: SuggestionModeState,
+): void {
+  const insertionType = view.state.schema.marks["insertion"];
+  const deletionType = view.state.schema.marks["deletion"];
+  if (!insertionType || !deletionType) {
+    return;
+  }
+  // PM leaves the cursor at the end of the committed composition.
+  const to = view.state.selection.to;
+  if (to <= from) {
+    return;
+  }
+
+  const tr = view.state.tr;
+  tr.setMeta(SUGGESTION_META, true);
+  const markAttrs =
+    findAdjacentRevisionForRange(
+      view.state.doc,
+      from,
+      to,
+      "insertion",
+      pluginState.author,
+    ) || makeMarkAttrs(pluginState);
+  markRangeAsInserted(
+    tr,
+    view.state.doc,
+    from,
+    to,
+    insertionType,
+    deletionType,
+    markAttrs,
+  );
+  if (tr.steps.length === 0) {
+    return;
+  }
+
+  // Collapse the caret right after the committed text, mirroring
+  // applySuggestionInsert. Re-rendering the now-marked run can otherwise leave
+  // the painted caret before the range; positions are stable across add-mark
+  // steps but map anyway to stay correct if that changes.
+  const caret = tr.mapping.map(to);
+  tr.setSelection(TextSelection.create(tr.doc, caret));
+  view.dispatch(tr);
+}
+
+/**
  * Create the suggestion mode plugin.
  * When active, text edits become tracked changes.
  */
@@ -647,6 +707,19 @@ export function createSuggestionModePlugin(
   initialActive = false,
   author = "User",
 ): Plugin {
+  // IME composition tracking. Each call returns a fresh Plugin, so a separate
+  // view never shares this closure — the flag is per editor instance.
+  //   - `composing` gates the `appendTransaction` catch-all so it never mutates
+  //     the document mid-composition (mid-composition mark changes corrupt CJK
+  //     input). It stays true until the deferred `compositionend` marking runs,
+  //     so the catch-all also skips PM's own composition-commit transaction:
+  //     `view.composing` flips false slightly before that final flush, hence the
+  //     manual flag. eigenpal/docx-editor#938.
+  //   - `compositionFrom` records where the composition began so
+  //     `compositionend` can mark exactly the committed range as an insertion.
+  let composing = false;
+  let compositionFrom: number | null = null;
+
   return new Plugin({
     key: suggestionModeKey,
 
@@ -665,6 +738,45 @@ export function createSuggestionModePlugin(
 
     props: {
       handleDOMEvents: {
+        // Remember where the composition starts and suppress the catch-all
+        // while it runs. Composed text is marked as an insertion later, on
+        // compositionend — never mid-composition. eigenpal/docx-editor#938.
+        compositionstart(view: EditorView) {
+          const pluginState = suggestionModeKey.getState(view.state);
+          if (!pluginState?.active) {
+            return false;
+          }
+          composing = true;
+          compositionFrom = view.state.selection.from;
+          return false;
+        },
+        // Mark the committed text as a tracked insertion AFTER the composition
+        // settles. PM commits the composed text in its own compositionend flush
+        // (which runs after this handler); `composing` stays true across that
+        // flush so the catch-all skips it, then the range is marked and the flag
+        // cleared one microtask later. See `markComposedAsInsertion`.
+        compositionend(view: EditorView) {
+          const pluginState = suggestionModeKey.getState(view.state);
+          const from = compositionFrom;
+          compositionFrom = null;
+          if (!pluginState?.active || from == null) {
+            composing = false;
+            return false;
+          }
+          queueMicrotask(() => {
+            try {
+              // Re-read state: suggestion mode may have been toggled off (or the
+              // author changed) between scheduling and running this callback.
+              const current = suggestionModeKey.getState(view.state);
+              if (current?.active) {
+                markComposedAsInsertion(view, from, current);
+              }
+            } finally {
+              composing = false;
+            }
+          });
+          return false;
+        },
         // Intercept text input at the DOM level. ProseMirror's handleTextInput
         // is NOT reliably called when the hidden PM has complex mark structures
         // (it requires the change to span exactly one text node). By handling
@@ -672,6 +784,14 @@ export function createSuggestionModePlugin(
         beforeinput(view: EditorView, event: InputEvent) {
           const pluginState = suggestionModeKey.getState(view.state);
           if (!pluginState?.active) {
+            return false;
+          }
+
+          // Never intercept while an IME composition is active. Calling
+          // preventDefault() or dispatching a transaction here desyncs the
+          // browser's composition from the DOM and garbles CJK input — the
+          // committed text is handled by compositionend instead.
+          if (composing || event.isComposing) {
             return false;
           }
 
@@ -727,6 +847,13 @@ export function createSuggestionModePlugin(
         if (!pluginState?.active) {
           return false;
         }
+        // During / right after an IME composition, ProseMirror has already
+        // applied the composed text from the DOM. Re-inserting it here would
+        // duplicate it (and desync the view), so defer to compositionend.
+        // eigenpal/docx-editor#938.
+        if (composing || view.composing) {
+          return false;
+        }
         return applySuggestionInsert(view, from, to, text, pluginState);
       },
 
@@ -746,6 +873,15 @@ export function createSuggestionModePlugin(
     appendTransaction(transactions, _oldState, newState) {
       const pluginState = suggestionModeKey.getState(newState);
       if (!pluginState?.active) {
+        return null;
+      }
+
+      // Leave composed text un-marked while an IME composition is in flight.
+      // `compositionend` marks the final committed range once, after the IME
+      // settles; marking here (mid-composition, or during PM's compositionend
+      // commit) re-wraps the active text node and corrupts CJK input.
+      // eigenpal/docx-editor#938.
+      if (composing) {
         return null;
       }
 

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
@@ -747,7 +747,35 @@ export function createSuggestionModePlugin(
             return false;
           }
           composing = true;
-          compositionFrom = view.state.selection.from;
+          const { from, to } = view.state.selection;
+          // Composing over a non-empty selection: record the replaced range as a
+          // tracked deletion up front (mirrors applySuggestionInsert) and
+          // collapse the caret after it, so the composed text commits as an
+          // insertion on compositionend instead of the selected text being
+          // dropped natively with no redline. eigenpal/docx-editor#938.
+          if (from !== to) {
+            const insertionType = view.state.schema.marks["insertion"];
+            const deletionType = view.state.schema.marks["deletion"];
+            if (insertionType && deletionType) {
+              const tr = view.state.tr;
+              tr.setMeta(SUGGESTION_META, true);
+              markRangeAsDeleted(
+                tr,
+                view.state.doc,
+                from,
+                to,
+                insertionType,
+                deletionType,
+                pluginState,
+              );
+              const caret = tr.mapping.map(to);
+              tr.setSelection(TextSelection.create(tr.doc, caret));
+              view.dispatch(tr);
+              compositionFrom = caret;
+              return false;
+            }
+          }
+          compositionFrom = from;
           return false;
         },
         // Mark the committed text as a tracked insertion AFTER the composition

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -208,6 +208,7 @@ import {
   twipsToPixels,
 } from "./sectionGeometry";
 import { SelectionOverlay } from "./SelectionOverlay";
+import { resizeColumnPair } from "./tableColumnResize";
 import { tableInsertButtonOffset } from "./tableInsertButtonGeometry";
 import { getTransactionDirtyRange } from "./transactionDirtyRange";
 import { useDragAutoScroll } from "./useDragAutoScroll";
@@ -2049,6 +2050,7 @@ export function PagedEditor(
     right: 0,
   });
   const resizeHandleRef = useRef<HTMLElement | null>(null);
+  const resizeBidiRef = useRef(false);
 
   // Row resize state
   const isResizingRowRef = useRef(false);
@@ -4576,6 +4578,7 @@ export function PagedEditor(
           : null;
         resizeStartXRef.current = e.clientX;
         resizeHandleRef.current = target;
+        resizeBidiRef.current = target.dataset["bidi"] === "true";
         target.classList.add("dragging");
 
         const colIndex = Number.parseInt(
@@ -4864,11 +4867,13 @@ export function PagedEditor(
           // Update stored widths (convert pixel delta to twips: 1px ≈ 15 twips at 96dpi)
           const deltaTwips = Math.round(delta * 15);
           const minWidth = 300; // ~0.2 inches minimum
-          const newLeft = resizeOrigWidthsRef.current.left + deltaTwips;
-          const newRight = resizeOrigWidthsRef.current.right - deltaTwips;
-          if (newLeft >= minWidth && newRight >= minWidth) {
-            resizeOrigWidthsRef.current = { left: newLeft, right: newRight };
-          }
+          resizeOrigWidthsRef.current = resizeColumnPair(
+            resizeOrigWidthsRef.current.left,
+            resizeOrigWidthsRef.current.right,
+            deltaTwips,
+            resizeBidiRef.current,
+            minWidth,
+          );
         }
         return;
       }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -208,6 +208,7 @@ import {
   twipsToPixels,
 } from "./sectionGeometry";
 import { SelectionOverlay } from "./SelectionOverlay";
+import { tableInsertButtonOffset } from "./tableInsertButtonGeometry";
 import { getTransactionDirtyRange } from "./transactionDirtyRange";
 import { useDragAutoScroll } from "./useDragAutoScroll";
 // Visual line navigation hook
@@ -5368,8 +5369,18 @@ export function PagedEditor(
             const rowCenterY = rowRect.top + rowRect.height / 2;
             setTableInsertButton({
               type: "row",
-              x: tableRect.left - viewportRect.left - 24,
-              y: rowCenterY - viewportRect.top - 10,
+              x: tableInsertButtonOffset(
+                tableRect.left,
+                viewportRect.left,
+                zoom,
+                24,
+              ),
+              y: tableInsertButtonOffset(
+                rowCenterY,
+                viewportRect.top,
+                zoom,
+                10,
+              ),
               cellPmPos: pmPos,
             });
             clearTableInsertTimer();
@@ -5391,8 +5402,18 @@ export function PagedEditor(
             const cellCenterX = cellRect.left + cellRect.width / 2;
             setTableInsertButton({
               type: "column",
-              x: cellCenterX - viewportRect.left - 10,
-              y: tableRect.top - viewportRect.top - 24,
+              x: tableInsertButtonOffset(
+                cellCenterX,
+                viewportRect.left,
+                zoom,
+                10,
+              ),
+              y: tableInsertButtonOffset(
+                tableRect.top,
+                viewportRect.top,
+                zoom,
+                24,
+              ),
               cellPmPos: pmPos,
             });
             clearTableInsertTimer();
@@ -5409,7 +5430,7 @@ export function PagedEditor(
         }, TABLE_INSERT_HIDE_DELAY);
       }
     },
-    [readOnly, clearTableInsertTimer],
+    [readOnly, clearTableInsertTimer, zoom],
   );
 
   /**

--- a/packages/folio/src/paged-editor/tableColumnResize.test.ts
+++ b/packages/folio/src/paged-editor/tableColumnResize.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import { resizeColumnPair } from "./tableColumnResize";
+
+const MIN = 300;
+
+describe("resizeColumnPair", () => {
+  test("LTR: dragging the boundary right grows the left column and shrinks the right", () => {
+    expect(resizeColumnPair(2000, 3000, 150, false, MIN)).toEqual({
+      left: 2150,
+      right: 2850,
+    });
+  });
+
+  test("RTL (bidiVisual): the delta is inverted so the visual-left (logical right) column grows (eigenpal/docx-editor#940)", () => {
+    expect(resizeColumnPair(2000, 3000, 150, true, MIN)).toEqual({
+      left: 1850,
+      right: 3150,
+    });
+  });
+
+  test("keeps the original widths when a side would fall below the minimum", () => {
+    // LTR drag left that would push the left column under MIN.
+    expect(resizeColumnPair(MIN, 3000, -50, false, MIN)).toEqual({
+      left: MIN,
+      right: 3000,
+    });
+    // Same guard under RTL inversion (here a positive delta shrinks the left).
+    expect(resizeColumnPair(MIN, 3000, 50, true, MIN)).toEqual({
+      left: MIN,
+      right: 3000,
+    });
+  });
+});

--- a/packages/folio/src/paged-editor/tableColumnResize.ts
+++ b/packages/folio/src/paged-editor/tableColumnResize.ts
@@ -1,0 +1,27 @@
+/**
+ * Resize a pair of adjacent column widths (in twips) as the boundary handle
+ * between them is dragged by `deltaTwips`.
+ *
+ * For RTL (`w:bidiVisual`) tables the two columns either side of the boundary
+ * are visually mirrored — the `left` column paints on the right — so the drag
+ * delta is inverted: dragging the handle right grows the visual-left (logical
+ * `right`) column and shrinks the visual-right (logical `left`) one, which also
+ * keeps the committed boundary under the cursor. Returns the original widths
+ * unchanged when either side would drop below `minWidth`.
+ * eigenpal/docx-editor#940.
+ */
+export const resizeColumnPair = (
+  left: number,
+  right: number,
+  deltaTwips: number,
+  bidi: boolean,
+  minWidth: number,
+): { left: number; right: number } => {
+  const signedDelta = bidi ? -deltaTwips : deltaTwips;
+  const newLeft = left + signedDelta;
+  const newRight = right - signedDelta;
+  if (newLeft >= minWidth && newRight >= minWidth) {
+    return { left: newLeft, right: newRight };
+  }
+  return { left, right };
+};

--- a/packages/folio/src/paged-editor/tableInsertButtonGeometry.test.ts
+++ b/packages/folio/src/paged-editor/tableInsertButtonGeometry.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { tableInsertButtonOffset } from "./tableInsertButtonGeometry";
+
+describe("tableInsertButtonOffset", () => {
+  test("at 100% zoom the offset is the plain screen delta minus the nudge", () => {
+    expect(tableInsertButtonOffset(200, 50, 1, 24)).toBe(126);
+  });
+
+  test("scales the screen delta down by zoom so the button tracks the table edge (eigenpal/docx-editor#934)", () => {
+    // (200-50)/2 = 75 viewport px, then the 24px nudge in button-local space.
+    expect(tableInsertButtonOffset(200, 50, 2, 24)).toBe(51);
+    // Zoomed out: the delta grows in viewport space.
+    expect(tableInsertButtonOffset(200, 50, 0.5, 24)).toBe(276);
+  });
+
+  test("treats a zero zoom as 100% instead of dividing by zero", () => {
+    expect(tableInsertButtonOffset(200, 50, 0, 24)).toBe(126);
+  });
+});

--- a/packages/folio/src/paged-editor/tableInsertButtonGeometry.ts
+++ b/packages/folio/src/paged-editor/tableInsertButtonGeometry.ts
@@ -1,0 +1,17 @@
+/**
+ * Position the table insert ("+") button inside the zoom-scaled viewport.
+ *
+ * The button is an absolute child of `.paged-editor__viewport`, which carries
+ * `transform: scale(zoom)`. `getBoundingClientRect` returns already-scaled
+ * screen pixels, so the screen-space delta from the viewport origin must be
+ * divided by `zoom` to land in the viewport's own coordinate space. The
+ * constant nudge then stays in that (button-local) space so it tracks the
+ * button, which is scaled too. Without the divisor the button drifts off the
+ * table edge at any zoom other than 100% (eigenpal/docx-editor#934).
+ */
+export const tableInsertButtonOffset = (
+  edge: number,
+  viewportEdge: number,
+  zoom: number,
+  nudge: number,
+): number => (edge - viewportEdge) / (zoom || 1) - nudge;


### PR DESCRIPTION
Ports four fixes from upstream `eigenpal/docx-editor` (folio's source fork), each with a regression test written first. Files are disjoint per fix.

- **Comment ranges across tracked changes** (`eigenpal/docx-editor#927`): a comment spanning a tracked-change run — or an atom whose node spec drops the comment mark — serialized into multiple `commentRange` pairs for one id, which is invalid OOXML. The range now spans the interrupting node. Computed from each comment's last offset (open on first occurrence, close once it cannot reappear) rather than upstream's child-index two-pass, which does not fit folio's text-splitting/run-merging.
- **CJK/IME input in track changes** (`eigenpal/docx-editor#938`): the suggesting-mode plugin had no composition awareness, so an IME composition was re-inserted and the surrounding text struck as a deletion. Adds composition state, `compositionstart`/`compositionend` handlers, guards on `beforeinput`/`handleTextInput`/the append-transaction catch-all, and a deferred compositionend pass that marks the committed range exactly once.
- **RTL `w:bidiVisual` tables** (`eigenpal/docx-editor#940`): the flag was parsed and round-tripped but the painter always drew columns left-to-right. The painter now mirrors cell x-positions, outer-border sides, and column resize handles when `bidi` is set. Geometry-only; LTR tables and saved DOCX are unchanged.
- **Table insert button at non-100% zoom** (`eigenpal/docx-editor#934`): the button is a child of the scaled viewport but was positioned from unscaled screen deltas, so it drifted at non-100% zoom. The screen delta is now divided by the zoom factor via a small pure, unit-tested helper. (The PR's caret-height half is N/A — folio derives caret height from `offsetHeight`, which CSS transforms do not scale.)
