### PR TITLE
fix(api): run migrations via Bun SQL client

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -54,9 +54,9 @@ jobs:
         run: bash scripts/check-migrations.sh
 
   apply-fresh:
-    # Validates that `drizzle-kit migrate` can apply every migration end-to-end
-    # against an empty Postgres. Catches: missing `_journal.json`, ordering bugs,
-    # syntax errors, and any migration that would crash on a real DB.
+    # Validates that the shipped migrate entrypoint can apply every migration
+    # end-to-end against an empty Postgres. Catches: ordering bugs, syntax
+    # errors, and any migration that would crash on a real DB.
     if: github.event.pull_request.draft != true || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -109,7 +109,9 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
-        run: bun --bun drizzle-kit migrate
+        # Exercises the shipped migrate path (Bun SQL + drizzle migrator),
+        # the same entrypoint the deploy runs, not the drizzle-kit CLI.
+        run: bun run src/db/migrate.ts
 
       - name: Verify schema parity with schema.ts
         working-directory: apps/api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           docker run --rm --network host \
             --env DATABASE_URL \
             stella-api:smoke \
-            bun --bun drizzle-kit migrate
+            bun run src/db/migrate.ts
 
       - name: Run smoke container
         env:

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -5,7 +5,7 @@
 # .github/workflows/db-migrations.yml.
 pg_version = "18.0"
 
-# `drizzle-kit migrate` wraps every migration in a transaction.
+# The drizzle migrator wraps every migration in a transaction.
 assume_in_transaction = true
 
 # Keep lock-safety rules active. Migrations that need concurrent indexes can

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -68,8 +68,12 @@ RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 COPY --chown=stella:stella --from=builder /app/server /app/server
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
+# Loose files for the one-off migrate task (the API itself is the compiled
+# /app/server binary). migrate.ts runs the drizzle migrator over Bun's SQL
+# client; it imports db-url.ts and reads the drizzle/ migration folder.
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle.config.ts /app/apps/api/drizzle.config.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/src/db-url.ts /app/apps/api/src/db-url.ts
+COPY --chown=stella:stella --from=builder /app/apps/api/src/db/migrate.ts /app/apps/api/src/db/migrate.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle /app/apps/api/drizzle
 RUN mkdir -p '/$bunfs/root'
 COPY --chown=stella:stella --from=builder /app/runtime-workers /\$bunfs/root/workers

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/api",
     "format": "oxfmt .",
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",
-    "db:migrate": "bun run --env-file=.env drizzle-kit migrate",
+    "db:migrate": "bun run --env-file=.env src/db/migrate.ts",
     "db:push": "bun run --env-file=.env drizzle-kit push",
     "db:seed-test-user": "bun scripts/seed-test-user.ts",
     "db:seed-dev": "bun scripts/seed-dev.ts",

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -1,0 +1,45 @@
+import { panic } from "better-result";
+import { SQL } from "bun";
+import { drizzle } from "drizzle-orm/bun-sql";
+import { migrate } from "drizzle-orm/bun-sql/migrator";
+import nodePath from "node:path";
+
+// Relative import (not the `@/api` alias): this script ships as a loose
+// file in the runtime image, which has no tsconfig to resolve paths.
+import { resolveDatabaseUrl } from "../db-url";
+
+// Migrations run through Bun's SQL client — the same driver the API uses
+// at runtime — so TLS is negotiated identically. The drizzle-kit CLI
+// instead forces node-postgres, whose pg-connection-string maps
+// `sslmode=require` to `verify-full` and then rejects the RDS private CA
+// (no bundle is shipped), failing every migration with
+// SELF_SIGNED_CERT_IN_CHAIN. Bun's client honours `sslmode=require`
+// without that chain check, matching the runtime connection.
+//
+// Running the migrator programmatically (rather than via the CLI) is also
+// what gives this entrypoint a deterministic exit code: a failure throws
+// and exits non-zero instead of the CLI's nondeterministic exit on error.
+const url = resolveDatabaseUrl();
+if (!url) {
+  panic(
+    "migrate: no database connection; set DATABASE_URL or the DB_* components",
+  );
+}
+
+const client = new SQL({ url, max: 1 });
+
+try {
+  await migrate(drizzle({ client }), {
+    // cwd is the migrate task's workingDirectory (/app/apps/api); mirrors
+    // the path that assert-migrations-applied.ts checks at startup.
+    migrationsFolder: nodePath.resolve(process.cwd(), "drizzle"),
+  });
+  // eslint-disable-next-line no-console -- migrate CLI entrypoint; stdout is its interface (no app logger in this minimal-env task)
+  console.info("[migrate] migrations applied");
+} catch (error) {
+  // eslint-disable-next-line no-console -- migrate CLI entrypoint; surface the failure to the deploy log
+  console.error("[migrate] failed:", error);
+  process.exitCode = 1;
+} finally {
+  await client.end();
+}

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -68,7 +68,7 @@ export const assertMigrationsApplied = async (): Promise<void> => {
       `[startup] Schema drift: ${missing.length} migration(s) in code are not applied to the database. ` +
         `Code has ${local.length}; DB has ${appliedHashes.size}. ` +
         `Missing or modified after apply: ${missingNames}. ` +
-        `Run \`bunx drizzle-kit migrate\` against this database, or set ${ESCAPE_HATCH_ENV}=true ` +
+        `Run \`bun run db:migrate\` against this database, or set ${ESCAPE_HATCH_ENV}=true ` +
         "to bypass the check (emergency only).",
     );
   }


### PR DESCRIPTION
Run database migrations through Bun's `SQL` client — the same driver the API uses at runtime — via drizzle's programmatic migrator, instead of the `drizzle-kit migrate` CLI.

## Why

`drizzle-kit migrate` connects through node-postgres, whose
`pg-connection-string` maps `sslmode=require` to `verify-full` (full CA
chain verification). The API runtime instead connects via
`drizzle-orm/bun-sql`, which honours `sslmode=require` without that chain
check. Routing migrations through the same Bun SQL client makes the
migrate path's TLS behaviour consistent with the runtime, and invoking
the migrator programmatically gives the one-off migrate task a
deterministic exit code (the CLI's exit code on a failed connection is
not reliable).

This stays vanilla drizzle: `migrate.ts` calls
`drizzle-orm/bun-sql/migrator` over the same client `root.ts` uses,
reading the same `drizzle/` folder and writing the same
`drizzle.__drizzle_migrations` table.

## Changes

- `apps/api/src/db/migrate.ts` — programmatic migrator over Bun SQL
- `apps/api/package.json` — `db:migrate` runs the script
- `apps/api/Dockerfile` — ship the loose `migrate.ts` in the runtime image
- `.github/workflows/{release,db-migrations}.yml` — exercise the shipped path
- comment fixups (`assert-migrations-applied`, `.squawk.toml`)

Requires the matching infra change that points the migrate task at
`bun run src/db/migrate.ts`.
