### PR TITLE
refactor(case-law): extract shared inline-tree utilities

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
@@ -26,6 +26,10 @@ import {
   CZ_JUDGE_NAME_RE as SIGNATURE_RE,
   CZ_JUDGE_TITLE_RE as PREDSEDA_RE,
 } from "./cz-patterns";
+import {
+  inlinesToPlainText,
+  walkInlines as walkInlinesShared,
+} from "./shared-inlines";
 
 // ── Public API ─────────────────────────────────────────────
 
@@ -222,67 +226,7 @@ type RawChunk =
 const walkInlines = (
   $: cheerio.CheerioAPI,
   el: cheerio.Cheerio<AnyNode>,
-): Inline[] => {
-  const inlines: Inline[] = [];
-
-  el.contents().each((_, node) => {
-    if (isText(node)) {
-      const text = $(node).text();
-      if (text) {
-        inlines.push({ type: "text", text });
-      }
-      return;
-    }
-
-    if (!isTag(node)) {
-      return;
-    }
-
-    const tag = node.tagName.toLowerCase();
-    const $node = $(node);
-
-    if (tag === "style" || tag === "script") {
-      return;
-    }
-
-    if (tag === "br") {
-      inlines.push({ type: "line-break" });
-      return;
-    }
-
-    if (tag === "b" || tag === "strong") {
-      const children = walkInlines($, $node);
-      if (children.length > 0) {
-        inlines.push({ type: "bold", children });
-      }
-      return;
-    }
-
-    if (tag === "i" || tag === "em") {
-      const children = walkInlines($, $node);
-      if (children.length > 0) {
-        inlines.push({ type: "italic", children });
-      }
-      return;
-    }
-
-    if (tag === "a") {
-      const href = sanitizeUrl($node.attr("href") ?? "");
-      const children = walkInlines($, $node);
-      if (href && children.length > 0) {
-        inlines.push({ type: "link", href, children });
-      } else if (children.length > 0) {
-        inlines.push(...children);
-      }
-      return;
-    }
-
-    // Unwrap presentational wrappers
-    inlines.push(...walkInlines($, $node));
-  });
-
-  return inlines;
-};
+): Inline[] => walkInlinesShared($, el, { sanitizeHref: sanitizeUrl });
 
 const isCentered = (el: cheerio.Cheerio<AnyNode>): boolean => {
   if (el.attr("align") === "center") {
@@ -501,34 +445,6 @@ export const extractRawChunks = ($: cheerio.CheerioAPI): RawChunk[] => {
 // ── Pass 2: raw chunks -> semantic blocks ──────────────────
 
 // ── Helpers (must precede classifyBlocks) ─────────────────
-
-const inlinesToPlainText = (inlines: readonly Inline[]): string => {
-  let text = "";
-  for (const inline of inlines) {
-    switch (inline.type) {
-      case "text": {
-        text += inline.text;
-        break;
-      }
-      case "bold":
-      case "italic": {
-        text += inlinesToPlainText(inline.children);
-        break;
-      }
-      case "link": {
-        text += inlinesToPlainText(inline.children);
-        break;
-      }
-      case "line-break": {
-        text += "\n";
-        break;
-      }
-      default:
-        break;
-    }
-  }
-  return text;
-};
 
 export const blocksToPlainText = (blocks: readonly Block[]): string =>
   blocks

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -24,7 +24,6 @@
  */
 
 import * as cheerio from "cheerio";
-import { isText } from "domhandler";
 import type { AnyNode } from "domhandler";
 
 import type {
@@ -38,6 +37,11 @@ import {
   CZ_CLOSING_RE as CLOSING_RE,
   CZ_JUDGE_TITLE_RE as SIGNATURE_RE,
 } from "./cz-patterns";
+import {
+  inlinesToPlainText,
+  stripInlinePrefix,
+  walkInlines as walkInlinesShared,
+} from "./shared-inlines";
 
 // ── Public API ─────────────────────────────────────────────
 
@@ -106,131 +110,8 @@ export const parseNssDecisionHtml = (
 const walkInlines = (
   $: cheerio.CheerioAPI,
   el: cheerio.Cheerio<AnyNode>,
-): Inline[] => {
-  const inlines: Inline[] = [];
-
-  el.contents().each((_, node) => {
-    if (isText(node)) {
-      const text = $(node).text();
-      if (text) {
-        inlines.push({ type: "text", text });
-      }
-      return;
-    }
-
-    // oxlint-disable-next-line typescript/no-unsafe-enum-comparison -- must skip on exactly "tag"; domhandler isTag() also matches script/style, changing skip behavior
-    if (node.type !== "tag") {
-      return;
-    }
-
-    const tag = node.tagName.toLowerCase();
-    const $node = $(node);
-
-    if (tag === "br") {
-      inlines.push({ type: "line-break" });
-      return;
-    }
-
-    // Extract alt text from images (e.g., decorative headers,
-    // embedded labels). Some decisions embed meaningful text
-    // in <img alt="...">.
-    if (tag === "img") {
-      const alt = $node.attr("alt")?.trim();
-      if (alt) {
-        inlines.push({ type: "text", text: alt });
-      }
-      return;
-    }
-
-    if (tag === "span") {
-      const style = $node.attr("style") ?? "";
-
-      // Skip Aspose spacer spans only when they contain no
-      // meaningful text. Modern exports use these for tab stops
-      // and invisible fills (whitespace-only), but older 2004-era
-      // conversions sometimes place real words inside them.
-      if (
-        style.includes("-aw-import:ignore") ||
-        style.includes("-aw-import:spaces") ||
-        style.includes("display:inline-block")
-      ) {
-        const innerText = $node.text().trim();
-        if (!innerText) {
-          return;
-        }
-      }
-
-      const isBold = style.includes("font-weight:bold");
-      const isItalic = style.includes("font-style:italic");
-
-      const children = walkInlines($, $node);
-      if (children.length === 0) {
-        return;
-      }
-
-      if (isBold && isItalic) {
-        inlines.push({
-          type: "bold",
-          children: [{ type: "italic", children }],
-        });
-      } else if (isBold) {
-        inlines.push({ type: "bold", children });
-      } else if (isItalic) {
-        inlines.push({ type: "italic", children });
-      } else {
-        inlines.push(...children);
-      }
-      return;
-    }
-
-    if (tag === "b" || tag === "strong") {
-      const children = walkInlines($, $node);
-      if (children.length > 0) {
-        inlines.push({ type: "bold", children });
-      }
-      return;
-    }
-
-    if (tag === "i" || tag === "em") {
-      const children = walkInlines($, $node);
-      if (children.length > 0) {
-        inlines.push({ type: "italic", children });
-      }
-      return;
-    }
-
-    if (tag === "a") {
-      const href = $node.attr("href");
-      const children = walkInlines($, $node);
-      if (href && children.length > 0) {
-        inlines.push({ type: "link", href, children });
-      } else if (children.length > 0) {
-        inlines.push(...children);
-      }
-      return;
-    }
-
-    // Unwrap other tags
-    inlines.push(...walkInlines($, $node));
-  });
-
-  return inlines;
-};
-
-const inlinesToPlainText = (inlines: readonly Inline[]): string => {
-  let text = "";
-  for (const node of inlines) {
-    if (node.type === "text") {
-      text += node.text;
-    } else if (node.type === "line-break") {
-      text += "\n";
-    } else {
-      // bold | italic | link — all carry children
-      text += inlinesToPlainText(node.children);
-    }
-  }
-  return text;
-};
+): Inline[] =>
+  walkInlinesShared($, el, { parseImgAlt: true, parseSpanStyle: true });
 
 // ── Chunk extraction ───────────────────────────────────────
 
@@ -495,70 +376,6 @@ const makeAnchorId = (prefix: string, index: number): string =>
  * italic, and other wrapper nodes by recursively counting
  * their text content.
  */
-const stripInlinePrefix = (
-  inlines: readonly Inline[],
-  charCount: number,
-): Inline[] => {
-  if (charCount <= 0) {
-    return [...inlines];
-  }
-
-  const result: Inline[] = [];
-  let remaining = charCount;
-
-  for (const node of inlines) {
-    if (remaining <= 0) {
-      result.push(node);
-      continue;
-    }
-
-    if (node.type === "text") {
-      if (node.text.length <= remaining) {
-        remaining -= node.text.length;
-      } else {
-        const rest = node.text.slice(remaining);
-        remaining = 0;
-        if (rest) {
-          result.push({ type: "text", text: rest });
-        }
-      }
-      continue;
-    }
-
-    if (node.type === "line-break") {
-      remaining -= 1;
-      continue;
-    }
-
-    // Remaining variants (bold | italic | link) all carry children.
-    const nodeTextLen = inlinesToPlainText(node.children).length;
-    if (nodeTextLen <= remaining) {
-      // Entire node consumed by prefix
-      remaining -= nodeTextLen;
-    } else {
-      // Partial strip inside the node
-      const stripped = stripInlinePrefix(node.children, remaining);
-      remaining = 0;
-      if (stripped.length > 0) {
-        result.push({ ...node, children: stripped });
-      }
-    }
-  }
-
-  // Trim leading whitespace from the first text node
-  const first = result[0];
-  if (result.length > 0 && first?.type === "text") {
-    const trimmed = first.text.trimStart();
-    if (trimmed) {
-      result[0] = { type: "text", text: trimmed };
-    } else {
-      result.shift();
-    }
-  }
-
-  return result;
-};
-
 const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
   let blockCounter = 0;
   const makeBlockId = (): string => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
@@ -44,7 +44,6 @@
  */
 
 import * as cheerio from "cheerio";
-import { type AnyNode, isText } from "domhandler";
 
 import type {
   Block,
@@ -61,6 +60,7 @@ import {
   CZ_JUDGE_NAME_RE as JUDGE_NAME_RE,
   CZ_JUDGE_TITLE_RE as SIGNATURE_RE,
 } from "./cz-patterns";
+import { inlinesToPlainText, stripInlinePrefix } from "./shared-inlines";
 
 // ── Public API ─────────────────────────────────────────────
 
@@ -199,85 +199,6 @@ const extractCrossReferences = ($: cheerio.CheerioAPI): CrossReference[] => {
   });
 
   return refs;
-};
-
-// ── Inline walking (HTML fallback) ────────────────────────
-
-const _walkInlines = (
-  $: cheerio.CheerioAPI,
-  el: cheerio.Cheerio<AnyNode>,
-): Inline[] => {
-  const inlines: Inline[] = [];
-
-  el.contents().each((_, node) => {
-    if (isText(node)) {
-      const text = $(node).text();
-      if (text) {
-        inlines.push({ type: "text", text });
-      }
-      return;
-    }
-
-    // oxlint-disable-next-line typescript/no-unsafe-enum-comparison -- isTag() also matches script/style; literal "tag" skips those, and domhandler does not re-export ElementType
-    if (node.type !== "tag") {
-      return;
-    }
-
-    const tag = node.tagName.toLowerCase();
-    const $node = $(node);
-
-    if (tag === "br") {
-      inlines.push({ type: "line-break" });
-      return;
-    }
-
-    if (tag === "b" || tag === "strong") {
-      const children = _walkInlines($, $node);
-      if (children.length > 0) {
-        inlines.push({ type: "bold", children });
-      }
-      return;
-    }
-
-    if (tag === "i" || tag === "em") {
-      const children = _walkInlines($, $node);
-      if (children.length > 0) {
-        inlines.push({ type: "italic", children });
-      }
-      return;
-    }
-
-    if (tag === "a") {
-      const href = $node.attr("href");
-      const children = _walkInlines($, $node);
-      if (href && children.length > 0) {
-        inlines.push({ type: "link", href, children });
-      } else if (children.length > 0) {
-        inlines.push(...children);
-      }
-      return;
-    }
-
-    // Unwrap presentational wrappers (span, font, etc.)
-    inlines.push(..._walkInlines($, $node));
-  });
-
-  return inlines;
-};
-
-const inlinesToPlainText = (inlines: readonly Inline[]): string => {
-  let text = "";
-  for (const node of inlines) {
-    if (node.type === "text") {
-      text += node.text;
-    } else if (node.type === "line-break") {
-      text += "\n";
-    } else {
-      // bold | italic | link — all carry children
-      text += inlinesToPlainText(node.children);
-    }
-  }
-  return text;
 };
 
 /** Create a simple text inline helper. */
@@ -550,68 +471,6 @@ const makeAnchorId = (prefix: string, index: number): string =>
 /**
  * Strip a character-counted prefix from inlines.
  */
-const stripInlinePrefix = (
-  inlines: readonly Inline[],
-  charCount: number,
-): Inline[] => {
-  if (charCount <= 0) {
-    return [...inlines];
-  }
-
-  const result: Inline[] = [];
-  let remaining = charCount;
-
-  for (const node of inlines) {
-    if (remaining <= 0) {
-      result.push(node);
-      continue;
-    }
-
-    if (node.type === "text") {
-      if (node.text.length <= remaining) {
-        remaining -= node.text.length;
-      } else {
-        const rest = node.text.slice(remaining);
-        remaining = 0;
-        if (rest) {
-          result.push({ type: "text", text: rest });
-        }
-      }
-      continue;
-    }
-
-    if (node.type === "line-break") {
-      remaining -= 1;
-      continue;
-    }
-
-    // Remaining variants (bold | italic | link) all carry children.
-    const nodeTextLen = inlinesToPlainText(node.children).length;
-    if (nodeTextLen <= remaining) {
-      remaining -= nodeTextLen;
-    } else {
-      const stripped = stripInlinePrefix(node.children, remaining);
-      remaining = 0;
-      if (stripped.length > 0) {
-        result.push({ ...node, children: stripped });
-      }
-    }
-  }
-
-  // Trim leading whitespace from the first text node
-  const first = result[0];
-  if (result.length > 0 && first?.type === "text") {
-    const trimmed = first.text.trimStart();
-    if (trimmed) {
-      result[0] = { type: "text", text: trimmed };
-    } else {
-      result.shift();
-    }
-  }
-
-  return result;
-};
-
 /**
  * Classify extracted lines into semantic blocks.
  *

--- a/apps/api/src/handlers/case-law/ingestion/parsers/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/pl-courts.ts
@@ -28,6 +28,12 @@ import {
 import { sanitizeUrl } from "@/api/lib/sanitize-url";
 import { includes } from "@/api/lib/type-guards";
 
+import {
+  appendTextInline,
+  inlinesToPlainText,
+  walkInlines as walkInlinesShared,
+} from "./shared-inlines";
+
 type ParsePlDecisionInput = {
   caseNumber: string;
   ecli: string | undefined;
@@ -203,113 +209,12 @@ const textInline = (text: string, anonymized = false): Inline[] =>
       ]
     : [];
 
-const appendTextInline = (
-  target: Inline[],
-  text: string,
-  anonymized = false,
-): void => {
-  if (!text) {
-    return;
-  }
-
-  const last = target.at(-1);
-  if (
-    last?.type === "text" &&
-    last.anonymized === (anonymized ? true : undefined)
-  ) {
-    last.text += text;
-    return;
-  }
-
-  target.push({
-    type: "text",
-    text,
-    ...(anonymized && { anonymized: true as const }),
-  });
-};
-
 const walkInlines = (
   $: cheerio.CheerioAPI,
   el: cheerio.Cheerio<AnyNode>,
   anonymized = false,
-): Inline[] => {
-  const inlines: Inline[] = [];
-
-  el.contents().each((_, node) => {
-    if (isText(node)) {
-      appendTextInline(inlines, $(node).text(), anonymized);
-      return;
-    }
-
-    if (!isTag(node)) {
-      return;
-    }
-
-    const $node = $(node);
-    const tag = node.tagName.toLowerCase();
-    // isTag() also matches <script>/<style>; never emit their raw text.
-    if (tag === "script" || tag === "style") {
-      return;
-    }
-    const isAnon = anonymized || $node.hasClass("anon-block");
-
-    if (tag === "br") {
-      inlines.push({ type: "line-break" });
-      return;
-    }
-
-    if (tag === "strong" || tag === "b") {
-      const children = walkInlines($, $node, isAnon);
-      if (children.length > 0) {
-        inlines.push({ type: "bold", children });
-      }
-      return;
-    }
-
-    if (tag === "em" || tag === "i") {
-      const children = walkInlines($, $node, isAnon);
-      if (children.length > 0) {
-        inlines.push({ type: "italic", children });
-      }
-      return;
-    }
-
-    if (tag === "a") {
-      const children = walkInlines($, $node, isAnon);
-      const href = sanitizeUrl($node.attr("href") ?? "");
-      if (href && children.length > 0) {
-        inlines.push({ type: "link", href, children });
-      } else if (children.length > 0) {
-        inlines.push(...children);
-      }
-      return;
-    }
-
-    inlines.push(...walkInlines($, $node, isAnon));
-  });
-
-  return inlines;
-};
-
-const inlinesToPlainText = (inlines: readonly Inline[]): string => {
-  let text = "";
-
-  for (const inline of inlines) {
-    if (inline.type === "text") {
-      text += inline.text;
-      continue;
-    }
-
-    if (inline.type === "line-break") {
-      text += "\n";
-      continue;
-    }
-
-    text += inlinesToPlainText(inline.children);
-  }
-
-  return text;
-};
+): Inline[] =>
+  walkInlinesShared($, el, { sanitizeHref: sanitizeUrl, anonymized });
 
 const inferParagraphRole = (
   state: ParserState,

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.test.ts
@@ -122,4 +122,22 @@ describe("stripInlinePrefix", () => {
     const stripped = stripInlinePrefix(inlines, "Hello ".length);
     expect(inlinesToPlainText(stripped)).toBe("World");
   });
+
+  test("preserves the anonymized flag when slicing a text node", () => {
+    const inlines: Inline[] = [
+      { type: "text", text: "1. Secret", anonymized: true },
+    ];
+    expect(stripInlinePrefix(inlines, 3)).toEqual([
+      { type: "text", text: "Secret", anonymized: true },
+    ]);
+  });
+
+  test("preserves the anonymized flag through the leading-whitespace trim", () => {
+    const inlines: Inline[] = [
+      { type: "text", text: "12 Secret", anonymized: true },
+    ];
+    expect(stripInlinePrefix(inlines, 2)).toEqual([
+      { type: "text", text: "Secret", anonymized: true },
+    ]);
+  });
 });

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import * as cheerio from "cheerio";
+
+import type { Inline } from "@/api/handlers/case-law/document-ast";
+import {
+  inlinesToPlainText,
+  stripInlinePrefix,
+  walkInlines,
+  type WalkInlinesOptions,
+} from "@/api/handlers/case-law/ingestion/parsers/shared-inlines";
+
+const walk = (html: string, options?: WalkInlinesOptions): Inline[] => {
+  const $ = cheerio.load(html);
+  return walkInlines($, $("body"), options);
+};
+
+describe("walkInlines", () => {
+  test("builds an inline tree from formatting tags", () => {
+    const inlines = walk(
+      "foo <b>bar</b> <i>baz</i><br><a href='https://x.test'>link</a>",
+    );
+    expect(inlines).toEqual([
+      { type: "text", text: "foo " },
+      { type: "bold", children: [{ type: "text", text: "bar" }] },
+      { type: "text", text: " " },
+      { type: "italic", children: [{ type: "text", text: "baz" }] },
+      { type: "line-break" },
+      {
+        type: "link",
+        href: "https://x.test",
+        children: [{ type: "text", text: "link" }],
+      },
+    ]);
+  });
+
+  test("merges adjacent text separated by a skipped/empty node", () => {
+    expect(walk("a<span></span>b")).toEqual([{ type: "text", text: "ab" }]);
+  });
+
+  test("unwraps presentational wrappers, keeping unwrapped siblings separate", () => {
+    // Text spliced in via unwrap (push(...children)) is not coalesced at
+    // the seam; only direct adjacent text children merge.
+    expect(walk("<span>x</span><font>y</font>")).toEqual([
+      { type: "text", text: "x" },
+      { type: "text", text: "y" },
+    ]);
+  });
+
+  test("sanitizeHref drops unsafe links to their text", () => {
+    const options: WalkInlinesOptions = {
+      sanitizeHref: (href) => (href.startsWith("https:") ? href : undefined),
+    };
+    expect(walk("<a href='javascript:alert(1)'>x</a>", options)).toEqual([
+      { type: "text", text: "x" },
+    ]);
+    expect(walk("<a href='https://ok.test'>x</a>", options)).toEqual([
+      {
+        type: "link",
+        href: "https://ok.test",
+        children: [{ type: "text", text: "x" }],
+      },
+    ]);
+  });
+
+  test("parseImgAlt emits alt text only when enabled", () => {
+    expect(walk("<img alt='Header'>", { parseImgAlt: true })).toEqual([
+      { type: "text", text: "Header" },
+    ]);
+    expect(walk("<img alt='Header'>")).toEqual([]);
+  });
+
+  test("parseSpanStyle reads emphasis and skips empty spacer spans", () => {
+    expect(
+      walk("<span style='font-weight:bold'>x</span>", { parseSpanStyle: true }),
+    ).toEqual([{ type: "bold", children: [{ type: "text", text: "x" }] }]);
+    expect(
+      walk("<span style='-aw-import:spaces'>   </span>", {
+        parseSpanStyle: true,
+      }),
+    ).toEqual([]);
+  });
+
+  test("anonymization spans mark text and coalesce", () => {
+    expect(walk("<span class='anon-block'>a<span></span>b</span>")).toEqual([
+      { type: "text", text: "ab", anonymized: true },
+    ]);
+  });
+
+  test("non-anonymized and anonymized text do not merge together", () => {
+    const inlines = walk("plain<span class='anon-block'>secret</span>");
+    expect(inlines).toEqual([
+      { type: "text", text: "plain" },
+      { type: "text", text: "secret", anonymized: true },
+    ]);
+  });
+});
+
+describe("stripInlinePrefix", () => {
+  test("strips a leading prefix and trims the first text node", () => {
+    const inlines: Inline[] = [{ type: "text", text: "1. Hello" }];
+    expect(stripInlinePrefix(inlines, 3)).toEqual([
+      { type: "text", text: "Hello" },
+    ]);
+  });
+
+  test("strips into a nested formatting node", () => {
+    const inlines: Inline[] = [
+      { type: "bold", children: [{ type: "text", text: "12" }] },
+      { type: "text", text: "34" },
+    ];
+    expect(stripInlinePrefix(inlines, 1)).toEqual([
+      { type: "bold", children: [{ type: "text", text: "2" }] },
+      { type: "text", text: "34" },
+    ]);
+  });
+
+  test("invariant: stripping N chars equals the plain text minus that prefix", () => {
+    const inlines: Inline[] = [
+      { type: "text", text: "Hello " },
+      { type: "bold", children: [{ type: "text", text: "World" }] },
+    ];
+    const stripped = stripInlinePrefix(inlines, "Hello ".length);
+    expect(inlinesToPlainText(stripped)).toBe("World");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
@@ -1,0 +1,268 @@
+/**
+ * Shared inline-tree utilities for case-law HTML parsers.
+ *
+ * Every HTML court parser (cz-ns, cz-nss, cz-us, pl-courts) walks a
+ * cheerio DOM into the canonical `Inline[]` tree, flattens that tree to
+ * plain text, and strips a leading character prefix while preserving
+ * nested formatting. These operations were duplicated per parser (with
+ * `stripInlinePrefix` byte-for-byte identical between cz-nss and cz-us).
+ * The genuine per-court differences — link sanitization and Aspose
+ * `<span>`/`<img>` handling — are expressed as options so each parser
+ * keeps a thin local alias over one core.
+ */
+
+import * as cheerio from "cheerio";
+import { type AnyNode, isTag, isText } from "domhandler";
+
+import type { Inline } from "@/api/handlers/case-law/document-ast";
+
+/**
+ * Append text to an inline list, dropping empty strings and coalescing
+ * with the previous text node when their anonymization state matches.
+ * Merging keeps the AST canonical (no redundant adjacent text nodes)
+ * and ensures consecutive anonymized fragments render as a single
+ * bracketed span. Plain-text output is identical either way, so search,
+ * AI, citation extraction, and the AST validator are unaffected.
+ */
+export const appendTextInline = (
+  target: Inline[],
+  text: string,
+  anonymized = false,
+): void => {
+  if (!text) {
+    return;
+  }
+
+  const last = target.at(-1);
+  if (
+    last?.type === "text" &&
+    last.anonymized === (anonymized ? true : undefined)
+  ) {
+    last.text += text;
+    return;
+  }
+
+  target.push({
+    type: "text",
+    text,
+    ...(anonymized && { anonymized: true as const }),
+  });
+};
+
+export type WalkInlinesOptions = {
+  /**
+   * Map/validate `<a>` hrefs (e.g. `sanitizeUrl`, which returns
+   * `undefined` for unsafe URLs). When omitted the raw `href` attribute
+   * is kept verbatim.
+   */
+  sanitizeHref?: (href: string) => string | undefined;
+  /** Emit `<img alt="...">` text as a text inline (Aspose headers). */
+  parseImgAlt?: boolean;
+  /**
+   * Read emphasis from `<span style="font-weight/-style">` and skip
+   * Aspose spacer spans (NSS Aspose.Words HTML).
+   */
+  parseSpanStyle?: boolean;
+  /** Seed the anonymization flag for the whole subtree (pl-courts). */
+  anonymized?: boolean;
+};
+
+export const walkInlines = (
+  $: cheerio.CheerioAPI,
+  el: cheerio.Cheerio<AnyNode>,
+  options: WalkInlinesOptions = {},
+): Inline[] => {
+  const walk = (
+    node: cheerio.Cheerio<AnyNode>,
+    anonymized: boolean,
+  ): Inline[] => {
+    const inlines: Inline[] = [];
+
+    node.contents().each((_, child) => {
+      if (isText(child)) {
+        appendTextInline(inlines, $(child).text(), anonymized);
+        return;
+      }
+
+      if (!isTag(child)) {
+        return;
+      }
+
+      const tag = child.tagName.toLowerCase();
+      // isTag() also matches <script>/<style>; never emit their raw text.
+      if (tag === "script" || tag === "style") {
+        return;
+      }
+
+      const $child = $(child);
+      const childAnon = anonymized || $child.hasClass("anon-block");
+
+      if (tag === "br") {
+        inlines.push({ type: "line-break" });
+        return;
+      }
+
+      if (options.parseImgAlt && tag === "img") {
+        const alt = $child.attr("alt")?.trim();
+        if (alt) {
+          appendTextInline(inlines, alt, childAnon);
+        }
+        return;
+      }
+
+      if (options.parseSpanStyle && tag === "span") {
+        const style = $child.attr("style") ?? "";
+
+        // Skip Aspose spacer spans only when they contain no meaningful
+        // text. Modern exports use these for tab stops and invisible
+        // fills, but older conversions sometimes place real words inside.
+        if (
+          style.includes("-aw-import:ignore") ||
+          style.includes("-aw-import:spaces") ||
+          style.includes("display:inline-block")
+        ) {
+          if (!$child.text().trim()) {
+            return;
+          }
+        }
+
+        const isBold = style.includes("font-weight:bold");
+        const isItalic = style.includes("font-style:italic");
+        const children = walk($child, childAnon);
+        if (children.length === 0) {
+          return;
+        }
+
+        if (isBold && isItalic) {
+          inlines.push({
+            type: "bold",
+            children: [{ type: "italic", children }],
+          });
+        } else if (isBold) {
+          inlines.push({ type: "bold", children });
+        } else if (isItalic) {
+          inlines.push({ type: "italic", children });
+        } else {
+          inlines.push(...children);
+        }
+        return;
+      }
+
+      if (tag === "b" || tag === "strong") {
+        const children = walk($child, childAnon);
+        if (children.length > 0) {
+          inlines.push({ type: "bold", children });
+        }
+        return;
+      }
+
+      if (tag === "i" || tag === "em") {
+        const children = walk($child, childAnon);
+        if (children.length > 0) {
+          inlines.push({ type: "italic", children });
+        }
+        return;
+      }
+
+      if (tag === "a") {
+        const rawHref = $child.attr("href");
+        const href = options.sanitizeHref
+          ? options.sanitizeHref(rawHref ?? "")
+          : rawHref;
+        const children = walk($child, childAnon);
+        if (href && children.length > 0) {
+          inlines.push({ type: "link", href, children });
+        } else if (children.length > 0) {
+          inlines.push(...children);
+        }
+        return;
+      }
+
+      // Unwrap presentational wrappers.
+      inlines.push(...walk($child, childAnon));
+    });
+
+    return inlines;
+  };
+
+  return walk(el, options.anonymized ?? false);
+};
+
+export const inlinesToPlainText = (inlines: readonly Inline[]): string => {
+  let text = "";
+  for (const node of inlines) {
+    if (node.type === "text") {
+      text += node.text;
+    } else if (node.type === "line-break") {
+      text += "\n";
+    } else {
+      // bold | italic | link — all carry children
+      text += inlinesToPlainText(node.children);
+    }
+  }
+  return text;
+};
+
+export const stripInlinePrefix = (
+  inlines: readonly Inline[],
+  charCount: number,
+): Inline[] => {
+  if (charCount <= 0) {
+    return [...inlines];
+  }
+
+  const result: Inline[] = [];
+  let remaining = charCount;
+
+  for (const node of inlines) {
+    if (remaining <= 0) {
+      result.push(node);
+      continue;
+    }
+
+    if (node.type === "text") {
+      if (node.text.length <= remaining) {
+        remaining -= node.text.length;
+      } else {
+        const rest = node.text.slice(remaining);
+        remaining = 0;
+        if (rest) {
+          result.push({ type: "text", text: rest });
+        }
+      }
+      continue;
+    }
+
+    if (node.type === "line-break") {
+      remaining -= 1;
+      continue;
+    }
+
+    // Remaining variants (bold | italic | link) all carry children.
+    const nodeTextLen = inlinesToPlainText(node.children).length;
+    if (nodeTextLen <= remaining) {
+      // Entire node consumed by prefix
+      remaining -= nodeTextLen;
+    } else {
+      // Partial strip inside the node
+      const stripped = stripInlinePrefix(node.children, remaining);
+      remaining = 0;
+      if (stripped.length > 0) {
+        result.push({ ...node, children: stripped });
+      }
+    }
+  }
+
+  // Trim leading whitespace from the first text node
+  const first = result[0];
+  if (result.length > 0 && first?.type === "text") {
+    const trimmed = first.text.trimStart();
+    if (trimmed) {
+      result[0] = { type: "text", text: trimmed };
+    } else {
+      result.shift();
+    }
+  }
+
+  return result;
+};

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
@@ -11,7 +11,7 @@
  * keeps a thin local alias over one core.
  */
 
-import * as cheerio from "cheerio";
+import type * as cheerio from "cheerio";
 import { type AnyNode, isTag, isText } from "domhandler";
 
 import type { Inline } from "@/api/handlers/case-law/document-ast";
@@ -121,7 +121,8 @@ export const walkInlines = (
           style.includes("-aw-import:spaces") ||
           style.includes("display:inline-block")
         ) {
-          if (!$child.text().trim()) {
+          const innerText = $child.text().trim();
+          if (!innerText) {
             return;
           }
         }
@@ -227,7 +228,7 @@ export const stripInlinePrefix = (
         const rest = node.text.slice(remaining);
         remaining = 0;
         if (rest) {
-          result.push({ type: "text", text: rest });
+          result.push({ ...node, text: rest });
         }
       }
       continue;
@@ -258,7 +259,7 @@ export const stripInlinePrefix = (
   if (result.length > 0 && first?.type === "text") {
     const trimmed = first.text.trimStart();
     if (trimmed) {
-      result[0] = { type: "text", text: trimmed };
+      result[0] = { ...first, text: trimmed };
     } else {
       result.shift();
     }


### PR DESCRIPTION
The four HTML court parsers (cz-ns, cz-nss, cz-us, pl-courts) each carried their own copy of `walkInlines`, `inlinesToPlainText`, and `stripInlinePrefix` — with `stripInlinePrefix` duplicated byte-for-byte between cz-nss and cz-us.

- Extract the three into `parsers/shared-inlines.ts`. The genuine per-court differences (link sanitization, Aspose `<span>`/`<img>` handling, anonymization spans) are options, so each parser keeps a thin local alias and existing call sites are unchanged.
- Unify the text emitter on the merging variant (coalesce adjacent same-anonymization text). It is plain-text-invariant, so search, AI, citation extraction, and the AST validator are unaffected; only rare adjacent-text-node boundaries change.
- Remove cz-us's vestigial `_walkInlines` (its HTML walker was dead code; inlines come from the RTF parser).
- Add unit tests covering each variation, the text-merging behavior, and the strip/plain-text invariant.

Net ~500 fewer lines across the parsers. Full case-law suite green.