### PR TITLE
refactor(web): extract pure decision logic into colocated .logic modules

### DIFF
--- a/apps/web/src/components/ai-suggestions/host.logic.test.ts
+++ b/apps/web/src/components/ai-suggestions/host.logic.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AISuggestion } from "@stll/folio";
+
+import {
+  anchorSuggestion,
+  buildGenerateInput,
+  deriveChatStatus,
+  joinPromptWithPasted,
+  parseStoredApplyMode,
+  resolveAcceptGroupGate,
+  resolveAcceptOneGate,
+  resolveApplyMode,
+  selectResponseSuggestions,
+} from "./host.logic";
+
+const baseSuggestion: AISuggestion = {
+  id: "s1",
+  topic: "Clarity",
+  severity: "style",
+  range: { from: 4, to: 10 },
+  originalText: "old",
+  suggestedText: "new",
+  contextBefore: "",
+  contextAfter: "",
+  rationale: "",
+  status: "pending",
+};
+
+describe("parseStoredApplyMode", () => {
+  test("accepts the two known modes verbatim", () => {
+    expect(parseStoredApplyMode("direct")).toBe("direct");
+    expect(parseStoredApplyMode("tracked-changes")).toBe("tracked-changes");
+  });
+
+  test("rejects null, empty, and unknown values", () => {
+    expect(parseStoredApplyMode(null)).toBeNull();
+    expect(parseStoredApplyMode("")).toBeNull();
+    expect(parseStoredApplyMode("Direct")).toBeNull();
+    expect(parseStoredApplyMode("tracked")).toBeNull();
+  });
+});
+
+describe("resolveApplyMode", () => {
+  test("prefers the stored preference over everything", () => {
+    expect(resolveApplyMode("tracked-changes", "direct")).toBe(
+      "tracked-changes",
+    );
+    expect(resolveApplyMode("direct", "tracked-changes")).toBe("direct");
+  });
+
+  test("falls back to the host default when nothing is stored", () => {
+    expect(resolveApplyMode(null, "tracked-changes")).toBe("tracked-changes");
+  });
+
+  test("falls back to direct when neither stored nor default is set", () => {
+    expect(resolveApplyMode(null, undefined)).toBe("direct");
+  });
+});
+
+describe("deriveChatStatus", () => {
+  test("generating wins over pending suggestions", () => {
+    expect(deriveChatStatus(true, 0)).toBe("generating");
+    expect(deriveChatStatus(true, 5)).toBe("generating");
+  });
+
+  test("review-ready when not generating but suggestions are pending", () => {
+    expect(deriveChatStatus(false, 1)).toBe("review-ready");
+  });
+
+  test("idle when not generating and nothing pending", () => {
+    expect(deriveChatStatus(false, 0)).toBe("idle");
+  });
+});
+
+describe("resolveAcceptOneGate", () => {
+  test("defers the accept when no mode is stored and the target is pending", () => {
+    expect(resolveAcceptOneGate(null, "s1", true)).toEqual({
+      type: "defer",
+      pending: { kind: "one", suggestionId: "s1" },
+    });
+  });
+
+  test("noops when no mode is stored and the target is not pending", () => {
+    expect(resolveAcceptOneGate(null, "s1", false)).toEqual({ type: "noop" });
+  });
+
+  test("accepts immediately once a mode is stored, regardless of pending", () => {
+    expect(resolveAcceptOneGate("direct", "s1", true)).toEqual({
+      type: "accept",
+    });
+    expect(resolveAcceptOneGate("tracked-changes", "s1", false)).toEqual({
+      type: "accept",
+    });
+  });
+});
+
+describe("resolveAcceptGroupGate", () => {
+  test("defers the accept when no mode is stored and the message has pending", () => {
+    expect(resolveAcceptGroupGate(null, "m1", true)).toEqual({
+      type: "defer",
+      pending: { kind: "group", messageId: "m1" },
+    });
+  });
+
+  test("noops when no mode is stored and the message has no pending", () => {
+    expect(resolveAcceptGroupGate(null, "m1", false)).toEqual({ type: "noop" });
+  });
+
+  test("accepts immediately once a mode is stored", () => {
+    expect(resolveAcceptGroupGate("direct", "m1", true)).toEqual({
+      type: "accept",
+    });
+    expect(resolveAcceptGroupGate("tracked-changes", "m1", false)).toEqual({
+      type: "accept",
+    });
+  });
+});
+
+describe("joinPromptWithPasted", () => {
+  test("leaves the prompt untouched when there is no pasted text", () => {
+    expect(joinPromptWithPasted("hello", undefined)).toBe("hello");
+    expect(joinPromptWithPasted("hello", "")).toBe("hello");
+  });
+
+  test("uses just the pasted text when the prompt is empty", () => {
+    expect(joinPromptWithPasted("", "pasted body")).toBe("pasted body");
+  });
+
+  test("joins prompt and pasted text with a blank line", () => {
+    expect(joinPromptWithPasted("question", "pasted body")).toBe(
+      "question\n\npasted body",
+    );
+  });
+});
+
+describe("buildGenerateInput", () => {
+  const common = {
+    fullPrompt: "do the thing",
+    mode: "edit" as const,
+    selectionText: "sel",
+    selectionRange: { from: 1, to: 3 },
+    cursorPosition: { from: 1, to: 1 },
+    documentText: "the whole doc",
+    visibleText: "visible part",
+    visibleRange: { from: 0, to: 50 },
+  };
+
+  test("maps the extracted values straight onto the payload", () => {
+    expect(buildGenerateInput({ ...common, presetId: undefined })).toEqual({
+      prompt: "do the thing",
+      mode: "edit",
+      selectionText: "sel",
+      selectionRange: { from: 1, to: 3 },
+      cursorPosition: { from: 1, to: 1 },
+      documentText: "the whole doc",
+      visibleText: "visible part",
+      visibleRange: { from: 0, to: 50 },
+    });
+  });
+
+  test("omits presetId entirely when it is undefined", () => {
+    const out = buildGenerateInput({ ...common, presetId: undefined });
+    expect("presetId" in out).toBe(false);
+  });
+
+  test("includes presetId when present", () => {
+    const out = buildGenerateInput({ ...common, presetId: "summarize" });
+    expect(out.presetId).toBe("summarize");
+  });
+
+  test("threads null ranges through (PDF / no selection)", () => {
+    const out = buildGenerateInput({
+      ...common,
+      selectionRange: null,
+      cursorPosition: null,
+      visibleRange: null,
+      presetId: undefined,
+    });
+    expect(out.selectionRange).toBeNull();
+    expect(out.cursorPosition).toBeNull();
+    expect(out.visibleRange).toBeNull();
+  });
+});
+
+describe("selectResponseSuggestions", () => {
+  test("drops all suggestions in ask mode", () => {
+    expect(selectResponseSuggestions("ask", [baseSuggestion])).toEqual([]);
+  });
+
+  test("keeps the response list in edit mode", () => {
+    expect(selectResponseSuggestions("edit", [baseSuggestion])).toEqual([
+      baseSuggestion,
+    ]);
+  });
+
+  test("collapses a missing list to empty in edit mode", () => {
+    expect(selectResponseSuggestions("edit", undefined)).toEqual([]);
+  });
+});
+
+describe("anchorSuggestion", () => {
+  test("keeps the suggestion verbatim when no editor view (anchor undefined)", () => {
+    expect(anchorSuggestion(baseSuggestion, undefined)).toBe(baseSuggestion);
+  });
+
+  test("marks the suggestion stale when the anchor lookup fails (null)", () => {
+    const out = anchorSuggestion(baseSuggestion, null);
+    expect(out.status).toBe("stale");
+    expect(out.range).toEqual(baseSuggestion.range);
+  });
+
+  test("re-anchors the range when an anchor is resolved", () => {
+    const out = anchorSuggestion(baseSuggestion, { from: 20, to: 30 });
+    expect(out.range).toEqual({ from: 20, to: 30 });
+    expect(out.status).toBe("pending");
+  });
+});

--- a/apps/web/src/components/ai-suggestions/host.logic.ts
+++ b/apps/web/src/components/ai-suggestions/host.logic.ts
@@ -1,0 +1,206 @@
+/**
+ * Pure decision logic extracted from the file-anchored AI chat host
+ * (`host.tsx`). These functions take plain inputs and return plain
+ * outputs — no React, no DOM, no ProseMirror, no side effects — so the
+ * host's most fragile business rules (apply-mode fallback, the
+ * first-accept gate, the generate payload assembly, suggestion
+ * anchoring) can be unit-tested in isolation.
+ *
+ * The host still owns all hooks, state setters, effects, the actual
+ * API call, and every editor/DOM read; it feeds the already-extracted
+ * plain values into these helpers.
+ */
+
+import type {
+  AIChatMode,
+  AIGenerateInput,
+  AISuggestion,
+  AISuggestionApplyMode,
+} from "@stll/folio";
+
+import type { FileAIChatStatus } from "./types";
+
+/**
+ * The accept the user most recently triggered while the apply-mode
+ * preference was unset. Held until they answer the one-time prompt;
+ * then applied with the chosen mode.
+ */
+export type PendingFirstAccept =
+  | { kind: "one"; suggestionId: string }
+  | { kind: "group"; messageId: string };
+
+/**
+ * Validate a raw localStorage value into the apply-mode union. Returns
+ * null for anything that isn't a known mode (absent key, corrupt
+ * value), which the caller treats as "no preference yet".
+ */
+export const parseStoredApplyMode = (
+  raw: string | null,
+): AISuggestionApplyMode | null => {
+  if (raw === "direct" || raw === "tracked-changes") {
+    return raw;
+  }
+  return null;
+};
+
+/**
+ * Effective apply mode. When the stored preference is null we still
+ * need a value for code paths that read it (e.g., the auto-flush effect
+ * after unlock); fall back to the host default, then to "direct". The
+ * user-facing "ask once" prompt only blocks the very first accept
+ * attempt — this resolution never blocks.
+ */
+export const resolveApplyMode = (
+  storedMode: AISuggestionApplyMode | null,
+  defaultMode: AISuggestionApplyMode | undefined,
+): AISuggestionApplyMode => storedMode ?? defaultMode ?? "direct";
+
+/**
+ * Derive the bar status from the live generation flag and the count of
+ * pending suggestions. Generation wins over review-ready; both fall
+ * back to idle.
+ */
+export const deriveChatStatus = (
+  generating: boolean,
+  pendingCount: number,
+): FileAIChatStatus => {
+  if (generating) {
+    return "generating";
+  }
+  if (pendingCount > 0) {
+    return "review-ready";
+  }
+  return "idle";
+};
+
+type FirstAcceptGate =
+  | { type: "defer"; pending: PendingFirstAccept }
+  | { type: "accept" }
+  | { type: "noop" };
+
+/**
+ * First-time single accept: decide whether to defer behind the
+ * one-time apply-mode prompt, accept immediately, or do nothing.
+ *
+ * - When no apply mode is stored yet, defer iff the target is still
+ *   resolvable (pending); otherwise noop (nothing to defer).
+ * - Once a mode is stored, the gate is open: accept.
+ */
+export const resolveAcceptOneGate = (
+  storedMode: AISuggestionApplyMode | null,
+  suggestionId: string,
+  targetIsPending: boolean,
+): FirstAcceptGate => {
+  if (storedMode === null) {
+    if (!targetIsPending) {
+      return { type: "noop" };
+    }
+    return { type: "defer", pending: { kind: "one", suggestionId } };
+  }
+  return { type: "accept" };
+};
+
+/**
+ * First-time group accept: mirror of {@link resolveAcceptOneGate} for
+ * accepting every pending suggestion in a message. Defers only when a
+ * mode hasn't been chosen and the message still has at least one
+ * pending suggestion.
+ */
+export const resolveAcceptGroupGate = (
+  storedMode: AISuggestionApplyMode | null,
+  messageId: string,
+  hasPending: boolean,
+): FirstAcceptGate => {
+  if (storedMode === null) {
+    if (!hasPending) {
+      return { type: "noop" };
+    }
+    return { type: "defer", pending: { kind: "group", messageId } };
+  }
+  return { type: "accept" };
+};
+
+/**
+ * Join the typed prompt with optional pasted text. An empty prompt
+ * collapses to just the pasted text; otherwise the two are separated by
+ * a blank line. No paste leaves the prompt untouched.
+ */
+export const joinPromptWithPasted = (
+  promptText: string,
+  pastedText: string | undefined,
+): string => {
+  if (!pastedText) {
+    return promptText;
+  }
+  return promptText.length === 0
+    ? pastedText
+    : `${promptText}\n\n${pastedText}`;
+};
+
+type BuildGenerateInputArgs = {
+  fullPrompt: string;
+  mode: AIChatMode;
+  selectionText: string;
+  selectionRange: { from: number; to: number } | null;
+  cursorPosition: { from: number; to: number } | null;
+  documentText: string;
+  visibleText: string;
+  visibleRange: { from: number; to: number } | null;
+  presetId: string | undefined;
+};
+
+/**
+ * Assemble the `AIGenerateInput` payload from already-extracted plain
+ * values. The caller does the editor/DOM reads (selection, visible
+ * range, document text); this just decides the final shape, including
+ * dropping `presetId` when absent so it stays an optional field.
+ */
+export const buildGenerateInput = (
+  args: BuildGenerateInputArgs,
+): AIGenerateInput => ({
+  prompt: args.fullPrompt,
+  mode: args.mode,
+  selectionText: args.selectionText,
+  selectionRange: args.selectionRange,
+  cursorPosition: args.cursorPosition,
+  documentText: args.documentText,
+  visibleText: args.visibleText,
+  visibleRange: args.visibleRange,
+  ...(args.presetId === undefined ? {} : { presetId: args.presetId }),
+});
+
+/**
+ * Decide which raw suggestions to keep from a generate response: none
+ * in "ask" mode (pure answer, no edits), the response list otherwise.
+ * Missing lists collapse to empty.
+ */
+export const selectResponseSuggestions = (
+  mode: AIChatMode,
+  responseSuggestions: AISuggestion[] | undefined,
+): AISuggestion[] => (mode === "ask" ? [] : (responseSuggestions ?? []));
+
+/**
+ * Decide the anchored form of one suggestion given the anchor the
+ * caller resolved against the live document:
+ *
+ * - `anchor === undefined`: no editor view available; keep the
+ *   suggestion verbatim.
+ * - `anchor === null`: anchor lookup failed; mark stale.
+ * - otherwise: re-anchor the range.
+ *
+ * `undefined` vs `null` are kept distinct on purpose: the host passes
+ * `undefined` when there's no PM view at all (PDF), and `null` when a
+ * view exists but the text could not be located.
+ */
+export const anchorSuggestion = (
+  suggestion: AISuggestion,
+  anchor: { from: number; to: number } | null | undefined,
+): AISuggestion => {
+  if (anchor === undefined) {
+    return suggestion;
+  }
+  if (anchor === null) {
+    return { ...suggestion, status: "stale" };
+  }
+  return { ...suggestion, range: anchor };
+};

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -65,6 +65,18 @@ import { PromptEditorContent } from "@/components/prompt-editor";
 import { usePulse } from "@/hooks/use-pulse";
 import type { TranslationKey } from "@/i18n/types";
 
+import {
+  anchorSuggestion,
+  buildGenerateInput,
+  deriveChatStatus,
+  joinPromptWithPasted,
+  parseStoredApplyMode,
+  resolveAcceptGroupGate,
+  resolveAcceptOneGate,
+  resolveApplyMode,
+  selectResponseSuggestions,
+} from "./host.logic";
+import type { PendingFirstAccept } from "./host.logic";
 import type {
   AssistantThreadMessage,
   FileAIChatConfig,
@@ -82,15 +94,12 @@ const APPLY_MODE_STORAGE_KEY = "stella:ai-suggestions:apply-mode";
 
 function readStoredApplyMode(): AISuggestionApplyMode | null {
   try {
-    const raw = localStorage.getItem(APPLY_MODE_STORAGE_KEY);
-    if (raw === "direct" || raw === "tracked-changes") {
-      return raw;
-    }
+    return parseStoredApplyMode(localStorage.getItem(APPLY_MODE_STORAGE_KEY));
   } catch {
     // localStorage may be disabled (private mode, third-party cookie
     // restrictions); fall through to "no preference".
+    return null;
   }
-  return null;
 }
 
 /**
@@ -224,11 +233,8 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
    * preference was unset. Held until they answer the prompt; then
    * applied with the chosen mode.
    */
-  const [pendingFirstAccept, setPendingFirstAccept] = useState<
-    | { kind: "one"; suggestionId: string }
-    | { kind: "group"; messageId: string }
-    | null
-  >(null);
+  const [pendingFirstAccept, setPendingFirstAccept] =
+    useState<PendingFirstAccept | null>(null);
   const {
     messages,
     setMessages,
@@ -257,8 +263,10 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
    * default. The user-facing "ask once" prompt only blocks the very
    * first accept attempt.
    */
-  const applyMode: AISuggestionApplyMode =
-    applyModeStored ?? config.defaultApplyMode ?? "direct";
+  const applyMode: AISuggestionApplyMode = resolveApplyMode(
+    applyModeStored,
+    config.defaultApplyMode,
+  );
 
   const persistApplyMode = useCallback((next: AISuggestionApplyMode) => {
     setApplyModeStored(next);
@@ -293,12 +301,7 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
     (m) => m.role === "assistant" && m.status === "loading",
   );
 
-  let status: FileAIChatStatus = "idle";
-  if (generating) {
-    status = "generating";
-  } else if (pendingCount > 0) {
-    status = "review-ready";
-  }
+  const status: FileAIChatStatus = deriveChatStatus(generating, pendingCount);
 
   // ---- decoration push (DOCX only) ----------------------------------------
 
@@ -388,13 +391,7 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
 
       const token = ++generationToken.current;
 
-      let fullPrompt = promptText;
-      if (input.pastedText) {
-        fullPrompt =
-          promptText.length === 0
-            ? input.pastedText
-            : `${promptText}\n\n${input.pastedText}`;
-      }
+      const fullPrompt = joinPromptWithPasted(promptText, input.pastedText);
 
       const docText = editorView
         ? editorView.state.doc.textBetween(
@@ -435,8 +432,8 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
               "\n",
             )
           : "";
-      const generateInput: AIGenerateInput = {
-        prompt: fullPrompt,
+      const generateInput: AIGenerateInput = buildGenerateInput({
+        fullPrompt,
         mode,
         selectionText,
         selectionRange:
@@ -447,28 +444,24 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
         documentText: docText,
         visibleText,
         visibleRange: visible,
-        ...(input.presetId === undefined ? {} : { presetId: input.presetId }),
-      };
+        presetId: input.presetId,
+      });
 
       try {
         const response = await config.onGenerate(generateInput);
         if (generationToken.current !== token) {
           return;
         }
-        const rawSuggestions =
-          mode === "ask" ? [] : (response.suggestions ?? []);
+        const rawSuggestions = selectResponseSuggestions(
+          mode,
+          response.suggestions,
+        );
         const anchored: AISuggestion[] = [];
         for (const s of rawSuggestions) {
-          if (!editorView) {
-            anchored.push(s);
-            continue;
-          }
-          const anchor = resolveSuggestionAnchor(editorView.state.doc, s);
-          anchored.push(
-            anchor === null
-              ? { ...s, status: "stale" }
-              : { ...s, range: anchor },
-          );
+          const anchor = editorView
+            ? resolveSuggestionAnchor(editorView.state.doc, s)
+            : undefined;
+          anchored.push(anchorSuggestion(s, anchor));
         }
         updateAssistantMessage(assistantId, (m) => ({
           id: m.id,
@@ -578,12 +571,17 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
     (suggestionId: string) => {
       // First-time accept: ask whether to apply with tracked changes,
       // remember the answer, and defer this accept until they pick.
-      if (applyModeStored === null) {
-        const target = findSuggestion(suggestionId);
-        if (!target || target.status !== "pending") {
-          return;
-        }
-        setPendingFirstAccept({ kind: "one", suggestionId });
+      const target = findSuggestion(suggestionId);
+      const gate = resolveAcceptOneGate(
+        applyModeStored,
+        suggestionId,
+        target?.status === "pending",
+      );
+      if (gate.type === "noop") {
+        return;
+      }
+      if (gate.type === "defer") {
+        setPendingFirstAccept(gate.pending);
         return;
       }
       acceptOneAtMode(suggestionId, applyMode);
@@ -659,21 +657,22 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
 
   const handleAcceptGroup = useCallback(
     (messageId: string) => {
-      if (applyModeStored === null) {
-        const message = messages.find(
-          (m): m is AssistantThreadMessage =>
-            m.role === "assistant" && m.id === messageId,
-        );
-        if (!message) {
-          return;
-        }
-        const hasPending = message.suggestions.some(
-          (s) => s.status === "pending",
-        );
-        if (!hasPending) {
-          return;
-        }
-        setPendingFirstAccept({ kind: "group", messageId });
+      const message = messages.find(
+        (m): m is AssistantThreadMessage =>
+          m.role === "assistant" && m.id === messageId,
+      );
+      const hasPending =
+        message?.suggestions.some((s) => s.status === "pending") ?? false;
+      const gate = resolveAcceptGroupGate(
+        applyModeStored,
+        messageId,
+        hasPending,
+      );
+      if (gate.type === "noop") {
+        return;
+      }
+      if (gate.type === "defer") {
+        setPendingFirstAccept(gate.pending);
         return;
       }
       acceptGroupAtMode(messageId, applyMode);

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -42,6 +42,18 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import { getChatHitRoute } from "@/components/search-dialog.logic";
+import {
+  clearTime,
+  resolveUpdatedFrom,
+  resolveUpdatedTo,
+  setCustomTime,
+  setPresetTime,
+  toggleArrayMember,
+} from "@/components/search-filters.logic";
+import type {
+  SearchFilters,
+  TimeFilter,
+} from "@/components/search-filters.logic";
 import { UserAvatar } from "@/components/user-avatar";
 import {
   isPublicLawPreviewEnabled,
@@ -56,7 +68,6 @@ import { toAPIError } from "@/lib/errors";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { toSafeId } from "@/lib/safe-id";
 import {
-  presetUpdatedFrom,
   searchFacetOptions,
   searchInfiniteOptions,
   TIME_PRESETS,
@@ -234,21 +245,6 @@ const mergeSelectedBuckets = (
   return [...buckets, ...missing];
 };
 
-type TimeFilter =
-  | { mode: "preset"; preset: TimePreset }
-  | { mode: "custom"; updatedFrom?: string; updatedTo?: string };
-
-type SearchFilters = {
-  workspaceIds: string[];
-  types: GlobalSearchResultType[];
-  editedByUserIds: string[];
-  mimeTypes: string[];
-  time?: TimeFilter;
-};
-
-const filterUpdatedTo = (filters: SearchFilters): string | undefined =>
-  filters.time?.mode === "custom" ? filters.time.updatedTo : undefined;
-
 type SearchDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -298,17 +294,12 @@ export const SearchDialog = ({
   // whenever the user picks a new preset or runs a new query, while
   // staying stable across pagination so `fetchNextPage` keeps using
   // the same cutoff as page 1.
-  const updatedFrom = useMemo(() => {
-    if (filters.time?.mode === "preset") {
-      return presetUpdatedFrom(filters.time.preset);
-    }
-    if (filters.time?.mode === "custom") {
-      return filters.time.updatedFrom;
-    }
-    return undefined;
+  const updatedFrom = useMemo(
+    () => resolveUpdatedFrom(filters.time),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: include searchQuery so each new query gets a fresh preset cutoff
-  }, [filters.time, searchQuery]);
-  const updatedTo = filterUpdatedTo(filters);
+    [filters.time, searchQuery],
+  );
+  const updatedTo = resolveUpdatedTo(filters.time);
   const selectedSearchTypes = filters.types.filter(
     (type) =>
       isSearchKindOption(type) &&
@@ -588,86 +579,46 @@ export const SearchDialog = ({
   };
 
   const toggleTypeFilter = (type: GlobalSearchResultType) => {
-    setFilters((prev) => {
-      const next = prev.types.includes(type)
-        ? prev.types.filter((item) => item !== type)
-        : [...prev.types, type];
-      return {
-        ...prev,
-        types: next,
-      };
-    });
+    setFilters((prev) => ({
+      ...prev,
+      types: toggleArrayMember(prev.types, type),
+    }));
   };
 
   const toggleWorkspaceFilter = (workspaceId: string) => {
-    setFilters((prev) => {
-      const next = prev.workspaceIds.includes(workspaceId)
-        ? prev.workspaceIds.filter((id) => id !== workspaceId)
-        : [...prev.workspaceIds, workspaceId];
-      return { ...prev, workspaceIds: next };
-    });
+    setFilters((prev) => ({
+      ...prev,
+      workspaceIds: toggleArrayMember(prev.workspaceIds, workspaceId),
+    }));
   };
 
   const toggleEditorFilter = (editorId: string) => {
-    setFilters((prev) => {
-      const next = prev.editedByUserIds.includes(editorId)
-        ? prev.editedByUserIds.filter((id) => id !== editorId)
-        : [...prev.editedByUserIds, editorId];
-      return {
-        ...prev,
-        editedByUserIds: next,
-      };
-    });
+    setFilters((prev) => ({
+      ...prev,
+      editedByUserIds: toggleArrayMember(prev.editedByUserIds, editorId),
+    }));
   };
 
   const setTimePreset = (preset: TimePreset | undefined) => {
-    setFilters((prev): SearchFilters => {
-      const { time: _, ...rest } = prev;
-      if (!preset) {
-        return rest;
-      }
-      return { ...rest, time: { mode: "preset", preset } };
-    });
+    setFilters((prev) => setPresetTime(prev, preset));
   };
 
   const setCustomDateRange = (range: {
     updatedFrom?: string;
     updatedTo?: string;
   }) => {
-    setFilters((prev): SearchFilters => {
-      const { time: _, ...rest } = prev;
-      return {
-        ...rest,
-        time: {
-          mode: "custom",
-          ...(range.updatedFrom !== undefined && {
-            updatedFrom: range.updatedFrom,
-          }),
-          ...(range.updatedTo !== undefined && {
-            updatedTo: range.updatedTo,
-          }),
-        },
-      };
-    });
+    setFilters((prev) => setCustomTime(prev, range));
   };
 
   const clearTimeFilter = () => {
-    setFilters((prev): SearchFilters => {
-      const { time: _, ...rest } = prev;
-      return rest;
-    });
+    setFilters(clearTime);
   };
 
   const toggleMimeTypeFilter = (mimeType: string) => {
-    setFilters((prev) => {
-      const next = prev.mimeTypes.includes(mimeType)
-        ? prev.mimeTypes.filter((item) => item !== mimeType)
-        : [...prev.mimeTypes, mimeType];
-      return {
-        ...prev,
-        mimeTypes: next,
-      };
-    });
+    setFilters((prev) => ({
+      ...prev,
+      mimeTypes: toggleArrayMember(prev.mimeTypes, mimeType),
+    }));
   };
 
   const handleResultClick = async (hit: GlobalSearchHit) => {

--- a/apps/web/src/components/search-filters.logic.test.ts
+++ b/apps/web/src/components/search-filters.logic.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import * as search from "@/lib/search";
+
+import {
+  clearTime,
+  resolveUpdatedFrom,
+  resolveUpdatedTo,
+  setCustomTime,
+  setPresetTime,
+  toggleArrayMember,
+} from "./search-filters.logic";
+import type { SearchFilters } from "./search-filters.logic";
+
+const baseFilters = (
+  overrides: Partial<SearchFilters> = {},
+): SearchFilters => ({
+  workspaceIds: [],
+  types: [],
+  editedByUserIds: [],
+  mimeTypes: [],
+  ...overrides,
+});
+
+afterEach(() => {
+  // Restore any spy installed on the shared search module so a preset
+  // test cannot leak a stubbed clock into the next test.
+  spyOn(search, "presetUpdatedFrom").mockRestore();
+});
+
+describe("resolveUpdatedFrom", () => {
+  test("returns no lower bound when there is no time filter", () => {
+    expect(resolveUpdatedFrom(undefined)).toBeUndefined();
+  });
+
+  test("delegates a preset to presetUpdatedFrom", () => {
+    const stub = spyOn(search, "presetUpdatedFrom").mockReturnValue(
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    expect(resolveUpdatedFrom({ mode: "preset", preset: "week" })).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+    expect(stub).toHaveBeenCalledWith("week");
+  });
+
+  test("returns the custom lower bound verbatim", () => {
+    expect(
+      resolveUpdatedFrom({
+        mode: "custom",
+        updatedFrom: "2026-03-10T00:00:00.000Z",
+        updatedTo: "2026-03-20T23:59:59.999Z",
+      }),
+    ).toBe("2026-03-10T00:00:00.000Z");
+  });
+
+  test("returns undefined for a custom filter with only an upper bound", () => {
+    expect(
+      resolveUpdatedFrom({
+        mode: "custom",
+        updatedTo: "2026-03-20T23:59:59.999Z",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveUpdatedTo", () => {
+  test("returns no upper bound when there is no time filter", () => {
+    expect(resolveUpdatedTo(undefined)).toBeUndefined();
+  });
+
+  test("never derives an upper bound from a preset", () => {
+    expect(
+      resolveUpdatedTo({ mode: "preset", preset: "month" }),
+    ).toBeUndefined();
+  });
+
+  test("returns the custom upper bound verbatim", () => {
+    expect(
+      resolveUpdatedTo({
+        mode: "custom",
+        updatedTo: "2026-03-20T23:59:59.999Z",
+      }),
+    ).toBe("2026-03-20T23:59:59.999Z");
+  });
+
+  test("returns undefined for a custom filter with only a lower bound", () => {
+    expect(
+      resolveUpdatedTo({
+        mode: "custom",
+        updatedFrom: "2026-03-10T00:00:00.000Z",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("clearTime", () => {
+  test("removes the time key entirely rather than setting it to undefined", () => {
+    const result = clearTime(
+      baseFilters({ time: { mode: "preset", preset: "day" } }),
+    );
+
+    expect("time" in result).toBe(false);
+  });
+
+  test("is a no-op shape change when there is already no time filter", () => {
+    const filters = baseFilters({ workspaceIds: ["w1"], types: ["document"] });
+
+    expect(clearTime(filters)).toEqual(filters);
+  });
+
+  test("preserves every non-time filter field", () => {
+    const result = clearTime(
+      baseFilters({
+        workspaceIds: ["w1", "w2"],
+        types: ["matter", "document"],
+        editedByUserIds: ["u1"],
+        mimeTypes: ["application/pdf"],
+        time: { mode: "custom", updatedFrom: "2026-03-10T00:00:00.000Z" },
+      }),
+    );
+
+    expect(result).toEqual(
+      baseFilters({
+        workspaceIds: ["w1", "w2"],
+        types: ["matter", "document"],
+        editedByUserIds: ["u1"],
+        mimeTypes: ["application/pdf"],
+      }),
+    );
+  });
+});
+
+describe("setPresetTime", () => {
+  test("clears the time filter when the preset is undefined (toggle-off)", () => {
+    const result = setPresetTime(
+      baseFilters({ time: { mode: "preset", preset: "week" } }),
+      undefined,
+    );
+
+    expect("time" in result).toBe(false);
+  });
+
+  test("clearing via setPresetTime matches clearTime exactly", () => {
+    const filters = baseFilters({
+      workspaceIds: ["w1"],
+      time: { mode: "custom", updatedTo: "2026-03-20T23:59:59.999Z" },
+    });
+
+    expect(setPresetTime(filters, undefined)).toEqual(clearTime(filters));
+  });
+
+  test("replaces any existing time filter with the new preset", () => {
+    const result = setPresetTime(
+      baseFilters({
+        time: { mode: "custom", updatedFrom: "2026-03-10T00:00:00.000Z" },
+      }),
+      "year",
+    );
+
+    expect(result.time).toEqual({ mode: "preset", preset: "year" });
+  });
+});
+
+describe("setCustomTime", () => {
+  test("omits an absent lower bound rather than writing undefined", () => {
+    const result = setCustomTime(baseFilters(), {
+      updatedTo: "2026-03-20T23:59:59.999Z",
+    });
+
+    expect(result.time).toEqual({
+      mode: "custom",
+      updatedTo: "2026-03-20T23:59:59.999Z",
+    });
+    expect(result.time && "updatedFrom" in result.time).toBe(false);
+  });
+
+  test("omits an absent upper bound rather than writing undefined", () => {
+    const result = setCustomTime(baseFilters(), {
+      updatedFrom: "2026-03-10T00:00:00.000Z",
+    });
+
+    expect(result.time).toEqual({
+      mode: "custom",
+      updatedFrom: "2026-03-10T00:00:00.000Z",
+    });
+    expect(result.time && "updatedTo" in result.time).toBe(false);
+  });
+
+  test("an empty range produces a bare custom filter (custom toggle-on)", () => {
+    expect(setCustomTime(baseFilters(), {}).time).toEqual({ mode: "custom" });
+  });
+
+  test("replaces a preset filter with the custom range", () => {
+    const result = setCustomTime(
+      baseFilters({ time: { mode: "preset", preset: "day" } }),
+      {
+        updatedFrom: "2026-03-10T00:00:00.000Z",
+        updatedTo: "2026-03-20T23:59:59.999Z",
+      },
+    );
+
+    expect(result.time).toEqual({
+      mode: "custom",
+      updatedFrom: "2026-03-10T00:00:00.000Z",
+      updatedTo: "2026-03-20T23:59:59.999Z",
+    });
+  });
+});
+
+describe("toggleArrayMember", () => {
+  test("adds a value that is not present", () => {
+    expect(toggleArrayMember(["a"], "b")).toEqual(["a", "b"]);
+  });
+
+  test("removes a value that is present", () => {
+    expect(toggleArrayMember(["a", "b", "c"], "b")).toEqual(["a", "c"]);
+  });
+
+  test("does not mutate the input array", () => {
+    const input = ["a", "b"];
+    toggleArrayMember(input, "c");
+    expect(input).toEqual(["a", "b"]);
+  });
+
+  test("removes only the first/all equal entries via filter semantics", () => {
+    expect(toggleArrayMember(["a", "a"], "a")).toEqual([]);
+  });
+});

--- a/apps/web/src/components/search-filters.logic.ts
+++ b/apps/web/src/components/search-filters.logic.ts
@@ -1,0 +1,72 @@
+import type { GlobalSearchResultType } from "@stll/api/types";
+
+import { presetUpdatedFrom } from "@/lib/search";
+import type { TimePreset } from "@/lib/search";
+
+export type TimeFilter =
+  | { mode: "preset"; preset: TimePreset }
+  | { mode: "custom"; updatedFrom?: string; updatedTo?: string };
+
+export type SearchFilters = {
+  workspaceIds: string[];
+  types: GlobalSearchResultType[];
+  editedByUserIds: string[];
+  mimeTypes: string[];
+  time?: TimeFilter;
+};
+
+export const resolveUpdatedFrom = (
+  time: TimeFilter | undefined,
+): string | undefined => {
+  if (time?.mode === "preset") {
+    return presetUpdatedFrom(time.preset);
+  }
+  if (time?.mode === "custom") {
+    return time.updatedFrom;
+  }
+  return undefined;
+};
+
+export const resolveUpdatedTo = (
+  time: TimeFilter | undefined,
+): string | undefined => (time?.mode === "custom" ? time.updatedTo : undefined);
+
+export const clearTime = (filters: SearchFilters): SearchFilters => {
+  const { time: _, ...rest } = filters;
+  return rest;
+};
+
+export const setPresetTime = (
+  filters: SearchFilters,
+  preset: TimePreset | undefined,
+): SearchFilters => {
+  const rest = clearTime(filters);
+  if (!preset) {
+    return rest;
+  }
+  return { ...rest, time: { mode: "preset", preset } };
+};
+
+type CustomTimeRange = { updatedFrom?: string; updatedTo?: string };
+
+export const setCustomTime = (
+  filters: SearchFilters,
+  range: CustomTimeRange,
+): SearchFilters => {
+  const rest = clearTime(filters);
+  return {
+    ...rest,
+    time: {
+      mode: "custom",
+      ...(range.updatedFrom !== undefined && {
+        updatedFrom: range.updatedFrom,
+      }),
+      ...(range.updatedTo !== undefined && { updatedTo: range.updatedTo }),
+    },
+  };
+};
+
+export const toggleArrayMember = <T>(items: readonly T[], value: T): T[] =>
+  items.includes(value)
+    ? items.filter((item) => item !== value)
+    : [...items, value];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -83,6 +83,16 @@ import {
   shouldFinalizeEditSession,
 } from "./docx-browser-editor.logic";
 import type { OptimisticPreviewFile } from "./docx-browser-editor.logic";
+import {
+  aggregateAnonymizationMatches,
+  buildAnonymizationDetectionKey,
+  buildExcludedCanonicalsSet,
+  decideAnonymizationDetectionRun,
+  dedupeDetectedAnonymizationTerms,
+  mergeAnonymizationTerms,
+  resolveCheckpointAutosaveStatus,
+} from "./docx-edit-mode.logic";
+import type { AutosaveStatus } from "./docx-edit-mode.logic";
 import type { EditSessionErrorReason } from "./use-edit-session";
 import { useEditSession } from "./use-edit-session";
 
@@ -99,8 +109,6 @@ const colorFromStableId = (value: string) => {
   const color = (hash * 2_654_435_761) % COLLABORATOR_COLOR_SPACE;
   return `#${color.toString(16).padStart(6, "0")}`;
 };
-
-type AutosaveStatus = "synced" | "pending" | "syncing";
 
 type DocxBrowserEditorBaseProps = {
   workspaceId: string;
@@ -287,13 +295,24 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       if (cancelled) {
         return;
       }
-      if (Date.now() < inFlightUntil) {
-        return;
-      }
       const text = view.state.doc.textContent;
       const excluded = excludedCanonicalsRef.current;
-      const cacheKey = `${[...excluded].sort().join("|")}~${text}`;
-      if (text.length === 0) {
+      const excludedSet = new Set(excluded);
+      const cacheKey = buildAnonymizationDetectionKey({
+        text,
+        excludedCanonicals: excludedSet,
+      });
+      const decision = decideAnonymizationDetectionRun({
+        text,
+        cacheKey,
+        lastDeliveredKey,
+        inFlightUntil,
+        now: Date.now(),
+      });
+      if (decision.action === "skip") {
+        return;
+      }
+      if (decision.action === "markRan") {
         // Empty doc: nothing to detect. Release the
         // "in flight" lock so the facet exits the
         // "Detecting…" placeholder instead of stalling
@@ -301,7 +320,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
         markRan();
         return;
       }
-      if (cacheKey === lastDeliveredKey) {
+      if (decision.action === "alreadyDelivered") {
         // Already delivered for this exact text +
         // exclusions; no-op without flipping the
         // started state (we're not running anything).
@@ -323,17 +342,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             return;
           }
           lastDeliveredKey = cacheKey;
-          const byCanonical = new Map<string, AnonymizationTerm>();
-          for (const pair of result.pairs) {
-            const key = `${pair.label} ${pair.original.toLowerCase()}`;
-            if (!byCanonical.has(key)) {
-              byCanonical.set(key, {
-                canonical: pair.original,
-                label: pair.label,
-              });
-            }
-          }
-          setDetectedAnonymizationTerms([...byCanonical.values()]);
+          setDetectedAnonymizationTerms(
+            dedupeDetectedAnonymizationTerms(result.pairs),
+          );
           markRan();
           return;
         })
@@ -377,13 +388,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     ...anonymizationAllowlistOptions({ workspaceId, entityId }),
     enabled: isAnonymizationActive,
   });
-  const excludedCanonicalsSet = useMemo(() => {
-    const set = new Set<string>();
-    for (const entry of allowlistQuery.data?.entries ?? []) {
-      set.add(entry.canonical.toLocaleLowerCase());
-    }
-    return set;
-  }, [allowlistQuery.data]);
+  const excludedCanonicalsSet = useMemo(
+    () => buildExcludedCanonicalsSet(allowlistQuery.data?.entries ?? []),
+    [allowlistQuery.data],
+  );
   // Hold the latest list in a ref so the chat-anon polling effect
   // sees fresh exclusions without re-installing its heartbeat on
   // every keystroke / mutation.
@@ -395,24 +403,21 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     // having to wait up to 2s for the next heartbeat tick.
     runDetectionRef.current?.();
   }, [excludedCanonicalsSet]);
-  const mergedAnonymizationTerms = useMemo<AnonymizationTerm[]>(() => {
-    if (!isAnonymizationActive) {
-      return [];
-    }
-    const filteredWorkspace =
-      excludedCanonicalsSet.size === 0
-        ? workspaceAnonymizationTerms
-        : workspaceAnonymizationTerms.filter(
-            (term) =>
-              !excludedCanonicalsSet.has(term.canonical.toLocaleLowerCase()),
-          );
-    return [...filteredWorkspace, ...detectedAnonymizationTerms];
-  }, [
-    isAnonymizationActive,
-    workspaceAnonymizationTerms,
-    detectedAnonymizationTerms,
-    excludedCanonicalsSet,
-  ]);
+  const mergedAnonymizationTerms = useMemo<AnonymizationTerm[]>(
+    () =>
+      mergeAnonymizationTerms({
+        isAnonymizationActive,
+        workspaceTerms: workspaceAnonymizationTerms,
+        detectedTerms: detectedAnonymizationTerms,
+        excludedCanonicals: excludedCanonicalsSet,
+      }),
+    [
+      isAnonymizationActive,
+      workspaceAnonymizationTerms,
+      detectedAnonymizationTerms,
+      excludedCanonicalsSet,
+    ],
+  );
   // Dispatch the live term list into the plugin. We can't simply
   // read matches right after `dispatch` because DOCX content
   // loads asynchronously: the first dispatch hits an empty doc
@@ -452,22 +457,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       if (!isAnonymizationActive) {
         return;
       }
-      const countByCanonical = new Map<string, number>();
-      const labelByCanonical = new Map<string, string>();
-      for (const match of matches) {
-        countByCanonical.set(
-          match.canonical,
-          (countByCanonical.get(match.canonical) ?? 0) + 1,
-        );
-        if (!labelByCanonical.has(match.canonical)) {
-          labelByCanonical.set(match.canonical, match.label);
-        }
-      }
-      publish(fieldId, {
-        totalMatches: matches.length,
-        countByCanonical,
-        labelByCanonical,
-      });
+      publish(fieldId, aggregateAnonymizationMatches(matches));
     },
     [fieldId, isAnonymizationActive],
   );
@@ -927,12 +917,15 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     setAutosaveStatus("syncing");
     void (async () => {
       const buffer = await ref.save({ selective: true });
-      if (buffer) {
-        const saved = await saveActiveCheckpoint(buffer);
-        setAutosaveStatus(saved ? "synced" : "pending");
-        return;
-      }
-      setAutosaveStatus("pending");
+      const checkpointSaved = buffer
+        ? await saveActiveCheckpoint(buffer)
+        : false;
+      setAutosaveStatus(
+        resolveCheckpointAutosaveStatus({
+          buffer: buffer ?? null,
+          checkpointSaved,
+        }),
+      );
     })();
   }, [saveActiveCheckpoint]);
 
@@ -948,12 +941,13 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     clearQueuedChangeCheckpoint();
     setAutosaveStatus("syncing");
     const buffer = await ref.save({ selective: true });
-    if (!buffer) {
-      setAutosaveStatus("pending");
-      return;
-    }
-    const saved = await saveActiveCheckpoint(buffer);
-    setAutosaveStatus(saved ? "synced" : "pending");
+    const checkpointSaved = buffer ? await saveActiveCheckpoint(buffer) : false;
+    setAutosaveStatus(
+      resolveCheckpointAutosaveStatus({
+        buffer: buffer ?? null,
+        checkpointSaved,
+      }),
+    );
   }, [clearQueuedChangeCheckpoint, saveActiveCheckpoint]);
 
   // Cmd+S / Ctrl+S checkpoints only while the document is actively editable.
@@ -977,12 +971,15 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       setAutosaveStatus("syncing");
       void (async () => {
         const buffer = await ref.save({ selective: true });
-        if (buffer) {
-          const saved = await saveActiveCheckpoint(buffer);
-          setAutosaveStatus(saved ? "synced" : "pending");
-          return;
-        }
-        setAutosaveStatus("pending");
+        const checkpointSaved = buffer
+          ? await saveActiveCheckpoint(buffer)
+          : false;
+        setAutosaveStatus(
+          resolveCheckpointAutosaveStatus({
+            buffer: buffer ?? null,
+            checkpointSaved,
+          }),
+        );
       })();
     };
     document.addEventListener("keydown", handler);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -295,19 +295,28 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       if (cancelled) {
         return;
       }
+      // Cheap in-flight short-circuit before serializing the doc:
+      // `view.state.doc.textContent` walks the whole ProseMirror
+      // tree, so on large DOCX files we must not pay it every 2s
+      // tick while a worker request is still pending. The decision
+      // helper repeats this guard for its own correctness, but the
+      // expensive read has to stay behind it.
+      const now = Date.now();
+      if (now < inFlightUntil) {
+        return;
+      }
       const text = view.state.doc.textContent;
       const excluded = excludedCanonicalsRef.current;
-      const excludedSet = new Set(excluded);
       const cacheKey = buildAnonymizationDetectionKey({
         text,
-        excludedCanonicals: excludedSet,
+        excludedCanonicals: excluded,
       });
       const decision = decideAnonymizationDetectionRun({
         text,
         cacheKey,
         lastDeliveredKey,
         inFlightUntil,
-        now: Date.now(),
+        now,
       });
       if (decision.action === "skip") {
         return;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  aggregateAnonymizationMatches,
+  buildAnonymizationDetectionKey,
+  buildExcludedCanonicalsSet,
+  decideAnonymizationDetectionRun,
+  dedupeDetectedAnonymizationTerms,
+  mergeAnonymizationTerms,
+  resolveCheckpointAutosaveStatus,
+} from "./docx-edit-mode.logic";
+
+const buffer = (values: number[]) => new Uint8Array(values).buffer;
+
+describe("checkpoint autosave status", () => {
+  test("syncs when the round-trip succeeds", () => {
+    expect(
+      resolveCheckpointAutosaveStatus({
+        buffer: buffer([1]),
+        checkpointSaved: true,
+      }),
+    ).toBe("synced");
+  });
+
+  test("stays pending when the round-trip fails", () => {
+    expect(
+      resolveCheckpointAutosaveStatus({
+        buffer: buffer([1]),
+        checkpointSaved: false,
+      }),
+    ).toBe("pending");
+  });
+
+  test("stays pending when serialization produced no buffer", () => {
+    // A missing buffer is the only case where `checkpointSaved`
+    // is never consulted; both flush and debounced paths short
+    // out before persisting.
+    expect(
+      resolveCheckpointAutosaveStatus({ buffer: null, checkpointSaved: false }),
+    ).toBe("pending");
+    expect(
+      resolveCheckpointAutosaveStatus({ buffer: null, checkpointSaved: true }),
+    ).toBe("pending");
+  });
+
+  test("treats an empty buffer as present, not missing", () => {
+    expect(
+      resolveCheckpointAutosaveStatus({
+        buffer: new ArrayBuffer(0),
+        checkpointSaved: true,
+      }),
+    ).toBe("synced");
+  });
+});
+
+describe("anonymization detection cache key", () => {
+  test("is stable regardless of exclusion insertion order", () => {
+    const a = buildAnonymizationDetectionKey({
+      text: "Acme Corp",
+      excludedCanonicals: new Set(["beta", "alpha"]),
+    });
+    const b = buildAnonymizationDetectionKey({
+      text: "Acme Corp",
+      excludedCanonicals: new Set(["alpha", "beta"]),
+    });
+    expect(a).toBe(b);
+  });
+
+  test("changes when the exclusion set changes", () => {
+    const without = buildAnonymizationDetectionKey({
+      text: "Acme Corp",
+      excludedCanonicals: new Set(),
+    });
+    const withExclusion = buildAnonymizationDetectionKey({
+      text: "Acme Corp",
+      excludedCanonicals: new Set(["acme corp"]),
+    });
+    expect(without).not.toBe(withExclusion);
+  });
+
+  test("changes when the text changes", () => {
+    const first = buildAnonymizationDetectionKey({
+      text: "Acme Corp",
+      excludedCanonicals: new Set(["alpha"]),
+    });
+    const second = buildAnonymizationDetectionKey({
+      text: "Beta Corp",
+      excludedCanonicals: new Set(["alpha"]),
+    });
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("anonymization detection decision", () => {
+  test("skips while a request is still in flight", () => {
+    expect(
+      decideAnonymizationDetectionRun({
+        text: "Acme",
+        cacheKey: "k",
+        lastDeliveredKey: null,
+        inFlightUntil: 1000,
+        now: 500,
+      }),
+    ).toEqual({ action: "skip" });
+  });
+
+  test("marks ran for an empty document", () => {
+    expect(
+      decideAnonymizationDetectionRun({
+        text: "",
+        cacheKey: "~",
+        lastDeliveredKey: null,
+        inFlightUntil: 0,
+        now: 500,
+      }),
+    ).toEqual({ action: "markRan" });
+  });
+
+  test("treats an empty doc as ran even with a stale in-flight window", () => {
+    // The in-flight check fires first only while the window is
+    // open; once it has elapsed, an empty doc releases the lock.
+    expect(
+      decideAnonymizationDetectionRun({
+        text: "",
+        cacheKey: "~",
+        lastDeliveredKey: null,
+        inFlightUntil: 100,
+        now: 500,
+      }),
+    ).toEqual({ action: "markRan" });
+  });
+
+  test("no-ops when results for the exact key already landed", () => {
+    expect(
+      decideAnonymizationDetectionRun({
+        text: "Acme",
+        cacheKey: "k",
+        lastDeliveredKey: "k",
+        inFlightUntil: 0,
+        now: 500,
+      }),
+    ).toEqual({ action: "alreadyDelivered" });
+  });
+
+  test("runs for fresh text past the in-flight window", () => {
+    expect(
+      decideAnonymizationDetectionRun({
+        text: "Acme",
+        cacheKey: "k",
+        lastDeliveredKey: "previous",
+        inFlightUntil: 100,
+        now: 500,
+      }),
+    ).toEqual({ action: "run" });
+  });
+
+  test("in-flight skip wins over an already-delivered key", () => {
+    expect(
+      decideAnonymizationDetectionRun({
+        text: "Acme",
+        cacheKey: "k",
+        lastDeliveredKey: "k",
+        inFlightUntil: 1000,
+        now: 500,
+      }),
+    ).toEqual({ action: "skip" });
+  });
+});
+
+describe("detected term deduplication", () => {
+  test("collapses pairs sharing a label and case-insensitive original", () => {
+    const terms = dedupeDetectedAnonymizationTerms([
+      { original: "Acme", label: "organization" },
+      { original: "acme", label: "organization" },
+    ]);
+    expect(terms).toEqual([{ canonical: "Acme", label: "organization" }]);
+  });
+
+  test("keeps the first occurrence's casing", () => {
+    const terms = dedupeDetectedAnonymizationTerms([
+      { original: "ACME", label: "organization" },
+      { original: "acme", label: "organization" },
+    ]);
+    expect(terms[0]?.canonical).toBe("ACME");
+  });
+
+  test("keeps the same surface form under different labels", () => {
+    const terms = dedupeDetectedAnonymizationTerms([
+      { original: "Washington", label: "person" },
+      { original: "Washington", label: "location" },
+    ]);
+    expect(terms).toHaveLength(2);
+  });
+});
+
+describe("excluded canonicals set", () => {
+  test("lowercases entries for case-insensitive membership", () => {
+    const set = buildExcludedCanonicalsSet([
+      { canonical: "Acme Corp" },
+      { canonical: "BETA" },
+    ]);
+    expect(set.has("acme corp")).toBe(true);
+    expect(set.has("beta")).toBe(true);
+    expect(set.has("Acme Corp")).toBe(false);
+  });
+});
+
+describe("merged anonymization terms", () => {
+  test("is empty while the facet is off-screen", () => {
+    expect(
+      mergeAnonymizationTerms({
+        isAnonymizationActive: false,
+        workspaceTerms: [{ canonical: "Acme", label: "organization" }],
+        detectedTerms: [{ canonical: "Bob", label: "person" }],
+        excludedCanonicals: new Set(),
+      }),
+    ).toEqual([]);
+  });
+
+  test("returns the workspace list unfiltered when nothing is excluded", () => {
+    const workspaceTerms = [{ canonical: "Acme", label: "organization" }];
+    const merged = mergeAnonymizationTerms({
+      isAnonymizationActive: true,
+      workspaceTerms,
+      detectedTerms: [],
+      excludedCanonicals: new Set(),
+    });
+    expect(merged).toEqual(workspaceTerms);
+  });
+
+  test("strips allowlisted catalog terms case-insensitively, keeps detected", () => {
+    const merged = mergeAnonymizationTerms({
+      isAnonymizationActive: true,
+      workspaceTerms: [
+        { canonical: "Acme", label: "organization" },
+        { canonical: "Beta", label: "organization" },
+      ],
+      detectedTerms: [{ canonical: "Bob", label: "person" }],
+      excludedCanonicals: new Set(["acme"]),
+    });
+    expect(merged).toEqual([
+      { canonical: "Beta", label: "organization" },
+      { canonical: "Bob", label: "person" },
+    ]);
+  });
+});
+
+describe("aggregated anonymization matches", () => {
+  test("counts matches per canonical and keeps the first label", () => {
+    const result = aggregateAnonymizationMatches([
+      { canonical: "Acme", label: "organization" },
+      { canonical: "Acme", label: "misc" },
+      { canonical: "Bob", label: "person" },
+    ]);
+    expect(result.totalMatches).toBe(3);
+    expect(result.countByCanonical.get("Acme")).toBe(2);
+    expect(result.countByCanonical.get("Bob")).toBe(1);
+    expect(result.labelByCanonical.get("Acme")).toBe("organization");
+  });
+
+  test("returns empty maps for no matches", () => {
+    const result = aggregateAnonymizationMatches([]);
+    expect(result.totalMatches).toBe(0);
+    expect(result.countByCanonical.size).toBe(0);
+    expect(result.labelByCanonical.size).toBe(0);
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
@@ -31,14 +31,15 @@ export const resolveCheckpointAutosaveStatus = ({
 
 type BuildAnonymizationDetectionKeyOptions = {
   text: string;
-  excludedCanonicals: ReadonlySet<string>;
+  excludedCanonicals: Iterable<string>;
 };
 
 /**
  * Cache key for the detection heartbeat. Exclusions are part of
  * the key because marking an entity as a false positive must rerun
- * detection against the same text with the new allowlist. The set
- * is sorted so the key is stable regardless of insertion order.
+ * detection against the same text with the new allowlist. Accepts
+ * any iterable (set or already-deduped array) and sorts it so the
+ * key is stable regardless of order.
  */
 export const buildAnonymizationDetectionKey = ({
   text,
@@ -131,7 +132,7 @@ export const buildExcludedCanonicalsSet = (
 ): Set<string> => {
   const set = new Set<string>();
   for (const entry of entries) {
-    set.add(entry.canonical.toLocaleLowerCase());
+    set.add(entry.canonical.toLowerCase());
   }
   return set;
 };
@@ -166,7 +167,7 @@ export const mergeAnonymizationTerms = ({
     excludedCanonicals.size === 0
       ? workspaceTerms
       : workspaceTerms.filter(
-          (term) => !excludedCanonicals.has(term.canonical.toLocaleLowerCase()),
+          (term) => !excludedCanonicals.has(term.canonical.toLowerCase()),
         );
   return [...filteredWorkspace, ...detectedTerms];
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
@@ -1,0 +1,209 @@
+import type { AnonymizationTerm } from "@stll/folio";
+
+export type AutosaveStatus = "synced" | "pending" | "syncing";
+
+type ResolveCheckpointAutosaveStatusOptions = {
+  buffer: ArrayBuffer | null;
+  checkpointSaved: boolean;
+};
+
+/**
+ * Shared decision for the three near-duplicate checkpoint paths
+ * (debounced autosave, awaitable flush, and the Cmd/Ctrl+S
+ * handler). All three serialize the live editor, then persist the
+ * resulting buffer: a missing buffer or a failed round-trip leaves
+ * the session "pending"; a successful round-trip is "synced".
+ *
+ * The `null` buffer case mirrors `ref.save()` returning nothing
+ * (nothing to persist), so callers pass `null` rather than
+ * branching on it themselves.
+ */
+export const resolveCheckpointAutosaveStatus = ({
+  buffer,
+  checkpointSaved,
+}: ResolveCheckpointAutosaveStatusOptions): AutosaveStatus => {
+  if (buffer === null) {
+    return "pending";
+  }
+
+  return checkpointSaved ? "synced" : "pending";
+};
+
+type BuildAnonymizationDetectionKeyOptions = {
+  text: string;
+  excludedCanonicals: ReadonlySet<string>;
+};
+
+/**
+ * Cache key for the detection heartbeat. Exclusions are part of
+ * the key because marking an entity as a false positive must rerun
+ * detection against the same text with the new allowlist. The set
+ * is sorted so the key is stable regardless of insertion order.
+ */
+export const buildAnonymizationDetectionKey = ({
+  text,
+  excludedCanonicals,
+}: BuildAnonymizationDetectionKeyOptions): string =>
+  `${[...excludedCanonicals].sort().join("|")}~${text}`;
+
+type DecideAnonymizationDetectionRunOptions = {
+  text: string;
+  cacheKey: string;
+  lastDeliveredKey: string | null;
+  inFlightUntil: number;
+  now: number;
+};
+
+export type AnonymizationDetectionDecision =
+  | { action: "skip" }
+  | { action: "markRan" }
+  | { action: "alreadyDelivered" }
+  | { action: "run" };
+
+/**
+ * Decides what the detection heartbeat should do for the current
+ * doc text and allowlist:
+ * - `skip`: a request is still in flight, do nothing.
+ * - `markRan`: empty doc, release the placeholder without running.
+ * - `alreadyDelivered`: results for this exact key already landed.
+ * - `run`: dispatch a fresh worker request.
+ */
+export const decideAnonymizationDetectionRun = ({
+  text,
+  cacheKey,
+  lastDeliveredKey,
+  inFlightUntil,
+  now,
+}: DecideAnonymizationDetectionRunOptions): AnonymizationDetectionDecision => {
+  if (now < inFlightUntil) {
+    return { action: "skip" };
+  }
+
+  if (text.length === 0) {
+    return { action: "markRan" };
+  }
+
+  if (cacheKey === lastDeliveredKey) {
+    return { action: "alreadyDelivered" };
+  }
+
+  return { action: "run" };
+};
+
+type DetectionPair = {
+  original: string;
+  label: string;
+};
+
+/**
+ * Collapses worker-detected pairs into a deduplicated term list.
+ * Two pairs collide when they share a label and a
+ * case-insensitive original surface form; the first occurrence
+ * wins and keeps its original casing.
+ */
+export const dedupeDetectedAnonymizationTerms = (
+  pairs: readonly DetectionPair[],
+): AnonymizationTerm[] => {
+  const byCanonical = new Map<string, AnonymizationTerm>();
+  for (const pair of pairs) {
+    const key = `${pair.label} ${pair.original.toLowerCase()}`;
+    if (!byCanonical.has(key)) {
+      byCanonical.set(key, {
+        canonical: pair.original,
+        label: pair.label,
+      });
+    }
+  }
+  return [...byCanonical.values()];
+};
+
+type AllowlistEntry = {
+  canonical: string;
+};
+
+/**
+ * Per-doc allowlist of canonicals flagged as false positives,
+ * lowercased so membership checks are case-insensitive against
+ * both worker output and catalog terms.
+ */
+export const buildExcludedCanonicalsSet = (
+  entries: readonly AllowlistEntry[],
+): Set<string> => {
+  const set = new Set<string>();
+  for (const entry of entries) {
+    set.add(entry.canonical.toLocaleLowerCase());
+  }
+  return set;
+};
+
+type MergeAnonymizationTermsOptions = {
+  isAnonymizationActive: boolean;
+  workspaceTerms: readonly AnonymizationTerm[];
+  detectedTerms: readonly AnonymizationTerm[];
+  excludedCanonicals: ReadonlySet<string>;
+};
+
+/**
+ * The live term list dispatched into the Folio decoration plugin:
+ * catalog vocabulary minus allowlisted canonicals, plus
+ * worker-detected entities. Empty while the facet is off-screen.
+ *
+ * Catalog terms go straight to Folio without passing through the
+ * worker, so they must be filtered here; worker-detected terms are
+ * already allowlist-filtered upstream.
+ */
+export const mergeAnonymizationTerms = ({
+  isAnonymizationActive,
+  workspaceTerms,
+  detectedTerms,
+  excludedCanonicals,
+}: MergeAnonymizationTermsOptions): AnonymizationTerm[] => {
+  if (!isAnonymizationActive) {
+    return [];
+  }
+
+  const filteredWorkspace =
+    excludedCanonicals.size === 0
+      ? workspaceTerms
+      : workspaceTerms.filter(
+          (term) => !excludedCanonicals.has(term.canonical.toLocaleLowerCase()),
+        );
+  return [...filteredWorkspace, ...detectedTerms];
+};
+
+type AnonymizationMatch = {
+  canonical: string;
+  label: string;
+};
+
+export type AggregatedAnonymizationMatches = {
+  totalMatches: number;
+  countByCanonical: Map<string, number>;
+  labelByCanonical: Map<string, string>;
+};
+
+/**
+ * Folds the plugin's live match list into the per-canonical counts
+ * and labels the inspector facet publishes. The first label seen
+ * for a canonical wins.
+ */
+export const aggregateAnonymizationMatches = (
+  matches: readonly AnonymizationMatch[],
+): AggregatedAnonymizationMatches => {
+  const countByCanonical = new Map<string, number>();
+  const labelByCanonical = new Map<string, string>();
+  for (const match of matches) {
+    countByCanonical.set(
+      match.canonical,
+      (countByCanonical.get(match.canonical) ?? 0) + 1,
+    );
+    if (!labelByCanonical.has(match.canonical)) {
+      labelByCanonical.set(match.canonical, match.label);
+    }
+  }
+  return {
+    totalMatches: matches.length,
+    countByCanonical,
+    labelByCanonical,
+  };
+};


### PR DESCRIPTION
The AI-suggestions host, DOCX browser editor, and search dialog each buried decision logic inside ~1.7-1.8k-line components, reachable only through full-component E2E. Extract the pure parts into colocated `.logic.ts` modules with unit tests; components keep all React, effects, editor/network/store wiring, and JSX.

- `ai-suggestions/host.logic.ts`: apply-mode resolution, accept-gate (first-accept defer/accept/noop union), prompt+paste join, generate-input build, response-suggestion + anchoring decisions.
- `docx/docx-edit-mode.logic.ts`: the save+checkpoint autosave-status decision shared by the three save paths, plus anonymization detection-key/run/dedupe/merge/aggregate.
- `search-filters.logic.ts`: time-preset→ISO bounds, filter normalize, and a single clear-time helper (the two prior paths were identical).

Behavior-preserving (pure reads moved out of conditionals stay side-effect-free). 71 new unit tests.