### PR TITLE
fix(folio): preserve explicit nil/none borders on export

### DIFF
--- a/packages/folio/src/core/docx/__tests__/nil-borders-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/__tests__/nil-borders-roundtrip.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Explicit `nil`/`none` borders must survive serialization (eigenpal/docx-editor#959).
+ *
+ * `serializeBorder` used to drop any side whose style was `nil`/`none`, treating
+ * an explicit "border off" the same as "no border specified". For the common
+ * form/layout pattern — a table grid via `w:tblBorders` (`insideH`/`insideV` =
+ * `single`) hidden per cell with all-`nil` `w:tcBorders` — the overrides were
+ * omitted on save, so each cell re-inherited the table default and the hidden
+ * gridlines reappeared as a full grid on reload. The fix emits explicit nil
+ * sides as `<w:side w:val="nil"/>` across table, paragraph, and page borders.
+ *
+ * Also covers two latent parse bugs fixed alongside: table `w:color="auto"`
+ * stored as `{auto:true}` (not literal `rgb:"auto"`), and style-defined table
+ * borders honouring the RTL `w:start`/`w:end` fallbacks.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseSectionProperties } from "../sectionParser";
+import { serializeBorder } from "../serializer/borderSerializer";
+import { serializeParagraphFormatting } from "../serializer/paragraphSerializer";
+import { serializeSectionProperties } from "../serializer/sectionPropertiesSerializer";
+import { serializeTableCellFormatting } from "../serializer/tableSerializer";
+import { parseStyles } from "../styleParser";
+import { parseTableCellProperties, parseTableProperties } from "../tableParser";
+import type { XmlElement } from "../xmlParser";
+import { parseXmlDocument } from "../xmlParser";
+
+const W_NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+const parseSectPr = (inner: string) => {
+  const node = parseXmlDocument(
+    `<w:sectPr ${W_NS}>${inner}</w:sectPr>`,
+  ) as XmlElement | null;
+  if (!node) {
+    throw new Error("Failed to parse sectPr fixture");
+  }
+  return parseSectionProperties(node);
+};
+
+describe("serializeBorder", () => {
+  test("emits an explicit nil side instead of dropping it", () => {
+    expect(serializeBorder({ style: "nil" }, "top")).toBe(
+      '<w:top w:val="nil"/>',
+    );
+    expect(serializeBorder({ style: "none" }, "bottom")).toBe(
+      '<w:bottom w:val="none"/>',
+    );
+  });
+
+  test("serializes a normal border with size, space, and color", () => {
+    expect(
+      serializeBorder(
+        { style: "single", size: 4, space: 24, color: { rgb: "FF0000" } },
+        "top",
+      ),
+    ).toBe('<w:top w:val="single" w:sz="4" w:space="24" w:color="FF0000"/>');
+  });
+
+  test("emits auto color", () => {
+    expect(
+      serializeBorder({ style: "single", color: { auto: true } }, "left"),
+    ).toBe('<w:left w:val="single" w:color="auto"/>');
+  });
+
+  test("preserves custom page-border art relationship ids", () => {
+    expect(
+      serializeBorder({ style: "single", artRelationshipId: "rId7" }, "top"),
+    ).toContain('w:id="rId7"');
+  });
+
+  test("escapes untrusted style/color so a crafted value cannot inject markup", () => {
+    const out = serializeBorder(
+      { style: 'single"/><w:evil', color: { rgb: 'x"/>' } },
+      "top",
+    );
+    expect(out).not.toContain('"/><w:evil');
+    expect(out).toContain("&quot;");
+    expect(out).toContain("&lt;w:evil");
+  });
+
+  test("returns empty string for an absent border", () => {
+    expect(serializeBorder(undefined, "top")).toBe("");
+  });
+});
+
+describe("table cell nil borders (#947 form pattern)", () => {
+  test("all-nil tcBorders are written, not dropped", () => {
+    const xml = serializeTableCellFormatting({
+      borders: {
+        top: { style: "nil" },
+        left: { style: "nil" },
+        bottom: { style: "nil" },
+        right: { style: "nil" },
+      },
+    });
+    expect(xml).toContain("<w:tcBorders>");
+    expect(xml).toContain('<w:top w:val="nil"/>');
+    expect(xml).toContain('<w:left w:val="nil"/>');
+    expect(xml).toContain('<w:bottom w:val="nil"/>');
+    expect(xml).toContain('<w:right w:val="nil"/>');
+  });
+
+  test("nil cell borders round-trip through parse → serialize", () => {
+    const tcPr = parseXmlDocument(
+      `<w:tcPr ${W_NS}><w:tcBorders><w:top w:val="nil"/><w:bottom w:val="nil"/></w:tcBorders></w:tcPr>`,
+    ) as XmlElement | null;
+    const formatting = parseTableCellProperties(tcPr);
+    expect(formatting?.borders?.top?.style).toBe("nil");
+
+    const out = serializeTableCellFormatting(formatting);
+    expect(out).toContain('<w:top w:val="nil"/>');
+    expect(out).toContain('<w:bottom w:val="nil"/>');
+  });
+
+  test("mixed sides keep both the visible and the nil override", () => {
+    const xml = serializeTableCellFormatting({
+      borders: {
+        top: { style: "single", size: 4 },
+        bottom: { style: "nil" },
+      },
+    });
+    expect(xml).toContain('<w:top w:val="single"');
+    expect(xml).toContain('<w:bottom w:val="nil"/>');
+  });
+
+  test("does not emit tcBorders when none are set", () => {
+    expect(serializeTableCellFormatting({})).not.toContain("<w:tcBorders");
+  });
+});
+
+describe("paragraph nil borders", () => {
+  test("explicit nil paragraph border is written", () => {
+    const xml = serializeParagraphFormatting({
+      borders: { bottom: { style: "nil" } },
+    });
+    expect(xml).toContain("<w:pBdr>");
+    expect(xml).toContain('<w:bottom w:val="nil"/>');
+  });
+
+  test("does not emit pBdr when no borders are set", () => {
+    expect(serializeParagraphFormatting({})).not.toContain("<w:pBdr");
+  });
+});
+
+describe("page (section) nil borders", () => {
+  test("explicit nil page border round-trips through parse → serialize", () => {
+    const section = parseSectPr(
+      '<w:pgBorders><w:top w:val="nil"/><w:bottom w:val="single" w:sz="4" w:space="24" w:color="000000"/></w:pgBorders>',
+    );
+    expect(section.pageBorders?.top?.style).toBe("nil");
+
+    const out = serializeSectionProperties(section);
+    expect(out).toContain('<w:top w:val="nil"/>');
+    expect(out).toContain('<w:bottom w:val="single"');
+  });
+});
+
+describe("table border parse fixes", () => {
+  test('w:color="auto" is parsed as {auto:true}, not rgb:"auto"', () => {
+    const tblPr = parseXmlDocument(
+      `<w:tblPr ${W_NS}><w:tblBorders><w:top w:val="single" w:sz="4" w:color="auto"/></w:tblBorders></w:tblPr>`,
+    ) as XmlElement | null;
+    const formatting = parseTableProperties(tblPr);
+    expect(formatting?.borders?.top?.color).toEqual({ auto: true });
+  });
+
+  test("style-defined table borders honour the RTL w:start/w:end fallback", () => {
+    const styleMap = parseStyles(
+      `<w:styles ${W_NS}>
+        <w:style w:type="table" w:styleId="RtlGrid">
+          <w:name w:val="Rtl Grid"/>
+          <w:tblPr>
+            <w:tblBorders>
+              <w:start w:val="single" w:sz="4"/>
+              <w:end w:val="dashed" w:sz="6"/>
+            </w:tblBorders>
+          </w:tblPr>
+        </w:style>
+      </w:styles>`,
+      null,
+    );
+    const style = styleMap.get("RtlGrid");
+    expect(style?.tblPr?.borders?.left?.style).toBe("single");
+    expect(style?.tblPr?.borders?.right?.style).toBe("dashed");
+  });
+});

--- a/packages/folio/src/core/docx/__tests__/pageBorders-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/__tests__/pageBorders-roundtrip.test.ts
@@ -186,7 +186,7 @@ describe("pgBorders serializer round-trip", () => {
     expect(xml).toContain('w:frame="true"');
   });
 
-  test("emits each side once and only when set", () => {
+  test("emits each set side, including explicit none/nil overrides", () => {
     const xml = serializeSectionProperties({
       pageBorders: {
         top: { style: "single", size: 4 },
@@ -198,8 +198,23 @@ describe("pgBorders serializer round-trip", () => {
 
     expect(xml).toContain('<w:top w:val="single"');
     expect(xml).toContain('<w:bottom w:val="double"');
+    // An explicit "border off" must round-trip so it overrides an inherited
+    // page border instead of silently re-inheriting it (eigenpal/docx-editor#959).
+    expect(xml).toContain('<w:left w:val="none"/>');
+    expect(xml).toContain('<w:right w:val="nil"/>');
+  });
+
+  test("omits sides that are not set at all", () => {
+    const xml = serializeSectionProperties({
+      pageBorders: {
+        top: { style: "single", size: 4 },
+      },
+    });
+
+    expect(xml).toContain('<w:top w:val="single"');
     expect(xml).not.toContain("<w:left");
     expect(xml).not.toContain("<w:right");
+    expect(xml).not.toContain("<w:bottom");
   });
 
   test("round-trips custom art-border relationship ids", () => {

--- a/packages/folio/src/core/docx/serializer/borderSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/borderSerializer.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared single-border serializer for every `CT_Border` field — table borders
+ * (`w:tblBorders`/`w:tcBorders`), paragraph borders (`w:pBdr`), and page borders
+ * (`w:pgBorders`). The per-container helpers in the table/paragraph/section
+ * serializers all delegate here so a border rule round-trips identically
+ * everywhere; previously each carried its own copy and the same bug three times
+ * (eigenpal/docx-editor#959).
+ */
+
+import type { BorderSpec } from "../../types/document";
+import { escapeXml, intAttr } from "./xmlUtils";
+
+/**
+ * Serialize a single border element (`<w:top .../>`, `<w:left .../>`, ...).
+ *
+ * `nil`/`none` mean "no border", but an *explicit* one overrides an inherited
+ * border (a table-level grid via `w:tblBorders`, a paragraph-style border, a
+ * section page border), so it must still round-trip as `<w:side w:val="nil"/>`.
+ * A `BorderSpec` only reaches here when the source set it or the user turned the
+ * border off, so emitting it is faithful, not noise — dropping it silently
+ * re-inherited the container default (e.g. hidden table gridlines reappeared as
+ * a full grid on reload). `nil`/`none` carry no size/color/space, so emit just
+ * the value.
+ *
+ * `style` and the color values come straight from the parsed DOCX (the parser
+ * casts `w:val`/`w:color` without validating the enum), so they are
+ * untrusted and are `escapeXml`'d before re-entering XML attributes; for valid
+ * documents these are enum/hex values, so escaping is a no-op.
+ */
+export function serializeBorder(
+  border: BorderSpec | undefined,
+  elementName: string,
+): string {
+  if (!border) {
+    return "";
+  }
+
+  if (border.style === "none" || border.style === "nil") {
+    return `<w:${elementName} w:val="${border.style}"/>`;
+  }
+
+  const attrs: string[] = [`w:val="${escapeXml(border.style)}"`];
+
+  if (border.size !== undefined) {
+    attrs.push(`w:sz="${intAttr(border.size)}"`);
+  }
+
+  if (border.space !== undefined) {
+    attrs.push(`w:space="${intAttr(border.space)}"`);
+  }
+
+  if (border.color) {
+    if (border.color.auto) {
+      attrs.push('w:color="auto"');
+    } else if (border.color.rgb) {
+      attrs.push(`w:color="${escapeXml(border.color.rgb)}"`);
+    }
+
+    if (border.color.themeColor) {
+      attrs.push(`w:themeColor="${escapeXml(border.color.themeColor)}"`);
+    }
+
+    if (border.color.themeTint) {
+      attrs.push(`w:themeTint="${escapeXml(border.color.themeTint)}"`);
+    }
+
+    if (border.color.themeShade) {
+      attrs.push(`w:themeShade="${escapeXml(border.color.themeShade)}"`);
+    }
+  }
+
+  if (border.shadow) {
+    attrs.push('w:shadow="true"');
+  }
+
+  if (border.frame) {
+    attrs.push('w:frame="true"');
+  }
+
+  // Custom page-border art relationship ids (only present on `w:pgBorders`
+  // sides; undefined for table/paragraph borders, so skipped there).
+  if (border.artRelationshipId) {
+    attrs.push(`w:id="${escapeXml(border.artRelationshipId)}"`);
+  }
+
+  if (border.topLeftArtRelationshipId) {
+    attrs.push(`w:topLeft="${escapeXml(border.topLeftArtRelationshipId)}"`);
+  }
+
+  if (border.topRightArtRelationshipId) {
+    attrs.push(`w:topRight="${escapeXml(border.topRightArtRelationshipId)}"`);
+  }
+
+  if (border.bottomLeftArtRelationshipId) {
+    attrs.push(
+      `w:bottomLeft="${escapeXml(border.bottomLeftArtRelationshipId)}"`,
+    );
+  }
+
+  if (border.bottomRightArtRelationshipId) {
+    attrs.push(
+      `w:bottomRight="${escapeXml(border.bottomRightArtRelationshipId)}"`,
+    );
+  }
+
+  return `<w:${elementName} ${attrs.join(" ")}/>`;
+}

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -30,12 +30,12 @@ import type {
   MoveToRangeStart,
   ParagraphPropertyChange,
   TabStop,
-  BorderSpec,
   ShadingProperties,
   TextFormatting,
   TrackedChangeInfo,
 } from "../../types/document";
 import { numPrEqual } from "../numberingParser";
+import { serializeBorder } from "./borderSerializer";
 // oxlint-disable-next-line import/no-cycle -- OOXML model is mutually recursive: paragraphs hold runs, shape-textbox runs hold paragraphs
 import { serializeRun, serializeTextFormatting } from "./runSerializer";
 import { serializeSectionProperties } from "./sectionPropertiesSerializer";
@@ -44,59 +44,6 @@ import { escapeXml, intAttr } from "./xmlUtils";
 // ============================================================================
 // BORDER SERIALIZATION
 // ============================================================================
-
-/**
- * Serialize a single border element
- */
-function serializeBorder(
-  border: BorderSpec | undefined,
-  elementName: string,
-): string {
-  if (!border || border.style === "none" || border.style === "nil") {
-    return "";
-  }
-
-  const attrs: string[] = [`w:val="${border.style}"`];
-
-  if (border.size !== undefined) {
-    attrs.push(`w:sz="${intAttr(border.size)}"`);
-  }
-
-  if (border.space !== undefined) {
-    attrs.push(`w:space="${intAttr(border.space)}"`);
-  }
-
-  // Color
-  if (border.color) {
-    if (border.color.auto) {
-      attrs.push('w:color="auto"');
-    } else if (border.color.rgb) {
-      attrs.push(`w:color="${border.color.rgb}"`);
-    }
-
-    if (border.color.themeColor) {
-      attrs.push(`w:themeColor="${border.color.themeColor}"`);
-    }
-
-    if (border.color.themeTint) {
-      attrs.push(`w:themeTint="${border.color.themeTint}"`);
-    }
-
-    if (border.color.themeShade) {
-      attrs.push(`w:themeShade="${border.color.themeShade}"`);
-    }
-  }
-
-  if (border.shadow) {
-    attrs.push('w:shadow="true"');
-  }
-
-  if (border.frame) {
-    attrs.push('w:frame="true"');
-  }
-
-  return `<w:${elementName} ${attrs.join(" ")}/>`;
-}
 
 /**
  * Serialize paragraph borders (w:pBdr)

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
@@ -1,5 +1,4 @@
 import type {
-  BorderSpec,
   EndnoteProperties,
   FooterReference,
   FootnoteProperties,
@@ -8,68 +7,8 @@ import type {
   SectionProperties,
 } from "../../types/document";
 import { getUnserializedSectionPropertyChildNames } from "../sectionParser";
+import { serializeBorder } from "./borderSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
-
-function serializeBorder(
-  border: BorderSpec | undefined,
-  elementName: string,
-): string {
-  if (!border || border.style === "none" || border.style === "nil") {
-    return "";
-  }
-
-  const attrs: string[] = [`w:val="${border.style}"`];
-
-  if (border.size !== undefined) {
-    attrs.push(`w:sz="${intAttr(border.size)}"`);
-  }
-  if (border.space !== undefined) {
-    attrs.push(`w:space="${intAttr(border.space)}"`);
-  }
-  if (border.color) {
-    if (border.color.auto) {
-      attrs.push('w:color="auto"');
-    } else if (border.color.rgb) {
-      attrs.push(`w:color="${border.color.rgb}"`);
-    }
-    if (border.color.themeColor) {
-      attrs.push(`w:themeColor="${border.color.themeColor}"`);
-    }
-    if (border.color.themeTint) {
-      attrs.push(`w:themeTint="${border.color.themeTint}"`);
-    }
-    if (border.color.themeShade) {
-      attrs.push(`w:themeShade="${border.color.themeShade}"`);
-    }
-  }
-  if (border.shadow) {
-    attrs.push('w:shadow="true"');
-  }
-  if (border.frame) {
-    attrs.push('w:frame="true"');
-  }
-  if (border.artRelationshipId) {
-    attrs.push(`w:id="${escapeXml(border.artRelationshipId)}"`);
-  }
-  if (border.topLeftArtRelationshipId) {
-    attrs.push(`w:topLeft="${escapeXml(border.topLeftArtRelationshipId)}"`);
-  }
-  if (border.topRightArtRelationshipId) {
-    attrs.push(`w:topRight="${escapeXml(border.topRightArtRelationshipId)}"`);
-  }
-  if (border.bottomLeftArtRelationshipId) {
-    attrs.push(
-      `w:bottomLeft="${escapeXml(border.bottomLeftArtRelationshipId)}"`,
-    );
-  }
-  if (border.bottomRightArtRelationshipId) {
-    attrs.push(
-      `w:bottomRight="${escapeXml(border.bottomRightArtRelationshipId)}"`,
-    );
-  }
-
-  return `<w:${elementName} ${attrs.join(" ")}/>`;
-}
 
 const serializeHeaderReference = (ref: HeaderReference): string =>
   `<w:headerReference w:type="${ref.type}" r:id="${ref.rId}"/>`;

--- a/packages/folio/src/core/docx/serializer/tableSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/tableSerializer.ts
@@ -31,10 +31,10 @@ import type {
   CellMargins,
   FloatingTableProperties,
   ConditionalFormatStyle,
-  BorderSpec,
   ShadingProperties,
   Paragraph,
 } from "../../types/document";
+import { serializeBorder } from "./borderSerializer";
 import { serializeParagraph } from "./paragraphSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
 
@@ -106,59 +106,6 @@ function serializeMeasurement(
 // ============================================================================
 // BORDER SERIALIZATION
 // ============================================================================
-
-/**
- * Serialize a single border element
- */
-function serializeBorder(
-  border: BorderSpec | undefined,
-  elementName: string,
-): string {
-  if (!border || border.style === "none" || border.style === "nil") {
-    return "";
-  }
-
-  const attrs: string[] = [`w:val="${border.style}"`];
-
-  if (border.size !== undefined) {
-    attrs.push(`w:sz="${intAttr(border.size)}"`);
-  }
-
-  if (border.space !== undefined) {
-    attrs.push(`w:space="${intAttr(border.space)}"`);
-  }
-
-  // Color
-  if (border.color) {
-    if (border.color.auto) {
-      attrs.push('w:color="auto"');
-    } else if (border.color.rgb) {
-      attrs.push(`w:color="${border.color.rgb}"`);
-    }
-
-    if (border.color.themeColor) {
-      attrs.push(`w:themeColor="${border.color.themeColor}"`);
-    }
-
-    if (border.color.themeTint) {
-      attrs.push(`w:themeTint="${border.color.themeTint}"`);
-    }
-
-    if (border.color.themeShade) {
-      attrs.push(`w:themeShade="${border.color.themeShade}"`);
-    }
-  }
-
-  if (border.shadow) {
-    attrs.push('w:shadow="true"');
-  }
-
-  if (border.frame) {
-    attrs.push('w:frame="true"');
-  }
-
-  return `<w:${elementName} ${attrs.join(" ")}/>`;
-}
 
 /**
  * Serialize table borders (w:tblBorders or w:tcBorders)

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -844,12 +844,16 @@ function parseTableBorders(
     borders.bottom = bottom;
   }
 
-  const left = parseBorderSpec(findChild(tblBorders, "w", "left"));
+  const left = parseBorderSpec(
+    findChild(tblBorders, "w", "left") ?? findChild(tblBorders, "w", "start"),
+  );
   if (left) {
     borders.left = left;
   }
 
-  const right = parseBorderSpec(findChild(tblBorders, "w", "right"));
+  const right = parseBorderSpec(
+    findChild(tblBorders, "w", "right") ?? findChild(tblBorders, "w", "end"),
+  );
   if (right) {
     borders.right = right;
   }

--- a/packages/folio/src/core/docx/tableParser.ts
+++ b/packages/folio/src/core/docx/tableParser.ts
@@ -189,7 +189,9 @@ export function parseBorderSpec(
   const themeShade = getAttribute(element, "w", "themeShade");
   if (color || themeColor || themeTint || themeShade) {
     const colorVal: ColorValue = {};
-    if (color !== null) {
+    if (color === "auto") {
+      colorVal.auto = true;
+    } else if (color !== null) {
       colorVal.rgb = color;
     }
     const validatedThemeColor = narrowEnum(themeColor, ThemeColorSlotSchema);


### PR DESCRIPTION
## Summary

Folio's `serializeBorder` dropped any side whose style was `nil`/`none`, treating an explicit "border off" the same as "no border specified". The common form/layout pattern — a table grid declared via `w:tblBorders` (`insideH`/`insideV` = `single`) and hidden per cell with `w:tcBorders` set to `nil` — lost those per-cell overrides on save, so on reload each cell re-inherited the table default and the hidden gridlines reappeared as a full grid. The same applied to paragraph (`w:pBdr`) and page (`w:pgBorders`) borders.

Ports the fix from `eigenpal/docx-editor#959` (their issue #947), adapted to folio's structure.

## Fix

- Explicit `nil`/`none` sides now serialize as `<w:side w:val="nil"/>` so the override survives the round-trip across table, paragraph, and page borders.
- The three byte-identical `serializeBorder` copies (table / paragraph / section serializers) are unified into one shared `serializer/borderSerializer.ts`. It's based on the section variant so page-border art-relationship ids are still emitted, and it `escapeXml`s the `style`/`color` attributes (which the parser passes through unvalidated) before re-emitting them.
- Unlike upstream, this keeps the consolidation to the serializer only and leaves the parsers as-is — folio's border parsers genuinely diverge (section art ids, differing missing-`w:val` defaults, the body parser's existing RTL fallback), so a wholesale merge would not be behavior-preserving here.

## Latent parse bugs fixed alongside

- The table-body border parser stored `w:color="auto"` as `{ rgb: "auto" }` instead of `{ auto: true }` (the other parsers already routed through `parseColorValue`, which was correct).
- Style-defined table borders ignored the RTL `w:start`/`w:end` fallback that the body parser already had.

## Tests

- New `__tests__/nil-borders-roundtrip.test.ts` (15 cases): unit coverage of `serializeBorder` (nil/none emission, normal/auto color, art-id preservation, attribute escaping, empty input), table-cell / paragraph / page round-trips, empty-container guards, and both parse fixes.
- Corrected `pageBorders-roundtrip.test.ts`, whose "emits each side once" case had encoded the old bug (asserted nil/none were dropped); it now asserts explicit nil/none round-trip, plus a new "omits sides not set at all" case.
- Full folio suite green (2248 pass / 0 fail); oxfmt + oxlint clean.