### PR TITLE
feat(folio): per-character East-Asian font selection

### DIFF
--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -199,6 +199,12 @@ export type DocumentSettings = {
    * it is a document-wide flag; absent means odd/even share one header.
    */
   evenAndOddHeaders?: boolean;
+  /**
+   * `w:themeFontLang` (§17.15.1.88) — language Word uses to fill empty
+   * `<a:ea>`/`<a:cs>` theme font slots from the script-specific
+   * `<a:font script="…">` entries. Absent for non-CJK/bidi docs.
+   */
+  themeFontLang?: { eastAsia?: string; bidi?: string };
 };
 
 /**

--- a/packages/folio/src/core/docx/parser.test.ts
+++ b/packages/folio/src/core/docx/parser.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+
+const XML_DECLARATION = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`;
+
+/**
+ * A doc whose theme leaves `<a:ea>` empty (the Office default) and lists the
+ * real CJK typeface in `<a:font script="Jpan">`, plus `w:themeFontLang` selects
+ * Japanese and a run references `minorEastAsia`. Phase 2 must resolve the run's
+ * EastAsian font to the Japanese face rather than an empty string.
+ */
+async function createEmptyEaThemeFixture(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
+  );
+  zip.file(
+    "word/settings.xml",
+    `${XML_DECLARATION}
+<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:themeFontLang w:val="en-US" w:eastAsia="ja-JP"/>
+</w:settings>`,
+  );
+  zip.file(
+    "word/theme/theme1.xml",
+    `${XML_DECLARATION}
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+  <a:themeElements>
+    <a:clrScheme name="Office"/>
+    <a:fontScheme name="Office">
+      <a:majorFont>
+        <a:latin typeface="Calibri Light"/>
+        <a:ea typeface=""/>
+        <a:cs typeface=""/>
+        <a:font script="Jpan" typeface="ＭＳ ゴシック"/>
+      </a:majorFont>
+      <a:minorFont>
+        <a:latin typeface="Calibri"/>
+        <a:ea typeface=""/>
+        <a:cs typeface=""/>
+        <a:font script="Jpan" typeface="ＭＳ 明朝"/>
+      </a:minorFont>
+    </a:fontScheme>
+  </a:themeElements>
+</a:theme>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:rPr><w:rFonts w:eastAsiaTheme="minorEastAsia"/></w:rPr>
+        <w:t>日本語</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+describe("parseDocx — w:themeFontLang resolves empty EastAsian theme slots", () => {
+  test("a minorEastAsia run resolves to the Japanese theme face", async () => {
+    const buffer = await createEmptyEaThemeFixture();
+    const doc = await parseDocx(buffer);
+
+    const paragraph = doc.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("expected a paragraph");
+    }
+
+    const run = paragraph.content.at(0);
+    expect(run?.type).toBe("run");
+    if (run?.type !== "run") {
+      throw new Error("expected a run");
+    }
+
+    // Without Phase 2 this is the empty string (or falls back to ascii/hAnsi);
+    // with themeFontLang it is the script-specific Japanese face.
+    expect(run.formatting?.fontFamily?.eastAsia).toBe("ＭＳ 明朝");
+    expect(run.formatting?.fontFamily?.eastAsiaTheme).toBe("minorEastAsia");
+  });
+});

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -64,7 +64,7 @@ import {
 import { parseSettings } from "./settingsParser";
 import { parseStylesPackage } from "./styleParser";
 import type { StyleMap } from "./styleParser";
-import { parseTheme } from "./themeParser";
+import { applyThemeFontLang, parseTheme } from "./themeParser";
 import { normalizeTrackedMoveRanges } from "./trackedMoveRangeNormalization";
 import { unzipDocx, getMediaMimeType, mediaToDataUrl } from "./unzip";
 import type { DocxUnzipLimits, RawDocxContent } from "./unzip";
@@ -161,6 +161,14 @@ export async function parseDocx(
     // ========================================================================
     onProgress("Parsing theme...", 15);
     const theme = timeStage("theme", () => parseTheme(raw.themeXml));
+    // Settings must be read before styles so `w:themeFontLang` can fill the
+    // theme's empty EastAsian/complex-script slots (eigenpal/docx-editor#949);
+    // styles, body, and header/footer parsing all resolve theme fonts off this
+    // mutated theme object.
+    const settings = timeStage("settings", () =>
+      parseSettings(raw.settingsXml),
+    );
+    applyThemeFontLang(theme, settings.themeFontLang);
     onProgress("Parsed theme", 20);
 
     // ========================================================================
@@ -187,13 +195,6 @@ export async function parseDocx(
       parseNumbering(raw.numberingXml),
     );
     onProgress("Parsed numbering", 35);
-
-    // Settings (`word/settings.xml`) — currently only used for
-    // `w:defaultTabStop`, but staged here so future settings flow through
-    // the same point. Cheap; no separate progress band.
-    const settings = timeStage("settings", () =>
-      parseSettings(raw.settingsXml),
-    );
 
     // ========================================================================
     // STAGE 6: Build media file map (35-40%)

--- a/packages/folio/src/core/docx/settingsParser.test.ts
+++ b/packages/folio/src/core/docx/settingsParser.test.ts
@@ -66,3 +66,33 @@ describe("parseSettings — w:evenAndOddHeaders (§17.10.1)", () => {
     ).toBeUndefined();
   });
 });
+
+describe("parseSettings — w:themeFontLang (§17.15.1.88)", () => {
+  test("reads eastAsia and bidi tags", () => {
+    expect(
+      parseSettings(
+        wrap(
+          `<w:themeFontLang w:val="en-US" w:eastAsia="ja-JP" w:bidi="ar-SA"/>`,
+        ),
+      ).themeFontLang,
+    ).toEqual({ eastAsia: "ja-JP", bidi: "ar-SA" });
+  });
+
+  test("keeps only the EastAsian tag when bidi is absent", () => {
+    expect(
+      parseSettings(wrap(`<w:themeFontLang w:val="en-US" w:eastAsia="ja-JP"/>`))
+        .themeFontLang,
+    ).toEqual({ eastAsia: "ja-JP" });
+  });
+
+  test("is undefined when only the primary (w:val) lang is present", () => {
+    expect(
+      parseSettings(wrap(`<w:themeFontLang w:val="en-US"/>`)).themeFontLang,
+    ).toBeUndefined();
+  });
+
+  test("is undefined when the element is absent", () => {
+    expect(parseSettings(wrap("")).themeFontLang).toBeUndefined();
+    expect(parseSettings(null).themeFontLang).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/docx/settingsParser.ts
+++ b/packages/folio/src/core/docx/settingsParser.ts
@@ -44,6 +44,24 @@ export function parseSettings(xml: string | null): DocumentSettings {
   if (evenAndOddHeaders && parseBooleanElement(evenAndOddHeaders)) {
     settings.evenAndOddHeaders = true;
   }
+
+  // `w:themeFontLang` selects the concrete typeface for the empty `<a:ea>` /
+  // `<a:cs>` theme slots (see eigenpal/docx-editor#949). Record only the
+  // EastAsian/bidi tags; the primary `w:val` lang does not drive theme fonts.
+  const themeFontLangEl = root ? findChild(root, "w", "themeFontLang") : null;
+  const eastAsiaLang = themeFontLangEl
+    ? getAttribute(themeFontLangEl, "w", "eastAsia") || undefined
+    : undefined;
+  const bidiLang = themeFontLangEl
+    ? getAttribute(themeFontLangEl, "w", "bidi") || undefined
+    : undefined;
+  if (eastAsiaLang || bidiLang) {
+    settings.themeFontLang = {
+      ...(eastAsiaLang ? { eastAsia: eastAsiaLang } : {}),
+      ...(bidiLang ? { bidi: bidiLang } : {}),
+    };
+  }
+
   return settings;
 }
 

--- a/packages/folio/src/core/docx/themeParser.test.ts
+++ b/packages/folio/src/core/docx/themeParser.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Theme, ThemeFontScheme } from "../types/document";
+import { applyThemeFontLang, resolveThemeFontRef } from "./themeParser";
+
+/**
+ * Builds a theme that mirrors Office's default font scheme: the `<a:ea>` /
+ * `<a:cs>` slots are empty and the real CJK/complex-script typefaces live in
+ * script-specific `<a:font>` entries.
+ */
+function officeLikeTheme(): Theme & { fontScheme: ThemeFontScheme } {
+  return {
+    name: "Office",
+    colorScheme: {
+      dk1: "000000",
+      lt1: "FFFFFF",
+      dk2: "44546A",
+      lt2: "E7E6E6",
+      accent1: "4472C4",
+      accent2: "ED7D31",
+      accent3: "A5A5A5",
+      accent4: "FFC000",
+      accent5: "5B9BD5",
+      accent6: "70AD47",
+      hlink: "0563C1",
+      folHlink: "954F72",
+    },
+    fontScheme: {
+      majorFont: {
+        latin: "Arial",
+        ea: "",
+        cs: "",
+        fonts: {
+          Jpan: "ＭＳ ゴシック",
+          Hang: "맑은 고딕",
+          Hans: "宋体",
+          Arab: "Times New Roman",
+        },
+      },
+      minorFont: {
+        latin: "Century",
+        ea: "",
+        cs: "",
+        fonts: {
+          Jpan: "ＭＳ 明朝",
+          Hang: "맑은 고딕",
+          Hans: "宋体",
+          Arab: "Arial",
+        },
+      },
+    },
+  };
+}
+
+describe("applyThemeFontLang", () => {
+  test("fills empty EastAsian slots from the Japanese script font", () => {
+    const theme = officeLikeTheme();
+    applyThemeFontLang(theme, { eastAsia: "ja-JP" });
+
+    expect(theme.fontScheme.minorFont?.ea).toBe("ＭＳ 明朝");
+    expect(theme.fontScheme.majorFont?.ea).toBe("ＭＳ ゴシック");
+    // A run referencing minorEastAsia now resolves to a concrete typeface.
+    expect(resolveThemeFontRef(theme, "minorEastAsia")).toBe("ＭＳ 明朝");
+  });
+
+  test("selects the Hant typeface for Traditional Chinese locales", () => {
+    const theme = officeLikeTheme();
+    theme.fontScheme.minorFont!.fonts = { Hans: "宋体", Hant: "新細明體" };
+    applyThemeFontLang(theme, { eastAsia: "zh-TW" });
+    expect(theme.fontScheme.minorFont?.ea).toBe("新細明體");
+  });
+
+  test("fills empty complex-script slots from the bidi language", () => {
+    const theme = officeLikeTheme();
+    applyThemeFontLang(theme, { bidi: "ar-SA" });
+    // Untouched without an eastAsia lang.
+    expect(theme.fontScheme.minorFont?.ea).toBe("");
+    expect(theme.fontScheme.minorFont?.cs).toBe("Arial");
+    expect(theme.fontScheme.majorFont?.cs).toBe("Times New Roman");
+  });
+
+  test("does not overwrite a non-empty ea typeface", () => {
+    const theme = officeLikeTheme();
+    theme.fontScheme.minorFont!.ea = "Yu Mincho";
+    applyThemeFontLang(theme, { eastAsia: "ja-JP" });
+    expect(theme.fontScheme.minorFont?.ea).toBe("Yu Mincho");
+  });
+
+  test("is a no-op without themeFontLang", () => {
+    const theme = officeLikeTheme();
+    applyThemeFontLang(theme, undefined);
+    expect(theme.fontScheme.minorFont?.ea).toBe("");
+  });
+
+  test("leaves slots empty when no script font matches the language", () => {
+    const theme = officeLikeTheme();
+    theme.fontScheme.minorFont!.fonts = { Hang: "맑은 고딕" };
+    applyThemeFontLang(theme, { eastAsia: "ja-JP" });
+    expect(theme.fontScheme.minorFont?.ea).toBe("");
+  });
+});

--- a/packages/folio/src/core/docx/themeParser.ts
+++ b/packages/folio/src/core/docx/themeParser.ts
@@ -326,6 +326,91 @@ export function parseTheme(themeXml: string | null): Theme {
 }
 
 /**
+ * Map a `w:themeFontLang` EastAsian language tag to the DrawingML `script`
+ * attribute used by the theme's `<a:font script="…">` entries.
+ */
+function eastAsiaLangToScript(lang: string): string | null {
+  const l = lang.toLowerCase();
+  if (l.startsWith("ja")) {
+    return "Jpan";
+  }
+  if (l.startsWith("ko")) {
+    return "Hang";
+  }
+  if (l.startsWith("zh")) {
+    // Traditional Chinese locales use the Hant typeface; everything else Hans.
+    if (l.includes("hant") || /-(?:tw|hk|mo)\b/u.test(l)) {
+      return "Hant";
+    }
+    return "Hans";
+  }
+  return null;
+}
+
+/**
+ * Map a `w:themeFontLang` bidi/complex-script language tag to a DrawingML
+ * `script` attribute.
+ */
+function bidiLangToScript(lang: string): string | null {
+  const l = lang.toLowerCase();
+  if (l.startsWith("ar")) {
+    return "Arab";
+  }
+  if (l.startsWith("he") || l.startsWith("iw")) {
+    return "Hebr";
+  }
+  if (l.startsWith("th")) {
+    return "Thai";
+  }
+  if (l.startsWith("hi") || l.startsWith("mr") || l.startsWith("ne")) {
+    return "Deva";
+  }
+  return null;
+}
+
+/**
+ * Resolve empty EastAsian/complex-script theme font slots using the document's
+ * `w:themeFontLang` (port of eigenpal/docx-editor#949).
+ *
+ * Office's default theme leaves `<a:ea typeface="">`/`<a:cs typeface="">` empty
+ * and instead lists the real typeface per script (`<a:font script="Jpan" …>`).
+ * Word selects among those by the language declared in `w:themeFontLang`. A run
+ * that references `minorEastAsia` in a Japanese document then resolves to
+ * `ＭＳ 明朝` rather than an empty string — an empty font breaks both line-break
+ * measurement and CJK rendering, so text overflows the right margin.
+ *
+ * Mutates the theme in place; the original `theme1.xml` is preserved verbatim on
+ * save, so this only affects the in-memory model used for layout/rendering.
+ */
+export function applyThemeFontLang(
+  theme: Theme | null | undefined,
+  themeFontLang: { eastAsia?: string; bidi?: string } | undefined,
+): void {
+  if (!theme?.fontScheme || !themeFontLang) {
+    return;
+  }
+
+  const eaScript = themeFontLang.eastAsia
+    ? eastAsiaLangToScript(themeFontLang.eastAsia)
+    : null;
+  const csScript = themeFontLang.bidi
+    ? bidiLangToScript(themeFontLang.bidi)
+    : null;
+
+  for (const font of [theme.fontScheme.majorFont, theme.fontScheme.minorFont]) {
+    if (!font) {
+      continue;
+    }
+    if (!font.ea && eaScript && font.fonts?.[eaScript]) {
+      font.ea = font.fonts[eaScript];
+    }
+    if (!font.cs && csScript && font.fonts?.[csScript]) {
+      font.cs = font.fonts[csScript];
+    }
+  }
+}
+
+/**
  * Get a color from the theme by slot name
  *
  * @param theme - Parsed theme

--- a/packages/folio/src/core/layout-bridge/clickToPosition-surrogate.test.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition-surrogate.test.ts
@@ -1,0 +1,29 @@
+/**
+ * A click landing in the second half of an astral CJK glyph must not resolve to
+ * the offset between its surrogate pair, or ProseMirror could place/edit a
+ * selection inside the pair.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { snapPastTrailingSurrogate } from "./clickToPosition";
+
+describe("snapPastTrailingSurrogate", () => {
+  const text = "A𠀀B"; // A, astral ideograph (surrogates at 1,2), B
+
+  test("nudges a mid-pair offset forward to the code-point boundary", () => {
+    // Offset 2 is the trailing surrogate of 𠀀 — snap to 3 (after the glyph).
+    expect(snapPastTrailingSurrogate(text, 2)).toBe(3);
+  });
+
+  test("leaves valid code-point boundaries unchanged", () => {
+    expect(snapPastTrailingSurrogate(text, 0)).toBe(0); // before A
+    expect(snapPastTrailingSurrogate(text, 1)).toBe(1); // before 𠀀 (high surrogate)
+    expect(snapPastTrailingSurrogate(text, 3)).toBe(3); // after 𠀀, before B
+    expect(snapPastTrailingSurrogate(text, 4)).toBe(4); // end
+  });
+
+  test("leaves all-BMP text untouched", () => {
+    expect(snapPastTrailingSurrogate("hello", 3)).toBe(3);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -58,6 +58,25 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
 }
 
 /**
+ * A click in the second half of an astral glyph can resolve to the UTF-16
+ * offset between its surrogate pair (`measureRun` emits a 0-width entry for the
+ * trailing surrogate). Nudge such an offset forward to the code-point boundary
+ * so ProseMirror never receives — or edits inside — a half-pair position.
+ */
+export function snapPastTrailingSurrogate(
+  text: string,
+  offset: number,
+): number {
+  if (offset < text.length) {
+    const codeUnit = text.codePointAt(offset);
+    if (codeUnit >= 0xdc_00 && codeUnit <= 0xdf_ff) {
+      return offset + 1;
+    }
+  }
+  return offset;
+}
+
+/**
  * Slice the runs that are part of a specific line.
  * Returns only the text portions that belong to the line.
  */
@@ -361,7 +380,10 @@ function findCharacterInLine(
       if (adjustedX <= runEndX) {
         // Click is within this run - find exact character
         const localX = adjustedX - currentX;
-        const charInRun = findCharAtX(localX, measurement.charWidths);
+        const charInRun = snapPastTrailingSurrogate(
+          text,
+          findCharAtX(localX, measurement.charWidths),
+        );
         const charOffset = currentCharOffset + charInRun;
         return { charOffset, pmPosition: pmStart + charOffset };
       }

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -13,6 +13,7 @@ import {
   measuredLineContentOffset,
 } from "../layout-engine/lineFlow";
 import {
+  buildRunFontStyle,
   measureRun,
   findCharacterAtX as findCharAtX,
 } from "../layout-engine/measure/measureContainer";
@@ -53,20 +54,7 @@ export type PositionResult = {
  * Extract FontStyle from a run for measurement.
  */
 function runToFontStyle(run: TextRun | TabRun): FontStyle {
-  return {
-    fontFamily: run.fontFamily ?? "Arial",
-    fontSize: run.fontSize ?? 12,
-    ...(run.bold !== undefined ? { bold: run.bold } : {}),
-    ...(run.italic !== undefined ? { italic: run.italic } : {}),
-    ...(run.letterSpacing !== undefined
-      ? { letterSpacing: run.letterSpacing }
-      : {}),
-    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
-    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
-    ...(run.horizontalScale !== undefined
-      ? { horizontalScale: run.horizontalScale }
-      : {}),
-  };
+  return buildRunFontStyle(run, "Arial", 12);
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -67,11 +67,12 @@ export function snapPastTrailingSurrogate(
   text: string,
   offset: number,
 ): number {
-  if (offset < text.length) {
-    const codeUnit = text.codePointAt(offset);
-    if (codeUnit >= 0xdc_00 && codeUnit <= 0xdf_ff) {
-      return offset + 1;
-    }
+  // codePointAt at a low-surrogate index returns that surrogate's code unit
+  // (it only combines when read at the leading surrogate); guard undefined for
+  // the out-of-range case the length check already excludes.
+  const codeUnit = offset < text.length ? text.codePointAt(offset) : undefined;
+  if (codeUnit !== undefined && codeUnit >= 0xdc_00 && codeUnit <= 0xdf_ff) {
+    return offset + 1;
   }
   return offset;
 }

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -11,7 +11,10 @@
 import { getHeaderRowsHeight } from "../layout-engine/index";
 import { measuredLineContentOffset } from "../layout-engine/lineFlow";
 import { measureParagraph } from "../layout-engine/measure";
-import { measureRun } from "../layout-engine/measure/measureContainer";
+import {
+  buildRunFontStyle,
+  measureRun,
+} from "../layout-engine/measure/measureContainer";
 import type { FontStyle } from "../layout-engine/measure/measureContainer";
 import {
   buildTableCellFloatingZones,
@@ -92,20 +95,7 @@ const DEFAULT_TABLE_CELL_PADDING_TOP = 1;
  * Extract FontStyle from a run for measurement.
  */
 function runToFontStyle(run: TextRun | TabRun): FontStyle {
-  return {
-    fontFamily: run.fontFamily ?? "Arial",
-    fontSize: run.fontSize ?? 12,
-    ...(run.bold !== undefined ? { bold: run.bold } : {}),
-    ...(run.italic !== undefined ? { italic: run.italic } : {}),
-    ...(run.letterSpacing !== undefined
-      ? { letterSpacing: run.letterSpacing }
-      : {}),
-    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
-    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
-    ...(run.horizontalScale !== undefined
-      ? { horizontalScale: run.horizontalScale }
-      : {}),
-  };
+  return buildRunFontStyle(run, "Arial", 12);
 }
 
 function mathRunToFontStyle(run: MathRun): FontStyle {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -112,6 +112,68 @@ describe("toFlowBlocks style cascade", () => {
     expect(firstRun(blocks).fontFamily).toBe("Arial Narrow");
   });
 
+  test("inherits the East Asian font from the paragraph style default (eigenpal/docx-editor#949)", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { fontFamily: { ascii: "Arial", eastAsia: "MS Mincho" } },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Normal" },
+      content: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "和文 mixed" }],
+        },
+      ],
+    };
+
+    const run = firstRun(
+      toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {}),
+    );
+
+    expect(run.fontFamily).toBe("Arial");
+    expect(run.eastAsiaFontFamily).toBe("MS Mincho");
+  });
+
+  test("a direct eastAsia run mark overrides the inherited EA default", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { fontFamily: { ascii: "Arial", eastAsia: "MS Mincho" } },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Normal" },
+      content: [
+        {
+          type: "run",
+          formatting: { fontFamily: { eastAsia: "MS Gothic" } },
+          content: [{ type: "text", text: "和文" }],
+        },
+      ],
+    };
+
+    const run = firstRun(
+      toFlowBlocks(toProseDoc(makeDoc(paragraph, styles), { styles }), {}),
+    );
+
+    expect(run.eastAsiaFontFamily).toBe("MS Gothic");
+  });
+
   test("explicit run formatting toggles override paragraph style defaults", () => {
     const styles: StyleDefinitions = {
       styles: [

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -771,6 +771,12 @@ function paragraphRunDefaults(
   if (fontFamily) {
     result.fontFamily = fontFamily;
   }
+  // East-Asian font inherited from the paragraph style / docDefaults, so CJK
+  // runs without a direct `w:eastAsia` still get per-character EA selection. A
+  // run's own fontFamily mark overrides this via mergeRunFormatting.
+  if (defaultTextFormatting.fontFamily?.eastAsia) {
+    result.eastAsiaFontFamily = defaultTextFormatting.fontFamily.eastAsia;
+  }
   if (defaultTextFormatting.fontSize !== undefined) {
     result.fontSize = defaultTextFormatting.fontSize / 2;
   }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -512,6 +512,9 @@ function extractRunFormatting(
         if (font) {
           formatting.fontFamily = font;
         }
+        if (attrs.eastAsia) {
+          formatting.eastAsiaFontFamily = attrs.eastAsia;
+        }
         break;
       }
 

--- a/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
@@ -54,24 +54,7 @@ describe("measureTextWidth with eastAsiaFontFamily", () => {
     );
   });
 
-  test("applies letter spacing once across the whole mixed string", () => {
-    withFakeTextMeasure(
-      () => {
-        // glyphs 10 (base) + 100 (EA) = 110, plus letterSpacing 5 * (2 - 1) = 5
-        expect(
-          measureTextWidth("Aあ", {
-            fontFamily: "FolioBaseTestFont",
-            eastAsiaFontFamily: "FolioEaTestFont",
-            fontSize: 12,
-            letterSpacing: 5,
-          }),
-        ).toBe(115);
-      },
-      { charWidth: eaAwareCharWidth },
-    );
-  });
-
-  test("counts letter spacing by code point for astral CJK, matching measureRun", () => {
+  test("gates the EA font off for letter-spaced runs so measure matches measureRun", () => {
     withFakeTextMeasure(
       () => {
         const style = {
@@ -80,11 +63,29 @@ describe("measureTextWidth with eastAsiaFontFamily", () => {
           fontSize: 12,
           letterSpacing: 5,
         };
-        // "A𠀀B" is 3 code points → 2 spacing gaps (not 3 from UTF-16 length).
-        // glyphs 10 (base) + 100 (EA) + 10 (base) = 120, plus 5 * 2 = 10.
-        expect(measureTextWidth("A𠀀B", style)).toBe(130);
-        // Caret/selection measurement must arrive at the same total.
-        expect(measureRun("A𠀀B", style).width).toBe(130);
+        // CSS letter-spacing cannot bridge the painter's per-script sibling
+        // spans, so a letter-spaced run keeps the base font for CJK too. "Aあ":
+        // both at base (10 + 10) + 5 * (2 - 1) = 25 — not the EA width.
+        expect(measureTextWidth("Aあ", style)).toBe(25);
+        expect(measureRun("Aあ", style).width).toBe(25);
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
+
+  test("counts letter spacing by code point for astral text (base font), matching measureRun", () => {
+    withFakeTextMeasure(
+      () => {
+        const style = {
+          fontFamily: "FolioBaseTestFont",
+          eastAsiaFontFamily: "FolioEaTestFont",
+          fontSize: 12,
+          letterSpacing: 5,
+        };
+        // "A𠀀B" is 3 code points → 2 gaps (not 3 from UTF-16 length); base font
+        // throughout (letter-spaced): glyphs 10 + 10 + 10 = 30, plus 5 * 2 = 10.
+        expect(measureTextWidth("A𠀀B", style)).toBe(40);
+        expect(measureRun("A𠀀B", style).width).toBe(40);
       },
       { charWidth: eaAwareCharWidth },
     );

--- a/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
@@ -70,6 +70,25 @@ describe("measureTextWidth with eastAsiaFontFamily", () => {
       { charWidth: eaAwareCharWidth },
     );
   });
+
+  test("counts letter spacing by code point for astral CJK, matching measureRun", () => {
+    withFakeTextMeasure(
+      () => {
+        const style = {
+          fontFamily: "FolioBaseTestFont",
+          eastAsiaFontFamily: "FolioEaTestFont",
+          fontSize: 12,
+          letterSpacing: 5,
+        };
+        // "A𠀀B" is 3 code points → 2 spacing gaps (not 3 from UTF-16 length).
+        // glyphs 10 (base) + 100 (EA) + 10 (base) = 120, plus 5 * 2 = 10.
+        expect(measureTextWidth("A𠀀B", style)).toBe(130);
+        // Caret/selection measurement must arrive at the same total.
+        expect(measureRun("A𠀀B", style).width).toBe(130);
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
 });
 
 describe("measureRun with eastAsiaFontFamily", () => {

--- a/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { measureRun, measureTextWidth } from "../measureContainer";
+import {
+  buildRunFontStyle,
+  measureRun,
+  measureTextWidth,
+} from "../measureContainer";
 import type { FakeCharWidth } from "./fakeTextMeasure";
 import { withFakeTextMeasure } from "./fakeTextMeasure";
 
@@ -100,5 +104,25 @@ describe("measureRun with eastAsiaFontFamily", () => {
       },
       { charWidth: eaAwareCharWidth },
     );
+  });
+});
+
+describe("buildRunFontStyle", () => {
+  test("carries eastAsiaFontFamily so every measurement path measures CJK with the EA font", () => {
+    const style = buildRunFontStyle(
+      { fontFamily: "Latin", eastAsiaFontFamily: "Mincho", fontSize: 12 },
+      "Arial",
+      11,
+    );
+    expect(style.fontFamily).toBe("Latin");
+    expect(style.eastAsiaFontFamily).toBe("Mincho");
+    expect(style.fontSize).toBe(12);
+  });
+
+  test("applies the family/size fallbacks when the run declares neither", () => {
+    const style = buildRunFontStyle({}, "Arial", 11);
+    expect(style.fontFamily).toBe("Arial");
+    expect(style.fontSize).toBe(11);
+    expect(style.eastAsiaFontFamily).toBeUndefined();
   });
 });

--- a/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
@@ -1,0 +1,86 @@
+/**
+ * `eastAsiaFontFamily` makes the measurer pick the East-Asian font for CJK code
+ * points and the base font for the rest, matching the painter's per-script span
+ * split so wrapping and click positioning stay in sync.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { measureRun, measureTextWidth } from "../measureContainer";
+import type { FakeCharWidth } from "./fakeTextMeasure";
+import { withFakeTextMeasure } from "./fakeTextMeasure";
+
+// CJK or Latin code points measure 100px when the active canvas font is the EA
+// test font, 10px otherwise — so a test can prove the font was switched.
+const eaAwareCharWidth: FakeCharWidth = (_char, font) =>
+  font.includes("FolioEaTestFont") ? 100 : 10;
+
+describe("measureTextWidth with eastAsiaFontFamily", () => {
+  test("measures CJK with the EA font and Latin with the base font", () => {
+    withFakeTextMeasure(
+      () => {
+        const baseOnly = measureTextWidth("Aあ", {
+          fontFamily: "FolioBaseTestFont",
+          fontSize: 12,
+        });
+        expect(baseOnly).toBe(20); // both chars at base font (10 + 10)
+
+        const mixed = measureTextWidth("Aあ", {
+          fontFamily: "FolioBaseTestFont",
+          eastAsiaFontFamily: "FolioEaTestFont",
+          fontSize: 12,
+        });
+        expect(mixed).toBe(110); // A = 10 (base), あ = 100 (EA)
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
+
+  test("falls back to the base font for CJK when no EA font is set", () => {
+    withFakeTextMeasure(
+      () => {
+        expect(
+          measureTextWidth("世界", {
+            fontFamily: "FolioBaseTestFont",
+            fontSize: 12,
+          }),
+        ).toBe(20); // both CJK at base font → 10 + 10
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
+
+  test("applies letter spacing once across the whole mixed string", () => {
+    withFakeTextMeasure(
+      () => {
+        // glyphs 10 (base) + 100 (EA) = 110, plus letterSpacing 5 * (2 - 1) = 5
+        expect(
+          measureTextWidth("Aあ", {
+            fontFamily: "FolioBaseTestFont",
+            eastAsiaFontFamily: "FolioEaTestFont",
+            fontSize: 12,
+            letterSpacing: 5,
+          }),
+        ).toBe(115);
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
+});
+
+describe("measureRun with eastAsiaFontFamily", () => {
+  test("per-character widths use the EA font for CJK code points", () => {
+    withFakeTextMeasure(
+      () => {
+        const { charWidths, width } = measureRun("AあB", {
+          fontFamily: "FolioBaseTestFont",
+          eastAsiaFontFamily: "FolioEaTestFont",
+          fontSize: 12,
+        });
+        expect(charWidths).toEqual([10, 100, 10]); // A base, あ EA, B base
+        expect(width).toBe(120);
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
+});

--- a/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
@@ -83,4 +83,22 @@ describe("measureRun with eastAsiaFontFamily", () => {
       { charWidth: eaAwareCharWidth },
     );
   });
+
+  test("measures an astral CJK ideograph with the EA font, keeping UTF-16-aligned widths", () => {
+    withFakeTextMeasure(
+      () => {
+        // "A𠀀B": the Ext-B ideograph is a surrogate pair (2 UTF-16 units), so
+        // charWidths has 4 entries — the astral glyph's width on the first unit
+        // and 0 on the second — and it is measured with the EA font.
+        const { charWidths, width } = measureRun("A𠀀B", {
+          fontFamily: "FolioBaseTestFont",
+          eastAsiaFontFamily: "FolioEaTestFont",
+          fontSize: 12,
+        });
+        expect(charWidths).toEqual([10, 100, 0, 10]);
+        expect(width).toBe(120);
+      },
+      { charWidth: eaAwareCharWidth },
+    );
+  });
 });

--- a/packages/folio/src/core/layout-engine/measure/cache.ts
+++ b/packages/folio/src/core/layout-engine/measure/cache.ts
@@ -290,7 +290,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}`,
+        `t:${run.text}|${run.fontFamily}|${run.eastAsiaFontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);

--- a/packages/folio/src/core/layout-engine/measure/font-metrics.worker.ts
+++ b/packages/folio/src/core/layout-engine/measure/font-metrics.worker.ts
@@ -18,6 +18,7 @@
 import { TaggedError } from "better-result";
 
 import {
+  countCodePoints,
   WORKER_FONT_FINGERPRINT_TEXT,
   type MeasureRequestEntry,
   type MeasureResponseEntry,
@@ -80,8 +81,12 @@ function measureEntry(entry: MeasureRequestEntry): MeasureResponseEntry | null {
   }
   const raw = context.measureText(entry.text).width;
   let width = raw;
-  if (entry.letterSpacing !== 0 && entry.text.length > 1) {
-    width += entry.letterSpacing * (entry.text.length - 1);
+  // Count code points so astral text matches the main thread's letter-spacing
+  // width (a surrogate pair is one glyph), keeping the prewarmed cache entry
+  // consistent with measureContainer.
+  const codePoints = countCodePoints(entry.text);
+  if (entry.letterSpacing !== 0 && codePoints > 1) {
+    width += entry.letterSpacing * (codePoints - 1);
   }
   width *= entry.horizontalScale;
   return {

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -527,32 +527,36 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
       : undefined;
 
   const letterSpacing = style.letterSpacing ?? 0;
+  const scale = getHorizontalScaleFactor(style);
   const charWidths: number[] = [];
   let totalWidth = 0;
 
-  // Measure each character individually for click positioning
-  for (let i = 0; i < text.length; i++) {
-    // SAFETY: i < text.length in for loop
-    const rawChar = text[i]!;
-    const char = applyTextTransform(rawChar, style);
+  // Measure each character for click positioning. Iterate whole code points so
+  // an astral CJK ideograph (a surrogate pair) gets the EA font and a real
+  // width; `charWidths` stays one entry per UTF-16 unit (the second unit of an
+  // astral pair carries 0) so it keeps aligning with ProseMirror offsets.
+  let offset = 0;
+  for (const char of text) {
+    // SAFETY: for...of over a string yields whole code points.
+    const cp = char.codePointAt(0)!;
+    const measured = applyTextTransform(char, style);
     if (eastAsiaFont !== undefined) {
-      ctx.font = isCjkCodePoint(rawChar.codePointAt(0)!)
-        ? eastAsiaFont
-        : baseFont;
+      ctx.font = isCjkCodePoint(cp) ? eastAsiaFont : baseFont;
     }
-    const charMetrics = ctx.measureText(char);
+    let charWidth = ctx.measureText(measured).width;
 
-    // Use advance width for individual characters
-    let charWidth = charMetrics.width;
-
-    // Add letter spacing after each character except the last
-    if (letterSpacing && i < text.length - 1) {
+    // Add letter spacing after each code point except the last.
+    if (letterSpacing && offset + char.length < text.length) {
       charWidth += letterSpacing;
     }
 
-    charWidth *= getHorizontalScaleFactor(style);
+    charWidth *= scale;
     charWidths.push(charWidth);
+    if (char.length === 2) {
+      charWidths.push(0);
+    }
     totalWidth += charWidth;
+    offset += char.length;
   }
 
   return {

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -20,6 +20,7 @@ import {
   isCjkCodePoint,
   segmentByScript,
 } from "../../utils/scriptSegments";
+import type { RunFormatting } from "../types";
 import {
   getCachedFontMetrics,
   getCachedTextWidth,
@@ -62,6 +63,38 @@ export type FontStyle = {
   fontVariant?: "small-caps";
   horizontalScale?: number;
 };
+
+/**
+ * Build a measurement `FontStyle` from a run's formatting. Single source of
+ * truth for run → FontStyle so every measurement path (layout line-breaking,
+ * click-to-position, selection rects) carries the same fields — notably
+ * `eastAsiaFontFamily`, which must reach the measurer for CJK click/selection
+ * offsets to match what was wrapped and painted. Callers pass their own family
+ * and size fallbacks for runs that declare neither.
+ */
+export function buildRunFontStyle(
+  run: RunFormatting,
+  fallbackFontFamily: string,
+  fallbackFontSize: number,
+): FontStyle {
+  return {
+    fontFamily: run.fontFamily ?? fallbackFontFamily,
+    ...(run.eastAsiaFontFamily !== undefined
+      ? { eastAsiaFontFamily: run.eastAsiaFontFamily }
+      : {}),
+    fontSize: run.fontSize ?? fallbackFontSize,
+    ...(run.bold !== undefined ? { bold: run.bold } : {}),
+    ...(run.italic !== undefined ? { italic: run.italic } : {}),
+    ...(run.letterSpacing !== undefined
+      ? { letterSpacing: run.letterSpacing }
+      : {}),
+    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
+  };
+}
 
 /**
  * Typography metrics for a font

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -336,6 +336,27 @@ export function getFontMetrics(style: FontStyle): FontMetrics {
 }
 
 /**
+ * Count whole code points (not UTF-16 units) so letter spacing is applied once
+ * per rendered glyph — astral CJK ideographs are one glyph. Avoids allocating
+ * an array on the hot measurement path. Matches `measureRun`'s per-code-point
+ * iteration so layout and caret/selection agree on astral text with spacing.
+ */
+function countCodePoints(text: string): number {
+  let count = 0;
+  for (let i = 0; i < text.length; i++) {
+    count++;
+    const code = text.codePointAt(i);
+    if (code >= 0xd8_00 && code <= 0xdb_ff && i + 1 < text.length) {
+      const next = text.codePointAt(i + 1);
+      if (next >= 0xdc_00 && next <= 0xdf_ff) {
+        i++;
+      }
+    }
+  }
+  return count;
+}
+
+/**
  * Measure the width of a text string with specific styling
  *
  * @param text - The text to measure
@@ -372,8 +393,11 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   let width = metrics.width;
 
   // Apply letter spacing if specified
-  if (letterSpacing && measuredText.length > 1) {
-    width += letterSpacing * (measuredText.length - 1);
+  if (letterSpacing) {
+    const codePoints = countCodePoints(measuredText);
+    if (codePoints > 1) {
+      width += letterSpacing * (codePoints - 1);
+    }
   }
 
   const scaledWidth = width * horizontalScale;
@@ -468,8 +492,11 @@ function measureMixedScriptWidth(
   }
 
   let width = glyphWidth;
-  if (letterSpacing && measuredText.length > 1) {
-    width += letterSpacing * (measuredText.length - 1);
+  if (letterSpacing) {
+    const codePoints = countCodePoints(measuredText);
+    if (codePoints > 1) {
+      width += letterSpacing * (codePoints - 1);
+    }
   }
   return width * horizontalScale;
 }

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -29,7 +29,10 @@ import {
   setCachedTextWidth,
 } from "./cache";
 import { canPrefetchMeasurement, prefetchMeasurement } from "./measureWorker";
-import { WORKER_FONT_FINGERPRINT_TEXT } from "./measureWorkerProtocol";
+import {
+  countCodePoints,
+  WORKER_FONT_FINGERPRINT_TEXT,
+} from "./measureWorkerProtocol";
 
 // Constants for OOXML unit conversions
 const TWIPS_PER_INCH = 1440;
@@ -333,25 +336,6 @@ export function getFontMetrics(style: FontStyle): FontMetrics {
   };
   setCachedFontMetrics(fontFamily, fontSize, bold, italic, result, fontVariant);
   return result;
-}
-
-/**
- * Count whole code points (not UTF-16 units) so letter spacing is applied once
- * per rendered glyph — astral CJK ideographs are one glyph. Avoids allocating
- * an array on the hot measurement path. Matches `measureRun`'s per-code-point
- * iteration so layout and caret/selection agree on astral text with spacing.
- */
-function countCodePoints(text: string): number {
-  let count = 0;
-  let i = 0;
-  while (i < text.length) {
-    const code = text.codePointAt(i);
-    // codePointAt returns the combined code point at a leading surrogate, so a
-    // value above the BMP spans two UTF-16 units — skip the trailing surrogate.
-    i += code !== undefined && code > 0xff_ff ? 2 : 1;
-    count += 1;
-  }
-  return count;
 }
 
 /**

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -16,6 +16,11 @@ import { panic } from "better-result";
 import { resolveFontFamily } from "../../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../../utils/fontWeights";
 import {
+  hasCjk,
+  isCjkCodePoint,
+  segmentByScript,
+} from "../../utils/scriptSegments";
+import {
   getCachedFontMetrics,
   getCachedTextWidth,
   getTextWidthCacheGeneration,
@@ -42,6 +47,13 @@ const DEFAULT_DESCENT_RATIO = 0.2;
  */
 export type FontStyle = {
   fontFamily?: string;
+  /**
+   * East-Asian font for CJK code points. When set, `measureTextWidth` /
+   * `measureRun` measure CJK code points with this font and the rest with
+   * `fontFamily`, matching the painter's per-script span split so wrapping
+   * and click positioning stay in sync.
+   */
+  eastAsiaFontFamily?: string;
   fontSize?: number; // in points
   bold?: boolean;
   italic?: boolean;
@@ -303,6 +315,10 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   }
   const measuredText = applyTextTransform(text, style);
 
+  if (style.eastAsiaFontFamily && hasCjk(measuredText)) {
+    return measureMixedScriptWidth(measuredText, style);
+  }
+
   const ctx = getCanvasContext();
   const font = buildFontString(style);
   const letterSpacing = style.letterSpacing ?? 0;
@@ -362,6 +378,67 @@ export function measureTextWidth(text: string, style: FontStyle): number {
     horizontalScale,
   );
   return scaledWidth;
+}
+
+/**
+ * Build a glyph-advance-only style for one script segment: keep the properties
+ * that change advance width (family, size, bold/italic, small-caps) and drop
+ * letter spacing, horizontal scale, transform, and the EA font so the segment
+ * takes the single-font path (no double-counting, no recursion).
+ */
+function glyphAdvanceStyle(
+  style: FontStyle,
+  fontFamily: string | undefined,
+): FontStyle {
+  const result: FontStyle = {};
+  if (fontFamily !== undefined) {
+    result.fontFamily = fontFamily;
+  }
+  if (style.fontSize !== undefined) {
+    result.fontSize = style.fontSize;
+  }
+  if (style.bold !== undefined) {
+    result.bold = style.bold;
+  }
+  if (style.italic !== undefined) {
+    result.italic = style.italic;
+  }
+  if (style.fontVariant !== undefined) {
+    result.fontVariant = style.fontVariant;
+  }
+  return result;
+}
+
+/**
+ * Width of text whose CJK code points use `style.eastAsiaFontFamily` and whose
+ * other code points use `style.fontFamily`. Each script segment is measured
+ * with its own font (reusing the single-font cache); letter spacing and
+ * horizontal scale are applied once over the whole string so the total matches
+ * the painter, which renders the same segments as sibling spans.
+ */
+function measureMixedScriptWidth(
+  measuredText: string,
+  style: FontStyle,
+): number {
+  const letterSpacing = style.letterSpacing ?? 0;
+  const horizontalScale = getHorizontalScaleFactor(style);
+
+  let glyphWidth = 0;
+  for (const segment of segmentByScript(measuredText)) {
+    const fontFamily = segment.isCjk
+      ? style.eastAsiaFontFamily
+      : style.fontFamily;
+    glyphWidth += measureTextWidth(
+      segment.text,
+      glyphAdvanceStyle(style, fontFamily),
+    );
+  }
+
+  let width = glyphWidth;
+  if (letterSpacing && measuredText.length > 1) {
+    width += letterSpacing * (measuredText.length - 1);
+  }
+  return width * horizontalScale;
 }
 
 /**
@@ -439,7 +516,15 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
   }
 
   const ctx = getCanvasContext();
-  ctx.font = buildFontString(style);
+  const baseFont = buildFontString(style);
+  ctx.font = baseFont;
+  // CJK code points measure with the EA font (matching the painter); the rest
+  // keep the base font. Only built when an EA font is present so the common
+  // path keeps a single `ctx.font` assignment.
+  const eastAsiaFont =
+    style.eastAsiaFontFamily !== undefined
+      ? buildFontString({ ...style, fontFamily: style.eastAsiaFontFamily })
+      : undefined;
 
   const letterSpacing = style.letterSpacing ?? 0;
   const charWidths: number[] = [];
@@ -448,7 +533,13 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
   // Measure each character individually for click positioning
   for (let i = 0; i < text.length; i++) {
     // SAFETY: i < text.length in for loop
-    const char = applyTextTransform(text[i]!, style);
+    const rawChar = text[i]!;
+    const char = applyTextTransform(rawChar, style);
+    if (eastAsiaFont !== undefined) {
+      ctx.font = isCjkCodePoint(rawChar.codePointAt(0)!)
+        ? eastAsiaFont
+        : baseFont;
+    }
     const charMetrics = ctx.measureText(char);
 
     // Use advance width for individual characters

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -367,7 +367,15 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   }
   const measuredText = applyTextTransform(text, style);
 
-  if (style.eastAsiaFontFamily && hasCjk(measuredText)) {
+  // Letter spacing is left to a single span: CSS letter-spacing does not add a
+  // gap across the per-script sibling spans the painter would emit, so a
+  // letter-spaced run keeps the base font for CJK too (measurement and painting
+  // agree; the EA typeface is the trade-off for that narrow case).
+  if (
+    style.eastAsiaFontFamily &&
+    !style.letterSpacing &&
+    hasCjk(measuredText)
+  ) {
     return measureMixedScriptWidth(measuredText, style);
   }
 
@@ -577,10 +585,11 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
   const baseFont = buildFontString(style);
   ctx.font = baseFont;
   // CJK code points measure with the EA font (matching the painter); the rest
-  // keep the base font. Only built when an EA font is present so the common
-  // path keeps a single `ctx.font` assignment.
+  // keep the base font. Only built when an EA font is present and the run has no
+  // letter spacing (which the painter leaves to a single base-font span), so the
+  // common path keeps a single `ctx.font` assignment.
   const eastAsiaFont =
-    style.eastAsiaFontFamily !== undefined
+    style.eastAsiaFontFamily !== undefined && !style.letterSpacing
       ? buildFontString({ ...style, fontFamily: style.eastAsiaFontFamily })
       : undefined;
 

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -343,15 +343,13 @@ export function getFontMetrics(style: FontStyle): FontMetrics {
  */
 function countCodePoints(text: string): number {
   let count = 0;
-  for (let i = 0; i < text.length; i++) {
-    count++;
+  let i = 0;
+  while (i < text.length) {
     const code = text.codePointAt(i);
-    if (code >= 0xd8_00 && code <= 0xdb_ff && i + 1 < text.length) {
-      const next = text.codePointAt(i + 1);
-      if (next >= 0xdc_00 && next <= 0xdf_ff) {
-        i++;
-      }
-    }
+    // codePointAt returns the combined code point at a leading surrogate, so a
+    // value above the BMP spans two UTF-16 units — skip the trailing surrogate.
+    i += code !== undefined && code > 0xff_ff ? 2 : 1;
+    count += 1;
   }
   return count;
 }

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.test.ts
@@ -803,6 +803,23 @@ describe("all-caps paragraph measurement", () => {
 
     expect(spacedHash).not.toBe(plainHash);
   });
+
+  test("includes the East Asian font in paragraph cache keys", () => {
+    // Measurement now depends on eastAsiaFontFamily, so the cache key must too —
+    // otherwise a CJK run keeps stale measurements when only its EA face changes.
+    const minchoHash = hashParagraphBlock({
+      kind: "paragraph",
+      id: "mincho",
+      runs: [{ kind: "text", text: "日本語", eastAsiaFontFamily: "MS Mincho" }],
+    });
+    const gothicHash = hashParagraphBlock({
+      kind: "paragraph",
+      id: "gothic",
+      runs: [{ kind: "text", text: "日本語", eastAsiaFontFamily: "MS Gothic" }],
+    });
+
+    expect(minchoHash).not.toBe(gothicHash);
+  });
 });
 
 describe("clampFloatingWrapMargins", () => {

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -1070,20 +1070,14 @@ export function measureParagraph(
       // Measure the field at its resolved value when known so the line breaker
       // agrees with the painter; otherwise the cached fallback text.
       const fallback = fieldMeasureText(run, options?.fieldValues);
-      const style: FontStyle = {
-        fontFamily: run.fontFamily ?? DEFAULT_FONT_FAMILY,
-        fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
-        ...(run.bold !== undefined ? { bold: run.bold } : {}),
-        ...(run.italic !== undefined ? { italic: run.italic } : {}),
-        ...(run.letterSpacing !== undefined
-          ? { letterSpacing: run.letterSpacing }
-          : {}),
-        ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
-        ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
-        ...(run.horizontalScale !== undefined
-          ? { horizontalScale: run.horizontalScale }
-          : {}),
-      };
+      // Use the shared builder so the field result measures with the same fields
+      // the painter renders — notably eastAsiaFontFamily, so a CJK field result
+      // (DATE/TIME/PAGEREF/REF) wraps and tab-positions with its East-Asian font.
+      const style = buildRunFontStyle(
+        run,
+        DEFAULT_FONT_FAMILY,
+        DEFAULT_FONT_SIZE,
+      );
       updateMaxFont(style);
 
       const fieldWidth = measureTextWidth(fallback, style);

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -35,6 +35,7 @@ import {
 } from "./floatingZones";
 import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import {
+  buildRunFontStyle,
   measureTextWidth,
   measureRun,
   getFontMetrics,
@@ -132,23 +133,7 @@ type LineState = {
  * (FieldRun page numbers, etc.) consistent with TextRun handling.
  */
 function runToFontStyle(run: TextRun | TabRun | FieldRun | MathRun): FontStyle {
-  return {
-    fontFamily: run.fontFamily ?? DEFAULT_FONT_FAMILY,
-    ...(run.eastAsiaFontFamily !== undefined
-      ? { eastAsiaFontFamily: run.eastAsiaFontFamily }
-      : {}),
-    fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
-    ...(run.bold !== undefined ? { bold: run.bold } : {}),
-    ...(run.italic !== undefined ? { italic: run.italic } : {}),
-    ...(run.letterSpacing !== undefined
-      ? { letterSpacing: run.letterSpacing }
-      : {}),
-    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
-    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
-    ...(run.horizontalScale !== undefined
-      ? { horizontalScale: run.horizontalScale }
-      : {}),
-  };
+  return buildRunFontStyle(run, DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE);
 }
 
 /**

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -134,6 +134,9 @@ type LineState = {
 function runToFontStyle(run: TextRun | TabRun | FieldRun | MathRun): FontStyle {
   return {
     fontFamily: run.fontFamily ?? DEFAULT_FONT_FAMILY,
+    ...(run.eastAsiaFontFamily !== undefined
+      ? { eastAsiaFontFamily: run.eastAsiaFontFamily }
+      : {}),
     fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
     ...(run.bold !== undefined ? { bold: run.bold } : {}),
     ...(run.italic !== undefined ? { italic: run.italic } : {}),

--- a/packages/folio/src/core/layout-engine/measure/measureWorkerProtocol.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureWorkerProtocol.ts
@@ -45,6 +45,23 @@ export type MeasureRequestEntry = {
 export const WORKER_FONT_FINGERPRINT_TEXT = "HAMBURGEFONTS ivwqy 0123456789";
 
 /**
+ * Count whole code points (not UTF-16 units) so letter spacing is applied once
+ * per rendered glyph — an astral character is one glyph spanning two units.
+ * Shared by the main thread (`measureContainer`) and the worker so their cached
+ * widths agree on astral text with letter spacing. Allocation-free.
+ */
+export function countCodePoints(text: string): number {
+  let count = 0;
+  let i = 0;
+  while (i < text.length) {
+    const code = text.codePointAt(i);
+    i += code !== undefined && code > 0xff_ff ? 2 : 1;
+    count += 1;
+  }
+  return count;
+}
+
+/**
  * Worker → main response for a single entry. Echoes the input keys the
  * proxy needs in order to look up the right cache slot.
  */

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -48,6 +48,14 @@ export type RunFormatting = {
    */
   shading?: string;
   fontFamily?: string;
+  /**
+   * Resolved East-Asian font (`w:eastAsia` / `eastAsiaTheme`). CJK code points
+   * in this run measure and paint with this font; non-CJK keeps `fontFamily`
+   * (ascii/hAnsi). Both the measurer and the painter segment identically (see
+   * `segmentByScript`) so wrapping stays correct. Absent means CJK falls back
+   * to `fontFamily`.
+   */
+  eastAsiaFontFamily?: string;
   fontSize?: number;
   letterSpacing?: number;
   superscript?: boolean;

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2877,6 +2877,9 @@ function runContentKey(run: Run): string {
   if (run.fontFamily) {
     parts.push(`ff:${run.fontFamily}`);
   }
+  if (run.eastAsiaFontFamily) {
+    parts.push(`ea:${run.eastAsiaFontFamily}`);
+  }
   if (run.fontSize !== undefined) {
     parts.push(`fs:${run.fontSize}`);
   }

--- a/packages/folio/src/core/layout-painter/renderParagraph-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-eastAsia.test.ts
@@ -102,4 +102,17 @@ describe("splitTextRunsByEastAsia", () => {
 
     expect(result.every((r) => r.bold === true)).toBe(true);
   });
+
+  test("does not split a letter-spaced run (keeps the base font, CSS spacing intact)", () => {
+    const run = textRun({
+      text: "A世B",
+      fontFamily: "Latin",
+      eastAsiaFontFamily: "Mincho",
+      letterSpacing: 5,
+      pmStart: 0,
+      pmEnd: 3,
+    });
+
+    expect(splitTextRunsByEastAsia([run])).toEqual([run]);
+  });
 });

--- a/packages/folio/src/core/layout-painter/renderParagraph-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-eastAsia.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `splitTextRunsByEastAsia` is the paint-side half of per-character East-Asian
+ * font selection: a text run carrying an EA font is split into per-script
+ * sub-runs (CJK → `eastAsiaFontFamily`, rest → `fontFamily`) before rendering,
+ * with each sub-run keeping a contiguous, exact PM range so selection and
+ * click-to-caret stay correct.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { TextRun } from "../layout-engine/types";
+import { splitTextRunsByEastAsia } from "./renderParagraph";
+
+const textRun = (over: Partial<TextRun> & { text: string }): TextRun => ({
+  kind: "text",
+  ...over,
+});
+
+describe("splitTextRunsByEastAsia", () => {
+  test("splits a mixed run into per-script sub-runs with the EA font on CJK", () => {
+    const run = textRun({
+      text: "AB世界CD",
+      fontFamily: "Latin",
+      eastAsiaFontFamily: "Mincho",
+      pmStart: 10,
+      pmEnd: 16,
+    });
+
+    const result = splitTextRunsByEastAsia([run]) as TextRun[];
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      text: "AB",
+      fontFamily: "Latin",
+      pmStart: 10,
+      pmEnd: 12,
+    });
+    expect(result[1]).toMatchObject({
+      text: "世界",
+      fontFamily: "Mincho",
+      pmStart: 12,
+      pmEnd: 14,
+    });
+    expect(result[2]).toMatchObject({
+      text: "CD",
+      fontFamily: "Latin",
+      pmStart: 14,
+      pmEnd: 16,
+    });
+  });
+
+  test("passes through a run with no EA font", () => {
+    const run = textRun({
+      text: "A世",
+      fontFamily: "Latin",
+      pmStart: 0,
+      pmEnd: 2,
+    });
+    expect(splitTextRunsByEastAsia([run])).toEqual([run]);
+  });
+
+  test("passes through an EA-carrying run that has no CJK", () => {
+    const run = textRun({
+      text: "plain",
+      fontFamily: "Latin",
+      eastAsiaFontFamily: "Mincho",
+      pmStart: 0,
+      pmEnd: 5,
+    });
+    expect(splitTextRunsByEastAsia([run])).toEqual([run]);
+  });
+
+  test("sub-run PM ranges partition the original run exactly", () => {
+    const run = textRun({
+      text: "a世b界c",
+      fontFamily: "L",
+      eastAsiaFontFamily: "M",
+      pmStart: 100,
+      pmEnd: 105,
+    });
+
+    const result = splitTextRunsByEastAsia([run]) as TextRun[];
+
+    expect(result[0]?.pmStart).toBe(100);
+    expect(result.at(-1)?.pmEnd).toBe(105);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]?.pmStart).toBe(result[i - 1]?.pmEnd);
+    }
+  });
+
+  test("preserves other run formatting on every sub-run", () => {
+    const run = textRun({
+      text: "x世",
+      fontFamily: "Latin",
+      eastAsiaFontFamily: "Mincho",
+      bold: true,
+      pmStart: 0,
+      pmEnd: 2,
+    });
+
+    const result = splitTextRunsByEastAsia([run]) as TextRun[];
+
+    expect(result.every((r) => r.bold === true)).toBe(true);
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1030,6 +1030,31 @@ function renderFieldRun(
     text,
   };
 
+  // A CJK field result is generated text inside one atomic pm range, so the
+  // measurer's per-script EA segmentation must be mirrored for the font only:
+  // the outer span keeps the field's styles + pm range, child spans carry each
+  // segment's font (CJK → EA, the rest inherit the base font). Letter-spaced and
+  // hyperlink fields stay one span, matching splitTextRunsByEastAsia / measurer.
+  if (
+    resolvedRun.eastAsiaFontFamily !== undefined &&
+    !resolvedRun.letterSpacing &&
+    !resolvedRun.hyperlink &&
+    hasCjk(text)
+  ) {
+    const wrapper = renderTextRun({ ...resolvedRun, text: "" }, doc);
+    for (const segment of segmentByScript(text)) {
+      const child = doc.createElement("span");
+      if (segment.isCjk) {
+        child.style.fontFamily = resolveFontFamily(
+          resolvedRun.eastAsiaFontFamily,
+        ).cssFallback;
+      }
+      child.textContent = segment.text;
+      wrapper.append(child);
+    }
+    return wrapper;
+  }
+
   return renderTextRun(resolvedRun, doc);
 }
 
@@ -1215,6 +1240,10 @@ export function splitTextRunsByEastAsia(runs: Run[]): Run[] {
     if (
       !isTextRun(run) ||
       run.eastAsiaFontFamily === undefined ||
+      // A letter-spaced run stays one span: CSS letter-spacing would not bridge
+      // the gap between per-script sibling spans, so it keeps the base font for
+      // CJK too (the measurer skips the EA path identically, so widths agree).
+      run.letterSpacing ||
       !hasCjk(run.text)
     ) {
       result.push(run);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1405,6 +1405,70 @@ function measureFollowingContentWidth(
 }
 
 /**
+ * Width of the decimal prefix (text before the first ".") that follows a tab,
+ * accumulated per run so a prefix spanning multiple fonts measures each part in
+ * its own font. After the EA split a prefix like `合計12` is a CJK sub-run (EA
+ * font) followed by a Latin sub-run, so measuring the whole prefix in the first
+ * sub-run's font would force the digits into the EA face and drift the decimal
+ * point from the measured tab stop.
+ */
+function measureDecimalPrefixWidth(
+  runs: Run[],
+  tabRunIndex: number,
+  decimalIndex: number,
+  measureText: (
+    text: string,
+    fontSize?: number,
+    fontFamily?: string,
+    style?: TextMeasureStyle,
+  ) => number,
+  context?: RenderContext,
+): number {
+  let width = 0;
+  let consumed = 0;
+  for (
+    let i = tabRunIndex + 1;
+    i < runs.length && consumed < decimalIndex;
+    i++
+  ) {
+    const run = runs[i]!; // SAFETY: i < runs.length
+    if (isTabRun(run) || isLineBreakRun(run)) {
+      break;
+    }
+    // Images contribute no characters to the following text (getTextAfterTab),
+    // so they never shift the decimal offset.
+    if (!isTextRun(run) && !isFieldRun(run) && !isMathRun(run)) {
+      continue;
+    }
+
+    let runText: string;
+    if (isFieldRun(run)) {
+      const resolved = resolveFieldText(run, context);
+      runText = run.allCaps ? resolved.toLocaleUpperCase() : resolved;
+    } else if (isMathRun(run)) {
+      runText = run.plainText;
+    } else {
+      runText = run.allCaps ? run.text.toLocaleUpperCase() : run.text;
+    }
+
+    const take = Math.min(runText.length, decimalIndex - consumed);
+    if (take > 0) {
+      const scale = run.horizontalScale ?? 100;
+      width +=
+        measureText(
+          runText.slice(0, take),
+          run.fontSize ?? 11,
+          run.fontFamily ?? "Calibri",
+          runMeasureStyle(run),
+        ) *
+        (scale / 100);
+    }
+    consumed += runText.length;
+  }
+  return width;
+}
+
+/**
  * Build a stable key for an inline image run.
  * PM positions are preferred because they uniquely identify the source node.
  */
@@ -1766,34 +1830,19 @@ export function renderLine(
       );
       const followingText = getTextAfterTab(runsForLine, i, options?.context);
       const decimalIndex = followingText.indexOf(".");
-      // Resolve the first text/field run after the tab and measure the
-      // decimal prefix in *its* font/style. Defaulting to 11px Calibri
-      // (the `measureText` fallback) drifts on sized/bold/italic runs and
-      // breaks decimal alignment — eigenpal #576 gemini review on PR #512.
-      const firstFollowingRun = (() => {
-        for (let j = i + 1; j < runsForLine.length; j++) {
-          const next = runsForLine[j];
-          if (!next || isTabRun(next) || isLineBreakRun(next)) {
-            return undefined;
-          }
-          if (isTextRun(next) || isFieldRun(next)) {
-            return next;
-          }
-          if (isMathRun(next)) {
-            return next;
-          }
-        }
-        return undefined;
-      })();
+      // Measure the decimal prefix run-by-run so each part uses its own
+      // font/size/style. A single-font pass over the joined prefix drifts on
+      // sized/bold/italic runs (eigenpal #576) and, after the EA split, on
+      // mixed CJK+Latin prefixes (eigenpal/docx-editor follow-up).
       const decimalPrefixWidth =
         decimalIndex !== -1
-          ? measureText(
-              followingText.slice(0, decimalIndex),
-              firstFollowingRun?.fontSize,
-              firstFollowingRun?.fontFamily,
-              firstFollowingRun ? runMeasureStyle(firstFollowingRun) : {},
-            ) *
-            ((firstFollowingRun?.horizontalScale ?? 100) / 100)
+          ? measureDecimalPrefixWidth(
+              runsForLine,
+              i,
+              decimalIndex,
+              measureText,
+              options?.context,
+            )
           : 0;
 
       const tabResult = calculateTabWidth(currentX, tabContext, {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -40,6 +40,7 @@ import {
   parseRotationDegrees,
   rotatedBoundingBox,
 } from "../utils/rotationBoundingBox";
+import { hasCjk, segmentByScript } from "../utils/scriptSegments";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import {
   applyImageVisualAttrs,
@@ -1199,6 +1200,48 @@ export function sliceRunsForLine(
 }
 
 /**
+ * Split each text run carrying an East-Asian font into per-script sub-runs, so
+ * CJK code points render with `eastAsiaFontFamily` and the rest with
+ * `fontFamily`. Each sub-run gets a contiguous, exact `pmStart`/`pmEnd` (the
+ * same offset math as `sliceRunsForLine`), keeping PM position mapping,
+ * selection rects, and click-to-caret correct. The measurer segments the same
+ * way, so the per-run advances sum to the measured run width. Non-text runs and
+ * runs without CJK pass through unchanged (the common path).
+ */
+export function splitTextRunsByEastAsia(runs: Run[]): Run[] {
+  const result: Run[] = [];
+
+  for (const run of runs) {
+    if (
+      !isTextRun(run) ||
+      run.eastAsiaFontFamily === undefined ||
+      !hasCjk(run.text)
+    ) {
+      result.push(run);
+      continue;
+    }
+
+    let offset = 0;
+    for (const segment of segmentByScript(run.text)) {
+      result.push({
+        ...run,
+        text: segment.text,
+        ...(segment.isCjk ? { fontFamily: run.eastAsiaFontFamily } : {}),
+        ...(run.pmStart !== undefined
+          ? {
+              pmStart: run.pmStart + offset,
+              pmEnd: run.pmStart + offset + segment.text.length,
+            }
+          : {}),
+      });
+      offset += segment.text.length;
+    }
+  }
+
+  return result;
+}
+
+/**
  * Options for rendering a line with justify support
  */
 type RenderLineOptions = {
@@ -1477,7 +1520,7 @@ export function renderLine(
   lineEl.style.lineHeight = `${line.lineHeight}px`;
 
   // Get runs for this line
-  const runsForLine = sliceRunsForLine(block, line);
+  const runsForLine = splitTextRunsByEastAsia(sliceRunsForLine(block, line));
   // OOXML `<m:oMathPara>` (display math) defaults to `jc="centerGroup"` —
   // Word renders display math centred on its own paragraph. When the line
   // holds a single block math run, centre it horizontally so the equation

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1327,6 +1327,9 @@ function runMeasureStyle(run: TextRun | FieldRun | MathRun): TextMeasureStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
+    ...(run.eastAsiaFontFamily !== undefined
+      ? { eastAsiaFontFamily: run.eastAsiaFontFamily }
+      : {}),
   };
 }
 
@@ -1465,6 +1468,9 @@ type TextMeasureStyle = {
   italic?: boolean;
   letterSpacing?: number;
   smallCaps?: boolean;
+  /** EA font for CJK code points; segments the measured text by script when set
+   * (and the run has no letter spacing), mirroring measureContainer. */
+  eastAsiaFontFamily?: string;
 };
 
 function applyLetterSpacingToMeasuredWidth(
@@ -1508,18 +1514,35 @@ function createTextMeasurer(
     const cssFallback = resolveFontFamily(fontFamily).cssFallback;
     // Convert pt to px for canvas (1pt = 96/72 px)
     const fontSizePx = (fontSize * 96) / 72;
-    const fontParts: string[] = [];
+    const fontPrefixParts: string[] = [];
     if (style.italic) {
-      fontParts.push("italic");
+      fontPrefixParts.push("italic");
     }
     if (style.smallCaps) {
-      fontParts.push("small-caps");
+      fontPrefixParts.push("small-caps");
     }
     if (style.bold) {
-      fontParts.push(DOCX_BOLD_FONT_WEIGHT);
+      fontPrefixParts.push(DOCX_BOLD_FONT_WEIGHT);
     }
-    fontParts.push(`${fontSizePx}px`, cssFallback);
-    ctx.font = fontParts.join(" ");
+    fontPrefixParts.push(`${fontSizePx}px`);
+    const fontPrefix = fontPrefixParts.join(" ");
+
+    // CJK code points measure with the EA font (matching the per-script sub-spans
+    // the painter emits and measureContainer's segmentation). Gated off for
+    // letter-spaced runs, which keep a single base-font span.
+    if (style.eastAsiaFontFamily && !style.letterSpacing && hasCjk(text)) {
+      const eaFallback = resolveFontFamily(
+        style.eastAsiaFontFamily,
+      ).cssFallback;
+      let segmentedWidth = 0;
+      for (const segment of segmentByScript(text)) {
+        ctx.font = `${fontPrefix} ${segment.isCjk ? eaFallback : cssFallback}`;
+        segmentedWidth += ctx.measureText(segment.text).width;
+      }
+      return segmentedWidth;
+    }
+
+    ctx.font = `${fontPrefix} ${cssFallback}`;
     return applyLetterSpacingToMeasuredWidth(
       ctx.measureText(text).width,
       text,
@@ -1968,14 +1991,7 @@ export function renderLine(
         run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
         fontSize,
         fontFamily,
-        {
-          ...(run.bold !== undefined ? { bold: run.bold } : {}),
-          ...(run.italic !== undefined ? { italic: run.italic } : {}),
-          ...(run.letterSpacing !== undefined
-            ? { letterSpacing: run.letterSpacing }
-            : {}),
-          ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
-        },
+        runMeasureStyle(run),
       );
       reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
       currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1044,9 +1044,23 @@ function renderFieldRun(
   ) {
     const wrapper = doc.createElement("span");
     applyPmPositions(wrapper, resolvedRun.pmStart, resolvedRun.pmEnd);
+    // horizontalScale lives on the wrapper (inline-block so the reserved width
+    // the render loop sets via reserveScaledAdvance applies, scaleX so the
+    // segments scale uniformly); the segments drop it to avoid double-scaling.
+    if (resolvedRun.horizontalScale && resolvedRun.horizontalScale !== 100) {
+      wrapper.style.display = "inline-block";
+      wrapper.style.transform = `scaleX(${resolvedRun.horizontalScale / 100})`;
+      wrapper.style.transformOrigin = "left center";
+    }
     // The pm range lives on the wrapper; segments carry none (the field is one
-    // atomic unit), so drop pmStart/pmEnd before spreading into each segment.
-    const { pmStart: _pmStart, pmEnd: _pmEnd, ...segmentBase } = resolvedRun;
+    // atomic unit), so drop pmStart/pmEnd (and the wrapper-applied scale) before
+    // spreading into each segment.
+    const {
+      pmStart: _pmStart,
+      pmEnd: _pmEnd,
+      horizontalScale: _horizontalScale,
+      ...segmentBase
+    } = resolvedRun;
     for (const segment of segmentByScript(text)) {
       const segmentRun: TextRun = {
         ...segmentBase,

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1031,26 +1031,31 @@ function renderFieldRun(
   };
 
   // A CJK field result is generated text inside one atomic pm range, so the
-  // measurer's per-script EA segmentation must be mirrored for the font only:
-  // the outer span keeps the field's styles + pm range, child spans carry each
-  // segment's font (CJK → EA, the rest inherit the base font). Letter-spaced and
-  // hyperlink fields stay one span, matching splitTextRunsByEastAsia / measurer.
+  // measurer's per-script EA segmentation is mirrored for the font: each script
+  // segment renders through renderTextRun (keeping the field's full styles, and
+  // its own anchor when the field is a hyperlink) with the CJK segments switched
+  // to the EA font. The pm range stays on the grouping wrapper; the segments
+  // carry no pm (the field is atomic). Letter-spaced fields stay one span,
+  // matching splitTextRunsByEastAsia and the measurer.
   if (
     resolvedRun.eastAsiaFontFamily !== undefined &&
     !resolvedRun.letterSpacing &&
-    !resolvedRun.hyperlink &&
     hasCjk(text)
   ) {
-    const wrapper = renderTextRun({ ...resolvedRun, text: "" }, doc);
+    const wrapper = doc.createElement("span");
+    applyPmPositions(wrapper, resolvedRun.pmStart, resolvedRun.pmEnd);
+    // The pm range lives on the wrapper; segments carry none (the field is one
+    // atomic unit), so drop pmStart/pmEnd before spreading into each segment.
+    const { pmStart: _pmStart, pmEnd: _pmEnd, ...segmentBase } = resolvedRun;
     for (const segment of segmentByScript(text)) {
-      const child = doc.createElement("span");
-      if (segment.isCjk) {
-        child.style.fontFamily = resolveFontFamily(
-          resolvedRun.eastAsiaFontFamily,
-        ).cssFallback;
-      }
-      child.textContent = segment.text;
-      wrapper.append(child);
+      const segmentRun: TextRun = {
+        ...segmentBase,
+        text: segment.text,
+        ...(segment.isCjk
+          ? { fontFamily: resolvedRun.eastAsiaFontFamily }
+          : {}),
+      };
+      wrapper.append(renderTextRun(segmentRun, doc));
     }
     return wrapper;
   }

--- a/packages/folio/src/core/utils/fontResolver.test.ts
+++ b/packages/folio/src/core/utils/fontResolver.test.ts
@@ -82,3 +82,22 @@ describe("fontResolver — unmapped native serif faces stay serif", () => {
     });
   }
 });
+
+describe("fontResolver — aliased families keep the authored name first", () => {
+  // Meiryo / Yu Gothic / Yu Mincho alias to the MS Gothic/Mincho mapping, whose
+  // stack does not name them — so the authored family must be prepended for the
+  // viewer's own copy to win.
+  for (const name of ["Meiryo", "Yu Gothic", "Yu Mincho", "メイリオ"]) {
+    test(`${name} is the first fallback`, () => {
+      const resolved = resolveFontFamily(name);
+      // First family in the stack, with the optional CSS quotes stripped.
+      const first = resolved.cssFallback.split(", ")[0]?.replace(/^"|"$/gu, "");
+      expect(first).toBe(name);
+    });
+  }
+
+  test("does not duplicate a name the target stack already lists (PMingLiU)", () => {
+    const { cssFallback } = resolveFontFamily("PMingLiU");
+    expect(cssFallback.match(/PMingLiU/giu)?.length).toBe(1);
+  });
+});

--- a/packages/folio/src/core/utils/fontResolver.test.ts
+++ b/packages/folio/src/core/utils/fontResolver.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { getGoogleFontEquivalent, resolveFontFamily } from "./fontResolver";
+
+describe("fontResolver — native CJK theme typefaces map to matched Noto fonts", () => {
+  // The names `applyThemeFontLang` writes into the empty `<a:ea>` slot are the
+  // native typeface names from `theme1.xml`, not the romanized ones. Each must
+  // resolve to the matching Noto family so measurement and rendering agree, as
+  // Japanese already does. (folio bundles no CJK webfonts; the Noto family is a
+  // CSS fallback token that resolves to the viewer's OS face when present.)
+  const nativeCases: [string, string][] = [
+    // Simplified Chinese
+    ["宋体", "Noto Serif SC"],
+    ["黑体", "Noto Sans SC"],
+    ["微软雅黑", "Noto Sans SC"],
+    ["等线", "Noto Sans SC"],
+    ["仿宋", "Noto Serif SC"],
+    ["楷体", "Noto Serif SC"],
+    // Traditional Chinese
+    ["新細明體", "Noto Serif TC"],
+    ["細明體", "Noto Serif TC"],
+    ["微軟正黑體", "Noto Sans TC"],
+    ["標楷體", "Noto Serif TC"],
+    // Korean
+    ["맑은 고딕", "Noto Sans KR"],
+    ["굴림", "Noto Sans KR"],
+    ["돋움", "Noto Sans KR"],
+    ["바탕", "Noto Serif KR"],
+    ["궁서", "Noto Serif KR"],
+    // Japanese native (full-width) — Phase 2 theme path writes these.
+    ["ＭＳ 明朝", "Noto Serif JP"],
+    ["ＭＳ ゴシック", "Noto Sans JP"],
+  ];
+
+  for (const [name, font] of nativeCases) {
+    test(`${name} → ${font}`, () => {
+      const resolved = resolveFontFamily(name);
+      expect(resolved.googleFont).toBe(font);
+      expect(resolved.hasGoogleEquivalent).toBe(true);
+      expect(getGoogleFontEquivalent(name)).toBe(font);
+    });
+  }
+});
+
+describe("fontResolver — romanized CJK aliases resolve to the native entry", () => {
+  // Word writes the romanized name in run `rFonts`; it must land on the same
+  // Noto family + serif/sans category as the native theme name.
+  const aliasCases: [string, string, "serif" | "sans-serif"][] = [
+    ["SimSun", "Noto Serif SC", "serif"],
+    ["Microsoft YaHei", "Noto Sans SC", "sans-serif"],
+    ["DengXian", "Noto Sans SC", "sans-serif"],
+    ["PMingLiU", "Noto Serif TC", "serif"],
+    ["Microsoft JhengHei", "Noto Sans TC", "sans-serif"],
+    ["Batang", "Noto Serif KR", "serif"],
+    ["Malgun Gothic", "Noto Sans KR", "sans-serif"],
+    ["MS Mincho", "Noto Serif JP", "serif"],
+    ["Meiryo", "Noto Sans JP", "sans-serif"],
+    ["Yu Mincho", "Noto Serif JP", "serif"],
+  ];
+
+  for (const [name, font, category] of aliasCases) {
+    test(`${name} → ${font} (${category})`, () => {
+      const resolved = resolveFontFamily(name);
+      expect(resolved.googleFont).toBe(font);
+      expect(resolved.hasGoogleEquivalent).toBe(true);
+      // A serif Noto family means the run will render with a serif fallback,
+      // which is what the serif/sans split must preserve.
+      const isSerif = /Noto Serif/u.test(resolved.googleFont ?? "");
+      expect(isSerif).toBe(category === "serif");
+    });
+  }
+});
+
+describe("fontResolver — unmapped native serif faces stay serif", () => {
+  // `detectFontCategory` must keep a 明朝/明體/宋 face serif even with no direct
+  // mapping, so the generic fallback tail is `serif`, not `sans-serif`.
+  for (const name of ["源ノ明朝", "未知明體", "某宋体变体"]) {
+    test(`${name} falls back to a serif stack`, () => {
+      const resolved = resolveFontFamily(name);
+      expect(resolved.cssFallback.endsWith("serif")).toBe(true);
+      expect(resolved.cssFallback.includes("sans-serif")).toBe(false);
+    });
+  }
+});

--- a/packages/folio/src/core/utils/fontResolver.ts
+++ b/packages/folio/src/core/utils/fontResolver.ts
@@ -203,10 +203,44 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     fallbackStack: ["MS Mincho", "Noto Serif JP", "serif"],
     singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
   },
+  // Native Japanese typeface names as they appear in `theme1.xml`'s
+  // `<a:font script="Jpan">` entries (full-width "ＭＳ"). Office stores these
+  // rather than the romanized "MS Mincho"/"MS Gothic" names, so map them too.
+  // NOTE: keys are matched against `name.toLowerCase()`, and full-width Latin
+  // letters lowercase too (Ｍ→ｍ, Ｓ→ｓ, Ｐ→ｐ) — so these keys are lowercased.
+  "ｍｓ 明朝": {
+    googleFont: "Noto Serif JP",
+    category: "serif",
+    fallbackStack: ["MS Mincho", "ＭＳ 明朝", "Noto Serif JP", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  "ｍｓ ｐ明朝": {
+    googleFont: "Noto Serif JP",
+    category: "serif",
+    fallbackStack: ["MS PMincho", "ＭＳ Ｐ明朝", "Noto Serif JP", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
   "ms gothic": {
     googleFont: "Noto Sans JP",
     category: "sans-serif",
     fallbackStack: ["MS Gothic", "Noto Sans JP", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  "ｍｓ ゴシック": {
+    googleFont: "Noto Sans JP",
+    category: "sans-serif",
+    fallbackStack: ["MS Gothic", "ＭＳ ゴシック", "Noto Sans JP", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  "ｍｓ ｐゴシック": {
+    googleFont: "Noto Sans JP",
+    category: "sans-serif",
+    fallbackStack: [
+      "MS PGothic",
+      "ＭＳ Ｐゴシック",
+      "Noto Sans JP",
+      "sans-serif",
+    ],
     singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
   },
   simhei: {
@@ -225,6 +259,119 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     googleFont: "Noto Sans KR",
     category: "sans-serif",
     fallbackStack: ["Malgun Gothic", "Noto Sans KR", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  // Native CJK typeface names as stored in `theme1.xml`'s `<a:font script="…">`
+  // entries (port of eigenpal/docx-editor#957). `applyThemeFontLang` resolves
+  // empty `<a:ea>` slots to these native names (not the romanized
+  // "SimSun"/"Malgun Gothic"), so map them to the same Noto families. folio
+  // bundles no CJK webfonts: the Noto family resolves to the viewer's OS face
+  // when present, else the generic serif/sans tail. (CJK has no letter case, so
+  // `.toLowerCase()` leaves these keys unchanged.)
+
+  // Simplified Chinese
+  宋体: {
+    googleFont: "Noto Serif SC",
+    category: "serif",
+    fallbackStack: ["SimSun", "宋体", "Noto Serif SC", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  黑体: {
+    googleFont: "Noto Sans SC",
+    category: "sans-serif",
+    fallbackStack: ["SimHei", "黑体", "Noto Sans SC", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  微软雅黑: {
+    googleFont: "Noto Sans SC",
+    category: "sans-serif",
+    fallbackStack: [
+      "Microsoft YaHei",
+      "微软雅黑",
+      "Noto Sans SC",
+      "sans-serif",
+    ],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  等线: {
+    googleFont: "Noto Sans SC",
+    category: "sans-serif",
+    fallbackStack: ["DengXian", "等线", "Noto Sans SC", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  仿宋: {
+    googleFont: "Noto Serif SC",
+    category: "serif",
+    fallbackStack: ["FangSong", "仿宋", "Noto Serif SC", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  楷体: {
+    googleFont: "Noto Serif SC",
+    category: "serif",
+    fallbackStack: ["KaiTi", "楷体", "Noto Serif SC", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+
+  // Traditional Chinese
+  新細明體: {
+    googleFont: "Noto Serif TC",
+    category: "serif",
+    fallbackStack: ["PMingLiU", "新細明體", "Noto Serif TC", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  細明體: {
+    googleFont: "Noto Serif TC",
+    category: "serif",
+    fallbackStack: ["MingLiU", "細明體", "Noto Serif TC", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  微軟正黑體: {
+    googleFont: "Noto Sans TC",
+    category: "sans-serif",
+    fallbackStack: [
+      "Microsoft JhengHei",
+      "微軟正黑體",
+      "Noto Sans TC",
+      "sans-serif",
+    ],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  標楷體: {
+    googleFont: "Noto Serif TC",
+    category: "serif",
+    fallbackStack: ["DFKai-SB", "標楷體", "Noto Serif TC", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+
+  // Korean
+  "맑은 고딕": {
+    googleFont: "Noto Sans KR",
+    category: "sans-serif",
+    fallbackStack: ["Malgun Gothic", "맑은 고딕", "Noto Sans KR", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  굴림: {
+    googleFont: "Noto Sans KR",
+    category: "sans-serif",
+    fallbackStack: ["Gulim", "굴림", "Noto Sans KR", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  돋움: {
+    googleFont: "Noto Sans KR",
+    category: "sans-serif",
+    fallbackStack: ["Dotum", "돋움", "Noto Sans KR", "sans-serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  바탕: {
+    googleFont: "Noto Serif KR",
+    category: "serif",
+    fallbackStack: ["Batang", "바탕", "Noto Serif KR", "serif"],
+    singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
+  },
+  궁서: {
+    googleFont: "Noto Serif KR",
+    category: "serif",
+    fallbackStack: ["Gungsuh", "궁서", "Noto Serif KR", "serif"],
     singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
   },
 };
@@ -269,6 +416,9 @@ function detectFontCategory(fontName: string): FontCategory {
     lower.includes("bodoni") ||
     lower.includes("cambria") ||
     lower.includes("mincho") ||
+    lower.includes("明朝") ||
+    lower.includes("明體") ||
+    lower.includes("宋") ||
     lower.includes("ming") ||
     lower.includes("song") ||
     lower.includes("serif")
@@ -292,6 +442,41 @@ function detectFontCategory(fontName: string): FontCategory {
 }
 
 /**
+ * Romanized CJK font spellings → the native key already present in
+ * FONT_MAPPINGS (port of eigenpal/docx-editor#957). Word writes either the
+ * native typeface name (the theme path, e.g. `新細明體`) or the romanized name
+ * (run `rFonts`, e.g. `PMingLiU`); both must resolve to the same Noto family +
+ * CSS stack + category. Aliasing keeps a single set of CJK entries instead of
+ * duplicating each under both spellings. (Keys already present directly in
+ * FONT_MAPPINGS — `simsun`, `simhei`, `malgun gothic`, `ms mincho`,
+ * `ms gothic` — are intentionally omitted.)
+ */
+const CJK_FONT_ALIASES: Record<string, string> = {
+  // Simplified Chinese
+  "microsoft yahei": "微软雅黑",
+  dengxian: "等线",
+  fangsong: "仿宋",
+  kaiti: "楷体",
+  // Traditional Chinese
+  pmingliu: "新細明體",
+  mingliu: "細明體",
+  "microsoft jhenghei": "微軟正黑體",
+  "dfkai-sb": "標楷體",
+  // Korean
+  gulim: "굴림",
+  dotum: "돋움",
+  batang: "바탕",
+  gungsuh: "궁서",
+  // Japanese — Meiryo / Yu share Noto Sans/Serif JP with MS Gothic/Mincho
+  meiryo: "ms gothic",
+  メイリオ: "ms gothic",
+  "yu gothic": "ms gothic",
+  游ゴシック: "ms gothic",
+  "yu mincho": "ms mincho",
+  游明朝: "ms mincho",
+};
+
+/**
  * Resolve a DOCX font name to a Google Font and CSS fallback stack
  *
  * @param docxFontName - The font name from the DOCX file
@@ -300,8 +485,9 @@ function detectFontCategory(fontName: string): FontCategory {
 export function resolveFontFamily(docxFontName: string): ResolvedFont {
   const normalizedName = docxFontName.trim().toLowerCase();
 
-  // Check if we have a direct mapping
-  const mapping = FONT_MAPPINGS[normalizedName];
+  // Direct mapping, or a romanized CJK spelling aliased to its native entry.
+  const mapping =
+    FONT_MAPPINGS[CJK_FONT_ALIASES[normalizedName] ?? normalizedName];
 
   if (mapping) {
     return {
@@ -440,9 +626,8 @@ export function buildFontFamilyString(
  * @returns Google Font name or null
  */
 export function getGoogleFontEquivalent(docxFontName: string): string | null {
-  const normalizedName = docxFontName.trim().toLowerCase();
-  const mapping = FONT_MAPPINGS[normalizedName];
-  return mapping?.googleFont ?? null;
+  // Delegate so CJK romanized aliases are honored identically to the CSS path.
+  return resolveFontFamily(docxFontName).googleFont;
 }
 
 /**

--- a/packages/folio/src/core/utils/fontResolver.ts
+++ b/packages/folio/src/core/utils/fontResolver.ts
@@ -486,13 +486,21 @@ export function resolveFontFamily(docxFontName: string): ResolvedFont {
   const normalizedName = docxFontName.trim().toLowerCase();
 
   // Direct mapping, or a romanized CJK spelling aliased to its native entry.
-  const mapping =
-    FONT_MAPPINGS[CJK_FONT_ALIASES[normalizedName] ?? normalizedName];
+  const aliasTarget = CJK_FONT_ALIASES[normalizedName];
+  const mapping = FONT_MAPPINGS[aliasTarget ?? normalizedName];
 
   if (mapping) {
+    // When reached via an alias, the authored family may be absent from the
+    // target's stack (e.g. Meiryo / Yu Gothic alias to the MS Gothic mapping).
+    // Prepend it so the viewer's own copy of the named face is tried first.
+    const fallbackStack =
+      aliasTarget &&
+      !mapping.fallbackStack.some((f) => f.toLowerCase() === normalizedName)
+        ? [docxFontName, ...mapping.fallbackStack]
+        : mapping.fallbackStack;
     return {
       googleFont: mapping.googleFont,
-      cssFallback: mapping.fallbackStack.map(quoteFontName).join(", "),
+      cssFallback: fallbackStack.map(quoteFontName).join(", "),
       originalFont: docxFontName,
       hasGoogleEquivalent: true,
       singleLineRatio: mapping.singleLineRatio,

--- a/packages/folio/src/core/utils/scriptSegments.test.ts
+++ b/packages/folio/src/core/utils/scriptSegments.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Script segmentation drives per-character East-Asian font selection, so it
+ * must classify boundary code points correctly and split mixed text into
+ * font-homogeneous spans without breaking surrogate pairs.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { hasCjk, isCjkCodePoint, segmentByScript } from "./scriptSegments";
+
+describe("isCjkCodePoint", () => {
+  test("classifies representative East-Asian code points as CJK", () => {
+    expect(isCjkCodePoint("世".codePointAt(0)!)).toBe(true); // CJK ideograph
+    expect(isCjkCodePoint("あ".codePointAt(0)!)).toBe(true); // Hiragana
+    expect(isCjkCodePoint("カ".codePointAt(0)!)).toBe(true); // Katakana
+    expect(isCjkCodePoint("한".codePointAt(0)!)).toBe(true); // Hangul syllable
+    expect(isCjkCodePoint("、".codePointAt(0)!)).toBe(true); // CJK punctuation
+    expect(isCjkCodePoint("Ａ".codePointAt(0)!)).toBe(true); // fullwidth Latin A
+    expect(isCjkCodePoint("𠀀".codePointAt(0)!)).toBe(true); // Ext B (astral)
+  });
+
+  test("classifies Latin and common punctuation as non-CJK", () => {
+    expect(isCjkCodePoint("A".codePointAt(0)!)).toBe(false);
+    expect(isCjkCodePoint("z".codePointAt(0)!)).toBe(false);
+    expect(isCjkCodePoint("1".codePointAt(0)!)).toBe(false);
+    expect(isCjkCodePoint(" ".codePointAt(0)!)).toBe(false);
+    expect(isCjkCodePoint(".".codePointAt(0)!)).toBe(false);
+    expect(isCjkCodePoint("é".codePointAt(0)!)).toBe(false);
+  });
+});
+
+describe("hasCjk", () => {
+  test("detects any CJK presence and the all-Latin fast path", () => {
+    expect(hasCjk("Hello world")).toBe(false);
+    expect(hasCjk("Hello 世界")).toBe(true);
+    expect(hasCjk("")).toBe(false);
+    expect(hasCjk("𠀀")).toBe(true);
+  });
+});
+
+describe("segmentByScript", () => {
+  test("splits mixed text into maximal same-script segments", () => {
+    expect(segmentByScript("Hello世界foo")).toEqual([
+      { text: "Hello", isCjk: false },
+      { text: "世界", isCjk: true },
+      { text: "foo", isCjk: false },
+    ]);
+  });
+
+  test("returns one segment for single-class input", () => {
+    expect(segmentByScript("plain ascii")).toEqual([
+      { text: "plain ascii", isCjk: false },
+    ]);
+    expect(segmentByScript("日本語")).toEqual([
+      { text: "日本語", isCjk: true },
+    ]);
+  });
+
+  test("returns no segments for empty input", () => {
+    expect(segmentByScript("")).toEqual([]);
+  });
+
+  test("keeps an astral ideograph whole within its CJK segment", () => {
+    const segments = segmentByScript("x𠀀y");
+    expect(segments).toEqual([
+      { text: "x", isCjk: false },
+      { text: "𠀀", isCjk: true },
+      { text: "y", isCjk: false },
+    ]);
+    // The astral glyph must not be split across the surrogate pair.
+    expect(segments[1]?.text.length).toBe(2);
+  });
+
+  test("reassembles exactly to the original text", () => {
+    const input = "ABCあいうDEFがぎぐ。XYZ";
+    expect(
+      segmentByScript(input)
+        .map((s) => s.text)
+        .join(""),
+    ).toBe(input);
+  });
+});

--- a/packages/folio/src/core/utils/scriptSegments.test.ts
+++ b/packages/folio/src/core/utils/scriptSegments.test.ts
@@ -15,6 +15,8 @@ describe("isCjkCodePoint", () => {
     expect(isCjkCodePoint("カ".codePointAt(0)!)).toBe(true); // Katakana
     expect(isCjkCodePoint("한".codePointAt(0)!)).toBe(true); // Hangul syllable
     expect(isCjkCodePoint("、".codePointAt(0)!)).toBe(true); // CJK punctuation
+    expect(isCjkCodePoint("ㄅ".codePointAt(0)!)).toBe(true); // Bopomofo (Traditional Chinese)
+    expect(isCjkCodePoint("⼀".codePointAt(0)!)).toBe(true); // Kangxi radical
     expect(isCjkCodePoint("Ａ".codePointAt(0)!)).toBe(true); // fullwidth Latin A
     expect(isCjkCodePoint("𠀀".codePointAt(0)!)).toBe(true); // Ext B (astral)
   });

--- a/packages/folio/src/core/utils/scriptSegments.ts
+++ b/packages/folio/src/core/utils/scriptSegments.ts
@@ -23,15 +23,15 @@ export type ScriptSegment = {
  */
 export function isCjkCodePoint(cp: number): boolean {
   return (
-    (cp >= 0x30_00 && cp <= 0x30_3f) || // CJK symbols and punctuation
-    (cp >= 0x30_40 && cp <= 0x30_ff) || // Hiragana + Katakana
-    (cp >= 0x31_f0 && cp <= 0x31_ff) || // Katakana phonetic extensions
+    (cp >= 0x2e_80 && cp <= 0x2f_ff) || // CJK & Kangxi radicals, ideographic description
+    (cp >= 0x30_00 && cp <= 0x33_ff) || // symbols/punctuation, kana, Bopomofo, Hangul compat Jamo, Kanbun, Bopomofo ext, CJK strokes, Katakana phonetic ext, enclosed/compatibility CJK
     (cp >= 0x34_00 && cp <= 0x4d_bf) || // CJK Unified Ideographs Extension A
     (cp >= 0x4e_00 && cp <= 0x9f_ff) || // CJK Unified Ideographs
-    (cp >= 0xf9_00 && cp <= 0xfa_ff) || // CJK compatibility ideographs
-    (cp >= 0xac_00 && cp <= 0xd7_af) || // Hangul syllables
+    (cp >= 0xa9_60 && cp <= 0xa9_7f) || // Hangul Jamo Extended-A
+    (cp >= 0xac_00 && cp <= 0xd7_ff) || // Hangul syllables + Jamo Extended-B
     (cp >= 0x11_00 && cp <= 0x11_ff) || // Hangul Jamo
-    (cp >= 0x31_30 && cp <= 0x31_8f) || // Hangul compatibility Jamo
+    (cp >= 0xf9_00 && cp <= 0xfa_ff) || // CJK compatibility ideographs
+    (cp >= 0xfe_30 && cp <= 0xfe_4f) || // CJK compatibility forms
     (cp >= 0xff_00 && cp <= 0xff_ef) || // Halfwidth and fullwidth forms
     (cp >= 0x2_00_00 && cp <= 0x3_ff_ff) // CJK Unified Ideographs Extension B+ (astral)
   );

--- a/packages/folio/src/core/utils/scriptSegments.ts
+++ b/packages/folio/src/core/utils/scriptSegments.ts
@@ -1,0 +1,86 @@
+/**
+ * Script segmentation for per-character East-Asian font selection.
+ *
+ * Word resolves a run's font per character: East-Asian (CJK) code points use
+ * the run's `w:eastAsia` font slot, everything else uses `w:ascii`/`w:hAnsi`.
+ * folio mirrors this by splitting a run's text into maximal same-script
+ * segments that the measurer and the painter both consume, so line wrapping
+ * stays in sync with rendering.
+ *
+ * Ranges are authored with `\u` escapes only — never pasted glyphs (a pasted
+ * glyph once silently corrupted an RTL character class here).
+ */
+
+export type ScriptSegment = {
+  text: string;
+  isCjk: boolean;
+};
+
+/**
+ * True when a code point belongs to an East-Asian script that Word renders with
+ * the `w:eastAsia` font slot: CJK ideographs, kana, Hangul, CJK symbols and
+ * punctuation, and fullwidth/halfwidth forms.
+ */
+export function isCjkCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x30_00 && cp <= 0x30_3f) || // CJK symbols and punctuation
+    (cp >= 0x30_40 && cp <= 0x30_ff) || // Hiragana + Katakana
+    (cp >= 0x31_f0 && cp <= 0x31_ff) || // Katakana phonetic extensions
+    (cp >= 0x34_00 && cp <= 0x4d_bf) || // CJK Unified Ideographs Extension A
+    (cp >= 0x4e_00 && cp <= 0x9f_ff) || // CJK Unified Ideographs
+    (cp >= 0xf9_00 && cp <= 0xfa_ff) || // CJK compatibility ideographs
+    (cp >= 0xac_00 && cp <= 0xd7_af) || // Hangul syllables
+    (cp >= 0x11_00 && cp <= 0x11_ff) || // Hangul Jamo
+    (cp >= 0x31_30 && cp <= 0x31_8f) || // Hangul compatibility Jamo
+    (cp >= 0xff_00 && cp <= 0xff_ef) || // Halfwidth and fullwidth forms
+    (cp >= 0x2_00_00 && cp <= 0x3_ff_ff) // CJK Unified Ideographs Extension B+ (astral)
+  );
+}
+
+/**
+ * True when the text contains at least one East-Asian code point. Callers use
+ * this to skip segmentation entirely on the common all-Latin path.
+ */
+export function hasCjk(text: string): boolean {
+  for (const ch of text) {
+    // SAFETY: for...of over a string yields whole code points.
+    if (isCjkCodePoint(ch.codePointAt(0)!)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Split text into maximal runs of one script class (CJK vs. non-CJK). Iterates
+ * by code point so astral ideographs (surrogate pairs) are never split between
+ * fonts. Empty input yields no segments; single-class input yields one.
+ */
+export function segmentByScript(text: string): ScriptSegment[] {
+  const segments: ScriptSegment[] = [];
+  let current = "";
+  let currentIsCjk = false;
+
+  for (const ch of text) {
+    // SAFETY: for...of over a string yields whole code points.
+    const cjk = isCjkCodePoint(ch.codePointAt(0)!);
+    if (current.length === 0) {
+      current = ch;
+      currentIsCjk = cjk;
+      continue;
+    }
+    if (cjk === currentIsCjk) {
+      current += ch;
+      continue;
+    }
+    segments.push({ text: current, isCjk: currentIsCjk });
+    current = ch;
+    currentIsCjk = cjk;
+  }
+
+  if (current.length > 0) {
+    segments.push({ text: current, isCjk: currentIsCjk });
+  }
+
+  return segments;
+}


### PR DESCRIPTION
## Summary

folio measured and painted every run with its `ascii`/`hAnsi` font and never used the run's `eastAsia` font for CJK characters, so CJK text rendered in the viewer's OS default fallback face instead of the document's specified typeface (e.g. a run asking for a Mincho serif showed the OS sans-serif). Wrapping was already correct — the measurer and painter both fell back to the OS CJK font consistently — so this is a **typeface-fidelity** fix, not a wrapping fix.

Implements per-character East-Asian font selection: the layout half of `eigenpal/docx-editor#949` plus its theme/`themeFontLang` half and the `#957` CJK font-name mapping.

## Phase 1 — per-character selection

- New pure `core/utils/scriptSegments.ts` (`isCjkCodePoint` / `hasCjk` / `segmentByScript`; Unicode ranges authored as `\u`/code-point checks, astral-safe) shared by the measurer and the painter so they segment identically.
- Flow runs carry a resolved `eastAsiaFontFamily` (from `attrs.eastAsia` in `toFlowBlocks`).
- `measureTextWidth` sums per-script segment widths (letter spacing and horizontal scale applied once over the whole string); `measureRun` switches the canvas font per CJK code point for correct per-character widths.
- The painter splits each already-sliced run into per-script **sibling sub-runs**, each with an exact `pmStart`/`pmEnd` (the same offset math as `sliceRunsForLine`), so the existing single-span renderer and per-run advance handle them unchanged and PM mapping / selection rects / click-to-caret stay correct.
- Gated on an EA font being present **and** the run containing CJK, so the all-Latin path is unchanged.

## Phase 2 — `w:themeFontLang` resolution

- Office's default theme leaves `<a:ea>`/`<a:cs>` empty and lists the real per-script typeface in `<a:font script="…">`, selected by `w:themeFontLang`. `settingsParser` now parses it, and `applyThemeFontLang` fills the empty theme slots from the script-specific font before styles are resolved — so theme-driven `minorEastAsia` runs resolve to the real CJK face.
- `fontResolver` maps native CJK typeface names (as stored in `theme1.xml`) and their romanized aliases to the matching Noto Sans/Serif SC/TC/KR/JP families, preserving serif vs sans.

### No CJK webfonts bundled or fetched

folio bundles only Latin metric-compatible fonts. The Noto CJK families are CSS fallback tokens only — they resolve to the viewer's OS face when present, else the generic `serif`/`sans-serif` tail. `loadFont` only probes system availability (there is no `@font-face` `src` for them), so nothing is fetched. This is a deliberate choice to avoid multi-MB bundle growth.

## Tests

Per-layer coverage: `scriptSegments`, measure (`measureContainer-eastAsia`), paint split (`renderParagraph-eastAsia`), `settingsParser` / `themeParser` / `fontResolver`, and an end-to-end `parser.test` fixture (empty `<a:ea>` + `themeFontLang="ja-JP"` + a `minorEastAsia` run → resolves to `ＭＳ 明朝`). Full folio suite green (2290 pass / 0 fail).