### PR TITLE
fix(lint): import ultracite oxlint config via package export

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,8 +7,8 @@ import {
   stellaLowercasePluginSpecifier,
 } from "@stll/oxlint-config";
 
-import core from "./node_modules/ultracite/config/oxlint/core/index.mjs";
-import react from "./node_modules/ultracite/config/oxlint/react/index.mjs";
+import core from "ultracite/oxlint/core";
+import react from "ultracite/oxlint/react";
 
 // All workspaces run oxlint from the repo root via:
 //   cd ../.. && oxlint -c oxlint.config.ts --type-aware <workspace-dir>


### PR DESCRIPTION
Switch the two ultracite config imports from hardcoded `./node_modules/ultracite/config/oxlint/*/index.mjs` paths to the package's official `ultracite/oxlint/*` export specifiers. ultracite's `exports` map (`"./oxlint/*"`) resolves to the same files, so lint behavior is unchanged (full `apps/api` lint passes).

Why: the literal `./node_modules/...` path only resolves when node_modules sits at that exact relative location. It breaks wherever the layout differs — most visibly in git worktrees without a local install, where oxlint can't load the config at all (`Cannot find module './node_modules/ultracite/...'`). The bare export specifier resolves via standard module resolution, so it works regardless of node_modules layout and restores local linting in worktrees.