### PR TITLE
refactor: use callback refs for node observers

### DIFF
--- a/.agents/skills/conventions-use-effect/SKILL.md
+++ b/.agents/skills/conventions-use-effect/SKILL.md
@@ -108,9 +108,14 @@ sync — never derived state, an event relay, or a fetch.
 useExternalSyncEffect(() => editorRef.current?.setZoom(zoom), [zoom]);
 ```
 
-When the external lifecycle is "set up once per DOM node," prefer a **callback
-ref** over an effect (it ties setup/teardown to the node, not to a render) — see
-the `ResizeObserver`/fit-zoom pattern in the docx viewers.
+When the external lifecycle is "set up once per DOM node," use a **callback
+ref** over an effect (it ties setup/teardown to the node, not to a render) —
+see the `ResizeObserver`/fit-zoom pattern in the docx viewers. This is the
+canonical shape for `ResizeObserver`, `IntersectionObserver`, DOM listeners,
+and imperative widgets whose lifecycle belongs to a specific element. Keep an
+effect only when the component does not own the node/ref API yet, or when the
+work is truly "push a changing React value into an already-attached external
+system."
 
 ## useLayoutEffect
 

--- a/.ai/local-skills/conventions-use-effect/SKILL.md
+++ b/.ai/local-skills/conventions-use-effect/SKILL.md
@@ -108,9 +108,14 @@ sync — never derived state, an event relay, or a fetch.
 useExternalSyncEffect(() => editorRef.current?.setZoom(zoom), [zoom]);
 ```
 
-When the external lifecycle is "set up once per DOM node," prefer a **callback
-ref** over an effect (it ties setup/teardown to the node, not to a render) — see
-the `ResizeObserver`/fit-zoom pattern in the docx viewers.
+When the external lifecycle is "set up once per DOM node," use a **callback
+ref** over an effect (it ties setup/teardown to the node, not to a render) —
+see the `ResizeObserver`/fit-zoom pattern in the docx viewers. This is the
+canonical shape for `ResizeObserver`, `IntersectionObserver`, DOM listeners,
+and imperative widgets whose lifecycle belongs to a specific element. Keep an
+effect only when the component does not own the node/ref API yet, or when the
+work is truly "push a changing React value into an already-attached external
+system."
 
 ## useLayoutEffect
 

--- a/.claude/commands/conventions-use-effect.md
+++ b/.claude/commands/conventions-use-effect.md
@@ -103,9 +103,14 @@ sync — never derived state, an event relay, or a fetch.
 useExternalSyncEffect(() => editorRef.current?.setZoom(zoom), [zoom]);
 ```
 
-When the external lifecycle is "set up once per DOM node," prefer a **callback
-ref** over an effect (it ties setup/teardown to the node, not to a render) — see
-the `ResizeObserver`/fit-zoom pattern in the docx viewers.
+When the external lifecycle is "set up once per DOM node," use a **callback
+ref** over an effect (it ties setup/teardown to the node, not to a render) —
+see the `ResizeObserver`/fit-zoom pattern in the docx viewers. This is the
+canonical shape for `ResizeObserver`, `IntersectionObserver`, DOM listeners,
+and imperative widgets whose lifecycle belongs to a specific element. Keep an
+effect only when the component does not own the node/ref API yet, or when the
+work is truly "push a changing React value into an already-attached external
+system."
 
 ## useLayoutEffect
 

--- a/apps/web/src/components/inspector/measured-pdf-provider.tsx
+++ b/apps/web/src/components/inspector/measured-pdf-provider.tsx
@@ -1,7 +1,6 @@
-import { useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import type { PropsWithChildren } from "react";
 
-import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { PDFProvider } from "@/lib/pdf/pdf-context";
 import type { PDFPageFallback } from "@/lib/pdf/pdf-page";
 
@@ -22,41 +21,37 @@ export const MeasuredPdfProvider = ({
   onError,
 }: MeasuredPdfProviderProps) => {
   const [initialFitWidth, setInitialFitWidth] = useState<number | undefined>();
-  const containerRef = useRef<HTMLDivElement>(null);
 
-  useExternalSyncEffect(() => {
-    if (!active || initialFitWidth !== undefined) {
-      return undefined;
-    }
-
-    const container = containerRef.current;
-    if (!container) {
-      return undefined;
-    }
-
-    const updateWidth = (width: number) => {
-      if (width > 0) {
-        setInitialFitWidth(width);
-      }
-    };
-
-    updateWidth(container.clientWidth);
-
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) {
-        return;
+  const containerRef = useCallback(
+    (container: HTMLDivElement | null) => {
+      if (!active || initialFitWidth !== undefined || !container) {
+        return undefined;
       }
 
-      updateWidth(entry.contentRect.width);
-    });
+      const updateWidth = (width: number) => {
+        if (width > 0) {
+          setInitialFitWidth(width);
+        }
+      };
 
-    observer.observe(container);
+      updateWidth(container.clientWidth);
 
-    return () => {
-      observer.disconnect();
-    };
-  }, [active, initialFitWidth]);
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries.at(0);
+        if (!entry) {
+          return;
+        }
+
+        updateWidth(entry.contentRect.width);
+      });
+
+      observer.observe(container);
+      return () => {
+        observer.disconnect();
+      };
+    },
+    [active, initialFitWidth],
+  );
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col" ref={containerRef}>

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { UseMutationResult } from "@tanstack/react-query";
 import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
@@ -272,8 +272,6 @@ export const SearchDialog = ({
   const [resultsElement, setResultsElement] = useState<HTMLDivElement | null>(
     null,
   );
-  const loadMoreRef = useRef<HTMLDivElement>(null);
-
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
@@ -738,33 +736,29 @@ export const SearchDialog = ({
     searchQuery,
   ]);
 
-  useExternalSyncEffect(() => {
-    const root = resultsElement;
-    const target = loadMoreRef.current;
-    if (!hasQuery || !hasNextPage || !root || !target) {
-      return undefined;
-    }
+  const loadMoreRef = useCallback(
+    (target: HTMLDivElement | null) => {
+      const root = resultsElement;
+      if (!hasQuery || !hasNextPage || !root || !target) {
+        return undefined;
+      }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries.at(0);
-        if (!entry?.isIntersecting || isFetchingNextPage) {
-          return;
-        }
-        void fetchNextPage();
-      },
-      { root, rootMargin: "160px 0px" },
-    );
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const entry = entries.at(0);
+          if (!entry?.isIntersecting || isFetchingNextPage) {
+            return;
+          }
+          void fetchNextPage();
+        },
+        { root, rootMargin: "160px 0px" },
+      );
 
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [
-    fetchNextPage,
-    hasNextPage,
-    hasQuery,
-    isFetchingNextPage,
-    resultsElement,
-  ]);
+      observer.observe(target);
+      return () => observer.disconnect();
+    },
+    [fetchNextPage, hasNextPage, hasQuery, isFetchingNextPage, resultsElement],
+  );
 
   return (
     <CommandDialog onOpenChange={onOpenChange} open={open}>

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -55,7 +55,6 @@ import type {
   TimeFilter,
 } from "@/components/search-filters.logic";
 import { UserAvatar } from "@/components/user-avatar";
-import { useExternalSyncEffect } from "@/hooks/use-effect";
 import {
   isPublicLawPreviewEnabled,
   usePublicLawPreviewEnabled,

--- a/apps/web/src/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/hooks/use-stick-to-bottom.ts
@@ -1,15 +1,13 @@
-import { createContext, use, useRef, useState } from "react";
-import type { RefObject } from "react";
+import { createContext, use, useCallback, useRef, useState } from "react";
+import type { RefCallback } from "react";
 
 import { panic } from "better-result";
-
-import { useMountEffect } from "@/hooks/use-effect";
 
 const NEAR_BOTTOM_THRESHOLD_PX = 50;
 
 type StickToBottomContext = {
-  scrollRef: RefObject<HTMLDivElement | null>;
-  contentRef: RefObject<HTMLDivElement | null>;
+  scrollRef: RefCallback<HTMLDivElement>;
+  contentRef: RefCallback<HTMLDivElement>;
   isAtBottom: boolean;
   isScrollable: boolean;
   scrollToBottom: () => void;
@@ -61,8 +59,7 @@ const isSelectingInside = (scrollEl: HTMLElement | null): boolean => {
  * and rAF-synchronized ResizeObserver callbacks.
  */
 export const useStickToBottom = () => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
+  const scrollElementRef = useRef<HTMLDivElement | null>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
   /** Whether the scroll container has more content than fits the viewport. */
   const [isScrollable, setIsScrollable] = useState(false);
@@ -78,7 +75,7 @@ export const useStickToBottom = () => {
   const programmaticScroll = useRef(false);
 
   const scrollToBottom = () => {
-    const el = scrollRef.current;
+    const el = scrollElementRef.current;
     if (!el) {
       return;
     }
@@ -88,13 +85,12 @@ export const useStickToBottom = () => {
     setIsAtBottom(true);
   };
 
-  // Track user scroll direction to detect intentional scroll-up.
-  useMountEffect(() => {
-    const el = scrollRef.current;
+  const scrollRef = useCallback((el: HTMLDivElement | null) => {
     if (!el) {
       return undefined;
     }
 
+    scrollElementRef.current = el;
     let lastScrollTop = el.scrollTop;
 
     const onScroll = () => {
@@ -144,26 +140,27 @@ export const useStickToBottom = () => {
     el.addEventListener("scroll", onScroll, { passive: true });
     el.addEventListener("wheel", onWheel, { passive: true });
     return () => {
+      scrollElementRef.current = null;
       el.removeEventListener("scroll", onScroll);
       el.removeEventListener("wheel", onWheel);
     };
-  });
+  }, []);
 
-  // Observe content resizes and auto-scroll when pinned.
-  useMountEffect(() => {
-    const content = contentRef.current;
+  const contentRef = useCallback((content: HTMLDivElement | null) => {
     if (!content) {
       return undefined;
     }
 
+    let raf = 0;
     const observer = new ResizeObserver(() => {
       // Defer to rAF to avoid layout thrashing; the
       // ResizeObserver callback fires between style
       // recalc and paint, so reading scroll metrics here
       // can force a synchronous layout. Matching the
       // original library's synchronization approach.
-      requestAnimationFrame(() => {
-        const el = scrollRef.current;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const el = scrollElementRef.current;
         if (!el) {
           return;
         }
@@ -171,7 +168,7 @@ export const useStickToBottom = () => {
         if (userScrolledUp.current) {
           return;
         }
-        if (isSelectingInside(scrollRef.current)) {
+        if (isSelectingInside(scrollElementRef.current)) {
           return;
         }
         el.scrollTo({
@@ -183,8 +180,11 @@ export const useStickToBottom = () => {
     });
 
     observer.observe(content);
-    return () => observer.disconnect();
-  });
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+  }, []);
 
   return { scrollRef, contentRef, isAtBottom, isScrollable, scrollToBottom };
 };

--- a/apps/web/src/lib/pdf/hooks/use-page-visibility.ts
+++ b/apps/web/src/lib/pdf/hooks/use-page-visibility.ts
@@ -1,15 +1,19 @@
-import { useEffectEvent, useRef } from "react";
+import { useCallback, useEffectEvent, useRef } from "react";
+import type { RefCallback, RefObject } from "react";
 
 import { useThrottledCallback } from "use-debounce";
 
-import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { PAGE_ID_ATTRIBUTE } from "@/lib/pdf/consts";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 
 type UsePageVisibilityProps = {
-  containerRef: React.RefObject<HTMLDivElement | null>;
   pageIds: string[];
   onPageChanged?: ((page: number) => void) | undefined;
+};
+
+type UsePageVisibilityResult = {
+  containerRef: RefCallback<HTMLDivElement>;
+  lastReportedPageRef: RefObject<number | null>;
 };
 
 /**
@@ -23,10 +27,9 @@ type UsePageVisibilityProps = {
  * intentional navigation.
  */
 export const usePageVisibility = ({
-  containerRef,
   pageIds,
   onPageChanged,
-}: UsePageVisibilityProps) => {
+}: UsePageVisibilityProps): UsePageVisibilityResult => {
   const updateVisiblePages = usePDFStore((s) => s.updateVisiblePages);
 
   const visiblePageRatiosRef = useRef(new Map<string, number>());
@@ -39,72 +42,74 @@ export const usePageVisibility = ({
 
   const throttledUpdate = useThrottledCallback(updateVisiblePages, 150);
 
-  useExternalSyncEffect(() => {
-    const container = containerRef.current;
-    if (!container || pageIds.length === 0) {
-      return undefined;
-    }
+  const containerRef = useCallback(
+    (container: HTMLDivElement | null) => {
+      if (!container || pageIds.length === 0) {
+        return undefined;
+      }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const ratios = visiblePageRatiosRef.current;
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const ratios = visiblePageRatiosRef.current;
 
-        for (const entry of entries) {
-          const pageId = entry.target.getAttribute(PAGE_ID_ATTRIBUTE);
-          if (!pageId) {
-            continue;
+          for (const entry of entries) {
+            const pageId = entry.target.getAttribute(PAGE_ID_ATTRIBUTE);
+            if (!pageId) {
+              continue;
+            }
+
+            if (entry.intersectionRatio >= 0.33) {
+              ratios.set(pageId, entry.intersectionRatio);
+            } else {
+              ratios.delete(pageId);
+            }
           }
 
-          if (entry.intersectionRatio >= 0.33) {
-            ratios.set(pageId, entry.intersectionRatio);
-          } else {
-            ratios.delete(pageId);
+          if (ratios.size === 0) {
+            return;
           }
-        }
 
-        if (ratios.size === 0) {
-          return;
-        }
+          const visiblePageIds = [...ratios.keys()];
+          throttledUpdate(visiblePageIds);
 
-        const visiblePageIds = [...ratios.keys()];
-        throttledUpdate(visiblePageIds);
+          let nextPageId: string | undefined;
+          let leadingRatio = 0;
 
-        let nextPageId: string | undefined;
-        let leadingRatio = 0;
-
-        for (const [id, ratio] of ratios) {
-          if (ratio >= leadingRatio) {
-            leadingRatio = ratio;
-            nextPageId = id;
+          for (const [id, ratio] of ratios) {
+            if (ratio >= leadingRatio) {
+              leadingRatio = ratio;
+              nextPageId = id;
+            }
           }
-        }
 
-        if (nextPageId !== undefined) {
-          const idx = pageIds.indexOf(nextPageId);
-          if (idx !== -1) {
-            onPageChangedEvent(idx + 1);
+          if (nextPageId !== undefined) {
+            const idx = pageIds.indexOf(nextPageId);
+            if (idx !== -1) {
+              onPageChangedEvent(idx + 1);
+            }
           }
-        }
-      },
-      { threshold: [0, 0.33, 0.66, 1] },
-    );
+        },
+        { threshold: [0, 0.33, 0.66, 1] },
+      );
 
-    const pageElements = container.querySelectorAll<HTMLElement>(
-      `[${PAGE_ID_ATTRIBUTE}]`,
-    );
+      const pageElements = container.querySelectorAll<HTMLElement>(
+        `[${PAGE_ID_ATTRIBUTE}]`,
+      );
 
-    for (const pageElement of pageElements) {
-      observer.observe(pageElement);
-    }
+      for (const pageElement of pageElements) {
+        observer.observe(pageElement);
+      }
 
-    const ratios = visiblePageRatiosRef.current;
+      const ratios = visiblePageRatiosRef.current;
 
-    return () => {
-      observer.disconnect();
-      throttledUpdate.cancel();
-      ratios.clear();
-    };
-  }, [pageIds, containerRef, throttledUpdate]);
+      return () => {
+        observer.disconnect();
+        throttledUpdate.cancel();
+        ratios.clear();
+      };
+    },
+    [pageIds, throttledUpdate],
+  );
 
-  return lastReportedPageRef;
+  return { containerRef, lastReportedPageRef };
 };

--- a/apps/web/src/lib/pdf/hooks/use-pdf-fit-to-width.ts
+++ b/apps/web/src/lib/pdf/hooks/use-pdf-fit-to-width.ts
@@ -1,4 +1,5 @@
-import type { RefObject } from "react";
+import { useCallback } from "react";
+import type { RefCallback, RefObject } from "react";
 
 import { useDebouncedCallback } from "use-debounce";
 import { useShallow } from "zustand/react/shallow";
@@ -12,7 +13,9 @@ type UsePDFFitToWidthArgs = {
   containerRef: RefObject<HTMLDivElement | null>;
 };
 
-export const usePDFFitToWidth = ({ containerRef }: UsePDFFitToWidthArgs) => {
+export const usePDFFitToWidth = ({
+  containerRef,
+}: UsePDFFitToWidthArgs): RefCallback<HTMLDivElement> => {
   const [
     fitToWidth,
     scaleOffset,
@@ -45,52 +48,52 @@ export const usePDFFitToWidth = ({ containerRef }: UsePDFFitToWidthArgs) => {
       }
     }
 
-    if (fitToWidth === undefined || scaleOffset !== 0) {
-      return undefined;
-    }
+    return undefined;
+  }, [consumePendingScrollAnchor, containerRef, effectiveScale]);
 
-    const container = containerRef.current;
-    if (!container) {
-      return undefined;
-    }
-
-    // Observe the ScrollArea viewport (the visible area),
-    // not the content container. The content container's
-    // width is determined by the PDF pages themselves,
-    // creating a circular dependency.
-    const viewport = container.closest<HTMLElement>(
-      SCROLL_AREA_VIEWPORT_SELECTOR,
-    );
-    const observeTarget = viewport ?? container;
-
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries.at(0);
-      if (!entry) {
-        return;
+  return useCallback(
+    (container: HTMLDivElement | null) => {
+      if (!container || fitToWidth === undefined || scaleOffset !== 0) {
+        return undefined;
       }
 
-      const containerWidth = entry.contentRect.width;
-      if (containerWidth <= 0) {
-        return;
-      }
+      // Observe the ScrollArea viewport (the visible area),
+      // not the content container. The content container's
+      // width is determined by the PDF pages themselves,
+      // creating a circular dependency.
+      const viewport = container.closest<HTMLElement>(
+        SCROLL_AREA_VIEWPORT_SELECTOR,
+      );
+      const observeTarget = viewport ?? container;
 
-      updateContainerWidth(containerWidth, container);
-      debouncedRerender(effectiveScale);
-    });
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries.at(0);
+        if (!entry) {
+          return;
+        }
 
-    observer.observe(observeTarget);
+        const containerWidth = entry.contentRect.width;
+        if (containerWidth <= 0) {
+          return;
+        }
 
-    return () => {
-      observer.disconnect();
-      debouncedRerender.cancel();
-    };
-  }, [
-    fitToWidth,
-    scaleOffset,
-    effectiveScale,
-    updateContainerWidth,
-    consumePendingScrollAnchor,
-    debouncedRerender,
-    containerRef,
-  ]);
+        updateContainerWidth(containerWidth, container);
+        debouncedRerender(effectiveScale);
+      });
+
+      observer.observe(observeTarget);
+
+      return () => {
+        observer.disconnect();
+        debouncedRerender.cancel();
+      };
+    },
+    [
+      fitToWidth,
+      scaleOffset,
+      effectiveScale,
+      updateContainerWidth,
+      debouncedRerender,
+    ],
+  );
 };

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useEffectEvent,
   useId,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -123,7 +124,7 @@ const PDFViewerContent = ({
   );
 
   const effectiveScale = scale + scaleOffset;
-  const pageIds = pages.keys().toArray();
+  const pageIds = useMemo(() => pages.keys().toArray(), [pages]);
   const viewportStyle: PDFViewportStyle = {
     "--pdf-page-filter": shouldInvert ? "invert(1) hue-rotate(180deg)" : "none",
     "--scale-factor": effectiveScale,

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -31,6 +31,7 @@ import type { PDFDocument } from "@/lib/pdf/pdf-loader";
 import type { PDFPageProps } from "@/lib/pdf/pdf-page";
 import { approximateFraction } from "@/lib/pdf/pdfjs-utils";
 import { getDevicePixelRatio } from "@/lib/pdf/utils";
+import { composeRefs } from "@/lib/slot";
 
 export { usePDFStore } from "@/lib/pdf/pdf-context";
 
@@ -139,18 +140,18 @@ const PDFViewerContent = ({
   }, [document, setDocument]);
 
   useTextSelection(containerRef);
-  usePDFFitToWidth({
+  const fitToWidthRef = usePDFFitToWidth({
     containerRef,
   });
   usePDFControlledScaleOffset({
     containerRef,
     controlledScaleOffset: scaleOffset,
   });
-  const lastReportedPageRef = usePageVisibility({
-    containerRef,
-    pageIds,
-    onPageChanged,
-  });
+  const { containerRef: pageVisibilityRef, lastReportedPageRef } =
+    usePageVisibility({
+      pageIds,
+      onPageChanged,
+    });
   usePDFExternalPageSync({
     page,
     pageIds,
@@ -166,11 +167,16 @@ const PDFViewerContent = ({
     onPageCountChangedEvent(pageIds.length);
   }, [pageIds.length]);
 
+  const pdfContentRef = useMemo(
+    () => composeRefs(containerRef, fitToWidthRef, pageVisibilityRef),
+    [fitToWidthRef, pageVisibilityRef],
+  );
+
   return (
     <ScrollArea>
       <div className={className}>
         <div
-          ref={containerRef}
+          ref={pdfContentRef}
           className={contentClassName}
           style={viewportStyle}
         >

--- a/apps/web/src/lib/slot.tsx
+++ b/apps/web/src/lib/slot.tsx
@@ -52,9 +52,18 @@ export const composeRefs =
           cleanups.push(() => {
             void cleanup();
           });
+        } else if (node !== null) {
+          cleanups.push(() => {
+            void ref(null);
+          });
         }
       } else if (ref !== undefined && ref !== null) {
         ref.current = node;
+        if (node !== null) {
+          cleanups.push(() => {
+            ref.current = null;
+          });
+        }
       }
     }
     if (cleanups.length > 0) {

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 import {
   BanknoteIcon,
@@ -20,7 +20,6 @@ import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
-import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { sanitizeHref } from "@/lib/sanitize-href";
 
@@ -234,26 +233,29 @@ export const CatalogueDetailPanel = ({
  */
 const ExpandableText = ({ text }: { text: string }) => {
   const t = useTranslations();
-  const ref = useRef<HTMLParagraphElement>(null);
   const [expanded, setExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
 
   // Measure only while clamped, so overflow is detected against the
   // line-clamp height. A ResizeObserver keeps it correct across font
   // loads, panel animation, and width changes.
-  useExternalSyncEffect(() => {
-    const el = ref.current;
-    if (expanded || !el) {
-      return () => {
-        /* no-op cleanup */
+  const textRef = useCallback(
+    (el: HTMLParagraphElement | null) => {
+      if (expanded || !el) {
+        return undefined;
+      }
+
+      const measure = () => {
+        setOverflowing(el.scrollHeight > el.clientHeight + 1);
       };
-    }
-    const observer = new ResizeObserver(() => {
-      setOverflowing(el.scrollHeight > el.clientHeight + 1);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [text, expanded]);
+
+      measure();
+      const observer = new ResizeObserver(measure);
+      observer.observe(el);
+      return () => observer.disconnect();
+    },
+    [expanded, text],
+  );
 
   return (
     <div className="flex flex-col items-start gap-1.5">
@@ -262,7 +264,7 @@ const ExpandableText = ({ text }: { text: string }) => {
           "text-foreground text-sm leading-relaxed text-pretty",
           !expanded && "line-clamp-5",
         )}
-        ref={ref}
+        ref={textRef}
       >
         {text}
       </p>

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-detail-panel.tsx
@@ -254,7 +254,7 @@ const ExpandableText = ({ text }: { text: string }) => {
       observer.observe(el);
       return () => observer.disconnect();
     },
-    [expanded, text],
+    [expanded],
   );
 
   return (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/index.tsx
@@ -20,7 +20,8 @@ import { useTranslations } from "use-intl";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
-import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { composeRefs } from "@/lib/slot";
 import { BottomRow } from "@/routes/_protected.workspaces/$workspaceId/-components/bottom-row";
 import { BulkAddColumns } from "@/routes/_protected.workspaces/$workspaceId/-components/bulk-add-columns";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";
@@ -369,23 +370,25 @@ export const WorkspaceTable = ({
     );
   }, [handleColumnReorder, t]);
 
-  useMountEffect(() => {
-    const element = tableWrapperRef.current;
-    if (!element) {
-      return undefined;
-    }
+  const tableWrapperObserverRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element) {
+        return undefined;
+      }
 
-    setWrapperWidth(element.clientWidth);
-    setVerticalScrollbarWidth(getVerticalScrollbarWidth(element));
-
-    const resizeObserver = new ResizeObserver(() => {
       setWrapperWidth(element.clientWidth);
       setVerticalScrollbarWidth(getVerticalScrollbarWidth(element));
-    });
-    resizeObserver.observe(element);
 
-    return () => resizeObserver.disconnect();
-  });
+      const resizeObserver = new ResizeObserver(() => {
+        setWrapperWidth(element.clientWidth);
+        setVerticalScrollbarWidth(getVerticalScrollbarWidth(element));
+      });
+      resizeObserver.observe(element);
+
+      return () => resizeObserver.disconnect();
+    },
+    [],
+  );
 
   useLayoutEffect(() => {
     const element = tableWrapperRef.current;
@@ -410,6 +413,11 @@ export const WorkspaceTable = ({
     }
   }, [horizontalMaxScroll]);
 
+  const tableWrapperComposedRef = useMemo(
+    () => composeRefs(tableWrapperRef, tableWrapperObserverRef),
+    [tableWrapperObserverRef],
+  );
+
   return (
     <div
       className={cn(
@@ -417,7 +425,7 @@ export const WorkspaceTable = ({
         addPropertyColumn && ADD_PROPERTY_RAIL_ACTIVE_CLASS_NAME,
       )}
     >
-      <div className="h-full overflow-auto" ref={tableWrapperRef}>
+      <div className="h-full overflow-auto" ref={tableWrapperComposedRef}>
         <div
           aria-colcount={visibleColumnCount}
           aria-rowcount={rowModel.rows.length}

--- a/scripts/react-compiler-bailouts.json
+++ b/scripts/react-compiler-bailouts.json
@@ -21,6 +21,7 @@
   "apps/web/src/hooks/use-effect.ts": 0,
   "apps/web/src/hooks/use-external-file-drop.ts": 0,
   "apps/web/src/lib/anonymize/use-overlay-rects.ts": 1,
+  "apps/web/src/lib/pdf/hooks/use-page-visibility.ts": 1,
   "apps/web/src/lib/sse.ts": 0,
   "apps/web/src/routes/_protected.chat/-hooks/use-workspace-chat-mention-registration.ts": 4,
   "apps/web/src/routes/_protected.chat/index.tsx": 4,


### PR DESCRIPTION
- move node-owned ResizeObserver and IntersectionObserver lifecycles to React 19 cleanup callback refs
- preserve composed-ref cleanup semantics for React 19 refs
- document callback refs as the convention for node-bound observer/listener/widget lifecycles