### PR TITLE
chore: replace ref mirrors with effect events

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -272,8 +272,11 @@ const MatterItem = ({
   const canDrag = isPinned && !!onReorder;
   const isCollapsed = state === "collapsed" && !isMobile;
 
-  const onReorderRef = useRef(onReorder);
-  onReorderRef.current = onReorder;
+  const handleReorder = useEffectEvent(
+    (draggedId: string, targetId: string) => {
+      onReorder?.(draggedId, targetId);
+    },
+  );
 
   useExternalSyncEffect(() => {
     const el = dropRef.current;
@@ -299,7 +302,7 @@ const MatterItem = ({
           if (typeof draggedId !== "string" || draggedId === ws.id) {
             return;
           }
-          onReorderRef.current?.(draggedId, ws.id);
+          handleReorder(draggedId, ws.id);
         },
       }),
     );

--- a/apps/web/src/hooks/use-external-file-drop.ts
+++ b/apps/web/src/hooks/use-external-file-drop.ts
@@ -1,4 +1,4 @@
-import { useEffectEvent, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 import { containsFiles } from "@atlaskit/pragmatic-drag-and-drop/external/file";
@@ -60,28 +60,12 @@ export const useExternalFileDrop = ({
   const [isDropTarget, setIsDropTarget] = useState(false);
   const [isInnerActive, setIsInnerActive] = useState(false);
 
-  const handleDroppedTree = useEffectEvent((tree: DroppedFileTree) => {
-    if (tree.files.length === 0 && tree.directoryPaths.length === 0) {
-      return;
-    }
-
-    if (onDropTree) {
-      onDropTree(tree);
-      return;
-    }
-
-    const files = tree.files.map(({ file }) => file);
-    if (files.length > 0) {
-      onDrop(files);
-    }
-  });
-  const handleDropError = useEffectEvent((error: Error) => {
-    onError?.(error);
-    stellaToast.add({
-      title: t("errors.uploadFailed"),
-      type: "error",
-    });
-  });
+  const onDropRef = useRef(onDrop);
+  onDropRef.current = onDrop;
+  const onDropTreeRef = useRef(onDropTree);
+  onDropTreeRef.current = onDropTree;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   useExternalSyncEffect(() => {
     const el = ref.current;
@@ -108,7 +92,22 @@ export const useExternalFileDrop = ({
           return;
         }
         void collectDroppedFileTree(source)
-          .then(handleDroppedTree)
+          .then((tree) => {
+            if (tree.files.length === 0 && tree.directoryPaths.length === 0) {
+              return undefined;
+            }
+
+            if (onDropTreeRef.current) {
+              onDropTreeRef.current(tree);
+              return undefined;
+            }
+
+            const files = tree.files.map(({ file }) => file);
+            if (files.length > 0) {
+              onDropRef.current(files);
+            }
+            return undefined;
+          })
           .catch((error: unknown) => {
             const normalized =
               error instanceof Error
@@ -118,11 +117,15 @@ export const useExternalFileDrop = ({
                     message: "Failed to read dropped files",
                     cause: error,
                   });
-            handleDropError(normalized);
+            onErrorRef.current?.(normalized);
+            stellaToast.add({
+              title: t("errors.uploadFailed"),
+              type: "error",
+            });
           });
       },
     });
-  }, [enabled, ref]);
+  }, [enabled, ref, t]);
 
   return { ref, isDropTarget, isInnerActive };
 };

--- a/apps/web/src/hooks/use-external-file-drop.ts
+++ b/apps/web/src/hooks/use-external-file-drop.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 
 import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 import { containsFiles } from "@atlaskit/pragmatic-drag-and-drop/external/file";
@@ -60,13 +60,28 @@ export const useExternalFileDrop = ({
   const [isDropTarget, setIsDropTarget] = useState(false);
   const [isInnerActive, setIsInnerActive] = useState(false);
 
-  // Store callback in a ref to avoid re-registering the drop target
-  const onDropRef = useRef(onDrop);
-  onDropRef.current = onDrop;
-  const onDropTreeRef = useRef(onDropTree);
-  onDropTreeRef.current = onDropTree;
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  const handleDroppedTree = useEffectEvent((tree: DroppedFileTree) => {
+    if (tree.files.length === 0 && tree.directoryPaths.length === 0) {
+      return;
+    }
+
+    if (onDropTree) {
+      onDropTree(tree);
+      return;
+    }
+
+    const files = tree.files.map(({ file }) => file);
+    if (files.length > 0) {
+      onDrop(files);
+    }
+  });
+  const handleDropError = useEffectEvent((error: Error) => {
+    onError?.(error);
+    stellaToast.add({
+      title: t("errors.uploadFailed"),
+      type: "error",
+    });
+  });
 
   useExternalSyncEffect(() => {
     const el = ref.current;
@@ -93,22 +108,7 @@ export const useExternalFileDrop = ({
           return;
         }
         void collectDroppedFileTree(source)
-          .then((tree) => {
-            if (tree.files.length === 0 && tree.directoryPaths.length === 0) {
-              return undefined;
-            }
-
-            if (onDropTreeRef.current) {
-              onDropTreeRef.current(tree);
-              return undefined;
-            }
-
-            const files = tree.files.map(({ file }) => file);
-            if (files.length > 0) {
-              onDropRef.current(files);
-            }
-            return undefined;
-          })
+          .then(handleDroppedTree)
           .catch((error: unknown) => {
             const normalized =
               error instanceof Error
@@ -118,15 +118,11 @@ export const useExternalFileDrop = ({
                     message: "Failed to read dropped files",
                     cause: error,
                   });
-            onErrorRef.current?.(normalized);
-            stellaToast.add({
-              title: t("errors.uploadFailed"),
-              type: "error",
-            });
+            handleDropError(normalized);
           });
       },
     });
-  }, [enabled, ref, t]);
+  }, [enabled, ref]);
 
   return { ref, isDropTarget, isInnerActive };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { PlusIcon, SquareCheckIcon } from "lucide-react";
@@ -81,8 +81,7 @@ export const CalendarDayCell = ({
   const dropRef = useRef<HTMLDivElement>(null);
   const [isDropTarget, setIsDropTarget] = useState(false);
 
-  const onDropRef = useRef(onDrop);
-  onDropRef.current = onDrop;
+  const handleEntityDrop = useEffectEvent(onDrop);
 
   useExternalSyncEffect(() => {
     const el = dropRef.current;
@@ -99,7 +98,7 @@ export const CalendarDayCell = ({
         const entityId = source.data["entityId"];
         const kind = source.data["kind"];
         if (typeof entityId === "string") {
-          onDropRef.current(
+          handleEntityDrop(
             entityId,
             typeof kind === "string" ? kind : "document",
           );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  useEffectEvent,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -224,10 +218,8 @@ export const ExistingFileOrganizerDialog = ({
     let cancelled = false;
     const fetchSuggestions = async () => {
       setSuggestionStatus("generating");
-      const {
-        locale: requestLocale,
-        userInstructions: trimmedInstructions,
-      } = getSuggestionRequestContext();
+      const { locale: requestLocale, userInstructions: trimmedInstructions } =
+        getSuggestionRequestContext();
       const response = await api
         .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
         ["organize-suggestions"].post({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -125,10 +131,10 @@ export const ExistingFileOrganizerDialog = ({
     return window.localStorage.getItem(userInstructionsKey) ?? "";
   });
   const [showInstructions, setShowInstructions] = useState(false);
-  const userInstructionsRef = useRef(userInstructions);
-  userInstructionsRef.current = userInstructions;
-  const localeRef = useRef(locale);
-  localeRef.current = locale;
+  const getSuggestionRequestContext = useEffectEvent(() => ({
+    locale,
+    userInstructions: userInstructions.trim(),
+  }));
   const [rows, setRows] = useState<ExistingOrganizerRow[]>([]);
   const [suggestionStatus, setSuggestionStatus] =
     useState<SuggestionStatus>("idle");
@@ -218,7 +224,10 @@ export const ExistingFileOrganizerDialog = ({
     let cancelled = false;
     const fetchSuggestions = async () => {
       setSuggestionStatus("generating");
-      const trimmedInstructions = userInstructionsRef.current.trim();
+      const {
+        locale: requestLocale,
+        userInstructions: trimmedInstructions,
+      } = getSuggestionRequestContext();
       const response = await api
         .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
         ["organize-suggestions"].post({
@@ -231,7 +240,7 @@ export const ExistingFileOrganizerDialog = ({
             entityId: toSafeId<"entity">(file.entityId),
             originalName: file.originalName,
           })),
-          locale: localeRef.current,
+          locale: requestLocale,
           ...(trimmedInstructions.length > 0
             ? { userInstructions: trimmedInstructions }
             : {}),
@@ -894,11 +903,8 @@ const OrganizerTreePreview = ({
   const root = useMemo(() => buildOrganizerTree(rows), [rows]);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isRootOver, setIsRootOver] = useState(false);
-
-  const onMoveFileRef = useRef(onMoveFile);
-  onMoveFileRef.current = onMoveFile;
-  const onMoveFolderRef = useRef(onMoveFolder);
-  onMoveFolderRef.current = onMoveFolder;
+  const handleMoveFile = useEffectEvent(onMoveFile);
+  const handleMoveFolder = useEffectEvent(onMoveFolder);
 
   useMountEffect(() => {
     const el = containerRef.current;
@@ -928,9 +934,9 @@ const OrganizerTreePreview = ({
           return;
         }
         if (data.kind === "file") {
-          onMoveFileRef.current(data.rowId, "");
+          handleMoveFile(data.rowId, "");
         } else {
-          onMoveFolderRef.current(data.folderPath, "");
+          handleMoveFolder(data.folderPath, "");
         }
       },
     });
@@ -1001,11 +1007,8 @@ const OrganizerFolderNode = ({
   const [isEditing, setIsEditing] = useState(false);
 
   const t = useTranslations();
-
-  const onMoveFileRef = useRef(onMoveFile);
-  onMoveFileRef.current = onMoveFile;
-  const onMoveFolderRef = useRef(onMoveFolder);
-  onMoveFolderRef.current = onMoveFolder;
+  const handleMoveFile = useEffectEvent(onMoveFile);
+  const handleMoveFolder = useEffectEvent(onMoveFolder);
 
   useExternalSyncEffect(() => {
     const el = headerRef.current;
@@ -1050,9 +1053,9 @@ const OrganizerFolderNode = ({
             return;
           }
           if (data.kind === "file") {
-            onMoveFileRef.current(data.rowId, folder.path);
+            handleMoveFile(data.rowId, folder.path);
           } else if (data.folderPath !== folder.path) {
-            onMoveFolderRef.current(data.folderPath, folder.path);
+            handleMoveFolder(data.folderPath, folder.path);
           }
         },
       }),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -2,6 +2,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -540,14 +541,13 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   // Only react to `toggleVersion` changes; `toggleAll` is
   // intentionally excluded to avoid an infinite loop
   // (toggleAll → allExpanded → setFolderState → re-render).
-  const toggleAllRef = useRef(toggleAll);
-  toggleAllRef.current = toggleAll;
+  const handleToggleAll = useEffectEvent(toggleAll);
   // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (toggleVersion bump → toggleAll); the trigger is in ViewToolbar's FolderExpandToggle (separate file), but the toggle reads local expandedIds/allFolderIds here, so the action can't be lifted to the button without threading local state up
   useEffect(() => {
     if (toggleVersion === 0) {
       return;
     }
-    toggleAllRef.current();
+    handleToggleAll();
   }, [toggleVersion]);
 
   useExternalSyncEffect(() => {
@@ -637,8 +637,21 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   const [isRootDropTarget, setIsRootDropTarget] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
   const rootBarRef = useRef<HTMLDivElement>(null);
-  const moveEntityRefRoot = useRef(moveEntity);
-  moveEntityRefRoot.current = moveEntity;
+  const handleMoveEntitiesToRoot = useEffectEvent((entityIds: string[]) => {
+    for (const entityId of entityIds) {
+      moveEntity.mutate(
+        { workspaceId, entityId, parentId: null },
+        {
+          onError: () => {
+            stellaToast.add({
+              title: t("errors.actionFailed"),
+              type: "error",
+            });
+          },
+        },
+      );
+    }
+  });
 
   // Track whether an entity drag is active and whether any
   // dragged entity is nested (has a parentId). Only show the
@@ -683,22 +696,10 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
         if (!entityIds) {
           return;
         }
-        for (const entityId of entityIds) {
-          moveEntityRefRoot.current.mutate(
-            { workspaceId, entityId, parentId: null },
-            {
-              onError: () => {
-                stellaToast.add({
-                  title: t("errors.actionFailed"),
-                  type: "error",
-                });
-              },
-            },
-          );
-        }
+        handleMoveEntitiesToRoot(entityIds);
       },
     });
-  }, [workspaceId, t]);
+  }, []);
 
   if (data.length === 0) {
     return (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 
 import {
@@ -175,9 +175,7 @@ export const KanbanColumn = ({
 
   const isDraggable = columnValue !== null && onReorderColumn !== undefined;
 
-  // Store callbacks in refs to keep effect deps stable.
-  const onDropRef = useRef(onDrop);
-  onDropRef.current = onDrop;
+  const handleEntityDrop = useEffectEvent(onDrop);
 
   const { isDropTarget, isInnerActive } = useExternalFileDrop({
     externalRef: columnRef,
@@ -252,7 +250,7 @@ export const KanbanColumn = ({
           if (typeof entityId !== "string") {
             return;
           }
-          onDropRef.current(entityId);
+          handleEntityDrop(entityId);
         },
       }),
     ];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 
 import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
@@ -646,8 +646,7 @@ const KanbanBoard = ({ children, onReorderColumn }: KanbanBoardProps) => {
   // Track the last valid drop position so drops in the
   // gap between columns still work (monitors always fire).
   const lastPosition = useRef<ColumnDragPosition | null>(null);
-  const onReorderRef = useRef(onReorderColumn);
-  onReorderRef.current = onReorderColumn;
+  const handleColumnReorder = useEffectEvent(onReorderColumn);
 
   useMountEffect(() => {
     const el = scrollRef.current;
@@ -693,7 +692,7 @@ const KanbanBoard = ({ children, onReorderColumn }: KanbanBoardProps) => {
           const pos = lastPosition.current;
           lastPosition.current = null;
           if (pos) {
-            onReorderRef.current?.(pos.sourceValue, pos.targetValue, pos.edge);
+            handleColumnReorder(pos.sourceValue, pos.targetValue, pos.edge);
           }
         },
       }),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -646,7 +646,11 @@ const KanbanBoard = ({ children, onReorderColumn }: KanbanBoardProps) => {
   // Track the last valid drop position so drops in the
   // gap between columns still work (monitors always fire).
   const lastPosition = useRef<ColumnDragPosition | null>(null);
-  const handleColumnReorder = useEffectEvent(onReorderColumn);
+  const handleColumnReorder = useEffectEvent(
+    (sourceValue: string, targetValue: string, edge: Edge | null) => {
+      onReorderColumn?.(sourceValue, targetValue, edge);
+    },
+  );
 
   useMountEffect(() => {
     const el = scrollRef.current;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -347,8 +347,7 @@ const ViewTab = ({
   const [isDropTarget, setIsDropTarget] = useState(false);
   const updateView = useUpdateView(workspaceId);
   const containerRef = useRef<HTMLDivElement>(null);
-  const onReorderRef = useRef(onReorder);
-  onReorderRef.current = onReorder;
+  const handleReorder = useEffectEvent(onReorder);
 
   useExternalSyncEffect(() => {
     const el = containerRef.current;
@@ -380,7 +379,7 @@ const ViewTab = ({
           if (typeof draggedViewId !== "string") {
             return;
           }
-          onReorderRef.current(draggedViewId, id);
+          handleReorder(draggedViewId, id);
         },
       }),
     );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useEffectEvent, useRef } from "react";
 
 import {
   useIsMutating,
@@ -82,24 +82,17 @@ export const useCreateBBoxes = ({
     },
   });
 
-  // Refs keep callback identity stable — avoids re-triggering
-  // effects in PeekJustification that list this as a dependency.
-  const pendingRef = useRef(pendingMutationsCount);
-  pendingRef.current = pendingMutationsCount;
-  const mutateRef = useRef(mutation.mutate);
-  mutateRef.current = mutation.mutate;
-
-  return useCallback(() => {
+  return useEffectEvent(() => {
     if (!aiAvailability?.available) {
       return;
     }
 
-    if (pendingRef.current > 0) {
+    if (pendingMutationsCount > 0) {
       return;
     }
 
-    mutateRef.current();
-  }, [aiAvailability?.available]);
+    mutation.mutate();
+  });
 };
 
 export const useIsCreatingBBoxes = () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -1,4 +1,4 @@
-import { useEffectEvent, useRef } from "react";
+import { useCallback, useRef } from "react";
 
 import {
   useIsMutating,
@@ -82,17 +82,22 @@ export const useCreateBBoxes = ({
     },
   });
 
-  return useEffectEvent(() => {
+  const pendingRef = useRef(pendingMutationsCount);
+  pendingRef.current = pendingMutationsCount;
+  const mutateRef = useRef(mutation.mutate);
+  mutateRef.current = mutation.mutate;
+
+  return useCallback(() => {
     if (!aiAvailability?.available) {
       return;
     }
 
-    if (pendingMutationsCount > 0) {
+    if (pendingRef.current > 0) {
       return;
     }
 
-    mutation.mutate();
-  });
+    mutateRef.current();
+  }, [aiAvailability?.available]);
 };
 
 export const useIsCreatingBBoxes = () => {


### PR DESCRIPTION
## Summary
- replace latest-value ref mirrors in external drag/drop registrations with useEffectEvent
- remove pending/mutate mirror refs from bounding box creation
- read organizer request context through an effect event instead of render-time refs