### PR TITLE
chore: add authenticated route render smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,7 @@ jobs:
           # --preload registers the dev/test-only mock-AI generator; .env.example
           # sets USE_MOCK_AI=true, so e2e must route through the mock rather than
           # the real provider (which would fail on the placeholder API key).
-          NODE_ENV=development nohup bun --port 3001 --preload ./src/dev/register-mock-ai.ts src/index.ts > /tmp/api.log 2>&1 &
+          NODE_ENV=development E2E_DISABLE_AUTH_RATE_LIMIT=true nohup bun --port 3001 --preload ./src/dev/register-mock-ai.ts src/index.ts > /tmp/api.log 2>&1 &
           echo $! > /tmp/api.pid
 
       - name: Wait for API

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -70,6 +70,17 @@ const envApi = createEnv({
     ),
     REDIS_URL: v.pipe(v.string(), v.url()),
     USE_MOCK_AI: v.optional(v.pipe(v.string(), v.parseBoolean()), "false"),
+    E2E_DISABLE_AUTH_RATE_LIMIT: v.optional(
+      v.pipe(
+        v.string(),
+        v.parseBoolean(),
+        v.check(
+          (disabled) => !disabled || process.env.NODE_ENV === "development",
+          "E2E_DISABLE_AUTH_RATE_LIMIT is test-only and requires NODE_ENV=development.",
+        ),
+      ),
+      "false",
+    ),
     BETTER_AUTH_SECRET: v.pipe(v.string(), v.minLength(32)),
     BETTER_AUTH_URL: v.pipe(v.string(), v.url()),
     BETTER_AUTH_COOKIE_PREFIX: v.optional(

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -227,7 +227,7 @@ const createAuth = () => {
       useSecureCookies: !env.isDev,
     },
     rateLimit: {
-      enabled: true,
+      enabled: !env.E2E_DISABLE_AUTH_RATE_LIMIT,
       window: AUTH_RATE_LIMITS.global.window,
       max: AUTH_RATE_LIMITS.global.max,
       customStorage: createAuthRateLimitStorage(

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -16,6 +16,8 @@ type BrowserErrorFixtures = {
 // connection codes, not the broader "failed to load resource" family.
 const TRANSIENT_NETWORK_ERROR =
   /net::(?:ERR_EMPTY_RESPONSE|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED|ERR_NETWORK_CHANGED)/u;
+const RESOURCE_NOT_FOUND_CONSOLE_ERROR =
+  /^Failed to load resource: the server responded with a status of 404 \(Not Found\)$/u;
 
 export const createBrowserErrorCollector = (): BrowserErrorCollector & {
   add: (message: string) => void;
@@ -43,6 +45,10 @@ export const createBrowserErrorCollector = (): BrowserErrorCollector & {
 
         const text = message.text();
         if (TRANSIENT_NETWORK_ERROR.test(text)) {
+          return;
+        }
+
+        if (RESOURCE_NOT_FOUND_CONSOLE_ERROR.test(text)) {
           return;
         }
 

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -1,9 +1,10 @@
 import { expect, test as base } from "@playwright/test";
-import type { ConsoleMessage } from "@playwright/test";
+import type { ConsoleMessage, Page } from "@playwright/test";
 
 type BrowserErrorCollector = {
   entries: () => string[];
   assertEmpty: (label: string) => void;
+  trackPage: (page: Page) => () => void;
 };
 
 type BrowserErrorFixtures = {
@@ -30,16 +31,9 @@ const createBrowserErrorCollector = (): BrowserErrorCollector & {
       const collected = errors.splice(0);
       expect(collected, `${label}\n\n${collected.join("\n\n")}`).toEqual([]);
     },
-  };
-};
-
-export const test = base.extend<BrowserErrorFixtures>({
-  browserErrors: [
-    async ({ page }, runFixture) => {
-      const browserErrors = createBrowserErrorCollector();
-
+    trackPage: (page) => {
       const onPageError = (error: Error) => {
-        browserErrors.add(`pageerror: ${error.message}`);
+        errors.push(`pageerror: ${error.message}`);
       };
 
       const onConsole = (message: ConsoleMessage) => {
@@ -52,17 +46,30 @@ export const test = base.extend<BrowserErrorFixtures>({
           return;
         }
 
-        browserErrors.add(`console.error: ${text}`);
+        errors.push(`console.error: ${text}`);
       };
 
       page.on("pageerror", onPageError);
       page.on("console", onConsole);
 
+      return () => {
+        page.off("pageerror", onPageError);
+        page.off("console", onConsole);
+      };
+    },
+  };
+};
+
+export const test = base.extend<BrowserErrorFixtures>({
+  browserErrors: [
+    async ({ page }, runFixture) => {
+      const browserErrors = createBrowserErrorCollector();
+      const detachPage = browserErrors.trackPage(page);
+
       try {
         await runFixture(browserErrors);
       } finally {
-        page.off("pageerror", onPageError);
-        page.off("console", onConsole);
+        detachPage();
       }
 
       browserErrors.assertEmpty("unexpected browser errors");

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -1,7 +1,7 @@
 import { expect, test as base } from "@playwright/test";
 import type { ConsoleMessage, Page } from "@playwright/test";
 
-type BrowserErrorCollector = {
+export type BrowserErrorCollector = {
   entries: () => string[];
   assertEmpty: (label: string) => void;
   trackPage: (page: Page) => () => void;
@@ -17,7 +17,7 @@ type BrowserErrorFixtures = {
 const TRANSIENT_NETWORK_ERROR =
   /net::(?:ERR_EMPTY_RESPONSE|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED|ERR_NETWORK_CHANGED)/u;
 
-const createBrowserErrorCollector = (): BrowserErrorCollector & {
+export const createBrowserErrorCollector = (): BrowserErrorCollector & {
   add: (message: string) => void;
 } => {
   const errors: string[] = [];

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -19,13 +19,13 @@ const TRANSIENT_NETWORK_ERROR =
 const RESOURCE_NOT_FOUND_CONSOLE_ERROR =
   /^Failed to load resource: the server responded with a status of 404 \(Not Found\)$/u;
 
-// Static assets (lazy route chunks, styles, fonts, images) must never 404: a
-// missing chunk surfaces only as this console error while the shell still
-// renders, so those stay fatal. Smoke specs deliberately probe non-existent
-// records (random thread/entity ids), so 404s from data/API requests are
-// tolerated.
+// Static assets (lazy route chunks, wasm runtimes, styles, fonts, images) must
+// never 404: a missing chunk surfaces only as this console error while the
+// shell still renders, so those stay fatal. Smoke specs deliberately probe
+// non-existent records (random thread/entity ids), so 404s from data/API
+// requests are tolerated.
 const STATIC_ASSET_URL =
-  /\.(?:js|mjs|cjs|css|map|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|webp|avif|ico)(?:[?#]|$)/u;
+  /\.(?:js|mjs|cjs|wasm|css|map|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|webp|avif|ico)(?:[?#]|$)/u;
 
 const isToleratedResourceNotFound = (message: ConsoleMessage): boolean =>
   RESOURCE_NOT_FOUND_CONSOLE_ERROR.test(message.text()) &&

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -58,10 +58,13 @@ export const test = base.extend<BrowserErrorFixtures>({
       page.on("pageerror", onPageError);
       page.on("console", onConsole);
 
-      await runFixture(browserErrors);
+      try {
+        await runFixture(browserErrors);
+      } finally {
+        page.off("pageerror", onPageError);
+        page.off("console", onConsole);
+      }
 
-      page.off("pageerror", onPageError);
-      page.off("console", onConsole);
       browserErrors.assertEmpty("unexpected browser errors");
     },
     { auto: true },

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -1,0 +1,71 @@
+import { expect, test as base } from "@playwright/test";
+import type { ConsoleMessage } from "@playwright/test";
+
+type BrowserErrorCollector = {
+  entries: () => string[];
+  assertEmpty: (label: string) => void;
+};
+
+type BrowserErrorFixtures = {
+  browserErrors: BrowserErrorCollector;
+};
+
+// Transport-layer connection drops the browser reports as console errors.
+// These are dev-server infra flakes, not app errors. Match only dropped
+// connection codes, not the broader "failed to load resource" family.
+const TRANSIENT_NETWORK_ERROR =
+  /net::(?:ERR_EMPTY_RESPONSE|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED|ERR_NETWORK_CHANGED)/u;
+
+const createBrowserErrorCollector = (): BrowserErrorCollector & {
+  add: (message: string) => void;
+} => {
+  const errors: string[] = [];
+
+  return {
+    add: (message) => {
+      errors.push(message);
+    },
+    entries: () => [...errors],
+    assertEmpty: (label) => {
+      const collected = errors.splice(0);
+      expect(collected, `${label}\n\n${collected.join("\n\n")}`).toEqual([]);
+    },
+  };
+};
+
+export const test = base.extend<BrowserErrorFixtures>({
+  browserErrors: [
+    async ({ page }, runFixture) => {
+      const browserErrors = createBrowserErrorCollector();
+
+      const onPageError = (error: Error) => {
+        browserErrors.add(`pageerror: ${error.message}`);
+      };
+
+      const onConsole = (message: ConsoleMessage) => {
+        if (message.type() !== "error") {
+          return;
+        }
+
+        const text = message.text();
+        if (TRANSIENT_NETWORK_ERROR.test(text)) {
+          return;
+        }
+
+        browserErrors.add(`console.error: ${text}`);
+      };
+
+      page.on("pageerror", onPageError);
+      page.on("console", onConsole);
+
+      await runFixture(browserErrors);
+
+      page.off("pageerror", onPageError);
+      page.off("console", onConsole);
+      browserErrors.assertEmpty("unexpected browser errors");
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -19,6 +19,18 @@ const TRANSIENT_NETWORK_ERROR =
 const RESOURCE_NOT_FOUND_CONSOLE_ERROR =
   /^Failed to load resource: the server responded with a status of 404 \(Not Found\)$/u;
 
+// Static assets (lazy route chunks, styles, fonts, images) must never 404: a
+// missing chunk surfaces only as this console error while the shell still
+// renders, so those stay fatal. Smoke specs deliberately probe non-existent
+// records (random thread/entity ids), so 404s from data/API requests are
+// tolerated.
+const STATIC_ASSET_URL =
+  /\.(?:js|mjs|cjs|css|map|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|webp|avif|ico)(?:[?#]|$)/u;
+
+const isToleratedResourceNotFound = (message: ConsoleMessage): boolean =>
+  RESOURCE_NOT_FOUND_CONSOLE_ERROR.test(message.text()) &&
+  !STATIC_ASSET_URL.test(message.location().url);
+
 export const createBrowserErrorCollector = (): BrowserErrorCollector & {
   add: (message: string) => void;
 } => {
@@ -48,7 +60,7 @@ export const createBrowserErrorCollector = (): BrowserErrorCollector & {
           return;
         }
 
-        if (RESOURCE_NOT_FOUND_CONSOLE_ERROR.test(text)) {
+        if (isToleratedResourceNotFound(message)) {
           return;
         }
 

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../helpers/test";
 
 // The seeded e2e user (test@stella.dev) is an org owner whose org has NO
 // usage_entitlements row — the dark-launch default every production org

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -4,7 +4,12 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { apiDelete, apiGet, apiPut, apiUploadDocx } from "../helpers/api";
-import { expect, test } from "../helpers/test";
+import {
+  type BrowserErrorCollector,
+  createBrowserErrorCollector,
+  expect,
+  test,
+} from "../helpers/test";
 import {
   type TestWorkspace,
   createTestWorkspace,
@@ -86,8 +91,9 @@ const AUTHENTICATED_ROUTE_PREFIXES = [
   "/workspaces",
 ];
 
+const ROUTE_SMOKE_BATCH_SIZE = 4;
+
 test("authenticated routes render without browser errors", async ({
-  browserErrors,
   context,
   request,
 }) => {
@@ -129,9 +135,11 @@ test("authenticated routes render without browser errors", async ({
 
     await expectAuthenticatedRouteCoverage(routes);
 
-    for (const route of routes) {
-      // eslint-disable-next-line no-await-in-loop -- each route gets an isolated page so browser errors can be attributed to its direct render without cross-route reload noise
-      await smokeRoute({ browserErrors, context, route });
+    for (const routeBatch of chunkRoutes(routes, ROUTE_SMOKE_BATCH_SIZE)) {
+      // eslint-disable-next-line no-await-in-loop -- small batches keep each route isolated without turning the smoke into a long serial crawl
+      await Promise.all(
+        routeBatch.map(async (route) => await smokeRoute({ context, route })),
+      );
     }
   } finally {
     await Promise.all(cleanupTasks.map(async (cleanup) => await cleanup()));
@@ -225,18 +233,14 @@ const createDocumentRoute = async (
 };
 
 const smokeRoute = async ({
-  browserErrors,
   context,
   route,
 }: {
-  browserErrors: {
-    assertEmpty: (label: string) => void;
-    trackPage: (page: Page) => () => void;
-  };
   context: BrowserContext;
   route: SmokeRoute;
 }) => {
   const page = await context.newPage();
+  const browserErrors = createBrowserErrorCollector();
   const detachPage = browserErrors.trackPage(page);
 
   try {
@@ -252,7 +256,7 @@ const renderSmokeRoute = async ({
   page,
   route,
 }: {
-  browserErrors: { assertEmpty: (label: string) => void };
+  browserErrors: Pick<BrowserErrorCollector, "assertEmpty">;
   page: Page;
   route: SmokeRoute;
 }) => {
@@ -326,3 +330,16 @@ const isAuthenticatedRouteTemplate = (route: string): boolean =>
   AUTHENTICATED_ROUTE_PREFIXES.some(
     (prefix) => route === prefix || route.startsWith(`${prefix}/`),
   );
+
+const chunkRoutes = (
+  routes: readonly SmokeRoute[],
+  batchSize: number,
+): SmokeRoute[][] => {
+  const batches: SmokeRoute[][] = [];
+
+  for (let index = 0; index < routes.length; index += batchSize) {
+    batches.push(routes.slice(index, index + batchSize));
+  }
+
+  return batches;
+};

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -61,17 +61,17 @@ const STATIC_AUTHENTICATED_ROUTES: readonly SmokeRoute[] = [
   {
     template: "/knowledge/mcp",
     path: "/knowledge/mcp",
-    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools?kind=mcp" },
   },
   {
     template: "/knowledge/prompts",
     path: "/knowledge/prompts",
-    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools?kind=skill" },
   },
   {
     template: "/knowledge/skills",
     path: "/knowledge/skills",
-    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools?kind=skill" },
   },
   { template: "/knowledge/templates", path: "/knowledge/templates" },
   { template: "/knowledge/tools", path: "/knowledge/tools" },
@@ -319,15 +319,28 @@ const assertFinalDestination = (page: Page, route: SmokeRoute) => {
     return;
   }
 
-  const expectedPath =
-    expectation.kind === "redirectsTo"
-      ? expectation.to
-      : new URL(route.path, page.url()).pathname;
+  const target =
+    expectation.kind === "redirectsTo" ? expectation.to : route.path;
+  const expected = new URL(target, page.url());
+  const actual = new URL(page.url());
 
-  expect(
-    new URL(page.url()).pathname,
-    `${route.template} settled on an unexpected route`,
-  ).toBe(expectedPath);
+  // A redirectsTo target opts into search assertion by spelling out a query
+  // string (e.g. the legacy knowledge redirects must preserve ?kind=...).
+  // Otherwise compare pathname only: render-in-place routes may inject default
+  // search params, and a route that drops a required param (e.g. the document
+  // route) bounces to a different pathname, which this assertion already catches.
+  const assertSearch =
+    expectation.kind === "redirectsTo" && expected.search !== "";
+  const expectedHref = assertSearch
+    ? expected.pathname + expected.search
+    : expected.pathname;
+  const actualHref = assertSearch
+    ? actual.pathname + actual.search
+    : actual.pathname;
+
+  expect(actualHref, `${route.template} settled on an unexpected route`).toBe(
+    expectedHref,
+  );
 };
 
 const assertNoRouteBoundary = async (page: Page, routeTemplate: string) => {

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -24,30 +24,74 @@ const ROUTE_TREE_PATH = path.resolve(
   "../../src/routeTree.gen.ts",
 );
 
+type RouteExpectation =
+  | { kind: "rendersInPlace" }
+  | { kind: "redirectsTo"; to: string }
+  | { kind: "settles" };
+
 type SmokeRoute = {
   template: string;
   path: string;
   settleMs?: number;
+  // Where the route settles. Defaults to rendering in place (the pathname stays
+  // put). `redirectsTo` pins a deterministic beforeLoad/Navigate target so a
+  // regression that silently bounces the page to another route is caught.
+  // `settles` covers routes whose destination depends on env or runtime data
+  // (freshly minted ids, dev-only gates), where only "left /auth and rendered"
+  // is assertable.
+  expectation?: RouteExpectation;
 };
 
 const STATIC_AUTHENTICATED_ROUTES: readonly SmokeRoute[] = [
   { template: "/chat", path: "/chat" },
   { template: "/chat/$threadId", path: `/chat/${randomUUID()}` },
-  { template: "/chat/new", path: "/chat/new" },
+  {
+    template: "/chat/new",
+    path: "/chat/new",
+    expectation: { kind: "settles" },
+  },
   { template: "/contacts", path: "/contacts" },
-  { template: "/dev/autocomplete", path: "/dev/autocomplete" },
+  {
+    template: "/dev/autocomplete",
+    path: "/dev/autocomplete",
+    expectation: { kind: "settles" },
+  },
   { template: "/knowledge", path: "/knowledge" },
   { template: "/knowledge/clauses", path: "/knowledge/clauses" },
-  { template: "/knowledge/mcp", path: "/knowledge/mcp" },
-  { template: "/knowledge/prompts", path: "/knowledge/prompts" },
-  { template: "/knowledge/skills", path: "/knowledge/skills" },
+  {
+    template: "/knowledge/mcp",
+    path: "/knowledge/mcp",
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
+  },
+  {
+    template: "/knowledge/prompts",
+    path: "/knowledge/prompts",
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
+  },
+  {
+    template: "/knowledge/skills",
+    path: "/knowledge/skills",
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
+  },
   { template: "/knowledge/templates", path: "/knowledge/templates" },
   { template: "/knowledge/tools", path: "/knowledge/tools" },
-  { template: "/settings", path: "/settings" },
-  { template: "/settings/account/beta", path: "/settings/account/beta" },
+  {
+    template: "/settings",
+    path: "/settings",
+    expectation: { kind: "redirectsTo", to: "/settings/account/profile" },
+  },
+  {
+    template: "/settings/account/beta",
+    path: "/settings/account/beta",
+    expectation: { kind: "settles" },
+  },
   { template: "/settings/account/desktop", path: "/settings/account/desktop" },
   { template: "/settings/account/profile", path: "/settings/account/profile" },
-  { template: "/settings/organization", path: "/settings/organization" },
+  {
+    template: "/settings/organization",
+    path: "/settings/organization",
+    expectation: { kind: "redirectsTo", to: "/settings/organization/members" },
+  },
   { template: "/settings/organization/ai", path: "/settings/organization/ai" },
   {
     template: "/settings/organization/anonymization",
@@ -56,6 +100,7 @@ const STATIC_AUTHENTICATED_ROUTES: readonly SmokeRoute[] = [
   {
     template: "/settings/organization/catalogue",
     path: "/settings/organization/catalogue",
+    expectation: { kind: "redirectsTo", to: "/knowledge/tools" },
   },
   {
     template: "/settings/organization/matter-numbering",
@@ -81,16 +126,6 @@ const INTENTIONALLY_NOT_SMOKED = new Set([
   "/workspaces/$workspaceId/invoices/$invoiceId",
 ]);
 
-const AUTHENTICATED_ROUTE_PREFIXES = [
-  "/chat",
-  "/contacts",
-  "/dev/autocomplete",
-  "/knowledge",
-  "/settings",
-  "/todos",
-  "/workspaces",
-];
-
 test("authenticated routes render without browser errors", async ({
   context,
   request,
@@ -112,7 +147,7 @@ test("authenticated routes render without browser errors", async ({
 
     const documentRoute = await createDocumentRoute(request, workspace);
 
-    const routes = [
+    const routes: SmokeRoute[] = [
       ...STATIC_AUTHENTICATED_ROUTES,
       ...createWorkspaceRoutes(workspace),
       {
@@ -123,6 +158,7 @@ test("authenticated routes render without browser errors", async ({
         template: "/workspaces/$workspaceId/entities/$entityId",
         path: `/workspaces/${workspace.id}/entities/${documentRoute.entityId}`,
         settleMs: 1500,
+        expectation: { kind: "settles" },
       },
       {
         template: "/workspaces/$workspaceId/$viewId/document",
@@ -152,10 +188,12 @@ const createWorkspaceRoutes = (workspace: TestWorkspace): SmokeRoute[] => [
   {
     template: "/chat/workspaces/$workspaceId/new",
     path: `/chat/workspaces/${workspace.id}/new`,
+    expectation: { kind: "settles" },
   },
   {
     template: "/workspaces/$workspaceId",
     path: `/workspaces/${workspace.id}`,
+    expectation: { kind: "settles" },
   },
   {
     template: "/workspaces/$workspaceId/expenses",
@@ -168,6 +206,7 @@ const createWorkspaceRoutes = (workspace: TestWorkspace): SmokeRoute[] => [
   {
     template: "/workspaces/$workspaceId/timesheets",
     path: `/workspaces/${workspace.id}/timesheets`,
+    expectation: { kind: "settles" },
   },
   {
     template: "/workspaces/$workspaceId/$viewId",
@@ -266,7 +305,29 @@ const renderSmokeRoute = async ({
   await page.waitForTimeout(route.settleMs ?? 250);
 
   await assertNoRouteBoundary(page, route.template);
+  assertFinalDestination(page, route);
   browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);
+};
+
+// A route counts as smoked only if it settled on its own component or its
+// declared redirect target; bouncing to an unrelated route means the component
+// under test never rendered. `settles` routes opt out because their final URL
+// depends on env or runtime data.
+const assertFinalDestination = (page: Page, route: SmokeRoute) => {
+  const expectation = route.expectation ?? { kind: "rendersInPlace" };
+  if (expectation.kind === "settles") {
+    return;
+  }
+
+  const expectedPath =
+    expectation.kind === "redirectsTo"
+      ? expectation.to
+      : new URL(route.path, page.url()).pathname;
+
+  expect(
+    new URL(page.url()).pathname,
+    `${route.template} settled on an unexpected route`,
+  ).toBe(expectedPath);
 };
 
 const assertNoRouteBoundary = async (page: Page, routeTemplate: string) => {
@@ -304,27 +365,17 @@ const readAuthenticatedRouteTemplates = async (): Promise<string[]> => {
 
   return body
     .split("\n")
-    .map(parseRouteTreeLine)
+    .map(parseAuthenticatedRouteTemplate)
     .filter((route): route is string => route !== null)
-    .filter(isAuthenticatedRouteTemplate)
     .toSorted();
 };
 
-const parseRouteTreeLine = (line: string): string | null => {
-  const trimmed = line.trimStart();
-  if (!trimmed.startsWith("'")) {
-    return null;
-  }
+// The generated route tree types every authenticated `to` path against a
+// `Protected*` route (the `_protected` layout). Deriving the smoke set from
+// that structural marker, rather than a hand-maintained prefix allow-list,
+// means a newly added authenticated top-level section fails this spec until it
+// is either smoked or placed in INTENTIONALLY_NOT_SMOKED.
+const PROTECTED_ROUTE_LINE = /^'(?<path>[^']+)':\s*typeof\s+Protected/u;
 
-  const routeEnd = trimmed.indexOf("':", 1);
-  if (routeEnd === -1) {
-    return null;
-  }
-
-  return trimmed.slice(1, routeEnd);
-};
-
-const isAuthenticatedRouteTemplate = (route: string): boolean =>
-  AUTHENTICATED_ROUTE_PREFIXES.some(
-    (prefix) => route === prefix || route.startsWith(`${prefix}/`),
-  );
+const parseAuthenticatedRouteTemplate = (line: string): string | null =>
+  PROTECTED_ROUTE_LINE.exec(line.trimStart())?.groups?.["path"] ?? null;

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -200,14 +200,14 @@ const createDocumentRoute = async (
   );
 
   const entity = await apiGet<{
-    fields: {
+    fields?: {
       id: string;
       propertyId: string;
       content: { type: string };
     }[];
   }>(request, `/entities/${workspace.id}/entity/${uploaded.entityId}`);
 
-  const fileField = entity.fields.find(
+  const fileField = entity.fields?.find(
     (field) =>
       field.propertyId === workspace.filePropertyId &&
       field.content.type === "file",
@@ -236,6 +236,7 @@ const smokeRoute = async ({
   await page.goto(route.path, { waitUntil: "domcontentloaded" });
   await expect(page, route.template).not.toHaveURL(/\/auth(?:\/|$)/u);
   await assertNoRouteBoundary(page, route.template);
+  await expect(page.locator("main").first(), route.template).toBeVisible();
 
   await page.waitForTimeout(route.settleMs ?? 750);
 

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -1,0 +1,304 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { apiDelete, apiGet, apiPut, apiUploadDocx } from "../helpers/api";
+import { expect, test } from "../helpers/test";
+import {
+  type TestWorkspace,
+  createTestWorkspace,
+  deleteTestWorkspace,
+} from "../helpers/workspace";
+
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
+const ROUTE_TREE_PATH = path.resolve(
+  import.meta.dirname,
+  "../../src/routeTree.gen.ts",
+);
+
+type SmokeRoute = {
+  template: string;
+  path: string;
+  settleMs?: number;
+};
+
+const STATIC_AUTHENTICATED_ROUTES: readonly SmokeRoute[] = [
+  { template: "/chat", path: "/chat" },
+  { template: "/chat/$threadId", path: `/chat/${randomUUID()}` },
+  { template: "/chat/new", path: "/chat/new" },
+  { template: "/contacts", path: "/contacts" },
+  { template: "/dev/autocomplete", path: "/dev/autocomplete" },
+  { template: "/knowledge", path: "/knowledge" },
+  { template: "/knowledge/clauses", path: "/knowledge/clauses" },
+  { template: "/knowledge/mcp", path: "/knowledge/mcp" },
+  { template: "/knowledge/prompts", path: "/knowledge/prompts" },
+  { template: "/knowledge/skills", path: "/knowledge/skills" },
+  { template: "/knowledge/templates", path: "/knowledge/templates" },
+  { template: "/knowledge/tools", path: "/knowledge/tools" },
+  { template: "/settings", path: "/settings" },
+  { template: "/settings/account/beta", path: "/settings/account/beta" },
+  { template: "/settings/account/desktop", path: "/settings/account/desktop" },
+  { template: "/settings/account/profile", path: "/settings/account/profile" },
+  { template: "/settings/organization", path: "/settings/organization" },
+  { template: "/settings/organization/ai", path: "/settings/organization/ai" },
+  {
+    template: "/settings/organization/anonymization",
+    path: "/settings/organization/anonymization",
+  },
+  {
+    template: "/settings/organization/catalogue",
+    path: "/settings/organization/catalogue",
+  },
+  {
+    template: "/settings/organization/matter-numbering",
+    path: "/settings/organization/matter-numbering",
+  },
+  {
+    template: "/settings/organization/members",
+    path: "/settings/organization/members",
+  },
+  {
+    template: "/settings/organization/usage",
+    path: "/settings/organization/usage",
+  },
+  { template: "/todos", path: "/todos" },
+  { template: "/workspaces", path: "/workspaces" },
+];
+
+// These routes need richer domain setup than cheap route smoke should own.
+// Keeping them explicit means a newly added authenticated route fails this spec
+// until it is either smoked or deliberately placed here.
+const INTENTIONALLY_NOT_SMOKED = new Set([
+  "/knowledge/tools/$skillId",
+  "/workspaces/$workspaceId/invoices/$invoiceId",
+]);
+
+const AUTHENTICATED_ROUTE_PREFIXES = [
+  "/chat",
+  "/contacts",
+  "/dev/autocomplete",
+  "/knowledge",
+  "/settings",
+  "/todos",
+  "/workspaces",
+];
+
+test("authenticated routes render without browser errors", async ({
+  browserErrors,
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+
+  const cleanupTasks: (() => Promise<void>)[] = [];
+
+  try {
+    const workspace = await createTestWorkspace(request, "route-smoke");
+    cleanupTasks.push(
+      async () => await deleteTestWorkspace(request, workspace.id),
+    );
+
+    const contactId = await createContact(request);
+    cleanupTasks.push(
+      async () => await apiDelete(request, `/contacts/${contactId}`),
+    );
+
+    const documentRoute = await createDocumentRoute(request, workspace);
+
+    const routes = [
+      ...STATIC_AUTHENTICATED_ROUTES,
+      ...createWorkspaceRoutes(workspace),
+      {
+        template: "/contacts/$contactId",
+        path: `/contacts/${contactId}`,
+      },
+      {
+        template: "/workspaces/$workspaceId/entities/$entityId",
+        path: `/workspaces/${workspace.id}/entities/${documentRoute.entityId}`,
+        settleMs: 1500,
+      },
+      {
+        template: "/workspaces/$workspaceId/$viewId/document",
+        path: documentRoute.path,
+        settleMs: 2000,
+      },
+    ];
+
+    await expectAuthenticatedRouteCoverage(routes);
+
+    for (const route of routes) {
+      // eslint-disable-next-line no-await-in-loop -- route smoke must navigate sequentially on one page so browser errors can be attributed to the route that just rendered
+      await smokeRoute({ browserErrors, page, route });
+    }
+  } finally {
+    await Promise.all(cleanupTasks.map(async (cleanup) => await cleanup()));
+  }
+});
+
+const createWorkspaceRoutes = (workspace: TestWorkspace): SmokeRoute[] => [
+  {
+    template: "/chat/workspaces/$workspaceId/$threadId",
+    path: `/chat/workspaces/${workspace.id}/${randomUUID()}`,
+  },
+  {
+    template: "/chat/workspaces/$workspaceId/new",
+    path: `/chat/workspaces/${workspace.id}/new`,
+  },
+  {
+    template: "/workspaces/$workspaceId",
+    path: `/workspaces/${workspace.id}`,
+  },
+  {
+    template: "/workspaces/$workspaceId/expenses",
+    path: `/workspaces/${workspace.id}/expenses`,
+  },
+  {
+    template: "/workspaces/$workspaceId/invoices",
+    path: `/workspaces/${workspace.id}/invoices`,
+  },
+  {
+    template: "/workspaces/$workspaceId/timesheets",
+    path: `/workspaces/${workspace.id}/timesheets`,
+  },
+  {
+    template: "/workspaces/$workspaceId/$viewId",
+    path: `/workspaces/${workspace.id}/${workspace.viewId}`,
+  },
+];
+
+const createContact = async (request: APIRequestContext): Promise<string> => {
+  const contactId = randomUUID();
+
+  await apiPut(request, "/contacts", {
+    id: contactId,
+    type: "person",
+    displayName: `Route Smoke ${contactId.slice(0, 8)}`,
+    firstName: "Route",
+    lastName: "Smoke",
+  });
+
+  return contactId;
+};
+
+const createDocumentRoute = async (
+  request: APIRequestContext,
+  workspace: TestWorkspace,
+): Promise<{ entityId: string; path: string }> => {
+  const docxBuffer = await readFile(DOCX_PATH);
+  const uploaded = await apiUploadDocx(
+    request,
+    workspace.id,
+    workspace.filePropertyId,
+    {
+      name: "route-smoke.docx",
+      mimeType: DOCX_MIME,
+      buffer: docxBuffer,
+    },
+  );
+
+  const entity = await apiGet<{
+    fields: {
+      id: string;
+      propertyId: string;
+      content: { type: string };
+    }[];
+  }>(request, `/entities/${workspace.id}/entity/${uploaded.entityId}`);
+
+  const fileField = entity.fields.find(
+    (field) =>
+      field.propertyId === workspace.filePropertyId &&
+      field.content.type === "file",
+  );
+  if (!fileField) {
+    throw new Error("Uploaded entity did not include the expected file field");
+  }
+
+  return {
+    entityId: uploaded.entityId,
+    path:
+      `/workspaces/${workspace.id}/${workspace.viewId}/document` +
+      `?entity=${uploaded.entityId}&field=${fileField.id}`,
+  };
+};
+
+const smokeRoute = async ({
+  browserErrors,
+  page,
+  route,
+}: {
+  browserErrors: { assertEmpty: (label: string) => void };
+  page: Page;
+  route: SmokeRoute;
+}) => {
+  await page.goto(route.path, { waitUntil: "domcontentloaded" });
+  await expect(page, route.template).not.toHaveURL(/\/auth(?:\/|$)/u);
+  await assertNoRouteBoundary(page, route.template);
+
+  await page.waitForTimeout(route.settleMs ?? 750);
+
+  await assertNoRouteBoundary(page, route.template);
+  browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);
+};
+
+const assertNoRouteBoundary = async (page: Page, routeTemplate: string) => {
+  await expect(
+    page.getByRole("heading", { name: "Something went wrong" }),
+    `route error boundary rendered on ${routeTemplate}`,
+  ).toHaveCount(0);
+};
+
+const expectAuthenticatedRouteCoverage = async (
+  routes: readonly SmokeRoute[],
+) => {
+  const actual = await readAuthenticatedRouteTemplates();
+  const expected = [
+    ...routes.map((route) => route.template),
+    ...INTENTIONALLY_NOT_SMOKED,
+  ].toSorted();
+
+  expect(actual).toEqual(expected);
+};
+
+const readAuthenticatedRouteTemplates = async (): Promise<string[]> => {
+  const source = await readFile(ROUTE_TREE_PATH, "utf-8");
+  const marker = "export interface FileRoutesByTo {";
+  const bodyStart = source.indexOf(marker);
+  if (bodyStart === -1) {
+    throw new Error("Could not find FileRoutesByTo in routeTree.gen.ts");
+  }
+  const routeBodyStart = bodyStart + marker.length;
+  const bodyEnd = source.indexOf("\n}", routeBodyStart);
+  if (bodyEnd === -1) {
+    throw new Error("Could not find end of FileRoutesByTo in routeTree.gen.ts");
+  }
+  const body = source.slice(routeBodyStart, bodyEnd);
+
+  return body
+    .split("\n")
+    .map(parseRouteTreeLine)
+    .filter((route): route is string => route !== null)
+    .filter(isAuthenticatedRouteTemplate)
+    .toSorted();
+};
+
+const parseRouteTreeLine = (line: string): string | null => {
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith("'")) {
+    return null;
+  }
+
+  const routeEnd = trimmed.indexOf("':", 1);
+  if (routeEnd === -1) {
+    return null;
+  }
+
+  return trimmed.slice(1, routeEnd);
+};
+
+const isAuthenticatedRouteTemplate = (route: string): boolean =>
+  AUTHENTICATED_ROUTE_PREFIXES.some(
+    (prefix) => route === prefix || route.startsWith(`${prefix}/`),
+  );

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -1,4 +1,4 @@
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { APIRequestContext, BrowserContext, Page } from "@playwright/test";
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -88,7 +88,7 @@ const AUTHENTICATED_ROUTE_PREFIXES = [
 
 test("authenticated routes render without browser errors", async ({
   browserErrors,
-  page,
+  context,
   request,
 }) => {
   test.setTimeout(120_000);
@@ -130,8 +130,8 @@ test("authenticated routes render without browser errors", async ({
     await expectAuthenticatedRouteCoverage(routes);
 
     for (const route of routes) {
-      // eslint-disable-next-line no-await-in-loop -- route smoke must navigate sequentially on one page so browser errors can be attributed to the route that just rendered
-      await smokeRoute({ browserErrors, page, route });
+      // eslint-disable-next-line no-await-in-loop -- each route gets an isolated page so browser errors can be attributed to its direct render without cross-route reload noise
+      await smokeRoute({ browserErrors, context, route });
     }
   } finally {
     await Promise.all(cleanupTasks.map(async (cleanup) => await cleanup()));
@@ -225,6 +225,29 @@ const createDocumentRoute = async (
 };
 
 const smokeRoute = async ({
+  browserErrors,
+  context,
+  route,
+}: {
+  browserErrors: {
+    assertEmpty: (label: string) => void;
+    trackPage: (page: Page) => () => void;
+  };
+  context: BrowserContext;
+  route: SmokeRoute;
+}) => {
+  const page = await context.newPage();
+  const detachPage = browserErrors.trackPage(page);
+
+  try {
+    await renderSmokeRoute({ browserErrors, page, route });
+  } finally {
+    detachPage();
+    await page.close();
+  }
+};
+
+const renderSmokeRoute = async ({
   browserErrors,
   page,
   route,

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -91,8 +91,6 @@ const AUTHENTICATED_ROUTE_PREFIXES = [
   "/workspaces",
 ];
 
-const ROUTE_SMOKE_BATCH_SIZE = 4;
-
 test("authenticated routes render without browser errors", async ({
   context,
   request,
@@ -135,11 +133,9 @@ test("authenticated routes render without browser errors", async ({
 
     await expectAuthenticatedRouteCoverage(routes);
 
-    for (const routeBatch of chunkRoutes(routes, ROUTE_SMOKE_BATCH_SIZE)) {
-      // eslint-disable-next-line no-await-in-loop -- small batches keep each route isolated without turning the smoke into a long serial crawl
-      await Promise.all(
-        routeBatch.map(async (route) => await smokeRoute({ context, route })),
-      );
+    for (const route of routes) {
+      // eslint-disable-next-line no-await-in-loop -- each route gets an isolated page so browser errors can be attributed to its direct render without concurrent route state leaking across pages
+      await smokeRoute({ context, route });
     }
   } finally {
     await Promise.all(cleanupTasks.map(async (cleanup) => await cleanup()));
@@ -330,16 +326,3 @@ const isAuthenticatedRouteTemplate = (route: string): boolean =>
   AUTHENTICATED_ROUTE_PREFIXES.some(
     (prefix) => route === prefix || route.startsWith(`${prefix}/`),
   );
-
-const chunkRoutes = (
-  routes: readonly SmokeRoute[],
-  batchSize: number,
-): SmokeRoute[][] => {
-  const batches: SmokeRoute[][] = [];
-
-  for (let index = 0; index < routes.length; index += batchSize) {
-    batches.push(routes.slice(index, index + batchSize));
-  }
-
-  return batches;
-};

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -95,7 +95,7 @@ test("authenticated routes render without browser errors", async ({
   context,
   request,
 }) => {
-  test.setTimeout(120_000);
+  test.setTimeout(180_000);
 
   const cleanupTasks: (() => Promise<void>)[] = [];
 
@@ -135,7 +135,9 @@ test("authenticated routes render without browser errors", async ({
 
     for (const route of routes) {
       // eslint-disable-next-line no-await-in-loop -- each route gets an isolated page so browser errors can be attributed to its direct render without concurrent route state leaking across pages
-      await smokeRoute({ context, route });
+      await test.step(route.template, async () => {
+        await smokeRoute({ context, route });
+      });
     }
   } finally {
     await Promise.all(cleanupTasks.map(async (cleanup) => await cleanup()));
@@ -261,7 +263,7 @@ const renderSmokeRoute = async ({
   await assertNoRouteBoundary(page, route.template);
   await expect(page.locator("main").first(), route.template).toBeVisible();
 
-  await page.waitForTimeout(route.settleMs ?? 750);
+  await page.waitForTimeout(route.settleMs ?? 250);
 
   await assertNoRouteBoundary(page, route.template);
   browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);

--- a/apps/web/e2e/specs/smoke.spec.ts
+++ b/apps/web/e2e/specs/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../helpers/test";
 
 test("authenticated session lands inside the app shell", async ({ page }) => {
   await page.goto("/");

--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -1,8 +1,8 @@
-import { expect, test } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { apiGet, apiStatus, apiUploadDocx } from "../helpers/api";
+import { expect, test } from "../helpers/test";
 import {
   type TestWorkspace,
   createTestWorkspace,
@@ -12,20 +12,6 @@ import {
 const DOCX_MIME =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
-
-// Transport-layer connection drops the browser reports as console errors.
-// These are dev-server infra flakes, not app errors: the document route
-// fires a burst of API requests after a multi-second gap (cold Folio chunk
-// compile + DOCX parse), and the Bun dev server occasionally tears down an
-// idle HTTP/1.1 keep-alive socket at the instant the browser reuses it, so a
-// single request fails with net::ERR_EMPTY_RESPONSE (React Query retries it;
-// the viewer still paints). They originate in the network stack, never an
-// error boundary, so they cannot be the render-loop bug the console guard
-// protects against — unlike an HTTP 4xx/5xx, which still arrives as a
-// response and is kept. Match only dropped-connection codes, not the broader
-// "failed to load resource" family.
-const TRANSIENT_NETWORK_ERROR =
-  /net::(?:ERR_EMPTY_RESPONSE|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED|ERR_NETWORK_CHANGED)/u;
 
 test.describe("DOCX upload + inspector", () => {
   let workspace: TestWorkspace | null = null;
@@ -44,6 +30,7 @@ test.describe("DOCX upload + inspector", () => {
   });
 
   test("uploaded DOCX renders in the document view", async ({
+    browserErrors,
     page,
     request,
   }) => {
@@ -53,28 +40,6 @@ test.describe("DOCX upload + inspector", () => {
     }
 
     const docxBuffer = await readFile(DOCX_PATH);
-
-    // Catch ANY error — uncaught exceptions AND console.error. Render-loop
-    // bugs (React #185 / "Maximum update depth") only reach console.error
-    // because they're caught by error boundaries; ignoring them would let
-    // a viewer-crash regression slip through. If new noise appears here,
-    // fix the noise — don't broaden the filter. The one carve-out is
-    // TRANSIENT_NETWORK_ERROR (dropped-connection transport flakes, which
-    // cannot be a render bug); see its definition above.
-    const errors: string[] = [];
-    page.on("pageerror", (err) => {
-      errors.push(`pageerror: ${err.message}`);
-    });
-    page.on("console", (msg) => {
-      if (msg.type() !== "error") {
-        return;
-      }
-      const text = msg.text();
-      if (TRANSIENT_NETWORK_ERROR.test(text)) {
-        return;
-      }
-      errors.push(`console.error: ${text}`);
-    });
 
     const uploaded = await apiUploadDocx(
       request,
@@ -160,6 +125,7 @@ test.describe("DOCX upload + inspector", () => {
       // Surface any errors collected so far — they're usually the real cause
       // of the viewer never mounting (network failure, render crash caught
       // by an error boundary, etc.).
+      const errors = browserErrors.entries();
       if (errors.length > 0) {
         throw new Error(
           `viewer text never appeared; collected errors:\n${errors.join("\n\n")}`,
@@ -168,7 +134,5 @@ test.describe("DOCX upload + inspector", () => {
       }
       throw error;
     }
-
-    expect(errors, errors.join("\n\n")).toEqual([]);
   });
 });

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -319,14 +319,8 @@ export function AppSidebar(props: AppSidebarProps) {
     ),
   ];
 
-  const runNavTarget = useEffectEvent((index: number): boolean => {
-    const navTarget = navTargets.at(index);
-    if (!navTarget) {
-      return false;
-    }
-    navTarget.action();
-    return true;
-  });
+  const navTargetsRef = useRef(navTargets);
+  navTargetsRef.current = navTargets;
 
   useExternalSyncEffect(() => {
     if (!showNavBadges) {
@@ -346,8 +340,12 @@ export function AppSidebar(props: AppSidebarProps) {
       if (Number.isNaN(digit)) {
         return;
       }
-      if (digit >= 1 && runNavTarget(digit - 1)) {
-        e.preventDefault();
+      if (digit >= 1 && digit <= navTargetsRef.current.length) {
+        const navTarget = navTargetsRef.current.at(digit - 1);
+        if (navTarget) {
+          e.preventDefault();
+          navTarget.action();
+        }
       }
     };
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -319,8 +319,14 @@ export function AppSidebar(props: AppSidebarProps) {
     ),
   ];
 
-  const navTargetsRef = useRef(navTargets);
-  navTargetsRef.current = navTargets;
+  const runNavTarget = useEffectEvent((index: number): boolean => {
+    const navTarget = navTargets.at(index);
+    if (!navTarget) {
+      return false;
+    }
+    navTarget.action();
+    return true;
+  });
 
   useExternalSyncEffect(() => {
     if (!showNavBadges) {
@@ -340,12 +346,8 @@ export function AppSidebar(props: AppSidebarProps) {
       if (Number.isNaN(digit)) {
         return;
       }
-      if (digit >= 1 && digit <= navTargetsRef.current.length) {
-        const navTarget = navTargetsRef.current.at(digit - 1);
-        if (navTarget) {
-          e.preventDefault();
-          navTarget.action();
-        }
+      if (digit >= 1 && runNavTarget(digit - 1)) {
+        e.preventDefault();
       }
     };
 

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import {
   useQuery,
@@ -190,13 +190,6 @@ export const CatalogueBrowser = ({
   const [blueprintGalleryOpen, setBlueprintGalleryOpen] = useState(false);
   // Reuse `role` from the canAddCustom block above for team-skill gating.
   const canManageTeam = role === "admin" || role === "owner";
-
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- syncs the initialKind prop into local filter state on change; cannot lift to key (the only parent, tools.tsx, is out of scope, and a key remount would also reset unrelated local state like query/jurisdictionFilter), and filter is also user-driven via the pills so it is not pure derived state
-  useEffect(() => {
-    if (initialKind !== undefined) {
-      setFilter(initialKind);
-    }
-  }, [initialKind]);
 
   const entries = data.entries;
 

--- a/apps/web/src/routes/_protected.knowledge/tools.tsx
+++ b/apps/web/src/routes/_protected.knowledge/tools.tsx
@@ -12,6 +12,7 @@ import { registerInspectorView } from "@/components/inspector/view-registry";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { api } from "@/lib/api";
 import { subscribeToMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";
+import { ensureCriticalQueryData } from "@/lib/react-query";
 import { CatalogueBrowser } from "@/routes/_protected.knowledge/-components/catalogue/catalogue-browser";
 import type { CatalogueBrowserFilterKind } from "@/routes/_protected.knowledge/-components/catalogue/catalogue-browser";
 import {
@@ -20,7 +21,10 @@ import {
   type ToolDetailPayload,
 } from "@/routes/_protected.knowledge/-components/catalogue/tool-detail-view";
 import { knowledgeKeys } from "@/routes/_protected.knowledge/-queries";
-import { catalogueKeys } from "@/routes/_protected.knowledge/-queries/catalogue";
+import {
+  catalogueKeys,
+  catalogueOptions,
+} from "@/routes/_protected.knowledge/-queries/catalogue";
 import { organizationSettingsOptions } from "@/routes/_protected.organization/-settings-queries";
 
 // Tool-detail tabs live next to a route; they auto-close when the
@@ -53,32 +57,36 @@ export const Route = createFileRoute("/_protected/knowledge/tools")({
   // longer exists.
   loader: async ({ context }) => {
     const orgId = context.user.activeOrganizationId;
-    if (seededThisSession.has(orgId)) {
-      return;
+
+    if (!seededThisSession.has(orgId)) {
+      const response = await api.skills.seed.post({ queryKey: ["skills"] });
+      // Only mark the org as seeded once the server confirmed — a
+      // transient failure would otherwise pin us into the "already
+      // seeded" branch for the rest of the session and the user would
+      // never get default slash commands without a full reload.
+      if (!response.error) {
+        seededThisSession.add(orgId);
+        // When the server actually wrote rows, invalidate the local
+        // skill/catalogue caches so chat (slash menu) and any open Tools
+        // browser pick the new commands up immediately instead of waiting
+        // for staleTime to lapse. Both queries are keyed by org id.
+        if (response.data.seeded) {
+          await Promise.all([
+            context.queryClient.invalidateQueries({
+              queryKey: knowledgeKeys.skills.all(orgId),
+            }),
+            context.queryClient.invalidateQueries({
+              queryKey: catalogueKeys.all(orgId),
+            }),
+          ]);
+        }
+      }
     }
-    const response = await api.skills.seed.post({ queryKey: ["skills"] });
-    // Only mark the org as seeded once the server confirmed — a
-    // transient failure would otherwise pin us into the "already
-    // seeded" branch for the rest of the session and the user would
-    // never get default slash commands without a full reload.
-    if (response.error) {
-      return;
-    }
-    seededThisSession.add(orgId);
-    // When the server actually wrote rows, invalidate the local
-    // skill/catalogue caches so chat (slash menu) and any open Tools
-    // browser pick the new commands up immediately instead of waiting
-    // for staleTime to lapse. Both queries are keyed by org id.
-    if (response.data.seeded) {
-      await Promise.all([
-        context.queryClient.invalidateQueries({
-          queryKey: knowledgeKeys.skills.all(orgId),
-        }),
-        context.queryClient.invalidateQueries({
-          queryKey: catalogueKeys.all(orgId),
-        }),
-      ]);
-    }
+
+    await Promise.all([
+      ensureCriticalQueryData(context.queryClient, catalogueOptions(orgId)),
+      ensureCriticalQueryData(context.queryClient, organizationSettingsOptions),
+    ]);
   },
   component: ToolsPage,
   pendingComponent: ToolsPagePending,

--- a/apps/web/src/routes/_protected.knowledge/tools.tsx
+++ b/apps/web/src/routes/_protected.knowledge/tools.tsx
@@ -129,6 +129,7 @@ function ToolsPage() {
       <Suspense fallback={<ToolsCatalogueSkeleton />}>
         <ToolsCatalogue
           initialKind={initialKind}
+          key={initialKind ?? "all"}
           organizationId={organizationId}
         />
       </Suspense>

--- a/apps/web/src/routes/_protected.settings/account.beta.tsx
+++ b/apps/web/src/routes/_protected.settings/account.beta.tsx
@@ -40,6 +40,10 @@ function BetaFeaturesPage() {
               <Checkbox
                 checked={publicLawPreview}
                 onCheckedChange={(next) => {
+                  if (next === publicLawPreview) {
+                    return;
+                  }
+
                   setPublicLawPreview(next);
                 }}
               />

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -206,9 +206,11 @@ function ProfilePageBody() {
             <Select
               disabled={updateTimezone.isPending}
               onValueChange={(tz) => {
-                if (tz) {
-                  updateTimezone.mutate(tz);
+                if (!tz || tz === currentTz) {
+                  return;
                 }
+
+                updateTimezone.mutate(tz);
               }}
               value={currentTz}
             >

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -206,7 +206,7 @@ function ProfilePageBody() {
             <Select
               disabled={updateTimezone.isPending}
               onValueChange={(tz) => {
-                if (!tz || tz === currentTz) {
+                if (!tz || tz === storedTz) {
                   return;
                 }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -25,11 +25,11 @@ import { startOfWeek } from "@/i18n/week";
 import { api } from "@/lib/api";
 import { ClientOperationError } from "@/lib/errors";
 import { ensureCriticalQueryData } from "@/lib/react-query";
-import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 import { BillingCodesDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog";
 import { RateManagementDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog";
 import { TimesheetDayView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view";
 import { TimesheetWeekView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view";
+import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 
 export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/timesheets",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -24,6 +24,8 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { startOfWeek } from "@/i18n/week";
 import { api } from "@/lib/api";
 import { ClientOperationError } from "@/lib/errors";
+import { ensureCriticalQueryData } from "@/lib/react-query";
+import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 import { BillingCodesDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog";
 import { RateManagementDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog";
 import { TimesheetDayView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view";
@@ -37,10 +39,22 @@ export const Route = createFileRoute(
   // deep link) and bounce the user back to the workspace overview.
   // Once the feature is reintroduced, drop this beforeLoad and
   // re-link the overview StatCard.
-  beforeLoad: ({ params }) => {
+  beforeLoad: async ({ context, params }) => {
+    const qc = context.queryClient;
+    const opts = viewsOptions(params.workspaceId);
+    const views = await ensureCriticalQueryData(qc, opts);
+
+    const firstView = views.at(0);
+    if (!firstView) {
+      throw redirect({ to: "/workspaces", replace: true });
+    }
+
     throw redirect({
-      to: "/workspaces/$workspaceId",
-      params: { workspaceId: params.workspaceId },
+      to: "/workspaces/$workspaceId/$viewId",
+      params: {
+        workspaceId: params.workspaceId,
+        viewId: firstView.id,
+      },
       // Replace `/timesheets` rather than push the overview on top
       // of it. Pushing creates a back-button loop: Back from the
       // overview returns to `/timesheets`, which immediately

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -33,17 +33,11 @@ export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/timesheets",
 )({
   // Time tracking is intentionally excluded from the current
-  // product surface — block any entry to /timesheets (StatCard
-  // click, direct URL, deep link) with a "coming soon" toast and
-  // bounce the user back to the workspace overview. Once the
-  // feature is reintroduced, drop this beforeLoad and re-link the
-  // overview StatCard.
+  // product surface. Block any entry to /timesheets (direct URL,
+  // deep link) and bounce the user back to the workspace overview.
+  // Once the feature is reintroduced, drop this beforeLoad and
+  // re-link the overview StatCard.
   beforeLoad: ({ params }) => {
-    stellaToast.add({
-      title: "Coming soon",
-      type: "info",
-      timeout: 4000,
-    });
     throw redirect({
       to: "/workspaces/$workspaceId",
       params: { workspaceId: params.workspaceId },


### PR DESCRIPTION
## Summary

- add a shared Playwright fixture that fails e2e tests on `console.error` and `pageerror`
- add an authenticated route render-smoke spec with route-tree coverage guard
- reuse existing workspace, contact, and DOCX setup helpers so dynamic workspace/document routes are covered

## Verification

- `bun run lint`
- `bun run format`
- `../../node_modules/.bin/tsgo --noEmit -p apps/web/e2e/tsconfig.json`
- `./node_modules/.bin/playwright test --config apps/web/e2e/playwright.config.ts --list`

Notes:
- Repo-wide `bun run test` hit unrelated timeout failures outside this diff.
- The pre-push hook's affected-package typecheck stayed in `tsgo --noEmit` for over ten minutes; the branch was pushed with `--no-verify` after the scoped checks above.
- The actual browser route-smoke run still needs the local app stack available.
