### PR TITLE
chore: enable react jsx-no-target-blank lint rule

### DIFF
--- a/apps/web/src/components/auth/sign-in-panel.tsx
+++ b/apps/web/src/components/auth/sign-in-panel.tsx
@@ -41,7 +41,7 @@ const renderTermsLink = (chunks: ReactNode) => (
   <a
     className="hover:text-foreground underline"
     href={termsUrl}
-    rel="noopener"
+    rel="noreferrer"
     target="_blank"
   >
     {chunks}

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -315,7 +315,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
               <a
                 aria-label={t("selfhost.viewReleaseNotes")}
                 href={CHANGELOG_URL}
-                rel="noopener"
+                rel="noreferrer"
                 target="_blank"
               />
             }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
     "react/style-prop-object": "error",
     "react/jsx-no-comment-textnodes": "error",
     "react/iframe-missing-sandbox": "error",
+    "react/jsx-no-target-blank": "error",
     "react/jsx-no-script-url": "error",
     "react/button-has-type": "error",
     "react/no-object-type-as-default-prop": "error",


### PR DESCRIPTION
Enables the React jsx-no-target-blank lint rule and updates existing external links to satisfy it.\n\nValidation:\n- bun --bun oxlint -c oxlint.config.ts --deny react/jsx-no-target-blank --no-error-on-unmatched-pattern apps/web/src packages/ui/src\n- pre-commit hook passed\n- pre-push format and i18n checks passed before the concurrent local hook run was interrupted during typecheck