### PR TITLE
chore: enable checked input lint rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
     "react/jsx-no-target-blank": "error",
     "react/jsx-no-script-url": "error",
     "react/button-has-type": "error",
+    "react/checked-requires-onchange-or-readonly": "error",
     "react/no-object-type-as-default-prop": "error",
     // Allow component creation in prop position: i18n rich-text render
     // callbacks (`t.rich({ link: (chunks) => <a/> })`) and IIFE-as-prop


### PR DESCRIPTION
Enables the React checked-requires-onchange-or-readonly lint rule in oxlint.\n\nValidation:\n- bun --bun oxlint -c oxlint.config.ts --deny react/checked-requires-onchange-or-readonly --no-error-on-unmatched-pattern apps/web/src packages/ui/src\n- pre-commit hook passed\n- pre-push format and i18n checks passed before the concurrent local hook run was interrupted during typecheck