### PR TITLE
chore: enable vitest valid expect lint rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1415,6 +1415,7 @@ export default defineConfig({
         "no-dangerous-type-assertions/no-dangerous-type-assertions": "off",
         "security-guards/no-unsanitized-href": "off",
         "security-guards/no-unscoped-user-query": "off",
+        "vitest/valid-expect": "error",
         "vitest/prefer-importing-vitest-globals": "off",
         // bun:test globals (describe/test/expect/it/…) resolve as `error` type
         // when test files are excluded from the main tsconfig (packages/folio).


### PR DESCRIPTION
Enables the Vitest valid-expect lint rule for test files.\n\nValidation:\n- bun --bun oxlint -c oxlint.config.ts --deny vitest/valid-expect --no-error-on-unmatched-pattern '**/*.{test,spec}.{ts,tsx,js,jsx}' '**/__tests__/**/*.{ts,tsx,js,jsx}'\n- pre-commit hook passed