### PR TITLE
chore: enable no-array-sort lint rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -220,7 +220,7 @@ export default defineConfig({
     "unicorn/no-immediate-mutation": "off",
     "unicorn/prefer-ternary": "off",
     "unicorn/no-array-reduce": "error",
-    "unicorn/no-array-sort": "off",
+    "unicorn/no-array-sort": "error",
     "unicorn/no-useless-spread": "off",
     "oxc/no-map-spread": "error",
     "unicorn/no-await-expression-member": "off",


### PR DESCRIPTION
Enables the unicorn no-array-sort lint rule.\n\nValidation:\n- bun --bun oxlint -c oxlint.config.ts --allow all --deny unicorn/no-array-sort --no-error-on-unmatched-pattern apps packages scripts currently reports an existing backlog of Array#sort call sites across web, api, landing, scripts, packages, and tests.\n- pre-commit hook passed\n\nThis is a draft adoption PR; the rule is enabled here so the remaining migration work is visible and reviewable separately.