### PR TITLE
feat(filters): faceted value counts in the filter builder

### DIFF
--- a/apps/api/src/handlers/entities/read-property-facets.ts
+++ b/apps/api/src/handlers/entities/read-property-facets.ts
@@ -1,0 +1,110 @@
+import { Result } from "better-result";
+import { and, eq, sql } from "drizzle-orm";
+import { t } from "elysia";
+
+import { entities, fields } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tConditionNode } from "@/api/lib/conditions/contract";
+import { tSafeId } from "@/api/lib/custom-schema";
+import {
+  buildFilterConditions,
+  fieldValueExpr,
+} from "@/api/lib/entity-filters";
+import { LIMITS } from "@/api/lib/limits";
+
+const FACET_VALUE_LIMIT = 50;
+
+const config = {
+  permissions: { workspace: ["read"] },
+  body: t.Object({
+    propertyId: tSafeId("property"),
+    filters: t.Optional(
+      t.Array(tConditionNode, { maxItems: LIMITS.propertiesCount }),
+    ),
+  }),
+} satisfies HandlerConfig;
+
+type FacetValueRow = {
+  value: string;
+  count: number;
+};
+
+/**
+ * Counts distinct present values for one property across the workspace,
+ * respecting the supplied filter set. A multi-select stores its value as
+ * a JSONB array, every other faceted property as a scalar string, so the
+ * value expression unnests arrays element-by-element and falls back to
+ * the scalar `fieldValueExpr` extraction otherwise. Each distinct value
+ * counts the entities that carry it; for multi-select an entity counts
+ * once per distinct value it holds.
+ *
+ * Counts respect the full current filter set, including any condition on
+ * the faceted property itself. A future refinement could exclude the
+ * facet's own property for true Notion-style "available options" counts;
+ * that is intentionally not implemented here.
+ */
+const readPropertyFacets = createSafeHandler(
+  config,
+  async function* ({ safeDb, workspaceId, body }) {
+    const filterConditions = buildFilterConditions(body.filters ?? []);
+    const whereClause = and(
+      eq(entities.workspaceId, workspaceId),
+      ...filterConditions,
+    );
+
+    const facetValue = sql`CASE
+      WHEN jsonb_typeof(${fields.content}->'value') = 'array'
+        THEN array_value.value
+      ELSE ${fieldValueExpr(fields.content)}
+    END`;
+
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            value: sql<string>`${facetValue}`.as("facet_value"),
+            count: sql<number>`count(distinct ${entities.id})::int`.as(
+              "facet_count",
+            ),
+          })
+          .from(fields)
+          .innerJoin(
+            entities,
+            and(
+              eq(fields.entityVersionId, entities.currentVersionId),
+              eq(fields.propertyId, body.propertyId),
+              whereClause,
+            ),
+          )
+          // The LATERAL function is evaluated for every left row before the
+          // join's ON predicate, so a scalar value would crash
+          // jsonb_array_elements_text. Feed it an empty array for non-arrays;
+          // the scalar branch of `facetValue` supplies those values instead.
+          .leftJoin(
+            sql`LATERAL jsonb_array_elements_text(
+              CASE
+                WHEN jsonb_typeof(${fields.content}->'value') = 'array'
+                  THEN ${fields.content}->'value'
+                ELSE '[]'::jsonb
+              END
+            ) AS array_value(value)`,
+            sql`true`,
+          )
+          .groupBy(sql`facet_value`)
+          .having(sql`${facetValue} <> ''`)
+          .orderBy(sql`facet_count DESC`, sql`facet_value ASC`)
+          .limit(FACET_VALUE_LIMIT + 1),
+      ),
+    );
+
+    const truncated = rows.length > FACET_VALUE_LIMIT;
+    const values: FacetValueRow[] = rows
+      .slice(0, FACET_VALUE_LIMIT)
+      .map((row) => ({ value: row.value, count: row.count }));
+
+    return Result.ok({ values, truncated });
+  },
+);
+
+export default readPropertyFacets;

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -26,6 +26,7 @@ import readFieldFile from "@/api/handlers/entities/read-field-file";
 import readFilesystemTree from "@/api/handlers/entities/read-filesystem-tree";
 import readGroupCounts from "@/api/handlers/entities/read-group-counts";
 import readKanbanGroup from "@/api/handlers/entities/read-kanban-group";
+import readPropertyFacets from "@/api/handlers/entities/read-property-facets";
 import readEntitySummaries from "@/api/handlers/entities/read-summaries";
 import readVersionById from "@/api/handlers/entities/read-version-by-id";
 import readVersions from "@/api/handlers/entities/read-versions";
@@ -151,6 +152,10 @@ export const entitiesRoute = new Elysia({
   .post("/group-counts", readGroupCounts.handler, {
     body: readGroupCounts.config.body,
     permissions: readGroupCounts.config.permissions,
+  })
+  .post("/property-facets", readPropertyFacets.handler, {
+    body: readPropertyFacets.config.body,
+    permissions: readPropertyFacets.config.permissions,
   })
   .post("/organize-suggestions", organizeSuggestions.handler, {
     body: organizeSuggestions.config.body,

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -329,7 +329,7 @@ export const applySorts = <T extends FilterableEntity>(
  * Covers text, single-select, date, int (via `value` key)
  * and file (via `fileName` key).
  */
-const fieldValueExpr = (contentCol: typeof fields.content): SQL =>
+export const fieldValueExpr = (contentCol: typeof fields.content): SQL =>
   sql`COALESCE(${contentCol}->>'value', ${contentCol}->>'fileName', '')`;
 
 const numericFieldValueExpr = (contentCol: typeof fields.content): SQL => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
@@ -36,13 +36,18 @@ import {
   replaceChild,
   valueEditorFor,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
-import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";
+import type { FacetContext } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-select-values";
+import {
+  MultiSelectValue,
+  SingleSelectValue,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-select-values";
 
 type ConditionBuilderProps = {
   value: ConditionNode | null;
   onChange: (next: GroupNode) => void;
   fields: FieldOption[];
   allowGroups?: boolean;
+  facetContext?: FacetContext | undefined;
 };
 
 export const ConditionBuilder = ({
@@ -50,6 +55,7 @@ export const ConditionBuilder = ({
   onChange,
   fields,
   allowGroups = false,
+  facetContext,
 }: ConditionBuilderProps) => {
   const t = useTranslations();
   const group = asGroup(value);
@@ -78,6 +84,7 @@ export const ConditionBuilder = ({
           if (child.type === "group" && allowGroups) {
             return (
               <NestedGroupRow
+                facetContext={facetContext}
                 fields={fields}
                 key={index}
                 onChange={(next) => onChange(replaceChild(group, index, next))}
@@ -88,6 +95,7 @@ export const ConditionBuilder = ({
           }
           return (
             <LeafRow
+              facetContext={facetContext}
               fields={fields}
               key={index}
               node={child}
@@ -164,6 +172,7 @@ const CombinatorControl = ({
 type NestedGroupRowProps = {
   value: GroupNode;
   fields: FieldOption[];
+  facetContext?: FacetContext | undefined;
   onChange: (next: GroupNode) => void;
   onRemove: () => void;
 };
@@ -171,6 +180,7 @@ type NestedGroupRowProps = {
 const NestedGroupRow = ({
   value,
   fields,
+  facetContext,
   onChange,
   onRemove,
 }: NestedGroupRowProps) => (
@@ -178,6 +188,7 @@ const NestedGroupRow = ({
     <div className="flex-1">
       <ConditionBuilder
         allowGroups
+        facetContext={facetContext}
         fields={fields}
         onChange={onChange}
         value={value}
@@ -192,11 +203,18 @@ const NestedGroupRow = ({
 type LeafRowProps = {
   node: ConditionNode;
   fields: FieldOption[];
+  facetContext?: FacetContext | undefined;
   onChange: (next: ConditionNode) => void;
   onRemove: () => void;
 };
 
-const LeafRow = ({ node, fields, onChange, onRemove }: LeafRowProps) => {
+const LeafRow = ({
+  node,
+  fields,
+  facetContext,
+  onChange,
+  onRemove,
+}: LeafRowProps) => {
   const t = useTranslations();
   const operand = leafOperand(node);
   const fieldIndex = operand
@@ -284,6 +302,7 @@ const LeafRow = ({ node, fields, onChange, onRemove }: LeafRowProps) => {
 
       <LeafValueEditor
         editorKind={editorKind}
+        facetContext={facetContext}
         field={field}
         node={node}
         onChange={onChange}
@@ -302,6 +321,7 @@ type LeafValueEditorProps = {
   field: FieldOption;
   node: ConditionNode;
   operator: ConditionOperator;
+  facetContext?: FacetContext | undefined;
   onChange: (next: ConditionNode) => void;
 };
 
@@ -310,6 +330,7 @@ const LeafValueEditor = ({
   field,
   node,
   operator,
+  facetContext,
   onChange,
 }: LeafValueEditorProps) => {
   const t = useTranslations();
@@ -326,6 +347,7 @@ const LeafValueEditor = ({
     if (isMultiValue(operator)) {
       return (
         <MultiSelectValue
+          facetContext={facetContext}
           field={field}
           onChange={emit}
           value={leafValueList(node)}
@@ -334,6 +356,7 @@ const LeafValueEditor = ({
     }
     return (
       <SingleSelectValue
+        facetContext={facetContext}
         field={field}
         onChange={emit}
         value={leafValueString(node)}
@@ -372,102 +395,5 @@ const LeafValueEditor = ({
       size="sm"
       value={leafValueString(node)}
     />
-  );
-};
-
-type SelectValueEditorProps = {
-  field: FieldOption;
-  value: string;
-  onChange: (value: string) => void;
-};
-
-const SingleSelectValue = ({
-  field,
-  value,
-  onChange,
-}: SelectValueEditorProps) => {
-  const t = useTranslations();
-  const options = field.options ?? [];
-  const selected = options.find((option) => option.value === value);
-
-  return (
-    <Select
-      onValueChange={(next) => {
-        if (next !== null) {
-          onChange(next);
-        }
-      }}
-      value={value}
-    >
-      <SelectTrigger className="h-7 min-h-0 w-auto min-w-28 text-xs" size="sm">
-        <SelectValue placeholder={t("workspaces.fields.selectAValue")}>
-          {() =>
-            selected ? (
-              <span className="flex items-center gap-1.5">
-                {selected.color !== undefined && (
-                  <SelectColorIcon color={selected.color} />
-                )}
-                {selected.label}
-              </span>
-            ) : (
-              t("workspaces.fields.selectAValue")
-            )
-          }
-        </SelectValue>
-      </SelectTrigger>
-      <SelectPopup alignItemWithTrigger={false}>
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            <span className="flex items-center gap-1.5">
-              {option.color !== undefined && (
-                <SelectColorIcon color={option.color} />
-              )}
-              {option.label}
-            </span>
-          </SelectItem>
-        ))}
-      </SelectPopup>
-    </Select>
-  );
-};
-
-type MultiSelectValueProps = {
-  field: FieldOption;
-  value: string[];
-  onChange: (value: string[]) => void;
-};
-
-const MultiSelectValue = ({
-  field,
-  value,
-  onChange,
-}: MultiSelectValueProps) => {
-  const t = useTranslations();
-  const options = field.options ?? [];
-  const label =
-    value.length === 0
-      ? t("workspaces.fields.selectValues")
-      : value
-          .map((v) => options.find((option) => option.value === v)?.label ?? v)
-          .join(", ");
-
-  return (
-    <Select multiple onValueChange={(next) => onChange(next)} value={value}>
-      <SelectTrigger className="h-7 min-h-0 w-auto min-w-28 text-xs" size="sm">
-        <SelectValue>{() => label}</SelectValue>
-      </SelectTrigger>
-      <SelectPopup alignItemWithTrigger={false}>
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            <span className="flex items-center gap-1.5">
-              {option.color !== undefined && (
-                <SelectColorIcon color={option.color} />
-              )}
-              {option.label}
-            </span>
-          </SelectItem>
-        ))}
-      </SelectPopup>
-    </Select>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-select-values.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-select-values.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
+import type { ConditionNode } from "@stll/conditions";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { cn } from "@stll/ui/lib/utils";
+
+import type { FieldOption } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";
+import type { PropertyFacetCounts } from "@/routes/_protected.workspaces/$workspaceId/-queries/property-facets";
+import { propertyFacetsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/property-facets";
+
+/**
+ * The data the value editors need to fetch facet counts: the workspace
+ * and the view's active filter set. Undefined when the condition builder
+ * runs outside an entity-faceting context (e.g. property auto-fill
+ * rules), in which case options render without counts.
+ */
+export type FacetContext = {
+  workspaceId: string;
+  filters: ConditionNode[];
+};
+
+type FacetedSelectProps = {
+  field: FieldOption;
+  facetContext?: FacetContext | undefined;
+  className?: string | undefined;
+};
+
+type SingleSelectValueProps = FacetedSelectProps & {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const SingleSelectValue = ({
+  field,
+  facetContext,
+  className,
+  value,
+  onChange,
+}: SingleSelectValueProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+  const facets = usePropertyFacetCounts({ field, facetContext, open });
+  const options = sortOptionsByCount(field.options ?? [], facets);
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <Select
+      onOpenChange={setOpen}
+      onValueChange={(next) => {
+        if (next !== null) {
+          onChange(next);
+        }
+      }}
+      value={value}
+    >
+      <SelectTrigger
+        className={cn("h-7 min-h-0 w-auto min-w-28 text-xs", className)}
+        size="sm"
+      >
+        <SelectValue placeholder={t("workspaces.fields.selectAValue")}>
+          {() =>
+            selected ? (
+              <span className="flex items-center gap-1.5">
+                {selected.color !== undefined && (
+                  <SelectColorIcon color={selected.color} />
+                )}
+                {selected.label}
+              </span>
+            ) : (
+              t("workspaces.fields.selectAValue")
+            )
+          }
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup alignItemWithTrigger={false}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            <OptionRow
+              color={option.color}
+              count={facets?.counts.get(option.value)}
+              label={option.label}
+              showCounts={facets !== undefined}
+            />
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+};
+
+type MultiSelectValueProps = FacetedSelectProps & {
+  value: string[];
+  onChange: (value: string[]) => void;
+};
+
+export const MultiSelectValue = ({
+  field,
+  facetContext,
+  className,
+  value,
+  onChange,
+}: MultiSelectValueProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+  const facets = usePropertyFacetCounts({ field, facetContext, open });
+  const options = sortOptionsByCount(field.options ?? [], facets);
+  const label =
+    value.length === 0
+      ? t("workspaces.fields.selectValues")
+      : value
+          .map((v) => options.find((option) => option.value === v)?.label ?? v)
+          .join(", ");
+
+  return (
+    <Select
+      multiple
+      onOpenChange={setOpen}
+      onValueChange={(next) => onChange(next)}
+      value={value}
+    >
+      <SelectTrigger
+        className={cn("h-7 min-h-0 w-auto min-w-28 text-xs", className)}
+        size="sm"
+      >
+        <SelectValue>{() => label}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup alignItemWithTrigger={false}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            <OptionRow
+              color={option.color}
+              count={facets?.counts.get(option.value)}
+              label={option.label}
+              showCounts={facets !== undefined}
+            />
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+};
+
+type OptionRowProps = {
+  label: string;
+  color: string | undefined;
+  count: number | undefined;
+  showCounts: boolean;
+};
+
+const OptionRow = ({ label, color, count, showCounts }: OptionRowProps) => (
+  <span className="flex w-full items-center gap-1.5">
+    {color !== undefined && <SelectColorIcon color={color} />}
+    <span className="flex-1 truncate">{label}</span>
+    {showCounts && (
+      <span className="text-muted-foreground tabular-nums">{count ?? 0}</span>
+    )}
+  </span>
+);
+
+type FacetOption = NonNullable<FieldOption["options"]>[number];
+
+const sortOptionsByCount = (
+  options: FacetOption[],
+  facets: PropertyFacetCounts | undefined,
+): FacetOption[] => {
+  if (!facets) {
+    return options;
+  }
+  return [...options].toSorted(
+    (a, b) =>
+      (facets.counts.get(b.value) ?? 0) - (facets.counts.get(a.value) ?? 0),
+  );
+};
+
+const usePropertyFacetCounts = ({
+  field,
+  facetContext,
+  open,
+}: {
+  field: FieldOption;
+  facetContext: FacetContext | undefined;
+  open: boolean;
+}): PropertyFacetCounts | undefined => {
+  const propertyId =
+    field.operand.type === "property" ? field.operand.propertyId : null;
+  const enabled = open && facetContext !== undefined && propertyId !== null;
+
+  const { data } = useQuery({
+    ...propertyFacetsOptions({
+      workspaceId: facetContext?.workspaceId ?? "",
+      propertyId: propertyId ?? "",
+      filters: facetContext?.filters ?? [],
+    }),
+    enabled,
+  });
+
+  return data;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -60,18 +60,25 @@ import {
   operatorsFor,
   valueEditorFor,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.logic";
+import type { FacetContext } from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-select-values";
+import {
+  MultiSelectValue,
+  SingleSelectValue,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-select-values";
 import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 
 type FilterChipsProps = {
   filters: ConditionNode[];
   properties: WorkspaceProperty[];
+  facetContext?: FacetContext | undefined;
   onUpdate: (filters: ConditionNode[]) => void;
 };
 
 export const FilterChips = ({
   filters,
   properties,
+  facetContext,
   onUpdate,
 }: FilterChipsProps) => {
   const t = useTranslations();
@@ -118,6 +125,7 @@ export const FilterChips = ({
         if (node.type === "group") {
           return (
             <AdvancedFilterChip
+              facetContext={facetContext}
               fields={fields}
               key={index}
               node={node}
@@ -128,6 +136,7 @@ export const FilterChips = ({
         }
         return (
           <FilterChip
+            facetContext={facetContext}
             fields={fields}
             key={index}
             node={node}
@@ -156,11 +165,18 @@ export const FilterChips = ({
 type FilterChipProps = {
   node: ConditionNode;
   fields: FieldOption[];
+  facetContext?: FacetContext | undefined;
   onChange: (next: ConditionNode) => void;
   onRemove: () => void;
 };
 
-const FilterChip = ({ node, fields, onChange, onRemove }: FilterChipProps) => {
+const FilterChip = ({
+  node,
+  fields,
+  facetContext,
+  onChange,
+  onRemove,
+}: FilterChipProps) => {
   const t = useTranslations();
   const [open, setOpen] = useState(false);
   const field = fieldForNode(node, fields);
@@ -199,6 +215,7 @@ const FilterChip = ({ node, fields, onChange, onRemove }: FilterChipProps) => {
       </PopoverTrigger>
       <PopoverPopup align="start" className="w-72 p-0">
         <FilterEditBody
+          facetContext={facetContext}
           field={field}
           node={node}
           onChange={onChange}
@@ -217,6 +234,7 @@ type FilterEditBodyProps = {
   field: FieldOption;
   node: ConditionNode;
   operator: ConditionOperator;
+  facetContext?: FacetContext | undefined;
   onChange: (next: ConditionNode) => void;
   onRemove: () => void;
 };
@@ -225,6 +243,7 @@ const FilterEditBody = ({
   field,
   node,
   operator,
+  facetContext,
   onChange,
   onRemove,
 }: FilterEditBodyProps) => {
@@ -289,6 +308,7 @@ const FilterEditBody = ({
 
         <ValueEditor
           editorKind={editorKind}
+          facetContext={facetContext}
           field={field}
           node={node}
           onChange={onChange}
@@ -304,6 +324,7 @@ type ValueEditorProps = {
   field: FieldOption;
   node: ConditionNode;
   operator: ConditionOperator;
+  facetContext?: FacetContext | undefined;
   onChange: (next: ConditionNode) => void;
 };
 
@@ -312,6 +333,7 @@ const ValueEditor = ({
   field,
   node,
   operator,
+  facetContext,
   onChange,
 }: ValueEditorProps) => {
   const t = useTranslations();
@@ -328,6 +350,8 @@ const ValueEditor = ({
     if (isMultiValue(operator)) {
       return (
         <MultiSelectValue
+          className="w-full"
+          facetContext={facetContext}
           field={field}
           onChange={emit}
           value={leafValueList(node)}
@@ -336,6 +360,8 @@ const ValueEditor = ({
     }
     return (
       <SingleSelectValue
+        className="w-full"
+        facetContext={facetContext}
         field={field}
         onChange={emit}
         value={leafValueString(node)}
@@ -379,108 +405,12 @@ const ValueEditor = ({
   );
 };
 
-type SingleSelectValueProps = {
-  field: FieldOption;
-  value: string;
-  onChange: (value: string) => void;
-};
-
-const SingleSelectValue = ({
-  field,
-  value,
-  onChange,
-}: SingleSelectValueProps) => {
-  const t = useTranslations();
-  const options = field.options ?? [];
-  const selected = options.find((option) => option.value === value);
-
-  return (
-    <Select
-      onValueChange={(next) => {
-        if (next !== null) {
-          onChange(next);
-        }
-      }}
-      value={value}
-    >
-      <SelectTrigger className="h-7 min-h-0 w-full text-xs" size="sm">
-        <SelectValue placeholder={t("workspaces.fields.selectAValue")}>
-          {() =>
-            selected ? (
-              <span className="flex items-center gap-1.5">
-                {selected.color !== undefined && (
-                  <SelectColorIcon color={selected.color} />
-                )}
-                {selected.label}
-              </span>
-            ) : (
-              t("workspaces.fields.selectAValue")
-            )
-          }
-        </SelectValue>
-      </SelectTrigger>
-      <SelectPopup alignItemWithTrigger={false}>
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            <span className="flex items-center gap-1.5">
-              {option.color !== undefined && (
-                <SelectColorIcon color={option.color} />
-              )}
-              {option.label}
-            </span>
-          </SelectItem>
-        ))}
-      </SelectPopup>
-    </Select>
-  );
-};
-
-type MultiSelectValueProps = {
-  field: FieldOption;
-  value: string[];
-  onChange: (value: string[]) => void;
-};
-
-const MultiSelectValue = ({
-  field,
-  value,
-  onChange,
-}: MultiSelectValueProps) => {
-  const t = useTranslations();
-  const options = field.options ?? [];
-  const label =
-    value.length === 0
-      ? t("workspaces.fields.selectValues")
-      : value
-          .map((v) => options.find((option) => option.value === v)?.label ?? v)
-          .join(", ");
-
-  return (
-    <Select multiple onValueChange={(next) => onChange(next)} value={value}>
-      <SelectTrigger className="h-7 min-h-0 w-full text-xs" size="sm">
-        <SelectValue>{() => label}</SelectValue>
-      </SelectTrigger>
-      <SelectPopup alignItemWithTrigger={false}>
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            <span className="flex items-center gap-1.5">
-              {option.color !== undefined && (
-                <SelectColorIcon color={option.color} />
-              )}
-              {option.label}
-            </span>
-          </SelectItem>
-        ))}
-      </SelectPopup>
-    </Select>
-  );
-};
-
 // ── Advanced (AND/OR group) chip ──────────────────────────
 
 type AdvancedFilterChipProps = {
   node: GroupNode;
   fields: FieldOption[];
+  facetContext?: FacetContext | undefined;
   onChange: (next: GroupNode) => void;
   onRemove: () => void;
 };
@@ -488,6 +418,7 @@ type AdvancedFilterChipProps = {
 const AdvancedFilterChip = ({
   node,
   fields,
+  facetContext,
   onChange,
   onRemove,
 }: AdvancedFilterChipProps) => {
@@ -517,6 +448,7 @@ const AdvancedFilterChip = ({
       <PopoverPopup align="start" className="w-[34rem] max-w-[90vw] p-3">
         <ConditionBuilder
           allowGroups
+          facetContext={facetContext}
           fields={fields}
           onChange={onChange}
           value={node}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -113,6 +113,7 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
       )}
 
       <FilterChips
+        facetContext={{ workspaceId, filters }}
         filters={filters}
         onUpdate={(updatedFilters) => handleUpdate({ filters: updatedFilters })}
         properties={properties}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/property-facets.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/property-facets.ts
@@ -1,0 +1,56 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors";
+import type { QueryOptionsInput } from "@/lib/react-query";
+import { toSafeId } from "@/lib/safe-id";
+import type { ConditionNode } from "@/lib/types";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
+
+export type PropertyFacetsKey = {
+  workspaceId: string;
+  propertyId: string;
+  filters: ConditionNode[];
+};
+
+export const propertyFacetsKeys = {
+  facets: ({ workspaceId, propertyId, filters }: PropertyFacetsKey) => [
+    ...entitiesKeys.all(workspaceId),
+    "property-facets",
+    { propertyId, filters },
+  ],
+};
+
+type PropertyFacetsOptionsInput = QueryOptionsInput<PropertyFacetsKey>;
+
+export type PropertyFacetCounts = {
+  counts: Map<string, number>;
+  truncated: boolean;
+};
+
+export const propertyFacetsOptions = (key: PropertyFacetsOptionsInput) =>
+  queryOptions({
+    queryKey: propertyFacetsKeys.facets(key),
+    queryFn: async ({ signal }) => {
+      const response = await api
+        .entities({ workspaceId: toSafeId<"workspace">(key.workspaceId) })
+        ["property-facets"].post(
+          {
+            propertyId: toSafeId<"property">(key.propertyId),
+            filters: key.filters,
+          },
+          { fetch: { signal } },
+        );
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      const counts = new Map<string, number>();
+      for (const entry of response.data.values) {
+        counts.set(entry.value, entry.count);
+      }
+
+      return { counts, truncated: response.data.truncated };
+    },
+  });


### PR DESCRIPTION
When building a filter on a single/multi-select property, show the per-value entity count next to each option (Notion-style facets), so it's clear which values actually have rows before applying.

- New `POST /entities/:workspaceId/property-facets` read endpoint returns counts per value for a property under the current filters.
- `condition-select-values` renders the value picker with counts + the option colour swatch; wired into the filter builder and the toolbar filter chips.
- Counts respect the active filters and tenant scope.

Built on the merged `@stll/conditions` AST; no schema changes (read-only over existing fields).