### PR TITLE
chore(auth): autofill the dev email-OTP into the sign-in code field

### DIFF
--- a/apps/web/src/components/auth/otp-panel.tsx
+++ b/apps/web/src/components/auth/otp-panel.tsx
@@ -30,6 +30,9 @@ import { COMMON_TIMEZONES } from "@/lib/timezones";
 type OTPPanelProps = {
   className?: string;
   email: string;
+  // Dev-only: the mirrored code is prefilled so sign-in does not require
+  // copying it from the email. Always undefined in production.
+  initialOtp?: string | undefined;
   redirectTo: string;
   surface?: "frame" | "bare";
   onUseDifferentEmail?: () => void;
@@ -42,6 +45,7 @@ const OTP_EXPIRED_MESSAGE = "OTP expired";
 export function OTPPanel({
   className,
   email,
+  initialOtp,
   redirectTo,
   surface = "frame",
   onUseDifferentEmail,
@@ -50,7 +54,7 @@ export function OTPPanel({
   const t = useTranslations();
   const analytics = useAnalytics();
   const navigate = useNavigate();
-  const [otp, setOtp] = useState("");
+  const [otp, setOtp] = useState(initialOtp ?? "");
   const invalidateSession = useInvalidateSession();
   const isOtpComplete = otp.length === OTP_LENGTH;
   const { isPulsing: isOtpPulsing, pulse: pulseOtp } = usePulse(600);

--- a/apps/web/src/components/auth/sign-in-dialog.tsx
+++ b/apps/web/src/components/auth/sign-in-dialog.tsx
@@ -42,7 +42,16 @@ export function SignInDialog({
   };
 
   const showOtpStep = async (email: string) => {
-    setStep({ status: "otp", email, devOtp: await fetchDevOtp(email) });
+    // Transition immediately; the dev OTP fills in once it arrives so a slow or
+    // unreachable dev API never blocks the OTP screen. The panel is keyed by the
+    // code, so it remounts and picks up the prefill when it lands.
+    setStep({ status: "otp", email, devOtp: null });
+    const devOtp = await fetchDevOtp(email);
+    setStep((prev) =>
+      prev.status === "otp" && prev.email === email
+        ? { status: "otp", email, devOtp }
+        : prev,
+    );
   };
 
   return (
@@ -62,6 +71,7 @@ export function SignInDialog({
             />
           ) : (
             <OTPPanel
+              key={step.devOtp ?? "empty"}
               email={step.email}
               initialOtp={step.devOtp ?? undefined}
               redirectTo={redirectTo}

--- a/apps/web/src/components/auth/sign-in-dialog.tsx
+++ b/apps/web/src/components/auth/sign-in-dialog.tsx
@@ -13,6 +13,7 @@ import {
 
 import { OTPPanel } from "@/components/auth/otp-panel";
 import { SignInPanel } from "@/components/auth/sign-in-panel";
+import { fetchDevOtp } from "@/lib/dev-otp";
 
 type SignInDialogProps = {
   onOpenChange: (open: boolean) => void;
@@ -22,7 +23,7 @@ type SignInDialogProps = {
 
 type SignInDialogStep =
   | { status: "sign-in" }
-  | { status: "otp"; email: string };
+  | { status: "otp"; email: string; devOtp: string | null };
 
 export function SignInDialog({
   onOpenChange,
@@ -40,6 +41,10 @@ export function SignInDialog({
     }
   };
 
+  const showOtpStep = async (email: string) => {
+    setStep({ status: "otp", email, devOtp: await fetchDevOtp(email) });
+  };
+
   return (
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogPopup className="max-w-md">
@@ -52,12 +57,13 @@ export function SignInDialog({
               redirectTo={redirectTo}
               showHeading={false}
               onOtpSent={({ email }) => {
-                setStep({ status: "otp", email });
+                void showOtpStep(email);
               }}
             />
           ) : (
             <OTPPanel
               email={step.email}
+              initialOtp={step.devOtp ?? undefined}
               redirectTo={redirectTo}
               surface="bare"
               onUseDifferentEmail={() => {

--- a/apps/web/src/components/auth/sign-in-panel.tsx
+++ b/apps/web/src/components/auth/sign-in-panel.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import { useForm } from "@tanstack/react-form";
 import { useNavigate } from "@tanstack/react-router";
 import { useSelector } from "@tanstack/react-store";
-import { Result } from "better-result";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
@@ -124,32 +123,6 @@ export function SignInPanel({
           });
         }
         return;
-      }
-
-      if (import.meta.env.DEV) {
-        const probe = await Result.tryPromise(async () => {
-          const url = new URL("/dev-public/last-otp", env.VITE_API_URL);
-          url.searchParams.set("email", parsedValue.email);
-          const response = await fetch(url, {
-            credentials: "include",
-            signal: AbortSignal.timeout(10_000),
-          });
-          if (!response.ok) {
-            return null;
-          }
-          const parsed = v.safeParse(
-            v.object({ otp: v.string() }),
-            await response.json(),
-          );
-          return parsed.success ? parsed.output.otp : null;
-        });
-        if (Result.isOk(probe) && probe.value !== null) {
-          stellaToast.add({
-            title: `Dev OTP: ${probe.value}`,
-            type: "info",
-            timeout: 8000,
-          });
-        }
       }
 
       await handleOtpSent(parsedValue.email);

--- a/apps/web/src/lib/dev-otp.ts
+++ b/apps/web/src/lib/dev-otp.ts
@@ -21,7 +21,7 @@ export const fetchDevOtp = async (email: string): Promise<string | null> => {
     url.searchParams.set("email", email);
     const response = await fetch(url, {
       credentials: "include",
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(3000),
     });
     if (!response.ok) {
       return null;

--- a/apps/web/src/lib/dev-otp.ts
+++ b/apps/web/src/lib/dev-otp.ts
@@ -1,0 +1,34 @@
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import { env } from "@/env";
+
+const devOtpSchema = v.object({ otp: v.string() });
+
+/**
+ * Reads (and consumes) the email-OTP the dev API mirrors for an address so the
+ * sign-in flow can prefill the code instead of making you copy it by hand. The
+ * mirror endpoint only exists in dev, so this resolves to `null` in production
+ * (and the fetch is tree-shaken out) and whenever no mirrored code is waiting.
+ */
+export const fetchDevOtp = async (email: string): Promise<string | null> => {
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+
+  const result = await Result.tryPromise(async () => {
+    const url = new URL("/dev-public/last-otp", env.VITE_API_URL);
+    url.searchParams.set("email", email);
+    const response = await fetch(url, {
+      credentials: "include",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const parsed = v.safeParse(devOtpSchema, await response.json());
+    return parsed.success ? parsed.output.otp : null;
+  });
+
+  return Result.isOk(result) ? result.value : null;
+};

--- a/apps/web/src/routes/auth/otp.tsx
+++ b/apps/web/src/routes/auth/otp.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import * as v from "valibot";
 
 import { OTPPanel } from "@/components/auth/otp-panel";
+import { fetchDevOtp } from "@/lib/dev-otp";
 import { redirectToSchema } from "@/lib/redirect";
 import { emailSchema } from "@/lib/schema";
 
@@ -12,6 +13,7 @@ const searchSchema = v.strictObject({
 
 export const Route = createFileRoute("/auth/otp")({
   validateSearch: searchSchema,
+  loaderDeps: ({ search }) => ({ email: search.email }),
   beforeLoad: ({ context, search }) => {
     if (context.session) {
       throw redirect({
@@ -21,6 +23,7 @@ export const Route = createFileRoute("/auth/otp")({
       });
     }
   },
+  loader: async ({ deps }) => ({ devOtp: await fetchDevOtp(deps.email) }),
   component: OTP,
 });
 
@@ -28,6 +31,13 @@ function OTP() {
   const { email, redirectTo } = Route.useSearch({
     select: (s) => ({ email: s.email, redirectTo: s.redirectTo }),
   });
+  const devOtp = Route.useLoaderData({ select: (d) => d.devOtp });
 
-  return <OTPPanel email={email} redirectTo={redirectTo} />;
+  return (
+    <OTPPanel
+      email={email}
+      initialOtp={devOtp ?? undefined}
+      redirectTo={redirectTo}
+    />
+  );
 }


### PR DESCRIPTION
## What

In development the API mirrors the most recent email-OTP at `/dev-public/last-otp`. This reads that code where it is actually entered and prefills the OTP input, so signing in locally no longer requires copying the code by hand.

- `lib/dev-otp.ts`: small `fetchDevOtp(email)` helper returning `string | null`.
- `/auth/otp`: DEV-only route loader prefills the panel through a new `initialOtp` prop on `OTPPanel`.
- Inline sign-in dialog: fetches and prefills on its OTP step too, so both sign-in surfaces behave the same.
- `sign-in-panel`: the send-time `Dev OTP` toast is removed. The endpoint pops the code, so the read moves from send time to the entry point.

## Notes

- Production is unaffected: `fetchDevOtp` short-circuits and is tree-shaken out when not in dev.
- Prefill only: the code lands in the field and you click Verify (no auto-submit).