### PR TITLE
fix(ingestion): bound concurrent adapter cycles + add liveness watchdog

### DIFF
--- a/apps/legal-atlas-runner/src/env.ts
+++ b/apps/legal-atlas-runner/src/env.ts
@@ -2,4 +2,10 @@ export const LEGAL_ATLAS_RUNNER_ENV = {
   disabledAdapters: Bun.env["DISABLED_ADAPTERS"] ?? "",
   maxConcurrentDbWrites:
     Number.parseInt(Bun.env["MAX_CONCURRENT_DB_WRITES"] ?? "2", 10) || 2,
+  // Cap on adapters crawling at once. Each cycle fetches + enriches + parses
+  // outside the DB-write semaphore, so without this bound every source crawls
+  // its backlog concurrently and saturates a small worker (0.5 vCPU), starving
+  // the event loop so no page completes within its cycle budget.
+  maxConcurrentAdapterCycles:
+    Number.parseInt(Bun.env["MAX_CONCURRENT_ADAPTER_CYCLES"] ?? "2", 10) || 2,
 } as const;

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -135,6 +135,71 @@ const CITATION_AUTHORITY_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const IDLE_THRESHOLD = 3;
 const IDLE_DELAY_MS = 24 * 60 * 60 * 1000;
 
+// Liveness watchdog. A self-scheduling timer measures how late it fires
+// versus its interval; sustained lag means the event loop is starved (a
+// runaway cycle or a wedged connection pool) and the daemon is making no
+// progress. After enough consecutive starved ticks it exits so ECS can
+// relaunch a fresh task, instead of sitting alive-but-stuck forever (the
+// per-adapter retry/backoff only recovers from *thrown* errors, not from
+// awaits that never settle). Thresholds are well above any healthy pause:
+// idle adapters keep the loop responsive, so lag stays near zero.
+const WATCHDOG_TICK_MS = 10_000;
+const WATCHDOG_LAG_THRESHOLD_MS = 90_000;
+const WATCHDOG_MAX_STARVED_TICKS = 3;
+
+type Semaphore = {
+  acquire: (signal?: AbortSignal) => Promise<void>;
+  release: () => void;
+};
+
+/**
+ * Fair counting semaphore: bounds how many holders run concurrently and
+ * hands the slot to the longest-waiting acquirer on release. An optional
+ * abort signal removes a pending waiter and rejects with AbortError.
+ */
+const createSemaphore = (label: string, capacity: number): Semaphore => {
+  const max = Math.max(1, capacity);
+  let active = 0;
+  const queue: (() => void)[] = [];
+
+  const acquire = async (signal?: AbortSignal): Promise<void> => {
+    if (signal?.aborted) {
+      throw new DOMException(`${label} acquisition aborted`, "AbortError");
+    }
+    if (active < max) {
+      active++;
+      await Promise.resolve();
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const entry = () => {
+        signal?.removeEventListener("abort", onAbort);
+        active++;
+        resolve();
+      };
+      const onAbort = () => {
+        const idx = queue.indexOf(entry);
+        if (idx !== -1) {
+          queue.splice(idx, 1);
+        }
+        reject(new DOMException(`${label} acquisition aborted`, "AbortError"));
+      };
+      queue.push(entry);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+
+  const release = (): void => {
+    active--;
+    const next = queue.shift();
+    if (next) {
+      next();
+    }
+  };
+
+  return { acquire, release };
+};
+
 /**
  * Max adapters doing DB-heavy work (insert + search index +
  * citation extraction) simultaneously. The pipeline acquires
@@ -146,49 +211,64 @@ const MAX_CONCURRENT_DB_WRITES = Math.max(
   1,
   LEGAL_ATLAS_RUNNER_ENV.maxConcurrentDbWrites,
 );
+const dbWriteSemaphore = createSemaphore("DB slot", MAX_CONCURRENT_DB_WRITES);
 
-let activeDbSlots = 0;
-const dbSlotQueue: (() => void)[] = [];
-
-const acquireDbSlot = async (signal?: AbortSignal): Promise<void> => {
-  if (signal?.aborted) {
-    throw new DOMException("DB slot acquisition aborted", "AbortError");
-  }
-  if (activeDbSlots < MAX_CONCURRENT_DB_WRITES) {
-    activeDbSlots++;
-    await Promise.resolve();
-    return;
-  }
-  await new Promise<void>((resolve, reject) => {
-    const entry = () => {
-      signal?.removeEventListener("abort", onAbort);
-      activeDbSlots++;
-      resolve();
-    };
-    const onAbort = () => {
-      const idx = dbSlotQueue.indexOf(entry);
-      if (idx !== -1) {
-        dbSlotQueue.splice(idx, 1);
-      }
-      reject(new DOMException("DB slot acquisition aborted", "AbortError"));
-    };
-    dbSlotQueue.push(entry);
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
-};
-
-const releaseDbSlot = (): void => {
-  activeDbSlots--;
-  const next = dbSlotQueue.shift();
-  if (next) {
-    return next();
-  }
-};
+/**
+ * Max adapter cycles running concurrently. Unlike the DB-write slot, this
+ * also covers the fetch + finaldoc-enrich + AST-parse phase, which is
+ * CPU-heavy and otherwise unbounded: every source would crawl its backlog
+ * at once and saturate a small worker, so no page completes within its
+ * cycle budget. Bounding cycles lets a few sources make real progress and
+ * advance their cursors instead of collapsing under N-way contention.
+ */
+const MAX_CONCURRENT_ADAPTER_CYCLES = Math.max(
+  1,
+  LEGAL_ATLAS_RUNNER_ENV.maxConcurrentAdapterCycles,
+);
+const cycleSemaphore = createSemaphore(
+  "adapter cycle",
+  MAX_CONCURRENT_ADAPTER_CYCLES,
+);
 
 const writeHeartbeat = () => {
   void Bun.write(HEARTBEAT_PATH, new Date().toISOString()).catch(() => {
     // Non-fatal; health check will notice staleness
   });
+};
+
+/**
+ * Start the event-loop liveness watchdog (daemon mode only). Self-schedules
+ * every WATCHDOG_TICK_MS and compares actual delay to the expected interval;
+ * each tick whose lag exceeds WATCHDOG_LAG_THRESHOLD_MS counts as starved,
+ * and WATCHDOG_MAX_STARVED_TICKS in a row triggers a process exit so ECS
+ * relaunches a healthy task. A single fast tick clears the streak.
+ */
+const startEventLoopWatchdog = (): void => {
+  let starvedTicks = 0;
+  let expectedAt = performance.now() + WATCHDOG_TICK_MS;
+
+  const tick = () => {
+    const lag = performance.now() - expectedAt;
+    if (lag > WATCHDOG_LAG_THRESHOLD_MS) {
+      starvedTicks++;
+      logError(
+        `[watchdog] event loop starved: lag=${Math.round(lag)}ms ` +
+          `(${starvedTicks}/${WATCHDOG_MAX_STARVED_TICKS})`,
+      );
+      if (starvedTicks >= WATCHDOG_MAX_STARVED_TICKS) {
+        logError(
+          "[watchdog] sustained event-loop starvation; exiting for ECS restart",
+        );
+        process.exit(1);
+      }
+    } else {
+      starvedTicks = 0;
+    }
+    expectedAt = performance.now() + WATCHDOG_TICK_MS;
+    setTimeout(tick, WATCHDOG_TICK_MS);
+  };
+
+  setTimeout(tick, WATCHDOG_TICK_MS);
 };
 
 // Adapters to skip. Set DISABLED_ADAPTERS env var to a
@@ -329,7 +409,7 @@ const runOneCycle = async (
     result = await runIngestionPipeline({
       source,
       scopedDb: ingestionDb,
-      dbSlot: { acquire: acquireDbSlot, release: releaseDbSlot },
+      dbSlot: dbWriteSemaphore,
       signal: AbortSignal.timeout(cycleMs),
       ...(bounds.maxPages !== undefined && { maxPages: bounds.maxPages }),
       ...(bounds.maxDecisions !== undefined && {
@@ -412,8 +492,20 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
 
   while (true) {
     try {
-      // oxlint-disable-next-line no-await-in-loop -- continuous daemon: each adapter cycle must finish before the next so the persisted cursor advances in order
-      const { outcome, inserted } = await runOneCycle(adapterKey, name);
+      // Bound concurrent cycles: the fetch/enrich/parse phase runs outside
+      // the DB-write slot, so without this every source crawls its backlog
+      // at once and saturates the worker. Held only for the cycle and
+      // released before the inter-cycle delay, so idle adapters free the slot.
+      // oxlint-disable-next-line no-await-in-loop -- continuous daemon: one cycle at a time per adapter so the persisted cursor advances in order
+      await cycleSemaphore.acquire();
+      let cycle: CycleResult;
+      try {
+        // oxlint-disable-next-line no-await-in-loop -- continuous daemon: one cycle at a time per adapter so the persisted cursor advances in order
+        cycle = await runOneCycle(adapterKey, name);
+      } finally {
+        cycleSemaphore.release();
+      }
+      const { outcome, inserted } = cycle;
 
       if (outcome === "failed") {
         consecutiveFailures++;
@@ -559,6 +651,7 @@ export const runCaseLawIngest = async (
   // All adapters: independent concurrent loops.
   daemonMode = true;
   logInfo("Ingestion daemon started.");
+  startEventLoopWatchdog();
   await refreshS3();
   await refreshCorpusS3();
   writeHeartbeat();

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -370,6 +370,7 @@ type CycleOutcome = "completed" | "failed" | "timeout";
 type CycleResult = {
   outcome: CycleOutcome;
   inserted: number;
+  pagesProcessed: number;
 };
 
 /**
@@ -475,7 +476,11 @@ const runOneCycle = async (
     logError(`[${adapterKey}] Failed: ${errorMessage}`);
   }
 
-  return { outcome, inserted: result?.inserted ?? 0 };
+  return {
+    outcome,
+    inserted: result?.inserted ?? 0,
+    pagesProcessed: result?.pagesProcessed ?? 0,
+  };
 };
 
 /**
@@ -489,6 +494,13 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
   let backoffFailures = 0;
   /** Consecutive completed cycles with zero inserts; drives idle backoff. */
   let idleCycles = 0;
+  /**
+   * Consecutive timeout cycles that completed zero pages: the adapter cannot
+   * finish even one page within its budget. Tracked separately because a
+   * "timeout" (unlike "failed") resets the failure counter, so a full stall
+   * would otherwise never reach the sustained-failure alert.
+   */
+  let stalledCycles = 0;
 
   while (true) {
     try {
@@ -505,7 +517,13 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       } finally {
         cycleSemaphore.release();
       }
-      const { outcome, inserted } = cycle;
+      const { outcome, inserted, pagesProcessed } = cycle;
+
+      // A timeout that completed no pages means the adapter is stuck (cannot
+      // finish even one page), not merely slow. Anything else — a completed
+      // cycle, or a timeout that did advance pages — clears the stall streak.
+      stalledCycles =
+        outcome === "timeout" && pagesProcessed === 0 ? stalledCycles + 1 : 0;
 
       if (outcome === "failed") {
         consecutiveFailures++;
@@ -533,6 +551,9 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         }
       }
     } catch (error) {
+      // A thrown cycle is already counted as a failure below; it is not a
+      // page-completion stall, so clear that streak.
+      stalledCycles = 0;
       consecutiveFailures++;
       backoffFailures++;
       const msg = error instanceof Error ? error.message : String(error);
@@ -543,14 +564,22 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
     }
 
-    if (consecutiveFailures >= SUSTAINED_FAILURE_THRESHOLD) {
+    // Alert on either a run of hard failures or a run of zero-page timeouts:
+    // both mean the source has made no forward progress for many cycles, but
+    // only the failure path used to reach the sustained-failure metric.
+    if (
+      consecutiveFailures >= SUSTAINED_FAILURE_THRESHOLD ||
+      stalledCycles >= SUSTAINED_FAILURE_THRESHOLD
+    ) {
       logger.error("case_law.ingestion.sustained_failure", {
         adapterKey,
         consecutiveFailures,
+        stalledCycles,
       });
-      // Reset alert counter to avoid flooding; backoffFailures
+      // Reset alert counters to avoid flooding; backoffFailures
       // stays high so the delay doesn't collapse.
       consecutiveFailures = 0;
+      stalledCycles = 0;
     }
 
     writeHeartbeat();

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -147,6 +147,14 @@ const WATCHDOG_TICK_MS = 10_000;
 const WATCHDOG_LAG_THRESHOLD_MS = 90_000;
 const WATCHDOG_MAX_STARVED_TICKS = 3;
 
+// Hard wall-clock ceiling on a single held cycle. The lag watchdog catches a
+// CPU-starved loop, but a cycle wedged on an await that ignores the per-cycle
+// signal (e.g. a DB call before/after the pipeline's AbortSignal) leaves the
+// loop responsive AND keeps its concurrency slot, which would park every other
+// adapter. If a cycle outlives this ceiling — well above the longest adapter
+// maxCycleMs (30m) plus slack — the worker is wedged: exit so ECS relaunches.
+const CYCLE_HARD_DEADLINE_MS = 45 * 60 * 1000;
+
 type Semaphore = {
   acquire: (signal?: AbortSignal) => Promise<void>;
   release: () => void;
@@ -190,6 +198,9 @@ const createSemaphore = (label: string, capacity: number): Semaphore => {
   };
 
   const release = (): void => {
+    if (active === 0) {
+      panic(`${label} semaphore released without an active acquisition`);
+    }
     active--;
     const next = queue.shift();
     if (next) {
@@ -265,10 +276,12 @@ const startEventLoopWatchdog = (): void => {
       starvedTicks = 0;
     }
     expectedAt = performance.now() + WATCHDOG_TICK_MS;
-    setTimeout(tick, WATCHDOG_TICK_MS);
+    // unref: the watchdog observes the loop, it must not be the sole handle
+    // keeping the process alive once everything else has finished.
+    setTimeout(tick, WATCHDOG_TICK_MS).unref();
   };
 
-  setTimeout(tick, WATCHDOG_TICK_MS);
+  setTimeout(tick, WATCHDOG_TICK_MS).unref();
 };
 
 // Adapters to skip. Set DISABLED_ADAPTERS env var to a
@@ -511,10 +524,25 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       // oxlint-disable-next-line no-await-in-loop -- continuous daemon: one cycle at a time per adapter so the persisted cursor advances in order
       await cycleSemaphore.acquire();
       let cycle: CycleResult;
+      // Hard wall-clock backstop on the held slot. runOneCycle has awaits that
+      // ignore the per-cycle abort signal (the source lookup before it is
+      // created, the event write after the pipeline); if one wedges on a
+      // broken connection the cycle never returns, the finally never runs, and
+      // the slot parks every other adapter. The lag watchdog can't see an
+      // I/O-wait hang (the loop stays responsive), so bound it here: if a cycle
+      // outlives the ceiling, exit so ECS relaunches a healthy task.
+      const deadline = setTimeout(() => {
+        logError(
+          `[${adapterKey}] cycle exceeded ${CYCLE_HARD_DEADLINE_MS}ms hard deadline (wedged await); exiting for ECS restart`,
+        );
+        process.exit(1);
+      }, CYCLE_HARD_DEADLINE_MS);
+      deadline.unref();
       try {
         // oxlint-disable-next-line no-await-in-loop -- continuous daemon: one cycle at a time per adapter so the persisted cursor advances in order
         cycle = await runOneCycle(adapterKey, name);
       } finally {
+        clearTimeout(deadline);
         cycleSemaphore.release();
       }
       const { outcome, inserted, pagesProcessed } = cycle;

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -502,18 +502,17 @@ const runOneCycle = async (
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity -- preserves the daemon's existing retry, alert, and idle-backoff state machine.
 const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
-  let consecutiveFailures = 0;
-  /** Separate counter for backoff; not reset by alert threshold. */
+  /**
+   * Consecutive cycles with no forward progress — a hard failure OR a timeout
+   * that completed zero pages. A single streak so an adapter that alternates
+   * between the two (each of which would otherwise reset the other's counter)
+   * still reaches the sustained-failure alert.
+   */
+  let noProgressStreak = 0;
+  /** Separate counter for backoff; not reset by the alert threshold. */
   let backoffFailures = 0;
   /** Consecutive completed cycles with zero inserts; drives idle backoff. */
   let idleCycles = 0;
-  /**
-   * Consecutive timeout cycles that completed zero pages: the adapter cannot
-   * finish even one page within its budget. Tracked separately because a
-   * "timeout" (unlike "failed") resets the failure counter, so a full stall
-   * would otherwise never reach the sustained-failure alert.
-   */
-  let stalledCycles = 0;
 
   while (true) {
     try {
@@ -547,17 +546,18 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
       const { outcome, inserted, pagesProcessed } = cycle;
 
-      // A timeout that completed no pages means the adapter is stuck (cannot
-      // finish even one page), not merely slow. Anything else — a completed
-      // cycle, or a timeout that did advance pages — clears the stall streak.
-      stalledCycles =
-        outcome === "timeout" && pagesProcessed === 0 ? stalledCycles + 1 : 0;
+      // Forward progress = a clean cycle, or a timeout that still advanced at
+      // least one page. A "failed" or a zero-page "timeout" is a stall; both
+      // grow the one streak, so an adapter alternating between them still
+      // reaches the alert.
+      const madeProgress =
+        outcome === "completed" ||
+        (outcome === "timeout" && pagesProcessed > 0);
+      noProgressStreak = madeProgress ? 0 : noProgressStreak + 1;
 
       if (outcome === "failed") {
-        consecutiveFailures++;
         backoffFailures++;
       } else {
-        consecutiveFailures = 0;
         backoffFailures = 0;
         // Only "completed" outcomes count toward idle. A "timeout"
         // means the cycle hit MAX_CYCLE_MS mid-work; the adapter is
@@ -579,10 +579,8 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         }
       }
     } catch (error) {
-      // A thrown cycle is already counted as a failure below; it is not a
-      // page-completion stall, so clear that streak.
-      stalledCycles = 0;
-      consecutiveFailures++;
+      // A thrown cycle made no forward progress either.
+      noProgressStreak++;
       backoffFailures++;
       const msg = error instanceof Error ? error.message : String(error);
       if (isTransientConnectionError(msg)) {
@@ -592,26 +590,19 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
     }
 
-    // Alert on either a run of hard failures or a run of zero-page timeouts:
-    // both mean the source has made no forward progress for many cycles, but
-    // only the failure path used to reach the sustained-failure metric.
-    if (
-      consecutiveFailures >= SUSTAINED_FAILURE_THRESHOLD ||
-      stalledCycles >= SUSTAINED_FAILURE_THRESHOLD
-    ) {
+    // A run of no-progress cycles (failures and/or zero-page timeouts) means
+    // the source is stalled; surface it on the sustained-failure metric.
+    if (noProgressStreak >= SUSTAINED_FAILURE_THRESHOLD) {
       logger.error("case_law.ingestion.sustained_failure", {
         adapterKey,
-        consecutiveFailures,
-        stalledCycles,
+        noProgressStreak,
       });
-      // Reset alert counters to avoid flooding; backoffFailures stays high so
-      // the delay doesn't collapse. Both are read again at the top of the next
-      // iteration (`consecutiveFailures++` / `stalledCycles + 1`); the rule's
-      // forward-only liveness can't see the loop back-edge.
+      // Reset to avoid flooding; backoffFailures stays high so the delay
+      // doesn't collapse. The value is read again at the top of the next
+      // iteration (`noProgressStreak + 1`); the rule's forward-only liveness
+      // can't see the loop back-edge.
       // oxlint-disable-next-line no-useless-assignment -- reset read on next loop iteration
-      consecutiveFailures = 0;
-      // oxlint-disable-next-line no-useless-assignment -- reset read on next loop iteration
-      stalledCycles = 0;
+      noProgressStreak = 0;
     }
 
     writeHeartbeat();

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -193,7 +193,7 @@ const createSemaphore = (label: string, capacity: number): Semaphore => {
     active--;
     const next = queue.shift();
     if (next) {
-      next();
+      return next();
     }
   };
 
@@ -576,9 +576,13 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         consecutiveFailures,
         stalledCycles,
       });
-      // Reset alert counters to avoid flooding; backoffFailures
-      // stays high so the delay doesn't collapse.
+      // Reset alert counters to avoid flooding; backoffFailures stays high so
+      // the delay doesn't collapse. Both are read again at the top of the next
+      // iteration (`consecutiveFailures++` / `stalledCycles + 1`); the rule's
+      // forward-only liveness can't see the loop back-edge.
+      // oxlint-disable-next-line no-useless-assignment -- reset read on next loop iteration
       consecutiveFailures = 0;
+      // oxlint-disable-next-line no-useless-assignment -- reset read on next loop iteration
       stalledCycles = 0;
     }
 


### PR DESCRIPTION
## Problem

The case-law ingestion daemon runs one loop per source. Three weaknesses compounded into a worker that could pin its CPU, make zero progress, and neither self-heal nor alarm correctly:

1. **Unbounded cold-start concurrency.** The DB-write phase is bounded by a semaphore, but the fetch + finaldoc-enrich + AST-parse phase ran with no cap. When several sources are behind and crawl at once, the worker's CPU saturates, the event loop starves, and no page finishes within its per-cycle time budget — so cursors never advance while the worker is pinned at full CPU. Steady state hides this because caught-up adapters drop to daily polling.
2. **No self-recovery from a hung loop.** The existing recovery paths (per-adapter `try/catch` + backoff, `unhandledRejection` suppression) only react to *thrown* errors. A loop that is starved, or wedged on awaits that never settle, throws nothing — so it sits alive-but-stuck with no recovery.
3. **A stall could go unalarmed.** A stuck adapter returns `timeout`, which reset the failure counter; only a hard `failed` outcome reached the sustained-failure metric. So a full stall (every source stuck on `timeout`) produced no alert unless one source happened to fail outright.

## Changes

- **Bound concurrent adapter cycles.** New `MAX_CONCURRENT_ADAPTER_CYCLES` (default `2`) gates the whole cycle, so only a few sources crawl at once and each can complete a page and advance its cursor instead of collapsing under N-way contention. The existing DB-write slot is generalized into a shared `createSemaphore` helper (fair FIFO, abort-aware) used by both.
- **Event-loop liveness watchdog.** A self-scheduling timer measures its own lag; sustained starvation (lag over threshold for N consecutive ticks) exits the process so the orchestrator relaunches a healthy task. Closes the "alive but not progressing" gap that retry/backoff cannot see. (A fully synchronous freeze would need a worker-thread watchdog — noted as a follow-up.)
- **Alarm on zero-progress timeouts.** Track consecutive `timeout` cycles that completed zero pages per adapter, and emit the same sustained-failure signal when they pile up — so a worker that is alive but making no forward progress is alarmable, not just one that fails outright.

All limits are env-tunable; no behavior change for healthy, caught-up sources.

## Testing

- Unit-checked the semaphore: concurrency never exceeds capacity, FIFO ordering, and abort removes a pending waiter without corrupting the queue.
- Typechecks and formats clean.