### PR TITLE
chore(mcp): run stella-docs server in-process instead of spawning a child

### DIFF
--- a/.claude/mcp/stella-docs.ts
+++ b/.claude/mcp/stella-docs.ts
@@ -1,39 +1,26 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import path from "node:path";
 
 // Auto-install deps if missing (worktrees, fresh clones).
 // Check for a specific package rather than just node_modules/
 // to handle partial or interrupted installs.
-const sentinel = join(
+const sentinel = path.join(
   import.meta.dir,
   "node_modules",
   "@modelcontextprotocol",
 );
 if (!existsSync(sentinel)) {
-  const proc = Bun.spawnSync(
-    ["bun", "install", "--frozen-lockfile"],
-    { cwd: import.meta.dir, stderr: "inherit" },
-  );
+  const proc = Bun.spawnSync(["bun", "install", "--frozen-lockfile"], {
+    cwd: import.meta.dir,
+    stderr: "inherit",
+  });
   if (proc.exitCode !== 0) {
     process.exit(1);
   }
 }
 
-// Spawn server as a child process so Bun doesn't eagerly
-// resolve its dependency graph before install finishes.
-const server = join(import.meta.dir, "server.ts");
-const child = Bun.spawn(["bun", "run", server], {
-  cwd: import.meta.dir,
-  stdin: "inherit",
-  stdout: "inherit",
-  stderr: "inherit",
-});
-
-// Forward signals so the child doesn't outlive the bootstrap
-for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
-  process.on(sig, () => {
-    child.kill();
-  });
-}
-
-process.exitCode = await child.exited;
+// Run the server in this same process. A dynamic import defers
+// dependency resolution until runtime (after the install above); a
+// static top-level import would resolve it at parse time, before the
+// deps exist. This avoids a second "babysitter" process per session.
+await import("./server.ts");


### PR DESCRIPTION
The stella-docs MCP bootstrap (`stella-docs.ts`) spawned the server as a
separate child process and then existed only to forward signals and wait on
it, doubling the bun process count for every session that connects.

Replace the `Bun.spawn` child with an in-process dynamic
`import("./server.ts")`. The dynamic import preserves the original reason for
the child: dependency resolution is deferred to runtime, after the
auto-install, whereas a static top-level import would resolve the server's
deps at parse time, before they exist on a fresh worktree or clone.

Net effect: one process per session instead of two.

Also switches `node:path` to a default import to satisfy
`unicorn/import-style`.

Verified with an MCP stdio handshake: `initialize` returns the server info and
`tools/list` returns all four tools, with a clean exit.