### PR TITLE
fix(e2e): stabilize chat-nav timeout and fix route-smoke /knowledge flake at the source

### DIFF
--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -36,8 +36,11 @@ test("chat composer sends a message and renders the assistant reply", async ({
   // Sending from /chat fires the request and navigates to the new
   // thread (apps/web/src/routes/_protected.chat/index.tsx:389); the
   // thread id is a client-generated uuidv7.
+  // The thread-creation request + client nav can exceed the default 10s expect
+  // timeout on a cold CI runner — the same headroom the waits below use.
   await expect(page).toHaveURL(
     /\/chat\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u,
+    { timeout: 30_000 },
   );
 
   const transcript = page.getByRole("log");

--- a/apps/web/src/routes/_protected.knowledge/tools.tsx
+++ b/apps/web/src/routes/_protected.knowledge/tools.tsx
@@ -13,6 +13,7 @@ import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { api } from "@/lib/api";
 import { subscribeToMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { ensureCriticalQueryData } from "@/lib/react-query";
+import { roleOptions } from "@/routes/-queries";
 import { CatalogueBrowser } from "@/routes/_protected.knowledge/-components/catalogue/catalogue-browser";
 import type { CatalogueBrowserFilterKind } from "@/routes/_protected.knowledge/-components/catalogue/catalogue-browser";
 import {
@@ -86,6 +87,12 @@ export const Route = createFileRoute("/_protected/knowledge/tools")({
     await Promise.all([
       ensureCriticalQueryData(context.queryClient, catalogueOptions(orgId)),
       ensureCriticalQueryData(context.queryClient, organizationSettingsOptions),
+      // CatalogueBrowser reads the member role via a non-suspense useQuery; seed
+      // it here so it is a synchronous cache hit on mount. Otherwise a cold-cache
+      // fetch resolving mid-mount notifies the not-yet-mounted fiber (React
+      // "state update on a component that hasn't mounted yet"), which flaked the
+      // route-smoke e2e on /knowledge/skills (and its twin /knowledge/prompts).
+      ensureCriticalQueryData(context.queryClient, roleOptions),
     ]);
   },
   component: ToolsPage,


### PR DESCRIPTION
Two targeted stabilizations for flaky e2e specs, plus the removal of a test-side warning suppression in favor of a source fix.

## chat.spec.ts — chat-nav timeout
The thread-creation request plus the client-side navigation to the new thread can exceed the default 10s `expect` timeout on a cold CI runner. The `toHaveURL` wait now uses the same 30s headroom as the surrounding visibility waits.

## /knowledge route-smoke — root-cause fix
`CatalogueBrowser` reads the member role via a non-suspense `useQuery(roleOptions)` that the `/knowledge/tools` loader never awaited. On a cold cache the fetch resolved mid-mount and notified a not-yet-mounted fiber, producing the React dev warning "Can't perform a React state update on a component that hasn't mounted yet". This flaked the route-smoke spec on `/knowledge/skills` and its twin `/knowledge/prompts` (both redirect to `/knowledge/tools?kind=skill`).

The loader now seeds `roleOptions` alongside the other critical queries, so it is a synchronous cache hit on mount and the async update no longer races mounting.

This replaces the previous test-side toleration of the warning with a source fix, so the e2e harness keeps asserting on unexpected console errors instead of silently allowing this one.

## Files changed
- `apps/web/e2e/specs/chat.spec.ts`
- `apps/web/src/routes/_protected.knowledge/tools.tsx`
