### PR TITLE
ci(e2e): authenticate docker pulls + cold-CI timeout for route-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,11 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+    env:
+      # Authenticated Docker Hub pulls (when these secrets are set) avoid the
+      # anonymous per-IP pull-rate limit that intermittently fails the docker
+      # stack bring-up on shared GitHub runners.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
       - name: Checkout
@@ -523,6 +528,16 @@ jobs:
           cd ../web
           mv .env.example .env
 
+      - name: Log in to Docker Hub
+        # Skipped automatically until DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo
+        # secrets exist; authenticated pulls raise the rate limit well above the
+        # shared-runner anonymous cap that flakes the gotenberg image pull.
+        if: steps.changed.outputs.run == 'true' && env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Start docker stack
         if: steps.changed.outputs.run == 'true'
         # `--wait` only on long-running services; `minio-setup` is a one-shot
@@ -540,7 +555,7 @@ jobs:
             fi
             echo "::warning::docker stack start failed (attempt ${attempt}/3); tearing down and retrying"
             docker compose --profile dev down --volumes --remove-orphans || true
-            sleep 10
+            sleep "$((attempt * 20))"
           done
           echo "::error::docker stack failed to start after 3 attempts"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,7 @@ jobs:
       # anonymous per-IP pull-rate limit that intermittently fails the docker
       # stack bring-up on shared GitHub runners.
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - name: Checkout
@@ -532,7 +533,7 @@ jobs:
         # Skipped automatically until DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo
         # secrets exist; authenticated pulls raise the rate limit well above the
         # shared-runner anonymous cap that flakes the gotenberg image pull.
-        if: steps.changed.outputs.run == 'true' && env.DOCKERHUB_USERNAME != ''
+        if: steps.changed.outputs.run == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -300,7 +300,11 @@ const renderSmokeRoute = async ({
   await page.goto(route.path, { waitUntil: "domcontentloaded" });
   await expect(page, route.template).not.toHaveURL(/\/auth(?:\/|$)/u);
   await assertNoRouteBoundary(page, route.template);
-  await expect(page.locator("main").first(), route.template).toBeVisible();
+  // Cold-compiled route chunks can take longer than the default 10s expect
+  // timeout to paint <main> on a fresh CI runner.
+  await expect(page.locator("main").first(), route.template).toBeVisible({
+    timeout: 30_000,
+  });
 
   await page.waitForTimeout(route.settleMs ?? 250);
 


### PR DESCRIPTION
## Why

Two recurring e2e CI flakes, both confirmed from CI logs.

### 1. `Start docker stack` hit the Docker Hub anonymous pull-rate limit

The `gotenberg` image pull intermittently failed with the anonymous per-IP
pull-rate limit on shared GitHub runners (`Head https://registry-1.docker.io/...`
/ `Get https://auth.docker.io/token...`), surviving all 3 existing retries and
failing the whole `e2e` job.

Changes:
- Add a conditional **Log in to Docker Hub** step before `Start docker stack`.
  Authenticated pulls raise the rate limit well above the shared-runner
  anonymous cap.
- Lengthen the retry backoff to exponential (`sleep "$((attempt * 20))"`)
  instead of a flat `sleep 10`, so a transient throttle has time to clear
  between attempts.

### 2. `route-smoke.spec.ts` `<main>` visibility used the default 10s timeout

A cold-compiled route chunk occasionally needs longer than the default 10s
`expect` timeout to paint `<main>` on a fresh runner. Give that assertion the
same 30s cold-CI headroom other waits in the suite already use.