### PR TITLE
feat(i18n): RTL/number lint follow-ups

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-unformatted-number.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-unformatted-number.fixture.tsx
@@ -30,6 +30,10 @@ export const _length = () => (
   // oxlint-disable-next-line no-unformatted-number/no-unformatted-number
   <span>{x.items.length}</span>
 );
+export const _bareWithSibling = () => (
+  // oxlint-disable-next-line no-unformatted-number/no-unformatted-number
+  <span>{x.count} left</span>
+);
 
 // --- Allowed: formatted, non-numeric, or a non-display attribute ---
 export const _formatted = () => <span>{getFormatter().number(x.count)}</span>;

--- a/.oxlint-plugins/__fixtures__/no-unformatted-number.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-unformatted-number.fixture.tsx
@@ -34,6 +34,10 @@ export const _bareWithSibling = () => (
   // oxlint-disable-next-line no-unformatted-number/no-unformatted-number
   <span>{x.count} left</span>
 );
+export const _bareInFragment = () => (
+  // oxlint-disable-next-line no-unformatted-number/no-unformatted-number
+  <>{x.count} left</>
+);
 
 // --- Allowed: formatted, non-numeric, or a non-display attribute ---
 export const _formatted = () => <span>{getFormatter().number(x.count)}</span>;

--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -25,6 +25,12 @@ export const _file = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
   <span>{x.fileName}</span>
 );
+export const _nameWithSibling = () => (
+  <span>
+    {/* oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name */}
+    {x.displayName} <small>(archived)</small>
+  </span>
+);
 
 // --- Allowed: dir present, <bdi>, or a non-name expression ---
 export const _ok1 = () => <span dir="auto">{x.displayName}</span>;

--- a/.oxlint-plugins/no-unformatted-number.ts
+++ b/.oxlint-plugins/no-unformatted-number.ts
@@ -111,10 +111,13 @@ export default {
               return;
             }
             const expr = node.expression;
-            // A bare `{numericName}` rendered as element text (whether it is the
-            // sole child or sits alongside text/siblings, e.g. `{hours}h`) shows
-            // Latin digits too, so flag it the same as String()/template forms.
-            const isTextChild = node.parent?.type === "JSXElement";
+            // A bare `{numericName}` rendered as element/fragment text (whether
+            // it is the sole child or sits alongside text/siblings, e.g.
+            // `{hours}h` or `<>{count} left</>`) shows Latin digits too, so flag
+            // it the same as String()/template forms.
+            const isTextChild =
+              node.parent?.type === "JSXElement" ||
+              node.parent?.type === "JSXFragment";
             if (
               isStringCall(expr) ||
               isNumericTemplate(expr) ||

--- a/.oxlint-plugins/no-unformatted-number.ts
+++ b/.oxlint-plugins/no-unformatted-number.ts
@@ -107,28 +107,20 @@ export default {
       create(context) {
         return {
           JSXExpressionContainer(node) {
-            const expr = node.expression;
-            if (
-              (isStringCall(expr) || isNumericTemplate(expr)) &&
-              !inNonDisplayAttr(node)
-            ) {
-              context.report({ node, messageId: "unformatted" });
-            }
-          },
-          JSXElement(node) {
-            const kids = node.children.filter(
-              (child) =>
-                !(child.type === "JSXText" && child.value.trim().length === 0),
-            );
-            if (kids.length !== 1) {
+            if (inNonDisplayAttr(node)) {
               return;
             }
-            const child = kids[0];
+            const expr = node.expression;
+            // A bare `{numericName}` rendered as element text (whether it is the
+            // sole child or sits alongside text/siblings, e.g. `{hours}h`) shows
+            // Latin digits too, so flag it the same as String()/template forms.
+            const isTextChild = node.parent?.type === "JSXElement";
             if (
-              child.type === "JSXExpressionContainer" &&
-              isNumericExpr(child.expression)
+              isStringCall(expr) ||
+              isNumericTemplate(expr) ||
+              (isTextChild && isNumericExpr(expr))
             ) {
-              context.report({ node: child, messageId: "unformatted" });
+              context.report({ node, messageId: "unformatted" });
             }
           },
         };

--- a/.oxlint-plugins/require-dir-on-rendered-name.ts
+++ b/.oxlint-plugins/require-dir-on-rendered-name.ts
@@ -43,6 +43,12 @@ const meaningfulChildren = (children) =>
     (child) => !(child.type === "JSXText" && child.value.trim().length === 0),
   );
 
+const isNameExpr = (expr) =>
+  (expr.type === "MemberExpression" ||
+    expr.type === "OptionalMemberExpression") &&
+  expr.property.type === "Identifier" &&
+  NAME_PROPS.has(expr.property.name);
+
 export default {
   meta: { name: "require-dir-on-rendered-name" },
   rules: {
@@ -54,6 +60,10 @@ export default {
             "User-provided name rendered without bidi isolation reorders " +
             'under RTL (e.g. ".Tatra Motor a.s"). Add dir="auto" to the ' +
             "element (or wrap the value in <bdi>).",
+          missingBidi:
+            "User-provided name rendered alongside other content reorders " +
+            "under RTL; wrap it in <bdi> (dir on the parent would also " +
+            "reorder its siblings).",
         },
       },
       create(context) {
@@ -66,25 +76,26 @@ export default {
             ) {
               return;
             }
-            if (hasDirAttr(opening)) {
-              return;
-            }
             const kids = meaningfulChildren(node.children);
-            if (kids.length !== 1) {
+            const nameKids = kids.filter(
+              (child) =>
+                child.type === "JSXExpressionContainer" &&
+                isNameExpr(child.expression),
+            );
+            if (nameKids.length === 0) {
               return;
             }
-            const child = kids[0];
-            if (child.type !== "JSXExpressionContainer") {
+            // Sole child: dir="auto" on the element isolates it.
+            if (kids.length === 1) {
+              if (!hasDirAttr(opening)) {
+                context.report({ node: opening, messageId: "missingDir" });
+              }
               return;
             }
-            const expr = child.expression;
-            if (
-              (expr.type === "MemberExpression" ||
-                expr.type === "OptionalMemberExpression") &&
-              expr.property.type === "Identifier" &&
-              NAME_PROPS.has(expr.property.name)
-            ) {
-              context.report({ node: opening, messageId: "missingDir" });
+            // Mixed children: dir on the element would reorder the siblings too,
+            // so the name itself must be wrapped in <bdi>.
+            for (const child of nameKids) {
+              context.report({ node: child, messageId: "missingBidi" });
             }
           },
         };

--- a/apps/web/src/components/chat/chat-matter-picker.tsx
+++ b/apps/web/src/components/chat/chat-matter-picker.tsx
@@ -2,7 +2,7 @@ import { useDeferredValue, useRef, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDownIcon, LayersIcon, SearchIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import {
   Menu,
@@ -64,6 +64,7 @@ export const ChatMatterPicker = ({
   onChange,
 }: ChatMatterPickerProps) => {
   const t = useTranslations();
+  const format = useFormatter();
   const [search, setSearch] = useState("");
   const deferredSearch = useDeferredValue(search);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -250,7 +251,7 @@ export const ChatMatterPicker = ({
             className="bg-muted text-foreground rounded-sm px-1 text-[10px] font-medium tabular-nums"
             style={extraCountStyle}
           >
-            +{extraCount}
+            +{format.number(extraCount)}
           </span>
         )}
         <ChevronDownIcon
@@ -395,6 +396,7 @@ const ClientMatterToggle = ({
   isSelected,
   onToggle,
 }: ClientMatterToggleProps) => {
+  const format = useFormatter();
   const groupAllSelected = group.allMatters.every((m) => isSelected(m.id));
   const groupSelectedCount = group.allMatters.filter((m) =>
     isSelected(m.id),
@@ -411,7 +413,8 @@ const ClientMatterToggle = ({
         <span className="min-w-0 truncate">{group.label}</span>
         {groupSelectedCount > 0 && !groupAllSelected && (
           <span className="text-muted-foreground ms-auto shrink-0 text-[10px] tabular-nums">
-            {groupSelectedCount}/{group.allMatters.length}
+            {format.number(groupSelectedCount)}/
+            {format.number(group.allMatters.length)}
           </span>
         )}
       </span>

--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -6,7 +6,7 @@ import {
   ChevronRightIcon,
   LoaderCircleIcon,
 } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
@@ -47,6 +47,7 @@ export const DocumentAiSourceBar = ({
   workspaceId: string;
 }) => {
   const t = useTranslations();
+  const format = useFormatter();
   const openFile = useInspectorStore((s) => s.openFile);
 
   const propertiesQuery = useQuery(propertiesOptions(workspaceId));
@@ -418,7 +419,7 @@ export const DocumentAiSourceBar = ({
           <DirectionalIcon className="size-3.5" icon={ChevronLeftIcon} />
         </Button>
         <span className="text-muted-foreground min-w-8 text-center text-[10px] tabular-nums">
-          {currentIdx + 1} / {slots.length}
+          {format.number(currentIdx + 1)} / {format.number(slots.length)}
         </span>
         <Button
           disabled={!nextSlot}

--- a/apps/web/src/features/case-law/components/decision-filters.tsx
+++ b/apps/web/src/features/case-law/components/decision-filters.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
 import { useDebouncedCallback } from "use-debounce";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import { Input } from "@stll/ui/components/input";
 import {
@@ -30,6 +30,7 @@ export const DecisionFilters = ({
   facets,
 }: DecisionFiltersProps) => {
   const t = useTranslations();
+  const format = useFormatter();
 
   /** Update a single filter key, omitting it when empty. */
   const updateFilter = useCallback(
@@ -95,7 +96,7 @@ export const DecisionFilters = ({
             <SelectItem value="">{t("common.all")}</SelectItem>
             {countryBuckets.map((b) => (
               <SelectItem key={b.value} value={b.value}>
-                {b.value} ({b.count})
+                {b.value} ({format.number(b.count)})
               </SelectItem>
             ))}
           </SelectPopup>
@@ -122,7 +123,7 @@ export const DecisionFilters = ({
             <SelectItem value="">{t("common.all")}</SelectItem>
             {courtBuckets.map((b) => (
               <SelectItem key={b.value} value={b.value}>
-                {b.value} ({b.count})
+                {b.value} ({format.number(b.count)})
               </SelectItem>
             ))}
           </SelectPopup>

--- a/apps/web/src/i18n/i18n-lint-baseline.json
+++ b/apps/web/src/i18n/i18n-lint-baseline.json
@@ -753,6 +753,10 @@
       }
     },
     "chat.emptyThreadDescription": {
+      "ar": {
+        "source": "Ask about this matter, draft text, or request a short research note.",
+        "target": "اسأل عن هذه القضية، أو صُغ نصاً، أو اطلب مذكّرة بحثية موجزة."
+      },
       "de": {
         "source": "Ask about this matter, draft text, or request a short research note.",
         "target": "Fragen Sie zu dieser Sache, entwerfen Sie Text oder bitten Sie um eine kurze Recherche."
@@ -763,9 +767,19 @@
       }
     },
     "chat.greetingSubtitle": {
+      "ar": {
+        "source": "Start with a matter, document, or plain question.",
+        "target": "ابدأ بقضية أو مستند أو سؤال مباشر."
+      },
       "de": {
         "source": "Start with a matter, document, or plain question.",
         "target": "Beginnen Sie mit einer Sache, einem Dokument oder einer einfachen Frage."
+      }
+    },
+    "chat.mention.category.entities": {
+      "ar": {
+        "source": "In this matter",
+        "target": "في هذه القضية"
       }
     },
     "clauses.clauseDeletedHint": {
@@ -792,6 +806,48 @@
         "target": "جهة الاتصال هذه ليست عميلاً في أي قضية."
       }
     },
+    "errors.failedToCreateWorkspace": {
+      "ar": {
+        "source": "Failed to create matter",
+        "target": "تعذّر إنشاء القضية"
+      }
+    },
+    "errors.failedToDeleteWorkspace": {
+      "ar": {
+        "source": "Failed to delete matter",
+        "target": "تعذّر حذف القضية"
+      }
+    },
+    "errors.failedToRenameWorkspace": {
+      "ar": {
+        "source": "Failed to rename matter",
+        "target": "تعذّرت إعادة تسمية القضية"
+      }
+    },
+    "errors.failedToUpdateWorkspace": {
+      "ar": {
+        "source": "Failed to update matter",
+        "target": "تعذّر تحديث القضية"
+      }
+    },
+    "errors.matterNotFound": {
+      "ar": {
+        "source": "Matter not found",
+        "target": "لم يتم العثور على القضية"
+      }
+    },
+    "errors.partyAlreadyExists": {
+      "ar": {
+        "source": "Contact already has this role on the matter",
+        "target": "جهة الاتصال لديها هذا الدور في القضية بالفعل"
+      }
+    },
+    "inspector.anonymization.ignoreScopeDocument": {
+      "ar": {
+        "source": "Ignore in this matter",
+        "target": "تجاهُل في هذه القضية"
+      }
+    },
     "inspector.matterPicker.noMatter": {
       "ar": {
         "source": "No matter",
@@ -802,6 +858,18 @@
       "ar": {
         "source": "No matter matches “{query}”.",
         "target": "لا توجد قضية تطابق «{query}»."
+      }
+    },
+    "inspector.matterPicker.title": {
+      "ar": {
+        "source": "Matter context",
+        "target": "سياق القضية"
+      }
+    },
+    "inspector.metadata.matterColumnsHeading": {
+      "ar": {
+        "source": "Matter columns",
+        "target": "أعمدة القضية"
       }
     },
     "navigation.newMatter": {
@@ -822,6 +890,18 @@
       "sk": {
         "source": "Matter",
         "target": "Vec"
+      }
+    },
+    "success.workspaceDeletedSuccessfully": {
+      "ar": {
+        "source": "Matter deleted successfully",
+        "target": "تم حذف القضية بنجاح"
+      }
+    },
+    "success.workspaceDuplicatedSuccessfully": {
+      "ar": {
+        "source": "Matter duplicated successfully",
+        "target": "تم تكرار القضية بنجاح"
       }
     },
     "templates.checkNoIssues": {
@@ -848,10 +928,22 @@
         "target": "النقل إلى قضية"
       }
     },
+    "templates.newFromTemplateFillHint": {
+      "ar": {
+        "source": "Fill in the fields; the document is created in this matter.",
+        "target": "عبّئ الحقول؛ ويُنشأ المستند في هذه القضية."
+      }
+    },
     "templates.newTemplate": {
       "sk": {
         "source": "New template",
         "target": "Nová šablóna"
+      }
+    },
+    "templates.prefillMatterDocuments": {
+      "ar": {
+        "source": "Documents from this matter",
+        "target": "مستندات من هذه القضية"
       }
     },
     "templates.studio.scopeTemplate": {
@@ -896,6 +988,18 @@
         "target": "Kedy sa má táto šablóna použiť? (pomáha AI s výberom šablóny)"
       }
     },
+    "translate.dialog.description": {
+      "ar": {
+        "source": "Translate the open document via DeepL. The translated copy lands in this matter as a new document.",
+        "target": "ترجمة المستند المفتوح عبر DeepL. تُحفَظ النسخة المترجَمة في هذه القضية كمستند جديد."
+      }
+    },
+    "workspaces.copyToMatter.copied": {
+      "ar": {
+        "source": "Copied to Matter",
+        "target": "تم النسخ إلى القضية"
+      }
+    },
     "workspaces.copyToMatter.description": {
       "ar": {
         "source": "Copy or move \"{name}\" to another Matter",
@@ -914,16 +1018,88 @@
         "target": "نسخ/نقل إلى قضية"
       }
     },
+    "workspaces.copyToMatter.moved": {
+      "ar": {
+        "source": "Moved to Matter",
+        "target": "تم النقل إلى القضية"
+      }
+    },
+    "workspaces.copyToMatter.targetMatter": {
+      "ar": {
+        "source": "Target Matter",
+        "target": "القضية الهدف"
+      }
+    },
     "workspaces.copyToMatter.title": {
       "ar": {
         "source": "Copy to Matter",
         "target": "نسخ إلى قضية"
       }
     },
+    "workspaces.create.ownerTypeToggle": {
+      "ar": {
+        "source": "Matter type",
+        "target": "نوع القضية"
+      }
+    },
     "workspaces.createNewWorkspace": {
       "ar": {
         "source": "Create new matter",
         "target": "إنشاء قضية جديدة"
+      }
+    },
+    "workspaces.deleteWorkspace": {
+      "ar": {
+        "source": "Delete matter",
+        "target": "حذف القضية"
+      }
+    },
+    "workspaces.deleteWorkspaceConfirmDescription": {
+      "ar": {
+        "source": "Are you sure you want to delete this matter? This action cannot be undone.",
+        "target": "هل أنت متأكد من رغبتك في حذف هذه القضية؟ لا يمكن التراجع عن هذا الإجراء."
+      }
+    },
+    "workspaces.deletingWorkspace": {
+      "ar": {
+        "source": "Deleting matter",
+        "target": "جارٍ حذف القضية"
+      }
+    },
+    "workspaces.duplicateMatter": {
+      "ar": {
+        "source": "Duplicate matter",
+        "target": "تكرار القضية"
+      }
+    },
+    "workspaces.duplicateMatterDescription": {
+      "ar": {
+        "source": "You will duplicate the matter, its name, client, team members, parties, and views.",
+        "target": "ستقوم بتكرار القضية واسمها وعميلها وأعضاء فريقها وأطرافها وطرق عرضها."
+      }
+    },
+    "workspaces.duplicateMatterWithContentDescription": {
+      "ar": {
+        "source": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+        "target": "ستقوم بتكرار القضية واسمها وعميلها وأعضاء فريقها وأطرافها وطرق عرضها ومحتواها."
+      }
+    },
+    "workspaces.duplicatingWorkspace": {
+      "ar": {
+        "source": "Duplicating matter",
+        "target": "جارٍ تكرار القضية"
+      }
+    },
+    "workspaces.emptyDocuments.description": {
+      "ar": {
+        "source": "Upload documents to enable table extraction, document organization, in-browser editing, and search across this matter.",
+        "target": "ارفع المستندات لتمكين استخراج الجداول وتنظيم المستندات والتحرير داخل المتصفح والبحث عبر هذه القضية."
+      }
+    },
+    "workspaces.emptyDocuments.videoLabel": {
+      "ar": {
+        "source": "Matter documents overview",
+        "target": "نظرة عامة على مستندات القضية"
       }
     },
     "workspaces.emptyMatters.description": {
@@ -946,10 +1122,22 @@
         "target": "Looge esimene asi"
       }
     },
+    "workspaces.emptyMatters.videoLabel": {
+      "ar": {
+        "source": "Matter setup overview",
+        "target": "نظرة عامة على إعداد القضية"
+      }
+    },
     "workspaces.importOrganizer.instructionsHelp": {
       "ar": {
         "source": "Saved per matter. Used in addition to the system prompt.",
         "target": "تُحفظ لكل قضية على حدة. تُستخدم بالإضافة إلى موجّه النظام."
+      }
+    },
+    "workspaces.matterInfo": {
+      "ar": {
+        "source": "Matter info",
+        "target": "معلومات القضية"
       }
     },
     "workspaces.mattersCount": {
@@ -960,6 +1148,24 @@
       "et": {
         "source": "{count, plural, one {# matter} other {# matters}}",
         "target": "{count, plural, one {# asi} other {# asja}}"
+      }
+    },
+    "workspaces.members.addMember": {
+      "ar": {
+        "source": "Add to matter",
+        "target": "إضافة إلى القضية"
+      }
+    },
+    "workspaces.members.addMemberDescription": {
+      "ar": {
+        "source": "Choose an existing team member to add to this matter",
+        "target": "اختر عضو فريق موجودًا لإضافته إلى هذه القضية"
+      }
+    },
+    "workspaces.members.removeMemberConfirm": {
+      "ar": {
+        "source": "Remove this member from the matter?",
+        "target": "هل تريد إزالة هذا العضو من القضية؟"
       }
     },
     "workspaces.newMatter": {
@@ -982,13 +1188,51 @@
         "target": "Asju pole veel. Alustamiseks looge oma esimene asi."
       }
     },
+    "workspaces.overview.matterDetails": {
+      "ar": {
+        "source": "Matter details",
+        "target": "تفاصيل القضية"
+      }
+    },
+    "workspaces.parties.noParties": {
+      "ar": {
+        "source": "No parties added to this matter.",
+        "target": "لم تتم إضافة أي أطراف إلى هذه القضية."
+      }
+    },
+    "workspaces.parties.promoteDescription": {
+      "ar": {
+        "source": "Attach a client to share this matter with the team. This is one-way — promoted matters cannot return to personal.",
+        "target": "أرفِق عميلًا لمشاركة هذه القضية مع الفريق. هذا الإجراء أحادي الاتجاه — لا يمكن للقضايا المُرقّاة العودة إلى الحالة الشخصية."
+      }
+    },
+    "workspaces.parties.promotedSuccess": {
+      "ar": {
+        "source": "Matter promoted",
+        "target": "تمت ترقية القضية"
+      }
+    },
+    "workspaces.parties.removePartyConfirm": {
+      "ar": {
+        "source": "Are you sure you want to remove this party from the matter?",
+        "target": "هل أنت متأكد من رغبتك في إزالة هذا الطرف من القضية؟"
+      }
+    },
     "workspaces.properties.scopeMatter": {
+      "ar": {
+        "source": "Entire matter",
+        "target": "القضية بأكملها"
+      },
       "et": {
         "source": "Entire matter",
         "target": "Kogu asi"
       }
     },
     "workspaces.properties.scopeMatterDescription": {
+      "ar": {
+        "source": "Use all file columns and run the matter.",
+        "target": "استخدم جميع أعمدة الملفات وشغِّل القضية."
+      },
       "et": {
         "source": "Use all file columns and run the matter.",
         "target": "Kasutage kõiki failiveerge ja käivitage asi."

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -4926,6 +4926,7 @@ const OutlineRow = ({
   count?: number;
 }) => {
   const t = useTranslations();
+  const format = useFormatter();
   const actions = useTemplateStudioStore((s) => s.actions);
 
   const jump = () => {
@@ -4960,7 +4961,7 @@ const OutlineRow = ({
             <span className="text-muted-foreground ms-auto flex shrink-0 items-center gap-1.5">
               {count > 1 ? (
                 <span className="text-muted-foreground text-[10px] tabular-nums">
-                  {count}×
+                  {format.number(count)}×
                 </span>
               ) : null}
               <FieldCapabilityIcons field={field} />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-subtasks.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-subtasks.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2Icon, CircleIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import { cn } from "@stll/ui/lib/utils";
 
@@ -13,6 +13,7 @@ export const SubtasksSection = ({
   onToggle,
 }: SubtasksSectionProps) => {
   const t = useTranslations("tasks");
+  const format = useFormatter();
 
   if (subtasks.length === 0) {
     return null;
@@ -21,7 +22,7 @@ export const SubtasksSection = ({
   return (
     <div className="border-t px-4 py-3">
       <h3 className="text-muted-foreground mb-2 text-xs font-medium">
-        {t("subtasks")} ({subtasks.length})
+        {t("subtasks")} ({format.number(subtasks.length)})
       </h3>
       <div className="space-y-1">
         {subtasks.map((sub) => (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -428,10 +428,12 @@ const InvoiceDetail = ({
                     </td>
                     <td className="px-4 py-2 text-end tabular-nums">
                       {format.number(entry.billedMinutes / 60, {
+                        style: "unit",
+                        unit: "hour",
+                        unitDisplay: "short",
                         minimumFractionDigits: 1,
                         maximumFractionDigits: 1,
                       })}
-                      h
                     </td>
                     <td className="px-4 py-2 text-end tabular-nums">
                       {formatCurrencyAmount(

--- a/packages/scripts/src/i18n-lint.test.ts
+++ b/packages/scripts/src/i18n-lint.test.ts
@@ -244,4 +244,33 @@ describe("terminology", () => {
       findForbiddenTerms("Open this matter", "Sachenrecht gilt", "de", rules),
     ).toEqual([]);
   });
+
+  test("matches an Arabic forbidden term carrying proclitics (ال/و prefixes)", () => {
+    const arRules = buildForbiddenRules(
+      parseGlossary(
+        JSON.stringify({
+          verbs: [],
+          legalConcepts: [
+            {
+              id: "matter",
+              en: "Matter",
+              forbidden: { ar: ["قضية"] },
+              translations: fill("x"),
+            },
+          ],
+          ptBR: [],
+        }),
+      ),
+    );
+    // bare, ال-prefixed, and و+ال-prefixed forms all count.
+    expect(
+      findForbiddenTerms("Open this matter", "افتح قضية", "ar", arRules),
+    ).toEqual(["قضية"]);
+    expect(
+      findForbiddenTerms("Open this matter", "افتح القضية", "ar", arRules),
+    ).toEqual(["قضية"]);
+    expect(
+      findForbiddenTerms("Open this matter", "والقضية مفتوحة", "ar", arRules),
+    ).toEqual(["قضية"]);
+  });
 });

--- a/packages/scripts/src/i18n-lint.ts
+++ b/packages/scripts/src/i18n-lint.ts
@@ -384,13 +384,29 @@ export const findDroppedExactSelectors = (
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
+// Arabic attaches proclitics to the front of a word — conjunctions (و/ف),
+// prepositions (ب/ك/ل/س), and the definite article ال — so a forbidden term
+// like قضية also surfaces as القضية / وقضية / بالقضية / للقضية. Allow an
+// optional proclitic cluster before the term for Arabic; the trailing word
+// boundary still guards against substrings, and other scripts are unaffected.
+const ARABIC_PROCLITIC_PREFIX = "[وفبكلس]*(?:ال)?";
+
 /** Whole-word, script-aware (Unicode) containment test. */
 const wordRegexCache = new Map<string, RegExp>();
-const containsWord = (haystack: string, needle: string): boolean => {
-  let regex = wordRegexCache.get(needle);
+const containsWord = (
+  haystack: string,
+  needle: string,
+  locale: string,
+): boolean => {
+  const cacheKey = `${locale}:${needle}`;
+  let regex = wordRegexCache.get(cacheKey);
   if (!regex) {
-    regex = new RegExp(`(?<!\\p{L})${escapeRegExp(needle)}(?!\\p{L})`, "iu");
-    wordRegexCache.set(needle, regex);
+    const prefix = locale === "ar" ? ARABIC_PROCLITIC_PREFIX : "";
+    regex = new RegExp(
+      `(?<!\\p{L})${prefix}${escapeRegExp(needle)}(?!\\p{L})`,
+      "iu",
+    );
+    wordRegexCache.set(cacheKey, regex);
   }
   return regex.test(haystack);
 };
@@ -434,12 +450,12 @@ export const findForbiddenTerms = (
     const forbidden = rule.byLocale[locale];
     if (
       !forbidden ||
-      !rule.triggers.some((trigger) => containsWord(source, trigger))
+      !rule.triggers.some((trigger) => containsWord(source, trigger, "en"))
     ) {
       continue;
     }
     for (const term of forbidden) {
-      if (containsWord(target, term)) {
+      if (containsWord(target, term, locale)) {
         hits.push(term);
       }
     }


### PR DESCRIPTION
Follow-ups to the i18n quality-lint (#807) and RTL/Arabic polish (#808).

## Lint rules (broadened — both AST-only, no type info)
- **`no-unformatted-number`** now flags a bare numeric expression rendered as JSX text in *any* position, not only as an element's sole child — catching `+{count}`, `{a}/{b}`, `(N)`, `{n}×`, etc. Repo-wide it surfaced 8 sites (all fixed below).
- **`require-dir-on-rendered-name`** now also flags a user-name property rendered among sibling content, recommending `<bdi>` (adding `dir` to the parent would reorder the siblings, so it needs a different fix than the sole-child case). Zero existing violations.
- Fixtures cover the new multi-child cases.

## Localization fixes
- Routed the 8 surfaced counts through `useFormatter().number(...)` so they render locale digits (e.g. Eastern-Arabic) instead of always-Latin. `tabular-nums` styling preserved.
- Invoice line-item hours now use `{ style: "unit", unit: "hour" }` instead of a hardcoded `h`, matching the overview view's hour formatting.

## Terminology lint — Arabic
- The forbidden-term matcher now allows Arabic proclitics (conjunctions و/ف, prepositions ب/ك/ل/س, definite article ال) before a term, so e.g. قضية is still caught inside القضية / والقضية. Other scripts are unaffected, and the trailing word boundary still guards against substrings.