### PR TITLE
fix: harden folio upstream sync

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -26,12 +26,10 @@ import { getFormattingLocale } from "@/i18n/i18n-store";
 import { startOfWeek } from "@/i18n/week";
 import { api } from "@/lib/api";
 import { ClientOperationError } from "@/lib/errors";
-import { ensureCriticalQueryData } from "@/lib/react-query";
 import { BillingCodesDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog";
 import { RateManagementDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog";
 import { TimesheetDayView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view";
 import { TimesheetWeekView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view";
-import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 
 export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/timesheets",
@@ -41,21 +39,11 @@ export const Route = createFileRoute(
   // deep link) and bounce the user back to the workspace overview.
   // Once the feature is reintroduced, drop this beforeLoad and
   // re-link the overview StatCard.
-  beforeLoad: async ({ context, params }) => {
-    const qc = context.queryClient;
-    const opts = viewsOptions(params.workspaceId);
-    const views = await ensureCriticalQueryData(qc, opts);
-
-    const firstView = views.at(0);
-    if (!firstView) {
-      throw redirect({ to: "/workspaces", replace: true });
-    }
-
+  beforeLoad: ({ params }) => {
     throw redirect({
-      to: "/workspaces/$workspaceId/$viewId",
+      to: "/workspaces/$workspaceId",
       params: {
         workspaceId: params.workspaceId,
-        viewId: firstView.id,
       },
       // Replace `/timesheets` rather than push the overview on top
       // of it. Pushing creates a back-button loop: Back from the

--- a/packages/folio/src/core/docx/rezip-coreprops-redos.test.ts
+++ b/packages/folio/src/core/docx/rezip-coreprops-redos.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { updateCoreProperties } from "./rezip";
+
+describe("updateCoreProperties dcterms:modified", () => {
+  test("rewrites an existing modified date", () => {
+    const xml =
+      '<cp:coreProperties><dcterms:modified xsi:type="dcterms:W3CDTF">2000-01-01T00:00:00Z</dcterms:modified></cp:coreProperties>';
+    const out = updateCoreProperties(xml, { updateModifiedDate: true });
+
+    expect(out).not.toContain("2000-01-01");
+    expect(out).toContain("<dcterms:modified");
+  });
+
+  test("stays linear on malformed core.xml", () => {
+    const evil = "<dcterms:modified".repeat(100_000);
+    const start = performance.now();
+    updateCoreProperties(evil, { updateModifiedDate: true });
+    expect(performance.now() - start).toBeLessThan(5000);
+  });
+});

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1654,7 +1654,7 @@ export function updateCoreProperties(
     // Update dcterms:modified
     if (result.includes("<dcterms:modified")) {
       result = result.replace(
-        /<dcterms:modified[^>]*>[^<]*<\/dcterms:modified>/u,
+        /<dcterms:modified[^<>]*>[^<]*<\/dcterms:modified>/u,
         `<dcterms:modified xsi:type="dcterms:W3CDTF">${now}</dcterms:modified>`,
       );
     } else {

--- a/packages/folio/src/core/utils/__tests__/clipboard.test.ts
+++ b/packages/folio/src/core/utils/__tests__/clipboard.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Run } from "../../types/document";
-import { getClipboardImageFiles, runsToClipboardContent } from "../clipboard";
+import {
+  cleanWordHtml,
+  getClipboardImageFiles,
+  runsToClipboardContent,
+} from "../clipboard";
+
+const withDomParserStub = (run: () => void): void => {
+  const originalParser = globalThis.DOMParser;
+  Object.defineProperty(globalThis, "DOMParser", {
+    configurable: true,
+    value: class {
+      parseFromString(html: string) {
+        return {
+          body: {
+            innerHTML: html,
+            querySelectorAll: () => [],
+          },
+        };
+      }
+    },
+  });
+
+  try {
+    run();
+  } finally {
+    if (originalParser) {
+      Object.defineProperty(globalThis, "DOMParser", {
+        configurable: true,
+        value: originalParser,
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, "DOMParser");
+    }
+  }
+};
 
 describe("getClipboardImageFiles", () => {
   test("returns image files from clipboardData.files", () => {
@@ -136,5 +170,34 @@ describe("runsToClipboardContent", () => {
     expect(html).not.toContain(scriptScheme);
     expect(html).not.toContain("color: #000000;background");
     expect(html).not.toContain("background-color:");
+  });
+});
+
+describe("cleanWordHtml", () => {
+  test("removes unterminated comments without leaving a stray opener", () => {
+    withDomParserStub(() => {
+      expect(cleanWordHtml("safe<!--dangling")).toBe("safe");
+    });
+  });
+
+  test("strips many unterminated Office namespace openers in linear time", () => {
+    withDomParserStub(() => {
+      const evil = "<o:p>".repeat(100_000);
+      const start = performance.now();
+      cleanWordHtml(evil);
+      expect(performance.now() - start).toBeLessThan(5000);
+    });
+  });
+
+  test("removes self-closing namespace tags without stripping later content", () => {
+    withDomParserStub(() => {
+      expect(cleanWordHtml("a<o:p/>keep</o:p>tail")).toContain("keep");
+    });
+  });
+
+  test("keeps original indices when stripping namespace tags after expanded lowercase characters", () => {
+    withDomParserStub(() => {
+      expect(cleanWordHtml("İ<o:p>junk</o:p>B")).toBe("İB");
+    });
   });
 });

--- a/packages/folio/src/core/utils/__tests__/clipboard.test.ts
+++ b/packages/folio/src/core/utils/__tests__/clipboard.test.ts
@@ -4,6 +4,7 @@ import type { Run } from "../../types/document";
 import {
   cleanWordHtml,
   getClipboardImageFiles,
+  htmlToRuns,
   runsToClipboardContent,
 } from "../clipboard";
 
@@ -35,6 +36,94 @@ const withDomParserStub = (run: () => void): void => {
       Reflect.deleteProperty(globalThis, "DOMParser");
     }
   }
+};
+
+type FakeDomNode = FakeTextNode | FakeElementNode;
+
+class FakeTextNode {
+  readonly childNodes: FakeDomNode[] = [];
+  nextSibling: FakeDomNode | null = null;
+  readonly nodeType = 3;
+  readonly textContent: string;
+
+  constructor(textContent: string) {
+    this.textContent = textContent;
+  }
+}
+
+class FakeElementNode {
+  readonly childNodes: FakeDomNode[];
+  nextSibling: FakeDomNode | null = null;
+  readonly nodeType = 1;
+  readonly style = {
+    backgroundColor: "",
+    color: "",
+    fontFamily: "",
+    fontSize: "",
+    fontStyle: "",
+    fontWeight: "",
+    textDecoration: "",
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string, childNodes: FakeDomNode[] = []) {
+    this.tagName = tagName;
+    this.childNodes = childNodes;
+
+    for (let index = 0; index < childNodes.length; index++) {
+      childNodes[index]!.nextSibling = childNodes.at(index + 1) ?? null;
+    }
+  }
+
+  getAttribute(): string | null {
+    return null;
+  }
+}
+
+const withDomTree = (body: FakeElementNode, run: () => void): void => {
+  const originalNode = globalThis.Node;
+  const originalElement = globalThis.HTMLElement;
+  const originalParser = globalThis.DOMParser;
+
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: { TEXT_NODE: 3 },
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: FakeElementNode,
+  });
+  Object.defineProperty(globalThis, "DOMParser", {
+    configurable: true,
+    value: class {
+      parseFromString() {
+        return { body };
+      }
+    },
+  });
+
+  try {
+    run();
+  } finally {
+    restoreGlobal("Node", originalNode);
+    restoreGlobal("HTMLElement", originalElement);
+    restoreGlobal("DOMParser", originalParser);
+  }
+};
+
+const restoreGlobal = <K extends "DOMParser" | "HTMLElement" | "Node">(
+  key: K,
+  value: (typeof globalThis)[K] | undefined,
+): void => {
+  if (value) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+    });
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
 };
 
 describe("getClipboardImageFiles", () => {
@@ -170,6 +259,32 @@ describe("runsToClipboardContent", () => {
     expect(html).not.toContain(scriptScheme);
     expect(html).not.toContain("color: #000000;background");
     expect(html).not.toContain("background-color:");
+  });
+});
+
+describe("htmlToRuns", () => {
+  test("preserves visible text inside pasted form controls", () => {
+    const body = new FakeElementNode("body", [
+      new FakeElementNode("p", [new FakeTextNode("Before")]),
+      new FakeElementNode("form", [
+        new FakeElementNode("textarea", [new FakeTextNode("Field value")]),
+      ]),
+      new FakeElementNode("p", [new FakeTextNode("After")]),
+    ]);
+
+    withDomTree(body, () => {
+      const runs = htmlToRuns(
+        "<p>Before</p><form><textarea>Field value</textarea></form><p>After</p>",
+        "",
+      );
+      const text = runs
+        .map((run) => run.content.map((part) => part.text).join(""))
+        .join("");
+
+      expect(text).toContain("Before");
+      expect(text).toContain("Field value");
+      expect(text).toContain("After");
+    });
   });
 });
 

--- a/packages/folio/src/core/utils/clipboard.ts
+++ b/packages/folio/src/core/utils/clipboard.ts
@@ -75,8 +75,6 @@ const SKIPPED_CLIPBOARD_ELEMENTS = new Set([
   "iframe",
   "object",
   "embed",
-  "form",
-  "textarea",
   "svg",
   "math",
 ]);

--- a/packages/folio/src/core/utils/clipboard.ts
+++ b/packages/folio/src/core/utils/clipboard.ts
@@ -69,6 +69,18 @@ export const CLIPBOARD_TYPES = {
   PLAIN: "text/plain",
 } as const;
 
+const SKIPPED_CLIPBOARD_ELEMENTS = new Set([
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "textarea",
+  "svg",
+  "math",
+]);
+
 /**
  * Extract image files from clipboard data (if present).
  */
@@ -447,24 +459,132 @@ export function isEditorHtml(html: string): boolean {
 }
 
 /**
+ * Strip every HTML comment, including unterminated comments.
+ */
+function stripHtmlComments(html: string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const start = html.indexOf("<!--", cursor);
+    if (start === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    result += html.slice(cursor, start);
+    const end = html.indexOf("-->", start + 4);
+    if (end === -1) {
+      break;
+    }
+
+    cursor = end + 3;
+  }
+
+  return result;
+}
+
+const ASCII_UPPER_A = 65;
+const ASCII_UPPER_Z = 90;
+const ASCII_LOWERCASE_OFFSET = 32;
+
+function toAsciiLowerCode(code: number): number {
+  if (code < ASCII_UPPER_A || code > ASCII_UPPER_Z) {
+    return code;
+  }
+
+  return code + ASCII_LOWERCASE_OFFSET;
+}
+
+function indexOfAsciiCaseInsensitive(
+  text: string,
+  search: string,
+  fromIndex: number,
+): number {
+  const maxStart = text.length - search.length;
+
+  for (let index = fromIndex; index <= maxStart; index++) {
+    let matches = true;
+
+    for (let offset = 0; offset < search.length; offset++) {
+      const textCode = toAsciiLowerCode(text.codePointAt(index + offset) ?? -1);
+      const searchCode = search.codePointAt(offset) ?? -1;
+
+      if (textCode !== searchCode) {
+        matches = false;
+        break;
+      }
+    }
+
+    if (matches) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Remove paired namespace blocks such as Word/Office `<w:...>` and `<o:...>`
+ * tags without regex backtracking on hostile clipboard HTML.
+ */
+function stripPairedNamespaceTags(html: string, prefix: string): string {
+  const open = `<${prefix}`;
+  const close = `</${prefix}`;
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const start = indexOfAsciiCaseInsensitive(html, open, cursor);
+    if (start === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    const openTagEnd = html.indexOf(">", start);
+    if (openTagEnd === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+    const openingTag = html.slice(start, openTagEnd).trimEnd();
+    if (openingTag.endsWith("/")) {
+      result += html.slice(cursor, start);
+      cursor = openTagEnd + 1;
+      continue;
+    }
+
+    const closeStart = indexOfAsciiCaseInsensitive(html, close, openTagEnd + 1);
+    const closeTagEnd = closeStart === -1 ? -1 : html.indexOf(">", closeStart);
+    if (closeTagEnd === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    result += html.slice(cursor, start);
+    cursor = closeTagEnd + 1;
+  }
+
+  return result;
+}
+
+/**
  * Clean Microsoft Word HTML
  */
 export function cleanWordHtml(html: string): string {
   let cleaned = html;
 
-  // Remove Word-specific comments
-  cleaned = cleaned.replace(/<!--\[if[\s\S]*?<!\[endif\]-->/gi, "");
-  cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, "");
+  // Remove Word-specific comments and any other HTML comments.
+  cleaned = stripHtmlComments(cleaned);
 
   // Remove XML declarations
   cleaned = cleaned.replace(/<\?xml[^>]*>/gi, "");
 
-  // Remove o: (Office) namespace tags
-  cleaned = cleaned.replace(/<o:[^>]*>[\s\S]*?<\/o:[^>]*>/gi, "");
+  // Remove o: (Office) namespace tags.
+  cleaned = stripPairedNamespaceTags(cleaned, "o:");
   cleaned = cleaned.replace(/<o:[^>]*\/>/gi, "");
 
-  // Remove w: (Word) namespace tags
-  cleaned = cleaned.replace(/<w:[^>]*>[\s\S]*?<\/w:[^>]*>/gi, "");
+  // Remove w: (Word) namespace tags.
+  cleaned = stripPairedNamespaceTags(cleaned, "w:");
   cleaned = cleaned.replace(/<w:[^>]*\/>/gi, "");
 
   cleaned = cleanWordAttributes(cleaned);
@@ -561,6 +681,9 @@ function processNode(
 
   const element = node;
   const tagName = element.tagName.toLowerCase();
+  if (SKIPPED_CLIPBOARD_ELEMENTS.has(tagName)) {
+    return;
+  }
 
   // Merge formatting from this element
   const formatting = { ...inheritedFormatting, ...extractFormatting(element) };

--- a/packages/folio/src/core/utils/fontResolver.test.ts
+++ b/packages/folio/src/core/utils/fontResolver.test.ts
@@ -101,3 +101,23 @@ describe("fontResolver — aliased families keep the authored name first", () =>
     expect(cssFallback.match(/PMingLiU/giu)?.length).toBe(1);
   });
 });
+
+describe("fontResolver — untrusted family names are quoted safely", () => {
+  test("escapes backslashes and quotes inside quoted CSS family names", () => {
+    const { cssFallback } = resolveFontFamily('Evil\\"};x:y');
+
+    expect(cssFallback.startsWith('"')).toBe(true);
+    expect(cssFallback).toContain("\\\\");
+    expect(cssFallback).toContain('\\"');
+    expect(/[^\\]"\};x/u.test(cssFallback)).toBe(false);
+  });
+
+  test("hex-escapes CSS newline characters inside quoted family names", () => {
+    const { cssFallback } = resolveFontFamily("a\nb\rc\fd");
+
+    expect(cssFallback).not.toMatch(/[\n\r\f]/u);
+    expect(cssFallback).toContain("\\a ");
+    expect(cssFallback).toContain("\\d ");
+    expect(cssFallback).toContain("\\c ");
+  });
+});

--- a/packages/folio/src/core/utils/fontResolver.ts
+++ b/packages/folio/src/core/utils/fontResolver.ts
@@ -535,6 +535,21 @@ export function resolveFontFamily(docxFontName: string): ResolvedFont {
   };
 }
 
+const CSS_NEWLINE_ESCAPES: Record<string, string> = {
+  "\n": "\\a ",
+  "\r": "\\d ",
+  "\f": "\\c ",
+};
+
+/**
+ * Escape a DOCX-supplied font name for a double-quoted CSS string.
+ */
+function escapeQuotedFontName(fontName: string): string {
+  return fontName
+    .replace(/["\\]/g, "\\$&")
+    .replace(/[\n\r\f]/g, (char) => CSS_NEWLINE_ESCAPES[char] ?? char);
+}
+
 /**
  * Quote a font name if it contains spaces or special characters
  */
@@ -555,7 +570,7 @@ function quoteFontName(fontName: string): string {
 
   // Quote if contains spaces or special characters
   if (/[\s,'"()]/.test(fontName)) {
-    return `"${fontName.replace(/"/g, '\\"')}"`;
+    return `"${escapeQuotedFontName(fontName)}"`;
   }
 
   return fontName;


### PR DESCRIPTION
## Summary
- harden Folio DOCX core properties and clipboard parsing against malformed inputs
- escape DOCX-supplied font family names before writing CSS fallback strings
- add regression coverage for the upstream-synced edge cases

## Checks
- bun run lint && bun run format && bun run typecheck && bun run test
- security audit: no critical/high findings in changed files