### PR TITLE
fix: make sheet sides logical

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -188,7 +188,7 @@ function Sidebar({
           data-mobile="true"
           data-sidebar="sidebar"
           data-slot="sidebar"
-          side={side}
+          side={side === "left" ? "inline-start" : "inline-end"}
           style={{
             "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
           }}

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -115,7 +115,7 @@ export const ThreadsSheet = ({
           {triggerLabel}
         </SheetTrigger>
       )}
-      <SheetPopup side="right">
+      <SheetPopup side="inline-end">
         <SheetHeader>
           <SheetTitle>{triggerLabel}</SheetTitle>
         </SheetHeader>

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/add-mcp-server-sheet.tsx
@@ -192,7 +192,7 @@ export const AddMcpServerSheet = ({
         onOpenChange(next);
       }}
     >
-      <SheetPopup className="w-full sm:max-w-[460px]" side="right">
+      <SheetPopup className="w-full sm:max-w-[460px]" side="inline-end">
         <SheetHeader>
           <SheetTitle>{t("knowledge.mcp.addServerCardTitle")}</SheetTitle>
         </SheetHeader>

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -794,9 +794,9 @@ export function UiPlayground() {
                 <div className="flex flex-wrap items-center gap-2">
                   <Sheet>
                     <SheetTrigger render={<Button variant="outline" />}>
-                      Right sheet
+                      Inline-end sheet
                     </SheetTrigger>
-                    <SheetPopup side="right" variant="inset">
+                    <SheetPopup side="inline-end" variant="inset">
                       <SheetHeader>
                         <SheetTitle>Matter details</SheetTitle>
                         <SheetDescription>
@@ -829,7 +829,7 @@ export function UiPlayground() {
                     <SheetTrigger render={<Button variant="outline" />}>
                       Bottom sheet
                     </SheetTrigger>
-                    <SheetPopup side="bottom">
+                    <SheetPopup side="block-end">
                       <SheetHeader>
                         <SheetTitle>Batch actions</SheetTitle>
                         <SheetDescription>

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -11,6 +11,8 @@ const Sheet = SheetPrimitive.Root;
 
 const SheetPortal = SheetPrimitive.Portal;
 
+type SheetSide = "inline-start" | "inline-end" | "block-start" | "block-end";
+
 function SheetTrigger(props: SheetPrimitive.Trigger.Props) {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
@@ -38,17 +40,17 @@ function SheetViewport({
   variant = "default",
   ...props
 }: SheetPrimitive.Viewport.Props & {
-  side?: "right" | "left" | "top" | "bottom";
+  side?: SheetSide;
   variant?: "default" | "inset";
 }) {
   return (
     <SheetPrimitive.Viewport
       className={cn(
         "fixed inset-0 z-50 grid",
-        side === "bottom" && "grid grid-rows-[1fr_auto] pt-12",
-        side === "top" && "grid grid-rows-[auto_1fr] pb-12",
-        side === "left" && "flex justify-start",
-        side === "right" && "flex justify-end",
+        side === "block-end" && "grid grid-rows-[1fr_auto] pt-12",
+        side === "block-start" && "grid grid-rows-[auto_1fr] pb-12",
+        side === "inline-start" && "flex justify-start",
+        side === "inline-end" && "flex justify-end",
         variant === "inset" && "sm:p-4",
       )}
       data-slot="sheet-viewport"
@@ -61,12 +63,12 @@ function SheetPopup({
   className,
   children,
   showCloseButton = true,
-  side = "right",
+  side = "inline-end",
   variant = "default",
   ...props
 }: SheetPrimitive.Popup.Props & {
   showCloseButton?: boolean;
-  side?: "right" | "left" | "top" | "bottom";
+  side?: SheetSide;
   variant?: "default" | "inset";
 }) {
   return (
@@ -76,14 +78,14 @@ function SheetPopup({
         <SheetPrimitive.Popup
           className={cn(
             "bg-popover text-popover-foreground relative flex max-h-full min-h-0 w-full min-w-0 flex-col shadow-lg/5 transition-[opacity,translate] duration-200 ease-in-out will-change-transform not-dark:bg-clip-padding before:pointer-events-none before:absolute before:inset-0 before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:opacity-0 data-starting-style:opacity-0 max-sm:before:hidden dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
-            side === "bottom" &&
+            side === "block-end" &&
               "row-start-2 border-t data-ending-style:translate-y-8 data-starting-style:translate-y-8",
-            side === "top" &&
+            side === "block-start" &&
               "border-b data-ending-style:-translate-y-8 data-starting-style:-translate-y-8",
-            side === "left" &&
-              "w-[calc(100%-(--spacing(12)))] max-w-md border-e data-ending-style:-translate-x-8 data-starting-style:-translate-x-8",
-            side === "right" &&
-              "col-start-2 w-[calc(100%-(--spacing(12)))] max-w-md border-s data-ending-style:translate-x-8 data-starting-style:translate-x-8",
+            side === "inline-start" &&
+              "w-[calc(100%-(--spacing(12)))] max-w-md border-e data-ending-style:-translate-x-8 data-starting-style:-translate-x-8 rtl:data-ending-style:translate-x-8 rtl:data-starting-style:translate-x-8",
+            side === "inline-end" &&
+              "w-[calc(100%-(--spacing(12)))] max-w-md border-s data-ending-style:translate-x-8 data-starting-style:translate-x-8 rtl:data-ending-style:-translate-x-8 rtl:data-starting-style:-translate-x-8",
             variant === "inset" &&
               "before:hidden sm:rounded-2xl sm:border sm:before:rounded-[calc(var(--radius-2xl)-1px)] sm:**:data-[slot=sheet-footer]:rounded-b-[calc(var(--radius-2xl)-1px)]",
             className,
@@ -202,3 +204,4 @@ export {
   SheetDescription,
   SheetPanel,
 };
+export type { SheetSide };

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -46,7 +46,7 @@ function SheetViewport({
   return (
     <SheetPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 grid",
+        "fixed inset-0 z-50",
         side === "block-end" && "grid grid-rows-[1fr_auto] pt-12",
         side === "block-start" && "grid grid-rows-[auto_1fr] pb-12",
         side === "inline-start" && "flex justify-start",


### PR DESCRIPTION
## Summary

- change the shared sheet side API from physical sides to logical inline/block sides
- update sheet callers to use inline-end and block-end intent
- adapt the mobile sidebar's existing physical side prop at the sheet boundary