### PR TITLE
fix: add bidi text wrapper

### DIFF
--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -35,10 +35,16 @@ export const _nameWithSibling = () => (
     {x.displayName} <small>(archived)</small>
   </span>
 );
+export const _rawDir = () => (
+  // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
+  <span dir="auto">{x.displayName}</span>
+);
+export const _rawBdi = () => (
+  // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
+  <bdi>{x.displayName}</bdi>
+);
 
-// --- Allowed: dir present, <bdi>, or a non-name expression ---
-export const _ok1 = () => <span dir="auto">{x.displayName}</span>;
-export const _ok2 = () => <bdi>{x.displayName}</bdi>;
-export const _ok3 = () => <span>{x.name}</span>;
-export const _ok4 = () => <BidiText>{x.displayName}</BidiText>;
-export const _ok5 = () => <UserText>{x.fileName}</UserText>;
+// --- Allowed: wrapper present or a non-name expression ---
+export const _ok1 = () => <span>{x.name}</span>;
+export const _ok2 = () => <BidiText>{x.displayName}</BidiText>;
+export const _ok3 = () => <UserText>{x.fileName}</UserText>;

--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -41,7 +41,7 @@ export const _rawDir = () => (
 );
 export const _rawDirLink = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
-  <a dir="auto" href="#">
+  <a dir="auto" href="/contacts">
     {x.displayName}
   </a>
 );

--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -15,6 +15,9 @@ declare const x: {
 };
 declare const BidiText: (props: { children: ReactNode }) => ReactNode;
 declare const UserText: (props: { children: ReactNode }) => ReactNode;
+declare const Foo: {
+  Label: (props: { children: ReactNode; dir?: string }) => ReactNode;
+};
 
 // --- Flagged: a bare user-content name property rendered without dir ---
 export const _display = () => (
@@ -48,6 +51,10 @@ export const _rawDirLink = () => (
 export const _rawBdi = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
   <bdi>{x.displayName}</bdi>
+);
+export const _compound = () => (
+  // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
+  <Foo.Label dir="auto">{x.displayName}</Foo.Label>
 );
 
 // --- Allowed: wrapper present or a non-name expression ---

--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -5,12 +5,16 @@
 // a regression makes them unused and CI fails. Lines without a directive
 // cover the allow-list and must keep passing.
 
+import type { ReactNode } from "react";
+
 declare const x: {
   displayName: string;
   fileName: string;
   name: string;
   client: { displayName: string };
 };
+declare const BidiText: (props: { children: ReactNode }) => ReactNode;
+declare const UserText: (props: { children: ReactNode }) => ReactNode;
 
 // --- Flagged: a bare user-content name property rendered without dir ---
 export const _display = () => (
@@ -36,3 +40,5 @@ export const _nameWithSibling = () => (
 export const _ok1 = () => <span dir="auto">{x.displayName}</span>;
 export const _ok2 = () => <bdi>{x.displayName}</bdi>;
 export const _ok3 = () => <span>{x.name}</span>;
+export const _ok4 = () => <BidiText>{x.displayName}</BidiText>;
+export const _ok5 = () => <UserText>{x.fileName}</UserText>;

--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -41,7 +41,9 @@ export const _rawDir = () => (
 );
 export const _rawDirLink = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
-  <a dir="auto">{x.displayName}</a>
+  <a dir="auto" href="#">
+    {x.displayName}
+  </a>
 );
 export const _rawBdi = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name

--- a/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-dir-on-rendered-name.fixture.tsx
@@ -39,6 +39,10 @@ export const _rawDir = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
   <span dir="auto">{x.displayName}</span>
 );
+export const _rawDirLink = () => (
+  // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
+  <a dir="auto">{x.displayName}</a>
+);
 export const _rawBdi = () => (
   // oxlint-disable-next-line require-dir-on-rendered-name/require-dir-on-rendered-name
   <bdi>{x.displayName}</bdi>

--- a/.oxlint-plugins/require-dir-on-rendered-name.ts
+++ b/.oxlint-plugins/require-dir-on-rendered-name.ts
@@ -33,18 +33,6 @@ const NAME_PROPS = new Set([
 
 const SELF_ISOLATING = new Set(["BidiText", "UserText"]);
 const RAW_ISOLATING = new Set(["bdi", "bdo"]);
-const TEXT_ELEMENTS = new Set([
-  "div",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "p",
-  "span",
-  ...RAW_ISOLATING,
-]);
 
 const hasDirAttr = (opening) =>
   opening.attributes.some(
@@ -110,7 +98,6 @@ export default {
             // Sole child: dir="auto" on the element isolates it.
             if (kids.length === 1) {
               if (
-                TEXT_ELEMENTS.has(opening.name.name) &&
                 (hasDirAttr(opening) ||
                   RAW_ISOLATING.has(opening.name.name))
               ) {

--- a/.oxlint-plugins/require-dir-on-rendered-name.ts
+++ b/.oxlint-plugins/require-dir-on-rendered-name.ts
@@ -78,12 +78,12 @@ export default {
         return {
           JSXElement(node) {
             const opening = node.openingElement;
-            if (opening.name.type !== "JSXIdentifier") {
-              return;
-            }
-            if (
-              SELF_ISOLATING.has(opening.name.name)
-            ) {
+            // Compound components (`<Foo.Label>`) have a member-expression name
+            // with no string identifier; they can still wrap a tracked name, so
+            // keep inspecting their children instead of bailing out.
+            const elementName =
+              opening.name.type === "JSXIdentifier" ? opening.name.name : null;
+            if (elementName !== null && SELF_ISOLATING.has(elementName)) {
               return;
             }
             const kids = meaningfulChildren(node.children);
@@ -98,8 +98,8 @@ export default {
             // Sole child: dir="auto" on the element isolates it.
             if (kids.length === 1) {
               if (
-                (hasDirAttr(opening) ||
-                  RAW_ISOLATING.has(opening.name.name))
+                hasDirAttr(opening) ||
+                (elementName !== null && RAW_ISOLATING.has(elementName))
               ) {
                 context.report({ node: opening, messageId: "preferComponent" });
                 return;

--- a/.oxlint-plugins/require-dir-on-rendered-name.ts
+++ b/.oxlint-plugins/require-dir-on-rendered-name.ts
@@ -3,13 +3,14 @@
 //
 // A Latin name with trailing neutral characters inside the RTL UI gets
 // reordered — e.g. "Tatra Motor a.s." renders as ".Tatra Motor a.s" —
-// unless the element resolves direction from its own content. The fix is
-// `dir="auto"` on the element (or wrapping the value in <bdi>).
+// unless the element resolves direction from its own content. The preferred
+// fix is wrapping the value in <BidiText> / <UserText> (or <bdi> for raw HTML).
 //
 // Flagged: an element whose only child is `{<expr>.<nameProp>}` (a known
 // user-content name property) and which has no `dir` attribute.
-// Allowed: a `dir` attribute is present, the element is <bdi>/<bdo>, or the
-// value is anything other than a bare member access to a name property.
+// Allowed: a `dir` attribute is present, the element is <BidiText>,
+// <UserText>, <bdi>/<bdo>, or the value is anything other than a bare member
+// access to a name property.
 
 const NAME_PROPS = new Set([
   "displayName",
@@ -28,7 +29,7 @@ const NAME_PROPS = new Set([
   "folderName",
 ]);
 
-const SELF_ISOLATING = new Set(["bdi", "bdo"]);
+const SELF_ISOLATING = new Set(["BidiText", "UserText", "bdi", "bdo"]);
 
 const hasDirAttr = (opening) =>
   opening.attributes.some(
@@ -58,12 +59,12 @@ export default {
         messages: {
           missingDir:
             "User-provided name rendered without bidi isolation reorders " +
-            'under RTL (e.g. ".Tatra Motor a.s"). Add dir="auto" to the ' +
-            "element (or wrap the value in <bdi>).",
+            'under RTL (e.g. ".Tatra Motor a.s"). Wrap the value in ' +
+            '<BidiText> / <UserText>, or add dir="auto" to the element.',
           missingBidi:
             "User-provided name rendered alongside other content reorders " +
-            "under RTL; wrap it in <bdi> (dir on the parent would also " +
-            "reorder its siblings).",
+            "under RTL; wrap it in <BidiText> / <UserText> (dir on the " +
+            "parent would also reorder its siblings).",
         },
       },
       create(context) {

--- a/.oxlint-plugins/require-dir-on-rendered-name.ts
+++ b/.oxlint-plugins/require-dir-on-rendered-name.ts
@@ -1,16 +1,15 @@
-// Require `dir` when rendering a user-provided NAME as an element's text,
-// so it isn't bidi-reordered under an RTL UI.
+// Require BidiText/UserText when rendering a user-provided identifier as an
+// element's text, so it isn't bidi-reordered under an RTL UI.
 //
 // A Latin name with trailing neutral characters inside the RTL UI gets
 // reordered — e.g. "Tatra Motor a.s." renders as ".Tatra Motor a.s" —
-// unless the element resolves direction from its own content. The preferred
-// fix is wrapping the value in <BidiText> / <UserText> (or <bdi> for raw HTML).
+// unless the element resolves direction from its own content as an isolated run.
+// The preferred fix is wrapping the value in <BidiText> / <UserText>.
 //
-// Flagged: an element whose only child is `{<expr>.<nameProp>}` (a known
-// user-content name property) and which has no `dir` attribute.
-// Allowed: a `dir` attribute is present, the element is <BidiText>,
-// <UserText>, <bdi>/<bdo>, or the value is anything other than a bare member
-// access to a name property.
+// Flagged: an app JSX element whose only child is `{<expr>.<nameProp>}` (a
+// known user-content identifier property) and which is not <BidiText> /
+// <UserText>. Raw `dir` and raw <bdi>/<bdo> are intentionally flagged so app
+// code converges on one typed wrapper.
 
 const NAME_PROPS = new Set([
   "displayName",
@@ -27,9 +26,25 @@ const NAME_PROPS = new Set([
   "entityName",
   "fileName",
   "folderName",
+  "email",
+  "caseNumber",
+  "citationText",
 ]);
 
-const SELF_ISOLATING = new Set(["BidiText", "UserText", "bdi", "bdo"]);
+const SELF_ISOLATING = new Set(["BidiText", "UserText"]);
+const RAW_ISOLATING = new Set(["bdi", "bdo"]);
+const TEXT_ELEMENTS = new Set([
+  "div",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "span",
+  ...RAW_ISOLATING,
+]);
 
 const hasDirAttr = (opening) =>
   opening.attributes.some(
@@ -60,19 +75,25 @@ export default {
           missingDir:
             "User-provided name rendered without bidi isolation reorders " +
             'under RTL (e.g. ".Tatra Motor a.s"). Wrap the value in ' +
-            '<BidiText> / <UserText>, or add dir="auto" to the element.',
+            "<BidiText> / <UserText>.",
           missingBidi:
             "User-provided name rendered alongside other content reorders " +
             "under RTL; wrap it in <BidiText> / <UserText> (dir on the " +
             "parent would also reorder its siblings).",
+          preferComponent:
+            "Use <BidiText> / <UserText> for rendered user-provided text. " +
+            'Raw dir="auto" / <bdi> does not provide the app-level typed ' +
+            "contract.",
         },
       },
       create(context) {
         return {
           JSXElement(node) {
             const opening = node.openingElement;
+            if (opening.name.type !== "JSXIdentifier") {
+              return;
+            }
             if (
-              opening.name.type === "JSXIdentifier" &&
               SELF_ISOLATING.has(opening.name.name)
             ) {
               return;
@@ -88,13 +109,21 @@ export default {
             }
             // Sole child: dir="auto" on the element isolates it.
             if (kids.length === 1) {
+              if (
+                TEXT_ELEMENTS.has(opening.name.name) &&
+                (hasDirAttr(opening) ||
+                  RAW_ISOLATING.has(opening.name.name))
+              ) {
+                context.report({ node: opening, messageId: "preferComponent" });
+                return;
+              }
               if (!hasDirAttr(opening)) {
                 context.report({ node: opening, messageId: "missingDir" });
               }
               return;
             }
             // Mixed children: dir on the element would reorder the siblings too,
-            // so the name itself must be wrapped in <bdi>.
+            // so the name itself must be wrapped in BidiText/UserText.
             for (const child of nameKids) {
               context.report({ node: child, messageId: "missingBidi" });
             }

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -36,6 +36,7 @@ import type {
   FolioAIEditSeverity,
   FolioAIEditSnapshot,
 } from "@stll/folio";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { cn } from "@stll/ui/lib/utils";
 
 import { PromptBar } from "@/components/ai-suggestions/host";
@@ -1274,9 +1275,12 @@ const FileChatOverlayInner = ({
             (activeFile || activeExternal) && filePlaceholderAction ? (
               <span className="text-foreground-ghost flex min-w-0 items-center gap-1.5 text-[13px] leading-5">
                 <span className="shrink-0">{filePlaceholderAction}</span>
-                <span className="text-foreground-label max-w-64 truncate">
+                <BidiText
+                  as="span"
+                  className="text-foreground-label max-w-64 truncate"
+                >
                   {activeFile?.fileName ?? activeExternal?.title}
-                </span>
+                </BidiText>
               </span>
             ) : undefined
           }

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -56,6 +56,7 @@ import type {
   AISuggestionPreset,
   AISuggestionSeverity,
 } from "@stll/folio";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import {
@@ -2307,7 +2308,7 @@ function CitationChip(props: CitationChipProps) {
             onClick={() => onActivate(citation)}
             aria-label={t("chat.openCitation", { label: citation.label })}
           >
-            <bdi>[{citation.label}]</bdi>
+            <BidiText>[{citation.label}]</BidiText>
           </button>
         }
       />

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -27,6 +27,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import {
@@ -849,17 +850,18 @@ const MatterItem = ({
           >
             <MatterIcon color={ws.color} id={ws.id} />
             <span className="flex min-w-0 flex-col">
-              <span className="truncate" dir="auto">
+              <BidiText as="span" className="truncate">
                 {ws.name}
-              </span>
+              </BidiText>
               <span
                 className="text-muted-foreground truncate text-[0.625rem] leading-tight opacity-60 transition-opacity duration-200 group-hover/sidebar-menu-button:opacity-100"
-                dir="auto"
                 title={formatFullTimestamp(ws.lastActivityAt)}
               >
-                {ws.client
-                  ? ws.client.displayName
-                  : t("workspaces.parties.personalLabel")}
+                <BidiText>
+                  {ws.client
+                    ? ws.client.displayName
+                    : t("workspaces.parties.personalLabel")}
+                </BidiText>
                 {relTime ? ` · ${relTime}` : ""}
               </span>
             </span>

--- a/apps/web/src/components/auth/otp-panel.tsx
+++ b/apps/web/src/components/auth/otp-panel.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import type { ReactNode } from "react";
 
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import {
   Frame,
@@ -209,11 +211,17 @@ function OTPPanelContent({
   onUseDifferentEmail: () => void;
 }) {
   const t = useTranslations();
+  const renderEmail = (chunks: ReactNode) => (
+    <BidiText direction="ltr">{chunks}</BidiText>
+  );
 
   const header = (
     <>
       <FrameDescription>
-        {t("auth.weSentCodeTo", { email })}
+        {t.rich("auth.weSentCodeTo", {
+          email: renderEmail,
+          emailAddress: email,
+        })}
         {" · "}
         <Button
           className="h-auto p-0 align-baseline text-sm font-normal text-inherit underline"
@@ -274,7 +282,10 @@ function OTPPanelContent({
           size="sm"
           variant="link"
         >
-          {t("auth.resendCode", { email })}
+          {t.rich("auth.resendCode", {
+            email: renderEmail,
+            emailAddress: email,
+          })}
         </Button>
       </div>
     </>

--- a/apps/web/src/components/breadcrumbs/contact-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/contact-breadcrumb.tsx
@@ -2,6 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
 import type { ResolveParams } from "@tanstack/react-router";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
+
 import { BreadcrumbLink } from "@/components/breadcrumbs/shared";
 import { contactOptions } from "@/routes/_protected.contacts/-queries";
 
@@ -19,7 +21,7 @@ export const ContactBreadcrumb = ({
 
   return (
     <BreadcrumbLink to="/contacts/$contactId">
-      {contact?.displayName ?? contactId}
+      <BidiText>{contact?.displayName ?? contactId}</BidiText>
     </BreadcrumbLink>
   );
 };

--- a/apps/web/src/components/breadcrumbs/pdf-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/pdf-breadcrumb.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link, useMatch } from "@tanstack/react-router";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 
 import { fileMetadataOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
@@ -42,7 +43,7 @@ export const PdfBreadcrumb = () => {
         search={currentSearch}
         to="/workspaces/$workspaceId/$viewId/document"
       >
-        {fileName ?? fieldId}
+        <BidiText>{fileName ?? fieldId}</BidiText>
       </Link>
     </BreadcrumbItem>
   );

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -6,11 +6,11 @@ import type { ResolveParams } from "@tanstack/react-router";
 import { LayersIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   BreadcrumbItem,
   BreadcrumbSeparator,
 } from "@stll/ui/components/breadcrumb";
-import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   ColorPicker,
   ColorPickerContent,

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -10,6 +10,7 @@ import {
   BreadcrumbItem,
   BreadcrumbSeparator,
 } from "@stll/ui/components/breadcrumb";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   ColorPicker,
   ColorPickerContent,
@@ -144,14 +145,13 @@ export const WorkspaceBreadcrumb = ({
       <BreadcrumbItem className="min-w-8 shrink">
         <Link
           className="hover:text-foreground min-w-0 truncate transition-colors"
-          dir="auto"
           onClick={() => {
             updateMattersConfig({ clientFilter: client.id });
           }}
           title={client.displayName}
           to="/workspaces"
         >
-          {client.displayName}
+          <BidiText>{client.displayName}</BidiText>
         </Link>
       </BreadcrumbItem>
       <BreadcrumbSeparator className="shrink-0" />
@@ -311,9 +311,9 @@ export const WorkspaceBreadcrumb = ({
                     }}
                   />
                 </span>
-                <span className="truncate" dir="auto">
+                <BidiText as="span" className="truncate">
                   {displayName}
-                </span>
+                </BidiText>
                 {workspace.reference && !isEditingRef ? (
                   <span
                     className="text-foreground-muted shrink-0 text-sm"

--- a/apps/web/src/components/chat/needs-matter-card.tsx
+++ b/apps/web/src/components/chat/needs-matter-card.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { contentDir } from "@stll/ui/hooks/use-content-dir";
@@ -340,17 +341,19 @@ const MatterPickerSection = ({
                         color: isSelected ? undefined : swatch,
                       }}
                     />
-                    <span className="min-w-0 flex-1 truncate">{m.name}</span>
+                    <BidiText as="span" className="min-w-0 flex-1 truncate">
+                      {m.name}
+                    </BidiText>
                     {m.client?.displayName && (
-                      <span
+                      <BidiText
+                        as="span"
                         className={cn(
                           "shrink-0 text-[10px]",
                           isSelected ? "opacity-80" : "text-muted-foreground",
                         )}
-                        dir="auto"
                       >
                         {m.client.displayName}
-                      </span>
+                      </BidiText>
                     )}
                   </button>
                 );
@@ -391,9 +394,9 @@ const CreatedSuccessCard = ({ output, onOpen }: CreatedSuccessCardProps) => {
     <>
       <DocumentThumbnail />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-xs font-semibold" dir="auto">
+        <BidiText as="span" className="truncate text-xs font-semibold">
           {output.fileName}
-        </span>
+        </BidiText>
         {canOpen && (
           <span className="text-muted-foreground inline-flex items-center gap-1 text-[11px]">
             {t("chat.createDocument.openInFolio")}

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -11,6 +11,7 @@ import type {
   ChatPart,
   ChatSourceDocument,
 } from "@stll/api/types";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { cn } from "@stll/ui/lib/utils";
 
 import { openEntityInInspector } from "@/components/chat/entity-open";
@@ -266,7 +267,9 @@ const ExternalSourceChip = ({
         loaded={faviconRequested}
         url={source.url}
       />
-      <span className="max-w-[20ch] truncate">{source.title}</span>
+      <BidiText as="span" className="max-w-[20ch] truncate">
+        {source.title}
+      </BidiText>
     </button>
   );
 };
@@ -389,7 +392,9 @@ const SourceChip = ({
         kind={sourceDocument.kind}
         mimeType={sourceDocument.mimeType}
       />
-      <span className="max-w-[20ch] truncate">{sourceDocument.title}</span>
+      <BidiText as="span" className="max-w-[20ch] truncate">
+        {sourceDocument.title}
+      </BidiText>
     </button>
   );
 };

--- a/apps/web/src/components/contact-picker.tsx
+++ b/apps/web/src/components/contact-picker.tsx
@@ -6,6 +6,7 @@ import { BuildingIcon, PlusIcon, SearchIcon, UserIcon } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Combobox,
   ComboboxEmpty,
@@ -145,7 +146,7 @@ export const ContactPicker = ({
                 ) : (
                   <BuildingIcon className="text-muted-foreground size-3.5" />
                 )}
-                <span dir="auto">{contact.displayName}</span>
+                <BidiText>{contact.displayName}</BidiText>
               </div>
             </ComboboxItem>
           ))}

--- a/apps/web/src/components/file-tree/file-tree.tsx
+++ b/apps/web/src/components/file-tree/file-tree.tsx
@@ -212,11 +212,7 @@ export function FileTree({
                 {renderName ? (
                   renderName(node)
                 ) : (
-                  <BidiText
-                    as="span"
-                    className="truncate"
-                    title={node.name}
-                  >
+                  <BidiText as="span" className="truncate" title={node.name}>
                     {node.name}
                   </BidiText>
                 )}

--- a/apps/web/src/components/file-tree/file-tree.tsx
+++ b/apps/web/src/components/file-tree/file-tree.tsx
@@ -7,6 +7,7 @@ import {
   FolderOpenIcon,
 } from "lucide-react";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -211,9 +212,13 @@ export function FileTree({
                 {renderName ? (
                   renderName(node)
                 ) : (
-                  <span className="truncate" dir="auto" title={node.name}>
+                  <BidiText
+                    as="span"
+                    className="truncate"
+                    title={node.name}
+                  >
                     {node.name}
-                  </span>
+                  </BidiText>
                 )}
               </FileTreeNameCell>
             </div>

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Input } from "@stll/ui/components/input";
 import { Label } from "@stll/ui/components/label";
@@ -127,16 +128,16 @@ export const MatterTargetPicker = ({
                       className="size-4 shrink-0"
                       style={{ color: swatch }}
                     />
-                    <span className="min-w-0 flex-1 truncate" dir="auto">
+                    <BidiText as="span" className="min-w-0 flex-1 truncate">
                       {workspace.name}
-                    </span>
+                    </BidiText>
                     {workspace.client?.displayName !== undefined && (
-                      <span
+                      <BidiText
+                        as="span"
                         className="text-muted-foreground max-w-32 shrink-0 truncate text-xs"
-                        dir="auto"
                       >
                         {workspace.client.displayName}
-                      </span>
+                      </BidiText>
                     )}
                   </button>
                 );
@@ -258,9 +259,9 @@ const FolderPicker = ({
             type="button"
           >
             <FolderIcon className="size-4 shrink-0" />
-            <span className="truncate" dir="auto">
+            <BidiText as="span" className="truncate">
               {folder.name}
-            </span>
+            </BidiText>
           </button>
         </div>
         {hasChildren && isExpanded && (

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -26,6 +26,7 @@ import type {
   GlobalSearchHit,
   GlobalSearchResultType,
 } from "@stll/api/types";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import {
@@ -1275,13 +1276,15 @@ const SearchRecents = ({
                   <FileTextIcon className="text-muted-foreground size-4 shrink-0" />
                 )}
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate">{file.title}</span>
-                  <span
+                  <BidiText as="span" className="block truncate">
+                    {file.title}
+                  </BidiText>
+                  <BidiText
+                    as="span"
                     className="text-muted-foreground block truncate text-xs"
-                    dir="auto"
                   >
                     {file.workspaceName}
-                  </span>
+                  </BidiText>
                 </span>
               </Button>
             ))}

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Avatar,
   AvatarFallback,
@@ -102,19 +103,27 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
               <div className="flex min-w-0 flex-col justify-center">
                 {user.name ? (
                   <>
-                    <span className="truncate text-sm font-medium">
+                    <BidiText as="span" className="truncate text-sm font-medium">
                       {user.name}
-                    </span>
+                    </BidiText>
                     {user.email && (
-                      <span className="text-muted-foreground truncate text-xs">
+                      <BidiText
+                        as="span"
+                        className="text-muted-foreground truncate text-xs"
+                        direction="ltr"
+                      >
                         {user.email}
-                      </span>
+                      </BidiText>
                     )}
                   </>
                 ) : (
-                  <span className="truncate text-sm font-medium">
+                  <BidiText
+                    as="span"
+                    className="truncate text-sm font-medium"
+                    direction={user.email ? "ltr" : "auto"}
+                  >
                     {user.email || t("common.user")}
-                  </span>
+                  </BidiText>
                 )}
               </div>
               <ChevronsUpDownIcon className="ms-auto size-4 opacity-50" />

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -11,12 +11,12 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@stll/ui/components/avatar";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Menu,
   MenuGroup,
@@ -103,7 +103,10 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
               <div className="flex min-w-0 flex-col justify-center">
                 {user.name ? (
                   <>
-                    <BidiText as="span" className="truncate text-sm font-medium">
+                    <BidiText
+                      as="span"
+                      className="truncate text-sm font-medium"
+                    >
                       {user.name}
                     </BidiText>
                     {user.email && (

--- a/apps/web/src/components/user-avatar.tsx
+++ b/apps/web/src/components/user-avatar.tsx
@@ -3,6 +3,7 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@stll/ui/components/avatar";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { cn } from "@stll/ui/lib/utils";
 
 import { getInitials } from "@/lib/get-initials";
@@ -74,7 +75,8 @@ export const UserIdentity = ({
         name={displayName}
       />
       <div className="min-w-0 flex-1">
-        <div
+        <BidiText
+          as="div"
           className={cn(
             "truncate text-sm font-medium",
             deleted && "text-muted-foreground",
@@ -82,16 +84,17 @@ export const UserIdentity = ({
           )}
         >
           {displayName}
-        </div>
+        </BidiText>
         {secondaryText ? (
-          <div
+          <BidiText
+            as="div"
             className={cn(
               "text-muted-foreground truncate text-xs",
               secondaryClassName,
             )}
           >
             {secondaryText}
-          </div>
+          </BidiText>
         ) : null}
       </div>
     </div>

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
 
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { OutlineRail } from "@stll/ui/components/outline-rail";
 import type { OutlineItem } from "@stll/ui/components/outline-rail";
@@ -213,7 +214,7 @@ export function DecisionWorkspace(props: DecisionWorkspaceProps) {
         <div>
           <p className="text-muted-foreground text-xs">{decision.court}</p>
           <h1 className="text-xl font-semibold">
-            <bdi>{decision.caseNumber}</bdi>
+            <BidiText>{decision.caseNumber}</BidiText>
           </h1>
         </div>
         {aiEnabled ? (

--- a/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
@@ -275,7 +275,7 @@ export const MetadataPanel = ({ decision }: MetadataPanelProps) => {
           <ul className="space-y-1">
             {decision.citationsFrom.slice(0, 10).map((citation) => (
               <li className="text-muted-foreground text-xs" key={citation.id}>
-                <bdi>{citation.citationText}</bdi>
+                <BidiText>{citation.citationText}</BidiText>
               </li>
             ))}
           </ul>
@@ -290,7 +290,7 @@ export const MetadataPanel = ({ decision }: MetadataPanelProps) => {
           <ul className="space-y-1">
             {decision.citationsTo.slice(0, 10).map((citation) => (
               <li className="text-muted-foreground text-xs" key={citation.id}>
-                <bdi>{citation.citationText}</bdi>
+                <BidiText>{citation.citationText}</BidiText>
               </li>
             ))}
           </ul>

--- a/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useFormatter, useTranslations } from "use-intl";
 
 import { getDocumentAstMetadata } from "@stll/legal-ast/document-ast";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 
 import { getFormattingLocale } from "@/i18n/i18n-store";
@@ -83,7 +84,7 @@ const MetadataField = ({
     value instanceof Date ? (
       value.toLocaleDateString(getFormattingLocale())
     ) : (
-      <bdi>{value}</bdi>
+      <BidiText>{value}</BidiText>
     );
 
   return (

--- a/apps/web/src/features/case-law/components/decision-table.tsx
+++ b/apps/web/src/features/case-law/components/decision-table.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { useFormatter, useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
@@ -162,7 +163,7 @@ const renderCaseNumberCell = (decision: Decision) => {
           }}
           to="/law/$country/cases/$court/$language/$slug"
         >
-          <bdi>{caseNumber}</bdi>
+          <BidiText>{caseNumber}</BidiText>
         </Link>
       ) : (
         <Link
@@ -174,7 +175,7 @@ const renderCaseNumberCell = (decision: Decision) => {
           }}
           to="/law/$country/cases/$court/$slug"
         >
-          <bdi>{caseNumber}</bdi>
+          <BidiText>{caseNumber}</BidiText>
         </Link>
       )}
       {headline && (

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "أو سجّل الدخول بالبريد الإلكتروني",
     "organizationNamePlaceholder": "مؤسستي",
     "rateLimitExceeded": "محاولات كثيرة جدًا. يُرجى المحاولة مرة أخرى لاحقًا.",
-    "resendCode": "إرسال الرمز مرة أخرى إلى {email}",
+    "resendCode": "إرسال الرمز مرة أخرى إلى <email>{emailAddress}</email>",
     "selectOrganization": "اختر مؤسسة",
     "signIn": "تسجيل الدخول",
     "signInBeforeInvitation": "يجب تسجيل الدخول قبل أن تتمكن من قبول دعوة للانضمام إلى مؤسسة.",
     "subtitle": "المستندات والسوابق القضائية والمراجعة تحت السيطرة. مدعومة بالذكاء الاصطناعي.",
     "useDifferentEmail": "استخدام بريد إلكتروني مختلف",
-    "weSentCodeTo": "أرسلنا رمزًا إلى {email}"
+    "weSentCodeTo": "أرسلنا رمزًا إلى <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "إضافة إدخال",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "nebo se přihlaste e-mailem",
     "organizationNamePlaceholder": "Moje organizace",
     "rateLimitExceeded": "Příliš mnoho pokusů. Zkuste to prosím později.",
-    "resendCode": "Poslat kód znovu na {email}",
+    "resendCode": "Poslat kód znovu na <email>{emailAddress}</email>",
     "selectOrganization": "Vyberte organizaci",
     "signIn": "Přihlásit se",
     "signInBeforeInvitation": "Pro přijetí pozvánky do organizace se musíte nejprve přihlásit.",
     "subtitle": "Dokumenty, judikatura i revize pod kontrolou. S pomocí AI.",
     "useDifferentEmail": "Použít jiný e-mail",
-    "weSentCodeTo": "Kód jsme odeslali na {email}"
+    "weSentCodeTo": "Kód jsme odeslali na <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Přidat záznam",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "oder mit E-Mail anmelden",
     "organizationNamePlaceholder": "Meine Organisation",
     "rateLimitExceeded": "Zu viele Versuche. Bitte versuchen Sie es später erneut.",
-    "resendCode": "Code erneut an {email} senden",
+    "resendCode": "Code erneut an <email>{emailAddress}</email> senden",
     "selectOrganization": "Organisation auswählen",
     "signIn": "Anmelden",
     "signInBeforeInvitation": "Sie müssen sich anmelden, bevor Sie eine Einladung zu einer Organisation annehmen können.",
     "subtitle": "Dokumente, Rechtsprechung und Prüfung im Griff. Mit Hilfe von KI.",
     "useDifferentEmail": "Andere E-Mail verwenden",
-    "weSentCodeTo": "Wir haben einen Code an {email} gesendet"
+    "weSentCodeTo": "Wir haben einen Code an <email>{emailAddress}</email> gesendet"
   },
   "billing": {
     "addEntry": "Eintrag hinzufügen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "or sign in with email",
     "organizationNamePlaceholder": "My organization",
     "rateLimitExceeded": "Too many attempts. Please try again later.",
-    "resendCode": "Send code again to {email}",
+    "resendCode": "Send code again to <email>{emailAddress}</email>",
     "selectOrganization": "Select an organization",
     "signIn": "Sign in",
     "signInBeforeInvitation": "You need to sign in before you can accept an invitation to an organization.",
     "subtitle": "Documents, case law, and review under control. Powered by AI.",
     "useDifferentEmail": "Use a different email",
-    "weSentCodeTo": "We sent a code to {email}"
+    "weSentCodeTo": "We sent a code to <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Add entry",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "o inicia sesión con el correo electrónico",
     "organizationNamePlaceholder": "Mi Organización",
     "rateLimitExceeded": "Demasiados intentos. Inténtelo de nuevo más tarde.",
-    "resendCode": "Enviar código de nuevo a {email}",
+    "resendCode": "Enviar código de nuevo a <email>{emailAddress}</email>",
     "selectOrganization": "Seleccione una organización",
     "signIn": "Iniciar sesión",
     "signInBeforeInvitation": "Debe iniciar sesión antes de aceptar una invitación a una organización.",
     "subtitle": "Documentos, jurisprudencia y revisión bajo control. Con ayuda de la IA.",
     "useDifferentEmail": "Usar otro correo",
-    "weSentCodeTo": "Hemos enviado un código a {email}"
+    "weSentCodeTo": "Hemos enviado un código a <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Añadir entrada",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "või logi sisse e-postiga",
     "organizationNamePlaceholder": "Minu organisatsioon",
     "rateLimitExceeded": "Liiga palju katseid. Palun proovige hiljem uuesti.",
-    "resendCode": "Saada kood uuesti aadressile {email}",
+    "resendCode": "Saada kood uuesti aadressile <email>{emailAddress}</email>",
     "selectOrganization": "Valige organisatsioon",
     "signIn": "Logi sisse",
     "signInBeforeInvitation": "Enne organisatsiooni kutse vastuvõtmist peate sisse logima.",
     "subtitle": "Dokumendid, kohtupraktika ja ülevaatus kontrolli all. Tehisintellekti abiga.",
     "useDifferentEmail": "Kasuta teist e-posti aadressi",
-    "weSentCodeTo": "Saatsime koodi aadressile {email}"
+    "weSentCodeTo": "Saatsime koodi aadressile <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Lisa kanne",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "ou connectez-vous avec l'e-mail",
     "organizationNamePlaceholder": "Mon organisation",
     "rateLimitExceeded": "Trop de tentatives. Veuillez réessayer plus tard.",
-    "resendCode": "Renvoyer le code à {email}",
+    "resendCode": "Renvoyer le code à <email>{emailAddress}</email>",
     "selectOrganization": "Sélectionner une organisation",
     "signIn": "Se connecter",
     "signInBeforeInvitation": "Vous devez vous connecter avant de pouvoir accepter une invitation à une organisation.",
     "subtitle": "Documents, jurisprudence et revue sous contrôle. Avec l'aide de l'IA.",
     "useDifferentEmail": "Utiliser une autre adresse e-mail",
-    "weSentCodeTo": "Nous avons envoyé un code à {email}"
+    "weSentCodeTo": "Nous avons envoyé un code à <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Ajouter une entrée",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "vagy jelentkezz be e-maillel",
     "organizationNamePlaceholder": "Szervezetem",
     "rateLimitExceeded": "Túl sok próbálkozás. Kérjük, próbálja újra később.",
-    "resendCode": "Kód újraküldése erre: {email}",
+    "resendCode": "Kód újraküldése erre: <email>{emailAddress}</email>",
     "selectOrganization": "Válasszon szervezetet",
     "signIn": "Bejelentkezés",
     "signInBeforeInvitation": "A szervezeti meghívó elfogadásához először be kell jelentkeznie.",
     "subtitle": "Dokumentumok, ítélkezési gyakorlat és felülvizsgálat kézben tartva. AI segítségével.",
     "useDifferentEmail": "Másik e-mail-cím használata",
-    "weSentCodeTo": "Kódot küldtünk a következő címre: {email}"
+    "weSentCodeTo": "Kódot küldtünk a következő címre: <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Bejegyzés hozzáadása",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "arba prisijunkite el. paštu",
     "organizationNamePlaceholder": "Mano organizacija",
     "rateLimitExceeded": "Per daug bandymų. Bandykite dar kartą vėliau.",
-    "resendCode": "Siųsti kodą dar kartą adresu {email}",
+    "resendCode": "Siųsti kodą dar kartą adresu <email>{emailAddress}</email>",
     "selectOrganization": "Pasirinkite organizaciją",
     "signIn": "Prisijungti",
     "signInBeforeInvitation": "Norėdami priimti kvietimą į organizaciją, pirmiausia turite prisijungti.",
     "subtitle": "Dokumentai, teismų praktika ir peržiūra po kontrole. Su AI pagalba.",
     "useDifferentEmail": "Naudoti kitą el. pašto adresą",
-    "weSentCodeTo": "Išsiuntėme kodą adresu {email}"
+    "weSentCodeTo": "Išsiuntėme kodą adresu <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Pridėti įrašą",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "vai pierakstieties ar e-pastu",
     "organizationNamePlaceholder": "Mana organizācija",
     "rateLimitExceeded": "Pārāk daudz mēģinājumu. Lūdzu, mēģiniet vēlāk.",
-    "resendCode": "Nosūtīt kodu vēlreiz uz {email}",
+    "resendCode": "Nosūtīt kodu vēlreiz uz <email>{emailAddress}</email>",
     "selectOrganization": "Izvēlieties organizāciju",
     "signIn": "Pieslēgties",
     "signInBeforeInvitation": "Lai pieņemtu uzaicinājumu organizācijā, vispirms jāpieslēdzas.",
     "subtitle": "Dokumenti, tiesu prakse un pārskatīšana kontrolēti. Ar AI palīdzību.",
     "useDifferentEmail": "Izmantot citu e-pasta adresi",
-    "weSentCodeTo": "Mēs nosūtījām kodu uz {email}"
+    "weSentCodeTo": "Mēs nosūtījām kodu uz <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Pievienot ierakstu",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -84,13 +84,13 @@ type Messages = {
     "orSignInWithEmail": "or sign in with email";
     "organizationNamePlaceholder": "My organization";
     "rateLimitExceeded": "Too many attempts. Please try again later.";
-    "resendCode": "Send code again to {email}";
+    "resendCode": "Send code again to <email>{emailAddress}</email>";
     "selectOrganization": "Select an organization";
     "signIn": "Sign in";
     "signInBeforeInvitation": "You need to sign in before you can accept an invitation to an organization.";
     "subtitle": "Documents, case law, and review under control. Powered by AI.";
     "useDifferentEmail": "Use a different email";
-    "weSentCodeTo": "We sent a code to {email}";
+    "weSentCodeTo": "We sent a code to <email>{emailAddress}</email>";
   };
   "billing": {
     "addEntry": "Add entry";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "lub zaloguj się e-mailem",
     "organizationNamePlaceholder": "Moja organizacja",
     "rateLimitExceeded": "Zbyt wiele prób. Spróbuj ponownie później.",
-    "resendCode": "Wyślij kod ponownie na {email}",
+    "resendCode": "Wyślij kod ponownie na <email>{emailAddress}</email>",
     "selectOrganization": "Wybierz organizację",
     "signIn": "Zaloguj się",
     "signInBeforeInvitation": "Musisz się zalogować, zanim będziesz mógł przyjąć zaproszenie do organizacji.",
     "subtitle": "Dokumenty, orzecznictwo i przegląd pod kontrolą. Z pomocą AI.",
     "useDifferentEmail": "Użyj innego adresu e-mail",
-    "weSentCodeTo": "Wysłaliśmy kod na adres {email}"
+    "weSentCodeTo": "Wysłaliśmy kod na adres <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Dodaj wpis",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "ou faça login com e-mail",
     "organizationNamePlaceholder": "Minha organização",
     "rateLimitExceeded": "Muitas tentativas. Por favor, tente novamente mais tarde.",
-    "resendCode": "Enviar código novamente para {email}",
+    "resendCode": "Enviar código novamente para <email>{emailAddress}</email>",
     "selectOrganization": "Selecione uma organização",
     "signIn": "Faça login",
     "signInBeforeInvitation": "Você precisa fazer login antes de aceitar um convite para uma organização.",
     "subtitle": "Documentos, jurisprudência e revisão sob controle. Com tecnologia de IA.",
     "useDifferentEmail": "Use um e-mail diferente",
-    "weSentCodeTo": "Enviamos um código para {email}"
+    "weSentCodeTo": "Enviamos um código para <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Adicionar entrada",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -81,13 +81,13 @@
     "orSignInWithEmail": "alebo sa prihláste e-mailom",
     "organizationNamePlaceholder": "Moja organizácia",
     "rateLimitExceeded": "Príliš veľa pokusov. Skúste to znova neskôr.",
-    "resendCode": "Poslať kód znova na {email}",
+    "resendCode": "Poslať kód znova na <email>{emailAddress}</email>",
     "selectOrganization": "Vyberte organizáciu",
     "signIn": "Prihlásiť sa",
     "signInBeforeInvitation": "Na prijatie pozvánky do organizácie sa musíte najprv prihlásiť.",
     "subtitle": "Dokumenty, judikatúra aj revízie pod kontrolou. S pomocou AI.",
     "useDifferentEmail": "Použiť iný e-mail",
-    "weSentCodeTo": "Odoslali sme kód na {email}"
+    "weSentCodeTo": "Odoslali sme kód na <email>{emailAddress}</email>"
   },
   "billing": {
     "addEntry": "Pridať záznam",

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -15,6 +15,7 @@ import {
 import { MessageSquareIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import {
   Sheet,
@@ -283,7 +284,7 @@ const ThreadGroup = ({
     return (
       <div className="flex flex-col gap-1">
         <p className="text-muted-foreground px-1 text-xs font-medium uppercase">
-          {heading}
+          <BidiText>{heading}</BidiText>
         </p>
         <p className="text-muted-foreground py-4 text-center text-sm">
           {emptyLabel}
@@ -295,7 +296,7 @@ const ThreadGroup = ({
   return (
     <div className="flex flex-col gap-1">
       <p className="text-muted-foreground px-1 text-xs font-medium uppercase">
-        {heading}
+        <BidiText>{heading}</BidiText>
       </p>
       {threads.map((thread) => {
         const threadRef: ChatThreadRef =
@@ -335,11 +336,11 @@ const ThreadGroup = ({
                     },
                   })}
             >
-              <span className="truncate text-sm font-medium">
+              <BidiText as="span" className="truncate text-sm font-medium">
                 {isPlaceholderThreadTitle(thread.title)
                   ? t("chat.newChat")
                   : thread.title}
-              </span>
+              </BidiText>
               <span className="text-muted-foreground text-xs">
                 {new Date(thread.createdAt).toLocaleDateString(
                   getFormattingLocale(),

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -526,7 +527,13 @@ function ChatIndex() {
                   >
                     <LandingItemText
                       icon={<MessageSquareIcon className="size-4" />}
-                      meta={`${chat.workspaceName} - ${formatRelativeTime(chat.updatedAt)}`}
+                      meta={
+                        <>
+                          <BidiText>{chat.workspaceName}</BidiText>
+                          {" - "}
+                          {formatRelativeTime(chat.updatedAt)}
+                        </>
+                      }
                       title={
                         isPlaceholderThreadTitle(chat.title)
                           ? t("chat.newChat")
@@ -602,9 +609,9 @@ const LandingSection = ({ children, heading }: LandingSectionProps) => (
 
 type LandingButtonProps = {
   icon?: ReactElement;
-  meta?: string | undefined;
+  meta?: ReactNode | undefined;
   onClick: () => void;
-  title: string;
+  title: ReactNode;
 };
 
 const LandingButton = ({ icon, meta, onClick, title }: LandingButtonProps) => (
@@ -616,9 +623,12 @@ const LandingButton = ({ icon, meta, onClick, title }: LandingButtonProps) => (
     <span className="flex min-w-0 items-start gap-2">
       {icon !== undefined && <LandingRowIcon>{icon}</LandingRowIcon>}
       <span className="min-w-0 flex-1">
-        <span className="text-foreground block truncate text-sm font-medium">
+        <BidiText
+          as="span"
+          className="text-foreground block truncate text-sm font-medium"
+        >
           {title}
-        </span>
+        </BidiText>
         {meta && (
           <span className="text-muted-foreground block truncate text-xs">
             {meta}
@@ -632,8 +642,8 @@ const LandingButton = ({ icon, meta, onClick, title }: LandingButtonProps) => (
 type LandingItemTextProps = {
   icon?: ReactElement;
   iconTone?: "muted" | "matter" | undefined;
-  meta?: string | undefined;
-  title: string;
+  meta?: ReactNode | undefined;
+  title: ReactNode;
 };
 
 const LandingItemText = ({
@@ -647,12 +657,12 @@ const LandingItemText = ({
       <LandingRowIcon tone={iconTone}>{icon}</LandingRowIcon>
     )}
     <span className="min-w-0 flex-1">
-      <span
+      <BidiText
+        as="span"
         className="text-foreground block truncate text-sm font-medium"
-        dir="auto"
       >
         {title}
-      </span>
+      </BidiText>
       {meta && (
         <span className="text-muted-foreground block truncate text-xs">
           {meta}

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -629,11 +629,11 @@ const LandingButton = ({ icon, meta, onClick, title }: LandingButtonProps) => (
         >
           {title}
         </BidiText>
-        {meta && (
+        {meta !== undefined && meta !== null ? (
           <span className="text-muted-foreground block truncate text-xs">
             {meta}
           </span>
-        )}
+        ) : null}
       </span>
     </span>
   </button>
@@ -663,11 +663,11 @@ const LandingItemText = ({
       >
         {title}
       </BidiText>
-      {meta && (
+      {meta !== undefined && meta !== null ? (
         <span className="text-muted-foreground block truncate text-xs">
           {meta}
         </span>
-      )}
+      ) : null}
     </span>
   </span>
 );

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -9,6 +9,7 @@ import {
 import { ArrowLeftIcon, BuildingIcon, PlusIcon, UserIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
@@ -169,9 +170,9 @@ function ContactDetailPage() {
           ) : (
             <BuildingIcon className="text-muted-foreground size-5" />
           )}
-          <h1 className="text-xl font-bold" dir="auto">
+          <BidiText as="h1" className="text-xl font-bold">
             {contact.displayName}
-          </h1>
+          </BidiText>
           <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 text-xs">
             {t(`contacts.type.${contact.type}`)}
           </span>
@@ -431,9 +432,9 @@ function ContactDetailPage() {
                     workspaceId={matter.id}
                   >
                     <MatterIcon matter={matter} />
-                    <span className="font-medium" dir="auto">
+                    <BidiText as="span" className="font-medium">
                       {matter.name}
-                    </span>
+                    </BidiText>
                     <span className="text-muted-foreground ms-auto text-xs">
                       {t("common.createdAt", {
                         date: new Date(matter.createdAt).toLocaleDateString(

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -170,9 +170,9 @@ function ContactDetailPage() {
           ) : (
             <BuildingIcon className="text-muted-foreground size-5" />
           )}
-          <BidiText as="h1" className="text-xl font-bold">
-            {contact.displayName}
-          </BidiText>
+          <h1 className="text-xl font-bold">
+            <BidiText>{contact.displayName}</BidiText>
+          </h1>
           <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 text-xs">
             {t(`contacts.type.${contact.type}`)}
           </span>

--- a/apps/web/src/routes/_protected.contacts/-components/email-link.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/email-link.tsx
@@ -1,8 +1,10 @@
+import { BidiText } from "@stll/ui/components/bidi-text";
+
 export const EmailLink = ({ address }: { address: string }) => (
   <a
     className="hover:text-foreground min-w-0 break-all hover:underline"
     href={`mailto:${address}`}
   >
-    {address}
+    <BidiText direction="ltr">{address}</BidiText>
   </a>
 );

--- a/apps/web/src/routes/_protected.knowledge/-components/template-prefill-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-prefill-panel.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
@@ -305,9 +306,9 @@ const MatterDocumentPicker = ({
                 }
                 onCheckedChange={() => toggle(doc.entityId)}
               />
-              <span className="min-w-0 truncate">
+              <BidiText as="span" className="min-w-0 truncate">
                 {doc.name ?? doc.fileName}
-              </span>
+              </BidiText>
             </label>
           );
         })}

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
@@ -42,6 +42,7 @@ import type {
   DocxEditorRef,
   FolioAIEditSnapshot,
 } from "@stll/folio";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
@@ -1174,9 +1175,12 @@ const TemplateStudioChatInner = ({
               <span className="shrink-0">
                 {t("chat.editableFilePlaceholderAction")}
               </span>
-              <span className="text-foreground-label max-w-64 truncate">
+              <BidiText
+                as="span"
+                className="text-foreground-label max-w-64 truncate"
+              >
                 {fileName}
-              </span>
+              </BidiText>
             </span>
           }
           layout="floating"

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -10,6 +10,7 @@ import {
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import {
   DestructiveActionConfirmation,
@@ -555,7 +556,7 @@ function ProfilePageBody() {
                       >
                         <div className="flex flex-col gap-2">
                           <div className="text-muted-foreground text-xs">
-                            <span dir="auto">{group.workspaceName}</span>
+                            <BidiText as="span">{group.workspaceName}</BidiText>
                           </div>
                           {group.members.length > 0 ? (
                             <Select

--- a/apps/web/src/routes/_protected.settings/organization.members.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.members.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
@@ -314,7 +315,9 @@ function Members() {
               <TableBody>
                 {filteredInvitations.map((invitation) => (
                   <TableRow key={invitation.id}>
-                    <TableCell>{invitation.email}</TableCell>
+                    <TableCell>
+                      <BidiText direction="ltr">{invitation.email}</BidiText>
+                    </TableCell>
                     <TableCell>
                       {t(`organization.roles.${invitation.role}`)}
                     </TableCell>

--- a/apps/web/src/routes/_protected.settings/organization.usage.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.usage.tsx
@@ -111,9 +111,9 @@ function ActiveEntitlementCard({ data }: { data: UsageEntitlement }) {
       <FramePanel>
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
-            <BidiText as="h2" className="text-lg font-medium">
-              {data.policy.displayName}
-            </BidiText>
+            <h2 className="text-lg font-medium">
+              <BidiText>{data.policy.displayName}</BidiText>
+            </h2>
             <p className="text-muted-foreground text-sm">
               {data.entitlement.cancelAtPeriodEnd
                 ? t("settings.organization.usageEndsOnTemplate", {

--- a/apps/web/src/routes/_protected.settings/organization.usage.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.usage.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useFormatter, useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Skeleton } from "@stll/ui/components/skeleton";
@@ -110,9 +111,9 @@ function ActiveEntitlementCard({ data }: { data: UsageEntitlement }) {
       <FramePanel>
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
-            <h2 className="text-lg font-medium" dir="auto">
+            <BidiText as="h2" className="text-lg font-medium">
               {data.policy.displayName}
-            </h2>
+            </BidiText>
             <p className="text-muted-foreground text-sm">
               {data.entitlement.cancelAtPeriodEnd
                 ? t("settings.organization.usageEndsOnTemplate", {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/ai-cell-source-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/ai-cell-source-card.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   PreviewCard,
   PreviewCardPopup,
@@ -80,9 +81,9 @@ export const AICellSourceCard = ({
                 kind="document"
                 mimeType={primaryFile.mimeType}
               />
-              <span className="truncate" dir="auto">
+              <BidiText as="span" className="truncate">
                 {primaryFile.fileName}
-              </span>
+              </BidiText>
               {sourceFiles.length > 1 && (
                 <span className="text-muted-foreground shrink-0">
                   +{sourceFiles.length - 1}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-row.tsx
@@ -1,6 +1,7 @@
 import { PencilIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -49,7 +50,9 @@ export const ExpenseRow = ({
     <div className="group hover:bg-muted/50 flex items-center gap-3 rounded-md border px-3 py-2 transition-colors">
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-medium">{matterName}</span>
+          <BidiText as="span" className="truncate text-sm font-medium">
+            {matterName}
+          </BidiText>
           <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[0.625rem]">
             {
               {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from "use-intl";
 
 import { prorateHourlyCents } from "@stll/money";
 import type { CentsAmount } from "@stll/money";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { cn } from "@stll/ui/lib/utils";
@@ -87,7 +88,9 @@ export const TimeEntryRow = ({
 
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium">{matterName}</span>
+            <BidiText as="span" className="truncate text-sm font-medium">
+              {matterName}
+            </BidiText>
             {!entry.billable && (
               <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[0.625rem]">
                 {t("billing.nonBillable")}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -16,6 +16,7 @@ import {
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   MenuGroup,
   MenuGroupLabel,
@@ -317,7 +318,15 @@ const CellLockBadge = ({ provenance, onUnlock }: CellLockBadgeProps) => {
           {t("workspaces.table.lock.locked")}
         </span>
         <span className="text-muted-foreground block truncate text-xs">
-          {displayName ? `${displayName} · ${relativeTime}` : relativeTime}
+          {displayName ? (
+            <>
+              <BidiText>{displayName}</BidiText>
+              {" · "}
+              {relativeTime}
+            </>
+          ) : (
+            relativeTime
+          )}
         </span>
       </span>
     </span>
@@ -375,7 +384,15 @@ const FlagProvenanceTooltip = ({
       <span className="min-w-0">
         <span className="block truncate font-medium">{label}</span>
         <span className="text-muted-foreground block truncate text-xs">
-          {displayName ? `${displayName} · ${relativeTime}` : relativeTime}
+          {displayName ? (
+            <>
+              <BidiText>{displayName}</BidiText>
+              {" · "}
+              {relativeTime}
+            </>
+          ) : (
+            relativeTime
+          )}
         </span>
       </span>
     </span>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -4,6 +4,7 @@ import { Result } from "better-result";
 import { Loader2Icon, SquareMinusIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import Tooltip from "@/components/tooltip";
@@ -48,9 +49,9 @@ export const CellResult = ({
           strokeWidth={2.25}
         />
         {hasPreview ? (
-          <div className="line-clamp-2 min-w-0" dir="auto">
+          <BidiText as="div" className="line-clamp-2 min-w-0">
             {preview}
-          </div>
+          </BidiText>
         ) : (
           <PendingSkeleton contentType={property.content.type} />
         )}
@@ -229,9 +230,9 @@ const FileCell = ({
           fileName={fileName}
           mimeType={mimeType}
         />
-        <span className="min-w-0 truncate text-start" dir="auto">
+        <BidiText as="span" className="min-w-0 truncate text-start">
           {fileName}
-        </span>
+        </BidiText>
       </Tooltip>
     );
   }
@@ -248,7 +249,9 @@ const FileCell = ({
         fileName={fileName}
         mimeType={mimeType}
       />
-      <span className="min-w-0 truncate text-start">{fileName}</span>
+      <BidiText as="span" className="min-w-0 truncate text-start">
+        {fileName}
+      </BidiText>
     </Tooltip>
   );
 };
@@ -297,9 +300,9 @@ const SelectResult = ({ value, property }: SelectResultProps) => {
       }}
     >
       {!value && <SquareMinusIcon className="size-4" />}
-      <span className="truncate" dir="auto">
+      <BidiText as="span" className="truncate">
         {value ?? t("common.empty")}
-      </span>
+      </BidiText>
     </span>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -30,13 +30,13 @@ import {
 import { useDebouncedCallback } from "use-debounce";
 import { useLocale, useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@stll/ui/components/breadcrumb";
-import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Menu,
   MenuItem,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -36,6 +36,7 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@stll/ui/components/breadcrumb";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   Menu,
   MenuItem,
@@ -1411,9 +1412,9 @@ const FilesystemRow = ({
         />
       ) : (
         <span className="flex min-w-0 items-center gap-1.5">
-          <span className="truncate" title={name}>
+          <BidiText as="span" className="truncate" title={name}>
             {name}
-          </span>
+          </BidiText>
           {node.activeEditBy && (
             <ActiveEditBadge
               className="shrink-0"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -25,6 +25,7 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@stll/ui/components/avatar";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import {
   Menu,
@@ -1290,9 +1291,9 @@ const OverviewRow = ({ entity, workspaceId }: OverviewRowProps) => {
           </span>
         </span>
         {icon}
-        <span className="truncate" dir="auto">
+        <BidiText as="span" className="truncate">
           {entity.name}
-        </span>
+        </BidiText>
       </span>
       {relTime && (
         <span

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -378,7 +379,7 @@ const PromoteDialog = ({ workspaceId }: PromoteDialogProps) => {
             </span>
             {selectedContact ? (
               <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
-                <span dir="auto">{selectedContact.displayName}</span>
+                <BidiText>{selectedContact.displayName}</BidiText>
                 <Button
                   className="ms-auto"
                   onClick={() => setSelectedContact(null)}
@@ -661,7 +662,7 @@ const AddPartyDialog = ({
             </span>
             {selectedContact ? (
               <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
-                <span dir="auto">{selectedContact.displayName}</span>
+                <BidiText>{selectedContact.displayName}</BidiText>
                 <Button
                   className="ms-auto"
                   onClick={() => setSelectedContact(null)}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -176,11 +176,10 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
           )}
           <Link
             className="min-w-0 truncate text-sm font-medium hover:underline"
-            dir="auto"
             params={{ contactId: client.id }}
             to="/contacts/$contactId"
           >
-            {client.displayName}
+            <BidiText>{client.displayName}</BidiText>
           </Link>
         </div>
       </section>
@@ -512,11 +511,10 @@ const PartyRow = ({ party, workspaceId }: PartyRowProps) => {
       )}
       <Link
         className="text-sm font-medium hover:underline"
-        dir="auto"
         params={{ contactId: contact.id }}
         to="/contacts/$contactId"
       >
-        {contact.displayName}
+        <BidiText>{contact.displayName}</BidiText>
       </Link>
       <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 text-xs">
         {t(roleKey)}

--- a/apps/web/src/routes/_protected.workspaces/-components/client-group-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/client-group-header.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
 import { useFormatter } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -50,7 +51,6 @@ export const ClientGroupHeader = ({
         ) : (
           <span
             className="hover:underline"
-            dir="auto"
             onClick={(e) => {
               e.stopPropagation();
               void navigate({
@@ -70,7 +70,7 @@ export const ClientGroupHeader = ({
             role="link"
             tabIndex={0}
           >
-            {group.clientName}
+            <BidiText>{group.clientName}</BidiText>
           </span>
         )}
       </h3>
@@ -85,9 +85,9 @@ export const ClientGroupHeader = ({
       {group.type === "client" && group.responsibleAttorneyName && (
         <>
           <span className="text-foreground-subtle">·</span>
-          <span className="text-muted-foreground text-xs" dir="auto">
+          <BidiText as="span" className="text-muted-foreground text-xs">
             {group.responsibleAttorneyName}
-          </span>
+          </BidiText>
         </>
       )}
     </button>

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import {
   Combobox,
@@ -64,9 +65,9 @@ const SelectedClient = ({ client }: { client: MatterDraftClient }) => (
     ) : (
       <BuildingIcon className="text-muted-foreground size-4" />
     )}
-    <span className="truncate text-sm font-medium" dir="auto">
+    <BidiText as="span" className="truncate text-sm font-medium">
       {client.displayName}
-    </span>
+    </BidiText>
   </div>
 );
 

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -10,6 +10,7 @@ import {
   PreviewCardPopup,
   PreviewCardTrigger,
 } from "@stll/ui/components/preview-card";
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { cn } from "@stll/ui/lib/utils";
 
 import { getFormattingLocale } from "@/i18n/i18n-store";
@@ -146,12 +147,11 @@ export const MatterCard = ({
               (workspace.client ? (
                 <Link
                   className="text-muted-foreground hover:text-foreground relative z-10 -mt-1 truncate text-xs hover:underline"
-                  dir="auto"
                   onClick={(e) => e.stopPropagation()}
                   params={{ contactId: workspace.client.id }}
                   to="/contacts/$contactId"
                 >
-                  {workspace.client.displayName}
+                  <BidiText>{workspace.client.displayName}</BidiText>
                 </Link>
               ) : (
                 <span className="text-muted-foreground -mt-1 truncate text-xs italic">

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -5,12 +5,12 @@ import { Link } from "@tanstack/react-router";
 import { FileIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import {
   PreviewCard,
   PreviewCardPopup,
   PreviewCardTrigger,
 } from "@stll/ui/components/preview-card";
-import { BidiText } from "@stll/ui/components/bidi-text";
 import { cn } from "@stll/ui/lib/utils";
 
 import { getFormattingLocale } from "@/i18n/i18n-store";

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import {
@@ -178,10 +179,12 @@ export const MatterMenuHeader = ({
       className="max-w-48 border-s-2 px-2 py-1.5"
       style={{ borderColor: resolveMatterColor(id, color) }}
     >
-      <div className="truncate text-xs font-medium">{name}</div>
-      <div className="text-muted-foreground truncate text-xs">
+      <BidiText as="div" className="truncate text-xs font-medium">
+        {name}
+      </BidiText>
+      <BidiText as="div" className="text-muted-foreground truncate text-xs">
         {clientName ?? t("workspaces.parties.personalLabel")}
-      </div>
+      </BidiText>
     </div>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -5,6 +5,7 @@ import { ChevronRightIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Frame } from "@stll/ui/components/frame";
 import {
@@ -188,9 +189,9 @@ const NameCell = ({ workspace }: CellProps) => (
         backgroundColor: getMatterColor(workspace.id),
       }}
     />
-    <span className="truncate font-medium" dir="auto">
+    <BidiText as="span" className="truncate font-medium">
       {workspace.name}
-    </span>
+    </BidiText>
   </div>
 );
 
@@ -204,9 +205,9 @@ const ClientCell = ({ workspace }: CellProps) => {
     );
   }
   return (
-    <span className="text-muted-foreground block truncate" dir="auto">
+    <BidiText as="span" className="text-muted-foreground block truncate">
       {workspace.client.displayName}
-    </span>
+    </BidiText>
   );
 };
 
@@ -494,12 +495,11 @@ const MattersTableGroup = ({
             ) : (
               <Link
                 className="hover:underline"
-                dir="auto"
                 onClick={(e) => e.stopPropagation()}
                 params={{ contactId: group.clientId }}
                 to="/contacts/$contactId"
               >
-                {group.clientName}
+                <BidiText>{group.clientName}</BidiText>
               </Link>
             )}
             <span

--- a/apps/web/src/routes/_protected.workspaces/-filters/client-filter-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-filters/client-filter-popover.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { CheckIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import { Separator } from "@stll/ui/components/separator";
@@ -77,9 +78,9 @@ export const ClientFilterPopover = ({
                 onClick={() => toggle(c.id)}
                 type="button"
               >
-                <span className="truncate" dir="auto">
+                <BidiText as="span" className="truncate">
                   {c.displayName}
-                </span>
+                </BidiText>
                 {active && (
                   <CheckIcon className="text-primary size-3.5 shrink-0" />
                 )}

--- a/apps/web/src/routes/onboarding/-components/steps/invite-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/invite-step.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from "react";
 import { AlertTriangleIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import { cn } from "@stll/ui/lib/utils";
@@ -181,7 +182,9 @@ export const InviteStep = ({
                   {isExternal && (
                     <AlertTriangleIcon className="text-warning size-3 shrink-0" />
                   )}
-                  {email}
+                  <BidiText as="span" direction="ltr">
+                    {email}
+                  </BidiText>
                   <button
                     className="text-muted-foreground hover:text-foreground"
                     onClick={() => removeEmail(email)}

--- a/packages/ui/src/components/bidi-text.tsx
+++ b/packages/ui/src/components/bidi-text.tsx
@@ -41,78 +41,6 @@ export const BidiText = (props: BidiTextProps) => {
     );
   }
 
-  if (props.as === "h1") {
-    const { as: _as, className, direction = "auto", ...rest } = props;
-
-    return (
-      <h1
-        className={cn("[unicode-bidi:isolate]", className)}
-        dir={direction}
-        {...rest}
-      />
-    );
-  }
-
-  if (props.as === "h2") {
-    const { as: _as, className, direction = "auto", ...rest } = props;
-
-    return (
-      <h2
-        className={cn("[unicode-bidi:isolate]", className)}
-        dir={direction}
-        {...rest}
-      />
-    );
-  }
-
-  if (props.as === "h3") {
-    const { as: _as, className, direction = "auto", ...rest } = props;
-
-    return (
-      <h3
-        className={cn("[unicode-bidi:isolate]", className)}
-        dir={direction}
-        {...rest}
-      />
-    );
-  }
-
-  if (props.as === "h4") {
-    const { as: _as, className, direction = "auto", ...rest } = props;
-
-    return (
-      <h4
-        className={cn("[unicode-bidi:isolate]", className)}
-        dir={direction}
-        {...rest}
-      />
-    );
-  }
-
-  if (props.as === "h5") {
-    const { as: _as, className, direction = "auto", ...rest } = props;
-
-    return (
-      <h5
-        className={cn("[unicode-bidi:isolate]", className)}
-        dir={direction}
-        {...rest}
-      />
-    );
-  }
-
-  if (props.as === "h6") {
-    const { as: _as, className, direction = "auto", ...rest } = props;
-
-    return (
-      <h6
-        className={cn("[unicode-bidi:isolate]", className)}
-        dir={direction}
-        {...rest}
-      />
-    );
-  }
-
   const { as: _as, direction = "auto", ...rest } = props;
 
   return <bdi dir={direction} {...rest} />;
@@ -142,26 +70,10 @@ type ParagraphTextProps = Omit<React.ComponentPropsWithoutRef<"p">, "dir"> & {
   direction?: BidiDirection;
 };
 
-type HeadingTextProps<THeading extends BidiHeadingElement> = Omit<
-  React.ComponentPropsWithoutRef<THeading>,
-  "dir"
-> & {
-  as: THeading;
-  direction?: BidiDirection;
-};
-
-type BidiHeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-
 type BidiTextProps =
   | BdiElementProps
   | SpanTextProps
   | DivTextProps
-  | ParagraphTextProps
-  | HeadingTextProps<"h1">
-  | HeadingTextProps<"h2">
-  | HeadingTextProps<"h3">
-  | HeadingTextProps<"h4">
-  | HeadingTextProps<"h5">
-  | HeadingTextProps<"h6">;
+  | ParagraphTextProps;
 
 export type { BidiDirection, BidiTextProps };

--- a/packages/ui/src/components/bidi-text.tsx
+++ b/packages/ui/src/components/bidi-text.tsx
@@ -122,7 +122,7 @@ export const UserText = BidiText;
 
 type BidiDirection = "auto" | "ltr" | "rtl";
 
-type BdiTextProps = Omit<React.ComponentPropsWithoutRef<"bdi">, "dir"> & {
+type BdiElementProps = Omit<React.ComponentPropsWithoutRef<"bdi">, "dir"> & {
   as?: "bdi";
   direction?: BidiDirection;
 };
@@ -153,7 +153,7 @@ type HeadingTextProps<THeading extends BidiHeadingElement> = Omit<
 type BidiHeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 type BidiTextProps =
-  | BdiTextProps
+  | BdiElementProps
   | SpanTextProps
   | DivTextProps
   | ParagraphTextProps

--- a/packages/ui/src/components/bidi-text.tsx
+++ b/packages/ui/src/components/bidi-text.tsx
@@ -41,6 +41,78 @@ export const BidiText = (props: BidiTextProps) => {
     );
   }
 
+  if (props.as === "h1") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <h1
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "h2") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <h2
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "h3") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <h3
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "h4") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <h4
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "h5") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <h5
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "h6") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <h6
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
   const { as: _as, direction = "auto", ...rest } = props;
 
   return <bdi dir={direction} {...rest} />;
@@ -70,10 +142,26 @@ type ParagraphTextProps = Omit<React.ComponentPropsWithoutRef<"p">, "dir"> & {
   direction?: BidiDirection;
 };
 
+type HeadingTextProps<THeading extends BidiHeadingElement> = Omit<
+  React.ComponentPropsWithoutRef<THeading>,
+  "dir"
+> & {
+  as: THeading;
+  direction?: BidiDirection;
+};
+
+type BidiHeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
 type BidiTextProps =
   | BdiTextProps
   | SpanTextProps
   | DivTextProps
-  | ParagraphTextProps;
+  | ParagraphTextProps
+  | HeadingTextProps<"h1">
+  | HeadingTextProps<"h2">
+  | HeadingTextProps<"h3">
+  | HeadingTextProps<"h4">
+  | HeadingTextProps<"h5">
+  | HeadingTextProps<"h6">;
 
 export type { BidiDirection, BidiTextProps };

--- a/packages/ui/src/components/bidi-text.tsx
+++ b/packages/ui/src/components/bidi-text.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "@stll/ui/lib/utils";
+
+export const BidiText = (props: BidiTextProps) => {
+  if (props.as === "span") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <span
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "div") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <div
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  if (props.as === "p") {
+    const { as: _as, className, direction = "auto", ...rest } = props;
+
+    return (
+      <p
+        className={cn("[unicode-bidi:isolate]", className)}
+        dir={direction}
+        {...rest}
+      />
+    );
+  }
+
+  const { as: _as, direction = "auto", ...rest } = props;
+
+  return <bdi dir={direction} {...rest} />;
+};
+
+export const UserText = BidiText;
+
+type BidiDirection = "auto" | "ltr" | "rtl";
+
+type BdiTextProps = Omit<React.ComponentPropsWithoutRef<"bdi">, "dir"> & {
+  as?: "bdi";
+  direction?: BidiDirection;
+};
+
+type SpanTextProps = Omit<React.ComponentPropsWithoutRef<"span">, "dir"> & {
+  as: "span";
+  direction?: BidiDirection;
+};
+
+type DivTextProps = Omit<React.ComponentPropsWithoutRef<"div">, "dir"> & {
+  as: "div";
+  direction?: BidiDirection;
+};
+
+type ParagraphTextProps = Omit<React.ComponentPropsWithoutRef<"p">, "dir"> & {
+  as: "p";
+  direction?: BidiDirection;
+};
+
+type BidiTextProps =
+  | BdiTextProps
+  | SpanTextProps
+  | DivTextProps
+  | ParagraphTextProps;
+
+export type { BidiDirection, BidiTextProps };


### PR DESCRIPTION
## Summary

- add shared BidiText/UserText wrappers for isolated user-controlled text
- update the rendered-name bidi lint rule to recognize the wrappers as sanctioned isolation
- migrate representative contact and case-law renderings from ad hoc dir/bdi usage