### PR TITLE
fix: improve mobile viewport layouts

### DIFF
--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1336,7 +1336,7 @@ export function PromptBarPlaceholderContent({
   children: ReactNode;
 }) {
   return (
-    <span className="text-foreground-muted truncate text-[13px] leading-5">
+    <span className="text-foreground-muted block min-w-0 truncate text-[13px] leading-5">
       {children}
     </span>
   );

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -127,7 +127,7 @@ export const ChatInputSurface = ({
     >
       <ChatDraftAttachmentChips files={attachments} onRemove={removeFile} />
       <div
-        className="chat-editor relative px-3 pt-2 pb-1"
+        className="chat-editor relative min-w-0 overflow-hidden px-3 pt-2 pb-1"
         onKeyDown={(event) => event.stopPropagation()}
         role="presentation"
       >
@@ -138,7 +138,7 @@ export const ChatInputSurface = ({
         {isEmpty && attachments.length === 0 && (
           <span
             aria-hidden="true"
-            className="text-foreground-placeholder pointer-events-none absolute start-3 top-2 truncate pe-3 text-sm"
+            className="text-foreground-placeholder pointer-events-none absolute inset-x-3 top-2 truncate text-sm"
           >
             {placeholder}
           </span>

--- a/apps/web/src/components/inspector/inspector-panel.tsx
+++ b/apps/web/src/components/inspector/inspector-panel.tsx
@@ -424,20 +424,22 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
   });
 
   return (
-    <div className="bg-background flex h-full border-s shadow-lg">
-      <InspectorRail
-        activeId={activeId}
-        minimized={minimized}
-        onActivateTab={(tabId) => {
-          setActive(tabId);
-          setMinimized(false);
-        }}
-        onCloseTab={handleCloseTab}
-        onOpenChat={openChat}
-        onSetMinimized={setMinimized}
-        tabs={tabs}
-        workspaceId={workspaceId}
-      />
+    <div className="bg-background flex h-full shadow-lg md:border-s">
+      <div className="hidden md:contents">
+        <InspectorRail
+          activeId={activeId}
+          minimized={minimized}
+          onActivateTab={(tabId) => {
+            setActive(tabId);
+            setMinimized(false);
+          }}
+          onCloseTab={handleCloseTab}
+          onOpenChat={openChat}
+          onSetMinimized={setMinimized}
+          tabs={tabs}
+          workspaceId={workspaceId}
+        />
+      </div>
 
       {/* Task content */}
       {!minimized &&

--- a/apps/web/src/components/inspector/inspector-tab-header.tsx
+++ b/apps/web/src/components/inspector/inspector-tab-header.tsx
@@ -1,10 +1,13 @@
 import type { MouseEvent, ReactNode } from "react";
 
-import { LayersIcon, XIcon } from "lucide-react";
+import { ArrowLeftIcon, LayersIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useInspectorStore } from "@/components/inspector/inspector-store";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";
 
@@ -92,56 +95,77 @@ export const InspectorTabHeader = ({
   actions,
   matterColor,
   onClose,
-}: InspectorTabHeaderProps) => (
-  <div
-    className="flex h-12 shrink-0 items-center justify-between border-b px-3"
-    style={
-      matterColor
-        ? {
-            backgroundColor: `color-mix(in srgb, ${matterColor} 2%, transparent)`,
-          }
-        : undefined
-    }
-  >
-    <div className="flex min-w-0 items-center gap-2 overflow-hidden">
-      {rename?.active ? (
-        <InlineEdit
-          inputClassName="w-40 text-xs"
-          onCancel={rename.onCancel}
-          onChange={rename.onChange}
-          onCommit={rename.onCommit}
-          suffix={rename.suffix}
-          value={rename.value}
-        />
-      ) : (
-        <span
-          className={cn(
-            "truncate text-xs font-medium",
-            onStartRename !== undefined && "cursor-text",
-          )}
-          onContextMenu={onLabelContextMenu}
-          onDoubleClick={onStartRename}
+}: InspectorTabHeaderProps) => {
+  const tCommon = useTranslations("common");
+  const setMinimized = useInspectorStore((s) => s.setMinimized);
+
+  return (
+    <div
+      className="flex h-12 shrink-0 items-center justify-between border-b px-3"
+      style={
+        matterColor
+          ? {
+              backgroundColor: `color-mix(in srgb, ${matterColor} 2%, transparent)`,
+            }
+          : undefined
+      }
+    >
+      <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+        <Button
+          aria-label={tCommon("back")}
+          className="-ms-1 md:hidden"
+          onClick={() => setMinimized(true)}
+          size="icon-sm"
+          title={tCommon("back")}
+          variant="ghost"
         >
-          {label}
-        </span>
-      )}
-      {matter !== undefined && !rename?.active && (
-        <>
-          <span aria-hidden="true" className="text-foreground-subtle text-xs">
-            ·
+          <DirectionalIcon className="size-4" icon={ArrowLeftIcon} />
+        </Button>
+        {rename?.active ? (
+          <InlineEdit
+            inputClassName="w-40 text-xs"
+            onCancel={rename.onCancel}
+            onChange={rename.onChange}
+            onCommit={rename.onCommit}
+            suffix={rename.suffix}
+            value={rename.value}
+          />
+        ) : (
+          <span
+            className={cn(
+              "truncate text-xs font-medium",
+              onStartRename !== undefined && "cursor-text",
+            )}
+            onContextMenu={onLabelContextMenu}
+            onDoubleClick={onStartRename}
+          >
+            {label}
           </span>
-          {matter}
-        </>
-      )}
+        )}
+        {matter !== undefined && !rename?.active && (
+          <>
+            <span aria-hidden="true" className="text-foreground-subtle text-xs">
+              ·
+            </span>
+            {matter}
+          </>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1 ps-4">
+        {actions}
+        <Button
+          aria-label={tCommon("close")}
+          onClick={onClose}
+          size="icon-xs"
+          title={tCommon("close")}
+          variant="ghost"
+        >
+          <XIcon className="size-3.5" />
+        </Button>
+      </div>
     </div>
-    <div className="flex shrink-0 items-center gap-1 ps-4">
-      {actions}
-      <Button onClick={onClose} size="icon-xs" variant="ghost">
-        <XIcon className="size-3.5" />
-      </Button>
-    </div>
-  </div>
-);
+  );
+};
 
 /**
  * Standard "matter origin" link for tabs that bind to exactly one

--- a/apps/web/src/components/responsive-action-toolbar.tsx
+++ b/apps/web/src/components/responsive-action-toolbar.tsx
@@ -1,0 +1,41 @@
+import type * as React from "react";
+
+import { cn } from "@stll/ui/lib/utils";
+
+export type ResponsiveActionToolbarSlot = "primary" | "secondary" | "action";
+
+const RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS = {
+  primary:
+    "order-1 min-w-0 basis-full sm:order-none sm:min-w-56 sm:basis-0 sm:flex-1",
+  secondary: "order-2 min-w-0 flex-1 sm:order-none sm:flex-none",
+  action: "order-3 shrink-0 sm:order-none",
+} as const satisfies Record<ResponsiveActionToolbarSlot, string>;
+
+export function ResponsiveActionToolbar({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+type ResponsiveActionToolbarItemProps = React.PropsWithChildren<{
+  slot: ResponsiveActionToolbarSlot;
+  className?: string | undefined;
+}>;
+
+export function ResponsiveActionToolbarItem({
+  slot,
+  className,
+  children,
+}: ResponsiveActionToolbarItemProps) {
+  return (
+    <div className={cn(RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS[slot], className)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/shortcut-hints-overlay.tsx
+++ b/apps/web/src/components/shortcut-hints-overlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import { useHotkey, useKeyHold } from "@tanstack/react-hotkeys";
 import type { Hotkey } from "@tanstack/react-hotkeys";
@@ -10,7 +10,7 @@ import { Button } from "@stll/ui/components/button";
 import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
 import { cn } from "@stll/ui/lib/utils";
 
-import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import {
   formatHintKey,
   MOD_KEY,
@@ -22,6 +22,7 @@ import type { ShortcutContext, ShortcutHint } from "@/lib/hotkeys";
 const HOLD_DELAY_MS = 500;
 const HIGHLIGHT_DURATION_MS = 150;
 const SHORTCUT_HINTS_MIN_WIDTH_PX = 768;
+const SHORTCUT_HINTS_MEDIA_QUERY = `(min-width: ${SHORTCUT_HINTS_MIN_WIDTH_PX}px)`;
 
 export function ShortcutHintsOverlay() {
   const shouldRenderShortcutHints = useShortcutHintsViewport();
@@ -36,14 +37,24 @@ export function ShortcutHintsOverlay() {
 function ShortcutHintsOverlayContent() {
   const t = useTranslations();
   const isModHeld = useKeyHold(MOD_KEY);
+  const isMountedRef = useRef(false);
   const [isVisible, setIsVisible] = useState(false);
   const [isSuppressedUntilRelease, setIsSuppressedUntilRelease] =
     useState(false);
 
-  const showDialog = useDebouncedCallback(
-    () => setIsVisible(true),
-    HOLD_DELAY_MS,
-  );
+  const showDialog = useDebouncedCallback(() => {
+    if (isMountedRef.current) {
+      setIsVisible(true);
+    }
+  }, HOLD_DELAY_MS);
+
+  useMountEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      showDialog.cancel();
+    };
+  });
 
   // Cancel overlay when any non-modifier key is pressed with Mod
   // held (the user is executing a shortcut, not browsing hints).
@@ -153,34 +164,26 @@ function ShortcutHintsOverlayContent() {
   );
 }
 
-const useShortcutHintsViewport = () => {
-  const [shouldRender, setShouldRender] = useState(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
+const subscribeShortcutHintsViewport = (callback: () => void) => {
+  const mediaQuery = window.matchMedia(SHORTCUT_HINTS_MEDIA_QUERY);
+  mediaQuery.addEventListener("change", callback);
 
-    return window.matchMedia(`(min-width: ${SHORTCUT_HINTS_MIN_WIDTH_PX}px)`)
-      .matches;
-  });
-
-  useExternalSyncEffect(() => {
-    const mediaQuery = window.matchMedia(
-      `(min-width: ${SHORTCUT_HINTS_MIN_WIDTH_PX}px)`,
-    );
-    const syncViewport = () => {
-      setShouldRender(mediaQuery.matches);
-    };
-
-    syncViewport();
-    mediaQuery.addEventListener("change", syncViewport);
-
-    return () => {
-      mediaQuery.removeEventListener("change", syncViewport);
-    };
-  }, []);
-
-  return shouldRender;
+  return () => {
+    mediaQuery.removeEventListener("change", callback);
+  };
 };
+
+const getShortcutHintsViewportSnapshot = () =>
+  window.matchMedia(SHORTCUT_HINTS_MEDIA_QUERY).matches;
+
+const getShortcutHintsViewportServerSnapshot = () => false;
+
+const useShortcutHintsViewport = () =>
+  useSyncExternalStore(
+    subscribeShortcutHintsViewport,
+    getShortcutHintsViewportSnapshot,
+    getShortcutHintsViewportServerSnapshot,
+  );
 
 const useShortcutContext = (): ShortcutContext => {
   const pdfMatch = useMatch({
@@ -212,12 +215,36 @@ const HotkeyHint = ({ hint, setIsVisible }: HotkeyHintProps) => {
   const t = useTranslations();
   const context = useShortcutContext();
   const isActive = hint.contexts.some((c) => c === "global" || c === context);
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(false);
   const [isActivated, setIsActivated] = useState(false);
 
+  useMountEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (highlightTimerRef.current !== null) {
+        clearTimeout(highlightTimerRef.current);
+      }
+    };
+  });
+
   const handleActivateHotkey = (hotkey?: Hotkey) => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
     setIsActivated(true);
 
-    setTimeout(() => {
+    if (highlightTimerRef.current !== null) {
+      clearTimeout(highlightTimerRef.current);
+    }
+
+    highlightTimerRef.current = setTimeout(() => {
+      highlightTimerRef.current = null;
+      if (!isMountedRef.current) {
+        return;
+      }
       setIsVisible(false);
       setIsActivated(false);
       if (hotkey) {

--- a/apps/web/src/components/shortcut-hints-overlay.tsx
+++ b/apps/web/src/components/shortcut-hints-overlay.tsx
@@ -21,8 +21,19 @@ import type { ShortcutContext, ShortcutHint } from "@/lib/hotkeys";
 
 const HOLD_DELAY_MS = 500;
 const HIGHLIGHT_DURATION_MS = 150;
+const SHORTCUT_HINTS_MIN_WIDTH_PX = 768;
 
 export function ShortcutHintsOverlay() {
+  const shouldRenderShortcutHints = useShortcutHintsViewport();
+
+  if (!shouldRenderShortcutHints) {
+    return null;
+  }
+
+  return <ShortcutHintsOverlayContent />;
+}
+
+function ShortcutHintsOverlayContent() {
   const t = useTranslations();
   const isModHeld = useKeyHold(MOD_KEY);
   const [isVisible, setIsVisible] = useState(false);
@@ -141,6 +152,35 @@ export function ShortcutHintsOverlay() {
     </Dialog>
   );
 }
+
+const useShortcutHintsViewport = () => {
+  const [shouldRender, setShouldRender] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return window.matchMedia(`(min-width: ${SHORTCUT_HINTS_MIN_WIDTH_PX}px)`)
+      .matches;
+  });
+
+  useExternalSyncEffect(() => {
+    const mediaQuery = window.matchMedia(
+      `(min-width: ${SHORTCUT_HINTS_MIN_WIDTH_PX}px)`,
+    );
+    const syncViewport = () => {
+      setShouldRender(mediaQuery.matches);
+    };
+
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncViewport);
+    };
+  }, []);
+
+  return shouldRender;
+};
 
 const useShortcutContext = (): ShortcutContext => {
   const pdfMatch = useMatch({

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 
-import {
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   CheckIcon,
@@ -54,7 +50,6 @@ import {
 } from "@/components/responsive-action-toolbar";
 import type { TranslationKey } from "@/i18n/types";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";
-import { roleOptions } from "@/routes/-queries";
 import {
   BlueprintGallerySheet,
   type BlueprintCreatedSkill,
@@ -91,6 +86,12 @@ type CatalogueBrowserProps = {
    * for the onboarding flow.
    */
   showAddCustom?: boolean;
+  /**
+   * Caller-resolved permission gate for creating custom team tools. The route
+   * owns role loading so this browser cannot trigger a cold non-suspense query
+   * during mount.
+   */
+  canManageCustomTools: boolean;
   /**
    * Seeds the jurisdiction filter so a CZ-based user lands on Tools and
    * sees only CZ + EU entries by default. Mirrors the onboarding step.
@@ -140,16 +141,12 @@ export const CatalogueBrowser = ({
   organizationId,
   initialKind,
   showAddCustom = true,
+  canManageCustomTools,
   practiceJurisdictions,
 }: CatalogueBrowserProps) => {
   const t = useTranslations();
   const navigate = useNavigate();
   const { data } = useSuspenseQuery(catalogueOptions(organizationId));
-  const { data: role } = useQuery(roleOptions);
-  // Match the backend gate: only admins/owners can create MCP
-  // connectors (see `POST /mcp/connectors`). Members would see the
-  // form open and the submit 403, so hide the affordance entirely.
-  const canAddCustom = role === "admin" || role === "owner";
   const [filter, setFilter] = useState<CatalogueBrowserFilterKind>(
     initialKind ?? "all",
   );
@@ -194,8 +191,6 @@ export const CatalogueBrowser = ({
   const [jurisdictionQuery, setJurisdictionQuery] = useState("");
   const [addMcpOpen, setAddMcpOpen] = useState(false);
   const [blueprintGalleryOpen, setBlueprintGalleryOpen] = useState(false);
-  // Reuse `role` from the canAddCustom block above for team-skill gating.
-  const canManageTeam = role === "admin" || role === "owner";
 
   const entries = data.entries;
 
@@ -294,10 +289,12 @@ export const CatalogueBrowser = ({
   );
   const otherFiltered = filtered.filter((entry) => !entry.isRecommendedForOrg);
   const hasMcpEntries = entries.some((entry) => entry.kind === "mcp");
+  const canShowAddCustom = showAddCustom && canManageCustomTools;
   // On a truly empty MCP catalogue, replace the generic "no entries" + reset
   // line with a prominent add-MCP call to action. Gated to admins/owners
   // like the add-custom menu, since members can't create connectors.
-  const showMcpEmptyCta = filter === "mcp" && !hasMcpEntries && canAddCustom;
+  const showMcpEmptyCta =
+    filter === "mcp" && !hasMcpEntries && canManageCustomTools;
 
   return (
     <div className="flex flex-col gap-6">
@@ -444,7 +441,7 @@ export const CatalogueBrowser = ({
           </Popover>
         </ResponsiveActionToolbarItem>
 
-        {showAddCustom && canAddCustom && (
+        {canShowAddCustom && (
           <ResponsiveActionToolbarItem
             className="ms-auto sm:ms-0"
             slot="action"
@@ -603,7 +600,7 @@ export const CatalogueBrowser = ({
         organizationId={organizationId}
       />
       <BlueprintGallerySheet
-        canManageTeam={canManageTeam}
+        canManageTeam={canManageCustomTools}
         onCreated={onBlueprintCreated}
         onOpenChange={setBlueprintGalleryOpen}
         open={blueprintGalleryOpen}

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -48,6 +48,10 @@ import type { ContextMenuAction } from "@/components/context-menu";
 import { useInspectorStore } from "@/components/inspector/inspector-store";
 import { useInspectorView } from "@/components/inspector/use-inspector-view";
 import { McpIcon } from "@/components/mcp-icon";
+import {
+  ResponsiveActionToolbar,
+  ResponsiveActionToolbarItem,
+} from "@/components/responsive-action-toolbar";
 import type { TranslationKey } from "@/i18n/types";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";
 import { roleOptions } from "@/routes/-queries";
@@ -297,155 +301,176 @@ export const CatalogueBrowser = ({
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-2">
-        <InputGroup className="flex-1">
-          <InputGroupAddon>
-            <SearchIcon className="text-muted-foreground" />
-          </InputGroupAddon>
-          <InputGroupInput
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={t("onboarding.catalogueSearchPlaceholder")}
-            value={query}
-          />
-          {query.length > 0 && (
-            <InputGroupAddon align="inline-end">
-              <Button
-                aria-label={t("onboarding.catalogueClearSearch")}
-                onClick={() => setQuery("")}
-                size="icon-xs"
-                type="button"
-                variant="ghost"
-              >
-                <XIcon />
-              </Button>
+      <ResponsiveActionToolbar>
+        <ResponsiveActionToolbarItem slot="primary">
+          <InputGroup className="min-h-11 sm:min-h-0">
+            <InputGroupAddon>
+              <SearchIcon className="text-muted-foreground" />
             </InputGroupAddon>
-          )}
-        </InputGroup>
-        <Popover>
-          <PopoverTrigger
-            render={
-              <Button className="shrink-0" type="button" variant="outline" />
-            }
-          >
-            <GlobeIcon className="size-3.5" />
-            {jurisdictionFilter.size === 0
-              ? t("common.all")
-              : [...jurisdictionFilter].sort().join(", ")}
-            <ChevronDownIcon className="size-3.5" />
-          </PopoverTrigger>
-          <PopoverPopup align="end" className="w-60" side="bottom">
-            <div className="border-border border-b p-2">
-              <InputGroup>
-                <InputGroupAddon>
-                  <SearchIcon className="text-muted-foreground" />
-                </InputGroupAddon>
-                <InputGroupInput
-                  autoFocus
-                  onChange={(e) => setJurisdictionQuery(e.target.value)}
-                  placeholder={t("common.search")}
-                  size="sm"
-                  value={jurisdictionQuery}
+            <InputGroupInput
+              className="max-sm:h-11 max-sm:leading-11"
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("onboarding.catalogueSearchPlaceholder")}
+              type="search"
+              value={query}
+            />
+            {query.length > 0 && (
+              <InputGroupAddon align="inline-end">
+                <Button
+                  aria-label={t("onboarding.catalogueClearSearch")}
+                  onClick={() => setQuery("")}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <XIcon />
+                </Button>
+              </InputGroupAddon>
+            )}
+          </InputGroup>
+        </ResponsiveActionToolbarItem>
+
+        <ResponsiveActionToolbarItem slot="secondary">
+          <Popover>
+            <PopoverTrigger
+              render={
+                <Button
+                  className="h-11 w-full justify-start sm:h-8 sm:w-auto"
+                  type="button"
+                  variant="outline"
                 />
-              </InputGroup>
-            </div>
-            <div className="flex max-h-[260px] flex-col overflow-y-auto p-1">
-              {jurisdictionQuery.trim() === "" && (
-                <>
-                  <button
-                    aria-pressed={jurisdictionFilter.size === 0}
-                    className="hover:bg-muted flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors"
-                    onClick={() => setJurisdictionFilter(new Set())}
-                    type="button"
-                  >
-                    <span
-                      className={cn(
-                        "border-border flex size-4 items-center justify-center rounded-sm border",
-                        jurisdictionFilter.size === 0 &&
-                          "border-foreground bg-foreground",
-                      )}
-                    >
-                      {jurisdictionFilter.size === 0 && (
-                        <CheckIcon className="text-background size-3" />
-                      )}
-                    </span>
-                    <span className="text-foreground font-medium">
-                      {t("common.all")}
-                    </span>
-                  </button>
-                  <div className="bg-border my-1 h-px" />
-                </>
-              )}
-              {(() => {
-                const matches = allJurisdictionCodes.filter((code) =>
-                  code
-                    .toLowerCase()
-                    .includes(jurisdictionQuery.trim().toLowerCase()),
-                );
-                if (matches.length === 0) {
-                  return (
-                    <p className="text-muted-foreground px-2 py-3 text-center text-xs">
-                      {t("common.noResults")}
-                    </p>
-                  );
-                }
-                return matches.map((code) => {
-                  const active = jurisdictionFilter.has(code);
-                  return (
+              }
+            >
+              <GlobeIcon className="size-3.5" />
+              <span className="min-w-0 truncate">
+                {jurisdictionFilter.size === 0
+                  ? t("common.all")
+                  : [...jurisdictionFilter].sort().join(", ")}
+              </span>
+              <ChevronDownIcon className="size-3.5" />
+            </PopoverTrigger>
+            <PopoverPopup align="end" className="w-60" side="bottom">
+              <div className="border-border border-b p-2">
+                <InputGroup>
+                  <InputGroupAddon>
+                    <SearchIcon className="text-muted-foreground" />
+                  </InputGroupAddon>
+                  <InputGroupInput
+                    autoFocus
+                    onChange={(e) => setJurisdictionQuery(e.target.value)}
+                    placeholder={t("common.search")}
+                    size="sm"
+                    value={jurisdictionQuery}
+                  />
+                </InputGroup>
+              </div>
+              <div className="flex max-h-[260px] flex-col overflow-y-auto p-1">
+                {jurisdictionQuery.trim() === "" && (
+                  <>
                     <button
-                      aria-pressed={active}
+                      aria-pressed={jurisdictionFilter.size === 0}
                       className="hover:bg-muted flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors"
-                      key={code}
-                      onClick={() =>
-                        setJurisdictionFilter((prev) => {
-                          const next = new Set(prev);
-                          if (next.has(code)) {
-                            next.delete(code);
-                          } else {
-                            next.add(code);
-                          }
-                          return next;
-                        })
-                      }
+                      onClick={() => setJurisdictionFilter(new Set())}
                       type="button"
                     >
                       <span
                         className={cn(
                           "border-border flex size-4 items-center justify-center rounded-sm border",
-                          active && "border-foreground bg-foreground",
+                          jurisdictionFilter.size === 0 &&
+                            "border-foreground bg-foreground",
                         )}
                       >
-                        {active && (
+                        {jurisdictionFilter.size === 0 && (
                           <CheckIcon className="text-background size-3" />
                         )}
                       </span>
-                      <span className="text-foreground">{code}</span>
+                      <span className="text-foreground font-medium">
+                        {t("common.all")}
+                      </span>
                     </button>
+                    <div className="bg-border my-1 h-px" />
+                  </>
+                )}
+                {(() => {
+                  const matches = allJurisdictionCodes.filter((code) =>
+                    code
+                      .toLowerCase()
+                      .includes(jurisdictionQuery.trim().toLowerCase()),
                   );
-                });
-              })()}
-            </div>
-          </PopoverPopup>
-        </Popover>
+                  if (matches.length === 0) {
+                    return (
+                      <p className="text-muted-foreground px-2 py-3 text-center text-xs">
+                        {t("common.noResults")}
+                      </p>
+                    );
+                  }
+                  return matches.map((code) => {
+                    const active = jurisdictionFilter.has(code);
+                    return (
+                      <button
+                        aria-pressed={active}
+                        className="hover:bg-muted flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors"
+                        key={code}
+                        onClick={() =>
+                          setJurisdictionFilter((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(code)) {
+                              next.delete(code);
+                            } else {
+                              next.add(code);
+                            }
+                            return next;
+                          })
+                        }
+                        type="button"
+                      >
+                        <span
+                          className={cn(
+                            "border-border flex size-4 items-center justify-center rounded-sm border",
+                            active && "border-foreground bg-foreground",
+                          )}
+                        >
+                          {active && (
+                            <CheckIcon className="text-background size-3" />
+                          )}
+                        </span>
+                        <span className="text-foreground">{code}</span>
+                      </button>
+                    );
+                  });
+                })()}
+              </div>
+            </PopoverPopup>
+          </Popover>
+        </ResponsiveActionToolbarItem>
+
         {showAddCustom && canAddCustom && (
-          <Menu>
-            <MenuTrigger render={<Button className="shrink-0" type="button" />}>
-              <PlusIcon className="size-3.5" />
-              {t("catalogue.addCustom")}
-              <ChevronDownIcon className="size-3.5" />
-            </MenuTrigger>
-            <MenuPopup align="end" className="w-56">
-              <MenuItem onClick={() => setAddMcpOpen(true)}>
-                <McpIcon className="size-4" />
-                {t("catalogue.addCustomMcp")}
-              </MenuItem>
-              <MenuItem onClick={() => setBlueprintGalleryOpen(true)}>
-                <GraduationCapIcon className="size-4" />
-                {t("catalogue.addCustomSkill")}
-              </MenuItem>
-            </MenuPopup>
-          </Menu>
+          <ResponsiveActionToolbarItem
+            className="ms-auto sm:ms-0"
+            slot="action"
+          >
+            <Menu>
+              <MenuTrigger
+                render={<Button className="h-11 sm:h-8" type="button" />}
+              >
+                <PlusIcon className="size-3.5" />
+                {t("catalogue.addCustom")}
+                <ChevronDownIcon className="size-3.5" />
+              </MenuTrigger>
+              <MenuPopup align="end" className="w-56">
+                <MenuItem onClick={() => setAddMcpOpen(true)}>
+                  <McpIcon className="size-4" />
+                  {t("catalogue.addCustomMcp")}
+                </MenuItem>
+                <MenuItem onClick={() => setBlueprintGalleryOpen(true)}>
+                  <GraduationCapIcon className="size-4" />
+                  {t("catalogue.addCustomSkill")}
+                </MenuItem>
+              </MenuPopup>
+            </Menu>
+          </ResponsiveActionToolbarItem>
         )}
-      </div>
+      </ResponsiveActionToolbar>
 
       {jurisdictionFilter.size > 0 && (
         <p className="text-muted-foreground -mt-3 text-xs">

--- a/apps/web/src/routes/_protected.knowledge/-components/category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/category-sidebar.tsx
@@ -1,3 +1,4 @@
+import type { DragEvent, ReactNode } from "react";
 import { useCallback, useState } from "react";
 
 import {
@@ -83,7 +84,7 @@ export type CategoryMobileExtraFilter = {
   label: string;
   active: boolean;
   onSelect: () => void;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
 };
 
 /** Drag-and-drop wiring, supplied only by features that support reassigning a
@@ -108,7 +109,7 @@ type CategorySidebarProps = {
   onCategoryCreated?: (category: CategoryEntity) => void;
   /** Optional extra content rendered below the category list (e.g. the
    *  Templates tag filter). */
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export const CategorySidebar = ({
@@ -212,25 +213,8 @@ type CategoryMobileFilterBarProps = {
   extraFilters?: readonly CategoryMobileExtraFilter[];
 };
 
-type CategoryMobileFilterOption =
-  | { type: "all"; label: string; active: boolean }
-  | { type: "uncategorized"; label: string; active: boolean }
-  | { type: "category"; id: string; label: string; active: boolean }
-  | {
-      type: "extra";
-      id: string;
-      label: string;
-      active: boolean;
-      icon: React.ReactNode | undefined;
-      onSelect: () => void;
-    };
-
-const CATEGORY_MOBILE_FILTER_TYPE_CLASS = {
-  all: "",
-  uncategorized: "",
-  category: "",
-  extra: "border-dashed",
-} as const satisfies Record<CategoryMobileFilterOption["type"], string>;
+const EMPTY_CATEGORY_MOBILE_EXTRA_FILTERS: readonly CategoryMobileExtraFilter[] =
+  [];
 
 export const CategoryMobileFilterBar = ({
   categories,
@@ -240,52 +224,50 @@ export const CategoryMobileFilterBar = ({
   onSelect,
   onCreateCategory,
   onSelectAll,
-  extraFilters = [],
+  extraFilters,
 }: CategoryMobileFilterBarProps) => {
   const t = useTranslations();
-  const hasActiveExtraFilter = extraFilters.some((filter) => filter.active);
-  const options: CategoryMobileFilterOption[] = [
-    {
-      type: "all",
-      label: labels.all,
-      active: selectedId === null && !hasActiveExtraFilter,
-    },
-    {
-      type: "uncategorized",
-      label: t("common.uncategorized"),
-      active: selectedId === "uncategorized",
-    },
-  ];
-
-  for (const category of categories) {
-    options.push({
-      type: "category",
-      id: category.id,
-      label: category.name,
-      active: selectedId === category.id,
-    });
-  }
-
-  for (const filter of extraFilters) {
-    options.push({
-      type: "extra",
-      id: filter.id,
-      label: filter.label,
-      active: filter.active,
-      icon: filter.icon,
-      onSelect: filter.onSelect,
-    });
-  }
+  const resolvedExtraFilters =
+    extraFilters ?? EMPTY_CATEGORY_MOBILE_EXTRA_FILTERS;
+  const hasActiveExtraFilter = resolvedExtraFilters.some(
+    (filter) => filter.active,
+  );
 
   return (
     <div className="border-b px-3 py-2 md:hidden">
       <div className="flex gap-1 overflow-x-auto pb-0.5">
-        {options.map((option) => (
+        <CategoryMobileFilterButton
+          active={selectedId === null && !hasActiveExtraFilter}
+          label={labels.all}
+          onSelect={() => {
+            if (onSelectAll) {
+              onSelectAll();
+              return;
+            }
+            onSelect(null);
+          }}
+        />
+        <CategoryMobileFilterButton
+          active={selectedId === "uncategorized"}
+          label={t("common.uncategorized")}
+          onSelect={() => onSelect("uncategorized")}
+        />
+        {categories.map((category) => (
           <CategoryMobileFilterButton
-            key={getCategoryMobileFilterKey(option)}
-            onSelect={onSelect}
-            onSelectAll={onSelectAll}
-            option={option}
+            active={selectedId === category.id}
+            key={`category:${category.id}`}
+            label={category.name}
+            onSelect={() => onSelect(category.id)}
+          />
+        ))}
+        {resolvedExtraFilters.map((filter) => (
+          <CategoryMobileFilterButton
+            active={filter.active}
+            icon={filter.icon}
+            key={`extra:${filter.id}`}
+            label={filter.label}
+            onSelect={filter.onSelect}
+            variant="extra"
           />
         ))}
         {canCreate && (
@@ -306,79 +288,50 @@ export const CategoryMobileFilterBar = ({
 };
 
 type CategoryMobileFilterButtonProps = {
-  option: CategoryMobileFilterOption;
-  onSelect: (id: string | null) => void;
-  onSelectAll: (() => void) | undefined;
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+  icon?: ReactNode;
+  variant?: "default" | "extra";
 };
 
 const CategoryMobileFilterButton = ({
-  option,
   onSelect,
-  onSelectAll,
+  label,
+  active,
+  icon,
+  variant,
 }: CategoryMobileFilterButtonProps) => {
-  const onClick = () => {
-    switch (option.type) {
-      case "all":
-        if (onSelectAll) {
-          onSelectAll();
-          return;
-        }
-        onSelect(null);
-        return;
-      case "uncategorized":
-        onSelect("uncategorized");
-        return;
-      case "category":
-        onSelect(option.id);
-        return;
-      case "extra":
-        option.onSelect();
-        return;
-    }
-  };
+  const resolvedVariant = variant ?? "default";
 
   return (
     <button
-      aria-pressed={option.active}
+      aria-pressed={active}
       className={cn(
         "border-input bg-popover text-foreground relative inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-sm font-medium transition-colors pointer-coarse:after:absolute pointer-coarse:after:start-0 pointer-coarse:after:top-1/2 pointer-coarse:after:h-11 pointer-coarse:after:w-full pointer-coarse:after:-translate-y-1/2",
-        CATEGORY_MOBILE_FILTER_TYPE_CLASS[option.type],
-        option.active
+        resolvedVariant === "extra" && "border-dashed",
+        active
           ? "border-foreground bg-foreground text-background"
           : "hover:bg-muted",
       )}
-      onClick={onClick}
+      onClick={onSelect}
       type="button"
     >
-      {option.type === "extra" && option.icon}
+      {icon ?? null}
       <span className="max-w-40 truncate" dir="auto">
-        {option.label}
+        {label}
       </span>
     </button>
   );
-};
-
-const getCategoryMobileFilterKey = (
-  option: CategoryMobileFilterOption,
-): string => {
-  switch (option.type) {
-    case "all":
-    case "uncategorized":
-      return option.type;
-    case "category":
-      return `category:${option.id}`;
-    case "extra":
-      return `extra:${option.id}`;
-  }
 };
 
 // ── Drop target ─────────────────────────────────────
 
 type DropTarget = {
   isDragOver: boolean;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragLeave: (e: React.DragEvent) => void;
-  onDrop: (e: React.DragEvent) => void;
+  onDragOver: (e: DragEvent) => void;
+  onDragLeave: (e: DragEvent) => void;
+  onDrop: (e: DragEvent) => void;
 };
 
 const noop = () => undefined;
@@ -405,7 +358,7 @@ const useCategoryDropTarget = (
     return INERT_DROP_TARGET;
   }
 
-  const onDragOver = (e: React.DragEvent) => {
+  const onDragOver = (e: DragEvent) => {
     if (!e.dataTransfer.types.includes(dragAndDrop.mime)) {
       return;
     }
@@ -414,12 +367,12 @@ const useCategoryDropTarget = (
     setIsDragOver(true);
   };
 
-  const onDragLeave = (e: React.DragEvent) => {
+  const onDragLeave = (e: DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
   };
 
-  const onDrop = (e: React.DragEvent) => {
+  const onDrop = (e: DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
     const itemId = e.dataTransfer.getData(dragAndDrop.mime);

--- a/apps/web/src/routes/_protected.knowledge/-components/category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/category-sidebar.tsx
@@ -78,6 +78,14 @@ export type CategoryLabels = {
   namePlaceholder: string;
 };
 
+export type CategoryMobileExtraFilter = {
+  id: string;
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+  icon?: React.ReactNode;
+};
+
 /** Drag-and-drop wiring, supplied only by features that support reassigning a
  *  dragged item onto a category (Templates). When omitted, no drop targets
  *  render (Clauses). */
@@ -191,6 +199,177 @@ export const CategorySidebar = ({
       />
     </div>
   );
+};
+
+type CategoryMobileFilterBarProps = {
+  categories: CategoryEntity[];
+  selectedId: string | null;
+  labels: CategoryLabels;
+  canCreate: boolean;
+  onSelect: (id: string | null) => void;
+  onCreateCategory: () => void;
+  onSelectAll?: () => void;
+  extraFilters?: readonly CategoryMobileExtraFilter[];
+};
+
+type CategoryMobileFilterOption =
+  | { type: "all"; label: string; active: boolean }
+  | { type: "uncategorized"; label: string; active: boolean }
+  | { type: "category"; id: string; label: string; active: boolean }
+  | {
+      type: "extra";
+      id: string;
+      label: string;
+      active: boolean;
+      icon: React.ReactNode | undefined;
+      onSelect: () => void;
+    };
+
+const CATEGORY_MOBILE_FILTER_TYPE_CLASS = {
+  all: "",
+  uncategorized: "",
+  category: "",
+  extra: "border-dashed",
+} as const satisfies Record<CategoryMobileFilterOption["type"], string>;
+
+export const CategoryMobileFilterBar = ({
+  categories,
+  selectedId,
+  labels,
+  canCreate,
+  onSelect,
+  onCreateCategory,
+  onSelectAll,
+  extraFilters = [],
+}: CategoryMobileFilterBarProps) => {
+  const t = useTranslations();
+  const hasActiveExtraFilter = extraFilters.some((filter) => filter.active);
+  const options: CategoryMobileFilterOption[] = [
+    {
+      type: "all",
+      label: labels.all,
+      active: selectedId === null && !hasActiveExtraFilter,
+    },
+    {
+      type: "uncategorized",
+      label: t("common.uncategorized"),
+      active: selectedId === "uncategorized",
+    },
+  ];
+
+  for (const category of categories) {
+    options.push({
+      type: "category",
+      id: category.id,
+      label: category.name,
+      active: selectedId === category.id,
+    });
+  }
+
+  for (const filter of extraFilters) {
+    options.push({
+      type: "extra",
+      id: filter.id,
+      label: filter.label,
+      active: filter.active,
+      icon: filter.icon,
+      onSelect: filter.onSelect,
+    });
+  }
+
+  return (
+    <div className="border-b px-3 py-2 md:hidden">
+      <div className="flex gap-1 overflow-x-auto pb-0.5">
+        {options.map((option) => (
+          <CategoryMobileFilterButton
+            key={getCategoryMobileFilterKey(option)}
+            onSelect={onSelect}
+            onSelectAll={onSelectAll}
+            option={option}
+          />
+        ))}
+        {canCreate && (
+          <Button
+            className="h-8 shrink-0"
+            onClick={onCreateCategory}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <PlusIcon />
+            {labels.createCategory}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+type CategoryMobileFilterButtonProps = {
+  option: CategoryMobileFilterOption;
+  onSelect: (id: string | null) => void;
+  onSelectAll: (() => void) | undefined;
+};
+
+const CategoryMobileFilterButton = ({
+  option,
+  onSelect,
+  onSelectAll,
+}: CategoryMobileFilterButtonProps) => {
+  const onClick = () => {
+    switch (option.type) {
+      case "all":
+        if (onSelectAll) {
+          onSelectAll();
+          return;
+        }
+        onSelect(null);
+        return;
+      case "uncategorized":
+        onSelect("uncategorized");
+        return;
+      case "category":
+        onSelect(option.id);
+        return;
+      case "extra":
+        option.onSelect();
+        return;
+    }
+  };
+
+  return (
+    <button
+      aria-pressed={option.active}
+      className={cn(
+        "border-input bg-popover text-foreground relative inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-sm font-medium transition-colors pointer-coarse:after:absolute pointer-coarse:after:start-0 pointer-coarse:after:top-1/2 pointer-coarse:after:h-11 pointer-coarse:after:w-full pointer-coarse:after:-translate-y-1/2",
+        CATEGORY_MOBILE_FILTER_TYPE_CLASS[option.type],
+        option.active
+          ? "border-foreground bg-foreground text-background"
+          : "hover:bg-muted",
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      {option.type === "extra" && option.icon}
+      <span className="max-w-40 truncate" dir="auto">
+        {option.label}
+      </span>
+    </button>
+  );
+};
+
+const getCategoryMobileFilterKey = (
+  option: CategoryMobileFilterOption,
+): string => {
+  switch (option.type) {
+    case "all":
+    case "uncategorized":
+      return option.type;
+    case "category":
+      return `category:${option.id}`;
+    case "extra":
+      return `extra:${option.id}`;
+  }
 };
 
 // ── Drop target ─────────────────────────────────────

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -18,10 +18,18 @@ import {
 } from "@stll/ui/components/input-group";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import {
+  ResponsiveActionToolbar,
+  ResponsiveActionToolbarItem,
+} from "@/components/responsive-action-toolbar";
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
-import { CategorySidebar } from "@/routes/_protected.knowledge/-components/category-sidebar";
+import {
+  CategoryFormDialog,
+  CategoryMobileFilterBar,
+  CategorySidebar,
+} from "@/routes/_protected.knowledge/-components/category-sidebar";
 import type {
   CategoryLabels,
   CategoryOps,
@@ -81,6 +89,9 @@ export const ClauseList = ({
   const canCreateClause = usePermissions({ clause: ["create"] });
   const [searchInput, setSearchInput] = useState("");
   const [importOpen, setImportOpen] = useState(false);
+  const [createCategoryOpen, setCreateCategoryOpen] = useState(false);
+  const categoryLabels = useClauseCategoryLabels();
+  const categoryOps = useClauseCategoryOps();
 
   const debouncedSearch = useDebouncedCallback(
     (value: string) => onSearch(value),
@@ -124,58 +135,103 @@ export const ClauseList = ({
   };
 
   return (
-    <div className="flex min-h-0 flex-1">
-      {/* Category sidebar */}
-      <ClauseCategorySidebar
-        categories={categories}
-        onCategoriesChanged={onCategoriesChanged}
-        onSelect={onCategorySelect}
-        selectedId={selectedCategoryId}
-      />
+    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+      <div className="hidden md:contents">
+        <ClauseCategorySidebar
+          categories={categories}
+          labels={categoryLabels}
+          onCategoriesChanged={onCategoriesChanged}
+          onSelect={onCategorySelect}
+          ops={categoryOps}
+          selectedId={selectedCategoryId}
+        />
+      </div>
 
-      {/* Clause list */}
-      <div className="flex min-h-0 flex-1 flex-col border-s">
-        <div className="flex items-center justify-between border-b px-4 py-2">
-          <InputGroup className="me-3 flex-1">
-            <InputGroupInput
-              onChange={handleSearchChange}
-              placeholder={t("clauses.searchPlaceholder")}
-              size="sm"
-              value={searchInput}
-            />
-            <InputGroupAddon>
-              <SearchIcon />
-            </InputGroupAddon>
-          </InputGroup>
-          <div className="flex gap-1">
-            {canCreateClause && (
-              <Button
-                onClick={() => setImportOpen(true)}
-                size="sm"
-                variant="outline"
-              >
-                <UploadIcon />
-                {t("clauses.import")}
-              </Button>
-            )}
-            <Button
-              onClick={() => {
-                void handleExport();
-              }}
-              size="sm"
-              variant="outline"
+      <div className="flex min-h-0 flex-1 flex-col md:border-s">
+        <div className="border-b px-4 py-2">
+          <ResponsiveActionToolbar>
+            <ResponsiveActionToolbarItem slot="primary">
+              <InputGroup className="min-h-11 sm:min-h-0">
+                <InputGroupInput
+                  className="max-sm:h-11 max-sm:leading-11"
+                  onChange={handleSearchChange}
+                  placeholder={t("clauses.searchPlaceholder")}
+                  size="sm"
+                  type="search"
+                  value={searchInput}
+                />
+                <InputGroupAddon>
+                  <SearchIcon />
+                </InputGroupAddon>
+              </InputGroup>
+            </ResponsiveActionToolbarItem>
+            <ResponsiveActionToolbarItem
+              className="ms-auto sm:ms-0"
+              slot="action"
             >
-              <DownloadIcon />
-              {t("clauses.export")}
-            </Button>
-            {canCreateClause && (
-              <Button onClick={onNewClause} size="sm">
-                <PlusIcon />
-                {t("clauses.createClause")}
-              </Button>
-            )}
-          </div>
+              <div className="flex gap-1">
+                {canCreateClause && (
+                  <Button
+                    aria-label={t("clauses.import")}
+                    onClick={() => setImportOpen(true)}
+                    size="sm"
+                    title={t("clauses.import")}
+                    variant="outline"
+                  >
+                    <UploadIcon />
+                    <span className="hidden sm:inline">
+                      {t("clauses.import")}
+                    </span>
+                  </Button>
+                )}
+                <Button
+                  aria-label={t("clauses.export")}
+                  onClick={() => {
+                    void handleExport();
+                  }}
+                  size="sm"
+                  title={t("clauses.export")}
+                  variant="outline"
+                >
+                  <DownloadIcon />
+                  <span className="hidden sm:inline">
+                    {t("clauses.export")}
+                  </span>
+                </Button>
+                {canCreateClause && (
+                  <Button
+                    aria-label={t("clauses.createClause")}
+                    onClick={onNewClause}
+                    size="sm"
+                    title={t("clauses.createClause")}
+                  >
+                    <PlusIcon />
+                    <span className="hidden sm:inline">
+                      {t("clauses.createClause")}
+                    </span>
+                  </Button>
+                )}
+              </div>
+            </ResponsiveActionToolbarItem>
+          </ResponsiveActionToolbar>
         </div>
+
+        <CategoryMobileFilterBar
+          canCreate={canCreateClause}
+          categories={categories}
+          labels={categoryLabels}
+          onCreateCategory={() => setCreateCategoryOpen(true)}
+          onSelect={onCategorySelect}
+          selectedId={selectedCategoryId}
+        />
+
+        <CategoryFormDialog
+          labels={categoryLabels}
+          onChanged={onCategoriesChanged}
+          onOpenChange={setCreateCategoryOpen}
+          open={createCategoryOpen}
+          ops={categoryOps}
+        />
 
         <ClauseImportDialog
           onImported={onRefresh}
@@ -278,6 +334,8 @@ type ClauseCategorySidebarProps = {
   selectedId: string | null;
   onSelect: (id: string | null) => void;
   onCategoriesChanged: () => void;
+  labels: CategoryLabels;
+  ops: CategoryOps;
 };
 
 /** Thin wrapper over the shared `CategorySidebar`: resolves clause
@@ -288,12 +346,12 @@ const ClauseCategorySidebar = ({
   selectedId,
   onSelect,
   onCategoriesChanged,
+  labels,
+  ops,
 }: ClauseCategorySidebarProps) => {
   const canCreate = usePermissions({ clause: ["create"] });
   const canUpdate = usePermissions({ clause: ["update"] });
   const canDelete = usePermissions({ clause: ["delete"] });
-  const ops = useClauseCategoryOps();
-  const labels = useClauseCategoryLabels();
 
   return (
     <CategorySidebar

--- a/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
@@ -100,7 +100,7 @@ const useTemplateCategoryOps = (): CategoryOps => {
   };
 };
 
-const useTemplateCategoryLabels = (): CategoryLabels => {
+export const useTemplateCategoryLabels = (): CategoryLabels => {
   const t = useTranslations();
   return {
     all: t("templates.allTemplates"),

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -74,9 +74,11 @@ import { DOCX_MIME, TOOLBAR_ROW_MIN_HEIGHT } from "@/lib/consts";
 import { userErrorMessage } from "@/lib/errors";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { toSafeId } from "@/lib/safe-id";
+import { CategoryMobileFilterBar } from "@/routes/_protected.knowledge/-components/category-sidebar";
 import {
   CategoryFormDialog,
   TemplateCategorySidebar,
+  useTemplateCategoryLabels,
 } from "@/routes/_protected.knowledge/-components/template-category-sidebar";
 import type { TemplateCategoryItem } from "@/routes/_protected.knowledge/-components/template-category-sidebar";
 import { TEMPLATE_DRAG_MIME } from "@/routes/_protected.knowledge/-components/template-drag";
@@ -145,6 +147,8 @@ export const TemplateList = ({
   const [tagFilter, setTagFilter] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [density, setDensity] = useState<TemplateDensity>(readTemplateDensity);
+  const [createCategoryOpen, setCreateCategoryOpen] = useState(false);
+  const categoryLabels = useTemplateCategoryLabels();
 
   const changeDensity = (next: TemplateDensity) => {
     setDensity(next);
@@ -259,7 +263,7 @@ export const TemplateList = ({
 
   return (
     <div
-      className="relative flex min-h-0 flex-1"
+      className="relative flex min-h-0 flex-1 flex-col md:flex-row"
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
@@ -272,21 +276,23 @@ export const TemplateList = ({
         </div>
       )}
 
-      <TemplateCategorySidebar
-        categories={categories}
-        onAssignCategory={assignCategory}
-        onCategoriesChanged={onCategoriesChanged}
-        onSelect={onCategorySelect}
-        onSelectTag={setTagFilter}
-        selectedId={selectedCategoryId}
-        selectedTag={tagFilter}
-        tags={allTags}
-      />
+      <div className="hidden md:contents">
+        <TemplateCategorySidebar
+          categories={categories}
+          onAssignCategory={assignCategory}
+          onCategoriesChanged={onCategoriesChanged}
+          onSelect={onCategorySelect}
+          onSelectTag={setTagFilter}
+          selectedId={selectedCategoryId}
+          selectedTag={tagFilter}
+          tags={allTags}
+        />
+      </div>
 
-      <div className="flex min-h-0 flex-1 flex-col border-s">
+      <div className="flex min-h-0 flex-1 flex-col md:border-s">
         <div
           className={cn(
-            "flex items-center justify-between gap-3 border-b px-4",
+            "flex flex-wrap items-center justify-between gap-2 border-b px-4 py-2 md:py-0",
             TOOLBAR_ROW_MIN_HEIGHT,
           )}
         >
@@ -339,6 +345,26 @@ export const TemplateList = ({
           </div>
         </div>
 
+        <CategoryMobileFilterBar
+          canCreate={canCreateTemplate}
+          categories={categories}
+          extraFilters={allTags.map((tag) => ({
+            id: tag,
+            label: tag,
+            active: tagFilter === tag,
+            icon: <TagIcon className="size-3.5" />,
+            onSelect: () => setTagFilter(tagFilter === tag ? null : tag),
+          }))}
+          labels={categoryLabels}
+          onCreateCategory={() => setCreateCategoryOpen(true)}
+          onSelect={onCategorySelect}
+          onSelectAll={() => {
+            onCategorySelect(null);
+            setTagFilter(null);
+          }}
+          selectedId={selectedCategoryId}
+        />
+
         <div className="flex-1 overflow-y-auto">
           {visibleTemplates.length === 0 && (
             <div className="flex items-center justify-center p-8">
@@ -365,6 +391,12 @@ export const TemplateList = ({
           </ul>
         </div>
       </div>
+
+      <CategoryFormDialog
+        onOpenChange={setCreateCategoryOpen}
+        onSaved={onCategoriesChanged}
+        open={createCategoryOpen}
+      />
     </div>
   );
 };
@@ -672,21 +704,36 @@ const TemplateRow = ({
   // mirroring the clause list; Use (fill) stays an explicit CTA.
   const actions = (
     <div className="relative z-10 flex shrink-0 items-center gap-2">
-      <Button onClick={() => setUseOpen(true)} size="xs" variant="outline">
+      <Button
+        className="max-sm:hidden"
+        onClick={() => setUseOpen(true)}
+        size="xs"
+        variant="outline"
+      >
         {t("templates.useTemplate")}
       </Button>
-      <Tooltip
-        content={template.authorName}
-        render={<span className="inline-flex" />}
-      >
-        <UserAvatar
-          className="size-6 shrink-0 text-[0.5625rem]"
-          image={template.authorImage}
-          name={template.authorName}
-        />
-      </Tooltip>
+      <span className="hidden sm:inline-flex">
+        <Tooltip
+          content={template.authorName}
+          render={<span className="inline-flex" />}
+        >
+          <UserAvatar
+            className="size-6 shrink-0 text-[0.5625rem]"
+            image={template.authorImage}
+            name={template.authorName}
+          />
+        </Tooltip>
+      </span>
       <DropdownMenu>
-        <DropdownMenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("common.actions")}
+              size="icon-xs"
+              variant="ghost"
+            />
+          }
+        >
           <MoreHorizontalIcon />
         </DropdownMenuTrigger>
         <DropdownMenuContent>

--- a/apps/web/src/routes/_protected.knowledge/tools.tsx
+++ b/apps/web/src/routes/_protected.knowledge/tools.tsx
@@ -273,8 +273,15 @@ function ToolsCatalogue({ initialKind, organizationId }: ToolsCatalogueProps) {
   const { data: settings } = useSuspenseQuery(
     organizationSettingsOptions(organizationId),
   );
+  const { data: role } = useSuspenseQuery(roleOptions);
+  // Match the backend gate: only admins/owners can create MCP connectors
+  // (see `POST /mcp/connectors`). Members would see the form open and
+  // the submit 403, so hide the affordance entirely.
+  const canManageCustomTools = role === "admin" || role === "owner";
+
   return (
     <LazyCatalogueBrowser
+      canManageCustomTools={canManageCustomTools}
       initialKind={initialKind}
       organizationId={organizationId}
       practiceJurisdictions={settings.practiceJurisdictions}

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -594,16 +594,6 @@ const getInspectorTabWorkspaceId = (
   return exhaustive;
 };
 
-type InspectorSheetSide = "left" | "right";
-
-const getMobileInspectorSheetSide = (): InspectorSheetSide => {
-  if (typeof document === "undefined") {
-    return "right";
-  }
-
-  return document.documentElement.dir === "rtl" ? "left" : "right";
-};
-
 /**
  * Workspace inspector pane — file viewers + chat tabs. Mounted at
  * the protected layout level (next to `TemplateAssistantSidePanel`)
@@ -675,7 +665,6 @@ function WorkspaceInspectorSidePanel() {
   // user hasn't minimized do we widen to the full pane width.
   const widthPx = `${showPaneContent ? width : INSPECTOR_RAIL_WIDTH}px`;
   const reservedInlineEndWidthPx = isMobile ? "0px" : widthPx;
-  const mobileSheetSide = getMobileInspectorSheetSide();
 
   useExternalSyncEffect(() => {
     // The toast offset is consumed via a logical `end-` utility, so the same
@@ -730,7 +719,7 @@ function WorkspaceInspectorSidePanel() {
         <SheetPopup
           className="h-dvh w-full max-w-none border-0 p-0 md:hidden"
           showCloseButton={false}
-          side={mobileSheetSide}
+          side="inline-end"
         >
           <SheetHeader className="sr-only">
             <SheetTitle>{t("inspector.title")}</SheetTitle>

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useRef, useState } from "react";
-import type { MouseEvent } from "react";
+import type { MouseEvent, PointerEvent } from "react";
 
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
@@ -26,6 +26,12 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { Separator } from "@stll/ui/components/separator";
+import {
+  Sheet,
+  SheetHeader,
+  SheetPopup,
+  SheetTitle,
+} from "@stll/ui/components/sheet";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
@@ -108,6 +114,26 @@ const InspectorRailFallback = () => (
           <MessageSquarePlusIcon className="size-4" />
         </span>
       </div>
+    </div>
+  </div>
+);
+
+const MobileInspectorFallback = () => (
+  <div className="bg-background flex h-full min-w-0 flex-col">
+    <div
+      className={cn(
+        "flex shrink-0 items-center gap-2 border-b px-3",
+        TOOLBAR_ROW_HEIGHT,
+      )}
+    >
+      <Skeleton className="h-4 w-16" />
+      <Skeleton className="h-4 flex-1" />
+      <Skeleton className="size-7 rounded-md" />
+    </div>
+    <div className="space-y-3 px-4 py-4">
+      <Skeleton className="h-7 w-2/3" />
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-8 w-full" />
     </div>
   </div>
 );
@@ -349,11 +375,11 @@ function ProtectedContent() {
     }
     toggleInspector();
   };
-  // Show the chrome inspector button only before the rail exists.
-  // Once tabs exist, the rail remains visible even when the pane
-  // content is minimized, and its top button is the restore/hide
-  // affordance.
-  const canShowInspectorButton = inspectorTabsCount === 0;
+  // Desktop keeps the rail mounted once tabs exist, so the rail is
+  // the restore affordance. Mobile has no rail; after Back minimizes
+  // the sheet, the chrome button must reappear so the user can return.
+  const canShowInspectorButton =
+    inspectorTabsCount === 0 || (isMobile && inspectorMinimized);
   const inspectorButtonTitle = (() => {
     if (inspectorTabsCount === 0) {
       return t("inspector.openChat");
@@ -511,6 +537,73 @@ const INSPECTOR_PANE_MAX_WIDTH = 800;
 // toast / find-replace right-offset CSS vars under the visible rail.
 const INSPECTOR_RAIL_WIDTH = 48;
 
+type InspectorWorkspaceResolutionInput = {
+  activeId: string | null;
+  routeWorkspaceId: string | undefined;
+  tabs: readonly InspectorTab[];
+};
+
+const resolveInspectorWorkspaceId = ({
+  activeId,
+  routeWorkspaceId,
+  tabs,
+}: InspectorWorkspaceResolutionInput): string | undefined => {
+  const activeTab =
+    activeId === null ? undefined : tabs.find((tab) => tab.id === activeId);
+  const activeWorkspaceId = getInspectorTabWorkspaceId(activeTab);
+  if (activeWorkspaceId !== undefined) {
+    return activeWorkspaceId;
+  }
+
+  if (routeWorkspaceId !== undefined) {
+    return routeWorkspaceId;
+  }
+
+  for (const tab of tabs) {
+    const tabWorkspaceId = getInspectorTabWorkspaceId(tab);
+    if (tabWorkspaceId !== undefined) {
+      return tabWorkspaceId;
+    }
+  }
+
+  return undefined;
+};
+
+const getInspectorTabWorkspaceId = (
+  tab: InspectorTab | undefined,
+): string | undefined => {
+  if (tab === undefined) {
+    return undefined;
+  }
+
+  switch (tab.type) {
+    case "pdf":
+    case "matter":
+    case "task":
+      return tab.workspaceId;
+    case "chat":
+      return tab.workspaceId ?? tab.contextMatterIds.at(0);
+    case "external":
+      return tab.workspaceId ?? undefined;
+    case "skill-resource":
+    case "view":
+      return undefined;
+  }
+
+  const exhaustive: never = tab;
+  return exhaustive;
+};
+
+type InspectorSheetSide = "left" | "right";
+
+const getMobileInspectorSheetSide = (): InspectorSheetSide => {
+  if (typeof document === "undefined") {
+    return "right";
+  }
+
+  return document.documentElement.dir === "rtl" ? "left" : "right";
+};
+
 /**
  * Workspace inspector pane — file viewers + chat tabs. Mounted at
  * the protected layout level (next to `TemplateAssistantSidePanel`)
@@ -522,6 +615,8 @@ const INSPECTOR_RAIL_WIDTH = 48;
  * inspector chrome.
  */
 function WorkspaceInspectorSidePanel() {
+  const t = useTranslations();
+  const { isMobile } = useSidebar();
   const projectMatch = useMatch({
     from: "/_protected/workspaces/$workspaceId",
     shouldThrow: false,
@@ -530,62 +625,17 @@ function WorkspaceInspectorSidePanel() {
   const tabs = useInspectorStore((s) => s.tabs);
   const activeId = useInspectorStore((s) => s.activeId);
   const minimized = useInspectorStore((s) => s.minimized);
-  // The inspector rail is always mounted — even with zero tabs it
-  // shows the toggle + new-chat affordances so the user has a
-  // consistent right-side anchor point. The pane *content* area is
-  // hidden when there are no tabs or when the user has minimized.
+  const setMinimized = useInspectorStore((s) => s.setMinimized);
+  // Desktop keeps a rail-mounted inspector shell; mobile uses a
+  // sheet and relies on the topbar restore button after Back.
+  // Pane content is shown only when a tab exists and the inspector
+  // is not minimized.
   const showPaneContent = tabs.length > 0 && !minimized;
-
-  // Pin the inspector's "current matter" to the ACTIVE TAB's
-  // origin so documents and started chats keep showing the
-  // matter they came from, even after the user navigates away
-  // to another matter (or to a non-workspace route like the
-  // knowledge / case-law viewer). Resolution order:
-  //   1. Active tab's origin (PDF.workspaceId, Matter.workspaceId,
-  //      or started-chat contextMatterIds[0])
-  //   2. The current route's matter (for blank chats or task
-  //      tabs while inside a workspace)
-  //   3. Any other tab's stored workspaceId — keeps the pane
-  //      mounted when the user navigates away from a workspace
-  //      with only blank chats active but PDFs from earlier
-  //      matters still open in the rail.
-  const activeTab = tabs.find((tab) => tab.id === activeId);
-  const tabOriginWorkspaceId = (() => {
-    if (activeTab?.type === "pdf") {
-      return activeTab.workspaceId;
-    }
-    if (activeTab?.type === "matter") {
-      return activeTab.workspaceId;
-    }
-    if (activeTab?.type === "chat") {
-      return activeTab.contextMatterIds.at(0) ?? null;
-    }
-    return null;
-  })();
-  // Last-resort: pick *any* tab's stored workspace so the inspector
-  // mounts even when the active tab can't dictate one (a task tab,
-  // or a chat that hasn't been pinned to a matter yet) and the
-  // route is also non-workspace. PDF tabs carry workspaceId
-  // directly; matter tabs carry workspaceId directly; chat tabs
-  // surface theirs via contextMatterIds[0].
-  const fallbackPdfTab = tabs.find(
-    (tab): tab is Extract<InspectorTab, { type: "pdf" }> => tab.type === "pdf",
-  );
-  const fallbackMatterTab = tabs.find(
-    (tab): tab is Extract<InspectorTab, { type: "matter" }> =>
-      tab.type === "matter",
-  );
-  const fallbackChatTab = tabs.find(
-    (tab): tab is Extract<InspectorTab, { type: "chat" }> =>
-      tab.type === "chat" && tab.contextMatterIds.length > 0,
-  );
-  const fallbackTabWorkspaceId =
-    fallbackPdfTab?.workspaceId ??
-    fallbackMatterTab?.workspaceId ??
-    fallbackChatTab?.contextMatterIds.at(0) ??
-    null;
-  const activeWorkspaceId =
-    tabOriginWorkspaceId ?? routeWorkspaceId ?? fallbackTabWorkspaceId;
+  const activeWorkspaceId = resolveInspectorWorkspaceId({
+    activeId,
+    routeWorkspaceId,
+    tabs,
+  });
   const [width, setWidth] = useState(INSPECTOR_PANE_DEFAULT_WIDTH);
   const isDragging = useRef(false);
   // Re-run the offset effect once the new bundle applies: `loadedLang` (not
@@ -593,13 +643,13 @@ function WorkspaceInspectorSidePanel() {
   // reads the correct direction.
   const loadedLang = useI18nStore((s) => s.loadedLang);
 
-  const handlePointerDown = (e: React.PointerEvent) => {
+  const handlePointerDown = (e: PointerEvent<HTMLElement>) => {
     e.preventDefault();
     isDragging.current = true;
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
-  const handlePointerMove = (e: React.PointerEvent) => {
+  const handlePointerMove = (e: PointerEvent<HTMLElement>) => {
     if (!isDragging.current) {
       return;
     }
@@ -624,11 +674,16 @@ function WorkspaceInspectorSidePanel() {
   // Rail is always shown; only when there are real tabs and the
   // user hasn't minimized do we widen to the full pane width.
   const widthPx = `${showPaneContent ? width : INSPECTOR_RAIL_WIDTH}px`;
+  const reservedInlineEndWidthPx = isMobile ? "0px" : widthPx;
+  const mobileSheetSide = getMobileInspectorSheetSide();
 
   useExternalSyncEffect(() => {
     // The toast offset is consumed via a logical `end-` utility, so the same
     // value reserves the correct edge in both directions.
-    document.documentElement.style.setProperty(TOAST_RIGHT_OFFSET_VAR, widthPx);
+    document.documentElement.style.setProperty(
+      TOAST_RIGHT_OFFSET_VAR,
+      reservedInlineEndWidthPx,
+    );
     // Folio's find/replace overlay is `justify-end`, so it packs against the
     // inline-end edge: the right in LTR, the LEFT under RTL. The inspector
     // docks to that same edge, so reserve the offset on whichever physical
@@ -640,12 +695,12 @@ function WorkspaceInspectorSidePanel() {
     const isRtl = document.documentElement.dir === "rtl";
     document.documentElement.style.setProperty(
       "--folio-find-replace-right",
-      isRtl ? "0px" : widthPx,
+      isRtl ? "0px" : reservedInlineEndWidthPx,
     );
     if (isRtl) {
       document.documentElement.style.setProperty(
         "--folio-find-replace-left",
-        widthPx,
+        reservedInlineEndWidthPx,
       );
     } else {
       document.documentElement.style.removeProperty(
@@ -662,7 +717,31 @@ function WorkspaceInspectorSidePanel() {
         "--folio-find-replace-left",
       );
     };
-  }, [widthPx, loadedLang]);
+  }, [reservedInlineEndWidthPx, loadedLang]);
+
+  if (isMobile) {
+    return (
+      <Sheet
+        onOpenChange={(open) => {
+          setMinimized(!open);
+        }}
+        open={showPaneContent}
+      >
+        <SheetPopup
+          className="h-dvh w-full max-w-none border-0 p-0 md:hidden"
+          showCloseButton={false}
+          side={mobileSheetSide}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>{t("inspector.title")}</SheetTitle>
+          </SheetHeader>
+          <Suspense fallback={<MobileInspectorFallback />}>
+            <LazyInspectorPanel workspaceId={activeWorkspaceId} />
+          </Suspense>
+        </SheetPopup>
+      </Sheet>
+    );
+  }
 
   return (
     <div
@@ -685,7 +764,7 @@ function WorkspaceInspectorSidePanel() {
         )}
         <div className="bg-sidebar flex h-full w-full flex-col">
           <Suspense fallback={<InspectorRailFallback />}>
-            <LazyInspectorPanel workspaceId={activeWorkspaceId ?? undefined} />
+            <LazyInspectorPanel workspaceId={activeWorkspaceId} />
           </Suspense>
         </div>
       </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -290,23 +290,26 @@ function ViewShell({ activeView, workspaceId }: ViewContentProps) {
 
   return (
     <>
-      <div
-        className={cn(
-          "flex min-w-0 items-center justify-between border-b",
-          TOOLBAR_ROW_HEIGHT,
-        )}
-      >
-        <ViewSwitcher
-          activeViewId={activeView.id}
-          onViewChange={(viewId) => {
-            void navigate({
-              to: "/workspaces/$workspaceId/$viewId",
-              params: { workspaceId, viewId },
-              search: { page: undefined },
-            });
-          }}
-          workspaceId={workspaceId}
-        />
+      <div className="flex min-w-0 flex-col border-b md:flex-row md:items-center md:justify-between">
+        <div
+          className={cn(
+            "flex min-w-0 items-center",
+            TOOLBAR_ROW_HEIGHT,
+            activeView.layout.type !== "overview" && "border-b md:border-b-0",
+          )}
+        >
+          <ViewSwitcher
+            activeViewId={activeView.id}
+            onViewChange={(viewId) => {
+              void navigate({
+                to: "/workspaces/$workspaceId/$viewId",
+                params: { workspaceId, viewId },
+                search: { page: undefined },
+              });
+            }}
+            workspaceId={workspaceId}
+          />
+        </div>
         {activeView.layout.type !== "overview" && (
           <ViewToolbar view={activeView} workspaceId={workspaceId} />
         )}
@@ -423,15 +426,14 @@ function ViewPendingComponent() {
     <>
       <div
         className={cn(
-          "flex min-w-0 items-center justify-between border-b px-3",
-          TOOLBAR_ROW_HEIGHT,
+          "flex min-w-0 flex-col border-b px-3 md:flex-row md:items-center md:justify-between",
         )}
       >
-        <div className="flex items-center gap-1.5">
+        <div className={cn("flex items-center gap-1.5", TOOLBAR_ROW_HEIGHT)}>
           <Skeleton className="h-7 w-24 rounded-md" />
           <Skeleton className="h-7 w-20 rounded-md" />
         </div>
-        <div className="flex items-center gap-1.5">
+        <div className={cn("flex items-center gap-1.5", TOOLBAR_ROW_HEIGHT)}>
           <Skeleton className="size-7 rounded-md" />
           <Skeleton className="size-7 rounded-md" />
           <Skeleton className="h-7 w-24 rounded-md" />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bulk-add-columns.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bulk-add-columns.tsx
@@ -168,15 +168,19 @@ const BulkTrigger = ({ triggerVariant }: BulkTriggerProps) => {
       <DialogTrigger
         render={
           <Button
+            aria-label={t("workspaces.properties.newColumn")}
             className="text-muted-foreground hover:bg-accent gap-1 px-2 font-normal"
             size="xs"
+            title={t("workspaces.properties.newColumn")}
             type="button"
             variant="ghost"
           />
         }
       >
         <PlusIcon className="size-3" />
-        {t("workspaces.properties.newColumn")}
+        <span className="hidden sm:inline">
+          {t("workspaces.properties.newColumn")}
+        </span>
       </DialogTrigger>
     );
   }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -104,6 +104,10 @@ type OverviewViewProps = {
   workspaceId: string;
 };
 
+const OVERVIEW_PANEL_CLASS = "bg-background overflow-hidden rounded-lg border";
+const TEAM_HEATMAP_GRID_CLASS =
+  "grid grid-cols-[minmax(3.5rem,1fr)_repeat(7,1.375rem)] items-center gap-x-1 px-3 sm:grid-cols-[minmax(8rem,1fr)_repeat(7,1.75rem)_2.5rem] sm:gap-x-2 sm:px-4";
+
 type UpcomingTaskContext = {
   entityId: string;
   name: string;
@@ -426,7 +430,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
   );
 
   return (
-    <div className="@container flex flex-1 flex-col gap-6 overflow-y-auto p-6 tabular-nums">
+    <div className="@container flex flex-1 flex-col gap-6 overflow-y-auto p-4 tabular-nums sm:p-6">
       {/* Stats grid */}
       <div className="grid gap-3 @sm:grid-cols-2 @3xl:grid-cols-4">
         <StatCard
@@ -708,32 +712,36 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
         </section>
 
         {/* Time & Team */}
-        <section className="flex flex-col">
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-muted-foreground text-sm font-medium">
+        <section className="flex min-w-0 flex-col">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h2 className="text-muted-foreground min-w-0 text-sm font-medium">
               <ClockIcon className="me-1.5 inline size-3.5" />
               {t("workspaces.overview.timeAndTeam")}
             </h2>
-            <Button className="h-7 text-xs" disabled size="sm" variant="ghost">
+            <Button
+              className="h-7 shrink-0 text-xs"
+              disabled
+              size="sm"
+              variant="ghost"
+            >
               <PlusIcon className="size-3" />
               {t("common.logTime")}
             </Button>
           </div>
-          <div className="bg-background flex-1 overflow-hidden rounded-lg border">
-            {/* Day labels — i18n via Intl.DateTimeFormat */}
-            <div className="flex min-h-12 items-center gap-3 border-b px-4 py-2">
-              <span className="w-16 shrink-0 @sm:w-20 @lg:w-28" />
-              <div className="flex min-w-0 flex-1 justify-between">
-                {Array.from({ length: 7 }, (_, i) => (
-                  <span
-                    className="text-muted-foreground w-5 text-center text-[0.625rem] @sm:w-7"
-                    key={i}
-                  >
-                    {getLocaleDayLabel(i, lang, firstWeekday)}
-                  </span>
-                ))}
-              </div>
-              <span className="hidden w-10 shrink-0 @sm:block" />
+          <div className={cn(OVERVIEW_PANEL_CLASS, "flex-1")}>
+            <div
+              className={cn(TEAM_HEATMAP_GRID_CLASS, "min-h-12 border-b py-2")}
+            >
+              <span />
+              {Array.from({ length: 7 }, (_, i) => (
+                <span
+                  className="text-muted-foreground text-center text-[0.625rem]"
+                  key={i}
+                >
+                  {getLocaleDayLabel(i, lang, firstWeekday)}
+                </span>
+              ))}
+              <span className="hidden sm:block" />
             </div>
             <div className="divide-y">
               {(() => {
@@ -749,10 +757,10 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
 
                   return (
                     <div
-                      className="flex min-h-14 items-center gap-3 px-4 py-2.5"
+                      className={cn(TEAM_HEATMAP_GRID_CLASS, "min-h-14 py-2.5")}
                       key={member.userId}
                     >
-                      <div className="flex w-16 shrink-0 items-center gap-2 @sm:w-20 @lg:w-28">
+                      <div className="flex min-w-0 items-center gap-2">
                         <Avatar className="size-5 text-[0.5rem]">
                           {member.image && <AvatarImage src={member.image} />}
                           <AvatarFallback>
@@ -764,108 +772,107 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
                               .slice(0, 2)}
                           </AvatarFallback>
                         </Avatar>
-                        <span className="min-w-0 truncate text-xs">
+                        <span className="min-w-0 truncate text-sm">
                           {member.name}
                         </span>
                       </div>
-                      <div className="flex min-w-0 flex-1 justify-between">
-                        {member.daily.map((hours, dayIdx) => {
-                          const opacity = maxDaily > 0 ? hours / maxDaily : 0;
-                          const entries = member.dailyEntries[dayIdx] ?? [];
+                      {member.daily.map((hours, dayIdx) => {
+                        const opacity = maxDaily > 0 ? hours / maxDaily : 0;
+                        const entries = member.dailyEntries[dayIdx] ?? [];
+                        const dayLabel = getLocaleDayLabel(
+                          dayIdx,
+                          lang,
+                          firstWeekday,
+                        );
 
-                          const cell = (
-                            <div
-                              className={cn(
-                                "bg-primary/10 size-4 rounded-sm transition-transform @sm:size-5",
-                                hours > 0 && "cursor-pointer hover:scale-110",
-                              )}
-                              style={
-                                hours > 0
-                                  ? {
-                                      backgroundColor: `color-mix(in srgb, var(--color-primary) ${Math.round(opacity * 80 + 10)}%, transparent)`,
-                                    }
-                                  : undefined
-                              }
-                            />
-                          );
+                        const cell = (
+                          <div
+                            className={cn(
+                              "bg-primary/10 size-5 rounded-sm transition-transform",
+                              hours > 0 && "hover:scale-110",
+                            )}
+                            style={
+                              hours > 0
+                                ? {
+                                    backgroundColor: `color-mix(in srgb, var(--color-primary) ${Math.round(opacity * 80 + 10)}%, transparent)`,
+                                  }
+                                : undefined
+                            }
+                          />
+                        );
 
-                          if (hours === 0) {
-                            return (
-                              <div
-                                className="flex w-5 justify-center @sm:w-7"
-                                key={dayIdx}
-                              >
-                                {cell}
-                              </div>
-                            );
-                          }
-
+                        if (hours === 0) {
                           return (
                             <div
-                              className="flex w-5 justify-center @sm:w-7"
+                              className="flex size-6 items-center justify-center sm:size-7"
                               key={dayIdx}
                             >
-                              <Popover>
-                                <TooltipRoot>
-                                  <PopoverTrigger
-                                    render={
-                                      <TooltipTrigger
-                                        render={
-                                          <button
-                                            className="cursor-pointer"
-                                            type="button"
-                                          />
-                                        }
-                                      />
-                                    }
-                                  >
-                                    {cell}
-                                  </PopoverTrigger>
-                                  <TooltipPopup>
-                                    {formatHours(hours)}
-                                  </TooltipPopup>
-                                </TooltipRoot>
-                                <PopoverPopup className="w-56" sideOffset={8}>
-                                  <div className="p-2">
-                                    <p className="text-muted-foreground mb-2 text-xs font-medium">
-                                      {member.name} ·{" "}
-                                      {getLocaleDayLabel(
-                                        dayIdx,
-                                        lang,
-                                        firstWeekday,
-                                      )}
-                                      {" · "}
-                                      {formatHours(hours)}
-                                    </p>
-                                    {entries.length > 0 ? (
-                                      <div className="space-y-1.5">
-                                        {entries.map((entry) => (
-                                          <div
-                                            className="flex items-start justify-between gap-2"
-                                            key={entry.id}
-                                          >
-                                            <span className="text-xs">
-                                              {entry.description}
-                                            </span>
-                                            <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-                                              {formatHours(entry.hours)}
-                                            </span>
-                                          </div>
-                                        ))}
-                                      </div>
-                                    ) : (
-                                      <p className="text-muted-foreground text-xs">
-                                        {t("common.noResults")}
-                                      </p>
-                                    )}
-                                  </div>
-                                </PopoverPopup>
-                              </Popover>
+                              {cell}
                             </div>
                           );
-                        })}
-                      </div>
-                      <span className="text-muted-foreground hidden w-10 shrink-0 text-end text-xs tabular-nums @sm:block">
+                        }
+
+                        return (
+                          <div
+                            className="flex size-6 items-center justify-center sm:size-7"
+                            key={dayIdx}
+                          >
+                            <Popover>
+                              <TooltipRoot>
+                                <PopoverTrigger
+                                  render={
+                                    <TooltipTrigger
+                                      render={
+                                        <button
+                                          aria-label={`${member.name}, ${dayLabel}: ${formatHours(hours)}`}
+                                          className="flex size-6 cursor-pointer items-center justify-center sm:size-7"
+                                          type="button"
+                                        />
+                                      }
+                                    />
+                                  }
+                                >
+                                  {cell}
+                                </PopoverTrigger>
+                                <TooltipPopup>
+                                  {formatHours(hours)}
+                                </TooltipPopup>
+                              </TooltipRoot>
+                              <PopoverPopup className="w-56" sideOffset={8}>
+                                <div className="p-2">
+                                  <p className="text-muted-foreground mb-2 text-xs font-medium">
+                                    {member.name} · {dayLabel}
+                                    {" · "}
+                                    {formatHours(hours)}
+                                  </p>
+                                  {entries.length > 0 ? (
+                                    <div className="space-y-1.5">
+                                      {entries.map((entry) => (
+                                        <div
+                                          className="flex items-start justify-between gap-2"
+                                          key={entry.id}
+                                        >
+                                          <span className="text-xs">
+                                            {entry.description}
+                                          </span>
+                                          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                                            {formatHours(entry.hours)}
+                                          </span>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : (
+                                    <p className="text-muted-foreground text-xs">
+                                      {t("common.noResults")}
+                                    </p>
+                                  )}
+                                </div>
+                              </PopoverPopup>
+                            </Popover>
+                          </div>
+                        );
+                      })}
+                      <span className="text-muted-foreground hidden text-end text-xs tabular-nums sm:block">
                         {total > 0 ? formatHours(total) : ""}
                       </span>
                     </div>
@@ -960,7 +967,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
               {t("common.uploadFiles")}
             </Button>
           </div>
-          <div className="bg-background divide-y overflow-hidden rounded-lg border">
+          <div className={cn(OVERVIEW_PANEL_CLASS, "divide-y")}>
             {recentEntities.map((entity) => (
               <OverviewRow
                 entity={entity}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/playbooks-manager.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/playbooks-manager.tsx
@@ -114,14 +114,18 @@ export const PlaybooksManager = ({ workspaceId }: PlaybooksManagerProps) => {
   return (
     <>
       <Button
+        aria-label={t("workspaces.playbooks.action")}
         className="text-muted-foreground hover:bg-accent gap-1 px-2 font-normal"
         onClick={() => setOpen(true)}
         size="xs"
+        title={t("workspaces.playbooks.action")}
         type="button"
         variant="ghost"
       >
         <WandSparklesIcon className="size-3" />
-        {t("workspaces.playbooks.action")}
+        <span className="hidden sm:inline">
+          {t("workspaces.playbooks.action")}
+        </span>
       </Button>
       {open && (
         <PlaybooksDialog

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -38,6 +38,7 @@ import {
 import type { EntityGroup } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic";
 import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";
 import { GroupScopeProvider } from "@/routes/_protected.workspaces/$workspaceId/-components/table/group-scope";
+import { MobileTableOrientationGate } from "@/routes/_protected.workspaces/$workspaceId/-components/table/mobile-table-orientation-gate";
 import {
   DEFAULT_TABLE_COLUMN_MIN_SIZE,
   useTableColumns,
@@ -257,33 +258,35 @@ export const GroupedTableLayout = ({
     // `w-max min-w-full` sizes the column to the widest group's table content
     // so every section — populated, empty, and the add-row — stretches to the
     // full table width (their bands then run the whole scroll width).
-    <div className="flex w-max min-w-full flex-col" ref={scrollRef}>
-      {groups.map((group) => (
-        <GroupSection
+    <MobileTableOrientationGate>
+      <div className="flex w-max min-w-full flex-col" ref={scrollRef}>
+        {groups.map((group) => (
+          <GroupSection
+            columns={columns}
+            count={
+              countsLoaded ? (countByValue.get(group.value) ?? 0) : undefined
+            }
+            fieldIds={fieldIds}
+            group={group}
+            groupByPropertyId={groupByPropertyId}
+            key={groupKeyFor(group.value)}
+            optionValues={optionValues}
+            outerScrollRef={scrollRef}
+            reportGroupTreeData={reportGroupTreeData}
+            selectAllPreservableRowIds={allRowIds}
+            sumProperties={sumProperties}
+            tableState={tableState}
+            view={view}
+            workspaceId={workspaceId}
+          />
+        ))}
+        <GroupedAddRow
           columns={columns}
-          count={
-            countsLoaded ? (countByValue.get(group.value) ?? 0) : undefined
-          }
-          fieldIds={fieldIds}
-          group={group}
-          groupByPropertyId={groupByPropertyId}
-          key={groupKeyFor(group.value)}
-          optionValues={optionValues}
-          outerScrollRef={scrollRef}
-          reportGroupTreeData={reportGroupTreeData}
-          selectAllPreservableRowIds={allRowIds}
-          sumProperties={sumProperties}
           tableState={tableState}
-          view={view}
           workspaceId={workspaceId}
         />
-      ))}
-      <GroupedAddRow
-        columns={columns}
-        tableState={tableState}
-        workspaceId={workspaceId}
-      />
-    </div>
+      </div>
+    </MobileTableOrientationGate>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/mobile-table-orientation-gate.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/mobile-table-orientation-gate.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { TableIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+type MobileTableOrientationGateProps = {
+  children: ReactNode;
+};
+
+export const MobileTableOrientationGate = ({
+  children,
+}: MobileTableOrientationGateProps) => {
+  const t = useTranslations();
+
+  return (
+    <>
+      <div className="bg-background hidden min-h-64 flex-1 flex-col items-center justify-center gap-3 px-6 text-center max-md:portrait:flex">
+        <div className="bg-muted text-muted-foreground flex size-11 items-center justify-center rounded-lg">
+          <TableIcon className="size-5" />
+        </div>
+        <div className="max-w-72 space-y-1">
+          <h2 className="text-sm font-medium">
+            {t("workspaces.table.portraitTitle")}
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            {t("workspaces.table.portraitDescription")}
+          </p>
+        </div>
+      </div>
+      <div className="contents max-md:portrait:hidden">{children}</div>
+    </>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -51,18 +51,37 @@ type TableLayoutProps = {
   view: WorkspaceView<"table">;
 };
 
+type WorkspaceTableKeyInput = {
+  workspaceId: string;
+  viewId: string;
+};
+
+const getWorkspaceTableKey = ({
+  workspaceId,
+  viewId,
+}: WorkspaceTableKeyInput) => `workspace-table:${workspaceId}:${viewId}`;
+
 export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   const { openIfAIUnavailable } = useAIKeyGate();
+  const tableKey = getWorkspaceTableKey({ workspaceId, viewId: view.id });
 
   useMountEffect(() => {
     openIfAIUnavailable();
   });
 
   if (view.layout.groupByPropertyId) {
-    return <GroupedTableLayout view={view} workspaceId={workspaceId} />;
+    return (
+      <GroupedTableLayout
+        key={tableKey}
+        view={view}
+        workspaceId={workspaceId}
+      />
+    );
   }
 
-  return <FlatTableLayout view={view} workspaceId={workspaceId} />;
+  return (
+    <FlatTableLayout key={tableKey} view={view} workspaceId={workspaceId} />
+  );
 };
 
 const FlatTableLayout = ({ workspaceId, view }: TableLayoutProps) => {
@@ -115,9 +134,10 @@ const FlatTableLayout = ({ workspaceId, view }: TableLayoutProps) => {
     entityIdChunks: justificationEntityIdChunks,
   });
   useSyncSelectedEntities({ viewId: view.id, treeData });
+  const tableKey = getWorkspaceTableKey({ workspaceId, viewId: view.id });
 
   const table = useTable({
-    key: `workspace-table:${workspaceId}:${view.id}`,
+    key: tableKey,
     features: workspaceTableFeatures,
     columnResizeMode: "onChange",
     data: treeData,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -17,6 +17,7 @@ import {
   FilteredEmptyState,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
 import { GroupedTableLayout } from "@/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout";
+import { MobileTableOrientationGate } from "@/routes/_protected.workspaces/$workspaceId/-components/table/mobile-table-orientation-gate";
 import {
   DEFAULT_TABLE_COLUMN_MIN_SIZE,
   useTableColumns,
@@ -116,6 +117,7 @@ const FlatTableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   useSyncSelectedEntities({ viewId: view.id, treeData });
 
   const table = useTable({
+    key: `workspace-table:${workspaceId}:${view.id}`,
     features: workspaceTableFeatures,
     columnResizeMode: "onChange",
     data: treeData,
@@ -154,7 +156,7 @@ const FlatTableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   }
 
   return (
-    <>
+    <MobileTableOrientationGate>
       <WorkspaceTable
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
@@ -172,6 +174,6 @@ const FlatTableLayout = ({ workspaceId, view }: TableLayoutProps) => {
           </Suspense>
         </ClientOnly>
       ) : null}
-    </>
+    </MobileTableOrientationGate>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
@@ -2,21 +2,22 @@ import { useEffect, useRef, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
-import { XIcon } from "lucide-react";
+import { ArrowLeftIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Input } from "@stll/ui/components/input";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useInspectorStore } from "@/components/inspector/inspector-store";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
-import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import {
   isTaskPriority,
   isTaskStatus,
@@ -52,12 +53,15 @@ export const TaskDetailPanel = ({
   taskId,
 }: TaskDetailPanelProps) => {
   const t = useTranslations("tasks");
+  const tCommon = useTranslations("common");
   const closeTab = useInspectorStore((s) => s.closeTab);
+  const setMinimized = useInspectorStore((s) => s.setMinimized);
   const isNewTask = useInspectorStore((s) => {
     const found = s.tabs.find((tab) => tab.id === taskId);
     return found?.type === "task" && found.isNew;
   });
   const clearNewFlag = useInspectorStore((s) => s.clearTaskNewFlag);
+  const handleBack = () => setMinimized(true);
   const handleClose = () => closeTab(taskId);
   const queryClient = useQueryClient();
   const userId = useRouteContext({
@@ -224,8 +228,24 @@ export const TaskDetailPanel = ({
             TOOLBAR_ROW_HEIGHT,
           )}
         >
+          <Button
+            aria-label={tCommon("back")}
+            className="-ms-1 md:hidden"
+            onClick={handleBack}
+            size="icon-sm"
+            title={tCommon("back")}
+            variant="ghost"
+          >
+            <DirectionalIcon className="size-4" icon={ArrowLeftIcon} />
+          </Button>
           <Skeleton className="h-4 flex-1" />
-          <Button onClick={handleClose} size="icon-xs" variant="ghost">
+          <Button
+            aria-label={tCommon("close")}
+            onClick={handleClose}
+            size="icon-xs"
+            title={tCommon("close")}
+            variant="ghost"
+          >
             <XIcon className="size-3.5" />
           </Button>
         </div>
@@ -247,10 +267,26 @@ export const TaskDetailPanel = ({
             TOOLBAR_ROW_HEIGHT,
           )}
         >
+          <Button
+            aria-label={tCommon("back")}
+            className="-ms-1 md:hidden"
+            onClick={handleBack}
+            size="icon-sm"
+            title={tCommon("back")}
+            variant="ghost"
+          >
+            <DirectionalIcon className="size-4" icon={ArrowLeftIcon} />
+          </Button>
           <span className="text-muted-foreground flex-1 text-xs">
             {t("notFound")}
           </span>
-          <Button onClick={handleClose} size="icon-xs" variant="ghost">
+          <Button
+            aria-label={tCommon("close")}
+            onClick={handleClose}
+            size="icon-xs"
+            title={tCommon("close")}
+            variant="ghost"
+          >
             <XIcon className="size-3.5" />
           </Button>
         </div>
@@ -279,10 +315,26 @@ export const TaskDetailPanel = ({
           TOOLBAR_ROW_HEIGHT,
         )}
       >
+        <Button
+          aria-label={tCommon("back")}
+          className="-ms-1 md:hidden"
+          onClick={handleBack}
+          size="icon-sm"
+          title={tCommon("back")}
+          variant="ghost"
+        >
+          <DirectionalIcon className="size-4" icon={ArrowLeftIcon} />
+        </Button>
         <span className="min-w-0 flex-1 truncate text-xs font-medium">
           {isNewTask ? t("newTask") : name}
         </span>
-        <Button onClick={handleClose} size="icon-xs" variant="ghost">
+        <Button
+          aria-label={tCommon("close")}
+          onClick={handleClose}
+          size="icon-xs"
+          title={tCommon("close")}
+          variant="ghost"
+        >
           <XIcon className="size-3.5" />
         </Button>
       </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -110,9 +110,17 @@ export const FilterChips = ({
         onAddAdvanced={() => append(emptyAdvancedGroup())}
         onAddField={(field) => append(leafFromField(field))}
         trigger={
-          <Button className="gap-1.5" size="xs" variant="ghost">
+          <Button
+            aria-label={t("workspaces.views.filter")}
+            className="gap-1.5"
+            size="xs"
+            title={t("workspaces.views.filter")}
+            variant="ghost"
+          >
             <FilterIcon className="size-3.5" />
-            {t("workspaces.views.filter")}
+            <span className="hidden sm:inline">
+              {t("workspaces.views.filter")}
+            </span>
           </Button>
         }
       />
@@ -150,9 +158,17 @@ export const FilterChips = ({
         onAddAdvanced={() => append(emptyAdvancedGroup())}
         onAddField={(field) => append(leafFromField(field))}
         trigger={
-          <Button className="gap-1.5" size="xs" variant="ghost">
+          <Button
+            aria-label={t("workspaces.views.filter")}
+            className="gap-1.5"
+            size="xs"
+            title={t("workspaces.views.filter")}
+            variant="ghost"
+          >
             <FilterIcon className="size-3.5" />
-            {t("workspaces.views.filter")}
+            <span className="hidden sm:inline">
+              {t("workspaces.views.filter")}
+            </span>
           </Button>
         }
       />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -101,7 +101,7 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
   };
 
   return (
-    <div className="flex shrink-0 flex-wrap items-center gap-1 px-2 py-1">
+    <div className="flex min-w-0 shrink-0 [scrollbar-width:none] flex-nowrap items-center gap-1 overflow-x-auto px-2 py-1 [-ms-overflow-style:none] md:ms-auto md:flex-wrap md:justify-end md:overflow-visible [&::-webkit-scrollbar]:hidden">
       {view.layout.type === "filesystem" && folderState.hasFolders && (
         <>
           <FolderExpandToggle
@@ -523,18 +523,34 @@ const FilesystemOrganizerAction = ({
   return (
     <>
       <Button
+        aria-label={
+          selectedFiles.length > 0
+            ? t("workspaces.importOrganizer.actionSelected", {
+                count: organizerFiles.length,
+              })
+            : t("workspaces.importOrganizer.action")
+        }
         disabled={organizerFiles.length === 0}
         onClick={() => setOpen(true)}
         size="xs"
+        title={
+          selectedFiles.length > 0
+            ? t("workspaces.importOrganizer.actionSelected", {
+                count: organizerFiles.length,
+              })
+            : t("workspaces.importOrganizer.action")
+        }
         type="button"
         variant="outline"
       >
         <Rows3Icon />
-        {selectedFiles.length > 0
-          ? t("workspaces.importOrganizer.actionSelected", {
-              count: organizerFiles.length,
-            })
-          : t("workspaces.importOrganizer.action")}
+        <span className="hidden sm:inline">
+          {selectedFiles.length > 0
+            ? t("workspaces.importOrganizer.actionSelected", {
+                count: organizerFiles.length,
+              })
+            : t("workspaces.importOrganizer.action")}
+        </span>
       </Button>
       <ExistingFileOrganizerDialog
         existingFolders={existingFolders}
@@ -601,7 +617,7 @@ const GroupByControl = ({
 
   return (
     <span className="flex shrink-0 items-center gap-1 text-xs whitespace-nowrap">
-      <span className="text-muted-foreground shrink-0">
+      <span className="text-muted-foreground hidden shrink-0 sm:inline">
         {t("workspaces.views.groupBy")}
       </span>
       <Select
@@ -613,7 +629,10 @@ const GroupByControl = ({
         }}
         value={resolvedId}
       >
-        <SelectTrigger className="h-6 min-h-0 min-w-24 text-xs" size="sm">
+        <SelectTrigger
+          className="h-7 min-h-0 w-28 text-xs sm:h-6 sm:w-auto sm:min-w-24"
+          size="sm"
+        >
           <SelectValue placeholder={resolvedLabel}>{resolvedLabel}</SelectValue>
         </SelectTrigger>
         <SelectPopup>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-default-view-redirect.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-default-view-redirect.ts
@@ -1,0 +1,36 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { redirect } from "@tanstack/react-router";
+
+import { ensureRouteQueryData } from "@/lib/react-query";
+import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
+
+type RedirectToDefaultWorkspaceViewInput = {
+  queryClient: QueryClient;
+  workspaceId: string;
+};
+
+export const redirectToDefaultWorkspaceView = async ({
+  queryClient,
+  workspaceId,
+}: RedirectToDefaultWorkspaceViewInput): Promise<never> => {
+  const options = viewsOptions(workspaceId);
+
+  // Avoid serving stale cache from a previous workspace that had no views.
+  await queryClient.invalidateQueries({ queryKey: options.queryKey });
+
+  const views = await ensureRouteQueryData(queryClient, options);
+  const firstView = views.at(0);
+
+  if (!firstView) {
+    throw redirect({ to: "/workspaces", replace: true });
+  }
+
+  throw redirect({
+    to: "/workspaces/$workspaceId/$viewId",
+    params: {
+      workspaceId,
+      viewId: firstView.id,
+    },
+    replace: true,
+  });
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/index.tsx
@@ -1,31 +1,12 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
-import { ensureRouteQueryData } from "@/lib/react-query";
-import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
+import { redirectToDefaultWorkspaceView } from "@/routes/_protected.workspaces/$workspaceId/-default-view-redirect";
 
 export const Route = createFileRoute("/_protected/workspaces/$workspaceId/")({
   beforeLoad: async ({ context, params }) => {
-    const qc = context.queryClient;
-    const opts = viewsOptions(params.workspaceId);
-
-    // Invalidate first to avoid serving stale cache from a
-    // previous workspace that had no views.
-    await qc.invalidateQueries({ queryKey: opts.queryKey });
-
-    const views = await ensureRouteQueryData(qc, opts);
-
-    const firstView = views.at(0);
-    if (!firstView) {
-      throw redirect({ to: "/workspaces", replace: true });
-    }
-
-    throw redirect({
-      to: "/workspaces/$workspaceId/$viewId",
-      params: {
-        workspaceId: params.workspaceId,
-        viewId: firstView.id,
-      },
-      replace: true,
+    await redirectToDefaultWorkspaceView({
+      queryClient: context.queryClient,
+      workspaceId: params.workspaceId,
     });
   },
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -6,8 +6,8 @@ export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/timesheets",
 )({
   // Time tracking is intentionally excluded from the current product surface.
-  // Keep this route redirect-only so abandoned /timesheets navigations cannot
-  // mount the old billing query tree before the redirect commits.
+  // Keep the disabled route redirect-only so dormant UI cannot mount during
+  // direct URL or deep-link navigation.
   beforeLoad: async ({ context, params }) => {
     await redirectToDefaultWorkspaceView({
       queryClient: context.queryClient,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -1,4 +1,6 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { redirectToDefaultWorkspaceView } from "@/routes/_protected.workspaces/$workspaceId/-default-view-redirect";
 
 export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/timesheets",
@@ -6,13 +8,10 @@ export const Route = createFileRoute(
   // Time tracking is intentionally excluded from the current product surface.
   // Keep this route redirect-only so abandoned /timesheets navigations cannot
   // mount the old billing query tree before the redirect commits.
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: "/workspaces/$workspaceId",
-      params: {
-        workspaceId: params.workspaceId,
-      },
-      replace: true,
+  beforeLoad: async ({ context, params }) => {
+    await redirectToDefaultWorkspaceView({
+      queryClient: context.queryClient,
+      workspaceId: params.workspaceId,
     });
   },
 });

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -42,6 +42,7 @@ import { useConfigStore } from "@/stores/config-store";
 
 const MAX_VISIBLE_AVATARS = 3;
 const MATTER_INLINE_EDIT_SELECTOR = "[data-matter-inline-edit]";
+const MATTERS_TABLE_NAME_COLUMN_WIDTH_PX = 260;
 
 type MattersTableProps = {
   workspaces: Workspace[];
@@ -81,8 +82,12 @@ export const MattersTable = ({
   const columns = COLUMNS.filter((col) =>
     col.id === "name" ? true : visibleColumnSet.has(col.id),
   );
+  const minTableWidth = columns.reduce(
+    (sum, column) => sum + column.widthPx,
+    0,
+  );
 
-  const filterTrigger = (id: string) => {
+  const filterTrigger = (id: ColumnDef["id"]) => {
     if (!isFilterableColumnId(id)) {
       return null;
     }
@@ -90,14 +95,11 @@ export const MattersTable = ({
   };
 
   return (
-    <Frame>
-      <Table className="table-fixed">
+    <Frame className="overflow-hidden rounded-lg sm:rounded-2xl">
+      <Table className="table-fixed" style={{ minWidth: `${minTableWidth}px` }}>
         <colgroup>
           {columns.map((col) => (
-            <col
-              key={col.id}
-              style={col.width ? { width: col.width } : undefined}
-            />
+            <col key={col.id} style={{ width: `${col.widthPx}px` }} />
           ))}
         </colgroup>
         <TableHeader>
@@ -240,11 +242,15 @@ const toLocalISODate = (date: Date): string => {
 };
 
 const TeamCell = ({ workspace }: CellProps) => (
-  <TeamAvatars
-    leadUserId={workspace.leadUserId}
-    maxVisible={MAX_VISIBLE_AVATARS}
-    members={workspace.members}
-  />
+  <div className="flex min-w-0 justify-end sm:justify-start">
+    <TeamAvatars
+      leadUserId={workspace.leadUserId}
+      maxVisible={MAX_VISIBLE_AVATARS}
+      members={workspace.members}
+      size="size-5 sm:size-6"
+      textSize="text-[0.55rem] sm:text-[0.625rem]"
+    />
+  </div>
 );
 
 const CreatedAtCell = ({ workspace }: CellProps) => {
@@ -266,20 +272,20 @@ type ColumnDef =
   | {
       id: MattersColumnId | "name";
       sortKey: MattersSortKey;
-      width?: string;
+      widthPx: number;
       Cell: (props: CellProps) => React.ReactNode;
     }
   | {
       id: MattersColumnId;
       sortKey?: undefined;
-      width?: string;
+      widthPx: number;
       Cell: (props: CellProps) => React.ReactNode;
     };
 
 type MattersTableRowProps = {
   workspace: Workspace;
   globalIndex: number;
-  columns: ColumnDef[];
+  columns: readonly ColumnDef[];
   focusIndex: number;
 };
 
@@ -371,40 +377,45 @@ const MattersTableRow = ({
   );
 };
 
-const COLUMNS: ColumnDef[] = [
-  { id: "name", sortKey: "name", Cell: NameCell },
-  { id: "client", sortKey: "clientName", width: "240px", Cell: ClientCell },
-  { id: "team", width: "160px", Cell: TeamCell },
+const COLUMNS = [
+  {
+    id: "name",
+    sortKey: "name",
+    widthPx: MATTERS_TABLE_NAME_COLUMN_WIDTH_PX,
+    Cell: NameCell,
+  },
+  { id: "client", sortKey: "clientName", widthPx: 240, Cell: ClientCell },
+  { id: "team", widthPx: 160, Cell: TeamCell },
   {
     id: "reference",
     sortKey: "reference",
-    width: "120px",
+    widthPx: 120,
     Cell: ReferenceCell,
   },
   {
     id: "entityCount",
     sortKey: "entityCount",
-    width: "96px",
+    widthPx: 96,
     Cell: EntityCountCell,
   },
   {
     id: "lastActivityAt",
     sortKey: "lastActivityAt",
-    width: "140px",
+    widthPx: 140,
     Cell: LastActivityCell,
   },
   {
     id: "createdAt",
     sortKey: "createdAt",
-    width: "120px",
+    widthPx: 120,
     Cell: CreatedAtCell,
   },
-];
+] as const satisfies readonly ColumnDef[];
 
 type MattersTableGroupProps = {
   group: WorkspaceGroup;
   workspaces: Workspace[];
-  columns: ColumnDef[];
+  columns: readonly ColumnDef[];
   focusIndex: number;
   collapsed: boolean;
   onToggle: () => void;

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { Link, useNavigate } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
@@ -96,77 +98,82 @@ export const MattersTable = ({
 
   return (
     <Frame className="overflow-hidden rounded-lg sm:rounded-2xl">
-      <Table className="table-fixed" style={{ minWidth: `${minTableWidth}px` }}>
-        <colgroup>
-          {columns.map((col) => (
-            <col key={col.id} style={{ width: `${col.widthPx}px` }} />
-          ))}
-        </colgroup>
-        <TableHeader>
-          <TableRow>
-            {columns.map((col) => {
-              const trailing = filterTrigger(col.id);
-              if (!col.sortKey) {
-                return (
-                  <TableHead className="group/header" key={col.id}>
-                    <span className="inline-flex items-center gap-1">
-                      <span className="truncate">{columnLabels[col.id]}</span>
-                      {trailing}
-                    </span>
-                  </TableHead>
-                );
-              }
-              const key = col.sortKey;
-              const direction: "asc" | "desc" | null = (() => {
-                if (sortKey !== key) {
-                  return null;
+      <div className="overflow-x-auto">
+        <Table
+          className="table-fixed"
+          style={{ minWidth: `${minTableWidth}px` }}
+        >
+          <colgroup>
+            {columns.map((col) => (
+              <col key={col.id} style={{ width: `${col.widthPx}px` }} />
+            ))}
+          </colgroup>
+          <TableHeader>
+            <TableRow>
+              {columns.map((col) => {
+                const trailing = filterTrigger(col.id);
+                if (col.type === "static") {
+                  return (
+                    <TableHead className="group/header" key={col.id}>
+                      <span className="inline-flex items-center gap-1">
+                        <span className="truncate">{columnLabels[col.id]}</span>
+                        {trailing}
+                      </span>
+                    </TableHead>
+                  );
                 }
-                return sortDesc ? "desc" : "asc";
-              })();
-              return (
-                <SortableHead
-                  className="group/header"
-                  key={col.id}
-                  onSort={() => {
-                    if (sortKey === key) {
-                      update({ sortDesc: !sortDesc });
-                    } else {
-                      update({ sortKey: key, sortDesc: true });
-                    }
-                  }}
-                  sortDirection={direction}
-                  trailing={trailing}
-                >
-                  {sortLabels[key]}
-                </SortableHead>
-              );
-            })}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {groups && groups.length > 0
-            ? groups.map((group) => (
-                <MattersTableGroup
-                  collapsed={collapsedGroups.includes(group.groupId)}
-                  columns={columns}
-                  focusIndex={focusIndex}
-                  group={group}
-                  key={group.groupId}
-                  onToggle={() => onToggleGroup(group.groupId)}
-                  workspaces={workspaces}
-                />
-              ))
-            : workspaces.map((ws, i) => (
-                <MattersTableRow
-                  columns={columns}
-                  focusIndex={focusIndex}
-                  globalIndex={i}
-                  key={ws.id}
-                  workspace={ws}
-                />
-              ))}
-        </TableBody>
-      </Table>
+                const key = col.sortKey;
+                const direction: "asc" | "desc" | null = (() => {
+                  if (sortKey !== key) {
+                    return null;
+                  }
+                  return sortDesc ? "desc" : "asc";
+                })();
+                return (
+                  <SortableHead
+                    className="group/header"
+                    key={col.id}
+                    onSort={() => {
+                      if (sortKey === key) {
+                        update({ sortDesc: !sortDesc });
+                      } else {
+                        update({ sortKey: key, sortDesc: true });
+                      }
+                    }}
+                    sortDirection={direction}
+                    trailing={trailing}
+                  >
+                    {sortLabels[key]}
+                  </SortableHead>
+                );
+              })}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {groups && groups.length > 0
+              ? groups.map((group) => (
+                  <MattersTableGroup
+                    collapsed={collapsedGroups.includes(group.groupId)}
+                    columns={columns}
+                    focusIndex={focusIndex}
+                    group={group}
+                    key={group.groupId}
+                    onToggle={() => onToggleGroup(group.groupId)}
+                    workspaces={workspaces}
+                  />
+                ))
+              : workspaces.map((ws, i) => (
+                  <MattersTableRow
+                    columns={columns}
+                    focusIndex={focusIndex}
+                    globalIndex={i}
+                    key={ws.id}
+                    workspace={ws}
+                  />
+                ))}
+          </TableBody>
+        </Table>
+      </div>
     </Frame>
   );
 };
@@ -270,16 +277,17 @@ const CreatedAtCell = ({ workspace }: CellProps) => {
 
 type ColumnDef =
   | {
+      type: "sortable";
       id: MattersColumnId | "name";
       sortKey: MattersSortKey;
       widthPx: number;
-      Cell: (props: CellProps) => React.ReactNode;
+      Cell: (props: CellProps) => ReactNode;
     }
   | {
+      type: "static";
       id: MattersColumnId;
-      sortKey?: undefined;
       widthPx: number;
-      Cell: (props: CellProps) => React.ReactNode;
+      Cell: (props: CellProps) => ReactNode;
     };
 
 type MattersTableRowProps = {
@@ -379,32 +387,43 @@ const MattersTableRow = ({
 
 const COLUMNS = [
   {
+    type: "sortable",
     id: "name",
     sortKey: "name",
     widthPx: MATTERS_TABLE_NAME_COLUMN_WIDTH_PX,
     Cell: NameCell,
   },
-  { id: "client", sortKey: "clientName", widthPx: 240, Cell: ClientCell },
-  { id: "team", widthPx: 160, Cell: TeamCell },
   {
+    type: "sortable",
+    id: "client",
+    sortKey: "clientName",
+    widthPx: 240,
+    Cell: ClientCell,
+  },
+  { type: "static", id: "team", widthPx: 160, Cell: TeamCell },
+  {
+    type: "sortable",
     id: "reference",
     sortKey: "reference",
     widthPx: 120,
     Cell: ReferenceCell,
   },
   {
+    type: "sortable",
     id: "entityCount",
     sortKey: "entityCount",
     widthPx: 96,
     Cell: EntityCountCell,
   },
   {
+    type: "sortable",
     id: "lastActivityAt",
     sortKey: "lastActivityAt",
     widthPx: 140,
     Cell: LastActivityCell,
   },
   {
+    type: "sortable",
     id: "createdAt",
     sortKey: "createdAt",
     widthPx: 120,

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-toolbar.tsx
@@ -73,7 +73,7 @@ export const MattersToolbar = ({
       )}
     >
       <Input
-        className="w-64 max-w-[40%]"
+        className="min-w-0 flex-1 sm:w-64 sm:max-w-[40%] sm:flex-none"
         onChange={(e) => onSearchChange(e.currentTarget.value)}
         placeholder={t("common.search")}
         ref={searchRef}
@@ -84,9 +84,18 @@ export const MattersToolbar = ({
       <ToolbarSeparator />
 
       <Menu>
-        <MenuTrigger render={<Button size="xs" variant="ghost" />}>
+        <MenuTrigger
+          render={
+            <Button
+              aria-label={t("common.sort")}
+              size="xs"
+              title={t("common.sort")}
+              variant="ghost"
+            />
+          }
+        >
           <SlidersHorizontalIcon />
-          <span className="text-muted-foreground text-xs">
+          <span className="text-muted-foreground hidden text-xs sm:inline">
             {sortLabels[config.sortKey]}
           </span>
           {config.sortDesc ? (
@@ -154,17 +163,26 @@ export const MattersToolbar = ({
           })
         }
         size="xs"
+        title={
+          config.viewMode === "grid"
+            ? t("workspaces.views.layouts.table")
+            : t("workspaces.views.layouts.grid")
+        }
         variant="ghost"
       >
         {config.viewMode === "grid" ? (
           <>
             <ListIcon />
-            {t("workspaces.views.layouts.table")}
+            <span className="hidden sm:inline">
+              {t("workspaces.views.layouts.table")}
+            </span>
           </>
         ) : (
           <>
             <LayoutGridIcon />
-            {t("workspaces.views.layouts.grid")}
+            <span className="hidden sm:inline">
+              {t("workspaces.views.layouts.grid")}
+            </span>
           </>
         )}
       </Button>
@@ -197,9 +215,15 @@ const CreateMatterPopover = ({ className }: CreateMatterPopoverProps) => {
   }
 
   return (
-    <Button className={className} onClick={() => openCreateMatter()} size="xs">
+    <Button
+      aria-label={t("workspaces.newMatter")}
+      className={className}
+      onClick={() => openCreateMatter()}
+      size="xs"
+      title={t("workspaces.newMatter")}
+    >
       <PlusIcon />
-      {t("workspaces.newMatter")}
+      <span className="hidden sm:inline">{t("workspaces.newMatter")}</span>
     </Button>
   );
 };


### PR DESCRIPTION
## Summary
- improve mobile viewport behavior for workspace chrome, inspector/task details, matters, knowledge tools/templates/clauses, and dense tables
- add shared responsive toolbar and mobile category filter primitives
- hide desktop-only shortcut hints/rails on small screens and gate dense tables behind a landscape prompt