### PR TITLE
chore: finish tsgo migration and drop the direct typescript dependency

### DIFF
--- a/apps/collab/package.json
+++ b/apps/collab/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@hocuspocus/provider": "^4.2.0",
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,7 +31,6 @@
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
     "@vitejs/plugin-react": "catalog:",
-    "typescript": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -28,7 +28,6 @@
     "@astrojs/check": "^0.9.9",
     "@resvg/resvg-js": "^2.6.2",
     "@types/react": "catalog:react19",
-    "@types/react-dom": "catalog:react19",
-    "typescript": "catalog:"
+    "@types/react-dom": "catalog:react19"
   }
 }

--- a/apps/legal-atlas-runner/package.json
+++ b/apps/legal-atlas-runner/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -26,7 +26,6 @@
     "@types/react-dom": "catalog:react19",
     "@vitejs/plugin-react": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware apps/playground",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/playground",
     "format": "oxfmt ."

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -132,7 +132,6 @@
     "elysia": "catalog:",
     "react-grab": "0.1.44",
     "rollup-plugin-visualizer": "^7.0.1",
-    "typescript": "catalog:",
     "unified": "^11.0.5"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,6 @@
         "@hocuspocus/provider": "^4.2.0",
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "apps/desktop": {
@@ -157,7 +156,6 @@
         "@types/react": "catalog:react19",
         "@types/react-dom": "catalog:react19",
         "@vitejs/plugin-react": "catalog:",
-        "typescript": "catalog:",
         "vite": "catalog:",
       },
     },
@@ -179,7 +177,6 @@
         "@resvg/resvg-js": "^2.6.2",
         "@types/react": "catalog:react19",
         "@types/react-dom": "catalog:react19",
-        "typescript": "catalog:",
       },
     },
     "apps/legal-atlas-runner": {
@@ -193,7 +190,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "apps/playground": {
@@ -213,7 +209,6 @@
         "@types/react-dom": "catalog:react19",
         "@vitejs/plugin-react": "catalog:",
         "tailwindcss": "catalog:",
-        "typescript": "catalog:",
         "vite": "catalog:",
       },
     },
@@ -330,7 +325,6 @@
         "elysia": "catalog:",
         "react-grab": "0.1.44",
         "rollup-plugin-visualizer": "^7.0.1",
-        "typescript": "catalog:",
         "unified": "^11.0.5",
       },
     },
@@ -340,7 +334,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/anonymize-chat": {
@@ -353,7 +346,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/boe": {
@@ -362,7 +354,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/business-registries": {
@@ -375,7 +366,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/catalogue": {
@@ -388,7 +378,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/conditions": {
@@ -401,7 +390,6 @@
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
         "fast-check": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/country-codes": {
@@ -410,7 +398,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/docx-core": {
@@ -423,7 +410,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/docx-utils": {
@@ -435,7 +421,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/errors": {
@@ -447,7 +432,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/folio": {
@@ -491,7 +475,6 @@
         "fast-check": "catalog:",
         "react": "catalog:react19",
         "react-dom": "catalog:react19",
-        "typescript": "catalog:",
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -511,7 +494,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/legal-ast": {
@@ -523,7 +505,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/legal-atlas": {
@@ -536,7 +517,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/locales": {
@@ -545,7 +525,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/money": {
@@ -554,7 +533,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/permissions": {
@@ -566,7 +544,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/scripts": {
@@ -586,7 +563,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/skills": {
@@ -598,7 +574,6 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/template-conditions": {
@@ -612,7 +587,6 @@
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
         "fast-check": "catalog:",
-        "typescript": "catalog:",
       },
     },
     "packages/transactional": {
@@ -629,7 +603,6 @@
         "@stll/typescript-config": "workspace:*",
         "@types/react": "catalog:react19",
         "react-email": "^6.6.0",
-        "typescript": "catalog:",
       },
     },
     "packages/typescript-config": {
@@ -653,7 +626,6 @@
         "@types/bun": "catalog:",
         "@types/react": "catalog:react19",
         "tailwindcss": "catalog:",
-        "typescript": "catalog:",
       },
     },
   },

--- a/packages/ai-catalog/package.json
+++ b/packages/ai-catalog/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/anonymize-chat/package.json
+++ b/packages/anonymize-chat/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/boe/package.json
+++ b/packages/boe/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -109,7 +109,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
@@ -124,7 +124,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/catalogue/package.json
+++ b/packages/catalogue/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/conditions/package.json
+++ b/packages/conditions/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:",
-    "fast-check": "catalog:",
-    "typescript": "catalog:"
+    "fast-check": "catalog:"
   }
 }

--- a/packages/country-codes/package.json
+++ b/packages/country-codes/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "bun test src",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/docx-core",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/docx-core",
     "format": "oxfmt ."

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -7,7 +7,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "test": "bun test src",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/docx-utils",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/docx-utils",
     "format": "oxfmt ."

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -16,7 +16,7 @@
     "./editor.css": "./src/styles/editor.css"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/folio",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/folio",
     "format": "oxfmt .",

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -63,8 +63,7 @@
     "@types/react-dom": "catalog:react19",
     "fast-check": "catalog:",
     "react": "catalog:react19",
-    "react-dom": "catalog:react19",
-    "typescript": "catalog:"
+    "react-dom": "catalog:react19"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/infosoud/package.json
+++ b/packages/infosoud/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
     "extract:codes": "bun scripts/extract-codes.ts",
     "extract:codes:check": "bun scripts/extract-codes.ts --check",
     "pack:dry-run": "bun pm pack --dry-run",
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/legal-ast/package.json
+++ b/packages/legal-ast/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/legal-atlas/package.json
+++ b/packages/legal-atlas/package.json
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/money/package.json
+++ b/packages/money/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/template-conditions/package.json
+++ b/packages/template-conditions/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:",
-    "fast-check": "catalog:",
-    "typescript": "catalog:"
+    "fast-check": "catalog:"
   }
 }

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -31,7 +31,6 @@
     "@react-email/ui": "6.6.0",
     "@stll/typescript-config": "workspace:*",
     "@types/react": "catalog:react19",
-    "react-email": "^6.6.0",
-    "typescript": "catalog:"
+    "react-email": "^6.6.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,6 @@
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:",
     "@types/react": "catalog:react19",
-    "tailwindcss": "catalog:",
-    "typescript": "catalog:"
+    "tailwindcss": "catalog:"
   }
 }


### PR DESCRIPTION
## What

Finishes moving the repo's type-checking and library builds onto `tsgo`
(`@typescript/native-preview`) and removes `typescript` as a direct
dependency of the workspace packages.

- **Typecheck**: the last four packages still on classic `tsc --noEmit`
  (`packages/folio`, `packages/docx-core`, `packages/docx-utils`,
  `apps/playground`) now use `tsgo --noEmit`, matching every other
  package. The whole repo's typecheck path is now a single compiler, so
  a type can no longer pass one compiler and fail the other.
- **Build/emit**: the five publishable packages that emit `dist/`
  (`country-codes`, `locales`, `boe`, `infosoud`, `business-registries`)
  switch from `tsc -p tsconfig.build.json` to `tsgo -p`. Verified against
  `tsc`: identical `.js` output, declarations identical apart from
  string-literal quote style, only sourcemap formatting differs. These
  configs use `isolatedDeclarations`, so declaration emit is syntactic.
- **Dependency**: `typescript` is dropped as a direct dependency from all
  workspace packages. It remains a single root dev dependency because it
  is still required transitively by the Astro type-checker
  (`apps/landing` runs `astro check`) and by the eslint plugins that
  oxlint consumes; neither has a Go-native equivalent yet.

## Verification

- All nine migrated packages typecheck clean on `tsgo`.
- All five build packages emit on `tsgo` (exit 0).
- `apps/landing` `astro check` still resolves `typescript` (0 errors).