### PR TITLE
feat(web): morph chat send/stop button; fix composer update loop

### DIFF
--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -22,7 +22,7 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
 import type { EditorState, Plugin, PluginKey } from "@tiptap/pm/state";
-import type { Editor, JSONContent } from "@tiptap/react";
+import type { Editor } from "@tiptap/react";
 import { useEditor } from "@tiptap/react";
 import { panic, Result } from "better-result";
 import { useDebouncedCallback } from "use-debounce";
@@ -55,8 +55,10 @@ import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import {
+  areDraftDocsEqual,
   createChatDraftState,
   createEmptyChatDraftDoc,
+  nextDraftForEditorUpdate,
   useChatDraftStore,
 } from "@/lib/chat-draft-store";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
@@ -225,9 +227,6 @@ const isSuggestionPluginActive = (state: EditorState): boolean =>
     const pluginState: unknown = plugin.getState(state);
     return isSuggestionPluginState(pluginState) && pluginState.active;
   });
-
-const areDocsEqual = (left: JSONContent, right: JSONContent) =>
-  JSON.stringify(left) === JSON.stringify(right);
 
 const getEditorHtml = (editor: Editor) =>
   editor.isEmpty ? "" : editor.getHTML().trim();
@@ -547,7 +546,7 @@ export const useChatEditor = ({
   const draftDoc = draft?.doc ?? EMPTY_CHAT_DRAFT_DOC;
   const attachments = draft?.attachments ?? EMPTY_ATTACHMENTS;
   const [isEmpty, setIsEmpty] = useState(() =>
-    areDocsEqual(draftDoc, EMPTY_CHAT_DRAFT_DOC),
+    areDraftDocsEqual(draftDoc, EMPTY_CHAT_DRAFT_DOC),
   );
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
@@ -719,17 +718,26 @@ export const useChatEditor = ({
       return;
     }
 
+    // `nextDraftForEditorUpdate` returns null for no-op updates whose document
+    // already matches the stored draft. tiptap emits `update` even when a
+    // transaction leaves the document unchanged (e.g. editor props re-applied
+    // while the page re-renders during response streaming); persisting an
+    // identical draft would churn the store reference, retrigger this handler,
+    // and loop until React's max-update-depth guard throws.
+    const nextDraft = nextDraftForEditorUpdate({
+      attachments: attachmentsRef.current,
+      nextDoc: nextEditor.getJSON(),
+      storedDoc: draftDoc,
+    });
+    if (!nextDraft) {
+      return;
+    }
+
     if (!isNavigatingHistoryRef.current) {
       messageHistoryIndexRef.current = null;
     }
 
-    setDraft(
-      threadKey,
-      createChatDraftState({
-        attachments: attachmentsRef.current,
-        doc: nextEditor.getJSON(),
-      }),
-    );
+    setDraft(threadKey, nextDraft);
 
     if (!nextEditor.isEmpty) {
       markDraftStarted();
@@ -1057,7 +1065,7 @@ export const useChatEditor = ({
     if (!isUsableEditor(editor)) {
       return undefined;
     }
-    if (areDocsEqual(editor.getJSON(), draftDoc)) {
+    if (areDraftDocsEqual(editor.getJSON(), draftDoc)) {
       setIsEmpty(editor.isEmpty);
       return undefined;
     }

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -53,7 +53,6 @@ export const ChatInputSurface = ({
   onStop,
   anonymized = false,
 }: ChatInputSurfaceProps) => {
-  const t = useTranslations();
   const rootRef = useRef<HTMLDivElement>(null);
   const {
     attachments,
@@ -163,34 +162,65 @@ export const ChatInputSurface = ({
           type="file"
         />
         <div className="ms-auto flex items-center gap-1">
-          {isGenerating && onStop && (
-            <Button
-              aria-label={t("chat.stopResponse")}
-              className="shrink-0"
-              onClick={onStop}
-              size="icon-sm"
-              variant="outline"
-            >
-              <SquareIcon className="size-3.5" />
-            </Button>
-          )}
-          <Button
-            aria-label={t("chat.sendPrompt")}
-            className={cn(
-              "bg-foreground text-background hover:bg-foreground/90 shrink-0",
-              (submitDisabled || !canSubmit) && "opacity-50",
-            )}
-            disabled={submitDisabled || !canSubmit}
-            onClick={() => {
+          <ChatSubmitButton
+            canSend={!submitDisabled && canSubmit}
+            isGenerating={isGenerating}
+            onSend={() => {
               void submitDraft();
             }}
-            size="icon-sm"
-            variant="default"
-          >
-            <ArrowUpIcon className="size-3.5" />
-          </Button>
+            onStop={onStop}
+          />
         </div>
       </div>
     </div>
+  );
+};
+
+type ChatSubmitButtonProps = {
+  canSend: boolean;
+  isGenerating: boolean;
+  onSend: () => void;
+  onStop?: (() => void) | undefined;
+};
+
+// The single primary affordance morphs between send and stop so a
+// running turn is cancelled from the same button that submits it,
+// rather than a separate control sitting beside the input.
+const ChatSubmitButton = ({
+  canSend,
+  isGenerating,
+  onSend,
+  onStop,
+}: ChatSubmitButtonProps) => {
+  const t = useTranslations();
+
+  if (isGenerating && onStop) {
+    return (
+      <Button
+        aria-label={t("chat.stopResponse")}
+        className="bg-foreground text-background hover:bg-foreground/90 shrink-0"
+        onClick={onStop}
+        size="icon-sm"
+        variant="default"
+      >
+        <SquareIcon className="size-3.5" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      aria-label={t("chat.sendPrompt")}
+      className={cn(
+        "bg-foreground text-background hover:bg-foreground/90 shrink-0",
+        !canSend && "opacity-50",
+      )}
+      disabled={!canSend}
+      onClick={onSend}
+      size="icon-sm"
+      variant="default"
+    >
+      <ArrowUpIcon className="size-3.5" />
+    </Button>
   );
 };

--- a/apps/web/src/lib/chat-draft-store.test.ts
+++ b/apps/web/src/lib/chat-draft-store.test.ts
@@ -1,13 +1,22 @@
+import type { JSONContent } from "@tiptap/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { ChatDraftAttachment } from "@/components/chat-editor-provider";
 import type { ChatMentionOption } from "@/components/chat-mention-extension";
 import {
   appendMentionToDraftDoc,
+  areDraftDocsEqual,
   createChatDraftState,
   createEmptyChatDraftDoc,
+  nextDraftForEditorUpdate,
   useChatDraftStore,
 } from "@/lib/chat-draft-store";
 import { getChatThreadKey, toChatThreadId } from "@/lib/chat-thread-ref";
+
+const docWithText = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+});
 
 const mention: ChatMentionOption = {
   id: "entity-1",
@@ -47,6 +56,54 @@ describe("appendMentionToDraftDoc", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("areDraftDocsEqual", () => {
+  test("compares by value, not reference", () => {
+    expect(
+      areDraftDocsEqual(createEmptyChatDraftDoc(), createEmptyChatDraftDoc()),
+    ).toBe(true);
+    expect(areDraftDocsEqual(docWithText("a"), docWithText("b"))).toBe(false);
+  });
+});
+
+describe("nextDraftForEditorUpdate", () => {
+  // Regression guard: tiptap emits `update` for transactions that leave the
+  // document unchanged (e.g. while the page re-renders during response
+  // streaming). Returning a fresh draft for those no-op updates churned the
+  // store reference and looped the editor's onUpdate until React threw
+  // "Maximum update depth exceeded". A no-op update must yield null.
+  test("returns null when the document is unchanged (distinct but equal docs)", () => {
+    const result = nextDraftForEditorUpdate({
+      attachments: [],
+      nextDoc: createEmptyChatDraftDoc(),
+      storedDoc: createEmptyChatDraftDoc(),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns a new draft state carrying the edited doc and attachments", () => {
+    const attachments: ChatDraftAttachment[] = [
+      {
+        file: new File(["x"], "a.pdf", { type: "application/pdf" }),
+        filename: "a.pdf",
+        id: "att-1",
+        mimeType: "application/pdf",
+      },
+    ];
+    const nextDoc = docWithText("hello");
+
+    const result = nextDraftForEditorUpdate({
+      attachments,
+      nextDoc,
+      storedDoc: createEmptyChatDraftDoc(),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.doc).toEqual(nextDoc);
+    expect(result?.attachments).toBe(attachments);
   });
 });
 

--- a/apps/web/src/lib/chat-draft-store.ts
+++ b/apps/web/src/lib/chat-draft-store.ts
@@ -90,6 +90,33 @@ export const createChatDraftState = (
   updatedAt: overrides?.updatedAt ?? Date.now(),
 });
 
+export const areDraftDocsEqual = (
+  left: JSONContent,
+  right: JSONContent,
+): boolean => JSON.stringify(left) === JSON.stringify(right);
+
+type NextDraftForEditorUpdateOptions = {
+  attachments: ChatDraftAttachment[];
+  nextDoc: JSONContent;
+  storedDoc: JSONContent;
+};
+
+// Decides whether a tiptap `update` event should be persisted to the draft
+// store. Returns `null` for no-op updates whose document matches what is
+// already stored: tiptap emits `update` even for transactions that leave the
+// document unchanged (e.g. editor props re-applied while the page re-renders
+// during response streaming). Persisting an identical draft would churn the
+// store entry's reference, retrigger the editor's onUpdate, and loop until
+// React's max-update-depth guard throws. Only genuine edits yield a new state.
+export const nextDraftForEditorUpdate = ({
+  attachments,
+  nextDoc,
+  storedDoc,
+}: NextDraftForEditorUpdateOptions): ChatDraftState | null =>
+  areDraftDocsEqual(nextDoc, storedDoc)
+    ? null
+    : createChatDraftState({ attachments, doc: nextDoc });
+
 export const useChatDraftStore = create<ChatDraftStore>((set, get) => ({
   clearDraft: (threadKey) =>
     set((state) => {


### PR DESCRIPTION
## Summary

Two related chat-composer changes:

- **feat:** Collapse the composer's send and stop controls into one primary button that morphs — the send arrow when idle, a stop square while a response is generating. Removes the separate outline stop button that sat beside send. Mid-turn queueing via Enter is preserved.
- **fix:** Prevent a composer render loop. tiptap emits `update` for transactions that leave the document unchanged (e.g. editor props re-applied while the page re-renders during response streaming); the `onUpdate` handler persisted the draft on every such event, churning the draft-store reference and retriggering `onUpdate` until React's max-update-depth guard threw. The handler now persists only on real edits, via a unit-tested `nextDraftForEditorUpdate` guard in `chat-draft-store.ts`.
