### PR TITLE
chore: enable typescript/prefer-readonly

### DIFF
--- a/apps/api/src/lib/rate-limit/index.ts
+++ b/apps/api/src/lib/rate-limit/index.ts
@@ -31,8 +31,8 @@ export const scopedGenerator =
  */
 export class InMemoryRateLimitContext implements Context {
   private durationMs = 60_000;
-  private store = new Map<string, RateLimitEntry>();
-  private cleanupTimer: ReturnType<typeof setInterval>;
+  private readonly store = new Map<string, RateLimitEntry>();
+  private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
   constructor() {
     this.cleanupTimer = setInterval(

--- a/apps/web/src/lib/upload-queue.ts
+++ b/apps/web/src/lib/upload-queue.ts
@@ -59,15 +59,15 @@ const sleep = async (ms: number) =>
 export class UploadQueue<T> {
   private state: UploadState = "idle";
   private pending: File[] = [];
-  private inflight = new Map<File, AbortController>();
+  private readonly inflight = new Map<File, AbortController>();
   private completed: T[] = [];
   private failed: FailedUpload[] = [];
   private total = 0;
   private retrying = 0;
-  private concurrency: number;
-  private uploadFn: UploadFn<T>;
+  private readonly concurrency: number;
+  private readonly uploadFn: UploadFn<T>;
   private rateLimitTimer: ReturnType<typeof setTimeout> | null = null;
-  private listeners: ListenerMap<T> = {
+  private readonly listeners: ListenerMap<T> = {
     done: new Set(),
     progress: new Set(),
     "rate-limited": new Set(),

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -184,7 +184,7 @@ export default defineConfig({
     "typescript/no-inferrable-types": "off",
     "typescript/consistent-return": "error",
     "typescript/dot-notation": "error",
-    "typescript/prefer-readonly": "off",
+    "typescript/prefer-readonly": "error",
     "typescript/no-unnecessary-type-conversion": "error",
     "typescript/no-unnecessary-condition": [
       "error",

--- a/packages/folio/src/core/layout-painter/index.ts
+++ b/packages/folio/src/core/layout-painter/index.ts
@@ -117,9 +117,9 @@ export class LayoutPainter {
   private blockLookup: BlockLookup = new Map();
   private pageStates: PageState[] = [];
   private totalPages = 0;
-  private options: PainterOptions;
-  private doc: Document;
-  private registry: FeatureRegistry;
+  private readonly options: PainterOptions;
+  private readonly doc: Document;
+  private readonly registry: FeatureRegistry;
 
   constructor(options: PainterOptions = {}) {
     this.options = options;

--- a/packages/folio/src/core/managers/ErrorManager.ts
+++ b/packages/folio/src/core/managers/ErrorManager.ts
@@ -20,7 +20,7 @@ import type {
 export class ErrorManager extends Subscribable<ErrorManagerSnapshot> {
   private notifications: ErrorNotification[] = [];
   private idCounter = 0;
-  private timers = new Set<ReturnType<typeof setTimeout>>();
+  private readonly timers = new Set<ReturnType<typeof setTimeout>>();
 
   constructor() {
     super({ notifications: [] });

--- a/packages/folio/src/core/managers/Subscribable.ts
+++ b/packages/folio/src/core/managers/Subscribable.ts
@@ -10,7 +10,7 @@
  */
 
 export abstract class Subscribable<TSnapshot> {
-  private listeners = new Set<() => void>();
+  private readonly listeners = new Set<() => void>();
   private snapshot: TSnapshot;
 
   constructor(initialSnapshot: TSnapshot) {

--- a/packages/folio/src/core/prosemirror/extensions/ExtensionManager.ts
+++ b/packages/folio/src/core/prosemirror/extensions/ExtensionManager.ts
@@ -20,7 +20,7 @@ import type {
 } from "./types";
 
 export class ExtensionManager {
-  private extensions: AnyExtension[];
+  private readonly extensions: AnyExtension[];
   private schema: Schema | null = null;
   private plugins: PMPlugin[] = [];
   private commands: CommandMap = {};

--- a/packages/folio/src/hooks/useHistory.ts
+++ b/packages/folio/src/hooks/useHistory.ts
@@ -451,10 +451,10 @@ export class HistoryManager<T> {
   private undoStack: HistoryEntry<T>[] = [];
   private redoStack: HistoryEntry<T>[] = [];
   private currentState: T;
-  private maxEntries: number;
-  private groupingInterval: number;
+  private readonly maxEntries: number;
+  private readonly groupingInterval: number;
   private lastPushTime: number = 0;
-  private isEqual: (a: T, b: T) => boolean;
+  private readonly isEqual: (a: T, b: T) => boolean;
 
   constructor(
     initialState: T,

--- a/packages/folio/src/paged-editor/LayoutSelectionGate.ts
+++ b/packages/folio/src/paged-editor/LayoutSelectionGate.ts
@@ -33,7 +33,7 @@ export class LayoutSelectionGate {
   #pendingRender: RenderCallback | null = null;
 
   /** Registered render callbacks */
-  #renderCallbacks = new Set<RenderCallback>();
+  readonly #renderCallbacks = new Set<RenderCallback>();
 
   /**
    * Set the document state sequence (call when document changes).


### PR DESCRIPTION
Turns on the `typescript/prefer-readonly` oxlint rule (was `"off"`) and resolves the 16 resulting violations by marking never-reassigned private/`#` class members as `readonly`.

The rule is type-aware, so it runs under `--type-aware` alongside the other type-aware rules; no new violations remain.

Touched members (all assigned only at declaration or in the constructor):
- `apps/api/src/lib/rate-limit/index.ts`: `store`, `cleanupTimer`
- `apps/web/src/lib/upload-queue.ts`: `inflight`, `concurrency`, `uploadFn`, `listeners`
- `packages/folio/` (5 files): `extensions`, `maxEntries`, `groupingInterval`, `isEqual`, `listeners`, `options`, `doc`, `registry`, `#renderCallbacks`, `timers`