### PR TITLE
chore: centralize workspace field rendering

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-workspace-field-value-drift.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-workspace-field-value-drift.fixture.tsx
@@ -1,0 +1,96 @@
+// Passive regression fixture for
+// `no-workspace-field-value-drift/no-workspace-field-value-drift`.
+//
+// `oxlint-disable-next-line` directives suppress cases the rule MUST flag;
+// a regression makes them unused and CI fails. Lines without a directive
+// cover the allow-list and must keep passing.
+
+type WorkspaceFieldContent =
+  | { type: "file"; fileName: string }
+  | { type: "pending" }
+  | { type: "text"; value: string }
+  | { type: "date"; value: string | null }
+  | { type: "int"; value: number }
+  | { type: "single-select"; value: string | null }
+  | { type: "multi-select"; value: string[] };
+
+type WorkspaceProperty = {
+  content: { type: "file" | "date" | "single-select" };
+};
+
+declare const field: { content: WorkspaceFieldContent };
+declare const fieldContent: WorkspaceFieldContent | undefined;
+declare const content: WorkspaceFieldContent;
+declare const property: WorkspaceProperty;
+
+export const _aliasBranch = () => {
+  const type = field.content.type;
+
+  // oxlint-disable-next-line no-workspace-field-value-drift/no-workspace-field-value-drift
+  if (type === "date") {
+    return null;
+  }
+
+  return <FieldValue content={field.content} property={property} />;
+};
+
+export const _directBranch = () => {
+  // oxlint-disable-next-line no-workspace-field-value-drift/no-workspace-field-value-drift
+  if (field.content.type === "int") {
+    return null;
+  }
+
+  return <FieldValue content={field.content} property={property} />;
+};
+
+export const _optionalBranch = () => {
+  // oxlint-disable-next-line no-workspace-field-value-drift/no-workspace-field-value-drift
+  if (fieldContent?.type === "single-select") {
+    return null;
+  }
+
+  return <FieldValue content={fieldContent} property={property} />;
+};
+
+export const _switchBranch = () => {
+  switch (content.type) {
+    // oxlint-disable-next-line no-workspace-field-value-drift/no-workspace-field-value-drift
+    case "text":
+      return null;
+    case "file":
+      return null;
+    default:
+      return <FieldValue content={content} property={property} />;
+  }
+};
+
+// --- Allowed: file/pending branches drive routing/loading, not display drift ---
+
+export const _fileBranch = () => {
+  if (field.content.type === "file") {
+    return <button type="button">{field.content.fileName}</button>;
+  }
+
+  return <FieldValue content={field.content} property={property} />;
+};
+
+export const _pendingBranch = () => {
+  if (fieldContent?.type === "pending") {
+    return <span>loading</span>;
+  }
+
+  return <FieldValue content={fieldContent} property={property} />;
+};
+
+export const _propertyTypeBranch = () => {
+  if (property.content.type === "date") {
+    return <span>date property</span>;
+  }
+
+  return null;
+};
+
+const FieldValue = (_props: {
+  content: WorkspaceFieldContent | undefined;
+  property: WorkspaceProperty;
+}) => null;

--- a/.oxlint-plugins/__fixtures__/no-workspace-field-value-drift.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-workspace-field-value-drift.fixture.tsx
@@ -90,7 +90,18 @@ export const _propertyTypeBranch = () => {
   return null;
 };
 
+export const _rawBidiText = () => (
+  // oxlint-disable-next-line no-workspace-field-value-drift/no-raw-field-value-bidi-text
+  <div dir="auto">שלום v ABC-123</div>
+);
+
+export const _isolatedBidiText = () => (
+  <BidiText as="div">שלום v ABC-123</BidiText>
+);
+
 const FieldValue = (_props: {
   content: WorkspaceFieldContent | undefined;
   property: WorkspaceProperty;
 }) => null;
+
+const BidiText = (_props: { as: "div"; children: string }) => null;

--- a/.oxlint-plugins/no-workspace-field-value-drift.ts
+++ b/.oxlint-plugins/no-workspace-field-value-drift.ts
@@ -14,9 +14,46 @@ const DISPLAY_FIELD_TYPES = new Set([
   "clip",
 ]);
 
+const BIDI_TEXT_COMPONENTS = new Set(["BidiText", "UserText"]);
+
 const isMemberLike = (node) =>
   node?.type === "MemberExpression" ||
   node?.type === "OptionalMemberExpression";
+
+const jsxElementName = (name) => {
+  if (name?.type === "JSXIdentifier") {
+    return name.name;
+  }
+
+  return null;
+};
+
+const getJsxAttr = (node, name) =>
+  node.attributes.find(
+    (attr) =>
+      attr.type === "JSXAttribute" &&
+      attr.name?.type === "JSXIdentifier" &&
+      attr.name.name === name,
+  );
+
+const literalAttrValue = (attr) => {
+  if (!attr?.value) {
+    return undefined;
+  }
+
+  if (attr.value.type === "Literal") {
+    return attr.value.value;
+  }
+
+  if (
+    attr.value.type === "JSXExpressionContainer" &&
+    attr.value.expression?.type === "Literal"
+  ) {
+    return attr.value.expression.value;
+  }
+
+  return undefined;
+};
 
 const rootIdentifierName = (node) => {
   const unwrapped = unwrapExpression(node);
@@ -174,6 +211,36 @@ export default {
               node,
               messageId: "noWorkspaceFieldValueDrift",
               data: { type },
+            });
+          },
+        };
+      },
+    },
+    "no-raw-field-value-bidi-text": {
+      meta: {
+        type: "problem",
+        messages: {
+          noRawFieldValueBidiText:
+            'Workspace field value text with `dir="auto"` must use <BidiText /> so bidi isolation stays attached.',
+        },
+      },
+      create(context) {
+        return {
+          JSXOpeningElement(node) {
+            const elementName = jsxElementName(node.name);
+            const dirAttr = getJsxAttr(node, "dir");
+
+            if (
+              !elementName ||
+              BIDI_TEXT_COMPONENTS.has(elementName) ||
+              literalAttrValue(dirAttr) !== "auto"
+            ) {
+              return;
+            }
+
+            context.report({
+              node: dirAttr ?? node,
+              messageId: "noRawFieldValueBidiText",
             });
           },
         };

--- a/.oxlint-plugins/no-workspace-field-value-drift.ts
+++ b/.oxlint-plugins/no-workspace-field-value-drift.ts
@@ -1,0 +1,183 @@
+import {
+  getPropertyName,
+  isIdentifier,
+  isStringLiteral,
+  unwrapExpression,
+} from "./utils.ts";
+
+const DISPLAY_FIELD_TYPES = new Set([
+  "text",
+  "date",
+  "int",
+  "single-select",
+  "multi-select",
+  "clip",
+]);
+
+const isMemberLike = (node) =>
+  node?.type === "MemberExpression" ||
+  node?.type === "OptionalMemberExpression";
+
+const rootIdentifierName = (node) => {
+  const unwrapped = unwrapExpression(node);
+
+  if (isIdentifier(unwrapped)) {
+    return unwrapped.name;
+  }
+
+  if (!isMemberLike(unwrapped)) {
+    return null;
+  }
+
+  return rootIdentifierName(unwrapped.object);
+};
+
+const isPropertyContentAccess = (node) => {
+  const rootName = rootIdentifierName(node);
+  return rootName === "property" || rootName?.endsWith("Property") === true;
+};
+
+const isFieldContentObject = (node) => {
+  const unwrapped = unwrapExpression(node);
+
+  if (isIdentifier(unwrapped)) {
+    return (
+      unwrapped.name === "content" ||
+      unwrapped.name === "fieldContent" ||
+      unwrapped.name.endsWith("FieldContent")
+    );
+  }
+
+  if (!isMemberLike(unwrapped)) {
+    return false;
+  }
+
+  if (getPropertyName(unwrapped.property) !== "content") {
+    return false;
+  }
+
+  return !isPropertyContentAccess(unwrapped);
+};
+
+const isFieldContentTypeAccess = (node) => {
+  const unwrapped = unwrapExpression(node);
+
+  if (!isMemberLike(unwrapped)) {
+    return false;
+  }
+
+  return (
+    getPropertyName(unwrapped.property) === "type" &&
+    isFieldContentObject(unwrapped.object)
+  );
+};
+
+const literalDisplayFieldType = (node) => {
+  const unwrapped = unwrapExpression(node);
+
+  if (!isStringLiteral(unwrapped)) {
+    return null;
+  }
+
+  return DISPLAY_FIELD_TYPES.has(unwrapped.value) ? unwrapped.value : null;
+};
+
+const comparisonFieldType = (node, aliases) => {
+  if (
+    node.type !== "BinaryExpression" ||
+    !["==", "===", "!=", "!=="].includes(node.operator)
+  ) {
+    return null;
+  }
+
+  const leftLiteral = literalDisplayFieldType(node.left);
+  const rightLiteral = literalDisplayFieldType(node.right);
+
+  if (leftLiteral && isFieldTypeExpression(node.right, aliases)) {
+    return leftLiteral;
+  }
+
+  if (rightLiteral && isFieldTypeExpression(node.left, aliases)) {
+    return rightLiteral;
+  }
+
+  return null;
+};
+
+const isFieldTypeExpression = (node, aliases) => {
+  const unwrapped = unwrapExpression(node);
+
+  return (
+    isFieldContentTypeAccess(unwrapped) ||
+    (isIdentifier(unwrapped) && aliases.has(unwrapped.name))
+  );
+};
+
+export default {
+  meta: { name: "no-workspace-field-value-drift" },
+  rules: {
+    "no-workspace-field-value-drift": {
+      meta: {
+        type: "problem",
+        messages: {
+          noWorkspaceFieldValueDrift:
+            'Workspace field value display for "{{type}}" must go through <FieldValue /> or <EditableField />. Keep surface behavior local, but do not reimplement field-type rendering branches.',
+        },
+      },
+      create(context) {
+        const fieldTypeAliases = new Set();
+
+        return {
+          VariableDeclarator(node) {
+            if (
+              !isIdentifier(node.id) ||
+              !isFieldContentTypeAccess(node.init)
+            ) {
+              return;
+            }
+
+            fieldTypeAliases.add(node.id.name);
+          },
+
+          BinaryExpression(node) {
+            const type = comparisonFieldType(node, fieldTypeAliases);
+
+            if (!type) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: "noWorkspaceFieldValueDrift",
+              data: { type },
+            });
+          },
+
+          SwitchCase(node) {
+            const parent = node.parent;
+
+            if (
+              !parent ||
+              parent.type !== "SwitchStatement" ||
+              !isFieldTypeExpression(parent.discriminant, fieldTypeAliases)
+            ) {
+              return;
+            }
+
+            const type = literalDisplayFieldType(node.test);
+
+            if (!type) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: "noWorkspaceFieldValueDrift",
+              data: { type },
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -250,6 +250,9 @@ describe("custom oxlint guardrails", () => {
       "no-workspace-field-value-drift/no-workspace-field-value-drift",
     );
     expect(configSource).toContain(
+      "no-workspace-field-value-drift/no-raw-field-value-bidi-text",
+    );
+    expect(configSource).toContain(
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx",
     );
     expect(configSource).toContain(
@@ -265,6 +268,8 @@ describe("custom oxlint guardrails", () => {
     expect(pluginSource).toContain('"single-select"');
     expect(pluginSource).toContain("isFieldContentTypeAccess");
     expect(pluginSource).toContain("<FieldValue /> or <EditableField />");
+    expect(pluginSource).toContain("BIDI_TEXT_COMPONENTS");
+    expect(pluginSource).toContain("noRawFieldValueBidiText");
   });
 
   test("public SEO endpoints cannot import auth or protected code", () => {

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -237,6 +237,36 @@ describe("custom oxlint guardrails", () => {
     expect(pluginSource).toContain("Navigate");
   });
 
+  test("workspace field value surfaces must use the shared renderer", () => {
+    const configSource = readRootFixture("oxlint.config.ts");
+    const pluginSource = readRootFixture(
+      ".oxlint-plugins/no-workspace-field-value-drift.ts",
+    );
+
+    expect(configSource).toContain(
+      "./.oxlint-plugins/no-workspace-field-value-drift.ts",
+    );
+    expect(configSource).toContain(
+      "no-workspace-field-value-drift/no-workspace-field-value-drift",
+    );
+    expect(configSource).toContain(
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx",
+    );
+    expect(configSource).toContain(
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx",
+    );
+    expect(configSource).toContain(
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx",
+    );
+    expect(configSource).toContain(
+      "apps/web/src/components/inspector/entity-metadata-panel.tsx",
+    );
+    expect(pluginSource).toContain("DISPLAY_FIELD_TYPES");
+    expect(pluginSource).toContain('"single-select"');
+    expect(pluginSource).toContain("isFieldContentTypeAccess");
+    expect(pluginSource).toContain("<FieldValue /> or <EditableField />");
+  });
+
   test("public SEO endpoints cannot import auth or protected code", () => {
     const configSource = readRootFixture("oxlint.config.ts");
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -1,21 +1,11 @@
-import type { ReactNode } from "react";
-
-import { Result } from "better-result";
-import { Loader2Icon, SquareMinusIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
-
 import { BidiText } from "@stll/ui/components/bidi-text";
-import { Skeleton } from "@stll/ui/components/skeleton";
 
 import Tooltip from "@/components/tooltip";
 import { isFileDisplayable } from "@/lib/types";
 import type { WorkspaceField, WorkspaceProperty } from "@/lib/types";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
+import { FieldValue } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
-import {
-  emptyColor,
-  resolveOptionColor,
-} from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
 
 type CellResultProps = {
   extractionPreview?: string | null;
@@ -28,52 +18,11 @@ export const CellResult = ({
   field,
   property,
 }: CellResultProps) => {
-  const t = useTranslations();
-  const format = useFormatter();
-
   if (!field) {
     return null;
   }
 
   const type = field.content.type;
-
-  if (type === "pending") {
-    const preview = extractionPreview?.trim();
-    const hasPreview = preview !== undefined && preview.length > 0;
-
-    return (
-      <>
-        <Loader2Icon
-          aria-hidden="true"
-          className="text-muted-foreground absolute end-1 top-1 z-20 size-3 shrink-0 animate-spin"
-          strokeWidth={2.25}
-        />
-        {hasPreview ? (
-          <BidiText as="div" className="line-clamp-2 min-w-0">
-            {preview}
-          </BidiText>
-        ) : (
-          <PendingSkeleton contentType={property.content.type} />
-        )}
-      </>
-    );
-  }
-
-  if (type === "error") {
-    return (
-      <div className="text-destructive line-clamp-2 italic">
-        {t("workspaces.fields.errored")}
-      </div>
-    );
-  }
-
-  if (type === "unsupported") {
-    return (
-      <div className="text-muted-foreground line-clamp-2 italic">
-        {t("workspaces.fields.formatNotSupported")}
-      </div>
-    );
-  }
 
   if (type === "file") {
     return (
@@ -90,86 +39,13 @@ export const CellResult = ({
     );
   }
 
-  if (type === "single-select") {
-    return <SelectResult property={property} value={field.content.value} />;
-  }
-
-  if (type === "multi-select") {
-    return field.content.value.length > 0 ? (
-      <div className="flex min-w-0 flex-wrap gap-1.5">
-        {field.content.value.map((value) => (
-          <SelectResult key={value} property={property} value={value} />
-        ))}
-      </div>
-    ) : (
-      <SelectResult property={property} value={null} />
-    );
-  }
-
-  if (type === "date") {
-    if (!field.content.value) {
-      return <SelectResult property={property} value={null} />;
-    }
-
-    const formatted = format.dateTime(new Date(field.content.value), {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      timeZone: "UTC",
-    });
-
-    return <div>{formatted}</div>;
-  }
-
-  if (type === "int") {
-    return (
-      <IntCell currency={field.content.currency} value={field.content.value} />
-    );
-  }
-
-  if (type === "clip") {
-    return (
-      <div className="text-muted-foreground truncate">{field.content.url}</div>
-    );
-  }
-
   return (
-    <div className="line-clamp-2" dir="auto">
-      {field.content.value}
-    </div>
-  );
-};
-
-type PendingSkeletonProps = {
-  contentType: WorkspaceProperty["content"]["type"];
-};
-
-const PendingSkeleton = ({ contentType }: PendingSkeletonProps) => {
-  if (contentType === "single-select") {
-    return <Skeleton className="h-4 w-16 rounded-full" />;
-  }
-  if (contentType === "multi-select") {
-    return (
-      <div className="flex flex-wrap gap-1">
-        <Skeleton className="h-4 w-12 rounded-full" />
-        <Skeleton className="h-4 w-16 rounded-full" />
-      </div>
-    );
-  }
-  if (contentType === "date") {
-    return <Skeleton className="h-3.5 w-20" />;
-  }
-  if (contentType === "int") {
-    return <Skeleton className="h-3.5 w-10" />;
-  }
-  if (contentType === "file") {
-    return <Skeleton className="h-4 w-24" />;
-  }
-  return (
-    <div className="flex w-full max-w-[12rem] flex-col gap-1">
-      <Skeleton className="h-3 w-full" />
-      <Skeleton className="h-3 w-3/4" />
-    </div>
+    <FieldValue
+      content={field.content}
+      pendingPreview={extractionPreview}
+      property={property}
+      variant="table"
+    />
   );
 };
 
@@ -254,92 +130,4 @@ const FileCell = ({
       </BidiText>
     </Tooltip>
   );
-};
-
-const getSelectPropertyColor = (
-  property: WorkspaceProperty,
-  option: string | null,
-) => {
-  if (!option) {
-    return emptyColor;
-  }
-
-  if (
-    property.content.type === "file" ||
-    property.content.type === "text" ||
-    property.content.type === "date" ||
-    property.content.type === "int"
-  ) {
-    return undefined;
-  }
-
-  const color = property.content.options.find((o) => o.value === option)?.color;
-
-  if (!color) {
-    return undefined;
-  }
-
-  return resolveOptionColor(color);
-};
-
-type SelectResultProps = {
-  value: string | null;
-  property: WorkspaceProperty;
-};
-
-const SelectResult = ({ value, property }: SelectResultProps) => {
-  const t = useTranslations();
-  const color = getSelectPropertyColor(property, value);
-
-  return (
-    <span
-      className="flex max-w-full items-center gap-x-1 rounded px-1 py-0.25 font-medium"
-      style={{
-        backgroundColor: color?.background,
-        color: color?.foreground,
-      }}
-    >
-      {!value && <SquareMinusIcon className="size-4" />}
-      <BidiText as="span" className="truncate">
-        {value ?? t("common.empty")}
-      </BidiText>
-    </span>
-  );
-};
-
-type IntCellProps = {
-  value: number;
-  currency: string | null;
-};
-
-const IntCellContainer = ({ children }: { children: ReactNode }) => (
-  <div className="max-w-full min-w-0 truncate text-start tabular-nums">
-    {children}
-  </div>
-);
-
-const IntCell = ({ value, currency }: IntCellProps) => {
-  const format = useFormatter();
-
-  if (!currency) {
-    return <IntCellContainer>{format.number(value)}</IntCellContainer>;
-  }
-
-  const formattedResult = Result.try(() =>
-    format.number(value, {
-      style: "currency",
-      currency,
-      minimumFractionDigits: 0,
-    }),
-  );
-
-  if (formattedResult.isErr()) {
-    return (
-      <IntCellContainer>
-        {format.number(value)} {currency}
-      </IntCellContainer>
-    );
-  }
-
-  return <IntCellContainer>{formattedResult.value}</IntCellContainer>;
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
@@ -13,7 +13,7 @@
 import { useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
@@ -29,11 +29,11 @@ import type {
   WorkspaceProperty,
 } from "@/lib/types";
 import type { EditableFieldContent } from "@/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog";
-import { FieldValueSelect } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value-select";
 import {
-  emptyColor,
-  resolveOptionColor,
-} from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
+  FieldValue,
+  IntFieldValue,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/field-value";
+import { FieldValueSelect } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value-select";
 import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 
@@ -71,11 +71,11 @@ export const EditableField = ({
     content?.type === "unsupported" ||
     content?.type === "clip"
   ) {
-    return <ReadOnlyDisplay content={content} />;
+    return <FieldValue content={content} property={property} />;
   }
 
   if (readonly) {
-    return <ReadOnlyValue content={content} property={property} />;
+    return <FieldValue content={content} property={property} />;
   }
 
   return (
@@ -91,112 +91,6 @@ export const EditableField = ({
       workspaceId={workspaceId}
     />
   );
-};
-
-// -- Read-only fallbacks --
-
-const ReadOnlyDisplay = ({
-  content,
-}: {
-  content: WorkspaceFieldContent | undefined;
-}) => {
-  const t = useTranslations();
-
-  if (!content) {
-    return <span className="text-muted-foreground text-sm">—</span>;
-  }
-
-  if (content.type === "pending") {
-    return (
-      <span className="text-muted-foreground flex items-center gap-1.5 text-sm">
-        {t("workspaces.fields.calculating")}
-        <span className="bg-muted-foreground size-2 animate-pulse rounded-full" />
-      </span>
-    );
-  }
-
-  if (content.type === "error") {
-    return (
-      <span className="text-destructive text-sm italic">
-        {t("workspaces.fields.errored")}
-      </span>
-    );
-  }
-
-  if (content.type === "unsupported") {
-    return (
-      <span className="text-muted-foreground block truncate text-sm italic">
-        {t("workspaces.fields.formatNotSupported")}
-      </span>
-    );
-  }
-
-  if (content.type === "clip") {
-    return (
-      <span className="text-muted-foreground block truncate text-sm">
-        {content.url}
-      </span>
-    );
-  }
-
-  return <span className="text-muted-foreground text-sm">—</span>;
-};
-
-const ReadOnlyValue = ({
-  content,
-  property,
-}: {
-  content: WorkspaceFieldContent | undefined;
-  property: WorkspaceProperty;
-}) => {
-  const format = useFormatter();
-
-  if (!content || content.type === "error" || content.type === "pending") {
-    return <span className="text-muted-foreground text-sm">—</span>;
-  }
-
-  if (content.type === "text") {
-    return <span className="line-clamp-2 text-sm">{content.value}</span>;
-  }
-
-  if (content.type === "date") {
-    if (!content.value) {
-      return <span className="text-muted-foreground text-sm">—</span>;
-    }
-    return (
-      <span className="text-sm">
-        {format.dateTime(new Date(content.value), {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        })}
-      </span>
-    );
-  }
-
-  if (content.type === "int") {
-    return <IntDisplay currency={content.currency} value={content.value} />;
-  }
-
-  if (content.type === "single-select") {
-    return <SelectChip property={property} value={content.value} />;
-  }
-
-  if (content.type === "multi-select") {
-    if (content.value.length === 0) {
-      return <span className="text-muted-foreground text-sm">—</span>;
-    }
-    return (
-      <div className="flex flex-wrap gap-1">
-        {content.value.map((v) => (
-          <SelectChip key={v} property={property} value={v} />
-        ))}
-      </div>
-    );
-  }
-
-  return <span className="text-muted-foreground text-sm">—</span>;
 };
 
 // -- Inline editor --
@@ -422,7 +316,7 @@ const InlineIntEditor = ({
         }}
         type="button"
       >
-        <IntDisplay currency={currency} value={value} />
+        <IntFieldValue content={{ type: "int", version: 1, value, currency }} />
       </button>
     );
   }
@@ -451,75 +345,5 @@ const InlineIntEditor = ({
       }}
       value={draft}
     />
-  );
-};
-
-// -- Shared display helpers --
-
-const intDisplayClass =
-  "block min-w-0 max-w-full truncate tabular-nums text-start text-sm";
-
-const IntDisplay = ({
-  value,
-  currency,
-}: {
-  value: number;
-  currency: string | null;
-}) => {
-  const format = useFormatter();
-
-  if (!currency) {
-    return <span className={intDisplayClass}>{format.number(value)}</span>;
-  }
-
-  try {
-    const formatted = format.number(value, {
-      style: "currency",
-      currency,
-      minimumFractionDigits: 0,
-    });
-    return <span className={intDisplayClass}>{formatted}</span>;
-  } catch {
-    return (
-      <span className={intDisplayClass}>
-        {format.number(value)} {currency}
-      </span>
-    );
-  }
-};
-
-const SelectChip = ({
-  property,
-  value,
-}: {
-  property: WorkspaceProperty;
-  value: string | null;
-}) => {
-  const t = useTranslations();
-
-  const color = (() => {
-    if (!value) {
-      return emptyColor;
-    }
-    if (
-      property.content.type !== "single-select" &&
-      property.content.type !== "multi-select"
-    ) {
-      return undefined;
-    }
-    const opt = property.content.options.find((o) => o.value === value)?.color;
-    return opt ? resolveOptionColor(opt) : undefined;
-  })();
-
-  return (
-    <span
-      className="flex w-max items-center gap-x-1 rounded px-1 py-0.25 text-sm font-medium"
-      style={{
-        backgroundColor: color?.background,
-        color: color?.foreground,
-      }}
-    >
-      {value ?? t("common.empty")}
-    </span>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.logic.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { getClipFieldValueLabel } from "./field-value.logic";
+
+describe("clip field value label", () => {
+  test("prefers a non-empty citation", () => {
+    expect(
+      getClipFieldValueLabel({
+        citation: "  Exhibit A at 4  ",
+        url: "https://example.com/source.pdf",
+      }),
+    ).toBe("Exhibit A at 4");
+  });
+
+  test("falls back to the url when the citation is blank", () => {
+    expect(
+      getClipFieldValueLabel({
+        citation: "   ",
+        url: "https://example.com/source.pdf",
+      }),
+    ).toBe("https://example.com/source.pdf");
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.logic.ts
@@ -1,0 +1,15 @@
+export const getClipFieldValueLabel = ({
+  citation,
+  url,
+}: {
+  citation: string | null | undefined;
+  url: string;
+}) => {
+  const trimmedCitation = citation?.trim();
+
+  if (trimmedCitation) {
+    return trimmedCitation;
+  }
+
+  return url;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
@@ -1,0 +1,470 @@
+import { Result } from "better-result";
+import { Loader2Icon, SquareMinusIcon } from "lucide-react";
+import { useFormatter, useTranslations } from "use-intl";
+
+import { Skeleton } from "@stll/ui/components/skeleton";
+
+import type { WorkspaceFieldContent, WorkspaceProperty } from "@/lib/types";
+import {
+  emptyColor,
+  resolveOptionColor,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
+
+type FieldValueVariant = "default" | "table" | "kanban";
+
+type FieldValueProps = {
+  content: WorkspaceFieldContent | undefined;
+  property: WorkspaceProperty;
+  pendingPreview?: string | null | undefined;
+  variant?: FieldValueVariant;
+};
+
+export const FieldValue = ({
+  content,
+  property,
+  pendingPreview,
+  variant = "default",
+}: FieldValueProps) => {
+  if (!content) {
+    return variant === "table" ? null : <EmptyFieldValue variant={variant} />;
+  }
+
+  if (content.type === "pending") {
+    return (
+      <PendingFieldValue
+        contentType={property.content.type}
+        preview={pendingPreview}
+        variant={variant}
+      />
+    );
+  }
+
+  if (content.type === "error") {
+    return <ErrorFieldValue variant={variant} />;
+  }
+
+  if (content.type === "unsupported") {
+    return <UnsupportedFieldValue variant={variant} />;
+  }
+
+  if (content.type === "file") {
+    return <FileFieldValue content={content} variant={variant} />;
+  }
+
+  if (content.type === "text") {
+    return <TextFieldValue content={content} variant={variant} />;
+  }
+
+  if (content.type === "date") {
+    return (
+      <DateFieldValue content={content} property={property} variant={variant} />
+    );
+  }
+
+  if (content.type === "int") {
+    return <IntFieldValue content={content} variant={variant} />;
+  }
+
+  if (content.type === "single-select") {
+    return (
+      <SelectFieldValue
+        property={property}
+        value={content.value}
+        variant={variant}
+      />
+    );
+  }
+
+  if (content.type === "multi-select") {
+    return (
+      <MultiSelectFieldValue
+        property={property}
+        value={content.value}
+        variant={variant}
+      />
+    );
+  }
+
+  return <ClipFieldValue content={content} variant={variant} />;
+};
+
+export const IntFieldValue = ({
+  content,
+  variant = "default",
+}: {
+  content: Extract<WorkspaceFieldContent, { type: "int" }>;
+  variant?: FieldValueVariant;
+}) => {
+  const format = useFormatter();
+  const className = getIntClassName(variant);
+  const fallback = `${format.number(content.value)} ${content.currency}`;
+
+  if (!content.currency) {
+    return <span className={className}>{format.number(content.value)}</span>;
+  }
+
+  const formattedResult = Result.try(() =>
+    format.number(content.value, {
+      style: "currency",
+      currency: content.currency ?? undefined,
+      minimumFractionDigits: 0,
+    }),
+  );
+
+  if (formattedResult.isErr()) {
+    return <span className={className}>{fallback}</span>;
+  }
+
+  return <span className={className}>{formattedResult.value}</span>;
+};
+
+const EmptyFieldValue = ({ variant }: { variant: FieldValueVariant }) => {
+  if (variant === "kanban") {
+    return null;
+  }
+
+  return <span className="text-muted-foreground text-sm">—</span>;
+};
+
+const PendingFieldValue = ({
+  contentType,
+  preview,
+  variant,
+}: {
+  contentType: WorkspaceProperty["content"]["type"];
+  preview: string | null | undefined;
+  variant: FieldValueVariant;
+}) => {
+  const t = useTranslations();
+  const trimmedPreview = preview?.trim();
+  const hasPreview = trimmedPreview !== undefined && trimmedPreview.length > 0;
+
+  if (variant === "kanban") {
+    return null;
+  }
+
+  if (variant === "table") {
+    return (
+      <>
+        <Loader2Icon
+          aria-hidden="true"
+          className="text-muted-foreground absolute end-1 top-1 z-20 size-3 shrink-0 animate-spin"
+          strokeWidth={2.25}
+        />
+        {hasPreview ? (
+          <div className="line-clamp-2 min-w-0" dir="auto">
+            {trimmedPreview}
+          </div>
+        ) : (
+          <PendingSkeleton contentType={contentType} />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <span className="text-muted-foreground flex items-center gap-1.5 text-sm">
+      {t("workspaces.fields.calculating")}
+      <span className="bg-muted-foreground size-2 animate-pulse rounded-full" />
+    </span>
+  );
+};
+
+const ErrorFieldValue = ({ variant }: { variant: FieldValueVariant }) => {
+  const t = useTranslations();
+
+  if (variant === "kanban") {
+    return null;
+  }
+
+  return (
+    <span className="text-destructive line-clamp-2 text-sm italic">
+      {t("workspaces.fields.errored")}
+    </span>
+  );
+};
+
+const UnsupportedFieldValue = ({ variant }: { variant: FieldValueVariant }) => {
+  const t = useTranslations();
+
+  if (variant === "kanban") {
+    return null;
+  }
+
+  return (
+    <span className="text-muted-foreground line-clamp-2 text-sm italic">
+      {t("workspaces.fields.formatNotSupported")}
+    </span>
+  );
+};
+
+const FileFieldValue = ({
+  content,
+  variant,
+}: {
+  content: Extract<WorkspaceFieldContent, { type: "file" }>;
+  variant: FieldValueVariant;
+}) => {
+  if (variant === "kanban") {
+    return null;
+  }
+
+  return (
+    <span className={variant === "table" ? "truncate" : "text-sm"} dir="auto">
+      {content.fileName}
+    </span>
+  );
+};
+
+const TextFieldValue = ({
+  content,
+  variant,
+}: {
+  content: Extract<WorkspaceFieldContent, { type: "text" }>;
+  variant: FieldValueVariant;
+}) => {
+  if (variant === "kanban") {
+    if (!content.value.trim()) {
+      return null;
+    }
+
+    return (
+      <span className="text-muted-foreground line-clamp-2 min-w-0 basis-full text-xs leading-4">
+        {content.value}
+      </span>
+    );
+  }
+
+  const className =
+    variant === "table" ? "line-clamp-2" : "line-clamp-2 text-sm";
+
+  return (
+    <span className={className} dir="auto">
+      {content.value}
+    </span>
+  );
+};
+
+const DateFieldValue = ({
+  content,
+  property,
+  variant,
+}: {
+  content: Extract<WorkspaceFieldContent, { type: "date" }>;
+  property: WorkspaceProperty;
+  variant: FieldValueVariant;
+}) => {
+  const format = useFormatter();
+
+  if (!content.value) {
+    if (variant === "table") {
+      return (
+        <SelectFieldValue property={property} value={null} variant={variant} />
+      );
+    }
+    return <EmptyFieldValue variant={variant} />;
+  }
+
+  const formatted = format.dateTime(new Date(content.value), {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  if (variant === "kanban") {
+    return (
+      <span className="text-muted-foreground bg-muted/60 rounded px-1.5 py-0.5 text-xs leading-none">
+        {formatted}
+      </span>
+    );
+  }
+
+  return (
+    <span className={variant === "default" ? "text-sm" : undefined}>
+      {formatted}
+    </span>
+  );
+};
+
+const SelectFieldValue = ({
+  property,
+  value,
+  variant,
+}: {
+  property: WorkspaceProperty;
+  value: string | null;
+  variant: FieldValueVariant;
+}) => {
+  const t = useTranslations();
+  const color = getSelectPropertyColor(property, value);
+
+  if (variant === "kanban") {
+    return (
+      <span
+        className="max-w-full truncate rounded px-1.5 py-0.5 text-xs leading-none font-medium"
+        style={{
+          backgroundColor: color?.background,
+          color: color?.foreground,
+        }}
+      >
+        {value ?? t("common.empty")}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={
+        variant === "table"
+          ? "flex max-w-full items-center gap-x-1 rounded px-1 py-0.25 font-medium"
+          : "flex w-max max-w-full items-center gap-x-1 rounded px-1 py-0.25 text-sm font-medium"
+      }
+      style={{
+        backgroundColor: color?.background,
+        color: color?.foreground,
+      }}
+    >
+      {variant === "table" && !value && <SquareMinusIcon className="size-4" />}
+      <span className="truncate" dir="auto">
+        {value ?? t("common.empty")}
+      </span>
+    </span>
+  );
+};
+
+const MultiSelectFieldValue = ({
+  property,
+  value,
+  variant,
+}: {
+  property: WorkspaceProperty;
+  value: string[];
+  variant: FieldValueVariant;
+}) => {
+  if (value.length === 0) {
+    if (variant === "table") {
+      return (
+        <SelectFieldValue property={property} value={null} variant={variant} />
+      );
+    }
+    return <EmptyFieldValue variant={variant} />;
+  }
+
+  return (
+    <span
+      className={
+        variant === "table"
+          ? "flex min-w-0 flex-wrap gap-1.5"
+          : "flex flex-wrap gap-1"
+      }
+    >
+      {value.map((option) => (
+        <SelectFieldValue
+          key={option}
+          property={property}
+          value={option}
+          variant={variant}
+        />
+      ))}
+    </span>
+  );
+};
+
+const ClipFieldValue = ({
+  content,
+  variant,
+}: {
+  content: Extract<WorkspaceFieldContent, { type: "clip" }>;
+  variant: FieldValueVariant;
+}) => {
+  const value = content.citation ?? content.url;
+
+  if (variant === "kanban") {
+    return (
+      <span className="text-muted-foreground bg-muted/60 truncate rounded px-1.5 py-0.5 text-xs leading-none">
+        {value}
+      </span>
+    );
+  }
+
+  return (
+    <span className="text-muted-foreground block truncate text-sm" dir="auto">
+      {value}
+    </span>
+  );
+};
+
+type PendingSkeletonProps = {
+  contentType: WorkspaceProperty["content"]["type"];
+};
+
+const PendingSkeleton = ({ contentType }: PendingSkeletonProps) => {
+  if (contentType === "single-select") {
+    return <Skeleton className="h-4 w-16 rounded-full" />;
+  }
+
+  if (contentType === "multi-select") {
+    return (
+      <div className="flex flex-wrap gap-1">
+        <Skeleton className="h-4 w-12 rounded-full" />
+        <Skeleton className="h-4 w-16 rounded-full" />
+      </div>
+    );
+  }
+
+  if (contentType === "date") {
+    return <Skeleton className="h-3.5 w-20" />;
+  }
+
+  if (contentType === "int") {
+    return <Skeleton className="h-3.5 w-10" />;
+  }
+
+  if (contentType === "file") {
+    return <Skeleton className="h-4 w-24" />;
+  }
+
+  return (
+    <div className="flex w-full max-w-[12rem] flex-col gap-1">
+      <Skeleton className="h-3 w-full" />
+      <Skeleton className="h-3 w-3/4" />
+    </div>
+  );
+};
+
+const getSelectPropertyColor = (
+  property: WorkspaceProperty,
+  option: string | null,
+) => {
+  if (!option) {
+    return emptyColor;
+  }
+
+  if (
+    property.content.type !== "single-select" &&
+    property.content.type !== "multi-select"
+  ) {
+    return undefined;
+  }
+
+  const color = property.content.options.find((o) => o.value === option)?.color;
+
+  if (!color) {
+    return undefined;
+  }
+
+  return resolveOptionColor(color);
+};
+
+const getIntClassName = (variant: FieldValueVariant) => {
+  if (variant === "kanban") {
+    return "text-muted-foreground bg-muted/60 rounded px-1.5 py-0.5 text-xs leading-none tabular-nums";
+  }
+
+  if (variant === "table") {
+    return "block max-w-full min-w-0 truncate text-start tabular-nums";
+  }
+
+  return "block min-w-0 max-w-full truncate text-start text-sm tabular-nums";
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
@@ -6,6 +6,7 @@ import { BidiText } from "@stll/ui/components/bidi-text";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import type { WorkspaceFieldContent, WorkspaceProperty } from "@/lib/types";
+import { getClipFieldValueLabel } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value.logic";
 import {
   emptyColor,
   resolveOptionColor,
@@ -162,9 +163,9 @@ const PendingFieldValue = ({
           strokeWidth={2.25}
         />
         {hasPreview ? (
-          <div className="line-clamp-2 min-w-0" dir="auto">
+          <BidiText as="div" className="line-clamp-2 min-w-0">
             {trimmedPreview}
-          </div>
+          </BidiText>
         ) : (
           <PendingSkeleton contentType={contentType} />
         )}
@@ -242,9 +243,12 @@ const TextFieldValue = ({
     }
 
     return (
-      <span className="text-muted-foreground line-clamp-2 min-w-0 basis-full text-xs leading-4">
+      <BidiText
+        as="span"
+        className="text-muted-foreground line-clamp-2 min-w-0 basis-full text-xs leading-4"
+      >
         {content.value}
-      </span>
+      </BidiText>
     );
   }
 
@@ -252,9 +256,9 @@ const TextFieldValue = ({
     variant === "table" ? "line-clamp-2" : "line-clamp-2 text-sm";
 
   return (
-    <span className={className} dir="auto">
+    <BidiText as="span" className={className}>
       {content.value}
-    </span>
+    </BidiText>
   );
 };
 
@@ -315,7 +319,8 @@ const SelectFieldValue = ({
 
   if (variant === "kanban") {
     return (
-      <span
+      <BidiText
+        as="span"
         className="max-w-full truncate rounded px-1.5 py-0.5 text-xs leading-none font-medium"
         style={{
           backgroundColor: color?.background,
@@ -323,7 +328,7 @@ const SelectFieldValue = ({
         }}
       >
         {value ?? t("common.empty")}
-      </span>
+      </BidiText>
     );
   }
 
@@ -340,9 +345,9 @@ const SelectFieldValue = ({
       }}
     >
       {variant === "table" && !value && <SquareMinusIcon className="size-4" />}
-      <span className="truncate" dir="auto">
+      <BidiText as="span" className="truncate">
         {value ?? t("common.empty")}
-      </span>
+      </BidiText>
     </span>
   );
 };
@@ -392,20 +397,29 @@ const ClipFieldValue = ({
   content: Extract<WorkspaceFieldContent, { type: "clip" }>;
   variant: FieldValueVariant;
 }) => {
-  const value = content.citation ?? content.url;
+  const value = getClipFieldValueLabel({
+    citation: content.citation,
+    url: content.url,
+  });
 
   if (variant === "kanban") {
     return (
-      <span className="text-muted-foreground bg-muted/60 truncate rounded px-1.5 py-0.5 text-xs leading-none">
+      <BidiText
+        as="span"
+        className="text-muted-foreground bg-muted/60 truncate rounded px-1.5 py-0.5 text-xs leading-none"
+      >
         {value}
-      </span>
+      </BidiText>
     );
   }
 
   return (
-    <span className="text-muted-foreground block truncate text-sm" dir="auto">
+    <BidiText
+      as="span"
+      className="text-muted-foreground block truncate text-sm"
+    >
       {value}
-    </span>
+    </BidiText>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
@@ -24,10 +24,14 @@ export const FieldValue = ({
   content,
   property,
   pendingPreview,
-  variant = "default",
+  variant,
 }: FieldValueProps) => {
+  const resolvedVariant = variant ?? "default";
+
   if (!content) {
-    return variant === "table" ? null : <EmptyFieldValue variant={variant} />;
+    return resolvedVariant === "table" ? null : (
+      <EmptyFieldValue variant={resolvedVariant} />
+    );
   }
 
   if (content.type === "pending") {
@@ -35,35 +39,39 @@ export const FieldValue = ({
       <PendingFieldValue
         contentType={property.content.type}
         preview={pendingPreview}
-        variant={variant}
+        variant={resolvedVariant}
       />
     );
   }
 
   if (content.type === "error") {
-    return <ErrorFieldValue variant={variant} />;
+    return <ErrorFieldValue variant={resolvedVariant} />;
   }
 
   if (content.type === "unsupported") {
-    return <UnsupportedFieldValue variant={variant} />;
+    return <UnsupportedFieldValue variant={resolvedVariant} />;
   }
 
   if (content.type === "file") {
-    return <FileFieldValue content={content} variant={variant} />;
+    return <FileFieldValue content={content} variant={resolvedVariant} />;
   }
 
   if (content.type === "text") {
-    return <TextFieldValue content={content} variant={variant} />;
+    return <TextFieldValue content={content} variant={resolvedVariant} />;
   }
 
   if (content.type === "date") {
     return (
-      <DateFieldValue content={content} property={property} variant={variant} />
+      <DateFieldValue
+        content={content}
+        property={property}
+        variant={resolvedVariant}
+      />
     );
   }
 
   if (content.type === "int") {
-    return <IntFieldValue content={content} variant={variant} />;
+    return <IntFieldValue content={content} variant={resolvedVariant} />;
   }
 
   if (content.type === "single-select") {
@@ -71,7 +79,7 @@ export const FieldValue = ({
       <SelectFieldValue
         property={property}
         value={content.value}
-        variant={variant}
+        variant={resolvedVariant}
       />
     );
   }
@@ -81,23 +89,24 @@ export const FieldValue = ({
       <MultiSelectFieldValue
         property={property}
         value={content.value}
-        variant={variant}
+        variant={resolvedVariant}
       />
     );
   }
 
-  return <ClipFieldValue content={content} variant={variant} />;
+  return <ClipFieldValue content={content} variant={resolvedVariant} />;
 };
 
 export const IntFieldValue = ({
   content,
-  variant = "default",
+  variant,
 }: {
   content: Extract<WorkspaceFieldContent, { type: "int" }>;
   variant?: FieldValueVariant;
 }) => {
   const format = useFormatter();
-  const className = getIntClassName(variant);
+  const resolvedVariant = variant ?? "default";
+  const className = getIntClassName(resolvedVariant);
   const fallback = `${format.number(content.value)} ${content.currency}`;
 
   if (!content.currency) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { Loader2Icon, SquareMinusIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
 
+import { BidiText } from "@stll/ui/components/bidi-text";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import type { WorkspaceFieldContent, WorkspaceProperty } from "@/lib/types";
@@ -210,9 +211,12 @@ const FileFieldValue = ({
   }
 
   return (
-    <span className={variant === "table" ? "truncate" : "text-sm"} dir="auto">
+    <BidiText
+      as="span"
+      className={variant === "table" ? "truncate" : "text-sm"}
+    >
       {content.fileName}
-    </span>
+    </BidiText>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
@@ -256,7 +256,8 @@ const DateFieldValue = ({
 }) => {
   const format = useFormatter();
 
-  if (!content.value) {
+  const date = content.value ? new Date(content.value) : null;
+  if (!date || Number.isNaN(date.getTime())) {
     if (variant === "table") {
       return (
         <SelectFieldValue property={property} value={null} variant={variant} />
@@ -265,7 +266,7 @@ const DateFieldValue = ({
     return <EmptyFieldValue variant={variant} />;
   }
 
-  const formatted = format.dateTime(new Date(content.value), {
+  const formatted = format.dateTime(date, {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.logic.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { getInternalPropertyId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
-import { getKanbanCardMetadataVisibility } from "./kanban-card.logic";
+import {
+  getKanbanCardMetadataVisibility,
+  getKanbanCardRenameInitialValue,
+} from "./kanban-card.logic";
 
 describe("kanban card metadata visibility", () => {
   test("preserves task metadata chips for non-task cards", () => {
@@ -38,4 +41,81 @@ describe("kanban card metadata visibility", () => {
       showDueDate: false,
     });
   });
+});
+
+describe("kanban card rename initial value", () => {
+  test("prefers editable text field value over the rendered fallback name", () => {
+    const entity = createEntity({
+      fields: {
+        title: {
+          entityId: "entity-1",
+          id: "field-1",
+          content: { type: "text", version: 1, value: "Contract title" },
+        },
+      },
+    });
+
+    expect(getKanbanCardRenameInitialValue(entity, "Contract.pdf")).toBe(
+      "Contract title",
+    );
+  });
+
+  test("falls back when the text field is empty", () => {
+    const entity = createEntity({
+      fields: {
+        title: {
+          entityId: "entity-1",
+          id: "field-1",
+          content: { type: "text", version: 1, value: "  " },
+        },
+      },
+    });
+
+    expect(getKanbanCardRenameInitialValue(entity, "Contract.pdf")).toBe(
+      "Contract.pdf",
+    );
+  });
+});
+
+type EntityInput = Parameters<typeof getKanbanCardRenameInitialValue>[0];
+
+const createEntity = (overrides: Partial<EntityInput>): EntityInput => ({
+  entityId: "entity-1",
+  kind: "document",
+  name: null,
+  parentId: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  createdBy: null,
+  createdByImage: null,
+  createdByDeletedAt: null,
+  updatedAt: null,
+  version: 1,
+  status: null,
+  priority: null,
+  dueDate: null,
+  agendaKind: "event",
+  startAt: null,
+  endAt: null,
+  occurredAt: null,
+  remindAt: null,
+  allDay: false,
+  timeZone: null,
+  location: null,
+  onlineMeetingUrl: null,
+  availability: null,
+  sensitivity: null,
+  organizer: null,
+  attendees: null,
+  recurrence: null,
+  agendaSource: "manual",
+  externalSource: null,
+  externalId: null,
+  externalChangeKey: null,
+  externalICalUid: null,
+  readOnly: false,
+  sortOrder: null,
+  activeEditBy: null,
+  fields: {},
+  cellMetadata: {},
+  ...overrides,
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.logic.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceEntity } from "@/lib/types";
 import { getInternalPropertyId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 export type KanbanCardMetadataVisibility = {
@@ -17,3 +18,16 @@ export const getKanbanCardMetadataVisibility = (
   showDueDate:
     !isTask && visibleCardFields.includes(getInternalPropertyId("due-date")),
 });
+
+export const getKanbanCardRenameInitialValue = (
+  entity: WorkspaceEntity,
+  fallbackName: string,
+) => {
+  const textField = Object.values(entity.fields).find(
+    (field) => field.content.type === "text",
+  );
+  const textName =
+    textField?.content.type === "text" ? textField.content.value.trim() : "";
+
+  return textName || fallbackName;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -4,7 +4,7 @@ import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { CalendarIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
+import { useFormatter, useTranslations } from "use-intl";
 
 import {
   Avatar,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -4,7 +4,7 @@ import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { CalendarIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   Avatar,
@@ -25,9 +25,13 @@ import type {
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";
 import { EntityKindIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/entity-kind-icon";
+import { FieldValue } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
-import { getKanbanCardMetadataVisibility } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.logic";
+import {
+  getKanbanCardMetadataVisibility,
+  getKanbanCardRenameInitialValue,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.logic";
 import { RowActions } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
 import { TaskBadges } from "@/routes/_protected.workspaces/$workspaceId/-components/tasks/task-badges";
 import {
@@ -38,10 +42,6 @@ import {
   STATUS_COLORS,
   STATUS_ICONS,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-constants";
-import {
-  emptyColor,
-  resolveOptionColor,
-} from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
 import { useInspectorFlash } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash";
 import {
   formatRelativeTime,
@@ -75,13 +75,6 @@ export const KanbanCard = ({
     const tab = s.tabs.find((t) => t.id === s.activeId);
     return tab?.type === "pdf" && tab.entityId === entity.entityId;
   });
-  // For editing, use the text field value (not the file name)
-  const textField = Object.values(entity.fields).find(
-    (f) => f.content.type === "text",
-  );
-  const textName =
-    textField?.content.type === "text" ? textField.content.value.trim() : "";
-
   const rename = useInlineRename({
     initial: name,
     onCommit: (value) => {
@@ -139,7 +132,7 @@ export const KanbanCard = ({
   }, [entity.entityId, name, entity.kind, file?.mimeType, entity.parentId]);
 
   const startEditing = () => {
-    rename.startEditing(textName || name);
+    rename.startEditing(getKanbanCardRenameInitialValue(entity, name));
   };
 
   const icon = (
@@ -484,107 +477,9 @@ type KanbanCardFieldValueProps = {
 const KanbanCardFieldValue = ({
   content,
   property,
-}: KanbanCardFieldValueProps) => {
-  const format = useFormatter();
-
-  if (
-    content.type === "error" ||
-    content.type === "pending" ||
-    content.type === "unsupported" ||
-    content.type === "file"
-  ) {
-    return null;
-  }
-
-  if (content.type === "text") {
-    if (!content.value.trim()) {
-      return null;
-    }
-    return (
-      <span className="text-muted-foreground line-clamp-2 min-w-0 basis-full text-xs leading-4">
-        {content.value}
-      </span>
-    );
-  }
-
-  if (content.type === "date") {
-    if (!content.value) {
-      return null;
-    }
-    return (
-      <span className="text-muted-foreground bg-muted/60 rounded px-1.5 py-0.5 text-xs leading-none">
-        {format.dateTime(new Date(content.value), {
-          day: "numeric",
-          month: "short",
-          year: "numeric",
-          timeZone: "UTC",
-        })}
-      </span>
-    );
-  }
-
-  if (content.type === "int") {
-    const value = format.number(content.value);
-    return (
-      <span className="text-muted-foreground bg-muted/60 rounded px-1.5 py-0.5 text-xs leading-none">
-        {content.currency ? `${value} ${content.currency}` : value}
-      </span>
-    );
-  }
-
-  if (content.type === "single-select") {
-    return <KanbanSelectChip property={property} value={content.value} />;
-  }
-
-  if (content.type === "multi-select") {
-    return content.value.map((value) => (
-      <KanbanSelectChip key={value} property={property} value={value} />
-    ));
-  }
-
-  return (
-    <span className="text-muted-foreground bg-muted/60 truncate rounded px-1.5 py-0.5 text-xs leading-none">
-      {content.citation ?? content.url}
-    </span>
-  );
-};
-
-const KanbanSelectChip = ({
-  property,
-  value,
-}: {
-  property: WorkspaceProperty;
-  value: string | null;
-}) => {
-  const t = useTranslations();
-  const color = (() => {
-    if (!value) {
-      return emptyColor;
-    }
-    if (
-      property.content.type !== "single-select" &&
-      property.content.type !== "multi-select"
-    ) {
-      return undefined;
-    }
-    const optionColor = property.content.options.find(
-      (option) => option.value === value,
-    )?.color;
-    return optionColor ? resolveOptionColor(optionColor) : undefined;
-  })();
-
-  return (
-    <span
-      className="max-w-full truncate rounded px-1.5 py-0.5 text-xs leading-none font-medium"
-      style={{
-        backgroundColor: color?.background,
-        color: color?.foreground,
-      }}
-    >
-      {value ?? t("common.empty")}
-    </span>
-  );
-};
+}: KanbanCardFieldValueProps) => (
+  <FieldValue content={content} property={property} variant="kanban" />
+);
 
 type KanbanCardFooterProps = {
   entity: WorkspaceEntity;

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1094,6 +1094,15 @@ export default defineConfig({
       },
     },
     {
+      files: [
+        "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx",
+        ".oxlint-plugins/__fixtures__/no-workspace-field-value-drift.fixture.tsx",
+      ],
+      rules: {
+        "no-workspace-field-value-drift/no-raw-field-value-bidi-text": "error",
+      },
+    },
+    {
       files: ["apps/web/src/routes/**/*.{ts,tsx}"],
       rules: {
         "@tanstack/router/create-route-property-order": "error",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -358,6 +358,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-centered-scroll-column.ts",
     "./.oxlint-plugins/no-static-devtools-import.ts",
     "./.oxlint-plugins/no-static-catalogue-route-import.ts",
+    "./.oxlint-plugins/no-workspace-field-value-drift.ts",
   ],
 
   overrides: [
@@ -829,6 +830,15 @@ export default defineConfig({
       },
     },
     {
+      files: [
+        ".oxlint-plugins/__fixtures__/no-workspace-field-value-drift.fixture.tsx",
+      ],
+      rules: {
+        "no-workspace-field-value-drift/no-workspace-field-value-drift":
+          "error",
+      },
+    },
+    {
       files: [".oxlint-plugins/__fixtures__/require-query-limit.fixture.ts"],
       rules: {
         "require-query-limit/require-query-limit": "error",
@@ -1066,6 +1076,21 @@ export default defineConfig({
       ],
       rules: {
         "no-shared-suspense-query/no-shared-suspense-query": "error",
+      },
+    },
+    {
+      // Field value display must stay centralized in FieldValue /
+      // EditableField. These surfaces own table/kanban/inspector shell
+      // behavior, but must not reimplement per-field display branches.
+      files: [
+        "apps/web/src/components/inspector/entity-metadata-panel.tsx",
+        "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx",
+        "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx",
+        "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx",
+      ],
+      rules: {
+        "no-workspace-field-value-drift/no-workspace-field-value-drift":
+          "error",
       },
     },
     {


### PR DESCRIPTION
Centralizes workspace field value display behind a shared FieldValue renderer and adds a scoped oxlint guardrail to prevent table, kanban, and inspector display drift.