### PR TITLE
chore: cover DOCX browser save e2e

### DIFF
--- a/apps/web/e2e/helpers/api.ts
+++ b/apps/web/e2e/helpers/api.ts
@@ -113,3 +113,21 @@ export const apiUploadDocx = async (
     renamed: boolean;
   };
 };
+
+export const apiDownloadFileField = async (
+  request: APIRequestContext,
+  workspaceId: string,
+  fieldId: string,
+): Promise<Buffer> => {
+  const metadata = await apiGet<{ presignedUrl: string }>(
+    request,
+    `/files/${workspaceId}/url/${fieldId}?purpose=download`,
+  );
+  const response = await request.get(metadata.presignedUrl);
+  if (!response.ok()) {
+    throw new Error(
+      `GET presigned file ${fieldId} -> ${String(response.status())}: ${await response.text()}`,
+    );
+  }
+  return await response.body();
+};

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -283,6 +283,35 @@ const smokeRoute = async ({
   context: BrowserContext;
   route: SmokeRoute;
 }) => {
+  const expectation = route.expectation;
+
+  if (expectation?.kind === "redirectsTo") {
+    // Redirect aliases do not own UI. Assert the alias lands correctly, then
+    // smoke the declared target directly so browser-error collection belongs to
+    // the page that actually renders.
+    await assertRedirectRoute({ context, route, expectation });
+    await smokeRouteTarget({
+      context,
+      route: {
+        template: `${route.template} target`,
+        path: expectation.to,
+        ...(route.settleMs === undefined ? {} : { settleMs: route.settleMs }),
+        expectation: { kind: "redirectsTo", to: expectation.to },
+      },
+    });
+    return;
+  }
+
+  await smokeRouteTarget({ context, route });
+};
+
+const smokeRouteTarget = async ({
+  context,
+  route,
+}: {
+  context: BrowserContext;
+  route: SmokeRoute;
+}) => {
   const page = await context.newPage();
   const browserErrors = createBrowserErrorCollector();
   const detachPage = browserErrors.trackPage(page);
@@ -291,6 +320,28 @@ const smokeRoute = async ({
     await renderSmokeRoute({ browserErrors, page, route });
   } finally {
     detachPage();
+    await page.close();
+  }
+};
+
+const assertRedirectRoute = async ({
+  context,
+  route,
+  expectation,
+}: {
+  context: BrowserContext;
+  route: SmokeRoute;
+  expectation: { kind: "redirectsTo"; to: string };
+}) => {
+  const page = await context.newPage();
+  const redirectRoute = { ...route, expectation };
+
+  try {
+    await page.goto(redirectRoute.path, { waitUntil: "domcontentloaded" });
+    await expect(page, redirectRoute.template).not.toHaveURL(/\/auth(?:\/|$)/u);
+    await waitForRedirectDestination(page, redirectRoute);
+    assertFinalDestination(page, redirectRoute);
+  } finally {
     await page.close();
   }
 };

--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -1,7 +1,14 @@
+import type { APIRequestContext } from "@playwright/test";
+import JSZip from "jszip";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { apiGet, apiStatus, apiUploadDocx } from "../helpers/api";
+import {
+  apiDownloadFileField,
+  apiGet,
+  apiStatus,
+  apiUploadDocx,
+} from "../helpers/api";
 import { expect, test } from "../helpers/test";
 import {
   type TestWorkspace,
@@ -12,6 +19,43 @@ import {
 const DOCX_MIME =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
+
+type EntityFileField = {
+  id: string;
+  propertyId: string;
+  content: { type: string };
+};
+
+type EntityWithFields = {
+  fields: EntityFileField[];
+};
+
+const readEntity = async (
+  request: APIRequestContext,
+  workspaceId: string,
+  entityId: string,
+) =>
+  await apiGet<EntityWithFields>(
+    request,
+    `/entities/${workspaceId}/entity/${entityId}`,
+  );
+
+const findFileFieldForProperty = (
+  entity: EntityWithFields,
+  propertyId: string,
+) =>
+  entity.fields.find(
+    (field) => field.propertyId === propertyId && field.content.type === "file",
+  );
+
+const readDocumentXml = async (docxBuffer: Buffer) => {
+  const zip = await JSZip.loadAsync(docxBuffer);
+  const documentXml = await zip.file("word/document.xml")?.async("text");
+  if (documentXml === undefined) {
+    throw new Error("Saved DOCX is missing word/document.xml");
+  }
+  return documentXml;
+};
 
 test.describe("DOCX upload + inspector", () => {
   let workspace: TestWorkspace | null = null;
@@ -56,18 +100,14 @@ test.describe("DOCX upload + inspector", () => {
     // The document view requires both entity + field URL params (see
     // apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx:198).
     // Read the entity to find the file field id.
-    const entity = await apiGet<{
-      fields: {
-        id: string;
-        propertyId: string;
-        content: { type: string };
-      }[];
-    }>(request, `/entities/${testWorkspace.id}/entity/${uploaded.entityId}`);
-
-    const fileField = entity.fields.find(
-      (f) =>
-        f.propertyId === testWorkspace.filePropertyId &&
-        f.content.type === "file",
+    const entity = await readEntity(
+      request,
+      testWorkspace.id,
+      uploaded.entityId,
+    );
+    const fileField = findFileFieldForProperty(
+      entity,
+      testWorkspace.filePropertyId,
     );
     expect(fileField, "uploaded file field present on entity").toBeTruthy();
 
@@ -134,5 +174,128 @@ test.describe("DOCX upload + inspector", () => {
       }
       throw error;
     }
+  });
+
+  test("browser edit save creates a persisted DOCX version with the typed text", async ({
+    page,
+    request,
+  }) => {
+    const testWorkspace = workspace;
+    if (testWorkspace === null) {
+      throw new Error("Test workspace was not created");
+    }
+
+    const docxBuffer = await readFile(DOCX_PATH);
+    const uploaded = await apiUploadDocx(
+      request,
+      testWorkspace.id,
+      testWorkspace.filePropertyId,
+      {
+        name: "stella-e2e-edit.docx",
+        mimeType: DOCX_MIME,
+        buffer: docxBuffer,
+      },
+    );
+
+    const originalEntity = await readEntity(
+      request,
+      testWorkspace.id,
+      uploaded.entityId,
+    );
+    const originalFileField = findFileFieldForProperty(
+      originalEntity,
+      testWorkspace.filePropertyId,
+    );
+    expect(
+      originalFileField,
+      "uploaded file field present on entity",
+    ).toBeTruthy();
+
+    const { cookies } = await request.storageState();
+    await page.context().addCookies(cookies);
+
+    await expect
+      .poll(
+        async () =>
+          await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
+        {
+          message: "browser context can read the created workspace",
+          timeout: 10_000,
+        },
+      )
+      .toBe(200);
+
+    const editToken = `E2ESAVETOKEN${String(Date.now())}`;
+    await page.goto(
+      `/workspaces/${testWorkspace.id}/${testWorkspace.viewId}/document` +
+        `?entity=${uploaded.entityId}&field=${originalFileField!.id}&editing=true`,
+      { waitUntil: "domcontentloaded" },
+    );
+
+    const finishEditingButton = page.getByRole("button", {
+      name: "Finish editing",
+    });
+    await expect(finishEditingButton).toBeEnabled({ timeout: 45_000 });
+
+    const firstParagraphText = page.locator(".layout-run-text", {
+      hasText: "Stella E2E test document.",
+    });
+    await expect(firstParagraphText).toBeVisible({ timeout: 45_000 });
+
+    await firstParagraphText.click();
+    await page.keyboard.type(editToken);
+    await expect(
+      page.locator(".layout-run-text", { hasText: editToken }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    const finalizeResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/desktop-edit-sessions/") &&
+        response.url().endsWith("/finalize"),
+      { timeout: 45_000 },
+    );
+    await finishEditingButton.click();
+    expect((await finalizeResponse).ok()).toBe(true);
+
+    await expect
+      .poll(
+        async () => {
+          const entity = await readEntity(
+            request,
+            testWorkspace.id,
+            uploaded.entityId,
+          );
+          const fileField = findFileFieldForProperty(
+            entity,
+            testWorkspace.filePropertyId,
+          );
+          return fileField?.id !== originalFileField!.id ? fileField?.id : null;
+        },
+        {
+          message: "saved DOCX version appears on the entity",
+          timeout: 30_000,
+        },
+      )
+      .not.toBeNull();
+
+    const latestEntity = await readEntity(
+      request,
+      testWorkspace.id,
+      uploaded.entityId,
+    );
+    const latestFileField = findFileFieldForProperty(
+      latestEntity,
+      testWorkspace.filePropertyId,
+    );
+    expect(latestFileField, "saved file field present on entity").toBeTruthy();
+
+    const savedBuffer = await apiDownloadFileField(
+      request,
+      testWorkspace.id,
+      latestFileField!.id,
+    );
+    const documentXml = await readDocumentXml(savedBuffer);
+    expect(documentXml).toContain(editToken);
   });
 });

--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -270,7 +270,9 @@ test.describe("DOCX upload + inspector", () => {
             entity,
             testWorkspace.filePropertyId,
           );
-          return fileField?.id !== originalFileField!.id ? fileField?.id : null;
+          return fileField && fileField.id !== originalFileField!.id
+            ? fileField.id
+            : null;
         },
         {
           message: "saved DOCX version appears on the entity",


### PR DESCRIPTION
Adds end-to-end coverage for the DOCX browser edit/save flow. The test uploads a DOCX, opens it in browser edit mode, types a unique token, finalizes the edit session, downloads the new DOCX version, and verifies the saved document XML contains the typed text.