### PR TITLE
fix: require tooltips for icon-only controls

### DIFF
--- a/.oxlint-plugins/__fixtures__/icon-button-requires-tooltip.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/icon-button-requires-tooltip.fixture.tsx
@@ -1,0 +1,59 @@
+import { SettingsIcon, XIcon } from "lucide-react";
+
+import { Button } from "@stll/ui/components/button";
+import { MenuTrigger } from "@stll/ui/components/menu";
+import {
+  Tooltip as TooltipRoot,
+  TooltipPopup,
+  TooltipTrigger,
+} from "@stll/ui/components/tooltip";
+
+import Tooltip from "@/components/tooltip";
+
+const t = (key: string) => key;
+
+export const Fixture = () => (
+  <div>
+    <Tooltip content={t("settings")} render={<Button size="icon" />}>
+      <SettingsIcon />
+    </Tooltip>
+
+    <TooltipRoot>
+      <TooltipTrigger render={<Button size="icon-xs" />}>
+        <XIcon />
+      </TooltipTrigger>
+      <TooltipPopup>{t("close")}</TooltipPopup>
+    </TooltipRoot>
+
+    <Button size="sm">
+      <SettingsIcon />
+      {t("settings")}
+    </Button>
+
+    <Button size="icon" tooltip={t("settings")}>
+      <SettingsIcon />
+    </Button>
+
+    <Tooltip
+      content={t("more")}
+      render={<MenuTrigger render={<Button size="icon-xs" />} />}
+    >
+      <SettingsIcon />
+    </Tooltip>
+
+    {/* oxlint-disable-next-line icon-button-requires-tooltip/icon-button-requires-tooltip -- fixture: unlabeled icon-only Button must be reported */}
+    <Button size="icon">
+      <SettingsIcon />
+    </Button>
+
+    {/* oxlint-disable-next-line icon-button-requires-tooltip/icon-button-requires-tooltip -- fixture: native icon-only button without tooltip must be reported */}
+    <button aria-label={t("close")} type="button">
+      <XIcon />
+    </button>
+
+    {/* oxlint-disable-next-line icon-button-requires-tooltip/icon-button-requires-tooltip -- fixture: trigger rendered as an icon Button without tooltip must be reported */}
+    <MenuTrigger render={<Button size="icon-xs" />}>
+      <SettingsIcon />
+    </MenuTrigger>
+  </div>
+);

--- a/.oxlint-plugins/icon-button-requires-tooltip.ts
+++ b/.oxlint-plugins/icon-button-requires-tooltip.ts
@@ -1,0 +1,390 @@
+// Require tooltips for icon-only interactive controls.
+//
+// Accessible names (`aria-label`) are necessary for screen readers, but they do
+// not help sighted users discover unfamiliar icon actions. Stella's UI pattern
+// is to wrap icon-only actions in the shared Tooltip component, or to use a
+// component-level `tooltip` prop when the primitive provides one.
+
+type AstNode = { type: string } & Record<string, unknown>;
+
+type RuleContext = {
+  filename?: string;
+  getFilename?: () => string;
+  report: (diagnostic: {
+    node: unknown;
+    messageId: "missingTooltip";
+    data?: Record<string, string>;
+  }) => void;
+};
+
+const INTERACTIVE_ELEMENTS = new Set([
+  "AlertDialogClose",
+  "Button",
+  "DialogClose",
+  "MenuTrigger",
+  "PopoverTrigger",
+  "SheetClose",
+  "button",
+]);
+
+const TOOLTIP_ELEMENTS = new Set(["Tooltip", "TooltipRoot"]);
+const TOOLTIP_ATTRS = new Set(["tooltip"]);
+const AUTO_TOOLTIP_ELEMENTS = new Set([
+  "AlertDialogClose",
+  "AlertDialogTrigger",
+  "Button",
+  "DialogClose",
+  "DialogTrigger",
+  "MenuTrigger",
+  "PopoverTrigger",
+  "SheetClose",
+  "SheetTrigger",
+]);
+const AUTO_TOOLTIP_ATTRS = new Set(["aria-label", "title"]);
+const NATIVE_TOOLTIP_ATTRS = new Set(["title"]);
+
+const isAstNode = (node: unknown): node is AstNode =>
+  typeof node === "object" &&
+  node !== null &&
+  "type" in node &&
+  typeof (node as { type: unknown }).type === "string";
+
+const getJsxName = (node: unknown): string | null => {
+  if (!isAstNode(node)) {
+    return null;
+  }
+  if (node.type === "JSXIdentifier" && typeof node.name === "string") {
+    return node.name;
+  }
+  if (node.type === "JSXMemberExpression") {
+    return getJsxName(node.property);
+  }
+  if (node.type === "JSXNamespacedName") {
+    return getJsxName(node.name);
+  }
+  return null;
+};
+
+const getElementName = (element: unknown): string | null => {
+  if (!isAstNode(element) || element.type !== "JSXElement") {
+    return null;
+  }
+  const openingElement = element.openingElement;
+  if (!isAstNode(openingElement)) {
+    return null;
+  }
+  return getJsxName(openingElement.name);
+};
+
+const getOpeningElement = (element: unknown): AstNode | null => {
+  if (!isAstNode(element) || element.type !== "JSXElement") {
+    return null;
+  }
+  return isAstNode(element.openingElement) ? element.openingElement : null;
+};
+
+const getAttributes = (openingElement: unknown): unknown[] => {
+  if (!isAstNode(openingElement) || !Array.isArray(openingElement.attributes)) {
+    return [];
+  }
+  return openingElement.attributes;
+};
+
+const getAttributeName = (attribute: unknown): string | null => {
+  if (!isAstNode(attribute) || attribute.type !== "JSXAttribute") {
+    return null;
+  }
+  return getJsxName(attribute.name);
+};
+
+const findAttribute = (openingElement: unknown, name: string): AstNode | null =>
+  getAttributes(openingElement).find(
+    (attribute): attribute is AstNode => getAttributeName(attribute) === name,
+  ) ?? null;
+
+const hasAttribute = (openingElement: unknown, names: ReadonlySet<string>) =>
+  getAttributes(openingElement).some((attribute) => {
+    const name = getAttributeName(attribute);
+    return name !== null && names.has(name);
+  });
+
+const getStaticStringValue = (node: unknown): string | null => {
+  if (!isAstNode(node)) {
+    return null;
+  }
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return node.value;
+  }
+  if (
+    node.type === "JSXExpressionContainer" &&
+    isAstNode(node.expression) &&
+    node.expression.type === "Literal" &&
+    typeof node.expression.value === "string"
+  ) {
+    return node.expression.value;
+  }
+  return null;
+};
+
+const getClassName = (openingElement: unknown): string => {
+  const className = findAttribute(openingElement, "className");
+  return getStaticStringValue(className?.value) ?? "";
+};
+
+const isScreenReaderOnly = (element: unknown): boolean => {
+  const openingElement = getOpeningElement(element);
+  return getClassName(openingElement).split(/\s+/u).includes("sr-only");
+};
+
+const isLikelyIconExpression = (node: unknown): boolean => {
+  if (!isAstNode(node)) {
+    return false;
+  }
+
+  if (node.type === "Identifier" && typeof node.name === "string") {
+    return /(?:^|[a-z])(?:icon|mark)$/iu.test(node.name);
+  }
+
+  if (
+    node.type !== "MemberExpression" &&
+    node.type !== "OptionalMemberExpression"
+  ) {
+    return false;
+  }
+
+  const property = node.property;
+  return (
+    isAstNode(property) &&
+    property.type === "Identifier" &&
+    typeof property.name === "string" &&
+    /(?:^|[a-z])(?:icon|mark)$/iu.test(property.name)
+  );
+};
+
+const hasVisibleText = (node: unknown): boolean => {
+  if (!isAstNode(node)) {
+    return false;
+  }
+
+  if (node.type === "JSXText") {
+    return typeof node.value === "string" && /\p{L}|\p{N}/u.test(node.value);
+  }
+
+  if (node.type === "Literal") {
+    return typeof node.value === "string" && /\p{L}|\p{N}/u.test(node.value);
+  }
+
+  if (node.type === "CallExpression" || node.type === "TemplateLiteral") {
+    return true;
+  }
+
+  if (node.type === "Identifier" || node.type === "MemberExpression") {
+    return !isLikelyIconExpression(node);
+  }
+
+  if (node.type === "ConditionalExpression") {
+    return hasVisibleText(node.consequent) || hasVisibleText(node.alternate);
+  }
+
+  if (node.type === "LogicalExpression") {
+    return hasVisibleText(node.right);
+  }
+
+  if (node.type === "BinaryExpression") {
+    return true;
+  }
+
+  if (
+    node.type === "TSAsExpression" ||
+    node.type === "TSSatisfiesExpression" ||
+    node.type === "TSNonNullExpression"
+  ) {
+    return hasVisibleText(node.expression);
+  }
+
+  if (node.type === "JSXExpressionContainer") {
+    return hasVisibleText(node.expression);
+  }
+
+  if (node.type !== "JSXElement" || isScreenReaderOnly(node)) {
+    return false;
+  }
+
+  const children = Array.isArray(node.children) ? node.children : [];
+  return children.some(hasVisibleText);
+};
+
+const isIconElement = (node: unknown): boolean => {
+  if (!isAstNode(node) || node.type !== "JSXElement") {
+    return false;
+  }
+  const name = getElementName(node);
+  if (name === null) {
+    return false;
+  }
+  return (
+    name === "svg" ||
+    name === "DirectionalIcon" ||
+    name === "StellaMark" ||
+    name.endsWith("Icon")
+  );
+};
+
+const hasIconChild = (node: unknown): boolean => {
+  if (!isAstNode(node) || node.type !== "JSXElement") {
+    return false;
+  }
+  const children = Array.isArray(node.children) ? node.children : [];
+  return children.some((child) => {
+    if (isIconElement(child)) {
+      return true;
+    }
+    if (!isAstNode(child) || child.type !== "JSXExpressionContainer") {
+      return false;
+    }
+    return isIconElement(child.expression);
+  });
+};
+
+const isIconSizeButton = (node: unknown): boolean => {
+  const openingElement = getOpeningElement(node);
+  const name = getJsxName(openingElement?.name);
+  if (name !== "Button" && name !== "button") {
+    return false;
+  }
+
+  const size = findAttribute(openingElement, "size");
+  const sizeValue = getStaticStringValue(size?.value);
+  if (typeof sizeValue === "string" && sizeValue.startsWith("icon")) {
+    return true;
+  }
+
+  return getClassName(openingElement)
+    .split(/\s+/u)
+    .some((className) => /^size-\d/u.test(className));
+};
+
+const getRenderElement = (openingElement: unknown): unknown => {
+  const render = findAttribute(openingElement, "render");
+  if (!isAstNode(render)) {
+    return null;
+  }
+  const value = render.value;
+  if (!isAstNode(value)) {
+    return null;
+  }
+  if (value.type === "JSXExpressionContainer") {
+    return value.expression;
+  }
+  return value;
+};
+
+const hasTooltip = (node: unknown): boolean => {
+  let current = isAstNode(node) ? node : null;
+  while (isAstNode(current)) {
+    if (current.type === "JSXElement") {
+      const openingElement = getOpeningElement(current);
+      const name = getJsxName(openingElement?.name);
+      if (name !== null && TOOLTIP_ELEMENTS.has(name)) {
+        return true;
+      }
+      if (hasAttribute(openingElement, TOOLTIP_ATTRS)) {
+        return true;
+      }
+      if (
+        name !== null &&
+        AUTO_TOOLTIP_ELEMENTS.has(name) &&
+        hasAttribute(openingElement, AUTO_TOOLTIP_ATTRS)
+      ) {
+        return true;
+      }
+      if (
+        name === "button" &&
+        hasAttribute(openingElement, NATIVE_TOOLTIP_ATTRS)
+      ) {
+        return true;
+      }
+      const renderElement = getRenderElement(openingElement);
+      const renderOpeningElement = getOpeningElement(renderElement);
+      if (hasAttribute(renderOpeningElement, TOOLTIP_ATTRS)) {
+        return true;
+      }
+      const renderElementName = getJsxName(renderOpeningElement?.name);
+      if (
+        renderElementName !== null &&
+        AUTO_TOOLTIP_ELEMENTS.has(renderElementName) &&
+        hasAttribute(renderOpeningElement, AUTO_TOOLTIP_ATTRS)
+      ) {
+        return true;
+      }
+      if (
+        renderElementName === "button" &&
+        hasAttribute(renderOpeningElement, NATIVE_TOOLTIP_ATTRS)
+      ) {
+        return true;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+};
+
+const isIconOnlyInteractive = (node: unknown): boolean => {
+  const name = getElementName(node);
+  if (name === null || !INTERACTIVE_ELEMENTS.has(name)) {
+    return false;
+  }
+  if (hasVisibleText(node)) {
+    return false;
+  }
+
+  const openingElement = getOpeningElement(node);
+  const renderElement = getRenderElement(openingElement);
+  if (isIconSizeButton(renderElement)) {
+    return true;
+  }
+
+  if (isIconSizeButton(node)) {
+    return hasIconChild(node);
+  }
+
+  return hasIconChild(node);
+};
+
+const filenameOf = (context: RuleContext): string =>
+  context.filename ?? context.getFilename?.() ?? "";
+
+export default {
+  meta: { name: "icon-button-requires-tooltip" },
+  rules: {
+    "icon-button-requires-tooltip": {
+      meta: {
+        type: "problem",
+        messages: {
+          missingTooltip:
+            "Icon-only {{tag}} needs a tooltip. Wrap it in <Tooltip> with content, or use a component-level tooltip prop.",
+        },
+      },
+      create(context: RuleContext) {
+        const filename = filenameOf(context);
+        if (!filename.endsWith(".tsx")) {
+          return {};
+        }
+
+        return {
+          JSXElement(node: AstNode) {
+            if (!isIconOnlyInteractive(node) || hasTooltip(node)) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: "missingTooltip",
+              data: { tag: getElementName(node) ?? "control" },
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/.oxlint-plugins/icon-button-requires-tooltip.ts
+++ b/.oxlint-plugins/icon-button-requires-tooltip.ts
@@ -19,11 +19,14 @@ type RuleContext = {
 
 const INTERACTIVE_ELEMENTS = new Set([
   "AlertDialogClose",
+  "AlertDialogTrigger",
   "Button",
   "DialogClose",
+  "DialogTrigger",
   "MenuTrigger",
   "PopoverTrigger",
   "SheetClose",
+  "SheetTrigger",
   "button",
 ]);
 

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -109,6 +109,7 @@ export const ConversationScrollButton = ({
     isScrollable &&
     !isAtBottom && (
       <Button
+        aria-label="Scroll to bottom"
         className={cn(
           // The outline variant is translucent in dark mode (content shows
           // through the button) and its `::before` highlight is a rounded

--- a/apps/web/src/components/ai-suggestions/review-panel.impl.tsx
+++ b/apps/web/src/components/ai-suggestions/review-panel.impl.tsx
@@ -468,6 +468,7 @@ export const ReviewPanelImpl = ({
             </div>
             <button
               aria-label={t("docxReview.dismiss")}
+              title={t("docxReview.dismiss")}
               className="text-muted-foreground hover:text-foreground rounded-md p-1"
               onClick={() => dismissPanel(entityId)}
               type="button"

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -97,6 +97,7 @@ export const ApiVersionMismatchBanner = () => {
         </span>
         <button
           aria-label={t("app.versionMismatch.dismiss")}
+          title={t("app.versionMismatch.dismiss")}
           className="hover:bg-accent-foreground/10 -me-1 rounded-sm p-1"
           onClick={handleDismiss}
           type="button"

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -895,7 +895,10 @@ const MatterItem = ({
               }}
               open={menuOpen}
             >
-              <MenuTrigger className="text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent flex size-5 items-center justify-center rounded-md outline-hidden data-popup-open:opacity-100">
+              <MenuTrigger
+                aria-label={t("common.actions")}
+                className="text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent flex size-5 items-center justify-center rounded-md outline-hidden data-popup-open:opacity-100"
+              >
                 <EllipsisVerticalIcon className="size-4" />
               </MenuTrigger>
               <MenuPopup

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -53,6 +53,7 @@ export const ChatInputSurface = ({
   onStop,
   anonymized = false,
 }: ChatInputSurfaceProps) => {
+  const t = useTranslations();
   const rootRef = useRef<HTMLDivElement>(null);
   const {
     attachments,
@@ -71,6 +72,7 @@ export const ChatInputSurface = ({
     removeFile,
   } = controller;
   const inputDisabled = disabled;
+  const attachFileLabel = t("chat.attachFile");
   // Submitting stays enabled while the assistant streams: a send
   // during a turn is queued by `useChatSession` and dispatched once
   // the response finishes, so overlapping requests can't happen.
@@ -145,7 +147,7 @@ export const ChatInputSurface = ({
       </div>
       <div className="flex items-center gap-0.5 px-1.5 pb-1.5">
         <Button
-          aria-label={t("chat.attachFile")}
+          aria-label={attachFileLabel}
           disabled={inputDisabled}
           onClick={openFilePicker}
           size="icon-sm"

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -145,6 +145,7 @@ export const ChatInputSurface = ({
       </div>
       <div className="flex items-center gap-0.5 px-1.5 pb-1.5">
         <Button
+          aria-label={t("chat.attachFile")}
           disabled={inputDisabled}
           onClick={openFilePicker}
           size="icon-sm"

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -333,6 +333,7 @@ export const ChatMentionList = ({
                         </Button>
                         {isWorkspace && (
                           <Button
+                            aria-label={t("common.open")}
                             className="text-muted-foreground size-7 shrink-0"
                             onClick={() => handleDrillDown(item)}
                             size="icon-sm"

--- a/apps/web/src/components/chat/chat-draft-attachment-chips.tsx
+++ b/apps/web/src/components/chat/chat-draft-attachment-chips.tsx
@@ -1,4 +1,5 @@
 import { XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
@@ -15,6 +16,8 @@ export const ChatDraftAttachmentChips = ({
   files,
   onRemove,
 }: ChatDraftAttachmentChipsProps) => {
+  const t = useTranslations();
+
   if (files.length === 0) {
     return null;
   }
@@ -34,6 +37,7 @@ export const ChatDraftAttachmentChips = ({
           />
           <span className="max-w-[120px] truncate">{file.filename}</span>
           <Button
+            aria-label={t("common.remove")}
             className="size-4 p-0"
             onClick={() => onRemove(file.id)}
             size="icon-xs"

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -465,6 +465,7 @@ export const ToolCallCard = ({
         {canExpand && (!headerOpensSkillResource || showDetails) && (
           <button
             aria-label={t("chat.toolCall.toggleDetails")}
+            title={t("chat.toolCall.toggleDetails")}
             className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 shrink-0 rounded focus-visible:ring-2 focus-visible:outline-none"
             onClick={() => {
               setExpanded((e) => !e);

--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -435,6 +435,7 @@ const EmptyScreenVideoOverlay = ({
 
   return (
     <div
+      aria-label={playableVideo.title}
       aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/72 p-6 backdrop-blur-sm"
       role="dialog"

--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -435,7 +435,6 @@ const EmptyScreenVideoOverlay = ({
 
   return (
     <div
-      aria-label={playableVideo.title}
       aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/72 p-6 backdrop-blur-sm"
       role="dialog"

--- a/apps/web/src/components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/components/inspector/chat-tab-panel.tsx
@@ -672,7 +672,13 @@ const PromptBarPlaceholder = ({ tab }: { tab: ChatTab }) => {
           {t("chat.contextPlaceholder", { context: chatContextLabel })}
         </PromptBarPlaceholderContent>
       </div>
-      <Button className="rounded-full" disabled size="icon" type="button">
+      <Button
+        aria-label={t("chat.sendPrompt")}
+        className="rounded-full"
+        disabled
+        size="icon"
+        type="button"
+      >
         <ArrowUpIcon aria-hidden="true" />
       </Button>
     </PromptBarShell>

--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -396,6 +396,7 @@ export const DocumentAiSourceBar = ({
           </span>
         </button>
         <Button
+          aria-label={t("common.previous")}
           disabled={!prevSlot}
           onClick={() => {
             if (!prevSlot) {
@@ -422,6 +423,7 @@ export const DocumentAiSourceBar = ({
           {format.number(currentIdx + 1)} / {format.number(slots.length)}
         </span>
         <Button
+          aria-label={t("common.next")}
           disabled={!nextSlot}
           onClick={() => {
             if (!nextSlot) {

--- a/apps/web/src/components/inspector/inspector-pdf-error-fallback.tsx
+++ b/apps/web/src/components/inspector/inspector-pdf-error-fallback.tsx
@@ -23,7 +23,12 @@ export const InspectorPdfErrorFallback = ({
           TOOLBAR_ROW_HEIGHT,
         )}
       >
-        <Button onClick={onClose} size="icon-xs" variant="ghost">
+        <Button
+          aria-label={t("common.close")}
+          onClick={onClose}
+          size="icon-xs"
+          variant="ghost"
+        >
           <XIcon className="size-3.5" />
         </Button>
       </div>

--- a/apps/web/src/components/jurisdiction-picker.tsx
+++ b/apps/web/src/components/jurisdiction-picker.tsx
@@ -154,6 +154,9 @@ export const JurisdictionPicker = ({
                   aria-label={t("onboarding.jurisdictionMakePrimary", {
                     name: country.name,
                   })}
+                  title={t("onboarding.jurisdictionMakePrimary", {
+                    name: country.name,
+                  })}
                   className={cn(
                     "hover:bg-background/40 flex size-8 items-center justify-center rounded-md transition-colors",
                     isPrimary

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -232,6 +232,7 @@ const FolderPicker = ({
               className="hover:bg-muted rounded p-0.5"
               aria-expanded={isExpanded}
               aria-label={folder.name}
+              title={folder.name}
               onClick={(e) => {
                 e.stopPropagation();
                 toggleExpand(folder.entityId);

--- a/apps/web/src/components/selfhost-update-banner.tsx
+++ b/apps/web/src/components/selfhost-update-banner.tsx
@@ -118,6 +118,7 @@ export const SelfhostUpdateBanner = () => {
         </span>
         <button
           aria-label={t("selfhost.dismissUpdate")}
+          title={t("selfhost.dismissUpdate")}
           className="hover:bg-warning/20 -me-1 rounded-sm p-1"
           onClick={handleDismiss}
           type="button"

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -263,6 +263,7 @@ function SidebarTrigger({
 
   return (
     <Button
+      aria-label={t("navigation.toggleSidebar")}
       className={cn("size-7", className)}
       data-sidebar="trigger"
       data-slot="sidebar-trigger"

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "مسح العلامات",
+      "collapseRow": "طي الصف",
+      "expandRow": "توسيع الصف",
       "flagCell": "وضع علامة على الخلية",
       "flags": {
         "contradiction": "تناقض",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Odstranit označení",
+      "collapseRow": "Sbalit řádek",
+      "expandRow": "Rozbalit řádek",
       "flagCell": "Označit buňku",
       "flags": {
         "contradiction": "Rozpor",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Markierungen löschen",
+      "collapseRow": "Zeile einklappen",
+      "expandRow": "Zeile erweitern",
       "flagCell": "Zelle markieren",
       "flags": {
         "contradiction": "Widerspruch",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Clear flags",
+      "collapseRow": "Collapse row",
+      "expandRow": "Expand row",
       "flagCell": "Flag cell",
       "flags": {
         "contradiction": "Contradiction",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Borrar marcas",
+      "collapseRow": "Contraer fila",
+      "expandRow": "Expandir fila",
       "flagCell": "Marcar celda",
       "flags": {
         "contradiction": "Contradicción",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Eemalda märgised",
+      "collapseRow": "Ahenda rida",
+      "expandRow": "Laienda rida",
       "flagCell": "Märgista lahter",
       "flags": {
         "contradiction": "Vastuolu",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Effacer les marqueurs",
+      "collapseRow": "Réduire la ligne",
+      "expandRow": "Développer la ligne",
       "flagCell": "Marquer la cellule",
       "flags": {
         "contradiction": "Contradiction",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Jelölések törlése",
+      "collapseRow": "Sor összecsukása",
+      "expandRow": "Sor kibontása",
       "flagCell": "Cella megjelölése",
       "flags": {
         "contradiction": "Ellentmondás",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Išvalyti žymas",
+      "collapseRow": "Suskleisti eilutę",
+      "expandRow": "Išskleisti eilutę",
       "flagCell": "Pažymėti langelį",
       "flags": {
         "contradiction": "Prieštara",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Notīrīt atzīmes",
+      "collapseRow": "Sakļaut rindu",
+      "expandRow": "Izvērst rindu",
       "flagCell": "Atzīmēt šūnu",
       "flags": {
         "contradiction": "Pretruna",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2853,6 +2853,8 @@ type Messages = {
     };
     "table": {
       "clearFlags": "Clear flags";
+      "collapseRow": "Collapse row";
+      "expandRow": "Expand row";
       "flagCell": "Flag cell";
       "flags": {
         "contradiction": "Contradiction";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Wyczyść oznaczenia",
+      "collapseRow": "Zwiń wiersz",
+      "expandRow": "Rozwiń wiersz",
       "flagCell": "Oznacz komórkę",
       "flags": {
         "contradiction": "Sprzeczność",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Limpar sinalizadores",
+      "collapseRow": "Recolher linha",
+      "expandRow": "Expandir linha",
       "flagCell": "Célula sinalizadora",
       "flags": {
         "contradiction": "Contradição",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2850,6 +2850,8 @@
     },
     "table": {
       "clearFlags": "Vymazať označenia",
+      "collapseRow": "Zbaliť riadok",
+      "expandRow": "Rozbaliť riadok",
       "flagCell": "Označiť bunku",
       "flags": {
         "contradiction": "Rozpor",

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -224,6 +224,7 @@ const DeleteThreadButton = ({
 
   return (
     <Button
+      aria-label={t("chat.deleteThread")}
       className="me-1 opacity-0 group-hover:opacity-100"
       disabled={deleteThread.isPending}
       onClick={() =>

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -156,6 +156,7 @@ function ContactDetailPage() {
       {/* Header */}
       <div className="flex items-center gap-3">
         <Button
+          aria-label={t("common.back")}
           onClick={() => {
             void (async () => await navigate({ to: "/contacts" }))();
           }}

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -731,7 +731,6 @@ const CatalogueEntryRow = ({
     // (e.g. anonymisation that gates AI access).
     actions = (
       <span
-        aria-label={t("catalogue.installedShort")}
         className="text-muted-foreground inline-flex items-center gap-1 text-xs"
         title={t("catalogue.installedShort")}
       >

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -593,6 +593,7 @@ export const ClauseEditor = ({
         </Button>
         <div className="bg-border mx-1 h-4 w-px" />
         <Button
+          aria-label={t("folio.bold")}
           className={
             editorReady && editor.isActive("bold") ? "bg-muted" : undefined
           }
@@ -605,6 +606,7 @@ export const ClauseEditor = ({
           <BoldIcon className="size-3.5" />
         </Button>
         <Button
+          aria-label={t("folio.italic")}
           className={
             editorReady && editor.isActive("italic") ? "bg-muted" : undefined
           }
@@ -618,6 +620,7 @@ export const ClauseEditor = ({
         </Button>
         <div className="bg-border mx-1 h-4 w-px" />
         <Button
+          aria-label="H1"
           className={
             editorReady && editor.isActive("heading", { level: 1 })
               ? "bg-muted"
@@ -632,6 +635,7 @@ export const ClauseEditor = ({
           <Heading1Icon className="size-3.5" />
         </Button>
         <Button
+          aria-label="H2"
           className={
             editorReady && editor.isActive("heading", { level: 2 })
               ? "bg-muted"
@@ -646,6 +650,7 @@ export const ClauseEditor = ({
           <Heading2Icon className="size-3.5" />
         </Button>
         <Button
+          aria-label="H3"
           className={
             editorReady && editor.isActive("heading", { level: 3 })
               ? "bg-muted"

--- a/apps/web/src/routes/_protected.knowledge/-components/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/condition-builder.tsx
@@ -374,6 +374,7 @@ const RuleRow = ({
         value={rule.value}
       />
       <Button
+        aria-label={t("common.delete")}
         disabled={!removable}
         onClick={onRemove}
         size="icon-xs"

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -1088,6 +1088,7 @@ const ArrayFieldRenderer = ({
           key={`${field.path}-${String(index)}`}
         >
           <Button
+            aria-label={t("common.delete")}
             className="absolute end-2 top-2"
             onClick={() => removeItem(index)}
             size="icon-xs"

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -308,6 +308,7 @@ export const TemplateList = ({
                 {tagFilter}
                 <button
                   aria-label={t("common.remove")}
+                  title={t("common.remove")}
                   className="text-muted-foreground hover:text-foreground rounded-full p-0.5"
                   onClick={() => setTagFilter(null)}
                   type="button"
@@ -1077,6 +1078,7 @@ const TemplateTagsDialogBody = ({
                 {tag}
                 <button
                   aria-label={t("common.remove")}
+                  title={t("common.remove")}
                   className="text-muted-foreground hover:text-foreground rounded-full p-0.5"
                   onClick={() =>
                     setTags((current) => current.filter((x) => x !== tag))
@@ -1312,6 +1314,7 @@ const TemplateLanguagesField = ({
               <span className="text-muted-foreground uppercase">{tag}</span>
               <button
                 aria-label={t("common.remove")}
+                title={t("common.remove")}
                 className="text-muted-foreground hover:text-foreground rounded-full p-0.5"
                 onClick={() => onChange(languages.filter((x) => x !== tag))}
                 type="button"

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -2075,7 +2075,6 @@ const SelectionGesturePopover = ({
   const [preview, setPreview] = useState<GestureInsertKind | null>(null);
   return (
     <div
-      aria-label={t("templates.studio.insert")}
       className="bg-popover text-popover-foreground absolute z-50 flex max-h-[min(26rem,80vh)] max-w-[min(92vw,30rem)] flex-col overflow-y-auto rounded-lg border p-1 shadow-lg/5 transition-opacity duration-100 starting:opacity-0"
       role="group"
       style={{

--- a/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
@@ -688,11 +688,13 @@ const OptionsTagInput = ({
         >
           {option}
           <button
+            aria-label={t("common.remove")}
             className="h-full shrink-0 cursor-pointer px-1.5 opacity-80 hover:opacity-100"
             onClick={(e) => {
               e.stopPropagation();
               removeOption(i);
             }}
+            title={t("common.remove")}
             type="button"
           >
             <XIcon className="size-3.5" />

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -31,7 +31,6 @@ import type {
   RoleModelSelections,
   RoleValue,
 } from "@/components/ai-config-role-models.logic";
-import Tooltip from "@/components/tooltip";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
@@ -249,20 +248,15 @@ export const AIConfigCard = () => {
               </span>
             ))}
           </div>
-          <Tooltip
-            content={removeLabel}
-            render={
-              <Button
-                aria-label={removeLabel}
-                loading={deleteMutation.isPending}
-                onClick={() => deleteMutation.mutate()}
-                size="sm"
-                variant="ghost"
-              />
-            }
+          <Button
+            aria-label={removeLabel}
+            loading={deleteMutation.isPending}
+            onClick={() => deleteMutation.mutate()}
+            size="sm"
+            variant="ghost"
           >
             <Trash2Icon className="size-4" />
-          </Tooltip>
+          </Button>
         </div>
       )}
       <Frame>

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -31,6 +31,7 @@ import type {
   RoleModelSelections,
   RoleValue,
 } from "@/components/ai-config-role-models.logic";
+import Tooltip from "@/components/tooltip";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
@@ -219,6 +220,7 @@ export const AIConfigCard = () => {
   });
 
   const providerValues = getProviderValues(providers);
+  const removeLabel = tCommon("remove");
   const canSave =
     hasUsableProviderDrafts(providers) &&
     serializeOverrideModels({ providers: providerValues, roleModels }) !== null;
@@ -247,14 +249,20 @@ export const AIConfigCard = () => {
               </span>
             ))}
           </div>
-          <Button
-            loading={deleteMutation.isPending}
-            onClick={() => deleteMutation.mutate()}
-            size="sm"
-            variant="ghost"
+          <Tooltip
+            content={removeLabel}
+            render={
+              <Button
+                aria-label={removeLabel}
+                loading={deleteMutation.isPending}
+                onClick={() => deleteMutation.mutate()}
+                size="sm"
+                variant="ghost"
+              />
+            }
           >
             <Trash2Icon className="size-4" />
-          </Button>
+          </Tooltip>
         </div>
       )}
       <Frame>

--- a/apps/web/src/routes/_protected.settings/-components/organization/deepl-key-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/deepl-key-card.tsx
@@ -18,7 +18,6 @@ import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
 
-import Tooltip from "@/components/tooltip";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { deepLConfigOptions, deepLKeys } from "@/lib/deepl/queries";
@@ -119,20 +118,15 @@ export const DeepLKeyCard = () => {
               ({deeplConfig.tier === "free" ? t("tierFree") : t("tierPro")})
             </span>
           </div>
-          <Tooltip
-            content={removeLabel}
-            render={
-              <Button
-                aria-label={removeLabel}
-                loading={deleteMutation.isPending}
-                onClick={() => deleteMutation.mutate()}
-                size="sm"
-                variant="ghost"
-              />
-            }
+          <Button
+            aria-label={removeLabel}
+            loading={deleteMutation.isPending}
+            onClick={() => deleteMutation.mutate()}
+            size="sm"
+            variant="ghost"
           >
             <Trash2Icon className="size-4" />
-          </Tooltip>
+          </Button>
         </div>
       )}
 

--- a/apps/web/src/routes/_protected.settings/-components/organization/deepl-key-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/deepl-key-card.tsx
@@ -18,6 +18,7 @@ import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import Tooltip from "@/components/tooltip";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { deepLConfigOptions, deepLKeys } from "@/lib/deepl/queries";
@@ -96,6 +97,7 @@ export const DeepLKeyCard = () => {
 
   const isConfigured = deeplConfig?.configured === true;
   const canSave = apiKey.trim().length > 0 && !saveMutation.isPending;
+  const removeLabel = t("remove");
 
   return (
     <div className="flex flex-col gap-4">
@@ -117,15 +119,20 @@ export const DeepLKeyCard = () => {
               ({deeplConfig.tier === "free" ? t("tierFree") : t("tierPro")})
             </span>
           </div>
-          <Button
-            aria-label={t("remove")}
-            loading={deleteMutation.isPending}
-            onClick={() => deleteMutation.mutate()}
-            size="sm"
-            variant="ghost"
+          <Tooltip
+            content={removeLabel}
+            render={
+              <Button
+                aria-label={removeLabel}
+                loading={deleteMutation.isPending}
+                onClick={() => deleteMutation.mutate()}
+                size="sm"
+                variant="ghost"
+              />
+            }
           >
             <Trash2Icon className="size-4" />
-          </Button>
+          </Tooltip>
         </div>
       )}
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
@@ -245,6 +245,7 @@ export const BillingCodesDialog = ({
                       <Checkbox checked={code.active} />
                     </Button>
                     <Button
+                      aria-label={t("common.delete")}
                       className="text-destructive size-7"
                       onClick={() => handleDelete(code.id)}
                       size="icon"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-row.tsx
@@ -100,6 +100,7 @@ export const ExpenseRow = ({
       <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
         {expense.status === "draft" && canUpdateExpense && (
           <Button
+            aria-label={t("common.edit")}
             className="size-7"
             onClick={() => onEdit(expense.id)}
             size="icon"
@@ -110,6 +111,7 @@ export const ExpenseRow = ({
         )}
         {expense.status === "draft" && canDeleteExpense && (
           <Button
+            aria-label={t("common.delete")}
             className="text-destructive size-7"
             onClick={() => onDelete(expense.id)}
             size="icon"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
@@ -280,6 +280,7 @@ const RateTablesView = ({
                   </Button>
                 )}
                 <Button
+                  aria-label={t("common.delete")}
                   className="text-destructive size-7"
                   onClick={() => handleDelete(table.id)}
                   size="icon"
@@ -514,7 +515,13 @@ const RateEntriesView = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-2">
-        <Button className="size-7" onClick={onBack} size="icon" variant="ghost">
+        <Button
+          aria-label={t("common.back")}
+          className="size-7"
+          onClick={onBack}
+          size="icon"
+          variant="ghost"
+        >
           <DirectionalIcon className="size-4" icon={ArrowLeftIcon} />
         </Button>
         <h3 className="text-sm font-medium">
@@ -606,6 +613,7 @@ const RateEntriesView = ({
               </div>
 
               <Button
+                aria-label={t("common.delete")}
                 className="text-destructive size-7 opacity-0 transition-opacity group-hover:opacity-100"
                 onClick={() => handleDelete(entry.id)}
                 size="icon"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/split-entry-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/split-entry-dialog.tsx
@@ -146,6 +146,7 @@ export const SplitEntryDialog = ({
               </div>
               {splits.length > 2 && (
                 <Button
+                  aria-label={t("common.delete")}
                   className="text-destructive size-8"
                   onClick={() => removeSplit(index)}
                   size="icon"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
@@ -178,6 +178,7 @@ export const TimeEntryRow = ({
 
           {entry.status === "draft" && canUpdateEntry && (
             <Button
+              aria-label={t("common.edit")}
               className="size-7"
               onClick={() => onEdit(entry.id)}
               size="icon"
@@ -188,6 +189,7 @@ export const TimeEntryRow = ({
           )}
           {entry.status === "draft" && canDeleteEntry && (
             <Button
+              aria-label={t("common.delete")}
               className="text-destructive size-7"
               onClick={() => onDelete(entry.id)}
               size="icon"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
@@ -140,6 +140,7 @@ export const CalendarDayCell = ({
         {isEditable && (
           <Menu>
             <MenuTrigger
+              aria-label={t("common.add")}
               render={
                 <button
                   aria-label={t("common.add")}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-header.tsx
@@ -40,10 +40,20 @@ export const CalendarHeader = ({
       <Button onClick={onNavigateToday} size="sm" variant="outline">
         {t("common.today")}
       </Button>
-      <Button onClick={onNavigatePrev} size="icon-sm" variant="ghost">
+      <Button
+        aria-label={t("common.previous")}
+        onClick={onNavigatePrev}
+        size="icon-sm"
+        variant="ghost"
+      >
         <DirectionalIcon icon={ChevronLeftIcon} />
       </Button>
-      <Button onClick={onNavigateNext} size="icon-sm" variant="ghost">
+      <Button
+        aria-label={t("common.next")}
+        onClick={onNavigateNext}
+        size="icon-sm"
+        variant="ghost"
+      >
         <DirectionalIcon icon={ChevronRightIcon} />
       </Button>
       <Popover>
@@ -63,6 +73,7 @@ export const CalendarHeader = ({
         >
           <div className="flex items-center justify-between pb-1">
             <Button
+              aria-label={t("common.previous")}
               onClick={() =>
                 onSetViewDate(new Date(Date.UTC(year - 1, month, 1)))
               }
@@ -73,6 +84,7 @@ export const CalendarHeader = ({
             </Button>
             <span className="text-xs font-medium">{year}</span>
             <Button
+              aria-label={t("common.next")}
               onClick={() =>
                 onSetViewDate(new Date(Date.UTC(year + 1, month, 1)))
               }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
@@ -183,28 +183,34 @@ const NestedGroupRow = ({
   facetContext,
   onChange,
   onRemove,
-}: NestedGroupRowProps) => (
-  <div className="border-border/70 bg-muted/20 flex items-start gap-2 rounded-md border p-2">
-    <div className="flex-1">
-      <ConditionBuilder
-        allowGroups
-        facetContext={facetContext}
-        fields={fields}
-        onChange={onChange}
-        value={value}
-      />
+}: NestedGroupRowProps) => {
+  const t = useTranslations();
+  const removeLabel = t("common.remove");
+
+  return (
+    <div className="border-border/70 bg-muted/20 flex items-start gap-2 rounded-md border p-2">
+      <div className="flex-1">
+        <ConditionBuilder
+          allowGroups
+          facetContext={facetContext}
+          fields={fields}
+          onChange={onChange}
+          value={value}
+        />
+      </div>
+      <Button
+        aria-label={removeLabel}
+        onClick={onRemove}
+        size="icon-xs"
+        tooltip={removeLabel}
+        type="button"
+        variant="ghost"
+      >
+        <XIcon />
+      </Button>
     </div>
-    <Button
-      aria-label={t("common.remove")}
-      onClick={onRemove}
-      size="icon-xs"
-      type="button"
-      variant="ghost"
-    >
-      <XIcon />
-    </Button>
-  </div>
-);
+  );
+};
 
 type LeafRowProps = {
   node: ConditionNode;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/conditions/condition-builder.tsx
@@ -194,7 +194,13 @@ const NestedGroupRow = ({
         value={value}
       />
     </div>
-    <Button onClick={onRemove} size="icon-xs" type="button" variant="ghost">
+    <Button
+      aria-label={t("common.remove")}
+      onClick={onRemove}
+      size="icon-xs"
+      type="button"
+      variant="ghost"
+    >
       <XIcon />
     </Button>
   </div>
@@ -309,7 +315,13 @@ const LeafRow = ({
         operator={operator}
       />
 
-      <Button onClick={onRemove} size="icon-xs" type="button" variant="ghost">
+      <Button
+        aria-label={t("common.remove")}
+        onClick={onRemove}
+        size="icon-xs"
+        type="button"
+        variant="ghost"
+      >
         <XIcon />
       </Button>
     </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.tsx
@@ -340,6 +340,7 @@ const FolderPicker = ({
               className="hover:bg-muted rounded p-0.5"
               aria-expanded={isExpanded}
               aria-label={folder.name}
+              title={folder.name}
               onClick={(e) => {
                 e.stopPropagation();
                 toggleExpand(folder.entityId);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -735,10 +735,12 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
               <BreadcrumbList>
                 <BreadcrumbItem>
                   <button
+                    aria-label={t("workspaces.copyToMatter.rootFolder")}
                     className="text-muted-foreground hover:text-foreground text-xs"
                     onClick={() => {
                       void navigateToFolder();
                     }}
+                    title={t("workspaces.copyToMatter.rootFolder")}
                     type="button"
                   >
                     <FolderIcon className="size-3.5" />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -402,7 +402,10 @@ export const KanbanColumn = ({
         )}
         {hasColumnActions && (
           <Menu>
-            <MenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
+            <MenuTrigger
+              aria-label={t("common.actions")}
+              render={<Button size="icon-xs" variant="ghost" />}
+            >
               <EllipsisVerticalIcon />
             </MenuTrigger>
             <MenuPopup>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -380,6 +380,7 @@ const PromoteDialog = ({ workspaceId }: PromoteDialogProps) => {
               <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
                 <BidiText>{selectedContact.displayName}</BidiText>
                 <Button
+                  aria-label={t("common.remove")}
                   className="ms-auto"
                   onClick={() => setSelectedContact(null)}
                   size="icon-xs"
@@ -662,6 +663,7 @@ const AddPartyDialog = ({
               <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
                 <BidiText>{selectedContact.displayName}</BidiText>
                 <Button
+                  aria-label={t("common.remove")}
                   className="ms-auto"
                   onClick={() => setSelectedContact(null)}
                   size="icon-xs"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/composer-primitives.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/composer-primitives.tsx
@@ -243,6 +243,7 @@ const ReadingChip = ({ label, onRemove }: ReadingChipProps) => {
       {onRemove && (
         <button
           aria-label={t("common.remove")}
+          title={t("common.remove")}
           className="text-foreground-placeholder hover:text-foreground ms-0.5 -me-1 inline-flex size-3.5 items-center justify-center opacity-0 group-hover:opacity-100"
           onClick={onRemove}
           type="button"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/inline-option-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/inline-option-editor.tsx
@@ -199,6 +199,7 @@ const OptionRow = ({
         value={draft}
       />
       <Button
+        aria-label={t("common.remove")}
         className="text-foreground-placeholder size-5 opacity-0 group-hover:opacity-100"
         onClick={onRemove}
         size="icon-sm"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
@@ -10,6 +10,7 @@ import {
   row_getIsSomeSelected,
 } from "@tanstack/react-table/static-functions";
 import { ChevronRightIcon, FolderIcon, FolderOpenIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
 
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
@@ -765,9 +766,11 @@ const FolderCell = ({
   onStopEditing,
   onRename,
 }: FolderCellProps) => {
+  const t = useTranslations("workspaces.table");
   const name = getEntityName(entity);
   const isEditing = editingEntityId === entity.entityId;
   const [editValue, setEditValue] = useState(name);
+  const rowToggleLabel = isExpanded ? t("collapseRow") : t("expandRow");
 
   const commitRename = () => {
     onStopEditing();
@@ -785,9 +788,9 @@ const FolderCell = ({
       }}
     >
       <button
-        aria-label={isExpanded ? "Collapse row" : "Expand row"}
+        aria-label={rowToggleLabel}
         className="flex shrink-0 items-center"
-        title={isExpanded ? "Collapse row" : "Expand row"}
+        title={rowToggleLabel}
         type="button"
       >
         <DirectionalIcon

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
@@ -784,7 +784,12 @@ const FolderCell = ({
         paddingLeft: depth > 0 ? `${depth * 20}px` : undefined,
       }}
     >
-      <button className="flex shrink-0 items-center" type="button">
+      <button
+        aria-label={isExpanded ? "Collapse row" : "Expand row"}
+        className="flex shrink-0 items-center"
+        title={isExpanded ? "Collapse row" : "Expand row"}
+        type="button"
+      >
         <DirectionalIcon
           className={cn(
             "size-3.5 transition-transform",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -174,6 +174,7 @@ export const AssigneePicker = ({
   assignees,
 }: AssigneePickerProps) => {
   const t = useTranslations("tasks");
+  const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
   const { data: members } = useQuery(workspaceMembersOptions(workspaceId));
 
@@ -260,7 +261,7 @@ export const AssigneePicker = ({
             </span>
           ) : null}
           <Button
-            aria-label={t("common.remove")}
+            aria-label={tCommon("remove")}
             className="size-5 opacity-0 transition-opacity group-hover/assignee:opacity-100"
             disabled={removeAssignee.isPending}
             onClick={() => removeAssignee.mutate(a.user.id)}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -260,6 +260,7 @@ export const AssigneePicker = ({
             </span>
           ) : null}
           <Button
+            aria-label={t("common.remove")}
             className="size-5 opacity-0 transition-opacity group-hover/assignee:opacity-100"
             disabled={removeAssignee.isPending}
             onClick={() => removeAssignee.mutate(a.user.id)}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -238,6 +238,7 @@ export const ViewSwitcher = ({
           }}
         >
           <MenuTrigger
+            aria-label={t("common.add")}
             render={
               <Button
                 disabled={createView.isPending}
@@ -544,6 +545,7 @@ const ViewTabMenu = ({
       )}
       <Menu>
         <MenuTrigger
+          aria-label={t("common.actions")}
           render={
             <Button className={className} size="icon-xs" variant="ghost" />
           }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -275,7 +275,10 @@ const FilterEditBody = ({
           {field.label}
         </span>
         <Menu>
-          <MenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
+          <MenuTrigger
+            aria-label={t("common.actions")}
+            render={<Button size="icon-xs" variant="ghost" />}
+          >
             <MoreHorizontalIcon />
           </MenuTrigger>
           <MenuPopup align="end">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-sorts.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-sorts.tsx
@@ -4,6 +4,7 @@ import {
   ArrowUpIcon,
   XIcon,
 } from "lucide-react";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -96,6 +97,7 @@ const SortChip = ({
   onToggle,
   onRemove,
 }: SortChipProps) => {
+  const t = useTranslations();
   const SortIcon = desc ? ArrowDownIcon : ArrowUpIcon;
   const hint = getSortChipLabel(propertyType, desc);
 
@@ -106,7 +108,12 @@ const SortChip = ({
         {propertyName}
         {hint && <span className="text-muted-foreground">{hint}</span>}
       </Button>
-      <Button onClick={onRemove} size="icon-xs" variant="ghost">
+      <Button
+        aria-label={t("common.remove")}
+        onClick={onRemove}
+        size="icon-xs"
+        variant="ghost"
+      >
         <XIcon />
       </Button>
     </div>
@@ -123,27 +130,34 @@ const AddSortButton = ({
   properties,
   sortedPropertyIds,
   onAdd,
-}: AddSortButtonProps) => (
-  <Menu>
-    <MenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
-      <ArrowUpDownIcon />
-    </MenuTrigger>
-    <MenuPopup>
-      {properties.map((property) => (
-        <MenuItem
-          disabled={sortedPropertyIds.has(property.id)}
-          key={property.id}
-          onClick={() =>
-            onAdd({
-              propertyId: property.id,
-              desc: false,
-            })
-          }
-        >
-          <PropertyIcon type={property.content.type} />
-          {property.name}
-        </MenuItem>
-      ))}
-    </MenuPopup>
-  </Menu>
-);
+}: AddSortButtonProps) => {
+  const t = useTranslations();
+
+  return (
+    <Menu>
+      <MenuTrigger
+        aria-label={t("common.add")}
+        render={<Button size="icon-xs" variant="ghost" />}
+      >
+        <ArrowUpDownIcon />
+      </MenuTrigger>
+      <MenuPopup>
+        {properties.map((property) => (
+          <MenuItem
+            disabled={sortedPropertyIds.has(property.id)}
+            key={property.id}
+            onClick={() =>
+              onAdd({
+                propertyId: property.id,
+                desc: false,
+              })
+            }
+          >
+            <PropertyIcon type={property.content.type} />
+            {property.name}
+          </MenuItem>
+        ))}
+      </MenuPopup>
+    </Menu>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -693,7 +693,10 @@ const PropertiesToggle = ({
 
   return (
     <Menu>
-      <MenuTrigger render={<Button size="icon-xs" variant="ghost" />}>
+      <MenuTrigger
+        aria-label={t("common.columns")}
+        render={<Button size="icon-xs" variant="ghost" />}
+      >
         <EyeIcon className="size-3.5" />
       </MenuTrigger>
       <MenuPopup>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
@@ -108,6 +108,7 @@ function ExpensesPage() {
           </Button>
           <div className="flex items-center">
             <Button
+              aria-label={t("common.previous")}
               className="size-7"
               onClick={() => navigateWeek(-1)}
               size="icon"
@@ -119,6 +120,7 @@ function ExpensesPage() {
               {dateLabel}
             </span>
             <Button
+              aria-label={t("common.next")}
               className="size-7"
               onClick={() => navigateWeek(1)}
               size="icon"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -82,7 +82,7 @@ function InvoiceDetailPage() {
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-3 border-b px-4 py-3">
         <Link params={{ workspaceId }} to="/workspaces/$workspaceId/invoices">
-          <Button size="icon" variant="ghost">
+          <Button aria-label={t("common.back")} size="icon" variant="ghost">
             <DirectionalIcon className="size-4" icon={ArrowLeftIcon} />
           </Button>
         </Link>
@@ -447,6 +447,7 @@ const InvoiceDetail = ({
                     {invoiceStatus === "draft" && (
                       <td className="px-4 py-2">
                         <Button
+                          aria-label={t("common.remove")}
                           className="size-6"
                           onClick={() => removeEntryMutation.mutate(entry.id)}
                           size="icon"
@@ -513,6 +514,7 @@ const InvoiceDetail = ({
                     {invoiceStatus === "draft" && (
                       <td className="px-4 py-2">
                         <Button
+                          aria-label={t("common.remove")}
                           className="size-6"
                           onClick={() =>
                             removeExpenseMutation.mutate(expense.id)

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -83,6 +83,7 @@ const OwnerTypeToggle = ({
   const t = useTranslations();
   return (
     <div
+      aria-label={t("workspaces.create.ownerTypeToggle")}
       className="bg-muted/40 inline-flex w-fit gap-1 rounded-lg border p-0.5"
       role="radiogroup"
     >

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -83,7 +83,6 @@ const OwnerTypeToggle = ({
   const t = useTranslations();
   return (
     <div
-      aria-label={t("workspaces.create.ownerTypeToggle")}
       className="bg-muted/40 inline-flex w-fit gap-1 rounded-lg border p-0.5"
       role="radiogroup"
     >

--- a/apps/web/src/routes/_protected.workspaces/-filters/column-filter-button.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-filters/column-filter-button.tsx
@@ -66,6 +66,7 @@ export const ColumnFilterButton = ({
   return (
     <Popover>
       <PopoverTrigger
+        aria-label={t("common.filter")}
         render={
           <button
             aria-label={t("common.filter")}

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -152,7 +152,11 @@ function PublicLawSidebar({
   useHotkey(HOTKEYS.SEARCH, openSearch);
 
   return (
-    <Sidebar className="border-sidebar-border/35" collapsible="icon">
+    <Sidebar
+      aria-label={t("navigation.toggleSidebar")}
+      className="border-sidebar-border/35"
+      collapsible="icon"
+    >
       <SidebarHeader className="border-sidebar-border/35 h-12 border-b p-0">
         <div
           className={
@@ -163,6 +167,7 @@ function PublicLawSidebar({
         >
           {!isCollapsed && <StellaWordmark className="h-5 w-auto" />}
           <Button
+            aria-label={t("navigation.toggleSidebar")}
             className="text-muted-foreground size-7"
             onClick={toggleSidebar}
             size="icon"

--- a/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
+++ b/apps/web/src/routes/onboarding/-components/catalogue-detail-preview.tsx
@@ -49,6 +49,7 @@ export const CatalogueDetailPreview = ({
       <div className="bg-background border-border/40 relative flex h-full max-h-full w-full max-w-[340px] flex-col rounded-2xl border shadow-[0_1px_2px_rgb(0_0_0/0.04),0_8px_24px_rgb(0_0_0/0.06)]">
         <button
           aria-label={t("common.close")}
+          title={t("common.close")}
           className="text-muted-foreground hover:text-foreground absolute end-4 top-4 transition-colors"
           onClick={onCancel}
           type="button"
@@ -192,7 +193,6 @@ const Field = ({
 
   return (
     <div
-      aria-label={fieldLabel}
       className="flex w-fit max-w-full min-w-0 items-center gap-2"
       title={fieldLabel}
     >
@@ -255,7 +255,6 @@ const AuthorField = ({
 
   return (
     <div
-      aria-label={fieldLabel}
       className="flex w-fit max-w-full min-w-0 items-center gap-2"
       title={fieldLabel}
     >
@@ -273,11 +272,7 @@ const ChipRow = ({
   ariaLabel: string;
   values: readonly string[];
 }) => (
-  <div
-    aria-label={ariaLabel}
-    className="flex items-center gap-2"
-    title={ariaLabel}
-  >
+  <div className="flex items-center gap-2" title={ariaLabel}>
     <Icon
       aria-hidden="true"
       className="text-muted-foreground size-4 shrink-0"

--- a/apps/web/src/routes/onboarding/-components/onboarding-layout.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-layout.tsx
@@ -45,6 +45,7 @@ export const OnboardingLayout = ({
           {onBack && (
             <button
               aria-label={t("common.goBack")}
+              title={t("common.goBack")}
               className="text-muted-foreground hover:text-foreground absolute -top-12 flex size-8 items-center justify-center rounded-md transition-colors"
               onClick={onBack}
               style={{ insetInlineStart: "-12px" }}

--- a/apps/web/src/routes/onboarding/-components/steps/invite-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/invite-step.tsx
@@ -186,8 +186,10 @@ export const InviteStep = ({
                     {email}
                   </BidiText>
                   <button
+                    aria-label={t("common.remove")}
                     className="text-muted-foreground hover:text-foreground"
                     onClick={() => removeEmail(email)}
+                    title={t("common.remove")}
                     type="button"
                   >
                     <XIcon className="size-3" />

--- a/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
@@ -300,6 +300,7 @@ export const JurisdictionGlobePreview = ({
               {onChange && (
                 <button
                   aria-label={t("onboarding.jurisdictionRemove", { name })}
+                  title={t("onboarding.jurisdictionRemove", { name })}
                   className="text-muted-foreground hover:text-foreground"
                   onClick={() =>
                     onChange(

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -359,6 +359,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-static-devtools-import.ts",
     "./.oxlint-plugins/no-static-catalogue-route-import.ts",
     "./.oxlint-plugins/no-workspace-field-value-drift.ts",
+    "./.oxlint-plugins/icon-button-requires-tooltip.ts",
   ],
 
   overrides: [
@@ -626,6 +627,17 @@ export default defineConfig({
       ],
       rules: {
         "no-centered-scroll-column/no-centered-scroll-column": "error",
+      },
+    },
+    {
+      // Icon-only actions need visible hover/focus affordance for sighted users;
+      // aria-label alone is not discoverable. Decorative icons are ignored.
+      files: [
+        "apps/web/src/**/*.tsx",
+        ".oxlint-plugins/__fixtures__/icon-button-requires-tooltip.fixture.tsx",
+      ],
+      rules: {
+        "icon-button-requires-tooltip/icon-button-requires-tooltip": "error",
       },
     },
     {

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import type * as React from "react";
+
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
 
+import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
 import { cn } from "@stll/ui/lib/utils";
 
 const AlertDialogCreateHandle = AlertDialogPrimitive.createHandle;
@@ -10,14 +13,20 @@ const AlertDialog = AlertDialogPrimitive.Root;
 
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
-function AlertDialogTrigger(props: AlertDialogPrimitive.Trigger.Props) {
-  return (
-    <AlertDialogPrimitive.Trigger
-      data-slot="alert-dialog-trigger"
-      nativeButton={false}
-      {...props}
-    />
-  );
+function AlertDialogTrigger({
+  tooltip,
+  ...props
+}: AlertDialogPrimitive.Trigger.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: (
+      <AlertDialogPrimitive.Trigger
+        data-slot="alert-dialog-trigger"
+        nativeButton={false}
+        {...props}
+      />
+    ),
+  });
 }
 
 function AlertDialogBackdrop({
@@ -165,10 +174,16 @@ function AlertDialogDescription({
   );
 }
 
-function AlertDialogClose(props: AlertDialogPrimitive.Close.Props) {
-  return (
-    <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />
-  );
+function AlertDialogClose({
+  tooltip,
+  ...props
+}: AlertDialogPrimitive.Close.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: (
+      <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />
+    ),
+  });
 }
 
 export {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -8,6 +8,7 @@ import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
 import { LoaderIcon } from "lucide-react";
 
+import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
 import { cn } from "@stll/ui/lib/utils";
 
 const buttonVariants = cva(
@@ -55,6 +56,7 @@ type ButtonProps = {
   variant?: VariantProps<typeof buttonVariants>["variant"];
   size?: VariantProps<typeof buttonVariants>["size"];
   loading?: boolean;
+  tooltip?: React.ReactNode;
 } & useRender.ComponentProps<"button">;
 
 function Button({
@@ -65,6 +67,7 @@ function Button({
   loading,
   children,
   disabled,
+  tooltip,
   ...props
 }: ButtonProps) {
   const typeValue: React.ButtonHTMLAttributes<HTMLButtonElement>["type"] =
@@ -85,10 +88,15 @@ function Button({
     type: typeValue,
   };
 
-  return useRender({
+  const button = useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(defaultProps, props),
     render,
+  });
+
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: button,
   });
 }
 

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import type * as React from "react";
+
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
 
 import { Button } from "@stll/ui/components/button";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
+import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
 import { cn } from "@stll/ui/lib/utils";
 
 const DialogCreateHandle = DialogPrimitive.createHandle;
@@ -13,12 +16,24 @@ const Dialog = DialogPrimitive.Root;
 
 const DialogPortal = DialogPrimitive.Portal;
 
-function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+function DialogTrigger({
+  tooltip,
+  ...props
+}: DialogPrimitive.Trigger.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />,
+  });
 }
 
-function DialogClose(props: DialogPrimitive.Close.Props) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+function DialogClose({
+  tooltip,
+  ...props
+}: DialogPrimitive.Close.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: <DialogPrimitive.Close data-slot="dialog-close" {...props} />,
+  });
 }
 
 function DialogBackdrop({

--- a/packages/ui/src/components/menu.tsx
+++ b/packages/ui/src/components/menu.tsx
@@ -6,6 +6,7 @@ import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { ChevronRightIcon } from "lucide-react";
 
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
+import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
 import { cn } from "@stll/ui/lib/utils";
 
 const MenuCreateHandle = MenuPrimitive.createHandle;
@@ -14,10 +15,16 @@ const Menu = MenuPrimitive.Root;
 
 const MenuPortal = MenuPrimitive.Portal;
 
-function MenuTrigger(props: MenuPrimitive.Trigger.Props) {
-  return (
-    <MenuPrimitive.Trigger data-slot="menu-trigger" nativeButton {...props} />
-  );
+function MenuTrigger({
+  tooltip,
+  ...props
+}: MenuPrimitive.Trigger.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: (
+      <MenuPrimitive.Trigger data-slot="menu-trigger" nativeButton {...props} />
+    ),
+  });
 }
 
 function MenuPopup({

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,17 +1,27 @@
 "use client";
 
+import type * as React from "react";
 import type { ComponentProps } from "react";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 
+import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
 import { cn } from "@stll/ui/lib/utils";
 
 const PopoverCreateHandle = PopoverPrimitive.createHandle;
 
 const Popover = PopoverPrimitive.Root;
 
-function PopoverTrigger(props: PopoverPrimitive.Trigger.Props) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+function PopoverTrigger({
+  tooltip,
+  ...props
+}: PopoverPrimitive.Trigger.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: (
+      <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+    ),
+  });
 }
 
 function PopoverPopup({

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import type * as React from "react";
+
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
 
 import { Button } from "@stll/ui/components/button";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
+import { renderTooltipTrigger } from "@stll/ui/components/tooltip-trigger-helper";
 import { cn } from "@stll/ui/lib/utils";
 
 const Sheet = SheetPrimitive.Root;
@@ -13,12 +16,24 @@ const SheetPortal = SheetPrimitive.Portal;
 
 type SheetSide = "inline-start" | "inline-end" | "block-start" | "block-end";
 
-function SheetTrigger(props: SheetPrimitive.Trigger.Props) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+function SheetTrigger({
+  tooltip,
+  ...props
+}: SheetPrimitive.Trigger.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />,
+  });
 }
 
-function SheetClose(props: SheetPrimitive.Close.Props) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+function SheetClose({
+  tooltip,
+  ...props
+}: SheetPrimitive.Close.Props & { tooltip?: React.ReactNode }) {
+  return renderTooltipTrigger({
+    tooltip: tooltip ?? props["aria-label"] ?? props.title,
+    trigger: <SheetPrimitive.Close data-slot="sheet-close" {...props} />,
+  });
 }
 
 function SheetBackdrop({ className, ...props }: SheetPrimitive.Backdrop.Props) {

--- a/packages/ui/src/components/tooltip-trigger-helper.tsx
+++ b/packages/ui/src/components/tooltip-trigger-helper.tsx
@@ -10,11 +10,16 @@ import {
 
 type TooltipTriggerOptions = {
   trigger: React.ReactElement;
-  tooltip: React.ReactNode | undefined;
+  tooltip: React.ReactNode | undefined | false;
 };
 
 const renderTooltipTrigger = ({ trigger, tooltip }: TooltipTriggerOptions) => {
-  if (tooltip === undefined || tooltip === null || tooltip === "") {
+  if (
+    tooltip === undefined ||
+    tooltip === null ||
+    tooltip === "" ||
+    tooltip === false
+  ) {
     return trigger;
   }
 

--- a/packages/ui/src/components/tooltip-trigger-helper.tsx
+++ b/packages/ui/src/components/tooltip-trigger-helper.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type * as React from "react";
+
+import {
+  Tooltip,
+  TooltipPopup,
+  TooltipTrigger,
+} from "@stll/ui/components/tooltip";
+
+type TooltipTriggerOptions = {
+  trigger: React.ReactElement;
+  tooltip: React.ReactNode | undefined;
+};
+
+const renderTooltipTrigger = ({ trigger, tooltip }: TooltipTriggerOptions) => {
+  if (tooltip === undefined || tooltip === null || tooltip === "") {
+    return trigger;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={trigger} />
+      <TooltipPopup>{tooltip}</TooltipPopup>
+    </Tooltip>
+  );
+};
+
+export { renderTooltipTrigger };


### PR DESCRIPTION
Summary:
- Adds an app-wide custom oxlint rule for icon-only interactive controls without tooltips.
- Adds shared tooltip support and aria/title fallbacks to UI button and trigger primitives.
- Labels existing icon-only controls covered by the new rule.