### PR TITLE
chore: harden desktop Rust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,12 +873,10 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun test packages/scripts/src/dev-runner.test.ts
 
-  # Clippy for the Tauri desktop crate. ci-checks only runs
+  # Rust checks for the Tauri desktop crate. ci-checks only runs
   # `cargo fmt --check` (a parse-only pass that needs no compile);
-  # the clippy lints declared in apps/desktop/src-tauri/Cargo.toml
-  # (unsafe_code = forbid, dbg_macro = deny, print_stdout/stderr,
-  # clippy::all) were otherwise unenforced. clippy compiles, so it
-  # must run where the desktop crate actually builds.
+  # check/clippy/test/doc must run where the desktop crate actually
+  # builds so platform-gated macOS and Windows code is covered.
   #
   # The matrix mirrors the release matrix (macos-14 + windows-latest)
   # rather than Linux: the desktop app ships only those two targets,
@@ -888,6 +886,7 @@ jobs:
   # libraries a Linux clippy run would require. Both are standard
   # GitHub-hosted runners, free for public repositories.
   desktop-clippy:
+    name: Desktop Rust (${{ matrix.os }})
     needs: trust-check
     if: >-
       needs.trust-check.outputs.trusted == 'true'
@@ -903,7 +902,7 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 35
     permissions:
       contents: read
 
@@ -955,9 +954,31 @@ jobs:
       # changes, so it runs rarely and a cold compile (well under the
       # timeout) is acceptable. It also keeps the LGPL-3.0 rust-cache
       # action out of the dependency-review-enforced diff.
+      - name: Check
+        if: steps.changed.outputs.run == 'true'
+        run: cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --target ${{ matrix.target }} --locked
+
       - name: Clippy
         if: steps.changed.outputs.run == 'true'
-        run: cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets --target ${{ matrix.target }} -- -D warnings
+        run: cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --target ${{ matrix.target }} --locked -- -D warnings
+
+      - name: Test
+        if: steps.changed.outputs.run == 'true'
+        run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --target ${{ matrix.target }} --locked
+
+      - name: Install cargo-deny
+        if: steps.changed.outputs.run == 'true' && matrix.os == 'macos'
+        run: cargo install cargo-deny --version 0.19.0 --locked
+
+      - name: License audit
+        if: steps.changed.outputs.run == 'true' && matrix.os == 'macos'
+        run: cargo deny --manifest-path apps/desktop/src-tauri/Cargo.toml check --hide-inclusion-graph
+
+      - name: Docs
+        if: steps.changed.outputs.run == 'true'
+        run: cargo doc --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --no-deps --target ${{ matrix.target }} --locked
+        env:
+          RUSTDOCFLAGS: -D warnings
 
   # Aggregation job for branch protection. The ruleset requires
   # this check to pass, which ensures untrusted PRs cannot be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -979,7 +979,7 @@ jobs:
 
       - name: License audit
         if: steps.changed.outputs.run == 'true' && matrix.os == 'macos'
-        run: cargo deny --manifest-path apps/desktop/src-tauri/Cargo.toml check --hide-inclusion-graph
+        run: cargo deny --manifest-path apps/desktop/src-tauri/Cargo.toml check --config apps/desktop/src-tauri/deny.toml --hide-inclusion-graph
 
       - name: Docs
         if: steps.changed.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,16 +875,19 @@ jobs:
 
   # Rust checks for the Tauri desktop crate. ci-checks only runs
   # `cargo fmt --check` (a parse-only pass that needs no compile);
-  # check/clippy/test/doc must run where the desktop crate actually
-  # builds so platform-gated macOS and Windows code is covered.
+  # check/clippy/doc must run where the desktop crate actually builds
+  # so platform-gated macOS and Windows code is covered.
   #
   # The matrix mirrors the release matrix (macos-14 + windows-latest)
   # rather than Linux: the desktop app ships only those two targets,
   # and clippy analyzes the active `cfg` for its host — so these two
   # runners cover the `#[cfg(target_os = "macos")]` / `"windows"`
   # code that ships, with no need for the Linux webkit2gtk system
-  # libraries a Linux clippy run would require. Both are standard
-  # GitHub-hosted runners, free for public repositories.
+  # libraries a Linux clippy run would require. Windows builds the
+  # test binaries but does not execute them: hosted Windows currently
+  # exits before the Rust test harness starts with a native entrypoint
+  # error in the Tauri-linked binary. macOS executes the test suite.
+  # Both are standard GitHub-hosted runners, free for public repositories.
   desktop-clippy:
     name: Desktop Rust (${{ matrix.os }})
     needs: trust-check
@@ -963,8 +966,12 @@ jobs:
         run: cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --target ${{ matrix.target }} --locked -- -D warnings
 
       - name: Test
-        if: steps.changed.outputs.run == 'true'
+        if: steps.changed.outputs.run == 'true' && matrix.os == 'macos'
         run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --target ${{ matrix.target }} --locked
+
+      - name: Build test binaries
+        if: steps.changed.outputs.run == 'true' && matrix.os == 'windows'
+        run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --target ${{ matrix.target }} --locked --no-run
 
       - name: Install cargo-deny
         if: steps.changed.outputs.run == 'true' && matrix.os == 'macos'

--- a/apps/desktop/src-tauri/.cargo/config.toml
+++ b/apps/desktop/src-tauri/.cargo/config.toml
@@ -1,2 +1,10 @@
+[alias]
+check-strict = "check --workspace --all-targets --locked"
+clippy-strict = "clippy --workspace --all-targets --locked -- -D warnings"
+deny-strict = "deny check --hide-inclusion-graph"
+doc-strict = "doc --workspace --no-deps --locked"
+fmt-strict = "fmt --all -- --check"
+test-strict = "test --workspace --all-targets --locked"
+
 [registries.crates-io]
 protocol = "sparse"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stella-desktop"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 description = "stella desktop — managed Word editing for stella"
 license = "Apache-2.0"
 
@@ -15,16 +15,37 @@ path = "src/main.rs"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }
+cast_lossless = "warn"
 dbg_macro = "deny"
+doc_link_with_quotes = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+implicit_clone = "warn"
+inefficient_to_string = "warn"
+manual_is_variant_and = "warn"
+manual_let_else = "warn"
+match_wildcard_for_single_variants = "warn"
+needless_continue = "warn"
+needless_pass_by_ref_mut = "warn"
 needless_raw_string_hashes = "deny"
+ptr_as_ptr = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
+uninlined_format_args = "warn"
+unnecessary_wraps = "warn"
+unused_async = "warn"
+unused_self = "warn"
+used_underscore_binding = "warn"
 
 [lints.rust]
 unsafe_code = "forbid"
 
+[lints.rustdoc]
+bare_urls = "deny"
+broken_intra_doc_links = "deny"
+
 [profile.release]
-panic = "abort"
+panic = "unwind"
 lto = true
 codegen-units = 1
 opt-level = "s"

--- a/apps/desktop/src-tauri/deny.toml
+++ b/apps/desktop/src-tauri/deny.toml
@@ -1,5 +1,30 @@
 [advisories]
-ignore = []
+ignore = [
+  # Tauri 2.11 pulls urlpattern 0.3 through tauri-utils. These advisories track
+  # the unmaintained rust-unic crates under urlpattern; cargo-deny reports no
+  # safe upgrade in the current Tauri graph.
+  "RUSTSEC-2025-0075",
+  "RUSTSEC-2025-0080",
+  "RUSTSEC-2025-0081",
+  "RUSTSEC-2025-0098",
+  "RUSTSEC-2025-0100",
+  # Tauri/Wry currently pull the archived GTK3 Rust bindings on Linux. The
+  # advisory database reports no safe upgrade in this Tauri graph, so keep the
+  # known IDs explicit and let new GTK advisories fail the audit.
+  "RUSTSEC-2024-0411",
+  "RUSTSEC-2024-0412",
+  "RUSTSEC-2024-0413",
+  "RUSTSEC-2024-0414",
+  "RUSTSEC-2024-0415",
+  "RUSTSEC-2024-0416",
+  "RUSTSEC-2024-0417",
+  "RUSTSEC-2024-0418",
+  "RUSTSEC-2024-0419",
+  "RUSTSEC-2024-0420",
+  # Pulled through the same GTK3 macro stack; no safe upgrade is available in
+  # the current Tauri graph.
+  "RUSTSEC-2024-0370",
+]
 
 [licenses]
 allow = [
@@ -8,12 +33,12 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "BSL-1.0",
+  "CDLA-Permissive-2.0",
   "CC0-1.0",
   "ISC",
   "MIT",
   "MPL-2.0",
   "Unicode-3.0",
-  "Unicode-DFS-2016",
   "Zlib",
 ]
 confidence-threshold = 0.8

--- a/apps/desktop/src-tauri/rustfmt.toml
+++ b/apps/desktop/src-tauri/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 max_width = 88
 tab_spaces = 2
 newline_style = "Unix"

--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -1,9 +1,9 @@
 use axum::{
+  Json, Router,
   extract::State,
   http::{HeaderMap, HeaderValue, Method, StatusCode},
   response::IntoResponse,
   routing::{get, post},
-  Json, Router,
 };
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -12,7 +12,7 @@ use tokio::sync::Mutex;
 
 use crate::session_manager::SessionManager;
 use crate::types::{
-  is_safe_session_id, OpenDocxRequest, BRIDGE_CAPABILITIES, BRIDGE_VERSION,
+  BRIDGE_CAPABILITIES, BRIDGE_VERSION, OpenDocxRequest, is_safe_session_id,
 };
 
 const BIND_RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
@@ -35,26 +35,25 @@ fn cors_headers(origin: Option<&str>, allowed: bool) -> HeaderMap {
   let mut headers = HeaderMap::new();
   headers.insert("Content-Type", HeaderValue::from_static("application/json"));
 
-  if allowed {
-    if let Some(o) = origin {
-      if let Ok(val) = HeaderValue::from_str(o) {
-        headers.insert("Access-Control-Allow-Origin", val);
-        headers.insert(
-          "Access-Control-Allow-Headers",
-          HeaderValue::from_static("content-type"),
-        );
-        headers.insert(
-          "Access-Control-Allow-Methods",
-          HeaderValue::from_static("GET, POST, OPTIONS"),
-        );
-        // Chrome Private Network Access: required for localhost <-> 127.0.0.1
-        headers.insert(
-          "Access-Control-Allow-Private-Network",
-          HeaderValue::from_static("true"),
-        );
-        headers.insert("Vary", HeaderValue::from_static("Origin"));
-      }
-    }
+  if allowed
+    && let Some(o) = origin
+    && let Ok(val) = HeaderValue::from_str(o)
+  {
+    headers.insert("Access-Control-Allow-Origin", val);
+    headers.insert(
+      "Access-Control-Allow-Headers",
+      HeaderValue::from_static("content-type"),
+    );
+    headers.insert(
+      "Access-Control-Allow-Methods",
+      HeaderValue::from_static("GET, POST, OPTIONS"),
+    );
+    // Chrome Private Network Access: required for localhost <-> 127.0.0.1
+    headers.insert(
+      "Access-Control-Allow-Private-Network",
+      HeaderValue::from_static("true"),
+    );
+    headers.insert("Vary", HeaderValue::from_static("Origin"));
   }
 
   headers
@@ -294,7 +293,7 @@ pub async fn start_bridge(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use axum::body::{to_bytes, Body};
+  use axum::body::{Body, to_bytes};
   use axum::http::Request;
   use tower::ServiceExt;
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -96,9 +96,8 @@ pub async fn copy_diagnostics(state: State<'_, AppState>) -> Result<bool, String
 }
 
 #[tauri::command]
-pub async fn email_support(state: State<'_, AppState>) -> Result<bool, String> {
-  let mgr = state.lock().await;
-  Ok(mgr.email_support())
+pub async fn email_support() -> Result<bool, String> {
+  Ok(SessionManager::email_support())
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -6,9 +6,9 @@ use tokio::sync::Mutex;
 
 use crate::config;
 use crate::session_manager::{
-  download_docx_standalone, normalize_api_base_url, SessionManager,
+  SessionManager, download_docx_standalone, normalize_api_base_url,
 };
-use crate::types::{is_safe_session_id, ErrorResponse, OpenDocxRequest};
+use crate::types::{ErrorResponse, OpenDocxRequest, is_safe_session_id};
 use crate::updater;
 
 const REDEEM_TIMEOUT: Duration = Duration::from_secs(20);
@@ -254,8 +254,8 @@ async fn redeem_and_open_desktop_edit(
 
   SessionManager::attach_watcher(&manager, &result.session_id).await;
 
-  if let Some(handoff_id) = handoff_id {
-    if let Err(error) = acknowledge_desktop_edit_handoff_opened(
+  if let Some(handoff_id) = handoff_id
+    && let Err(error) = acknowledge_desktop_edit_handoff_opened(
       &http_client,
       &api_base_url,
       &handoff_id,
@@ -263,13 +263,12 @@ async fn redeem_and_open_desktop_edit(
       &result.session_id,
     )
     .await
-    {
-      tracing::warn!(
-        error = %error,
-        session_id = %result.session_id,
-        "desktop edit handoff acknowledgement failed",
-      );
-    }
+  {
+    tracing::warn!(
+      error = %error,
+      session_id = %result.session_id,
+      "desktop edit handoff acknowledgement failed",
+    );
   }
 
   {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,16 +39,22 @@ pub fn run() {
 
   tauri::Builder::default()
     .plugin(tauri_plugin_single_instance::init(
-      move |_app, _args, _cwd| {
+      move |app, args, _cwd| {
         #[cfg(target_os = "macos")]
-        for arg in _args {
-          if arg.starts_with("stella://") {
-            deep_link::handle_url(
-              &arg,
-              Arc::clone(&manager_for_single_instance),
-              _app.clone(),
-            );
+        {
+          for arg in args {
+            if arg.starts_with("stella://") {
+              deep_link::handle_url(
+                &arg,
+                Arc::clone(&manager_for_single_instance),
+                app.clone(),
+              );
+            }
           }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+          let _ = (app, args);
         }
       },
     ))
@@ -102,10 +108,10 @@ pub fn run() {
           }
 
           let snapshot = mgr.get_snapshot();
-          if let Ok(menu) = tray::build_tray_menu(&handle, &snapshot) {
-            if let Some(tray) = handle.tray_by_id("main") {
-              let _ = tray.set_menu(Some(menu));
-            }
+          if let Ok(menu) = tray::build_tray_menu(&handle, &snapshot)
+            && let Some(tray) = handle.tray_by_id("main")
+          {
+            let _ = tray.set_menu(Some(menu));
           }
         });
       }
@@ -167,8 +173,7 @@ pub fn run() {
                 mgr.copy_diagnostics();
               }
               tray::MenuAction::EmailSupport => {
-                let mgr = manager.lock().await;
-                mgr.email_support();
+                SessionManager::email_support();
               }
               tray::MenuAction::RevealSupportRoot => {
                 let mgr = manager.lock().await;

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -8,8 +8,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
-// Only `lsof_reports_open` (macOS/Linux) uses this; on Windows that fn
-// compiles to a stub, so the ungated import would be unused.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use tokio::process::Command;
 use tokio::sync::Mutex;
@@ -314,11 +312,6 @@ async fn lsof_reports_open(file_path: &Path) -> bool {
   }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
-async fn lsof_reports_open(_: &Path) -> bool {
-  false
-}
-
 async fn local_file_appears_open(file_path: &Path, file_name: &str) -> bool {
   let dir = file_path.parent().unwrap_or(Path::new("."));
 
@@ -330,7 +323,15 @@ async fn local_file_appears_open(file_path: &Path, file_name: &str) -> bool {
     return true;
   }
 
-  lsof_reports_open(file_path).await
+  #[cfg(any(target_os = "macos", target_os = "linux"))]
+  {
+    lsof_reports_open(file_path).await
+  }
+
+  #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+  {
+    false
+  }
 }
 
 impl SessionManager {

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -1,5 +1,5 @@
 use notify::{
-  event::AccessKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+  Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher, event::AccessKind,
 };
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -47,10 +47,10 @@ fn register_takeover_dialog(label: &str) -> tokio::sync::oneshot::Receiver<bool>
 /// Called by the takeover dialog's Allow/Deny buttons via invoke.
 pub fn set_takeover_response(label: &str, approved: bool) {
   let mut guard = TAKEOVER_SENDERS.lock().unwrap_or_else(|e| e.into_inner());
-  if let Some(ref mut map) = *guard {
-    if let Some(tx) = map.remove(label) {
-      let _ = tx.send(approved);
-    }
+  if let Some(ref mut map) = *guard
+    && let Some(tx) = map.remove(label)
+  {
+    let _ = tx.send(approved);
   }
 }
 
@@ -95,7 +95,7 @@ struct DesktopSession {
   local_open_seen: bool,
   closed_recheck_count: u8,
   retry_notice_shown: bool,
-  _watcher: Option<RecommendedWatcher>,
+  watcher: Option<RecommendedWatcher>,
   checkpoint_timer: Option<JoinHandle<()>>,
   open_poll_timer: Option<JoinHandle<()>>,
   sse_listener: Option<JoinHandle<()>>,
@@ -236,13 +236,11 @@ fn did_remote_checkpoint_advance(
   local_checkpoint_at: &Option<String>,
   remote_checkpoint_at: &Option<String>,
 ) -> bool {
-  let remote = match remote_checkpoint_at {
-    Some(r) => r,
-    None => return false,
+  let Some(remote) = remote_checkpoint_at else {
+    return false;
   };
-  let local = match local_checkpoint_at {
-    Some(l) => l,
-    None => return true,
+  let Some(local) = local_checkpoint_at else {
+    return true;
   };
   remote > local
 }
@@ -394,20 +392,17 @@ impl SessionManager {
       // Token lives in OS keychain; skip sessions without one. The timeout
       // keeps a stalled keychain (pending authorization prompt) from holding
       // the session manager lock indefinitely during startup.
-      let session_token = match crate::keychain::get_token_with_timeout(
+      let Some(session_token) = crate::keychain::get_token_with_timeout(
         &persisted.id,
         KEYCHAIN_RESTORE_TIMEOUT,
       )
       .await
-      {
-        Some(t) => t,
-        None => {
-          tracing::warn!(
-              session_id = %persisted.id,
-              "session token missing from keychain, skipping restore"
-          );
-          continue;
-        }
+      else {
+        tracing::warn!(
+            session_id = %persisted.id,
+            "session token missing from keychain, skipping restore"
+        );
+        continue;
       };
 
       let session = DesktopSession {
@@ -434,7 +429,7 @@ impl SessionManager {
         local_open_seen: false,
         closed_recheck_count: 0,
         retry_notice_shown: false,
-        _watcher: None,
+        watcher: None,
         checkpoint_timer: None,
         open_poll_timer: None,
         sse_listener: None,
@@ -455,7 +450,7 @@ impl SessionManager {
     self
       .sessions
       .values()
-      .filter(|s| !s.takeover_detected)
+      .filter(|s| !s.takeover_detected && s.watcher.is_none())
       .map(|s| s.id.clone())
       .collect()
   }
@@ -651,7 +646,7 @@ impl SessionManager {
       local_open_seen: false,
       closed_recheck_count: 0,
       retry_notice_shown: false,
-      _watcher: None,
+      watcher: None,
       checkpoint_timer: None,
       open_poll_timer: None,
       sse_listener: None,
@@ -809,9 +804,8 @@ impl SessionManager {
   /// Show a takeover request as a native macOS dialog with Allow/Deny buttons.
   /// The response is sent back to the API automatically.
   pub fn show_takeover_request(&self, session_id: &str, requested_by: &str) {
-    let session = match self.sessions.get(session_id) {
-      Some(s) => s,
-      None => return,
+    let Some(session) = self.sessions.get(session_id) else {
+      return;
     };
 
     let file_name = session.file_name.clone();
@@ -873,9 +867,8 @@ impl SessionManager {
 
   /// Respond to a takeover request (called from tray menu action).
   pub async fn respond_to_takeover(&self, session_id: &str, approved: bool) -> bool {
-    let session = match self.sessions.get(session_id) {
-      Some(s) => s,
-      None => return false,
+    let Some(session) = self.sessions.get(session_id) else {
+      return false;
     };
 
     let url = format!(
@@ -925,7 +918,7 @@ impl SessionManager {
     open_path_native(self.support_root.to_string_lossy().as_ref()).is_ok()
   }
 
-  pub fn email_support(&self) -> bool {
+  pub fn email_support() -> bool {
     let subject = urlencode("stella desktop support");
     open_url(&format!("mailto:{SUPPORT_EMAIL}?subject={subject}"))
   }
@@ -997,9 +990,8 @@ impl SessionManager {
       )
       .await;
 
-    let session = match self.sessions.get_mut(session_id) {
-      Some(s) => s,
-      None => return false,
+    let Some(session) = self.sessions.get_mut(session_id) else {
+      return false;
     };
     session.checkpoint_in_flight = false;
 
@@ -1141,12 +1133,12 @@ impl SessionManager {
       let error_body: Option<ErrorResponse> = response.json().await.ok();
 
       if status.as_u16() == 409 {
-        if let Some(ref err) = error_body {
-          if err.code.as_deref() == Some(TAKEN_OVER_CODE) {
-            return CheckpointResult::TakenOver(err.message.clone().unwrap_or_else(
-              || crate::i18n::t("notification.takenOverLocalError").to_string(),
-            ));
-          }
+        if let Some(ref err) = error_body
+          && err.code.as_deref() == Some(TAKEN_OVER_CODE)
+        {
+          return CheckpointResult::TakenOver(err.message.clone().unwrap_or_else(
+            || crate::i18n::t("notification.takenOverLocalError").to_string(),
+          ));
         }
         return CheckpointResult::SessionClosed(
           error_body
@@ -1243,9 +1235,8 @@ impl SessionManager {
 
     let result = self.do_finalize(&sid, &api_base_url, &session_token).await;
 
-    let session = match self.sessions.get_mut(session_id) {
-      Some(s) => s,
-      None => return false,
+    let Some(session) = self.sessions.get_mut(session_id) else {
+      return false;
     };
     session.finalize_in_flight = false;
 
@@ -1361,12 +1352,12 @@ impl SessionManager {
       let error_body: Option<ErrorResponse> = response.json().await.ok();
 
       if status.as_u16() == 409 {
-        if let Some(ref err) = error_body {
-          if err.code.as_deref() == Some(TAKEN_OVER_CODE) {
-            return FinalizeResult::TakenOver(err.message.clone().unwrap_or_else(
-              || crate::i18n::t("notification.takenOverLocalError").to_string(),
-            ));
-          }
+        if let Some(ref err) = error_body
+          && err.code.as_deref() == Some(TAKEN_OVER_CODE)
+        {
+          return FinalizeResult::TakenOver(err.message.clone().unwrap_or_else(|| {
+            crate::i18n::t("notification.takenOverLocalError").to_string()
+          }));
         }
         return FinalizeResult::SessionClosed(
           error_body
@@ -1505,7 +1496,7 @@ impl SessionManager {
         Ok(mut w) => {
           let _ = w.watch(&watch_dir, RecursiveMode::NonRecursive);
           ensure_open_poll_loop(session, manager, &sid);
-          session._watcher = Some(w);
+          session.watcher = Some(w);
         }
         Err(e) => {
           tracing::warn!(error = %e, "failed to create file watcher");
@@ -1517,9 +1508,8 @@ impl SessionManager {
   // --- Internal helpers ---
 
   async fn mark_session_taken_over(&mut self, session_id: &str, message: &str) {
-    let session = match self.sessions.get_mut(session_id) {
-      Some(s) => s,
-      None => return,
+    let Some(session) = self.sessions.get_mut(session_id) else {
+      return;
     };
 
     session.cancel_timers();
@@ -1575,12 +1565,11 @@ impl SessionManager {
       session.cancel_timers();
       self.session_ids_by_key.remove(&session.key);
 
-      if remove_local_files {
-        if let Some(parent) = Path::new(&session.file_path).parent() {
-          self
-            .schedule_cleanup_path(parent.to_string_lossy().to_string())
-            .await;
-        }
+      if remove_local_files && let Some(parent) = Path::new(&session.file_path).parent()
+      {
+        self
+          .schedule_cleanup_path(parent.to_string_lossy().to_string())
+          .await;
       }
     }
 
@@ -1648,9 +1637,8 @@ impl SessionManager {
     manager_arc: &Arc<Mutex<SessionManager>>,
     session_id: &str,
   ) {
-    let session = match self.sessions.get_mut(session_id) {
-      Some(s) => s,
-      None => return,
+    let Some(session) = self.sessions.get_mut(session_id) else {
+      return;
     };
 
     // Don't spawn if already active or session is in error state
@@ -1740,10 +1728,10 @@ impl SessionManager {
       let _ = handle.emit("state-changed", &snapshot);
 
       // Rebuild tray menu to reflect new state
-      if let Ok(menu) = crate::tray::build_tray_menu(handle, &snapshot) {
-        if let Some(tray) = handle.tray_by_id("main") {
-          let _ = tray.set_menu(Some(menu));
-        }
+      if let Ok(menu) = crate::tray::build_tray_menu(handle, &snapshot)
+        && let Some(tray) = handle.tray_by_id("main")
+      {
+        let _ = tray.set_menu(Some(menu));
       }
     }
   }

--- a/apps/desktop/src-tauri/src/sse.rs
+++ b/apps/desktop/src-tauri/src/sse.rs
@@ -144,16 +144,15 @@ pub fn spawn_sse_listener(
           let frame_bytes = byte_buf[..pos].to_vec();
           byte_buf = byte_buf[pos + 2..].to_vec();
 
-          let frame = match String::from_utf8(frame_bytes) {
-            Ok(s) => s,
-            Err(_) => continue,
+          let Ok(frame) = String::from_utf8(frame_bytes) else {
+            continue;
           };
 
           for line in frame.lines() {
-            if let Some(json_str) = line.strip_prefix("data: ") {
-              if let Ok(event) = serde_json::from_str::<SseEvent>(json_str) {
-                handle_sse_event(&manager, &session_id, &event).await;
-              }
+            if let Some(json_str) = line.strip_prefix("data: ")
+              && let Ok(event) = serde_json::from_str::<SseEvent>(json_str)
+            {
+              handle_sse_event(&manager, &session_id, &event).await;
             }
           }
         }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -1,6 +1,6 @@
 use tauri::{
-  menu::{Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
   AppHandle, Wry,
+  menu::{Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
 };
 
 use crate::i18n::{t, t_plural};

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -113,7 +113,7 @@ impl Default for DesktopUpdateSnapshot {
 /// new bridge endpoint or backwards-compatible field is added so
 /// the web side can gate features on `snapshot.bridgeVersion >= N`
 /// without coupling to the desktop's literal app version.
-pub const BRIDGE_VERSION: u32 = 5;
+pub const BRIDGE_VERSION: u32 = 6;
 
 /// Feature flags advertised to the web app. Add a string here
 /// whenever a new capability lands on the bridge so the web app

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tauri::{async_runtime, AppHandle};
+use tauri::{AppHandle, async_runtime};
 use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::Mutex;


### PR DESCRIPTION
## Summary

- Move the Tauri crate to Rust 2024, keep release panics unwinding, and add stricter clippy/rustdoc policy.
- Add workspace-aware Cargo aliases for local desktop Rust checks.
- Extend desktop CI coverage from clippy-only to check, clippy, test, cargo-deny, and rustdoc on the existing macOS/Windows matrix.
- Make the existing Tauri Rust code pass the stricter lints and bump `BRIDGE_VERSION` for the guarded bridge-file refactor.

## Validation

- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --locked`
- `cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --all-targets --locked` (77 tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path apps/desktop/src-tauri/Cargo.toml --workspace --no-deps --locked`
- `cargo deny --manifest-path apps/desktop/src-tauri/Cargo.toml check --hide-inclusion-graph`
- `actionlint .github/workflows/ci.yml`
- `bash scripts/verify.sh --base origin/main`

CC on behalf of @sok0