### PR TITLE
chore(deps): bump eslint-plugin-sonarjs to 4.1.0

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -139,7 +139,6 @@ const LABEL_PATTERNS: Record<string, RegExp> = {
  * "předseda/předsedkyně senátu" label.
  */
 const JUDGE_RE =
-  // oxlint-disable-next-line sonarjs/slow-regex -- signature extraction scans one bounded decision text
   /(?:JUDr\.|Mgr\.|doc\.|prof\.)\s+[\p{L}\s,.-]+?(?=\s*předsed[ay]\s+senátu)/iu;
 
 const extractJudge = (text: string): string | undefined => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -12,7 +12,6 @@ import { describe, expect, test } from "bun:test";
 
 const stripHtml = (html: string): string =>
   html
-    // oxlint-disable-next-line sonarjs/slow-regex -- test fixture HTML is small and controlled
     .replace(/<[^>]+>/gu, " ")
     .replace(/\s+/gu, " ")
     .trim();
@@ -39,7 +38,6 @@ const parseResultRows = (html: string): ParsedRow[] => {
     }
 
     const citMatch =
-      // oxlint-disable-next-line sonarjs/slow-regex -- test fixture rows are bounded representative NSS HTML snippets
       /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.)[\s]*(?<caseNumber>[^"]+?)(?:-\d+)?"/iu.exec(
         block,
       );

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -228,7 +228,6 @@ const parseResultRows = (html: string): ParsedRow[] => {
     // č may appear as literal or HTML entity (&#x10D; &#x10d; &#269;)
     // Stop at comma to exclude publication reference (e.g. ", č. 421/2004 Sb. NSS")
     const citMatch =
-      // oxlint-disable-next-line sonarjs/slow-regex -- tbody blocks are bounded search-result rows from NSS
       /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.|&#x10[dD];j\.|&#26[89];j\.)[\s]*(?<caseNumber>[^",]+?)(?:-\d+)?[",]/iu.exec(
         block,
       );
@@ -808,11 +807,8 @@ export const czNssAdapter: SourceAdapter = {
       const html = await response.text();
 
       const countPatterns = [
-        // oxlint-disable-next-line sonarjs/slow-regex -- count labels are matched once against one NSS result page
         /Nalezeno\s+(?<count>\d[\d\s]*)\s+záznam/iu,
-        // oxlint-disable-next-line sonarjs/slow-regex -- count labels are matched once against one NSS result page
         /Celkem\s+(?<count>\d[\d\s]*)\s+záznam/iu,
-        // oxlint-disable-next-line sonarjs/slow-regex -- count labels are matched once against one NSS result page
         /(?<count>\d[\d\s]*)\s+výsledk/iu,
         /resCount[^>]*>(?<count>\d[\d\s]*)</iu,
         /myResCount[^>]*>(?<count>\d[\d\s]*)</iu,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -69,10 +69,8 @@ const FIRST_YEAR = 1993;
 const toYearSuffix = (year: number): string =>
   String(year % 100).padStart(2, "0");
 
-// oxlint-disable-next-line sonarjs/slow-regex -- registry sign is a short label extracted from NALUS metadata
 const REGISTRY_SIGN_PATTERN = /^(?<caseNumber>.+?)\s+ze\s+dne\s+(?<date>.+)$/u;
 const DOC_CONTENT_PATTERN = /class="DocContent">(?<body>[\s\S]*?)<\/table>/u;
-// oxlint-disable-next-line sonarjs/slow-regex -- judge extraction scans one decision signature block
 const JUDGE_PATTERN = /(?<judge>\S+(?:\s+\S+){0,2})\s+\(soudce\s+zpravodaj\)/iu;
 
 /** Extract text from a labeled span. */

--- a/apps/api/src/handlers/case-law/ingestion/adapters/utils.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/utils.ts
@@ -68,7 +68,6 @@ export const toOptionalValue = <T>(
 export const stripHtml = (html: string): string =>
   html
     .replace(/<br\s*\/?>/gi, "\n")
-    // oxlint-disable-next-line sonarjs/slow-regex -- adapter strips known court HTML fragments before parsing text
     .replace(/<[^>]*>/g, "")
     .replace(/&nbsp;/g, " ")
     .replace(/&amp;/g, "&")

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
@@ -457,7 +457,6 @@ export const blocksToPlainText = (blocks: readonly Block[]): string =>
 
 // ── Pattern constants ─────────────────────────────────────
 
-// oxlint-disable-next-line sonarjs/slow-regex -- title detection runs on one paragraph line
 const DECISION_TITLE_RE = /^[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]\s+[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ\s]+$/u;
 
 const DECISION_TYPE_WORDS = new Set([
@@ -605,11 +604,9 @@ const mergeBlocks = (
       const text = firstPara.plainText;
       // Check for embedded title
       const titleMatch =
-        // oxlint-disable-next-line sonarjs/slow-regex -- first paragraph text is bounded by parser block splitting
         /(?<title>[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]\s+[A-ZÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ\s]{5,})\s*$/u.exec(
           text,
         );
-      // oxlint-disable-next-line sonarjs/slow-regex -- first paragraph text is bounded by parser block splitting
       const caseMatch = /(?<caseNumber>\d+\s+\w+\s+\d+\/\d{4}[^\s]*)/u.exec(
         text,
       );
@@ -654,7 +651,6 @@ const mergeBlocks = (
   // have their own type; plain paragraphs in this zone
   // get role "holding".
   // Match "takto:", "takto :", "t a k t o :", etc.
-  // oxlint-disable-next-line sonarjs/slow-regex -- matched against individual block plainText
   const TAKTO_RE = /t\s*a\s*k\s*t\s*o\s*:?\s*$/iu;
   let inHolding = false;
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -331,17 +331,14 @@ const SKIP_RE = /^\[OBRÁZEK\]|^pokračování$|^ČESKÁ REPUBLIKA$/u;
 const TITLE_RE = /^(?:ROZSUDEK|USNESENÍ|JMÉNEM REPUBLIKY)$/u;
 
 /** "takto:" separator. */
-// oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
 const TAKTO_RE = /^t\s*a\s*k\s*t\s*o\s*:?\s*$/iu;
 
 /** "Odůvodnění:" separator. */
 const ODUVODNENI_RE =
-  // oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
   /^(?:O\s*d\s*ů\s*v\s*o\s*d\s*n\s*ě\s*n\s*í|Odůvodnění)\s*:?\s*$/iu;
 
 /** "Poučení:" as standalone or inline prefix. */
 const POUCENI_STANDALONE_RE =
-  // oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
   /^(?:P\s*o\s*u\s*č\s*e\s*n\s*í|Poučení)\s*:?\s*$/iu;
 const POUCENI_INLINE_RE = /^(?:P\s*o\s*u\s*č\s*e\s*n\s*í|Poučení)\s*:\s*/iu;
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
@@ -445,12 +445,10 @@ const collapseSpaces = (text: string): string =>
   text.replace(/(?<keep>\S)\s+(?=\S)/gu, "$<keep>");
 
 /** "takto:" separator (with spaced variants). */
-// oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
 const TAKTO_RE = /^t\s*a\s*k\s*t\s*o\s*:?\s*$/iu;
 
 /** "Odůvodnění:" separator (with spaced variants). */
 const ODUVODNENI_RE =
-  // oxlint-disable-next-line sonarjs/slow-regex -- matched against individual normalized parser lines
   /^(?:O\s*d\s*[uů]\s*v\s*o\s*d\s*n\s*[eě]\s*n\s*[ií]|Odůvodnění)\s*:?\s*$/iu;
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/parsers/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/pl-courts.ts
@@ -73,7 +73,6 @@ const DECISION_TITLES: ReadonlySet<string> = new Set(
 );
 const CASE_NUMBER_RE = /^sygn(?:atura)?\.?\s*akt[:\s]/iu;
 const REASONS_HEADING_RE = /^uzasadnienie\b/iu;
-// oxlint-disable-next-line sonarjs/slow-regex -- heading check runs against one normalized line, not unbounded document text
 const HOLDING_HEADING_RE = /^(?:orzeka|postanawia|uchwala|zarządza)\s*:?\s*$/iu;
 const HOLDING_ITEM_RE = /^(?:[IVXLC]+\s*[.)]|[0-9]+\s*[.)]|[a-z][)])\s*/u;
 const OPERATIVE_VERB_RE =
@@ -100,7 +99,6 @@ const hasHtmlTags = (content: string): boolean =>
 const normalizeWhitespace = (text: string): string =>
   text
     .replace(/\u00a0/gu, " ")
-    // oxlint-disable-next-line sonarjs/slow-regex -- source text is already split from one court document and replacement is line-local
     .replace(/[ \t]+\n/gu, "\n")
     .trim();
 

--- a/apps/api/src/handlers/case-law/ingestion/segmenter.ts
+++ b/apps/api/src/handlers/case-law/ingestion/segmenter.ts
@@ -15,23 +15,19 @@ const SECTION_PATTERNS: {
   // Czech patterns (compact headings)
   {
     type: "ruling",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^V\s*[ýy]\s*r\s*o\s*k\s*[:.]?\s*$/imu,
   },
   {
     type: "argumentation",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Od[uů]vodn[eě]n[ií]\s*[:.]?\s*$/imu,
   },
   {
     type: "dissent",
     pattern:
-      // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
       /^(?:Odli[šs]n[ée]\s+stanovisko|Stanovisko\s+men[šs]iny)\s*[:.]?\s*$/imu,
   },
   {
     type: "footer",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Pou[čc]en[ií]\s*[:.]?\s*$/imu,
   },
 
@@ -43,12 +39,10 @@ const SECTION_PATTERNS: {
   },
   {
     type: "argumentation",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^O\s+d\s+[ůu]\s+v\s+o\s+d\s+n\s+[ěe]\s+n\s+[ií]\s*[:.]?\s*$/imu,
   },
   {
     type: "footer",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^P\s+o\s+u\s+[čc]\s+e\s+n\s+[ií]\s*[:.]?\s*$/imu,
   },
 
@@ -67,17 +61,14 @@ const SECTION_PATTERNS: {
   // Slovak patterns
   {
     type: "ruling",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^(?:V[ýy]rok|Rozhodnutie)\s*[:.]?\s*$/imu,
   },
   {
     type: "argumentation",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Od[ôo]vodnenie\s*[:.]?\s*$/imu,
   },
   {
     type: "footer",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Pou[čc]enie\s*[:.]?\s*$/imu,
   },
 
@@ -85,29 +76,24 @@ const SECTION_PATTERNS: {
   {
     type: "history",
     pattern:
-      // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
       /^(?:Pr[uů]b[eě]h\s+[řr][ií]zen[ií]|Procesn[ií]\s+historie)\s*[:.]?\s*$/imu,
   },
 
   // Polish patterns
   {
     type: "ruling",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^(?:Sentencja|Tenor)\s*[:.]?\s*$/imu,
   },
   {
     type: "argumentation",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Uzasadnienie\s*[:.]?\s*$/imu,
   },
   {
     type: "dissent",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Zdanie\s+odr[eę]bne\s*[:.]?\s*$/imu,
   },
   {
     type: "footer",
-    // oxlint-disable-next-line sonarjs/slow-regex -- section patterns are matched against a single trimmed line
     pattern: /^Pouczenie\s*[:.]?\s*$/imu,
   },
 ];

--- a/apps/api/src/handlers/chat/get-suggested-prompts.ts
+++ b/apps/api/src/handlers/chat/get-suggested-prompts.ts
@@ -46,7 +46,6 @@ const SUGGEST_CLEANUP_STEPS = [
   /^\d+[.\-)]\s*/u, // Numbered list: "1. " or "2) " at start (optional trailing space)
   /^[-*•]\s*/u, // Bullet point at start
   /^["'([[]+/u, // Opening quotes, parens, brackets at start
-  // eslint-disable-next-line sonarjs/slow-regex -- anchored at $, no alternation, safe
   /[\])"'\s]+$/u, // Closing quotes, parens, brackets, whitespace at end
 ] as const;
 

--- a/apps/api/src/handlers/docx/extract-text.ts
+++ b/apps/api/src/handlers/docx/extract-text.ts
@@ -23,7 +23,6 @@ import type {
  * each other.
  */
 const DIRECTIVE_RE =
-  // oxlint-disable-next-line sonarjs/slow-regex -- DOCX directive text is one paragraph collected from OOXML
   /^\s*\{\{(?<tag>#if|#elseif|#else|#each|\/if|\/each)\s*(?<expr>.*?)\}\}\s*$/u;
 
 const DIRECTIVE_KIND_MAP: Record<string, BlockDirectiveKind> = {

--- a/apps/api/src/handlers/docx/patch-template-numbering.test.ts
+++ b/apps/api/src/handlers/docx/patch-template-numbering.test.ts
@@ -43,7 +43,6 @@ const docTextOf = async (buffer: Buffer): Promise<string> => {
   let previous = "";
   while (text !== previous) {
     previous = text;
-    // oxlint-disable-next-line sonarjs/slow-regex -- test helper on small, controlled document XML
     text = text.replace(/<[^>]+>/gu, "");
   }
   return text;

--- a/apps/api/src/handlers/files/xlsx-preprocess.ts
+++ b/apps/api/src/handlers/files/xlsx-preprocess.ts
@@ -2,7 +2,6 @@ import JSZip from "jszip";
 
 const REGEX_HAS_PAGE_SET_UP_PR = /<pageSetUpPr[\s/>]/u;
 const REGEX_EXTRACT_PAGE_SET_UP_PR = /<pageSetUpPr(?<attrs>[^/]*?)\/>/gu;
-// oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries
 const REGEX_REMOVE_FIT_TO_PAGE = /\s*fitToPage="[^"]*"/u;
 const REGEX_HAS_OPEN_SHEET_PR = /<sheetPr[^>]*>[\s\S]*?<\/sheetPr>/u;
 const REGEX_EXTRACT_OPEN_SHEET_PR =
@@ -14,11 +13,8 @@ const REGEX_SHEET_LANDMARK =
 const REGEX_WORKSHEET_OPEN = /<worksheet[^>]*>/u;
 const REGEX_HAS_PAGE_SETUP = /<pageSetup[\s/>]/u;
 const REGEX_EXTRACT_PAGE_SETUP = /<pageSetup(?<attrs>[^/]*?)\/>/gu;
-// oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries
 const REGEX_REMOVE_SCALE = /\s*scale="[^"]*"/u;
-// oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries
 const REGEX_REMOVE_FIT_TO_WIDTH = /\s*fitToWidth="[^"]*"/u;
-// oxlint-disable-next-line sonarjs/slow-regex -- worksheet attribute rewrite runs on bounded XLSX XML entries
 const REGEX_REMOVE_FIT_TO_HEIGHT = /\s*fitToHeight="[^"]*"/u;
 const REGEX_WORKSHEET_CLOSE = /<\/worksheet>/u;
 const REGEX_SHEET_FILENAME = /^xl\/worksheets\/sheet\d+\.xml$/u;

--- a/apps/api/src/lib/docx-stamp.ts
+++ b/apps/api/src/lib/docx-stamp.ts
@@ -57,7 +57,6 @@ const WID_RE = /w:id="(?<id>\d+)"/gu;
 const FOOTER_FILE_RE = /^word\/footer\d+\.xml$/u;
 const WT_TEXT_RE = /<w:t[^>]*>(?<text>[^<]*)<\/w:t>/gu;
 const STL_CODE_RE = /stl:(?<code>[abcdefghjkmnpqrstuvwxyz23456789]{10})/u;
-// oxlint-disable-next-line sonarjs/slow-regex -- footer text is bounded OOXML text and suffix is short
 const STL_SUFFIX_RE = /\s*stl:[abcdefghjkmnpqrstuvwxyz23456789]+\s*$/u;
 const SECT_PR_RE = /(?<sect><w:sectPr[^>]*>)/u;
 const CLOSING_BODY_RE = /<\/w:body>/u;

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -68,7 +68,6 @@ const baseUrl = (): string => {
       "CORPUS_INDEX_ENDPOINT is required when the corpus index search provider is selected",
     );
   }
-  // eslint-disable-next-line sonarjs/slow-regex -- trims trailing slashes on a trusted config URL, not user input
   return value.replace(/\/+$/u, "");
 };
 

--- a/apps/api/src/lib/matter-reference.ts
+++ b/apps/api/src/lib/matter-reference.ts
@@ -5,7 +5,6 @@ class PatternError extends TaggedError("PatternError")<{
 }>() {}
 
 const RECOGNIZED_TOKENS = ["{SEQ}", "{YYYY}", "{YY}", "{MM}"] as const;
-// oxlint-disable-next-line sonarjs/slow-regex -- matter patterns are user input capped by MAX_REFERENCE_LENGTH validation
 const TOKEN_REGEX = /\{[^}]+\}/gu;
 const FORBIDDEN_CHARS = /[<>&]/u;
 

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -183,7 +183,6 @@ const DIRECTIVE_NAMES = new Set([
   "recitals",
 ]);
 const DIRECTIVE_NAME_CHAR_RE = /[a-z_]/iu;
-// oxlint-disable-next-line sonarjs/slow-regex -- input is single-line paragraph text; linear backtracking only
 const PLACEHOLDER_RE = /\[\[(?<inner>[^\]]+?)\]\]/gu;
 const CLAUSE_HEADING_RE = /^@clause +\d+ *"(?<title>[^"]*)" *$/iu;
 const stripDirectivePrefix = (line: string): string => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -111,7 +111,6 @@ const buildContent = (
 
 const promptFromHtml = (html: string): string =>
   // Strip HTML tags to get a quick "is the prompt empty" check.
-  // eslint-disable-next-line sonarjs/slow-regex -- input is bounded TipTap editor HTML; linear backtracking only
   html.replace(/<[^>]+>/g, "").trim();
 
 export const CreateProperty = ({

--- a/bun.lock
+++ b/bun.lock
@@ -657,7 +657,7 @@
     "elysia": "1.4.29",
     "eslint": "10.5.0",
     "eslint-plugin-drizzle": "0.2.3",
-    "eslint-plugin-sonarjs": "4.0.3",
+    "eslint-plugin-sonarjs": "4.1.0",
     "fast-check": "^4.8.0",
     "jszip": "3.10.1",
     "lucide-react": "1.21.0",
@@ -2464,7 +2464,7 @@
 
     "eslint-plugin-drizzle": ["eslint-plugin-drizzle@0.2.3", "", { "peerDependencies": { "eslint": ">=8.0.0" } }, "sha512-BO+ymHo33IUNoJlC0rbd7HP9EwwpW4VIp49R/tWQF/d2E1K2kgTf0tCXT0v9MSiBr6gGR1LtPwMLapTKEWSg9A=="],
 
-    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.0.3", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.4.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.5", "scslre": "^0.3.0", "semver": "^7.7.4", "ts-api-utils": "^2.5.0", "typescript": ">=5" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g=="],
+    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.1.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.6.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.5", "scslre": "^0.3.0", "semver": "^7.8.4", "ts-api-utils": "^2.5.0", "typescript": ">=5", "yaml": "^2.9.0" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "elysia": "1.4.29",
     "eslint": "10.5.0",
     "eslint-plugin-drizzle": "0.2.3",
-    "eslint-plugin-sonarjs": "4.0.3",
+    "eslint-plugin-sonarjs": "4.1.0",
     "fast-check": "^4.8.0",
     "jszip": "3.10.1",
     "lucide-react": "1.21.0",

--- a/packages/folio/src/core/layout-painter/renderParagraph-decimal-tab.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-decimal-tab.test.ts
@@ -69,7 +69,6 @@ class FakeElement {
       font: "",
       measureText(text: string): { width: number } {
         // Parse "<weight?> <px>px <family>" — grab the numeric pixel size.
-        // oxlint-disable-next-line sonarjs/slow-regex -- fixed font string from the test, linear backtracking only
         const match = /(?<size>\d+(?:\.\d+)?)px/u.exec(ctx.font);
         const fontSizePx = match
           ? Number(match.groups?.["size"])

--- a/packages/scripts/src/i18n-check.ts
+++ b/packages/scripts/src/i18n-check.ts
@@ -238,7 +238,6 @@ const isTriviallyIdentical = (value: string): boolean => {
   const trimmed = value.trim();
   // Ignore ICU placeholders so "{n}" / "{value}%" count as letter-free.
   // Pattern is linear: [^}] cannot match the closing }, so no backtracking.
-  // oxlint-disable-next-line sonarjs/slow-regex -- linear: [^}] excludes the closing }, no backtracking
   const literal = trimmed.replace(/\{[^}]*\}/gu, "");
   // Exempt only language-neutral content: no letters (numbers, punctuation,
   // placeholder-only) or an explicit allowed token. Do NOT blanket-exempt by

--- a/packages/template-conditions/src/markers.ts
+++ b/packages/template-conditions/src/markers.ts
@@ -110,7 +110,6 @@ export const hasBlockDirectivePattern = (): RegExp => /\{\{\s*[#/]/u;
 
 /** A whole line that is a single block directive — `tag` and `expr` groups. */
 export const blockDirectiveLinePattern = (): RegExp =>
-  // oxlint-disable-next-line sonarjs/slow-regex -- runs on one OOXML paragraph at a time
   /^\s*\{\{\s*(?<tag>#if|#elseif|#else|#each|\/if|\/each)\s*(?<expr>.*?)\}\}\s*$/u;
 
 // ── Classifier ───────────────────────────────────────────


### PR DESCRIPTION
Bumps `eslint-plugin-sonarjs` 4.0.3 -> 4.1.0.

4.1.0 improves the `slow-regex` analysis, which no longer flags a set of bounded/linear regexes that were previously suppressed. With `--report-unused-disable-directives=error`, those `oxlint-disable`/`eslint-disable sonarjs/slow-regex` directives became unused and failed lint, so this removes the now-redundant ones (50 directives across 22 files).

Suppressions for other sonarjs rules (`regex-complexity`, `no-empty-collection`) are unaffected and left in place. No regex or runtime behavior changes.