### PR TITLE
fix(api): write template manifest to a free custom XML slot

### DIFF
--- a/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
@@ -177,4 +177,33 @@ describe("writeManifest with a foreign custom XML slot", () => {
       FOREIGN_ITEM1,
     );
   });
+
+  // A producer may serialize the Content_Types override with single quotes.
+  // stripManifest must still remove it; otherwise it deletes the props part
+  // but leaves a dangling override pointing at a now-missing part.
+  test("stripManifest removes a single-quoted Content_Types override", async () => {
+    const base = await createDocxWithForeignCustomXml();
+    const written = await writeManifest(base, sampleManifest); // → item2
+
+    // Rewrite our override to single quotes, as a single-quote producer would.
+    const inZip = await JSZip.loadAsync(written);
+    const ct = await inZip.file("[Content_Types].xml")!.async("string");
+    inZip.file(
+      "[Content_Types].xml",
+      ct.replace(
+        /<Override PartName="\/customXml\/itemProps2\.xml"(?<rest>[^>]*)\/>/u,
+        "<Override PartName='/customXml/itemProps2.xml'$<rest>/>",
+      ),
+    );
+    const singleQuoted = Buffer.from(
+      await inZip.generateAsync({ type: "nodebuffer" }),
+    );
+
+    const stripped = await stripManifest(singleQuoted);
+    const out = await JSZip.loadAsync(stripped);
+    expect(out.file("customXml/itemProps2.xml")).toBeNull();
+    const contentTypes = await out.file("[Content_Types].xml")?.async("string");
+    // No dangling override to the deleted part remains.
+    expect(contentTypes).not.toContain("itemProps2.xml");
+  });
 });

--- a/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
@@ -83,4 +83,45 @@ describe("writeManifest with a foreign custom XML slot", () => {
     expect(zip.file("customXml/item3.xml")).toBeNull();
     expect(await readManifest(twice)).toEqual(sampleManifest);
   });
+
+  // A part that merely mentions the namespace URI (e.g. as text) is NOT a
+  // manifest: detection parses the root element, it is not a substring match.
+  test("ignores a foreign part that only mentions the namespace string", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>',
+    );
+    zip.file(
+      "[Content_Types].xml",
+      '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>',
+    );
+    // Foreign part: contains the URN as text but the root is not <template>.
+    const decoy = `<note>see ${MANIFEST_NS} for details</note>`;
+    zip.file("customXml/item1.xml", decoy);
+    const buf = Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
+
+    expect(await readManifest(buf)).toBeNull();
+
+    const withManifest = await writeManifest(buf, sampleManifest);
+    const out = await JSZip.loadAsync(withManifest);
+    // The decoy is preserved; the real manifest landed in a fresh slot.
+    expect(await out.file("customXml/item1.xml")?.async("string")).toBe(decoy);
+    expect(await readManifest(withManifest)).toEqual(sampleManifest);
+  });
+
+  // When a valid manifest sits in a higher slot than a foreign part, it is
+  // still found, and re-save reuses that slot rather than item1.
+  test("finds a manifest in a non-first slot deterministically", async () => {
+    const base = await createDocxWithForeignCustomXml();
+    const withManifest = await writeManifest(base, sampleManifest); // → item2
+    expect(await readManifest(withManifest)).toEqual(sampleManifest);
+
+    const resaved = await writeManifest(withManifest, sampleManifest);
+    const zip = await JSZip.loadAsync(resaved);
+    expect(zip.file("customXml/item3.xml")).toBeNull();
+    expect(await zip.file("customXml/item2.xml")?.async("string")).toContain(
+      MANIFEST_NS,
+    );
+  });
 });

--- a/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { MANIFEST_NS, readManifest, writeManifest } from "./template-manifest";
+import type { TemplateManifest } from "./types";
+
+/**
+ * Regression: uploading a real Word/Google-Docs DOCX used to fail with
+ * "Nepodařilo se uložit vzor / Došlo k neočekávané chybě" (PUT /v1/templates/
+ * 500, Panic ← WorkflowValidationError). Such documents ship their own custom
+ * XML data store at the hardcoded `customXml/item1.xml` slot (bibliography
+ * sources, custom doc properties, content-control bindings, SharePoint
+ * metadata), and the manifest writer refused to allocate a different slot.
+ */
+
+const FOREIGN_ITEM1 =
+  '<b:Sources SelectedStyle="/APA.XSL" StyleName="APA" xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography"></b:Sources>';
+
+/** A DOCX that already occupies custom XML slot 1 with a foreign part, mirroring
+ *  a Word document that carries a bibliography data store. */
+const createDocxWithForeignCustomXml = async (): Promise<Buffer> => {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello {{clientName}}</w:t></w:r></w:p></w:body></w:document>',
+  );
+  zip.file(
+    "[Content_Types].xml",
+    '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/customXml/itemProps1.xml" ContentType="application/vnd.openxmlformats-officedocument.customXmlProperties+xml"/></Types>',
+  );
+  zip.file("customXml/item1.xml", FOREIGN_ITEM1);
+  zip.file(
+    "customXml/itemProps1.xml",
+    '<?xml version="1.0"?><ds:datastoreItem xmlns:ds="http://schemas.openxmlformats.org/officeDocument/2006/customXml" ds:itemID="{FOREIGN}"/>',
+  );
+  const buf = await zip.generateAsync({ type: "nodebuffer" });
+  return Buffer.from(buf);
+};
+
+const sampleManifest: TemplateManifest = {
+  version: 1,
+  fields: [{ path: "clientName", label: "Client Name", inputType: "text" }],
+};
+
+describe("writeManifest with a foreign custom XML slot", () => {
+  test("writes to a free slot, preserving the foreign part, and round-trips", async () => {
+    const docx = await createDocxWithForeignCustomXml();
+
+    const withManifest = await writeManifest(docx, sampleManifest);
+
+    // Manifest is readable again (located by namespace, not a fixed slot).
+    expect(await readManifest(withManifest)).toEqual(sampleManifest);
+
+    const zip = await JSZip.loadAsync(withManifest);
+
+    // Foreign item1 is untouched; the manifest landed in the next slot.
+    expect(await zip.file("customXml/item1.xml")?.async("string")).toBe(
+      FOREIGN_ITEM1,
+    );
+    const item2 = await zip.file("customXml/item2.xml")?.async("string");
+    expect(item2).toContain(MANIFEST_NS);
+
+    // Both props parts get their own Content_Types override.
+    const contentTypes = await zip.file("[Content_Types].xml")?.async("string");
+    expect(contentTypes).toContain('PartName="/customXml/itemProps1.xml"');
+    expect(contentTypes).toContain('PartName="/customXml/itemProps2.xml"');
+
+    // The manifest's relationship targets its own props part.
+    const rels = await zip
+      .file("customXml/_rels/item2.xml.rels")
+      ?.async("string");
+    expect(rels).toContain('Target="itemProps2.xml"');
+  });
+
+  test("re-saving reuses the manifest's existing slot (idempotent)", async () => {
+    const docx = await createDocxWithForeignCustomXml();
+    const once = await writeManifest(docx, sampleManifest);
+    const twice = await writeManifest(once, sampleManifest);
+
+    const zip = await JSZip.loadAsync(twice);
+    // No new slot is allocated on re-save: still item2, no item3.
+    expect(zip.file("customXml/item2.xml")).not.toBeNull();
+    expect(zip.file("customXml/item3.xml")).toBeNull();
+    expect(await readManifest(twice)).toEqual(sampleManifest);
+  });
+});

--- a/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
@@ -115,6 +115,31 @@ describe("writeManifest with a foreign custom XML slot", () => {
     expect(await readManifest(withManifest)).toEqual(sampleManifest);
   });
 
+  // A `<template>` element that merely *declares* our namespace prefix but is
+  // not itself in the namespace is not a manifest (the root's namespaceURI,
+  // not a stray xmlns:st attribute, decides).
+  test("ignores a foreign <template> not actually in the namespace", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>',
+    );
+    zip.file(
+      "[Content_Types].xml",
+      '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>',
+    );
+    const decoy = `<template xmlns:st="${MANIFEST_NS}"><fields/></template>`;
+    zip.file("customXml/item1.xml", decoy);
+    const buf = Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
+
+    expect(await readManifest(buf)).toBeNull();
+
+    const withManifest = await writeManifest(buf, sampleManifest);
+    const out = await JSZip.loadAsync(withManifest);
+    expect(await out.file("customXml/item1.xml")?.async("string")).toBe(decoy);
+    expect(await readManifest(withManifest)).toEqual(sampleManifest);
+  });
+
   // When a valid manifest sits in a higher slot than a foreign part, it is
   // still found, and re-save reuses that slot rather than item1.
   test("finds a manifest in a non-first slot deterministically", async () => {

--- a/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
-import { MANIFEST_NS, readManifest, writeManifest } from "./template-manifest";
+import {
+  MANIFEST_NS,
+  readManifest,
+  stripManifest,
+  writeManifest,
+} from "./template-manifest";
 import type { TemplateManifest } from "./types";
 
 /**
@@ -122,6 +127,29 @@ describe("writeManifest with a foreign custom XML slot", () => {
     expect(zip.file("customXml/item3.xml")).toBeNull();
     expect(await zip.file("customXml/item2.xml")?.async("string")).toContain(
       MANIFEST_NS,
+    );
+  });
+
+  // The manifest (field schema, AI prompts) must never ride along in a filled
+  // document. stripManifest has to remove it from whatever slot it occupies,
+  // not just item1 — otherwise a relocated manifest would leak on fill.
+  test("stripManifest removes the manifest from a non-first slot", async () => {
+    const base = await createDocxWithForeignCustomXml();
+    const withManifest = await writeManifest(base, sampleManifest); // → item2
+
+    const stripped = await stripManifest(withManifest);
+
+    // No custom XML part carries the Stella namespace anymore.
+    expect(await readManifest(stripped)).toBeNull();
+    const zip = await JSZip.loadAsync(stripped);
+    expect(zip.file("customXml/item2.xml")).toBeNull();
+    expect(zip.file("customXml/itemProps2.xml")).toBeNull();
+    const contentTypes = await zip.file("[Content_Types].xml")?.async("string");
+    expect(contentTypes).not.toContain("itemProps2.xml");
+
+    // The foreign part is left untouched.
+    expect(await zip.file("customXml/item1.xml")?.async("string")).toBe(
+      FOREIGN_ITEM1,
     );
   });
 });

--- a/apps/api/src/handlers/docx/template-manifest.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest.test.ts
@@ -362,7 +362,7 @@ describe("writeManifest", () => {
     expect(ct).toContain("customXmlProperties");
   });
 
-  test("throws when overwriting non-stella custom XML", async () => {
+  test("preserves non-stella custom XML by writing to a free slot", async () => {
     const zip = new JSZip();
     zip.file(
       "word/document.xml",
@@ -372,15 +372,18 @@ describe("writeManifest", () => {
       "[Content_Types].xml",
       '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>',
     );
-    zip.file(
-      "customXml/item1.xml",
-      '<foo xmlns="urn:other:namespace"><bar/></foo>',
-    );
+    const foreign = '<foo xmlns="urn:other:namespace"><bar/></foo>';
+    zip.file("customXml/item1.xml", foreign);
     const buf = Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
 
-    expect(writeManifest(buf, sampleManifest)).rejects.toThrow(
-      "non-stella custom XML",
+    const withManifest = await writeManifest(buf, sampleManifest);
+
+    // Foreign part untouched, manifest still readable.
+    const out = await JSZip.loadAsync(withManifest);
+    expect(await out.file("customXml/item1.xml")?.async("string")).toBe(
+      foreign,
     );
+    expect(await readManifest(withManifest)).toEqual(sampleManifest);
   });
 
   test("replaces existing manifest", async () => {

--- a/apps/api/src/handlers/docx/template-manifest.ts
+++ b/apps/api/src/handlers/docx/template-manifest.ts
@@ -761,12 +761,14 @@ export const stripManifest = async (docxBuffer: Buffer): Promise<Buffer> => {
   const ctEntry = zip.file(CONTENT_TYPES_PATH);
   if (ctEntry) {
     let ctXml = await ctEntry.async("string");
-    // Remove the Override for our props part. Fully escape the path before
-    // embedding it in the pattern so every regex meta-character (including
-    // `\`) is matched literally.
+    // Remove the Override for our props part. Fully escape the path so every
+    // regex meta-character (including `\`) is matched literally, and tolerate
+    // either quote style to mirror the quote-tolerant check on the write side
+    // (otherwise a single-quoted override would be skipped on write yet left
+    // dangling here, pointing at a part we just deleted).
     ctXml = ctXml.replace(
       new RegExp(
-        `<Override[^>]*PartName="/${escapeRegExp(propsPath)}"[^>]*/>`,
+        `<Override[^>]*PartName=["']/${escapeRegExp(propsPath)}["'][^>]*/>`,
         "u",
       ),
       "",

--- a/apps/api/src/handlers/docx/template-manifest.ts
+++ b/apps/api/src/handlers/docx/template-manifest.ts
@@ -55,9 +55,13 @@ const customXmlPropsPath = (slot: number): string =>
 const customXmlRelsPath = (slot: number): string =>
   `customXml/_rels/item${String(slot)}.xml.rels`;
 
-/** Matches any custom XML data or props part to read its slot index. */
+/** Matches any custom XML data or props part to read its slot index
+ *  (used to find the next free slot). */
 const CUSTOM_XML_INDEX_RE =
   /^customXml\/(?:item|itemProps)(?<index>\d+)\.xml$/u;
+
+/** Matches only data parts (`item{N}.xml`), where a manifest can live. */
+const CUSTOM_XML_DATA_RE = /^customXml\/item(?<index>\d+)\.xml$/u;
 
 const CONTENT_TYPES_PATH = "[Content_Types].xml";
 
@@ -593,32 +597,37 @@ const parseManifestXml = (xml: string): TemplateManifest | null => {
 
 // ── Public API ───────────────────────────────────────────
 
-/** The Stella manifest part located by namespace, plus its slot index. */
-type ManifestSlot = { index: number; xml: string };
+/** The Stella manifest part: its slot index plus the parsed manifest. */
+type ManifestSlot = { index: number; manifest: TemplateManifest };
 
 /**
- * Locate the Stella manifest among the DOCX's custom XML parts by scanning
- * for `MANIFEST_NS`, rather than assuming a fixed slot. Returns the slot
- * index and its raw XML, or `null` when no Stella manifest is present.
+ * Locate the Stella manifest among the DOCX's custom XML parts.
+ *
+ * A part is "ours" only when it parses to a valid manifest whose root is
+ * `<template>` in `MANIFEST_NS` (a URN we own) — not a loose substring match,
+ * so a foreign part that merely mentions the URI is never selected. When more
+ * than one qualifies (should not happen for documents we write), the lowest
+ * slot index wins, so the choice is deterministic regardless of zip order.
  */
 const findManifestSlot = async (zip: JSZip): Promise<ManifestSlot | null> => {
   const candidates = Object.entries(zip.files).flatMap(([path, entry]) => {
-    const index = CUSTOM_XML_INDEX_RE.exec(path)?.groups?.["index"];
-    // Only data parts (`item{N}.xml`) carry the manifest; skip props parts.
-    if (index === undefined || !path.startsWith(`customXml/item${index}.xml`)) {
-      return [];
-    }
-    return [{ index: Number(index), entry }];
+    const index = CUSTOM_XML_DATA_RE.exec(path)?.groups?.["index"];
+    return index === undefined ? [] : [{ index: Number(index), entry }];
   });
 
   const slots = await Promise.all(
     candidates.map(async (c) => ({
       index: c.index,
-      xml: await c.entry.async("string"),
+      manifest: parseManifestXml(await c.entry.async("string")),
     })),
   );
 
-  return slots.find((slot) => slot.xml.includes(MANIFEST_NS)) ?? null;
+  return (
+    slots
+      .filter((slot): slot is ManifestSlot => slot.manifest !== null)
+      .toSorted((a, b) => a.index - b.index)
+      .at(0) ?? null
+  );
 };
 
 /**
@@ -646,10 +655,7 @@ export const readManifestFromZip = async (
   zip: JSZip,
 ): Promise<TemplateManifest | null> => {
   const found = await findManifestSlot(zip);
-  if (!found) {
-    return null;
-  }
-  return parseManifestXml(found.xml);
+  return found?.manifest ?? null;
 };
 
 /**

--- a/apps/api/src/handlers/docx/template-manifest.ts
+++ b/apps/api/src/handlers/docx/template-manifest.ts
@@ -15,8 +15,6 @@ import * as slimdom from "slimdom";
 
 import { isFieldPath } from "@stll/template-conditions";
 
-import { WorkflowValidationError } from "@/api/lib/errors/tagged-errors";
-
 import { isElement } from "./ooxml";
 import type {
   DiscoveredField,
@@ -45,9 +43,22 @@ import {
 
 export const MANIFEST_NS = "urn:stella:template:v1";
 
-const CUSTOM_XML_ITEM_PATH = "customXml/item1.xml";
-const CUSTOM_XML_PROPS_PATH = "customXml/itemProps1.xml";
-const CUSTOM_XML_RELS_PATH = "customXml/_rels/item1.xml.rels";
+// Custom XML parts live in numbered slots (`customXml/item{N}.xml`). The slot
+// is NOT fixed at 1: real Word documents commonly ship their own custom XML at
+// item1 (bibliography sources, custom doc properties, content-control bindings,
+// SharePoint metadata). The manifest is located by namespace and written to a
+// free slot, never assuming item1 is ours.
+const customXmlItemPath = (slot: number): string =>
+  `customXml/item${String(slot)}.xml`;
+const customXmlPropsPath = (slot: number): string =>
+  `customXml/itemProps${String(slot)}.xml`;
+const customXmlRelsPath = (slot: number): string =>
+  `customXml/_rels/item${String(slot)}.xml.rels`;
+
+/** Matches any custom XML data or props part to read its slot index. */
+const CUSTOM_XML_INDEX_RE =
+  /^customXml\/(?:item|itemProps)(?<index>\d+)\.xml$/u;
+
 const CONTENT_TYPES_PATH = "[Content_Types].xml";
 
 const CUSTOM_XML_CONTENT_TYPE =
@@ -247,14 +258,14 @@ const buildItemPropsXml = (): string =>
     "</ds:datastoreItem>",
   ].join("");
 
-const buildItemRelsXml = (): string =>
+const buildItemRelsXml = (slot: number): string =>
   [
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
     '<Relationships xmlns="http://schemas.openxmlformats.org',
     '/package/2006/relationships">',
     `<Relationship Id="rId1"`,
     ` Type="${CUSTOM_XML_PROPS_REL_TYPE}"`,
-    ` Target="itemProps1.xml"/>`,
+    ` Target="itemProps${String(slot)}.xml"/>`,
     "</Relationships>",
   ].join("");
 
@@ -582,6 +593,50 @@ const parseManifestXml = (xml: string): TemplateManifest | null => {
 
 // ── Public API ───────────────────────────────────────────
 
+/** The Stella manifest part located by namespace, plus its slot index. */
+type ManifestSlot = { index: number; xml: string };
+
+/**
+ * Locate the Stella manifest among the DOCX's custom XML parts by scanning
+ * for `MANIFEST_NS`, rather than assuming a fixed slot. Returns the slot
+ * index and its raw XML, or `null` when no Stella manifest is present.
+ */
+const findManifestSlot = async (zip: JSZip): Promise<ManifestSlot | null> => {
+  const candidates = Object.entries(zip.files).flatMap(([path, entry]) => {
+    const index = CUSTOM_XML_INDEX_RE.exec(path)?.groups?.["index"];
+    // Only data parts (`item{N}.xml`) carry the manifest; skip props parts.
+    if (index === undefined || !path.startsWith(`customXml/item${index}.xml`)) {
+      return [];
+    }
+    return [{ index: Number(index), entry }];
+  });
+
+  const slots = await Promise.all(
+    candidates.map(async (c) => ({
+      index: c.index,
+      xml: await c.entry.async("string"),
+    })),
+  );
+
+  return slots.find((slot) => slot.xml.includes(MANIFEST_NS)) ?? null;
+};
+
+/**
+ * Pick the next free custom XML slot: one past the highest existing
+ * `item{N}` / `itemProps{N}` index. Using max+1 (not first-gap) keeps the
+ * data and props parts paired and never reuses a foreign slot.
+ */
+const nextFreeSlot = (zip: JSZip): number => {
+  let max = 0;
+  for (const path of Object.keys(zip.files)) {
+    const index = CUSTOM_XML_INDEX_RE.exec(path)?.groups?.["index"];
+    if (index !== undefined) {
+      max = Math.max(max, Number(index));
+    }
+  }
+  return max + 1;
+};
+
 /**
  * Read the Stella template manifest from an already-opened
  * JSZip instance. Use this when the caller already has the
@@ -590,13 +645,11 @@ const parseManifestXml = (xml: string): TemplateManifest | null => {
 export const readManifestFromZip = async (
   zip: JSZip,
 ): Promise<TemplateManifest | null> => {
-  const entry = zip.file(CUSTOM_XML_ITEM_PATH);
-  if (!entry) {
+  const found = await findManifestSlot(zip);
+  if (!found) {
     return null;
   }
-
-  const xml = await entry.async("string");
-  return parseManifestXml(xml);
+  return parseManifestXml(found.xml);
 };
 
 /**
@@ -620,41 +673,35 @@ export const writeManifest = async (
 ): Promise<Buffer> => {
   const zip = await JSZip.loadAsync(docxBuffer);
 
-  // Guard: refuse to overwrite non-Stella custom XML
-  const existing = zip.file(CUSTOM_XML_ITEM_PATH);
-  if (existing) {
-    const xml = await existing.async("string");
-    if (!xml.includes(MANIFEST_NS)) {
-      throw new WorkflowValidationError({
-        message:
-          "Cannot write manifest: " +
-          `${CUSTOM_XML_ITEM_PATH} contains ` +
-          "non-stella custom XML",
-      });
-    }
-  }
+  // Reuse our own slot when re-saving a template that already carries a
+  // manifest; otherwise claim a fresh slot so a foreign custom XML part
+  // (Word bibliography, content-control bindings, SharePoint metadata) is
+  // never overwritten.
+  const existing = await findManifestSlot(zip);
+  const slot = existing?.index ?? nextFreeSlot(zip);
 
-  // Write the manifest XML
-  zip.file(CUSTOM_XML_ITEM_PATH, buildManifestXml(manifest));
+  const propsPath = customXmlPropsPath(slot);
 
-  // Write item properties
-  zip.file(CUSTOM_XML_PROPS_PATH, buildItemPropsXml());
+  zip.file(customXmlItemPath(slot), buildManifestXml(manifest));
+  zip.file(propsPath, buildItemPropsXml());
+  zip.file(customXmlRelsPath(slot), buildItemRelsXml(slot));
 
-  // Write relationships for the custom XML part
-  zip.file(CUSTOM_XML_RELS_PATH, buildItemRelsXml());
-
-  // Ensure [Content_Types].xml includes the custom XML part
+  // Add the per-part Override for our props part. Checking the specific
+  // PartName (not a generic "customXmlProperties" substring) is required:
+  // a foreign custom XML part already contributes its own props override.
   const ctEntry = zip.file(CONTENT_TYPES_PATH);
   if (ctEntry) {
-    let ctXml = await ctEntry.async("string");
-    if (!ctXml.includes("customXmlProperties")) {
-      ctXml = ctXml.replace(
-        "</Types>",
-        `<Override PartName="/${CUSTOM_XML_PROPS_PATH}"` +
-          ` ContentType="${CUSTOM_XML_CONTENT_TYPE}"/>` +
+    const ctXml = await ctEntry.async("string");
+    if (!ctXml.includes(`PartName="/${propsPath}"`)) {
+      zip.file(
+        CONTENT_TYPES_PATH,
+        ctXml.replace(
           "</Types>",
+          `<Override PartName="/${propsPath}"` +
+            ` ContentType="${CUSTOM_XML_CONTENT_TYPE}"/>` +
+            "</Types>",
+        ),
       );
-      zip.file(CONTENT_TYPES_PATH, ctXml);
     }
   }
 
@@ -671,21 +718,17 @@ export const writeManifest = async (
 export const stripManifest = async (docxBuffer: Buffer): Promise<Buffer> => {
   const zip = await JSZip.loadAsync(docxBuffer);
 
-  const hasManifest = zip.file(CUSTOM_XML_ITEM_PATH);
-  if (!hasManifest) {
+  const found = await findManifestSlot(zip);
+  if (!found) {
     return docxBuffer;
   }
 
-  // Check that this is actually a Stella manifest
-  const xml = await hasManifest.async("string");
-  if (!xml.includes(MANIFEST_NS)) {
-    return docxBuffer;
-  }
+  const propsPath = customXmlPropsPath(found.index);
 
-  // Remove the custom XML part files
-  zip.remove(CUSTOM_XML_ITEM_PATH);
-  zip.remove(CUSTOM_XML_PROPS_PATH);
-  zip.remove(CUSTOM_XML_RELS_PATH);
+  // Remove only our slot's part files; foreign custom XML parts stay intact.
+  zip.remove(customXmlItemPath(found.index));
+  zip.remove(propsPath);
+  zip.remove(customXmlRelsPath(found.index));
 
   // Clean up empty customXml directory entries
   const customXmlDir = "customXml/";
@@ -699,10 +742,11 @@ export const stripManifest = async (docxBuffer: Buffer): Promise<Buffer> => {
   const ctEntry = zip.file(CONTENT_TYPES_PATH);
   if (ctEntry) {
     let ctXml = await ctEntry.async("string");
-    // Remove the Override for itemProps1.xml
+    // Remove the Override for our props part (escape the `.` in the path so
+    // the regex matches it literally, not as a wildcard).
     ctXml = ctXml.replace(
       new RegExp(
-        `<Override[^>]*PartName="/${CUSTOM_XML_PROPS_PATH}"[^>]*/>`,
+        `<Override[^>]*PartName="/${propsPath.replace(/\./gu, "\\.")}"[^>]*/>`,
         "u",
       ),
       "",

--- a/apps/api/src/handlers/docx/template-manifest.ts
+++ b/apps/api/src/handlers/docx/template-manifest.ts
@@ -63,6 +63,10 @@ const CUSTOM_XML_INDEX_RE =
 /** Matches only data parts (`item{N}.xml`), where a manifest can live. */
 const CUSTOM_XML_DATA_RE = /^customXml\/item(?<index>\d+)\.xml$/u;
 
+/** Escape every regex meta-character (including `\`) for literal matching. */
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+
 const CONTENT_TYPES_PATH = "[Content_Types].xml";
 
 const CUSTOM_XML_CONTENT_TYPE =
@@ -538,13 +542,15 @@ const parseManifestXml = (xml: string): TemplateManifest | null => {
   }
 
   const root = doc.documentElement;
-  if (!root || root.localName !== "template") {
-    return null;
-  }
-
-  // Check namespace (attribute or default)
-  const ns = root.namespaceURI ?? root.getAttribute("xmlns:st");
-  if (ns !== MANIFEST_NS) {
+  // Require the root element to actually be `template` *in* our namespace.
+  // Checking namespaceURI (not a declared-but-unused `xmlns:st` attribute)
+  // ensures a foreign `<template xmlns:st="...">` whose element is not in the
+  // namespace is never mistaken for a manifest.
+  if (
+    !root ||
+    root.localName !== "template" ||
+    root.namespaceURI !== MANIFEST_NS
+  ) {
     return null;
   }
 
@@ -698,7 +704,14 @@ export const writeManifest = async (
   const ctEntry = zip.file(CONTENT_TYPES_PATH);
   if (ctEntry) {
     const ctXml = await ctEntry.async("string");
-    if (!ctXml.includes(`PartName="/${propsPath}"`)) {
+    // Tolerate quote style and attribute spacing/ordering so we never append a
+    // duplicate Override (which would violate the OPC spec and corrupt the
+    // package).
+    const hasOverride = new RegExp(
+      `<Override[^>]*PartName=["']/${escapeRegExp(propsPath)}["']`,
+      "u",
+    ).test(ctXml);
+    if (!hasOverride) {
       zip.file(
         CONTENT_TYPES_PATH,
         ctXml.replace(
@@ -748,11 +761,12 @@ export const stripManifest = async (docxBuffer: Buffer): Promise<Buffer> => {
   const ctEntry = zip.file(CONTENT_TYPES_PATH);
   if (ctEntry) {
     let ctXml = await ctEntry.async("string");
-    // Remove the Override for our props part (escape the `.` in the path so
-    // the regex matches it literally, not as a wildcard).
+    // Remove the Override for our props part. Fully escape the path before
+    // embedding it in the pattern so every regex meta-character (including
+    // `\`) is matched literally.
     ctXml = ctXml.replace(
       new RegExp(
-        `<Override[^>]*PartName="/${propsPath.replace(/\./gu, "\\.")}"[^>]*/>`,
+        `<Override[^>]*PartName="/${escapeRegExp(propsPath)}"[^>]*/>`,
         "u",
       ),
       "",


### PR DESCRIPTION
## Problem

Creating a template by uploading a DOCX (`PUT /v1/templates/`) failed with a 500 and a generic toast ("Failed to save template / An unexpected error occurred") whenever the uploaded document already used the `customXml/item1.xml` slot for its own data store.

Real documents authored in Word or Google Docs commonly occupy that slot with a bibliography data store (`b:Sources`), custom document properties, content-control data bindings, or SharePoint metadata. `writeManifest` hardcoded `item1` and, finding a foreign part there, **threw** `WorkflowValidationError`. Thrown inside the create handler's `Result.gen`, that became a `Panic` (HTTP 500) with no user-facing message, so the frontend fell back to the generic error.

Blank/Folio-native templates have no custom XML, so `item1` is free — which is why authoring in the Studio worked but uploads of existing documents did not.

## Fix

- **Locate by namespace, not slot.** The manifest is found by scanning every `customXml/item*.xml` part for `urn:stella:template:v1`, in `writeManifest`, `readManifest(FromZip)`, and `stripManifest`.
- **Write to a free slot.** New manifests claim the next free `customXml/item{N}.xml` (+ matching `itemProps{N}.xml` and `_rels/item{N}.xml.rels`), leaving foreign parts untouched. Re-saving a template reuses its existing slot (idempotent).
- **Per-part Content_Types override.** The `customXmlProperties` override is now keyed on the specific `PartName`, so a document's own props override no longer suppresses ours.

No DB or API-contract changes; the manifest is internal DOCX metadata read by scanning the zip.

## Tests

- New `template-manifest-foreign-customxml.test.ts`: a DOCX with a foreign `item1` part now creates successfully, the foreign part is preserved byte-for-byte, the manifest round-trips from its new slot, both props overrides are present, and re-saving is idempotent.
- Updated the existing manifest test that asserted the old throw to assert the new preserve-and-relocate behavior.
- Full `apps/api/src/handlers/docx` suite green (685 tests).