### PR TITLE
fix(web): pre-bundle better-auth client entrypoints in optimizeDeps

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -116,9 +116,13 @@ export default defineConfig(({ mode }) => {
       // Vite's dep optimizer handles them during the cold pass, before any
       // navigation. Two graphs trip this:
       //
-      //   1. better-auth: src/lib/auth.ts statically imports the public
-      //      entrypoints, but better-auth reaches these deep subpaths only at
-      //      runtime, so the crawler misses them until a protected route runs.
+      //   1. better-auth: src/lib/auth.ts statically imports the client
+      //      entrypoints (better-auth/react + /client + /client/plugins,
+      //      @better-auth/oauth-provider/client), but their runtime-only deep
+      //      subpaths (e.g. the multi-tab session `broadcast-channel`) are not
+      //      statically reachable, so the cold crawl misses them until a
+      //      protected route actually runs the auth client. Listing the
+      //      entrypoints makes the optimizer bundle their full graph up front.
       //   2. @stll/folio: the document route lazy-loads it via
       //      `await import("@stll/folio")` ($viewId.document.tsx), dragging in
       //      the prosemirror family + jszip + fast-xml-parser, none of which
@@ -146,6 +150,10 @@ export default defineConfig(({ mode }) => {
         "@better-auth/core/error",
         "@better-auth/core/utils/error-codes",
         "@better-auth/core/utils/string",
+        "better-auth/react",
+        "better-auth/client",
+        "better-auth/client/plugins",
+        "@better-auth/oauth-provider/client",
         "@better-fetch/fetch",
         "defu",
         "nanostores",


### PR DESCRIPTION
## Problem

The `authenticated routes render without browser errors` e2e (`route-smoke.spec.ts`) intermittently fails at the `/chat/workspaces/$workspaceId/new` step: the page renders **blank**, `<main>` never mounts, and the assertion times out at 30s.

## Root cause (from the failing run's trace)

- The Playwright trace shows a TanStack Router **`<MatchInnerImpl>` render error** with an empty thrown value (`name:''`, `message:'undefined'`) — a rejected dynamic import — and a blank-page screenshot.
- `api.log` is **empty** on the run: the backend never errors. This is the signature, already documented in `vite.config.ts`, of the **dev server re-optimizing mid-test** (a late dep discovery forces a full-page reload that tears the page down before it paints).
- `src/lib/auth.ts` statically imports the better-auth client entrypoints (`better-auth/react`, `better-auth/client`, `better-auth/client/plugins`, `@better-auth/oauth-provider/client`), but their **runtime-only** deep subpaths (e.g. the multi-tab session `broadcast-channel`) are not statically reachable. The cold crawl misses them, so the first protected route that actually runs the auth client triggers a late optimize pass. Under a heavy route — `/chat/.../new` pulls in `@stll/folio` + the ProseMirror family — the reload lands while that large graph is loading and blanks the page.
- In the failing trace, `better-auth` was served as **~1,782 raw module requests** instead of a pre-bundled chunk, confirming it was never optimized in the cold pass.

## Fix

List the better-auth client entrypoints in `optimizeDeps.include` so the optimizer bundles their full graph (including the runtime-only subpaths) up front, exactly as already done for folio/ProseMirror/better-fetch. All four resolve to real browser client ESM entrypoints.

**Dev-only:** production uses Rollup and ignores `optimizeDeps`, so there is no production/runtime behavior change. The real validation is this PR's own `e2e` job, which runs against a cold dev server.