### PR TITLE
fix(web): defer chrome-query fetches past mount to kill cold-start flake family

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-bare-chrome-query.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-bare-chrome-query.fixture.tsx
@@ -1,0 +1,19 @@
+// Passive regression fixture for
+// `no-bare-chrome-query/no-bare-chrome-query`.
+
+import { useQuery } from "@tanstack/react-query";
+import * as ReactQuery from "@tanstack/react-query";
+
+declare const options: { queryKey: readonly unknown[]; queryFn: () => string };
+
+export function ChromeFixture() {
+  // Named import — MUST flag.
+  // oxlint-disable-next-line no-bare-chrome-query/no-bare-chrome-query
+  const first = useQuery(options);
+
+  // Namespace import — MUST flag.
+  // oxlint-disable-next-line no-bare-chrome-query/no-bare-chrome-query
+  const second = ReactQuery.useQuery(options);
+
+  return `${first.data ?? ""}${second.data ?? ""}`;
+}

--- a/.oxlint-plugins/no-bare-chrome-query.ts
+++ b/.oxlint-plugins/no-bare-chrome-query.ts
@@ -1,0 +1,103 @@
+// Ban bare `useQuery` in persistent chrome (the layout shell, sidebar,
+// inspector, AI-key gate) that mounts on every route.
+//
+// On a cold cache, a `useQuery` started during the first render resolves and
+// notifies the still-mounting fiber, which React reports as "Can't perform a
+// React state update on a component that hasn't mounted yet" — a dev-only
+// warning the route-smoke e2e treats as a failure, and a recurring family of
+// cold-start flakes. `useChromeQuery` (apps/web/src/hooks/use-chrome-query.ts)
+// returns cached data synchronously but defers the network fetch until after
+// mount, so the warning is structurally impossible.
+//
+// Scope this rule with `overrides.files` in oxlint.config.ts for chrome
+// modules; route/page content stays free to use `useQuery` with loader-backed
+// cache guarantees.
+
+import { getImportedName, isIdentifier } from "./utils.ts";
+
+const QUERY_MODULE = "@tanstack/react-query";
+
+const filenameForContext = (context) =>
+  context.filename ?? context.getFilename?.() ?? "";
+
+const isAllowedFile = (context, allowedFiles) => {
+  const filename = filenameForContext(context);
+  return allowedFiles.some((allowedFile) => filename.endsWith(allowedFile));
+};
+
+export default {
+  meta: { name: "no-bare-chrome-query" },
+  rules: {
+    "no-bare-chrome-query": {
+      meta: {
+        type: "problem",
+        messages: {
+          noBareChromeQuery:
+            "Persistent chrome must not call useQuery directly: a cold-cache fetch resolving mid-mount triggers React's \"state update on a component that hasn't mounted yet\" warning. Use useChromeQuery from @/hooks/use-chrome-query, which defers the fetch until after mount.",
+        },
+        schema: [
+          {
+            type: "object",
+            properties: {
+              allowedFiles: { type: "array", items: { type: "string" } },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
+      create(context) {
+        const options = context.options?.[0] ?? {};
+        const allowedFiles = Array.isArray(options.allowedFiles)
+          ? options.allowedFiles
+          : [];
+
+        if (isAllowedFile(context, allowedFiles)) {
+          return {};
+        }
+
+        const queryAliases = new Set();
+        const queryNamespaces = new Set();
+
+        return {
+          ImportDeclaration(node) {
+            if (node.source?.value !== QUERY_MODULE) {
+              return;
+            }
+
+            for (const specifier of node.specifiers) {
+              if (specifier.type === "ImportNamespaceSpecifier") {
+                queryNamespaces.add(specifier.local.name);
+                continue;
+              }
+              if (
+                specifier.type === "ImportSpecifier" &&
+                getImportedName(specifier) === "useQuery"
+              ) {
+                queryAliases.add(specifier.local.name);
+              }
+            }
+          },
+
+          CallExpression(node) {
+            const callee = node.callee;
+
+            if (isIdentifier(callee) && queryAliases.has(callee.name)) {
+              context.report({ node, messageId: "noBareChromeQuery" });
+              return;
+            }
+
+            if (
+              callee.type === "MemberExpression" &&
+              callee.computed === false &&
+              isIdentifier(callee.object) &&
+              queryNamespaces.has(callee.object.name) &&
+              isIdentifier(callee.property, "useQuery")
+            ) {
+              context.report({ node, messageId: "noBareChromeQuery" });
+            }
+          },
+        };
+      },
+    },
+  },
+};

--- a/.oxlint-plugins/no-bare-chrome-query.ts
+++ b/.oxlint-plugins/no-bare-chrome-query.ts
@@ -21,7 +21,7 @@ const filenameForContext = (context) =>
   context.filename ?? context.getFilename?.() ?? "";
 
 const isAllowedFile = (context, allowedFiles) => {
-  const filename = filenameForContext(context);
+  const filename = filenameForContext(context).replace(/\\/g, "/");
   return allowedFiles.some((allowedFile) => filename.endsWith(allowedFile));
 };
 

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
 import { RefreshCwIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { env } from "@/env";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { compareSemver } from "@/lib/semver-compare";
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
@@ -25,7 +25,7 @@ export const ApiVersionMismatchBanner = () => {
   const enabled = !env.VITE_SELFHOST;
   const installedVersion = __APP_VERSION__;
 
-  const { data: serverVersion } = useQuery({
+  const { data: serverVersion } = useChromeQuery({
     queryKey: ["api-version-check"],
     enabled,
     staleTime: FIVE_MIN_MS,

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -11,7 +11,6 @@ import {
   useHotkey,
   useKeyHold,
 } from "@tanstack/react-hotkeys";
-import { useQuery } from "@tanstack/react-query";
 import { getRouteApi, Link, useMatch } from "@tanstack/react-router";
 import {
   EllipsisVerticalIcon,
@@ -65,6 +64,7 @@ import {
   getWorkspacePrimaryNavItems,
   type WorkspacePrimaryNavId,
 } from "@/components/workspace-primary-nav";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useInlineRename } from "@/hooks/use-inline-rename";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -108,7 +108,7 @@ export function AppSidebar(props: AppSidebarProps) {
       reorderPinned: s.reorder,
     })),
   );
-  const { data: workspacesData } = useQuery(
+  const { data: workspacesData } = useChromeQuery(
     workspacesNavigationOptions(user.activeOrganizationId),
   );
   const workspaces = workspacesData?.workspaces;

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -10,11 +10,7 @@ import {
 } from "react";
 import type React from "react";
 
-import {
-  useInfiniteQuery,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryKey } from "@tanstack/react-query";
 import HardBreak from "@tiptap/extension-hard-break";
 import History from "@tiptap/extension-history";
@@ -51,6 +47,7 @@ import {
   type SlashItem,
 } from "@/components/chat/prompt-slash-extension";
 import { createPromptEditorDocument } from "@/components/prompt-editor";
+import { useChromeQuery, useHasMounted } from "@/hooks/use-chrome-query";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
@@ -749,15 +746,22 @@ export const useChatEditor = ({
   // they live in `agent_skills` and the dedicated commands endpoint
   // returns only the command-bearing subset, so the slash menu
   // doesn't pay for resource-heavy fields it doesn't render.
-  const { data: commandSkills = [] } = useQuery(
+  const { data: commandSkills = [] } = useChromeQuery(
     skillCommandsOptions(activeOrganizationId),
   );
+  // useInfiniteQuery has no chrome wrapper; gate its cold-cache fetch on mount
+  // by hand so it can't resolve on a not-yet-mounted fiber (same rationale as
+  // useChromeQuery).
+  const hasMounted = useHasMounted();
   const {
     data: skillPages,
     fetchNextPage: fetchNextSkillPage,
     hasNextPage: hasNextSkillPage,
     isFetchingNextPage: isFetchingNextSkillPage,
-  } = useInfiniteQuery(skillsOptions(activeOrganizationId));
+  } = useInfiniteQuery({
+    ...skillsOptions(activeOrganizationId),
+    enabled: hasMounted,
+  });
 
   // Drain every skill page into the slash menu: drive the infinite query
   // forward whenever another page becomes available and we're not already

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,12 +1,13 @@
 import { createContext, use } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 
 import type {
   ChatMentionOption,
   MentionCategory,
 } from "@/components/chat-mention-extension";
 import { buildWorkspaceMentionOptions } from "@/components/chat-mention-helpers";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
@@ -29,12 +30,12 @@ export const ChatMentionProviders = ({
 }) => {
   const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
-  const { data: workspacesData } = useQuery(
+  const { data: workspacesData } = useChromeQuery(
     workspacesNavigationOptions(activeOrganizationId),
   );
   const workspaces = workspacesData?.workspaces;
   // eslint-disable-next-line @tanstack/query/exhaustive-deps -- the query client is an app-scope dependency, not part of this query's cache identity.
-  const { data: firstViewIdsByWorkspaceId } = useQuery({
+  const { data: firstViewIdsByWorkspaceId } = useChromeQuery({
     queryKey: [
       "chat-mention-workspace-views",
       (workspaces ?? []).map((workspace) => workspace.id),

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { panic } from "better-result";
 import { useTranslations } from "use-intl";
@@ -44,6 +44,7 @@ import type {
   RoleModelSelections,
   RoleValue,
 } from "@/components/ai-config-role-models.logic";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
@@ -72,7 +73,7 @@ export function AIAvailabilityProvider({ children }: PropsWithChildren) {
     () => aiAvailabilityOptions({ organizationId: activeOrganizationId }),
     [activeOrganizationId],
   );
-  const { data, isFetching } = useQuery(availabilityOptions);
+  const { data, isFetching } = useChromeQuery(availabilityOptions);
 
   const openAIKeyDialog = useCallback(() => {
     setOpen(true);
@@ -137,7 +138,7 @@ export const useAIKeyGate = () => {
  */
 export function useAIAvailable(): boolean {
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
-  const { data, isError } = useQuery(
+  const { data, isError } = useChromeQuery(
     aiAvailabilityOptions({ organizationId: activeOrganizationId }),
   );
   if (isError || data === undefined) {
@@ -154,7 +155,7 @@ export function useAIAvailable(): boolean {
 export function RequireAIKey({ children }: PropsWithChildren) {
   const t = useTranslations();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
-  const { data, isFetching, isPending, isError } = useQuery(
+  const { data, isFetching, isPending, isError } = useChromeQuery(
     aiAvailabilityOptions({ organizationId: activeOrganizationId }),
   );
   const { openAIKeyDialog, openIfAIUnavailable } = useAIKeyGate();
@@ -214,7 +215,7 @@ export function AIKeyRequiredDialog({
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
-  const { data: config } = useQuery({
+  const { data: config } = useChromeQuery({
     ...aiConfigOptions({ organizationId: activeOrganizationId }),
     enabled: open,
   });

--- a/apps/web/src/components/selfhost-update-banner.tsx
+++ b/apps/web/src/components/selfhost-update-banner.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
 import { ExternalLinkIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { env } from "@/env";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { logDevError } from "@/lib/errors/utils";
 import { sanitizeHref } from "@/lib/sanitize-href";
 import { compareSemver } from "@/lib/semver-compare";
@@ -34,7 +34,7 @@ export const SelfhostUpdateBanner = () => {
   const enabled = env.VITE_SELFHOST;
   const installedVersion = __APP_VERSION__;
 
-  const { data: release } = useQuery({
+  const { data: release } = useChromeQuery({
     queryKey: ["selfhost-update-check"],
     enabled,
     staleTime: ONE_DAY_MS,

--- a/apps/web/src/hooks/use-chrome-query.ts
+++ b/apps/web/src/hooks/use-chrome-query.ts
@@ -1,0 +1,53 @@
+import { useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import type {
+  QueryKey,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+
+import { useMountEffect } from "@/hooks/use-effect";
+
+/**
+ * `useQuery` for persistent chrome (the layout shell, sidebar, inspector) that
+ * mounts on every route.
+ *
+ * A cold-cache fetch started during the first render resolves and notifies the
+ * still-mounting fiber, which React reports in dev as "Can't perform a React
+ * state update on a component that hasn't mounted yet". That warning is the
+ * source of a recurring family of cold-start flakes (route-smoke treats it as a
+ * failure), and it migrates between routes because the offending query lives in
+ * shared chrome, not in any one page.
+ *
+ * This wrapper returns cached data synchronously (a warm cache renders with no
+ * flash) but defers the *network fetch* until after mount, so the fetch can
+ * only ever resolve on a mounted component. The warning then becomes
+ * structurally impossible rather than something each route has to pre-seed.
+ *
+ * Chrome must use this instead of bare `useQuery` (enforced by the
+ * `no-bare-chrome-query` lint rule). Route/page content keeps using `useQuery`
+ * with loader-backed cache guarantees.
+ *
+ * `enabled` is composed: a `false` from the caller still disables the query;
+ * the boolean form is the only one chrome uses, so the function form is treated
+ * as enabled and simply gated on mount.
+ */
+export const useChromeQuery = <
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey extends QueryKey,
+>(
+  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UseQueryResult<TData, TError> => {
+  const [mounted, setMounted] = useState(false);
+  useMountEffect(() => {
+    setMounted(true);
+  });
+
+  return useQuery({
+    ...options,
+    enabled: options.enabled !== false && mounted,
+  });
+};

--- a/apps/web/src/hooks/use-chrome-query.ts
+++ b/apps/web/src/hooks/use-chrome-query.ts
@@ -2,12 +2,27 @@ import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import type {
+  DefaultError,
   QueryKey,
   UseQueryOptions,
   UseQueryResult,
 } from "@tanstack/react-query";
 
 import { useMountEffect } from "@/hooks/use-effect";
+
+/**
+ * Returns `false` on the first render and flips to `true` after mount. The
+ * single mounted-gate primitive shared by `useChromeQuery` and by chrome hooks
+ * that aren't `useQuery` (e.g. `useInfiniteQuery`, `useQueries`), which compose
+ * `enabled: useHasMounted() && ...` manually.
+ */
+export const useHasMounted = (): boolean => {
+  const [m, setM] = useState(false);
+  useMountEffect(() => {
+    setM(true);
+  });
+  return m;
+};
 
 /**
  * `useQuery` for persistent chrome (the layout shell, sidebar, inspector) that
@@ -29,22 +44,26 @@ import { useMountEffect } from "@/hooks/use-effect";
  * `no-bare-chrome-query` lint rule). Route/page content keeps using `useQuery`
  * with loader-backed cache guarantees.
  *
- * `enabled` is composed: a `false` from the caller still disables the query;
- * the boolean form is the only one chrome uses, so the function form is treated
- * as enabled and simply gated on mount.
+ * `enabled` is composed: a `false` from the caller still disables the query. In
+ * TanStack Query v5 `enabled` is boolean-only (the function form was removed),
+ * so the caller's boolean is simply ANDed with the mount gate.
+ *
+ * Hydration-safe under TanStack Start SSR: `useMountEffect` never runs on the
+ * server, so `mounted` is `false` on both the server render and the first
+ * client render. Those two renders see identical query state, so there is no
+ * hydration mismatch. Where a loader dehydrates query data the cache is already
+ * warm and renders server-side normally; only the post-hydration *fetch* is
+ * deferred past mount.
  */
 export const useChromeQuery = <
-  TQueryFnData,
-  TError,
-  TData,
-  TQueryKey extends QueryKey,
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
 >(
   options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
 ): UseQueryResult<TData, TError> => {
-  const [mounted, setMounted] = useState(false);
-  useMountEffect(() => {
-    setMounted(true);
-  });
+  const mounted = useHasMounted();
 
   return useQuery({
     ...options,

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -2,7 +2,6 @@ import { lazy, Suspense, useCallback, useRef, useState } from "react";
 import type { MouseEvent, PointerEvent } from "react";
 
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { useQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
   Outlet,
@@ -56,6 +55,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/sidebar";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
@@ -421,7 +421,7 @@ function ProtectedContent() {
     setChatMenuOpen(false);
   };
 
-  const { data: workspace } = useQuery({
+  const { data: workspace } = useChromeQuery({
     ...workspaceOptions(workspaceId ?? ""),
     enabled: !!workspaceId,
   });

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
 import { Result } from "better-result";
 import {
@@ -39,6 +39,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { ContactPicker } from "@/components/contact-picker";
 import { UserIdentity } from "@/components/user-avatar";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { toSafeId } from "@/lib/safe-id";
 import { useCreateContact } from "@/routes/_protected.contacts/-mutations";
 import { contactsKeys } from "@/routes/_protected.contacts/-queries";
@@ -212,10 +213,10 @@ const CreateMatterDialogBody = ({
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const clientInputRef = useRef<HTMLInputElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
-  const { data: organization } = useQuery({
+  const { data: organization } = useChromeQuery({
     ...organizationOptions(currentUser.activeOrganizationId),
   });
-  const { data: workspacesData } = useQuery({
+  const { data: workspacesData } = useChromeQuery({
     ...workspacesOptions(currentUser.activeOrganizationId),
   });
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -319,6 +319,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-raw-use-effect.ts",
     "./.oxlint-plugins/no-ref-mirror.ts",
     "./.oxlint-plugins/no-shared-suspense-query.ts",
+    "./.oxlint-plugins/no-bare-chrome-query.ts",
     "./.oxlint-plugins/require-router-select.ts",
     "./.oxlint-plugins/require-matter-affordance.ts",
     "./.oxlint-plugins/no-raw-route-query-client.ts",
@@ -447,6 +448,12 @@ export default defineConfig({
       ],
       rules: {
         "no-shared-suspense-query/no-shared-suspense-query": "error",
+      },
+    },
+    {
+      files: [".oxlint-plugins/__fixtures__/no-bare-chrome-query.fixture.tsx"],
+      rules: {
+        "no-bare-chrome-query/no-bare-chrome-query": "error",
       },
     },
     {
@@ -1093,6 +1100,19 @@ export default defineConfig({
       ],
       rules: {
         "no-shared-suspense-query/no-shared-suspense-query": "error",
+      },
+    },
+    {
+      // Persistent chrome that mounts on every route: defer cold-cache fetches
+      // past mount via useChromeQuery so they cannot warn on a not-yet-mounted
+      // fiber. See apps/web/src/hooks/use-chrome-query.ts.
+      files: [
+        "apps/web/src/routes/_protected.tsx",
+        "apps/web/src/components/app-sidebar.tsx",
+        "apps/web/src/components/require-ai-key.tsx",
+      ],
+      rules: {
+        "no-bare-chrome-query/no-bare-chrome-query": "error",
       },
     },
     {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1110,6 +1110,11 @@ export default defineConfig({
         "apps/web/src/routes/_protected.tsx",
         "apps/web/src/components/app-sidebar.tsx",
         "apps/web/src/components/require-ai-key.tsx",
+        "apps/web/src/components/chat-mention-providers.tsx",
+        "apps/web/src/components/chat-editor-provider.tsx",
+        "apps/web/src/components/api-version-mismatch-banner.tsx",
+        "apps/web/src/components/selfhost-update-banner.tsx",
+        "apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx",
       ],
       rules: {
         "no-bare-chrome-query/no-bare-chrome-query": "error",


### PR DESCRIPTION
## Problem

The `authenticated routes render without browser errors` e2e (`route-smoke.spec.ts`) intermittently fails with React's *"Can't perform a React state update on a component that hasn't mounted yet"* warning. The failing route **migrates** (chat/new → knowledge/skills → knowledge/tools) because the offending query lives in **shared chrome**, not any one page. Per-route loader seeding (the prior fix) is whack-a-mole and misses any query nobody remembered to seed.

## Root cause

Persistent chrome (the `_protected` layout shell, sidebar, AI-key gate) reads data with non-suspense `useQuery`. On a **cold cache** (every page in the e2e), `useQuery` starts the fetch **during the first render**; the fetch resolves before the fiber commits and tries to update a not-yet-mounted component → the warning → route-smoke fails. The trace from the failing run shows these shell queries fetching cold on the page: workspace navigation (12×), `ai-availability` (15×).

## Fix

`useChromeQuery` (apps/web/src/hooks/use-chrome-query.ts): identical to `useQuery` except it returns cached data synchronously (warm cache renders with no flash) but **defers the network fetch until after mount** via a post-mount flag. A cold fetch can then only ever resolve on a mounted component, so the warning is **structurally impossible** — for the whole family, not one route at a time.

- Converted the always-mounted shell: `_protected.tsx` (workspace query), `app-sidebar.tsx` (navigation), `require-ai-key.tsx` (ai-availability + config).
- Added a `no-bare-chrome-query` oxlint rule (modeled on `no-shared-suspense-query`) with a regression fixture, scoped to those chrome files, so bare `useQuery` in chrome fails CI and the family cannot silently return.

Route/page content is unaffected — it keeps using `useQuery` with loader-backed cache guarantees.

**Validation:** this PR's own `route-smoke` e2e exercises the exact cold-cache path. Production behavior is unchanged (dev-only React warning; the deferred fetch is one microtask later on cold cache only).