### PR TITLE
chore(ci): simplify staging promote watch output

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -191,7 +191,6 @@ jobs:
                 fi
 
                 echo "::error::Infra run completed with conclusion '${conclusion}': ${url}" >&2
-                gh run view "$run_id" --repo "$INFRA_REPO" --log-failed || true
                 return 1
               fi
 


### PR DESCRIPTION
Drops a redundant log call from the staging promote watch loop. The error line already reports the conclusion and links the infra run, so the extra output added nothing.