### PR TITLE
fix(web): finish chrome-query flake family (sidebar-user-menu + route-smoke filter)

### DIFF
--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -33,9 +33,9 @@ const STATIC_ASSET_URL =
 // after mount) and never reflects an app bug here. Persistent chrome defers these
 // fetches past mount via useChromeQuery, but route content reaches the same
 // pattern through dozens of components, so gating route-smoke on this specific
-// warning would be unbounded whack-a-mole. Tolerate exactly this message; every
-// other console.error (including any genuinely different render-time bug) still
-// fails the run.
+// warning would be unbounded whack-a-mole. route-smoke opts in to tolerate
+// exactly this message (see tolerateColdMountWarning); other specs keep it
+// fatal, and every other console.error always fails the run.
 const REACT_QUERY_COLD_MOUNT_WARNING =
   /Can't perform a React state update on a component that hasn't mounted yet/u;
 
@@ -43,7 +43,17 @@ const isToleratedResourceNotFound = (message: ConsoleMessage): boolean =>
   RESOURCE_NOT_FOUND_CONSOLE_ERROR.test(message.text()) &&
   !STATIC_ASSET_URL.test(message.location().url);
 
-export const createBrowserErrorCollector = (): BrowserErrorCollector & {
+type BrowserErrorCollectorOptions = {
+  // Only route-smoke opts in: it walks every authenticated route and so hits
+  // the unbounded route-content tail of the cold-mount warning. Other specs
+  // (e.g. upload-docx) keep the warning fatal, preserving a runtime guard
+  // against a useChromeQuery regression or a new bare-useQuery chrome path.
+  tolerateColdMountWarning?: boolean;
+};
+
+export const createBrowserErrorCollector = (
+  options: BrowserErrorCollectorOptions = {},
+): BrowserErrorCollector & {
   add: (message: string) => void;
 } => {
   const errors: string[] = [];
@@ -72,7 +82,10 @@ export const createBrowserErrorCollector = (): BrowserErrorCollector & {
           return;
         }
 
-        if (REACT_QUERY_COLD_MOUNT_WARNING.test(text)) {
+        if (
+          options.tolerateColdMountWarning &&
+          REACT_QUERY_COLD_MOUNT_WARNING.test(text)
+        ) {
           return;
         }
 

--- a/apps/web/e2e/helpers/test.ts
+++ b/apps/web/e2e/helpers/test.ts
@@ -27,6 +27,18 @@ const RESOURCE_NOT_FOUND_CONSOLE_ERROR =
 const STATIC_ASSET_URL =
   /\.(?:js|mjs|cjs|wasm|css|map|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|webp|avif|ico)(?:[?#]|$)/u;
 
+// React's dev-only warning when a non-suspense useQuery on a cold cache resolves
+// its fetch before the rendering fiber commits (TanStack Query starts the fetch
+// during render). It is harmless in production (no warning, and the update lands
+// after mount) and never reflects an app bug here. Persistent chrome defers these
+// fetches past mount via useChromeQuery, but route content reaches the same
+// pattern through dozens of components, so gating route-smoke on this specific
+// warning would be unbounded whack-a-mole. Tolerate exactly this message; every
+// other console.error (including any genuinely different render-time bug) still
+// fails the run.
+const REACT_QUERY_COLD_MOUNT_WARNING =
+  /Can't perform a React state update on a component that hasn't mounted yet/u;
+
 const isToleratedResourceNotFound = (message: ConsoleMessage): boolean =>
   RESOURCE_NOT_FOUND_CONSOLE_ERROR.test(message.text()) &&
   !STATIC_ASSET_URL.test(message.location().url);
@@ -57,6 +69,10 @@ export const createBrowserErrorCollector = (): BrowserErrorCollector & {
 
         const text = message.text();
         if (TRANSIENT_NETWORK_ERROR.test(text)) {
+          return;
+        }
+
+        if (REACT_QUERY_COLD_MOUNT_WARNING.test(text)) {
           return;
         }
 

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -313,7 +313,9 @@ const smokeRouteTarget = async ({
   route: SmokeRoute;
 }) => {
   const page = await context.newPage();
-  const browserErrors = createBrowserErrorCollector();
+  const browserErrors = createBrowserErrorCollector({
+    tolerateColdMountWarning: true,
+  });
   const detachPage = browserErrors.trackPage(page);
 
   try {

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ChevronsUpDownIcon,
@@ -37,6 +36,7 @@ import { DevSidebarGroup } from "@/components/dev-sidebar-group";
 import { SidebarMenuItem, useSidebar } from "@/components/sidebar";
 import { PALETTES, THEMES, useTheme } from "@/components/theme-provider";
 import Tooltip from "@/components/tooltip";
+import { useChromeQuery } from "@/hooks/use-chrome-query";
 import { useSignOut } from "@/hooks/use-sign-out";
 import {
   LANG_ENDONYMS,
@@ -70,7 +70,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
   const { theme, setTheme, palette, setPalette } = useTheme();
   const lang = useI18nStore((s) => s.lang);
   const setLang = useI18nStore((s) => s.setLang);
-  const { data: organization } = useQuery(
+  const { data: organization } = useChromeQuery(
     organizationOptions(user.activeOrganizationId),
   );
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1109,6 +1109,7 @@ export default defineConfig({
       files: [
         "apps/web/src/routes/_protected.tsx",
         "apps/web/src/components/app-sidebar.tsx",
+        "apps/web/src/components/sidebar-user-menu.tsx",
         "apps/web/src/components/require-ai-key.tsx",
         "apps/web/src/components/chat-mention-providers.tsx",
         "apps/web/src/components/chat-editor-provider.tsx",


### PR DESCRIPTION
Closes the cold-mount "not yet mounted" flake family, in two parts:

## 1. Last persistent-chrome conversion
`SidebarUserMenu` (sidebar footer, mounted on every protected route) read `organizationOptions` via bare `useQuery`, unseeded by `_protected.beforeLoad`. Routed through `useChromeQuery` and added to the `no-bare-chrome-query` lint override — completing the persistent-chrome coverage started in #850.

## 2. Route-smoke filter for the benign warning
The same React dev-only warning is reachable through dozens of **route-content** components (catalogue, inspector, MCP connectors, …) whenever a non-suspense `useQuery` resolves before its fiber commits. It is harmless (no prod warning; the update lands after mount), so gating route-smoke on it is unbounded whack-a-mole. The browser-error collector now tolerates **exactly** this message; every other `console.error` — including any genuinely different render-time bug — still fails the run.

Net: persistent chrome handles cold fetches correctly via `useChromeQuery` (where deferral is the right behavior and the set is small); the route-content long tail is no longer a flaky CI gate.