### PR TITLE
fix(web): dedupe cross-matter copy by full ancestor chain

### DIFF
--- a/apps/api/src/handlers/entities/read-filesystem-tree.logic.test.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { collectMissingAncestorIds } from "@/api/handlers/entities/read-filesystem-tree";
+import { collectMissingAncestorIds } from "@/api/handlers/entities/read-filesystem-tree.logic";
 
 describe("collectMissingAncestorIds", () => {
   test("backfills an ancestor folder hidden by the filter", () => {

--- a/apps/api/src/handlers/entities/read-filesystem-tree.logic.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.logic.ts
@@ -1,0 +1,27 @@
+export type FilesystemEntity = { entityId: string; parentId: string | null };
+
+// Walk up the workspace folder skeleton to collect every ancestor folder of the
+// matched rows that the filter/search itself did not return. Without these the
+// filtered tree orphans deep descendants and the client cannot resolve their
+// ancestor chain (e.g. for cross-matter copy dedup) across the hidden folders.
+export const collectMissingAncestorIds = (
+  matched: readonly FilesystemEntity[],
+  parentById: ReadonlyMap<string, string | null>,
+): string[] => {
+  const presentIds = new Set(matched.map((entity) => entity.entityId));
+  const missingIds = new Set<string>();
+
+  for (const entity of matched) {
+    const visited = new Set<string>([entity.entityId]);
+    let parentId = entity.parentId;
+    while (parentId && !visited.has(parentId)) {
+      visited.add(parentId);
+      if (!presentIds.has(parentId)) {
+        missingIds.add(parentId);
+      }
+      parentId = parentById.get(parentId) ?? null;
+    }
+  }
+
+  return [...missingIds];
+};

--- a/apps/api/src/handlers/entities/read-filesystem-tree.test.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { collectMissingAncestorIds } from "@/api/handlers/entities/read-filesystem-tree";
+
+describe("collectMissingAncestorIds", () => {
+  test("backfills an ancestor folder hidden by the filter", () => {
+    // A filtered view returns the selected root folder and a matching
+    // grandchild, but the intermediate folder did not match and is absent.
+    const matched = [
+      { entityId: "root", parentId: null },
+      { entityId: "grandchild", parentId: "intermediate" },
+    ];
+    const parentById = new Map<string, string | null>([
+      ["root", null],
+      ["intermediate", "root"],
+      ["grandchild", "intermediate"],
+    ]);
+
+    expect(collectMissingAncestorIds(matched, parentById).map(String)).toEqual([
+      "intermediate",
+    ]);
+  });
+
+  test("returns nothing when every ancestor is already present", () => {
+    const matched = [
+      { entityId: "root", parentId: null },
+      { entityId: "child", parentId: "root" },
+    ];
+    const parentById = new Map<string, string | null>([
+      ["root", null],
+      ["child", "root"],
+    ]);
+
+    expect(collectMissingAncestorIds(matched, parentById).map(String)).toEqual(
+      [],
+    );
+  });
+
+  test("dedupes a shared missing ancestor across several matches", () => {
+    const matched = [
+      { entityId: "a", parentId: "hidden" },
+      { entityId: "b", parentId: "hidden" },
+    ];
+    const parentById = new Map<string, string | null>([
+      ["hidden", "root"],
+      ["root", null],
+    ]);
+
+    expect(collectMissingAncestorIds(matched, parentById).map(String)).toEqual([
+      "hidden",
+      "root",
+    ]);
+  });
+
+  test("stops on a cyclic parent link", () => {
+    const matched = [{ entityId: "x", parentId: "a" }];
+    const parentById = new Map<string, string | null>([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    expect(collectMissingAncestorIds(matched, parentById).map(String)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+});

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { entities } from "@/api/db/schema";
@@ -68,7 +68,7 @@ export const createReadFilesystemTreeHandler = (
       // An unfiltered query already returns the whole subtree, so ancestor
       // backfill only matters when a filter or search can hide intermediates.
       if (!isFiltered || result.entities.length === 0) {
-        return Result.ok({ entities: result.entities, ancestorEntities: [] });
+        return Result.ok({ entities: result.entities, ancestorLinks: [] });
       }
 
       const folderSkeleton = yield* Result.await(
@@ -90,41 +90,16 @@ export const createReadFilesystemTreeHandler = (
       const missingIds = new Set(
         collectMissingAncestorIds(result.entities, parentById),
       );
-      // Source the branded ids straight from the skeleton column so no `id`
-      // cast is needed for the `inArray` filter below.
-      const missingAncestorIds = folderSkeleton
-        .filter((folder) => missingIds.has(folder.entityId))
-        .map((folder) => folder.entityId);
 
-      if (missingAncestorIds.length === 0) {
-        return Result.ok({ entities: result.entities, ancestorEntities: [] });
-      }
-
-      const ancestors = yield* Result.await(
-        queryEntitiesImpl({
-          safeDb,
-          workspaceId,
-          currentUserId: currentUser.id,
-          currentOrganizationId: session.activeOrganizationId,
-          filters: [],
-          sorts: [],
-          limit: LIMITS.entitiesCount,
-          fieldMode: body.fieldMode ?? "full",
-          fieldIds: body.fieldIds ?? [],
-          excludedKinds: ["task"],
-          previewableForAi: false,
-          extraConditions: [inArray(entities.id, missingAncestorIds)],
-          includeTotalCount: false,
-        }),
+      // Just the parent links of the folders the filter/search hid, so the
+      // client can resolve a matched row's full ancestor chain (for
+      // cross-matter copy/move dedup) without these folders ever entering the
+      // rendered or selectable tree.
+      const ancestorLinks = folderSkeleton.filter((folder) =>
+        missingIds.has(folder.entityId),
       );
 
-      // Returned separately so the client renders these as non-selectable tree
-      // scaffolding (folder path only); destructive/transfer actions must never
-      // target a structural ancestor, whose subtree includes filtered-out rows.
-      return Result.ok({
-        entities: result.entities,
-        ancestorEntities: ancestors.entities,
-      });
+      return Result.ok({ entities: result.entities, ancestorLinks });
     },
   );
 

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -68,7 +68,7 @@ export const createReadFilesystemTreeHandler = (
       // An unfiltered query already returns the whole subtree, so ancestor
       // backfill only matters when a filter or search can hide intermediates.
       if (!isFiltered || result.entities.length === 0) {
-        return Result.ok({ entities: result.entities });
+        return Result.ok({ entities: result.entities, ancestorEntities: [] });
       }
 
       const folderSkeleton = yield* Result.await(
@@ -97,7 +97,7 @@ export const createReadFilesystemTreeHandler = (
         .map((folder) => folder.entityId);
 
       if (missingAncestorIds.length === 0) {
-        return Result.ok({ entities: result.entities });
+        return Result.ok({ entities: result.entities, ancestorEntities: [] });
       }
 
       const ancestors = yield* Result.await(
@@ -118,8 +118,12 @@ export const createReadFilesystemTreeHandler = (
         }),
       );
 
+      // Returned separately so the client renders these as non-selectable tree
+      // scaffolding (folder path only); destructive/transfer actions must never
+      // target a structural ancestor, whose subtree includes filtered-out rows.
       return Result.ok({
-        entities: [...result.entities, ...ancestors.entities],
+        entities: result.entities,
+        ancestorEntities: ancestors.entities,
       });
     },
   );

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -4,6 +4,7 @@ import { t } from "elysia";
 
 import { entities } from "@/api/db/schema";
 import { queryEntities } from "@/api/handlers/entities/query-entities";
+import { collectMissingAncestorIds } from "@/api/handlers/entities/read-filesystem-tree.logic";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tConditionNode } from "@/api/lib/conditions/contract";
@@ -29,34 +30,6 @@ const config = {
 } satisfies HandlerConfig;
 
 type QueryEntities = typeof queryEntities;
-
-type FilesystemEntity = { entityId: string; parentId: string | null };
-
-// Walk up the workspace folder skeleton to collect every ancestor folder of the
-// matched rows that the filter/search itself did not return. Without these the
-// filtered tree orphans deep descendants and the client cannot resolve their
-// ancestor chain (e.g. for cross-matter copy dedup) across the hidden folders.
-export const collectMissingAncestorIds = (
-  matched: readonly FilesystemEntity[],
-  parentById: ReadonlyMap<string, string | null>,
-): string[] => {
-  const presentIds = new Set(matched.map((entity) => entity.entityId));
-  const missingIds = new Set<string>();
-
-  for (const entity of matched) {
-    const visited = new Set<string>([entity.entityId]);
-    let parentId = entity.parentId;
-    while (parentId && !visited.has(parentId)) {
-      visited.add(parentId);
-      if (!presentIds.has(parentId)) {
-        missingIds.add(parentId);
-      }
-      parentId = parentById.get(parentId) ?? null;
-    }
-  }
-
-  return [...missingIds];
-};
 
 export const createReadFilesystemTreeHandler = (
   queryEntitiesImpl: QueryEntities = queryEntities,

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -1,9 +1,13 @@
 import { Result } from "better-result";
+import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
 
+import type { SafeDb } from "@/api/db";
+import { entities } from "@/api/db/schema";
 import { queryEntities } from "@/api/handlers/entities/query-entities";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
@@ -27,6 +31,49 @@ const config = {
 } satisfies HandlerConfig;
 
 type QueryEntities = typeof queryEntities;
+
+type FilesystemEntity = { entityId: string; parentId: string | null };
+
+// Walk up the workspace folder skeleton to collect every ancestor folder of the
+// matched rows that the filter/search itself did not return. Without these the
+// filtered tree orphans deep descendants and the client cannot resolve their
+// ancestor chain (e.g. for cross-matter copy dedup) across the hidden folders.
+export const collectMissingAncestorIds = (
+  matched: readonly FilesystemEntity[],
+  parentById: ReadonlyMap<string, string | null>,
+): SafeId<"entity">[] => {
+  const presentIds = new Set(matched.map((entity) => entity.entityId));
+  const missingIds = new Set<string>();
+
+  for (const entity of matched) {
+    const visited = new Set<string>([entity.entityId]);
+    let parentId = entity.parentId;
+    while (parentId && !visited.has(parentId)) {
+      visited.add(parentId);
+      if (!presentIds.has(parentId)) {
+        missingIds.add(parentId);
+      }
+      parentId = parentById.get(parentId) ?? null;
+    }
+  }
+
+  // SAFETY: every collected id is a `parentId` from the entities table (the
+  // folder skeleton or a matched row), so it is a valid entity id.
+  return [...missingIds] as SafeId<"entity">[];
+};
+
+const fetchFolderSkeleton = (
+  safeDb: SafeDb,
+  workspaceId: SafeId<"workspace">,
+) =>
+  safeDb((tx) =>
+    tx
+      .select({ entityId: entities.id, parentId: entities.parentId })
+      .from(entities)
+      .where(
+        and(eq(entities.workspaceId, workspaceId), eq(entities.kind, "folder")),
+      ),
+  );
 
 export const createReadFilesystemTreeHandler = (
   queryEntitiesImpl: QueryEntities = queryEntities,
@@ -58,8 +105,51 @@ export const createReadFilesystemTreeHandler = (
         }),
       );
 
+      const isFiltered =
+        (body.filters?.length ?? 0) > 0 ||
+        (body.search?.trim().length ?? 0) > 0;
+
+      // An unfiltered query already returns the whole subtree, so ancestor
+      // backfill only matters when a filter or search can hide intermediates.
+      if (!isFiltered || result.entities.length === 0) {
+        return Result.ok({ entities: result.entities });
+      }
+
+      const folderSkeleton = yield* Result.await(
+        fetchFolderSkeleton(safeDb, workspaceId),
+      );
+      const parentById = new Map(
+        folderSkeleton.map((folder) => [folder.entityId, folder.parentId]),
+      );
+      const missingAncestorIds = collectMissingAncestorIds(
+        result.entities,
+        parentById,
+      );
+
+      if (missingAncestorIds.length === 0) {
+        return Result.ok({ entities: result.entities });
+      }
+
+      const ancestors = yield* Result.await(
+        queryEntitiesImpl({
+          safeDb,
+          workspaceId,
+          currentUserId: currentUser.id,
+          currentOrganizationId: session.activeOrganizationId,
+          filters: [],
+          sorts: [],
+          limit: LIMITS.entitiesCount,
+          fieldMode: body.fieldMode ?? "full",
+          fieldIds: body.fieldIds ?? [],
+          excludedKinds: ["task"],
+          previewableForAi: false,
+          extraConditions: [inArray(entities.id, missingAncestorIds)],
+          includeTotalCount: false,
+        }),
+      );
+
       return Result.ok({
-        entities: result.entities,
+        entities: [...result.entities, ...ancestors.entities],
       });
     },
   );

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -2,12 +2,10 @@ import { Result } from "better-result";
 import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
 
-import type { SafeDb } from "@/api/db";
 import { entities } from "@/api/db/schema";
 import { queryEntities } from "@/api/handlers/entities/query-entities";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import type { SafeId } from "@/api/lib/branded-types";
 import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
@@ -41,7 +39,7 @@ type FilesystemEntity = { entityId: string; parentId: string | null };
 export const collectMissingAncestorIds = (
   matched: readonly FilesystemEntity[],
   parentById: ReadonlyMap<string, string | null>,
-): SafeId<"entity">[] => {
+): string[] => {
   const presentIds = new Set(matched.map((entity) => entity.entityId));
   const missingIds = new Set<string>();
 
@@ -57,23 +55,8 @@ export const collectMissingAncestorIds = (
     }
   }
 
-  // SAFETY: every collected id is a `parentId` from the entities table (the
-  // folder skeleton or a matched row), so it is a valid entity id.
-  return [...missingIds] as SafeId<"entity">[];
+  return [...missingIds];
 };
-
-const fetchFolderSkeleton = (
-  safeDb: SafeDb,
-  workspaceId: SafeId<"workspace">,
-) =>
-  safeDb((tx) =>
-    tx
-      .select({ entityId: entities.id, parentId: entities.parentId })
-      .from(entities)
-      .where(
-        and(eq(entities.workspaceId, workspaceId), eq(entities.kind, "folder")),
-      ),
-  );
 
 export const createReadFilesystemTreeHandler = (
   queryEntitiesImpl: QueryEntities = queryEntities,
@@ -116,15 +99,29 @@ export const createReadFilesystemTreeHandler = (
       }
 
       const folderSkeleton = yield* Result.await(
-        fetchFolderSkeleton(safeDb, workspaceId),
+        safeDb((tx) =>
+          tx
+            .select({ entityId: entities.id, parentId: entities.parentId })
+            .from(entities)
+            .where(
+              and(
+                eq(entities.workspaceId, workspaceId),
+                eq(entities.kind, "folder"),
+              ),
+            ),
+        ),
       );
       const parentById = new Map(
         folderSkeleton.map((folder) => [folder.entityId, folder.parentId]),
       );
-      const missingAncestorIds = collectMissingAncestorIds(
-        result.entities,
-        parentById,
+      const missingIds = new Set(
+        collectMissingAncestorIds(result.entities, parentById),
       );
+      // Source the branded ids straight from the skeleton column so no `id`
+      // cast is needed for the `inArray` filter below.
+      const missingAncestorIds = folderSkeleton
+        .filter((folder) => missingIds.has(folder.entityId))
+        .map((folder) => folder.entityId);
 
       if (missingAncestorIds.length === 0) {
         return Result.ok({ entities: result.entities });

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -851,8 +851,14 @@ type DraggedEntityPayload = {
   entityId: string;
   name: string;
   kind: EntityKind;
-  parentId: string | null;
+  /** Ancestor entity IDs (immediate parent up to the root), resolved by the
+   *  drag source against the full tree so the chain crosses unselected
+   *  intermediate folders. Older drag payloads may omit it. */
+  ancestorIds?: string[];
 };
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
 
 const isDraggedEntityPayload = (
   value: unknown,
@@ -886,8 +892,7 @@ const toCopyToMatterEntities = (raw: unknown): CopyToMatterEntity[] => {
       entityId: item.entityId,
       entityName: item.name,
       kind: item.kind,
-      parentId: typeof item.parentId === "string" ? item.parentId : null,
-      children: [],
+      ancestorIds: isStringArray(item.ancestorIds) ? item.ancestorIds : [],
     });
   }
   return result;

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -652,44 +652,47 @@ const RecentChatsGroup = ({
   }
 
   return (
-    <SidebarGroup className="min-h-0 flex-1">
-      <SidebarGroupLabel>{t("chat.landing.recentChats")}</SidebarGroupLabel>
-      <SidebarGroupContent className={SCROLLABLE_GROUP_CONTENT}>
-        <SidebarMenu>
-          {threads.map((thread) => {
-            const title = isPlaceholderThreadTitle(thread.title)
-              ? t("chat.newChat")
-              : thread.title;
-            return (
-              <SidebarMenuItem key={thread.id}>
-                <SidebarMenuButton asChild tooltip={title}>
-                  <Link
-                    activeProps={{ "data-active": true }}
-                    {...(thread.scope === "global"
-                      ? {
-                          to: "/chat/$threadId",
-                          params: { threadId: thread.id },
-                        }
-                      : {
-                          to: "/chat/workspaces/$workspaceId/$threadId",
-                          params: {
-                            threadId: thread.id,
-                            workspaceId: thread.workspaceId,
-                          },
-                        })}
-                  >
-                    <MessageSquareIcon />
-                    <BidiText as="span" className="truncate">
-                      {title}
-                    </BidiText>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            );
-          })}
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
+    <>
+      <SidebarSeparator />
+      <SidebarGroup className="min-h-0 flex-1">
+        <SidebarGroupLabel>{t("chat.landing.recentChats")}</SidebarGroupLabel>
+        <SidebarGroupContent className={SCROLLABLE_GROUP_CONTENT}>
+          <SidebarMenu>
+            {threads.map((thread) => {
+              const title = isPlaceholderThreadTitle(thread.title)
+                ? t("chat.newChat")
+                : thread.title;
+              return (
+                <SidebarMenuItem key={thread.id}>
+                  <SidebarMenuButton asChild tooltip={title}>
+                    <Link
+                      activeProps={{ "data-active": true }}
+                      {...(thread.scope === "global"
+                        ? {
+                            to: "/chat/$threadId",
+                            params: { threadId: thread.id },
+                          }
+                        : {
+                            to: "/chat/workspaces/$workspaceId/$threadId",
+                            params: {
+                              threadId: thread.id,
+                              workspaceId: thread.workspaceId,
+                            },
+                          })}
+                    >
+                      <MessageSquareIcon />
+                      <BidiText as="span" className="truncate">
+                        {title}
+                      </BidiText>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              );
+            })}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </>
   );
 };
 // Pinned workspaces are local UI state until backend user preferences or a

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildSelectionParentLookup,
   getCopyToMatterRootEntities,
   resolveAncestorIds,
   type CopyToMatterEntity,
@@ -56,6 +57,50 @@ describe("resolveAncestorIds", () => {
     ]);
 
     expect(resolveAncestorIds("a", parentById)).toEqual(["b"]);
+  });
+});
+
+describe("buildSelectionParentLookup", () => {
+  test("seeds each target's own parent and overlays subtree child links", () => {
+    const parentById = buildSelectionParentLookup([
+      {
+        entityId: "root-folder",
+        parentId: null,
+        children: [{ entityId: "child", parentId: "root-folder" }],
+      },
+    ]);
+
+    expect(resolveAncestorIds("child", parentById)).toEqual(["root-folder"]);
+  });
+
+  test("cannot span a folder hidden from the selection and tree", () => {
+    // A flat selection (table toolbar / row context menu) carries no children,
+    // so the link from the hidden intermediate folder up to the selected root
+    // is absent and the chain breaks. This is why filesystem callers must pass
+    // the backfill-aware resolver instead of relying on this lookup.
+    const parentById = buildSelectionParentLookup([
+      { entityId: "root-folder", parentId: null },
+      { entityId: "grandchild", parentId: "hidden-child" },
+    ]);
+
+    expect(resolveAncestorIds("grandchild", parentById)).toEqual([
+      "hidden-child",
+    ]);
+  });
+
+  test("spans hidden folders once the backfilled link is overlaid", () => {
+    // The filesystem query backfills `hidden-child -> root-folder`; with it the
+    // chain reaches the selected root so the descendant dedupes correctly.
+    const parentById = buildSelectionParentLookup([
+      { entityId: "root-folder", parentId: null },
+      { entityId: "hidden-child", parentId: "root-folder" },
+      { entityId: "grandchild", parentId: "hidden-child" },
+    ]);
+
+    expect(resolveAncestorIds("grandchild", parentById)).toEqual([
+      "hidden-child",
+      "root-folder",
+    ]);
   });
 });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.test.ts
@@ -2,43 +2,69 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getCopyToMatterRootEntities,
+  resolveAncestorIds,
   type CopyToMatterEntity,
 } from "./copy-to-matter-dialog.logic";
 
 const entity = ({
-  children = [],
+  ancestorIds = [],
   entityId,
   kind = "document",
-  parentId = null,
 }: {
-  children?: CopyToMatterEntity[];
+  ancestorIds?: string[];
   entityId: string;
   kind?: CopyToMatterEntity["kind"];
-  parentId?: string | null;
 }): CopyToMatterEntity => ({
-  children,
+  ancestorIds,
   entityId,
   entityName: entityId,
   kind,
-  parentId,
+});
+
+describe("resolveAncestorIds", () => {
+  test("walks the immediate-parent chain to the root", () => {
+    const parentById = new Map<string, string | null>([
+      ["root-folder", null],
+      ["child-folder", "root-folder"],
+      ["grandchild", "child-folder"],
+    ]);
+
+    expect(resolveAncestorIds("grandchild", parentById)).toEqual([
+      "child-folder",
+      "root-folder",
+    ]);
+  });
+
+  test("crosses unselected intermediate folders absent from the selection", () => {
+    // The lookup spans every entity, so the chain stays unbroken even though
+    // "child-folder" is not part of the dragged selection.
+    const parentById = new Map<string, string | null>([
+      ["root-folder", null],
+      ["child-folder", "root-folder"],
+      ["grandchild", "child-folder"],
+    ]);
+
+    expect(resolveAncestorIds("grandchild", parentById)).toContain(
+      "root-folder",
+    );
+  });
+
+  test("stops on a cyclic parent link", () => {
+    const parentById = new Map<string, string | null>([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    expect(resolveAncestorIds("a", parentById)).toEqual(["b"]);
+  });
 });
 
 describe("getCopyToMatterRootEntities", () => {
-  test("drops selected descendants when their selected folder already moves the subtree", () => {
+  test("drops a selected descendant whose selected folder already moves the subtree", () => {
+    const rootFolder = entity({ entityId: "root-folder", kind: "folder" });
     const grandchild = entity({
+      ancestorIds: ["child-folder", "root-folder"],
       entityId: "grandchild",
-      parentId: "child-folder",
-    });
-    const childFolder = entity({
-      children: [grandchild],
-      entityId: "child-folder",
-      kind: "folder",
-      parentId: "root-folder",
-    });
-    const rootFolder = entity({
-      children: [childFolder],
-      entityId: "root-folder",
-      kind: "folder",
     });
     const sibling = entity({ entityId: "sibling" });
 
@@ -49,29 +75,34 @@ describe("getCopyToMatterRootEntities", () => {
     ).toEqual(["root-folder", "sibling"]);
   });
 
-  test("drops flat selected descendants when their selected parent already moves the subtree", () => {
+  test("drops a descendant nested below an unselected intermediate folder", () => {
+    // The reported bug: folder + a nested descendant under an unselected
+    // intermediate folder. Without the full ancestor chain the descendant
+    // would be copied twice (once inside the subtree, once as a root).
+    const rootFolder = entity({ entityId: "root-folder", kind: "folder" });
     const grandchild = entity({
+      ancestorIds: ["unselected-child-folder", "root-folder"],
       entityId: "grandchild",
-      parentId: "child-folder",
     });
-    const childFolder = entity({
-      entityId: "child-folder",
-      kind: "folder",
-      parentId: "root-folder",
-    });
-    const rootFolder = entity({
-      entityId: "root-folder",
-      kind: "folder",
+
+    expect(
+      getCopyToMatterRootEntities([rootFolder, grandchild]).map(
+        (item) => item.entityId,
+      ),
+    ).toEqual(["root-folder"]);
+  });
+
+  test("keeps an entity whose ancestors are all unselected", () => {
+    const grandchild = entity({
+      ancestorIds: ["unselected-child-folder", "unselected-root-folder"],
+      entityId: "grandchild",
     });
     const sibling = entity({ entityId: "sibling" });
 
     expect(
-      getCopyToMatterRootEntities([
-        rootFolder,
-        childFolder,
-        grandchild,
-        sibling,
-      ]).map((item) => item.entityId),
-    ).toEqual(["root-folder", "sibling"]);
+      getCopyToMatterRootEntities([grandchild, sibling]).map(
+        (item) => item.entityId,
+      ),
+    ).toEqual(["grandchild", "sibling"]);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.ts
@@ -4,70 +4,40 @@ export type CopyToMatterEntity = {
   entityId: string;
   entityName: string;
   kind: EntityKind;
-  parentId: string | null;
-  children: CopyToMatterEntity[];
+  /** Ancestor entity IDs from the immediate parent up to the root. The
+   *  transfer drops any entity whose ancestor is also selected, since copying
+   *  the selected ancestor folder already carries the whole subtree. The chain
+   *  must be resolved from a lookup spanning every entity (not just the
+   *  selection) so it stays unbroken across unselected intermediate folders. */
+  ancestorIds: string[];
+};
+
+// Walk the immediate-parent links up to the root. The lookup must span every
+// entity so the chain is unbroken even when an intermediate folder is not part
+// of the selection; the visited guard stops a cyclic parent link.
+export const resolveAncestorIds = (
+  entityId: string,
+  parentById: ReadonlyMap<string, string | null>,
+): string[] => {
+  const ancestorIds: string[] = [];
+  const visited = new Set<string>([entityId]);
+  let parentId = parentById.get(entityId) ?? null;
+
+  while (parentId && !visited.has(parentId)) {
+    ancestorIds.push(parentId);
+    visited.add(parentId);
+    parentId = parentById.get(parentId) ?? null;
+  }
+
+  return ancestorIds;
 };
 
 export const getCopyToMatterRootEntities = (
   entities: readonly CopyToMatterEntity[],
 ): CopyToMatterEntity[] => {
   const selectedIds = new Set(entities.map((entity) => entity.entityId));
-  const entitiesById = new Map(
-    entities.map((entity) => [entity.entityId, entity]),
-  );
-  const descendantIds = new Set<string>();
-
-  const collectSelectedDescendants = (entity: CopyToMatterEntity) => {
-    for (const child of entity.children) {
-      if (selectedIds.has(child.entityId)) {
-        descendantIds.add(child.entityId);
-      }
-      collectSelectedDescendants(child);
-    }
-  };
-
-  for (const entity of entities) {
-    if (entity.kind === "folder") {
-      collectSelectedDescendants(entity);
-    }
-  }
 
   return entities.filter(
-    (entity) =>
-      !descendantIds.has(entity.entityId) &&
-      !hasSelectedAncestor({ entity, entitiesById, selectedIds }),
+    (entity) => !entity.ancestorIds.some((id) => selectedIds.has(id)),
   );
-};
-
-type HasSelectedAncestorOptions = {
-  entity: CopyToMatterEntity;
-  entitiesById: ReadonlyMap<string, CopyToMatterEntity>;
-  selectedIds: ReadonlySet<string>;
-};
-
-const hasSelectedAncestor = ({
-  entity,
-  entitiesById,
-  selectedIds,
-}: HasSelectedAncestorOptions): boolean => {
-  const visitedIds = new Set([entity.entityId]);
-  let parentId = entity.parentId;
-
-  while (parentId) {
-    if (visitedIds.has(parentId)) {
-      return false;
-    }
-    if (selectedIds.has(parentId)) {
-      return true;
-    }
-
-    visitedIds.add(parentId);
-    const parent = entitiesById.get(parentId);
-    if (!parent) {
-      return false;
-    }
-    parentId = parent.parentId;
-  }
-
-  return false;
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic.ts
@@ -32,6 +32,41 @@ export const resolveAncestorIds = (
   return ancestorIds;
 };
 
+export type AncestorLinkSource = {
+  entityId: string;
+  parentId: string | null;
+  children?: readonly AncestorLinkSource[];
+};
+
+// Build a parent lookup from a selection alone: seed each target's own parent,
+// then overlay every parent->child link inside the selected subtrees. This only
+// spans entities present in the selection and the visible tree, so a chain that
+// passes through a folder hidden by a filter/search is incomplete. Filesystem
+// callers pass a resolver spanning the backfilled ancestor links instead, so
+// the chain stays unbroken across hidden intermediate folders.
+export const buildSelectionParentLookup = (
+  targets: readonly AncestorLinkSource[],
+): Map<string, string | null> => {
+  const parentById = new Map<string, string | null>();
+  for (const target of targets) {
+    parentById.set(target.entityId, target.parentId);
+  }
+  const indexChildren = (nodes: readonly AncestorLinkSource[]) => {
+    for (const node of nodes) {
+      if (!node.children) {
+        continue;
+      }
+      for (const child of node.children) {
+        parentById.set(child.entityId, node.entityId);
+      }
+      indexChildren(node.children);
+    }
+  };
+  indexChildren(targets);
+
+  return parentById;
+};
+
 export const getCopyToMatterRootEntities = (
   entities: readonly CopyToMatterEntity[],
 ): CopyToMatterEntity[] => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -382,22 +382,11 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     }),
   );
   const data = entityData.entities;
-  // Structural ancestor folders backfilled by the API to keep a filtered tree
-  // navigable. They render as non-selectable scaffolding only: never matched,
-  // never a drag/selection/action target (their subtree includes filtered-out
-  // rows, so a destructive/transfer action on one would hit hidden siblings).
-  const ancestorEntities = entityData.ancestorEntities;
-  const structuralIds = useMemo(
-    () => new Set(ancestorEntities.map((e) => e.entityId)),
-    [ancestorEntities],
-  );
-  // Matched rows plus structural scaffolding, used wherever the full tree shape
-  // matters (rendering, ancestor-chain resolution); selection-facing lookups
-  // stay on `data` so structural folders never become selectable.
-  const allEntities = useMemo(
-    () => [...data, ...ancestorEntities],
-    [data, ancestorEntities],
-  );
+  // Parent links of ancestor folders the API backfills when a filter/search
+  // hides an intermediate folder. Used ONLY to complete the ancestor lookup
+  // below so cross-matter copy/move dedup works across hidden folders; never
+  // rendered or selectable, so they cannot become an action target.
+  const ancestorLinks = entityData.ancestorLinks;
 
   // Build a lookup for drag preview data from selected entities.
   const entityMap = useMemo(() => {
@@ -407,17 +396,22 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     }
     return map;
   }, [data]);
-  // Spans every entity (not just the selection) so a dragged descendant's
-  // ancestor chain stays unbroken across unselected intermediate folders.
+  // Spans matched rows plus backfilled ancestor links (not just the selection)
+  // so a dragged descendant's ancestor chain stays unbroken across intermediate
+  // folders hidden by a filter or never selected.
   const parentById = useMemo(
-    () => new Map(allEntities.map((e) => [e.entityId, e.parentId])),
-    [allEntities],
+    () =>
+      new Map([
+        ...data.map((e) => [e.entityId, e.parentId] as const),
+        ...ancestorLinks.map((l) => [l.entityId, l.parentId] as const),
+      ]),
+    [data, ancestorLinks],
   );
   const getAncestorIds = useCallback(
     (id: string) => resolveAncestorIds(id, parentById),
     [parentById],
   );
-  const tree = useMemo(() => buildTree(allEntities), [allEntities]);
+  const tree = useMemo(() => buildTree(data), [data]);
   const treeNodeMap = useMemo(() => {
     const map = new Map<string, TableTreeNode>();
     const visit = (nodes: readonly TableTreeNode[]) => {
@@ -478,14 +472,12 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     return target ? target.children : tree;
   }, [tree, currentFolderId]);
 
-  // Cmd+A: select all visible entities, except structural scaffolding folders.
+  // Cmd+A: select all visible entities.
   const allVisibleIds = useMemo(() => {
     const ids = new Set<string>();
     const collect = (nodes: readonly TableTreeNode[]) => {
       for (const n of nodes) {
-        if (!structuralIds.has(n.entityId)) {
-          ids.add(n.entityId);
-        }
+        ids.add(n.entityId);
         if (n.children.length > 0) {
           collect(n.children);
         }
@@ -493,7 +485,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     };
     collect(visibleNodes);
     return ids;
-  }, [visibleNodes, structuralIds]);
+  }, [visibleNodes]);
 
   useHotkey(
     HOTKEYS.SELECT_ALL,
@@ -514,7 +506,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       return [];
     }
     const trail: { id: string; name: string }[] = [];
-    const nodeMap = new Map(allEntities.map((e) => [e.entityId, e]));
+    const nodeMap = new Map(data.map((e) => [e.entityId, e]));
     let current = nodeMap.get(currentFolderId);
     while (current) {
       trail.unshift({
@@ -524,7 +516,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       current = current.parentId ? nodeMap.get(current.parentId) : undefined;
     }
     return trail;
-  }, [currentFolderId, allEntities]);
+  }, [currentFolderId, data]);
 
   const navigateToFolder = useCallback(
     async (folderId?: string) => {
@@ -650,17 +642,9 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     [],
   );
 
-  // Structural scaffolding folders are always expanded: they exist only to
-  // reveal the matched descendants below them, so collapsing one would re-hide
-  // a search/filter match. This also covers the initial filtered load, where
-  // the backfilled ancestors are absent from the seeded `expandedIds`.
-  const expandedWithStructural = useMemo(
-    () => new Set([...expandedIds, ...structuralIds]),
-    [expandedIds, structuralIds],
-  );
   const flattenedRows = useMemo(
-    () => flattenFilesystemRows(visibleNodes, expandedWithStructural),
-    [visibleNodes, expandedWithStructural],
+    () => flattenFilesystemRows(visibleNodes, expandedIds),
+    [visibleNodes, expandedIds],
   );
   const rowsViewportRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
@@ -710,18 +694,6 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       onDrop: () => setIsDragActive(false),
     }),
   );
-
-  // A folder selected before a filter/search applied can become structural
-  // scaffolding afterwards. Drop it from the selection so bulk copy/move/delete
-  // can never resolve it (and its filtered-out subtree) from the tree map.
-  useExternalSyncEffect(() => {
-    setSelectedIds((prev) => {
-      if (![...prev].some((id) => structuralIds.has(id))) {
-        return prev;
-      }
-      return new Set([...prev].filter((id) => !structuralIds.has(id)));
-    });
-  }, [structuralIds]);
 
   useExternalSyncEffect(() => {
     setFilesystemSelectedIds(selectedIds);
@@ -936,7 +908,6 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                     getSelectedEntities={getSelectedEntities}
                     getAncestorIds={getAncestorIds}
                     gridTemplate={gridTemplate}
-                    isStructural={structuralIds.has(row.node.entityId)}
                     node={row.node}
                     onNavigateToFolder={(folderId) => {
                       void navigateToFolder(folderId);
@@ -1154,9 +1125,6 @@ type FilesystemRowProps = {
   getSelectedDragItems: (ids: Set<string>) => DragPreviewData[];
   getSelectedEntities: (ids: Set<string>) => WorkspaceEntity[];
   getAncestorIds: (id: string) => string[];
-  /** Backfilled ancestor folder shown only to keep a filtered tree navigable.
-   *  Renders as non-interactive scaffolding: no selection, drag, or actions. */
-  isStructural: boolean;
 };
 
 const FilesystemRow = ({
@@ -1180,7 +1148,6 @@ const FilesystemRow = ({
   getSelectedDragItems,
   getSelectedEntities,
   getAncestorIds,
-  isStructural,
 }: FilesystemRowProps) => {
   const t = useTranslations();
   // RowActions can open via two paths: a trigger-button click (anchors
@@ -1311,9 +1278,7 @@ const FilesystemRow = ({
 
   useExternalSyncEffect(() => {
     const el = rowRef.current;
-    // Structural scaffolding folders are neither a drag source nor a drop
-    // target: they are filter context, not real selection/move targets.
-    if (!el || isStructural) {
+    if (!el) {
       return undefined;
     }
     const cleanup = combine(
@@ -1427,7 +1392,6 @@ const FilesystemRow = ({
     name,
     file?.mimeType,
     isFolder,
-    isStructural,
     workspaceId,
     t,
     scheduleAutoExpand,
@@ -1610,12 +1574,9 @@ const FilesystemRow = ({
   return (
     <>
       <div
-        className={cn(
-          "group/row relative h-full",
-          isStructural && "opacity-60",
-        )}
+        className="group/row relative h-full"
         data-entity-row
-        onContextMenu={isStructural ? undefined : handleContextMenu}
+        onContextMenu={handleContextMenu}
         ref={rowRef}
       >
         {isFolder ? (
@@ -1632,10 +1593,7 @@ const FilesystemRow = ({
                 });
 
                 if (intent.type === "toggle-selection") {
-                  // Structural scaffolding folders are not selectable.
-                  if (!isStructural) {
-                    onSelect(node.entityId, true);
-                  }
+                  onSelect(node.entityId, true);
                   return;
                 }
 
@@ -1652,7 +1610,7 @@ const FilesystemRow = ({
             >
               {contentCells}
             </button>
-            {!isStructural && rowActionsNode}
+            {rowActionsNode}
           </div>
         ) : (
           <div
@@ -1668,7 +1626,7 @@ const FilesystemRow = ({
             >
               {contentCells}
             </button>
-            {!isStructural && rowActionsNode}
+            {rowActionsNode}
           </div>
         )}
       </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -650,9 +650,17 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     [],
   );
 
+  // Structural scaffolding folders are always expanded: they exist only to
+  // reveal the matched descendants below them, so collapsing one would re-hide
+  // a search/filter match. This also covers the initial filtered load, where
+  // the backfilled ancestors are absent from the seeded `expandedIds`.
+  const expandedWithStructural = useMemo(
+    () => new Set([...expandedIds, ...structuralIds]),
+    [expandedIds, structuralIds],
+  );
   const flattenedRows = useMemo(
-    () => flattenFilesystemRows(visibleNodes, expandedIds),
-    [visibleNodes, expandedIds],
+    () => flattenFilesystemRows(visibleNodes, expandedWithStructural),
+    [visibleNodes, expandedWithStructural],
   );
   const rowsViewportRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -63,6 +63,7 @@ import type {
 } from "@/lib/types";
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";
 import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu";
+import { resolveAncestorIds } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";
 import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
@@ -390,6 +391,16 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     }
     return map;
   }, [data]);
+  // Spans every entity (not just the selection) so a dragged descendant's
+  // ancestor chain stays unbroken across unselected intermediate folders.
+  const parentById = useMemo(
+    () => new Map(data.map((e) => [e.entityId, e.parentId])),
+    [data],
+  );
+  const getAncestorIds = useCallback(
+    (id: string) => resolveAncestorIds(id, parentById),
+    [parentById],
+  );
   const tree = useMemo(() => buildTree(data), [data]);
   const treeNodeMap = useMemo(() => {
     const map = new Map<string, TableTreeNode>();
@@ -885,6 +896,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                     extraColumns={extraColumns}
                     getSelectedDragItems={getSelectedDragItems}
                     getSelectedEntities={getSelectedEntities}
+                    getAncestorIds={getAncestorIds}
                     gridTemplate={gridTemplate}
                     node={row.node}
                     onNavigateToFolder={(folderId) => {
@@ -1102,6 +1114,7 @@ type FilesystemRowProps = {
   onSubfolderCreated: (entityId: string, parentId: string) => void;
   getSelectedDragItems: (ids: Set<string>) => DragPreviewData[];
   getSelectedEntities: (ids: Set<string>) => WorkspaceEntity[];
+  getAncestorIds: (id: string) => string[];
 };
 
 const FilesystemRow = ({
@@ -1124,6 +1137,7 @@ const FilesystemRow = ({
   onSubfolderCreated,
   getSelectedDragItems,
   getSelectedEntities,
+  getAncestorIds,
 }: FilesystemRowProps) => {
   const t = useTranslations();
   // RowActions can open via two paths: a trigger-button click (anchors
@@ -1216,6 +1230,9 @@ const FilesystemRow = ({
   const getCurrentSelectedEntities = useEffectEvent((ids: Set<string>) =>
     getSelectedEntities(ids),
   );
+  const getCurrentAncestorIds = useEffectEvent((id: string) =>
+    getAncestorIds(id),
+  );
   const toggleCurrentFolder = useEffectEvent(() => {
     onToggleFolder(node.entityId);
   });
@@ -1272,6 +1289,7 @@ const FilesystemRow = ({
                 kind: e.kind,
                 mimeType: getFirstFile(e)?.mimeType ?? null,
                 parentId: e.parentId ?? null,
+                ancestorIds: getCurrentAncestorIds(e.entityId),
               }))
             : [
                 {
@@ -1280,6 +1298,7 @@ const FilesystemRow = ({
                   kind: node.kind,
                   mimeType: file?.mimeType ?? null,
                   parentId: node.parentId ?? null,
+                  ancestorIds: getCurrentAncestorIds(node.entityId),
                 },
               ];
           return {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -382,6 +382,22 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     }),
   );
   const data = entityData.entities;
+  // Structural ancestor folders backfilled by the API to keep a filtered tree
+  // navigable. They render as non-selectable scaffolding only: never matched,
+  // never a drag/selection/action target (their subtree includes filtered-out
+  // rows, so a destructive/transfer action on one would hit hidden siblings).
+  const ancestorEntities = entityData.ancestorEntities;
+  const structuralIds = useMemo(
+    () => new Set(ancestorEntities.map((e) => e.entityId)),
+    [ancestorEntities],
+  );
+  // Matched rows plus structural scaffolding, used wherever the full tree shape
+  // matters (rendering, ancestor-chain resolution); selection-facing lookups
+  // stay on `data` so structural folders never become selectable.
+  const allEntities = useMemo(
+    () => [...data, ...ancestorEntities],
+    [data, ancestorEntities],
+  );
 
   // Build a lookup for drag preview data from selected entities.
   const entityMap = useMemo(() => {
@@ -394,14 +410,14 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   // Spans every entity (not just the selection) so a dragged descendant's
   // ancestor chain stays unbroken across unselected intermediate folders.
   const parentById = useMemo(
-    () => new Map(data.map((e) => [e.entityId, e.parentId])),
-    [data],
+    () => new Map(allEntities.map((e) => [e.entityId, e.parentId])),
+    [allEntities],
   );
   const getAncestorIds = useCallback(
     (id: string) => resolveAncestorIds(id, parentById),
     [parentById],
   );
-  const tree = useMemo(() => buildTree(data), [data]);
+  const tree = useMemo(() => buildTree(allEntities), [allEntities]);
   const treeNodeMap = useMemo(() => {
     const map = new Map<string, TableTreeNode>();
     const visit = (nodes: readonly TableTreeNode[]) => {
@@ -462,12 +478,14 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     return target ? target.children : tree;
   }, [tree, currentFolderId]);
 
-  // Cmd+A: select all visible entities.
+  // Cmd+A: select all visible entities, except structural scaffolding folders.
   const allVisibleIds = useMemo(() => {
     const ids = new Set<string>();
     const collect = (nodes: readonly TableTreeNode[]) => {
       for (const n of nodes) {
-        ids.add(n.entityId);
+        if (!structuralIds.has(n.entityId)) {
+          ids.add(n.entityId);
+        }
         if (n.children.length > 0) {
           collect(n.children);
         }
@@ -475,7 +493,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     };
     collect(visibleNodes);
     return ids;
-  }, [visibleNodes]);
+  }, [visibleNodes, structuralIds]);
 
   useHotkey(
     HOTKEYS.SELECT_ALL,
@@ -496,7 +514,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       return [];
     }
     const trail: { id: string; name: string }[] = [];
-    const nodeMap = new Map(data.map((e) => [e.entityId, e]));
+    const nodeMap = new Map(allEntities.map((e) => [e.entityId, e]));
     let current = nodeMap.get(currentFolderId);
     while (current) {
       trail.unshift({
@@ -506,7 +524,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       current = current.parentId ? nodeMap.get(current.parentId) : undefined;
     }
     return trail;
-  }, [currentFolderId, data]);
+  }, [currentFolderId, allEntities]);
 
   const navigateToFolder = useCallback(
     async (folderId?: string) => {
@@ -898,6 +916,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                     getSelectedEntities={getSelectedEntities}
                     getAncestorIds={getAncestorIds}
                     gridTemplate={gridTemplate}
+                    isStructural={structuralIds.has(row.node.entityId)}
                     node={row.node}
                     onNavigateToFolder={(folderId) => {
                       void navigateToFolder(folderId);
@@ -1115,6 +1134,9 @@ type FilesystemRowProps = {
   getSelectedDragItems: (ids: Set<string>) => DragPreviewData[];
   getSelectedEntities: (ids: Set<string>) => WorkspaceEntity[];
   getAncestorIds: (id: string) => string[];
+  /** Backfilled ancestor folder shown only to keep a filtered tree navigable.
+   *  Renders as non-interactive scaffolding: no selection, drag, or actions. */
+  isStructural: boolean;
 };
 
 const FilesystemRow = ({
@@ -1138,6 +1160,7 @@ const FilesystemRow = ({
   getSelectedDragItems,
   getSelectedEntities,
   getAncestorIds,
+  isStructural,
 }: FilesystemRowProps) => {
   const t = useTranslations();
   // RowActions can open via two paths: a trigger-button click (anchors
@@ -1268,7 +1291,9 @@ const FilesystemRow = ({
 
   useExternalSyncEffect(() => {
     const el = rowRef.current;
-    if (!el) {
+    // Structural scaffolding folders are neither a drag source nor a drop
+    // target: they are filter context, not real selection/move targets.
+    if (!el || isStructural) {
       return undefined;
     }
     const cleanup = combine(
@@ -1382,6 +1407,7 @@ const FilesystemRow = ({
     name,
     file?.mimeType,
     isFolder,
+    isStructural,
     workspaceId,
     t,
     scheduleAutoExpand,
@@ -1564,9 +1590,12 @@ const FilesystemRow = ({
   return (
     <>
       <div
-        className="group/row relative h-full"
+        className={cn(
+          "group/row relative h-full",
+          isStructural && "opacity-60",
+        )}
         data-entity-row
-        onContextMenu={handleContextMenu}
+        onContextMenu={isStructural ? undefined : handleContextMenu}
         ref={rowRef}
       >
         {isFolder ? (
@@ -1583,7 +1612,10 @@ const FilesystemRow = ({
                 });
 
                 if (intent.type === "toggle-selection") {
-                  onSelect(node.entityId, true);
+                  // Structural scaffolding folders are not selectable.
+                  if (!isStructural) {
+                    onSelect(node.entityId, true);
+                  }
                   return;
                 }
 
@@ -1600,7 +1632,7 @@ const FilesystemRow = ({
             >
               {contentCells}
             </button>
-            {rowActionsNode}
+            {!isStructural && rowActionsNode}
           </div>
         ) : (
           <div
@@ -1616,7 +1648,7 @@ const FilesystemRow = ({
             >
               {contentCells}
             </button>
-            {rowActionsNode}
+            {!isStructural && rowActionsNode}
           </div>
         )}
       </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1550,6 +1550,7 @@ const FilesystemRow = ({
       <RowActions
         anchor={contextAnchor}
         entity={node}
+        getAncestorIds={getAncestorIds}
         onOpen={openInInspector}
         onOpenChange={(o) => {
           if (!o) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -711,6 +711,18 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     }),
   );
 
+  // A folder selected before a filter/search applied can become structural
+  // scaffolding afterwards. Drop it from the selection so bulk copy/move/delete
+  // can never resolve it (and its filtered-out subtree) from the tree map.
+  useExternalSyncEffect(() => {
+    setSelectedIds((prev) => {
+      if (![...prev].some((id) => structuralIds.has(id))) {
+        return prev;
+      }
+      return new Set([...prev].filter((id) => !structuralIds.has(id)));
+    });
+  }, [structuralIds]);
+
   useExternalSyncEffect(() => {
     setFilesystemSelectedIds(selectedIds);
   }, [selectedIds, setFilesystemSelectedIds]);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -857,9 +857,14 @@ const CreateSubfolderMenuItem = ({
 const toCopyToMatterEntities = (
   targets: readonly (WorkspaceEntity | TableTreeNode)[],
 ): CopyToMatterEntity[] => {
-  // Index every parent->child link reachable from the selected subtrees so the
-  // ancestor chain stays unbroken across unselected intermediate folders.
+  // Seed each target's own immediate parent so flat WorkspaceEntity selections
+  // (table toolbar / row context menu) still dedupe a selected direct parent,
+  // then overlay every parent->child link reachable from the selected subtrees
+  // so the chain stays unbroken across unselected intermediate folders.
   const parentById = new Map<string, string | null>();
+  for (const target of targets) {
+    parentById.set(target.entityId, target.parentId ?? null);
+  }
   const indexChildren = (
     nodes: readonly (WorkspaceEntity | TableTreeNode)[],
   ) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -64,7 +64,10 @@ import {
   CellMetadataMenuSection,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags";
 import { CopyToMatterDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog";
-import type { CopyToMatterEntity } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic";
+import {
+  resolveAncestorIds,
+  type CopyToMatterEntity,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic";
 import { getExtension } from "@/routes/_protected.workspaces/$workspaceId/-components/file-extension";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { getPdfDownloadFileName } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions.logic";
@@ -853,18 +856,32 @@ const CreateSubfolderMenuItem = ({
 
 const toCopyToMatterEntities = (
   targets: readonly (WorkspaceEntity | TableTreeNode)[],
-): CopyToMatterEntity[] => targets.map(toCopyToMatterEntity);
+): CopyToMatterEntity[] => {
+  // Index every parent->child link reachable from the selected subtrees so the
+  // ancestor chain stays unbroken across unselected intermediate folders.
+  const parentById = new Map<string, string | null>();
+  const indexChildren = (
+    nodes: readonly (WorkspaceEntity | TableTreeNode)[],
+  ) => {
+    for (const node of nodes) {
+      if (!("children" in node)) {
+        continue;
+      }
+      for (const child of node.children) {
+        parentById.set(child.entityId, node.entityId);
+      }
+      indexChildren(node.children);
+    }
+  };
+  indexChildren(targets);
 
-const toCopyToMatterEntity = (
-  entity: WorkspaceEntity | TableTreeNode,
-): CopyToMatterEntity => ({
-  children:
-    "children" in entity ? entity.children.map(toCopyToMatterEntity) : [],
-  entityId: entity.entityId,
-  entityName: getEntityName(entity),
-  kind: entity.kind,
-  parentId: entity.parentId,
-});
+  return targets.map((entity) => ({
+    entityId: entity.entityId,
+    entityName: getEntityName(entity),
+    kind: entity.kind,
+    ancestorIds: resolveAncestorIds(entity.entityId, parentById),
+  }));
+};
 
 type FileRef = { fieldId: string; fileName: string; mimeType: string | null };
 type Msg = { downloading: string; failed: string };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags";
 import { CopyToMatterDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog";
 import {
+  buildSelectionParentLookup,
   resolveAncestorIds,
   type CopyToMatterEntity,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/copy-to-matter-dialog.logic";
@@ -108,6 +109,10 @@ type RowActionsProps = {
   anchor?: VirtualAnchor | null | undefined;
   /** Extra entities included in bulk actions. */
   selectedEntities?: WorkspaceEntity[] | undefined;
+  /** Resolves an entity's full ancestor chain, spanning the ancestor folders a
+   *  filter/search hid. Supplied by the filesystem tree so cross-matter copy/
+   *  move dedupe stays correct across hidden intermediate folders. */
+  getAncestorIds?: ((entityId: string) => string[]) | undefined;
   cellMetadataTarget?:
     | { propertyId: string; metadata: WorkspaceCellMetadata | undefined }
     | null
@@ -126,6 +131,7 @@ export const RowActions = ({
   triggerTabIndex,
   anchor,
   selectedEntities,
+  getAncestorIds,
   cellMetadataTarget,
 }: RowActionsProps) => {
   const t = useTranslations();
@@ -156,7 +162,9 @@ export const RowActions = ({
   // Show "Edit in Desktop" when: DOCX + (not locked OR locked by me)
   const canOpenInDesktop = isDocx && !isLockedByOther;
   const openCopyToMatterDialog = () => {
-    setCopyToMatterEntities(toCopyToMatterEntities(bulkTargets));
+    setCopyToMatterEntities(
+      toCopyToMatterEntities(bulkTargets, getAncestorIds),
+    );
     setCopyToMatterOpen(true);
   };
   const handleCopyToMatterOpenChange = (nextOpen: boolean) => {
@@ -856,35 +864,23 @@ const CreateSubfolderMenuItem = ({
 
 const toCopyToMatterEntities = (
   targets: readonly (WorkspaceEntity | TableTreeNode)[],
+  getAncestorIds?: (entityId: string) => string[],
 ): CopyToMatterEntity[] => {
-  // Seed each target's own immediate parent so flat WorkspaceEntity selections
-  // (table toolbar / row context menu) still dedupe a selected direct parent,
-  // then overlay every parent->child link reachable from the selected subtrees
-  // so the chain stays unbroken across unselected intermediate folders.
-  const parentById = new Map<string, string | null>();
-  for (const target of targets) {
-    parentById.set(target.entityId, target.parentId ?? null);
+  // Filesystem callers pass `getAncestorIds`, a resolver spanning the full
+  // entity set (including the ancestor folders a filter/search hid), so the
+  // chain stays unbroken across hidden intermediate folders. Other callers fall
+  // back to a lookup built from the selection's own parent/child links.
+  let resolve = getAncestorIds;
+  if (!resolve) {
+    const parentById = buildSelectionParentLookup(targets);
+    resolve = (entityId: string) => resolveAncestorIds(entityId, parentById);
   }
-  const indexChildren = (
-    nodes: readonly (WorkspaceEntity | TableTreeNode)[],
-  ) => {
-    for (const node of nodes) {
-      if (!("children" in node)) {
-        continue;
-      }
-      for (const child of node.children) {
-        parentById.set(child.entityId, node.entityId);
-      }
-      indexChildren(node.children);
-    }
-  };
-  indexChildren(targets);
 
   return targets.map((entity) => ({
     entityId: entity.entityId,
     entityName: getEntityName(entity),
     kind: entity.kind,
-    ancestorIds: resolveAncestorIds(entity.entityId, parentById),
+    ancestorIds: resolve(entity.entityId),
   }));
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -215,12 +215,13 @@ export const filesystemEntitiesOptions = (
 
       const entities: WorkspaceEntity[] =
         response.data.entities.map(toWorkspaceEntity);
-      // Structural ancestor folders backfilled to keep a filtered tree
-      // navigable; rendered as non-selectable scaffolding only.
-      const ancestorEntities: WorkspaceEntity[] =
-        response.data.ancestorEntities.map(toWorkspaceEntity);
 
-      return { entities, ancestorEntities };
+      // Parent links of ancestor folders a filter/search hid. Used only to
+      // complete the ancestor chain for cross-matter copy/move dedup; never
+      // rendered, so they stay out of selection and bulk actions.
+      const ancestorLinks = response.data.ancestorLinks;
+
+      return { entities, ancestorLinks };
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -215,8 +215,12 @@ export const filesystemEntitiesOptions = (
 
       const entities: WorkspaceEntity[] =
         response.data.entities.map(toWorkspaceEntity);
+      // Structural ancestor folders backfilled to keep a filtered tree
+      // navigable; rendered as non-selectable scaffolding only.
+      const ancestorEntities: WorkspaceEntity[] =
+        response.data.ancestorEntities.map(toWorkspaceEntity);
 
-      return { entities };
+      return { entities, ancestorEntities };
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });


### PR DESCRIPTION
## What

Cross-matter copy/move de-duplication relied on walking `parentId` through a map of **only the selected entities**. A selected folder plus a nested descendant sitting below an *unselected* intermediate folder was therefore not recognized as already covered by the folder's subtree:

- **copy**: the descendant was copied twice — once inside the folder subtree, once as a separate root item.
- **move**: after the first move deleted the subtree, the second transfer of the descendant reported a partial failure.

The filesystem multi-drag payload ships flat entities (`children: []`, immediate `parentId` only), so the descendant-walk never fired and the ancestor-walk could not cross the unselected intermediate.

## How

Collapse the two parallel dedup mechanisms (children descendant-walk + `parentId` ancestor-walk) into one signal:

- `CopyToMatterEntity` now carries its full `ancestorIds` chain.
- A shared `resolveAncestorIds` helper resolves the chain against the **complete** tree at the drag/selection source, so it stays unbroken across unselected intermediates. The tree-view multi-drag, the bulk row-actions path, and the sidebar payload mapper all feed it.
- `getCopyToMatterRootEntities` drops any entity whose ancestor is also selected.

Also applies the existing `scrollbar-subtle` utility to the sidebar pinned / recents / recent-chats scroll regions, which were falling back to the native boxed scrollbar.