### PR TITLE
fix(web): sync inline color-scheme on manual theme override

### DIFF
--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -110,6 +110,12 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
       const resolved = resolveTheme(theme);
       const restore = suppressTransitions();
       root.classList.toggle("dark", resolved === "dark");
+      // Override the inline color-scheme/background the pre-paint init script
+      // (dark-mode-init.js) may have set; inline styles win over the CSS
+      // `html { color-scheme }` rule, so without this a dark->light override
+      // would leave native scrollbars and form controls painted dark.
+      root.style.colorScheme = resolved;
+      root.style.removeProperty("background-color");
       setResolvedTheme(resolved);
       restore();
     };

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -114,7 +114,7 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
       // (dark-mode-init.js) may have set; inline styles win over the CSS
       // `html { color-scheme }` rule, so without this a dark->light override
       // would leave native scrollbars and form controls painted dark.
-      root.style.colorScheme = resolved;
+      root.style.setProperty("color-scheme", resolved);
       root.style.removeProperty("background-color");
       setResolvedTheme(resolved);
       restore();


### PR DESCRIPTION
The pre-paint init script (`dark-mode-init.js`) sets an inline `color-scheme: dark` and dark `background-color` on `<html>` when dark mode is active. Inline styles win over the CSS `html { color-scheme: light }` rule, so switching to a manual light override — which only toggled the `.dark` class — left the inline `color-scheme: dark` in place. Native UI painted by `color-scheme` (scrollbars, form controls) stayed dark in light mode.

`updateTheme()` now syncs the inline `color-scheme` to the resolved theme and clears the anti-flash inline `background-color`.