### PR TITLE
fix(api): make social account-linking policy explicit (trust Google + Microsoft)

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -200,6 +200,20 @@ const createAuth = () => {
       ...(env.EXTENSION_ORIGIN ? [env.EXTENSION_ORIGIN] : []),
     ],
     disabledPaths: ["/token"],
+    account: {
+      // Make the social-to-existing-account linking policy explicit rather
+      // than relying on library defaults. A social sign-in links to an
+      // existing same-email account only for providers we trust to assert
+      // the signed-in identity actually owns that email. Google asserts a
+      // verified email for consumer and Workspace addresses. Microsoft Entra
+      // omits the email_verified claim by default, so it must be listed
+      // explicitly for tenant SSO users to link instead of erroring
+      // account_not_linked; this is bounded to the single configured tenant.
+      accountLinking: {
+        enabled: true,
+        trustedProviders: ["google", "microsoft"],
+      },
+    },
     user: {
       additionalFields: {
         timezoneId: {


### PR DESCRIPTION
## What

Adds an explicit `account.accountLinking` block to the Better Auth config:

```ts
account: {
  accountLinking: {
    enabled: true,
    trustedProviders: ["google", "microsoft"],
  },
},
```

Previously there was no `accountLinking` config, so library defaults applied implicitly. With defaults, a social sign-in onto an existing same-email account is refused (`account_not_linked`) when the provider does not assert a verified email. Google asserts `email_verified` for consumer and Workspace addresses, so it already links; **Microsoft Entra omits the `email_verified` claim by default**, so SSO users could not link to their existing account. Trusting it explicitly fixes the Microsoft path, and is bounded to the single configured tenant.

## Why

- Makes the account-linking policy explicit and auditable instead of an implicit library default.
- Unblocks Microsoft Entra SSO users from linking to an existing same-email account.

## Scope note

`trustedProviders` only governs the *provider*-verified-email check. It does **not** relax the separate requirement that the *existing local user* be email-verified before a social account links to it — that guard is intentionally left in place (account-takeover protection). So this is the durable policy fix, not a blanket loosening.

CC on behalf of @jan-kubica