### PR TITLE
fix(web): align collapsed inspector rail footprint to 48px

### DIFF
--- a/apps/web/src/components/inspector-side-panel.tsx
+++ b/apps/web/src/components/inspector-side-panel.tsx
@@ -175,7 +175,7 @@ const LazyInspectorPanel = lazy(
 // the lazy chunk fetch. Buttons are inert; they activate once the
 // real panel mounts.
 const InspectorRailFallback = () => (
-  <div className="bg-background flex h-full border-s shadow-lg">
+  <div className="bg-background flex h-full shadow-lg">
     <div className={SIDE_RAIL_CONTAINER_CLASS}>
       <div
         aria-hidden="true"

--- a/apps/web/src/components/inspector/inspector-panel.tsx
+++ b/apps/web/src/components/inspector/inspector-panel.tsx
@@ -424,7 +424,7 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
   });
 
   return (
-    <div className="bg-background flex h-full shadow-lg md:border-s">
+    <div className="bg-background flex h-full shadow-lg">
       <div className="hidden md:contents">
         <InspectorRail
           activeId={activeId}

--- a/apps/web/src/lib/consts.ts
+++ b/apps/web/src/lib/consts.ts
@@ -71,9 +71,16 @@ export const TOOLBAR_ROW_HEIGHT_PX = 48 as const;
 export const SIDE_RAIL_WIDTH = "w-12" as const;
 /** Outer container classes for the inspector icon rail. The lazy-load
  * fallback rail must stay pixel-identical to the real rail, so both
- * read this single source instead of repeating the string. */
+ * read this single source instead of repeating the string.
+ *
+ * The divider lives on the rail's content-facing side (`border-s`) and
+ * is included in its `w-12` box, mirroring the collapsed left sidebar
+ * (whose 48px box already includes its own `border-e`). Drawing it here
+ * instead of on an outer wrapper keeps the rail's full footprint at
+ * exactly 48px; an extra wrapper border would push the box to 49px and
+ * overflow the slot by a pixel. */
 export const SIDE_RAIL_CONTAINER_CLASS =
-  `bg-sidebar flex shrink-0 flex-col border-e ${SIDE_RAIL_WIDTH}` as const;
+  `bg-sidebar flex shrink-0 flex-col border-s ${SIDE_RAIL_WIDTH}` as const;
 export const SIDE_RAIL_ICON_BUTTON_SIZE = "size-8" as const;
 /** Glyph size inside a rail tab button — matches the `size-3.5`
  * class every built-in rail icon uses. Numeric form is for

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -391,7 +391,7 @@ function PublicInspectorRail({
         )}
       >
         <div className="bg-sidebar flex h-full w-full flex-col">
-          <div className="bg-background flex h-full border-s shadow-lg">
+          <div className="bg-background flex h-full shadow-lg">
             <div className={SIDE_RAIL_CONTAINER_CLASS}>
               {railButton({
                 icon: <PanelRightIcon className="size-4" />,


### PR DESCRIPTION
The collapsed inspector rail rendered a full `w-12` (48px) box plus a 1px
`border-s` on an outer wrapper, inside a 48px slot — so its real footprint was
49px and overflowed the slot by a pixel, pushing the rail's `border-e` off the
viewport edge and leaving the toast / find-replace right-offset CSS var (`48px`)
a pixel short of the visible rail.

Move the divider onto the rail's content-facing side (`border-s`, inside its
`w-12` box) and drop the redundant outer wrapper border, mirroring the collapsed
left sidebar — whose 48px box already includes its own `border-e`. The rail's
full footprint is now exactly 48px, the offset var is pixel-accurate, and the
two collapsed rails are symmetric.

Applied to all three right-side rail consumers: the inspector panel, its
lazy-load fallback, and the public law shell.
