### PR TITLE
fix(web): center chat stop/send icon

### DIFF
--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -216,13 +216,13 @@ const ChatSubmitButton = ({
       >
         <SquareIcon
           className={cn(
-            "absolute inset-0 size-full transition-[opacity,transform] duration-150 ease-out",
+            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
             isStop ? "scale-100 opacity-100" : "scale-75 opacity-0",
           )}
         />
         <ArrowUpIcon
           className={cn(
-            "absolute inset-0 size-full transition-[opacity,transform] duration-150 ease-out",
+            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
             isStop ? "scale-75 opacity-0" : "scale-100 opacity-100",
           )}
         />


### PR DESCRIPTION
The chat composer's submit button overlays its stop/send icons with `absolute inset-0 size-full`. The `Button` base style applies `[&_svg]:-mx-0.5` to every descendant SVG, which offsets these absolutely-positioned icons ~2px off-center instead of just tightening inline spacing.

Add `mx-0!` to both icons to cancel the inherited negative margin so the square/arrow sit centered.