### PR TITLE
fix(api): build the server without minification

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,10 +36,10 @@ RUN bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lo
 FROM deps AS builder
 ENV NODE_ENV=production
 COPY --from=pruner /app/out/full/ .
+# Build the server unminified: `bun build --minify` can break Elysia's AOT
+# handler codegen (minified variable renames vs Sucrose). See elysiajs/elysia#1711.
 RUN bun build \
     --compile \
-    --minify-whitespace \
-    --minify-syntax \
     --target bun \
     --outfile /app/server \
     apps/api/src/index.ts


### PR DESCRIPTION
Build the API server binary without minification.

`bun build --minify` can break Elysia's AOT handler codegen (minified variable renames vs Sucrose's source parsing): https://github.com/elysiajs/elysia/issues/1711

This makes the prod build match what dev already runs (AOT on, unminified source). The server stays a `--compile` Bun binary, just slightly larger. No version bump.