### PR TITLE
feat(landing): show only feature releases in hero update chip

### DIFF
--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -12,6 +12,18 @@ export type ChangelogRelease = {
 const CHANGELOG_DIR = resolveRepoPath("docs", "changelog");
 const STABLE_CHANGELOG_FILE_PATTERN = /^v\d+\.\d+\.\d+\.md$/u;
 
+export type ReleaseKind = "major" | "minor" | "patch";
+
+export const getReleaseKind = (tagName: string): ReleaseKind => {
+  const [, minor, patch] = tagName.replace(/^v/u, "").split(".").map(Number);
+
+  if (patch !== 0) {
+    return "patch";
+  }
+
+  return minor === 0 ? "major" : "minor";
+};
+
 export const releaseAnchorId = (tagName: string) =>
   tagName
     .toLowerCase()
@@ -52,6 +64,11 @@ export const getChangelogReleases = (): ChangelogRelease[] => {
     right.tagName.localeCompare(left.tagName, "en", { numeric: true }),
   );
 };
+
+export const getLatestFeatureRelease = (): ChangelogRelease | undefined =>
+  getChangelogReleases().find(
+    (release) => getReleaseKind(release.tagName) !== "patch",
+  );
 
 const findHeading = (markdown: string, level: 1 | 2) => {
   const marker = "#".repeat(level);

--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -32,43 +32,46 @@ export const releaseAnchorId = (tagName: string) =>
     .replace(/-+/gu, "-")
     .replace(/^-|-$/gu, "");
 
-export const getChangelogReleases = (): ChangelogRelease[] => {
+const listReleaseTags = (): string[] => {
   if (!existsSync(CHANGELOG_DIR)) {
     return [];
   }
 
-  const releases: ChangelogRelease[] = [];
-
-  for (const fileName of readdirSync(CHANGELOG_DIR)) {
-    if (!STABLE_CHANGELOG_FILE_PATTERN.test(fileName)) {
-      continue;
-    }
-
-    const tagName = fileName.replace(/\.md$/u, "");
-    const markdown = readFileSync(path.join(CHANGELOG_DIR, fileName), "utf-8");
-    const heading = findHeading(markdown, 1);
-    const description =
-      findHeading(markdown, 2) ??
-      `Release notes for ${formatReleaseName(tagName)}.`;
-
-    releases.push({
-      description,
-      displayName: formatReleaseName(tagName),
-      heading,
-      slug: releaseAnchorId(tagName),
-      tagName,
-    });
-  }
-
-  return releases.sort((left, right) =>
-    right.tagName.localeCompare(left.tagName, "en", { numeric: true }),
-  );
+  return readdirSync(CHANGELOG_DIR)
+    .filter((fileName) => STABLE_CHANGELOG_FILE_PATTERN.test(fileName))
+    .map((fileName) => fileName.replace(/\.md$/u, ""))
+    .sort((left, right) => right.localeCompare(left, "en", { numeric: true }));
 };
 
-export const getLatestFeatureRelease = (): ChangelogRelease | undefined =>
-  getChangelogReleases().find(
-    (release) => getReleaseKind(release.tagName) !== "patch",
+const readRelease = (tagName: string): ChangelogRelease => {
+  const markdown = readFileSync(
+    path.join(CHANGELOG_DIR, `${tagName}.md`),
+    "utf-8",
   );
+  const heading = findHeading(markdown, 1);
+  const description =
+    findHeading(markdown, 2) ??
+    `Release notes for ${formatReleaseName(tagName)}.`;
+
+  return {
+    description,
+    displayName: formatReleaseName(tagName),
+    heading,
+    slug: releaseAnchorId(tagName),
+    tagName,
+  };
+};
+
+export const getChangelogReleases = (): ChangelogRelease[] =>
+  listReleaseTags().map(readRelease);
+
+export const getLatestFeatureRelease = (): ChangelogRelease | undefined => {
+  const tagName = listReleaseTags().find(
+    (tag) => getReleaseKind(tag) !== "patch",
+  );
+
+  return tagName ? readRelease(tagName) : undefined;
+};
 
 const findHeading = (markdown: string, level: 1 | 2) => {
   const marker = "#".repeat(level);

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -4,9 +4,9 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 import GitHubIcon from "../components/GitHubIcon.astro";
 import ProductShowcase from "../components/react/ProductShowcase";
 import { controlCapabilities } from "../data/capabilities";
-import { getChangelogReleases } from "../lib/changelog";
+import { getLatestFeatureRelease } from "../lib/changelog";
 
-const latestRelease = getChangelogReleases().at(0);
+const latestRelease = getLatestFeatureRelease();
 
 const appUrl = "https://my.stll.app";
 const discordUrl = "https://discord.gg/8dZjmVFjTK";


### PR DESCRIPTION
The hero update chip linked to the changelog surfaced the newest release of any kind, including patch/maintenance releases. It now shows the latest feature release (major or minor) instead.

- Add `getReleaseKind(tagName)` classifying `vX.Y.Z` tags as `major` / `minor` / `patch`.
- Add `getLatestFeatureRelease()` returning the newest non-patch release.
- Hero chip uses `getLatestFeatureRelease()`; the full `/changelog` page is unchanged and still lists every release.

The chip template already guards an undefined release, so the fallback copy is preserved when no feature release exists.