### PR TITLE
fix(api): Elysia AOT

### DIFF
--- a/apps/api/src/handlers/chat/routes.ts
+++ b/apps/api/src/handlers/chat/routes.ts
@@ -13,7 +13,7 @@ import sendMessage from "@/api/handlers/chat/send-message";
 import updateThread from "@/api/handlers/chat/update-thread";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 
-export const chatRoute = new Elysia({ prefix: "/chat" })
+export const chatRoute = new Elysia({ prefix: "/chat", aot: false })
   .use(workspaceAccessMacro)
   .use(permissionMacro)
   .guard({ validateAuth: true })

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -176,7 +176,11 @@ const buildRequestLogAttributes = ({
   return attributes;
 };
 
-const api = new Elysia()
+// Disable Elysia's ahead-of-time codegen (Sucrose): it reads handler source via
+// fn.toString(), which `bun build --compile` transforms — a known
+// incompatibility. Dynamic dispatch is correct in every build, and AOT can be
+// slower on Bun anyway. See elysiajs/elysia#740 and #1711.
+const api = new Elysia({ aot: false })
   .onRequest(({ request, set }) => {
     setSecurityHeaders(set);
 


### PR DESCRIPTION
Disable Elysia's ahead-of-time handler codegen (`aot: false`).

Elysia's AOT path (Sucrose) reads handler source via `fn.toString()`, which `bun build --compile` transforms — a known incompatibility (elysiajs/elysia#740, elysiajs/elysia#1711). Dynamic dispatch is correct in every build, and AOT can be slower on Bun anyway (elysiajs/elysia#1604).

Set on the root app and on the chat route.
