### PR TITLE
docs(selfhost): pull the prebuilt multi-arch API image by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,9 +374,15 @@ jobs:
           AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
           SHA: ${{ needs.resolve.outputs.release_sha }}
         run: |
-          docker buildx imagetools create \
-            -t "${IMAGE}:${RELEASE_REF}" \
-            -t "${IMAGE}:sha-${SHA:0:7}" \
+          tags=(-t "${IMAGE}:${RELEASE_REF}" -t "${IMAGE}:sha-${SHA:0:7}")
+          # Advance the convenience `:latest` tag only for stable releases, so
+          # self-host `docker compose pull` resolves to the newest stable image.
+          # Prereleases (e.g. v1.2.3-rc1, which contain a hyphen) must not move it.
+          case "${RELEASE_REF}" in
+            *-*) ;;
+            *) tags+=(-t "${IMAGE}:latest") ;;
+          esac
+          docker buildx imagetools create "${tags[@]}" \
             "${IMAGE}@${ARM64_DIGEST}" \
             "${IMAGE}@${AMD64_DIGEST}"
 

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,5 +1,11 @@
 services:
   api:
+    # Defaults to the prebuilt multi-arch (amd64/arm64) image published to GHCR
+    # on each release, so `docker compose pull` works without a local toolchain.
+    # Pin a version (e.g. ...:v0.5.2) for reproducible deploys, or point
+    # STELLA_API_IMAGE at your own registry. The `build:` block below stays as a
+    # fallback for `docker compose up --build` (build from source).
+    image: ${STELLA_API_IMAGE:-ghcr.io/stella/stella-api:latest}
     build:
       context: .
       dockerfile: apps/api/Dockerfile

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -185,6 +185,18 @@ separately as described above.
 docker compose --env-file apps/api/.env -f docker-compose.selfhost.yml up -d --build
 ```
 
+By default the API service pulls the prebuilt multi-arch (amd64/arm64) image
+published to GHCR on each release, so you can skip building from source:
+
+```bash
+docker compose --env-file apps/api/.env -f docker-compose.selfhost.yml pull
+docker compose --env-file apps/api/.env -f docker-compose.selfhost.yml up -d
+```
+
+Pin a specific release or use your own registry by setting `STELLA_API_IMAGE`
+(e.g. `STELLA_API_IMAGE=ghcr.io/stella/stella-api:v0.5.2`). Keep `--build` if you
+prefer to build from source instead.
+
 To use a different env file, set `STELLA_API_ENV_FILE` in that file:
 
 ```bash

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -193,9 +193,12 @@ docker compose --env-file apps/api/.env -f docker-compose.selfhost.yml pull
 docker compose --env-file apps/api/.env -f docker-compose.selfhost.yml up -d
 ```
 
-Pin a specific release or use your own registry by setting `STELLA_API_IMAGE`
-(e.g. `STELLA_API_IMAGE=ghcr.io/stella/stella-api:v0.5.2`). Keep `--build` if you
-prefer to build from source instead.
+The default tag is `:latest` (advanced only on stable releases). **For
+production, pin an explicit version** by setting `STELLA_API_IMAGE` (e.g.
+`STELLA_API_IMAGE=ghcr.io/stella/stella-api:v0.5.2`) so upgrades are deliberate
+— migrations are manual (`bun run db:migrate`), so always run them against the
+new version **before** `up -d` to avoid a newer API hitting an older schema.
+Keep `--build` if you prefer to build from source instead.
 
 To use a different env file, set `STELLA_API_ENV_FILE` in that file:
 


### PR DESCRIPTION
## What

The self-host Compose file (`docker-compose.selfhost.yml`) built the API from source. That meant the multi-arch (amd64/arm64) API image already published to GHCR on every release was never on the documented self-host path — self-hosters needed the full Bun + turbo + native-addon toolchain just to start the API.

## Change

- Add an `image:` default to the `api` service: `ghcr.io/stella/stella-api:latest`, overridable via `STELLA_API_IMAGE` (pin a version or point at your own registry).
- Keep the `build:` block as a `--build` fallback for building from source.
- Document the pull path (`docker compose pull` → `up -d`) alongside the existing `--build` flow.

Now `docker compose pull && docker compose up -d` works on amd64 or arm64 with no local toolchain — which is what the amd64 release build is for.

## Follow-up (not in this PR, intentionally tiny)

The **web** image is still not published (release.yml builds only `stella-api`). A separate PR can add `stella-web` multi-arch publishing + an `image:`/web service in the self-host Compose so the frontend has the same pull-based path.
