### PR TITLE
fix(api): return a typed 403 when no AI provider is configured

### DIFF
--- a/apps/api/src/lib/ai-models-no-provider.scenario.ts
+++ b/apps/api/src/lib/ai-models-no-provider.scenario.ts
@@ -1,0 +1,104 @@
+import { isPanic } from "better-result";
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import type { ModelRole, OrgAIConfig } from "@/api/lib/ai-models";
+import type * as AIModels from "@/api/lib/ai-models";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const MODEL_ROLES_UNDER_TEST = [
+  "fast",
+  "chat",
+  "reasoning",
+  "pdf",
+] as const satisfies readonly ModelRole[];
+
+const createOpenAIOrgConfig = (): OrgAIConfig => ({
+  providers: [
+    {
+      apiKey: "org-openai-secret",
+      provider: "openai",
+    },
+  ],
+  overrideModels: {
+    chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+    fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+    reasoning: { provider: "openai", modelId: "gpt-5.4" },
+    pdf: { provider: "openai", modelId: "gpt-5.4" },
+  },
+});
+
+let aiModels: typeof AIModels;
+
+beforeAll(async () => {
+  aiModels = await import("@/api/lib/ai-models");
+});
+
+const expectTyped403 = (run: () => unknown): void => {
+  let thrown: unknown;
+  try {
+    run();
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(isPanic(thrown)).toBe(false);
+  expect(thrown).toBeInstanceOf(HandlerError);
+  if (thrown instanceof HandlerError) {
+    expect(thrown.status).toBe(403);
+  }
+};
+
+const expectModelInfoForRoleTyped403 = (role: ModelRole): void => {
+  expectTyped403(() => aiModels.getModelInfoForRole(role));
+};
+
+const expectModelForRoleTyped403 = (role: ModelRole): void => {
+  expectTyped403(() =>
+    aiModels.getModelForRole(role, null, {
+      promptCachingEnabled: false,
+      scopeKey: null,
+      organizationId: null,
+      serviceTier: "standard",
+    }),
+  );
+};
+
+describe("no-provider model resolution", () => {
+  test("getModelInfoForRole throws a typed 403 for every role", () => {
+    for (const role of MODEL_ROLES_UNDER_TEST) {
+      expectModelInfoForRoleTyped403(role);
+    }
+  });
+
+  test("getModelInfoById throws a typed 403 when no provider override is given", () => {
+    expectTyped403(() => aiModels.getModelInfoById("gpt-5.4-mini"));
+  });
+
+  test("getModelById throws a typed 403 when no provider override is given", () => {
+    expectTyped403(() =>
+      aiModels.getModelById("gpt-5.4-mini", null, {
+        promptCachingEnabled: false,
+        scopeKey: null,
+        organizationId: null,
+        serviceTier: "standard",
+        role: "chat",
+      }),
+    );
+  });
+
+  test("getModelForRole throws a typed 403 for every role", () => {
+    for (const role of MODEL_ROLES_UNDER_TEST) {
+      expectModelForRoleTyped403(role);
+    }
+  });
+
+  test("getModelInfoForRole resolves byok for every role", () => {
+    const orgConfig = createOpenAIOrgConfig();
+    for (const role of MODEL_ROLES_UNDER_TEST) {
+      const info = aiModels.getModelInfoForRole(role, orgConfig);
+      expect(info.keySource).toBe("byok");
+      expect(info.provider).toBe("openai");
+      expect(info.modelId).toBe(orgConfig.overrideModels[role].modelId);
+    }
+  });
+});

--- a/apps/api/src/lib/ai-models-no-provider.test.ts
+++ b/apps/api/src/lib/ai-models-no-provider.test.ts
@@ -1,121 +1,53 @@
-import { isPanic } from "better-result";
-import { beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 
-import type { ModelRole, OrgAIConfig } from "@/api/lib/ai-models";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
-
-// Reproduce a bring-your-own-key deployment: BYOK is forced and the
-// instance has no platform provider key, so the request-path resolvers
-// have no provider to fall back on. The global analytics/model tests set
-// OPENAI_API_KEY, which masks this state, so the env is configured here
-// before the module under test is dynamically imported.
-const AI_PROVIDER_KEYS = [
-  "AI_PROVIDER",
-  "ANTHROPIC_API_KEY",
-  "AZURE_API_KEY",
-  "GOOGLE_AI_API_KEY_CH",
-  "GOOGLE_AI_API_KEY_EU",
-  "GOOGLE_GENERATIVE_AI_API_KEY",
-  "HUGGINGFACE_API_KEY",
-  "MISTRAL_API_KEY",
-  "OPENAI_API_KEY",
-  "OPENROUTER_API_KEY",
-  "USE_MOCK_AI",
-];
-
-for (const key of AI_PROVIDER_KEYS) {
-  delete process.env[key];
-}
-process.env["REQUIRE_PERSONAL_AI_KEY"] = "true";
-
-const MODEL_ROLES_UNDER_TEST = [
-  "fast",
-  "chat",
-  "reasoning",
-  "pdf",
-] as const satisfies readonly ModelRole[];
-
-const createOpenAIOrgConfig = (): OrgAIConfig => ({
-  providers: [
-    {
-      apiKey: "org-openai-secret",
-      provider: "openai",
-    },
-  ],
-  overrideModels: {
-    chat: { provider: "openai", modelId: "gpt-5.4-mini" },
-    fast: { provider: "openai", modelId: "gpt-5.4-nano" },
-    reasoning: { provider: "openai", modelId: "gpt-5.4" },
-    pdf: { provider: "openai", modelId: "gpt-5.4" },
-  },
-});
-
-let aiModels: typeof import("@/api/lib/ai-models");
-
-beforeAll(async () => {
-  aiModels = await import("@/api/lib/ai-models");
-});
-
-const expectTyped403 = (run: () => unknown): void => {
-  let thrown: unknown;
-  try {
-    run();
-  } catch (error) {
-    thrown = error;
-  }
-
-  expect(isPanic(thrown)).toBe(false);
-  if (!(thrown instanceof HandlerError)) {
-    throw new Error("Expected a HandlerError, got: " + String(thrown));
-  }
-  expect(thrown.status).toBe(403);
-};
+const API_DIR = fileURLToPath(new URL("../../", import.meta.url));
+const NO_PROVIDER_ENV = {
+  AI_PROVIDER: "",
+  AI_PROVIDER_BASE_URL: "",
+  ANTHROPIC_API_KEY: "",
+  AZURE_API_KEY: "",
+  AZURE_BASE_URL: "",
+  AZURE_RESOURCE_NAME: "",
+  GOOGLE_AI_API_KEY_CH: "",
+  GOOGLE_AI_API_KEY_EU: "",
+  GOOGLE_GENERATIVE_AI_API_KEY: "",
+  HUGGINGFACE_API_KEY: "",
+  HUGGINGFACE_BASE_URL: "",
+  MISTRAL_API_KEY: "",
+  OPENAI_API_KEY: "",
+  OPENROUTER_API_KEY: "",
+  REQUIRE_PERSONAL_AI_KEY: "true",
+  USE_MOCK_AI: "false",
+} as const;
 
 describe("request-path provider resolution without a configured provider", () => {
-  test("getModelInfoForRole throws a typed 403 for every role", () => {
-    for (const role of MODEL_ROLES_UNDER_TEST) {
-      expectTyped403(() => aiModels.getModelInfoForRole(role));
-    }
-  });
-
-  test("getModelInfoById throws a typed 403 when no provider override is given", () => {
-    expectTyped403(() => aiModels.getModelInfoById("gpt-5.4-mini"));
-  });
-
-  test("getModelById throws a typed 403 when no provider override is given", () => {
-    expectTyped403(() =>
-      aiModels.getModelById("gpt-5.4-mini", null, {
-        promptCachingEnabled: false,
-        scopeKey: null,
-        organizationId: null,
-        serviceTier: "standard",
-        role: "chat",
-      }),
+  test("throws typed 403s without poisoning the shared test module cache", async () => {
+    const subprocess = Bun.spawn(
+      [
+        process.execPath,
+        "test",
+        "--preload",
+        "./src/tests/setup-env.ts",
+        "./src/lib/ai-models-no-provider.scenario.ts",
+      ],
+      {
+        cwd: API_DIR,
+        env: {
+          ...process.env,
+          ...NO_PROVIDER_ENV,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
     );
-  });
 
-  test("getModelForRole throws a typed 403 for every role", () => {
-    for (const role of MODEL_ROLES_UNDER_TEST) {
-      expectTyped403(() =>
-        aiModels.getModelForRole(role, null, {
-          promptCachingEnabled: false,
-          scopeKey: null,
-          organizationId: null,
-          serviceTier: "standard",
-        }),
-      );
-    }
-  });
-});
+    const [exitCode, stdout, stderr] = await Promise.all([
+      subprocess.exited,
+      new Response(subprocess.stdout).text(),
+      new Response(subprocess.stderr).text(),
+    ]);
 
-describe("request-path provider resolution with valid BYOK config", () => {
-  test("getModelInfoForRole resolves byok for every role", () => {
-    const orgConfig = createOpenAIOrgConfig();
-    for (const role of MODEL_ROLES_UNDER_TEST) {
-      const info = aiModels.getModelInfoForRole(role, orgConfig);
-      expect(info.keySource).toBe("byok");
-      expect(info.provider).toBe("openai");
-      expect(info.modelId).toBe(orgConfig.overrideModels[role].modelId);
-    }
+    expect({ exitCode, stderr, stdout }).toMatchObject({ exitCode: 0 });
   });
 });

--- a/apps/api/src/lib/ai-models-no-provider.test.ts
+++ b/apps/api/src/lib/ai-models-no-provider.test.ts
@@ -1,0 +1,121 @@
+import { isPanic } from "better-result";
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import type { ModelRole, OrgAIConfig } from "@/api/lib/ai-models";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+// Reproduce a bring-your-own-key deployment: BYOK is forced and the
+// instance has no platform provider key, so the request-path resolvers
+// have no provider to fall back on. The global analytics/model tests set
+// OPENAI_API_KEY, which masks this state, so the env is configured here
+// before the module under test is dynamically imported.
+const AI_PROVIDER_KEYS = [
+  "AI_PROVIDER",
+  "ANTHROPIC_API_KEY",
+  "AZURE_API_KEY",
+  "GOOGLE_AI_API_KEY_CH",
+  "GOOGLE_AI_API_KEY_EU",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "HUGGINGFACE_API_KEY",
+  "MISTRAL_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "USE_MOCK_AI",
+];
+
+for (const key of AI_PROVIDER_KEYS) {
+  delete process.env[key];
+}
+process.env["REQUIRE_PERSONAL_AI_KEY"] = "true";
+
+const MODEL_ROLES_UNDER_TEST = [
+  "fast",
+  "chat",
+  "reasoning",
+  "pdf",
+] as const satisfies readonly ModelRole[];
+
+const createOpenAIOrgConfig = (): OrgAIConfig => ({
+  providers: [
+    {
+      apiKey: "org-openai-secret",
+      provider: "openai",
+    },
+  ],
+  overrideModels: {
+    chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+    fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+    reasoning: { provider: "openai", modelId: "gpt-5.4" },
+    pdf: { provider: "openai", modelId: "gpt-5.4" },
+  },
+});
+
+let aiModels: typeof import("@/api/lib/ai-models");
+
+beforeAll(async () => {
+  aiModels = await import("@/api/lib/ai-models");
+});
+
+const expectTyped403 = (run: () => unknown): void => {
+  let thrown: unknown;
+  try {
+    run();
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(isPanic(thrown)).toBe(false);
+  if (!(thrown instanceof HandlerError)) {
+    throw new Error("Expected a HandlerError, got: " + String(thrown));
+  }
+  expect(thrown.status).toBe(403);
+};
+
+describe("request-path provider resolution without a configured provider", () => {
+  test("getModelInfoForRole throws a typed 403 for every role", () => {
+    for (const role of MODEL_ROLES_UNDER_TEST) {
+      expectTyped403(() => aiModels.getModelInfoForRole(role));
+    }
+  });
+
+  test("getModelInfoById throws a typed 403 when no provider override is given", () => {
+    expectTyped403(() => aiModels.getModelInfoById("gpt-5.4-mini"));
+  });
+
+  test("getModelById throws a typed 403 when no provider override is given", () => {
+    expectTyped403(() =>
+      aiModels.getModelById("gpt-5.4-mini", null, {
+        promptCachingEnabled: false,
+        scopeKey: null,
+        organizationId: null,
+        serviceTier: "standard",
+        role: "chat",
+      }),
+    );
+  });
+
+  test("getModelForRole throws a typed 403 for every role", () => {
+    for (const role of MODEL_ROLES_UNDER_TEST) {
+      expectTyped403(() =>
+        aiModels.getModelForRole(role, null, {
+          promptCachingEnabled: false,
+          scopeKey: null,
+          organizationId: null,
+          serviceTier: "standard",
+        }),
+      );
+    }
+  });
+});
+
+describe("request-path provider resolution with valid BYOK config", () => {
+  test("getModelInfoForRole resolves byok for every role", () => {
+    const orgConfig = createOpenAIOrgConfig();
+    for (const role of MODEL_ROLES_UNDER_TEST) {
+      const info = aiModels.getModelInfoForRole(role, orgConfig);
+      expect(info.keySource).toBe("byok");
+      expect(info.provider).toBe("openai");
+      expect(info.modelId).toBe(orgConfig.overrideModels[role].modelId);
+    }
+  });
+});

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -1785,7 +1785,7 @@ export const getModelForRole = (
   // HandlerError instead so the request boundary returns 403 with
   // an actionable message.
   if (!hasInstanceProvider()) {
-    throw byokRoleNotConfiguredError(role);
+    throw aiProviderNotAvailableError(role);
   }
   const provider = getActiveProvider();
   const modelId = MODEL_OVERRIDES[role] ?? DEFAULT_MODELS[provider][role];
@@ -1802,13 +1802,15 @@ export const getModelForRole = (
   });
 };
 
-const byokRoleNotConfiguredError = (role: ModelRole): HandlerError =>
+const aiProviderNotAvailableError = (role?: ModelRole): HandlerError =>
   new HandlerError({
     status: 403,
-    message:
-      `AI is not available for the "${role}" role on this deployment. ` +
-      "Configure an organization-wide AI key (or include this role in " +
-      "the BYOK override list) in organization settings.",
+    message: role
+      ? `AI is not available for the "${role}" role on this deployment. ` +
+        "Configure an organization-wide AI key (or include this role in " +
+        "the BYOK override list) in organization settings."
+      : "AI is not available on this deployment. Configure an " +
+        "organization-wide AI key in organization settings.",
   });
 
 export const getModelInfoForRole = (
@@ -1826,6 +1828,9 @@ export const getModelInfoForRole = (
     };
   }
 
+  if (!hasInstanceProvider()) {
+    throw aiProviderNotAvailableError(role);
+  }
   const provider = getActiveProvider();
   return {
     keySource: "instance",
@@ -1851,6 +1856,9 @@ export const getModelInfoById = (
     };
   }
 
+  if (!override.provider && !hasInstanceProvider()) {
+    throw aiProviderNotAvailableError();
+  }
   const provider = override.provider ?? getActiveProvider();
   return {
     keySource: "instance",
@@ -1913,6 +1921,9 @@ export const getModelById = (
         allowServiceTierFallback,
       },
     );
+  }
+  if (!hasInstanceProvider()) {
+    throw aiProviderNotAvailableError(role);
   }
   const provider = getActiveProvider();
   return withInstrumentation(getInstanceFactory()(override.modelId), {


### PR DESCRIPTION
When a request has no usable AI provider — no organization key on a bring-your-own-key deployment and no instance provider — the model resolvers now throw a typed `HandlerError` (403) instead of an internal `panic`. Guards the no-provider branch of `getModelInfoForRole`, `getModelById`, and `getModelInfoById`, reusing the existing helper (renamed `aiProviderNotAvailableError`).

Adds `ai-models-no-provider.test.ts`: with `REQUIRE_PERSONAL_AI_KEY=true` and no platform key, asserts a typed 403 (not a panic) when there is no org config, and correct BYOK resolution for all roles.