### PR TITLE
feat(api): structured error fingerprint and opt-in unredacted 5xx logging

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -252,6 +252,18 @@ const envApi = createEnv({
     USAGE_ENFORCEMENT_ENABLED: featureFlagSchema,
 
     /**
+     * Break-glass diagnostics. When true, 5xx responses additionally
+     * log the full `error.msg` and `error.stack` so a deployment can be
+     * made fully diagnosable by flipping one env var, no rebuild needed.
+     * Default false preserves the redacted-by-default behaviour: only
+     * the non-PII structural fingerprint (class, code, code-location
+     * frames) is logged. Enable transiently for an investigation, never
+     * as a standing default, since stacks/messages may carry client
+     * data.
+     */
+    DEBUG_UNREDACTED_ERRORS: featureFlagSchema,
+
+    /**
      * Deployment-owned usage-policy seed list. JSON array of
      * { key, displayName, monthlyUsageUnits, hostedPolicyRef? }.
      * Default is intentionally empty so public source does not

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -65,7 +65,11 @@ import { getAuth } from "@/api/lib/auth";
 import { assertMigrationsApplied } from "@/api/lib/db/assert-migrations-applied";
 import { DEV_INSPECTOR_ORIGINS, frontendOrigins } from "@/api/lib/dev-origins";
 import { httpError } from "@/api/lib/errors/http-error";
-import { errorTag } from "@/api/lib/errors/utils";
+import {
+  errorFingerprint,
+  errorTag,
+  unredactedErrorFields,
+} from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
@@ -237,6 +241,10 @@ const api = new Elysia()
       });
 
       if (statusCode >= 500) {
+        Object.assign(attributes, errorFingerprint(error));
+        if (env.DEBUG_UNREDACTED_ERRORS) {
+          Object.assign(attributes, unredactedErrorFields(error));
+        }
         logger.error("request.failed", attributes);
       } else {
         logger.warn("request.failed", attributes);

--- a/apps/api/src/lib/analytics/index.ts
+++ b/apps/api/src/lib/analytics/index.ts
@@ -1,4 +1,8 @@
-import { errorTag, logDevError } from "@/api/lib/errors/utils";
+import {
+  errorFingerprint,
+  errorTag,
+  logDevError,
+} from "@/api/lib/errors/utils";
 import { getRequestContext } from "@/api/lib/observability/request-context";
 
 import { getAnalytics } from "./client";
@@ -59,6 +63,12 @@ const captureErrorWithOptions = (
       },
     ],
     $exception_type: tag,
+    // Non-PII structural fingerprint (class, stable code, top
+    // `file:line:col` frames). The redaction contract above still
+    // forbids the message and stack; a code location and class name
+    // carry no client data, so they make the exception actionable in
+    // the dashboard without violating it.
+    ...errorFingerprint(error),
     ...options.context,
     ...(options.organizationId
       ? { organization_id: options.organizationId }

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -32,7 +32,7 @@ import type {
   HandlerErrorCode,
   HandlerErrorStatusCode,
 } from "@/api/lib/errors/tagged-errors";
-import { errorTag } from "@/api/lib/errors/utils";
+import { errorFingerprint, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { getRequestContext } from "@/api/lib/observability/request-context";
 import { assertUsageAvailable } from "@/api/lib/usage";
@@ -696,6 +696,24 @@ const logAndCaptureSafeError = ({
       attributes[`${prefix}.type`] = errorTag(cause);
       cause = (cause as { cause?: unknown }).cause;
       depth++;
+    }
+  }
+
+  // 5xx are the un-diagnosable class: the message and stack are
+  // redacted from every sink, leaving only `error.type`. Attach a
+  // non-PII structural fingerprint (class, stable code, top
+  // `file:line:col` frames) under keys that survive the logger's PII
+  // redaction so a panic always carries a code location.
+  if (statusCode >= 500) {
+    Object.assign(attributes, errorFingerprint(error));
+
+    if (env.DEBUG_UNREDACTED_ERRORS && error instanceof Error) {
+      if (error.message) {
+        attributes["error.msg"] = error.message;
+      }
+      if (error.stack) {
+        attributes["error.stack"] = error.stack;
+      }
     }
   }
 

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -32,7 +32,12 @@ import type {
   HandlerErrorCode,
   HandlerErrorStatusCode,
 } from "@/api/lib/errors/tagged-errors";
-import { errorFingerprint, errorTag } from "@/api/lib/errors/utils";
+import {
+  errorFingerprint,
+  errorTag,
+  safeErrorCause,
+  unredactedErrorFields,
+} from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { getRequestContext } from "@/api/lib/observability/request-context";
 import { assertUsageAvailable } from "@/api/lib/usage";
@@ -650,12 +655,22 @@ type LogAndCaptureSafeErrorProps = {
 };
 
 const getErrorStatusCode = (error: Error): number | undefined => {
-  if ("statusCode" in error && typeof error.statusCode === "number") {
-    return error.statusCode;
-  }
+  try {
+    if ("statusCode" in error) {
+      const statusCode: unknown = Reflect.get(error, "statusCode");
+      if (typeof statusCode === "number") {
+        return statusCode;
+      }
+    }
 
-  if ("status" in error && typeof error.status === "number") {
-    return error.status;
+    if ("status" in error) {
+      const statusValue: unknown = Reflect.get(error, "status");
+      if (typeof statusValue === "number") {
+        return statusValue;
+      }
+    }
+  } catch {
+    return undefined;
   }
 
   return undefined;
@@ -688,13 +703,13 @@ const logAndCaptureSafeError = ({
     // (generator-result re-throws, AI SDK over fetch errors,
     // etc.) don't hide the underlying failure type.
     const seen = new WeakSet<object>([error]);
-    let cause: unknown = (error as { cause?: unknown }).cause;
+    let cause = safeErrorCause(error);
     let depth = 1;
     while (cause instanceof Error && depth <= 3 && !seen.has(cause)) {
       seen.add(cause);
       const prefix = depth === 1 ? "error.cause" : `error.cause${depth}`;
       attributes[`${prefix}.type`] = errorTag(cause);
-      cause = (cause as { cause?: unknown }).cause;
+      cause = safeErrorCause(cause);
       depth++;
     }
   }
@@ -707,13 +722,8 @@ const logAndCaptureSafeError = ({
   if (statusCode >= 500) {
     Object.assign(attributes, errorFingerprint(error));
 
-    if (env.DEBUG_UNREDACTED_ERRORS && error instanceof Error) {
-      if (error.message) {
-        attributes["error.msg"] = error.message;
-      }
-      if (error.stack) {
-        attributes["error.stack"] = error.stack;
-      }
+    if (env.DEBUG_UNREDACTED_ERRORS) {
+      Object.assign(attributes, unredactedErrorFields(error));
     }
   }
 

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -1,9 +1,11 @@
+import { panic } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import {
   connectionErrorFields,
   errorFingerprint,
   errorSystemFields,
+  unredactedErrorFields,
 } from "@/api/lib/errors/utils";
 import { sanitizeLogAttributes } from "@/api/lib/observability/logger";
 
@@ -42,6 +44,25 @@ describe("errorSystemFields", () => {
 
   test("handles non-Error values", () => {
     expect(errorSystemFields("boom")).toEqual({ "error.type": "UnknownError" });
+  });
+
+  test("never throws on hostile system-field accessors", () => {
+    const error = new Error("boom");
+    Object.defineProperties(error, {
+      cause: {
+        get: () => panic("cause getter failed"),
+      },
+      code: {
+        get: () => panic("code getter failed"),
+      },
+      errno: {
+        get: () => panic("errno getter failed"),
+      },
+      syscall: {
+        get: () => panic("syscall getter failed"),
+      },
+    });
+    expect(errorSystemFields(error)).toEqual({ "error.type": "Error" });
   });
 });
 
@@ -115,6 +136,44 @@ describe("errorFingerprint", () => {
     expect(errorFingerprint(minified)["error.frame"]).toBeUndefined();
   });
 
+  test("does not parse multiline message content as a stack frame", () => {
+    const error = new Error("privileged\nat merger-secret.docx:12:34");
+    error.stack = [
+      "Error: privileged",
+      "at merger-secret.docx:12:34",
+      "    at safeFrame (/repo/apps/api/src/lib/errors/utils.test.ts:123:45)",
+    ].join("\n");
+    const fingerprint = errorFingerprint(error);
+    expect(fingerprint["error.frame"]).toBe(
+      "/repo/apps/api/src/lib/errors/utils.test.ts:123:45",
+    );
+    for (const value of Object.values(fingerprint)) {
+      expect(value).not.toContain("merger-secret");
+    }
+  });
+
+  test("never throws on hostile Error accessors", () => {
+    const error = new Error("boom");
+    Object.defineProperties(error, {
+      cause: {
+        get: () => panic("cause getter failed"),
+      },
+      code: {
+        get: () => panic("code getter failed"),
+      },
+      constructor: {
+        get: () => panic("constructor getter failed"),
+      },
+      stack: {
+        get: () => panic("stack getter failed"),
+      },
+    });
+    expect(errorFingerprint(error)).toEqual({
+      "error.class": "Error",
+      "error.code": "Error",
+    });
+  });
+
   test("handles non-Error values", () => {
     expect(errorFingerprint("boom")).toEqual({ "error.class": "UnknownError" });
   });
@@ -141,5 +200,29 @@ describe("errorFingerprint", () => {
     for (const value of Object.values(fingerprint)) {
       expect(value).not.toContain("merger-secret");
     }
+  });
+});
+
+describe("unredactedErrorFields", () => {
+  test("returns raw message and stack for break-glass logging only", () => {
+    const error = new Error("privileged: alice uploaded merger-secret.docx");
+    error.stack = "Error: privileged\n    at frame (/repo/app.ts:1:2)";
+    expect(unredactedErrorFields(error)).toEqual({
+      "error.msg": "privileged: alice uploaded merger-secret.docx",
+      "error.stack": "Error: privileged\n    at frame (/repo/app.ts:1:2)",
+    });
+  });
+
+  test("never throws on hostile message or stack accessors", () => {
+    const error = new Error("boom");
+    Object.defineProperties(error, {
+      message: {
+        get: () => panic("message getter failed"),
+      },
+      stack: {
+        get: () => panic("stack getter failed"),
+      },
+    });
+    expect(unredactedErrorFields(error)).toEqual({});
   });
 });

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   connectionErrorFields,
+  errorFingerprint,
   errorSystemFields,
 } from "@/api/lib/errors/utils";
 import { sanitizeLogAttributes } from "@/api/lib/observability/logger";
@@ -75,5 +76,70 @@ describe("connectionErrorFields", () => {
     expect(sanitizeLogAttributes({ "error.message": "x" })).not.toHaveProperty(
       "error.message",
     );
+  });
+});
+
+describe("errorFingerprint", () => {
+  test("extracts the class, stable code, and a code-location frame", () => {
+    const error = new TypeError("cannot read property 'x' of undefined");
+    const fingerprint = errorFingerprint(error);
+    expect(fingerprint["error.class"]).toBe("TypeError");
+    // No `.code` property, so the stable code falls back to the tag.
+    expect(fingerprint["error.code"]).toBe("TypeError");
+    // The top frame is a `file:line:col` location, never user content.
+    expect(fingerprint["error.frame"]).toMatch(/:\d+:\d+$/u);
+    expect(fingerprint["error.frame"]).not.toContain("(");
+  });
+
+  test("prefers a `.code` string when present", () => {
+    const error = Object.assign(new Error("socket hang up"), {
+      code: "ECONNRESET",
+    });
+    expect(errorFingerprint(error)["error.code"]).toBe("ECONNRESET");
+  });
+
+  test("surfaces the deepest cause's top frame", () => {
+    const root = new Error("root failure");
+    const wrapped = new Error("wrapped", { cause: root });
+    const fingerprint = errorFingerprint(wrapped);
+    expect(fingerprint["error.cause.frame"]).toMatch(/:\d+:\d+$/u);
+  });
+
+  test("never throws on a missing or non-standard stack", () => {
+    const noStack = new Error("boom");
+    delete noStack.stack;
+    expect(errorFingerprint(noStack)["error.frame"]).toBeUndefined();
+
+    const minified = new Error("boom");
+    minified.stack = "Error: boom\n    at <anonymous>";
+    expect(errorFingerprint(minified)["error.frame"]).toBeUndefined();
+  });
+
+  test("handles non-Error values", () => {
+    expect(errorFingerprint("boom")).toEqual({ "error.class": "UnknownError" });
+  });
+
+  // The fingerprint exists to survive the logger's PII redaction. If a
+  // future key starts matching /(?:body|content|email|...)/i, it would
+  // be silently dropped and 5xx would go dark again — this guards that.
+  test("every fingerprint key survives the logger attribute sanitizer", () => {
+    const error = new TypeError("cannot read property 'x' of undefined");
+    const fingerprint = errorFingerprint(error);
+    const sanitized = sanitizeLogAttributes(fingerprint);
+    for (const [key, value] of Object.entries(fingerprint)) {
+      expect(sanitized?.[key]).toBe(value);
+    }
+    expect(sanitized?.["log.attributes_dropped"]).toBeUndefined();
+  });
+
+  test("carries no message-bearing key (PII boundary)", () => {
+    const error = new Error("privileged: alice uploaded merger-secret.docx");
+    const fingerprint = errorFingerprint(error);
+    expect(fingerprint["error.message"]).toBeUndefined();
+    expect(fingerprint["error.msg"]).toBeUndefined();
+    expect(fingerprint["error.stack"]).toBeUndefined();
+    for (const value of Object.values(fingerprint)) {
+      expect(value).not.toContain("merger-secret");
+    }
   });
 });

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -152,6 +152,22 @@ describe("errorFingerprint", () => {
     }
   });
 
+  test("does not parse indented multiline message content as a stack frame", () => {
+    const error = new Error("privileged\n    at merger-secret.docx:12:34");
+    error.stack = [
+      "Error: privileged",
+      "    at merger-secret.docx:12:34",
+      "    at safeFrame (/repo/apps/api/src/lib/errors/utils.test.ts:123:45)",
+    ].join("\n");
+    const fingerprint = errorFingerprint(error);
+    expect(fingerprint["error.frame"]).toBe(
+      "/repo/apps/api/src/lib/errors/utils.test.ts:123:45",
+    );
+    for (const value of Object.values(fingerprint)) {
+      expect(value).not.toContain("merger-secret");
+    }
+  });
+
   test("never throws on hostile Error accessors", () => {
     const error = new Error("boom");
     Object.defineProperties(error, {

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -88,6 +88,91 @@ export const connectionErrorFields = (
 };
 
 /**
+ * Non-PII structural fingerprint for diagnosing 5xx without shipping
+ * any user data. Three signals, all code-level, never content:
+ *  - `error.class`: the constructor name (e.g. "Panic", "TypeError").
+ *  - `error.code`: a stable code — a `.code` string when present
+ *    (HandlerError code, ECONNRESET, …), otherwise the structural tag.
+ *  - `error.frame`: the top stack frame as `file:line:col`, plus the
+ *    deepest `.cause`'s top frame under `error.cause.frame`.
+ *
+ * A class name, error code, and `file:line:col` code location carry no
+ * client data, so they are safe at any sink. The attribute keys are
+ * chosen to NOT match the logger's PII redaction regex
+ * (`/(?:body|content|email|fileName|message|name|title)/i`), so they
+ * survive `sanitizeLogAttributes`. Stack parsing is fully defensive:
+ * `stack` may be undefined, multiline, or minified, and this never
+ * throws — a missing frame is simply omitted.
+ */
+export type ErrorFingerprint = Record<string, string>;
+
+// Matches the trailing `file:line:col` of a V8 stack frame, with or
+// without surrounding parens. `[^()\s]+` stops at the opening paren so
+// the captured location never includes the leading "(".
+const STACK_FRAME_PATTERN = /([^()\s]+:\d+:\d+)\)?\s*$/u;
+
+const topStackFrame = (error: Error): string | undefined => {
+  const { stack } = error;
+  if (typeof stack !== "string") {
+    return undefined;
+  }
+  for (const line of stack.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("at ")) {
+      continue;
+    }
+    const match = STACK_FRAME_PATTERN.exec(trimmed);
+    if (match) {
+      return match[1];
+    }
+  }
+  return undefined;
+};
+
+const stableErrorCode = (error: Error): string => {
+  if ("code" in error && typeof error.code === "string" && error.code) {
+    return error.code;
+  }
+  return errorTag(error);
+};
+
+const deepestCause = (error: Error): Error | undefined => {
+  const seen = new WeakSet<object>([error]);
+  let current: unknown = error.cause;
+  let deepest: Error | undefined;
+  let depth = 0;
+  while (current instanceof Error && depth < 5 && !seen.has(current)) {
+    seen.add(current);
+    deepest = current;
+    current = current.cause;
+    depth += 1;
+  }
+  return deepest;
+};
+
+export const errorFingerprint = (error: unknown): ErrorFingerprint => {
+  if (!(error instanceof Error)) {
+    return { "error.class": "UnknownError" };
+  }
+  const fingerprint: ErrorFingerprint = {
+    "error.class": error.constructor.name,
+    "error.code": stableErrorCode(error),
+  };
+  const frame = topStackFrame(error);
+  if (frame !== undefined) {
+    fingerprint["error.frame"] = frame;
+  }
+  const cause = deepestCause(error);
+  if (cause) {
+    const causeFrame = topStackFrame(cause);
+    if (causeFrame !== undefined) {
+      fingerprint["error.cause.frame"] = causeFrame;
+    }
+  }
+  return fingerprint;
+};
+
+/**
  * Surface an error in dev. Two sinks:
  *  1) `console.error` — the interactive dev terminal sees it now.
  *  2) `apps/api/.dev-logs/errors.jsonl` — headless tools (CI repro

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -199,8 +199,10 @@ export const unredactedErrorFields = (
  * chosen to NOT match the logger's PII redaction regex
  * (`/(?:body|content|email|fileName|message|name|title)/i`), so they
  * survive `sanitizeLogAttributes`. Stack parsing is fully defensive:
- * `stack` may be undefined, multiline, or minified, and this never
- * throws — a missing frame is simply omitted.
+ * `stack` may be undefined, multiline, or minified. The message prefix
+ * is skipped before frame detection because user content may itself
+ * contain lines shaped like stack frames. This never throws; a missing
+ * frame is simply omitted.
  */
 export type ErrorFingerprint = Record<string, string>;
 
@@ -261,13 +263,34 @@ const frameLocation = (line: string): string | undefined => {
   return location;
 };
 
+const stackFrameLines = (error: Error, stack: string): string[] => {
+  const message = safeErrorMessage(error);
+  if (message === undefined) {
+    return [];
+  }
+
+  const lines = stack.split("\n");
+  const firstLine = lines.at(0);
+  if (firstLine === undefined) {
+    return [];
+  }
+
+  const messageLines = message.split("\n");
+  const firstMessageLine = messageLines.at(0);
+  if (firstMessageLine && !firstLine.endsWith(firstMessageLine)) {
+    return [];
+  }
+
+  return lines.slice(messageLines.length);
+};
+
 const topStackFrame = (error: Error): string | undefined => {
   try {
     const stack = safeErrorStack(error);
     if (stack === undefined) {
       return undefined;
     }
-    for (const line of stack.split("\n")) {
+    for (const line of stackFrameLines(error, stack)) {
       const location = frameLocation(line);
       if (location) {
         return location;

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -17,7 +17,7 @@ export const errorTag = (error: unknown): string => {
     return error._tag;
   }
   if (error instanceof Error) {
-    return error.constructor.name;
+    return errorClassName(error);
   }
   return "UnknownError";
 };
@@ -36,23 +36,26 @@ export const errorSystemFields = (error: unknown): Record<string, string> => {
   if (!(error instanceof Error)) {
     return fields;
   }
-  if ("code" in error && typeof error.code === "string") {
-    fields["error.code"] = error.code;
+  const code = safeErrorCode(error);
+  if (code !== undefined) {
+    fields["error.code"] = code;
   }
-  if ("errno" in error && typeof error.errno === "number") {
-    fields["error.errno"] = String(error.errno);
+  const errno = safeErrorNumberProperty(error, "errno");
+  if (errno !== undefined) {
+    fields["error.errno"] = String(errno);
   }
-  if ("syscall" in error && typeof error.syscall === "string") {
-    fields["error.syscall"] = error.syscall;
+  const syscall = safeErrorStringProperty(error, "syscall");
+  if (syscall !== undefined) {
+    fields["error.syscall"] = syscall;
   }
-  if (error.cause !== undefined) {
-    fields["error.cause.type"] = errorTag(error.cause);
-    if (
-      error.cause instanceof Error &&
-      "code" in error.cause &&
-      typeof error.cause.code === "string"
-    ) {
-      fields["error.cause.code"] = error.cause.code;
+  const cause = safeErrorCause(error);
+  if (cause !== undefined) {
+    fields["error.cause.type"] = errorTag(cause);
+    if (cause instanceof Error) {
+      const causeCode = safeErrorCode(cause);
+      if (causeCode !== undefined) {
+        fields["error.cause.code"] = causeCode;
+      }
     }
   }
   return fields;
@@ -81,8 +84,103 @@ export const connectionErrorFields = (
   error: unknown,
 ): Record<string, string> => {
   const fields = errorSystemFields(error);
-  if (error instanceof Error && error.message) {
-    fields["error.msg"] = error.message;
+  if (error instanceof Error) {
+    const message = safeErrorMessage(error);
+    if (message !== undefined) {
+      fields["error.msg"] = message;
+    }
+  }
+  return fields;
+};
+
+const safeErrorStringProperty = (
+  error: Error,
+  key: string,
+): string | undefined => {
+  try {
+    if (!(key in error)) {
+      return undefined;
+    }
+    const value: unknown = Reflect.get(error, key);
+    if (typeof value === "string" && value) {
+      return value;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
+const safeErrorNumberProperty = (
+  error: Error,
+  key: string,
+): number | undefined => {
+  try {
+    if (!(key in error)) {
+      return undefined;
+    }
+    const value: unknown = Reflect.get(error, key);
+    if (typeof value === "number") {
+      return value;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
+export const safeErrorCause = (error: Error): unknown => {
+  try {
+    return Reflect.get(error, "cause");
+  } catch {
+    return undefined;
+  }
+};
+
+const errorClassName = (error: Error): string => {
+  try {
+    const constructorValue: unknown = Reflect.get(error, "constructor");
+    if (typeof constructorValue !== "function") {
+      return "Error";
+    }
+    const name: unknown = Reflect.get(constructorValue, "name");
+    if (typeof name === "string" && name) {
+      return name;
+    }
+  } catch {
+    return "Error";
+  }
+  return "Error";
+};
+
+const safeErrorCode = (error: Error): string | undefined =>
+  safeErrorStringProperty(error, "code");
+
+const safeErrorMessage = (error: Error): string | undefined =>
+  safeErrorStringProperty(error, "message");
+
+const safeErrorStack = (error: Error): string | undefined =>
+  safeErrorStringProperty(error, "stack");
+
+/**
+ * Raw diagnostics for an explicitly enabled break-glass log path.
+ * This may include client data; never send it to analytics.
+ */
+export const unredactedErrorFields = (
+  error: unknown,
+): Record<string, string> => {
+  const fields: Record<string, string> = {};
+  if (!(error instanceof Error)) {
+    return fields;
+  }
+
+  const message = safeErrorMessage(error);
+  if (message !== undefined) {
+    fields["error.msg"] = message;
+  }
+  const stack = safeErrorStack(error);
+  if (stack !== undefined) {
+    fields["error.stack"] = stack;
   }
   return fields;
 };
@@ -106,48 +204,100 @@ export const connectionErrorFields = (
  */
 export type ErrorFingerprint = Record<string, string>;
 
-// Matches the trailing `file:line:col` of a V8 stack frame, with or
-// without surrounding parens. `[^()\s]+` stops at the opening paren so
-// the captured location never includes the leading "(".
-const STACK_FRAME_PATTERN = /([^()\s]+:\d+:\d+)\)?\s*$/u;
+const STACK_FRAME_PREFIX = "at ";
 
-const topStackFrame = (error: Error): string | undefined => {
-  const { stack } = error;
-  if (typeof stack !== "string") {
+const isAsciiDigits = (value: string): boolean => {
+  if (!value) {
+    return false;
+  }
+  for (const char of value) {
+    if (char < "0" || char > "9") {
+      return false;
+    }
+  }
+  return true;
+};
+
+const hasWhitespace = (value: string): boolean => {
+  for (const char of value) {
+    if (char.trim() === "") {
+      return true;
+    }
+  }
+  return false;
+};
+
+const frameLocation = (line: string): string | undefined => {
+  const trimmedStart = line.trimStart();
+  if (trimmedStart === line || !trimmedStart.startsWith(STACK_FRAME_PREFIX)) {
     return undefined;
   }
-  for (const line of stack.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith("at ")) {
-      continue;
+
+  const locationEnd = trimmedStart.endsWith(")")
+    ? trimmedStart.length - 1
+    : trimmedStart.length;
+  const columnSeparator = trimmedStart.lastIndexOf(":", locationEnd - 1);
+  if (columnSeparator === -1) {
+    return undefined;
+  }
+  const lineSeparator = trimmedStart.lastIndexOf(":", columnSeparator - 1);
+  if (lineSeparator === -1) {
+    return undefined;
+  }
+
+  const lineNumber = trimmedStart.slice(lineSeparator + 1, columnSeparator);
+  const columnNumber = trimmedStart.slice(columnSeparator + 1, locationEnd);
+  if (!isAsciiDigits(lineNumber) || !isAsciiDigits(columnNumber)) {
+    return undefined;
+  }
+
+  const openingParen = trimmedStart.lastIndexOf("(", lineSeparator);
+  const locationStart =
+    openingParen === -1 ? STACK_FRAME_PREFIX.length : openingParen + 1;
+  const location = trimmedStart.slice(locationStart, locationEnd);
+  if (!location || hasWhitespace(location)) {
+    return undefined;
+  }
+  return location;
+};
+
+const topStackFrame = (error: Error): string | undefined => {
+  try {
+    const stack = safeErrorStack(error);
+    if (stack === undefined) {
+      return undefined;
     }
-    const match = STACK_FRAME_PATTERN.exec(trimmed);
-    if (match) {
-      return match[1];
+    for (const line of stack.split("\n")) {
+      const location = frameLocation(line);
+      if (location) {
+        return location;
+      }
     }
+  } catch {
+    return undefined;
   }
   return undefined;
 };
 
-const stableErrorCode = (error: Error): string => {
-  if ("code" in error && typeof error.code === "string" && error.code) {
-    return error.code;
-  }
-  return errorTag(error);
-};
+const stableErrorCode = (error: Error): string =>
+  safeErrorCode(error) ?? errorTag(error);
 
 const deepestCause = (error: Error): Error | undefined => {
-  const seen = new WeakSet<object>([error]);
-  let current: unknown = error.cause;
-  let deepest: Error | undefined;
-  let depth = 0;
-  while (current instanceof Error && depth < 5 && !seen.has(current)) {
-    seen.add(current);
-    deepest = current;
-    current = current.cause;
-    depth += 1;
+  try {
+    const seen = new WeakSet<object>([error]);
+    let current = safeErrorCause(error);
+    let deepest: Error | undefined;
+    let depth = 0;
+    while (current instanceof Error && depth < 5 && !seen.has(current)) {
+      seen.add(current);
+      deepest = current;
+      current = safeErrorCause(current);
+      depth += 1;
+    }
+    return deepest;
+  } catch {
+    return undefined;
   }
-  return deepest;
 };
 
 export const errorFingerprint = (error: unknown): ErrorFingerprint => {
@@ -155,7 +305,7 @@ export const errorFingerprint = (error: unknown): ErrorFingerprint => {
     return { "error.class": "UnknownError" };
   }
   const fingerprint: ErrorFingerprint = {
-    "error.class": error.constructor.name,
+    "error.class": errorClassName(error),
     "error.code": stableErrorCode(error),
   };
   const frame = topStackFrame(error);
@@ -234,12 +384,14 @@ type SerializedError = {
 
 const serializeError = (error: unknown): unknown => {
   if (error instanceof Error) {
+    const stack = safeErrorStack(error);
+    const cause = safeErrorCause(error);
     const out: SerializedError = {
-      name: error.constructor.name,
-      message: error.message,
-      ...(error.stack !== undefined && { stack: error.stack }),
+      name: errorClassName(error),
+      message: safeErrorMessage(error) ?? "",
+      ...(stack !== undefined && { stack }),
       ...(isTaggedError(error) && { tag: error._tag }),
-      ...(error.cause !== undefined && { cause: serializeError(error.cause) }),
+      ...(cause !== undefined && { cause: serializeError(cause) }),
     };
     return out;
   }


### PR DESCRIPTION
Server errors now always carry a non-PII fingerprint that survives log redaction: `error.class`, `error.code`, the top stack frame (`error.frame`), and the deepest cause frame. Added to both the request-failure log and captured exceptions.

Adds `DEBUG_UNREDACTED_ERRORS` (default off): when enabled, the full message and stack are additionally logged for 5xx, so a deployment can be made fully diagnosable without a rebuild. Default behavior and message/content redaction are unchanged.