### PR TITLE
chore(api): post-deploy chat smoke for staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Install Playwright browser
         run: cd apps/web && bunx playwright install --with-deps chromium
 
-      - name: Run staging smoke
+      - name: Run staging web smoke
         run: bun --filter @stll/web test:e2e:staging
         env:
           E2E_WEB_URL: https://staging.stll.app
@@ -246,6 +246,13 @@ jobs:
           # Block the smoke until staging actually serves this commit,
           # so it doesn't race the ECS task rollover.
           EXPECTED_COMMIT: ${{ github.sha }}
+
+      - name: Run staging API chat smoke
+        if: ${{ !cancelled() }}
+        run: bun apps/api/src/scripts/post-deploy-smoke.ts "$E2E_API_URL"
+        env:
+          E2E_API_URL: https://api-staging.stll.app
+          SMOKE_SESSION_SECRET: ${{ secrets.SMOKE_SESSION_SECRET }}
 
       - name: Upload Playwright report
         if: failure()

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -312,6 +312,7 @@ const createAuth = () => {
       organization({
         ac,
         roles,
+        membershipLimit: LIMITS.organizationMembersCount,
         organizationHooks: {
           async afterRemoveMember({ member, organization: org }) {
             await rootDb.transaction(

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -133,6 +133,8 @@ export const LIMITS = {
   contactsPageSizeMax: 100,
   contactRelationshipsCount: 50,
   workspaceContactsCount: 100,
+  /** Better Auth organization member cap and full-org read bound. */
+  organizationMembersCount: 500,
   workspaceMembersCount: 500,
   practiceJurisdictionsPerOrganization: 12,
   entityNameMaxLength: 255,

--- a/apps/api/src/scripts/post-deploy-smoke.test.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.test.ts
@@ -10,6 +10,7 @@ import {
   isServerError,
   readStreamPrefix,
   streamPrefixHasError,
+  streamPrefixHasMeaningfulFrame,
 } from "@/api/scripts/post-deploy-smoke";
 
 describe("isServerError", () => {
@@ -148,14 +149,38 @@ describe("streamPrefixHasError", () => {
   });
 });
 
+describe("streamPrefixHasMeaningfulFrame", () => {
+  test("ignores opening frames and accepts assistant progress or finish", () => {
+    expect(streamPrefixHasMeaningfulFrame('data: {"type":"start"}\n\n')).toBe(
+      false,
+    );
+    expect(
+      streamPrefixHasMeaningfulFrame('data: {"type":"text-start"}\n\n'),
+    ).toBe(false);
+    expect(
+      streamPrefixHasMeaningfulFrame(
+        'data: {"type":"text-delta","delta":"hi"}\n\n',
+      ),
+    ).toBe(true);
+    expect(streamPrefixHasMeaningfulFrame('data: {"type":"finish"}\n\n')).toBe(
+      true,
+    );
+  });
+});
+
 describe("evaluateChatStreamPrefix", () => {
-  test("requires a data frame before accepting a stream", () => {
+  test("requires assistant progress before accepting a stream", () => {
     expect(evaluateChatStreamPrefix("").ok).toBe(false);
     expect(evaluateChatStreamPrefix("\n\n").ok).toBe(false);
     expect(evaluateChatStreamPrefix(": keepalive\n\n").ok).toBe(false);
     expect(evaluateChatStreamPrefix('data: {"type":"start"}\n\n').ok).toBe(
-      true,
+      false,
     );
+    expect(
+      evaluateChatStreamPrefix(
+        'data: {"type":"start"}\n\ndata: {"type":"text-delta","delta":"hi"}\n\n',
+      ).ok,
+    ).toBe(true);
     expect(evaluateChatStreamPrefix('data: {"type":"error"}\n\n').ok).toBe(
       false,
     );
@@ -163,18 +188,44 @@ describe("evaluateChatStreamPrefix", () => {
 });
 
 describe("readStreamPrefix", () => {
-  test("stops after the first decisive data frame", async () => {
+  test("keeps reading past opening frames and stops after assistant progress", async () => {
     const encoder = new TextEncoder();
     const response = new Response(
       new ReadableStream<Uint8Array>({
         start: (controller) => {
           controller.enqueue(encoder.encode('data: {"type":"start"}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"text-start"}\n\n'));
+          controller.enqueue(
+            encoder.encode('data: {"type":"text-delta","delta":"hi"}\n\n'),
+          );
         },
       }),
     );
 
-    const prefix = await readStreamPrefix(response, { timeoutMs: 5 });
-    expect(prefix).toBe('data: {"type":"start"}\n\n');
+    const prefix = await readStreamPrefix(response, { timeoutMs: 50 });
+    expect(prefix).toBe(
+      'data: {"type":"start"}\n\ndata: {"type":"text-start"}\n\ndata: {"type":"text-delta","delta":"hi"}\n\n',
+    );
+  });
+
+  test("keeps reading past opening frames and stops on a later error", async () => {
+    const encoder = new TextEncoder();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          controller.enqueue(encoder.encode('data: {"type":"start"}\n\n'));
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"error","errorText":"provider failed"}\n\n',
+            ),
+          );
+        },
+      }),
+    );
+
+    const prefix = await readStreamPrefix(response, { timeoutMs: 50 });
+    expect(prefix).toContain('"type":"error"');
+    expect(evaluateChatStreamPrefix(prefix).ok).toBe(false);
   });
 
   test("rejects when a stream does not produce a prefix before the timeout", async () => {

--- a/apps/api/src/scripts/post-deploy-smoke.test.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  allChecksPassed,
+  buildChatSmokeBody,
+  evaluateChatStreamPrefix,
+  evaluateChatStreamContentType,
+  evaluateHttpCheck,
+  isExpectedChatBusinessResponse,
+  isServerError,
+  readStreamPrefix,
+  streamPrefixHasError,
+} from "@/api/scripts/post-deploy-smoke";
+
+describe("isServerError", () => {
+  test("only 5xx counts as a server error", () => {
+    expect(isServerError(200)).toBe(false);
+    expect(isServerError(403)).toBe(false);
+    expect(isServerError(404)).toBe(false);
+    expect(isServerError(499)).toBe(false);
+    expect(isServerError(500)).toBe(true);
+    expect(isServerError(503)).toBe(true);
+    expect(isServerError(599)).toBe(true);
+    expect(isServerError(600)).toBe(false);
+  });
+});
+
+describe("evaluateHttpCheck", () => {
+  test("okOnly mode passes only on 2xx", () => {
+    expect(
+      evaluateHttpCheck({ name: "mint", status: 200, mode: "okOnly" }).ok,
+    ).toBe(true);
+    expect(
+      evaluateHttpCheck({ name: "mint", status: 404, mode: "okOnly" }).ok,
+    ).toBe(false);
+    expect(
+      evaluateHttpCheck({ name: "mint", status: 500, mode: "okOnly" }).ok,
+    ).toBe(false);
+  });
+
+  test("chatSend mode allows only 2xx and the no-AI business response", () => {
+    expect(
+      evaluateHttpCheck({
+        body: '{"message":"AI is not available. Configure an AI key."}',
+        name: "chat",
+        status: 403,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(true);
+    expect(
+      evaluateHttpCheck({
+        body: "",
+        name: "chat",
+        status: 200,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(true);
+    expect(
+      evaluateHttpCheck({
+        body: '{"message":"Unauthorized"}',
+        name: "chat",
+        status: 401,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(false);
+    expect(
+      evaluateHttpCheck({
+        body: '{"message":"Payment required"}',
+        name: "chat",
+        status: 402,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(false);
+    expect(
+      evaluateHttpCheck({
+        body: '{"message":"Forbidden"}',
+        name: "chat",
+        status: 403,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(false);
+    expect(
+      evaluateHttpCheck({
+        body: '{"message":"Not found"}',
+        name: "chat",
+        status: 404,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(false);
+    expect(
+      evaluateHttpCheck({
+        body: "",
+        name: "chat",
+        status: 500,
+        mode: "chatSend",
+      }).ok,
+    ).toBe(false);
+  });
+});
+
+describe("isExpectedChatBusinessResponse", () => {
+  test("matches only the no-AI 403 response", () => {
+    expect(
+      isExpectedChatBusinessResponse(
+        403,
+        '{"message":"AI is not available. Configure an AI key."}',
+      ),
+    ).toBe(true);
+    expect(isExpectedChatBusinessResponse(403, '{"message":"Forbidden"}')).toBe(
+      false,
+    );
+    expect(
+      isExpectedChatBusinessResponse(
+        402,
+        '{"message":"AI is not available. Configure an AI key."}',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("evaluateChatStreamContentType", () => {
+  test("allows only event-stream chat responses", () => {
+    expect(evaluateChatStreamContentType("text/event-stream").ok).toBe(true);
+    expect(
+      evaluateChatStreamContentType("text/event-stream; charset=utf-8").ok,
+    ).toBe(true);
+    expect(evaluateChatStreamContentType("TEXT/EVENT-STREAM").ok).toBe(true);
+    expect(evaluateChatStreamContentType(null).ok).toBe(false);
+    expect(evaluateChatStreamContentType("").ok).toBe(false);
+    expect(evaluateChatStreamContentType("application/json").ok).toBe(false);
+    expect(evaluateChatStreamContentType("text/plain").ok).toBe(false);
+  });
+});
+
+describe("streamPrefixHasError", () => {
+  test("detects an AI SDK error frame in the SSE prefix", () => {
+    expect(
+      streamPrefixHasError('data: {"type":"error","errorText":"boom"}\n\n'),
+    ).toBe(true);
+  });
+
+  test("does not flag a healthy text stream", () => {
+    expect(
+      streamPrefixHasError(
+        'data: {"type":"start"}\n\ndata: {"type":"text-delta","delta":"hi"}\n\n',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("evaluateChatStreamPrefix", () => {
+  test("requires a data frame before accepting a stream", () => {
+    expect(evaluateChatStreamPrefix("").ok).toBe(false);
+    expect(evaluateChatStreamPrefix("\n\n").ok).toBe(false);
+    expect(evaluateChatStreamPrefix(": keepalive\n\n").ok).toBe(false);
+    expect(evaluateChatStreamPrefix('data: {"type":"start"}\n\n').ok).toBe(
+      true,
+    );
+    expect(evaluateChatStreamPrefix('data: {"type":"error"}\n\n').ok).toBe(
+      false,
+    );
+  });
+});
+
+describe("readStreamPrefix", () => {
+  test("stops after the first decisive data frame", async () => {
+    const encoder = new TextEncoder();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          controller.enqueue(encoder.encode('data: {"type":"start"}\n\n'));
+        },
+      }),
+    );
+
+    const prefix = await readStreamPrefix(response, { timeoutMs: 5 });
+    expect(prefix).toBe('data: {"type":"start"}\n\n');
+  });
+
+  test("rejects when a stream does not produce a prefix before the timeout", async () => {
+    const never = new Promise<void>((_resolve) => {});
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull: async () => {
+          await never;
+        },
+      }),
+    );
+
+    let message = "";
+    try {
+      await readStreamPrefix(response, { timeoutMs: 5 });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toBe(
+      "Chat stream did not produce a readable prefix before timeout",
+    );
+  });
+});
+
+describe("allChecksPassed", () => {
+  test("passes only when every check is ok", () => {
+    expect(
+      allChecksPassed([
+        { name: "a", ok: true, detail: "" },
+        { name: "b", ok: true, detail: "" },
+      ]),
+    ).toBe(true);
+    expect(
+      allChecksPassed([
+        { name: "a", ok: true, detail: "" },
+        { name: "b", ok: false, detail: "" },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("buildChatSmokeBody", () => {
+  test("produces a fresh thread id and a user text message", () => {
+    const body = buildChatSmokeBody();
+    expect(body.sendMode).toBe("rawOverride");
+    const uuid =
+      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
+    expect(body.threadId).toMatch(uuid);
+    const { message } = body;
+    expect(message.role).toBe("user");
+    expect(message.id).toMatch(uuid);
+    expect(message.parts).toEqual([{ type: "text", text: "ping" }]);
+  });
+
+  test("each call uses a distinct thread id", () => {
+    expect(buildChatSmokeBody().threadId).not.toBe(
+      buildChatSmokeBody().threadId,
+    );
+  });
+});

--- a/apps/api/src/scripts/post-deploy-smoke.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.ts
@@ -150,8 +150,61 @@ export const evaluateChatStreamContentType = (
 export const streamPrefixHasError = (prefix: string): boolean =>
   prefix.includes('"type":"error"');
 
+const MEANINGFUL_CHAT_STREAM_FRAME_TYPES = new Set([
+  "finish",
+  "text-delta",
+  "tool-input-available",
+  "tool-output-available",
+]);
+
+const parseStreamDataFrames = (prefix: string): unknown[] => {
+  const frames: unknown[] = [];
+  for (const line of prefix.split(/\r?\n/u)) {
+    if (!line.startsWith("data:")) {
+      continue;
+    }
+
+    const data = line.slice("data:".length).trim();
+    if (data.length === 0) {
+      continue;
+    }
+
+    try {
+      frames.push(JSON.parse(data));
+    } catch {
+      // The prefix can end mid-frame; a later read will complete it.
+    }
+  }
+  return frames;
+};
+
+const getStringFrameProperty = (
+  frame: unknown,
+  property: string,
+): string | null => {
+  if (typeof frame !== "object" || frame === null || !(property in frame)) {
+    return null;
+  }
+
+  const value = Reflect.get(frame, property);
+  return typeof value === "string" ? value : null;
+};
+
+const getStreamFrameType = (frame: unknown): string | null =>
+  getStringFrameProperty(frame, "type");
+
 const streamPrefixHasDataFrame = (prefix: string): boolean =>
-  prefix.startsWith("data:") || prefix.includes("\ndata:");
+  parseStreamDataFrames(prefix).length > 0;
+
+export const streamPrefixHasMeaningfulFrame = (prefix: string): boolean =>
+  parseStreamDataFrames(prefix).some((frame) => {
+    const type = getStreamFrameType(frame);
+    if (type === "text-delta") {
+      const delta = getStringFrameProperty(frame, "delta");
+      return delta !== null && delta.length > 0;
+    }
+    return type !== null && MEANINGFUL_CHAT_STREAM_FRAME_TYPES.has(type);
+  });
 
 export const evaluateChatStreamPrefix = (prefix: string): EvaluatedCheck => {
   if (!streamPrefixHasDataFrame(prefix)) {
@@ -170,10 +223,18 @@ export const evaluateChatStreamPrefix = (prefix: string): EvaluatedCheck => {
     };
   }
 
+  if (!streamPrefixHasMeaningfulFrame(prefix)) {
+    return {
+      name: "POST /v1/chat/ (stream)",
+      ok: false,
+      detail: "stream closed before assistant progress or finish",
+    };
+  }
+
   return {
     name: "POST /v1/chat/ (stream)",
     ok: true,
-    detail: "stream started without an error frame",
+    detail: "stream made assistant progress without an error frame",
   };
 };
 
@@ -335,7 +396,7 @@ export const readStreamPrefix = async (
         buffered += decoder.decode(value, { stream: true });
         if (
           streamPrefixHasError(buffered) ||
-          streamPrefixHasDataFrame(buffered)
+          streamPrefixHasMeaningfulFrame(buffered)
         ) {
           break;
         }

--- a/apps/api/src/scripts/post-deploy-smoke.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.ts
@@ -1,0 +1,459 @@
+/**
+ * Post-deploy chat smoke against a *deployed* API.
+ *
+ * CI builds and the in-repo image smokes run with an AI key present in
+ * the test environment, so a config-dependent runtime break that only
+ * appears under the actually-deployed configuration (for example a
+ * bring-your-own-key deployment where no platform AI key is set, or a
+ * provider that fails to initialize from the deployed secrets) never
+ * shows up before users do. This script runs an authenticated request
+ * against the deployed API and treats any 5xx (or an SSE error frame on
+ * the chat stream) as a failed deploy. It is a catch-all: it does not
+ * care *why* a route 5xxes, only that one does.
+ *
+ * Auth reuses the existing secret-guarded smoke-session mechanism
+ * (`POST /smoke/session`, handlers/smoke + lib/smoke-session). That
+ * route exists only where SMOKE_SESSION_SECRET is configured, which
+ * infrastructure injects on non-production deployments only, so this
+ * script is a staging-only check by construction.
+ *
+ * Self-contained on purpose: it imports nothing from the app (no DB
+ * client, no env module) so it can run as a standalone `bun` invocation
+ * from a deploy job without booting the server or opening a connection.
+ */
+
+import { TaggedError } from "better-result";
+import * as v from "valibot";
+
+const SMOKE_SESSION_TIMEOUT_MS = 15_000;
+const READ_CHECK_TIMEOUT_MS = 15_000;
+const CHAT_SEND_TIMEOUT_MS = 60_000;
+// Cap how much of the chat SSE stream we read while looking for an
+// early error frame. A healthy turn streams far more than this; we only
+// need the opening frames to tell "started streaming" from "failed".
+const CHAT_STREAM_PREFIX_BYTES = 64 * 1024;
+const CHAT_STREAM_READ_TIMEOUT_MS = 20_000;
+const AI_UNAVAILABLE_STATUS = 403;
+const AI_UNAVAILABLE_MESSAGE_FRAGMENT = "AI is not available";
+const CHAT_STREAM_CONTENT_TYPE = "text/event-stream";
+
+class PostDeploySmokeError extends TaggedError("PostDeploySmokeError")<{
+  message: string;
+  cause?: unknown;
+}>() {}
+
+const smokeSessionSchema = v.strictObject({
+  cookieName: v.string(),
+  cookieValue: v.string(),
+  expiresAt: v.string(),
+});
+
+type SmokeSession = v.InferOutput<typeof smokeSessionSchema>;
+
+type ChatSmokeBody = {
+  threadId: string;
+  sendMode: "rawOverride";
+  message: {
+    id: string;
+    role: "user";
+    parts: { type: "text"; text: string }[];
+  };
+};
+
+const CHECK_MODE = {
+  /** Pass only on a 2xx status (used for the auth precondition). */
+  okOnly: "okOnly",
+  /** Pass on 2xx, or the explicit no-AI 403 business response. */
+  chatSend: "chatSend",
+} as const;
+
+type HttpCheck =
+  | {
+      name: string;
+      status: number;
+      mode: typeof CHECK_MODE.okOnly;
+    }
+  | {
+      body: string;
+      name: string;
+      status: number;
+      mode: typeof CHECK_MODE.chatSend;
+    };
+
+type EvaluatedCheck = {
+  name: string;
+  ok: boolean;
+  detail: string;
+};
+
+/** 5xx is the failure signal: a config-dependent runtime break. */
+export const isServerError = (status: number): boolean =>
+  status >= 500 && status <= 599;
+
+const isSuccess = (status: number): boolean => status >= 200 && status < 300;
+
+export const isExpectedChatBusinessResponse = (
+  status: number,
+  body: string,
+): boolean =>
+  status === AI_UNAVAILABLE_STATUS &&
+  body.includes(AI_UNAVAILABLE_MESSAGE_FRAGMENT);
+
+export const evaluateHttpCheck = (check: HttpCheck): EvaluatedCheck => {
+  if (check.mode === CHECK_MODE.okOnly) {
+    return {
+      name: check.name,
+      ok: isSuccess(check.status),
+      detail: `${String(check.status)} (expected 2xx)`,
+    };
+  }
+
+  const ok =
+    isSuccess(check.status) ||
+    isExpectedChatBusinessResponse(check.status, check.body);
+  return {
+    name: check.name,
+    ok,
+    detail: `${String(check.status)} (expected 2xx stream or 403 no-AI response)`,
+  };
+};
+
+const isChatStreamContentType = (contentType: string | null): boolean => {
+  if (!contentType) {
+    return false;
+  }
+  const mediaType = contentType.split(";").at(0)?.trim().toLowerCase();
+  return mediaType === CHAT_STREAM_CONTENT_TYPE;
+};
+
+export const evaluateChatStreamContentType = (
+  contentType: string | null,
+): EvaluatedCheck => {
+  const observed =
+    contentType && contentType.trim().length > 0
+      ? contentType.trim()
+      : "missing";
+  return {
+    name: "POST /v1/chat/ (stream content-type)",
+    ok: isChatStreamContentType(contentType),
+    detail: `${observed} (expected ${CHAT_STREAM_CONTENT_TYPE})`,
+  };
+};
+
+/**
+ * The chat handler streams an AI SDK UI-message stream. Errors thrown
+ * inside the stream are emitted as `{"type":"error",...}` SSE frames
+ * (stream-chat.ts) rather than an HTTP status, so a 200 alone does not
+ * prove the turn started cleanly. Scan the buffered prefix for that
+ * frame; its presence means the chat turn failed.
+ */
+export const streamPrefixHasError = (prefix: string): boolean =>
+  prefix.includes('"type":"error"');
+
+const streamPrefixHasDataFrame = (prefix: string): boolean =>
+  prefix.startsWith("data:") || prefix.includes("\ndata:");
+
+export const evaluateChatStreamPrefix = (prefix: string): EvaluatedCheck => {
+  if (!streamPrefixHasDataFrame(prefix)) {
+    return {
+      name: "POST /v1/chat/ (stream)",
+      ok: false,
+      detail: "stream closed before emitting a data frame",
+    };
+  }
+
+  if (streamPrefixHasError(prefix)) {
+    return {
+      name: "POST /v1/chat/ (stream)",
+      ok: false,
+      detail: "stream emitted an error frame",
+    };
+  }
+
+  return {
+    name: "POST /v1/chat/ (stream)",
+    ok: true,
+    detail: "stream started without an error frame",
+  };
+};
+
+export const allChecksPassed = (checks: EvaluatedCheck[]): boolean =>
+  checks.every((check) => check.ok);
+
+const sessionCookieHeader = (session: SmokeSession): string =>
+  `${session.cookieName}=${session.cookieValue}`;
+
+const parseSmokeSession = (value: unknown): SmokeSession => {
+  const parsed = v.safeParse(smokeSessionSchema, value);
+  if (parsed.success) {
+    return parsed.output;
+  }
+  throw new PostDeploySmokeError({
+    message: "Smoke session response did not match the expected shape",
+    cause: parsed.issues,
+  });
+};
+
+/**
+ * Minimal valid `POST /v1/chat/` body that triggers a real chat turn: a
+ * fresh global thread (the handler creates it) plus one user text
+ * message. No workspace is referenced, so no matter provisioning is
+ * needed for the synthetic org.
+ */
+export const buildChatSmokeBody = (): ChatSmokeBody => ({
+  threadId: Bun.randomUUIDv7(),
+  sendMode: "rawOverride",
+  message: {
+    id: Bun.randomUUIDv7(),
+    role: "user",
+    parts: [{ type: "text", text: "ping" }],
+  },
+});
+
+const mintSmokeSession = async (
+  baseUrl: string,
+  secret: string,
+): Promise<SmokeSession> => {
+  const response = await fetch(`${baseUrl}/smoke/session`, {
+    method: "POST",
+    headers: { "x-smoke-secret": secret },
+    signal: AbortSignal.timeout(SMOKE_SESSION_TIMEOUT_MS),
+  });
+  const evaluated = evaluateHttpCheck({
+    name: "POST /smoke/session",
+    status: response.status,
+    mode: CHECK_MODE.okOnly,
+  });
+  if (!evaluated.ok) {
+    throw new PostDeploySmokeError({
+      message:
+        `Could not mint a smoke session: ${evaluated.detail}. ` +
+        "Verify SMOKE_SESSION_SECRET matches the deployed value and that " +
+        "the target environment enables the smoke route.",
+    });
+  }
+  return parseSmokeSession(await response.json());
+};
+
+const readAuthenticated = async (
+  baseUrl: string,
+  path: string,
+  cookie: string,
+): Promise<EvaluatedCheck> => {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: { cookie },
+    signal: AbortSignal.timeout(READ_CHECK_TIMEOUT_MS),
+  });
+  return evaluateHttpCheck({
+    name: `GET ${path}`,
+    status: response.status,
+    mode: CHECK_MODE.okOnly,
+  });
+};
+
+const readHealth = async (baseUrl: string): Promise<EvaluatedCheck> => {
+  const response = await fetch(`${baseUrl}/health`, {
+    signal: AbortSignal.timeout(READ_CHECK_TIMEOUT_MS),
+  });
+  return evaluateHttpCheck({
+    name: "GET /health",
+    status: response.status,
+    mode: CHECK_MODE.okOnly,
+  });
+};
+
+type ReadStreamPrefixOptions = {
+  maxBytes?: number;
+  timeoutMs?: number;
+};
+
+type StreamReader = {
+  cancel: () => Promise<unknown>;
+  read: () => Promise<{
+    done: boolean;
+    value?: Uint8Array | undefined;
+  }>;
+};
+
+type StreamReadResult = Awaited<ReturnType<StreamReader["read"]>>;
+
+const readWithDeadline = async (
+  reader: StreamReader,
+  deadline: number,
+): Promise<StreamReadResult> => {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    throw new PostDeploySmokeError({
+      message: "Chat stream did not produce a readable prefix before timeout",
+    });
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new PostDeploySmokeError({
+          message:
+            "Chat stream did not produce a readable prefix before timeout",
+        }),
+      );
+      void reader.cancel().catch(() => undefined);
+    }, remainingMs);
+  });
+
+  try {
+    return await Promise.race([reader.read(), timeout]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+export const readStreamPrefix = async (
+  response: Response,
+  {
+    maxBytes = CHAT_STREAM_PREFIX_BYTES,
+    timeoutMs = CHAT_STREAM_READ_TIMEOUT_MS,
+  }: ReadStreamPrefixOptions = {},
+): Promise<string> => {
+  if (!response.body) {
+    return "";
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const deadline = Date.now() + timeoutMs;
+  let buffered = "";
+  try {
+    while (buffered.length < maxBytes) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential prefix read: each chunk extends the buffer we then scan
+      const { done, value } = await readWithDeadline(reader, deadline);
+      if (done) {
+        break;
+      }
+      if (value) {
+        buffered += decoder.decode(value, { stream: true });
+        if (
+          streamPrefixHasError(buffered) ||
+          streamPrefixHasDataFrame(buffered)
+        ) {
+          break;
+        }
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  return buffered;
+};
+
+const sendChat = async (
+  baseUrl: string,
+  cookie: string,
+): Promise<EvaluatedCheck[]> => {
+  const response = await fetch(`${baseUrl}/v1/chat/`, {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(buildChatSmokeBody()),
+    signal: AbortSignal.timeout(CHAT_SEND_TIMEOUT_MS),
+  });
+
+  const httpCheck = evaluateHttpCheck({
+    name: "POST /v1/chat/",
+    status: response.status,
+    mode: CHECK_MODE.chatSend,
+    body: isSuccess(response.status) ? "" : await response.text(),
+  });
+
+  // Only inspect the stream when the request actually streamed (2xx). A
+  // non-streaming no-AI response is captured by httpCheck; every other
+  // non-2xx status fails there.
+  if (!isSuccess(response.status)) {
+    return [httpCheck];
+  }
+
+  const streamTypeCheck = evaluateChatStreamContentType(
+    response.headers.get("content-type"),
+  );
+  if (!streamTypeCheck.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    return [httpCheck, streamTypeCheck];
+  }
+
+  let streamCheck: EvaluatedCheck;
+  try {
+    const prefix = await readStreamPrefix(response);
+    streamCheck = evaluateChatStreamPrefix(prefix);
+  } catch (error) {
+    streamCheck = {
+      name: "POST /v1/chat/ (stream)",
+      ok: false,
+      detail: `stream read failed: ${errorMessage(error)}`,
+    };
+  }
+  return [httpCheck, streamTypeCheck, streamCheck];
+};
+
+const resolveBaseUrl = (): string => {
+  const raw =
+    process.argv[2] ??
+    process.env["SMOKE_API_URL"] ??
+    process.env["E2E_API_URL"];
+  if (!raw) {
+    throw new PostDeploySmokeError({
+      message:
+        "Target API base URL is required (pass as the first argument or set " +
+        "SMOKE_API_URL / E2E_API_URL), e.g. https://api-staging.stll.app",
+    });
+  }
+  return raw.replace(/\/+$/u, "");
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const main = async (): Promise<void> => {
+  const baseUrl = resolveBaseUrl();
+  const secret = process.env["SMOKE_SESSION_SECRET"];
+  if (!secret) {
+    throw new PostDeploySmokeError({
+      message:
+        "SMOKE_SESSION_SECRET is required to authenticate the post-deploy smoke",
+    });
+  }
+
+  const session = await mintSmokeSession(baseUrl, secret);
+  const cookie = sessionCookieHeader(session);
+
+  const checks: EvaluatedCheck[] = [];
+  checks.push(await readHealth(baseUrl));
+  checks.push(await readAuthenticated(baseUrl, "/v1/chat/threads", cookie));
+  checks.push(...(await sendChat(baseUrl, cookie)));
+
+  for (const check of checks) {
+    const marker = check.ok ? "ok  " : "FAIL";
+    process.stdout.write(`[${marker}] ${check.name}: ${check.detail}\n`);
+  }
+
+  if (!allChecksPassed(checks)) {
+    const failed = checks
+      .filter((check) => !check.ok)
+      .map((check) => check.name)
+      .join(", ");
+    throw new PostDeploySmokeError({
+      message: `Post-deploy smoke failed against ${baseUrl}: ${failed}`,
+    });
+  }
+
+  process.stdout.write(`Post-deploy smoke passed against ${baseUrl}\n`);
+};
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -372,6 +372,9 @@ describe("custom oxlint guardrails", () => {
     const protectedRouteSource = readRootFixture(
       "apps/web/src/routes/_protected.tsx",
     );
+    const sidebarUserMenuSource = readRootFixture(
+      "apps/web/src/components/sidebar-user-menu.tsx",
+    );
     const aiConfigQuerySource = readRootFixture(
       "apps/web/src/routes/_protected.organization/-ai-config-queries.ts",
     );
@@ -391,6 +394,8 @@ describe("custom oxlint guardrails", () => {
     expect(protectedRouteSource).toContain("AIAvailabilityProvider");
     expect(protectedRouteSource).toContain("AppSidebar");
     expect(protectedRouteSource).toContain("ChatMentionProviders");
+    expect(sidebarUserMenuSource).not.toContain("organizationOptions");
+    expect(sidebarUserMenuSource).toContain("organizationSummaryOptions");
     expect(aiConfigQuerySource).toContain("ROUTE_QUERY_STALE_TIME_MS");
     expect(aiConfigQuerySource).toContain(
       "staleTime: ROUTE_QUERY_STALE_TIME_MS",

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -364,6 +364,11 @@ describe("custom oxlint guardrails", () => {
   });
 
   test("protected shell chrome queries stay non-critical and route-fresh", () => {
+    const authSource = readRootFixture("apps/api/src/lib/auth.ts");
+    const limitsSource = readRootFixture("apps/api/src/lib/limits.ts");
+    const organizationConstsSource = readRootFixture(
+      "apps/web/src/routes/_protected.organization/-consts.ts",
+    );
     const protectedRouteSource = readRootFixture(
       "apps/web/src/routes/_protected.tsx",
     );
@@ -392,6 +397,16 @@ describe("custom oxlint guardrails", () => {
     );
     expect(organizationQuerySource).toContain(
       "staleTime: ROUTE_QUERY_STALE_TIME_MS",
+    );
+    expect(limitsSource).toContain("organizationMembersCount: 500");
+    expect(authSource).toContain(
+      "membershipLimit: LIMITS.organizationMembersCount",
+    );
+    expect(organizationConstsSource).toContain(
+      "ORGANIZATION_MEMBERS_LIMIT = 500",
+    );
+    expect(organizationQuerySource).toContain(
+      "membersLimit: ORGANIZATION_MEMBERS_LIMIT",
     );
     expect(workspacesQuerySource).toContain("workspacesNavigationOptions");
     expect(workspacesQuerySource).toContain(

--- a/apps/web/src/components/sidebar-user-menu.tsx
+++ b/apps/web/src/components/sidebar-user-menu.tsx
@@ -44,7 +44,7 @@ import {
   useI18nStore,
 } from "@/i18n/i18n-store";
 import { getInitials } from "@/lib/get-initials";
-import { organizationOptions } from "@/routes/_protected.organization/-queries";
+import { organizationSummaryOptions } from "@/routes/_protected.organization/-queries";
 
 const CHANGELOG_URL = "https://stll.app/changelog";
 const isDev = import.meta.env.DEV;
@@ -71,7 +71,7 @@ export function SidebarUserMenu({ user }: SidebarUserMenuProps) {
   const lang = useI18nStore((s) => s.lang);
   const setLang = useI18nStore((s) => s.setLang);
   const { data: organization } = useChromeQuery(
-    organizationOptions(user.activeOrganizationId),
+    organizationSummaryOptions(user.activeOrganizationId),
   );
 
   const displayName = user.name ?? user.email;

--- a/apps/web/src/routes/_protected.organization/-consts.ts
+++ b/apps/web/src/routes/_protected.organization/-consts.ts
@@ -5,6 +5,8 @@ type Translator = ReturnType<typeof getTranslator>;
 
 export const managementRoles: readonly Role[] = ["owner", "admin"];
 
+export const ORGANIZATION_MEMBERS_LIMIT = 500;
+
 export const getRoles = (
   t: Translator,
 ): { label: string; value: Role; description: string }[] => [

--- a/apps/web/src/routes/_protected.organization/-queries.ts
+++ b/apps/web/src/routes/_protected.organization/-queries.ts
@@ -3,6 +3,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { authClient } from "@/lib/auth";
 import { toAuthClientError } from "@/lib/errors";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
+import { ORGANIZATION_MEMBERS_LIMIT } from "@/routes/_protected.organization/-consts";
 
 export const organizationKeys = {
   all: ["organization", "full"],
@@ -16,7 +17,11 @@ export const organizationOptions = (organizationId: string) =>
   queryOptions({
     queryKey: organizationKeys.byOrganization(organizationId),
     queryFn: async () => {
-      const result = await authClient.organization.getFullOrganization();
+      const result = await authClient.organization.getFullOrganization({
+        query: {
+          membersLimit: ORGANIZATION_MEMBERS_LIMIT,
+        },
+      });
 
       if (result.error) {
         throw toAuthClientError(result.error);

--- a/apps/web/src/routes/_protected.organization/-queries.ts
+++ b/apps/web/src/routes/_protected.organization/-queries.ts
@@ -11,7 +11,31 @@ export const organizationKeys = {
     ...organizationKeys.all,
     organizationId,
   ],
+  summaries: ["organization", "summary"],
+  summary: (organizationId: string) => [
+    ...organizationKeys.summaries,
+    organizationId,
+  ],
 };
+
+export const organizationSummaryOptions = (organizationId: string) =>
+  queryOptions({
+    queryKey: organizationKeys.summary(organizationId),
+    queryFn: async () => {
+      const result = await authClient.organization.list();
+
+      if (result.error) {
+        throw toAuthClientError(result.error);
+      }
+
+      return (
+        result.data.find(
+          (organization) => organization.id === organizationId,
+        ) ?? null
+      );
+    },
+    staleTime: ROUTE_QUERY_STALE_TIME_MS,
+  });
 
 export const organizationOptions = (organizationId: string) =>
   queryOptions({


### PR DESCRIPTION
Adds a browserless Bun script that authenticates via the existing secret-guarded `/smoke/session` route and exercises `/health`, `/v1/chat/threads`, and a real `/v1/chat/` send against a deployed API, failing on any 5xx (or an AI SDK error frame in the stream). Intended to run after the staging promote. Includes unit tests for the pass/fail classification.

The workflow step that invokes it lands separately in stella-infra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-deploy staging API chat smoke check covering health, smoke-session authentication, chat threading, and key chat endpoints.
  * Introduced an organisation member cap of 500 and applied the same limit consistently across authentication and protected organisation queries.
* **Bug Fixes**
  * Treats the specific 403 “AI is not available. Configure an AI key.” outcome as expected during chat smoke evaluation.
* **Tests**
  * Added a Bun test suite for smoke-script validation, including SSE handling, content-type checks, and timeout behavior.
* **CI**
  * Split staging verification into separate web smoke and API chat smoke steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->