### PR TITLE
chore(claude): make typescript-lsp plugin opt-in by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,6 @@
 {
-  "env": {
-    "ENABLE_LSP_TOOL": "1"
-  },
   "enabledPlugins": {
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": false
   },
   "mcpServers": {
     "playwright": {


### PR DESCRIPTION
Default the `typescript-lsp@claude-plugins-official` plugin to `false` and drop the `ENABLE_LSP_TOOL` env flag in `.claude/settings.json`.

The plugin eagerly spawns a per-session TypeScript language server (a heavyweight `tsserver` process) as soon as a session opens a TS file, regardless of whether the LSP tool is invoked. Defaulting it off makes the cost opt-in, which matters when running multiple concurrent sessions. Contributors who want LSP can re-enable it locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal plugin settings and removed an unused environment configuration. No user-facing behaviour changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->