### PR TITLE
fix(web): recover from failed route-chunk imports instead of blanking

### DIFF
--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -5,6 +5,7 @@ import { CancelledError } from "@tanstack/react-query";
 import { StartClient } from "@tanstack/react-start/client";
 
 import { initializeI18n } from "@/i18n/i18n-store";
+import { installPreloadErrorRecovery } from "@/lib/preload-error-recovery";
 import { isPublicSsrPath } from "@/lib/public-ssr-paths";
 
 const hydrate = () => {
@@ -28,6 +29,9 @@ const hydrate = () => {
     );
   });
 };
+
+// Recover from failed route-chunk imports before they blank the screen.
+installPreloadErrorRecovery();
 
 if (isPublicSsrPath(window.location.pathname)) {
   // The server rendered these paths with the bundled English (the only

--- a/apps/web/src/lib/preload-error-recovery.ts
+++ b/apps/web/src/lib/preload-error-recovery.ts
@@ -1,0 +1,61 @@
+// Recover from a failed dynamic route-chunk import. Vite dispatches
+// `vite:preloadError` on the window when a lazily imported module fails to
+// load — typically a stale chunk after a deploy, or a dev HMR / dep-reoptimize
+// race. Left unhandled this blanks the screen mid-navigation, before the
+// router's error boundary can render.
+//
+// Strategy: reload once to fetch the fresh chunk. If another preload fails
+// within a short cooldown, stop reloading and let the error bubble to the
+// router error boundary, so a genuinely broken chunk cannot reload-loop.
+
+const RELOAD_COOLDOWN_MS = 10_000;
+const STORAGE_KEY = "stella:preload-reload-at";
+
+// The single-reload guard relies on sessionStorage persisting across the
+// reload. sessionStorage can throw (private mode, sandboxed iframe, storage
+// disabled), so both access points are guarded: if we cannot read or record
+// the timestamp we skip the reload entirely and fall through to the error
+// boundary, rather than risk a reload loop with no working guard.
+const readReloadAt = (): number | null => {
+  try {
+    return Number(window.sessionStorage.getItem(STORAGE_KEY) ?? "0");
+  } catch {
+    return null;
+  }
+};
+
+const recordReloadAt = (timestamp: number): boolean => {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, String(timestamp));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Typed as Event: the WindowEventMap augmentation for "vite:preloadError" is
+// not guaranteed in scope, and we only need preventDefault() + the reload.
+export const installPreloadErrorRecovery = (): void => {
+  window.addEventListener("vite:preloadError", (event: Event) => {
+    const last = readReloadAt();
+    if (last === null) {
+      // No durable storage to enforce the single-reload guard; let the router
+      // error boundary handle it instead of risking a reload loop.
+      return;
+    }
+    const now = Date.now();
+    if (now - last < RELOAD_COOLDOWN_MS) {
+      // Already reloaded recently; the chunk is genuinely failing. Let the
+      // error boundary take over instead of looping.
+      return;
+    }
+    if (!recordReloadAt(now)) {
+      // Could not record the reload, so the guard would never trip. Skip the
+      // reload to avoid looping.
+      return;
+    }
+    // Cancel Vite's default rethrow; we recover by reloading for a fresh chunk.
+    event.preventDefault();
+    window.location.reload();
+  });
+};


### PR DESCRIPTION
A failed dynamic import of a route chunk (a stale chunk after a deploy, or a dev HMR / dep-reoptimize race) can blank the screen mid-navigation, before the router's error boundary renders.

This installs a `vite:preloadError` handler in the client entry that reloads once to fetch the fresh chunk, with a short cooldown so a genuinely broken chunk falls through to the existing error boundary instead of reload-looping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for failed page loads when a route chunk can’t be fetched.
  * Users are now more likely to see the app recover with a refresh instead of a blank screen.
* **Bug Fixes**
  * Reduced the impact of stale or missing deployed assets causing navigation failures.
  * Added safeguards to avoid repeated reload loops during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->