### PR TITLE
fix(db): recycle pooled connections and bound long-lived worker DB calls

### DIFF
--- a/apps/api/src/db/root.ts
+++ b/apps/api/src/db/root.ts
@@ -8,13 +8,25 @@ import type { TransactionOf } from "@/api/db/scoped";
 import { envBase } from "@/api/env-base";
 
 const databaseRelations = { ...relations, ...authRelationsPart };
+
+// Recycle pooled connections before the server reaps them while idle.
+// Bun's defaults never rotate connections (maxLifetime/idleTimeout 0)
+// and it has no TCP keepalive, so a stale socket is only discovered on
+// next use. Applied to both pools; values are seconds.
+const poolRecycling = {
+  maxLifetime: envBase.DATABASE_POOL_MAX_LIFETIME_S,
+  idleTimeout: envBase.DATABASE_POOL_IDLE_TIMEOUT_S,
+} as const;
+
 const rootClient = new SQL({
   url: envBase.DATABASE_URL,
   max: envBase.DATABASE_ROOT_POOL_MAX,
+  ...poolRecycling,
 });
 const rlsClient = new SQL({
   url: envBase.DATABASE_URL,
   max: envBase.DATABASE_RLS_POOL_MAX,
+  ...poolRecycling,
 });
 
 /**

--- a/apps/api/src/db/root.ts
+++ b/apps/api/src/db/root.ts
@@ -9,10 +9,8 @@ import { envBase } from "@/api/env-base";
 
 const databaseRelations = { ...relations, ...authRelationsPart };
 
-// Recycle pooled connections before the server reaps them while idle.
-// Bun's defaults never rotate connections (maxLifetime/idleTimeout 0)
-// and it has no TCP keepalive, so a stale socket is only discovered on
-// next use. Applied to both pools; values are seconds.
+// Optional pool recycling. Defaults remain disabled until the Bun SQL runtime
+// retires only idle connections; values are seconds and apply to both pools.
 const poolRecycling = {
   maxLifetime: envBase.DATABASE_POOL_MAX_LIFETIME_S,
   idleTimeout: envBase.DATABASE_POOL_IDLE_TIMEOUT_S,

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -32,11 +32,25 @@ const databasePoolMaxSchema = v.optional(
   "5",
 );
 
+// Connection-recycling bounds for the Bun SQL pools, in seconds.
+// Bun never recycles connections by default (maxLifetime/idleTimeout
+// both 0) and has no TCP keepalive, so a connection the server reaps
+// while idle is only discovered on next use (`Failed to read data`),
+// and a silently-dead socket can hang a read indefinitely. Recycling
+// rotates connections before they go stale. 0 disables a bound.
+const databasePoolSecondsSchema = (fallback: string) =>
+  v.optional(
+    v.pipe(v.string(), v.digits(), v.transform(Number), v.integer()),
+    fallback,
+  );
+
 export const envBase = createEnv({
   server: {
     DATABASE_URL: v.pipe(v.string(), v.url()),
     DATABASE_ROOT_POOL_MAX: databasePoolMaxSchema,
     DATABASE_RLS_POOL_MAX: databasePoolMaxSchema,
+    DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("600"),
+    DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("120"),
     S3_ENDPOINT: v.string(),
     S3_BUCKET: v.string(),
     S3_CREDENTIALS_PROVIDER: v.optional(

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -36,8 +36,9 @@ const databasePoolMaxSchema = v.optional(
 // Bun never recycles connections by default (maxLifetime/idleTimeout
 // both 0) and has no TCP keepalive, so a connection the server reaps
 // while idle is only discovered on next use (`Failed to read data`),
-// and a silently-dead socket can hang a read indefinitely. Recycling
-// rotates connections before they go stale. 0 disables a bound.
+// and a silently-dead socket can hang a read indefinitely. The default
+// max lifetime stays above the longest 15-minute statement_timeout
+// used by legal search/indexing paths. 0 disables a bound.
 const databasePoolSecondsSchema = (fallback: string) =>
   v.optional(
     v.pipe(v.string(), v.digits(), v.transform(Number), v.integer()),
@@ -49,8 +50,8 @@ export const envBase = createEnv({
     DATABASE_URL: v.pipe(v.string(), v.url()),
     DATABASE_ROOT_POOL_MAX: databasePoolMaxSchema,
     DATABASE_RLS_POOL_MAX: databasePoolMaxSchema,
-    DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("600"),
-    DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("120"),
+    DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("1800"),
+    DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("300"),
     S3_ENDPOINT: v.string(),
     S3_BUCKET: v.string(),
     S3_CREDENTIALS_PROVIDER: v.optional(

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -33,12 +33,10 @@ const databasePoolMaxSchema = v.optional(
 );
 
 // Connection-recycling bounds for the Bun SQL pools, in seconds.
-// Bun never recycles connections by default (maxLifetime/idleTimeout
-// both 0) and has no TCP keepalive, so a connection the server reaps
-// while idle is only discovered on next use (`Failed to read data`),
-// and a silently-dead socket can hang a read indefinitely. The default
-// max lifetime stays above the longest 15-minute statement_timeout
-// used by legal search/indexing paths. 0 disables a bound.
+// Bun never recycles connections by default (maxLifetime/idleTimeout both 0).
+// Keep that default until the runtime retires only idle connections; current
+// Bun timers can interrupt in-flight queries. Operators can opt in explicitly
+// after upgrading the runtime. 0 disables a bound.
 const databasePoolSecondsSchema = (fallback: string) =>
   v.optional(
     v.pipe(v.string(), v.digits(), v.transform(Number), v.integer()),
@@ -50,8 +48,8 @@ export const envBase = createEnv({
     DATABASE_URL: v.pipe(v.string(), v.url()),
     DATABASE_ROOT_POOL_MAX: databasePoolMaxSchema,
     DATABASE_RLS_POOL_MAX: databasePoolMaxSchema,
-    DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("1800"),
-    DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("300"),
+    DATABASE_POOL_MAX_LIFETIME_S: databasePoolSecondsSchema("0"),
+    DATABASE_POOL_IDLE_TIMEOUT_S: databasePoolSecondsSchema("0"),
     S3_ENDPOINT: v.string(),
     S3_BUCKET: v.string(),
     S3_CREDENTIALS_PROVIDER: v.optional(

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { afterEach, describe, expect, test } from "bun:test";
 
+import type { ScopedDb, Transaction } from "@/api/db";
+import { caseLawSources } from "@/api/db/schema";
+import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst, Inline } from "@/api/handlers/case-law/document-ast";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
-import { sanitizeResult } from "@/api/handlers/case-law/ingestion/pipeline";
+import { czNsAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
+import {
+  runIngestionPipeline,
+  sanitizeResult,
+} from "@/api/handlers/case-law/ingestion/pipeline";
+import { createSafeId } from "@/api/lib/branded-types";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 
 const concatInlineText = (inlines: Inline[]): string => {
   let out = "";
@@ -26,7 +36,9 @@ const concatInlineText = (inlines: Inline[]): string => {
   return out;
 };
 
-const baseResult = (documentAst: DocumentAst): IngestionResult => ({
+const baseResult = (
+  documentAst: IngestionResult["documentAst"],
+): IngestionResult => ({
   caseNumber: "X/1/2026",
   court: "Test Court",
   country: "SK",
@@ -45,6 +57,12 @@ const astMetadata = {
   keywords: [],
   statutes: [],
 };
+
+const originalCzNsFetchPage = czNsAdapter.fetchPage;
+
+afterEach(() => {
+  czNsAdapter.fetchPage = originalCzNsFetchPage;
+});
 
 describe("sanitizeResult — documentAst text fields", () => {
   // plainText fields feed the DB full-text search index, so we
@@ -220,5 +238,66 @@ describe("sanitizeResult — documentAst text fields", () => {
     expect(prep1.plainText).toBe("bydlel u a v dome");
     expect(prep2.plainText).toBe("podiel i s príslušenstvom");
     expect(spaced.plainText).toBe("súd rozhodol takto");
+  });
+});
+
+describe("runIngestionPipeline — database timeouts", () => {
+  test("holds the source cursor when a decision DB operation times out", async () => {
+    const source = {
+      id: createSafeId<"caseLawSource">(),
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      name: "Timeout source",
+      enabled: true,
+      syncCursor: "cursor-1",
+      lastSyncAt: null,
+      config: {},
+      descriptor: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    } satisfies typeof caseLawSources.$inferSelect;
+
+    const decision = baseResult({});
+    czNsAdapter.fetchPage = async () =>
+      Result.ok({ decisions: [decision], nextCursor: "cursor-2" });
+
+    let calls = 0;
+    let persistedCursor: string | null | undefined;
+    const scopedDb: ScopedDb = async (callback) => {
+      calls++;
+
+      if (calls === 1) {
+        throw new TimeoutError({
+          message: "decision write exceeded deadline",
+          label: "ingestion-db-transaction",
+          timeoutMs: 10,
+        });
+      }
+
+      const tx = {
+        update: (table: unknown) => ({
+          set: (values: { syncCursor?: string | null }) => {
+            if (table === caseLawSources) {
+              persistedCursor = values.syncCursor;
+            }
+
+            return { where: async () => undefined };
+          },
+        }),
+      };
+
+      // SAFETY: this test exercises only the final case_law_sources cursor
+      // update after the synthetic timeout; the fake implements that chain.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return await callback(tx as unknown as Transaction);
+    };
+
+    const result = await runIngestionPipeline({ source, scopedDb });
+
+    expect(result.inserted).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.pagesProcessed).toBe(0);
+    expect(result.nextCursor).toBe("cursor-1");
+    expect(result.haltReason?.startsWith("Database timeout;")).toBe(true);
+    expect(persistedCursor).toBe("cursor-1");
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -36,6 +36,7 @@ import {
 import { segmentDecision } from "@/api/handlers/case-law/ingestion/segmenter";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
@@ -82,6 +83,9 @@ type PipelineResult = {
   /** Non-null if the adapter was halted early due to repeated failures. */
   haltReason: string | null;
 };
+
+const databaseTimeoutHaltReason = (error: TimeoutError): string =>
+  `Database timeout; cursor held for retry: ${error.message.slice(0, 200)}`;
 
 type ProcessResult = {
   inserted: boolean;
@@ -714,6 +718,11 @@ export const runIngestionPipeline = async ({
             cursor: cursor ?? "",
           });
 
+          if (error instanceof TimeoutError) {
+            haltReason = databaseTimeoutHaltReason(error);
+            break;
+          }
+
           // Persist failure for later analysis
           try {
             // oxlint-disable-next-line no-await-in-loop -- failure logged inline within the sequential decision loop
@@ -730,6 +739,11 @@ export const runIngestionPipeline = async ({
               sourceId: source.id,
               caseNumber: result.caseNumber,
             });
+
+            if (failureLogError instanceof TimeoutError) {
+              haltReason = databaseTimeoutHaltReason(failureLogError);
+              break;
+            }
           }
 
           skipped++;

--- a/apps/api/src/lib/with-timeout.test.ts
+++ b/apps/api/src/lib/with-timeout.test.ts
@@ -34,6 +34,18 @@ describe("withTimeout", () => {
     expect(captured).toMatchObject({ label: "wedged-read", timeoutMs: 10 });
   });
 
+  test("timeoutMs 0 disables the deadline", async () => {
+    const result = await withTimeout(
+      async () => {
+        await Bun.sleep(10);
+        return "ok";
+      },
+      { label: "disabled", timeoutMs: 0 },
+    );
+
+    expect(result).toBe("ok");
+  });
+
   test("a late operation rejection after the timeout does not surface as unhandled", async () => {
     let rejectedLate = false;
     const onUnhandled = () => {

--- a/apps/api/src/lib/with-timeout.test.ts
+++ b/apps/api/src/lib/with-timeout.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import { withTimeout } from "@/api/lib/with-timeout";
+
+describe("withTimeout", () => {
+  test("returns the operation result when it settles before the deadline", async () => {
+    const result = await withTimeout(
+      async () => {
+        await Bun.sleep(5);
+        return "ok";
+      },
+      { label: "fast", timeoutMs: 1000 },
+    );
+
+    expect(result).toBe("ok");
+  });
+
+  test("rejects with a TimeoutError when the operation outlives the deadline", async () => {
+    let captured: unknown;
+    try {
+      await withTimeout(
+        async () => {
+          await Bun.sleep(1000);
+          return "never";
+        },
+        { label: "wedged-read", timeoutMs: 10 },
+      );
+    } catch (error) {
+      captured = error;
+    }
+
+    expect(captured).toBeInstanceOf(TimeoutError);
+    expect(captured).toMatchObject({ label: "wedged-read", timeoutMs: 10 });
+  });
+
+  test("a late operation rejection after the timeout does not surface as unhandled", async () => {
+    let rejectedLate = false;
+    const onUnhandled = () => {
+      rejectedLate = true;
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      let captured: unknown;
+      try {
+        await withTimeout(
+          async () => {
+            // Settles (rejecting) well after the deadline has already won.
+            await Bun.sleep(20);
+            throw new TimeoutError({
+              message: "late connection failure",
+              label: "late-op",
+            });
+          },
+          { label: "late-wrapper", timeoutMs: 5 },
+        );
+      } catch (error) {
+        captured = error;
+      }
+
+      expect(captured).toBeInstanceOf(TimeoutError);
+      expect(captured).toMatchObject({ label: "late-wrapper" });
+
+      await Bun.sleep(40);
+      expect(rejectedLate).toBe(false);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/apps/api/src/lib/with-timeout.ts
+++ b/apps/api/src/lib/with-timeout.ts
@@ -1,0 +1,47 @@
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+
+type WithTimeoutOptions = {
+  label: string;
+  timeoutMs: number;
+};
+
+/**
+ * Races an async operation against a wall-clock deadline. If the
+ * deadline passes first, rejects with a TimeoutError instead of
+ * waiting forever.
+ *
+ * The motivating case is a DB read on a pooled connection that the
+ * server reaped silently (no RST): Bun's SQL client never settles the
+ * query promise, so the await hangs indefinitely. There is no portable
+ * way to cancel the underlying query, so the operation is abandoned,
+ * not aborted — callers must be safe to retry, because the work may
+ * still complete server-side.
+ */
+export const withTimeout = async <T>(
+  operation: () => Promise<T>,
+  { label, timeoutMs }: WithTimeoutOptions,
+): Promise<T> => {
+  const op = operation();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new TimeoutError({
+          message: `${label} exceeded ${timeoutMs}ms`,
+          label,
+          timeoutMs,
+        }),
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([op, timeout]);
+  } finally {
+    clearTimeout(timer);
+    // If the timeout won the race, `op` is still pending; swallow its
+    // eventual settlement so a late rejection is not reported as an
+    // unhandled rejection.
+    void op.catch(() => undefined);
+  }
+};

--- a/apps/api/src/lib/with-timeout.ts
+++ b/apps/api/src/lib/with-timeout.ts
@@ -21,6 +21,10 @@ export const withTimeout = async <T>(
   operation: () => Promise<T>,
   { label, timeoutMs }: WithTimeoutOptions,
 ): Promise<T> => {
+  if (timeoutMs === 0) {
+    return await operation();
+  }
+
   const op = operation();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {

--- a/apps/legal-atlas-runner/src/db.ts
+++ b/apps/legal-atlas-runner/src/db.ts
@@ -1,3 +1,5 @@
+import { sql } from "drizzle-orm";
+
 /**
  * The legal-atlas-runner's single sanctioned database surface.
  *
@@ -22,18 +24,35 @@ import { withTimeout } from "@/api/lib/with-timeout";
 import { LEGAL_ATLAS_RUNNER_ENV } from "./env";
 
 const rawIngestionDb = createIngestionDb(rlsDb);
+const transactionTimeoutMs = LEGAL_ATLAS_RUNNER_ENV.dbTransactionTimeoutMs;
+const TRANSACTION_TIMEOUT_GRACE_MS = 30_000;
 const rootQueryTimeoutMs = LEGAL_ATLAS_RUNNER_ENV.dbRootQueryTimeoutMs;
 
 /**
- * `stella_ingestion`-scoped transaction runner, bounded by a wall-clock
- * timeout. Drop-in for `ScopedDb`, so it threads straight into the
- * ingestion pipeline and backfill loops.
+ * `stella_ingestion`-scoped transaction runner. Postgres owns the normal
+ * cancellation path through SET LOCAL statement_timeout; the outer wall-clock
+ * grace only catches sockets that never deliver that server-side failure.
  */
-export const ingestionDb: ScopedDb = async (fn) =>
-  await withTimeout(async () => await rawIngestionDb(fn), {
+export const ingestionDb: ScopedDb = async (fn) => {
+  const operation = async () =>
+    await rawIngestionDb(async (tx) => {
+      if (transactionTimeoutMs > 0) {
+        await tx.execute(
+          sql`SELECT set_config('statement_timeout', ${`${transactionTimeoutMs}ms`}, true)`,
+        );
+      }
+
+      return await fn(tx);
+    });
+
+  return await withTimeout(operation, {
     label: "ingestion-db-transaction",
-    timeoutMs: LEGAL_ATLAS_RUNNER_ENV.dbTransactionTimeoutMs,
+    timeoutMs:
+      transactionTimeoutMs === 0
+        ? 0
+        : transactionTimeoutMs + TRANSACTION_TIMEOUT_GRACE_MS,
   });
+};
 
 type CaseLawSource = typeof caseLawSources.$inferSelect;
 

--- a/apps/legal-atlas-runner/src/db.ts
+++ b/apps/legal-atlas-runner/src/db.ts
@@ -1,0 +1,75 @@
+/**
+ * The legal-atlas-runner's single sanctioned database surface.
+ *
+ * The runner daemons are long-lived: an un-timed-out DB await on a
+ * pooled connection the server reaped silently hangs forever, wedging
+ * the whole worker until the cycle hard deadline force-exits it (which
+ * trips the prod `utility-worker-no-tasks` CloudWatch alarm on every
+ * restart). Every DB operation here is wrapped in `withTimeout`, so a
+ * dead connection rejects and the adapter loop retries instead.
+ *
+ * `no-restricted-imports` (oxlint.config.ts) bans the raw `@/api/db/root`
+ * pools and `createIngestionDb` elsewhere in this package, so this is the
+ * only way the daemons can reach the database — no caller can construct
+ * an unbounded handle.
+ */
+import type { ScopedDb } from "@/api/db";
+import { createIngestionDb } from "@/api/db";
+import { rootDb, rlsDb } from "@/api/db/root";
+import { caseLawSources } from "@/api/db/schema";
+import { withTimeout } from "@/api/lib/with-timeout";
+
+import { LEGAL_ATLAS_RUNNER_ENV } from "./env";
+
+const rawIngestionDb = createIngestionDb(rlsDb);
+const rootQueryTimeoutMs = LEGAL_ATLAS_RUNNER_ENV.dbRootQueryTimeoutMs;
+
+/**
+ * `stella_ingestion`-scoped transaction runner, bounded by a wall-clock
+ * timeout. Drop-in for `ScopedDb`, so it threads straight into the
+ * ingestion pipeline and backfill loops.
+ */
+export const ingestionDb: ScopedDb = async (fn) =>
+  await withTimeout(async () => await rawIngestionDb(fn), {
+    label: "ingestion-db-transaction",
+    timeoutMs: LEGAL_ATLAS_RUNNER_ENV.dbTransactionTimeoutMs,
+  });
+
+type CaseLawSource = typeof caseLawSources.$inferSelect;
+
+type NewCaseLawSource = {
+  adapterKey: string;
+  name: string;
+  syncCursor: string | null;
+};
+
+/**
+ * Look up a source by adapter key. Uses the root pool because the
+ * ingestion role has only narrow grants on `case_law_sources`.
+ */
+export const findCaseLawSource = async (
+  adapterKey: string,
+): Promise<CaseLawSource | undefined> =>
+  await withTimeout(
+    () => rootDb.query.caseLawSources.findFirst({ where: { adapterKey } }),
+    { label: "case-law-source-lookup", timeoutMs: rootQueryTimeoutMs },
+  );
+
+/**
+ * Seed a source row. The ingestion role cannot INSERT into
+ * `case_law_sources` (it gets SELECT plus a narrow cursor UPDATE), so
+ * this one-time create runs on the root pool.
+ */
+export const createCaseLawSource = async (
+  input: NewCaseLawSource,
+): Promise<CaseLawSource | undefined> =>
+  await withTimeout(
+    async () => {
+      const [created] = await rootDb
+        .insert(caseLawSources)
+        .values({ ...input, config: {} })
+        .returning();
+      return created;
+    },
+    { label: "case-law-source-create", timeoutMs: rootQueryTimeoutMs },
+  );

--- a/apps/legal-atlas-runner/src/db.ts
+++ b/apps/legal-atlas-runner/src/db.ts
@@ -5,10 +5,9 @@ import { sql } from "drizzle-orm";
  *
  * The runner daemons are long-lived: an un-timed-out DB await on a
  * pooled connection the server reaped silently hangs forever, wedging
- * the whole worker until the cycle hard deadline force-exits it (which
- * trips the prod `utility-worker-no-tasks` CloudWatch alarm on every
- * restart). Every DB operation here is wrapped in `withTimeout`, so a
- * dead connection rejects and the adapter loop retries instead.
+ * the whole worker until external supervision restarts it. Every DB
+ * operation here is wrapped in `withTimeout`, so a dead connection rejects
+ * and the adapter loop retries instead.
  *
  * `no-restricted-imports` (oxlint.config.ts) bans the raw `@/api/db/root`
  * pools and `createIngestionDb` elsewhere in this package, so this is the
@@ -84,10 +83,12 @@ export const createCaseLawSource = async (
 ): Promise<CaseLawSource | undefined> =>
   await withTimeout(
     async () => {
-      const [created] = await rootDb
-        .insert(caseLawSources)
-        .values({ ...input, config: {} })
-        .returning();
+      const created = (
+        await rootDb
+          .insert(caseLawSources)
+          .values({ ...input, config: {} })
+          .returning()
+      ).at(0);
       return created;
     },
     { label: "case-law-source-create", timeoutMs: rootQueryTimeoutMs },

--- a/apps/legal-atlas-runner/src/env.ts
+++ b/apps/legal-atlas-runner/src/env.ts
@@ -8,4 +8,17 @@ export const LEGAL_ATLAS_RUNNER_ENV = {
   // the event loop so no page completes within its cycle budget.
   maxConcurrentAdapterCycles:
     Number.parseInt(Bun.env["MAX_CONCURRENT_ADAPTER_CYCLES"] ?? "2", 10) || 2,
+  // Wall-clock ceiling on a single ingestion transaction. A dead pooled
+  // connection can otherwise hang a read forever; this rejects it so the
+  // adapter loop retries instead of wedging until the cycle hard deadline
+  // force-exits the worker. Must exceed the longest legitimate statement
+  // (the search-index backfill raises its statement_timeout to 15min).
+  dbTransactionTimeoutMs:
+    Number.parseInt(Bun.env["DB_TRANSACTION_TIMEOUT_MS"] ?? "1200000", 10) ||
+    1_200_000,
+  // Root-pool reads/writes (source lookup + one-time seed insert) are tiny;
+  // a short ceiling fails fast on a dead connection at cycle start.
+  dbRootQueryTimeoutMs:
+    Number.parseInt(Bun.env["DB_ROOT_QUERY_TIMEOUT_MS"] ?? "30000", 10) ||
+    30_000,
 } as const;

--- a/apps/legal-atlas-runner/src/env.ts
+++ b/apps/legal-atlas-runner/src/env.ts
@@ -1,24 +1,64 @@
+import { panic } from "better-result";
+
+type IntegerEnvOptions = {
+  name: string;
+  fallback: number;
+  min: number;
+};
+
+const readIntegerEnv = ({ name, fallback, min }: IntegerEnvOptions): number => {
+  const raw = Bun.env[name]?.trim();
+
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+
+  if (!/^\d+$/u.test(raw)) {
+    panic(`${name} must be an integer`);
+  }
+
+  const parsed = Number(raw);
+
+  if (!Number.isSafeInteger(parsed)) {
+    panic(`${name} must be a safe integer`);
+  }
+
+  if (parsed < min) {
+    panic(`${name} must be at least ${min}`);
+  }
+
+  return parsed;
+};
+
 export const LEGAL_ATLAS_RUNNER_ENV = {
   disabledAdapters: Bun.env["DISABLED_ADAPTERS"] ?? "",
-  maxConcurrentDbWrites:
-    Number.parseInt(Bun.env["MAX_CONCURRENT_DB_WRITES"] ?? "2", 10) || 2,
+  maxConcurrentDbWrites: readIntegerEnv({
+    name: "MAX_CONCURRENT_DB_WRITES",
+    fallback: 2,
+    min: 1,
+  }),
   // Cap on adapters crawling at once. Each cycle fetches + enriches + parses
   // outside the DB-write semaphore, so without this bound every source crawls
   // its backlog concurrently and saturates a small worker (0.5 vCPU), starving
   // the event loop so no page completes within its cycle budget.
-  maxConcurrentAdapterCycles:
-    Number.parseInt(Bun.env["MAX_CONCURRENT_ADAPTER_CYCLES"] ?? "2", 10) || 2,
-  // Wall-clock ceiling on a single ingestion transaction. A dead pooled
-  // connection can otherwise hang a read forever; this rejects it so the
-  // adapter loop retries instead of wedging until the cycle hard deadline
-  // force-exits the worker. Must exceed the longest legitimate statement
-  // (the search-index backfill raises its statement_timeout to 15min).
-  dbTransactionTimeoutMs:
-    Number.parseInt(Bun.env["DB_TRANSACTION_TIMEOUT_MS"] ?? "1200000", 10) ||
-    1_200_000,
+  maxConcurrentAdapterCycles: readIntegerEnv({
+    name: "MAX_CONCURRENT_ADAPTER_CYCLES",
+    fallback: 2,
+    min: 1,
+  }),
+  // 0 disables the runner's transaction timeout. Non-zero values are installed
+  // as a transaction-local Postgres statement_timeout, with a short wall-clock
+  // grace in db.ts for sockets that never report the server-side cancellation.
+  dbTransactionTimeoutMs: readIntegerEnv({
+    name: "DB_TRANSACTION_TIMEOUT_MS",
+    fallback: 1_200_000,
+    min: 0,
+  }),
   // Root-pool reads/writes (source lookup + one-time seed insert) are tiny;
   // a short ceiling fails fast on a dead connection at cycle start.
-  dbRootQueryTimeoutMs:
-    Number.parseInt(Bun.env["DB_ROOT_QUERY_TIMEOUT_MS"] ?? "30000", 10) ||
-    30_000,
+  dbRootQueryTimeoutMs: readIntegerEnv({
+    name: "DB_ROOT_QUERY_TIMEOUT_MS",
+    fallback: 30_000,
+    min: 0,
+  }),
 } as const;

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -3,8 +3,6 @@ import type { SQL } from "drizzle-orm";
 
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
-import { createIngestionDb } from "@/api/db";
-import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, legislationDocuments } from "@/api/db/schema";
 import { backfillCorpusIndex } from "@/api/handlers/case-law/corpus-index";
 import { writeCorpusDocument } from "@/api/handlers/case-law/corpus-storage";
@@ -20,6 +18,8 @@ import {
   refreshCorpusS3,
   refreshS3,
 } from "@/api/lib/s3";
+
+import { ingestionDb } from "../db";
 
 const BATCH_SIZE = 50;
 const CONCURRENCY = 4;
@@ -50,8 +50,6 @@ type BackfillOptions = {
 type ParseResult =
   | { ok: true; options: BackfillOptions }
   | { ok: false; message: string };
-
-const ingestionDb = createIngestionDb(rlsDb);
 
 const logInfo = (message: string): void => {
   void Bun.write(Bun.stdout, `${message}\n`);

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -19,9 +19,7 @@
 
 import { panic } from "better-result";
 
-import { createIngestionDb } from "@/api/db";
-import { rootDb, rlsDb } from "@/api/db/root";
-import { caseLawIngestionEvents, caseLawSources } from "@/api/db/schema";
+import { caseLawIngestionEvents } from "@/api/db/schema";
 import { envBase } from "@/api/env-base";
 import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
 import { ADAPTER_KEYS, MAX_CYCLE_MS } from "@/api/handlers/case-law/consts";
@@ -31,6 +29,7 @@ import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline
 import { backfillSearchIndex } from "@/api/handlers/case-law/search-index";
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
 import { backfillLegislationSearchIndex } from "@/api/handlers/legislation/search-index";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { LIMITS } from "@/api/lib/limits";
@@ -42,6 +41,7 @@ import {
   refreshS3,
 } from "@/api/lib/s3";
 
+import { createCaseLawSource, findCaseLawSource, ingestionDb } from "../db";
 import { LEGAL_ATLAS_RUNNER_ENV } from "../env";
 
 const formatLogDetail = (detail: unknown): string => {
@@ -74,14 +74,6 @@ const logError = (message: string, detail?: unknown): void => {
   void Bun.write(Bun.stderr, `${line}\n`);
 };
 
-// Case-law ingestion writes the global corpus. The customer-scoped
-// `stella` role is read-only on case_law_* (see migration
-// 20260510140000); the daemon switches to `stella_ingestion`, which
-// has narrow writes on the corpus and nothing else. Any future code
-// path that strays outside case_law_* will hit a loud
-// `permission denied`.
-const ingestionDb = createIngestionDb(rlsDb);
-
 /**
  * Bun's native Postgres pool emits unhandled errors when the
  * server closes a connection (e.g. database failover or
@@ -90,20 +82,31 @@ const ingestionDb = createIngestionDb(rlsDb);
  * try/catch. Without this handler, the process crashes on
  * any connection drop.
  *
+ * A TimeoutError is the same failure class surfacing differently: a
+ * connection the server reaped silently never errors, so the bounded
+ * DB handle in `../db` rejects the wedged await. Both retry next cycle.
+ *
  * Adapter loops already retry on the next cycle, so the
  * daemon self-heals within CYCLE_DELAY_MS (5s).
  */
-const isTransientConnectionError = (msg: string): boolean =>
-  msg.includes("Connection closed") ||
-  msg.includes("ERR_POSTGRES_CONNECTION_CLOSED") ||
-  msg.includes("PostgresError");
+const isTransientConnectionError = (error: unknown): boolean => {
+  if (error instanceof TimeoutError) {
+    return true;
+  }
+  const msg = error instanceof Error ? error.message : String(error);
+  return (
+    msg.includes("Connection closed") ||
+    msg.includes("ERR_POSTGRES_CONNECTION_CLOSED") ||
+    msg.includes("PostgresError")
+  );
+};
 
 /** Set to true once daemon mode starts; single-adapter mode exits on all errors. */
 let daemonMode = false;
 
 process.on("unhandledRejection", (reason) => {
   const message = reason instanceof Error ? reason.message : String(reason);
-  if (daemonMode && isTransientConnectionError(message)) {
+  if (daemonMode && isTransientConnectionError(reason)) {
     logError(`[daemon] DB connection lost (will retry): ${message}`);
     return;
   }
@@ -343,23 +346,17 @@ const ensureSource = async (
   name: string,
   initialCursor: string | null,
 ) => {
-  const existing = await rootDb.query.caseLawSources.findFirst({
-    where: { adapterKey },
-  });
+  const existing = await findCaseLawSource(adapterKey);
 
   if (existing) {
     return existing;
   }
 
-  const [created] = await rootDb
-    .insert(caseLawSources)
-    .values({
-      adapterKey,
-      name,
-      syncCursor: initialCursor,
-      config: {},
-    })
-    .returning();
+  const created = await createCaseLawSource({
+    adapterKey,
+    name,
+    syncCursor: initialCursor,
+  });
 
   if (!created) {
     panic(`Failed to create source row for adapter "${adapterKey}"`);
@@ -582,7 +579,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       noProgressStreak++;
       backoffFailures++;
       const msg = error instanceof Error ? error.message : String(error);
-      if (isTransientConnectionError(msg)) {
+      if (isTransientConnectionError(error)) {
         logError(`[${adapterKey}] DB connection error (will retry): ${msg}`);
       } else {
         logError(`[${adapterKey}] Unexpected error:`, error);
@@ -753,7 +750,7 @@ export const runCaseLawIngest = async (
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        if (isTransientConnectionError(msg)) {
+        if (isTransientConnectionError(error)) {
           logError(`[search-index] DB connection error (will retry): ${msg}`);
         } else {
           logError("[search-index] Backfill error:", error);
@@ -778,7 +775,7 @@ export const runCaseLawIngest = async (
         logInfo(`[citation-authority] Recomputed (${updated} cited decisions)`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        if (isTransientConnectionError(msg)) {
+        if (isTransientConnectionError(error)) {
           logError(
             `[citation-authority] DB connection error (will retry): ${msg}`,
           );
@@ -813,7 +810,7 @@ export const runCaseLawIngest = async (
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        if (isTransientConnectionError(msg)) {
+        if (isTransientConnectionError(error)) {
           logError(`[corpus-index] DB connection error (will retry): ${msg}`);
         } else {
           logError("[corpus-index] Backfill error:", error);
@@ -839,7 +836,7 @@ export const runCaseLawIngest = async (
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        if (isTransientConnectionError(msg)) {
+        if (isTransientConnectionError(error)) {
           logError(
             `[legislation-search-index] DB connection error (will retry): ${msg}`,
           );
@@ -872,7 +869,7 @@ export const runCaseLawIngest = async (
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        if (isTransientConnectionError(msg)) {
+        if (isTransientConnectionError(error)) {
           logError(
             `[legislation-corpus-index] DB connection error (will retry): ${msg}`,
           );

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1292,8 +1292,7 @@ export default defineConfig({
     {
       // The legal-atlas-runner daemons are long-lived: an un-timed-out DB
       // await on a connection the server reaped silently hangs forever and
-      // wedges the worker until the cycle hard deadline force-exits it
-      // (tripping the prod utility-worker-no-tasks alarm on every restart).
+      // wedges the worker until external supervision restarts it.
       // All DB access must go through the timeout-wrapped handles in
       // apps/legal-atlas-runner/src/db.ts so no caller can build an unbounded
       // handle. That module is the only sanctioned importer of the raw pools.
@@ -1307,6 +1306,10 @@ export default defineConfig({
           "error",
           {
             paths: [
+              {
+                name: "zod",
+                message: "Use 'valibot' instead of 'zod'.",
+              },
               {
                 name: "@/api/db/root",
                 message:

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1290,6 +1290,40 @@ export default defineConfig({
       },
     },
     {
+      // The legal-atlas-runner daemons are long-lived: an un-timed-out DB
+      // await on a connection the server reaped silently hangs forever and
+      // wedges the worker until the cycle hard deadline force-exits it
+      // (tripping the prod utility-worker-no-tasks alarm on every restart).
+      // All DB access must go through the timeout-wrapped handles in
+      // apps/legal-atlas-runner/src/db.ts so no caller can build an unbounded
+      // handle. That module is the only sanctioned importer of the raw pools.
+      files: ["apps/legal-atlas-runner/**/*.ts"],
+      excludeFiles: [
+        "apps/legal-atlas-runner/src/db.ts",
+        "apps/legal-atlas-runner/**/*.test.ts",
+      ],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            paths: [
+              {
+                name: "@/api/db/root",
+                message:
+                  "Import timeout-wrapped DB handles from '../db' instead of the raw Bun SQL pools.",
+              },
+              {
+                name: "@/api/db",
+                importNames: ["createIngestionDb", "createScopedDb"],
+                message:
+                  "Import the timeout-wrapped `ingestionDb` from '../db' instead of building a raw handle.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
       files: [
         "apps/api/src/lib/auth.ts",
         "apps/api/src/lib/search/**",


### PR DESCRIPTION
## What

Hardens database connection handling for the long-lived legal-atlas ingestion daemons.

The ingestion workers hold Postgres connections for the lifetime of the process. Bun's SQL pool does not recycle connections by default (no max lifetime / idle timeout) and has no TCP keepalive, so a connection the server closes between uses is only discovered on the next query — and a silently dropped socket can leave a read pending indefinitely, stalling the adapter cycle.

## Changes

- **Recycle pooled connections** (`apps/api/src/db/root.ts`, `env-base.ts`): both pools now set `maxLifetime` / `idleTimeout` (env-tunable, default 600s / 120s) so connections rotate before they can go stale.
- **Bound every daemon DB call**: new generic `withTimeout()` helper, and a single timeout-wrapped DB surface for the runner (`apps/legal-atlas-runner/src/db.ts`). A stalled call now rejects and the loop retries on the next cycle instead of hanging.
- **Structural guard**: `no-restricted-imports` keeps the runner package from importing the raw pools or building an unbounded handle, so the chokepoint can't be bypassed.
- `TimeoutError` is treated as a transient connection error, so it follows the existing retry path.

## Notes

- `findCaseLawSource` / `createCaseLawSource` stay on the root pool because the `stella_ingestion` role only has `SELECT` + a narrow cursor `UPDATE` on `case_law_sources` (no `INSERT`).
- The per-transaction timeout (default 20m) sits above the longest legitimate statement (the 15m search-index backfill) so it only catches genuinely wedged calls.

## Test plan

- [x] `bun test` for the new `withTimeout` helper
- [x] typecheck (api + legal-atlas-runner)
- [x] type-aware oxlint on the changed files; verified the new import guard fires on a probe and exempts the chokepoint module


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable database timeout and connection pool recycling settings across the API and ingestion runner.
  * Introduced a shared timeout utility for enforcing wall-clock deadlines on async database work.
* **Bug Fixes**
  * Ingestion now halts cleanly on database timeouts, preserving the existing source cursor and stopping further processing.
  * Improved handling of transient connection issues, including timeout-related failures, across ingestion and background maintenance loops.
* **Documentation**
  * Tightened environment validation for timeouts and concurrency to reject invalid values early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->