### PR TITLE
chore(db): single-source the corpus backfill statement_timeout

### DIFF
--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -3,7 +3,7 @@ import { sql } from "drizzle-orm";
 
 import { courtWeightSql } from "@/api/handlers/case-law/citation-score";
 import { redistributableCaseLawSourceSqlFor } from "@/api/handlers/case-law/redistribution";
-import { CORPUS_BACKFILL_STATEMENT_TIMEOUT } from "@/api/lib/legal-search/backfill-statement-timeout";
+import { setCorpusBackfillStatementTimeout } from "@/api/lib/legal-search/backfill-statement-timeout";
 
 /**
  * Materialize the citation-authority ranking signal onto
@@ -53,11 +53,7 @@ export const recomputeCitationAuthorityForAll = async (
   // every decision so decisions with zero citations are reset to 0 too.
   // The inner JOIN on citing_d matches the original semantics (a
   // citation whose citing decision no longer exists does not count).
-  await tx.execute(
-    sql.raw(
-      `SET LOCAL statement_timeout = '${CORPUS_BACKFILL_STATEMENT_TIMEOUT}'`,
-    ),
-  );
+  await setCorpusBackfillStatementTimeout(tx);
   await tx.execute(sql`
     UPDATE case_law_decisions d
     SET

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 
 import { courtWeightSql } from "@/api/handlers/case-law/citation-score";
 import { redistributableCaseLawSourceSqlFor } from "@/api/handlers/case-law/redistribution";
+import { CORPUS_BACKFILL_STATEMENT_TIMEOUT } from "@/api/lib/legal-search/backfill-statement-timeout";
 
 /**
  * Materialize the citation-authority ranking signal onto
@@ -52,7 +53,11 @@ export const recomputeCitationAuthorityForAll = async (
   // every decision so decisions with zero citations are reset to 0 too.
   // The inner JOIN on citing_d matches the original semantics (a
   // citation whose citing decision no longer exists does not count).
-  await tx.execute(sql`SET LOCAL statement_timeout = '15min'`);
+  await tx.execute(
+    sql.raw(
+      `SET LOCAL statement_timeout = '${CORPUS_BACKFILL_STATEMENT_TIMEOUT}'`,
+    ),
+  );
   await tx.execute(sql`
     UPDATE case_law_decisions d
     SET

--- a/apps/api/src/handlers/case-law/search-index.ts
+++ b/apps/api/src/handlers/case-law/search-index.ts
@@ -10,6 +10,7 @@ import { resolveFtsConfig } from "@/api/handlers/case-law/fts-config";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
+import { CORPUS_BACKFILL_STATEMENT_TIMEOUT } from "@/api/lib/legal-search/backfill-statement-timeout";
 import { logger } from "@/api/lib/observability/logger";
 import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
 
@@ -91,7 +92,11 @@ export const indexDecision = async (
     // to_tsvector + unaccent on very long court decisions is
     // CPU-intensive. SET LOCAL scopes this to the current
     // transaction only; user-facing queries keep the default.
-    await tx.execute(sql`SET LOCAL statement_timeout = '15min'`);
+    await tx.execute(
+      sql.raw(
+        `SET LOCAL statement_timeout = '${CORPUS_BACKFILL_STATEMENT_TIMEOUT}'`,
+      ),
+    );
     await tx.execute(sql`
     INSERT INTO case_law_search_documents (
       decision_id, title, searchable_text,

--- a/apps/api/src/handlers/case-law/search-index.ts
+++ b/apps/api/src/handlers/case-law/search-index.ts
@@ -10,7 +10,7 @@ import { resolveFtsConfig } from "@/api/handlers/case-law/fts-config";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
-import { CORPUS_BACKFILL_STATEMENT_TIMEOUT } from "@/api/lib/legal-search/backfill-statement-timeout";
+import { setCorpusBackfillStatementTimeout } from "@/api/lib/legal-search/backfill-statement-timeout";
 import { logger } from "@/api/lib/observability/logger";
 import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
 
@@ -90,13 +90,9 @@ export const indexDecision = async (
   await scopedDb(async (tx) => {
     // Raise statement timeout for the tsvector upsert.
     // to_tsvector + unaccent on very long court decisions is
-    // CPU-intensive. SET LOCAL scopes this to the current
-    // transaction only; user-facing queries keep the default.
-    await tx.execute(
-      sql.raw(
-        `SET LOCAL statement_timeout = '${CORPUS_BACKFILL_STATEMENT_TIMEOUT}'`,
-      ),
-    );
+    // CPU-intensive. The helper scopes the higher timeout to
+    // this transaction only; user-facing queries keep the default.
+    await setCorpusBackfillStatementTimeout(tx);
     await tx.execute(sql`
     INSERT INTO case_law_search_documents (
       decision_id, title, searchable_text,

--- a/apps/api/src/handlers/legislation/search-index.ts
+++ b/apps/api/src/handlers/legislation/search-index.ts
@@ -11,7 +11,7 @@ import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
-import { CORPUS_BACKFILL_STATEMENT_TIMEOUT } from "@/api/lib/legal-search/backfill-statement-timeout";
+import { setCorpusBackfillStatementTimeout } from "@/api/lib/legal-search/backfill-statement-timeout";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
@@ -78,11 +78,7 @@ export const indexLegislationDocument = async (
   const tsvExpr = sql`to_tsvector(${fts.regconfig}, ${textExpr})`;
 
   await scopedDb(async (tx) => {
-    await tx.execute(
-      sql.raw(
-        `SET LOCAL statement_timeout = '${CORPUS_BACKFILL_STATEMENT_TIMEOUT}'`,
-      ),
-    );
+    await setCorpusBackfillStatementTimeout(tx);
     await tx.execute(sql`
     INSERT INTO legislation_search_documents (
       document_id, title, searchable_text,

--- a/apps/api/src/handlers/legislation/search-index.ts
+++ b/apps/api/src/handlers/legislation/search-index.ts
@@ -11,6 +11,7 @@ import type { DecisionSection } from "@/api/handlers/case-law/types";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
+import { CORPUS_BACKFILL_STATEMENT_TIMEOUT } from "@/api/lib/legal-search/backfill-statement-timeout";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
@@ -77,7 +78,11 @@ export const indexLegislationDocument = async (
   const tsvExpr = sql`to_tsvector(${fts.regconfig}, ${textExpr})`;
 
   await scopedDb(async (tx) => {
-    await tx.execute(sql`SET LOCAL statement_timeout = '15min'`);
+    await tx.execute(
+      sql.raw(
+        `SET LOCAL statement_timeout = '${CORPUS_BACKFILL_STATEMENT_TIMEOUT}'`,
+      ),
+    );
     await tx.execute(sql`
     INSERT INTO legislation_search_documents (
       document_id, title, searchable_text,

--- a/apps/api/src/lib/legal-search/backfill-statement-timeout.ts
+++ b/apps/api/src/lib/legal-search/backfill-statement-timeout.ts
@@ -1,14 +1,29 @@
+import type { SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
 /**
  * Statement timeout for corpus backfill writes (the tsvector search
  * projections and the citation-authority recompute).
  *
  * `to_tsvector` + `unaccent` over long court decisions is CPU-bound and
  * outruns the default `statement_timeout`, so these transactions raise it
- * with `SET LOCAL` (scoped to the transaction; user-facing queries keep
- * the default). Single-sourced here so the backfill paths cannot drift.
+ * with a transaction-local setting; user-facing queries keep the default.
+ * Single-sourced here so the backfill paths cannot drift.
  *
  * This bounds an actively executing statement and is independent of the
  * DB-level `idle_in_transaction_session_timeout`, which only fires on a
  * transaction sitting idle between statements, never on a running one.
  */
 export const CORPUS_BACKFILL_STATEMENT_TIMEOUT = "15min";
+
+type StatementTimeoutTx = {
+  execute: (query: SQL) => Promise<unknown>;
+};
+
+export const setCorpusBackfillStatementTimeout = async (
+  tx: StatementTimeoutTx,
+): Promise<void> => {
+  await tx.execute(
+    sql`SELECT set_config('statement_timeout', ${CORPUS_BACKFILL_STATEMENT_TIMEOUT}, true)`,
+  );
+};

--- a/apps/api/src/lib/legal-search/backfill-statement-timeout.ts
+++ b/apps/api/src/lib/legal-search/backfill-statement-timeout.ts
@@ -1,0 +1,14 @@
+/**
+ * Statement timeout for corpus backfill writes (the tsvector search
+ * projections and the citation-authority recompute).
+ *
+ * `to_tsvector` + `unaccent` over long court decisions is CPU-bound and
+ * outruns the default `statement_timeout`, so these transactions raise it
+ * with `SET LOCAL` (scoped to the transaction; user-facing queries keep
+ * the default). Single-sourced here so the backfill paths cannot drift.
+ *
+ * This bounds an actively executing statement and is independent of the
+ * DB-level `idle_in_transaction_session_timeout`, which only fires on a
+ * transaction sitting idle between statements, never on a running one.
+ */
+export const CORPUS_BACKFILL_STATEMENT_TIMEOUT = "15min";


### PR DESCRIPTION
## What

Single-sources the `statement_timeout` used by the corpus backfill writes.

The tsvector search projections (case-law + legislation) and the citation-authority recompute each raised `statement_timeout` to a duplicated `'15min'` literal across three files. This extracts a shared `CORPUS_BACKFILL_STATEMENT_TIMEOUT` constant so the values can't drift apart, and documents that the bound governs an actively executing statement — independent of the DB-level `idle_in_transaction_session_timeout`, which only applies to a transaction sitting idle between statements.

No behaviour change.

## Test plan

- [x] typecheck (api)
- [x] type-aware oxlint on the changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of search index and backfill updates for case law and legislation.
  * Reduced the risk of long-running database operations timing out during large index maintenance tasks.
  * Kept normal user-facing queries on the standard database timeout, helping avoid unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->