### PR TITLE
chore(folio): harden pre-existing layer-boundary matchers for consistency

### DIFF
--- a/.oxlint-plugins/folio-layer-boundaries.ts
+++ b/.oxlint-plugins/folio-layer-boundaries.ts
@@ -35,12 +35,22 @@ const ENGINE_PREFIX = "packages/folio/src/core/layout-engine/";
 
 type Layer = "painter" | "bridge" | "engine";
 
-const matchesLayerPrefix = (normalizedPath: string, prefix: string): boolean =>
+const matchesLayerPrefix = (
+  normalizedPath: string,
+  prefix: string,
+): boolean => {
   // Anchor on a path separator (or the string start) so a directory that merely
   // contains the prefix as a substring cannot false-match, mirroring isCoreFile.
-  normalizedPath.startsWith(prefix) ||
-  normalizedPath.includes(`/${prefix}`) ||
-  normalizedPath.endsWith(prefix.slice(0, -1));
+  // `bare` is the prefix without its trailing slash, for the barrel-target case
+  // (an import resolving to the layer directory itself).
+  const bare = prefix.slice(0, -1);
+  return (
+    normalizedPath.startsWith(prefix) ||
+    normalizedPath.includes(`/${prefix}`) ||
+    normalizedPath.endsWith(`/${bare}`) ||
+    normalizedPath === bare
+  );
+};
 
 const layerOf = (absolutePath: string): Layer | null => {
   const normalized = absolutePath.replaceAll("\\", "/");

--- a/.oxlint-plugins/folio-layer-boundaries.ts
+++ b/.oxlint-plugins/folio-layer-boundaries.ts
@@ -36,7 +36,10 @@ const ENGINE_PREFIX = "packages/folio/src/core/layout-engine/";
 type Layer = "painter" | "bridge" | "engine";
 
 const matchesLayerPrefix = (normalizedPath: string, prefix: string): boolean =>
-  normalizedPath.includes(prefix) ||
+  // Anchor on a path separator (or the string start) so a directory that merely
+  // contains the prefix as a substring cannot false-match, mirroring isCoreFile.
+  normalizedPath.startsWith(prefix) ||
+  normalizedPath.includes(`/${prefix}`) ||
   normalizedPath.endsWith(prefix.slice(0, -1));
 
 const layerOf = (absolutePath: string): Layer | null => {

--- a/packages/folio/src/core/__tests__/layer-boundaries.test.ts
+++ b/packages/folio/src/core/__tests__/layer-boundaries.test.ts
@@ -65,13 +65,20 @@ const layerOfPath = (absolutePath: string): Layer | null => {
 };
 
 // Match the specifier of every static import/export, bare side-effect import
-// (`import "../setup"`), and dynamic import (`import("../setup")`). The
-// literal `from ` elsewhere in the file (e.g. inside comments) is filtered
-// later by the
-// `specifier.startsWith(".")` check — only relative paths are checked. The
-// regex itself uses bounded character classes to keep matching linear.
+// (`import "../setup"`), and dynamic import (`import("../setup")`). Comments are
+// stripped first (see stripComments), so a relative path mentioned in prose
+// cannot false-fire; the regex uses bounded character classes to keep matching
+// linear.
 const IMPORT_REGEX =
   /\bfrom\s*["'](?<fromSpec>[^"']+)["']|\bimport\s*["'](?<importSpec>[^"']+)["']|\bimport\s*\(\s*["'](?<dynImportSpec>[^"']+)["']\s*\)/gu;
+
+// Strip block and line comments before the raw-text scan so an import mentioned
+// in a comment cannot trip it. The line-comment pattern keeps the character
+// before `//` so it does not eat a `:` from a `https://` URL.
+const stripComments = (source: string): string =>
+  source
+    .replaceAll(/\/\*[\s\S]*?\*\//gu, "")
+    .replaceAll(/(?<lead>^|[^:])\/\/[^\n]*/gmu, "$<lead>");
 
 type EdgeViolation = {
   importer: string;
@@ -94,7 +101,7 @@ const violationsForSource = (
     return [];
   }
   const violations: EdgeViolation[] = [];
-  for (const match of source.matchAll(IMPORT_REGEX)) {
+  for (const match of stripComments(source).matchAll(IMPORT_REGEX)) {
     const specifier =
       match.groups?.["fromSpec"] ??
       match.groups?.["importSpec"] ??
@@ -338,5 +345,19 @@ describe("folio layer-boundaries — synthetic violation fixtures", () => {
     expect(
       classifyEdge(fromLayer ?? "painter", toLayer ?? "bridge", resolved),
     ).toBe("layout-painter must not import from layout-bridge");
+  });
+
+  test("an import mentioned in a comment is ignored", () => {
+    const importer = resolve(CORE_DIR, "layout-painter/renderPage.ts");
+    const lineComment = violationsForSource(
+      importer,
+      '// historically: import { x } from "../layout-bridge/measuring";\nconst x = 1;',
+    );
+    const blockComment = violationsForSource(
+      importer,
+      '/* import { x } from "../layout-bridge/measuring" */\nconst y = 2;',
+    );
+    expect(lineComment).toEqual([]);
+    expect(blockComment).toEqual([]);
   });
 });

--- a/packages/folio/src/core/__tests__/layer-boundaries.test.ts
+++ b/packages/folio/src/core/__tests__/layer-boundaries.test.ts
@@ -72,13 +72,16 @@ const layerOfPath = (absolutePath: string): Layer | null => {
 const IMPORT_REGEX =
   /\bfrom\s*["'](?<fromSpec>[^"']+)["']|\bimport\s*["'](?<importSpec>[^"']+)["']|\bimport\s*\(\s*["'](?<dynImportSpec>[^"']+)["']\s*\)/gu;
 
-// Strip block and line comments before the raw-text scan so an import mentioned
-// in a comment cannot trip it. The line-comment pattern keeps the character
-// before `//` so it does not eat a `:` from a `https://` URL.
+// Strip block comments and whole-line `//` comments before the raw-text scan so
+// an import mentioned in prose cannot trip it. Only full-line comments are
+// stripped (not trailing/mid-line `//`), so a `//` inside a string or regex
+// literal on a code line is never mistaken for a comment and the rest of that
+// line is preserved. The AST-based `no-upstream-import` rule remains the
+// authoritative check.
 const stripComments = (source: string): string =>
   source
     .replaceAll(/\/\*[\s\S]*?\*\//gu, "")
-    .replaceAll(/(?<lead>^|[^:])\/\/[^\n]*/gmu, "$<lead>");
+    .replaceAll(/^[ \t]*\/\/[^\n]*/gmu, "");
 
 type EdgeViolation = {
   importer: string;


### PR DESCRIPTION
Follow-up to #884. Applies the same two hardenings introduced there to their pre-existing twins in `folio-layer-boundaries.ts` and its architecture test, so the older code matches the newer guards.

- `matchesLayerPrefix`: anchor the layer-prefix match on a path separator (or string start), mirroring `isCoreFile`, so a directory that merely contains a layer prefix as a substring cannot false-match.
- `layer-boundaries.test.ts`: strip block and line comments before the raw-text import scan, so a relative import path mentioned in a comment cannot false-fire. Adds a regression test.

No behavior change for real code paths; the layer-boundary rule still fires (verified on a probe), and the arch test passes (15 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import path matching so only true path boundaries are detected, reducing false positives from similarly named directories.
  * Ignored commented-out import statements when checking for import rule violations, so comments no longer trigger warnings.

* **Tests**
  * Added regression coverage for comment-only import text to confirm no violations are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->