### PR TITLE
refactor(folio): seam architecture foundation (measurement + model seams)

### DIFF
--- a/.oxlint-plugins/folio-layer-boundaries.ts
+++ b/.oxlint-plugins/folio-layer-boundaries.ts
@@ -130,7 +130,8 @@ type RuleContext = {
       | "bridgeToPainter"
       | "engineToPainter"
       | "engineToBridge"
-      | "reactInCore";
+      | "reactInCore"
+      | "modelImpureData";
   }) => void;
 };
 
@@ -258,6 +259,111 @@ const checkReactFreeCore = (
   context.report({ node: importNode, messageId: "reactInCore" });
 };
 
+// ---------------------------------------------------------------------------
+// Model-is-pure-data seam (Seam 2).
+//
+// The model layer is folio's behavior-free data lingua franca: the docx
+// document model (`core/types/*`), the layout/flow data shapes
+// (`layout-engine/types`), and the measurement data shapes
+// (`layout-engine/measure/measureTypes`). These modules describe data only;
+// they must never depend on behavior or a framework, so the engine, painter,
+// bridge, ProseMirror integration, and adapters can all sit on top of one
+// shared, swappable data surface.
+//
+// Forbidden from any model file:
+//   - bare `prosemirror-*`, `react`, `react-dom`, `@stll/ui`
+//   - a relative import that resolves into a behavior directory
+//     (`layout-painter`, `layout-bridge`, `prosemirror`, `managers`)
+//   - a relative import into `layout-engine/` at anything other than
+//     `layout-engine/types` (the model's own pure-data leaf). The measure
+//     model (`layout-engine/measure/measureTypes`) is itself a model file, so
+//     it may sit under `layout-engine/` without tripping this rule.
+// ---------------------------------------------------------------------------
+
+// ProseMirror ships as `prosemirror-state`, `prosemirror-view`, … so any
+// specifier starting with `prosemirror-` is behavior. React, react-dom, and
+// the UI kit are matched exactly (or as a subpath import) like no-react-in-core.
+const FORBIDDEN_MODEL_PACKAGES = ["react", "react-dom", "@stll/ui"];
+
+const FORBIDDEN_MODEL_BEHAVIOR_DIRS = [
+  "layout-painter",
+  "layout-bridge",
+  "prosemirror",
+  "managers",
+];
+
+const isForbiddenModelPackage = (specifier: string): boolean => {
+  if (specifier.startsWith("prosemirror-")) {
+    return true;
+  }
+  for (const pkg of FORBIDDEN_MODEL_PACKAGES) {
+    if (specifier === pkg || specifier.startsWith(`${pkg}/`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// Allowed engine targets are the model's own pure-data leaves:
+//   - `layout-engine/types`
+//   - `layout-engine/measure/measureTypes`
+// Any other relative reach into `layout-engine/` pulls engine behavior.
+const isAllowedModelEngineTarget = (stripped: string): boolean =>
+  stripped.endsWith("/layout-engine/types") ||
+  stripped.endsWith("layout-engine/types") ||
+  stripped.endsWith("/layout-engine/measure/measureTypes") ||
+  stripped.endsWith("layout-engine/measure/measureTypes");
+
+const resolvesIntoBehaviorDir = (stripped: string): boolean => {
+  for (const dir of FORBIDDEN_MODEL_BEHAVIOR_DIRS) {
+    if (
+      stripped.includes(`/${dir}/`) ||
+      stripped.endsWith(`/${dir}`) ||
+      stripped.startsWith(`${dir}/`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const checkModelPurity = (context: RuleContext, importNode: AstNode): void => {
+  const specifier = importSpecifierOf(importNode);
+  if (specifier === null) {
+    return;
+  }
+  const importerPath = filenameOf(context);
+  if (importerPath === "") {
+    return;
+  }
+
+  if (isForbiddenModelPackage(specifier)) {
+    context.report({ node: importNode, messageId: "modelImpureData" });
+    return;
+  }
+
+  if (!specifier.startsWith(".")) {
+    return;
+  }
+  const resolved = resolveCoreTarget(importerPath, specifier);
+  if (resolved === null) {
+    return;
+  }
+  const stripped = stripExtAndIndex(resolved);
+
+  if (resolvesIntoBehaviorDir(stripped)) {
+    context.report({ node: importNode, messageId: "modelImpureData" });
+    return;
+  }
+
+  if (
+    stripped.includes("/layout-engine/") &&
+    !isAllowedModelEngineTarget(stripped)
+  ) {
+    context.report({ node: importNode, messageId: "modelImpureData" });
+  }
+};
+
 export default {
   meta: { name: "folio-layer-boundaries" },
   rules: {
@@ -321,6 +427,36 @@ export default {
         const handle = (node: unknown) => {
           if (isAstNode(node)) {
             checkReactFreeCore(context, node);
+          }
+        };
+        return {
+          ImportDeclaration: handle,
+          ImportExpression: handle,
+          ExportNamedDeclaration: handle,
+          ExportAllDeclaration: handle,
+        };
+      },
+    },
+    "model-is-pure-data": {
+      meta: {
+        type: "problem",
+        messages: {
+          modelImpureData:
+            "The folio model layer (core/types, layout-engine/types, " +
+            "layout-engine/measure/measureTypes) is pure data — the " +
+            "behavior-free lingua franca that the engine, painter, bridge, " +
+            "ProseMirror integration, and adapters all sit on top of. It must " +
+            "not depend on ProseMirror, DOM render, React, @stll/ui, or engine " +
+            "behavior (layout-painter, layout-bridge, prosemirror, managers, " +
+            "or any layout-engine module other than layout-engine/types). Move " +
+            "behavior into the layer that owns it and keep the model describing " +
+            "data only.",
+        },
+      },
+      create(context: RuleContext) {
+        const handle = (node: unknown) => {
+          if (isAstNode(node)) {
+            checkModelPurity(context, node);
           }
         };
         return {

--- a/.oxlint-plugins/folio-layer-boundaries.ts
+++ b/.oxlint-plugins/folio-layer-boundaries.ts
@@ -310,13 +310,14 @@ const isForbiddenModelPackage = (specifier: string): boolean => {
 // Any other relative reach into `layout-engine/` pulls engine behavior.
 const isAllowedModelEngineTarget = (stripped: string): boolean =>
   stripped.endsWith("/layout-engine/types") ||
-  stripped.endsWith("layout-engine/types") ||
+  stripped === "layout-engine/types" ||
   stripped.endsWith("/layout-engine/measure/measureTypes") ||
-  stripped.endsWith("layout-engine/measure/measureTypes");
+  stripped === "layout-engine/measure/measureTypes";
 
 const resolvesIntoBehaviorDir = (stripped: string): boolean => {
   for (const dir of FORBIDDEN_MODEL_BEHAVIOR_DIRS) {
     if (
+      stripped === dir ||
       stripped.includes(`/${dir}/`) ||
       stripped.endsWith(`/${dir}`) ||
       stripped.startsWith(`${dir}/`)

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -573,6 +573,22 @@ export default defineConfig({
       },
     },
     {
+      // Folio model seam (Seam 2). The model type layer is pure data — the
+      // behavior-free lingua franca the engine, painter, bridge, ProseMirror
+      // integration, and adapters all sit on. Forbid it from importing
+      // ProseMirror, DOM render, React, @stll/ui, or engine behavior. See
+      // `.oxlint-plugins/folio-layer-boundaries.ts` and the matching test at
+      // `packages/folio/src/core/__tests__/model-purity.test.ts`.
+      files: [
+        "packages/folio/src/core/types/**/*.ts",
+        "packages/folio/src/core/layout-engine/types.ts",
+        "packages/folio/src/core/layout-engine/measure/measureTypes.ts",
+      ],
+      rules: {
+        "folio-layer-boundaries/model-is-pure-data": "error",
+      },
+    },
+    {
       // Drizzle schema files are guarded by check-migrations.sh, which
       // requires a new migration on any byte-level change. Keep regex
       // flags off here so adding the rule globally doesn't force an

--- a/packages/folio/bunfig.toml
+++ b/packages/folio/bunfig.toml
@@ -1,0 +1,6 @@
+[test]
+# Install the canvas MeasureProvider before any layout/measure test runs. The
+# layout engine measures through a pure provider seam whose default throws
+# until a backend is installed at a composition root (the React editor does
+# this at runtime).
+preload = ["./test/installMeasureProvider.preload.ts"]

--- a/packages/folio/docs/seam-architecture.md
+++ b/packages/folio/docs/seam-architecture.md
@@ -1,0 +1,220 @@
+# Folio seam architecture
+
+Target architecture for folio: a layered set of packages joined by explicit,
+typed seams, so that the same engine powers multiple framework adapters
+(React, Vue), multiple hosts (web, desktop, server), a future Rust core, headless
+agentic editing, and — eventually — additional OOXML formats (pptx, xlsx) as
+parallel verticals over a shared substrate.
+
+This doc defines the seams. It is the north star for the phased migration in
+[Phased path](#phased-path); we are not there yet.
+
+## Principle
+
+Cut the seams by **reason to change** and **portability profile**, not by
+"React or not". Today folio has one coarse seam — `core/` (React-free) vs the
+React adapter — which is why the adapter reaches into ~91 core modules: the
+boundary is in the wrong place. Replace it with layers where each boundary is a
+typed contract.
+
+## Responsibility map
+
+From most-portable (bottom) to most-framework-specific (top).
+
+| Layer           | Owns                                                                                                                                                                           | Profile                                  |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| `model`         | Pure data shapes: `Document`, `Layout`, `FlowBlock`, `Measure`, content types, ids                                                                                             | Language-agnostic (→ Rust serde)         |
+| `engine`        | Pure compute: OOXML read/write, `Document→FlowBlocks`, pagination/line-break, markdown, pure transforms (fields, content-controls, watermark, style resolution), AI diff/apply | **Rust target.** No DOM, no PM, no React |
+| `document`      | Editable model: PM schema, plugins, commands, extensions, `Document↔ProseMirror`                                                                                               | JS forever (ProseMirror is JS)           |
+| `render-dom`    | Paint `Layout`→DOM, hit-testing, span mapping, scroll, overlay geometry; the canvas measure provider                                                                           | JS forever, **framework-agnostic DOM**   |
+| `controller`    | Headless orchestration: layout loop, incremental measure, hidden PM view, selection/scroll; imperative API + events                                                            | Framework-agnostic JS                    |
+| `react` / `vue` | Thin: lifecycle, event wiring, chrome (toolbar/menus/dialogs)                                                                                                                  | Per-framework                            |
+
+`layout-bridge` today **conflates** two concerns: pure `Document→FlowBlocks`
+(belongs in `engine`) and DOM hit-testing (belongs in `render-dom`). Splitting
+it is part of the migration (P3).
+
+## The seams (the contracts)
+
+Everything crosses these; nothing reaches around them.
+
+### Seam 1 — `MeasureProvider` (the Rust linchpin)
+
+The engine must not know _how_ text is measured.
+
+```ts
+interface MeasureProvider {
+  measureWidths(reqs: MeasureRequest[]): number[]; // batched, pure
+  fontMetrics(fontString: string): FontMetrics; // ascent/descent/lineHeight
+  // Phase B (later): shapeRuns(...) -> positioned glyphs
+}
+type MeasureRequest = {
+  text: string;
+  font: string;
+  letterSpacing: number;
+  horizontalScale: number;
+};
+type FontMetrics = { ascent: number; descent: number; lineHeight: number };
+```
+
+Browser supplies a canvas-backed impl; Rust supplies a `rustybuzz`/`fontdb`
+impl; a headless/server path supplies either. This single inversion makes the
+layout engine pure and Rust-portable, and lets us swap measurement backends.
+
+> Note: this seam already half-exists as `layout-engine/measure/measureWorkerProtocol.ts`
+> (a serializable `MeasureRequestEntry[] → width[]` contract fulfilled by a
+> stateless worker). P2 generalizes it into `MeasureProvider`.
+
+### Seam 2 — the data lingua franca
+
+`Document`, `Layout`, `FlowBlock`, `Measure` are pure serializable types in
+`model`. They are the FFI payload (Rust mirrors them as serde structs). No
+behavior.
+
+### Seam 3 — `Document ↔ ProseMirror`
+
+`toDocument(pmDoc)` / `toProseDoc(document)` (today's `fromProseDoc` /
+`toProseDoc`). PM is the live editable state; `Document` is what the engine
+consumes. **The engine never sees ProseMirror.** Must be incremental-friendly
+(convert only changed blocks).
+
+### Seam 4 — `Layout → paint`
+
+Engine emits `Layout` (data); `render-dom` draws it. One-way, pure-data
+(already roughly enforced as `layout-engine → layout-painter`). Design `Layout`
+to optionally carry positioned-glyph data so Phase-B shaping is additive.
+
+### Seam 5 — `FolioHost` (environment capabilities)
+
+```ts
+interface FolioHost {
+  measureProvider: MeasureProvider;
+  loadFont(spec: FontSpec): Promise<FontResource>;
+  readFile?(path: string): Promise<Uint8Array>; // desktop; absent on web
+  writeFile?(path: string, bytes: Uint8Array): Promise<void>;
+  schedule(cb: () => void): void; // raf vs immediate
+}
+```
+
+Web, Tauri/Electrobun, and Node each provide a different host. The engine and
+controller stay identical across web/desktop/server.
+
+### Seam 6 — `FolioEditor` (headless API + events; the Vue/desktop linchpin)
+
+```ts
+interface FolioEditor {
+  mount(container: HTMLElement): void;
+  loadDocx(bytes: Uint8Array): Promise<void>;
+  getDocx(): Promise<Uint8Array>;
+  commands: { applyStyle(...): void; insertTable(...): void; /* ... */ };
+  on(evt: "selectionChange" | "docChange" | "layoutComplete", cb: () => void): () => void;
+  destroy(): void;
+}
+```
+
+Framework adapters only instantiate this, forward lifecycle/events, and render
+chrome. The editor _surface_ (pages) is painted imperatively by `render-dom`.
+
+### Seam 7 — Operation / Edit API (the agentic surface)
+
+A stable, versioned, documented schema of edit operations over `Document`
+(insert/replace/redline/fill-template/restructure), applied deterministically by
+the engine with tracked-change provenance (built on today's `ai-edits`
+apply/snapshot/diff). Agents emit ops as JSON; the engine applies them headless.
+Addressing uses stable, simple ids (block-id/para-id), never raw UUIDs.
+
+## Dependency direction (strictly one-way)
+
+```
+model  <-  engine  <-  measure-impl
+  ^          ^
+document(PM) |
+  ^          |
+render-dom --'        (render-dom uses model + Layout; ideally PM-free)
+  ^
+controller  ->  engine, document, render-dom, host
+  ^
+react / vue  ->  controller
+```
+
+`engine` depends only on `model` + the `MeasureProvider` interface. Adapters
+depend only on the `controller` API. The 91 reach-ins collapse to
+`adapter → FolioEditor`.
+
+## The measurement crux
+
+Seam 1 is the linchpin and the hardest part, because of a fidelity fork:
+
+- **Phase A:** provider returns advance _widths_; engine breaks lines; the
+  painter still emits text as DOM and lets the browser shape glyphs. Cheap, but
+  Rust-measured widths can drift from browser rendering.
+- **Phase B:** provider returns _positioned glyphs_; painter blits them; the
+  browser does no text layout. Fully deterministic and Rust-owned, and the only
+  honest path for Arabic/RTL/complex-script fidelity (shaping, not just width).
+  Bigger painter change.
+
+Design `Layout` to carry optional glyph positions from day one so B is additive.
+Fonts must be provisioned identically to `measure` and `paint` (same fallback
+chain) or layout drifts — a sub-problem of Seam 5.
+
+## Incremental layout & async transport (desktop)
+
+Don't re-serialize the whole `Document` per keystroke. Model the
+controller↔engine contract as a stateful `LayoutSession` (holds cached measures
+
+- previous layout, fed dirty ranges). Make its methods **async-tolerant**
+  (promise-returning) from the start: in the browser a WASM/worker call is
+  effectively in-process, but on desktop the engine may live across a Tauri IPC or
+  napi boundary, or off the UI thread. An async interface preserves that option at
+  no cost to the JS path.
+
+## Multi-format substrate (docx, pptx, …)
+
+docx and pptx share the OOXML container (zip / `[Content_Types].xml` / `.rels` /
+parts), DrawingML (shapes, images, charts, text-in-shapes), and theme/fonts.
+They diverge at the model (flowing WordprocessingML vs spatial PresentationML),
+layout (pagination/reflow vs fixed slide canvas with in-shape autofit), and
+editing (PM flow vs shape canvas). So formats are **parallel verticals over a
+shared substrate**, not a fork:
+
+```
+@folio/ooxml    container (zip/parts/rels), DrawingML, theme/fonts   [shared]
+@folio/measure  text shaping/measure seam                            [shared]
+@folio/host     capabilities                                         [shared]
+   |- docx: model(Document)     + engine(flow/paginate) + render(pages)  + PM-flow editing
+   '- pptx: model(Presentation) + engine(slide layout)  + render(canvas) + shape editing
+```
+
+The `MeasureProvider`, `FolioHost`, the WASM/native build, the controller/event
+pattern, and the agentic op pattern are all format-agnostic. If pptx is a real
+goal, draw the `@folio/ooxml` substrate boundary while carving the docx seams
+(P1–P3) so it is shared by construction.
+
+## Phased path
+
+Each phase ships in the monorepo, CI-checked. P1–P4 are pure TS refactors that
+also improve the current product (testability, clarity); you can stop after any
+phase with a strictly better codebase.
+
+- **P0 (done):** React-free core (`no-react-in-core` rule + arch test), headless
+  `@stll/folio/core` entry, `paged-layout` moved into core.
+- **P1 — model seam:** carve pure data types into a clear boundary.
+- **P2 — invert measurement (next, highest leverage):** generalize the worker
+  protocol into `MeasureProvider`; move canvas behind `canvasMeasureProvider`;
+  make `layout-engine` pure (no canvas/DOM). Headless-testable, Rust-ready.
+- **P3 — split the bridge:** pure `Document→FlowBlocks` → engine; DOM hit-test →
+  render-dom.
+- **P4 — extract the headless `controller`:** pull orchestration out of
+  `paged-editor`; the React adapter becomes a thin wrapper (proves the seam).
+- **P5 — package the boundaries:** the package split, now meaningful (clean
+  interfaces, not reach-ins). Standalone-repo extraction happens here.
+- **P6 — `@folio/vue`:** small if P4–P5 are right.
+- **P7 — Rust port (profiled):** `docx` I/O first (no font stack), then layout
+  (with a Rust measure provider).
+
+## Status
+
+P0 complete (merged in #884). P2 is the recommended next move: it makes the
+layout engine genuinely pure, which is simultaneously the precondition for the
+Rust port and a quality win today, and it de-risks the plan by proving the
+hardest seam first on a small surface.

--- a/packages/folio/docs/seam-architecture.md
+++ b/packages/folio/docs/seam-architecture.md
@@ -160,13 +160,13 @@ chain) or layout drifts — a sub-problem of Seam 5.
 ## Incremental layout & async transport (desktop)
 
 Don't re-serialize the whole `Document` per keystroke. Model the
-controller↔engine contract as a stateful `LayoutSession` (holds cached measures
-
-- previous layout, fed dirty ranges). Make its methods **async-tolerant**
-  (promise-returning) from the start: in the browser a WASM/worker call is
-  effectively in-process, but on desktop the engine may live across a Tauri IPC or
-  napi boundary, or off the UI thread. An async interface preserves that option at
-  no cost to the JS path.
+controller↔engine contract as a stateful `LayoutSession` (which holds cached
+measures and the previous layout, fed dirty ranges). Make its methods
+**async-tolerant** (promise-returning) from the start: in the browser a
+WASM/worker call is effectively in-process, but on desktop the engine may live
+across a Tauri IPC or napi boundary, or off the UI thread. An async interface
+preserves that option at
+no cost to the JS path.
 
 ## Multi-format substrate (docx, pptx, …)
 

--- a/packages/folio/scripts/bench-measure-worker.ts
+++ b/packages/folio/scripts/bench-measure-worker.ts
@@ -30,12 +30,13 @@ import { performance } from "node:perf_hooks";
 
 import {
   clearAllCaches,
+  measureTextWidth,
   setFolioMeasurementFlags,
   setTextCacheSize,
 } from "../src/core/layout-engine/measure";
 import { handleMeasureRequest } from "../src/core/layout-engine/measure/font-metrics.worker";
 import {
-  measureTextWidth,
+  installCanvasMeasureProvider,
   resetCanvasContext,
 } from "../src/core/layout-engine/measure/measureContainer";
 import {
@@ -279,6 +280,10 @@ function runScenario(label: string, enableWorker: boolean): number {
   drainDeferredQueue();
   return pass("pass 2 (warm cache)", runs);
 }
+
+// This script measures directly (no React editor), so install the canvas
+// MeasureProvider before any measurement runs.
+installCanvasMeasureProvider();
 
 console.log("=== folio measureTextWidth benchmark ===");
 console.log("fixture: 500 pages * 40 lines = 20,000 runs");

--- a/packages/folio/src/core/__tests__/model-purity.test.ts
+++ b/packages/folio/src/core/__tests__/model-purity.test.ts
@@ -85,11 +85,18 @@ const resolveRelative = (importerPath: string, specifier: string): string => {
 
 const isAllowedEngineTarget = (stripped: string): boolean =>
   stripped.endsWith("/layout-engine/types") ||
-  stripped.endsWith("/layout-engine/measure/measureTypes");
+  stripped === "layout-engine/types" ||
+  stripped.endsWith("/layout-engine/measure/measureTypes") ||
+  stripped === "layout-engine/measure/measureTypes";
 
 const resolvesIntoBehaviorDir = (stripped: string): boolean => {
   for (const dir of FORBIDDEN_BEHAVIOR_DIRS) {
-    if (stripped.includes(`/${dir}/`) || stripped.endsWith(`/${dir}`)) {
+    if (
+      stripped === dir ||
+      stripped.includes(`/${dir}/`) ||
+      stripped.endsWith(`/${dir}`) ||
+      stripped.startsWith(`${dir}/`)
+    ) {
       return true;
     }
   }

--- a/packages/folio/src/core/__tests__/model-purity.test.ts
+++ b/packages/folio/src/core/__tests__/model-purity.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Architecture test — the folio model layer is pure data (Seam 2).
+ *
+ * Defence in depth alongside the `folio-layer-boundaries/model-is-pure-data`
+ * oxlint rule. Lint can be silenced (config edit, file-scoped disable, or a
+ * config typo); this test asserts the same invariant on the actual file tree
+ * and fails the suite regardless of lint state.
+ *
+ * The model layer is folio's behavior-free data lingua franca: the docx
+ * document model (`core/types/*`), the layout/flow data shapes
+ * (`layout-engine/types`), and the measurement data shapes
+ * (`layout-engine/measure/measureTypes`). None of these may import a behavior
+ * or framework dependency — ProseMirror, DOM render, React, `@stll/ui`, or
+ * engine behavior (layout-painter, layout-bridge, prosemirror, managers, or any
+ * layout-engine module other than `layout-engine/types`). Type-only imports
+ * count, since they drag the dependency back into the model's type graph.
+ *
+ * Negative tests use synthetic fixture strings to prove the analyser flags the
+ * offending imports; the lint plugin's leading comment lists the same cases.
+ */
+
+import { Glob } from "bun";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const { resolve } = path;
+
+const CORE_DIR = resolve(import.meta.dir, "..");
+
+const FORBIDDEN_PACKAGES = ["react", "react-dom", "@stll/ui"];
+
+const FORBIDDEN_BEHAVIOR_DIRS = [
+  "layout-painter",
+  "layout-bridge",
+  "prosemirror",
+  "managers",
+];
+
+// Match the specifier of every static import/export, bare side-effect import
+// (`import "./setup"`), and dynamic import (`import("./setup")`). Bounded
+// character classes keep matching linear.
+const IMPORT_REGEX =
+  /\bfrom\s*["'](?<fromSpec>[^"']+)["']|\bimport\s*["'](?<importSpec>[^"']+)["']|\bimport\s*\(\s*["'](?<dynImportSpec>[^"']+)["']\s*\)/gu;
+
+const isForbiddenPackage = (specifier: string): boolean => {
+  if (specifier.startsWith("prosemirror-")) {
+    return true;
+  }
+  for (const pkg of FORBIDDEN_PACKAGES) {
+    if (specifier === pkg || specifier.startsWith(`${pkg}/`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// Resolve a relative specifier against the importing file's directory into a
+// normalized, extension/index-stripped path we can suffix-match. Non-relative
+// specifiers return null (handled by the package check instead).
+const resolveRelative = (importerPath: string, specifier: string): string => {
+  const stack = importerPath.replaceAll("\\", "/").split("/").slice(0, -1);
+  for (const part of specifier.split("/")) {
+    if (part === "" || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+  let value = stack.join("/");
+  for (const ext of [".ts", ".tsx", ".js", ".jsx"]) {
+    if (value.endsWith(ext)) {
+      value = value.slice(0, -ext.length);
+      break;
+    }
+  }
+  if (value.endsWith("/index")) {
+    value = value.slice(0, -"/index".length);
+  }
+  return value;
+};
+
+const isAllowedEngineTarget = (stripped: string): boolean =>
+  stripped.endsWith("/layout-engine/types") ||
+  stripped.endsWith("/layout-engine/measure/measureTypes");
+
+const resolvesIntoBehaviorDir = (stripped: string): boolean => {
+  for (const dir of FORBIDDEN_BEHAVIOR_DIRS) {
+    if (stripped.includes(`/${dir}/`) || stripped.endsWith(`/${dir}`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isForbiddenRelative = (
+  importerPath: string,
+  specifier: string,
+): boolean => {
+  if (!specifier.startsWith(".")) {
+    return false;
+  }
+  const stripped = resolveRelative(importerPath, specifier);
+  if (resolvesIntoBehaviorDir(stripped)) {
+    return true;
+  }
+  return (
+    stripped.includes("/layout-engine/") && !isAllowedEngineTarget(stripped)
+  );
+};
+
+type ImpureImport = { importer: string; specifier: string };
+
+// Strip block and line comments before the raw-text scan so a comment that
+// mentions an import (`from "react"` in prose) cannot trip it. The AST-based
+// model-is-pure-data rule is authoritative; this keeps the defence-in-depth
+// scan from false-firing on benign comments. The line-comment pattern keeps the
+// character before `//` so it does not eat a `:` from a `https://` URL.
+const stripComments = (source: string): string =>
+  source
+    .replaceAll(/\/\*[\s\S]*?\*\//gu, "")
+    .replaceAll(/(?<lead>^|[^:])\/\/[^\n]*/gmu, "$<lead>");
+
+const impureImportsForSource = (
+  filePath: string,
+  source: string,
+): ImpureImport[] => {
+  const found: ImpureImport[] = [];
+  for (const match of stripComments(source).matchAll(IMPORT_REGEX)) {
+    const specifier =
+      match.groups?.["fromSpec"] ??
+      match.groups?.["importSpec"] ??
+      match.groups?.["dynImportSpec"];
+    if (specifier === undefined) {
+      continue;
+    }
+    if (
+      isForbiddenPackage(specifier) ||
+      isForbiddenRelative(filePath, specifier)
+    ) {
+      found.push({ importer: filePath, specifier });
+    }
+  }
+  return found;
+};
+
+const impureImportsForFile = (filePath: string): ImpureImport[] =>
+  impureImportsForSource(filePath, readFileSync(filePath, "utf-8"));
+
+// The model set: the docx document model (types/*, excluding tests) plus the
+// layout/flow and measurement data-shape leaves.
+const collectModelFiles = (): string[] => {
+  const files: string[] = [];
+  const typesGlob = new Glob("types/**/*.ts");
+  for (const relative of typesGlob.scanSync({ cwd: CORE_DIR })) {
+    if (relative.endsWith(".test.ts")) {
+      continue;
+    }
+    files.push(resolve(CORE_DIR, relative));
+  }
+  files.push(resolve(CORE_DIR, "layout-engine/types.ts"));
+  files.push(resolve(CORE_DIR, "layout-engine/measure/measureTypes.ts"));
+  return files;
+};
+
+describe("folio model layer is pure data", () => {
+  test("the model set lists the expected leaf modules", () => {
+    // Guard the glob: if the model modules move or vanish, fail loudly rather
+    // than silently scanning nothing.
+    const files = collectModelFiles();
+    expect(files.length).toBeGreaterThanOrEqual(8);
+  });
+
+  test("no model file imports prosemirror, react, @stll/ui, or engine behavior", () => {
+    const violations = collectModelFiles().flatMap(impureImportsForFile);
+    if (violations.length > 0) {
+      const formatted = violations
+        .map(
+          (v) =>
+            `  ${v.importer.replace(CORE_DIR, "<core>")} -> "${v.specifier}"`,
+        )
+        .join("\n");
+      throw new Error(
+        "The folio model layer must stay pure data, but found behavior " +
+          `imports:\n${formatted}\n\n` +
+          "Move behavior into the layer that owns it (layout-engine, " +
+          "layout-bridge, layout-painter, prosemirror, managers) and keep the " +
+          "model describing data only.",
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+});
+
+describe("folio model purity — synthetic fixtures", () => {
+  const importer = resolve(CORE_DIR, "types/document.ts");
+
+  test("prosemirror-state import is rejected", () => {
+    const violations = impureImportsForSource(
+      importer,
+      'import { EditorState } from "prosemirror-state";',
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.specifier).toBe("prosemirror-state");
+  });
+
+  test("react import is rejected", () => {
+    const violations = impureImportsForSource(
+      importer,
+      'import type { CSSProperties } from "react";',
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  test("@stll/ui import is rejected", () => {
+    const violations = impureImportsForSource(
+      importer,
+      'import { Button } from "@stll/ui/button";',
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  test("relative import into a behavior directory is rejected", () => {
+    const painter = impureImportsForSource(
+      importer,
+      'import { renderPage } from "../layout-painter/renderPage";',
+    );
+    const managers = impureImportsForSource(
+      importer,
+      'import { DocManager } from "../managers/docManager";',
+    );
+    const bridge = impureImportsForSource(
+      importer,
+      'import { measureParagraph } from "../layout-bridge/measuring";',
+    );
+    expect(painter).toHaveLength(1);
+    expect(managers).toHaveLength(1);
+    expect(bridge).toHaveLength(1);
+  });
+
+  test("relative import into a non-types layout-engine module is rejected", () => {
+    const violations = impureImportsForSource(
+      importer,
+      'import { paginate } from "../layout-engine/paginator";',
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  test("the docx-core model surface is allowed", () => {
+    const violations = impureImportsForSource(
+      importer,
+      'export type * from "@stll/docx-core/model";',
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test("the pure-data engine leaves are allowed", () => {
+    const engineTypes = impureImportsForSource(
+      importer,
+      'import type { FlowBlock } from "../layout-engine/types";',
+    );
+    const measureTypes = impureImportsForSource(
+      importer,
+      'import type { RunMeasurement } from "../layout-engine/measure/measureTypes";',
+    );
+    expect(engineTypes).toEqual([]);
+    expect(measureTypes).toEqual([]);
+  });
+
+  test("sibling model imports are allowed", () => {
+    const violations = impureImportsForSource(
+      importer,
+      'import { deriveBlockId } from "./block-id";',
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test("a comment that mentions a behavior import is ignored", () => {
+    const lineComment = impureImportsForSource(
+      importer,
+      '// this module used to import from "prosemirror-state";\nconst x = 1;',
+    );
+    const blockComment = impureImportsForSource(
+      importer,
+      '/* historically: import { EditorView } from "prosemirror-view" */\nconst y = 2;',
+    );
+    expect(lineComment).toEqual([]);
+    expect(blockComment).toEqual([]);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -14,10 +14,10 @@ import {
 } from "../layout-engine/lineFlow";
 import {
   buildRunFontStyle,
-  measureRun,
   findCharacterAtX as findCharAtX,
-} from "../layout-engine/measure/measureContainer";
-import type { FontStyle } from "../layout-engine/measure/measureContainer";
+} from "../layout-engine/measure/measureHelpers";
+import { measureRun } from "../layout-engine/measure/measureProvider";
+import type { FontStyle } from "../layout-engine/measure/measureTypes";
 import type {
   ParagraphBlock,
   ParagraphFragment,

--- a/packages/folio/src/core/layout-bridge/measuring/index.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/index.ts
@@ -14,11 +14,17 @@
 export {
   getCanvasContext,
   resetCanvasContext,
-  buildFontString,
+} from "../../layout-engine/measure/measureContainer";
+
+export {
   getFontMetrics,
   measureTextWidth,
   measureText,
   measureRun,
+} from "../../layout-engine/measure/measureProvider";
+
+export {
+  buildFontString,
   findCharacterAtX,
   getXForCharacter,
   twipsToPx,
@@ -27,11 +33,14 @@ export {
   pxToPt,
   halfPtToPx,
   pxToHalfPt,
-  type FontStyle,
-  type FontMetrics,
-  type TextMeasurement,
-  type RunMeasurement,
-} from "../../layout-engine/measure/measureContainer";
+} from "../../layout-engine/measure/measureHelpers";
+
+export type {
+  FontStyle,
+  FontMetrics,
+  TextMeasurement,
+  RunMeasurement,
+} from "../../layout-engine/measure/measureTypes";
 
 export {
   measureParagraph,

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -11,11 +11,9 @@
 import { getHeaderRowsHeight } from "../layout-engine/index";
 import { measuredLineContentOffset } from "../layout-engine/lineFlow";
 import { measureParagraph } from "../layout-engine/measure";
-import {
-  buildRunFontStyle,
-  measureRun,
-} from "../layout-engine/measure/measureContainer";
-import type { FontStyle } from "../layout-engine/measure/measureContainer";
+import { buildRunFontStyle } from "../layout-engine/measure/measureHelpers";
+import { measureRun } from "../layout-engine/measure/measureProvider";
+import type { FontStyle } from "../layout-engine/measure/measureTypes";
 import {
   buildTableCellFloatingZones,
   getTableCellContentWidth,

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -19,9 +19,9 @@ import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
 import {
   bandFragmentX,
   bandTopContentY,
-  floatingTextBoxReservesBand,
   isPageFrameRelativeAnchor,
 } from "./textBoxFlow";
+import { floatingTextBoxReservesBand } from "./types";
 import type {
   FlowBlock,
   Measure,

--- a/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/__tests__/measureContainer-eastAsia.test.ts
@@ -6,11 +6,8 @@
 
 import { describe, expect, test } from "bun:test";
 
-import {
-  buildRunFontStyle,
-  measureRun,
-  measureTextWidth,
-} from "../measureContainer";
+import { buildRunFontStyle } from "../measureHelpers";
+import { measureRun, measureTextWidth } from "../measureProvider";
 import type { FakeCharWidth } from "./fakeTextMeasure";
 import { withFakeTextMeasure } from "./fakeTextMeasure";
 

--- a/packages/folio/src/core/layout-engine/measure/index.ts
+++ b/packages/folio/src/core/layout-engine/measure/index.ts
@@ -16,6 +16,10 @@ export {
   measureTextWidth,
   measureText,
   measureRun,
+  canvasMeasureProvider,
+  getMeasureProvider,
+  setMeasureProvider,
+  resetMeasureProvider,
   findCharacterAtX,
   getXForCharacter,
   twipsToPx,
@@ -28,6 +32,7 @@ export {
   type FontMetrics,
   type TextMeasurement,
   type RunMeasurement,
+  type MeasureProvider,
 } from "./measureContainer";
 
 export {

--- a/packages/folio/src/core/layout-engine/measure/index.ts
+++ b/packages/folio/src/core/layout-engine/measure/index.ts
@@ -9,17 +9,18 @@
  */
 
 export {
-  getCanvasContext,
-  resetCanvasContext,
-  buildFontString,
   getFontMetrics,
   measureTextWidth,
   measureText,
   measureRun,
-  canvasMeasureProvider,
   getMeasureProvider,
   setMeasureProvider,
   resetMeasureProvider,
+  type MeasureProvider,
+} from "./measureProvider";
+
+export {
+  buildFontString,
   findCharacterAtX,
   getXForCharacter,
   twipsToPx,
@@ -28,12 +29,14 @@ export {
   pxToPt,
   halfPtToPx,
   pxToHalfPt,
-  type FontStyle,
-  type FontMetrics,
-  type TextMeasurement,
-  type RunMeasurement,
-  type MeasureProvider,
-} from "./measureContainer";
+} from "./measureHelpers";
+
+export type {
+  FontStyle,
+  FontMetrics,
+  TextMeasurement,
+  RunMeasurement,
+} from "./measureTypes";
 
 export {
   measureParagraph,

--- a/packages/folio/src/core/layout-engine/measure/listMarkerWidth.ts
+++ b/packages/folio/src/core/layout-engine/measure/listMarkerWidth.ts
@@ -14,8 +14,9 @@
  * the first line's available width.
  */
 import type { ParagraphBlock, TextRun } from "../types";
-import { measureTextWidth, ptToPx } from "./measureContainer";
-import type { FontStyle } from "./measureContainer";
+import { ptToPx } from "./measureHelpers";
+import { measureTextWidth } from "./measureProvider";
+import type { FontStyle } from "./measureTypes";
 
 const DEFAULT_FONT_FAMILY = "Calibri";
 const DEFAULT_FONT_SIZE = 11;

--- a/packages/folio/src/core/layout-engine/measure/measureBlocks.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureBlocks.ts
@@ -2,12 +2,8 @@ import {
   recordMeasureBlock,
   recordMeasureBlockError,
 } from "../layoutInstrumentation";
-import {
-  bandTopContentY,
-  floatingTextBoxReservesBand,
-  isPageFrameRelativeAnchor,
-} from "../textBoxFlow";
-import { DEFAULT_TEXTBOX_MARGINS } from "../types";
+import { bandTopContentY, isPageFrameRelativeAnchor } from "../textBoxFlow";
+import { DEFAULT_TEXTBOX_MARGINS, floatingTextBoxReservesBand } from "../types";
 import type {
   FlowBlock,
   ImageBlock,

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -1,8 +1,13 @@
 /**
- * Measurement container for text layout
+ * Canvas-backed text measurement (the default MeasureProvider).
  *
- * Uses HTML5 Canvas API to measure text runs and calculate typography metrics.
- * Canvas-based measurement is more accurate and performant than DOM-based approaches.
+ * Uses the HTML5 Canvas API to measure text runs and calculate typography
+ * metrics. Canvas-based measurement is more accurate and performant than
+ * DOM-based approaches. This module touches canvas/`document`/the worker, so it
+ * lives off the layout engine's import path: the engine measures through the
+ * pure `measureProvider.ts` seam, and a composition root installs this backend
+ * via `installCanvasMeasureProvider()` (the React editor and the bun test
+ * preload do so).
  *
  * Typography conventions (matching Word behavior):
  * - ascent ≈ fontSize * 0.8 (baseline to top)
@@ -13,14 +18,11 @@
 
 import { panic } from "better-result";
 
-import { resolveFontFamily } from "../../utils/fontResolver";
-import { DOCX_BOLD_FONT_WEIGHT } from "../../utils/fontWeights";
 import {
   hasCjk,
   isCjkCodePoint,
   segmentByScript,
 } from "../../utils/scriptSegments";
-import type { RunFormatting } from "../types";
 import {
   getCachedFontMetrics,
   getCachedTextWidth,
@@ -28,120 +30,31 @@ import {
   setCachedFontMetrics,
   setCachedTextWidth,
 } from "./cache";
+import {
+  buildFontString,
+  DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_SIZE,
+  getResolvedData,
+  ptToPx,
+} from "./measureHelpers";
+import { setMeasureProvider } from "./measureProvider";
+import type { MeasureProvider } from "./measureProvider";
+import type {
+  FontMetrics,
+  FontStyle,
+  RunMeasurement,
+  TextMeasurement,
+} from "./measureTypes";
 import { canPrefetchMeasurement, prefetchMeasurement } from "./measureWorker";
 import {
   countCodePoints,
   WORKER_FONT_FINGERPRINT_TEXT,
 } from "./measureWorkerProtocol";
 
-// Constants for OOXML unit conversions
-const TWIPS_PER_INCH = 1440;
-const PX_PER_INCH = 96; // Standard CSS/DOM DPI
-const TWIPS_PER_PX = TWIPS_PER_INCH / PX_PER_INCH; // 15 twips per pixel
-
-// Default typography values
-const DEFAULT_FONT_SIZE = 11; // 11pt (Word 2007+ default)
-const DEFAULT_FONT_FAMILY = "Calibri";
+// Default typography ratios
 const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing (line=240)
 const DEFAULT_ASCENT_RATIO = 0.8;
 const DEFAULT_DESCENT_RATIO = 0.2;
-
-/**
- * Font styling properties for measurement
- */
-export type FontStyle = {
-  fontFamily?: string;
-  /**
-   * East-Asian font for CJK code points. When set, `measureTextWidth` /
-   * `measureRun` measure CJK code points with this font and the rest with
-   * `fontFamily`, matching the painter's per-script span split so wrapping
-   * and click positioning stay in sync.
-   */
-  eastAsiaFontFamily?: string;
-  fontSize?: number; // in points
-  bold?: boolean;
-  italic?: boolean;
-  letterSpacing?: number; // in pixels
-  textTransform?: "uppercase";
-  fontVariant?: "small-caps";
-  horizontalScale?: number;
-};
-
-/**
- * Build a measurement `FontStyle` from a run's formatting. Single source of
- * truth for run → FontStyle so every measurement path (layout line-breaking,
- * click-to-position, selection rects) carries the same fields — notably
- * `eastAsiaFontFamily`, which must reach the measurer for CJK click/selection
- * offsets to match what was wrapped and painted. Callers pass their own family
- * and size fallbacks for runs that declare neither.
- */
-export function buildRunFontStyle(
-  run: RunFormatting,
-  fallbackFontFamily: string,
-  fallbackFontSize: number,
-): FontStyle {
-  return {
-    fontFamily: run.fontFamily ?? fallbackFontFamily,
-    ...(run.eastAsiaFontFamily !== undefined
-      ? { eastAsiaFontFamily: run.eastAsiaFontFamily }
-      : {}),
-    fontSize: run.fontSize ?? fallbackFontSize,
-    ...(run.bold !== undefined ? { bold: run.bold } : {}),
-    ...(run.italic !== undefined ? { italic: run.italic } : {}),
-    ...(run.letterSpacing !== undefined
-      ? { letterSpacing: run.letterSpacing }
-      : {}),
-    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
-    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
-    ...(run.horizontalScale !== undefined
-      ? { horizontalScale: run.horizontalScale }
-      : {}),
-  };
-}
-
-/**
- * Typography metrics for a font
- */
-export type FontMetrics = {
-  fontSize: number;
-  ascent: number;
-  descent: number;
-  lineHeight: number;
-  fontFamily: string;
-  /** OS/2 single-line ratio for OOXML line spacing calculation */
-  singleLineRatio: number;
-};
-
-/**
- * Result of measuring a text string
- */
-export type TextMeasurement = {
-  width: number;
-  height: number;
-  ascent: number;
-  descent: number;
-};
-
-/**
- * Result of measuring a run of text
- */
-export type RunMeasurement = {
-  width: number;
-  charWidths: number[]; // Width of each character for click positioning
-  metrics: FontMetrics;
-};
-
-/**
- * Swappable text-measurement backend. The canvas implementation is the default;
- * a Rust/WASM or headless provider can be installed via `setMeasureProvider`
- * without the layout engine importing canvas directly.
- */
-export type MeasureProvider = {
-  getFontMetrics: (style: FontStyle) => FontMetrics;
-  measureTextWidth: (text: string, style: FontStyle) => number;
-  measureText: (text: string, style: FontStyle) => TextMeasurement;
-  measureRun: (text: string, style: FontStyle) => RunMeasurement;
-};
 
 // Cached canvas context for text measurement
 let canvasContext: CanvasRenderingContext2D | null = null;
@@ -194,77 +107,6 @@ function getWorkerFontFingerprintWidth(
   const width = ctx.measureText(WORKER_FONT_FINGERPRINT_TEXT).width;
   workerFontFingerprintCache.set(font, { generation, width });
   return width;
-}
-
-/** Cached resolved font data (CSS fallback + single-line ratio) */
-type ResolvedFontCache = {
-  cssFallback: string;
-  singleLineRatio: number;
-};
-
-/** Cache for resolved font data */
-const fontResolvedCache = new Map<string, ResolvedFontCache>();
-
-/**
- * Get the resolved font data for a font family, with caching.
- */
-function getResolvedData(fontFamily: string): ResolvedFontCache {
-  let cached = fontResolvedCache.get(fontFamily);
-  if (cached === undefined) {
-    const resolved = resolveFontFamily(fontFamily);
-    cached = {
-      cssFallback: resolved.cssFallback,
-      singleLineRatio: resolved.singleLineRatio,
-    };
-    fontResolvedCache.set(fontFamily, cached);
-  }
-  return cached;
-}
-
-/**
- * Get the CSS fallback string for a font family, with caching.
- */
-function getResolvedFallback(fontFamily: string): string {
-  return getResolvedData(fontFamily).cssFallback;
-}
-
-/**
- * Build a CSS font string from styling properties
- *
- * Font sizes are in points and need to be converted to pixels for canvas.
- * 1pt = 96/72 px ≈ 1.333px at standard web DPI.
- *
- * Uses the font resolver to get category-appropriate fallback stacks
- * (serif fonts get serif fallbacks, sans-serif get sans-serif, etc.)
- * matching the same stacks used in rendering for consistent measurements.
- *
- * @example
- * buildFontString({ fontFamily: "Arial", fontSize: 12, bold: true })
- * // Returns: "800 16px Arial, Arimo, Helvetica, sans-serif" (12pt = 16px)
- */
-export function buildFontString(style: FontStyle): string {
-  const parts: string[] = [];
-
-  if (style.italic) {
-    parts.push("italic");
-  }
-  if (style.fontVariant) {
-    parts.push(style.fontVariant);
-  }
-  if (style.bold) {
-    parts.push(DOCX_BOLD_FONT_WEIGHT);
-  }
-
-  // Convert points to pixels for canvas measurement
-  const fontSizePt = style.fontSize ?? DEFAULT_FONT_SIZE;
-  const fontSizePx = ptToPx(fontSizePt);
-  parts.push(`${fontSizePx}px`);
-
-  // Use the font resolver for category-appropriate fallback stacks
-  const fontFamily = style.fontFamily ?? DEFAULT_FONT_FAMILY;
-  parts.push(getResolvedFallback(fontFamily));
-
-  return parts.join(" ");
 }
 
 /**
@@ -639,29 +481,15 @@ export const canvasMeasureProvider: MeasureProvider = {
   measureRun: canvasMeasureRun,
 };
 
-let activeMeasureProvider: MeasureProvider = canvasMeasureProvider;
-
-export const getMeasureProvider = (): MeasureProvider => activeMeasureProvider;
-
-export const setMeasureProvider = (provider: MeasureProvider): void => {
-  activeMeasureProvider = provider;
+/**
+ * Install the canvas backend as the active MeasureProvider. Called once at each
+ * composition root (the React editor's layout pipeline and the bun test
+ * preload) before any layout runs. Explicit call, not a module side effect, so
+ * importing this module never silently swaps the active provider.
+ */
+export const installCanvasMeasureProvider = (): void => {
+  setMeasureProvider(canvasMeasureProvider);
 };
-
-export const resetMeasureProvider = (): void => {
-  activeMeasureProvider = canvasMeasureProvider;
-};
-
-export const getFontMetrics = (style: FontStyle): FontMetrics =>
-  activeMeasureProvider.getFontMetrics(style);
-
-export const measureTextWidth = (text: string, style: FontStyle): number =>
-  activeMeasureProvider.measureTextWidth(text, style);
-
-export const measureText = (text: string, style: FontStyle): TextMeasurement =>
-  activeMeasureProvider.measureText(text, style);
-
-export const measureRun = (text: string, style: FontStyle): RunMeasurement =>
-  activeMeasureProvider.measureRun(text, style);
 
 function applyTextTransform(text: string, style: FontStyle): string {
   if (style.textTransform === "uppercase") {
@@ -672,106 +500,4 @@ function applyTextTransform(text: string, style: FontStyle): string {
 
 function getHorizontalScaleFactor(style: FontStyle): number {
   return (style.horizontalScale ?? 100) / 100;
-}
-
-/**
- * Find the character offset at a given X position within a text run
- *
- * @param x - X position relative to run start
- * @param charWidths - Per-character widths from measureRun
- * @returns Character offset (0-based index)
- */
-export function findCharacterAtX(x: number, charWidths: number[]): number {
-  if (charWidths.length === 0) {
-    return 0;
-  }
-  if (x <= 0) {
-    return 0;
-  }
-
-  let accumulatedWidth = 0;
-
-  for (let i = 0; i < charWidths.length; i++) {
-    // SAFETY: i < charWidths.length in for loop
-    const charWidth = charWidths[i]!;
-    const charMidpoint = accumulatedWidth + charWidth / 2;
-
-    // If x is before the midpoint, the cursor is at this character
-    if (x <= charMidpoint) {
-      return i;
-    }
-
-    accumulatedWidth += charWidth;
-  }
-
-  // X is past all characters, return position after last character
-  return charWidths.length;
-}
-
-/**
- * Get the X position of a character offset within a text run
- *
- * @param offset - Character offset (0-based index)
- * @param charWidths - Per-character widths from measureRun
- * @returns X position in pixels
- */
-export function getXForCharacter(offset: number, charWidths: number[]): number {
-  if (offset <= 0 || charWidths.length === 0) {
-    return 0;
-  }
-
-  const clampedOffset = Math.min(offset, charWidths.length);
-  let x = 0;
-
-  for (let i = 0; i < clampedOffset; i++) {
-    // SAFETY: i < clampedOffset <= charWidths.length
-    x += charWidths[i]!;
-  }
-
-  return x;
-}
-
-// Unit conversion utilities
-
-/**
- * Convert twips to pixels
- */
-export function twipsToPx(twips: number): number {
-  return twips / TWIPS_PER_PX;
-}
-
-/**
- * Convert pixels to twips
- */
-export function pxToTwips(px: number): number {
-  return Math.round(px * TWIPS_PER_PX);
-}
-
-/**
- * Convert points to pixels
- */
-export function ptToPx(pt: number): number {
-  return (pt * PX_PER_INCH) / 72;
-}
-
-/**
- * Convert pixels to points
- */
-export function pxToPt(px: number): number {
-  return (px * 72) / PX_PER_INCH;
-}
-
-/**
- * Convert OOXML half-points to pixels
- * OOXML font sizes are in half-points (24 = 12pt)
- */
-export function halfPtToPx(halfPt: number): number {
-  return ptToPx(halfPt / 2);
-}
-
-/**
- * Convert pixels to OOXML half-points
- */
-export function pxToHalfPt(px: number): number {
-  return pxToPt(px) * 2;
 }

--- a/packages/folio/src/core/layout-engine/measure/measureContainer.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureContainer.ts
@@ -131,6 +131,18 @@ export type RunMeasurement = {
   metrics: FontMetrics;
 };
 
+/**
+ * Swappable text-measurement backend. The canvas implementation is the default;
+ * a Rust/WASM or headless provider can be installed via `setMeasureProvider`
+ * without the layout engine importing canvas directly.
+ */
+export type MeasureProvider = {
+  getFontMetrics: (style: FontStyle) => FontMetrics;
+  measureTextWidth: (text: string, style: FontStyle) => number;
+  measureText: (text: string, style: FontStyle) => TextMeasurement;
+  measureRun: (text: string, style: FontStyle) => RunMeasurement;
+};
+
 // Cached canvas context for text measurement
 let canvasContext: CanvasRenderingContext2D | null = null;
 
@@ -261,7 +273,7 @@ export function buildFontString(style: FontStyle): string {
  * Uses Canvas TextMetrics API when available for precise metrics,
  * falls back to ratio-based approximations.
  */
-export function getFontMetrics(style: FontStyle): FontMetrics {
+function canvasGetFontMetrics(style: FontStyle): FontMetrics {
   const fontSize = style.fontSize ?? DEFAULT_FONT_SIZE;
   const fontFamily = style.fontFamily ?? DEFAULT_FONT_FAMILY;
   const bold = style.bold ?? false;
@@ -345,7 +357,7 @@ export function getFontMetrics(style: FontStyle): FontMetrics {
  * @param style - Font styling properties
  * @returns Width in pixels
  */
-export function measureTextWidth(text: string, style: FontStyle): number {
+function canvasMeasureTextWidth(text: string, style: FontStyle): number {
   if (!text) {
     return 0;
   }
@@ -475,7 +487,7 @@ function measureMixedScriptWidth(
     const fontFamily = segment.isCjk
       ? style.eastAsiaFontFamily
       : style.fontFamily;
-    glyphWidth += measureTextWidth(
+    glyphWidth += canvasMeasureTextWidth(
       segment.text,
       glyphAdvanceStyle(style, fontFamily),
     );
@@ -535,9 +547,9 @@ function prefetchBinarySearchProbes(
 /**
  * Measure text and return full metrics
  */
-export function measureText(text: string, style: FontStyle): TextMeasurement {
-  const width = measureTextWidth(text, style);
-  const metrics = getFontMetrics(style);
+function canvasMeasureText(text: string, style: FontStyle): TextMeasurement {
+  const width = canvasMeasureTextWidth(text, style);
+  const metrics = canvasGetFontMetrics(style);
 
   return {
     width,
@@ -554,8 +566,8 @@ export function measureText(text: string, style: FontStyle): TextMeasurement {
  * @param style - Font styling properties
  * @returns Run measurement with width and per-character widths
  */
-export function measureRun(text: string, style: FontStyle): RunMeasurement {
-  const metrics = getFontMetrics(style);
+function canvasMeasureRun(text: string, style: FontStyle): RunMeasurement {
+  const metrics = canvasGetFontMetrics(style);
 
   if (!text) {
     return {
@@ -616,6 +628,40 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
     metrics,
   };
 }
+
+/**
+ * Default provider backed by the canvas measurement functions above.
+ */
+export const canvasMeasureProvider: MeasureProvider = {
+  getFontMetrics: canvasGetFontMetrics,
+  measureTextWidth: canvasMeasureTextWidth,
+  measureText: canvasMeasureText,
+  measureRun: canvasMeasureRun,
+};
+
+let activeMeasureProvider: MeasureProvider = canvasMeasureProvider;
+
+export const getMeasureProvider = (): MeasureProvider => activeMeasureProvider;
+
+export const setMeasureProvider = (provider: MeasureProvider): void => {
+  activeMeasureProvider = provider;
+};
+
+export const resetMeasureProvider = (): void => {
+  activeMeasureProvider = canvasMeasureProvider;
+};
+
+export const getFontMetrics = (style: FontStyle): FontMetrics =>
+  activeMeasureProvider.getFontMetrics(style);
+
+export const measureTextWidth = (text: string, style: FontStyle): number =>
+  activeMeasureProvider.measureTextWidth(text, style);
+
+export const measureText = (text: string, style: FontStyle): TextMeasurement =>
+  activeMeasureProvider.measureText(text, style);
+
+export const measureRun = (text: string, style: FontStyle): RunMeasurement =>
+  activeMeasureProvider.measureRun(text, style);
 
 function applyTextTransform(text: string, style: FontStyle): string {
   if (style.textTransform === "uppercase") {

--- a/packages/folio/src/core/layout-engine/measure/measureHelpers.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureHelpers.ts
@@ -1,0 +1,227 @@
+/**
+ * Pure measurement helpers — no canvas, no DOM, no worker.
+ *
+ * Unit conversions, font-string construction, run → FontStyle mapping, and
+ * char-offset geometry. The layout engine imports these directly so it never
+ * transitively pulls the canvas measurement backend; the canvas implementation
+ * (`measureContainer.ts`) consumes them too.
+ */
+
+import { resolveFontFamily } from "../../utils/fontResolver";
+import { DOCX_BOLD_FONT_WEIGHT } from "../../utils/fontWeights";
+import type { RunFormatting } from "../types";
+import type { FontStyle } from "./measureTypes";
+
+// Constants for OOXML unit conversions
+const TWIPS_PER_INCH = 1440;
+const PX_PER_INCH = 96; // Standard CSS/DOM DPI
+const TWIPS_PER_PX = TWIPS_PER_INCH / PX_PER_INCH; // 15 twips per pixel
+
+// Default typography values
+export const DEFAULT_FONT_SIZE = 11; // 11pt (Word 2007+ default)
+export const DEFAULT_FONT_FAMILY = "Calibri";
+
+/**
+ * Build a measurement `FontStyle` from a run's formatting. Single source of
+ * truth for run → FontStyle so every measurement path (layout line-breaking,
+ * click-to-position, selection rects) carries the same fields — notably
+ * `eastAsiaFontFamily`, which must reach the measurer for CJK click/selection
+ * offsets to match what was wrapped and painted. Callers pass their own family
+ * and size fallbacks for runs that declare neither.
+ */
+export function buildRunFontStyle(
+  run: RunFormatting,
+  fallbackFontFamily: string,
+  fallbackFontSize: number,
+): FontStyle {
+  return {
+    fontFamily: run.fontFamily ?? fallbackFontFamily,
+    ...(run.eastAsiaFontFamily !== undefined
+      ? { eastAsiaFontFamily: run.eastAsiaFontFamily }
+      : {}),
+    fontSize: run.fontSize ?? fallbackFontSize,
+    ...(run.bold !== undefined ? { bold: run.bold } : {}),
+    ...(run.italic !== undefined ? { italic: run.italic } : {}),
+    ...(run.letterSpacing !== undefined
+      ? { letterSpacing: run.letterSpacing }
+      : {}),
+    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
+  };
+}
+
+/** Cached resolved font data (CSS fallback + single-line ratio) */
+type ResolvedFontCache = {
+  cssFallback: string;
+  singleLineRatio: number;
+};
+
+/** Cache for resolved font data */
+const fontResolvedCache = new Map<string, ResolvedFontCache>();
+
+/**
+ * Get the resolved font data for a font family, with caching.
+ */
+export function getResolvedData(fontFamily: string): ResolvedFontCache {
+  let cached = fontResolvedCache.get(fontFamily);
+  if (cached === undefined) {
+    const resolved = resolveFontFamily(fontFamily);
+    cached = {
+      cssFallback: resolved.cssFallback,
+      singleLineRatio: resolved.singleLineRatio,
+    };
+    fontResolvedCache.set(fontFamily, cached);
+  }
+  return cached;
+}
+
+/**
+ * Get the CSS fallback string for a font family, with caching.
+ */
+function getResolvedFallback(fontFamily: string): string {
+  return getResolvedData(fontFamily).cssFallback;
+}
+
+/**
+ * Build a CSS font string from styling properties
+ *
+ * Font sizes are in points and need to be converted to pixels for canvas.
+ * 1pt = 96/72 px ≈ 1.333px at standard web DPI.
+ *
+ * Uses the font resolver to get category-appropriate fallback stacks
+ * (serif fonts get serif fallbacks, sans-serif get sans-serif, etc.)
+ * matching the same stacks used in rendering for consistent measurements.
+ *
+ * @example
+ * buildFontString({ fontFamily: "Arial", fontSize: 12, bold: true })
+ * // Returns: "800 16px Arial, Arimo, Helvetica, sans-serif" (12pt = 16px)
+ */
+export function buildFontString(style: FontStyle): string {
+  const parts: string[] = [];
+
+  if (style.italic) {
+    parts.push("italic");
+  }
+  if (style.fontVariant) {
+    parts.push(style.fontVariant);
+  }
+  if (style.bold) {
+    parts.push(DOCX_BOLD_FONT_WEIGHT);
+  }
+
+  // Convert points to pixels for canvas measurement
+  const fontSizePt = style.fontSize ?? DEFAULT_FONT_SIZE;
+  const fontSizePx = ptToPx(fontSizePt);
+  parts.push(`${fontSizePx}px`);
+
+  // Use the font resolver for category-appropriate fallback stacks
+  const fontFamily = style.fontFamily ?? DEFAULT_FONT_FAMILY;
+  parts.push(getResolvedFallback(fontFamily));
+
+  return parts.join(" ");
+}
+
+/**
+ * Find the character offset at a given X position within a text run
+ *
+ * @param x - X position relative to run start
+ * @param charWidths - Per-character widths from measureRun
+ * @returns Character offset (0-based index)
+ */
+export function findCharacterAtX(x: number, charWidths: number[]): number {
+  if (charWidths.length === 0) {
+    return 0;
+  }
+  if (x <= 0) {
+    return 0;
+  }
+
+  let accumulatedWidth = 0;
+
+  for (let i = 0; i < charWidths.length; i++) {
+    // SAFETY: i < charWidths.length in for loop
+    const charWidth = charWidths[i]!;
+    const charMidpoint = accumulatedWidth + charWidth / 2;
+
+    // If x is before the midpoint, the cursor is at this character
+    if (x <= charMidpoint) {
+      return i;
+    }
+
+    accumulatedWidth += charWidth;
+  }
+
+  // X is past all characters, return position after last character
+  return charWidths.length;
+}
+
+/**
+ * Get the X position of a character offset within a text run
+ *
+ * @param offset - Character offset (0-based index)
+ * @param charWidths - Per-character widths from measureRun
+ * @returns X position in pixels
+ */
+export function getXForCharacter(offset: number, charWidths: number[]): number {
+  if (offset <= 0 || charWidths.length === 0) {
+    return 0;
+  }
+
+  const clampedOffset = Math.min(offset, charWidths.length);
+  let x = 0;
+
+  for (let i = 0; i < clampedOffset; i++) {
+    // SAFETY: i < clampedOffset <= charWidths.length
+    x += charWidths[i]!;
+  }
+
+  return x;
+}
+
+// Unit conversion utilities
+
+/**
+ * Convert twips to pixels
+ */
+export function twipsToPx(twips: number): number {
+  return twips / TWIPS_PER_PX;
+}
+
+/**
+ * Convert pixels to twips
+ */
+export function pxToTwips(px: number): number {
+  return Math.round(px * TWIPS_PER_PX);
+}
+
+/**
+ * Convert points to pixels
+ */
+export function ptToPx(pt: number): number {
+  return (pt * PX_PER_INCH) / 72;
+}
+
+/**
+ * Convert pixels to points
+ */
+export function pxToPt(px: number): number {
+  return (px * 72) / PX_PER_INCH;
+}
+
+/**
+ * Convert OOXML half-points to pixels
+ * OOXML font sizes are in half-points (24 = 12pt)
+ */
+export function halfPtToPx(halfPt: number): number {
+  return ptToPx(halfPt / 2);
+}
+
+/**
+ * Convert pixels to OOXML half-points
+ */
+export function pxToHalfPt(px: number): number {
+  return pxToPt(px) * 2;
+}

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.test.ts
@@ -6,16 +6,13 @@ import {
   withFakeTextMeasure,
 } from "./__tests__/fakeTextMeasure";
 import { hashParagraphBlock } from "./cache";
-import {
-  buildFontString,
-  getFontMetrics,
-  measureTextWidth,
-} from "./measureContainer";
+import { buildFontString } from "./measureHelpers";
 import {
   clampFloatingWrapMargins,
   getRunCharWidths,
   measureParagraph,
 } from "./measureParagraph";
+import { getFontMetrics, measureTextWidth } from "./measureProvider";
 
 const PT_TO_PX = 96 / 72;
 

--- a/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureParagraph.ts
@@ -34,14 +34,13 @@ import {
   type FloatingLineSegmentZone,
 } from "./floatingZones";
 import { getListMarkerInlineWidth } from "./listMarkerWidth";
+import { buildRunFontStyle, ptToPx } from "./measureHelpers";
 import {
-  buildRunFontStyle,
-  measureTextWidth,
-  measureRun,
   getFontMetrics,
-  ptToPx,
-} from "./measureContainer";
-import type { FontStyle, FontMetrics } from "./measureContainer";
+  measureRun,
+  measureTextWidth,
+} from "./measureProvider";
+import type { FontMetrics, FontStyle } from "./measureTypes";
 
 export { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
 export type { FloatingImageZone } from "./floatingZones";

--- a/packages/folio/src/core/layout-engine/measure/measureProvider.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureProvider.ts
@@ -1,0 +1,69 @@
+/**
+ * Swappable text-measurement seam.
+ *
+ * Holds the provider interface, the active-provider registry, and the four
+ * public delegators the layout engine measures through. This module is pure:
+ * it never imports the canvas backend, so the engine's import graph stays
+ * canvas-free. The default provider throws — a composition root must install a
+ * concrete backend first (the React editor and the bun test preload call
+ * `installCanvasMeasureProvider()`).
+ */
+
+import { panic } from "better-result";
+
+import type {
+  FontMetrics,
+  FontStyle,
+  RunMeasurement,
+  TextMeasurement,
+} from "./measureTypes";
+
+/**
+ * Swappable text-measurement backend. A canvas implementation is installed at
+ * the composition roots; a Rust/WASM or headless provider can be installed via
+ * `setMeasureProvider` without the layout engine importing canvas directly.
+ */
+export type MeasureProvider = {
+  getFontMetrics: (style: FontStyle) => FontMetrics;
+  measureTextWidth: (text: string, style: FontStyle) => number;
+  measureText: (text: string, style: FontStyle) => TextMeasurement;
+  measureRun: (text: string, style: FontStyle) => RunMeasurement;
+};
+
+const throwingMeasureProvider: MeasureProvider = {
+  getFontMetrics: () => noProvider(),
+  measureTextWidth: () => noProvider(),
+  measureText: () => noProvider(),
+  measureRun: () => noProvider(),
+};
+
+function noProvider(): never {
+  panic(
+    "No MeasureProvider installed — install canvasMeasureProvider " +
+      "(the React editor and the test preload do this).",
+  );
+}
+
+let activeMeasureProvider: MeasureProvider = throwingMeasureProvider;
+
+export const getMeasureProvider = (): MeasureProvider => activeMeasureProvider;
+
+export const setMeasureProvider = (provider: MeasureProvider): void => {
+  activeMeasureProvider = provider;
+};
+
+export const resetMeasureProvider = (): void => {
+  activeMeasureProvider = throwingMeasureProvider;
+};
+
+export const getFontMetrics = (style: FontStyle): FontMetrics =>
+  activeMeasureProvider.getFontMetrics(style);
+
+export const measureTextWidth = (text: string, style: FontStyle): number =>
+  activeMeasureProvider.measureTextWidth(text, style);
+
+export const measureText = (text: string, style: FontStyle): TextMeasurement =>
+  activeMeasureProvider.measureText(text, style);
+
+export const measureRun = (text: string, style: FontStyle): RunMeasurement =>
+  activeMeasureProvider.measureRun(text, style);

--- a/packages/folio/src/core/layout-engine/measure/measureTypes.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureTypes.ts
@@ -1,0 +1,61 @@
+/**
+ * Measurement data shapes.
+ *
+ * Pure type declarations shared by the provider seam (`measureProvider.ts`),
+ * the pure helpers (`measureHelpers.ts`), and the canvas implementation
+ * (`measureContainer.ts`). Types only — this module has no runtime and never
+ * pulls canvas/DOM into an importer's graph.
+ */
+
+/**
+ * Font styling properties for measurement
+ */
+export type FontStyle = {
+  fontFamily?: string;
+  /**
+   * East-Asian font for CJK code points. When set, `measureTextWidth` /
+   * `measureRun` measure CJK code points with this font and the rest with
+   * `fontFamily`, matching the painter's per-script span split so wrapping
+   * and click positioning stay in sync.
+   */
+  eastAsiaFontFamily?: string;
+  fontSize?: number; // in points
+  bold?: boolean;
+  italic?: boolean;
+  letterSpacing?: number; // in pixels
+  textTransform?: "uppercase";
+  fontVariant?: "small-caps";
+  horizontalScale?: number;
+};
+
+/**
+ * Typography metrics for a font
+ */
+export type FontMetrics = {
+  fontSize: number;
+  ascent: number;
+  descent: number;
+  lineHeight: number;
+  fontFamily: string;
+  /** OS/2 single-line ratio for OOXML line spacing calculation */
+  singleLineRatio: number;
+};
+
+/**
+ * Result of measuring a text string
+ */
+export type TextMeasurement = {
+  width: number;
+  height: number;
+  ascent: number;
+  descent: number;
+};
+
+/**
+ * Result of measuring a run of text
+ */
+export type RunMeasurement = {
+  width: number;
+  charWidths: number[]; // Width of each character for click positioning
+  metrics: FontMetrics;
+};

--- a/packages/folio/src/core/layout-engine/measure/measureWorker.test.ts
+++ b/packages/folio/src/core/layout-engine/measure/measureWorker.test.ts
@@ -14,7 +14,8 @@ import {
   getCachedTextWidth,
 } from "./cache";
 import { setFolioMeasurementFlags } from "./featureFlags";
-import { measureTextWidth, resetCanvasContext } from "./measureContainer";
+import { resetCanvasContext } from "./measureContainer";
+import { measureTextWidth } from "./measureProvider";
 import {
   __disposeMeasureProxyForTests,
   __flushMeasureQueueForTests,

--- a/packages/folio/src/core/layout-engine/tableRowBreak.test.ts
+++ b/packages/folio/src/core/layout-engine/tableRowBreak.test.ts
@@ -8,7 +8,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { layoutDocument } from "./index";
-import { clearAllCaches, resetCanvasContext } from "./measure";
+import { clearAllCaches } from "./measure";
+import { resetCanvasContext } from "./measure/measureContainer";
 import { buildTableRowBreakInfo, snapRowBreak } from "./tableRowBreak";
 import type {
   FlowBlock,

--- a/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
@@ -7,11 +7,13 @@ import { describe, expect, test } from "bun:test";
 import {
   bandFragmentX,
   bandTopContentY,
+  isPageFrameRelativeAnchor,
+} from "./textBoxFlow";
+import {
   floatingTextBoxReservesBand,
   floatingTextBoxWrapsText,
   isFloatingTextBoxBlock,
-  isPageFrameRelativeAnchor,
-} from "./textBoxFlow";
+} from "./types";
 
 describe("isFloatingTextBoxBlock", () => {
   test("recognizes displayMode='float' as floating", () => {

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -1,44 +1,15 @@
 /**
- * Floating text-box predicates. Ported from eigenpal docx-editor #474.
+ * Floating text-box band geometry. Ported from eigenpal docx-editor #474/#694.
+ *
+ * The floating-box predicates (`isFloatingTextBoxBlock`,
+ * `floatingTextBoxWrapsText`, `floatingTextBoxReservesBand`) and the
+ * `TextBoxFlowAttrs` type are pure data and live in the model layer
+ * (`./types`); this module holds the page-anchor band geometry that depends on
+ * pixel/EMU unit conversion.
  */
 
-import { isFloatingWrapType, isWrapNone } from "../docx/wrapTypes";
 import { emuToPixels } from "../utils/units";
-import type { ImageRunPosition, TextBoxBlock } from "./types";
-
-export type TextBoxFlowAttrs = Pick<TextBoxBlock, "displayMode" | "wrapType">;
-
-/**
- * `true` when the text box is anchored outside normal block flow — either
- * via the `float` display mode or via an OOXML floating wrap type (which
- * includes `topAndBottom`; see {@link floatingTextBoxReservesBand}).
- */
-export function isFloatingTextBoxBlock(block: TextBoxFlowAttrs): boolean {
-  return block.displayMode === "float" || isFloatingWrapType(block.wrapType);
-}
-
-/**
- * `true` when a floating text box should also reduce surrounding text
- * line widths. Excludes wrapNone (`behind`/`inFront`) and `topAndBottom`
- * which are positioned floats but do not carve a horizontal exclusion.
- */
-export function floatingTextBoxWrapsText(block: TextBoxFlowAttrs): boolean {
-  return (
-    isFloatingTextBoxBlock(block) &&
-    !isWrapNone(block.wrapType) &&
-    block.wrapType !== "topAndBottom"
-  );
-}
-
-/**
- * `true` when a floating text box reserves a full-width vertical band rather
- * than a side exclusion. `topAndBottom` boxes break the text above and below
- * the box (no text beside it), so surrounding lines flow past the band.
- * Ported from eigenpal #694.
- */
-export function floatingTextBoxReservesBand(block: TextBoxFlowAttrs): boolean {
-  return isFloatingTextBoxBlock(block) && block.wrapType === "topAndBottom";
-}
+import type { ImageRunPosition } from "./types";
 
 type VerticalRelativeTo = NonNullable<
   ImageRunPosition["vertical"]

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -13,6 +13,7 @@ import type {
   TableWidthType,
 } from "@stll/docx-core/model";
 
+import { isFloatingWrapType, isWrapNone } from "../docx/wrapTypes";
 import type { OutlineStyleAttr } from "../types/documentEnumValues";
 
 /**
@@ -1326,13 +1327,36 @@ export const isTextWrappingFloatingImageRun = (run: ImageRun): boolean => {
   return run.displayMode === "float" && run.cssFloat !== "none";
 };
 
-// `TextBoxFlowAttrs`, `isFloatingTextBoxBlock`, and `floatingTextBoxWrapsText`
-// are re-exported from `./textBoxFlow.ts` (where they live next to the
-// related wrap-type helpers in `../docx/wrapTypes`). Re-exporting here keeps
-// the painter on a single import surface — `layout-engine/types`.
-export type { TextBoxFlowAttrs } from "./textBoxFlow";
-export {
-  isFloatingTextBoxBlock,
-  floatingTextBoxWrapsText,
-  floatingTextBoxReservesBand,
-} from "./textBoxFlow";
+export type TextBoxFlowAttrs = Pick<TextBoxBlock, "displayMode" | "wrapType">;
+
+/**
+ * `true` when the text box is anchored outside normal block flow — either
+ * via the `float` display mode or via an OOXML floating wrap type (which
+ * includes `topAndBottom`; see {@link floatingTextBoxReservesBand}).
+ */
+export function isFloatingTextBoxBlock(block: TextBoxFlowAttrs): boolean {
+  return block.displayMode === "float" || isFloatingWrapType(block.wrapType);
+}
+
+/**
+ * `true` when a floating text box should also reduce surrounding text
+ * line widths. Excludes wrapNone (`behind`/`inFront`) and `topAndBottom`
+ * which are positioned floats but do not carve a horizontal exclusion.
+ */
+export function floatingTextBoxWrapsText(block: TextBoxFlowAttrs): boolean {
+  return (
+    isFloatingTextBoxBlock(block) &&
+    !isWrapNone(block.wrapType) &&
+    block.wrapType !== "topAndBottom"
+  );
+}
+
+/**
+ * `true` when a floating text box reserves a full-width vertical band rather
+ * than a side exclusion. `topAndBottom` boxes break the text above and below
+ * the box (no text beside it), so surrounding lines flow past the band.
+ * Ported from eigenpal #694.
+ */
+export function floatingTextBoxReservesBand(block: TextBoxFlowAttrs): boolean {
+  return isFloatingTextBoxBlock(block) && block.wrapType === "topAndBottom";
+}

--- a/packages/folio/src/core/model.ts
+++ b/packages/folio/src/core/model.ts
@@ -1,0 +1,47 @@
+/**
+ * Folio model seam — the named, pure-data "lingua franca" surface (Seam 2).
+ *
+ * This barrel is the single entry point for folio's behavior-free data layer:
+ * the docx document model, block ids, enum-value tables, the layout/flow data
+ * shapes, and the measurement data shapes. It is pure data only — no
+ * ProseMirror, no DOM render, no React, no engine behavior. The
+ * `folio-layer-boundaries/model-is-pure-data` oxlint rule and the
+ * `core/__tests__/model-purity.test.ts` architecture test fence the underlying
+ * type modules so behavior can never creep into them.
+ *
+ * The document model (`types/*`) and the layout/flow model
+ * (`layout-engine/types`) share several simple names (`Run`, `TableCell`,
+ * `TableRow`) that are distinct types in each layer. To keep this surface
+ * lossless rather than silently dropping the colliding names, the document
+ * model is re-exported flat and the layout/measure shapes are namespaced
+ * (`Layout.FlowBlock`, `Measure.RunMeasurement`).
+ *
+ * This is an additive, parallel entry: existing imports are unchanged. The
+ * physical relocation of these modules under `core/model/` is deferred to the
+ * package split.
+ */
+
+// Document model: the full docx-core document surface (Document, Paragraph,
+// Section, content, hyperlinks, fields, images, tables, styles, theme, …).
+// `types/content`, `types/colors`, and `types/formatting` are curated subsets
+// of this same origin, so re-exporting `types/document` covers them too.
+export type * from "./types/document";
+
+// Block ids: the branded `FolioBlockId` plus its derivation/guard helpers
+// (runtime exports, hence `export *`).
+export * from "./types/block-id";
+
+// Enum-value tables: the `*_VALUES` arrays and their derived literal types
+// (runtime exports, hence `export *`).
+export * from "./types/documentEnumValues";
+
+// Layout/flow data model: `FlowBlock`, `ParagraphBlock`, `MeasuredLine`, layout
+// runs, and the textbox-margin constants. Namespaced because several names
+// (`Run`, `TableCell`, `TableRow`) collide with the document model above while
+// being distinct layout types.
+export * as Layout from "./layout-engine/types";
+
+// Measurement data shapes: `FontStyle`, `FontMetrics`, `TextMeasurement`,
+// `RunMeasurement`. Pure data describing measurement results; the measuring
+// behavior lives in the engine, not here.
+export type * as Measure from "./layout-engine/measure/measureTypes";

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -111,6 +111,7 @@ import {
   measureBlocks,
   measureSingleBlockWithoutFloatingZones,
 } from "../core/layout-engine/measure/measureBlocks";
+import { installCanvasMeasureProvider } from "../core/layout-engine/measure/measureContainer";
 import type {
   Layout,
   FlowBlock,
@@ -2293,6 +2294,10 @@ export function PagedEditor(
         reason?: LayoutRunReason;
       } = {},
     ) => {
+      // Composition root for text measurement: install the canvas backend
+      // before any layout/measure runs. Idempotent; the engine measures
+      // through the pure provider seam, which throws until a backend is set.
+      installCanvasMeasureProvider();
       const reason = options.reason ?? "manual";
       const recordPhaseDuration = (
         phase: LayoutPhase,

--- a/packages/folio/test/installMeasureProvider.preload.ts
+++ b/packages/folio/test/installMeasureProvider.preload.ts
@@ -1,0 +1,13 @@
+/**
+ * Bun test preload: install the canvas MeasureProvider before any test runs.
+ *
+ * The layout engine measures through the pure provider seam, whose default
+ * provider throws until a backend is installed. Tests exercise real layout via
+ * `withFakeTextMeasure` (which swaps `globalThis.document`, still read by the
+ * canvas backend), so the canvas provider must be active. Wired through
+ * `bunfig.toml` [test] preload, so it covers every layout/measure spec.
+ */
+
+import { installCanvasMeasureProvider } from "../src/core/layout-engine/measure/measureContainer";
+
+installCanvasMeasureProvider();


### PR DESCRIPTION
Lays the foundation for folio's layered seam architecture: a design doc plus the first two seams (measurement and model), so the editor core can grow toward multiple framework adapters, a headless/native engine, and additional document formats without reaching across permeable folder boundaries.

Full rationale and the phased plan are in `packages/folio/docs/seam-architecture.md`. This PR is phases P0–P2 of that doc; the larger phases (bridge split, headless controller) are deliberately left as separate future PRs.

## What's here

**Design doc** (`docs/seam-architecture.md`) — the responsibility map, the typed seams, the one-way dependency direction, the measurement fidelity considerations, and the P0–P7 path.

**Seam 1 — measurement, fully inverted:**
- *P2a:* wrap the canvas text-measurement functions behind a `MeasureProvider` interface with a small registry (`getMeasureProvider` / `setMeasureProvider` / `resetMeasureProvider`), defaulting to `canvasMeasureProvider`. The public `measureTextWidth` / `measureText` / `measureRun` / `getFontMetrics` become thin delegators, so all existing call sites and behaviour are unchanged while measurement is now injectable.
- *P2b:* move the canvas implementation out of the layout engine's import path. `measureProvider` (registry + delegators, throwing default), `measureTypes`, and `measureHelpers` are pure; the canvas impl lives separately and is installed at two composition roots — the editor's `runLayoutPipeline`, and a bun test preload. The layout engine no longer transitively imports canvas/DOM, so the `@stll/folio/server` entry and any future headless/native measure provider are canvas-free by construction.

**Seam 2 — model as an enforced pure-data boundary:**
- `core/model.ts` names the data lingua-franca surface (document model, layout/measure types, ids).
- A `folio-layer-boundaries/model-is-pure-data` lint rule (+ architecture test) forbids the model type layer from importing ProseMirror, DOM-render, React, or engine behaviour, so behaviour cannot creep into the data layer.
- The rule surfaced one real misplacement: three pure `TextBoxBlock` predicates were defined in an engine module and re-exported through `layout-engine/types`. They are now defined directly in the model where they belong; the painter/bridge import surface is unchanged and there is no new cycle.

The physical relocation of the type modules under a `core/model/` directory is intentionally deferred to the package-boundary phase, where the ~246 import sites are repointed once.

Folio typecheck, the full test suite (2443), and type-aware lint all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “model purity” architecture rule to prevent behaviour/framework imports in the model layer.
  * Introduced a pluggable measurement provider seam, with the canvas provider installed automatically before layout runs.
  * Added a clearer core model entry point exposing typed model data and measurement shapes.

* **Bug Fixes**
  * Improved measurement module wiring and alignment of font/text measurement utilities.

* **Documentation**
  * Added detailed seam/architecture guidance for the folio layered design.

* **Tests**
  * Added automated runtime checks to enforce the model-layer purity invariant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->