### PR TITLE
refactor(folio): start the headless controller (P4 slices 1–2c)

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -1481,6 +1481,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             autoOpenReviewSidebar={false}
             className="folio-docx-preview folio-peek h-full"
             documentBuffer={editorBuffer}
+            documentKey={previewIdentity}
             initialZoom={targetZoom}
             mode={isUnlocked ? editorMode : "viewing"}
             onModeChange={(mode) => {

--- a/packages/folio/docs/seam-architecture.md
+++ b/packages/folio/docs/seam-architecture.md
@@ -196,25 +196,33 @@ Each phase ships in the monorepo, CI-checked. P1–P4 are pure TS refactors that
 also improve the current product (testability, clarity); you can stop after any
 phase with a strictly better codebase.
 
-- **P0 (done):** React-free core (`no-react-in-core` rule + arch test), headless
-  `@stll/folio/core` entry, `paged-layout` moved into core.
-- **P1 — model seam:** carve pure data types into a clear boundary.
-- **P2 — invert measurement (next, highest leverage):** generalize the worker
-  protocol into `MeasureProvider`; move canvas behind `canvasMeasureProvider`;
-  make `layout-engine` pure (no canvas/DOM). Headless-testable, Rust-ready.
-- **P3 — split the bridge:** pure `Document→FlowBlocks` → engine; DOM hit-test →
-  render-dom.
-- **P4 — extract the headless `controller`:** pull orchestration out of
-  `paged-editor`; the React adapter becomes a thin wrapper (proves the seam).
-- **P5 — package the boundaries:** the package split, now meaningful (clean
-  interfaces, not reach-ins). Standalone-repo extraction happens here.
+- **P0 (done, #884):** React-free core (`no-react-in-core` rule + arch test),
+  headless `@stll/folio/core` entry, `paged-layout` moved into core.
+- **P1 (done, #887) — model seam:** `core/model.ts` lingua-franca barrel + the
+  `model-is-pure-data` lint rule. Physical `types/`→`model/` relocation (~246
+  imports) deferred to P5.
+- **P2 (done, #887) — measurement seam:** `MeasureProvider` (P2a) + the layout
+  engine's import graph made canvas-free (P2b). Headless-testable, Rust-ready.
+- **P4 (next) — extract the headless `controller`:** pull orchestration (layout
+  loop, incremental measure, hidden PM view, selection/scroll) out of
+  `paged-editor` into a framework-agnostic controller with an imperative API +
+  events. The React adapter becomes a thin wrapper. This is the Vue/desktop
+  linchpin and is self-contained.
+- **P5 — package the boundaries (incl. the bridge split):** form the `engine` /
+  `document` / `render-dom` packages and dissolve `layout-bridge` into them. The
+  bridge split (originally "P3") folds in here: the bridge is a cohesive
+  PM→FlowBlocks→measure cluster, so cleanly separating its pure-compute,
+  PM-conversion, and DOM pieces only works once those three packages exist as
+  homes — doing it earlier would mean throwaway intermediate dirs. The
+  standalone-repo extraction also happens here.
 - **P6 — `@folio/vue`:** small if P4–P5 are right.
 - **P7 — Rust port (profiled):** `docx` I/O first (no font stack), then layout
   (with a Rust measure provider).
 
 ## Status
 
-P0 complete (merged in #884). P2 is the recommended next move: it makes the
-layout engine genuinely pure, which is simultaneously the precondition for the
-Rust port and a quality win today, and it de-risks the plan by proving the
-hardest seam first on a small surface.
+P0, P1, and P2 are merged (#884, #886, #887): the React-free core, the model
+seam, and the fully-inverted measurement seam are in. **P4 (the headless
+controller) is next** — it's self-contained and is the Vue/desktop enabler. The
+bridge split folded into P5 (see P5 above) because cleanly separating that
+cluster requires the engine/document/render-dom package homes that P5 creates.

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -65,6 +65,13 @@ export type DocxEditorProps = {
   documentBuffer?: DocxInput | null;
   /** Pre-parsed document (alternative to documentBuffer) */
   document?: Document | null;
+  /**
+   * Stable identity of the loaded document (same across internal edits, distinct
+   * per loaded file, e.g. a file/document id). Used to distinguish a genuine
+   * external load from an edited document round-tripped back through state.
+   * Falls back to a document-metadata signature when omitted.
+   */
+  documentKey?: string;
   /** Callback when document is saved */
   onSave?: (buffer: ArrayBuffer) => void;
   /** Author name used for comments and track changes */

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -436,6 +436,7 @@ export function DocxEditor({
   ref,
   documentBuffer,
   document: initialDocument,
+  documentKey,
   onSave,
   author = "User",
   onChange,
@@ -3411,6 +3412,7 @@ export function DocxEditor({
                     <PagedEditor
                       ref={pagedEditorRef}
                       document={history.state}
+                      {...(documentKey !== undefined ? { documentKey } : {})}
                       theme={history.state.package.theme || theme || null}
                       sectionProperties={effectiveSectionProperties ?? null}
                       headerContent={headerContent}

--- a/packages/folio/src/core/controller/hiddenEditorApi.test.ts
+++ b/packages/folio/src/core/controller/hiddenEditorApi.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+import type { Command, Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import { schema } from "../prosemirror/schema";
+import {
+  createHiddenEditorApi,
+  type HiddenEditorApiDeps,
+} from "./hiddenEditorApi";
+
+// The API only touches a handful of EditorView members; a structural stub
+// keeps the tests free of a real DOM-backed view (the repo convention).
+type StubView = Pick<EditorView, "state" | "dispatch" | "hasFocus">;
+
+type StubViewOptions = {
+  focused?: boolean;
+  onDispatch?: (tr: Transaction) => void;
+};
+
+const makeStubView = (options: StubViewOptions = {}): StubView => ({
+  state: EditorState.create({ schema }),
+  dispatch: (tr: Transaction) => {
+    options.onDispatch?.(tr);
+  },
+  hasFocus: () => options.focused ?? false,
+});
+
+// SAFETY: the API under test only reads `state`, `dispatch`, and `hasFocus`,
+// all present on the structural stub; a real DOM-backed EditorView cannot be
+// constructed in this headless test environment.
+// eslint-disable-next-line typescript/no-unsafe-type-assertion
+const asView = (view: StubView): EditorView => view as EditorView;
+
+const makeDeps = (
+  view: StubView | null,
+  isDestroying = false,
+): HiddenEditorApiDeps => ({
+  getView: () => (view === null ? null : asView(view)),
+  getDocumentContext: () => null,
+  isDestroying: () => isDestroying,
+});
+
+describe("createHiddenEditorApi", () => {
+  test("getState returns the view's state", () => {
+    const view = makeStubView();
+    const api = createHiddenEditorApi(makeDeps(view));
+    expect(api.getState()).toBe(view.state);
+  });
+
+  test("getState returns null without a view", () => {
+    const api = createHiddenEditorApi(makeDeps(null));
+    expect(api.getState()).toBeNull();
+  });
+
+  test("getView passes the view through", () => {
+    const view = makeStubView();
+    const api = createHiddenEditorApi(makeDeps(view));
+    expect(api.getView()).toBe(asView(view));
+    expect(createHiddenEditorApi(makeDeps(null)).getView()).toBeNull();
+  });
+
+  test("getDocument returns null when the context document is null", () => {
+    const api = createHiddenEditorApi(makeDeps(makeStubView()));
+    expect(api.getDocument()).toBeNull();
+  });
+
+  test("isFocused reflects hasFocus()", () => {
+    expect(
+      createHiddenEditorApi(
+        makeDeps(makeStubView({ focused: true })),
+      ).isFocused(),
+    ).toBe(true);
+    expect(
+      createHiddenEditorApi(
+        makeDeps(makeStubView({ focused: false })),
+      ).isFocused(),
+    ).toBe(false);
+    expect(createHiddenEditorApi(makeDeps(null)).isFocused()).toBe(false);
+  });
+
+  test("dispatch forwards to the view when not destroying", () => {
+    let dispatched = 0;
+    const view = makeStubView({
+      onDispatch: () => {
+        dispatched += 1;
+      },
+    });
+    const api = createHiddenEditorApi(makeDeps(view));
+    api.dispatch(view.state.tr);
+    expect(dispatched).toBe(1);
+  });
+
+  test("dispatch is a no-op while destroying", () => {
+    let dispatched = 0;
+    const view = makeStubView({
+      onDispatch: () => {
+        dispatched += 1;
+      },
+    });
+    const api = createHiddenEditorApi(makeDeps(view, true));
+    api.dispatch(view.state.tr);
+    expect(dispatched).toBe(0);
+  });
+
+  test("executeCommand returns false without a view", () => {
+    const api = createHiddenEditorApi(makeDeps(null));
+    const command: Command = () => true;
+    expect(api.executeCommand(command)).toBe(false);
+  });
+
+  test("scrollToSelection is a no-op that does not throw", () => {
+    const api = createHiddenEditorApi(makeDeps(makeStubView()));
+    expect(() => {
+      api.scrollToSelection();
+    }).not.toThrow();
+  });
+});

--- a/packages/folio/src/core/controller/hiddenEditorApi.ts
+++ b/packages/folio/src/core/controller/hiddenEditorApi.ts
@@ -17,6 +17,10 @@ import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
 import type { Document } from "../types/document";
 
 export type HiddenEditorApi = {
+  /** Request the off-screen EditorView (idempotent; creates it when possible). */
+  ensureView: () => void;
+  /** Whether view creation has been requested. */
+  isViewRequested: () => boolean;
   /** Get the ProseMirror EditorState */
   getState: () => EditorState | null;
   /** Get the ProseMirror EditorView */
@@ -55,6 +59,8 @@ export type HiddenEditorApiDeps = {
   getView: () => EditorView | null;
   getDocumentContext: () => Document | null;
   isDestroying: () => boolean;
+  ensureView: () => void;
+  isViewRequested: () => boolean;
 };
 
 /**
@@ -95,6 +101,10 @@ export const createHiddenEditorApi = (
   };
 
   return {
+    ensureView: deps.ensureView,
+
+    isViewRequested: deps.isViewRequested,
+
     getState: () => deps.getView()?.state ?? null,
 
     getView: () => deps.getView() ?? null,

--- a/packages/folio/src/core/controller/hiddenEditorApi.ts
+++ b/packages/folio/src/core/controller/hiddenEditorApi.ts
@@ -81,12 +81,21 @@ const stateToDocument = (
 export const createHiddenEditorApi = (
   deps: HiddenEditorApiDeps,
 ): HiddenEditorApi => {
+  // Skip dispatching while the view is being destroyed. Every dispatching
+  // method routes through this so the framework-agnostic API is self-sufficient
+  // rather than relying on the host view's dispatchTransaction backstop.
+  const dispatchTr = (view: EditorView, tr: Transaction): void => {
+    if (!deps.isDestroying()) {
+      view.dispatch(tr);
+    }
+  };
+
   const setSelection = (anchor: number, head?: number): void => {
     const view = deps.getView();
     if (!view) {
       return;
     }
-    const { state, dispatch } = view;
+    const { state } = view;
     const docEnd = state.doc.content.size;
     const clampedAnchor = Math.max(0, Math.min(anchor, docEnd));
     const clampedHead =
@@ -97,7 +106,7 @@ export const createHiddenEditorApi = (
       head === undefined
         ? Selection.near($anchor)
         : TextSelection.between($anchor, $head);
-    dispatch(state.tr.setSelection(selection));
+    dispatchTr(view, state.tr.setSelection(selection));
   };
 
   return {
@@ -133,8 +142,8 @@ export const createHiddenEditorApi = (
 
     dispatch: (tr: Transaction) => {
       const view = deps.getView();
-      if (view && !deps.isDestroying()) {
-        view.dispatch(tr);
+      if (view) {
+        dispatchTr(view, tr);
       }
     },
 
@@ -143,7 +152,7 @@ export const createHiddenEditorApi = (
       if (!view) {
         return false;
       }
-      return command(view.state, view.dispatch, view);
+      return command(view.state, (tr) => dispatchTr(view, tr), view);
     },
 
     undo: () => {
@@ -151,7 +160,7 @@ export const createHiddenEditorApi = (
       if (!view) {
         return false;
       }
-      return undo(view.state, view.dispatch);
+      return undo(view.state, (tr) => dispatchTr(view, tr));
     },
 
     redo: () => {
@@ -159,7 +168,7 @@ export const createHiddenEditorApi = (
       if (!view) {
         return false;
       }
-      return redo(view.state, view.dispatch);
+      return redo(view.state, (tr) => dispatchTr(view, tr));
     },
 
     canUndo: () => {
@@ -185,10 +194,10 @@ export const createHiddenEditorApi = (
       if (!view) {
         return;
       }
-      const { state, dispatch } = view;
+      const { state } = view;
       try {
         const selection = NodeSelection.create(state.doc, pos);
-        dispatch(state.tr.setSelection(selection));
+        dispatchTr(view, state.tr.setSelection(selection));
       } catch {
         // Fallback to text selection if NodeSelection fails
         setSelection(pos);
@@ -200,14 +209,14 @@ export const createHiddenEditorApi = (
       if (!view) {
         return;
       }
-      const { state, dispatch } = view;
+      const { state } = view;
       try {
         const cellSel = CellSelection.create(
           state.doc,
           anchorCellPos,
           headCellPos,
         );
-        dispatch(state.tr.setSelection(cellSel));
+        dispatchTr(view, state.tr.setSelection(cellSel));
       } catch {
         // Fallback to text selection if positions aren't valid for CellSelection
         setSelection(anchorCellPos, headCellPos);

--- a/packages/folio/src/core/controller/hiddenEditorApi.ts
+++ b/packages/folio/src/core/controller/hiddenEditorApi.ts
@@ -1,0 +1,211 @@
+/**
+ * Hidden-editor imperative API
+ *
+ * Framework-agnostic method surface for the off-screen ProseMirror editor.
+ * Operates on an injected view accessor plus the document context and
+ * destruction guard, so the same imperative handle can be driven from the
+ * React component or a headless controller without depending on React.
+ */
+
+import { undo, redo } from "prosemirror-history";
+import type { Command, EditorState, Transaction } from "prosemirror-state";
+import { NodeSelection, Selection, TextSelection } from "prosemirror-state";
+import { CellSelection } from "prosemirror-tables";
+import type { EditorView } from "prosemirror-view";
+
+import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
+import type { Document } from "../types/document";
+
+export type HiddenEditorApi = {
+  /** Get the ProseMirror EditorState */
+  getState: () => EditorState | null;
+  /** Get the ProseMirror EditorView */
+  getView: () => EditorView | null;
+  /** Get the current Document from PM state */
+  getDocument: () => Document | null;
+  /** Focus the hidden editor */
+  focus: () => void;
+  /** Blur the hidden editor */
+  blur: () => void;
+  /** Check if focused */
+  isFocused: () => boolean;
+  /** Dispatch a transaction */
+  dispatch: (tr: Transaction) => void;
+  /** Execute a ProseMirror command */
+  executeCommand: (command: Command) => boolean;
+  /** Undo */
+  undo: () => boolean;
+  /** Redo */
+  redo: () => boolean;
+  /** Check if undo is available */
+  canUndo: () => boolean;
+  /** Check if redo is available */
+  canRedo: () => boolean;
+  /** Set selection by PM position */
+  setSelection: (anchor: number, head?: number) => void;
+  /** Set node selection at a PM position (for images, etc.) */
+  setNodeSelection: (pos: number) => void;
+  /** Set cell selection between two positions inside table cells */
+  setCellSelection: (anchorCellPos: number, headCellPos: number) => void;
+  /** Scroll the PM view to selection (no-op since hidden) */
+  scrollToSelection: () => void;
+};
+
+export type HiddenEditorApiDeps = {
+  getView: () => EditorView | null;
+  getDocumentContext: () => Document | null;
+  isDestroying: () => boolean;
+};
+
+/**
+ * Convert PM state to Document
+ */
+const stateToDocument = (
+  state: EditorState,
+  originalDoc: Document | null,
+): Document | null => {
+  if (!originalDoc) {
+    return null;
+  }
+
+  // fromProseDoc preserves the base document structure when provided
+  return fromProseDoc(state.doc, originalDoc);
+};
+
+export const createHiddenEditorApi = (
+  deps: HiddenEditorApiDeps,
+): HiddenEditorApi => {
+  const setSelection = (anchor: number, head?: number): void => {
+    const view = deps.getView();
+    if (!view) {
+      return;
+    }
+    const { state, dispatch } = view;
+    const docEnd = state.doc.content.size;
+    const clampedAnchor = Math.max(0, Math.min(anchor, docEnd));
+    const clampedHead =
+      head === undefined ? clampedAnchor : Math.max(0, Math.min(head, docEnd));
+    const $anchor = state.doc.resolve(clampedAnchor);
+    const $head = state.doc.resolve(clampedHead);
+    const selection =
+      head === undefined
+        ? Selection.near($anchor)
+        : TextSelection.between($anchor, $head);
+    dispatch(state.tr.setSelection(selection));
+  };
+
+  return {
+    getState: () => deps.getView()?.state ?? null,
+
+    getView: () => deps.getView() ?? null,
+
+    getDocument: () => {
+      const view = deps.getView();
+      if (!view) {
+        return null;
+      }
+      return stateToDocument(view.state, deps.getDocumentContext());
+    },
+
+    focus: () => {
+      deps.getView()?.focus();
+    },
+
+    blur: () => {
+      const view = deps.getView();
+      const dom = view?.dom;
+      if (view?.hasFocus() && dom instanceof HTMLElement) {
+        dom.blur();
+      }
+    },
+
+    isFocused: () => deps.getView()?.hasFocus() ?? false,
+
+    dispatch: (tr: Transaction) => {
+      const view = deps.getView();
+      if (view && !deps.isDestroying()) {
+        view.dispatch(tr);
+      }
+    },
+
+    executeCommand: (command: Command) => {
+      const view = deps.getView();
+      if (!view) {
+        return false;
+      }
+      return command(view.state, view.dispatch, view);
+    },
+
+    undo: () => {
+      const view = deps.getView();
+      if (!view) {
+        return false;
+      }
+      return undo(view.state, view.dispatch);
+    },
+
+    redo: () => {
+      const view = deps.getView();
+      if (!view) {
+        return false;
+      }
+      return redo(view.state, view.dispatch);
+    },
+
+    canUndo: () => {
+      const view = deps.getView();
+      if (!view) {
+        return false;
+      }
+      return undo(view.state);
+    },
+
+    canRedo: () => {
+      const view = deps.getView();
+      if (!view) {
+        return false;
+      }
+      return redo(view.state);
+    },
+
+    setSelection,
+
+    setNodeSelection: (pos: number) => {
+      const view = deps.getView();
+      if (!view) {
+        return;
+      }
+      const { state, dispatch } = view;
+      try {
+        const selection = NodeSelection.create(state.doc, pos);
+        dispatch(state.tr.setSelection(selection));
+      } catch {
+        // Fallback to text selection if NodeSelection fails
+        setSelection(pos);
+      }
+    },
+
+    setCellSelection: (anchorCellPos: number, headCellPos: number) => {
+      const view = deps.getView();
+      if (!view) {
+        return;
+      }
+      const { state, dispatch } = view;
+      try {
+        const cellSel = CellSelection.create(
+          state.doc,
+          anchorCellPos,
+          headCellPos,
+        );
+        dispatch(state.tr.setSelection(cellSel));
+      } catch {
+        // Fallback to text selection if positions aren't valid for CellSelection
+        setSelection(anchorCellPos, headCellPos);
+      }
+    },
+
+    scrollToSelection: () => {
+      // No-op for hidden editor - visual scrolling handled by PagedEditor
+    },
+  };
+};

--- a/packages/folio/src/core/controller/hiddenEditorManager.test.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.test.ts
@@ -40,6 +40,7 @@ const makeDeps = (
     getCollaborationModules: () => null,
     getPrecomputedInitialState: () => null,
     getReadOnly: () => false,
+    getDocumentKey: () => undefined,
     getDocumentContext: () => null,
     onTransaction: (_transaction: Transaction, _newState: EditorState) => {
       spies["onTransaction"].calls += 1;

--- a/packages/folio/src/core/controller/hiddenEditorManager.test.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.test.ts
@@ -40,7 +40,6 @@ const makeDeps = (
     getCollaborationModules: () => null,
     getPrecomputedInitialState: () => null,
     getReadOnly: () => false,
-    getDeferViewCreation: () => false,
     getDocumentContext: () => null,
     onTransaction: (_transaction: Transaction, _newState: EditorState) => {
       spies["onTransaction"].calls += 1;
@@ -80,19 +79,21 @@ describe("createHiddenEditorManager", () => {
     expect(manager.isInitialized()).toBe(false);
   });
 
-  test("createView is a no-op without a host (no view, stays uninitialized)", () => {
+  test("ensureView marks requested but creates nothing without a host", () => {
     const { deps, spies } = makeDeps({ getHost: () => null });
     const manager = createHiddenEditorManager(deps);
-    manager.createView();
+    manager.ensureView();
+    expect(manager.isViewRequested()).toBe(true);
     expect(manager.getView()).toBeNull();
     expect(manager.isInitialized()).toBe(false);
     expect(spies["onEditorViewReady"].calls).toBe(0);
   });
 
-  test("createView is a no-op while view creation is deferred", () => {
-    const { deps, spies } = makeDeps({ getDeferViewCreation: () => true });
+  test("retryViewCreation does nothing until creation is requested", () => {
+    const { deps, spies } = makeDeps({ getHost: () => null });
     const manager = createHiddenEditorManager(deps);
-    manager.createView();
+    manager.retryViewCreation();
+    expect(manager.isViewRequested()).toBe(false);
     expect(manager.getView()).toBeNull();
     expect(spies["onEditorViewReady"].calls).toBe(0);
   });

--- a/packages/folio/src/core/controller/hiddenEditorManager.test.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type { EditorState, Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import {
+  createHiddenEditorManager,
+  type HiddenEditorManagerDeps,
+  type HiddenProseMirrorRemoteSelection,
+} from "./hiddenEditorManager";
+
+// A real DOM-backed EditorView cannot be constructed in this headless test
+// environment (repo convention; see hiddenEditorApi.test.ts). These tests cover
+// the lifecycle guards that run before any EditorView exists, plus the
+// slice-2a API composition that shares the manager's view owner.
+
+type Spy = { calls: number };
+
+type DepsOverrides = Partial<HiddenEditorManagerDeps>;
+
+const makeDeps = (
+  overrides: DepsOverrides = {},
+): { deps: HiddenEditorManagerDeps; spies: Record<string, Spy> } => {
+  const spies: Record<string, Spy> = {
+    onTransaction: { calls: 0 },
+    onSelectionChange: { calls: 0 },
+    onKeyDown: { calls: 0 },
+    onReadOnlyEditAttempt: { calls: 0 },
+    onEditorViewReady: { calls: 0 },
+    onEditorViewDestroy: { calls: 0 },
+    onRemoteSelectionsChange: { calls: 0 },
+  };
+
+  const deps: HiddenEditorManagerDeps = {
+    getHost: () => null,
+    getDocument: () => null,
+    getStyles: () => null,
+    getExtensionManager: () => undefined,
+    getExternalPlugins: () => [],
+    getCollaboration: () => undefined,
+    getCollaborationModules: () => null,
+    getPrecomputedInitialState: () => null,
+    getReadOnly: () => false,
+    getDeferViewCreation: () => false,
+    getDocumentContext: () => null,
+    onTransaction: (_transaction: Transaction, _newState: EditorState) => {
+      spies["onTransaction"].calls += 1;
+    },
+    onSelectionChange: (_state: EditorState) => {
+      spies["onSelectionChange"].calls += 1;
+    },
+    onKeyDown: (_view: EditorView, _event: KeyboardEvent) => {
+      spies["onKeyDown"].calls += 1;
+      return false;
+    },
+    onReadOnlyEditAttempt: () => {
+      spies["onReadOnlyEditAttempt"].calls += 1;
+    },
+    onEditorViewReady: (_view: EditorView) => {
+      spies["onEditorViewReady"].calls += 1;
+    },
+    onEditorViewDestroy: () => {
+      spies["onEditorViewDestroy"].calls += 1;
+    },
+    onRemoteSelectionsChange: (
+      _selections: HiddenProseMirrorRemoteSelection[],
+    ) => {
+      spies["onRemoteSelectionsChange"].calls += 1;
+    },
+    ...overrides,
+  };
+
+  return { deps, spies };
+};
+
+describe("createHiddenEditorManager", () => {
+  test("starts with no view and uninitialized", () => {
+    const { deps } = makeDeps();
+    const manager = createHiddenEditorManager(deps);
+    expect(manager.getView()).toBeNull();
+    expect(manager.isInitialized()).toBe(false);
+  });
+
+  test("createView is a no-op without a host (no view, stays uninitialized)", () => {
+    const { deps, spies } = makeDeps({ getHost: () => null });
+    const manager = createHiddenEditorManager(deps);
+    manager.createView();
+    expect(manager.getView()).toBeNull();
+    expect(manager.isInitialized()).toBe(false);
+    expect(spies["onEditorViewReady"].calls).toBe(0);
+  });
+
+  test("createView is a no-op while view creation is deferred", () => {
+    const { deps, spies } = makeDeps({ getDeferViewCreation: () => true });
+    const manager = createHiddenEditorManager(deps);
+    manager.createView();
+    expect(manager.getView()).toBeNull();
+    expect(spies["onEditorViewReady"].calls).toBe(0);
+  });
+
+  test("destroyView is a no-op without a view", () => {
+    const { deps, spies } = makeDeps();
+    const manager = createHiddenEditorManager(deps);
+    manager.destroyView();
+    expect(spies["onEditorViewDestroy"].calls).toBe(0);
+  });
+
+  test("syncExternalDocument is a no-op without a view", () => {
+    const { deps, spies } = makeDeps();
+    const manager = createHiddenEditorManager(deps);
+    expect(() => {
+      manager.syncExternalDocument();
+    }).not.toThrow();
+    expect(spies["onSelectionChange"].calls).toBe(0);
+  });
+
+  test("syncEditable is a no-op without a view", () => {
+    const { deps } = makeDeps();
+    const manager = createHiddenEditorManager(deps);
+    expect(() => {
+      manager.syncEditable();
+    }).not.toThrow();
+  });
+
+  test("composes an API that shares the manager's (null) view owner", () => {
+    const { deps } = makeDeps();
+    const manager = createHiddenEditorManager(deps);
+    expect(manager.api.getView()).toBeNull();
+    expect(manager.api.getState()).toBeNull();
+    expect(manager.api.getDocument()).toBeNull();
+  });
+});

--- a/packages/folio/src/core/controller/hiddenEditorManager.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.ts
@@ -1,0 +1,618 @@
+/**
+ * Hidden-editor view lifecycle manager
+ *
+ * Framework-agnostic owner of the off-screen ProseMirror EditorView. Holds the
+ * view plus the bookkeeping that decides when an incoming document is a truly
+ * external change (vs. an internal edit echoed back through props), builds the
+ * editor state and `editorProps`, and composes the slice-2a imperative API so
+ * the API and the lifecycle share one view owner. The React adapter
+ * (`HiddenProseMirror`) keeps the input refs and its effects (which decide
+ * *when* to act) and drives this manager through the methods below.
+ */
+
+import { panic } from "better-result";
+import type { EditorState, Plugin, Transaction } from "prosemirror-state";
+import { EditorState as PMEditorState } from "prosemirror-state";
+import type { DirectEditorProps } from "prosemirror-view";
+import { EditorView } from "prosemirror-view";
+import type * as YProseMirror from "y-prosemirror";
+import type { Doc as YDoc, XmlFragment } from "yjs";
+import type * as Yjs from "yjs";
+
+import {
+  recordHiddenEditorPhase,
+  recordHiddenEditorStateCreate,
+  type HiddenEditorStateReason,
+} from "../layout-engine/layoutInstrumentation";
+import { suppressHiddenEditorScrollToSelection } from "../paged-layout/hiddenEditorScroll";
+import { isReadOnlyEditKey } from "../paged-layout/readOnlyEditAttempt";
+import { toProseDoc, createEmptyDoc } from "../prosemirror/conversion";
+import type { ExtensionManager } from "../prosemirror/extensions/ExtensionManager";
+import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
+import { createDocumentStylesPlugin } from "../prosemirror/plugins/documentStyles";
+import { schema } from "../prosemirror/schema";
+import type { Document, StyleDefinitions } from "../types/document";
+import { createHiddenEditorApi, type HiddenEditorApi } from "./hiddenEditorApi";
+
+type YProseMirrorModule = typeof YProseMirror;
+type YjsModule = typeof Yjs;
+
+export type CollaborationModules = {
+  yProseMirror: YProseMirrorModule;
+  yjs: YjsModule;
+};
+
+type CollaborationAwareness = {
+  clientID: number;
+  getStates: () => Map<number, unknown>;
+  off: (event: "change" | "update", handler: () => void) => void;
+  on: (event: "change" | "update", handler: () => void) => void;
+};
+
+export type HiddenProseMirrorCollaboration = {
+  awareness?: CollaborationAwareness | undefined;
+  onSeeded?: (() => void) | undefined;
+  shouldSeed?: boolean | undefined;
+  yXmlFragment: XmlFragment;
+};
+
+export type HiddenProseMirrorRemoteSelection = {
+  anchor: number;
+  clientId: number;
+  color: string;
+  head: number;
+  name: string;
+};
+
+type YSyncState = {
+  binding: {
+    mapping: Parameters<
+      YProseMirrorModule["relativePositionToAbsolutePosition"]
+    >[3];
+  };
+  doc: YDoc;
+  type: XmlFragment;
+};
+
+type AwarenessCursor = {
+  anchor: Record<string, unknown>;
+  head: Record<string, unknown>;
+};
+
+type AwarenessUser = {
+  color: string;
+  name: string;
+};
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isYSyncState = (value: unknown, yjs: YjsModule): value is YSyncState => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  const binding = value["binding"];
+  return (
+    value["doc"] instanceof yjs.Doc &&
+    value["type"] instanceof yjs.XmlFragment &&
+    isObjectRecord(binding) &&
+    binding["mapping"] instanceof Map
+  );
+};
+
+const readAwarenessCursor = (state: unknown): AwarenessCursor | null => {
+  if (!isObjectRecord(state)) {
+    return null;
+  }
+  const cursor = state["cursor"];
+  if (!isObjectRecord(cursor)) {
+    return null;
+  }
+  const anchor = cursor["anchor"];
+  const head = cursor["head"];
+  if (!isObjectRecord(anchor) || !isObjectRecord(head)) {
+    return null;
+  }
+  return { anchor, head };
+};
+
+const readAwarenessUser = (state: unknown, clientId: number): AwarenessUser => {
+  if (!isObjectRecord(state) || !isObjectRecord(state["user"])) {
+    return {
+      color: "var(--doc-image-selection)",
+      name: `User ${clientId}`,
+    };
+  }
+
+  const user = state["user"];
+  return {
+    color:
+      typeof user["color"] === "string"
+        ? user["color"]
+        : "var(--doc-image-selection)",
+    name: typeof user["name"] === "string" ? user["name"] : `User ${clientId}`,
+  };
+};
+
+export const collectRemoteSelections = (
+  state: EditorState,
+  awareness: CollaborationAwareness,
+  collaborationModules: CollaborationModules,
+): HiddenProseMirrorRemoteSelection[] => {
+  const syncState: unknown =
+    collaborationModules.yProseMirror.ySyncPluginKey.getState(state);
+  if (!isYSyncState(syncState, collaborationModules.yjs)) {
+    return [];
+  }
+
+  const selections: HiddenProseMirrorRemoteSelection[] = [];
+  for (const [clientId, remoteState] of awareness.getStates()) {
+    if (clientId === awareness.clientID) {
+      continue;
+    }
+
+    const cursor = readAwarenessCursor(remoteState);
+    if (cursor === null) {
+      continue;
+    }
+
+    const anchor =
+      collaborationModules.yProseMirror.relativePositionToAbsolutePosition(
+        syncState.doc,
+        syncState.type,
+        collaborationModules.yjs.createRelativePositionFromJSON(cursor.anchor),
+        syncState.binding.mapping,
+      );
+    const head =
+      collaborationModules.yProseMirror.relativePositionToAbsolutePosition(
+        syncState.doc,
+        syncState.type,
+        collaborationModules.yjs.createRelativePositionFromJSON(cursor.head),
+        syncState.binding.mapping,
+      );
+    if (anchor === null || head === null) {
+      continue;
+    }
+
+    const user = readAwarenessUser(remoteState, clientId);
+    selections.push({
+      anchor,
+      clientId,
+      color: user.color,
+      head,
+      name: user.name,
+    });
+  }
+
+  return selections;
+};
+
+const HIDDEN_EDITOR_ATTRIBUTES = {
+  "aria-label": "Document content",
+  "aria-multiline": "true",
+  autocapitalize: "off",
+  autocomplete: "off",
+  autocorrect: "off",
+  role: "textbox",
+  spellcheck: "false",
+  translate: "no",
+};
+
+/**
+ * Create ProseMirror state from document
+ *
+ * When an ExtensionManager is provided, it supplies the schema and plugins.
+ * Otherwise falls back to the default singleton schema with no extension plugins.
+ */
+export function createHiddenEditorState(
+  document: Document | null,
+  styles: StyleDefinitions | null | undefined,
+  manager?: ExtensionManager,
+  externalPlugins: Plugin[] = [],
+  collaboration?: HiddenProseMirrorCollaboration,
+  collaborationModules?: CollaborationModules | null,
+  reason: HiddenEditorStateReason = "mount",
+): EditorState {
+  recordHiddenEditorStateCreate(reason);
+
+  const activeSchema = manager?.getSchema() ?? schema;
+  let localDoc = createEmptyDoc();
+  if (document) {
+    const startedAt = performance.now();
+    localDoc =
+      styles === undefined || styles === null
+        ? toProseDoc(document)
+        : toProseDoc(document, { styles });
+    recordHiddenEditorPhase(
+      reason,
+      "to-prose-doc",
+      performance.now() - startedAt,
+    );
+  }
+
+  // Expose the document's styles to style-aware commands (e.g. the Enter
+  // handler's `w:next` switch from heading to body text). Same resolver for
+  // collab and non-collab paths.
+  const styleResolverPlugin = createDocumentStylesPlugin(
+    styles ?? document?.package.styles,
+  );
+  const plugins: Plugin[] = [
+    ...externalPlugins,
+    ...(manager?.getPlugins() ?? []),
+    styleResolverPlugin,
+  ];
+
+  if (collaboration) {
+    if (!collaborationModules) {
+      panic(
+        "Collaboration modules must be loaded before creating collaborative editor state.",
+      );
+    }
+
+    if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
+      const seedState = ensureParaIdsInState(
+        PMEditorState.create({
+          doc: localDoc,
+          schema: activeSchema,
+          plugins,
+        }),
+      );
+      collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
+        seedState.doc,
+        collaboration.yXmlFragment,
+      );
+      collaboration.onSeeded?.();
+    }
+
+    let { doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
+      collaboration.yXmlFragment,
+      activeSchema,
+    );
+
+    const initializedState = ensureParaIdsInState(
+      PMEditorState.create({
+        doc,
+        schema: activeSchema,
+        plugins,
+      }),
+    );
+    if (!initializedState.doc.eq(doc)) {
+      collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
+        initializedState.doc,
+        collaboration.yXmlFragment,
+      );
+      ({ doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
+        collaboration.yXmlFragment,
+        activeSchema,
+      ));
+    }
+
+    const startedAt = performance.now();
+    const state = ensureParaIdsInState(
+      PMEditorState.create({
+        doc,
+        schema: activeSchema,
+        plugins,
+      }),
+    );
+    recordHiddenEditorPhase(
+      reason,
+      "editor-state",
+      performance.now() - startedAt,
+    );
+    return state;
+  }
+
+  const startedAt = performance.now();
+  const state = ensureParaIdsInState(
+    PMEditorState.create({
+      doc: localDoc,
+      schema: activeSchema,
+      plugins,
+    }),
+  );
+  recordHiddenEditorPhase(
+    reason,
+    "editor-state",
+    performance.now() - startedAt,
+  );
+  return state;
+}
+
+function getDocumentIdentity(doc: Document | null): string {
+  if (!doc) {
+    return "empty";
+  }
+  // Use the document's package id or a hash of its structure.
+  // For simplicity, compare based on whether it has different metadata.
+  const meta = doc.package.properties;
+  const created = meta?.created ? String(meta.created) : "";
+  const modified = meta?.modified ? String(meta.modified) : "";
+  const title = meta?.title ?? "";
+  return `${created}-${modified}-${title}`;
+}
+
+function syncHiddenEditorAccessibility(
+  view: EditorView,
+  readOnly: boolean,
+): void {
+  const { dom } = view;
+  if (!dom.hasAttribute("tabindex")) {
+    dom.tabIndex = 0;
+  }
+  dom.setAttribute("aria-readonly", readOnly ? "true" : "false");
+}
+
+export type HiddenEditorManagerDeps = {
+  getHost: () => HTMLElement | null;
+  getDocument: () => Document | null;
+  getStyles: () => StyleDefinitions | null | undefined;
+  getExtensionManager: () => ExtensionManager | undefined;
+  getExternalPlugins: () => Plugin[];
+  getCollaboration: () => HiddenProseMirrorCollaboration | undefined;
+  getCollaborationModules: () => CollaborationModules | null;
+  getPrecomputedInitialState: () => EditorState | null | undefined;
+  getReadOnly: () => boolean;
+  getDeferViewCreation: () => boolean;
+  /** Document context for the API's `getDocument` (PM state -> Document). */
+  getDocumentContext: () => Document | null;
+  onTransaction: (transaction: Transaction, newState: EditorState) => void;
+  onSelectionChange: (state: EditorState) => void;
+  onKeyDown: (view: EditorView, event: KeyboardEvent) => boolean;
+  onReadOnlyEditAttempt: () => void;
+  onEditorViewReady: (view: EditorView) => void;
+  onEditorViewDestroy: () => void;
+  onRemoteSelectionsChange: (
+    selections: HiddenProseMirrorRemoteSelection[],
+  ) => void;
+};
+
+export type HiddenEditorManager = {
+  createView: () => void;
+  destroyView: () => void;
+  syncExternalDocument: () => void;
+  syncEditable: () => void;
+  getView: () => EditorView | null;
+  isInitialized: () => boolean;
+  api: HiddenEditorApi;
+};
+
+export const createHiddenEditorManager = (
+  deps: HiddenEditorManagerDeps,
+): HiddenEditorManager => {
+  let view: EditorView | null = null;
+  let isDestroying = false;
+  // Track if we've initialized - first render needs to set up state.
+  let isInitialized = false;
+  // Track the document identity to detect truly external changes vs changes
+  // that originated from editing (which get passed back through props).
+  let lastDocumentId: string | null = null;
+  let lastCollaborationFragment: XmlFragment | null = null;
+
+  const createView = (): void => {
+    if (deps.getDeferViewCreation()) {
+      return;
+    }
+    const host = deps.getHost();
+    if (!host || isDestroying) {
+      return;
+    }
+    const collaboration = deps.getCollaboration();
+    const collaborationModules = deps.getCollaborationModules();
+    if (collaboration && !collaborationModules) {
+      return;
+    }
+
+    const precomputedInitialState = deps.getPrecomputedInitialState();
+    const document = deps.getDocument();
+    const styles = deps.getStyles();
+    const extensionManager = deps.getExtensionManager();
+    const externalPlugins = deps.getExternalPlugins();
+
+    const initialState =
+      precomputedInitialState && !collaboration
+        ? precomputedInitialState
+        : createHiddenEditorState(
+            document,
+            styles,
+            extensionManager,
+            externalPlugins,
+            collaboration,
+            collaborationModules,
+            "mount",
+          );
+
+    const editorProps: DirectEditorProps = {
+      state: initialState,
+      attributes: HIDDEN_EDITOR_ATTRIBUTES,
+      editable: () => !deps.getReadOnly(),
+      dispatchTransaction: (transaction: Transaction) => {
+        if (!view || isDestroying) {
+          return;
+        }
+
+        if (deps.getReadOnly() && transaction.docChanged) {
+          deps.onReadOnlyEditAttempt();
+          return;
+        }
+
+        const newState = view.state.apply(transaction);
+        view.updateState(newState);
+
+        // Notify about transaction.
+        deps.onTransaction(transaction, newState);
+
+        // Notify about selection changes.
+        if (transaction.selectionSet || transaction.docChanged) {
+          deps.onSelectionChange(newState);
+        }
+
+        const currentCollaboration = deps.getCollaboration();
+        const currentCollaborationModules = deps.getCollaborationModules();
+        if (currentCollaboration?.awareness && currentCollaborationModules) {
+          deps.onRemoteSelectionsChange(
+            collectRemoteSelections(
+              newState,
+              currentCollaboration.awareness,
+              currentCollaborationModules,
+            ),
+          );
+        }
+      },
+      // Intercept key events before ProseMirror processes them
+      handleKeyDown: (pmView: EditorView, event: KeyboardEvent): boolean => {
+        if (deps.getReadOnly() && isReadOnlyEditKey(event)) {
+          deps.onReadOnlyEditAttempt();
+          event.preventDefault();
+          return true;
+        }
+
+        return deps.onKeyDown(pmView, event);
+      },
+      handleScrollToSelection: suppressHiddenEditorScrollToSelection,
+      // Prevent focus handling from interfering with visual layer
+      handleDOMEvents: {
+        focus: () => false,
+        blur: () => false,
+        beforeinput: (_view, event) => {
+          if (!deps.getReadOnly()) {
+            return false;
+          }
+          deps.onReadOnlyEditAttempt();
+          event.preventDefault();
+          return true;
+        },
+        paste: (_view, event) => {
+          if (!deps.getReadOnly()) {
+            return false;
+          }
+          deps.onReadOnlyEditAttempt();
+          event.preventDefault();
+          return true;
+        },
+        drop: (_view, event) => {
+          if (!deps.getReadOnly()) {
+            return false;
+          }
+          deps.onReadOnlyEditAttempt();
+          event.preventDefault();
+          return true;
+        },
+      },
+    };
+
+    const viewStartedAt = performance.now();
+    view = new EditorView(host, editorProps);
+    recordHiddenEditorPhase(
+      "mount",
+      "editor-view",
+      performance.now() - viewStartedAt,
+    );
+    syncHiddenEditorAccessibility(view, deps.getReadOnly());
+    isInitialized = true;
+    lastDocumentId = getDocumentIdentity(document);
+    lastCollaborationFragment = collaboration?.yXmlFragment ?? null;
+
+    // Notify that view is ready.
+    deps.onEditorViewReady(view);
+  };
+
+  const destroyView = (): void => {
+    if (view && !isDestroying) {
+      isDestroying = true;
+
+      deps.onEditorViewDestroy();
+
+      view.destroy();
+      view = null;
+      isDestroying = false;
+    }
+  };
+
+  // Update state when document changes externally (e.g., loading a new file).
+  // This should NOT run when the document prop changes due to internal edits
+  // being passed back through the parent component's state.
+  const syncExternalDocument = (): void => {
+    if (!view || isDestroying) {
+      return;
+    }
+    const collaboration = deps.getCollaboration();
+    const collaborationModules = deps.getCollaborationModules();
+    if (collaboration && !collaborationModules) {
+      return;
+    }
+
+    const document = deps.getDocument();
+    const currentDocId = getDocumentIdentity(document);
+    const currentCollaborationFragment = collaboration?.yXmlFragment ?? null;
+    const collaborationSourceChanged =
+      currentCollaborationFragment !== lastCollaborationFragment;
+
+    if (collaboration && !collaborationSourceChanged) {
+      return;
+    }
+
+    // Skip if this is the same document (likely passed back after internal edit)
+    // Only reset state if:
+    // 1. Not yet initialized (first mount)
+    // 2. Document identity changed (truly external change like loading a new file)
+    // 3. Collaboration starts/stops or switches sessions
+    if (
+      isInitialized &&
+      currentDocId === lastDocumentId &&
+      !collaborationSourceChanged
+    ) {
+      return;
+    }
+
+    // Update tracking state
+    isInitialized = true;
+    lastDocumentId = currentDocId;
+    lastCollaborationFragment = currentCollaborationFragment;
+
+    // Create new state from document
+    const newState = createHiddenEditorState(
+      document,
+      deps.getStyles(),
+      deps.getExtensionManager(),
+      deps.getExternalPlugins(),
+      collaboration,
+      collaborationModules,
+      "external-document",
+    );
+    const updateStartedAt = performance.now();
+    view.updateState(newState);
+    recordHiddenEditorPhase(
+      "external-document",
+      "update-state",
+      performance.now() - updateStartedAt,
+    );
+    syncHiddenEditorAccessibility(view, deps.getReadOnly());
+
+    deps.onSelectionChange(newState);
+  };
+
+  const syncEditable = (): void => {
+    if (!view) {
+      return;
+    }
+    // EditorView calls editable() dynamically; ARIA state needs explicit sync.
+    syncHiddenEditorAccessibility(view, deps.getReadOnly());
+  };
+
+  const api = createHiddenEditorApi({
+    getView: () => view,
+    getDocumentContext: deps.getDocumentContext,
+    isDestroying: () => isDestroying,
+  });
+
+  return {
+    createView,
+    destroyView,
+    syncExternalDocument,
+    syncEditable,
+    getView: () => view,
+    isInitialized: () => isInitialized,
+    api,
+  };
+};

--- a/packages/folio/src/core/controller/hiddenEditorManager.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.ts
@@ -204,15 +204,28 @@ const HIDDEN_EDITOR_ATTRIBUTES = {
  * When an ExtensionManager is provided, it supplies the schema and plugins.
  * Otherwise falls back to the default singleton schema with no extension plugins.
  */
+export type CreateHiddenEditorStateOptions = {
+  document: Document | null;
+  styles?: StyleDefinitions | null | undefined;
+  manager?: ExtensionManager | undefined;
+  externalPlugins?: Plugin[] | undefined;
+  collaboration?: HiddenProseMirrorCollaboration | undefined;
+  collaborationModules?: CollaborationModules | null | undefined;
+  reason?: HiddenEditorStateReason | undefined;
+};
+
 export function createHiddenEditorState(
-  document: Document | null,
-  styles: StyleDefinitions | null | undefined,
-  manager?: ExtensionManager,
-  externalPlugins: Plugin[] = [],
-  collaboration?: HiddenProseMirrorCollaboration,
-  collaborationModules?: CollaborationModules | null,
-  reason: HiddenEditorStateReason = "mount",
+  options: CreateHiddenEditorStateOptions,
 ): EditorState {
+  const {
+    document,
+    styles,
+    manager,
+    externalPlugins = [],
+    collaboration,
+    collaborationModules,
+    reason = "mount",
+  } = options;
   recordHiddenEditorStateCreate(reason);
 
   const activeSchema = manager?.getSchema() ?? schema;
@@ -431,15 +444,15 @@ export const createHiddenEditorManager = (
     const initialState =
       precomputedInitialState && !collaboration
         ? precomputedInitialState
-        : createHiddenEditorState(
+        : createHiddenEditorState({
             document,
             styles,
-            extensionManager,
+            manager: extensionManager,
             externalPlugins,
             collaboration,
             collaborationModules,
-            "mount",
-          );
+            reason: "mount",
+          });
 
     const editorProps: DirectEditorProps = {
       state: initialState,
@@ -603,15 +616,15 @@ export const createHiddenEditorManager = (
     lastCollaborationFragment = currentCollaborationFragment;
 
     // Create new state from document
-    const newState = createHiddenEditorState(
+    const newState = createHiddenEditorState({
       document,
-      deps.getStyles(),
-      deps.getExtensionManager(),
-      deps.getExternalPlugins(),
+      styles: deps.getStyles(),
+      manager: deps.getExtensionManager(),
+      externalPlugins: deps.getExternalPlugins(),
       collaboration,
       collaborationModules,
-      "external-document",
-    );
+      reason: "external-document",
+    });
     const updateStartedAt = performance.now();
     view.updateState(newState);
     recordHiddenEditorPhase(

--- a/packages/folio/src/core/controller/hiddenEditorManager.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.ts
@@ -353,6 +353,13 @@ export type HiddenEditorManagerDeps = {
   getCollaborationModules: () => CollaborationModules | null;
   getPrecomputedInitialState: () => EditorState | null | undefined;
   getReadOnly: () => boolean;
+  /**
+   * Caller-provided stable identity of the loaded document: the same key across
+   * internal edits (so typing does not trigger an external re-sync) and a
+   * distinct key per loaded file. Authoritative when present; a metadata
+   * signature is used as a fallback when undefined.
+   */
+  getDocumentKey: () => string | undefined;
   /** Document context for the API's `getDocument` (PM state -> Document). */
   getDocumentContext: () => Document | null;
   onTransaction: (transaction: Transaction, newState: EditorState) => void;
@@ -394,6 +401,12 @@ export const createHiddenEditorManager = (
   // that originated from editing (which get passed back through props).
   let lastDocumentId: string | null = null;
   let lastCollaborationFragment: XmlFragment | null = null;
+
+  // A caller-provided documentKey is authoritative (stable across internal
+  // edits, distinct per loaded file); fall back to a metadata signature when no
+  // key is supplied.
+  const currentDocumentIdentity = (): string =>
+    deps.getDocumentKey() ?? getDocumentIdentity(deps.getDocument());
 
   const tryCreate = (): void => {
     if (!requested || view !== null || isDestroying) {
@@ -516,7 +529,7 @@ export const createHiddenEditorManager = (
     );
     syncHiddenEditorAccessibility(view, deps.getReadOnly());
     isInitialized = true;
-    lastDocumentId = getDocumentIdentity(document);
+    lastDocumentId = currentDocumentIdentity();
     lastCollaborationFragment = collaboration?.yXmlFragment ?? null;
 
     // Notify that view is ready.
@@ -562,7 +575,7 @@ export const createHiddenEditorManager = (
     }
 
     const document = deps.getDocument();
-    const currentDocId = getDocumentIdentity(document);
+    const currentDocId = currentDocumentIdentity();
     const currentCollaborationFragment = collaboration?.yXmlFragment ?? null;
     const collaborationSourceChanged =
       currentCollaborationFragment !== lastCollaborationFragment;

--- a/packages/folio/src/core/controller/hiddenEditorManager.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.ts
@@ -353,7 +353,6 @@ export type HiddenEditorManagerDeps = {
   getCollaborationModules: () => CollaborationModules | null;
   getPrecomputedInitialState: () => EditorState | null | undefined;
   getReadOnly: () => boolean;
-  getDeferViewCreation: () => boolean;
   /** Document context for the API's `getDocument` (PM state -> Document). */
   getDocumentContext: () => Document | null;
   onTransaction: (transaction: Transaction, newState: EditorState) => void;
@@ -368,7 +367,11 @@ export type HiddenEditorManagerDeps = {
 };
 
 export type HiddenEditorManager = {
-  createView: () => void;
+  /** Request the view (sets the requested flag, then attempts creation). */
+  ensureView: () => void;
+  /** Re-attempt a previously-requested-but-deferred creation (no-op otherwise). */
+  retryViewCreation: () => void;
+  isViewRequested: () => boolean;
   destroyView: () => void;
   syncExternalDocument: () => void;
   syncEditable: () => void;
@@ -382,6 +385,9 @@ export const createHiddenEditorManager = (
 ): HiddenEditorManager => {
   let view: EditorView | null = null;
   let isDestroying = false;
+  // The React adapter requests the view explicitly (first interaction) or
+  // eagerly (collaboration); creation only proceeds once requested.
+  let requested = false;
   // Track if we've initialized - first render needs to set up state.
   let isInitialized = false;
   // Track the document identity to detect truly external changes vs changes
@@ -389,12 +395,12 @@ export const createHiddenEditorManager = (
   let lastDocumentId: string | null = null;
   let lastCollaborationFragment: XmlFragment | null = null;
 
-  const createView = (): void => {
-    if (deps.getDeferViewCreation()) {
+  const tryCreate = (): void => {
+    if (!requested || view !== null || isDestroying) {
       return;
     }
     const host = deps.getHost();
-    if (!host || isDestroying) {
+    if (!host) {
       return;
     }
     const collaboration = deps.getCollaboration();
@@ -517,6 +523,19 @@ export const createHiddenEditorManager = (
     deps.onEditorViewReady(view);
   };
 
+  const ensureView = (): void => {
+    requested = true;
+    tryCreate();
+  };
+
+  // Completes a previously-requested creation once a gate clears (e.g. the
+  // async collaboration modules finish loading); a no-op until requested.
+  const retryViewCreation = (): void => {
+    tryCreate();
+  };
+
+  const isViewRequested = (): boolean => requested;
+
   const destroyView = (): void => {
     if (view && !isDestroying) {
       isDestroying = true;
@@ -604,10 +623,14 @@ export const createHiddenEditorManager = (
     getView: () => view,
     getDocumentContext: deps.getDocumentContext,
     isDestroying: () => isDestroying,
+    ensureView,
+    isViewRequested,
   });
 
   return {
-    createView,
+    ensureView,
+    retryViewCreation,
+    isViewRequested,
     destroyView,
     syncExternalDocument,
     syncEditable,

--- a/packages/folio/src/core/controller/layoutScheduler.test.ts
+++ b/packages/folio/src/core/controller/layoutScheduler.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createLayoutScheduler,
+  type LayoutRunOptions,
+  type SchedulerClock,
+} from "./layoutScheduler";
+
+type TestState = { id: number };
+
+const makeFakeClock = () => {
+  let time = 0;
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+  const frames = new Map<number, () => void>();
+
+  const clock: SchedulerClock = {
+    now: () => time,
+    setTimer: (cb) => {
+      const id = nextId++;
+      timers.set(id, cb);
+      return id;
+    },
+    clearTimer: (id) => {
+      timers.delete(id);
+    },
+    requestFrame: (cb) => {
+      const id = nextId++;
+      frames.set(id, cb);
+      return id;
+    },
+    cancelFrame: (id) => {
+      frames.delete(id);
+    },
+  };
+
+  const fireAll = (map: Map<number, () => void>): void => {
+    const callbacks = [...map.values()];
+    map.clear();
+    for (const run of callbacks) {
+      run();
+    }
+  };
+
+  return {
+    clock,
+    advance: (ms: number) => {
+      time += ms;
+    },
+    fireTimers: () => fireAll(timers),
+    fireFrames: () => fireAll(frames),
+    pendingTimers: () => timers.size,
+    pendingFrames: () => frames.size,
+  };
+};
+
+describe("layoutScheduler", () => {
+  test("coalesces a burst into one layout run with the latest state", () => {
+    const fc = makeFakeClock();
+    const runs: TestState[] = [];
+    const scheduler = createLayoutScheduler<TestState>({
+      runLayout: (state) => {
+        runs.push(state);
+      },
+      debounceMs: 32,
+      maxDelayMs: 96,
+      clock: fc.clock,
+    });
+
+    scheduler.schedule({ id: 1 }, null);
+    scheduler.schedule({ id: 2 }, null);
+    scheduler.schedule({ id: 3 }, null);
+
+    // One armed debounce timer, nothing run yet.
+    expect(fc.pendingTimers()).toBe(1);
+    expect(runs).toHaveLength(0);
+
+    fc.fireTimers(); // debounce elapses -> schedules a frame
+    fc.fireFrames(); // frame runs layout once, with the latest state
+
+    expect(runs).toEqual([{ id: 3 }]);
+  });
+
+  test("passes the merged dirty range through to runLayout", () => {
+    const fc = makeFakeClock();
+    const optionsSeen: LayoutRunOptions[] = [];
+    const scheduler = createLayoutScheduler<TestState>({
+      runLayout: (_state, options) => {
+        optionsSeen.push(options);
+      },
+      debounceMs: 32,
+      maxDelayMs: 96,
+      clock: fc.clock,
+    });
+
+    scheduler.schedule({ id: 1 }, { from: 10, to: 20 });
+    scheduler.schedule({ id: 2 }, { from: 30, to: 40 });
+    fc.fireTimers();
+    fc.fireFrames();
+
+    expect(optionsSeen).toHaveLength(1);
+    expect(optionsSeen[0]?.reason).toBe("transaction");
+    // mergeDirtyRanges widens to cover both edits.
+    expect(optionsSeen[0]?.dirtyRange).toEqual({ from: 10, to: 40 });
+  });
+
+  test("exceeding maxDelay flushes with zero debounce", () => {
+    const fc = makeFakeClock();
+    const runs: TestState[] = [];
+    const scheduler = createLayoutScheduler<TestState>({
+      runLayout: (state) => {
+        runs.push(state);
+      },
+      debounceMs: 32,
+      maxDelayMs: 96,
+      clock: fc.clock,
+    });
+
+    scheduler.schedule({ id: 1 }, null);
+    fc.advance(100); // past maxDelay since the first edit
+    scheduler.schedule({ id: 2 }, null); // re-arms with delay 0
+    fc.fireTimers();
+    fc.fireFrames();
+
+    expect(runs).toEqual([{ id: 2 }]);
+  });
+
+  test("dispose cancels a pending run", () => {
+    const fc = makeFakeClock();
+    const runs: TestState[] = [];
+    const scheduler = createLayoutScheduler<TestState>({
+      runLayout: (state) => {
+        runs.push(state);
+      },
+      debounceMs: 32,
+      maxDelayMs: 96,
+      clock: fc.clock,
+    });
+
+    scheduler.schedule({ id: 1 }, null);
+    scheduler.dispose();
+    fc.fireTimers();
+    fc.fireFrames();
+
+    expect(runs).toHaveLength(0);
+    expect(fc.pendingTimers()).toBe(0);
+    expect(fc.pendingFrames()).toBe(0);
+  });
+});

--- a/packages/folio/src/core/controller/layoutScheduler.ts
+++ b/packages/folio/src/core/controller/layoutScheduler.ts
@@ -33,12 +33,16 @@ export type SchedulerClock = {
   now: () => number;
 };
 
+// The browser implementation of the injected clock. window.setTimeout is typed
+// to return a number (vs Node's Timeout); window is referenced only inside these
+// methods (call-time), so importing the scheduler in a non-browser host is safe
+// — that host passes its own SchedulerClock.
 export const browserClock: SchedulerClock = {
-  requestFrame: (callback) => requestAnimationFrame(callback),
-  cancelFrame: (id) => cancelAnimationFrame(id),
+  requestFrame: (callback) => window.requestAnimationFrame(callback),
+  cancelFrame: (id) => window.cancelAnimationFrame(id),
   setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
   clearTimer: (id) => window.clearTimeout(id),
-  now: () => performance.now(),
+  now: () => window.performance.now(),
 };
 
 export type LayoutSchedulerConfig<TState> = {
@@ -47,8 +51,12 @@ export type LayoutSchedulerConfig<TState> = {
   debounceMs: number;
   /** Hard cap on latency from the first edit in a burst. */
   maxDelayMs: number;
-  /** Defaults to the browser rAF/timer clock. */
-  clock?: SchedulerClock;
+  /**
+   * Timing source. Pass `browserClock` in the browser; a host injects its own
+   * for desktop/headless. Required (no browser default) so the scheduler never
+   * silently depends on `window`.
+   */
+  clock: SchedulerClock;
 };
 
 export type LayoutScheduler<TState> = {
@@ -73,7 +81,7 @@ type PendingLayoutRequest<TState> = {
 export const createLayoutScheduler = <TState>(
   config: LayoutSchedulerConfig<TState>,
 ): LayoutScheduler<TState> => {
-  const clock = config.clock ?? browserClock;
+  const clock = config.clock;
   let pending: PendingLayoutRequest<TState> | null = null;
 
   const flushPending = (): void => {

--- a/packages/folio/src/core/controller/layoutScheduler.ts
+++ b/packages/folio/src/core/controller/layoutScheduler.ts
@@ -1,0 +1,144 @@
+// Framework-agnostic layout scheduler — the first piece of the headless editor
+// controller (seam-architecture P4). It owns the "when to lay out" policy:
+// coalesce a burst of edits into a single layout pass after a short debounce,
+// while enforcing a hard latency cap from the first edit. It carries the editor
+// state opaquely (generic `TState`), so it has no ProseMirror or React
+// dependency; the React adapter wires it to its `runLayoutPipeline`.
+
+import type { LayoutRunReason } from "../layout-engine/layoutInstrumentation";
+import {
+  mergeDirtyRanges,
+  type DirtyRange,
+} from "../paged-layout/incrementalMeasure";
+
+export type LayoutRunOptions = {
+  dirtyRange?: DirtyRange;
+  forceFull?: boolean;
+  reason: LayoutRunReason;
+};
+
+export type RunLayout<TState> = (
+  state: TState,
+  options: LayoutRunOptions,
+) => void;
+
+// Injected timing primitives so the scheduler is environment-agnostic (browser
+// rAF today; a host-provided clock for desktop or deterministic tests). Mirrors
+// the FolioHost `schedule` seam.
+export type SchedulerClock = {
+  requestFrame: (callback: () => void) => number;
+  cancelFrame: (id: number) => void;
+  setTimer: (callback: () => void, delayMs: number) => number;
+  clearTimer: (id: number) => void;
+  now: () => number;
+};
+
+export const browserClock: SchedulerClock = {
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (id) => cancelAnimationFrame(id),
+  setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
+  clearTimer: (id) => window.clearTimeout(id),
+  now: () => performance.now(),
+};
+
+export type LayoutSchedulerConfig<TState> = {
+  runLayout: RunLayout<TState>;
+  /** Quiet-window debounce before an interactive layout pass. */
+  debounceMs: number;
+  /** Hard cap on latency from the first edit in a burst. */
+  maxDelayMs: number;
+  /** Defaults to the browser rAF/timer clock. */
+  clock?: SchedulerClock;
+};
+
+export type LayoutScheduler<TState> = {
+  /**
+   * Schedule a layout pass after a short coalescing window. Repeated calls in
+   * the window replace the pending state and merge dirty ranges, so a typing
+   * burst paints once while still honoring the max-latency cap.
+   */
+  schedule: (state: TState, dirtyRange: DirtyRange | null) => void;
+  /** Cancel any pending timer/frame. Call on teardown. */
+  dispose: () => void;
+};
+
+type PendingLayoutRequest<TState> = {
+  dirtyRange: DirtyRange | null;
+  firstScheduledAt: number;
+  rafId: number | null;
+  state: TState;
+  timerId: number | null;
+};
+
+export const createLayoutScheduler = <TState>(
+  config: LayoutSchedulerConfig<TState>,
+): LayoutScheduler<TState> => {
+  const clock = config.clock ?? browserClock;
+  let pending: PendingLayoutRequest<TState> | null = null;
+
+  const flushPending = (): void => {
+    if (!pending || pending.rafId !== null) {
+      return;
+    }
+    pending.timerId = null;
+    pending.rafId = clock.requestFrame(() => {
+      const latest = pending;
+      pending = null;
+      if (!latest) {
+        return;
+      }
+      const options: LayoutRunOptions = { reason: "transaction" };
+      if (latest.dirtyRange) {
+        options.dirtyRange = latest.dirtyRange;
+      }
+      config.runLayout(latest.state, options);
+    });
+  };
+
+  const armTimer = (request: PendingLayoutRequest<TState>): void => {
+    if (request.rafId !== null) {
+      return;
+    }
+    if (request.timerId !== null) {
+      clock.clearTimer(request.timerId);
+    }
+    const elapsedMs = clock.now() - request.firstScheduledAt;
+    const delayMs =
+      elapsedMs >= config.maxDelayMs
+        ? 0
+        : Math.min(config.debounceMs, config.maxDelayMs - elapsedMs);
+    request.timerId = clock.setTimer(flushPending, delayMs);
+  };
+
+  return {
+    schedule(state, dirtyRange) {
+      if (pending) {
+        pending.state = state;
+        pending.dirtyRange = mergeDirtyRanges(pending.dirtyRange, dirtyRange);
+        armTimer(pending);
+        return;
+      }
+      const next: PendingLayoutRequest<TState> = {
+        dirtyRange,
+        firstScheduledAt: clock.now(),
+        rafId: null,
+        state,
+        timerId: null,
+      };
+      pending = next;
+      armTimer(next);
+    },
+    dispose() {
+      if (!pending) {
+        return;
+      }
+      if (pending.timerId !== null) {
+        clock.clearTimer(pending.timerId);
+      }
+      if (pending.rafId !== null) {
+        clock.cancelFrame(pending.rafId);
+      }
+      pending = null;
+    },
+  };
+};

--- a/packages/folio/src/paged-editor/HiddenProseMirror.paraIds.test.ts
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.paraIds.test.ts
@@ -48,25 +48,21 @@ describe("createHiddenEditorState collaborative paraId allocation", () => {
     const ydoc = new yjs.Doc();
     const yXmlFragment = ydoc.get("prosemirror", yjs.XmlFragment);
 
-    const state = createHiddenEditorState(
-      docWithoutParaIds(),
-      null,
-      undefined,
-      [],
-      { shouldSeed: true, yXmlFragment },
+    const state = createHiddenEditorState({
+      document: docWithoutParaIds(),
+      styles: null,
+      collaboration: { shouldSeed: true, yXmlFragment },
       collaborationModules,
-    );
+    });
 
     expect(collectParaIds(state)[0]).toMatch(/^[0-9A-F]{8}$/u);
 
-    const reloaded = createHiddenEditorState(
-      null,
-      null,
-      undefined,
-      [],
-      { shouldSeed: false, yXmlFragment },
+    const reloaded = createHiddenEditorState({
+      document: null,
+      styles: null,
+      collaboration: { shouldSeed: false, yXmlFragment },
       collaborationModules,
-    );
+    });
     expect(collectParaIds(reloaded)[0]).toMatch(/^[0-9A-F]{8}$/u);
   });
 
@@ -78,25 +74,21 @@ describe("createHiddenEditorState collaborative paraId allocation", () => {
       yXmlFragment,
     );
 
-    const state = createHiddenEditorState(
-      null,
-      null,
-      undefined,
-      [],
-      { shouldSeed: false, yXmlFragment },
+    const state = createHiddenEditorState({
+      document: null,
+      styles: null,
+      collaboration: { shouldSeed: false, yXmlFragment },
       collaborationModules,
-    );
+    });
 
     expect(collectParaIds(state)[0]).toMatch(/^[0-9A-F]{8}$/u);
 
-    const reloaded = createHiddenEditorState(
-      null,
-      null,
-      undefined,
-      [],
-      { shouldSeed: false, yXmlFragment },
+    const reloaded = createHiddenEditorState({
+      document: null,
+      styles: null,
+      collaboration: { shouldSeed: false, yXmlFragment },
       collaborationModules,
-    );
+    });
     expect(collectParaIds(reloaded)[0]).toMatch(/^[0-9A-F]{8}$/u);
   });
 });

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -18,7 +18,6 @@
 import {
   useRef,
   useEffect,
-  useLayoutEffect,
   useCallback,
   useImperativeHandle,
   useState,
@@ -86,8 +85,6 @@ export type HiddenProseMirrorProps = {
   theme?: Theme | null;
   /** Width in pixels (should match document content width) */
   widthPx?: number;
-  /** Delay EditorView creation while the visible editor performs first layout. */
-  deferViewCreation?: boolean;
   /** Whether the editor is read-only */
   readOnly?: boolean;
   /** Callback when document changes via transaction */
@@ -116,6 +113,10 @@ export type HiddenProseMirrorProps = {
 };
 
 export type HiddenProseMirrorRef = {
+  /** Request the off-screen EditorView (idempotent; creates it when possible). */
+  ensureView: () => void;
+  /** Whether view creation has been requested. */
+  isViewRequested: () => boolean;
   /** Get the ProseMirror EditorState */
   getState: () => EditorState | null;
   /** Get the ProseMirror EditorView */
@@ -204,7 +205,6 @@ export function HiddenProseMirror(
     styles,
     theme: _theme,
     widthPx = 612, // Default Letter width at 72dpi
-    deferViewCreation = false,
     readOnly = false,
     onTransaction,
     onSelectionChange,
@@ -234,7 +234,6 @@ export function HiddenProseMirror(
   const stylesRef = useRef(styles);
   const extensionManagerRef = useRef(extensionManager);
   const externalPluginsRef = useRef(externalPlugins);
-  const deferViewCreationRef = useRef(deferViewCreation);
   const precomputedInitialStateRef = useRef(precomputedInitialState);
   const collaborationRef = useRef(collaboration);
   const collaborationModulesRef = useRef(collaborationModules);
@@ -254,7 +253,6 @@ export function HiddenProseMirror(
   stylesRef.current = styles;
   extensionManagerRef.current = extensionManager;
   externalPluginsRef.current = externalPlugins;
-  deferViewCreationRef.current = deferViewCreation;
   precomputedInitialStateRef.current = precomputedInitialState;
   onTransactionRef.current = onTransaction;
   onSelectionChangeRef.current = onSelectionChange;
@@ -286,7 +284,6 @@ export function HiddenProseMirror(
       getCollaborationModules: () => collaborationModulesRef.current,
       getPrecomputedInitialState: () => precomputedInitialStateRef.current,
       getReadOnly: () => readOnlyRef.current,
-      getDeferViewCreation: () => deferViewCreationRef.current,
       getDocumentContext: () => documentRef.current,
       onTransaction: (transaction, newState) =>
         onTransactionRef.current?.(transaction, newState),
@@ -335,12 +332,6 @@ export function HiddenProseMirror(
   // EditorView Lifecycle
   // ========================================================================
 
-  // Stable wrapper so the create-trigger effect keeps `createView` in its
-  // dependency array; the view-creation body lives in the manager.
-  const createView = useCallback(() => {
-    managerRef.current?.createView();
-  }, []);
-
   useEffect(() => {
     const awareness = collaboration?.awareness;
     if (!awareness || !managerRef.current?.getView() || !collaborationModules) {
@@ -373,18 +364,12 @@ export function HiddenProseMirror(
     managerRef.current?.destroyView();
   }, []);
 
-  useLayoutEffect(() => {
-    if (deferViewCreation) {
-      return;
-    }
-    if (managerRef.current?.getView()) {
-      return;
-    }
-    if (collaboration && !collaborationModules) {
-      return;
-    }
-    createView();
-  }, [collaboration, collaborationModules, createView, deferViewCreation]);
+  // Completes a previously-requested-but-deferred creation once the async
+  // collaboration modules load. Idempotent and gated by `requested` inside the
+  // manager, so it never eagerly creates a view nobody asked for.
+  useEffect(() => {
+    managerRef.current?.retryViewCreation();
+  }, [collaborationModules]);
 
   useEffect(() => () => destroyView(), [destroyView]);
 

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -375,14 +375,15 @@ export function HiddenProseMirror(
     managerRef.current?.destroyView();
   }, []);
 
-  // Completes a previously-requested-but-deferred creation once the async
-  // collaboration modules load. Idempotent and gated by `requested` inside the
+  // Completes a previously-requested-but-deferred creation once a gate clears:
+  // the async collaboration modules load, OR collaboration is cleared entirely
+  // (both unblock tryCreate). Idempotent and gated by `requested` inside the
   // manager, so it never eagerly creates a view nobody asked for. Runs in the
   // layout phase (like the former create trigger) so the view exists before the
   // passive awareness effect above subscribes to remote selections.
   useLayoutEffect(() => {
     managerRef.current?.retryViewCreation();
-  }, [collaborationModules]);
+  }, [collaboration, collaborationModules]);
 
   useEffect(() => () => destroyView(), [destroyView]);
 

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -26,21 +26,15 @@ import {
 import type { CSSProperties, Ref } from "react";
 
 import { panic } from "better-result";
-import { undo, redo } from "prosemirror-history";
 import type { Transaction, Command, Plugin } from "prosemirror-state";
-import {
-  EditorState,
-  NodeSelection,
-  Selection,
-  TextSelection,
-} from "prosemirror-state";
-import { CellSelection } from "prosemirror-tables";
+import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import type { DirectEditorProps } from "prosemirror-view";
 import type * as YProseMirror from "y-prosemirror";
 import type { Doc as YDoc, XmlFragment } from "yjs";
 import type * as Yjs from "yjs";
 
+import { createHiddenEditorApi } from "../core/controller/hiddenEditorApi";
 import {
   recordHiddenEditorPhase,
   recordHiddenEditorStateCreate,
@@ -49,7 +43,6 @@ import {
 import { suppressHiddenEditorScrollToSelection } from "../core/paged-layout/hiddenEditorScroll";
 import { isReadOnlyEditKey } from "../core/paged-layout/readOnlyEditAttempt";
 import { toProseDoc, createEmptyDoc } from "../core/prosemirror/conversion";
-import { fromProseDoc } from "../core/prosemirror/conversion/fromProseDoc";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { ensureParaIdsInState } from "../core/prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
@@ -481,21 +474,6 @@ export function createHiddenEditorState(
   return state;
 }
 
-/**
- * Convert PM state to Document
- */
-function stateToDocument(
-  state: EditorState,
-  originalDoc: Document | null,
-): Document | null {
-  if (!originalDoc) {
-    return null;
-  }
-
-  // fromProseDoc preserves the base document structure when provided
-  return fromProseDoc(state.doc, originalDoc);
-}
-
 function getDocumentIdentity(doc: Document | null): string {
   if (!doc) {
     return "empty";
@@ -909,138 +887,12 @@ export function HiddenProseMirror(
 
   useImperativeHandle(
     ref,
-    () => ({
-      getState() {
-        return viewRef.current?.state ?? null;
-      },
-
-      getView() {
-        return viewRef.current ?? null;
-      },
-
-      getDocument() {
-        if (!viewRef.current) {
-          return null;
-        }
-        return stateToDocument(viewRef.current.state, documentRef.current);
-      },
-
-      focus() {
-        viewRef.current?.focus();
-      },
-
-      blur() {
-        const dom = viewRef.current?.dom;
-        if (viewRef.current?.hasFocus() && dom instanceof HTMLElement) {
-          dom.blur();
-        }
-      },
-
-      isFocused() {
-        return viewRef.current?.hasFocus() ?? false;
-      },
-
-      dispatch(tr: Transaction) {
-        if (viewRef.current && !isDestroyingRef.current) {
-          viewRef.current.dispatch(tr);
-        }
-      },
-
-      executeCommand(command: Command) {
-        if (!viewRef.current) {
-          return false;
-        }
-        return command(
-          viewRef.current.state,
-          viewRef.current.dispatch,
-          viewRef.current,
-        );
-      },
-
-      undo() {
-        if (!viewRef.current) {
-          return false;
-        }
-        return undo(viewRef.current.state, viewRef.current.dispatch);
-      },
-
-      redo() {
-        if (!viewRef.current) {
-          return false;
-        }
-        return redo(viewRef.current.state, viewRef.current.dispatch);
-      },
-
-      canUndo() {
-        if (!viewRef.current) {
-          return false;
-        }
-        return undo(viewRef.current.state);
-      },
-
-      canRedo() {
-        if (!viewRef.current) {
-          return false;
-        }
-        return redo(viewRef.current.state);
-      },
-
-      setSelection(anchor: number, head?: number) {
-        if (!viewRef.current) {
-          return;
-        }
-        const { state, dispatch } = viewRef.current;
-        const docEnd = state.doc.content.size;
-        const clampedAnchor = Math.max(0, Math.min(anchor, docEnd));
-        const clampedHead =
-          head === undefined
-            ? clampedAnchor
-            : Math.max(0, Math.min(head, docEnd));
-        const $anchor = state.doc.resolve(clampedAnchor);
-        const $head = state.doc.resolve(clampedHead);
-        const selection =
-          head === undefined
-            ? Selection.near($anchor)
-            : TextSelection.between($anchor, $head);
-        dispatch(state.tr.setSelection(selection));
-      },
-
-      setNodeSelection(pos: number) {
-        if (!viewRef.current) {
-          return;
-        }
-        const { state, dispatch } = viewRef.current;
-        try {
-          const selection = NodeSelection.create(state.doc, pos);
-          dispatch(state.tr.setSelection(selection));
-        } catch {
-          // Fallback to text selection if NodeSelection fails
-          this.setSelection(pos);
-        }
-      },
-
-      setCellSelection(anchorCellPos: number, headCellPos: number) {
-        if (!viewRef.current) {
-          return;
-        }
-        const { state, dispatch } = viewRef.current;
-        try {
-          const cellSel = CellSelection.create(
-            state.doc,
-            anchorCellPos,
-            headCellPos,
-          );
-          dispatch(state.tr.setSelection(cellSel));
-        } catch {
-          // Fallback to text selection if positions aren't valid for CellSelection
-          this.setSelection(anchorCellPos, headCellPos);
-        }
-      },
-
-      scrollToSelection() {
-        // No-op for hidden editor - visual scrolling handled by PagedEditor
-      },
-    }),
+    () =>
+      createHiddenEditorApi({
+        getView: () => viewRef.current,
+        getDocumentContext: () => documentRef.current,
+        isDestroying: () => isDestroyingRef.current,
+      }),
     [],
   );
 

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -18,6 +18,7 @@
 import {
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useImperativeHandle,
   useState,
@@ -366,8 +367,10 @@ export function HiddenProseMirror(
 
   // Completes a previously-requested-but-deferred creation once the async
   // collaboration modules load. Idempotent and gated by `requested` inside the
-  // manager, so it never eagerly creates a view nobody asked for.
-  useEffect(() => {
+  // manager, so it never eagerly creates a view nobody asked for. Runs in the
+  // layout phase (like the former create trigger) so the view exists before the
+  // passive awareness effect above subscribes to remote selections.
+  useLayoutEffect(() => {
     managerRef.current?.retryViewCreation();
   }, [collaborationModules]);
 

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -80,6 +80,12 @@ const loadCollaborationModules = (): Promise<CollaborationModules> => {
 export type HiddenProseMirrorProps = {
   /** The document to edit */
   document: Document | null;
+  /**
+   * Stable identity of the loaded document (same across internal edits, distinct
+   * per loaded file). When provided it is authoritative for external-load
+   * detection; otherwise a document-metadata signature is used as a fallback.
+   */
+  documentKey?: string;
   /** Document styles for style resolution */
   styles?: StyleDefinitions | null;
   /** Theme for styling */
@@ -203,6 +209,7 @@ export function HiddenProseMirror(
   const {
     ref,
     document,
+    documentKey,
     styles,
     theme: _theme,
     widthPx = 612, // Default Letter width at 72dpi
@@ -232,6 +239,7 @@ export function HiddenProseMirror(
   // accessor functions, so it always sees the current render's value.
   const readOnlyRef = useRef(readOnly);
   const documentRef = useRef(document);
+  const documentKeyRef = useRef(documentKey);
   const stylesRef = useRef(styles);
   const extensionManagerRef = useRef(extensionManager);
   const externalPluginsRef = useRef(externalPlugins);
@@ -267,6 +275,7 @@ export function HiddenProseMirror(
 
   // Keep document ref in sync
   documentRef.current = document;
+  documentKeyRef.current = documentKey;
 
   // The off-screen EditorView lifecycle (create/destroy, editorProps, and the
   // external-document / editable sync) lives in the framework-agnostic manager;
@@ -285,6 +294,7 @@ export function HiddenProseMirror(
       getCollaborationModules: () => collaborationModulesRef.current,
       getPrecomputedInitialState: () => precomputedInitialStateRef.current,
       getReadOnly: () => readOnlyRef.current,
+      getDocumentKey: () => documentKeyRef.current,
       getDocumentContext: () => documentRef.current,
       onTransaction: (transaction, newState) =>
         onTransactionRef.current?.(transaction, newState),

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -395,6 +395,7 @@ export function HiddenProseMirror(
     managerRef.current?.syncExternalDocument();
   }, [
     document,
+    documentKey,
     styles,
     extensionManager,
     externalPlugins,

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -26,41 +26,36 @@ import {
 import type { CSSProperties, Ref } from "react";
 
 import { panic } from "better-result";
-import type { Transaction, Command, Plugin } from "prosemirror-state";
-import { EditorState } from "prosemirror-state";
-import { EditorView } from "prosemirror-view";
-import type { DirectEditorProps } from "prosemirror-view";
-import type * as YProseMirror from "y-prosemirror";
-import type { Doc as YDoc, XmlFragment } from "yjs";
-import type * as Yjs from "yjs";
+import type {
+  Transaction,
+  Command,
+  Plugin,
+  EditorState,
+} from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
 
-import { createHiddenEditorApi } from "../core/controller/hiddenEditorApi";
 import {
-  recordHiddenEditorPhase,
-  recordHiddenEditorStateCreate,
-  type HiddenEditorStateReason,
-} from "../core/layout-engine/layoutInstrumentation";
-import { suppressHiddenEditorScrollToSelection } from "../core/paged-layout/hiddenEditorScroll";
-import { isReadOnlyEditKey } from "../core/paged-layout/readOnlyEditAttempt";
-import { toProseDoc, createEmptyDoc } from "../core/prosemirror/conversion";
+  collectRemoteSelections,
+  createHiddenEditorManager,
+  type CollaborationModules,
+  type HiddenEditorManager,
+  type HiddenProseMirrorCollaboration,
+  type HiddenProseMirrorRemoteSelection,
+} from "../core/controller/hiddenEditorManager";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
-import { ensureParaIdsInState } from "../core/prosemirror/extensions/features/ParaIdAllocatorExtension";
-import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
-import { schema } from "../core/prosemirror/schema";
 import type { Document, Theme, StyleDefinitions } from "../core/types/document";
 // Import ProseMirror CSS
 import "prosemirror-view/style/prosemirror.css";
 
 import "../core/prosemirror/editor.css";
 
-const EMPTY_EXTERNAL_PLUGINS: Plugin[] = [];
+export type {
+  HiddenProseMirrorCollaboration,
+  HiddenProseMirrorRemoteSelection,
+} from "../core/controller/hiddenEditorManager";
+export { createHiddenEditorState } from "../core/controller/hiddenEditorManager";
 
-type YProseMirrorModule = typeof YProseMirror;
-type YjsModule = typeof Yjs;
-type CollaborationModules = {
-  yProseMirror: YProseMirrorModule;
-  yjs: YjsModule;
-};
+const EMPTY_EXTERNAL_PLUGINS: Plugin[] = [];
 
 let collaborationModulesPromise: Promise<CollaborationModules> | null = null;
 
@@ -120,28 +115,6 @@ export type HiddenProseMirrorProps = {
   onReadOnlyEditAttempt?: () => void;
 };
 
-export type HiddenProseMirrorCollaboration = {
-  awareness?: CollaborationAwareness | undefined;
-  onSeeded?: (() => void) | undefined;
-  shouldSeed?: boolean | undefined;
-  yXmlFragment: XmlFragment;
-};
-
-export type HiddenProseMirrorRemoteSelection = {
-  anchor: number;
-  clientId: number;
-  color: string;
-  head: number;
-  name: string;
-};
-
-type CollaborationAwareness = {
-  clientID: number;
-  getStates: () => Map<number, unknown>;
-  off: (event: "change" | "update", handler: () => void) => void;
-  on: (event: "change" | "update", handler: () => void) => void;
-};
-
 export type HiddenProseMirrorRef = {
   /** Get the ProseMirror EditorState */
   getState: () => EditorState | null;
@@ -175,129 +148,6 @@ export type HiddenProseMirrorRef = {
   setCellSelection: (anchorCellPos: number, headCellPos: number) => void;
   /** Scroll the PM view to selection (no-op since hidden) */
   scrollToSelection: () => void;
-};
-
-type YSyncState = {
-  binding: {
-    mapping: Parameters<
-      YProseMirrorModule["relativePositionToAbsolutePosition"]
-    >[3];
-  };
-  doc: YDoc;
-  type: XmlFragment;
-};
-
-type AwarenessCursor = {
-  anchor: Record<string, unknown>;
-  head: Record<string, unknown>;
-};
-
-type AwarenessUser = {
-  color: string;
-  name: string;
-};
-
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-const isYSyncState = (value: unknown, yjs: YjsModule): value is YSyncState => {
-  if (!isObjectRecord(value)) {
-    return false;
-  }
-  const binding = value["binding"];
-  return (
-    value["doc"] instanceof yjs.Doc &&
-    value["type"] instanceof yjs.XmlFragment &&
-    isObjectRecord(binding) &&
-    binding["mapping"] instanceof Map
-  );
-};
-
-const readAwarenessCursor = (state: unknown): AwarenessCursor | null => {
-  if (!isObjectRecord(state)) {
-    return null;
-  }
-  const cursor = state["cursor"];
-  if (!isObjectRecord(cursor)) {
-    return null;
-  }
-  const anchor = cursor["anchor"];
-  const head = cursor["head"];
-  if (!isObjectRecord(anchor) || !isObjectRecord(head)) {
-    return null;
-  }
-  return { anchor, head };
-};
-
-const readAwarenessUser = (state: unknown, clientId: number): AwarenessUser => {
-  if (!isObjectRecord(state) || !isObjectRecord(state["user"])) {
-    return {
-      color: "var(--doc-image-selection)",
-      name: `User ${clientId}`,
-    };
-  }
-
-  const user = state["user"];
-  return {
-    color:
-      typeof user["color"] === "string"
-        ? user["color"]
-        : "var(--doc-image-selection)",
-    name: typeof user["name"] === "string" ? user["name"] : `User ${clientId}`,
-  };
-};
-
-const collectRemoteSelections = (
-  state: EditorState,
-  awareness: CollaborationAwareness,
-  collaborationModules: CollaborationModules,
-): HiddenProseMirrorRemoteSelection[] => {
-  const syncState: unknown =
-    collaborationModules.yProseMirror.ySyncPluginKey.getState(state);
-  if (!isYSyncState(syncState, collaborationModules.yjs)) {
-    return [];
-  }
-
-  const selections: HiddenProseMirrorRemoteSelection[] = [];
-  for (const [clientId, remoteState] of awareness.getStates()) {
-    if (clientId === awareness.clientID) {
-      continue;
-    }
-
-    const cursor = readAwarenessCursor(remoteState);
-    if (cursor === null) {
-      continue;
-    }
-
-    const anchor =
-      collaborationModules.yProseMirror.relativePositionToAbsolutePosition(
-        syncState.doc,
-        syncState.type,
-        collaborationModules.yjs.createRelativePositionFromJSON(cursor.anchor),
-        syncState.binding.mapping,
-      );
-    const head =
-      collaborationModules.yProseMirror.relativePositionToAbsolutePosition(
-        syncState.doc,
-        syncState.type,
-        collaborationModules.yjs.createRelativePositionFromJSON(cursor.head),
-        syncState.binding.mapping,
-      );
-    if (anchor === null || head === null) {
-      continue;
-    }
-
-    const user = readAwarenessUser(remoteState, clientId);
-    selections.push({
-      anchor,
-      clientId,
-      color: user.color,
-      head,
-      name: user.name,
-    });
-  }
-
-  return selections;
 };
 
 // ============================================================================
@@ -338,166 +188,6 @@ const HIDDEN_HOST_STYLES: CSSProperties = {
   // Don't use visibility:hidden - the editor must remain focusable.
 };
 
-const HIDDEN_EDITOR_ATTRIBUTES = {
-  "aria-label": "Document content",
-  "aria-multiline": "true",
-  autocapitalize: "off",
-  autocomplete: "off",
-  autocorrect: "off",
-  role: "textbox",
-  spellcheck: "false",
-  translate: "no",
-};
-
-// ============================================================================
-// HELPER FUNCTIONS
-// ============================================================================
-
-/**
- * Create ProseMirror state from document
- *
- * When an ExtensionManager is provided, it supplies the schema and plugins.
- * Otherwise falls back to the default singleton schema with no extension plugins.
- */
-export function createHiddenEditorState(
-  document: Document | null,
-  styles: StyleDefinitions | null | undefined,
-  manager?: ExtensionManager,
-  externalPlugins: Plugin[] = [],
-  collaboration?: HiddenProseMirrorCollaboration,
-  collaborationModules?: CollaborationModules | null,
-  reason: HiddenEditorStateReason = "mount",
-): EditorState {
-  recordHiddenEditorStateCreate(reason);
-
-  const activeSchema = manager?.getSchema() ?? schema;
-  let localDoc = createEmptyDoc();
-  if (document) {
-    const startedAt = performance.now();
-    localDoc =
-      styles === undefined || styles === null
-        ? toProseDoc(document)
-        : toProseDoc(document, { styles });
-    recordHiddenEditorPhase(
-      reason,
-      "to-prose-doc",
-      performance.now() - startedAt,
-    );
-  }
-
-  // Expose the document's styles to style-aware commands (e.g. the Enter
-  // handler's `w:next` switch from heading to body text). Same resolver for
-  // collab and non-collab paths.
-  const styleResolverPlugin = createDocumentStylesPlugin(
-    styles ?? document?.package.styles,
-  );
-  const plugins: Plugin[] = [
-    ...externalPlugins,
-    ...(manager?.getPlugins() ?? []),
-    styleResolverPlugin,
-  ];
-
-  if (collaboration) {
-    if (!collaborationModules) {
-      panic(
-        "Collaboration modules must be loaded before creating collaborative editor state.",
-      );
-    }
-
-    if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
-      const seedState = ensureParaIdsInState(
-        EditorState.create({
-          doc: localDoc,
-          schema: activeSchema,
-          plugins,
-        }),
-      );
-      collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
-        seedState.doc,
-        collaboration.yXmlFragment,
-      );
-      collaboration.onSeeded?.();
-    }
-
-    let { doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
-      collaboration.yXmlFragment,
-      activeSchema,
-    );
-
-    const initializedState = ensureParaIdsInState(
-      EditorState.create({
-        doc,
-        schema: activeSchema,
-        plugins,
-      }),
-    );
-    if (!initializedState.doc.eq(doc)) {
-      collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
-        initializedState.doc,
-        collaboration.yXmlFragment,
-      );
-      ({ doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
-        collaboration.yXmlFragment,
-        activeSchema,
-      ));
-    }
-
-    const startedAt = performance.now();
-    const state = ensureParaIdsInState(
-      EditorState.create({
-        doc,
-        schema: activeSchema,
-        plugins,
-      }),
-    );
-    recordHiddenEditorPhase(
-      reason,
-      "editor-state",
-      performance.now() - startedAt,
-    );
-    return state;
-  }
-
-  const startedAt = performance.now();
-  const state = ensureParaIdsInState(
-    EditorState.create({
-      doc: localDoc,
-      schema: activeSchema,
-      plugins,
-    }),
-  );
-  recordHiddenEditorPhase(
-    reason,
-    "editor-state",
-    performance.now() - startedAt,
-  );
-  return state;
-}
-
-function getDocumentIdentity(doc: Document | null): string {
-  if (!doc) {
-    return "empty";
-  }
-  // Use the document's package id or a hash of its structure.
-  // For simplicity, compare based on whether it has different metadata.
-  const meta = doc.package.properties;
-  const created = meta?.created ? String(meta.created) : "";
-  const modified = meta?.modified ? String(meta.modified) : "";
-  const title = meta?.title ?? "";
-  return `${created}-${modified}-${title}`;
-}
-
-function syncHiddenEditorAccessibility(
-  view: EditorView,
-  readOnly: boolean,
-): void {
-  const { dom } = view;
-  if (!dom.hasAttribute("tabindex")) {
-    dom.tabIndex = 0;
-  }
-  dom.setAttribute("aria-readonly", readOnly ? "true" : "false");
-}
-
 // ============================================================================
 // COMPONENT
 // ============================================================================
@@ -537,18 +227,17 @@ export function HiddenProseMirror(
 
   // Refs
   const hostRef = useRef<HTMLDivElement>(null);
-  const viewRef = useRef<EditorView | null>(null);
+  // Manager-input refs: the framework-agnostic view manager reads these via
+  // accessor functions, so it always sees the current render's value.
   const readOnlyRef = useRef(readOnly);
   const documentRef = useRef(document);
+  const stylesRef = useRef(styles);
+  const extensionManagerRef = useRef(extensionManager);
+  const externalPluginsRef = useRef(externalPlugins);
+  const deferViewCreationRef = useRef(deferViewCreation);
+  const precomputedInitialStateRef = useRef(precomputedInitialState);
   const collaborationRef = useRef(collaboration);
   const collaborationModulesRef = useRef(collaborationModules);
-  const isDestroyingRef = useRef(false);
-  // Track the document identity to detect truly external changes
-  // vs changes that originated from editing (which get passed back through props)
-  const lastDocumentIdRef = useRef<string | null>(null);
-  const lastCollaborationFragmentRef = useRef<XmlFragment | null>(null);
-  // Track if we've initialized - first render needs to set up state
-  const isInitializedRef = useRef(false);
 
   // Store callbacks in refs to avoid dependency array issues that cause infinite loops
   // when the parent component passes unstable callback references
@@ -562,6 +251,11 @@ export function HiddenProseMirror(
 
   // Keep refs in sync
   readOnlyRef.current = readOnly;
+  stylesRef.current = styles;
+  extensionManagerRef.current = extensionManager;
+  externalPluginsRef.current = externalPlugins;
+  deferViewCreationRef.current = deferViewCreation;
+  precomputedInitialStateRef.current = precomputedInitialState;
   onTransactionRef.current = onTransaction;
   onSelectionChangeRef.current = onSelectionChange;
   onEditorViewReadyRef.current = onEditorViewReady;
@@ -574,6 +268,37 @@ export function HiddenProseMirror(
 
   // Keep document ref in sync
   documentRef.current = document;
+
+  // The off-screen EditorView lifecycle (create/destroy, editorProps, and the
+  // external-document / editable sync) lives in the framework-agnostic manager;
+  // this component keeps the input refs and its effects (which decide *when* to
+  // act) and drives the manager through its methods. Created once, like the
+  // layout scheduler in PagedEditor.
+  const managerRef = useRef<HiddenEditorManager | null>(null);
+  if (managerRef.current === null) {
+    managerRef.current = createHiddenEditorManager({
+      getHost: () => hostRef.current,
+      getDocument: () => documentRef.current,
+      getStyles: () => stylesRef.current,
+      getExtensionManager: () => extensionManagerRef.current,
+      getExternalPlugins: () => externalPluginsRef.current,
+      getCollaboration: () => collaborationRef.current,
+      getCollaborationModules: () => collaborationModulesRef.current,
+      getPrecomputedInitialState: () => precomputedInitialStateRef.current,
+      getReadOnly: () => readOnlyRef.current,
+      getDeferViewCreation: () => deferViewCreationRef.current,
+      getDocumentContext: () => documentRef.current,
+      onTransaction: (transaction, newState) =>
+        onTransactionRef.current?.(transaction, newState),
+      onSelectionChange: (state) => onSelectionChangeRef.current?.(state),
+      onKeyDown: (view, event) => onKeyDownRef.current?.(view, event) ?? false,
+      onReadOnlyEditAttempt: () => onReadOnlyEditAttemptRef.current?.(),
+      onEditorViewReady: (view) => onEditorViewReadyRef.current?.(view),
+      onEditorViewDestroy: () => onEditorViewDestroyRef.current?.(),
+      onRemoteSelectionsChange: (selections) =>
+        onRemoteSelectionsChangeRef.current?.(selections),
+    });
+  }
 
   useEffect(() => {
     if (!hasCollaboration) {
@@ -610,156 +335,26 @@ export function HiddenProseMirror(
   // EditorView Lifecycle
   // ========================================================================
 
-  /**
-   * Create EditorView with proper dispatch handling
-   * Uses refs for callbacks to avoid infinite re-render loops
-   */
+  // Stable wrapper so the create-trigger effect keeps `createView` in its
+  // dependency array; the view-creation body lives in the manager.
   const createView = useCallback(() => {
-    if (deferViewCreation) {
-      return;
-    }
-    if (!hostRef.current || isDestroyingRef.current) {
-      return;
-    }
-    if (collaboration && !collaborationModules) {
-      return;
-    }
-
-    const initialState =
-      precomputedInitialState && !collaboration
-        ? precomputedInitialState
-        : createHiddenEditorState(
-            document,
-            styles,
-            extensionManager,
-            externalPlugins,
-            collaboration,
-            collaborationModules,
-            "mount",
-          );
-
-    const editorProps: DirectEditorProps = {
-      state: initialState,
-      attributes: HIDDEN_EDITOR_ATTRIBUTES,
-      editable: () => !readOnlyRef.current,
-      dispatchTransaction: (transaction: Transaction) => {
-        if (!viewRef.current || isDestroyingRef.current) {
-          return;
-        }
-
-        if (readOnlyRef.current && transaction.docChanged) {
-          onReadOnlyEditAttemptRef.current?.();
-          return;
-        }
-
-        const newState = viewRef.current.state.apply(transaction);
-        viewRef.current.updateState(newState);
-
-        // Notify about transaction (use ref to avoid dependency issues)
-        onTransactionRef.current?.(transaction, newState);
-
-        // Notify about selection changes (use ref to avoid dependency issues)
-        if (transaction.selectionSet || transaction.docChanged) {
-          onSelectionChangeRef.current?.(newState);
-        }
-
-        const currentCollaboration = collaborationRef.current;
-        const currentCollaborationModules = collaborationModulesRef.current;
-        if (currentCollaboration?.awareness && currentCollaborationModules) {
-          onRemoteSelectionsChangeRef.current?.(
-            collectRemoteSelections(
-              newState,
-              currentCollaboration.awareness,
-              currentCollaborationModules,
-            ),
-          );
-        }
-      },
-      // Intercept key events before ProseMirror processes them
-      handleKeyDown: (view: EditorView, event: KeyboardEvent): boolean => {
-        if (readOnlyRef.current && isReadOnlyEditKey(event)) {
-          onReadOnlyEditAttemptRef.current?.();
-          event.preventDefault();
-          return true;
-        }
-
-        return onKeyDownRef.current?.(view, event) ?? false;
-      },
-      handleScrollToSelection: suppressHiddenEditorScrollToSelection,
-      // Prevent focus handling from interfering with visual layer
-      handleDOMEvents: {
-        focus: () => false,
-        blur: () => false,
-        beforeinput: (_view, event) => {
-          if (!readOnlyRef.current) {
-            return false;
-          }
-          onReadOnlyEditAttemptRef.current?.();
-          event.preventDefault();
-          return true;
-        },
-        paste: (_view, event) => {
-          if (!readOnlyRef.current) {
-            return false;
-          }
-          onReadOnlyEditAttemptRef.current?.();
-          event.preventDefault();
-          return true;
-        },
-        drop: (_view, event) => {
-          if (!readOnlyRef.current) {
-            return false;
-          }
-          onReadOnlyEditAttemptRef.current?.();
-          event.preventDefault();
-          return true;
-        },
-      },
-    };
-
-    const viewStartedAt = performance.now();
-    viewRef.current = new EditorView(hostRef.current, editorProps);
-    recordHiddenEditorPhase(
-      "mount",
-      "editor-view",
-      performance.now() - viewStartedAt,
-    );
-    syncHiddenEditorAccessibility(viewRef.current, readOnlyRef.current);
-    isInitializedRef.current = true;
-    lastDocumentIdRef.current = getDocumentIdentity(document);
-    lastCollaborationFragmentRef.current = collaboration?.yXmlFragment ?? null;
-
-    // Notify that view is ready (use ref to avoid dependency issues)
-    onEditorViewReadyRef.current?.(viewRef.current);
-  }, [
-    document,
-    styles,
-    externalPlugins,
-    collaboration,
-    collaborationModules,
-    extensionManager,
-    deferViewCreation,
-    precomputedInitialState,
-    // Callbacks removed from dependencies - accessed via refs
-  ]);
+    managerRef.current?.createView();
+  }, []);
 
   useEffect(() => {
     const awareness = collaboration?.awareness;
-    if (!awareness || !viewRef.current || !collaborationModules) {
+    if (!awareness || !managerRef.current?.getView() || !collaborationModules) {
       onRemoteSelectionsChangeRef.current?.([]);
       return undefined;
     }
 
     const publishRemoteSelections = () => {
-      if (!viewRef.current) {
+      const view = managerRef.current?.getView();
+      if (!view) {
         return;
       }
       onRemoteSelectionsChangeRef.current?.(
-        collectRemoteSelections(
-          viewRef.current.state,
-          awareness,
-          collaborationModules,
-        ),
+        collectRemoteSelections(view.state, awareness, collaborationModules),
       );
     };
 
@@ -772,27 +367,17 @@ export function HiddenProseMirror(
     };
   }, [collaboration?.awareness, collaborationModules]);
 
-  /**
-   * Destroy EditorView
-   */
+  // Stable wrapper so the unmount effect keeps `destroyView` in its dependency
+  // array; the teardown body lives in the manager.
   const destroyView = useCallback(() => {
-    if (viewRef.current && !isDestroyingRef.current) {
-      isDestroyingRef.current = true;
-
-      // Use ref to avoid dependency issues
-      onEditorViewDestroyRef.current?.();
-
-      viewRef.current.destroy();
-      viewRef.current = null;
-      isDestroyingRef.current = false;
-    }
+    managerRef.current?.destroyView();
   }, []);
 
   useLayoutEffect(() => {
     if (deferViewCreation) {
       return;
     }
-    if (viewRef.current || isDestroyingRef.current) {
+    if (managerRef.current?.getView()) {
       return;
     }
     if (collaboration && !collaborationModules) {
@@ -803,65 +388,12 @@ export function HiddenProseMirror(
 
   useEffect(() => () => destroyView(), [destroyView]);
 
-  // Update state when document changes externally (e.g., loading a new file)
+  // Update state when document changes externally (e.g., loading a new file).
   // This should NOT run when the document prop changes due to internal edits
-  // being passed back through the parent component's state
+  // being passed back through the parent component's state; the manager owns
+  // the external-vs-internal comparison.
   useEffect(() => {
-    if (!viewRef.current || isDestroyingRef.current) {
-      return;
-    }
-    if (collaboration && !collaborationModules) {
-      return;
-    }
-
-    const currentDocId = getDocumentIdentity(document);
-    const currentCollaborationFragment = collaboration?.yXmlFragment ?? null;
-    const collaborationSourceChanged =
-      currentCollaborationFragment !== lastCollaborationFragmentRef.current;
-
-    if (collaboration && !collaborationSourceChanged) {
-      return;
-    }
-
-    // Skip if this is the same document (likely passed back after internal edit)
-    // Only reset state if:
-    // 1. Not yet initialized (first mount)
-    // 2. Document identity changed (truly external change like loading a new file)
-    // 3. Collaboration starts/stops or switches sessions
-    if (
-      isInitializedRef.current &&
-      currentDocId === lastDocumentIdRef.current &&
-      !collaborationSourceChanged
-    ) {
-      return;
-    }
-
-    // Update tracking refs
-    isInitializedRef.current = true;
-    lastDocumentIdRef.current = currentDocId;
-    lastCollaborationFragmentRef.current = currentCollaborationFragment;
-
-    // Create new state from document
-    const newState = createHiddenEditorState(
-      document,
-      styles,
-      extensionManager,
-      externalPlugins,
-      collaboration,
-      collaborationModules,
-      "external-document",
-    );
-    const updateStartedAt = performance.now();
-    viewRef.current.updateState(newState);
-    recordHiddenEditorPhase(
-      "external-document",
-      "update-state",
-      performance.now() - updateStartedAt,
-    );
-    syncHiddenEditorAccessibility(viewRef.current, readOnlyRef.current);
-
-    // Use ref to avoid infinite loop when callback is unstable
-    onSelectionChangeRef.current?.(newState);
+    managerRef.current?.syncExternalDocument();
   }, [
     document,
     styles,
@@ -870,31 +402,17 @@ export function HiddenProseMirror(
     collaboration,
     collaborationModules,
   ]);
-  // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
 
   // Update editable state
   useEffect(() => {
-    if (!viewRef.current) {
-      return;
-    }
-    // EditorView calls editable() dynamically; ARIA state needs explicit sync.
-    syncHiddenEditorAccessibility(viewRef.current, readOnly);
+    managerRef.current?.syncEditable();
   }, [readOnly]);
 
   // ========================================================================
   // Imperative Handle
   // ========================================================================
 
-  useImperativeHandle(
-    ref,
-    () =>
-      createHiddenEditorApi({
-        getView: () => viewRef.current,
-        getDocumentContext: () => documentRef.current,
-        isDestroying: () => isDestroyingRef.current,
-      }),
-    [],
-  );
+  useImperativeHandle(ref, () => managerRef.current!.api, []);
 
   if (hasCollaboration && collaborationModulesError) {
     let detail = "unknown error";

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -19,11 +19,12 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useImperativeHandle,
 } from "react";
 import type { CSSProperties, Ref } from "react";
-import { createPortal, flushSync } from "react-dom";
+import { createPortal } from "react-dom";
 
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
@@ -1877,6 +1878,9 @@ export function PagedEditor(
   const [layout, setLayout] = useState<Layout | null>(null);
   const [blocks, setBlocks] = useState<FlowBlock[]>([]);
   const [measures, setMeasures] = useState<Measure[]>([]);
+  // Reactive "has the hidden editor been requested" signal. The manager owns
+  // the actual view creation imperatively (via ensureView); this flag only
+  // drives the pre-hidden initial-layout coordination below.
   const [shouldCreateHiddenEditorView, setShouldCreateHiddenEditorView] =
     useState(() => collaboration !== undefined);
   const shouldFocusHiddenEditorOnReadyRef = useRef(collaboration !== undefined);
@@ -2019,27 +2023,32 @@ export function PagedEditor(
   } | null>(null);
 
   const ensureHiddenEditorView = useCallback(
-    ({ focus = true, sync = false }: EnsureHiddenEditorViewOptions = {}) => {
+    ({ focus = true }: EnsureHiddenEditorViewOptions = {}) => {
       if (focus) {
         shouldFocusHiddenEditorOnReadyRef.current = true;
       } else if (
-        !shouldCreateHiddenEditorView &&
+        !hiddenPMRef.current?.isViewRequested() &&
         !hiddenPMRef.current?.getView()
       ) {
         shouldFocusHiddenEditorOnReadyRef.current = false;
       }
 
-      if (sync) {
-        flushSync(() => {
-          setShouldCreateHiddenEditorView(true);
-        });
-        return;
-      }
-
+      // Creation is synchronous now, so the former `sync`/flushSync path is
+      // gone; the `sync` option is accepted (and ignored) for call-site compat.
       setShouldCreateHiddenEditorView(true);
+      hiddenPMRef.current?.ensureView();
     },
-    [shouldCreateHiddenEditorView],
+    [],
   );
+
+  // Eagerly request the hidden editor when collaborating (matches the former
+  // `shouldCreateHiddenEditorView` initial-true for collaboration); the manager
+  // defers the actual creation until the collaboration modules load.
+  useLayoutEffect(() => {
+    if (collaboration !== undefined) {
+      hiddenPMRef.current?.ensureView();
+    }
+  }, [collaboration]);
 
   const queueHiddenEditorSelection = useCallback(
     (selection: PendingHiddenEditorSelection) => {
@@ -6989,7 +6998,6 @@ export function PagedEditor(
         ref={hiddenPMRef}
         document={document}
         widthPx={contentWidth}
-        deferViewCreation={!shouldCreateHiddenEditorView}
         precomputedInitialState={validPrecomputedInitialState}
         readOnly={readOnly}
         onTransaction={handleTransaction}

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -6407,15 +6407,14 @@ export function PagedEditor(
       return undefined;
     }
 
-    const initialState = createHiddenEditorState(
+    const initialState = createHiddenEditorState({
       document,
       styles,
-      extensionManager,
+      manager: extensionManager,
       externalPlugins,
-      undefined,
-      null,
-      "mount",
-    );
+      collaborationModules: null,
+      reason: "mount",
+    });
     precomputedInitialDocumentRef.current = document;
     setPrecomputedInitialState(initialState);
     anonymizationMatchesRef.current =

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -248,6 +248,12 @@ import { useVisualLineNavigation } from "./useVisualLineNavigation";
 export type PagedEditorProps = {
   /** The document to edit. */
   document: Document | null;
+  /**
+   * Stable identity of the loaded document (same across internal edits, distinct
+   * per loaded file), used to distinguish a genuine external load from an
+   * edited document passed back. Falls back to a metadata signature when omitted.
+   */
+  documentKey?: string;
   /** Document styles for style resolution. */
   styles?: StyleDefinitions | null;
   /** Theme for styling. */
@@ -1778,6 +1784,7 @@ export function PagedEditor(
   const {
     ref,
     document,
+    documentKey,
     styles,
     theme: _theme,
     sectionProperties,
@@ -6997,6 +7004,7 @@ export function PagedEditor(
       <HiddenProseMirror
         ref={hiddenPMRef}
         document={document}
+        {...(documentKey !== undefined ? { documentKey } : {})}
         widthPx={contentWidth}
         precomputedInitialState={validPrecomputedInitialState}
         readOnly={readOnly}

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -36,6 +36,11 @@ import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import type { AISuggestion } from "../core/ai-suggestions/types";
+import {
+  browserClock,
+  createLayoutScheduler,
+  type LayoutScheduler,
+} from "../core/controller/layoutScheduler";
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
 import { buildBookmarkText } from "../core/fields/bookmarkText";
@@ -143,10 +148,6 @@ import {
 } from "../core/paged-layout/headerFooterMargins";
 import { tryBuildIncrementalMeasures } from "../core/paged-layout/incrementalMeasure";
 import type { DirtyRange } from "../core/paged-layout/incrementalMeasure";
-import {
-  createLayoutScheduler,
-  type LayoutScheduler,
-} from "../core/controller/layoutScheduler";
 // Selection sync
 import { LayoutSelectionGate } from "../core/paged-layout/LayoutSelectionGate";
 import {
@@ -3123,6 +3124,7 @@ export function PagedEditor(
         runLayoutPipelineRef.current(state, options),
       debounceMs: TRANSACTION_LAYOUT_DEBOUNCE_MS,
       maxDelayMs: TRANSACTION_LAYOUT_MAX_DELAY_MS,
+      clock: browserClock,
     });
   }
   const documentChangeNotifyTimerRef = useRef<number | null>(null);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -141,11 +141,12 @@ import {
   computeHeaderFooterMarginExtender,
   extendSectionBreakMargins,
 } from "../core/paged-layout/headerFooterMargins";
-import {
-  mergeDirtyRanges,
-  tryBuildIncrementalMeasures,
-} from "../core/paged-layout/incrementalMeasure";
+import { tryBuildIncrementalMeasures } from "../core/paged-layout/incrementalMeasure";
 import type { DirtyRange } from "../core/paged-layout/incrementalMeasure";
+import {
+  createLayoutScheduler,
+  type LayoutScheduler,
+} from "../core/controller/layoutScheduler";
 // Selection sync
 import { LayoutSelectionGate } from "../core/paged-layout/LayoutSelectionGate";
 import {
@@ -1036,14 +1037,6 @@ type LayoutInputSignatureOptions = {
   sectionProperties: SectionProperties | null | undefined;
   styles: StyleDefinitions | null | undefined;
   theme: Theme | null | undefined;
-};
-
-type PendingLayoutRequest = {
-  dirtyRange: DirtyRange | null;
-  firstScheduledAt: number;
-  rafId: number | null;
-  state: EditorState;
-  timerId: number | null;
 };
 
 const getPageOverlayOffset = (pagesContainer: HTMLDivElement, zoom: number) => {
@@ -3120,12 +3113,18 @@ export function PagedEditor(
   // Coalesced Layout (rAF throttle)
   // =========================================================================
 
-  /**
-   * Ref holding the latest pending transaction layout request. Rapid typing
-   * updates this request in place so only the final state in the short
-   * coalescing window triggers an interactive layout pass.
-   */
-  const pendingLayoutRef = useRef<PendingLayoutRequest | null>(null);
+  // The "when to lay out" policy (coalesce a typing burst into one pass, with a
+  // latency cap) lives in the framework-agnostic layout scheduler; this adapter
+  // just feeds it transactions and points it at runLayoutPipeline.
+  const layoutSchedulerRef = useRef<LayoutScheduler<EditorState> | null>(null);
+  if (layoutSchedulerRef.current === null) {
+    layoutSchedulerRef.current = createLayoutScheduler<EditorState>({
+      runLayout: (state, options) =>
+        runLayoutPipelineRef.current(state, options),
+      debounceMs: TRANSACTION_LAYOUT_DEBOUNCE_MS,
+      maxDelayMs: TRANSACTION_LAYOUT_MAX_DELAY_MS,
+    });
+  }
   const documentChangeNotifyTimerRef = useRef<number | null>(null);
 
   const flushDocumentChangeNotification = useCallback(() => {
@@ -3151,96 +3150,19 @@ export function PagedEditor(
     }, DOCUMENT_CHANGE_NOTIFY_DELAY);
   }, [flushDocumentChangeNotification]);
 
-  const flushPendingLayout = useCallback(() => {
-    const pending = pendingLayoutRef.current;
-    if (!pending || pending.rafId !== null) {
-      return;
-    }
-
-    pending.timerId = null;
-    pending.rafId = requestAnimationFrame(() => {
-      const latest = pendingLayoutRef.current;
-      pendingLayoutRef.current = null;
-      if (!latest) {
-        return;
-      }
-
-      const layoutOptions: {
-        dirtyRange?: DirtyRange;
-        forceFull?: boolean;
-        reason: LayoutRunReason;
-      } = { reason: "transaction" };
-      if (latest.dirtyRange) {
-        layoutOptions.dirtyRange = latest.dirtyRange;
-      }
-      runLayoutPipeline(latest.state, layoutOptions);
-    });
-  }, [runLayoutPipeline]);
-
-  const armPendingLayoutTimer = useCallback(
-    (pending: PendingLayoutRequest) => {
-      if (pending.rafId !== null) {
-        return;
-      }
-      if (pending.timerId !== null) {
-        window.clearTimeout(pending.timerId);
-      }
-
-      const elapsedMs = performance.now() - pending.firstScheduledAt;
-      const delayMs =
-        elapsedMs >= TRANSACTION_LAYOUT_MAX_DELAY_MS
-          ? 0
-          : Math.min(
-              TRANSACTION_LAYOUT_DEBOUNCE_MS,
-              TRANSACTION_LAYOUT_MAX_DELAY_MS - elapsedMs,
-            );
-
-      pending.timerId = window.setTimeout(flushPendingLayout, delayMs);
-    },
-    [flushPendingLayout],
-  );
-
-  /**
-   * Schedule a layout pipeline run after a short coalescing window.
-   * If more transactions arrive before the timer fires, the pending state
-   * is replaced so rapid typing paints once for the burst while still
-   * enforcing a max latency from the first edit.
-   */
+  // Thin adapter over the framework-agnostic scheduler. Repeated calls in the
+  // coalescing window merge dirty ranges and paint once for the burst.
   const scheduleLayout = useCallback(
     (state: EditorState, dirtyRange: DirtyRange | null) => {
-      const pending = pendingLayoutRef.current;
-      if (pending) {
-        pending.state = state;
-        pending.dirtyRange = mergeDirtyRanges(pending.dirtyRange, dirtyRange);
-        armPendingLayoutTimer(pending);
-        return;
-      }
-
-      const nextPending: PendingLayoutRequest = {
-        dirtyRange,
-        firstScheduledAt: performance.now(),
-        rafId: null,
-        state,
-        timerId: null,
-      };
-      pendingLayoutRef.current = nextPending;
-      armPendingLayoutTimer(nextPending);
+      layoutSchedulerRef.current?.schedule(state, dirtyRange);
     },
-    [armPendingLayoutTimer],
+    [],
   );
 
-  // Clean up pending rAF on unmount
+  // Clean up the pending layout pass and the doc-change timer on unmount.
   useEffect(
     () => () => {
-      if (pendingLayoutRef.current) {
-        if (pendingLayoutRef.current.timerId !== null) {
-          window.clearTimeout(pendingLayoutRef.current.timerId);
-        }
-        if (pendingLayoutRef.current.rafId !== null) {
-          cancelAnimationFrame(pendingLayoutRef.current.rafId);
-        }
-        pendingLayoutRef.current = null;
-      }
+      layoutSchedulerRef.current?.dispose();
       if (documentChangeNotifyTimerRef.current !== null) {
         window.clearTimeout(documentChangeNotifyTimerRef.current);
         documentChangeNotifyTimerRef.current = null;


### PR DESCRIPTION
Begins the headless-controller phase (P4) of the seam architecture by peeling self-contained orchestration out of the 7k-line `PagedEditor` / `HiddenProseMirror` into framework-agnostic `core/controller/` modules, plus the phased-path reorder. Each slice leaves the editor working and is independently reviewable.

## Slices

- **Layout scheduler** (`core/controller/layoutScheduler.ts`) — the *when-to-lay-out* policy (coalesce a typing burst into one pass after a debounce, with a latency cap, merging dirty ranges). Generic over state, with an injected `SchedulerClock` (required, no `window` default — a non-browser host injects its own), so it has no React/ProseMirror dependency and is deterministically unit-tested. `PagedEditor` delegates to it.
- **Hidden-editor imperative API** (`core/controller/hiddenEditorApi.ts`) — the off-screen editor's method surface (`getState`/`getDocument`/`dispatch`/`undo`/`setSelection`/etc.) moved out of `HiddenProseMirror` behind an injected view accessor + refs; the component's `useImperativeHandle` now just returns `createHiddenEditorApi(...)`. Unit-tested with a stub view.
- **Doc reorder** — `docs/seam-architecture.md`: P4 (controller) promoted to next; the bridge split folds into P5 (it needs the engine/document/render-dom package homes P5 creates).

View creation and the React-conditional mount are deliberately untouched — those are the later, riskier controller sub-slices. The controller emerges by accretion.

Folio typecheck, full suite (2457), type-aware lint, and format all pass; the new modules have their own unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless hidden-editor imperative API and manager to support command handling, focus/selection control, and undo/redo even when the editor is off-screen.
  * Introduced coalesced layout scheduling to reduce redundant layout work during rapid updates.

* **Bug Fixes**
  * Improved editor safety when the editor view is unavailable or tearing down (safe no-ops and clamped selection updates).
  * Made transaction-to-layout updates more consistent by merging dirty ranges and enforcing a maximum delay.

* **Documentation**
  * Updated the phased roadmap/sequencing and status wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->