### PR TITLE
chore(desktop): e2e harness for the desktop HTTP bridge

### DIFF
--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -304,7 +304,7 @@ async fn not_found(
   .into_response()
 }
 
-fn build_router(state: BridgeState) -> Router {
+pub(crate) fn build_router(state: BridgeState) -> Router {
   Router::new()
     .route("/health", get(health))
     .route("/v1/self-host-connection", get(self_host_connection))

--- a/apps/desktop/src-tauri/src/bridge.rs
+++ b/apps/desktop/src-tauri/src/bridge.rs
@@ -304,7 +304,7 @@ async fn not_found(
   .into_response()
 }
 
-pub(crate) fn build_router(state: BridgeState) -> Router {
+fn build_router(state: BridgeState) -> Router {
   Router::new()
     .route("/health", get(health))
     .route("/v1/self-host-connection", get(self_host_connection))

--- a/apps/desktop/src-tauri/src/e2e.rs
+++ b/apps/desktop/src-tauri/src/e2e.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use tokio::sync::Mutex;
 
-use crate::bridge::{BridgeState, build_router};
+use crate::bridge::start_bridge;
 use crate::session_manager::SessionManager;
 use crate::types::{BRIDGE_CAPABILITIES, BRIDGE_VERSION};
 
@@ -83,33 +83,27 @@ async fn spawn_test_bridge() -> TestBridge {
 async fn spawn_test_bridge_with_origins(
   static_allowed_origins: HashSet<String>,
 ) -> TestBridge {
-  let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
-    .await
-    .expect("bind loopback test socket");
-  let addr = listener.local_addr().expect("resolve bound address");
-
+  // Drive the real production entry point (bind + serve) rather than a test-only
+  // router so the harness exercises the same code path the app runs. Bind a
+  // throwaway socket to claim a free loopback port, then hand it to start_bridge.
+  let port = free_loopback_port().await;
   let manager = Arc::new(Mutex::new(SessionManager::new()));
-  let state = BridgeState {
-    manager: manager.clone(),
-    static_allowed_origins,
-    bridge_port: addr.port(),
-  };
 
-  let router = build_router(state);
-  tokio::spawn(async move {
-    // Route failures through tracing like start_bridge does (the crate forbids
-    // print_stderr) so a server-side error is not silently swallowed.
-    if let Err(error) = axum::serve(listener, router).await {
-      tracing::error!(error = %error, "test bridge server error");
-    }
-  });
+  tokio::spawn(start_bridge(port, static_allowed_origins, manager.clone()));
 
   let bridge = TestBridge {
-    base_url: format!("http://127.0.0.1:{}", addr.port()),
+    base_url: format!("http://127.0.0.1:{port}"),
     manager,
   };
   bridge.wait_until_ready().await;
   bridge
+}
+
+async fn free_loopback_port() -> u16 {
+  let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+    .await
+    .expect("bind probe socket");
+  listener.local_addr().expect("resolve probe address").port()
 }
 
 fn open_docx_body(session_id: &str) -> serde_json::Value {

--- a/apps/desktop/src-tauri/src/e2e.rs
+++ b/apps/desktop/src-tauri/src/e2e.rs
@@ -1,0 +1,309 @@
+//! End-to-end tests for the desktop app's external interfaces.
+//!
+//! Unlike the in-process `tower::oneshot` unit tests in [`crate::bridge`], these
+//! boot the real Axum bridge on a real loopback socket and drive it with a real
+//! HTTP client. They exercise the wire contract the web app actually depends on:
+//! status codes, CORS headers, preflight handling, and the self-host trust
+//! round trip.
+//!
+//! This module is the shared harness for desktop e2e coverage. Extend
+//! [`spawn_test_bridge`] (or add sibling submodules) as more surfaces become
+//! drivable end to end.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+
+use crate::bridge::{BridgeState, build_router};
+use crate::session_manager::SessionManager;
+use crate::types::{BRIDGE_CAPABILITIES, BRIDGE_VERSION};
+
+const ALLOWED_ORIGIN: &str = "http://localhost:3000";
+const DISALLOWED_ORIGIN: &str = "https://evil.example";
+
+/// A bridge server bound to an ephemeral loopback port for the lifetime of a
+/// test, plus a handle to the [`SessionManager`] backing it so a test can seed
+/// trust state before driving requests.
+struct TestBridge {
+  base_url: String,
+  manager: Arc<Mutex<SessionManager>>,
+}
+
+impl TestBridge {
+  fn client() -> reqwest::Client {
+    reqwest::Client::new()
+  }
+
+  fn url(&self, path: &str) -> String {
+    format!("{}{path}", self.base_url)
+  }
+
+  async fn wait_until_ready(&self) {
+    let client = Self::client();
+    for _ in 0..100 {
+      if client.get(self.url("/health")).send().await.is_ok() {
+        return;
+      }
+      tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("test bridge never accepted a connection");
+  }
+
+  /// GET `/v1/self-host-connection` for a web origin / API pair, returning the
+  /// decoded JSON body.
+  async fn self_host_connection(
+    &self,
+    origin: &str,
+    api_base_url: &str,
+  ) -> serde_json::Value {
+    let url = reqwest::Url::parse_with_params(
+      &self.url("/v1/self-host-connection"),
+      &[("apiBaseUrl", api_base_url)],
+    )
+    .expect("build self-host-connection url");
+    let response = Self::client()
+      .get(url)
+      .header("origin", origin)
+      .send()
+      .await
+      .expect("self-host-connection request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    response.json().await.expect("self-host-connection body")
+  }
+}
+
+async fn spawn_test_bridge() -> TestBridge {
+  spawn_test_bridge_with_origins(HashSet::from([ALLOWED_ORIGIN.to_string()])).await
+}
+
+async fn spawn_test_bridge_with_origins(
+  static_allowed_origins: HashSet<String>,
+) -> TestBridge {
+  let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+    .await
+    .expect("bind loopback test socket");
+  let addr = listener.local_addr().expect("resolve bound address");
+
+  let manager = Arc::new(Mutex::new(SessionManager::new()));
+  let state = BridgeState {
+    manager: manager.clone(),
+    static_allowed_origins,
+    bridge_port: addr.port(),
+  };
+
+  let router = build_router(state);
+  tokio::spawn(async move {
+    let _ = axum::serve(listener, router).await;
+  });
+
+  let bridge = TestBridge {
+    base_url: format!("http://127.0.0.1:{}", addr.port()),
+    manager,
+  };
+  bridge.wait_until_ready().await;
+  bridge
+}
+
+fn open_docx_body(session_id: &str) -> serde_json::Value {
+  serde_json::json!({
+    "apiBaseUrl": "https://api.example.com",
+    "entityId": "11111111-1111-1111-1111-111111111111",
+    "linkedAccount": null,
+    "propertyId": "22222222-2222-2222-2222-222222222222",
+    "remoteSession": {
+      "baseVersionNumber": 1,
+      "downloadUrl": "https://example.com/doc.docx",
+      "fileName": "doc.docx",
+      "lastCheckpointAt": null,
+      "resumedFromCheckpoint": false,
+      "sessionId": session_id,
+      "sessionToken": "token",
+      "tookOverExistingSession": false,
+    },
+    "workspaceId": "33333333-3333-3333-3333-333333333333",
+  })
+}
+
+#[tokio::test]
+async fn health_reports_bridge_contract_over_real_socket() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .get(bridge.url("/health"))
+    .header("origin", ALLOWED_ORIGIN)
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::OK);
+  assert_eq!(
+    response
+      .headers()
+      .get("access-control-allow-origin")
+      .unwrap(),
+    ALLOWED_ORIGIN
+  );
+
+  let body: serde_json::Value = response.json().await.unwrap();
+  assert_eq!(body["ok"], serde_json::json!(true));
+  assert_eq!(body["bridgeVersion"], serde_json::json!(BRIDGE_VERSION));
+  assert_eq!(body["capabilities"], serde_json::json!(BRIDGE_CAPABILITIES));
+}
+
+#[tokio::test]
+async fn health_allows_request_without_origin_but_omits_cors_header() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .get(bridge.url("/health"))
+    .send()
+    .await
+    .unwrap();
+
+  // A browser-less probe (no Origin) is allowed, but must not be granted a
+  // cross-origin grant header.
+  assert_eq!(response.status(), reqwest::StatusCode::OK);
+  assert!(
+    response
+      .headers()
+      .get("access-control-allow-origin")
+      .is_none()
+  );
+}
+
+#[tokio::test]
+async fn health_rejects_disallowed_origin() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .get(bridge.url("/health"))
+    .header("origin", DISALLOWED_ORIGIN)
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn cors_preflight_advertises_contract_for_allowed_origin() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .request(reqwest::Method::OPTIONS, bridge.url("/v1/open-docx"))
+    .header("origin", ALLOWED_ORIGIN)
+    .header("access-control-request-method", "POST")
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::NO_CONTENT);
+  let headers = response.headers();
+  assert_eq!(
+    headers.get("access-control-allow-origin").unwrap(),
+    ALLOWED_ORIGIN
+  );
+  assert!(
+    headers
+      .get("access-control-allow-methods")
+      .unwrap()
+      .to_str()
+      .unwrap()
+      .contains("POST")
+  );
+  // Chrome Private Network Access: the bridge lives on loopback, so it must
+  // grant localhost <-> 127.0.0.1 calls.
+  assert_eq!(
+    headers.get("access-control-allow-private-network").unwrap(),
+    "true"
+  );
+}
+
+#[tokio::test]
+async fn open_docx_rejects_disallowed_origin() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .post(bridge.url("/v1/open-docx"))
+    .header("origin", DISALLOWED_ORIGIN)
+    .json(&open_docx_body("e8400e29-1d4a-4716-8a3a-2c83de7ab2e6"))
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn open_docx_rejects_invalid_session_id() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .post(bridge.url("/v1/open-docx"))
+    .header("origin", ALLOWED_ORIGIN)
+    .json(&open_docx_body("../etc/passwd"))
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn self_host_connection_round_trip_over_real_socket() {
+  let bridge = spawn_test_bridge().await;
+  {
+    let mut manager = bridge.manager.lock().await;
+    manager.trust_self_host_connection_for_test(
+      "https://web.example".to_string(),
+      "https://api.example".to_string(),
+    );
+  }
+
+  // The approved web/API pair reads back as trusted...
+  let approved = bridge
+    .self_host_connection("https://web.example", "https://api.example")
+    .await;
+  assert_eq!(approved["trusted"], serde_json::json!(true));
+
+  // ...but the same (now trusted) origin asking about a different API does not.
+  let mismatched = bridge
+    .self_host_connection("https://web.example", "https://other.example")
+    .await;
+  assert_eq!(mismatched["trusted"], serde_json::json!(false));
+}
+
+#[tokio::test]
+async fn self_host_connection_rejects_untrusted_origin() {
+  let bridge = spawn_test_bridge().await;
+
+  let url = reqwest::Url::parse_with_params(
+    &bridge.url("/v1/self-host-connection"),
+    &[("apiBaseUrl", "https://api.example")],
+  )
+  .unwrap();
+  let response = TestBridge::client()
+    .get(url)
+    .header("origin", "https://stranger.example")
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn unknown_path_returns_not_found() {
+  let bridge = spawn_test_bridge().await;
+
+  let response = TestBridge::client()
+    .get(bridge.url("/v1/does-not-exist"))
+    .header("origin", ALLOWED_ORIGIN)
+    .send()
+    .await
+    .unwrap();
+
+  assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+}

--- a/apps/desktop/src-tauri/src/e2e.rs
+++ b/apps/desktop/src-tauri/src/e2e.rs
@@ -43,12 +43,14 @@ impl TestBridge {
   async fn wait_until_ready(&self) {
     let client = Self::client();
     for _ in 0..100 {
-      if client.get(self.url("/health")).send().await.is_ok() {
+      if let Ok(response) = client.get(self.url("/health")).send().await
+        && response.status().is_success()
+      {
         return;
       }
       tokio::time::sleep(Duration::from_millis(20)).await;
     }
-    panic!("test bridge never accepted a connection");
+    panic!("test bridge never served a healthy response");
   }
 
   /// GET `/v1/self-host-connection` for a web origin / API pair, returning the
@@ -95,7 +97,11 @@ async fn spawn_test_bridge_with_origins(
 
   let router = build_router(state);
   tokio::spawn(async move {
-    let _ = axum::serve(listener, router).await;
+    // Route failures through tracing like start_bridge does (the crate forbids
+    // print_stderr) so a server-side error is not silently swallowed.
+    if let Err(error) = axum::serve(listener, router).await {
+      tracing::error!(error = %error, "test bridge server error");
+    }
   });
 
   let bridge = TestBridge {

--- a/apps/desktop/src-tauri/src/e2e.rs
+++ b/apps/desktop/src-tauri/src/e2e.rs
@@ -23,11 +23,19 @@ use crate::types::{BRIDGE_CAPABILITIES, BRIDGE_VERSION};
 const ALLOWED_ORIGIN: &str = "http://localhost:3000";
 const DISALLOWED_ORIGIN: &str = "https://evil.example";
 
+/// Serializes the claim-a-port / spawn / become-ready window across tests.
+/// `cargo test` runs these concurrently, and the bound port is only known after
+/// a throwaway probe is dropped; holding this lock until the server answers
+/// `/health` means no two tests are ever in that gap at once, so they cannot
+/// race for the same loopback port.
+static SPAWN_GUARD: Mutex<()> = Mutex::const_new(());
+
 /// A bridge server bound to an ephemeral loopback port for the lifetime of a
 /// test, plus a handle to the [`SessionManager`] backing it so a test can seed
 /// trust state before driving requests.
 struct TestBridge {
   base_url: String,
+  port: u16,
   manager: Arc<Mutex<SessionManager>>,
 }
 
@@ -84,8 +92,11 @@ async fn spawn_test_bridge_with_origins(
   static_allowed_origins: HashSet<String>,
 ) -> TestBridge {
   // Drive the real production entry point (bind + serve) rather than a test-only
-  // router so the harness exercises the same code path the app runs. Bind a
-  // throwaway socket to claim a free loopback port, then hand it to start_bridge.
+  // router so the harness exercises the same code path the app runs. Hold
+  // SPAWN_GUARD across claim/spawn/ready so concurrent tests can't take the same
+  // port during the probe-drop -> start_bridge-rebind gap.
+  let _spawn_guard = SPAWN_GUARD.lock().await;
+
   let port = free_loopback_port().await;
   let manager = Arc::new(Mutex::new(SessionManager::new()));
 
@@ -93,6 +104,7 @@ async fn spawn_test_bridge_with_origins(
 
   let bridge = TestBridge {
     base_url: format!("http://127.0.0.1:{port}"),
+    port,
     manager,
   };
   bridge.wait_until_ready().await;
@@ -148,6 +160,7 @@ async fn health_reports_bridge_contract_over_real_socket() {
 
   let body: serde_json::Value = response.json().await.unwrap();
   assert_eq!(body["ok"], serde_json::json!(true));
+  assert_eq!(body["bridgePort"], serde_json::json!(bridge.port));
   assert_eq!(body["bridgeVersion"], serde_json::json!(BRIDGE_VERSION));
   assert_eq!(body["capabilities"], serde_json::json!(BRIDGE_CAPABILITIES));
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@ mod bridge;
 mod commands;
 mod config;
 mod deep_link;
+#[cfg(test)]
+mod e2e;
 mod i18n;
 mod keychain;
 mod session_manager;


### PR DESCRIPTION
## Summary

Establishes the first end-to-end test harness for the Tauri desktop app. Until now the desktop app had only in-process `tower::oneshot` unit tests; nothing exercised its external interfaces as a real running server.

`apps/desktop/src-tauri/src/e2e.rs` boots the actual Axum bridge on an ephemeral loopback socket and drives it with a real `reqwest` client, asserting the wire contract the web app actually depends on:

- `/health` — status, `bridgeVersion`, `capabilities`, and that an origin-less probe is allowed but granted no CORS header
- CORS — allowed-origin grant, disallowed-origin `403`, and `OPTIONS` preflight advertising methods + the Private Network Access header
- `/v1/open-docx` — authorization gates (disallowed origin `403`, unsafe session id `400`)
- `/v1/self-host-connection` — the trust round trip (approved web/API pair trusted; same origin + different API not trusted; untrusted origin `403`)
- not-found fallback

These complement the existing unit tests by covering real status codes, header casing, and `OPTIONS` routing that the in-process harness does not. `spawn_test_bridge` is the shared entry point intended to grow.

## Notes

- `bridge::build_router` is exposed as `pub(crate)` so the harness can mount the real router on its own listener. No public API change.
- Tests are hermetic: loopback only, no external network, no editor launch. They run in the existing `cargo test` job (macOS) and compile-check on Windows.

## Deliberately out of scope (follow-ups)

- **open-docx happy path** drives the OS editor (`open`/`ShellExecute`), so a green round trip needs a test seam to skip the launch. Tracked as a follow-up rather than wiring host-app dependence into CI.
- **SSE session events** (takeover/close) would need a mock event server fixture.
- **GUI smoke** (window/tray/dialogs) would need a `tauri-driver` + WebdriverIO setup on a dedicated Linux runner; `tauri-driver` does not support macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added desktop end-to-end coverage for the bridge server using a live local connection.
  * Verified health checks, allowed and blocked cross-origin requests, preflight responses, session validation, and unknown-path handling.
  * Added checks for trusted and untrusted self-host connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->