### PR TITLE
refactor(folio): extract the layout controller — LayoutSession (1/n)

### DIFF
--- a/packages/folio/src/core/controller/folioEditorEvents.test.ts
+++ b/packages/folio/src/core/controller/folioEditorEvents.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createFolioEditorEmitter,
+  type FolioSelectionEvent,
+} from "./folioEditorEvents";
+
+describe("createFolioEditorEmitter", () => {
+  test("delivers an emitted payload to a subscriber", () => {
+    const emitter = createFolioEditorEmitter();
+    const seen: FolioSelectionEvent[] = [];
+    emitter.on("selectionChange", (s) => {
+      seen.push(s);
+    });
+
+    emitter.emit("selectionChange", { from: 1, to: 4 });
+
+    expect(seen).toEqual([{ from: 1, to: 4 }]);
+  });
+
+  test("only notifies listeners of the emitted event", () => {
+    const emitter = createFolioEditorEmitter();
+    let selectionCalls = 0;
+    let docCalls = 0;
+    emitter.on("selectionChange", () => {
+      selectionCalls += 1;
+    });
+    emitter.on("docChange", () => {
+      docCalls += 1;
+    });
+
+    emitter.emit("selectionChange", { from: 0, to: 0 });
+
+    expect(selectionCalls).toBe(1);
+    expect(docCalls).toBe(0);
+  });
+
+  test("fans out to every subscriber of an event", () => {
+    const emitter = createFolioEditorEmitter();
+    let a = 0;
+    let b = 0;
+    emitter.on("selectionChange", () => {
+      a += 1;
+    });
+    emitter.on("selectionChange", () => {
+      b += 1;
+    });
+
+    emitter.emit("selectionChange", { from: 0, to: 0 });
+
+    expect([a, b]).toEqual([1, 1]);
+  });
+
+  test("the returned unsubscribe stops further delivery", () => {
+    const emitter = createFolioEditorEmitter();
+    let calls = 0;
+    const off = emitter.on("selectionChange", () => {
+      calls += 1;
+    });
+
+    emitter.emit("selectionChange", { from: 0, to: 0 });
+    off();
+    emitter.emit("selectionChange", { from: 0, to: 0 });
+
+    expect(calls).toBe(1);
+  });
+
+  test("a listener that unsubscribes mid-emit does not perturb the current fan-out", () => {
+    const emitter = createFolioEditorEmitter();
+    const order: string[] = [];
+    const off = emitter.on("selectionChange", () => {
+      order.push("first");
+      off();
+    });
+    emitter.on("selectionChange", () => {
+      order.push("second");
+    });
+
+    emitter.emit("selectionChange", { from: 0, to: 0 });
+
+    // Both run on the snapshot taken before the unsubscribe.
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  test("clear drops all listeners", () => {
+    const emitter = createFolioEditorEmitter();
+    let calls = 0;
+    emitter.on("selectionChange", () => {
+      calls += 1;
+    });
+
+    emitter.clear();
+    emitter.emit("selectionChange", { from: 0, to: 0 });
+
+    expect(calls).toBe(0);
+  });
+
+  test("emitting with no listeners is a no-op", () => {
+    const emitter = createFolioEditorEmitter();
+    expect(() => {
+      emitter.emit("selectionChange", { from: 0, to: 0 });
+    }).not.toThrow();
+  });
+});

--- a/packages/folio/src/core/controller/folioEditorEvents.ts
+++ b/packages/folio/src/core/controller/folioEditorEvents.ts
@@ -1,0 +1,79 @@
+// The event half of the headless editor controller (seam-architecture Seam 6:
+// `FolioEditor`). Framework adapters subscribe here instead of threading prop
+// callbacks, and a desktop/headless host can observe the same stream. Kept as a
+// small typed emitter with no ProseMirror/React/DOM dependency so it stays
+// portable across hosts.
+
+import type { Layout } from "../layout-engine/types";
+import type { Document } from "../types/document";
+
+export type FolioSelectionEvent = {
+  from: number;
+  to: number;
+};
+
+// The payload for each editor event. Add events here as the controller grows
+// (e.g. `focusChange`, `error`); adapters get the new event typed for free.
+export type FolioEditorEventMap = {
+  selectionChange: FolioSelectionEvent;
+  docChange: Document;
+  layoutComplete: Layout;
+};
+
+export type FolioEditorEventName = keyof FolioEditorEventMap;
+
+export type FolioEditorEventListener<K extends FolioEditorEventName> = (
+  payload: FolioEditorEventMap[K],
+) => void;
+
+export type FolioEditorEmitter = {
+  /** Subscribe to an event. Returns an unsubscribe function. */
+  on: <K extends FolioEditorEventName>(
+    event: K,
+    listener: FolioEditorEventListener<K>,
+  ) => () => void;
+  /** Emit an event to all current listeners. */
+  emit: <K extends FolioEditorEventName>(
+    event: K,
+    payload: FolioEditorEventMap[K],
+  ) => void;
+  /** Drop all listeners (call on controller teardown). */
+  clear: () => void;
+};
+
+export const createFolioEditorEmitter = (): FolioEditorEmitter => {
+  // One listener set per event name. A mapped-type record (rather than a Map)
+  // keeps the key↔payload correlation: indexing `channels[event]` by a generic
+  // `K` resolves to `Set<FolioEditorEventListener<K>>`, so `on`/`emit` stay
+  // fully typed with no casts.
+  const channels: {
+    [K in FolioEditorEventName]: Set<FolioEditorEventListener<K>>;
+  } = {
+    selectionChange: new Set(),
+    docChange: new Set(),
+    layoutComplete: new Set(),
+  };
+
+  return {
+    on: (event, listener) => {
+      channels[event].add(listener);
+      return () => {
+        channels[event].delete(listener);
+      };
+    },
+
+    emit: (event, payload) => {
+      // Snapshot so a listener that unsubscribes mid-emit doesn't perturb the
+      // iteration.
+      for (const listener of [...channels[event]]) {
+        listener(payload);
+      }
+    },
+
+    clear: () => {
+      for (const channel of Object.values(channels)) {
+        channel.clear();
+      }
+    },
+  };
+};

--- a/packages/folio/src/core/controller/layoutPipeline.test.ts
+++ b/packages/folio/src/core/controller/layoutPipeline.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Regression coverage for the layout pipeline's commit-vs-discard contract.
+ *
+ * `runLayoutPipeline` wraps compute + paint + the session-memory commit in one
+ * try/catch. The hardening under test: the session is committed only after BOTH
+ * layout and paint succeed, and a throw anywhere in the body (notably the paint
+ * phase) discards the partial outcome AND leaves the session memory untouched,
+ * so the next run re-lays-out instead of skipping on a layout it never painted.
+ *
+ * Headless setup: a fake DOM (createElement -> FakeElement whose `getContext`
+ * returns a deterministic `measureText`) backs BOTH the canvas measurement seam
+ * the pipeline installs and the paint phase, so compute and paint run without a
+ * browser. Globals are swapped per-test and restored, and the canvas context +
+ * measure caches are reset so nothing leaks across files.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+
+import type { LayoutInstrumentation } from "../layout-engine/layoutInstrumentation";
+import { clearAllCaches } from "../layout-engine/measure/cache";
+import { resetCanvasContext } from "../layout-engine/measure/measureContainer";
+import { LayoutPainter } from "../layout-painter";
+import { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
+import { schema } from "../prosemirror/schema";
+import { runLayoutPipeline } from "./layoutPipeline";
+import type { LayoutPipelineDeps } from "./layoutPipeline";
+import { createLayoutSession } from "./layoutSession";
+import type { LayoutSession } from "./layoutSession";
+
+// --- Minimal fake DOM (paragraph rendering only) ---------------------------
+// Adapted from the proven fake element in renderPage-watermark-incremental;
+// the pipeline's paint path only renders plain paragraphs here.
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  parentElement: FakeElement | null = null;
+  private ownText = "";
+  readonly attributes = new Map<string, string>();
+  readonly classList: { add: (...names: string[]) => void };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+    this.classList = {
+      add: (...names: string[]) => {
+        const classes = new Set(this.className.split(/\s+/u).filter(Boolean));
+        for (const name of names) {
+          classes.add(name);
+        }
+        this.className = Array.from(classes).join(" ");
+      },
+    };
+  }
+
+  get firstChild(): FakeElement | null {
+    return this.children.at(0) ?? null;
+  }
+
+  get innerHTML(): string {
+    return this.textContent;
+  }
+
+  set innerHTML(_value: string) {
+    for (const child of this.children) {
+      child.parentElement = null;
+    }
+    this.children = [];
+    this.ownText = "";
+  }
+
+  get textContent(): string {
+    return (
+      this.ownText + this.children.map((child) => child.textContent).join("")
+    );
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children = [];
+  }
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      this.attach(child);
+      this.children.push(child);
+    }
+  }
+
+  prepend(...children: FakeElement[]): void {
+    for (let index = children.length - 1; index >= 0; index--) {
+      const child = children[index];
+      if (!child) {
+        continue;
+      }
+      this.attach(child);
+      this.children.unshift(child);
+    }
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.append(child);
+    return child;
+  }
+
+  insertBefore(child: FakeElement, before: FakeElement | null): FakeElement {
+    if (!before) {
+      this.append(child);
+      return child;
+    }
+    const index = this.children.indexOf(before);
+    if (index === -1) {
+      this.append(child);
+      return child;
+    }
+    this.attach(child);
+    this.children.splice(index, 0, child);
+    return child;
+  }
+
+  remove(): void {
+    const parent = this.parentElement;
+    if (!parent) {
+      return;
+    }
+    const index = parent.children.indexOf(this);
+    if (index !== -1) {
+      parent.children.splice(index, 1);
+    }
+    this.parentElement = null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  dispatchEvent(_event: Event): boolean {
+    return true;
+  }
+
+  getContext(_contextId: "2d"): CanvasRenderingContext2D {
+    return {
+      font: "",
+      measureText(text: string) {
+        return {
+          width: text.length * 7,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        };
+      },
+    } as CanvasRenderingContext2D;
+  }
+
+  getBoundingClientRect(): DOMRect {
+    return {
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return findByClass(this, classFromSelector(selector));
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const out: FakeElement[] = [];
+    collectByClass(this, classFromSelector(selector), out);
+    return out;
+  }
+
+  private attach(child: FakeElement): void {
+    child.remove();
+    child.parentElement = this;
+  }
+}
+
+const CLASS_SELECTOR_RE = /\.(?<cls>[\w-]+)/u;
+
+const classFromSelector = (selector: string): string =>
+  CLASS_SELECTOR_RE.exec(selector)?.groups?.["cls"] ?? "";
+
+const hasClass = (element: FakeElement, className: string): boolean =>
+  element.className.split(/\s+/u).includes(className);
+
+function findByClass(root: FakeElement, className: string): FakeElement | null {
+  for (const child of root.children) {
+    if (hasClass(child, className)) {
+      return child;
+    }
+    const inner = findByClass(child, className);
+    if (inner) {
+      return inner;
+    }
+  }
+  return null;
+}
+
+function collectByClass(
+  root: FakeElement,
+  className: string,
+  out: FakeElement[],
+): void {
+  for (const child of root.children) {
+    if (hasClass(child, className)) {
+      out.push(child);
+    }
+    collectByClass(child, className, out);
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+  createTextNode(text: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.textContent = text;
+    return node;
+  },
+};
+
+// The fake element structurally covers the subset of the DOM the paint phase
+// touches; the pipeline only forwards the container to `renderPages`.
+const asContainer = (value: object): HTMLDivElement =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fake DOM container
+  value as unknown as HTMLDivElement;
+
+class FakeIntersectionObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+class FakeCustomEvent<T> {
+  readonly bubbles: boolean;
+  readonly cancelable: boolean;
+  readonly detail: T | null;
+  readonly type: string;
+
+  constructor(type: string, init: CustomEventInit<T> = {}) {
+    this.type = type;
+    this.detail = init.detail ?? null;
+    this.bubbles = init.bubbles ?? false;
+    this.cancelable = init.cancelable ?? false;
+  }
+}
+
+// --- Global swap plumbing ---------------------------------------------------
+
+const originalGlobalDescriptors = new Map<
+  string,
+  PropertyDescriptor | undefined
+>();
+
+function setGlobal(name: string, value: unknown): void {
+  if (!originalGlobalDescriptors.has(name)) {
+    originalGlobalDescriptors.set(
+      name,
+      Object.getOwnPropertyDescriptor(globalThis, name),
+    );
+  }
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+}
+
+function restoreGlobals(): void {
+  for (const [name, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  }
+  originalGlobalDescriptors.clear();
+}
+
+// --- Pipeline deps + state builders ----------------------------------------
+
+const PAGE_SIZE = { w: 816, h: 1056 };
+const MARGINS = {
+  top: 72,
+  right: 72,
+  bottom: 72,
+  left: 72,
+  header: 36,
+  footer: 36,
+};
+
+const makeState = (): EditorState =>
+  EditorState.create({
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Hello world")]),
+      schema.node("paragraph", null, [schema.text("Second paragraph here.")]),
+    ]),
+  });
+
+type DepsOverrides = Partial<LayoutPipelineDeps<null>>;
+
+const makeDeps = (
+  session: LayoutSession,
+  overrides: DepsOverrides = {},
+): LayoutPipelineDeps<null> => ({
+  contentWidth: PAGE_SIZE.w - MARGINS.left - MARGINS.right,
+  columns: undefined,
+  pageSize: PAGE_SIZE,
+  margins: MARGINS,
+  pageGap: 24,
+  syncCoordinator: new LayoutSelectionGate(),
+  headerContent: null,
+  footerContent: null,
+  firstPageHeaderContent: null,
+  firstPageFooterContent: null,
+  headerContentRId: null,
+  footerContentRId: null,
+  firstPageHeaderContentRId: null,
+  firstPageFooterContentRId: null,
+  sectionHeaderFooterRefs: undefined,
+  theme: undefined,
+  sectionProperties: null,
+  document: null,
+  defaultTabStop: undefined,
+  styles: null,
+  layout: null,
+  hfPMs: null,
+  painter: null,
+  pagesContainer: null,
+  session,
+  renderHfFromContentOrPm: () => undefined,
+  renderHeaderFooterContentByRId: () => undefined,
+  documentFontsAreLoaded: () => true,
+  buildFootnoteRenderItems: () => new Map(),
+  describeInvalidHighlightMarks: () => "",
+  emptyTemplatePreviewEntries: [],
+  ...overrides,
+});
+
+// Capture the instrumentation callbacks the pipeline fires on
+// complete/error without spying on a directly-imported module.
+let layoutCompletes: { reason: string }[] = [];
+let layoutErrors: { message: string; reason: string }[] = [];
+
+describe("runLayoutPipeline", () => {
+  beforeEach(() => {
+    setGlobal("document", fakeDocument);
+    setGlobal("HTMLElement", FakeElement);
+    setGlobal("IntersectionObserver", FakeIntersectionObserver);
+    setGlobal("CustomEvent", FakeCustomEvent);
+    setGlobal("window", { innerHeight: 900 });
+    resetCanvasContext();
+    clearAllCaches();
+    layoutCompletes = [];
+    layoutErrors = [];
+    const instrumentation: LayoutInstrumentation = {
+      onLayoutComplete: (event) => {
+        layoutCompletes.push(event);
+      },
+      onLayoutError: (event) => {
+        layoutErrors.push(event);
+      },
+    };
+    globalThis.__folioLayoutInstrumentation = instrumentation;
+  });
+
+  afterEach(() => {
+    globalThis.__folioLayoutInstrumentation = undefined;
+    restoreGlobals();
+    resetCanvasContext();
+    clearAllCaches();
+  });
+
+  test("commits the session memory and returns a painted outcome on success", () => {
+    const session = createLayoutSession();
+    const state = makeState();
+    const container = fakeDocument.createElement("div");
+    const deps = makeDeps(session, {
+      painter: new LayoutPainter(),
+      pagesContainer: asContainer(container),
+    });
+
+    const outcome = runLayoutPipeline(deps, state);
+
+    // Outcome is fully populated, including the block lookup the paint phase
+    // builds when a painter is attached.
+    expect(outcome.blocks?.length ?? 0).toBeGreaterThan(0);
+    expect(outcome.measures?.length ?? 0).toBeGreaterThan(0);
+    expect(outcome.layout?.pages.length ?? 0).toBeGreaterThan(0);
+    expect(outcome.blockLookup).toBeInstanceOf(Map);
+    expect(outcome.blockLookup?.size ?? 0).toBeGreaterThan(0);
+
+    // Session memory is committed only after layout AND paint succeed.
+    expect(session.artifacts).not.toBeNull();
+    expect(session.artifacts?.blocks.length ?? 0).toBeGreaterThan(0);
+    expect(session.artifacts?.measures.length ?? 0).toBeGreaterThan(0);
+    expect(session.lastEditorState).toBe(state);
+    expect(session.lastPmDoc).toBe(state.doc);
+    expect(session.usedLoadedFonts).toBe(true);
+    expect(session.lastTemplatePreview).toEqual({ entries: [], mode: "plain" });
+
+    expect(layoutCompletes).toHaveLength(1);
+    expect(layoutErrors).toHaveLength(0);
+  });
+
+  test("commits the session without a block lookup when no painter is attached", () => {
+    const session = createLayoutSession();
+    const state = makeState();
+    const deps = makeDeps(session); // painter + pagesContainer default to null
+
+    const outcome = runLayoutPipeline(deps, state);
+
+    expect(outcome.layout?.pages.length ?? 0).toBeGreaterThan(0);
+    // Paint phase is skipped, so no block lookup is produced.
+    expect(outcome.blockLookup).toBeUndefined();
+    // The layout still succeeded, so the session is committed.
+    expect(session.artifacts).not.toBeNull();
+    expect(session.lastEditorState).toBe(state);
+    expect(layoutCompletes).toHaveLength(1);
+  });
+
+  test("discards the outcome and leaves the session unmutated when the paint phase throws", () => {
+    const session = createLayoutSession();
+    const state = makeState();
+
+    // The throw lands in the render-pages (paint) phase: `renderPages` is a
+    // direct import (not injectable), so we force it to throw on its very first
+    // container access. This is after the session is STAGED (measure step) but
+    // before it is COMMITTED, exactly the window the hardening protects.
+    const throwingContainer = asContainer(
+      new Proxy(
+        {},
+        {
+          get() {
+            throw new Error("paint phase exploded");
+          },
+        },
+      ),
+    );
+    const deps = makeDeps(session, {
+      painter: new LayoutPainter(),
+      pagesContainer: throwingContainer,
+    });
+
+    // The catch swallows the throw — the pipeline must not rethrow.
+    const outcome = runLayoutPipeline(deps, state);
+
+    // Nothing applied: the partial outcome is dropped.
+    expect(outcome).toEqual({});
+
+    // The session keeps its pre-call values, so the next run re-lays-out
+    // instead of skipping on pages that were never painted.
+    expect(session.artifacts).toBeNull();
+    expect(session.lastEditorState).toBeNull();
+    expect(session.lastPmDoc).toBeNull();
+    expect(session.usedLoadedFonts).toBe(false);
+    expect(session.lastTemplatePreview).toEqual({ entries: [], mode: "plain" });
+
+    // The error recorder ran; no completion was recorded.
+    expect(layoutErrors).toHaveLength(1);
+    expect(layoutCompletes).toHaveLength(0);
+  });
+});
+
+describe("createLayoutSession", () => {
+  test("returns the documented empty defaults", () => {
+    expect(createLayoutSession()).toEqual({
+      artifacts: null,
+      lastEditorState: null,
+      lastPmDoc: null,
+      usedLoadedFonts: false,
+      lastTemplatePreview: { entries: [], mode: "plain" },
+    });
+  });
+});

--- a/packages/folio/src/core/controller/layoutPipeline.ts
+++ b/packages/folio/src/core/controller/layoutPipeline.ts
@@ -1,0 +1,998 @@
+import type { EditorState } from "prosemirror-state";
+
+import { buildBookmarkPageMap } from "../fields/bookmarkPages";
+import { buildBookmarkText } from "../fields/bookmarkText";
+import {
+  buildHeaderFooterFieldValues,
+  fieldValuesEqual,
+  resolveFieldValues,
+} from "../fields/resolveFieldValues";
+import type { HeaderFooterFieldInputs } from "../fields/resolveFieldValues";
+import { buildSectionPageCounts } from "../fields/sectionPageCounts";
+import { buildSeqValues } from "../fields/seqValues";
+import {
+  FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+  buildFootnoteContentMap,
+  collectFootnoteRefs,
+} from "../layout-bridge/footnoteLayout";
+import type { MeasureBlocksFn } from "../layout-bridge/footnoteLayout";
+import type {
+  ConvertHeaderFooterOptions,
+  HeaderFooterMetrics,
+} from "../layout-bridge/headerFooterLayout";
+import { applyTemplatePreviewToBlocks } from "../layout-bridge/templatePreviewFlow";
+import { toFlowBlocks } from "../layout-bridge/toFlowBlocks";
+import type { ToFlowBlocksOptions } from "../layout-bridge/toFlowBlocks";
+import { layoutDocument } from "../layout-engine";
+import type { ColumnLayout, SectionLayoutConfig } from "../layout-engine";
+import {
+  recordLayoutComplete,
+  recordLayoutError,
+  recordLayoutPhase,
+} from "../layout-engine/layoutInstrumentation";
+import type {
+  LayoutPhase,
+  LayoutRunReason,
+} from "../layout-engine/layoutInstrumentation";
+import {
+  measureBlocks,
+  measureSingleBlockWithoutFloatingZones,
+} from "../layout-engine/measure/measureBlocks";
+import { installCanvasMeasureProvider } from "../layout-engine/measure/measureContainer";
+import type {
+  FlowBlock,
+  FootnoteContent,
+  Layout,
+  Measure,
+  PageHeaderFooterRefs,
+  PageMargins,
+  SectionBreakBlock,
+} from "../layout-engine/types";
+import type { BlockLookup, LayoutPainter } from "../layout-painter";
+import { renderPages } from "../layout-painter/renderPage";
+import type {
+  FootnoteRenderItem,
+  HeaderFooterContent,
+  RenderPageOptions,
+} from "../layout-painter/renderPage";
+import {
+  computeFirstPageHeaderFooterMarginExtender,
+  computeHeaderFooterMarginExtender,
+  extendSectionBreakMargins,
+} from "../paged-layout/headerFooterMargins";
+import { tryBuildIncrementalMeasures } from "../paged-layout/incrementalMeasure";
+import type { DirtyRange } from "../paged-layout/incrementalMeasure";
+import type { LayoutSelectionGate } from "../paged-layout/LayoutSelectionGate";
+import { computePerBlockMeasureInputs } from "../paged-layout/sectionBlockWidths";
+import { twipsToPixels } from "../paged-layout/sectionGeometry";
+import { templatePreviewValuesKey } from "../prosemirror/plugins/templatePreviewValues";
+import type { TemplatePreviewEntry } from "../prosemirror/plugins/templatePreviewValues";
+import type {
+  Document,
+  HeaderFooter,
+  SectionProperties,
+  StyleDefinitions,
+  Theme,
+  Watermark,
+} from "../types/document";
+import { getDocumentWatermark } from "../watermark";
+import type { LayoutSession } from "./layoutSession";
+
+function pageMarginsEqual(left: PageMargins, right: PageMargins): boolean {
+  return (
+    left.top === right.top &&
+    left.right === right.right &&
+    left.bottom === right.bottom &&
+    left.left === right.left &&
+    left.header === right.header &&
+    left.footer === right.footer
+  );
+}
+
+function optionalPageMarginsEqual(
+  left: PageMargins | undefined,
+  right: PageMargins | undefined,
+): boolean {
+  if (left === undefined || right === undefined) {
+    return left === right;
+  }
+  return pageMarginsEqual(left, right);
+}
+
+export type LayoutRunOptions = {
+  dirtyRange?: DirtyRange;
+  forceFull?: boolean;
+  reason?: LayoutRunReason;
+};
+
+// Different exit paths populate different subsets; the adapter applies whatever
+// is present in the original setter order.
+export type LayoutOutcome = {
+  blocks?: FlowBlock[];
+  measures?: Measure[];
+  layout?: Layout;
+  blockLookup?: BlockLookup;
+};
+
+// Everything the compute reads from the React adapter's scope. The adapter
+// rebuilds this on every call from current props/refs/handlers, so plain values
+// (not accessors) are safe: there is no stale-closure risk. `THfPMs` keeps the
+// hidden header/footer ProseMirror handle opaque to the controller — it is only
+// threaded through the injected render callbacks, never inspected here.
+export type LayoutPipelineDeps<THfPMs> = {
+  contentWidth: number;
+  columns: ColumnLayout | undefined;
+  pageSize: { w: number; h: number };
+  margins: PageMargins;
+  pageGap: number;
+  syncCoordinator: LayoutSelectionGate;
+  headerContent: HeaderFooter | null | undefined;
+  footerContent: HeaderFooter | null | undefined;
+  firstPageHeaderContent: HeaderFooter | null | undefined;
+  firstPageFooterContent: HeaderFooter | null | undefined;
+  headerContentRId: string | null | undefined;
+  footerContentRId: string | null | undefined;
+  firstPageHeaderContentRId: string | null | undefined;
+  firstPageFooterContentRId: string | null | undefined;
+  sectionHeaderFooterRefs: PageHeaderFooterRefs[] | undefined;
+  theme: Theme | null | undefined;
+  sectionProperties: SectionProperties | null | undefined;
+  document: Document | null;
+  defaultTabStop: number | undefined;
+  styles: StyleDefinitions | null | undefined;
+  layout: Layout | null;
+  // Refs read as their current value; `session` is the object itself because
+  // the body reads AND writes its fields and those writes must persist.
+  hfPMs: THfPMs;
+  painter: LayoutPainter | null;
+  pagesContainer: HTMLDivElement | null;
+  session: LayoutSession;
+  // Render/font helpers kept in the adapter; the controller calls them
+  // opaquely.
+  renderHfFromContentOrPm: (
+    hf: HeaderFooter | null | undefined,
+    rId: string | null | undefined,
+    hfPMs: THfPMs,
+    contentWidth: number,
+    metrics: HeaderFooterMetrics,
+    options: ConvertHeaderFooterOptions,
+  ) => HeaderFooterContent | undefined;
+  renderHeaderFooterContentByRId: (
+    source: Map<string, HeaderFooter> | undefined,
+    hfPMs: THfPMs,
+    contentWidth: number,
+    metrics: HeaderFooterMetrics,
+    options: ConvertHeaderFooterOptions,
+  ) => Map<string, HeaderFooterContent> | undefined;
+  documentFontsAreLoaded: () => boolean;
+  buildFootnoteRenderItems: (
+    pageFootnoteMap: Map<number, number[]>,
+    footnoteContentMap: Map<number, FootnoteContent>,
+    doc: Document | null,
+  ) => Map<number, FootnoteRenderItem[]>;
+  describeInvalidHighlightMarks: (doc: EditorState["doc"]) => string;
+  emptyTemplatePreviewEntries: readonly TemplatePreviewEntry[];
+};
+
+export function runLayoutPipeline<THfPMs>(
+  deps: LayoutPipelineDeps<THfPMs>,
+  state: EditorState,
+  options: LayoutRunOptions = {},
+): LayoutOutcome {
+  const {
+    contentWidth,
+    columns,
+    pageSize,
+    margins,
+    pageGap,
+    syncCoordinator,
+    headerContent,
+    footerContent,
+    firstPageHeaderContent,
+    firstPageFooterContent,
+    headerContentRId,
+    footerContentRId,
+    firstPageHeaderContentRId,
+    firstPageFooterContentRId,
+    sectionHeaderFooterRefs,
+    theme: _theme,
+    sectionProperties,
+    document,
+    defaultTabStop,
+    styles,
+    layout,
+    hfPMs,
+    painter,
+    pagesContainer,
+    session,
+    renderHfFromContentOrPm,
+    renderHeaderFooterContentByRId,
+    documentFontsAreLoaded,
+    buildFootnoteRenderItems,
+    describeInvalidHighlightMarks,
+    emptyTemplatePreviewEntries: EMPTY_TEMPLATE_PREVIEW_ENTRIES,
+  } = deps;
+  const outcome: LayoutOutcome = {};
+  // Composition root for text measurement: install the canvas backend
+  // before any layout/measure runs. Idempotent; the engine measures
+  // through the pure provider seam, which throws until a backend is set.
+  installCanvasMeasureProvider();
+  const reason = options.reason ?? "manual";
+  const recordPhaseDuration = (phase: LayoutPhase, startedAt: number): void => {
+    recordLayoutPhase(reason, phase, performance.now() - startedAt);
+  };
+
+  // Capture current state sequence for this layout run
+  const currentEpoch = syncCoordinator.getStateSeq();
+
+  // Signal layout is starting
+  syncCoordinator.onLayoutStart();
+
+  try {
+    // Step 1: Convert PM doc to flow blocks
+    let phaseStartedAt = performance.now();
+    const pageContentHeight = pageSize.h - margins.top - margins.bottom;
+    const flowOpts: ToFlowBlocksOptions = {
+      pageContentHeight,
+    };
+    if (_theme !== undefined) {
+      flowOpts.theme = _theme;
+    }
+    // Stamp the document's `w:defaultTabStop` onto every paragraph so
+    // list-marker tab-stop math (renderParagraph + measureParagraph)
+    // uses the right grid. Absent settings.xml falls back to the
+    // OOXML default inside `getListMarkerInlineWidth`.
+    if (defaultTabStop !== undefined) {
+      flowOpts.defaultTabStopTwips = defaultTabStop;
+    }
+    let newBlocks = toFlowBlocks(state.doc, flowOpts);
+    // Template fill preview: substitute each matched {{marker}} range
+    // with its typed value at the flow-block level so the pages lay out
+    // (wrap, paginate) as if the value were the document text. View-only:
+    // the PM doc — and with it the save path — is never modified.
+    const previewState = templatePreviewValuesKey.getState(state);
+    const previewEntries =
+      previewState?.entries ?? EMPTY_TEMPLATE_PREVIEW_ENTRIES;
+    const previewMode = previewState?.preview?.mode ?? "plain";
+    if (previewEntries.length > 0) {
+      newBlocks = applyTemplatePreviewToBlocks(newBlocks, {
+        entries: previewEntries,
+        mode: previewMode,
+      });
+    }
+    session.lastTemplatePreview = {
+      entries: previewEntries,
+      mode: previewMode,
+    };
+    outcome.blocks = newBlocks;
+    recordPhaseDuration("flow-blocks", phaseStartedAt);
+
+    // Step 2.5: Collect footnote references from blocks
+    phaseStartedAt = performance.now();
+    const footnoteRefs = collectFootnoteRefs(newBlocks);
+    const documentFootnotes = document?.package.footnotes;
+    const hasFootnotes =
+      footnoteRefs.length > 0 && documentFootnotes !== undefined;
+
+    // Step 2.75: Prepare header/footer content for rendering (needed before layout
+    // to compute effective margins when header content exceeds available space)
+    const hfMetricsHeader: HeaderFooterMetrics = {
+      section: "header",
+      pageSize,
+      margins,
+    };
+    const hfMetricsFooter: HeaderFooterMetrics = {
+      section: "footer",
+      pageSize,
+      margins,
+    };
+    // Header/footer blocks are measured once but painted on every page with
+    // a different page number. Measure with the prior render's page count
+    // first, then rebuild the prepared HF content with the final page count
+    // after body layout stabilizes so digit-boundary changes are reflected
+    // before paint.
+    const hfPageCountEstimate = layout?.pages.length ?? 1;
+    const hfClock = new Date();
+    const buildHfOptions = (
+      pageCount: number,
+      fieldInputs?: HeaderFooterFieldInputs,
+    ) => {
+      const hfMeasureBlocks: MeasureBlocksFn = (hfBlocks, hfWidth) =>
+        measureBlocks(
+          hfBlocks,
+          hfWidth,
+          undefined,
+          undefined,
+          buildHeaderFooterFieldValues(
+            hfBlocks,
+            pageCount,
+            hfClock,
+            fieldInputs,
+          ),
+        );
+      return {
+        ...(styles ? { styles } : {}),
+        ...(_theme !== undefined ? { theme: _theme } : {}),
+        measureBlocks: hfMeasureBlocks,
+        ...(defaultTabStop !== undefined
+          ? { defaultTabStopTwips: defaultTabStop }
+          : {}),
+      };
+    };
+    const hfOptions = buildHfOptions(hfPageCountEstimate);
+    let headerContentForRender = renderHfFromContentOrPm(
+      headerContent,
+      headerContentRId,
+      hfPMs,
+      contentWidth,
+      hfMetricsHeader,
+      hfOptions,
+    );
+    let footerContentForRender = renderHfFromContentOrPm(
+      footerContent,
+      footerContentRId,
+      hfPMs,
+      contentWidth,
+      hfMetricsFooter,
+      hfOptions,
+    );
+    const hasTitlePg = sectionProperties?.titlePg === true;
+    let firstPageHeaderForRender = hasTitlePg
+      ? renderHfFromContentOrPm(
+          firstPageHeaderContent,
+          firstPageHeaderContentRId,
+          hfPMs,
+          contentWidth,
+          hfMetricsHeader,
+          hfOptions,
+        )
+      : undefined;
+    let firstPageFooterForRender = hasTitlePg
+      ? renderHfFromContentOrPm(
+          firstPageFooterContent,
+          firstPageFooterContentRId,
+          hfPMs,
+          contentWidth,
+          hfMetricsFooter,
+          hfOptions,
+        )
+      : undefined;
+    let headerContentByRId = renderHeaderFooterContentByRId(
+      document?.package.headers,
+      hfPMs,
+      contentWidth,
+      hfMetricsHeader,
+      hfOptions,
+    );
+    let footerContentByRId = renderHeaderFooterContentByRId(
+      document?.package.footers,
+      hfPMs,
+      contentWidth,
+      hfMetricsFooter,
+      hfOptions,
+    );
+
+    // Rendered H/F content is shared across every extender; only the
+    // page size (body vs. a section's own) and the mode (default vs.
+    // first-page) vary.
+    const hfExtenderContent = {
+      headerContent: headerContentForRender,
+      footerContent: footerContentForRender,
+      firstPageHeaderContent: firstPageHeaderForRender,
+      firstPageFooterContent: firstPageFooterForRender,
+    };
+    const hfWarn = (msg: string): void => {
+      // eslint-disable-next-line no-console -- standalone editor package has no logger in scope
+      console.warn(`[PagedEditor] ${msg}`);
+    };
+    // Default extender — applied to pages 2+ of every section. It
+    // ignores firstPage H/F so a `<w:titlePg/>` section's
+    // overflowing first-page header doesn't push body content down
+    // on every subsequent page.
+    const extendForHfOverflow = computeHeaderFooterMarginExtender({
+      ...hfExtenderContent,
+      pageSize,
+      warn: hfWarn,
+    });
+    // First-page extender — used only for page 1 of a titlePg
+    // section so the title page's larger header reservation is
+    // honored without leaking onto pages 2+.
+    const extendForFirstPage = computeFirstPageHeaderFooterMarginExtender({
+      ...hfExtenderContent,
+      pageSize,
+      warn: hfWarn,
+    });
+    let effectiveMargins = extendForHfOverflow(margins);
+    let effectiveFirstPageMargins = hasTitlePg
+      ? extendForFirstPage(margins)
+      : undefined;
+    const sectionBreaks = newBlocks.filter(
+      (block): block is SectionBreakBlock => block.kind === "sectionBreak",
+    );
+    const originalSectionBreakMargins = new Map<
+      SectionBreakBlock["id"],
+      PageMargins | undefined
+    >();
+    for (const sectionBreak of sectionBreaks) {
+      originalSectionBreakMargins.set(
+        sectionBreak.id,
+        sectionBreak.margins ? { ...sectionBreak.margins } : undefined,
+      );
+    }
+    const restoreSectionBreakMargins = (): void => {
+      for (const sectionBreak of sectionBreaks) {
+        const originalMargins = originalSectionBreakMargins.get(
+          sectionBreak.id,
+        );
+        if (originalMargins === undefined) {
+          delete sectionBreak.margins;
+          continue;
+        }
+        sectionBreak.margins = { ...originalMargins };
+      }
+    };
+    const applySectionBreakMargins = (
+      content: typeof hfExtenderContent,
+      bodyMargins: PageMargins,
+    ): void => {
+      restoreSectionBreakMargins();
+      // Section-break blocks carry their own `pageSize`/`margins` from
+      // `<w:sectPr>` and the layout engine prefers those over the
+      // body-level fallback. Extend each against its own resolved page
+      // so an overflowing footer never re-overlaps body text on the next
+      // section. (Eigenpal #400.)
+      extendSectionBreakMargins(sectionBreaks, {
+        content,
+        bodyPageSize: pageSize,
+        bodyMargins,
+        warn: hfWarn,
+      });
+    };
+    applySectionBreakMargins(hfExtenderContent, effectiveMargins);
+    recordPhaseDuration("header-footer", phaseStartedAt);
+
+    // Compute per-block widths + band geometry from the EFFECTIVE margins
+    // layout uses (header/footer overflow extension + section-break margin
+    // extension applied above), so a page/margin-pinned topAndBottom band
+    // reserves its band at the same Y the box is painted. Measuring with the
+    // raw margins would mis-place the reserved band when a tall header/footer
+    // extends the margins. eigenpal #694.
+    phaseStartedAt = performance.now();
+    let bodyLayoutConfig: SectionLayoutConfig = {
+      pageSize,
+      margins: effectiveMargins,
+    };
+    if (columns !== undefined) {
+      bodyLayoutConfig.columns = columns;
+    }
+    let blockMeasureInputs = computePerBlockMeasureInputs({
+      blocks: newBlocks,
+      bodyConfig: bodyLayoutConfig,
+      finalConfig: bodyLayoutConfig,
+    });
+    let blockWidths = blockMeasureInputs.widths;
+    const previousArtifacts = session.artifacts;
+    const incrementalResult =
+      options.dirtyRange && !options.forceFull && previousArtifacts
+        ? tryBuildIncrementalMeasures({
+            previousBlocks: previousArtifacts.blocks,
+            previousMeasures: previousArtifacts.measures,
+            previousBlockWidths: previousArtifacts.blockWidths,
+            nextBlocks: newBlocks,
+            nextBlockWidths: blockWidths,
+            dirtyRange: options.dirtyRange,
+            measureBlock: measureSingleBlockWithoutFloatingZones,
+          })
+        : null;
+    let newMeasures =
+      incrementalResult?.measures ??
+      measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
+        pageHeight: blockMeasureInputs.pageHeights,
+        marginBottom: blockMeasureInputs.marginBottoms,
+      });
+    session.artifacts = {
+      blocks: newBlocks,
+      blockWidths,
+      measures: newMeasures,
+    };
+    outcome.measures = newMeasures;
+    recordPhaseDuration("measure-blocks", phaseStartedAt);
+
+    // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
+    phaseStartedAt = performance.now();
+    let newLayout: Layout;
+    let pageFootnoteMap = new Map<number, number[]>();
+    let footnoteContentMap = new Map<number, FootnoteContent>();
+
+    // Common layout options for all passes
+    // SAFETY: `sectionStart` may be `"nextColumn"`, which the layout engine's
+    // `bodyBreakType` does not model; the adapter narrows it away and passes the
+    // value through unchanged at runtime. Preserved verbatim from the adapter.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    const bodyBreakType = sectionProperties?.sectionStart as
+      | "continuous"
+      | "nextPage"
+      | "evenPage"
+      | "oddPage"
+      | undefined;
+    const buildLayoutOpts = (
+      nextMargins: PageMargins,
+      nextFirstPageMargins: PageMargins | undefined,
+    ): Parameters<typeof layoutDocument>[2] => {
+      const nextLayoutOpts: Parameters<typeof layoutDocument>[2] = {
+        pageSize,
+        margins: nextMargins,
+        pageGap,
+      };
+      if (nextFirstPageMargins !== undefined) {
+        nextLayoutOpts.firstPageMargins = nextFirstPageMargins;
+      }
+      if (columns !== undefined) {
+        nextLayoutOpts.columns = columns;
+      }
+      if (bodyBreakType !== undefined) {
+        nextLayoutOpts.bodyBreakType = bodyBreakType;
+      }
+      if (sectionHeaderFooterRefs !== undefined) {
+        nextLayoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
+      }
+      return nextLayoutOpts;
+    };
+    const layoutOpts = buildLayoutOpts(
+      effectiveMargins,
+      effectiveFirstPageMargins,
+    );
+    // The exact options the layout was produced with, reused if the field-
+    // width stabilization pass re-lays-out below.
+    let layoutOptsUsed: Parameters<typeof layoutDocument>[2] = layoutOpts;
+
+    if (hasFootnotes) {
+      // Build footnote content and measure heights up front. The
+      // per-fn height table feeds into the layout engine so each
+      // body line carrying an fn ref reserves space for that fn
+      // on its host page in a single pass — no convergence loop.
+      footnoteContentMap = buildFootnoteContentMap(
+        documentFootnotes,
+        footnoteRefs,
+        contentWidth,
+        (() => {
+          const footnoteOptions: Parameters<typeof buildFootnoteContentMap>[3] =
+            { measureBlocks };
+          if (styles) {
+            footnoteOptions.styles = styles;
+          }
+          if (_theme !== undefined) {
+            footnoteOptions.theme = _theme;
+          }
+          if (defaultTabStop !== undefined) {
+            footnoteOptions.defaultTabStopTwips = defaultTabStop;
+          }
+          return footnoteOptions;
+        })(),
+      );
+
+      const footnoteHeightById = new Map<number, number>();
+      // Any per-fn wrapper margin applied by the painter is reserved
+      // alongside content height. The value is zero for Word-like footnote
+      // spacing; source paragraph spacing inside each note carries the
+      // visible gaps.
+      for (const [id, content] of footnoteContentMap) {
+        footnoteHeightById.set(
+          id,
+          content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+        );
+      }
+      // Note: the layout engine adds the divider's height once per
+      // fn-bearing page (in paginator.addFootnoteHeight); we pass per-fn
+      // content plus any wrapper margin here.
+
+      layoutOptsUsed = { ...layoutOpts, footnoteHeightById };
+      newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
+
+      // The layout engine assigned `page.footnoteIds` line-by-
+      // line via `paginator.addFootnoteHeight(_, ids)`, so a fn
+      // ref in a continuation fragment of a split paragraph
+      // lands on the page where the ref-bearing line actually
+      // is. Build pageFootnoteMap from those page records (not
+      // from `mapFootnotesToPages`'s pmRange scan, which can't
+      // disambiguate split-paragraph halves; Codex PR #258).
+      pageFootnoteMap = new Map<number, number[]>();
+      for (const page of newLayout.pages) {
+        if (page.footnoteIds && page.footnoteIds.length > 0) {
+          pageFootnoteMap.set(page.number, page.footnoteIds);
+        }
+      }
+    } else {
+      // No footnotes — single pass
+      newLayout = layoutDocument(newBlocks, newMeasures, layoutOpts);
+    }
+
+    const rebuildFootnotePageMap = (): void => {
+      pageFootnoteMap = new Map<number, number[]>();
+      for (const page of newLayout.pages) {
+        if (page.footnoteIds && page.footnoteIds.length > 0) {
+          pageFootnoteMap.set(page.number, page.footnoteIds);
+        }
+      }
+    };
+
+    const withFootnoteHeights = (
+      nextLayoutOpts: Parameters<typeof layoutDocument>[2],
+    ): Parameters<typeof layoutDocument>[2] => {
+      if (!hasFootnotes) {
+        return nextLayoutOpts;
+      }
+      const footnoteHeightById = new Map<number, number>();
+      for (const [id, content] of footnoteContentMap) {
+        footnoteHeightById.set(
+          id,
+          content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+        );
+      }
+      return { ...nextLayoutOpts, footnoteHeightById };
+    };
+
+    const relayoutWithCurrentMeasures = (
+      nextLayoutOpts: Parameters<typeof layoutDocument>[2],
+    ): void => {
+      layoutOptsUsed = withFootnoteHeights(nextLayoutOpts);
+      newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
+      if (hasFootnotes) {
+        rebuildFootnotePageMap();
+      }
+    };
+
+    const stabilizeFieldWidths = (): void => {
+      if (incrementalResult) {
+        return;
+      }
+      const MAX_FIELD_STABILIZATION_PASSES = 3;
+      const fieldClock = new Date();
+      let previousFieldValues: Map<number, string> | null = null;
+      for (let pass = 0; pass < MAX_FIELD_STABILIZATION_PASSES; pass++) {
+        const seqValues = buildSeqValues(newBlocks);
+        const bookmarkTextInputs =
+          previousFieldValues === null
+            ? { seqValues }
+            : { fieldValues: previousFieldValues, seqValues };
+        const { values, changed } = resolveFieldValues(
+          newBlocks,
+          newLayout.pages,
+          {
+            totalPages: newLayout.pages.length,
+            bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
+            bookmarkText: buildBookmarkText(newBlocks, bookmarkTextInputs),
+            seqValues,
+            sectionPageCounts: buildSectionPageCounts(newLayout.pages),
+            now: fieldClock,
+          },
+        );
+        const settled =
+          previousFieldValues === null
+            ? !changed
+            : fieldValuesEqual(previousFieldValues, values);
+        if (settled) {
+          stabilizedFieldValues = values;
+          break;
+        }
+        previousFieldValues = values;
+        stabilizedFieldValues = values;
+        newMeasures = measureBlocks(
+          newBlocks,
+          blockWidths,
+          blockMeasureInputs.marginTops,
+          {
+            pageHeight: blockMeasureInputs.pageHeights,
+            marginBottom: blockMeasureInputs.marginBottoms,
+          },
+          values,
+        );
+        relayoutWithCurrentMeasures(layoutOptsUsed);
+        session.artifacts = {
+          blocks: newBlocks,
+          blockWidths,
+          measures: newMeasures,
+        };
+        outcome.measures = newMeasures;
+      }
+    };
+
+    // Field-width stabilization: fields were measured at their cached
+    // fallback text. Resolve them against this layout and, if a value's
+    // width differs, re-measure and re-lay-out so wrapping matches what the
+    // painter draws. PAGE/NUMPAGES depend on the layout they help produce,
+    // so a re-layout can shift pages and change values again — iterate to a
+    // fixed point with a small cap. Gated on a real change, so field-free
+    // documents and most edits do zero passes; skipped on the incremental
+    // (typing) path to keep keystrokes cheap.
+    let stabilizedFieldValues: Map<number, string> | undefined;
+    stabilizeFieldWidths();
+
+    const rebuildHeaderFooterForLayout = (): typeof hfExtenderContent => {
+      const seqValues = buildSeqValues(newBlocks);
+      const bookmarkTextInputs =
+        stabilizedFieldValues === undefined
+          ? { seqValues }
+          : { fieldValues: stabilizedFieldValues, seqValues };
+      const finalHfFieldInputs: HeaderFooterFieldInputs = {
+        bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
+        bookmarkText: buildBookmarkText(newBlocks, bookmarkTextInputs),
+        seqValues,
+        sectionPageCounts: buildSectionPageCounts(newLayout.pages),
+      };
+      const finalHfOptions = buildHfOptions(
+        newLayout.pages.length,
+        finalHfFieldInputs,
+      );
+      headerContentForRender = renderHfFromContentOrPm(
+        headerContent,
+        headerContentRId,
+        hfPMs,
+        contentWidth,
+        hfMetricsHeader,
+        finalHfOptions,
+      );
+      footerContentForRender = renderHfFromContentOrPm(
+        footerContent,
+        footerContentRId,
+        hfPMs,
+        contentWidth,
+        hfMetricsFooter,
+        finalHfOptions,
+      );
+      firstPageHeaderForRender = hasTitlePg
+        ? renderHfFromContentOrPm(
+            firstPageHeaderContent,
+            firstPageHeaderContentRId,
+            hfPMs,
+            contentWidth,
+            hfMetricsHeader,
+            finalHfOptions,
+          )
+        : undefined;
+      firstPageFooterForRender = hasTitlePg
+        ? renderHfFromContentOrPm(
+            firstPageFooterContent,
+            firstPageFooterContentRId,
+            hfPMs,
+            contentWidth,
+            hfMetricsFooter,
+            finalHfOptions,
+          )
+        : undefined;
+      headerContentByRId = renderHeaderFooterContentByRId(
+        document?.package.headers,
+        hfPMs,
+        contentWidth,
+        hfMetricsHeader,
+        finalHfOptions,
+      );
+      footerContentByRId = renderHeaderFooterContentByRId(
+        document?.package.footers,
+        hfPMs,
+        contentWidth,
+        hfMetricsFooter,
+        finalHfOptions,
+      );
+      return {
+        headerContent: headerContentForRender,
+        footerContent: footerContentForRender,
+        firstPageHeaderContent: firstPageHeaderForRender,
+        firstPageFooterContent: firstPageFooterForRender,
+      };
+    };
+
+    const MAX_HEADER_FOOTER_STABILIZATION_PASSES = 3;
+    for (let pass = 0; pass < MAX_HEADER_FOOTER_STABILIZATION_PASSES; pass++) {
+      const finalHfExtenderContent = rebuildHeaderFooterForLayout();
+      const finalEffectiveMargins = computeHeaderFooterMarginExtender({
+        ...finalHfExtenderContent,
+        pageSize,
+        warn: hfWarn,
+      })(margins);
+      const finalEffectiveFirstPageMargins = hasTitlePg
+        ? computeFirstPageHeaderFooterMarginExtender({
+            ...finalHfExtenderContent,
+            pageSize,
+            warn: hfWarn,
+          })(margins)
+        : undefined;
+
+      if (
+        !pageMarginsEqual(effectiveMargins, finalEffectiveMargins) ||
+        !optionalPageMarginsEqual(
+          effectiveFirstPageMargins,
+          finalEffectiveFirstPageMargins,
+        )
+      ) {
+        effectiveMargins = finalEffectiveMargins;
+        effectiveFirstPageMargins = finalEffectiveFirstPageMargins;
+        applySectionBreakMargins(finalHfExtenderContent, effectiveMargins);
+        bodyLayoutConfig = { pageSize, margins: effectiveMargins };
+        if (columns !== undefined) {
+          bodyLayoutConfig.columns = columns;
+        }
+        blockMeasureInputs = computePerBlockMeasureInputs({
+          blocks: newBlocks,
+          bodyConfig: bodyLayoutConfig,
+          finalConfig: bodyLayoutConfig,
+        });
+        blockWidths = blockMeasureInputs.widths;
+        newMeasures = measureBlocks(
+          newBlocks,
+          blockWidths,
+          blockMeasureInputs.marginTops,
+          {
+            pageHeight: blockMeasureInputs.pageHeights,
+            marginBottom: blockMeasureInputs.marginBottoms,
+          },
+        );
+        session.artifacts = {
+          blocks: newBlocks,
+          blockWidths,
+          measures: newMeasures,
+        };
+        outcome.measures = newMeasures;
+        relayoutWithCurrentMeasures(
+          buildLayoutOpts(effectiveMargins, effectiveFirstPageMargins),
+        );
+        stabilizeFieldWidths();
+        continue;
+      }
+      break;
+    }
+
+    outcome.layout = newLayout;
+    session.lastEditorState = state;
+    session.lastPmDoc = state.doc;
+    session.usedLoadedFonts = documentFontsAreLoaded();
+    recordLayoutComplete(reason);
+    recordPhaseDuration("layout-document", phaseStartedAt);
+
+    // Step 4: Paint to DOM
+    if (pagesContainer && painter) {
+      phaseStartedAt = performance.now();
+      // Build block lookup
+      const blockLookup: BlockLookup = new Map();
+      for (let i = 0; i < newBlocks.length; i++) {
+        const block = newBlocks[i];
+        const measure = newMeasures[i];
+        if (block && measure) {
+          blockLookup.set(String(block.id), { block, measure });
+        }
+      }
+      outcome.blockLookup = blockLookup;
+
+      // Build per-page footnote render items
+      const footnotesByPage = hasFootnotes
+        ? buildFootnoteRenderItems(
+            pageFootnoteMap,
+            footnoteContentMap,
+            document,
+          )
+        : undefined;
+
+      // Render pages to container.
+      // Built incrementally so optional fields are only present when
+      // defined (RenderPageOptions has `exactOptionalPropertyTypes`).
+      const renderOpts: RenderPageOptions & {
+        pageGap?: number;
+        footnotesByPage?: Map<number, FootnoteRenderItem[]>;
+      } = {
+        pageGap,
+        showShadow: true,
+        blockLookup,
+        titlePg: hasTitlePg,
+      };
+      if (headerContentForRender) {
+        renderOpts.headerContent = headerContentForRender;
+      }
+      if (footerContentForRender) {
+        renderOpts.footerContent = footerContentForRender;
+      }
+      if (firstPageHeaderForRender) {
+        renderOpts.firstPageHeaderContent = firstPageHeaderForRender;
+      }
+      if (firstPageFooterForRender) {
+        renderOpts.firstPageFooterContent = firstPageFooterForRender;
+      }
+      if (headerContentByRId) {
+        renderOpts.headerContentByRId = headerContentByRId;
+      }
+      if (footerContentByRId) {
+        renderOpts.footerContentByRId = footerContentByRId;
+      }
+      if (
+        sectionHeaderFooterRefs === undefined &&
+        sectionProperties?.headerDistance !== undefined &&
+        sectionProperties.headerDistance !== 0
+      ) {
+        renderOpts.headerDistance = twipsToPixels(
+          sectionProperties.headerDistance,
+        );
+      }
+      if (
+        sectionHeaderFooterRefs === undefined &&
+        sectionProperties?.footerDistance !== undefined &&
+        sectionProperties.footerDistance !== 0
+      ) {
+        renderOpts.footerDistance = twipsToPixels(
+          sectionProperties.footerDistance,
+        );
+      }
+      if (sectionProperties?.pageBorders) {
+        renderOpts.pageBorders = sectionProperties.pageBorders;
+      }
+      if (_theme) {
+        renderOpts.theme = _theme;
+      }
+      if (footnotesByPage !== undefined && footnotesByPage.size > 0) {
+        renderOpts.footnotesByPage = footnotesByPage;
+      }
+      // Map bookmarks to the pages they land on so PAGEREF fields resolve
+      // to live page numbers at paint.
+      const bookmarkPages = buildBookmarkPageMap(newLayout.pages, newBlocks);
+      if (bookmarkPages.size > 0) {
+        renderOpts.bookmarkPages = bookmarkPages;
+      }
+      // Assign SEQ caption numbers in document order so SEQ fields resolve.
+      const seqValues = buildSeqValues(newBlocks);
+      if (seqValues.size > 0) {
+        renderOpts.seqValues = seqValues;
+      }
+      // Bookmark text for REF cross-references.
+      const bookmarkTextInputs =
+        stabilizedFieldValues === undefined
+          ? { seqValues }
+          : { fieldValues: stabilizedFieldValues, seqValues };
+      const bookmarkText = buildBookmarkText(newBlocks, bookmarkTextInputs);
+      if (bookmarkText.size > 0) {
+        renderOpts.bookmarkText = bookmarkText;
+      }
+      // Per-section page counts so SECTIONPAGES fields resolve.
+      renderOpts.sectionPageCounts = buildSectionPageCounts(newLayout.pages);
+      // Document watermark (rendered behind every page). Build a
+      // per-header-rId map so titlePg / even-odd / per-section
+      // header parts each paint their own watermark; the painter
+      // falls back to `renderOpts.watermark` for documents that
+      // share one header. Picture watermarks need an image-rId →
+      // asset URL resolver that currently lives outside the
+      // editor; until that's wired in, the painter silently skips
+      // them.
+      if (document) {
+        const watermark = getDocumentWatermark(document);
+        if (watermark) {
+          renderOpts.watermark = watermark;
+        }
+        const headers = document.package.headers;
+        if (headers) {
+          const watermarkByHeaderRId = new Map<string, Watermark>();
+          for (const [rId, header] of headers) {
+            if (header.watermark) {
+              watermarkByHeaderRId.set(rId, header.watermark);
+            }
+          }
+          if (watermarkByHeaderRId.size > 0) {
+            renderOpts.watermarkByHeaderRId = watermarkByHeaderRId;
+          }
+        }
+      }
+      renderPages(newLayout.pages, pagesContainer, renderOpts);
+      recordPhaseDuration("render-pages", phaseStartedAt);
+    }
+  } catch (error) {
+    const invalidHighlights = describeInvalidHighlightMarks(state.doc);
+    recordLayoutError(
+      reason,
+      invalidHighlights
+        ? new Error(`${String(error)} Invalid highlights: ${invalidHighlights}`)
+        : error,
+    );
+    // Keep the previous visible layout if measurement or painting fails.
+  }
+
+  // Signal layout is complete for this sequence
+  syncCoordinator.onLayoutComplete(currentEpoch);
+
+  return outcome;
+}

--- a/packages/folio/src/core/controller/layoutPipeline.ts
+++ b/packages/folio/src/core/controller/layoutPipeline.ts
@@ -76,7 +76,11 @@ import type {
   Watermark,
 } from "../types/document";
 import { getDocumentWatermark } from "../watermark";
-import type { LayoutSession } from "./layoutSession";
+import type {
+  LayoutArtifacts,
+  LayoutSession,
+  LayoutTemplatePreview,
+} from "./layoutSession";
 
 function pageMarginsEqual(left: PageMargins, right: PageMargins): boolean {
   return (
@@ -213,6 +217,8 @@ export function runLayoutPipeline<THfPMs>(
     emptyTemplatePreviewEntries: EMPTY_TEMPLATE_PREVIEW_ENTRIES,
   } = deps;
   const outcome: LayoutOutcome = {};
+  let pendingArtifacts: LayoutArtifacts;
+  let pendingTemplatePreview: LayoutTemplatePreview;
   // Composition root for text measurement: install the canvas backend
   // before any layout/measure runs. Idempotent; the engine measures
   // through the pure provider seam, which throws until a backend is set.
@@ -260,7 +266,7 @@ export function runLayoutPipeline<THfPMs>(
         mode: previewMode,
       });
     }
-    session.lastTemplatePreview = {
+    pendingTemplatePreview = {
       entries: previewEntries,
       mode: previewMode,
     };
@@ -490,7 +496,7 @@ export function runLayoutPipeline<THfPMs>(
         pageHeight: blockMeasureInputs.pageHeights,
         marginBottom: blockMeasureInputs.marginBottoms,
       });
-    session.artifacts = {
+    pendingArtifacts = {
       blocks: newBlocks,
       blockWidths,
       measures: newMeasures,
@@ -688,7 +694,7 @@ export function runLayoutPipeline<THfPMs>(
           values,
         );
         relayoutWithCurrentMeasures(layoutOptsUsed);
-        session.artifacts = {
+        pendingArtifacts = {
           blocks: newBlocks,
           blockWidths,
           measures: newMeasures,
@@ -827,7 +833,7 @@ export function runLayoutPipeline<THfPMs>(
             marginBottom: blockMeasureInputs.marginBottoms,
           },
         );
-        session.artifacts = {
+        pendingArtifacts = {
           blocks: newBlocks,
           blockWidths,
           measures: newMeasures,
@@ -843,10 +849,6 @@ export function runLayoutPipeline<THfPMs>(
     }
 
     outcome.layout = newLayout;
-    session.lastEditorState = state;
-    session.lastPmDoc = state.doc;
-    session.usedLoadedFonts = documentFontsAreLoaded();
-    recordLayoutComplete(reason);
     recordPhaseDuration("layout-document", phaseStartedAt);
 
     // Step 4: Paint to DOM
@@ -980,6 +982,17 @@ export function runLayoutPipeline<THfPMs>(
       renderPages(newLayout.pages, pagesContainer, renderOpts);
       recordPhaseDuration("render-pages", phaseStartedAt);
     }
+
+    // Commit the session memory only after layout AND paint have succeeded. A
+    // paint throw is caught below and keeps the previous visible layout; marking
+    // the doc as laid out here would make the next run skip a needed rerun and
+    // leave stale pages.
+    session.artifacts = pendingArtifacts;
+    session.lastTemplatePreview = pendingTemplatePreview;
+    session.lastEditorState = state;
+    session.lastPmDoc = state.doc;
+    session.usedLoadedFonts = documentFontsAreLoaded();
+    recordLayoutComplete(reason);
   } catch (error) {
     const invalidHighlights = describeInvalidHighlightMarks(state.doc);
     recordLayoutError(

--- a/packages/folio/src/core/controller/layoutPipeline.ts
+++ b/packages/folio/src/core/controller/layoutPipeline.ts
@@ -216,7 +216,10 @@ export function runLayoutPipeline<THfPMs>(
     describeInvalidHighlightMarks,
     emptyTemplatePreviewEntries: EMPTY_TEMPLATE_PREVIEW_ENTRIES,
   } = deps;
-  const outcome: LayoutOutcome = {};
+  // Reassigned to {} in the catch so a failed run returns no outcome (the
+  // adapter then keeps the previously painted layout instead of advancing React
+  // state/overlays to a layout we failed to paint).
+  let outcome: LayoutOutcome = {};
   let pendingArtifacts: LayoutArtifacts;
   let pendingTemplatePreview: LayoutTemplatePreview;
   // Composition root for text measurement: install the canvas backend
@@ -1001,7 +1004,10 @@ export function runLayoutPipeline<THfPMs>(
         ? new Error(`${String(error)} Invalid highlights: ${invalidHighlights}`)
         : error,
     );
-    // Keep the previous visible layout if measurement or painting fails.
+    // Keep the previous visible layout if measurement or painting fails: drop
+    // any partial outcome so the adapter applies nothing and the next run (the
+    // session memory above was not committed) re-lays-out and repaints.
+    outcome = {};
   }
 
   // Signal layout is complete for this sequence

--- a/packages/folio/src/core/controller/layoutScheduler.property.test.ts
+++ b/packages/folio/src/core/controller/layoutScheduler.property.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Property-based tests for the layout scheduler's core invariant: any burst of
+ * schedule() calls that lands inside the coalescing window collapses to exactly
+ * one layout run, carrying the most-recent state and the merged dirty range of
+ * the whole burst. This is the guarantee that a typing storm paints once.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { createLayoutScheduler, type SchedulerClock } from "./layoutScheduler";
+
+type BurstItem = {
+  id: number;
+  dirty: { from: number; to: number } | null;
+};
+
+const makeFakeClock = () => {
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+  const frames = new Map<number, () => void>();
+
+  const clock: SchedulerClock = {
+    now: () => 0,
+    setTimer: (cb) => {
+      const id = nextId++;
+      timers.set(id, cb);
+      return id;
+    },
+    clearTimer: (id) => {
+      timers.delete(id);
+    },
+    requestFrame: (cb) => {
+      const id = nextId++;
+      frames.set(id, cb);
+      return id;
+    },
+    cancelFrame: (id) => {
+      frames.delete(id);
+    },
+  };
+
+  const fireAll = (map: Map<number, () => void>): void => {
+    const callbacks = [...map.values()];
+    map.clear();
+    for (const run of callbacks) {
+      run();
+    }
+  };
+
+  return {
+    clock,
+    fireTimers: () => fireAll(timers),
+    fireFrames: () => fireAll(frames),
+  };
+};
+
+const burstItem: fc.Arbitrary<BurstItem> = fc.record({
+  id: fc.integer(),
+  dirty: fc.option(
+    fc
+      .record({ from: fc.nat(1000), len: fc.nat(1000) })
+      .map(({ from, len }) => ({ from, to: from + len })),
+    { nil: null },
+  ),
+});
+
+describe("layoutScheduler (properties)", () => {
+  test("a coalesced burst runs layout once, with the last state and merged range", () => {
+    fc.assert(
+      fc.property(
+        fc.array(burstItem, { minLength: 1, maxLength: 40 }),
+        (burst) => {
+          const fake = makeFakeClock();
+          const runs: {
+            id: number;
+            dirty: { from: number; to: number } | undefined;
+          }[] = [];
+          const scheduler = createLayoutScheduler<{ id: number }>({
+            runLayout: (state, options) => {
+              runs.push({ id: state.id, dirty: options.dirtyRange });
+            },
+            debounceMs: 32,
+            maxDelayMs: 96,
+            clock: fake.clock,
+          });
+
+          // Whole burst scheduled at t=0 (now() is fixed at 0), so nothing
+          // exceeds maxDelay — it must coalesce into a single pass.
+          for (const item of burst) {
+            scheduler.schedule({ id: item.id }, item.dirty);
+          }
+          fake.fireTimers(); // debounce elapses -> arms one frame
+          fake.fireFrames(); // frame runs the single layout
+
+          expect(runs).toHaveLength(1);
+          expect(runs[0]?.id).toBe(burst.at(-1)?.id);
+
+          let merged: { from: number; to: number } | null = null;
+          for (const item of burst) {
+            if (!item.dirty) {
+              continue;
+            }
+            merged = merged
+              ? {
+                  from: Math.min(merged.from, item.dirty.from),
+                  to: Math.max(merged.to, item.dirty.to),
+                }
+              : { ...item.dirty };
+          }
+
+          if (merged) {
+            expect(runs[0]?.dirty).toEqual(merged);
+          } else {
+            expect(runs[0]?.dirty).toBeUndefined();
+          }
+        },
+      ),
+    );
+  });
+
+  test("dispose before the frame fires cancels the run entirely", () => {
+    fc.assert(
+      fc.property(
+        fc.array(burstItem, { minLength: 1, maxLength: 40 }),
+        (burst) => {
+          const fake = makeFakeClock();
+          let runCount = 0;
+          const scheduler = createLayoutScheduler<{ id: number }>({
+            runLayout: () => {
+              runCount += 1;
+            },
+            debounceMs: 32,
+            maxDelayMs: 96,
+            clock: fake.clock,
+          });
+
+          for (const item of burst) {
+            scheduler.schedule({ id: item.id }, item.dirty);
+          }
+          scheduler.dispose();
+          fake.fireTimers();
+          fake.fireFrames();
+
+          expect(runCount).toBe(0);
+        },
+      ),
+    );
+  });
+});

--- a/packages/folio/src/core/controller/layoutSession.ts
+++ b/packages/folio/src/core/controller/layoutSession.ts
@@ -1,0 +1,37 @@
+import type { EditorState } from "prosemirror-state";
+
+import type { FlowBlock, Measure } from "../layout-engine/types";
+import type {
+  TemplatePreviewEntry,
+  TemplatePreviewValues,
+} from "../prosemirror/plugins/templatePreviewValues";
+
+export type LayoutArtifacts = {
+  blocks: FlowBlock[];
+  blockWidths: number[];
+  measures: Measure[];
+};
+
+export type LayoutTemplatePreview = {
+  entries: readonly TemplatePreviewEntry[];
+  mode: TemplatePreviewValues["mode"];
+};
+
+// Controller-owned memory for the incremental layout loop: the previous run's
+// artifacts and the inputs that produced them, so a relayout can decide whether
+// it can reuse work or must recompute.
+export type LayoutSession = {
+  artifacts: LayoutArtifacts | null;
+  lastEditorState: EditorState | null;
+  lastPmDoc: EditorState["doc"] | null;
+  usedLoadedFonts: boolean;
+  lastTemplatePreview: LayoutTemplatePreview;
+};
+
+export const createLayoutSession = (): LayoutSession => ({
+  artifacts: null,
+  lastEditorState: null,
+  lastPmDoc: null,
+  usedLoadedFonts: false,
+  lastTemplatePreview: { entries: [], mode: "plain" },
+});

--- a/packages/folio/src/core/paged-layout/incrementalMeasure.property.test.ts
+++ b/packages/folio/src/core/paged-layout/incrementalMeasure.property.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Property-based tests for `mergeDirtyRanges` — the dirty-range fold the layout
+ * scheduler uses to coalesce a burst of edits into one pass. The invariants:
+ * `null` is the identity, the merge is the tight bounding span of both inputs,
+ * the span is commutative, and merging a range with itself is a no-op.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { mergeDirtyRanges, type DirtyRange } from "./incrementalMeasure";
+
+const range = fc
+  .record({ from: fc.nat(1000), len: fc.nat(1000) })
+  .map(({ from, len }): DirtyRange => ({ from, to: from + len }));
+
+const nullableRange = fc.option(range, { nil: null });
+
+describe("mergeDirtyRanges (properties)", () => {
+  test("null is the identity element on both sides", () => {
+    fc.assert(
+      fc.property(nullableRange, (r) => {
+        expect(mergeDirtyRanges(null, r)).toEqual(r);
+        expect(mergeDirtyRanges(r, null)).toEqual(r);
+      }),
+    );
+  });
+
+  test("the merge is the tight bounding span covering both inputs", () => {
+    fc.assert(
+      fc.property(range, range, (a, b) => {
+        const merged = mergeDirtyRanges(a, b);
+        expect(merged).not.toBeNull();
+        if (!merged) {
+          return;
+        }
+        // Covers both inputs...
+        expect(merged.from).toBeLessThanOrEqual(Math.min(a.from, b.from));
+        expect(merged.to).toBeGreaterThanOrEqual(Math.max(a.to, b.to));
+        // ...and no wider than necessary.
+        expect(merged.from).toBe(Math.min(a.from, b.from));
+        expect(merged.to).toBe(Math.max(a.to, b.to));
+      }),
+    );
+  });
+
+  test("the merged span is commutative, including with nulls", () => {
+    fc.assert(
+      fc.property(nullableRange, nullableRange, (a, b) => {
+        expect(mergeDirtyRanges(a, b)).toEqual(mergeDirtyRanges(b, a));
+      }),
+    );
+  });
+
+  test("merging a range with itself preserves its span", () => {
+    fc.assert(
+      fc.property(range, (a) => {
+        expect(mergeDirtyRanges(a, a)).toEqual({ from: a.from, to: a.to });
+      }),
+    );
+  });
+
+  test("folding a sequence yields the min-from / max-to of all ranges", () => {
+    fc.assert(
+      fc.property(fc.array(nullableRange), (ranges) => {
+        let folded: DirtyRange | null = null;
+        for (const r of ranges) {
+          folded = mergeDirtyRanges(folded, r);
+        }
+        const present = ranges.filter((r): r is DirtyRange => r !== null);
+        if (present.length === 0) {
+          expect(folded).toBeNull();
+          return;
+        }
+        expect(folded).toEqual({
+          from: Math.min(...present.map((r) => r.from)),
+          to: Math.max(...present.map((r) => r.to)),
+        });
+      }),
+    );
+  });
+});

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -1816,6 +1816,11 @@ export function PagedEditor(
 
   // State
   const [layout, setLayout] = useState<Layout | null>(null);
+  // Mirror `layout` in a ref so the layout pipeline reads the latest page-count
+  // estimate without `layout` in runLayoutPipeline's deps (which would recreate
+  // the callback every layout run and re-fire the effects keyed on its identity).
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
   const [blocks, setBlocks] = useState<FlowBlock[]>([]);
   const [measures, setMeasures] = useState<Measure[]>([]);
   // Reactive "has the hidden editor been requested" signal. The manager owns
@@ -2248,7 +2253,7 @@ export function PagedEditor(
           document,
           defaultTabStop,
           styles,
-          layout,
+          layout: layoutRef.current,
           hfPMs: hfPMsRef.current,
           painter: painterRef.current,
           pagesContainer: pagesContainerRef.current,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -37,6 +37,7 @@ import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import type { AISuggestion } from "../core/ai-suggestions/types";
+import { runLayoutPipeline as runLayoutPipelineCompute } from "../core/controller/layoutPipeline";
 import {
   browserClock,
   createLayoutScheduler,
@@ -44,16 +45,6 @@ import {
 } from "../core/controller/layoutScheduler";
 import { createLayoutSession } from "../core/controller/layoutSession";
 import { getFootnoteText } from "../core/docx/footnoteParser";
-import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
-import { buildBookmarkText } from "../core/fields/bookmarkText";
-import {
-  buildHeaderFooterFieldValues,
-  fieldValuesEqual,
-  resolveFieldValues,
-} from "../core/fields/resolveFieldValues";
-import type { HeaderFooterFieldInputs } from "../core/fields/resolveFieldValues";
-import { buildSectionPageCounts } from "../core/fields/sectionPageCounts";
-import { buildSeqValues } from "../core/fields/seqValues";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
 import { clickToPositionDom } from "../core/layout-bridge/clickToPositionDom";
 import {
@@ -67,12 +58,6 @@ import {
   findHfPmSpans,
   findHfSlotForTarget,
 } from "../core/layout-bridge/findHfPmSpans";
-import {
-  FOOTNOTE_ENTRY_MARGIN_BOTTOM,
-  collectFootnoteRefs,
-  buildFootnoteContentMap,
-} from "../core/layout-bridge/footnoteLayout";
-import type { MeasureBlocksFn } from "../core/layout-bridge/footnoteLayout";
 import {
   convertHeaderFooterPmDocToContent,
   convertHeaderFooterToContent,
@@ -95,30 +80,11 @@ import type {
   CaretPosition,
 } from "../core/layout-bridge/selectionRects";
 import type * as SelectionGeometry from "../core/layout-bridge/selectionRects";
-import {
-  applyTemplatePreviewToBlocks,
-  templatePreviewDirtyRange,
-} from "../core/layout-bridge/templatePreviewFlow";
-// Layout bridge
-import { toFlowBlocks } from "../core/layout-bridge/toFlowBlocks";
-import type { ToFlowBlocksOptions } from "../core/layout-bridge/toFlowBlocks";
+import { templatePreviewDirtyRange } from "../core/layout-bridge/templatePreviewFlow";
 // Layout engine
-import { layoutDocument } from "../core/layout-engine";
-import type { ColumnLayout, SectionLayoutConfig } from "../core/layout-engine";
-import {
-  recordLayoutComplete,
-  recordLayoutError,
-  recordLayoutPhase,
-} from "../core/layout-engine/layoutInstrumentation";
-import type {
-  LayoutPhase,
-  LayoutRunReason,
-} from "../core/layout-engine/layoutInstrumentation";
-import {
-  measureBlocks,
-  measureSingleBlockWithoutFloatingZones,
-} from "../core/layout-engine/measure/measureBlocks";
-import { installCanvasMeasureProvider } from "../core/layout-engine/measure/measureContainer";
+import type { ColumnLayout } from "../core/layout-engine";
+import { recordLayoutPhase } from "../core/layout-engine/layoutInstrumentation";
+import type { LayoutRunReason } from "../core/layout-engine/layoutInstrumentation";
 import type {
   Layout,
   FlowBlock,
@@ -126,29 +92,19 @@ import type {
   TableBlock,
   TableMeasure,
   PageMargins,
-  SectionBreakBlock,
   FootnoteContent,
   PageHeaderFooterRefs,
 } from "../core/layout-engine/types";
 // Layout painter
 import { LayoutPainter } from "../core/layout-painter";
-import type { BlockLookup } from "../core/layout-painter";
 import {
   findPageShellForPmPos,
   PAINTER_PAINTED_EVENT,
-  renderPages,
 } from "../core/layout-painter/renderPage";
 import type {
   HeaderFooterContent,
-  RenderPageOptions,
   FootnoteRenderItem,
 } from "../core/layout-painter/renderPage";
-import {
-  computeFirstPageHeaderFooterMarginExtender,
-  computeHeaderFooterMarginExtender,
-  extendSectionBreakMargins,
-} from "../core/paged-layout/headerFooterMargins";
-import { tryBuildIncrementalMeasures } from "../core/paged-layout/incrementalMeasure";
 import type { DirtyRange } from "../core/paged-layout/incrementalMeasure";
 // Selection sync
 import { LayoutSelectionGate } from "../core/paged-layout/LayoutSelectionGate";
@@ -163,7 +119,6 @@ import {
   PAGES_CONTAINER_CLASS,
   scrollPagesToPmPosition,
 } from "../core/paged-layout/scrollToPmPosition";
-import { computePerBlockMeasureInputs } from "../core/paged-layout/sectionBlockWidths";
 import {
   DEFAULT_PAGE_HEIGHT_PX,
   getMargins,
@@ -208,7 +163,6 @@ import type {
   StyleDefinitions,
   SectionProperties,
   HeaderFooter,
-  Watermark,
   TextFormatting,
 } from "../core/types/document";
 import {
@@ -216,7 +170,6 @@ import {
   htmlQueryAll,
   queryHtmlElement,
 } from "../core/utils/domGuards";
-import { getDocumentWatermark } from "../core/watermark";
 // Internal components
 import { AISuggestionRectsOverlay } from "./AISuggestionRectsOverlay";
 import type { AISuggestionRectGroup } from "./AISuggestionRectsOverlay";
@@ -1665,27 +1618,6 @@ function getTableRowOffset(
   return offsetY;
 }
 
-function pageMarginsEqual(left: PageMargins, right: PageMargins): boolean {
-  return (
-    left.top === right.top &&
-    left.right === right.right &&
-    left.bottom === right.bottom &&
-    left.left === right.left &&
-    left.header === right.header &&
-    left.footer === right.footer
-  );
-}
-
-function optionalPageMarginsEqual(
-  left: PageMargins | undefined,
-  right: PageMargins | undefined,
-): boolean {
-  if (left === undefined || right === undefined) {
-    return left === right;
-  }
-  return pageMarginsEqual(left, right);
-}
-
 /**
  * Extract column layout from section properties.
  * Returns undefined for single-column (default) to avoid unnecessary paginator overhead.
@@ -2294,794 +2226,55 @@ export function PagedEditor(
         reason?: LayoutRunReason;
       } = {},
     ) => {
-      // Composition root for text measurement: install the canvas backend
-      // before any layout/measure runs. Idempotent; the engine measures
-      // through the pure provider seam, which throws until a backend is set.
-      installCanvasMeasureProvider();
-      const reason = options.reason ?? "manual";
-      const recordPhaseDuration = (
-        phase: LayoutPhase,
-        startedAt: number,
-      ): void => {
-        recordLayoutPhase(reason, phase, performance.now() - startedAt);
-      };
-
-      // Capture current state sequence for this layout run
-      const currentEpoch = syncCoordinator.getStateSeq();
-
-      // Signal layout is starting
-      syncCoordinator.onLayoutStart();
-
-      try {
-        // Step 1: Convert PM doc to flow blocks
-        let phaseStartedAt = performance.now();
-        const pageContentHeight = pageSize.h - margins.top - margins.bottom;
-        const flowOpts: ToFlowBlocksOptions = {
-          pageContentHeight,
-        };
-        if (_theme !== undefined) {
-          flowOpts.theme = _theme;
-        }
-        // Stamp the document's `w:defaultTabStop` onto every paragraph so
-        // list-marker tab-stop math (renderParagraph + measureParagraph)
-        // uses the right grid. Absent settings.xml falls back to the
-        // OOXML default inside `getListMarkerInlineWidth`.
-        if (defaultTabStop !== undefined) {
-          flowOpts.defaultTabStopTwips = defaultTabStop;
-        }
-        let newBlocks = toFlowBlocks(state.doc, flowOpts);
-        // Template fill preview: substitute each matched {{marker}} range
-        // with its typed value at the flow-block level so the pages lay out
-        // (wrap, paginate) as if the value were the document text. View-only:
-        // the PM doc — and with it the save path — is never modified.
-        const previewState = templatePreviewValuesKey.getState(state);
-        const previewEntries =
-          previewState?.entries ?? EMPTY_TEMPLATE_PREVIEW_ENTRIES;
-        const previewMode = previewState?.preview?.mode ?? "plain";
-        if (previewEntries.length > 0) {
-          newBlocks = applyTemplatePreviewToBlocks(newBlocks, {
-            entries: previewEntries,
-            mode: previewMode,
-          });
-        }
-        layoutSessionRef.current.lastTemplatePreview = {
-          entries: previewEntries,
-          mode: previewMode,
-        };
-        setBlocks(newBlocks);
-        recordPhaseDuration("flow-blocks", phaseStartedAt);
-
-        // Step 2.5: Collect footnote references from blocks
-        phaseStartedAt = performance.now();
-        const footnoteRefs = collectFootnoteRefs(newBlocks);
-        const hasFootnotes =
-          footnoteRefs.length > 0 && document?.package.footnotes;
-
-        // Step 2.75: Prepare header/footer content for rendering (needed before layout
-        // to compute effective margins when header content exceeds available space)
-        const hfMetricsHeader: HeaderFooterMetrics = {
-          section: "header",
+      const outcome = runLayoutPipelineCompute(
+        {
+          contentWidth,
+          columns,
           pageSize,
           margins,
-        };
-        const hfMetricsFooter: HeaderFooterMetrics = {
-          section: "footer",
-          pageSize,
-          margins,
-        };
-        // Header/footer blocks are measured once but painted on every page with
-        // a different page number. Measure with the prior render's page count
-        // first, then rebuild the prepared HF content with the final page count
-        // after body layout stabilizes so digit-boundary changes are reflected
-        // before paint.
-        const hfPageCountEstimate = layout?.pages.length ?? 1;
-        const hfClock = new Date();
-        const buildHfOptions = (
-          pageCount: number,
-          fieldInputs?: HeaderFooterFieldInputs,
-        ) => {
-          const hfMeasureBlocks: MeasureBlocksFn = (hfBlocks, hfWidth) =>
-            measureBlocks(
-              hfBlocks,
-              hfWidth,
-              undefined,
-              undefined,
-              buildHeaderFooterFieldValues(
-                hfBlocks,
-                pageCount,
-                hfClock,
-                fieldInputs,
-              ),
-            );
-          return {
-            ...(styles ? { styles } : {}),
-            ...(_theme !== undefined ? { theme: _theme } : {}),
-            measureBlocks: hfMeasureBlocks,
-            ...(defaultTabStop !== undefined
-              ? { defaultTabStopTwips: defaultTabStop }
-              : {}),
-          };
-        };
-        const hfOptions = buildHfOptions(hfPageCountEstimate);
-        let headerContentForRender = renderHfFromContentOrPm(
+          pageGap,
+          syncCoordinator,
           headerContent,
-          headerContentRId,
-          hfPMsRef.current,
-          contentWidth,
-          hfMetricsHeader,
-          hfOptions,
-        );
-        let footerContentForRender = renderHfFromContentOrPm(
           footerContent,
+          firstPageHeaderContent,
+          firstPageFooterContent,
+          headerContentRId,
           footerContentRId,
-          hfPMsRef.current,
-          contentWidth,
-          hfMetricsFooter,
-          hfOptions,
-        );
-        const hasTitlePg = sectionProperties?.titlePg === true;
-        let firstPageHeaderForRender = hasTitlePg
-          ? renderHfFromContentOrPm(
-              firstPageHeaderContent,
-              firstPageHeaderContentRId,
-              hfPMsRef.current,
-              contentWidth,
-              hfMetricsHeader,
-              hfOptions,
-            )
-          : undefined;
-        let firstPageFooterForRender = hasTitlePg
-          ? renderHfFromContentOrPm(
-              firstPageFooterContent,
-              firstPageFooterContentRId,
-              hfPMsRef.current,
-              contentWidth,
-              hfMetricsFooter,
-              hfOptions,
-            )
-          : undefined;
-        let headerContentByRId = renderHeaderFooterContentByRId(
-          document?.package.headers,
-          hfPMsRef.current,
-          contentWidth,
-          hfMetricsHeader,
-          hfOptions,
-        );
-        let footerContentByRId = renderHeaderFooterContentByRId(
-          document?.package.footers,
-          hfPMsRef.current,
-          contentWidth,
-          hfMetricsFooter,
-          hfOptions,
-        );
-
-        // Rendered H/F content is shared across every extender; only the
-        // page size (body vs. a section's own) and the mode (default vs.
-        // first-page) vary.
-        const hfExtenderContent = {
-          headerContent: headerContentForRender,
-          footerContent: footerContentForRender,
-          firstPageHeaderContent: firstPageHeaderForRender,
-          firstPageFooterContent: firstPageFooterForRender,
-        };
-        const hfWarn = (msg: string): void => {
-          // eslint-disable-next-line no-console -- standalone editor package has no logger in scope
-          console.warn(`[PagedEditor] ${msg}`);
-        };
-        // Default extender — applied to pages 2+ of every section. It
-        // ignores firstPage H/F so a `<w:titlePg/>` section's
-        // overflowing first-page header doesn't push body content down
-        // on every subsequent page.
-        const extendForHfOverflow = computeHeaderFooterMarginExtender({
-          ...hfExtenderContent,
-          pageSize,
-          warn: hfWarn,
-        });
-        // First-page extender — used only for page 1 of a titlePg
-        // section so the title page's larger header reservation is
-        // honored without leaking onto pages 2+.
-        const extendForFirstPage = computeFirstPageHeaderFooterMarginExtender({
-          ...hfExtenderContent,
-          pageSize,
-          warn: hfWarn,
-        });
-        let effectiveMargins = extendForHfOverflow(margins);
-        let effectiveFirstPageMargins = hasTitlePg
-          ? extendForFirstPage(margins)
-          : undefined;
-        const sectionBreaks = newBlocks.filter(
-          (block): block is SectionBreakBlock => block.kind === "sectionBreak",
-        );
-        const originalSectionBreakMargins = new Map<
-          SectionBreakBlock["id"],
-          PageMargins | undefined
-        >();
-        for (const sectionBreak of sectionBreaks) {
-          originalSectionBreakMargins.set(
-            sectionBreak.id,
-            sectionBreak.margins ? { ...sectionBreak.margins } : undefined,
-          );
-        }
-        const restoreSectionBreakMargins = (): void => {
-          for (const sectionBreak of sectionBreaks) {
-            const originalMargins = originalSectionBreakMargins.get(
-              sectionBreak.id,
-            );
-            if (originalMargins === undefined) {
-              delete sectionBreak.margins;
-              continue;
-            }
-            sectionBreak.margins = { ...originalMargins };
-          }
-        };
-        const applySectionBreakMargins = (
-          content: typeof hfExtenderContent,
-          bodyMargins: PageMargins,
-        ): void => {
-          restoreSectionBreakMargins();
-          // Section-break blocks carry their own `pageSize`/`margins` from
-          // `<w:sectPr>` and the layout engine prefers those over the
-          // body-level fallback. Extend each against its own resolved page
-          // so an overflowing footer never re-overlaps body text on the next
-          // section. (Eigenpal #400.)
-          extendSectionBreakMargins(sectionBreaks, {
-            content,
-            bodyPageSize: pageSize,
-            bodyMargins,
-            warn: hfWarn,
-          });
-        };
-        applySectionBreakMargins(hfExtenderContent, effectiveMargins);
-        recordPhaseDuration("header-footer", phaseStartedAt);
-
-        // Compute per-block widths + band geometry from the EFFECTIVE margins
-        // layout uses (header/footer overflow extension + section-break margin
-        // extension applied above), so a page/margin-pinned topAndBottom band
-        // reserves its band at the same Y the box is painted. Measuring with the
-        // raw margins would mis-place the reserved band when a tall header/footer
-        // extends the margins. eigenpal #694.
-        phaseStartedAt = performance.now();
-        let bodyLayoutConfig: SectionLayoutConfig = {
-          pageSize,
-          margins: effectiveMargins,
-        };
-        if (columns !== undefined) {
-          bodyLayoutConfig.columns = columns;
-        }
-        let blockMeasureInputs = computePerBlockMeasureInputs({
-          blocks: newBlocks,
-          bodyConfig: bodyLayoutConfig,
-          finalConfig: bodyLayoutConfig,
-        });
-        let blockWidths = blockMeasureInputs.widths;
-        const previousArtifacts = layoutSessionRef.current.artifacts;
-        const incrementalResult =
-          options.dirtyRange && !options.forceFull && previousArtifacts
-            ? tryBuildIncrementalMeasures({
-                previousBlocks: previousArtifacts.blocks,
-                previousMeasures: previousArtifacts.measures,
-                previousBlockWidths: previousArtifacts.blockWidths,
-                nextBlocks: newBlocks,
-                nextBlockWidths: blockWidths,
-                dirtyRange: options.dirtyRange,
-                measureBlock: measureSingleBlockWithoutFloatingZones,
-              })
-            : null;
-        let newMeasures =
-          incrementalResult?.measures ??
-          measureBlocks(newBlocks, blockWidths, blockMeasureInputs.marginTops, {
-            pageHeight: blockMeasureInputs.pageHeights,
-            marginBottom: blockMeasureInputs.marginBottoms,
-          });
-        layoutSessionRef.current.artifacts = {
-          blocks: newBlocks,
-          blockWidths,
-          measures: newMeasures,
-        };
-        setMeasures(newMeasures);
-        recordPhaseDuration("measure-blocks", phaseStartedAt);
-
-        // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
-        phaseStartedAt = performance.now();
-        let newLayout: Layout;
-        let pageFootnoteMap = new Map<number, number[]>();
-        let footnoteContentMap = new Map<number, FootnoteContent>();
-
-        // Common layout options for all passes
-        const bodyBreakType = sectionProperties?.sectionStart as
-          | "continuous"
-          | "nextPage"
-          | "evenPage"
-          | "oddPage"
-          | undefined;
-        const buildLayoutOpts = (
-          nextMargins: PageMargins,
-          nextFirstPageMargins: PageMargins | undefined,
-        ): Parameters<typeof layoutDocument>[2] => {
-          const nextLayoutOpts: Parameters<typeof layoutDocument>[2] = {
-            pageSize,
-            margins: nextMargins,
-            pageGap,
-          };
-          if (nextFirstPageMargins !== undefined) {
-            nextLayoutOpts.firstPageMargins = nextFirstPageMargins;
-          }
-          if (columns !== undefined) {
-            nextLayoutOpts.columns = columns;
-          }
-          if (bodyBreakType !== undefined) {
-            nextLayoutOpts.bodyBreakType = bodyBreakType;
-          }
-          if (sectionHeaderFooterRefs !== undefined) {
-            nextLayoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
-          }
-          return nextLayoutOpts;
-        };
-        const layoutOpts = buildLayoutOpts(
-          effectiveMargins,
-          effectiveFirstPageMargins,
-        );
-        // The exact options the layout was produced with, reused if the field-
-        // width stabilization pass re-lays-out below.
-        let layoutOptsUsed: Parameters<typeof layoutDocument>[2] = layoutOpts;
-
-        if (hasFootnotes) {
-          // Build footnote content and measure heights up front. The
-          // per-fn height table feeds into the layout engine so each
-          // body line carrying an fn ref reserves space for that fn
-          // on its host page in a single pass — no convergence loop.
-          footnoteContentMap = buildFootnoteContentMap(
-            document!.package.footnotes!,
-            footnoteRefs,
-            contentWidth,
-            (() => {
-              const footnoteOptions: Parameters<
-                typeof buildFootnoteContentMap
-              >[3] = { measureBlocks };
-              if (styles) {
-                footnoteOptions.styles = styles;
-              }
-              if (_theme !== undefined) {
-                footnoteOptions.theme = _theme;
-              }
-              if (defaultTabStop !== undefined) {
-                footnoteOptions.defaultTabStopTwips = defaultTabStop;
-              }
-              return footnoteOptions;
-            })(),
-          );
-
-          const footnoteHeightById = new Map<number, number>();
-          // Any per-fn wrapper margin applied by the painter is reserved
-          // alongside content height. The value is zero for Word-like footnote
-          // spacing; source paragraph spacing inside each note carries the
-          // visible gaps.
-          for (const [id, content] of footnoteContentMap) {
-            footnoteHeightById.set(
-              id,
-              content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
-            );
-          }
-          // Note: the layout engine adds the divider's height once per
-          // fn-bearing page (in paginator.addFootnoteHeight); we pass per-fn
-          // content plus any wrapper margin here.
-
-          layoutOptsUsed = { ...layoutOpts, footnoteHeightById };
-          newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
-
-          // The layout engine assigned `page.footnoteIds` line-by-
-          // line via `paginator.addFootnoteHeight(_, ids)`, so a fn
-          // ref in a continuation fragment of a split paragraph
-          // lands on the page where the ref-bearing line actually
-          // is. Build pageFootnoteMap from those page records (not
-          // from `mapFootnotesToPages`'s pmRange scan, which can't
-          // disambiguate split-paragraph halves; Codex PR #258).
-          pageFootnoteMap = new Map<number, number[]>();
-          for (const page of newLayout.pages) {
-            if (page.footnoteIds && page.footnoteIds.length > 0) {
-              pageFootnoteMap.set(page.number, page.footnoteIds);
-            }
-          }
-        } else {
-          // No footnotes — single pass
-          newLayout = layoutDocument(newBlocks, newMeasures, layoutOpts);
-        }
-
-        const rebuildFootnotePageMap = (): void => {
-          pageFootnoteMap = new Map<number, number[]>();
-          for (const page of newLayout.pages) {
-            if (page.footnoteIds && page.footnoteIds.length > 0) {
-              pageFootnoteMap.set(page.number, page.footnoteIds);
-            }
-          }
-        };
-
-        const withFootnoteHeights = (
-          nextLayoutOpts: Parameters<typeof layoutDocument>[2],
-        ): Parameters<typeof layoutDocument>[2] => {
-          if (!hasFootnotes) {
-            return nextLayoutOpts;
-          }
-          const footnoteHeightById = new Map<number, number>();
-          for (const [id, content] of footnoteContentMap) {
-            footnoteHeightById.set(
-              id,
-              content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
-            );
-          }
-          return { ...nextLayoutOpts, footnoteHeightById };
-        };
-
-        const relayoutWithCurrentMeasures = (
-          nextLayoutOpts: Parameters<typeof layoutDocument>[2],
-        ): void => {
-          layoutOptsUsed = withFootnoteHeights(nextLayoutOpts);
-          newLayout = layoutDocument(newBlocks, newMeasures, layoutOptsUsed);
-          if (hasFootnotes) {
-            rebuildFootnotePageMap();
-          }
-        };
-
-        const stabilizeFieldWidths = (): void => {
-          if (incrementalResult) {
-            return;
-          }
-          const MAX_FIELD_STABILIZATION_PASSES = 3;
-          const fieldClock = new Date();
-          let previousFieldValues: Map<number, string> | null = null;
-          for (let pass = 0; pass < MAX_FIELD_STABILIZATION_PASSES; pass++) {
-            const seqValues = buildSeqValues(newBlocks);
-            const bookmarkTextInputs =
-              previousFieldValues === null
-                ? { seqValues }
-                : { fieldValues: previousFieldValues, seqValues };
-            const { values, changed } = resolveFieldValues(
-              newBlocks,
-              newLayout.pages,
-              {
-                totalPages: newLayout.pages.length,
-                bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
-                bookmarkText: buildBookmarkText(newBlocks, bookmarkTextInputs),
-                seqValues,
-                sectionPageCounts: buildSectionPageCounts(newLayout.pages),
-                now: fieldClock,
-              },
-            );
-            const settled =
-              previousFieldValues === null
-                ? !changed
-                : fieldValuesEqual(previousFieldValues, values);
-            if (settled) {
-              stabilizedFieldValues = values;
-              break;
-            }
-            previousFieldValues = values;
-            stabilizedFieldValues = values;
-            newMeasures = measureBlocks(
-              newBlocks,
-              blockWidths,
-              blockMeasureInputs.marginTops,
-              {
-                pageHeight: blockMeasureInputs.pageHeights,
-                marginBottom: blockMeasureInputs.marginBottoms,
-              },
-              values,
-            );
-            relayoutWithCurrentMeasures(layoutOptsUsed);
-            layoutSessionRef.current.artifacts = {
-              blocks: newBlocks,
-              blockWidths,
-              measures: newMeasures,
-            };
-            setMeasures(newMeasures);
-          }
-        };
-
-        // Field-width stabilization: fields were measured at their cached
-        // fallback text. Resolve them against this layout and, if a value's
-        // width differs, re-measure and re-lay-out so wrapping matches what the
-        // painter draws. PAGE/NUMPAGES depend on the layout they help produce,
-        // so a re-layout can shift pages and change values again — iterate to a
-        // fixed point with a small cap. Gated on a real change, so field-free
-        // documents and most edits do zero passes; skipped on the incremental
-        // (typing) path to keep keystrokes cheap.
-        let stabilizedFieldValues: Map<number, string> | undefined;
-        stabilizeFieldWidths();
-
-        const rebuildHeaderFooterForLayout = (): typeof hfExtenderContent => {
-          const seqValues = buildSeqValues(newBlocks);
-          const bookmarkTextInputs =
-            stabilizedFieldValues === undefined
-              ? { seqValues }
-              : { fieldValues: stabilizedFieldValues, seqValues };
-          const finalHfFieldInputs: HeaderFooterFieldInputs = {
-            bookmarkPages: buildBookmarkPageMap(newLayout.pages, newBlocks),
-            bookmarkText: buildBookmarkText(newBlocks, bookmarkTextInputs),
-            seqValues,
-            sectionPageCounts: buildSectionPageCounts(newLayout.pages),
-          };
-          const finalHfOptions = buildHfOptions(
-            newLayout.pages.length,
-            finalHfFieldInputs,
-          );
-          headerContentForRender = renderHfFromContentOrPm(
-            headerContent,
-            headerContentRId,
-            hfPMsRef.current,
-            contentWidth,
-            hfMetricsHeader,
-            finalHfOptions,
-          );
-          footerContentForRender = renderHfFromContentOrPm(
-            footerContent,
-            footerContentRId,
-            hfPMsRef.current,
-            contentWidth,
-            hfMetricsFooter,
-            finalHfOptions,
-          );
-          firstPageHeaderForRender = hasTitlePg
-            ? renderHfFromContentOrPm(
-                firstPageHeaderContent,
-                firstPageHeaderContentRId,
-                hfPMsRef.current,
-                contentWidth,
-                hfMetricsHeader,
-                finalHfOptions,
-              )
-            : undefined;
-          firstPageFooterForRender = hasTitlePg
-            ? renderHfFromContentOrPm(
-                firstPageFooterContent,
-                firstPageFooterContentRId,
-                hfPMsRef.current,
-                contentWidth,
-                hfMetricsFooter,
-                finalHfOptions,
-              )
-            : undefined;
-          headerContentByRId = renderHeaderFooterContentByRId(
-            document?.package.headers,
-            hfPMsRef.current,
-            contentWidth,
-            hfMetricsHeader,
-            finalHfOptions,
-          );
-          footerContentByRId = renderHeaderFooterContentByRId(
-            document?.package.footers,
-            hfPMsRef.current,
-            contentWidth,
-            hfMetricsFooter,
-            finalHfOptions,
-          );
-          return {
-            headerContent: headerContentForRender,
-            footerContent: footerContentForRender,
-            firstPageHeaderContent: firstPageHeaderForRender,
-            firstPageFooterContent: firstPageFooterForRender,
-          };
-        };
-
-        const MAX_HEADER_FOOTER_STABILIZATION_PASSES = 3;
-        for (
-          let pass = 0;
-          pass < MAX_HEADER_FOOTER_STABILIZATION_PASSES;
-          pass++
-        ) {
-          const finalHfExtenderContent = rebuildHeaderFooterForLayout();
-          const finalEffectiveMargins = computeHeaderFooterMarginExtender({
-            ...finalHfExtenderContent,
-            pageSize,
-            warn: hfWarn,
-          })(margins);
-          const finalEffectiveFirstPageMargins = hasTitlePg
-            ? computeFirstPageHeaderFooterMarginExtender({
-                ...finalHfExtenderContent,
-                pageSize,
-                warn: hfWarn,
-              })(margins)
-            : undefined;
-
-          if (
-            !pageMarginsEqual(effectiveMargins, finalEffectiveMargins) ||
-            !optionalPageMarginsEqual(
-              effectiveFirstPageMargins,
-              finalEffectiveFirstPageMargins,
-            )
-          ) {
-            effectiveMargins = finalEffectiveMargins;
-            effectiveFirstPageMargins = finalEffectiveFirstPageMargins;
-            applySectionBreakMargins(finalHfExtenderContent, effectiveMargins);
-            bodyLayoutConfig = { pageSize, margins: effectiveMargins };
-            if (columns !== undefined) {
-              bodyLayoutConfig.columns = columns;
-            }
-            blockMeasureInputs = computePerBlockMeasureInputs({
-              blocks: newBlocks,
-              bodyConfig: bodyLayoutConfig,
-              finalConfig: bodyLayoutConfig,
-            });
-            blockWidths = blockMeasureInputs.widths;
-            newMeasures = measureBlocks(
-              newBlocks,
-              blockWidths,
-              blockMeasureInputs.marginTops,
-              {
-                pageHeight: blockMeasureInputs.pageHeights,
-                marginBottom: blockMeasureInputs.marginBottoms,
-              },
-            );
-            layoutSessionRef.current.artifacts = {
-              blocks: newBlocks,
-              blockWidths,
-              measures: newMeasures,
-            };
-            setMeasures(newMeasures);
-            relayoutWithCurrentMeasures(
-              buildLayoutOpts(effectiveMargins, effectiveFirstPageMargins),
-            );
-            stabilizeFieldWidths();
-            continue;
-          }
-          break;
-        }
-
-        setLayout(newLayout);
-        layoutSessionRef.current.lastEditorState = state;
-        layoutSessionRef.current.lastPmDoc = state.doc;
-        layoutSessionRef.current.usedLoadedFonts = documentFontsAreLoaded();
-        recordLayoutComplete(reason);
-        recordPhaseDuration("layout-document", phaseStartedAt);
-
-        // Step 4: Paint to DOM
-        if (pagesContainerRef.current && painterRef.current) {
-          phaseStartedAt = performance.now();
-          // Build block lookup
-          const blockLookup: BlockLookup = new Map();
-          for (let i = 0; i < newBlocks.length; i++) {
-            const block = newBlocks[i];
-            const measure = newMeasures[i];
-            if (block && measure) {
-              blockLookup.set(String(block.id), { block, measure });
-            }
-          }
-          painterRef.current.setBlockLookup(blockLookup);
-
-          // Build per-page footnote render items
-          const footnotesByPage = hasFootnotes
-            ? buildFootnoteRenderItems(
-                pageFootnoteMap,
-                footnoteContentMap,
-                document,
-              )
-            : undefined;
-
-          // Render pages to container.
-          // Built incrementally so optional fields are only present when
-          // defined (RenderPageOptions has `exactOptionalPropertyTypes`).
-          const renderOpts: RenderPageOptions & {
-            pageGap?: number;
-            footnotesByPage?: Map<number, FootnoteRenderItem[]>;
-          } = {
-            pageGap,
-            showShadow: true,
-            blockLookup,
-            titlePg: hasTitlePg,
-          };
-          if (headerContentForRender) {
-            renderOpts.headerContent = headerContentForRender;
-          }
-          if (footerContentForRender) {
-            renderOpts.footerContent = footerContentForRender;
-          }
-          if (firstPageHeaderForRender) {
-            renderOpts.firstPageHeaderContent = firstPageHeaderForRender;
-          }
-          if (firstPageFooterForRender) {
-            renderOpts.firstPageFooterContent = firstPageFooterForRender;
-          }
-          if (headerContentByRId) {
-            renderOpts.headerContentByRId = headerContentByRId;
-          }
-          if (footerContentByRId) {
-            renderOpts.footerContentByRId = footerContentByRId;
-          }
-          if (
-            sectionHeaderFooterRefs === undefined &&
-            sectionProperties?.headerDistance
-          ) {
-            renderOpts.headerDistance = twipsToPixels(
-              sectionProperties.headerDistance,
-            );
-          }
-          if (
-            sectionHeaderFooterRefs === undefined &&
-            sectionProperties?.footerDistance
-          ) {
-            renderOpts.footerDistance = twipsToPixels(
-              sectionProperties.footerDistance,
-            );
-          }
-          if (sectionProperties?.pageBorders) {
-            renderOpts.pageBorders = sectionProperties.pageBorders;
-          }
-          if (_theme) {
-            renderOpts.theme = _theme;
-          }
-          if (footnotesByPage?.size) {
-            renderOpts.footnotesByPage = footnotesByPage;
-          }
-          // Map bookmarks to the pages they land on so PAGEREF fields resolve
-          // to live page numbers at paint.
-          const bookmarkPages = buildBookmarkPageMap(
-            newLayout.pages,
-            newBlocks,
-          );
-          if (bookmarkPages.size > 0) {
-            renderOpts.bookmarkPages = bookmarkPages;
-          }
-          // Assign SEQ caption numbers in document order so SEQ fields resolve.
-          const seqValues = buildSeqValues(newBlocks);
-          if (seqValues.size > 0) {
-            renderOpts.seqValues = seqValues;
-          }
-          // Bookmark text for REF cross-references.
-          const bookmarkTextInputs =
-            stabilizedFieldValues === undefined
-              ? { seqValues }
-              : { fieldValues: stabilizedFieldValues, seqValues };
-          const bookmarkText = buildBookmarkText(newBlocks, bookmarkTextInputs);
-          if (bookmarkText.size > 0) {
-            renderOpts.bookmarkText = bookmarkText;
-          }
-          // Per-section page counts so SECTIONPAGES fields resolve.
-          renderOpts.sectionPageCounts = buildSectionPageCounts(
-            newLayout.pages,
-          );
-          // Document watermark (rendered behind every page). Build a
-          // per-header-rId map so titlePg / even-odd / per-section
-          // header parts each paint their own watermark; the painter
-          // falls back to `renderOpts.watermark` for documents that
-          // share one header. Picture watermarks need an image-rId →
-          // asset URL resolver that currently lives outside the
-          // editor; until that's wired in, the painter silently skips
-          // them.
-          if (document) {
-            const watermark = getDocumentWatermark(document);
-            if (watermark) {
-              renderOpts.watermark = watermark;
-            }
-            const headers = document.package.headers;
-            if (headers) {
-              const watermarkByHeaderRId = new Map<string, Watermark>();
-              for (const [rId, header] of headers) {
-                if (header.watermark) {
-                  watermarkByHeaderRId.set(rId, header.watermark);
-                }
-              }
-              if (watermarkByHeaderRId.size > 0) {
-                renderOpts.watermarkByHeaderRId = watermarkByHeaderRId;
-              }
-            }
-          }
-          renderPages(newLayout.pages, pagesContainerRef.current, renderOpts);
-          recordPhaseDuration("render-pages", phaseStartedAt);
-        }
-      } catch (error) {
-        const invalidHighlights = describeInvalidHighlightMarks(state.doc);
-        recordLayoutError(
-          reason,
-          invalidHighlights
-            ? new Error(
-                `${String(error)} Invalid highlights: ${invalidHighlights}`,
-              )
-            : error,
-        );
-        // Keep the previous visible layout if measurement or painting fails.
+          firstPageHeaderContentRId,
+          firstPageFooterContentRId,
+          sectionHeaderFooterRefs,
+          theme: _theme,
+          sectionProperties,
+          document,
+          defaultTabStop,
+          styles,
+          layout,
+          hfPMs: hfPMsRef.current,
+          painter: painterRef.current,
+          pagesContainer: pagesContainerRef.current,
+          session: layoutSessionRef.current,
+          renderHfFromContentOrPm,
+          renderHeaderFooterContentByRId,
+          documentFontsAreLoaded,
+          buildFootnoteRenderItems,
+          describeInvalidHighlightMarks,
+          emptyTemplatePreviewEntries: EMPTY_TEMPLATE_PREVIEW_ENTRIES,
+        },
+        state,
+        options,
+      );
+      if (outcome.blocks) {
+        setBlocks(outcome.blocks);
       }
-
-      // Signal layout is complete for this sequence
-      syncCoordinator.onLayoutComplete(currentEpoch);
+      if (outcome.measures !== undefined) {
+        setMeasures(outcome.measures);
+      }
+      if (outcome.layout) {
+        setLayout(outcome.layout);
+      }
+      if (outcome.blockLookup) {
+        painterRef.current?.setBlockLookup(outcome.blockLookup);
+      }
     },
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- hand-curated dep set; ref-held values are intentionally omitted
     [

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2554,15 +2554,13 @@ export function PagedEditor(
           finalConfig: bodyLayoutConfig,
         });
         let blockWidths = blockMeasureInputs.widths;
+        const previousArtifacts = layoutSessionRef.current.artifacts;
         const incrementalResult =
-          options.dirtyRange &&
-          !options.forceFull &&
-          layoutSessionRef.current.artifacts
+          options.dirtyRange && !options.forceFull && previousArtifacts
             ? tryBuildIncrementalMeasures({
-                previousBlocks: layoutSessionRef.current.artifacts.blocks,
-                previousMeasures: layoutSessionRef.current.artifacts.measures,
-                previousBlockWidths:
-                  layoutSessionRef.current.artifacts.blockWidths,
+                previousBlocks: previousArtifacts.blocks,
+                previousMeasures: previousArtifacts.measures,
+                previousBlockWidths: previousArtifacts.blockWidths,
                 nextBlocks: newBlocks,
                 nextBlockWidths: blockWidths,
                 dirtyRange: options.dirtyRange,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -42,6 +42,7 @@ import {
   createLayoutScheduler,
   type LayoutScheduler,
 } from "../core/controller/layoutScheduler";
+import { createLayoutSession } from "../core/controller/layoutSession";
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { buildBookmarkPageMap } from "../core/fields/bookmarkPages";
 import { buildBookmarkText } from "../core/fields/bookmarkText";
@@ -1893,11 +1894,7 @@ export function PagedEditor(
   const shouldFocusHiddenEditorOnReadyRef = useRef(collaboration !== undefined);
   const [precomputedInitialState, setPrecomputedInitialState] =
     useState<EditorState | null>(null);
-  const layoutArtifactsRef = useRef<{
-    blocks: FlowBlock[];
-    blockWidths: number[];
-    measures: Measure[];
-  } | null>(null);
+  const layoutSessionRef = useRef(createLayoutSession());
   const precomputedInitialStateRef = useRef<EditorState | null>(null);
   const precomputedInitialDocumentRef = useRef<Document | null>(null);
   const preHiddenInitialLayoutDoneRef = useRef(false);
@@ -1906,9 +1903,6 @@ export function PagedEditor(
   const queuedInputBeforeHiddenEditorRef = useRef<QueuedHiddenEditorInput[]>(
     [],
   );
-  const lastLayoutEditorStateRef = useRef<EditorState | null>(null);
-  const lastLaidOutPmDocRef = useRef<EditorState["doc"] | null>(null);
-  const lastLayoutUsedLoadedFontsRef = useRef(false);
   const pendingInitialFontReadyLayoutRef = useRef(false);
   const suppressFontReadyUntilRef = useRef(0);
   const [isFocused, setIsFocused] = useState(false);
@@ -1952,14 +1946,10 @@ export function PagedEditor(
   // Template fill preview — the hidden editor's plugin keeps marker↔value
   // entries in sync; the layout pipeline substitutes them into the flow
   // blocks so the painted pages reflow as if the values were the text.
-  // `templatePreviewRef` mirrors the latest plugin state (change detection),
-  // `lastLaidOutTemplatePreviewRef` records what the last pipeline run
-  // actually substituted.
+  // `templatePreviewRef` mirrors the latest plugin state (change detection);
+  // the layout session's `lastTemplatePreview` records what the last pipeline
+  // run actually substituted.
   const templatePreviewRef = useRef<{
-    entries: readonly TemplatePreviewEntry[];
-    mode: TemplatePreviewValues["mode"];
-  }>({ entries: EMPTY_TEMPLATE_PREVIEW_ENTRIES, mode: "plain" });
-  const lastLaidOutTemplatePreviewRef = useRef<{
     entries: readonly TemplatePreviewEntry[];
     mode: TemplatePreviewValues["mode"];
   }>({ entries: EMPTY_TEMPLATE_PREVIEW_ENTRIES, mode: "plain" });
@@ -2354,7 +2344,7 @@ export function PagedEditor(
             mode: previewMode,
           });
         }
-        lastLaidOutTemplatePreviewRef.current = {
+        layoutSessionRef.current.lastTemplatePreview = {
           entries: previewEntries,
           mode: previewMode,
         };
@@ -2565,11 +2555,14 @@ export function PagedEditor(
         });
         let blockWidths = blockMeasureInputs.widths;
         const incrementalResult =
-          options.dirtyRange && !options.forceFull && layoutArtifactsRef.current
+          options.dirtyRange &&
+          !options.forceFull &&
+          layoutSessionRef.current.artifacts
             ? tryBuildIncrementalMeasures({
-                previousBlocks: layoutArtifactsRef.current.blocks,
-                previousMeasures: layoutArtifactsRef.current.measures,
-                previousBlockWidths: layoutArtifactsRef.current.blockWidths,
+                previousBlocks: layoutSessionRef.current.artifacts.blocks,
+                previousMeasures: layoutSessionRef.current.artifacts.measures,
+                previousBlockWidths:
+                  layoutSessionRef.current.artifacts.blockWidths,
                 nextBlocks: newBlocks,
                 nextBlockWidths: blockWidths,
                 dirtyRange: options.dirtyRange,
@@ -2582,7 +2575,7 @@ export function PagedEditor(
             pageHeight: blockMeasureInputs.pageHeights,
             marginBottom: blockMeasureInputs.marginBottoms,
           });
-        layoutArtifactsRef.current = {
+        layoutSessionRef.current.artifacts = {
           blocks: newBlocks,
           blockWidths,
           measures: newMeasures,
@@ -2777,7 +2770,7 @@ export function PagedEditor(
               values,
             );
             relayoutWithCurrentMeasures(layoutOptsUsed);
-            layoutArtifactsRef.current = {
+            layoutSessionRef.current.artifacts = {
               blocks: newBlocks,
               blockWidths,
               measures: newMeasures,
@@ -2920,7 +2913,7 @@ export function PagedEditor(
                 marginBottom: blockMeasureInputs.marginBottoms,
               },
             );
-            layoutArtifactsRef.current = {
+            layoutSessionRef.current.artifacts = {
               blocks: newBlocks,
               blockWidths,
               measures: newMeasures,
@@ -2936,9 +2929,9 @@ export function PagedEditor(
         }
 
         setLayout(newLayout);
-        lastLayoutEditorStateRef.current = state;
-        lastLaidOutPmDocRef.current = state.doc;
-        lastLayoutUsedLoadedFontsRef.current = documentFontsAreLoaded();
+        layoutSessionRef.current.lastEditorState = state;
+        layoutSessionRef.current.lastPmDoc = state.doc;
+        layoutSessionRef.current.usedLoadedFonts = documentFontsAreLoaded();
         recordLayoutComplete(reason);
         recordPhaseDuration("layout-document", phaseStartedAt);
 
@@ -6444,7 +6437,7 @@ export function PagedEditor(
       updateAnonymizationOverlay();
       updateDirectivesOverlay();
       if (fontsLoaded) {
-        lastLayoutUsedLoadedFontsRef.current = true;
+        layoutSessionRef.current.usedLoadedFonts = true;
         suppressFontReadyUntilRef.current =
           performance.now() + INITIAL_FONT_READY_SUPPRESSION_MS;
       }
@@ -6517,12 +6510,12 @@ export function PagedEditor(
         });
       };
 
-      if (lastLaidOutPmDocRef.current?.eq(view.state.doc)) {
+      if (layoutSessionRef.current.lastPmDoc?.eq(view.state.doc)) {
         // The doc is already laid out, but the painted pages may carry a
         // fill preview the fresh view's plugin no longer holds (or vice
         // versa) — the substituted values live in the flow blocks, so a
         // mismatch needs a pipeline re-run, not just overlay repaints.
-        const lastPreview = lastLaidOutTemplatePreviewRef.current;
+        const lastPreview = layoutSessionRef.current.lastTemplatePreview;
         if (
           templatePreviewRef.current.mode !== lastPreview.mode ||
           templatePreviewDirtyRange(
@@ -6565,7 +6558,7 @@ export function PagedEditor(
         clearAllCaches();
         runInitialLayout(currentView);
         if (fontsLoaded) {
-          lastLayoutUsedLoadedFontsRef.current = true;
+          layoutSessionRef.current.usedLoadedFonts = true;
           suppressFontReadyUntilRef.current =
             performance.now() + INITIAL_FONT_READY_SUPPRESSION_MS;
         }
@@ -6631,7 +6624,7 @@ export function PagedEditor(
 
         try {
           const positions = computeAnchorPositions(
-            lastLayoutEditorStateRef.current,
+            layoutSessionRef.current.lastEditorState,
             layout,
             blocks,
             measures,
@@ -6682,14 +6675,14 @@ export function PagedEditor(
       if (performance.now() < suppressFontReadyUntilRef.current) {
         return;
       }
-      lastLayoutUsedLoadedFontsRef.current = false;
+      layoutSessionRef.current.usedLoadedFonts = false;
     };
 
     const handleFontsLoaded = () => {
       if (
         pendingInitialFontReadyLayoutRef.current ||
         performance.now() < suppressFontReadyUntilRef.current ||
-        lastLayoutUsedLoadedFontsRef.current
+        layoutSessionRef.current.usedLoadedFonts
       ) {
         return;
       }
@@ -6735,7 +6728,7 @@ export function PagedEditor(
       lastLayoutInputSignatureRef.current = layoutInputSignature;
       if (
         !layoutInputsChanged &&
-        view.state.doc === lastLaidOutPmDocRef.current
+        view.state.doc === layoutSessionRef.current.lastPmDoc
       ) {
         return;
       }


### PR DESCRIPTION
Continues pulling folio's layout orchestration out of the `paged-editor` React adapter into the framework-agnostic `core/controller/`, after the hidden-editor controller and layout scheduler landed.

This first slice establishes the **LayoutSession** — the controller-owned incremental-layout memory — as one typed struct in `core/controller/layoutSession.ts`, replacing five loose `useRef`s in `PagedEditor` (previous artifacts, last editor state, last laid-out doc, loaded-fonts flag, last template preview). A ref-held mutable session has identical semantics to the separate refs, so there is no behavior change; it's the state the layout compute moves onto in the following slices.

Boundary-clean: the session's types come from `core` engine/document layers only; the one adapter-local constant (an empty template-preview list) is initialized in-place rather than imported, which is behaviorally identical (those entries are only ever content-diffed, never compared by identity).

Verified: typecheck, full folio suite (2464), format, and type-aware lint (incl. the layer-boundary rules) all green.

Follow-up slices on this branch: move the `runLayoutPipeline` compute stages onto the session, then compose the pieces into the `FolioEditor` controller (imperative API + events).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust pagination with incremental measuring plus automatic stabilisation of field widths, header/footer, and section-break margins.
  * Improved template preview and footnote handling during layout, with optional page painting support.
* **Bug Fixes**
  * Reduced layout inconsistencies when header/footer changes affect page margins.
  * Improved resilience: layout and paint outcomes are committed only when successful; failures are recorded without corrupting editor updates.
* **Tests**
  * Added coverage for the editor event system, layout pipeline commit/discard behaviour, scheduler coalescing, and dirty-range merging invariants.
* **Refactor**
  * Delegated layout execution to a shared pipeline using persistent session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->