### PR TITLE
refactor(folio): compose the FolioEditor controller (Seam 6)

### DIFF
--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -15,6 +15,7 @@ import type {
   SetContentControlContentInput,
   SetContentControlValueInput,
 } from "../core/content-controls";
+import type { FolioEditor } from "../core/controller/folioEditor";
 import type { DocxCompatibility } from "../core/docx/compatibility";
 import type { FolioSelectiveSaveFlags } from "../core/docx/selectiveSaveFlags";
 import type { TripwireResult } from "../core/docx/selectiveSaveTripwire";
@@ -281,6 +282,8 @@ export type DocxEditorRef = {
   hasPendingChanges: () => boolean;
   /** Get the editor ref */
   getEditorRef: () => PagedEditorRef | null;
+  /** The headless editor controller (Seam 6), or null before the editor mounts. */
+  getEditor: () => FolioEditor | null;
   /** Save the document to buffer. Pass { selective: false } to force full repack. */
   save: (options?: { selective?: boolean }) => Promise<ArrayBuffer | null>;
   /** Set zoom level */

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2718,6 +2718,7 @@ export function DocxEditor({
         );
       },
       getEditorRef: () => pagedEditorRef.current,
+      getEditor: () => pagedEditorRef.current?.getEditor() ?? null,
       save: handleSave,
       setZoom: setZoomWithViewportAnchor,
       getZoom: () => zoomRef.current,

--- a/packages/folio/src/core/controller/folioEditor.test.ts
+++ b/packages/folio/src/core/controller/folioEditor.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Command, EditorState, Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import type { Layout } from "../layout-engine/types";
+import type { Document } from "../types/document";
+import { createFolioEditor } from "./folioEditor";
+import { createFolioEditorEmitter } from "./folioEditorEvents";
+import type { HiddenEditorApi } from "./hiddenEditorApi";
+import type { LayoutRunOptions } from "./layoutScheduler";
+
+// Sentinels: opaque stand-ins for the heavy PM/layout objects. The controller
+// only forwards these through; it never inspects them, so a tagged object stands
+// in for the real type without constructing a real EditorState/Layout.
+/* oxlint-disable typescript/no-unsafe-type-assertion -- opaque test sentinels, forwarded only */
+const sentinelState = { sentinel: "state" } as unknown as EditorState;
+const sentinelView = { sentinel: "view" } as unknown as EditorView;
+const sentinelDocument = { sentinel: "document" } as unknown as Document;
+const sentinelLayout = { sentinel: "layout" } as unknown as Layout;
+const sentinelTr = { sentinel: "tr" } as unknown as Transaction;
+const sentinelCommand = { sentinel: "command" } as unknown as Command;
+/* oxlint-enable typescript/no-unsafe-type-assertion */
+
+type Call = { method: string; args: unknown[] };
+
+const createFakeApi = (): { api: HiddenEditorApi; calls: Call[] } => {
+  const calls: Call[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]): void => {
+      calls.push({ method, args });
+    };
+  const api: HiddenEditorApi = {
+    ensureView: record("ensureView"),
+    isViewRequested: () => {
+      calls.push({ method: "isViewRequested", args: [] });
+      return true;
+    },
+    getState: () => {
+      calls.push({ method: "getState", args: [] });
+      return sentinelState;
+    },
+    getView: () => {
+      calls.push({ method: "getView", args: [] });
+      return sentinelView;
+    },
+    getDocument: () => {
+      calls.push({ method: "getDocument", args: [] });
+      return sentinelDocument;
+    },
+    focus: record("focus"),
+    blur: record("blur"),
+    isFocused: () => {
+      calls.push({ method: "isFocused", args: [] });
+      return true;
+    },
+    dispatch: record("dispatch"),
+    executeCommand: (command) => {
+      calls.push({ method: "executeCommand", args: [command] });
+      return true;
+    },
+    undo: () => {
+      calls.push({ method: "undo", args: [] });
+      return true;
+    },
+    redo: () => {
+      calls.push({ method: "redo", args: [] });
+      return true;
+    },
+    canUndo: () => {
+      calls.push({ method: "canUndo", args: [] });
+      return true;
+    },
+    canRedo: () => {
+      calls.push({ method: "canRedo", args: [] });
+      return true;
+    },
+    setSelection: record("setSelection"),
+    setNodeSelection: record("setNodeSelection"),
+    setCellSelection: record("setCellSelection"),
+    scrollToSelection: record("scrollToSelection"),
+  };
+  return { api, calls };
+};
+
+describe("createFolioEditor", () => {
+  test("delegating methods forward args and return the underlying value", () => {
+    const { api, calls } = createFakeApi();
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => api,
+      getLayout: () => sentinelLayout,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    expect(editor.isViewRequested()).toBe(true);
+    expect(editor.getState()).toBe(sentinelState);
+    expect(editor.getView()).toBe(sentinelView);
+    expect(editor.getDocument()).toBe(sentinelDocument);
+    expect(editor.isFocused()).toBe(true);
+    expect(editor.executeCommand(sentinelCommand)).toBe(true);
+    expect(editor.undo()).toBe(true);
+    expect(editor.redo()).toBe(true);
+    expect(editor.canUndo()).toBe(true);
+    expect(editor.canRedo()).toBe(true);
+
+    editor.ensureView();
+    editor.focus();
+    editor.blur();
+    editor.dispatch(sentinelTr);
+    editor.setSelection(2, 5);
+    editor.setNodeSelection(7);
+    editor.setCellSelection(3, 9);
+    editor.scrollToSelection();
+
+    expect(calls).toContainEqual({ method: "ensureView", args: [] });
+    expect(calls).toContainEqual({ method: "dispatch", args: [sentinelTr] });
+    expect(calls).toContainEqual({ method: "setSelection", args: [2, 5] });
+    expect(calls).toContainEqual({ method: "setNodeSelection", args: [7] });
+    expect(calls).toContainEqual({ method: "setCellSelection", args: [3, 9] });
+    expect(calls).toContainEqual({
+      method: "executeCommand",
+      args: [sentinelCommand],
+    });
+  });
+
+  test("reads the editor api fresh on every call", () => {
+    let current: HiddenEditorApi | null = null;
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => current,
+      getLayout: () => null,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    expect(editor.getState()).toBeNull();
+
+    const { api } = createFakeApi();
+    current = api;
+    expect(editor.getState()).toBe(sentinelState);
+  });
+
+  test("getters yield documented defaults when there is no view", () => {
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => null,
+      getLayout: () => null,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    expect(editor.getState()).toBeNull();
+    expect(editor.getView()).toBeNull();
+    expect(editor.getDocument()).toBeNull();
+    expect(editor.isViewRequested()).toBe(false);
+    expect(editor.isFocused()).toBe(false);
+    expect(editor.executeCommand(sentinelCommand)).toBe(false);
+    expect(editor.undo()).toBe(false);
+    expect(editor.redo()).toBe(false);
+    expect(editor.canUndo()).toBe(false);
+    expect(editor.canRedo()).toBe(false);
+  });
+
+  test("void methods are no-ops when there is no view", () => {
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => null,
+      getLayout: () => null,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    expect(() => {
+      editor.ensureView();
+      editor.focus();
+      editor.blur();
+      editor.dispatch(sentinelTr);
+      editor.setSelection(0);
+      editor.setNodeSelection(0);
+      editor.setCellSelection(0, 1);
+      editor.scrollToSelection();
+    }).not.toThrow();
+  });
+
+  test("relayout runs layout for the current state with reason manual", () => {
+    const { api } = createFakeApi();
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => api,
+      getLayout: () => sentinelLayout,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    editor.relayout();
+
+    expect(runLayout).toHaveBeenCalledTimes(1);
+    expect(runLayout).toHaveBeenCalledWith(sentinelState, { reason: "manual" });
+  });
+
+  test("relayout is a no-op when there is no view", () => {
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => null,
+      getLayout: () => null,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    editor.relayout();
+
+    expect(runLayout).not.toHaveBeenCalled();
+  });
+
+  test("getLayout returns the dep's value", () => {
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => null,
+      getLayout: () => sentinelLayout,
+      runLayout,
+      emitter: createFolioEditorEmitter(),
+    });
+
+    expect(editor.getLayout()).toBe(sentinelLayout);
+  });
+
+  test("on subscribes through the emitter and the unsubscribe works", () => {
+    const emitter = createFolioEditorEmitter();
+    const runLayout = mock<(s: EditorState, o: LayoutRunOptions) => void>();
+    const editor = createFolioEditor({
+      getEditorApi: () => null,
+      getLayout: () => null,
+      runLayout,
+      emitter,
+    });
+
+    const seen: Document[] = [];
+    const unsubscribe = editor.on("docChange", (doc) => {
+      seen.push(doc);
+    });
+
+    emitter.emit("docChange", sentinelDocument);
+    expect(seen).toEqual([sentinelDocument]);
+
+    unsubscribe();
+    emitter.emit("docChange", sentinelDocument);
+    expect(seen).toEqual([sentinelDocument]);
+  });
+});

--- a/packages/folio/src/core/controller/folioEditor.ts
+++ b/packages/folio/src/core/controller/folioEditor.ts
@@ -78,5 +78,7 @@ export const createFolioEditor = (deps: FolioEditorDeps): FolioEditor => ({
     }
   },
 
-  on: deps.emitter.on,
+  // Wrap rather than tear off the method, so the contract holds for any emitter
+  // implementation (e.g. a class-based one whose `on` relies on `this`).
+  on: (event, listener) => deps.emitter.on(event, listener),
 });

--- a/packages/folio/src/core/controller/folioEditor.ts
+++ b/packages/folio/src/core/controller/folioEditor.ts
@@ -1,0 +1,82 @@
+// The composition half of the headless editor controller (seam-architecture
+// Seam 6: `FolioEditor`). Unifies the hidden-editor imperative API, layout
+// access, and the event emitter into one framework-agnostic object that
+// framework adapters and desktop/headless hosts drive. Kept in `core/` with no
+// React or `paged-editor/*` dependency so it stays portable across hosts.
+
+import type { EditorState } from "prosemirror-state";
+
+import type { Layout } from "../layout-engine/types";
+import type { FolioEditorEmitter } from "./folioEditorEvents";
+import type { HiddenEditorApi } from "./hiddenEditorApi";
+import type { LayoutRunOptions } from "./layoutScheduler";
+
+export type FolioEditorDeps = {
+  // The live hidden-editor API; null until the view exists (the adapter holds
+  // it in a ref), so it's read fresh on every call.
+  getEditorApi: () => HiddenEditorApi | null;
+  getLayout: () => Layout | null;
+  runLayout: (state: EditorState, options: LayoutRunOptions) => void;
+  emitter: FolioEditorEmitter;
+};
+
+// The headless controller surface (Seam 6). The HiddenEditorApi methods plus
+// layout access and event subscription.
+export type FolioEditor = HiddenEditorApi & {
+  getLayout: () => Layout | null;
+  /** Re-run layout for the current editor state (no-op if there is no view). */
+  relayout: () => void;
+  on: FolioEditorEmitter["on"];
+};
+
+export const createFolioEditor = (deps: FolioEditorDeps): FolioEditor => ({
+  ensureView: () => deps.getEditorApi()?.ensureView(),
+
+  isViewRequested: () => deps.getEditorApi()?.isViewRequested() ?? false,
+
+  getState: () => deps.getEditorApi()?.getState() ?? null,
+
+  getView: () => deps.getEditorApi()?.getView() ?? null,
+
+  getDocument: () => deps.getEditorApi()?.getDocument() ?? null,
+
+  focus: () => deps.getEditorApi()?.focus(),
+
+  blur: () => deps.getEditorApi()?.blur(),
+
+  isFocused: () => deps.getEditorApi()?.isFocused() ?? false,
+
+  dispatch: (tr) => deps.getEditorApi()?.dispatch(tr),
+
+  executeCommand: (command) =>
+    deps.getEditorApi()?.executeCommand(command) ?? false,
+
+  undo: () => deps.getEditorApi()?.undo() ?? false,
+
+  redo: () => deps.getEditorApi()?.redo() ?? false,
+
+  canUndo: () => deps.getEditorApi()?.canUndo() ?? false,
+
+  canRedo: () => deps.getEditorApi()?.canRedo() ?? false,
+
+  setSelection: (anchor, head) =>
+    deps.getEditorApi()?.setSelection(anchor, head),
+
+  setNodeSelection: (pos) => deps.getEditorApi()?.setNodeSelection(pos),
+
+  setCellSelection: (anchorCellPos, headCellPos) =>
+    deps.getEditorApi()?.setCellSelection(anchorCellPos, headCellPos),
+
+  scrollToSelection: () => deps.getEditorApi()?.scrollToSelection(),
+
+  getLayout: () => deps.getLayout(),
+
+  relayout: () => {
+    const state = deps.getEditorApi()?.getState();
+    if (state) {
+      deps.runLayout(state, { reason: "manual" });
+    }
+  },
+
+  on: deps.emitter.on,
+});

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -37,6 +37,9 @@ import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import type { AISuggestion } from "../core/ai-suggestions/types";
+import { createFolioEditor } from "../core/controller/folioEditor";
+import type { FolioEditor } from "../core/controller/folioEditor";
+import { createFolioEditorEmitter } from "../core/controller/folioEditorEvents";
 import { runLayoutPipeline as runLayoutPipelineCompute } from "../core/controller/layoutPipeline";
 import {
   browserClock,
@@ -2314,6 +2317,19 @@ export function PagedEditor(
   );
   const runLayoutPipelineRef = useRef(runLayoutPipeline);
   runLayoutPipelineRef.current = runLayoutPipeline;
+
+  const folioEmitterRef = useRef(createFolioEditorEmitter());
+  const folioEditorRef = useRef<FolioEditor | null>(null);
+  if (!folioEditorRef.current) {
+    folioEditorRef.current = createFolioEditor({
+      getEditorApi: () => hiddenPMRef.current,
+      getLayout: () => layoutRef.current,
+      runLayout: (state, options) =>
+        runLayoutPipelineRef.current(state, options),
+      emitter: folioEmitterRef.current,
+    });
+  }
+  const folioEditor = folioEditorRef.current;
 
   // =========================================================================
   // Coalesced Layout (rAF throttle)
@@ -5960,13 +5976,13 @@ export function PagedEditor(
     ref,
     () => ({
       getDocument() {
-        return hiddenPMRef.current?.getDocument() ?? null;
+        return folioEditor.getDocument();
       },
       getState() {
-        return hiddenPMRef.current?.getState() ?? null;
+        return folioEditor.getState();
       },
       getView() {
-        return hiddenPMRef.current?.getView() ?? null;
+        return folioEditor.getView();
       },
       getHfView(rId: string) {
         return hfPMsRef.current?.getView(rId) ?? null;
@@ -5981,42 +5997,39 @@ export function PagedEditor(
         ensureHiddenEditorView(options);
       },
       focus() {
-        hiddenPMRef.current?.focus();
+        folioEditor.focus();
         setIsFocused(true);
       },
       blur() {
-        hiddenPMRef.current?.blur();
+        folioEditor.blur();
         setIsFocused(false);
       },
       isFocused() {
-        return hiddenPMRef.current?.isFocused() ?? false;
+        return folioEditor.isFocused();
       },
       dispatch(tr: Transaction) {
-        hiddenPMRef.current?.dispatch(tr);
+        folioEditor.dispatch(tr);
       },
       undo() {
-        return hiddenPMRef.current?.undo() ?? false;
+        return folioEditor.undo();
       },
       redo() {
-        return hiddenPMRef.current?.redo() ?? false;
+        return folioEditor.redo();
       },
       canUndo() {
-        return hiddenPMRef.current?.canUndo() ?? false;
+        return folioEditor.canUndo();
       },
       canRedo() {
-        return hiddenPMRef.current?.canRedo() ?? false;
+        return folioEditor.canRedo();
       },
       setSelection(anchor: number, head?: number) {
-        hiddenPMRef.current?.setSelection(anchor, head);
+        folioEditor.setSelection(anchor, head);
       },
       getLayout() {
-        return layout;
+        return folioEditor.getLayout();
       },
       relayout() {
-        const state = hiddenPMRef.current?.getState();
-        if (state) {
-          runLayoutPipeline(state, { reason: "manual" });
-        }
+        folioEditor.relayout();
       },
       scrollToPosition: scrollToPositionImpl,
       scrollToPage: scrollToPageImpl,
@@ -6082,8 +6095,7 @@ export function PagedEditor(
     }),
     [
       ensureHiddenEditorView,
-      layout,
-      runLayoutPipeline,
+      folioEditor,
       scrollToPageImpl,
       scrollToPositionImpl,
     ],

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -331,6 +331,8 @@ export type PagedEditorProps = {
 };
 
 export type PagedEditorRef = {
+  /** The headless editor controller (imperative API + events; Seam 6). */
+  getEditor: () => FolioEditor;
   /** Get the current document. */
   getDocument: () => Document | null;
   /** Get the ProseMirror EditorState. */
@@ -5983,6 +5985,9 @@ export function PagedEditor(
   useImperativeHandle(
     ref,
     () => ({
+      getEditor() {
+        return folioEditor;
+      },
       getDocument() {
         return folioEditor.getDocument();
       },

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -1774,6 +1774,9 @@ export function PagedEditor(
   // Refs
   const containerRef = useRef<HTMLDivElement>(null);
   const pagesContainerRef = useRef<HTMLDivElement>(null);
+  // FolioEditor event emitter (Seam 6), declared early so the layout/selection/
+  // doc emission points below can publish to it.
+  const folioEmitterRef = useRef(createFolioEditorEmitter());
   const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
   const hfPMsRef = useRef<HiddenHeaderFooterPMsRef>(null);
   const painterRef = useRef<LayoutPainter | null>(null);
@@ -2283,6 +2286,9 @@ export function PagedEditor(
       if (outcome.blockLookup) {
         painterRef.current?.setBlockLookup(outcome.blockLookup);
       }
+      if (outcome.layout) {
+        folioEmitterRef.current.emit("layoutComplete", outcome.layout);
+      }
     },
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- hand-curated dep set; ref-held values are intentionally omitted
     [
@@ -2318,7 +2324,6 @@ export function PagedEditor(
   const runLayoutPipelineRef = useRef(runLayoutPipeline);
   runLayoutPipelineRef.current = runLayoutPipeline;
 
-  const folioEmitterRef = useRef(createFolioEditorEmitter());
   const folioEditorRef = useRef<FolioEditor | null>(null);
   if (!folioEditorRef.current) {
     folioEditorRef.current = createFolioEditor({
@@ -2359,6 +2364,7 @@ export function PagedEditor(
     const newDoc = hiddenPMRef.current?.getDocument();
     if (newDoc) {
       onDocumentChangeRef.current?.(newDoc);
+      folioEmitterRef.current.emit("docChange", newDoc);
     }
   }, []);
 
@@ -2534,6 +2540,7 @@ export function PagedEditor(
       // Always notify selection change (for toolbar sync) even if layout not ready
       // Use ref to avoid infinite loops when callback is unstable
       onSelectionChangeRef.current?.(from, to);
+      folioEmitterRef.current.emit("selectionChange", { from, to });
       // `onSelectionTextChange` carries the resolved text
       // alongside the range so consumers (anonymisation
       // term prefill, etc.) don't need to hold a reference
@@ -3349,6 +3356,7 @@ export function PagedEditor(
         // would freeze on the previous body selection while its actions
         // dispatch on the HF view.
         onSelectionChangeRef.current?.(from, to);
+        folioEmitterRef.current.emit("selectionChange", { from, to });
       }
     },
     [scheduleLayout, ensureHiddenEditorView],

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2289,6 +2289,11 @@ export function PagedEditor(
         painterRef.current?.setBlockLookup(outcome.blockLookup);
       }
       if (outcome.layout) {
+        // Publish to the ref before emitting so layoutComplete handlers that
+        // call folioEditor.getLayout() observe the layout that just completed
+        // (setLayout is async; the ref mirror otherwise only refreshes on the
+        // next render).
+        layoutRef.current = outcome.layout;
         folioEmitterRef.current.emit("layoutComplete", outcome.layout);
       }
     },


### PR DESCRIPTION
Final P4 slice: unify the extracted controller pieces (hidden-editor API, layout scheduler, layout session, layout pipeline) behind one headless `FolioEditor` — the imperative API + event surface that framework adapters and desktop/headless hosts drive (seam-architecture Seam 6). The React adapter becomes a thin wrapper over it.

Built in safe, additive slices:

1. **`createFolioEditor` factory** (this commit) — composes the hidden-editor imperative API (delegated null-safely), layout access (`getLayout`/`relayout`), and the event emitter into one `FolioEditor`. Framework-agnostic, standalone, unit-tested. No existing files touched.
2. *(next)* wire the emitter to its sources (`selectionChange`/`docChange`/`layoutComplete`), with the existing prop callbacks kept in parallel through the transition.
3. *(next)* route the adapter's imperative ref through the controller.
4. *(next)* expose it on the public `DocxEditor` surface.

Verified: typecheck, full folio suite, format, and type-aware lint all green.