### PR TITLE
refactor(folio): injectable chrome UI components (decouple from the app design system)

### DIFF
--- a/apps/web/src/components/docx/app-docx-editor.tsx
+++ b/apps/web/src/components/docx/app-docx-editor.tsx
@@ -1,0 +1,27 @@
+import type { Ref } from "react";
+
+import { DocxEditor as FolioDocxEditor } from "@stll/folio";
+import type { DocxEditorProps, DocxEditorRef } from "@stll/folio";
+
+import { folioUIComponents } from "@/lib/folio-ui-components";
+
+export type { DocxEditorProps, DocxEditorRef } from "@stll/folio";
+
+/**
+ * App-bound `DocxEditor`: folio's editor with the app's design-system chrome
+ * (`folioUIComponents`) pre-bound, so no render site can forget to inject the
+ * override. This is the single source of truth for the binding; app code should
+ * import `DocxEditor` from here rather than from `@stll/folio` directly. A
+ * caller may still override individual primitives by passing its own
+ * `components`, which take precedence over the shared override.
+ */
+export function DocxEditor(
+  props: DocxEditorProps & { ref?: Ref<DocxEditorRef> },
+) {
+  return (
+    <FolioDocxEditor
+      {...props}
+      components={{ ...folioUIComponents, ...props.components }}
+    />
+  );
+}

--- a/apps/web/src/components/markdown/markdown-folio-editor.impl.tsx
+++ b/apps/web/src/components/markdown/markdown-folio-editor.impl.tsx
@@ -16,6 +16,7 @@ import {
   useDocxFitZoom,
   useDocxWheelZoom,
 } from "@/components/docx-preview-zoom";
+import { folioUIComponents } from "@/lib/folio-ui-components";
 import { composeRefs } from "@/lib/slot";
 
 // Flatten Word constructs markdown can't carry so the emitted markdown stays
@@ -172,6 +173,7 @@ export function MarkdownFolioEditor({
     >
       <DocxEditor
         className="h-full"
+        components={folioUIComponents}
         document={doc}
         initialZoom={fitZoom}
         key={seed}

--- a/apps/web/src/components/markdown/markdown-folio-editor.impl.tsx
+++ b/apps/web/src/components/markdown/markdown-folio-editor.impl.tsx
@@ -5,8 +5,8 @@ import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 
 import "@stll/folio/editor.css";
-import { DocxEditor, fromMarkdown, toMarkdown } from "@stll/folio";
-import type { Document, DocxEditorRef, MarkdownOptions } from "@stll/folio";
+import { fromMarkdown, toMarkdown } from "@stll/folio";
+import type { Document, MarkdownOptions } from "@stll/folio";
 import { Button } from "@stll/ui/components/button";
 import { Textarea } from "@stll/ui/components/textarea";
 import { cn } from "@stll/ui/lib/utils";
@@ -16,7 +16,8 @@ import {
   useDocxFitZoom,
   useDocxWheelZoom,
 } from "@/components/docx-preview-zoom";
-import { folioUIComponents } from "@/lib/folio-ui-components";
+import { DocxEditor } from "@/components/docx/app-docx-editor";
+import type { DocxEditorRef } from "@/components/docx/app-docx-editor";
 import { composeRefs } from "@/lib/slot";
 
 // Flatten Word constructs markdown can't carry so the emitted markdown stays
@@ -173,7 +174,6 @@ export function MarkdownFolioEditor({
     >
       <DocxEditor
         className="h-full"
-        components={folioUIComponents}
         document={doc}
         initialZoom={fitZoom}
         key={seed}

--- a/apps/web/src/lib/folio-ui-components.ts
+++ b/apps/web/src/lib/folio-ui-components.ts
@@ -1,0 +1,12 @@
+import type { FolioUIComponents } from "@stll/folio";
+import { Button } from "@stll/ui/components/button";
+
+/**
+ * Chrome UI primitives injected into folio's `DocxEditor` so the editor keeps
+ * the app's design system while folio itself stays UI-agnostic. The object
+ * grows as folio decouples more primitives; render sites pass it once and need
+ * no further edits when the contract expands.
+ */
+export const folioUIComponents: Partial<FolioUIComponents> = {
+  Button,
+};

--- a/apps/web/src/lib/folio-ui-components.ts
+++ b/apps/web/src/lib/folio-ui-components.ts
@@ -1,12 +1,83 @@
 import type { FolioUIComponents } from "@stll/folio";
 import { Button } from "@stll/ui/components/button";
+import { Checkbox } from "@stll/ui/components/checkbox";
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogClose,
+  DialogPopup,
+  DialogPortal,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { Input } from "@stll/ui/components/input";
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuPopup,
+  MenuSeparator,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import {
+  Popover,
+  PopoverClose,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
 
 /**
  * Chrome UI primitives injected into folio's `DocxEditor` so the editor keeps
  * the app's design system while folio itself stays UI-agnostic. The object
  * grows as folio decouples more primitives; render sites pass it once and need
  * no further edits when the contract expands.
+ *
+ * Folio models compound primitives (Dialog, Select, Menu, Popover) as
+ * part-objects (`{ Root, Popup, … }`); the design system exports them as flat
+ * named components, so each compound entry is a small adapter mapping the flat
+ * exports onto the part shape.
  */
 export const folioUIComponents: Partial<FolioUIComponents> = {
   Button,
+  Checkbox,
+  Input,
+  Dialog: {
+    Root: Dialog,
+    Portal: DialogPortal,
+    Backdrop: DialogBackdrop,
+    Popup: DialogPopup,
+    Title: DialogTitle,
+    Close: DialogClose,
+  },
+  Select: {
+    Root: Select,
+    Trigger: SelectTrigger,
+    Value: SelectValue,
+    Popup: SelectPopup,
+    Item: SelectItem,
+  },
+  Menu: {
+    Root: Menu,
+    Trigger: MenuTrigger,
+    Popup: MenuPopup,
+    Item: MenuItem,
+    CheckboxItem: MenuCheckboxItem,
+    Group: MenuGroup,
+    GroupLabel: MenuGroupLabel,
+    Separator: MenuSeparator,
+  },
+  Popover: {
+    Root: Popover,
+    Trigger: PopoverTrigger,
+    Popup: PopoverPopup,
+    Close: PopoverClose,
+  },
 };

--- a/apps/web/src/lib/folio-ui-components.ts
+++ b/apps/web/src/lib/folio-ui-components.ts
@@ -1,6 +1,7 @@
 import type { FolioUIComponents } from "@stll/folio";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
+import { ColorPicker } from "@stll/ui/components/color-picker";
 import {
   Dialog,
   DialogBackdrop,
@@ -20,6 +21,7 @@ import {
   MenuSeparator,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { OutlineRail } from "@stll/ui/components/outline-rail";
 import {
   Popover,
   PopoverClose,
@@ -33,6 +35,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
+
+import { DatePickerPopover } from "@/components/date-picker-popover";
 
 /**
  * Chrome UI primitives injected into folio's `DocxEditor` so the editor keeps
@@ -49,6 +53,9 @@ export const folioUIComponents: Partial<FolioUIComponents> = {
   Button,
   Checkbox,
   Input,
+  ColorPicker,
+  DatePickerPopover,
+  OutlineRail,
   Dialog: {
     Root: Dialog,
     Portal: DialogPortal,

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -148,7 +148,6 @@ import {
   TOOLBAR_ROW_HEIGHT,
 } from "@/lib/consts";
 import { toAPIError, userErrorMessage } from "@/lib/errors";
-import { folioUIComponents } from "@/lib/folio-ui-components";
 import { toSafeId } from "@/lib/safe-id";
 import { inputTypeValueKind, VALUE_TYPE_META } from "@/lib/value-types";
 import {
@@ -201,7 +200,7 @@ import {
 } from "@/routes/_protected.knowledge/-queries";
 
 const DocxEditor = lazy(async () => {
-  const m = await import("@stll/folio");
+  const m = await import("@/components/docx/app-docx-editor");
   return { default: m.DocxEditor };
 });
 
@@ -2657,7 +2656,6 @@ export const TemplateStudioPage = ({
               ref={editorRef}
               autoOpenReviewSidebar={false}
               className="h-full"
-              components={folioUIComponents}
               documentBuffer={docBuffer}
               initialZoom={fitZoom}
               loadingIndicator={null}

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -148,6 +148,7 @@ import {
   TOOLBAR_ROW_HEIGHT,
 } from "@/lib/consts";
 import { toAPIError, userErrorMessage } from "@/lib/errors";
+import { folioUIComponents } from "@/lib/folio-ui-components";
 import { toSafeId } from "@/lib/safe-id";
 import { inputTypeValueKind, VALUE_TYPE_META } from "@/lib/value-types";
 import {
@@ -2656,6 +2657,7 @@ export const TemplateStudioPage = ({
               ref={editorRef}
               autoOpenReviewSidebar={false}
               className="h-full"
+              components={folioUIComponents}
               documentBuffer={docBuffer}
               initialZoom={fitZoom}
               loadingIndicator={null}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -78,7 +78,7 @@ import { PdfViewerControls } from "@/routes/_protected.workspaces/-components/pd
 import "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-docx.css";
 
 const ReadOnlyDocxViewer = lazy(async () => {
-  const m = await import("@stll/folio");
+  const m = await import("@/components/docx/app-docx-editor");
   return { default: m.DocxEditor };
 });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -1357,7 +1357,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
 
   useLayoutEffect(() => {
     const styleLabelElement = containerRef.current?.querySelector<HTMLElement>(
-      '[data-folio-style-picker] [data-slot="select-value"]',
+      '.folio-style-picker [data-slot="select-value"]',
     );
     if (!styleLabelElement) {
       return;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -25,7 +25,11 @@ import {
 import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
-import { FormattingBar, setAnonymizationTermsMeta } from "@stll/folio";
+import {
+  FolioUIProvider,
+  FormattingBar,
+  setAnonymizationTermsMeta,
+} from "@stll/folio";
 import type {
   AnonymizationTerm,
   DocxCompatibility,
@@ -45,21 +49,22 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useActiveDocxStore } from "@/components/ai-suggestions/active-docx-store";
 import type { ActiveDocxRegistrationToken } from "@/components/ai-suggestions/active-docx-store";
+import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";
 import "@stll/folio/editor.css";
 
-import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";
-import { DocxEditor } from "@/components/docx/app-docx-editor";
 import { useAutocompleteStream } from "@/components/autocomplete/use-autocomplete-stream";
 import {
   useDocxFitZoom,
   useDocxWheelZoom,
 } from "@/components/docx-preview-zoom";
+import { DocxEditor } from "@/components/docx/app-docx-editor";
 import { QuerySuspenseBoundary } from "@/components/query-suspense-boundary";
 import { StatusMessage } from "@/components/route-components";
 import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
+import { folioUIComponents } from "@/lib/folio-ui-components";
 import { composeRefs } from "@/lib/slot";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
@@ -1712,19 +1717,21 @@ const DocxLoadingToolbar = ({
 
   return (
     <div className="pointer-events-none z-50 flex shrink-0 flex-col gap-0 bg-[var(--doc-page)] [&_[data-slot=select-trigger]:focus-visible]:ring-0 [&_[data-slot=select-trigger]:hover]:!bg-transparent [&_[data-slot=select-trigger][data-pressed]]:!bg-transparent [&_button:active]:!bg-transparent [&_button:focus-visible]:ring-0 [&_button:hover]:!bg-transparent [&_button[data-pressed]]:!bg-transparent [&_button[data-pressed]]:shadow-none">
-      <FormattingBar
-        canRedo={false}
-        canUndo={false}
-        currentFormatting={{}}
-        onFormat={noop}
-        onRedo={noop}
-        onUndo={noop}
-        priorityExtra={<DocxLoadingPriorityExtra />}
-        stylePickerLabel={stylePickerLabel}
-        stylePickerLabelStyle={stylePickerLabelStyle}
-      >
-        {toolbarExtra}
-      </FormattingBar>
+      <FolioUIProvider components={folioUIComponents}>
+        <FormattingBar
+          canRedo={false}
+          canUndo={false}
+          currentFormatting={{}}
+          onFormat={noop}
+          onRedo={noop}
+          onUndo={noop}
+          priorityExtra={<DocxLoadingPriorityExtra />}
+          stylePickerLabel={stylePickerLabel}
+          stylePickerLabelStyle={stylePickerLabelStyle}
+        >
+          {toolbarExtra}
+        </FormattingBar>
+      </FolioUIProvider>
     </div>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -63,6 +63,7 @@ import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
+import { folioUIComponents } from "@/lib/folio-ui-components";
 import { composeRefs } from "@/lib/slot";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
@@ -1480,6 +1481,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             ref={editorRef}
             autoOpenReviewSidebar={false}
             className="folio-docx-preview folio-peek h-full"
+            components={folioUIComponents}
             documentBuffer={editorBuffer}
             documentKey={previewIdentity}
             initialZoom={targetZoom}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -25,11 +25,7 @@ import {
 import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
-import {
-  DocxEditor,
-  FormattingBar,
-  setAnonymizationTermsMeta,
-} from "@stll/folio";
+import { FormattingBar, setAnonymizationTermsMeta } from "@stll/folio";
 import type {
   AnonymizationTerm,
   DocxCompatibility,
@@ -52,6 +48,7 @@ import type { ActiveDocxRegistrationToken } from "@/components/ai-suggestions/ac
 import "@stll/folio/editor.css";
 
 import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";
+import { DocxEditor } from "@/components/docx/app-docx-editor";
 import { useAutocompleteStream } from "@/components/autocomplete/use-autocomplete-stream";
 import {
   useDocxFitZoom,
@@ -63,7 +60,6 @@ import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
-import { folioUIComponents } from "@/lib/folio-ui-components";
 import { composeRefs } from "@/lib/slot";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
@@ -1481,7 +1477,6 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             ref={editorRef}
             autoOpenReviewSidebar={false}
             className="folio-docx-preview folio-peek h-full"
-            components={folioUIComponents}
             documentBuffer={editorBuffer}
             documentKey={previewIdentity}
             initialZoom={targetZoom}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -39,6 +39,7 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { apiUrl } from "@/lib/api-url";
 import { DOCX_MIME } from "@/lib/consts";
 import { APIError } from "@/lib/errors";
+import { folioUIComponents } from "@/lib/folio-ui-components";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
@@ -505,6 +506,7 @@ const PeekDocxViewer = ({
         ref={editorRef}
         autoOpenReviewSidebar={false}
         className="folio-docx-preview folio-peek h-full"
+        components={folioUIComponents}
         documentBuffer={buffer}
         initialZoom={targetZoom}
         loadingIndicator={null}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -39,7 +39,6 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { apiUrl } from "@/lib/api-url";
 import { DOCX_MIME } from "@/lib/consts";
 import { APIError } from "@/lib/errors";
-import { folioUIComponents } from "@/lib/folio-ui-components";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
@@ -50,7 +49,7 @@ import { PageAnonymization } from "@/routes/_protected.workspaces/$workspaceId/-
 import { PageCitation } from "@/routes/_protected.workspaces/$workspaceId/-components/pdf/page-citation";
 
 const DocxEditor = lazy(async () => {
-  const m = await import("@stll/folio");
+  const m = await import("@/components/docx/app-docx-editor");
   return { default: m.DocxEditor };
 });
 
@@ -506,7 +505,6 @@ const PeekDocxViewer = ({
         ref={editorRef}
         autoOpenReviewSidebar={false}
         className="folio-docx-preview folio-peek h-full"
-        components={folioUIComponents}
         documentBuffer={buffer}
         initialZoom={targetZoom}
         loadingIndicator={null}

--- a/bun.lock
+++ b/bun.lock
@@ -448,7 +448,6 @@
         "@stll/docx-core": "workspace:*",
         "@stll/docx-utils": "workspace:*",
         "@stll/template-conditions": "workspace:*",
-        "@stll/ui": "workspace:*",
         "better-result": "catalog:",
         "csstype": "^3.1.3",
         "fast-xml-parser": "^5.9.3",

--- a/bun.lock
+++ b/bun.lock
@@ -438,6 +438,7 @@
       "name": "@stll/folio",
       "version": "0.1.0",
       "dependencies": {
+        "@base-ui/react": "catalog:",
         "@fontsource/arimo": "^5.2.8",
         "@fontsource/caladea": "^5.2.8",
         "@fontsource/carlito": "^5.2.8",

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -28,6 +28,7 @@
     "test:visual:report": "bunx playwright show-report"
   },
   "dependencies": {
+    "@base-ui/react": "catalog:",
     "@fontsource/arimo": "^5.2.8",
     "@fontsource/caladea": "^5.2.8",
     "@fontsource/carlito": "^5.2.8",

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -38,7 +38,6 @@
     "@stll/docx-core": "workspace:*",
     "@stll/docx-utils": "workspace:*",
     "@stll/template-conditions": "workspace:*",
-    "@stll/ui": "workspace:*",
     "better-result": "catalog:",
     "csstype": "^3.1.3",
     "fast-xml-parser": "^5.9.3",

--- a/packages/folio/src/components/CommentsSidebar.tsx
+++ b/packages/folio/src/components/CommentsSidebar.tsx
@@ -21,10 +21,9 @@ import React, {
 import { CheckIcon, MoreVerticalIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
 
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
-
 import type { Comment, Paragraph } from "../core/types/content";
 import { closestHtmlElement, queryHtmlElement } from "../core/utils/domGuards";
+import { containedHandler } from "../utils/contained-handler";
 
 /** Extract plain text from a Comment's paragraph content */
 function getCommentText(paragraphs?: Paragraph[]): string {

--- a/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
@@ -10,7 +10,7 @@
  * through `dispatchDropdownPick` / `dispatchDatePick` so the change rides
  * the normal undo stack.
  *
- * The dropdown popover uses `@stll/ui` `MenuItem` styling for visual + a11y
+ * The dropdown popover uses the injected `MenuItem` for visual + a11y
  * consistency with the rest of the editor.
  */
 
@@ -21,7 +21,6 @@ import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
-import { MenuItem } from "@stll/ui/components/menu";
 
 import {
   CONTENT_CONTROL_WIDGET_EVENT_NAME,
@@ -29,6 +28,7 @@ import {
   dispatchDropdownPick,
 } from "../core/prosemirror/plugins/contentControlWidgets";
 import type { ContentControlWidgetEvent } from "../core/prosemirror/plugins/contentControlWidgets";
+import { useFolioUI } from "../ui/folio-ui";
 
 type ListItem = { displayText: string; value: string };
 
@@ -87,6 +87,7 @@ type ContentControlWidgetsOverlayProps = {
 export function ContentControlWidgetsOverlay({
   getEditorView,
 }: ContentControlWidgetsOverlayProps) {
+  const { Item: MenuItem } = useFolioUI().Menu;
   const t = useTranslations("folio");
   const tCommon = useTranslations("common");
   const [open, setOpen] = useState<OpenPicker | null>(null);

--- a/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
@@ -20,8 +20,6 @@ import { createPortal } from "react-dom";
 import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
-import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
-
 import {
   CONTENT_CONTROL_WIDGET_EVENT_NAME,
   dispatchDatePick,
@@ -87,7 +85,9 @@ type ContentControlWidgetsOverlayProps = {
 export function ContentControlWidgetsOverlay({
   getEditorView,
 }: ContentControlWidgetsOverlayProps) {
-  const { Item: MenuItem } = useFolioUI().Menu;
+  const folioUI = useFolioUI();
+  const { Item: MenuItem } = folioUI.Menu;
+  const DatePickerPopover = folioUI.DatePickerPopover;
   const t = useTranslations("folio");
   const tCommon = useTranslations("common");
   const [open, setOpen] = useState<OpenPicker | null>(null);

--- a/packages/folio/src/components/DocumentOutline.tsx
+++ b/packages/folio/src/components/DocumentOutline.tsx
@@ -1,11 +1,12 @@
 /**
  * Document outline rail for the docx editor.
  *
- * Thin adapter over the shared `@stll/ui` OutlineRail: it supplies the
+ * Thin adapter over the injected OutlineRail chrome: it supplies the
  * editor-specific position source (heading PM position over the full document
  * size, since the paged editor virtualises pages) and active-heading detection
  * (walking the rendered anchors in the virtualisation buffer). The rail itself
- * — ticks, hover popover, collapsible tree — is shared with the rest of the app.
+ * — ticks, hover popover, collapsible tree — comes from the consumer's design
+ * system (or folio's minimal default).
  */
 
 import type React from "react";
@@ -18,13 +19,10 @@ import {
   useState,
 } from "react";
 
-import {
-  OutlineRail,
-  type OutlineItem,
-} from "@stll/ui/components/outline-rail";
-
 import { findBodyPmAnchors } from "../core/layout-bridge/findBodyPmSpans";
 import type { HeadingInfo } from "../core/utils/headingCollector";
+import { useFolioUI } from "../ui/folio-ui";
+import type { OutlineItem } from "../ui/folio-ui";
 
 export type DocumentOutlineProps = {
   headings: HeadingInfo[];
@@ -43,6 +41,7 @@ export const DocumentOutline: React.FC<DocumentOutlineProps> = ({
   docSize,
   onHeadingClick,
 }) => {
+  const OutlineRail = useFolioUI().OutlineRail;
   const [activeId, setActiveId] = useState<string | null>(null);
   // Suppress the scroll-driven active detector briefly after a click so the
   // in-flight smooth-scroll doesn't revert the highlight to the prior heading.

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -33,6 +33,7 @@ import type {
 } from "../core/types/document";
 import type { DocxInput } from "../core/utils/docxInput";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
+import type { FolioUIComponents } from "../ui/folio-ui";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
 // `EditorMode` is owned by `./hooks/useEditorMode`. Re-imported here for use
 // in `DocxEditorProps`; the canonical export is from the hook module.
@@ -130,6 +131,12 @@ export type DocxEditorProps = {
   readOnly?: boolean;
   /** Whether comments/tracked changes should auto-open the review sidebar (default: true) */
   autoOpenReviewSidebar?: boolean;
+  /**
+   * Override folio's built-in chrome UI primitives (Button, …) with a
+   * consumer's design-system components. Omitted entries fall back to folio's
+   * built-in defaults, so standalone folio works without any injection.
+   */
+  components?: Partial<FolioUIComponents>;
   /** Custom toolbar actions */
   toolbarExtra?: ReactNode;
   /** Additional CSS class name */

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2994,39 +2994,45 @@ export function DocxEditor({
     (!preserveDocumentWhileLoading || !history.state)
   ) {
     return (
-      <div
-        className={`folio-root folio-editor folio-editor-loading ${className}`}
-        style={containerStyle}
-        data-testid="folio-editor"
-      >
-        {loadingIndicator || <DefaultLoadingIndicator />}
-      </div>
+      <FolioUIProvider components={components}>
+        <div
+          className={`folio-root folio-editor folio-editor-loading ${className}`}
+          style={containerStyle}
+          data-testid="folio-editor"
+        >
+          {loadingIndicator || <DefaultLoadingIndicator />}
+        </div>
+      </FolioUIProvider>
     );
   }
 
   // Render error state
   if (state.documentLoad.status === "error") {
     return (
-      <div
-        className={`folio-root folio-editor folio-editor-error ${className}`}
-        style={containerStyle}
-        data-testid="folio-editor"
-      >
-        <ParseError message={state.documentLoad.message} />
-      </div>
+      <FolioUIProvider components={components}>
+        <div
+          className={`folio-root folio-editor folio-editor-error ${className}`}
+          style={containerStyle}
+          data-testid="folio-editor"
+        >
+          <ParseError message={state.documentLoad.message} />
+        </div>
+      </FolioUIProvider>
     );
   }
 
   // Render placeholder when no document
   if (!history.state) {
     return (
-      <div
-        className={`folio-root folio-editor folio-editor-empty ${className}`}
-        style={containerStyle}
-        data-testid="folio-editor"
-      >
-        {placeholder || <DefaultPlaceholder />}
-      </div>
+      <FolioUIProvider components={components}>
+        <div
+          className={`folio-root folio-editor folio-editor-empty ${className}`}
+          style={containerStyle}
+          data-testid="folio-editor"
+        >
+          {placeholder || <DefaultPlaceholder />}
+        </div>
+      </FolioUIProvider>
     );
   }
 

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -179,7 +179,7 @@ import { useDocumentHistory } from "../hooks/useHistory";
 import { useTableSelection } from "../hooks/useTableSelection";
 import { PagedEditor } from "../paged-editor/PagedEditor";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
-import { FolioUIProvider, useFolioUI } from "../ui/folio-ui";
+import { FolioUIProvider, DEFAULT_COMPONENTS } from "../ui/folio-ui";
 import { containedHandler } from "../utils/contained-handler";
 import { clampRangeToDocSize, resolveFolioAIBlockRange } from "./aiEditRange";
 import { resolveCommentCreationRange } from "./commentAnchors";
@@ -487,7 +487,10 @@ export function DocxEditor({
   onSelectiveSaveTripwire,
 }: DocxEditorProps & { ref?: Ref<DocxEditorRef> }) {
   const t = useTranslations("folio");
-  const { Button } = useFolioUI();
+  // DocxEditor renders FolioUIProvider itself, so it can't consume its own
+  // provider via useFolioUI() (that resolves to the default context). Resolve
+  // from the `components` prop directly, with the built-in default as fallback.
+  const Button = components?.Button ?? DEFAULT_COMPONENTS.Button;
 
   // State
   const [state, setState] = useState<EditorState>({

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -37,24 +37,6 @@ import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
 import {
-  Menu,
-  MenuCheckboxItem,
-  MenuGroup,
-  MenuGroupLabel,
-  MenuItem,
-  MenuPopup,
-  MenuSeparator,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import {
-  Select as StSelect,
-  SelectItem as StSelectItem,
-  SelectPopup as StSelectPopup,
-  SelectTrigger as StSelectTrigger,
-  SelectValue as StSelectValue,
-} from "@stll/ui/components/select";
-
-import {
   applyFolioAIEditOperations,
   createFolioAIEditSnapshot,
 } from "../core/ai-edits";
@@ -491,6 +473,23 @@ export function DocxEditor({
   // provider via useFolioUI() (that resolves to the default context). Resolve
   // from the `components` prop directly, with the built-in default as fallback.
   const Button = components?.Button ?? DEFAULT_COMPONENTS.Button;
+  const {
+    Root: Menu,
+    Trigger: MenuTrigger,
+    Popup: MenuPopup,
+    Item: MenuItem,
+    CheckboxItem: MenuCheckboxItem,
+    Group: MenuGroup,
+    GroupLabel: MenuGroupLabel,
+    Separator: MenuSeparator,
+  } = components?.Menu ?? DEFAULT_COMPONENTS.Menu;
+  const {
+    Root: StSelect,
+    Trigger: StSelectTrigger,
+    Value: StSelectValue,
+    Popup: StSelectPopup,
+    Item: StSelectItem,
+  } = components?.Select ?? DEFAULT_COMPONENTS.Select;
 
   // State
   const [state, setState] = useState<EditorState>({

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -36,7 +36,6 @@ import {
 import type { EditorView } from "prosemirror-view";
 import { useTranslations } from "use-intl";
 
-import { Button } from "@stll/ui/components/button";
 import {
   Menu,
   MenuCheckboxItem,
@@ -54,7 +53,6 @@ import {
   SelectTrigger as StSelectTrigger,
   SelectValue as StSelectValue,
 } from "@stll/ui/components/select";
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 
 import {
   applyFolioAIEditOperations,
@@ -181,6 +179,8 @@ import { useDocumentHistory } from "../hooks/useHistory";
 import { useTableSelection } from "../hooks/useTableSelection";
 import { PagedEditor } from "../paged-editor/PagedEditor";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
+import { FolioUIProvider, useFolioUI } from "../ui/folio-ui";
+import { containedHandler } from "../utils/contained-handler";
 import { clampRangeToDocSize, resolveFolioAIBlockRange } from "./aiEditRange";
 import { resolveCommentCreationRange } from "./commentAnchors";
 import {
@@ -454,6 +454,7 @@ export function DocxEditor({
   initialZoom = 1,
   readOnly: readOnlyProp = false,
   autoOpenReviewSidebar = true,
+  components,
   toolbarExtra,
   className = "",
   style,
@@ -486,6 +487,7 @@ export function DocxEditor({
   onSelectiveSaveTripwire,
 }: DocxEditorProps & { ref?: Ref<DocxEditorRef> }) {
   const t = useTranslations("folio");
+  const { Button } = useFolioUI();
 
   // State
   const [state, setState] = useState<EditorState>({
@@ -3303,699 +3305,704 @@ export function DocxEditor({
   );
 
   return (
-    <ErrorProvider>
-      <ErrorBoundary onError={handleEditorError}>
-        <div
-          ref={containerRef}
-          className={`folio-root folio-editor${displayMode !== "all-markup" ? ` folio-root--${displayMode}` : ""}${showHeaderFooterEditing ? "" : " folio-no-hf-edit"} ${className}`}
-          style={containerStyle}
-          data-testid="folio-editor"
-        >
-          {/* Main content area */}
-          <div style={mainContentStyle}>
-            {/* Wrapper for toolbar + scroll container + outline overlay */}
-            <div
-              style={{
-                position: "relative",
-                flex: 1,
-                minHeight: 0,
-                minWidth: 0,
-                display: "flex",
-                flexDirection: "column",
-              }}
-            >
-              {/* Toolbar - above the scroll container so scrollbar doesn't extend behind it */}
-              {/* Hide toolbar only when readOnly prop is explicitly set (not from viewing mode) */}
-              {showToolbar && !readOnlyProp && (
-                <div
-                  ref={toolbarRefCallback}
-                  className="z-50 flex flex-shrink-0 flex-col gap-0 bg-[var(--doc-page)]"
-                >
-                  <FormattingBar
-                    currentFormatting={state.selectionFormatting}
-                    onFormat={handleFormat}
-                    onUndo={undoActiveEditor}
-                    onRedo={redoActiveEditor}
-                    canUndo={
-                      hfEditPosition
-                        ? history.canUndo
-                        : bodyHistoryAvailability.canUndo
-                    }
-                    canRedo={
-                      hfEditPosition
-                        ? history.canRedo
-                        : bodyHistoryAvailability.canRedo
-                    }
-                    disabled={readOnly}
-                    theme={history.state.package.theme || theme || null}
-                    showZoomControl={showZoomControl}
-                    zoom={zoom}
-                    onZoomChange={setZoomWithViewportAnchor}
-                    editorRef={editorContentRef}
-                    onRefocusEditor={focusActiveEditor}
-                    onImageWrapType={handleImageWrapType}
-                    onImageTransform={handleImageTransform}
-                    onOpenImageProperties={handleOpenImageProperties}
-                    onTableAction={handleTableAction}
-                    priorityExtra={toolbarPriorityExtra}
-                    inlineExtra={toolbarInlineExtra}
-                    {...(history.state.package.styles?.styles
-                      ? {
-                          documentStyles: history.state.package.styles.styles,
-                        }
-                      : {})}
-                    {...(state.pmImageContext
-                      ? { imageContext: state.pmImageContext }
-                      : {})}
-                    {...(state.pmTableContext
-                      ? { tableContext: state.pmTableContext }
-                      : {})}
-                  >
-                    {toolbarChildren}
-                  </FormattingBar>
-                </div>
-              )}
-
-              {/* Editor container - this is the scroll container (toolbar is above, not inside) */}
+    <FolioUIProvider components={components}>
+      <ErrorProvider>
+        <ErrorBoundary onError={handleEditorError}>
+          <div
+            ref={containerRef}
+            className={`folio-root folio-editor${displayMode !== "all-markup" ? ` folio-root--${displayMode}` : ""}${showHeaderFooterEditing ? "" : " folio-no-hf-edit"} ${className}`}
+            style={containerStyle}
+            data-testid="folio-editor"
+          >
+            {/* Main content area */}
+            <div style={mainContentStyle}>
+              {/* Wrapper for toolbar + scroll container + outline overlay */}
               <div
-                ref={scrollContainerRef}
-                style={editorContainerStyle}
-                data-folio-scroll=""
-                onScroll={(event) => {
-                  onScrollTopChange?.(event.currentTarget.scrollTop);
-                  requestAnimationFrame(syncCommentHighlightStyles);
+                style={{
+                  position: "relative",
+                  flex: 1,
+                  minHeight: 0,
+                  minWidth: 0,
+                  display: "flex",
+                  flexDirection: "column",
                 }}
               >
-                {/* Editor content wrapper */}
+                {/* Toolbar - above the scroll container so scrollbar doesn't extend behind it */}
+                {/* Hide toolbar only when readOnly prop is explicitly set (not from viewing mode) */}
+                {showToolbar && !readOnlyProp && (
+                  <div
+                    ref={toolbarRefCallback}
+                    className="z-50 flex flex-shrink-0 flex-col gap-0 bg-[var(--doc-page)]"
+                  >
+                    <FormattingBar
+                      currentFormatting={state.selectionFormatting}
+                      onFormat={handleFormat}
+                      onUndo={undoActiveEditor}
+                      onRedo={redoActiveEditor}
+                      canUndo={
+                        hfEditPosition
+                          ? history.canUndo
+                          : bodyHistoryAvailability.canUndo
+                      }
+                      canRedo={
+                        hfEditPosition
+                          ? history.canRedo
+                          : bodyHistoryAvailability.canRedo
+                      }
+                      disabled={readOnly}
+                      theme={history.state.package.theme || theme || null}
+                      showZoomControl={showZoomControl}
+                      zoom={zoom}
+                      onZoomChange={setZoomWithViewportAnchor}
+                      editorRef={editorContentRef}
+                      onRefocusEditor={focusActiveEditor}
+                      onImageWrapType={handleImageWrapType}
+                      onImageTransform={handleImageTransform}
+                      onOpenImageProperties={handleOpenImageProperties}
+                      onTableAction={handleTableAction}
+                      priorityExtra={toolbarPriorityExtra}
+                      inlineExtra={toolbarInlineExtra}
+                      {...(history.state.package.styles?.styles
+                        ? {
+                            documentStyles: history.state.package.styles.styles,
+                          }
+                        : {})}
+                      {...(state.pmImageContext
+                        ? { imageContext: state.pmImageContext }
+                        : {})}
+                      {...(state.pmTableContext
+                        ? { tableContext: state.pmTableContext }
+                        : {})}
+                    >
+                      {toolbarChildren}
+                    </FormattingBar>
+                  </div>
+                )}
+
+                {/* Editor container - this is the scroll container (toolbar is above, not inside) */}
                 <div
-                  style={{
-                    display: "flex",
-                    flex: 1,
-                    minHeight: 0,
-                    position: "relative",
+                  ref={scrollContainerRef}
+                  style={editorContainerStyle}
+                  data-folio-scroll=""
+                  onScroll={(event) => {
+                    onScrollTopChange?.(event.currentTarget.scrollTop);
+                    requestAnimationFrame(syncCommentHighlightStyles);
                   }}
                 >
-                  {/* Editor content area */}
-                  {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions -- editor canvas; mouse handlers delegate focus to the child contenteditable, not an interactive control */}
+                  {/* Editor content wrapper */}
                   <div
-                    ref={editorContentRef}
-                    style={{ position: "relative", flex: 1, minWidth: 0 }}
-                    onMouseDown={containedHandler(editorContentRef, (e) => {
-                      // Focus editor when clicking on the background area (not the editor itself)
-                      // Using mouseDown for immediate response before focus can be lost
-                      if (e.target === e.currentTarget) {
-                        e.preventDefault();
-                        pagedEditorRef.current?.focus();
-                      }
-                    })}
-                    onContextMenu={handleEditorContextMenu}
+                    style={{
+                      display: "flex",
+                      flex: 1,
+                      minHeight: 0,
+                      position: "relative",
+                    }}
                   >
-                    <PagedEditor
-                      ref={pagedEditorRef}
-                      document={history.state}
-                      {...(documentKey !== undefined ? { documentKey } : {})}
-                      theme={history.state.package.theme || theme || null}
-                      sectionProperties={effectiveSectionProperties ?? null}
-                      headerContent={headerContent}
-                      footerContent={footerContent}
-                      firstPageHeaderContent={firstPageHeaderContent}
-                      firstPageFooterContent={firstPageFooterContent}
-                      headerContentRId={activeHeaderRId}
-                      footerContentRId={activeFooterRId}
-                      firstPageHeaderContentRId={activeFirstHeaderRId}
-                      firstPageFooterContentRId={activeFirstFooterRId}
-                      {...(history.state.package.styles
-                        ? { styles: history.state.package.styles }
-                        : {})}
-                      onHeaderFooterDoubleClick={
-                        showHeaderFooterEditing
-                          ? handleHeaderFooterDoubleClick
-                          : undefined
-                      }
-                      hfEditMode={hfEditPosition}
-                      onBodyClick={handleBodyClick}
-                      zoom={zoom}
-                      readOnly={readOnly}
-                      onDocumentChange={handleDocumentChange}
-                      extensionManager={extensionManager}
-                      {...(onReadonlyEditAttempt !== undefined
-                        ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
-                        : {})}
-                      onSelectionChange={(_from, _to) => {
-                        // Extract full selection state from whichever PM
-                        // is active. When the user is editing HF the
-                        // hfEditorRef delegates to the persistent hidden
-                        // HF view via pagedEditorRef.getHfView(activeRId);
-                        // reading body PM here would leave the toolbar
-                        // (FormattingBar, table / image context) showing
-                        // stale body-selection state while its actions
-                        // target the HF view (post-eigenpal#611).
-                        const view =
-                          getActiveEditorView() ??
-                          pagedEditorRef.current?.getView() ??
-                          null;
-                        if (view) {
-                          const selectionState = extractSelectionState(
-                            view.state,
-                          );
-                          handleSelectionChange(selectionState);
-                        } else {
-                          handleSelectionChange(null);
+                    {/* Editor content area */}
+                    {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions -- editor canvas; mouse handlers delegate focus to the child contenteditable, not an interactive control */}
+                    <div
+                      ref={editorContentRef}
+                      style={{ position: "relative", flex: 1, minWidth: 0 }}
+                      onMouseDown={containedHandler(editorContentRef, (e) => {
+                        // Focus editor when clicking on the background area (not the editor itself)
+                        // Using mouseDown for immediate response before focus can be lost
+                        if (e.target === e.currentTarget) {
+                          e.preventDefault();
+                          pagedEditorRef.current?.focus();
                         }
-                      }}
-                      {...(onSelectionTextChange !== undefined
-                        ? { onSelectionTextChange }
-                        : {})}
-                      {...(onEditorViewReady !== undefined
-                        ? { onEditorViewReady: reportEditorViewReady }
-                        : {})}
-                      externalPlugins={editorPlugins}
-                      showTemplateDirectives={showTemplateDirectives}
-                      {...(collaboration !== undefined
-                        ? { collaboration }
-                        : {})}
-                      onHyperlinkClick={handleHyperlinkClick}
-                      onContextMenu={handleContextMenu}
-                      commentsSidebarOpen={showCommentsSidebar}
-                      anchorPositionMode="comments"
-                      onAnonymizationTermClick={onAnonymizationTermClick}
-                      selectedAnonymizationCanonical={
-                        selectedAnonymizationCanonical
-                      }
-                      anonymizationSelectionSeq={anonymizationSelectionSeq}
-                      {...(showCommentsSidebar
-                        ? { onAnchorPositionsChange: setAnchorPositions }
-                        : {})}
-                      onTotalPagesChange={(totalPages) => {
-                        setScrollPageInfo((previous) =>
-                          updateScrollPageTotal(previous, totalPages),
-                        );
-                      }}
-                      scrollContainerRef={scrollContainerRef}
-                      sidebarOverlay={(() => {
-                        if (showCommentsSidebar) {
-                          return (
-                            <Suspense fallback={null}>
-                              <CommentsSidebar
-                                activeCommentId={activeCommentId}
-                                comments={visibleComments}
-                                anchorPositions={anchorPositions}
-                                pageWidth={(() => {
-                                  const sp =
-                                    history.state.package.document
-                                      .finalSectionProperties;
-                                  return sp?.pageWidth
-                                    ? Math.round(sp.pageWidth / 15)
-                                    : 816;
-                                })()}
-                                editorContainerRef={scrollContainerRef}
-                                onCommentClick={(id) => {
-                                  setActiveCommentId(id);
-                                }}
-                                onCommentResolve={(id) => {
-                                  updateComments((prev) =>
-                                    prev.map((c) =>
-                                      c.id === id
-                                        ? {
-                                            ...c,
-                                            done: true,
-                                          }
-                                        : c,
-                                    ),
-                                  );
-                                }}
-                                onCommentDelete={(id) => {
-                                  updateComments((prev) =>
-                                    prev.filter(
-                                      (c) => c.id !== id && c.parentId !== id,
-                                    ),
-                                  );
-                                  if (activeCommentId === id) {
-                                    setActiveCommentId(null);
-                                  }
-                                }}
-                                onCommentReply={(id, text) => {
-                                  updateComments((prev) => [
-                                    ...prev,
-                                    createComment(text, author, id),
-                                  ]);
-                                }}
-                                onAddComment={(addText) => {
-                                  const comment = createComment(
-                                    addText,
-                                    author,
-                                  );
-                                  // Replace pending comment mark with the real comment ID
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (!view || !commentSelectionRange) {
-                                    return false;
-                                  }
-                                  const marked = applyCommentMarkRange(
-                                    view,
-                                    commentSelectionRange,
-                                    comment.id,
-                                    {
-                                      replacePending: true,
-                                    },
-                                  );
-                                  if (!marked) {
-                                    return false;
-                                  }
-                                  const commentAuthor = getCommentAuthorKey(
-                                    comment.author,
-                                  );
-                                  setVisibleCommentAuthors((current) => {
-                                    if (current === null) {
-                                      return null;
-                                    }
-                                    const next = new Set(current);
-                                    next.add(commentAuthor);
-                                    return next;
-                                  });
-                                  setActiveCommentId(comment.id);
-                                  updateComments((prev) => [...prev, comment]);
-                                  pagedEditorRef.current?.relayout();
-                                  requestAnimationFrame(() => {
-                                    syncCommentHighlightStyles();
-                                    requestAnimationFrame(
-                                      syncCommentHighlightStyles,
+                      })}
+                      onContextMenu={handleEditorContextMenu}
+                    >
+                      <PagedEditor
+                        ref={pagedEditorRef}
+                        document={history.state}
+                        {...(documentKey !== undefined ? { documentKey } : {})}
+                        theme={history.state.package.theme || theme || null}
+                        sectionProperties={effectiveSectionProperties ?? null}
+                        headerContent={headerContent}
+                        footerContent={footerContent}
+                        firstPageHeaderContent={firstPageHeaderContent}
+                        firstPageFooterContent={firstPageFooterContent}
+                        headerContentRId={activeHeaderRId}
+                        footerContentRId={activeFooterRId}
+                        firstPageHeaderContentRId={activeFirstHeaderRId}
+                        firstPageFooterContentRId={activeFirstFooterRId}
+                        {...(history.state.package.styles
+                          ? { styles: history.state.package.styles }
+                          : {})}
+                        onHeaderFooterDoubleClick={
+                          showHeaderFooterEditing
+                            ? handleHeaderFooterDoubleClick
+                            : undefined
+                        }
+                        hfEditMode={hfEditPosition}
+                        onBodyClick={handleBodyClick}
+                        zoom={zoom}
+                        readOnly={readOnly}
+                        onDocumentChange={handleDocumentChange}
+                        extensionManager={extensionManager}
+                        {...(onReadonlyEditAttempt !== undefined
+                          ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
+                          : {})}
+                        onSelectionChange={(_from, _to) => {
+                          // Extract full selection state from whichever PM
+                          // is active. When the user is editing HF the
+                          // hfEditorRef delegates to the persistent hidden
+                          // HF view via pagedEditorRef.getHfView(activeRId);
+                          // reading body PM here would leave the toolbar
+                          // (FormattingBar, table / image context) showing
+                          // stale body-selection state while its actions
+                          // target the HF view (post-eigenpal#611).
+                          const view =
+                            getActiveEditorView() ??
+                            pagedEditorRef.current?.getView() ??
+                            null;
+                          if (view) {
+                            const selectionState = extractSelectionState(
+                              view.state,
+                            );
+                            handleSelectionChange(selectionState);
+                          } else {
+                            handleSelectionChange(null);
+                          }
+                        }}
+                        {...(onSelectionTextChange !== undefined
+                          ? { onSelectionTextChange }
+                          : {})}
+                        {...(onEditorViewReady !== undefined
+                          ? { onEditorViewReady: reportEditorViewReady }
+                          : {})}
+                        externalPlugins={editorPlugins}
+                        showTemplateDirectives={showTemplateDirectives}
+                        {...(collaboration !== undefined
+                          ? { collaboration }
+                          : {})}
+                        onHyperlinkClick={handleHyperlinkClick}
+                        onContextMenu={handleContextMenu}
+                        commentsSidebarOpen={showCommentsSidebar}
+                        anchorPositionMode="comments"
+                        onAnonymizationTermClick={onAnonymizationTermClick}
+                        selectedAnonymizationCanonical={
+                          selectedAnonymizationCanonical
+                        }
+                        anonymizationSelectionSeq={anonymizationSelectionSeq}
+                        {...(showCommentsSidebar
+                          ? { onAnchorPositionsChange: setAnchorPositions }
+                          : {})}
+                        onTotalPagesChange={(totalPages) => {
+                          setScrollPageInfo((previous) =>
+                            updateScrollPageTotal(previous, totalPages),
+                          );
+                        }}
+                        scrollContainerRef={scrollContainerRef}
+                        sidebarOverlay={(() => {
+                          if (showCommentsSidebar) {
+                            return (
+                              <Suspense fallback={null}>
+                                <CommentsSidebar
+                                  activeCommentId={activeCommentId}
+                                  comments={visibleComments}
+                                  anchorPositions={anchorPositions}
+                                  pageWidth={(() => {
+                                    const sp =
+                                      history.state.package.document
+                                        .finalSectionProperties;
+                                    return sp?.pageWidth
+                                      ? Math.round(sp.pageWidth / 15)
+                                      : 816;
+                                  })()}
+                                  editorContainerRef={scrollContainerRef}
+                                  onCommentClick={(id) => {
+                                    setActiveCommentId(id);
+                                  }}
+                                  onCommentResolve={(id) => {
+                                    updateComments((prev) =>
+                                      prev.map((c) =>
+                                        c.id === id
+                                          ? {
+                                              ...c,
+                                              done: true,
+                                            }
+                                          : c,
+                                      ),
                                     );
-                                  });
-                                  setIsAddingComment(false);
-                                  setCommentSelectionRange(null);
-                                  setAddCommentYPosition(null);
-                                  return true;
-                                }}
-                                onTrackedChangeReply={(revisionId, text) => {
-                                  updateComments((prev) => [
-                                    ...prev,
-                                    createComment(text, author, revisionId),
-                                  ]);
-                                }}
-                                onCancelAddComment={() => {
-                                  // Remove pending comment highlight
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (view && commentSelectionRange) {
-                                    removePendingCommentMarkRange(
+                                  }}
+                                  onCommentDelete={(id) => {
+                                    updateComments((prev) =>
+                                      prev.filter(
+                                        (c) => c.id !== id && c.parentId !== id,
+                                      ),
+                                    );
+                                    if (activeCommentId === id) {
+                                      setActiveCommentId(null);
+                                    }
+                                  }}
+                                  onCommentReply={(id, text) => {
+                                    updateComments((prev) => [
+                                      ...prev,
+                                      createComment(text, author, id),
+                                    ]);
+                                  }}
+                                  onAddComment={(addText) => {
+                                    const comment = createComment(
+                                      addText,
+                                      author,
+                                    );
+                                    // Replace pending comment mark with the real comment ID
+                                    const view =
+                                      pagedEditorRef.current?.getView();
+                                    if (!view || !commentSelectionRange) {
+                                      return false;
+                                    }
+                                    const marked = applyCommentMarkRange(
                                       view,
                                       commentSelectionRange,
+                                      comment.id,
+                                      {
+                                        replacePending: true,
+                                      },
                                     );
-                                  }
-                                  setIsAddingComment(false);
-                                  setCommentSelectionRange(null);
-                                  setAddCommentYPosition(null);
-                                }}
-                                onAcceptChange={(from, to) => {
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (view) {
-                                    acceptChange(from, to)(
-                                      view.state,
-                                      view.dispatch,
+                                    if (!marked) {
+                                      return false;
+                                    }
+                                    const commentAuthor = getCommentAuthorKey(
+                                      comment.author,
                                     );
-                                    extractTrackedChanges();
-                                  }
-                                }}
-                                onRejectChange={(from, to) => {
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (view) {
-                                    rejectChange(from, to)(
-                                      view.state,
-                                      view.dispatch,
-                                    );
-                                    extractTrackedChanges();
-                                  }
-                                }}
-                                isAddingComment={isAddingComment}
-                                addCommentYPosition={addCommentYPosition}
-                                topOffset={0}
-                              />
-                            </Suspense>
-                          );
-                        }
-                        return undefined;
-                      })()}
-                    />
+                                    setVisibleCommentAuthors((current) => {
+                                      if (current === null) {
+                                        return null;
+                                      }
+                                      const next = new Set(current);
+                                      next.add(commentAuthor);
+                                      return next;
+                                    });
+                                    setActiveCommentId(comment.id);
+                                    updateComments((prev) => [
+                                      ...prev,
+                                      comment,
+                                    ]);
+                                    pagedEditorRef.current?.relayout();
+                                    requestAnimationFrame(() => {
+                                      syncCommentHighlightStyles();
+                                      requestAnimationFrame(
+                                        syncCommentHighlightStyles,
+                                      );
+                                    });
+                                    setIsAddingComment(false);
+                                    setCommentSelectionRange(null);
+                                    setAddCommentYPosition(null);
+                                    return true;
+                                  }}
+                                  onTrackedChangeReply={(revisionId, text) => {
+                                    updateComments((prev) => [
+                                      ...prev,
+                                      createComment(text, author, revisionId),
+                                    ]);
+                                  }}
+                                  onCancelAddComment={() => {
+                                    // Remove pending comment highlight
+                                    const view =
+                                      pagedEditorRef.current?.getView();
+                                    if (view && commentSelectionRange) {
+                                      removePendingCommentMarkRange(
+                                        view,
+                                        commentSelectionRange,
+                                      );
+                                    }
+                                    setIsAddingComment(false);
+                                    setCommentSelectionRange(null);
+                                    setAddCommentYPosition(null);
+                                  }}
+                                  onAcceptChange={(from, to) => {
+                                    const view =
+                                      pagedEditorRef.current?.getView();
+                                    if (view) {
+                                      acceptChange(from, to)(
+                                        view.state,
+                                        view.dispatch,
+                                      );
+                                      extractTrackedChanges();
+                                    }
+                                  }}
+                                  onRejectChange={(from, to) => {
+                                    const view =
+                                      pagedEditorRef.current?.getView();
+                                    if (view) {
+                                      rejectChange(from, to)(
+                                        view.state,
+                                        view.dispatch,
+                                      );
+                                      extractTrackedChanges();
+                                    }
+                                  }}
+                                  isAddingComment={isAddingComment}
+                                  addCommentYPosition={addCommentYPosition}
+                                  topOffset={0}
+                                />
+                              </Suspense>
+                            );
+                          }
+                          return undefined;
+                        })()}
+                      />
 
-                    {/* Floating "add comment" button — appears on right edge of page at selection */}
-                    {floatingCommentBtn !== null &&
-                      !isAddingComment &&
-                      !readOnly && (
-                        <Tooltip
-                          content="Add comment"
-                          side="bottom"
-                          delayMs={300}
-                        >
-                          <button
-                            type="button"
-                            onMouseDown={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              const view = pagedEditorRef.current?.getView();
-                              if (!view) {
-                                setFloatingCommentBtn(null);
-                                return;
-                              }
-                              const capturedRange = {
-                                from: floatingCommentBtn.from,
-                                to: floatingCommentBtn.to,
-                              };
-                              const currentSelection = view.state.selection;
-                              const safeRange = resolveCommentCreationRange({
-                                docSize: view.state.doc.content.size,
-                                capturedRange,
-                                currentRange: {
-                                  from: currentSelection.from,
-                                  to: currentSelection.to,
-                                },
-                                savedRange: lastSelectionRef.current,
-                              });
-                              if (!safeRange) {
-                                setCommentSelectionRange(null);
-                                setFloatingCommentBtn(null);
-                                return;
-                              }
-                              setCommentSelectionRange(safeRange);
-                              const marked = applyCommentMarkRange(
-                                view,
-                                safeRange,
-                                PENDING_COMMENT_ID,
-                                { selectEnd: true },
-                              );
-                              if (!marked) {
-                                setCommentSelectionRange(null);
-                                setFloatingCommentBtn(null);
-                                return;
-                              }
-                              const yPos = findSelectionYPosition(
-                                scrollContainerRef.current,
-                                editorContentRef.current,
-                                safeRange.from,
-                              );
-                              setAddCommentYPosition(
-                                yPos ?? floatingCommentBtn.top,
-                              );
-                              setShowCommentsSidebar(true);
-                              setIsAddingComment(true);
-                              setFloatingCommentBtn(null);
-                            }}
-                            style={{
-                              position: "absolute",
-                              top: floatingCommentBtn.top,
-                              left: floatingCommentBtn.left,
-                              transform: "translate(-50%, -50%)",
-                              zIndex: 50,
-                              width: 28,
-                              height: 28,
-                              borderRadius: 6,
-                              border: "1px solid var(--doc-border)",
-                              backgroundColor: "var(--doc-page)",
-                              color: "var(--doc-text-muted)",
-                              cursor: "pointer",
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              boxShadow: "0 2px 8px var(--doc-border)",
-                              transition:
-                                "background-color 0.15s, box-shadow 0.15s",
-                            }}
-                            onMouseOver={(e) => {
-                              (
-                                e.currentTarget as HTMLButtonElement
-                              ).style.backgroundColor =
-                                "rgba(26, 115, 232, 0.08)";
-                              (
-                                e.currentTarget as HTMLButtonElement
-                              ).style.boxShadow =
-                                "0 1px 4px rgba(26, 115, 232, 0.3)";
-                            }}
-                            onFocus={(e) => {
-                              (
-                                e.currentTarget as HTMLButtonElement
-                              ).style.backgroundColor =
-                                "rgba(26, 115, 232, 0.08)";
-                            }}
-                            onMouseOut={(e) => {
-                              (
-                                e.currentTarget as HTMLButtonElement
-                              ).style.backgroundColor =
-                                "var(--doc-canvas, #fff)";
-                              (
-                                e.currentTarget as HTMLButtonElement
-                              ).style.boxShadow =
-                                "0 1px 3px rgba(60,64,67,0.2)";
-                            }}
-                            onBlur={(e) => {
-                              (
-                                e.currentTarget as HTMLButtonElement
-                              ).style.backgroundColor =
-                                "var(--doc-canvas, #fff)";
-                            }}
+                      {/* Floating "add comment" button — appears on right edge of page at selection */}
+                      {floatingCommentBtn !== null &&
+                        !isAddingComment &&
+                        !readOnly && (
+                          <Tooltip
+                            content="Add comment"
+                            side="bottom"
+                            delayMs={300}
                           >
-                            <SquarePenIcon size={16} />
-                          </button>
-                        </Tooltip>
-                      )}
+                            <button
+                              type="button"
+                              onMouseDown={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                const view = pagedEditorRef.current?.getView();
+                                if (!view) {
+                                  setFloatingCommentBtn(null);
+                                  return;
+                                }
+                                const capturedRange = {
+                                  from: floatingCommentBtn.from,
+                                  to: floatingCommentBtn.to,
+                                };
+                                const currentSelection = view.state.selection;
+                                const safeRange = resolveCommentCreationRange({
+                                  docSize: view.state.doc.content.size,
+                                  capturedRange,
+                                  currentRange: {
+                                    from: currentSelection.from,
+                                    to: currentSelection.to,
+                                  },
+                                  savedRange: lastSelectionRef.current,
+                                });
+                                if (!safeRange) {
+                                  setCommentSelectionRange(null);
+                                  setFloatingCommentBtn(null);
+                                  return;
+                                }
+                                setCommentSelectionRange(safeRange);
+                                const marked = applyCommentMarkRange(
+                                  view,
+                                  safeRange,
+                                  PENDING_COMMENT_ID,
+                                  { selectEnd: true },
+                                );
+                                if (!marked) {
+                                  setCommentSelectionRange(null);
+                                  setFloatingCommentBtn(null);
+                                  return;
+                                }
+                                const yPos = findSelectionYPosition(
+                                  scrollContainerRef.current,
+                                  editorContentRef.current,
+                                  safeRange.from,
+                                );
+                                setAddCommentYPosition(
+                                  yPos ?? floatingCommentBtn.top,
+                                );
+                                setShowCommentsSidebar(true);
+                                setIsAddingComment(true);
+                                setFloatingCommentBtn(null);
+                              }}
+                              style={{
+                                position: "absolute",
+                                top: floatingCommentBtn.top,
+                                left: floatingCommentBtn.left,
+                                transform: "translate(-50%, -50%)",
+                                zIndex: 50,
+                                width: 28,
+                                height: 28,
+                                borderRadius: 6,
+                                border: "1px solid var(--doc-border)",
+                                backgroundColor: "var(--doc-page)",
+                                color: "var(--doc-text-muted)",
+                                cursor: "pointer",
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                boxShadow: "0 2px 8px var(--doc-border)",
+                                transition:
+                                  "background-color 0.15s, box-shadow 0.15s",
+                              }}
+                              onMouseOver={(e) => {
+                                (
+                                  e.currentTarget as HTMLButtonElement
+                                ).style.backgroundColor =
+                                  "rgba(26, 115, 232, 0.08)";
+                                (
+                                  e.currentTarget as HTMLButtonElement
+                                ).style.boxShadow =
+                                  "0 1px 4px rgba(26, 115, 232, 0.3)";
+                              }}
+                              onFocus={(e) => {
+                                (
+                                  e.currentTarget as HTMLButtonElement
+                                ).style.backgroundColor =
+                                  "rgba(26, 115, 232, 0.08)";
+                              }}
+                              onMouseOut={(e) => {
+                                (
+                                  e.currentTarget as HTMLButtonElement
+                                ).style.backgroundColor =
+                                  "var(--doc-canvas, #fff)";
+                                (
+                                  e.currentTarget as HTMLButtonElement
+                                ).style.boxShadow =
+                                  "0 1px 3px rgba(60,64,67,0.2)";
+                              }}
+                              onBlur={(e) => {
+                                (
+                                  e.currentTarget as HTMLButtonElement
+                                ).style.backgroundColor =
+                                  "var(--doc-canvas, #fff)";
+                              }}
+                            >
+                              <SquarePenIcon size={16} />
+                            </button>
+                          </Tooltip>
+                        )}
 
-                    {/* Inline Header/Footer Editor — positioned over the target area */}
-                    {hfEditPosition &&
-                      (() => {
-                        const activeHf = (() => {
-                          if (hfEditIsFirstPage) {
-                            return (() => {
-                              if (hfEditPosition === "header") {
-                                return firstPageHeaderContent;
-                              }
-                              return firstPageFooterContent;
-                            })();
+                      {/* Inline Header/Footer Editor — positioned over the target area */}
+                      {hfEditPosition &&
+                        (() => {
+                          const activeHf = (() => {
+                            if (hfEditIsFirstPage) {
+                              return (() => {
+                                if (hfEditPosition === "header") {
+                                  return firstPageHeaderContent;
+                                }
+                                return firstPageFooterContent;
+                              })();
+                            }
+                            if (hfEditPosition === "header") {
+                              return headerContent;
+                            }
+                            return footerContent;
+                          })();
+                          if (!activeHf) {
+                            return null;
                           }
-                          if (hfEditPosition === "header") {
-                            return headerContent;
+                          const targetEl = getHfTargetElement(hfEditPosition);
+                          const parentEl = editorContentRef.current;
+                          if (!targetEl || !parentEl) {
+                            return null;
                           }
-                          return footerContent;
-                        })();
-                        if (!activeHf) {
-                          return null;
-                        }
-                        const targetEl = getHfTargetElement(hfEditPosition);
-                        const parentEl = editorContentRef.current;
-                        if (!targetEl || !parentEl) {
-                          return null;
-                        }
-                        // Resolve the active HF rId for this edit session;
-                        // the chrome delegates getView/focus/undo/redo to the
-                        // persistent hidden HF EditorView mounted by
-                        // HiddenHeaderFooterPMs (post-eigenpal#611). The
-                        // inline overlay no longer mounts its own visible PM.
-                        const activeRId = (() => {
-                          if (hfEditIsFirstPage) {
+                          // Resolve the active HF rId for this edit session;
+                          // the chrome delegates getView/focus/undo/redo to the
+                          // persistent hidden HF EditorView mounted by
+                          // HiddenHeaderFooterPMs (post-eigenpal#611). The
+                          // inline overlay no longer mounts its own visible PM.
+                          const activeRId = (() => {
+                            if (hfEditIsFirstPage) {
+                              return hfEditPosition === "header"
+                                ? activeFirstHeaderRId
+                                : activeFirstFooterRId;
+                            }
                             return hfEditPosition === "header"
-                              ? activeFirstHeaderRId
-                              : activeFirstFooterRId;
-                          }
-                          return hfEditPosition === "header"
-                            ? activeHeaderRId
-                            : activeFooterRId;
-                        })();
-                        const getActiveView = () =>
-                          activeRId
-                            ? (pagedEditorRef.current?.getHfView(activeRId) ??
-                              null)
-                            : null;
-                        return (
-                          <InlineHeaderFooterEditor
-                            ref={hfEditorRef}
-                            position={hfEditPosition}
-                            targetElement={targetEl}
-                            parentElement={parentEl}
-                            getActiveView={getActiveView}
-                            onClose={handleBodyClick}
-                            onRemove={handleRemoveHeaderFooter}
-                          />
-                        );
-                      })()}
+                              ? activeHeaderRId
+                              : activeFooterRId;
+                          })();
+                          const getActiveView = () =>
+                            activeRId
+                              ? (pagedEditorRef.current?.getHfView(activeRId) ??
+                                null)
+                              : null;
+                          return (
+                            <InlineHeaderFooterEditor
+                              ref={hfEditorRef}
+                              position={hfEditPosition}
+                              targetElement={targetEl}
+                              parentElement={parentEl}
+                              getActiveView={getActiveView}
+                              onClose={handleBodyClick}
+                              onRemove={handleRemoveHeaderFooter}
+                            />
+                          );
+                        })()}
+                    </div>
                   </div>
+                  {/* end editor flex wrapper */}
                 </div>
-                {/* end editor flex wrapper */}
+                {/* end scroll container */}
+
+                {/* Page indicator — Google Docs style, next to scrollbar while scrolling */}
+                {scrollPageInfo.totalPages > 1 && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      right: 24,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      backgroundColor: "var(--doc-text)",
+                      color: "var(--doc-page)",
+                      padding: "6px 12px",
+                      borderRadius: "4px",
+                      fontSize: "12px",
+                      fontWeight: 500,
+                      whiteSpace: "nowrap",
+                      pointerEvents: "none",
+                      zIndex: 1000,
+                      opacity: scrollPageInfo.visible ? 1 : 0,
+                      transition: "opacity 0.3s ease",
+                      userSelect: "none",
+                    }}
+                    aria-live="polite"
+                    role="status"
+                  >
+                    {scrollPageInfo.currentPage} of {scrollPageInfo.totalPages}
+                  </div>
+                )}
+
+                {/* Document outline sidebar — absolutely positioned, doesn't scroll */}
+                {showOutline && outlineHeadings.length > 1 && (
+                  <DocumentOutline
+                    headings={outlineHeadings}
+                    scrollContainerRef={scrollContainerRef}
+                    topOffset={toolbarHeight}
+                    docSize={
+                      pagedEditorRef.current?.getView()?.state.doc.content
+                        .size ?? 0
+                    }
+                    onHeadingClick={(pmPos) => {
+                      pagedEditorRef.current?.scrollToPosition(pmPos);
+                      // Wait for the paged editor to mount the target paragraph
+                      // (smooth-scroll + virtualisation buffer warm-up), then
+                      // trigger the CSS flash animation.
+                      let attempts = 0;
+                      const flash = () => {
+                        attempts++;
+                        const container = scrollContainerRef.current;
+                        if (!container) {
+                          return;
+                        }
+                        const el = container.querySelector<HTMLElement>(
+                          `.layout-page-content [data-pm-start="${String(pmPos)}"]`,
+                        );
+                        if (el) {
+                          delete el.dataset["folioOutlineFlash"];
+                          void el.offsetWidth;
+                          el.dataset["folioOutlineFlash"] = "";
+                          return;
+                        }
+                        if (attempts < 30) {
+                          requestAnimationFrame(flash);
+                        }
+                      };
+                      requestAnimationFrame(flash);
+                    }}
+                  />
+                )}
               </div>
-              {/* end scroll container */}
-
-              {/* Page indicator — Google Docs style, next to scrollbar while scrolling */}
-              {scrollPageInfo.totalPages > 1 && (
-                <div
-                  style={{
-                    position: "absolute",
-                    right: 24,
-                    top: "50%",
-                    transform: "translateY(-50%)",
-                    backgroundColor: "var(--doc-text)",
-                    color: "var(--doc-page)",
-                    padding: "6px 12px",
-                    borderRadius: "4px",
-                    fontSize: "12px",
-                    fontWeight: 500,
-                    whiteSpace: "nowrap",
-                    pointerEvents: "none",
-                    zIndex: 1000,
-                    opacity: scrollPageInfo.visible ? 1 : 0,
-                    transition: "opacity 0.3s ease",
-                    userSelect: "none",
-                  }}
-                  aria-live="polite"
-                  role="status"
-                >
-                  {scrollPageInfo.currentPage} of {scrollPageInfo.totalPages}
-                </div>
-              )}
-
-              {/* Document outline sidebar — absolutely positioned, doesn't scroll */}
-              {showOutline && outlineHeadings.length > 1 && (
-                <DocumentOutline
-                  headings={outlineHeadings}
-                  scrollContainerRef={scrollContainerRef}
-                  topOffset={toolbarHeight}
-                  docSize={
-                    pagedEditorRef.current?.getView()?.state.doc.content.size ??
-                    0
-                  }
-                  onHeadingClick={(pmPos) => {
-                    pagedEditorRef.current?.scrollToPosition(pmPos);
-                    // Wait for the paged editor to mount the target paragraph
-                    // (smooth-scroll + virtualisation buffer warm-up), then
-                    // trigger the CSS flash animation.
-                    let attempts = 0;
-                    const flash = () => {
-                      attempts++;
-                      const container = scrollContainerRef.current;
-                      if (!container) {
-                        return;
-                      }
-                      const el = container.querySelector<HTMLElement>(
-                        `.layout-page-content [data-pm-start="${String(pmPos)}"]`,
-                      );
-                      if (el) {
-                        delete el.dataset["folioOutlineFlash"];
-                        void el.offsetWidth;
-                        el.dataset["folioOutlineFlash"] = "";
-                        return;
-                      }
-                      if (attempts < 30) {
-                        requestAnimationFrame(flash);
-                      }
-                    };
-                    requestAnimationFrame(flash);
-                  }}
-                />
-              )}
+              {/* end wrapper for scroll container + outline */}
             </div>
-            {/* end wrapper for scroll container + outline */}
+
+            {/* Hyperlink popup (Google Docs-style) */}
+            <HyperlinkPopup
+              data={hyperlinkPopupData}
+              onNavigate={handleHyperlinkPopupNavigate}
+              onCopy={handleHyperlinkPopupCopy}
+              onEdit={handleHyperlinkPopupEdit}
+              onRemove={handleHyperlinkPopupRemove}
+              onClose={handleHyperlinkPopupClose}
+              readOnly={readOnly}
+            />
+
+            {/* Right-click context menu */}
+            {contextMenu.isOpen && (
+              <Suspense fallback={null}>
+                <TextContextMenu
+                  isOpen={contextMenu.isOpen}
+                  position={contextMenu.position}
+                  hasSelection={contextMenu.hasSelection}
+                  isEditable={!readOnly}
+                  items={contextMenuItems}
+                  onAction={(action) => {
+                    void handleContextMenuAction(action);
+                  }}
+                  onClose={handleContextMenuClose}
+                />
+              </Suspense>
+            )}
+
+            {/* Dropdown / date pickers for content controls */}
+            <ContentControlWidgetsOverlay
+              getEditorView={() => pagedEditorRef.current?.getView() ?? null}
+            />
+
+            {/* Toast notifications */}
+            {/* Toast notifications provided by host app */}
+
+            <DocxEditorDialogs
+              findReplace={{
+                state: findReplace.state,
+                onClose: findReplace.close,
+                onFind: handleFind,
+                onFindNext: handleFindNext,
+                onFindPrevious: handleFindPrevious,
+                onReplace: handleReplace,
+                onReplaceAll: handleReplaceAll,
+                currentResult: findResultRef.current,
+              }}
+              tableProperties={{
+                isOpen: tablePropsOpen,
+                onClose: () => setTablePropsOpen(false),
+                onApply: (props) => {
+                  const view = getActiveEditorView();
+                  if (view) {
+                    setTableProperties(props)(view.state, view.dispatch);
+                  }
+                },
+                currentProps: state.pmTableContext?.table?.attrs as
+                  | Record<string, unknown>
+                  | undefined,
+              }}
+              imagePosition={{
+                isOpen: imagePositionOpen,
+                onClose: () => setImagePositionOpen(false),
+                onApply: handleApplyImagePosition,
+              }}
+              imageProperties={{
+                isOpen: imagePropsOpen,
+                onClose: () => setImagePropsOpen(false),
+                onApply: handleApplyImageProperties,
+                currentData: imagePropertiesCurrentData,
+              }}
+              pageSetup={{
+                isOpen: showPageSetup,
+                onClose: () => setShowPageSetup(false),
+                onApply: handlePageSetupApply,
+                currentProps:
+                  history.state.package.document.finalSectionProperties,
+              }}
+              footnoteProperties={{
+                isOpen: footnotePropsOpen,
+                onClose: () => setFootnotePropsOpen(false),
+                onApply: handleApplyFootnoteProperties,
+                footnotePr:
+                  history.state.package.document.finalSectionProperties
+                    ?.footnotePr,
+                endnotePr:
+                  history.state.package.document.finalSectionProperties
+                    ?.endnotePr,
+              }}
+            />
+            {/* InlineHeaderFooterEditor is rendered inside the editor content area (position:relative div) */}
+            {/* Hidden file input for image insertion */}
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              style={{ display: "none" }}
+              onChange={handleImageFileChange}
+            />
           </div>
-
-          {/* Hyperlink popup (Google Docs-style) */}
-          <HyperlinkPopup
-            data={hyperlinkPopupData}
-            onNavigate={handleHyperlinkPopupNavigate}
-            onCopy={handleHyperlinkPopupCopy}
-            onEdit={handleHyperlinkPopupEdit}
-            onRemove={handleHyperlinkPopupRemove}
-            onClose={handleHyperlinkPopupClose}
-            readOnly={readOnly}
-          />
-
-          {/* Right-click context menu */}
-          {contextMenu.isOpen && (
-            <Suspense fallback={null}>
-              <TextContextMenu
-                isOpen={contextMenu.isOpen}
-                position={contextMenu.position}
-                hasSelection={contextMenu.hasSelection}
-                isEditable={!readOnly}
-                items={contextMenuItems}
-                onAction={(action) => {
-                  void handleContextMenuAction(action);
-                }}
-                onClose={handleContextMenuClose}
-              />
-            </Suspense>
-          )}
-
-          {/* Dropdown / date pickers for content controls */}
-          <ContentControlWidgetsOverlay
-            getEditorView={() => pagedEditorRef.current?.getView() ?? null}
-          />
-
-          {/* Toast notifications */}
-          {/* Toast notifications provided by host app */}
-
-          <DocxEditorDialogs
-            findReplace={{
-              state: findReplace.state,
-              onClose: findReplace.close,
-              onFind: handleFind,
-              onFindNext: handleFindNext,
-              onFindPrevious: handleFindPrevious,
-              onReplace: handleReplace,
-              onReplaceAll: handleReplaceAll,
-              currentResult: findResultRef.current,
-            }}
-            tableProperties={{
-              isOpen: tablePropsOpen,
-              onClose: () => setTablePropsOpen(false),
-              onApply: (props) => {
-                const view = getActiveEditorView();
-                if (view) {
-                  setTableProperties(props)(view.state, view.dispatch);
-                }
-              },
-              currentProps: state.pmTableContext?.table?.attrs as
-                | Record<string, unknown>
-                | undefined,
-            }}
-            imagePosition={{
-              isOpen: imagePositionOpen,
-              onClose: () => setImagePositionOpen(false),
-              onApply: handleApplyImagePosition,
-            }}
-            imageProperties={{
-              isOpen: imagePropsOpen,
-              onClose: () => setImagePropsOpen(false),
-              onApply: handleApplyImageProperties,
-              currentData: imagePropertiesCurrentData,
-            }}
-            pageSetup={{
-              isOpen: showPageSetup,
-              onClose: () => setShowPageSetup(false),
-              onApply: handlePageSetupApply,
-              currentProps:
-                history.state.package.document.finalSectionProperties,
-            }}
-            footnoteProperties={{
-              isOpen: footnotePropsOpen,
-              onClose: () => setFootnotePropsOpen(false),
-              onApply: handleApplyFootnoteProperties,
-              footnotePr:
-                history.state.package.document.finalSectionProperties
-                  ?.footnotePr,
-              endnotePr:
-                history.state.package.document.finalSectionProperties
-                  ?.endnotePr,
-            }}
-          />
-          {/* InlineHeaderFooterEditor is rendered inside the editor content area (position:relative div) */}
-          {/* Hidden file input for image insertion */}
-          <input
-            ref={imageInputRef}
-            type="file"
-            accept="image/*"
-            style={{ display: "none" }}
-            onChange={handleImageFileChange}
-          />
-        </div>
-      </ErrorBoundary>
-    </ErrorProvider>
+        </ErrorBoundary>
+      </ErrorProvider>
+    </FolioUIProvider>
   );
 }
 

--- a/packages/folio/src/components/ErrorBoundary.tsx
+++ b/packages/folio/src/components/ErrorBoundary.tsx
@@ -26,11 +26,10 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { Button } from "@stll/ui/components/button";
-
 import { ErrorManager } from "../core/managers/ErrorManager";
 import type { ErrorNotification } from "../core/managers/types";
 import { cn } from "../lib/utils";
+import { useFolioUI } from "../ui/folio-ui";
 
 /**
  * Error context value
@@ -364,6 +363,7 @@ function DefaultErrorFallback({
   onReset,
 }: DefaultErrorFallbackProps): React.ReactElement {
   const t = useTranslations("folio");
+  const { Button } = useFolioUI();
 
   return (
     <div className="bg-background m-5 flex min-h-[200px] flex-col items-center justify-center rounded-lg border p-10 text-center">
@@ -415,6 +415,7 @@ export function ParseErrorDisplay({
   onRetry,
   className = "",
 }: ParseErrorDisplayProps): React.ReactElement {
+  const { Button } = useFolioUI();
   return (
     <div
       className={cn(

--- a/packages/folio/src/components/FormattingBar.tsx
+++ b/packages/folio/src/components/FormattingBar.tsx
@@ -24,12 +24,10 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { ColorPicker } from "@stll/ui/components/color-picker";
-import type { ColorPreset } from "@stll/ui/components/color-picker";
-
 import type { ParagraphAlignment } from "../core/types/document";
 import { cn } from "../lib/utils";
 import { useFolioUI } from "../ui/folio-ui";
+import type { ColorPreset } from "../ui/folio-ui";
 import { containedHandler } from "../utils/contained-handler";
 import {
   ToolbarButton,
@@ -109,11 +107,9 @@ export function FormattingBar(props: FormattingBarProps) {
     inline = false,
   } = props;
 
-  const {
-    Root: Menu,
-    Trigger: MenuTrigger,
-    Popup: MenuPopup,
-  } = useFolioUI().Menu;
+  const folioUI = useFolioUI();
+  const { Root: Menu, Trigger: MenuTrigger, Popup: MenuPopup } = folioUI.Menu;
+  const ColorPicker = folioUI.ColorPicker;
   const t = useTranslations("folio");
   const barRef = useRef<HTMLDivElement>(null);
   const [showSecondaryInline, setShowSecondaryInline] = useState(false);

--- a/packages/folio/src/components/FormattingBar.tsx
+++ b/packages/folio/src/components/FormattingBar.tsx
@@ -27,10 +27,10 @@ import { useTranslations } from "use-intl";
 import { ColorPicker } from "@stll/ui/components/color-picker";
 import type { ColorPreset } from "@stll/ui/components/color-picker";
 import { Menu, MenuPopup, MenuTrigger } from "@stll/ui/components/menu";
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 
 import type { ParagraphAlignment } from "../core/types/document";
 import { cn } from "../lib/utils";
+import { containedHandler } from "../utils/contained-handler";
 import {
   ToolbarButton,
   ToolbarGroup,

--- a/packages/folio/src/components/FormattingBar.tsx
+++ b/packages/folio/src/components/FormattingBar.tsx
@@ -26,10 +26,10 @@ import { useTranslations } from "use-intl";
 
 import { ColorPicker } from "@stll/ui/components/color-picker";
 import type { ColorPreset } from "@stll/ui/components/color-picker";
-import { Menu, MenuPopup, MenuTrigger } from "@stll/ui/components/menu";
 
 import type { ParagraphAlignment } from "../core/types/document";
 import { cn } from "../lib/utils";
+import { useFolioUI } from "../ui/folio-ui";
 import { containedHandler } from "../utils/contained-handler";
 import {
   ToolbarButton,
@@ -109,6 +109,11 @@ export function FormattingBar(props: FormattingBarProps) {
     inline = false,
   } = props;
 
+  const {
+    Root: Menu,
+    Trigger: MenuTrigger,
+    Popup: MenuPopup,
+  } = useFolioUI().Menu;
   const t = useTranslations("folio");
   const barRef = useRef<HTMLDivElement>(null);
   const [showSecondaryInline, setShowSecondaryInline] = useState(false);

--- a/packages/folio/src/components/Toolbar.tsx
+++ b/packages/folio/src/components/Toolbar.tsx
@@ -14,9 +14,8 @@
 
 import React, { useCallback, useRef } from "react";
 
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
-
 import { cn } from "../lib/utils";
+import { containedHandler } from "../utils/contained-handler";
 import { FormattingBar } from "./FormattingBar";
 import {
   ToolbarButton,

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -20,9 +20,6 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { Checkbox } from "@stll/ui/components/checkbox";
-import { Input } from "@stll/ui/components/input";
-
 import { useFolioUI } from "../../ui/folio-ui";
 import {
   getFindDialogOpenBehavior,
@@ -125,7 +122,7 @@ export function FindReplaceDialog({
 }: FindReplaceDialogProps): React.ReactElement | null {
   const id = React.useId();
   const t = useTranslations("folio");
-  const { Button } = useFolioUI();
+  const { Button, Input, Checkbox } = useFolioUI();
   // State
   const [searchText, setSearchText] = useState("");
   const [matchCase, setMatchCase] = useState(false);

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -20,10 +20,10 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Input } from "@stll/ui/components/input";
 
+import { useFolioUI } from "../../ui/folio-ui";
 import {
   getFindDialogOpenBehavior,
   shouldRefreshFindDialogSearch,
@@ -125,6 +125,7 @@ export function FindReplaceDialog({
 }: FindReplaceDialogProps): React.ReactElement | null {
   const id = React.useId();
   const t = useTranslations("folio");
+  const { Button } = useFolioUI();
   // State
   const [searchText, setSearchText] = useState("");
   const [matchCase, setMatchCase] = useState(false);

--- a/packages/folio/src/components/dialogs/FootnotePropertiesDialog.tsx
+++ b/packages/folio/src/components/dialogs/FootnotePropertiesDialog.tsx
@@ -6,15 +6,6 @@
 
 import { useId, useState } from "react";
 
-import {
-  Dialog,
-  DialogPortal,
-  DialogBackdrop,
-  DialogPopup,
-  DialogTitle,
-  DialogClose,
-} from "@stll/ui/components/dialog";
-
 import type {
   FootnoteProperties,
   EndnoteProperties,
@@ -23,6 +14,7 @@ import type {
   NoteNumberRestart,
   NumberFormat,
 } from "../../core/types/document";
+import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
 // TYPES
@@ -63,6 +55,14 @@ export function FootnotePropertiesDialog({
   footnotePr,
   endnotePr,
 }: FootnotePropertiesDialogProps) {
+  const {
+    Root: Dialog,
+    Portal: DialogPortal,
+    Backdrop: DialogBackdrop,
+    Popup: DialogPopup,
+    Title: DialogTitle,
+    Close: DialogClose,
+  } = useFolioUI().Dialog;
   const id = useId();
   const [fnPosition, setFnPosition] = useState<FootnotePosition>(
     footnotePr?.position ?? "pageBottom",

--- a/packages/folio/src/components/dialogs/ImagePositionDialog.tsx
+++ b/packages/folio/src/components/dialogs/ImagePositionDialog.tsx
@@ -9,14 +9,7 @@
 
 import { useEffect, useId, useState } from "react";
 
-import {
-  Dialog,
-  DialogPortal,
-  DialogBackdrop,
-  DialogPopup,
-  DialogTitle,
-  DialogClose,
-} from "@stll/ui/components/dialog";
+import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
 // TYPES
@@ -56,6 +49,14 @@ export function ImagePositionDialog({
   onApply,
   currentData,
 }: ImagePositionDialogProps) {
+  const {
+    Root: Dialog,
+    Portal: DialogPortal,
+    Backdrop: DialogBackdrop,
+    Popup: DialogPopup,
+    Title: DialogTitle,
+    Close: DialogClose,
+  } = useFolioUI().Dialog;
   const id = useId();
   const [hMode, setHMode] = useState<"align" | "offset">("align");
   const [hAlign, setHAlign] = useState("center");

--- a/packages/folio/src/components/dialogs/ImagePropertiesDialog.tsx
+++ b/packages/folio/src/components/dialogs/ImagePropertiesDialog.tsx
@@ -8,14 +8,7 @@
 
 import { useEffect, useId, useState } from "react";
 
-import {
-  Dialog,
-  DialogPortal,
-  DialogBackdrop,
-  DialogPopup,
-  DialogTitle,
-  DialogClose,
-} from "@stll/ui/components/dialog";
+import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
 // TYPES
@@ -45,6 +38,14 @@ export function ImagePropertiesDialog({
   onApply,
   currentData,
 }: ImagePropertiesDialogProps) {
+  const {
+    Root: Dialog,
+    Portal: DialogPortal,
+    Backdrop: DialogBackdrop,
+    Popup: DialogPopup,
+    Title: DialogTitle,
+    Close: DialogClose,
+  } = useFolioUI().Dialog;
   const id = useId();
   const [alt, setAlt] = useState("");
   const [borderWidth, setBorderWidth] = useState(0);

--- a/packages/folio/src/components/dialogs/PageSetupDialog.tsx
+++ b/packages/folio/src/components/dialogs/PageSetupDialog.tsx
@@ -9,17 +9,9 @@
 
 import { useEffect, useId, useState } from "react";
 
-import {
-  Dialog,
-  DialogPortal,
-  DialogBackdrop,
-  DialogPopup,
-  DialogTitle,
-  DialogClose,
-} from "@stll/ui/components/dialog";
-
 import type { SectionProperties } from "../../core/types/document";
 import { TWIPS_PER_INCH } from "../../core/utils/units";
+import { useFolioUI } from "../../ui/folio-ui";
 
 /** Common page sizes in twips (width x height in portrait orientation) */
 const PAGE_SIZES = [
@@ -80,6 +72,14 @@ export function PageSetupDialog({
   onApply,
   currentProps,
 }: PageSetupDialogProps) {
+  const {
+    Root: Dialog,
+    Portal: DialogPortal,
+    Backdrop: DialogBackdrop,
+    Popup: DialogPopup,
+    Title: DialogTitle,
+    Close: DialogClose,
+  } = useFolioUI().Dialog;
   const id = useId();
   const [pageWidth, setPageWidth] = useState(DEFAULT_WIDTH);
   const [pageHeight, setPageHeight] = useState(DEFAULT_HEIGHT);

--- a/packages/folio/src/components/dialogs/TablePropertiesDialog.tsx
+++ b/packages/folio/src/components/dialogs/TablePropertiesDialog.tsx
@@ -4,14 +4,7 @@
 
 import { useCallback, useEffect, useId, useState } from "react";
 
-import {
-  Dialog,
-  DialogPortal,
-  DialogBackdrop,
-  DialogPopup,
-  DialogTitle,
-  DialogClose,
-} from "@stll/ui/components/dialog";
+import { useFolioUI } from "../../ui/folio-ui";
 
 export type TableProperties = {
   width?: number | null;
@@ -36,6 +29,14 @@ export function TablePropertiesDialog({
   onApply,
   currentProps,
 }: TablePropertiesDialogProps) {
+  const {
+    Root: Dialog,
+    Portal: DialogPortal,
+    Backdrop: DialogBackdrop,
+    Popup: DialogPopup,
+    Title: DialogTitle,
+    Close: DialogClose,
+  } = useFolioUI().Dialog;
   const id = useId();
   const [width, setWidth] = useState(currentProps?.width ?? 0);
   const [widthType, setWidthType] = useState(currentProps?.widthType ?? "auto");

--- a/packages/folio/src/components/ui/AlignmentButtons.tsx
+++ b/packages/folio/src/components/ui/AlignmentButtons.tsx
@@ -14,15 +14,9 @@ import {
   ChevronDownIcon,
 } from "lucide-react";
 
-import {
-  Popover,
-  PopoverClose,
-  PopoverPopup,
-  PopoverTrigger,
-} from "@stll/ui/components/popover";
-
 import type { ParagraphAlignment } from "../../core/types/document";
 import { cn } from "../../lib/utils";
+import { useFolioUI } from "../../ui/folio-ui";
 
 export type AlignmentButtonsProps = {
   value?: ParagraphAlignment;
@@ -66,6 +60,12 @@ export function AlignmentButtons({
   onChange,
   disabled = false,
 }: AlignmentButtonsProps) {
+  const {
+    Root: Popover,
+    Trigger: PopoverTrigger,
+    Popup: PopoverPopup,
+    Close: PopoverClose,
+  } = useFolioUI().Popover;
   const defaultOption = OPTIONS[0];
   if (!defaultOption) {
     panic("AlignmentButtons: OPTIONS is empty");

--- a/packages/folio/src/components/ui/FontPicker.tsx
+++ b/packages/folio/src/components/ui/FontPicker.tsx
@@ -3,13 +3,7 @@
  * Each item rendered in its own font for preview.
  */
 
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
+import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
 // TYPES
@@ -110,6 +104,13 @@ export function FontPicker({
   placeholder = "Font",
   width = 100,
 }: FontPickerProps) {
+  const {
+    Root: Select,
+    Trigger: SelectTrigger,
+    Value: SelectValue,
+    Popup: SelectPopup,
+    Item: SelectItem,
+  } = useFolioUI().Select;
   const fontOptions = fonts ?? DEFAULT_FONTS;
 
   return (

--- a/packages/folio/src/components/ui/FontSizePicker.tsx
+++ b/packages/folio/src/components/ui/FontSizePicker.tsx
@@ -3,13 +3,7 @@
  * Values are points; internally the editor stores half-points (OOXML w:sz).
  */
 
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
+import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
 // TYPES
@@ -49,6 +43,13 @@ export function FontSizePicker({
   placeholder = "",
   width = 56,
 }: FontSizePickerProps) {
+  const {
+    Root: Select,
+    Trigger: SelectTrigger,
+    Value: SelectValue,
+    Popup: SelectPopup,
+    Item: SelectItem,
+  } = useFolioUI().Select;
   const sizeOptions = sizes ?? Array.from(DEFAULT_SIZES);
   const selectedLabel = value === undefined ? undefined : formatSize(value);
 

--- a/packages/folio/src/components/ui/HyperlinkPopup.tsx
+++ b/packages/folio/src/components/ui/HyperlinkPopup.tsx
@@ -22,7 +22,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
+import { containedHandler } from "../../utils/contained-handler";
 
 export type HyperlinkPopupData = {
   href: string;

--- a/packages/folio/src/components/ui/StylePicker.tsx
+++ b/packages/folio/src/components/ui/StylePicker.tsx
@@ -199,8 +199,7 @@ export function StylePicker({
     >
       <SelectTrigger
         size="sm"
-        className={`h-8 min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)] ${className ?? ""}`}
-        data-folio-style-picker=""
+        className={`folio-style-picker h-8 min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)] ${className ?? ""}`}
         style={{
           width: typeof width === "number" ? `${width}px` : width,
         }}

--- a/packages/folio/src/components/ui/StylePicker.tsx
+++ b/packages/folio/src/components/ui/StylePicker.tsx
@@ -7,15 +7,8 @@
 
 import * as React from "react";
 
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
-
 import type { Style, StyleType, Theme } from "../../core/types/document";
+import { useFolioUI } from "../../ui/folio-ui";
 
 // ============================================================================
 // TYPES
@@ -150,6 +143,13 @@ export function StylePicker({
   className,
   width = 140,
 }: StylePickerProps) {
+  const {
+    Root: Select,
+    Trigger: SelectTrigger,
+    Value: SelectValue,
+    Popup: SelectPopup,
+    Item: SelectItem,
+  } = useFolioUI().Select;
   const styleOptions = React.useMemo(() => {
     if (!styles || styles.length === 0) {
       return DEFAULT_STYLES;

--- a/packages/folio/src/index.ts
+++ b/packages/folio/src/index.ts
@@ -6,6 +6,9 @@ export type {
 } from "./components/DocxEditor.props";
 export type { EditorMode } from "./components/hooks/useEditorMode";
 export type { FolioButtonProps, FolioUIComponents } from "./ui/folio-ui";
+// Consumers rendering folio chrome (e.g. FormattingBar) outside DocxEditor wrap
+// it in this provider to inject their own UI components.
+export { FolioUIProvider } from "./ui/folio-ui";
 export {
   FormattingBar,
   type FormattingBarProps,

--- a/packages/folio/src/index.ts
+++ b/packages/folio/src/index.ts
@@ -5,7 +5,12 @@ export type {
   DocxEditorRef,
 } from "./components/DocxEditor.props";
 export type { EditorMode } from "./components/hooks/useEditorMode";
-export type { FolioButtonProps, FolioUIComponents } from "./ui/folio-ui";
+export type {
+  ColorPreset,
+  FolioButtonProps,
+  FolioUIComponents,
+  OutlineItem,
+} from "./ui/folio-ui";
 // Consumers rendering folio chrome (e.g. FormattingBar) outside DocxEditor wrap
 // it in this provider to inject their own UI components.
 export { FolioUIProvider } from "./ui/folio-ui";

--- a/packages/folio/src/index.ts
+++ b/packages/folio/src/index.ts
@@ -5,6 +5,7 @@ export type {
   DocxEditorRef,
 } from "./components/DocxEditor.props";
 export type { EditorMode } from "./components/hooks/useEditorMode";
+export type { FolioButtonProps, FolioUIComponents } from "./ui/folio-ui";
 export {
   FormattingBar,
   type FormattingBarProps,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -32,8 +32,6 @@ import type { EditorState, Transaction, Plugin } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
 import type { EditorView } from "prosemirror-view";
 
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
-
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
 import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import type { AISuggestion } from "../core/ai-suggestions/types";
@@ -173,6 +171,7 @@ import {
   htmlQueryAll,
   queryHtmlElement,
 } from "../core/utils/domGuards";
+import { containedHandler } from "../utils/contained-handler";
 // Internal components
 import { AISuggestionRectsOverlay } from "./AISuggestionRectsOverlay";
 import type { AISuggestionRectGroup } from "./AISuggestionRectsOverlay";

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -1418,17 +1418,11 @@
   font-weight: 600;
 }
 
-.folio-default-dialog-close {
-  position: absolute;
-  top: 0.75rem;
-  inset-inline-end: 0.75rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
+/* Structurally unstyled: DialogClose wraps varied controls (a footer Cancel
+   button, an explicit close icon), so the default must not impose positioning
+   or chrome that fights the caller's className. */
+:where(.folio-default-dialog-close) {
   cursor: pointer;
-  color: var(--doc-text-muted, #6b7280);
 }
 
 /* ── Default chrome Input ──────────────────────────────────────────────

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -1113,3 +1113,113 @@
   width: 1.75rem;
   padding: 0;
 }
+
+/* ── Default chrome ColorPicker ────────────────────────────────────────
+   Styling for the built-in, dependency-free ColorPicker used when a consumer
+   does not inject one (see `ui/defaults/color-picker.tsx`). */
+.folio-default-color-picker-trigger {
+  display: inline-flex;
+}
+
+.folio-default-color-picker-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+}
+
+.folio-default-color-picker-clear {
+  display: flex;
+  align-items: center;
+  height: 1.5rem;
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--doc-text-muted, inherit);
+}
+
+.folio-default-color-picker-swatches {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.25rem;
+}
+
+.folio-default-color-picker-swatch {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  cursor: pointer;
+  padding: 0;
+}
+
+.folio-default-color-picker-swatch--selected {
+  outline: 2px solid var(--doc-primary, #2563eb);
+  outline-offset: 1px;
+}
+
+.folio-default-color-picker-custom {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--doc-text-muted, inherit);
+}
+
+/* ── Default chrome DatePickerPopover ──────────────────────────────────
+   Styling for the built-in, dependency-free date input used when a consumer
+   does not inject one (see `ui/defaults/date-picker-popover.tsx`). */
+.folio-default-date-input {
+  height: 1.75rem;
+  padding: 0 0.375rem;
+  font-size: 0.8125rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+}
+
+/* ── Default chrome OutlineRail ────────────────────────────────────────
+   Styling for the built-in, dependency-free outline nav used when a consumer
+   does not inject one (see `ui/defaults/outline-rail.tsx`). */
+.folio-default-outline-rail {
+  position: absolute;
+  inset-inline-end: 0;
+  overflow-y: auto;
+  max-height: 100%;
+  padding: 0.25rem 0;
+}
+
+.folio-default-outline-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.folio-default-outline-item {
+  display: block;
+  width: 100%;
+  padding-block: 0.25rem;
+  padding-inline-end: 0.5rem;
+  font-size: 0.8125rem;
+  text-align: start;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--doc-text-muted, inherit);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.folio-default-outline-item--active {
+  font-weight: 500;
+  color: var(--doc-text, inherit);
+}

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -1064,3 +1064,52 @@
   background: color-mix(in srgb, #f97316 28%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, #f97316 45%, transparent);
 }
+
+/* ── Default chrome button ─────────────────────────────────────────────
+   Styling for the built-in, dependency-free Button used when a consumer does
+   not inject one (see `ui/defaults/button.tsx`). Each rule is a single class so
+   a caller's `className` can override the defaults with equal-or-greater
+   specificity and later source order; inline styles would always outrank the
+   caller and hide pressed/active/layout visuals on the standalone path. */
+.folio-default-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-style: solid;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.folio-default-button--default {
+  background: var(--doc-primary, #2563eb);
+  color: var(--doc-primary-foreground, #ffffff);
+  border-color: var(--doc-primary, #2563eb);
+}
+
+.folio-default-button--ghost {
+  background: transparent;
+  color: var(--doc-text, inherit);
+  border-color: transparent;
+}
+
+.folio-default-button--sm {
+  height: 2rem;
+  padding: 0 0.625rem;
+  font-size: 0.8125rem;
+}
+
+.folio-default-button--xs {
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  font-size: 0.75rem;
+}
+
+.folio-default-button--icon-xs {
+  height: 1.75rem;
+  width: 1.75rem;
+  padding: 0;
+}

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -1223,3 +1223,267 @@
   font-weight: 500;
   color: var(--doc-text, inherit);
 }
+
+/* ── Default chrome Menu ───────────────────────────────────────────────
+   Styling for the built-in, dependency-free Menu (see `ui/defaults/menu.tsx`).
+   Single-class selectors so a caller's `className` can override. The popup is
+   the floating surface; the positioner only owns stacking. */
+.folio-default-menu-positioner {
+  z-index: 50;
+}
+
+.folio-default-menu-popup {
+  min-width: 12rem;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+}
+
+.folio-default-menu-item,
+.folio-default-menu-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--doc-text, inherit);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.folio-default-menu-checkbox-item {
+  padding-inline-start: 0.375rem;
+}
+
+.folio-default-menu-item[data-highlighted],
+.folio-default-menu-item:hover,
+.folio-default-menu-checkbox-item[data-highlighted],
+.folio-default-menu-checkbox-item:hover {
+  background: var(--doc-primary-light, #eff6ff);
+}
+
+.folio-default-menu-checkbox-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
+.folio-default-menu-group-label {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--doc-text-muted, #6b7280);
+}
+
+.folio-default-menu-separator {
+  margin: 0.25rem 0;
+  border-top: 1px solid var(--doc-border, #e5e7eb);
+}
+
+/* ── Default chrome Select ─────────────────────────────────────────────
+   Styling for the built-in, dependency-free Select (see
+   `ui/defaults/select.tsx`). The trigger reads `data-size` (sm/default/lg);
+   the popup mirrors the menu surface with a scroll cap. */
+.folio-default-select-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  height: 2rem;
+  padding: 0 0.625rem;
+  font-size: 0.8125rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+  cursor: pointer;
+}
+
+.folio-default-select-trigger[data-size="sm"] {
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  font-size: 0.75rem;
+}
+
+.folio-default-select-trigger[data-size="lg"] {
+  height: 2.5rem;
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.folio-default-select-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--doc-text-muted, #6b7280);
+}
+
+.folio-default-select-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folio-default-select-positioner {
+  z-index: 50;
+}
+
+.folio-default-select-popup {
+  min-width: 8rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+}
+
+.folio-default-select-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--doc-text, inherit);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.folio-default-select-item[data-highlighted] {
+  background: var(--doc-primary-light, #eff6ff);
+}
+
+.folio-default-select-item[data-selected] {
+  font-weight: 500;
+}
+
+/* ── Default chrome Popover ────────────────────────────────────────────
+   Styling for the built-in, dependency-free Popover (see
+   `ui/defaults/popover.tsx`). */
+.folio-default-popover-positioner {
+  z-index: 50;
+}
+
+.folio-default-popover-popup {
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+}
+
+/* ── Default chrome Dialog ─────────────────────────────────────────────
+   Styling for the built-in, dependency-free Dialog (see
+   `ui/defaults/dialog.tsx`). The default popup self-centers (no host viewport
+   grid); the backdrop sits below it. */
+.folio-default-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgb(0 0 0 / 40%);
+}
+
+.folio-default-dialog-popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 51;
+  width: 100%;
+  max-width: 28rem;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 20%);
+}
+
+.folio-default-dialog-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.folio-default-dialog-close {
+  position: absolute;
+  top: 0.75rem;
+  inset-inline-end: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--doc-text-muted, #6b7280);
+}
+
+/* ── Default chrome Input ──────────────────────────────────────────────
+   Styling for the built-in, dependency-free Input (see
+   `ui/defaults/input.tsx`). Reads `data-size` (sm/default/lg). */
+.folio-default-input {
+  height: 2rem;
+  padding: 0 0.625rem;
+  font-size: 0.8125rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-text, inherit);
+}
+
+.folio-default-input[data-size="sm"] {
+  height: 1.75rem;
+  font-size: 0.75rem;
+}
+
+.folio-default-input[data-size="lg"] {
+  height: 2.5rem;
+  font-size: 0.875rem;
+}
+
+.folio-default-input:focus-visible {
+  outline: 2px solid var(--doc-primary, #2563eb);
+  outline-offset: -1px;
+}
+
+/* ── Default chrome Checkbox ───────────────────────────────────────────
+   Styling for the built-in, dependency-free Checkbox (see
+   `ui/defaults/checkbox.tsx`). Reads `data-checked` for the filled state. */
+.folio-default-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border-radius: 0.25rem;
+  border: 1px solid var(--doc-border, #e5e7eb);
+  background: var(--doc-page, #ffffff);
+  color: var(--doc-primary-foreground, #ffffff);
+  cursor: pointer;
+}
+
+.folio-default-checkbox[data-checked] {
+  background: var(--doc-primary, #2563eb);
+  border-color: var(--doc-primary, #2563eb);
+}
+
+.folio-default-checkbox-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -1071,7 +1071,7 @@
    a caller's `className` can override the defaults with equal-or-greater
    specificity and later source order; inline styles would always outrank the
    caller and hide pressed/active/layout visuals on the standalone path. */
-.folio-default-button {
+:where(.folio-default-button) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1084,31 +1084,31 @@
   cursor: pointer;
 }
 
-.folio-default-button--default {
+:where(.folio-default-button--default) {
   background: var(--doc-primary, #2563eb);
   color: var(--doc-primary-foreground, #ffffff);
   border-color: var(--doc-primary, #2563eb);
 }
 
-.folio-default-button--ghost {
+:where(.folio-default-button--ghost) {
   background: transparent;
   color: var(--doc-text, inherit);
   border-color: transparent;
 }
 
-.folio-default-button--sm {
+:where(.folio-default-button--sm) {
   height: 2rem;
   padding: 0 0.625rem;
   font-size: 0.8125rem;
 }
 
-.folio-default-button--xs {
+:where(.folio-default-button--xs) {
   height: 1.75rem;
   padding: 0 0.5rem;
   font-size: 0.75rem;
 }
 
-.folio-default-button--icon-xs {
+:where(.folio-default-button--icon-xs) {
   height: 1.75rem;
   width: 1.75rem;
   padding: 0;
@@ -1292,7 +1292,7 @@
    Styling for the built-in, dependency-free Select (see
    `ui/defaults/select.tsx`). The trigger reads `data-size` (sm/default/lg);
    the popup mirrors the menu surface with a scroll cap. */
-.folio-default-select-trigger {
+:where(.folio-default-select-trigger) {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
@@ -1306,35 +1306,35 @@
   cursor: pointer;
 }
 
-.folio-default-select-trigger[data-size="sm"] {
+:where(.folio-default-select-trigger[data-size="sm"]) {
   height: 1.75rem;
   padding: 0 0.5rem;
   font-size: 0.75rem;
 }
 
-.folio-default-select-trigger[data-size="lg"] {
+:where(.folio-default-select-trigger[data-size="lg"]) {
   height: 2.5rem;
   padding: 0 0.75rem;
   font-size: 0.875rem;
 }
 
-.folio-default-select-icon {
+:where(.folio-default-select-icon) {
   display: inline-flex;
   flex-shrink: 0;
   color: var(--doc-text-muted, #6b7280);
 }
 
-.folio-default-select-value {
+:where(.folio-default-select-value) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.folio-default-select-positioner {
+:where(.folio-default-select-positioner) {
   z-index: 50;
 }
 
-.folio-default-select-popup {
+:where(.folio-default-select-popup) {
   min-width: 8rem;
   max-height: 18rem;
   overflow-y: auto;
@@ -1346,7 +1346,7 @@
   box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
 }
 
-.folio-default-select-item {
+:where(.folio-default-select-item) {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1359,11 +1359,11 @@
   outline: none;
 }
 
-.folio-default-select-item[data-highlighted] {
+:where(.folio-default-select-item[data-highlighted]) {
   background: var(--doc-primary-light, #eff6ff);
 }
 
-.folio-default-select-item[data-selected] {
+:where(.folio-default-select-item[data-selected]) {
   font-weight: 500;
 }
 
@@ -1434,7 +1434,7 @@
 /* ── Default chrome Input ──────────────────────────────────────────────
    Styling for the built-in, dependency-free Input (see
    `ui/defaults/input.tsx`). Reads `data-size` (sm/default/lg). */
-.folio-default-input {
+:where(.folio-default-input) {
   height: 2rem;
   padding: 0 0.625rem;
   font-size: 0.8125rem;
@@ -1444,17 +1444,17 @@
   color: var(--doc-text, inherit);
 }
 
-.folio-default-input[data-size="sm"] {
+:where(.folio-default-input[data-size="sm"]) {
   height: 1.75rem;
   font-size: 0.75rem;
 }
 
-.folio-default-input[data-size="lg"] {
+:where(.folio-default-input[data-size="lg"]) {
   height: 2.5rem;
   font-size: 0.875rem;
 }
 
-.folio-default-input:focus-visible {
+:where(.folio-default-input:focus-visible) {
   outline: 2px solid var(--doc-primary, #2563eb);
   outline-offset: -1px;
 }

--- a/packages/folio/src/ui/defaults/button.tsx
+++ b/packages/folio/src/ui/defaults/button.tsx
@@ -1,0 +1,81 @@
+import type { CSSProperties } from "react";
+
+import { cn } from "../../lib/utils";
+import type { FolioButtonProps } from "../folio-ui";
+
+/**
+ * Built-in, dependency-free Button used when a consumer does not inject one.
+ *
+ * Renders a native, accessible `<button>` honoring the `FolioButtonProps`
+ * subset. Styling is intentionally minimal: variant and size map to a small
+ * set of inline styles keyed off folio's `--doc-*` CSS variables (with safe
+ * fallbacks) so the default chrome is usable standalone. Consumers that want
+ * polished chrome inject their own design-system Button via `DocxEditor`'s
+ * `components` prop.
+ */
+export function DefaultButton({
+  variant = "default",
+  size = "sm",
+  className,
+  children,
+  ...props
+}: FolioButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn("folio-default-button", className)}
+      style={{ ...SIZE_STYLES[size], ...VARIANT_STYLES[variant] }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+const BASE_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "0.375rem",
+  borderRadius: "0.5rem",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  fontWeight: 500,
+  whiteSpace: "nowrap",
+  cursor: "pointer",
+};
+
+const SIZE_STYLES: Record<
+  NonNullable<FolioButtonProps["size"]>,
+  CSSProperties
+> = {
+  sm: {
+    ...BASE_STYLE,
+    height: "2rem",
+    padding: "0 0.625rem",
+    fontSize: "0.8125rem",
+  },
+  xs: {
+    ...BASE_STYLE,
+    height: "1.75rem",
+    padding: "0 0.5rem",
+    fontSize: "0.75rem",
+  },
+  "icon-xs": { ...BASE_STYLE, height: "1.75rem", width: "1.75rem", padding: 0 },
+};
+
+const VARIANT_STYLES: Record<
+  NonNullable<FolioButtonProps["variant"]>,
+  CSSProperties
+> = {
+  default: {
+    background: "var(--doc-primary, #2563eb)",
+    color: "var(--doc-primary-foreground, #ffffff)",
+    borderColor: "var(--doc-primary, #2563eb)",
+  },
+  ghost: {
+    background: "transparent",
+    color: "var(--doc-text, inherit)",
+    borderColor: "transparent",
+  },
+};

--- a/packages/folio/src/ui/defaults/button.tsx
+++ b/packages/folio/src/ui/defaults/button.tsx
@@ -1,5 +1,3 @@
-import type { CSSProperties } from "react";
-
 import { cn } from "../../lib/utils";
 import type { FolioButtonProps } from "../folio-ui";
 
@@ -7,9 +5,10 @@ import type { FolioButtonProps } from "../folio-ui";
  * Built-in, dependency-free Button used when a consumer does not inject one.
  *
  * Renders a native, accessible `<button>` honoring the `FolioButtonProps`
- * subset. Styling is intentionally minimal: variant and size map to a small
- * set of inline styles keyed off folio's `--doc-*` CSS variables (with safe
- * fallbacks) so the default chrome is usable standalone. Consumers that want
+ * subset. The minimal default styling lives in `editor.css`
+ * (`.folio-default-button*` classes, keyed off folio's `--doc-*` variables with
+ * safe fallbacks) rather than inline styles, so a caller's `className` can
+ * override the defaults through the normal cascade. Consumers that want
  * polished chrome inject their own design-system Button via `DocxEditor`'s
  * `components` prop.
  */
@@ -23,59 +22,15 @@ export function DefaultButton({
   return (
     <button
       type="button"
-      className={cn("folio-default-button", className)}
-      style={{ ...SIZE_STYLES[size], ...VARIANT_STYLES[variant] }}
+      className={cn(
+        "folio-default-button",
+        `folio-default-button--${variant}`,
+        `folio-default-button--${size}`,
+        className,
+      )}
       {...props}
     >
       {children}
     </button>
   );
 }
-
-const BASE_STYLE: CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  gap: "0.375rem",
-  borderRadius: "0.5rem",
-  borderWidth: "1px",
-  borderStyle: "solid",
-  fontWeight: 500,
-  whiteSpace: "nowrap",
-  cursor: "pointer",
-};
-
-const SIZE_STYLES: Record<
-  NonNullable<FolioButtonProps["size"]>,
-  CSSProperties
-> = {
-  sm: {
-    ...BASE_STYLE,
-    height: "2rem",
-    padding: "0 0.625rem",
-    fontSize: "0.8125rem",
-  },
-  xs: {
-    ...BASE_STYLE,
-    height: "1.75rem",
-    padding: "0 0.5rem",
-    fontSize: "0.75rem",
-  },
-  "icon-xs": { ...BASE_STYLE, height: "1.75rem", width: "1.75rem", padding: 0 },
-};
-
-const VARIANT_STYLES: Record<
-  NonNullable<FolioButtonProps["variant"]>,
-  CSSProperties
-> = {
-  default: {
-    background: "var(--doc-primary, #2563eb)",
-    color: "var(--doc-primary-foreground, #ffffff)",
-    borderColor: "var(--doc-primary, #2563eb)",
-  },
-  ghost: {
-    background: "transparent",
-    color: "var(--doc-text, inherit)",
-    borderColor: "transparent",
-  },
-};

--- a/packages/folio/src/ui/defaults/checkbox.tsx
+++ b/packages/folio/src/ui/defaults/checkbox.tsx
@@ -1,0 +1,35 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+
+import { cn } from "../../lib/utils";
+import type { FolioCheckboxProps } from "../folio-ui";
+
+/**
+ * Built-in, dependency-light Checkbox used when a consumer does not inject one.
+ * Wraps `@base-ui/react`'s accessible Checkbox primitive with a minimal check
+ * indicator; consumers inject their own design-system Checkbox for full polish.
+ */
+export function DefaultCheckbox({ className, ...props }: FolioCheckboxProps) {
+  return (
+    <CheckboxPrimitive.Root
+      className={cn("folio-default-checkbox", className)}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="folio-default-checkbox-indicator">
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="3"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
+        </svg>
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}

--- a/packages/folio/src/ui/defaults/color-picker.tsx
+++ b/packages/folio/src/ui/defaults/color-picker.tsx
@@ -25,6 +25,7 @@ export function DefaultColorPicker({
   onSelect,
   onClear,
   presets = EMPTY_PRESETS,
+  columns = 8,
   children,
 }: FolioColorPickerProps) {
   return (
@@ -51,7 +52,10 @@ export function DefaultColorPicker({
                 No color
               </PopoverPrimitive.Close>
             )}
-            <div className="folio-default-color-picker-swatches">
+            <div
+              className="folio-default-color-picker-swatches"
+              style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+            >
               {presets.map((preset) => (
                 <PopoverPrimitive.Close
                   aria-label={preset.label}

--- a/packages/folio/src/ui/defaults/color-picker.tsx
+++ b/packages/folio/src/ui/defaults/color-picker.tsx
@@ -1,0 +1,86 @@
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
+import { cn } from "../../lib/utils";
+import type { ColorPreset, FolioColorPickerProps } from "../folio-ui";
+
+/**
+ * Built-in, dependency-light ColorPicker used when a consumer does not inject
+ * one. Wraps `@base-ui/react`'s Popover primitive (focus management,
+ * portalling, collision-aware positioning) and renders the `presets` as a row
+ * of swatch buttons plus a native `<input type="color">` for a custom color.
+ * `onSelect` emits a preset value or a 6-char uppercase hex (no `#`), matching
+ * the design-system ColorPicker contract. Consumers inject a polished picker
+ * via `DocxEditor`'s `components` prop.
+ */
+const swatchColor = (preset: ColorPreset): string =>
+  preset.color ?? `#${preset.value}`;
+
+const normalizeHex = (hex: string): string =>
+  hex.replace(/^#/u, "").toUpperCase();
+
+const EMPTY_PRESETS: ColorPreset[] = [];
+
+export function DefaultColorPicker({
+  value,
+  onSelect,
+  onClear,
+  presets = EMPTY_PRESETS,
+  children,
+}: FolioColorPickerProps) {
+  return (
+    <PopoverPrimitive.Root>
+      <PopoverPrimitive.Trigger
+        nativeButton={false}
+        render={<div className="folio-default-color-picker-trigger" />}
+      >
+        {children}
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Positioner
+          align="start"
+          className="folio-default-popover-positioner"
+          side="bottom"
+          sideOffset={4}
+        >
+          <PopoverPrimitive.Popup className="folio-default-color-picker-popup">
+            {onClear && (
+              <PopoverPrimitive.Close
+                className="folio-default-color-picker-clear"
+                onClick={onClear}
+              >
+                No color
+              </PopoverPrimitive.Close>
+            )}
+            <div className="folio-default-color-picker-swatches">
+              {presets.map((preset) => (
+                <PopoverPrimitive.Close
+                  aria-label={preset.label}
+                  className={cn(
+                    "folio-default-color-picker-swatch",
+                    value === preset.value &&
+                      "folio-default-color-picker-swatch--selected",
+                  )}
+                  key={preset.value}
+                  onClick={() => onSelect?.(preset.value)}
+                  style={{ backgroundColor: swatchColor(preset) }}
+                  title={preset.label}
+                />
+              ))}
+            </div>
+            <label className="folio-default-color-picker-custom">
+              Custom
+              <input
+                aria-label="Custom color"
+                onChange={(event) =>
+                  onSelect?.(normalizeHex(event.target.value))
+                }
+                type="color"
+                value={value ? `#${normalizeHex(value)}` : "#000000"}
+              />
+            </label>
+          </PopoverPrimitive.Popup>
+        </PopoverPrimitive.Positioner>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/packages/folio/src/ui/defaults/date-picker-popover.tsx
+++ b/packages/folio/src/ui/defaults/date-picker-popover.tsx
@@ -1,0 +1,38 @@
+import type { FolioDatePickerPopoverProps } from "../folio-ui";
+
+/**
+ * Built-in, dependency-light DatePickerPopover used when a consumer does not
+ * inject one. Renders a native `<input type="date">` whose value is an ISO
+ * `yyyy-mm-dd` string; `onChange` emits that string (or `null` when cleared),
+ * matching the design-system picker contract. Consumers inject a polished
+ * calendar via `DocxEditor`'s `components` prop.
+ */
+const toISODate = (value: string | Date | null): string => {
+  if (value === null) {
+    return "";
+  }
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  return value.length >= 10 ? value.slice(0, 10) : value;
+};
+
+export function DefaultDatePickerPopover({
+  value,
+  onChange,
+  defaultOpen = false,
+}: FolioDatePickerPopoverProps) {
+  // The native date input is the intentional dependency-free fallback; a
+  // consumer injects a locale-aware DatePickerPopover via DocxEditor.
+  /* eslint-disable no-raw-date-input/no-raw-date-input -- intentional dependency-free fallback */
+  return (
+    <input
+      autoFocus={defaultOpen}
+      className="folio-default-date-input"
+      onChange={(event) => onChange(event.target.value || null)}
+      type="date"
+      value={toISODate(value)}
+    />
+    /* eslint-enable no-raw-date-input/no-raw-date-input */
+  );
+}

--- a/packages/folio/src/ui/defaults/date-picker-popover.tsx
+++ b/packages/folio/src/ui/defaults/date-picker-popover.tsx
@@ -12,7 +12,10 @@ const toISODate = (value: string | Date | null): string => {
     return "";
   }
   if (value instanceof Date) {
-    return value.toISOString().slice(0, 10);
+    const year = value.getFullYear().toString().padStart(4, "0");
+    const month = (value.getMonth() + 1).toString().padStart(2, "0");
+    const day = value.getDate().toString().padStart(2, "0");
+    return `${year}-${month}-${day}`;
   }
   return value.length >= 10 ? value.slice(0, 10) : value;
 };

--- a/packages/folio/src/ui/defaults/dialog.tsx
+++ b/packages/folio/src/ui/defaults/dialog.tsx
@@ -1,0 +1,76 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+
+import { cn } from "../../lib/utils";
+import type {
+  FolioDialogBackdropProps,
+  FolioDialogCloseProps,
+  FolioDialogPopupProps,
+  FolioDialogPortalProps,
+  FolioDialogRootProps,
+  FolioDialogTitleProps,
+} from "../folio-ui";
+
+/**
+ * Built-in, dependency-light Dialog parts used when a consumer does not inject
+ * its own. Each part wraps the matching `@base-ui/react` primitive — the same
+ * accessible primitive the app design system wraps — with minimal styling.
+ * Folio's chrome positions the popup itself via `className`, so the default
+ * popup is a bare portalled surface (no viewport grid); consumers inject a
+ * polished Dialog through `DocxEditor`'s `components` prop.
+ */
+
+function DefaultDialogRoot(props: FolioDialogRootProps) {
+  return <DialogPrimitive.Root {...props} />;
+}
+
+function DefaultDialogPortal(props: FolioDialogPortalProps) {
+  return <DialogPrimitive.Portal {...props} />;
+}
+
+function DefaultDialogBackdrop({
+  className,
+  ...props
+}: FolioDialogBackdropProps) {
+  return (
+    <DialogPrimitive.Backdrop
+      className={cn("folio-default-dialog-backdrop", className)}
+      {...props}
+    />
+  );
+}
+
+function DefaultDialogPopup({ className, ...props }: FolioDialogPopupProps) {
+  return (
+    <DialogPrimitive.Popup
+      className={cn("folio-default-dialog-popup", className)}
+      {...props}
+    />
+  );
+}
+
+function DefaultDialogTitle({ className, ...props }: FolioDialogTitleProps) {
+  return (
+    <DialogPrimitive.Title
+      className={cn("folio-default-dialog-title", className)}
+      {...props}
+    />
+  );
+}
+
+function DefaultDialogClose({ className, ...props }: FolioDialogCloseProps) {
+  return (
+    <DialogPrimitive.Close
+      className={cn("folio-default-dialog-close", className)}
+      {...props}
+    />
+  );
+}
+
+export const DefaultDialog = {
+  Root: DefaultDialogRoot,
+  Portal: DefaultDialogPortal,
+  Backdrop: DefaultDialogBackdrop,
+  Popup: DefaultDialogPopup,
+  Title: DefaultDialogTitle,
+  Close: DefaultDialogClose,
+};

--- a/packages/folio/src/ui/defaults/input.tsx
+++ b/packages/folio/src/ui/defaults/input.tsx
@@ -1,0 +1,42 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+
+import { cn } from "../../lib/utils";
+import type { FolioInputProps } from "../folio-ui";
+
+/**
+ * Built-in, dependency-light Input used when a consumer does not inject one.
+ *
+ * Wraps `@base-ui/react`'s Input primitive, honoring the `nativeInput` escape
+ * hatch (render a plain `<input>` when the caller needs uncontrolled native
+ * behavior) and folio's `size` shorthand. Styling is intentionally minimal;
+ * consumers inject their own design-system Input for full polish.
+ */
+export function DefaultInput({
+  className,
+  size = "default",
+  nativeInput = false,
+  ...props
+}: FolioInputProps) {
+  const inputClassName = cn("folio-default-input", className);
+  const numericSize = typeof size === "number" ? size : undefined;
+
+  if (nativeInput) {
+    return (
+      <input
+        className={inputClassName}
+        data-size={typeof size === "string" ? size : undefined}
+        size={numericSize}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <InputPrimitive
+      className={inputClassName}
+      data-size={typeof size === "string" ? size : undefined}
+      size={numericSize}
+      {...props}
+    />
+  );
+}

--- a/packages/folio/src/ui/defaults/menu.tsx
+++ b/packages/folio/src/ui/defaults/menu.tsx
@@ -1,0 +1,140 @@
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+
+import { cn } from "../../lib/utils";
+import type {
+  FolioMenuCheckboxItemProps,
+  FolioMenuGroupLabelProps,
+  FolioMenuGroupProps,
+  FolioMenuItemProps,
+  FolioMenuPopupProps,
+  FolioMenuRootProps,
+  FolioMenuSeparatorProps,
+  FolioMenuTriggerProps,
+} from "../folio-ui";
+
+/**
+ * Built-in, dependency-light Menu parts used when a consumer does not inject
+ * its own. Each part wraps the matching `@base-ui/react` primitive (real
+ * keyboard navigation, portalling, collision-aware positioning) with minimal
+ * styling. Consumers inject a polished Menu via `DocxEditor`'s `components`
+ * prop.
+ */
+
+function DefaultMenuRoot(props: FolioMenuRootProps) {
+  return <MenuPrimitive.Root {...props} />;
+}
+
+function DefaultMenuTrigger({
+  nativeButton = true,
+  ...props
+}: FolioMenuTriggerProps) {
+  return <MenuPrimitive.Trigger nativeButton={nativeButton} {...props} />;
+}
+
+function DefaultMenuPopup({
+  className,
+  children,
+  align = "center",
+  side = "bottom",
+  sideOffset = 4,
+  alignOffset,
+  ...props
+}: FolioMenuPopupProps) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        className="folio-default-menu-positioner"
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          className={cn("folio-default-menu-popup", className)}
+          {...props}
+        >
+          {children}
+        </MenuPrimitive.Popup>
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+function DefaultMenuItem({ className, ...props }: FolioMenuItemProps) {
+  return (
+    <MenuPrimitive.Item
+      className={cn("folio-default-menu-item", className)}
+      {...props}
+    />
+  );
+}
+
+function DefaultMenuCheckboxItem({
+  className,
+  children,
+  ...props
+}: FolioMenuCheckboxItemProps) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      className={cn("folio-default-menu-checkbox-item", className)}
+      {...props}
+    >
+      <MenuPrimitive.CheckboxItemIndicator className="folio-default-menu-checkbox-indicator">
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="3"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
+        </svg>
+      </MenuPrimitive.CheckboxItemIndicator>
+      <span>{children}</span>
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+function DefaultMenuGroup(props: FolioMenuGroupProps) {
+  return <MenuPrimitive.Group {...props} />;
+}
+
+function DefaultMenuGroupLabel({
+  className,
+  ...props
+}: FolioMenuGroupLabelProps) {
+  return (
+    <MenuPrimitive.GroupLabel
+      className={cn("folio-default-menu-group-label", className)}
+      {...props}
+    />
+  );
+}
+
+function DefaultMenuSeparator({
+  className,
+  ...props
+}: FolioMenuSeparatorProps) {
+  return (
+    <MenuPrimitive.Separator
+      className={cn("folio-default-menu-separator", className)}
+      {...props}
+    />
+  );
+}
+
+export const DefaultMenu = {
+  Root: DefaultMenuRoot,
+  Trigger: DefaultMenuTrigger,
+  Popup: DefaultMenuPopup,
+  Item: DefaultMenuItem,
+  CheckboxItem: DefaultMenuCheckboxItem,
+  Group: DefaultMenuGroup,
+  GroupLabel: DefaultMenuGroupLabel,
+  Separator: DefaultMenuSeparator,
+};

--- a/packages/folio/src/ui/defaults/outline-rail.tsx
+++ b/packages/folio/src/ui/defaults/outline-rail.tsx
@@ -1,0 +1,59 @@
+import { cn } from "../../lib/utils";
+import type { FolioOutlineRailProps } from "../folio-ui";
+
+/**
+ * Built-in, dependency-light OutlineRail used when a consumer does not inject
+ * one. Renders the outline as a plain semantic `<nav>` list of clickable
+ * entries indented by level; clicking an entry calls `onJump` with the resolved
+ * scroll container. Consumers inject the polished tick-rail + hover panel via
+ * `DocxEditor`'s `components` prop.
+ */
+export function DefaultOutlineRail({
+  items,
+  scrollContainerRef,
+  onJump,
+  activeId,
+  topOffset = 0,
+  panelWidth = 300,
+  ariaLabel = "Outline",
+}: FolioOutlineRailProps) {
+  if (items.length < 2) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className="folio-default-outline-rail"
+      style={{ top: topOffset, width: panelWidth }}
+    >
+      <ul className="folio-default-outline-list">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <li key={item.id}>
+              <button
+                aria-current={isActive ? "true" : undefined}
+                className={cn(
+                  "folio-default-outline-item",
+                  isActive && "folio-default-outline-item--active",
+                )}
+                onClick={() => {
+                  const container = scrollContainerRef.current;
+                  if (container) {
+                    onJump(item.id, container);
+                  }
+                }}
+                style={{ paddingInlineStart: `${item.level * 12 + 8}px` }}
+                title={item.label}
+                type="button"
+              >
+                {item.label}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/packages/folio/src/ui/defaults/popover.tsx
+++ b/packages/folio/src/ui/defaults/popover.tsx
@@ -1,0 +1,65 @@
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
+import { cn } from "../../lib/utils";
+import type {
+  FolioPopoverCloseProps,
+  FolioPopoverPopupProps,
+  FolioPopoverRootProps,
+  FolioPopoverTriggerProps,
+} from "../folio-ui";
+
+/**
+ * Built-in, dependency-light Popover parts used when a consumer does not inject
+ * its own. Each part wraps the matching `@base-ui/react` primitive (real focus
+ * management, portalling, and collision-aware positioning) with minimal
+ * styling. Consumers inject a polished Popover via `DocxEditor`'s `components`
+ * prop.
+ */
+
+function DefaultPopoverRoot(props: FolioPopoverRootProps) {
+  return <PopoverPrimitive.Root {...props} />;
+}
+
+function DefaultPopoverTrigger(props: FolioPopoverTriggerProps) {
+  return <PopoverPrimitive.Trigger {...props} />;
+}
+
+function DefaultPopoverPopup({
+  className,
+  children,
+  side = "bottom",
+  align = "center",
+  sideOffset = 4,
+  alignOffset = 0,
+  ...props
+}: FolioPopoverPopupProps) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        className="folio-default-popover-positioner"
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <PopoverPrimitive.Popup
+          className={cn("folio-default-popover-popup", className)}
+          {...props}
+        >
+          {children}
+        </PopoverPrimitive.Popup>
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function DefaultPopoverClose(props: FolioPopoverCloseProps) {
+  return <PopoverPrimitive.Close {...props} />;
+}
+
+export const DefaultPopover = {
+  Root: DefaultPopoverRoot,
+  Trigger: DefaultPopoverTrigger,
+  Popup: DefaultPopoverPopup,
+  Close: DefaultPopoverClose,
+};

--- a/packages/folio/src/ui/defaults/select.tsx
+++ b/packages/folio/src/ui/defaults/select.tsx
@@ -25,11 +25,13 @@ function DefaultSelectRoot(props: FolioSelectRootProps) {
 function DefaultSelectTrigger({
   className,
   children,
+  size,
   ...props
 }: FolioSelectTriggerProps) {
   return (
     <SelectPrimitive.Trigger
       className={cn("folio-default-select-trigger", className)}
+      data-size={size}
       {...props}
     >
       {children}

--- a/packages/folio/src/ui/defaults/select.tsx
+++ b/packages/folio/src/ui/defaults/select.tsx
@@ -1,0 +1,110 @@
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+
+import { cn } from "../../lib/utils";
+import type {
+  FolioSelectItemProps,
+  FolioSelectPopupProps,
+  FolioSelectRootProps,
+  FolioSelectTriggerProps,
+  FolioSelectValueProps,
+} from "../folio-ui";
+
+/**
+ * Built-in, dependency-light Select parts used when a consumer does not inject
+ * its own. Each part wraps the matching `@base-ui/react` primitive (real
+ * listbox semantics, keyboard navigation, portalled positioning) with minimal
+ * styling. The default popup omits the scroll arrows and item-aligned
+ * positioning of a fully styled design-system Select; consumers inject their
+ * own Select via `DocxEditor`'s `components` prop for that polish.
+ */
+
+function DefaultSelectRoot(props: FolioSelectRootProps) {
+  return <SelectPrimitive.Root {...props} />;
+}
+
+function DefaultSelectTrigger({
+  className,
+  children,
+  ...props
+}: FolioSelectTriggerProps) {
+  return (
+    <SelectPrimitive.Trigger
+      className={cn("folio-default-select-trigger", className)}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon className="folio-default-select-icon">
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="16"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="m7 15 5 5 5-5M7 9l5-5 5 5" />
+        </svg>
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function DefaultSelectValue({ className, ...props }: FolioSelectValueProps) {
+  return (
+    <SelectPrimitive.Value
+      className={cn("folio-default-select-value", className)}
+      {...props}
+    />
+  );
+}
+
+function DefaultSelectPopup({
+  className,
+  children,
+  ...props
+}: FolioSelectPopupProps) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        align="start"
+        className="folio-default-select-positioner"
+        side="bottom"
+        sideOffset={4}
+      >
+        <SelectPrimitive.Popup
+          className={cn("folio-default-select-popup", className)}
+          {...props}
+        >
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function DefaultSelectItem({
+  className,
+  children,
+  ...props
+}: FolioSelectItemProps) {
+  return (
+    <SelectPrimitive.Item
+      className={cn("folio-default-select-item", className)}
+      {...props}
+    >
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+export const DefaultSelect = {
+  Root: DefaultSelectRoot,
+  Trigger: DefaultSelectTrigger,
+  Value: DefaultSelectValue,
+  Popup: DefaultSelectPopup,
+  Item: DefaultSelectItem,
+};

--- a/packages/folio/src/ui/folio-ui.test.ts
+++ b/packages/folio/src/ui/folio-ui.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_COMPONENTS,
+  resolveFolioComponents,
+  type FolioButtonProps,
+} from "./folio-ui";
+
+// A sentinel override component; identity is all the resolution test checks.
+const InjectedButton = (_props: FolioButtonProps) => null;
+
+describe("resolveFolioComponents", () => {
+  test("returns the defaults when nothing is injected", () => {
+    expect(resolveFolioComponents()).toBe(DEFAULT_COMPONENTS);
+    expect(resolveFolioComponents(undefined)).toBe(DEFAULT_COMPONENTS);
+  });
+
+  test("an empty override still resolves every contract key to a default", () => {
+    // A non-undefined override forces a fresh merged object, so identity differs
+    // but every value equals its default.
+    expect(resolveFolioComponents({})).toEqual(DEFAULT_COMPONENTS);
+  });
+
+  test("an injected component wins; unspecified keys fall back to defaults", () => {
+    const resolved = resolveFolioComponents({ Button: InjectedButton });
+    expect(resolved.Button).toBe(InjectedButton);
+    // Every other key is untouched.
+    expect(resolved.Dialog).toBe(DEFAULT_COMPONENTS.Dialog);
+    expect(resolved.Select).toBe(DEFAULT_COMPONENTS.Select);
+    expect(resolved.Menu).toBe(DEFAULT_COMPONENTS.Menu);
+    expect(resolved.Input).toBe(DEFAULT_COMPONENTS.Input);
+  });
+
+  test("resolution does not mutate the shared defaults object", () => {
+    const before = { ...DEFAULT_COMPONENTS };
+    resolveFolioComponents({ Button: InjectedButton });
+    expect(DEFAULT_COMPONENTS).toEqual(before);
+    expect(DEFAULT_COMPONENTS.Button).not.toBe(InjectedButton);
+  });
+
+  test("every contract key has a non-null default (no gaps standalone)", () => {
+    for (const component of Object.values(DEFAULT_COMPONENTS)) {
+      expect(component).toBeDefined();
+    }
+  });
+});

--- a/packages/folio/src/ui/folio-ui.tsx
+++ b/packages/folio/src/ui/folio-ui.tsx
@@ -1,0 +1,66 @@
+import { createContext, useContext } from "react";
+import type { ComponentProps, ComponentType, ReactNode } from "react";
+
+import { DefaultButton } from "./defaults/button";
+
+/**
+ * Folio chrome (toolbars, dialogs, error states) renders UI primitives that a
+ * consumer can override with its own design system. Each entry in
+ * `FolioUIComponents` is a React component folio's chrome renders; the contract
+ * grows as more primitives are decoupled from a hard design-system dependency.
+ *
+ * Standalone folio uses {@link DEFAULT_COMPONENTS}; consumers inject overrides
+ * through `DocxEditor`'s `components` prop.
+ */
+
+/**
+ * The Button prop subset folio's chrome actually relies on. `variant` and
+ * `size` are deliberately narrow string-literal unions: each is a subset of the
+ * design-system Button's options so an external Button stays assignable as an
+ * override. Native attributes are picked from `<button>` so their types match
+ * exactly.
+ */
+export type FolioButtonProps = Pick<
+  ComponentProps<"button">,
+  | "onClick"
+  | "onMouseDown"
+  | "className"
+  | "disabled"
+  | "type"
+  | "title"
+  | "aria-label"
+  | "aria-pressed"
+  | "children"
+> & {
+  variant?: "default" | "ghost";
+  size?: "sm" | "xs" | "icon-xs";
+};
+
+export type FolioUIComponents = {
+  Button: ComponentType<FolioButtonProps>;
+};
+
+export const DEFAULT_COMPONENTS: FolioUIComponents = {
+  Button: DefaultButton,
+};
+
+const FolioUIContext = createContext<FolioUIComponents>(DEFAULT_COMPONENTS);
+
+export function FolioUIProvider({
+  components,
+  children,
+}: {
+  components?: Partial<FolioUIComponents> | undefined;
+  children: ReactNode;
+}) {
+  const value = components
+    ? { ...DEFAULT_COMPONENTS, ...components }
+    : DEFAULT_COMPONENTS;
+  return (
+    <FolioUIContext.Provider value={value}>{children}</FolioUIContext.Provider>
+  );
+}
+
+export function useFolioUI(): FolioUIComponents {
+  return useContext(FolioUIContext);
+}

--- a/packages/folio/src/ui/folio-ui.tsx
+++ b/packages/folio/src/ui/folio-ui.tsx
@@ -1,17 +1,49 @@
 import { createContext, useContext } from "react";
-import type { ComponentProps, ComponentType, ReactNode } from "react";
+import type {
+  ComponentProps,
+  ComponentType,
+  CSSProperties,
+  ReactNode,
+  RefAttributes,
+} from "react";
+
+import type { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+import type { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import type { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import type { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import type { Select as SelectPrimitive } from "@base-ui/react/select";
 
 import { DefaultButton } from "./defaults/button";
+import { DefaultCheckbox } from "./defaults/checkbox";
+import { DefaultDialog } from "./defaults/dialog";
+import { DefaultInput } from "./defaults/input";
+import { DefaultMenu } from "./defaults/menu";
+import { DefaultPopover } from "./defaults/popover";
+import { DefaultSelect } from "./defaults/select";
 
 /**
- * Folio chrome (toolbars, dialogs, error states) renders UI primitives that a
- * consumer can override with its own design system. Each entry in
- * `FolioUIComponents` is a React component folio's chrome renders; the contract
- * grows as more primitives are decoupled from a hard design-system dependency.
+ * Folio chrome (toolbars, dialogs, pickers, find/replace) renders UI primitives
+ * that a consumer can override with its own design system. Each entry in
+ * {@link FolioUIComponents} is a React component (or a part-object of compound
+ * sub-components) folio's chrome renders; the contract grows as more primitives
+ * are decoupled from a hard design-system dependency.
  *
- * Standalone folio uses {@link DEFAULT_COMPONENTS}; consumers inject overrides
- * through `DocxEditor`'s `components` prop.
+ * Compound primitives (Dialog, Select, Menu, Popover) are modeled as
+ * part-objects: a typed record of their sub-parts (`Root`, `Popup`, …). Chrome
+ * destructures the parts it needs from {@link useFolioUI}; the part shape keeps
+ * one key per primitive in the contract and lets the app inject a flat
+ * design-system module as a small adapter object. Each part's props are the
+ * subset of the underlying `@base-ui/react` part's props folio relies on, so an
+ * external component (which accepts a superset) stays assignable as an override.
+ *
+ * Standalone folio uses {@link DEFAULT_COMPONENTS} (built on `@base-ui/react`,
+ * the neutral primitive the app design system also wraps); consumers inject
+ * overrides through `DocxEditor`'s `components` prop.
  */
+
+// ============================================================================
+// Button
+// ============================================================================
 
 /**
  * The Button prop subset folio's chrome actually relies on. `variant` and
@@ -36,12 +68,209 @@ export type FolioButtonProps = Pick<
   size?: "sm" | "xs" | "icon-xs";
 };
 
+// ============================================================================
+// Dialog
+// ============================================================================
+
+export type FolioDialogRootProps = Pick<
+  DialogPrimitive.Root.Props,
+  "open" | "onOpenChange"
+> & { children?: ReactNode };
+export type FolioDialogPortalProps = { children?: ReactNode };
+export type FolioDialogBackdropProps = { className?: string };
+export type FolioDialogPopupProps = {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioDialogTitleProps = {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioDialogCloseProps = {
+  className?: string;
+  children?: ReactNode;
+};
+
+export type FolioDialog = {
+  Root: ComponentType<FolioDialogRootProps>;
+  Portal: ComponentType<FolioDialogPortalProps>;
+  Backdrop: ComponentType<FolioDialogBackdropProps>;
+  Popup: ComponentType<FolioDialogPopupProps>;
+  Title: ComponentType<FolioDialogTitleProps>;
+  Close: ComponentType<FolioDialogCloseProps>;
+};
+
+// ============================================================================
+// Select
+// ============================================================================
+
+export type FolioSelectRootProps = Pick<
+  SelectPrimitive.Root.Props<string>,
+  "value" | "onValueChange" | "disabled" | "items"
+> & { children?: ReactNode };
+export type FolioSelectTriggerProps = Pick<
+  SelectPrimitive.Trigger.Props,
+  "style"
+> & {
+  className?: string;
+  children?: ReactNode;
+  size?: "sm" | "default" | "lg";
+  "data-folio-style-picker"?: string;
+};
+export type FolioSelectValueProps = Pick<
+  SelectPrimitive.Value.Props,
+  "placeholder"
+> & {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioSelectPopupProps = {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioSelectItemProps = Pick<SelectPrimitive.Item.Props, "value"> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export type FolioSelect = {
+  Root: ComponentType<FolioSelectRootProps>;
+  Trigger: ComponentType<FolioSelectTriggerProps>;
+  Value: ComponentType<FolioSelectValueProps>;
+  Popup: ComponentType<FolioSelectPopupProps>;
+  Item: ComponentType<FolioSelectItemProps>;
+};
+
+// ============================================================================
+// Menu
+// ============================================================================
+
+export type FolioMenuRootProps = { children?: ReactNode };
+export type FolioMenuTriggerProps = Pick<
+  MenuPrimitive.Trigger.Props,
+  "render" | "disabled" | "type" | "aria-label" | "onMouseDown"
+> & {
+  className?: string;
+  children?: ReactNode;
+  nativeButton?: boolean;
+};
+export type FolioMenuPopupProps = {
+  className?: string;
+  children?: ReactNode;
+  align?: MenuPrimitive.Positioner.Props["align"];
+  side?: MenuPrimitive.Positioner.Props["side"];
+  sideOffset?: MenuPrimitive.Positioner.Props["sideOffset"];
+  alignOffset?: MenuPrimitive.Positioner.Props["alignOffset"];
+};
+export type FolioMenuItemProps = Pick<MenuPrimitive.Item.Props, "onClick"> & {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioMenuCheckboxItemProps = Pick<
+  MenuPrimitive.CheckboxItem.Props,
+  "checked" | "onCheckedChange"
+> & {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioMenuGroupProps = { children?: ReactNode };
+export type FolioMenuGroupLabelProps = {
+  className?: string;
+  children?: ReactNode;
+};
+export type FolioMenuSeparatorProps = { className?: string };
+
+export type FolioMenu = {
+  Root: ComponentType<FolioMenuRootProps>;
+  Trigger: ComponentType<FolioMenuTriggerProps>;
+  Popup: ComponentType<FolioMenuPopupProps>;
+  Item: ComponentType<FolioMenuItemProps>;
+  CheckboxItem: ComponentType<FolioMenuCheckboxItemProps>;
+  Group: ComponentType<FolioMenuGroupProps>;
+  GroupLabel: ComponentType<FolioMenuGroupLabelProps>;
+  Separator: ComponentType<FolioMenuSeparatorProps>;
+};
+
+// ============================================================================
+// Popover
+// ============================================================================
+
+export type FolioPopoverRootProps = { children?: ReactNode };
+export type FolioPopoverTriggerProps = Pick<
+  PopoverPrimitive.Trigger.Props,
+  "disabled" | "render"
+> & {
+  className?: string;
+  children?: ReactNode;
+  "data-testid"?: string;
+};
+export type FolioPopoverPopupProps = Pick<
+  PopoverPrimitive.Popup.Props,
+  "onMouseDown"
+> & {
+  className?: string;
+  children?: ReactNode;
+  side?: PopoverPrimitive.Positioner.Props["side"];
+  align?: PopoverPrimitive.Positioner.Props["align"];
+  sideOffset?: PopoverPrimitive.Positioner.Props["sideOffset"];
+  alignOffset?: PopoverPrimitive.Positioner.Props["alignOffset"];
+};
+export type FolioPopoverCloseProps = Pick<
+  PopoverPrimitive.Close.Props,
+  "render"
+> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export type FolioPopover = {
+  Root: ComponentType<FolioPopoverRootProps>;
+  Trigger: ComponentType<FolioPopoverTriggerProps>;
+  Popup: ComponentType<FolioPopoverPopupProps>;
+  Close: ComponentType<FolioPopoverCloseProps>;
+};
+
+// ============================================================================
+// Input / Checkbox (single primitives)
+// ============================================================================
+
+export type FolioInputProps = Omit<
+  ComponentProps<"input">,
+  "size" | "ref" | "style"
+> &
+  RefAttributes<HTMLInputElement> & {
+    style?: CSSProperties;
+    size?: "sm" | "default" | "lg" | number;
+    nativeInput?: boolean;
+  };
+
+export type FolioCheckboxProps = Pick<
+  CheckboxPrimitive.Root.Props,
+  "checked" | "onCheckedChange"
+> & { className?: string };
+
+// ============================================================================
+// Contract + context
+// ============================================================================
+
 export type FolioUIComponents = {
   Button: ComponentType<FolioButtonProps>;
+  Dialog: FolioDialog;
+  Select: FolioSelect;
+  Menu: FolioMenu;
+  Popover: FolioPopover;
+  Input: ComponentType<FolioInputProps>;
+  Checkbox: ComponentType<FolioCheckboxProps>;
 };
 
 export const DEFAULT_COMPONENTS: FolioUIComponents = {
   Button: DefaultButton,
+  Dialog: DefaultDialog,
+  Select: DefaultSelect,
+  Menu: DefaultMenu,
+  Popover: DefaultPopover,
+  Input: DefaultInput,
+  Checkbox: DefaultCheckbox,
 };
 
 const FolioUIContext = createContext<FolioUIComponents>(DEFAULT_COMPONENTS);

--- a/packages/folio/src/ui/folio-ui.tsx
+++ b/packages/folio/src/ui/folio-ui.tsx
@@ -5,6 +5,7 @@ import type {
   CSSProperties,
   ReactNode,
   RefAttributes,
+  RefObject,
 } from "react";
 
 import type { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
@@ -15,9 +16,12 @@ import type { Select as SelectPrimitive } from "@base-ui/react/select";
 
 import { DefaultButton } from "./defaults/button";
 import { DefaultCheckbox } from "./defaults/checkbox";
+import { DefaultColorPicker } from "./defaults/color-picker";
+import { DefaultDatePickerPopover } from "./defaults/date-picker-popover";
 import { DefaultDialog } from "./defaults/dialog";
 import { DefaultInput } from "./defaults/input";
 import { DefaultMenu } from "./defaults/menu";
+import { DefaultOutlineRail } from "./defaults/outline-rail";
 import { DefaultPopover } from "./defaults/popover";
 import { DefaultSelect } from "./defaults/select";
 
@@ -250,6 +254,93 @@ export type FolioCheckboxProps = Pick<
 > & { className?: string };
 
 // ============================================================================
+// ColorPicker
+// ============================================================================
+
+/**
+ * A color preset rendered as a swatch in the picker. Mirrors the design
+ * system's preset shape so an external ColorPicker stays assignable as an
+ * override; `color` is the optional CSS color for the swatch (falls back to
+ * `#${value}`), and `value` is what `onSelect` emits.
+ */
+export type ColorPreset = {
+  label: string;
+  value: string;
+  color?: string;
+};
+
+/**
+ * The ColorPicker prop subset folio's chrome relies on. The picker wraps a
+ * trigger (`children`) in a popover exposing the `presets` plus a custom-color
+ * input; `onSelect` fires with a preset value or a 6-char hex (no `#`), and
+ * `onClear` clears the color. The design-system ColorPicker accepts a superset
+ * (placement, expansion, className) so it stays assignable as an override.
+ */
+export type FolioColorPickerProps = {
+  value?: string | undefined;
+  onSelect?: (value: string) => void;
+  onClear?: () => void;
+  presets?: ColorPreset[];
+  columns?: number;
+  children: ReactNode;
+};
+
+// ============================================================================
+// DatePickerPopover
+// ============================================================================
+
+/**
+ * The DatePickerPopover prop subset folio's chrome relies on. `value` accepts
+ * an ISO string, a `Date`, or `null`; `onChange` emits an ISO `yyyy-mm-dd`
+ * string (or `null` when cleared). The design-system picker accepts a superset
+ * (locale, min/max, overdue styling) so it stays assignable as an override.
+ */
+export type FolioDatePickerPopoverProps = {
+  value: string | Date | null;
+  onChange: (value: string | null) => void;
+  clearLabel?: string;
+  defaultOpen?: boolean;
+  showIcon?: boolean;
+};
+
+// ============================================================================
+// OutlineRail
+// ============================================================================
+
+/**
+ * One entry in the document outline. Mirrors the design system's item shape so
+ * an external OutlineRail stays assignable as an override.
+ */
+export type OutlineItem = {
+  id: string;
+  label: string;
+  /** Nesting depth; drives indent + tick taper. */
+  level: number;
+  /** Optional trailing annotation in the panel (e.g. a page number). */
+  meta?: string;
+  /** Optional CSS custom-property name colouring this entry. */
+  color?: string;
+};
+
+/**
+ * The OutlineRail prop subset folio's chrome relies on. The rail resolves each
+ * item's vertical position via `resolvePct` and navigates via `onJump` (both
+ * receive the resolved scroll container). `activeId` controls the highlighted
+ * entry. The design-system rail accepts a superset so it stays assignable as an
+ * override.
+ */
+export type FolioOutlineRailProps = {
+  items: OutlineItem[];
+  scrollContainerRef: RefObject<HTMLElement | null>;
+  resolvePct: (id: string, container: HTMLElement) => number | null;
+  onJump: (id: string, container: HTMLElement) => void;
+  activeId?: string | null;
+  topOffset?: number;
+  panelWidth?: number;
+  ariaLabel?: string;
+};
+
+// ============================================================================
 // Contract + context
 // ============================================================================
 
@@ -261,6 +352,9 @@ export type FolioUIComponents = {
   Popover: FolioPopover;
   Input: ComponentType<FolioInputProps>;
   Checkbox: ComponentType<FolioCheckboxProps>;
+  ColorPicker: ComponentType<FolioColorPickerProps>;
+  DatePickerPopover: ComponentType<FolioDatePickerPopoverProps>;
+  OutlineRail: ComponentType<FolioOutlineRailProps>;
 };
 
 export const DEFAULT_COMPONENTS: FolioUIComponents = {
@@ -271,6 +365,9 @@ export const DEFAULT_COMPONENTS: FolioUIComponents = {
   Popover: DefaultPopover,
   Input: DefaultInput,
   Checkbox: DefaultCheckbox,
+  ColorPicker: DefaultColorPicker,
+  DatePickerPopover: DefaultDatePickerPopover,
+  OutlineRail: DefaultOutlineRail,
 };
 
 const FolioUIContext = createContext<FolioUIComponents>(DEFAULT_COMPONENTS);

--- a/packages/folio/src/ui/folio-ui.tsx
+++ b/packages/folio/src/ui/folio-ui.tsx
@@ -119,7 +119,6 @@ export type FolioSelectTriggerProps = Pick<
   className?: string;
   children?: ReactNode;
   size?: "sm" | "default" | "lg";
-  "data-folio-style-picker"?: string;
 };
 export type FolioSelectValueProps = Pick<
   SelectPrimitive.Value.Props,
@@ -372,6 +371,19 @@ export const DEFAULT_COMPONENTS: FolioUIComponents = {
 
 const FolioUIContext = createContext<FolioUIComponents>(DEFAULT_COMPONENTS);
 
+/**
+ * Merge a consumer's partial overrides over the built-in defaults: every key is
+ * present (defaults fill the gaps), and each provided override wins. Pure, so
+ * the resolution contract is unit-tested independently of React.
+ */
+export function resolveFolioComponents(
+  components?: Partial<FolioUIComponents>,
+): FolioUIComponents {
+  return components
+    ? { ...DEFAULT_COMPONENTS, ...components }
+    : DEFAULT_COMPONENTS;
+}
+
 export function FolioUIProvider({
   components,
   children,
@@ -379,9 +391,7 @@ export function FolioUIProvider({
   components?: Partial<FolioUIComponents> | undefined;
   children: ReactNode;
 }) {
-  const value = components
-    ? { ...DEFAULT_COMPONENTS, ...components }
-    : DEFAULT_COMPONENTS;
+  const value = resolveFolioComponents(components);
   return (
     <FolioUIContext.Provider value={value}>{children}</FolioUIContext.Provider>
   );

--- a/packages/folio/src/ui/no-design-system.test.ts
+++ b/packages/folio/src/ui/no-design-system.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Package-wide guard: no folio source file imports the app design system
+ * (`@stll/ui`). The chrome (toolbars, dialogs, pickers) renders the injectable
+ * {@link FolioUIComponents} contract with built-in defaults instead, so the
+ * whole package stays self-contained and consumers inject their own UI.
+ *
+ * `core/__tests__/react-free-core.test.ts` already forbids `@stll/ui` under
+ * `core/`; this extends the same boundary to the React chrome layer
+ * (`components/`, `ui/`, `paged-editor/`, …), where it previously lived. Bun
+ * arch test rather than an oxlint rule so it survives config-merge changes and
+ * documents the boundary alongside the code.
+ */
+
+import { Glob } from "bun";
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// `src/` root: this file lives in `src/ui/`.
+const SRC_DIR = path.resolve(import.meta.dir, "..");
+
+const FORBIDDEN = "@stll/ui";
+
+const IMPORT_REGEX =
+  /\bfrom\s*["'](?<fromSpec>[^"']+)["']|\bimport\s*["'](?<importSpec>[^"']+)["']|\bimport\s*\(\s*["'](?<dynImportSpec>[^"']+)["']\s*\)/gu;
+
+// Strip comments before the raw-text scan so prose mentioning the package
+// cannot trip it (keeps the char before `//` so it does not eat `https://`).
+const stripComments = (source: string): string =>
+  source
+    .replaceAll(/\/\*[\s\S]*?\*\//gu, "")
+    .replaceAll(/(?<lead>^|[^:])\/\/[^\n]*/gmu, "$<lead>");
+
+const isForbidden = (specifier: string): boolean =>
+  specifier === FORBIDDEN || specifier.startsWith(`${FORBIDDEN}/`);
+
+type Violation = { importer: string; specifier: string };
+
+const violationsForFile = (filePath: string): Violation[] => {
+  const found: Violation[] = [];
+  const source = stripComments(readFileSync(filePath, "utf-8"));
+  for (const match of source.matchAll(IMPORT_REGEX)) {
+    const specifier =
+      match.groups?.["fromSpec"] ??
+      match.groups?.["importSpec"] ??
+      match.groups?.["dynImportSpec"];
+    if (specifier !== undefined && isForbidden(specifier)) {
+      found.push({ importer: filePath, specifier });
+    }
+  }
+  return found;
+};
+
+// Test files carry synthetic `@stll/ui` fixture strings on purpose.
+const isTestFile = (relativePath: string): boolean =>
+  relativePath.includes("__tests__/") ||
+  relativePath.endsWith(".test.ts") ||
+  relativePath.endsWith(".test.tsx");
+
+const collectSourceFiles = (): string[] => {
+  const glob = new Glob("**/*.{ts,tsx}");
+  const files: string[] = [];
+  for (const relative of glob.scanSync({ cwd: SRC_DIR })) {
+    if (!isTestFile(relative)) {
+      files.push(path.resolve(SRC_DIR, relative));
+    }
+  }
+  return files;
+};
+
+describe("folio does not depend on the app design system", () => {
+  test("no folio source file imports @stll/ui", () => {
+    const violations = collectSourceFiles().flatMap(violationsForFile);
+    if (violations.length > 0) {
+      const formatted = violations
+        .map((v) => `  ${v.importer} -> ${v.specifier}`)
+        .join("\n");
+      throw new Error(
+        `folio must not import @stll/ui; use the injectable FolioUIComponents contract instead:\n${formatted}`,
+      );
+    }
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/packages/folio/src/utils/contained-handler.ts
+++ b/packages/folio/src/utils/contained-handler.ts
@@ -1,0 +1,57 @@
+import type * as React from "react";
+
+/**
+ * Wrap a React event handler so it only fires when the event target
+ * is a DOM descendant of the given ref.
+ *
+ * React forwards synthetic events through the parent React tree even
+ * when descendants are rendered via createPortal. That makes it unsafe
+ * for a parent element to attach `onMouseDown`, `onClick`, `onFocus`,
+ * etc. that side-effect (focus steal, preventDefault, selection changes)
+ * under the assumption "the target lives inside me" — a portaled popup
+ * (Dialog, Combobox, Tooltip) silently bypasses the DOM boundary and
+ * triggers the side effect, dismissing itself.
+ *
+ * Only use for event types whose `target` is the meaningful subject of
+ * the event: pointer/mouse/touch/click and `focus`. Do **not** wrap
+ * `onBlur`: blur's `target` is the element losing focus, not the new
+ * focus destination, so the containment test cannot answer "is focus
+ * leaving for a portaled child?". For that case test `relatedTarget`
+ * directly inside the handler.
+ *
+ * The `require-contained-handler` oxlint rule enforces this on any JSX
+ * element carrying both `ref={…}` and one of the watched handler props.
+ *
+ * @example
+ *   const barRef = useRef<HTMLDivElement>(null);
+ *   return (
+ *     <div
+ *       ref={barRef}
+ *       onMouseDown={containedHandler(barRef, (e) => {
+ *         e.preventDefault();
+ *         focusEditor();
+ *       })}
+ *     >
+ *       ...
+ *     </div>
+ *   );
+ */
+export const containedHandler =
+  <E extends { target: unknown }>(
+    ref: React.RefObject<HTMLElement | null> | null | undefined,
+    handler: ((event: E) => void) | undefined,
+  ) =>
+  (event: E): void => {
+    if (handler === undefined) {
+      return;
+    }
+    const container = ref?.current ?? null;
+    if (
+      container !== null &&
+      event.target instanceof Node &&
+      !container.contains(event.target)
+    ) {
+      return;
+    }
+    handler(event);
+  };


### PR DESCRIPTION
Folio's React chrome (toolbar, dialogs, menus) imported ~10 components directly from `@stll/ui`, hard-coupling the editor to the app's design system. This makes the chrome UI **injectable with built-in defaults**, so folio is self-contained (ships working defaults) while consumers can supply their own components.

**Mechanism:** a `FolioUIComponents` context with default implementations, a `components` override prop on `DocxEditor`, and `useFolioUI()` in chrome files. `apps/web` passes its `@stll/ui` components via the prop, so the app's look is unchanged.

Landing component-by-component to keep each step green and regression-free:

1. **Button** (this) — the mechanism + a native default + `apps/web` injecting `@stll/ui`'s Button. Also vendors the small `containedHandler` hook.
2. *(next)* Dialog, Select, Menu, Input, Checkbox, Popover, ColorPicker, DatePickerPopover, OutlineRail — each migrated with a default and the app injection added to the shared override object (no new call-site edits).

Verified: folio typecheck + full suite + format + type-aware lint (incl. layer-boundary and require-contained-handler rules), and the apps/web typecheck, all green. The large `DocxEditor.tsx` diff is whitespace-only reindent from wrapping the JSX in the provider (`git show -w` is minimal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folio editors now support injected UI chrome via a new `components` API, enabling consistent button, dialog, select, menu, popover, input, checkbox, colour picker, date picker, and outline rail rendering.
  * Added a “Folio chrome” UI provider and hook, plus dependency-light default UI implementations.
* **Bug Fixes**
  * Improved containment handling for interactive editor controls to reduce mis-clicks and unwanted event propagation.
* **Refactor**
  * Rewired editor and related UI elements to resolve chrome components from the injected UI context/provider for consistent behaviour across loading, error, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->