### PR TITLE
chore(packages): make folio's @stll dependency closure publish-ready

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,16 @@ env:
   NPM_VERSION: "11.11.1"
 
 on:
+  # Auto-release: a version bump merged to main publishes that package. The
+  # hardened action is idempotent, so the three packages you did not bump are
+  # packed but skipped (their version already exists on the registry).
+  push:
+    branches: [main]
+    paths:
+      - packages/conditions/package.json
+      - packages/template-conditions/package.json
+      - packages/docx-core/package.json
+      - packages/docx-utils/package.json
   workflow_dispatch:
     inputs:
       package:
@@ -45,7 +55,7 @@ on:
         default: false
 
 concurrency:
-  group: publish-npm-${{ inputs.package }}
+  group: publish-npm-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -68,11 +78,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # conditions before template-conditions (which depends on it); the
-          # docx packages are independent.
-          case "${{ inputs.package }}" in
+          # On push (auto-release) there is no input, so pack all and let the
+          # idempotent publish skip unchanged versions. conditions before
+          # template-conditions (which depends on it); the docx packages are
+          # independent.
+          selected="${{ github.event_name == 'workflow_dispatch' && inputs.package || 'all' }}"
+          case "${selected}" in
             all) pkgs=(conditions template-conditions docx-core docx-utils) ;;
-            *) pkgs=("${{ inputs.package }}") ;;
+            *) pkgs=("${selected}") ;;
           esac
 
           # Build, then transform each package.json from its in-repo source
@@ -114,11 +127,13 @@ jobs:
   publish:
     name: Publish @stll/${{ matrix.package }}
     needs: pack
-    if: ${{ inputs.publish }}
+    # Auto-publish on a version-bump push; on manual dispatch, only when ticked.
+    if: ${{ github.event_name == 'push' || inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # OIDC only here; build scripts already ran in the pack job
+      attestations: write # build provenance attestation for the published tarball
     strategy:
       fail-fast: false
       # Serialize: one publish at a time keeps logs legible and lets a

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -136,7 +136,10 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install npm for trusted publishing
-        run: npm install --global "npm@${{ env.NPM_VERSION }}"
+        # --ignore-scripts: this job holds id-token: write, so do not run any
+        # lifecycle hooks from the fetched npm package before the hardened
+        # publish step (npm itself needs none to run).
+        run: npm install --global --ignore-scripts "npm@${{ env.NPM_VERSION }}"
 
       - name: Download tarballs
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,6 +75,11 @@ jobs:
             *) pkgs=("${{ inputs.package }}") ;;
           esac
 
+          # Build, then transform each package.json from its in-repo source
+          # shape (exports -> ./src/*.ts) to the published dist shape
+          # (exports -> ./dist, real .d.ts, no src). No restore needed: this is
+          # an ephemeral checkout.
+          #
           # Pack with `bun pm pack`, NOT `npm pack`: only Bun rewrites the
           # `catalog:` / `workspace:*` dependency protocols to concrete versions
           # in the published package.json. npm would ship those literals, making
@@ -84,6 +89,7 @@ jobs:
           for p in "${pkgs[@]}"; do
             echo "::group::Build + pack @stll/${p}"
             (cd "packages/${p}" && bun run build)
+            bun scripts/prepare-publish.ts "packages/${p}"
             dest="release-artifacts/${p}"
             mkdir -p "${dest}"
             (cd "packages/${p}" && bun pm pack --destination "${GITHUB_WORKSPACE}/${dest}")

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,101 @@
+name: Publish npm packages
+
+# Publishes the shared @stll dependency packages (docx-core, docx-utils,
+# conditions, template-conditions) to npm with SLSA provenance via OIDC trusted
+# publishing — no long-lived NPM_TOKEN. These packages live in this monorepo
+# (stella's apps consume them) and are published from here; external consumers
+# install the published versions.
+#
+# Prerequisite (one-time, per package, by a maintainer on npmjs.com): configure
+# an npm "trusted publisher" for each @stll/* package pointing at this repository
+# and this workflow file. The hardened action refuses to fall back to token auth,
+# so the first publish will fail until the trusted publisher exists.
+#
+# Default run (publish unchecked) builds and packs only — a safe dry run. Tick
+# "publish" to actually push to npm. The hardened action is idempotent: it skips
+# any name@version already on the registry.
+
+env:
+  NODE_VERSION: "22"
+  NPM_VERSION: "11.11.1"
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package(s) to publish (dependency order enforced for "all")
+        type: choice
+        options:
+          - all
+          - conditions
+          - template-conditions
+          - docx-core
+          - docx-utils
+        default: all
+      publish:
+        description: Publish to npm (leave unchecked for a build + pack dry run)
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-npm-${{ inputs.package }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build, pack, and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC, required for trusted publishing + provenance
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm for trusted publishing
+        run: npm install --global "npm@${{ env.NPM_VERSION }}"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build and pack selected packages (dependency order)
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          # conditions before template-conditions (which depends on it); the
+          # docx packages are independent.
+          case "${{ inputs.package }}" in
+            all) pkgs=(conditions template-conditions docx-core docx-utils) ;;
+            *) pkgs=("${{ inputs.package }}") ;;
+          esac
+
+          mkdir -p release-artifacts
+          tarballs=()
+          for p in "${pkgs[@]}"; do
+            echo "::group::Build + pack @stll/${p}"
+            (cd "packages/${p}" && bun run build)
+            pack_json="$(
+              cd "packages/${p}" &&
+              npm pack --json --ignore-scripts \
+                --pack-destination "${GITHUB_WORKSPACE}/release-artifacts"
+            )"
+            file="$(echo "${pack_json}" | jq -r '.[0].filename')"
+            sha256sum "release-artifacts/${file}" >> release-artifacts/SHA256SUMS
+            tarballs+=("release-artifacts/${file}")
+            echo "::endgroup::"
+          done
+
+          echo "tarballs=${tarballs[*]}" >> "${GITHUB_OUTPUT}"
+          printf 'Packed:\n%s\n' "${tarballs[*]}"
+
+      - name: Publish to npm (OIDC trusted publishing + provenance)
+        if: ${{ inputs.publish }}
+        uses: stella/.github/.github/actions/npm-publish-hardened@96b8912e0786548c4e62046ce3965769991dd0e0
+        with:
+          tarballs: ${{ steps.pack.outputs.tarballs }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read # deliberately NO id-token: untrusted build scripts run here
     outputs:
-      tarballs: ${{ steps.pack.outputs.tarballs }}
+      packages: ${{ steps.pack.outputs.packages }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -78,22 +78,24 @@ jobs:
           # Pack with `bun pm pack`, NOT `npm pack`: only Bun rewrites the
           # `catalog:` / `workspace:*` dependency protocols to concrete versions
           # in the published package.json. npm would ship those literals, making
-          # the package uninstallable for external consumers.
-          tarballs=()
+          # the package uninstallable for external consumers. One tarball per
+          # package lands at release-artifacts/<pkg>/, so the publish matrix can
+          # resolve each by package name.
           for p in "${pkgs[@]}"; do
             echo "::group::Build + pack @stll/${p}"
             (cd "packages/${p}" && bun run build)
             dest="release-artifacts/${p}"
             mkdir -p "${dest}"
             (cd "packages/${p}" && bun pm pack --destination "${GITHUB_WORKSPACE}/${dest}")
-            tgz="${dest}/$(basename "$(ls "${dest}"/*.tgz)")"
-            sha256sum "${tgz}" >> release-artifacts/SHA256SUMS
-            tarballs+=("${tgz}")
+            sha256sum "${dest}"/*.tgz >> release-artifacts/SHA256SUMS
             echo "::endgroup::"
           done
 
-          echo "tarballs=${tarballs[*]}" >> "${GITHUB_OUTPUT}"
-          printf 'Packed:\n%s\n' "${tarballs[*]}"
+          # Emit the selected package names as a JSON array for the publish
+          # matrix (the hardened action publishes one tarball per invocation).
+          packages="$(printf '%s\n' "${pkgs[@]}" | jq -Rnc '[inputs]')"
+          echo "packages=${packages}" >> "${GITHUB_OUTPUT}"
+          printf 'Packed: %s\n' "${packages}"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -104,13 +106,23 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish to npm (OIDC trusted publishing + provenance)
+    name: Publish @stll/${{ matrix.package }}
     needs: pack
     if: ${{ inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # OIDC only here; build scripts already ran in the pack job
+    strategy:
+      fail-fast: false
+      # Serialize: one publish at a time keeps logs legible and lets a
+      # dependency land before a dependent (the hardened action is idempotent,
+      # so order is not strictly required, but it is the friendlier default).
+      max-parallel: 1
+      matrix:
+        # The hardened action publishes exactly one tarball per invocation, so
+        # fan out one matrix leg per selected package.
+        package: ${{ fromJSON(needs.pack.outputs.packages) }}
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -126,7 +138,15 @@ jobs:
           name: npm-tarballs
           path: release-artifacts/
 
+      - name: Resolve tarball path
+        id: tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          tgz="$(ls "release-artifacts/${{ matrix.package }}"/*.tgz)"
+          echo "path=${tgz}" >> "${GITHUB_OUTPUT}"
+
       - name: Publish to npm
         uses: stella/.github/.github/actions/npm-publish-hardened@96b8912e0786548c4e62046ce3965769991dd0e0
         with:
-          tarballs: ${{ needs.pack.outputs.tarballs }}
+          tarball: ${{ steps.tarball.outputs.path }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,6 +6,13 @@ name: Publish npm packages
 # (stella's apps consume them) and are published from here; external consumers
 # install the published versions.
 #
+# Least privilege: packing and publishing are separate jobs. The `pack` job runs
+# the untrusted build (bun install, prepack, bun pm pack) with NO id-token, so a
+# compromised build/postinstall script cannot mint an OIDC credential. Only the
+# `publish` job — which just downloads the prebuilt tarballs and runs the
+# hardened action — is granted id-token: write, and it runs only when `publish`
+# is ticked.
+#
 # Prerequisite (one-time, per package, by a maintainer on npmjs.com): configure
 # an npm "trusted publisher" for each @stll/* package pointing at this repository
 # and this workflow file. The hardened action refuses to fall back to token auth,
@@ -42,22 +49,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Build, pack, and publish
+  pack:
+    name: Build and pack
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # OIDC, required for trusted publishing + provenance
+      contents: read # deliberately NO id-token: untrusted build scripts run here
+    outputs:
+      tarballs: ${{ steps.pack.outputs.tarballs }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org
-
-      - name: Install npm for trusted publishing
-        run: npm install --global "npm@${{ env.NPM_VERSION }}"
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
@@ -83,10 +83,10 @@ jobs:
           for p in "${pkgs[@]}"; do
             echo "::group::Build + pack @stll/${p}"
             (cd "packages/${p}" && bun run build)
-            dest="${GITHUB_WORKSPACE}/release-artifacts/${p}"
+            dest="release-artifacts/${p}"
             mkdir -p "${dest}"
-            (cd "packages/${p}" && bun pm pack --destination "${dest}")
-            tgz="$(ls "${dest}"/*.tgz)"
+            (cd "packages/${p}" && bun pm pack --destination "${GITHUB_WORKSPACE}/${dest}")
+            tgz="${dest}/$(basename "$(ls "${dest}"/*.tgz)")"
             sha256sum "${tgz}" >> release-artifacts/SHA256SUMS
             tarballs+=("${tgz}")
             echo "::endgroup::"
@@ -95,8 +95,38 @@ jobs:
           echo "tarballs=${tarballs[*]}" >> "${GITHUB_OUTPUT}"
           printf 'Packed:\n%s\n' "${tarballs[*]}"
 
-      - name: Publish to npm (OIDC trusted publishing + provenance)
-        if: ${{ inputs.publish }}
+      - name: Upload tarballs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarballs
+          path: release-artifacts/
+          retention-days: 1
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm (OIDC trusted publishing + provenance)
+    needs: pack
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC only here; build scripts already ran in the pack job
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm for trusted publishing
+        run: npm install --global "npm@${{ env.NPM_VERSION }}"
+
+      - name: Download tarballs
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: npm-tarballs
+          path: release-artifacts/
+
+      - name: Publish to npm
         uses: stella/.github/.github/actions/npm-publish-hardened@96b8912e0786548c4e62046ce3965769991dd0e0
         with:
-          tarballs: ${{ steps.pack.outputs.tarballs }}
+          tarballs: ${{ needs.pack.outputs.tarballs }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,19 +75,20 @@ jobs:
             *) pkgs=("${{ inputs.package }}") ;;
           esac
 
-          mkdir -p release-artifacts
+          # Pack with `bun pm pack`, NOT `npm pack`: only Bun rewrites the
+          # `catalog:` / `workspace:*` dependency protocols to concrete versions
+          # in the published package.json. npm would ship those literals, making
+          # the package uninstallable for external consumers.
           tarballs=()
           for p in "${pkgs[@]}"; do
             echo "::group::Build + pack @stll/${p}"
             (cd "packages/${p}" && bun run build)
-            pack_json="$(
-              cd "packages/${p}" &&
-              npm pack --json --ignore-scripts \
-                --pack-destination "${GITHUB_WORKSPACE}/release-artifacts"
-            )"
-            file="$(echo "${pack_json}" | jq -r '.[0].filename')"
-            sha256sum "release-artifacts/${file}" >> release-artifacts/SHA256SUMS
-            tarballs+=("release-artifacts/${file}")
+            dest="${GITHUB_WORKSPACE}/release-artifacts/${p}"
+            mkdir -p "${dest}"
+            (cd "packages/${p}" && bun pm pack --destination "${dest}")
+            tgz="$(ls "${dest}"/*.tgz)"
+            sha256sum "${tgz}" >> release-artifacts/SHA256SUMS
+            tarballs+=("${tgz}")
             echo "::endgroup::"
           done
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -16,6 +16,7 @@
       "@stll/conditions": ["../../packages/conditions/src/index.ts"],
       "@stll/country-codes": ["../../packages/country-codes/src/index.ts"],
       "@stll/docx-core": ["../../packages/docx-core/src/index.ts"],
+      "@stll/docx-utils": ["../../packages/docx-utils/src/index.ts"],
       "@stll/errors": ["../../packages/errors/src/index.ts"],
       "@stll/folio": ["../../packages/folio/src/index.ts"],
       "@stll/infosoud": ["../../packages/infosoud/src/index.ts"],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,6 +13,7 @@
       "@stll/business-registries/*": [
         "../../packages/business-registries/src/*/index.ts"
       ],
+      "@stll/conditions": ["../../packages/conditions/src/index.ts"],
       "@stll/country-codes": ["../../packages/country-codes/src/index.ts"],
       "@stll/docx-core": ["../../packages/docx-core/src/index.ts"],
       "@stll/errors": ["../../packages/errors/src/index.ts"],
@@ -21,6 +22,9 @@
       "@stll/money": ["../../packages/money/src/index.ts"],
       "@stll/permissions": ["../../packages/permissions/src/index.ts"],
       "@stll/skills": ["../../packages/skills/src/index.ts"],
+      "@stll/template-conditions": [
+        "../../packages/template-conditions/src/index.ts"
+      ],
       "@stll/ui/*": ["../../packages/ui/src/*"]
     }
   },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -16,6 +16,9 @@
       "@stll/conditions": ["../../packages/conditions/src/index.ts"],
       "@stll/country-codes": ["../../packages/country-codes/src/index.ts"],
       "@stll/docx-core": ["../../packages/docx-core/src/index.ts"],
+      "@stll/docx-core/model": [
+        "../../packages/docx-core/src/model/document.ts"
+      ],
       "@stll/docx-utils": ["../../packages/docx-utils/src/index.ts"],
       "@stll/errors": ["../../packages/errors/src/index.ts"],
       "@stll/folio": ["../../packages/folio/src/index.ts"],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -197,23 +197,38 @@ export default defineConfig(({ mode }) => {
       alias: [
         {
           find: /^@stll\/conditions$/u,
-          replacement: path.resolve(APP_ROOT, "../../packages/conditions/src/index.ts"),
+          replacement: path.resolve(
+            APP_ROOT,
+            "../../packages/conditions/src/index.ts",
+          ),
         },
         {
           find: /^@stll\/template-conditions$/u,
-          replacement: path.resolve(APP_ROOT, "../../packages/template-conditions/src/index.ts"),
+          replacement: path.resolve(
+            APP_ROOT,
+            "../../packages/template-conditions/src/index.ts",
+          ),
         },
         {
           find: /^@stll\/docx-utils$/u,
-          replacement: path.resolve(APP_ROOT, "../../packages/docx-utils/src/index.ts"),
+          replacement: path.resolve(
+            APP_ROOT,
+            "../../packages/docx-utils/src/index.ts",
+          ),
         },
         {
           find: /^@stll\/docx-core$/u,
-          replacement: path.resolve(APP_ROOT, "../../packages/docx-core/src/index.ts"),
+          replacement: path.resolve(
+            APP_ROOT,
+            "../../packages/docx-core/src/index.ts",
+          ),
         },
         {
           find: /^@stll\/docx-core\/model$/u,
-          replacement: path.resolve(APP_ROOT, "../../packages/docx-core/src/model/document.ts"),
+          replacement: path.resolve(
+            APP_ROOT,
+            "../../packages/docx-core/src/model/document.ts",
+          ),
         },
       ],
       dedupe: [

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -188,6 +188,34 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       tsconfigPaths: true,
+      // These workspace packages publish `import -> dist` exports, but are
+      // consumed from source in the monorepo. Vite's `tsconfigPaths` only
+      // rewrites imports inside apps/web's own files; folio and
+      // template-conditions sources import these transitively, so without a
+      // global alias Vite follows the export to an unbuilt dist. Regex-exact so
+      // only these specifiers are touched.
+      alias: [
+        {
+          find: /^@stll\/conditions$/u,
+          replacement: path.resolve(APP_ROOT, "../../packages/conditions/src/index.ts"),
+        },
+        {
+          find: /^@stll\/template-conditions$/u,
+          replacement: path.resolve(APP_ROOT, "../../packages/template-conditions/src/index.ts"),
+        },
+        {
+          find: /^@stll\/docx-utils$/u,
+          replacement: path.resolve(APP_ROOT, "../../packages/docx-utils/src/index.ts"),
+        },
+        {
+          find: /^@stll\/docx-core$/u,
+          replacement: path.resolve(APP_ROOT, "../../packages/docx-core/src/index.ts"),
+        },
+        {
+          find: /^@stll\/docx-core\/model$/u,
+          replacement: path.resolve(APP_ROOT, "../../packages/docx-core/src/model/document.ts"),
+        },
+      ],
       dedupe: [
         "react",
         "react-dom",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -188,49 +188,6 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       tsconfigPaths: true,
-      // These workspace packages publish `import -> dist` exports, but are
-      // consumed from source in the monorepo. Vite's `tsconfigPaths` only
-      // rewrites imports inside apps/web's own files; folio and
-      // template-conditions sources import these transitively, so without a
-      // global alias Vite follows the export to an unbuilt dist. Regex-exact so
-      // only these specifiers are touched.
-      alias: [
-        {
-          find: /^@stll\/conditions$/u,
-          replacement: path.resolve(
-            APP_ROOT,
-            "../../packages/conditions/src/index.ts",
-          ),
-        },
-        {
-          find: /^@stll\/template-conditions$/u,
-          replacement: path.resolve(
-            APP_ROOT,
-            "../../packages/template-conditions/src/index.ts",
-          ),
-        },
-        {
-          find: /^@stll\/docx-utils$/u,
-          replacement: path.resolve(
-            APP_ROOT,
-            "../../packages/docx-utils/src/index.ts",
-          ),
-        },
-        {
-          find: /^@stll\/docx-core$/u,
-          replacement: path.resolve(
-            APP_ROOT,
-            "../../packages/docx-core/src/index.ts",
-          ),
-        },
-        {
-          find: /^@stll\/docx-core\/model$/u,
-          replacement: path.resolve(
-            APP_ROOT,
-            "../../packages/docx-core/src/model/document.ts",
-          ),
-        },
-      ],
       dedupe: [
         "react",
         "react-dom",

--- a/bun.lock
+++ b/bun.lock
@@ -383,7 +383,7 @@
     },
     "packages/conditions": {
       "name": "@stll/conditions",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "valibot": "catalog:",
       },
@@ -392,6 +392,7 @@
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
         "fast-check": "catalog:",
+        "tsdown": "catalog:",
       },
     },
     "packages/country-codes": {
@@ -412,6 +413,7 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
+        "tsdown": "catalog:",
       },
     },
     "packages/docx-utils": {
@@ -423,6 +425,7 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
+        "tsdown": "catalog:",
       },
     },
     "packages/errors": {
@@ -593,7 +596,7 @@
     },
     "packages/template-conditions": {
       "name": "@stll/template-conditions",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@stll/conditions": "workspace:*",
         "better-result": "catalog:",
@@ -603,6 +606,7 @@
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
         "fast-check": "catalog:",
+        "tsdown": "catalog:",
       },
     },
     "packages/transactional": {
@@ -681,6 +685,7 @@
     "oxlint": "1.71.0",
     "sherif": "1.11.1",
     "tailwindcss": "4.3.1",
+    "tsdown": "0.22.3",
     "typescript": "6.0.3",
     "ultracite": "7.8.3",
     "use-intl": "4.13.0",
@@ -1446,6 +1451,8 @@
 
     "@pydantic/genai-prices": ["@pydantic/genai-prices@0.0.66", "", { "dependencies": { "yargs": "^17.7.2" }, "bin": { "genai-prices": "dist/cli.js" } }, "sha512-jwa+NLyVxPrBYvl0cPO3XyU/8BRvpCg2ZpBAzzC5ivr36sIc8Duf5rDjKypBxUcVT5JJgDcjGRV7KTNO2ZkX6g=="],
 
+    "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
+
     "@react-email/body": ["@react-email/body@0.3.0", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug=="],
 
     "@react-email/button": ["@react-email/button@0.2.1", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A=="],
@@ -2162,7 +2169,7 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
+    "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -2175,6 +2182,8 @@
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
+
+    "ast-kit": ["ast-kit@3.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ=="],
 
     "astro": ["astro@7.0.2", "", { "dependencies": { "@astrojs/compiler-rs": "^0.2.2", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-satteri": "0.3.2", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.0" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-Rj31HS85pVSfiQTxKTwH6vTmF8y57iRfkgb1uiCTtdLIh3jlUKPAPXtEmHXRKp/PdTS00D4EXYlWXypY+AVVCA=="],
 
@@ -2210,6 +2219,8 @@
 
     "bippy": ["bippy@0.5.41", "", { "peerDependencies": { "react": ">=17.0.1" } }, "sha512-jCP2pXXLhXqPrAN+iSEFZmLI4uUM4fjSqajh0K+TmM062VehfDT3ZJNkrTGyN701Z5XMejs9qAudSqkMGhSMKg=="],
 
+    "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -2233,6 +2244,8 @@
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "bytestreamjs": ["bytestreamjs@2.0.1", "", {}, "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="],
+
+    "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -2468,6 +2481,8 @@
 
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
+    "dts-resolver": ["dts-resolver@3.0.0", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
@@ -2702,6 +2717,8 @@
 
     "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
+    "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
+
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
@@ -2735,6 +2752,8 @@
     "immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "import-without-cache": ["import-without-cache@0.4.0", "", {}, "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -3104,7 +3123,7 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
@@ -3296,6 +3315,8 @@
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
+    "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
@@ -3385,6 +3406,8 @@
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.26.0", "", { "dependencies": { "@babel/generator": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0", "@babel/parser": "^8.0.0", "ast-kit": "^3.0.0", "birpc": "^4.0.0", "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q=="],
 
     "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
 
@@ -3554,7 +3577,7 @@
 
     "tinyclip": ["tinyclip@0.1.12", "", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
 
-    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
@@ -3563,6 +3586,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -3575,6 +3600,8 @@
     "ts-import": ["ts-import@2.0.40", "", { "dependencies": { "options-defaults": "^2.0.39" } }, "sha512-yTP9fSDaBL1LvcN7/taRHbcQoazk7cLrDOEPyIDUVKLNYTMhaDkvZhfUwp41iXe+GlAFL6l87ZoGABWZRdIfjg=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
+
+    "tsdown": ["tsdown@0.22.3", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.3", "picomatch": "^4.0.4", "rolldown": "~1.1.1", "rolldown-plugin-dts": "^0.26.0", "semver": "^7.8.4", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.3", "@tsdown/exe": "0.22.3", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -3603,6 +3630,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "unbash": ["unbash@4.0.1", "", {}, "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA=="],
+
+    "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
@@ -3794,6 +3823,8 @@
 
     "@babel/core/@babel/traverse": ["@babel/traverse@8.0.0", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/template": "^8.0.0", "@babel/types": "^8.0.0", "obug": "^2.1.1" } }, "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw=="],
 
+    "@babel/core/obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "@babel/core/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "@babel/generator/@babel/parser": ["@babel/parser@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" }, "bin": "./bin/babel-parser.js" }, "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ=="],
@@ -3854,6 +3885,8 @@
 
     "@react-grab/cli/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "@react-grab/cli/tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
     "@selderee/plugin-htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "@stll/aho-corasick-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
@@ -3898,6 +3931,8 @@
 
     "@tanstack/router-utils/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
+    "@tanstack/router-utils/ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
+
     "@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
@@ -3934,11 +3969,19 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "ast-kit/@babel/parser": ["@babel/parser@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" }, "bin": "./bin/babel-parser.js" }, "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ=="],
+
+    "ast-kit/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "astro/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "astro/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "astro/get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
+
+    "astro/obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "astro/tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
     "astro/vite": ["vite@8.1.0", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "~1.1.2", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q=="],
 
@@ -4048,6 +4091,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "nypm/tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
     "ora/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -4076,6 +4121,10 @@
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
+    "rolldown-plugin-dts/@babel/parser": ["@babel/parser@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" }, "bin": "./bin/babel-parser.js" }, "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ=="],
+
+    "rolldown-plugin-dts/get-tsconfig": ["get-tsconfig@5.0.0-beta.5", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ=="],
+
     "rollup-plugin-visualizer/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -4091,6 +4140,10 @@
     "streamdown/tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "tsdown/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "tsdown/rolldown": ["rolldown@1.1.2", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.2", "@rolldown/binding-darwin-arm64": "1.1.2", "@rolldown/binding-darwin-x64": "1.1.2", "@rolldown/binding-freebsd-x64": "1.1.2", "@rolldown/binding-linux-arm-gnueabihf": "1.1.2", "@rolldown/binding-linux-arm64-gnu": "1.1.2", "@rolldown/binding-linux-arm64-musl": "1.1.2", "@rolldown/binding-linux-ppc64-gnu": "1.1.2", "@rolldown/binding-linux-s390x-gnu": "1.1.2", "@rolldown/binding-linux-x64-gnu": "1.1.2", "@rolldown/binding-linux-x64-musl": "1.1.2", "@rolldown/binding-openharmony-arm64": "1.1.2", "@rolldown/binding-wasm32-wasi": "1.1.2", "@rolldown/binding-win32-arm64-msvc": "1.1.2", "@rolldown/binding-win32-x64-msvc": "1.1.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ=="],
 
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -4603,6 +4656,36 @@
     "socket.io/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "tsdown/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.2", "", { "os": "android", "cpu": "arm64" }, "sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA=="],
+
+    "tsdown/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw=="],
+
+    "tsdown/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw=="],
+
+    "tsdown/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.2", "", { "os": "linux", "cpu": "arm" }, "sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw=="],
+
+    "tsdown/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.2", "", { "os": "none", "cpu": "arm64" }, "sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw=="],
+
+    "tsdown/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.2", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.5" }, "cpu": "none" }, "sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg=="],
+
+    "tsdown/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg=="],
+
+    "tsdown/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "oxlint": "1.71.0",
     "sherif": "1.11.1",
     "tailwindcss": "4.3.1",
+    "tsdown": "0.22.3",
     "typescript": "6.0.3",
     "ultracite": "7.8.3",
     "use-intl": "4.13.0",

--- a/packages/conditions/README.md
+++ b/packages/conditions/README.md
@@ -1,0 +1,51 @@
+# @stll/conditions
+
+A generic, side-effect-free boolean/predicate condition engine: a typed
+condition AST, its single evaluator, and a walker.
+
+The package owns one canonical structured-condition shape (compare, predicate,
+and group nodes combined with `and`/`or` and negation) so that different
+consumers — filters, gating, templates — share one set of operators and
+semantics and never drift apart. Domain code supplies a small `resolve`
+adapter that turns a non-literal operand into a concrete value; the evaluator
+handles operators, boolean combination, and negation.
+
+```ts
+import { evaluateCondition, type Condition } from "@stll/conditions";
+
+const condition: Condition = {
+  type: "group",
+  combinator: "and",
+  negated: false,
+  children: [
+    {
+      type: "compare",
+      op: "eq",
+      left: { type: "path", path: "status" },
+      right: { type: "literal", value: "open" },
+    },
+  ],
+};
+
+const result = evaluateCondition(condition, (operand) =>
+  operand.type === "path" ? data[operand.path] : undefined,
+);
+```
+
+## Install
+
+```sh
+bun add @stll/conditions
+```
+
+## Exports
+
+- `./schema` — the condition AST types and Valibot schemas
+  (`conditionSchema`, `conditionNodeSchema`, `emptyCondition`).
+- `./evaluate` — the single evaluator (`evaluateCondition`, `OperandResolver`,
+  `pruneIncomplete`).
+- `./walk` — AST traversal helpers (`conditionHasFormula`).
+
+## License
+
+Apache-2.0

--- a/packages/conditions/README.md
+++ b/packages/conditions/README.md
@@ -38,13 +38,16 @@ const result = evaluateCondition(condition, (operand) =>
 bun add @stll/conditions
 ```
 
-## Exports
+## API
 
-- `./schema` — the condition AST types and Valibot schemas
+Everything is exported from the package root (`@stll/conditions`). The surface
+is organised into three areas:
+
+- **schema** — the condition AST types and Valibot schemas
   (`conditionSchema`, `conditionNodeSchema`, `emptyCondition`).
-- `./evaluate` — the single evaluator (`evaluateCondition`, `OperandResolver`,
+- **evaluate** — the single evaluator (`evaluateCondition`, `OperandResolver`,
   `pruneIncomplete`).
-- `./walk` — AST traversal helpers (`conditionHasFormula`).
+- **walk** — AST traversal helpers (`conditionHasFormula`).
 
 ## License
 

--- a/packages/conditions/package.json
+++ b/packages/conditions/package.json
@@ -1,21 +1,56 @@
 {
   "name": "@stll/conditions",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
+  "description": "A generic boolean/predicate condition engine: schema, evaluate, walk.",
+  "keywords": [
+    "ast",
+    "boolean",
+    "condition",
+    "evaluate",
+    "predicate",
+    "rules",
+    "schema"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/conditions",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/conditions"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
   "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
-    "clean": "git clean -xdf .cache .turbo node_modules",
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
     "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/conditions",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/conditions",
-    "format": "oxfmt ."
+    "format": "oxfmt .",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "valibot": "catalog:"

--- a/packages/conditions/package.json
+++ b/packages/conditions/package.json
@@ -28,14 +28,8 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/conditions/package.json
+++ b/packages/conditions/package.json
@@ -33,8 +33,10 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "publishConfig": {
@@ -42,7 +44,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "build": "tsdown",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
@@ -59,6 +61,7 @@
     "@stll/property-testing": "workspace:*",
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:",
-    "fast-check": "catalog:"
+    "fast-check": "catalog:",
+    "tsdown": "catalog:"
   }
 }

--- a/packages/conditions/package.json
+++ b/packages/conditions/package.json
@@ -33,10 +33,8 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/conditions/tsconfig.build.json
+++ b/packages/conditions/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/conditions/tsconfig.json
+++ b/packages/conditions/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["bun"]
   },
   "include": ["."],
-  "exclude": ["node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/conditions/tsdown.config.ts
+++ b/packages/conditions/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/packages/docx-core/README.md
+++ b/packages/docx-core/README.md
@@ -1,0 +1,40 @@
+# @stll/docx-core
+
+A typed OOXML/DOCX document model with parsing, validation, and serialization.
+
+The package exposes a structured document model (paragraphs, runs, tables,
+styles, section properties) together with the tools to produce and check DOCX
+packages, plus a legal-source compiler that turns a plain legal draft into that
+model or a finished DOCX file.
+
+```ts
+import { compileLegalSourceToDocx, validateDocxPackage } from "@stll/docx-core";
+
+const { docx } = await compileLegalSourceToDocx(source);
+const result = await validateDocxPackage(docx);
+```
+
+The document model types are also available from a dedicated subpath:
+
+```ts
+import type { Document, Paragraph, Run } from "@stll/docx-core/model";
+```
+
+## Install
+
+```sh
+bun add @stll/docx-core
+```
+
+## Exports
+
+- `.` — the document model types, the legal-source compiler
+  (`parseLegalSource`, `compileLegalSourceToDocument`,
+  `compileLegalSourceToDocx`, `validateLegalDraft`), DOCX serialization
+  (`serializeDocumentToDocx`), and validation (`validateDocxPackage`,
+  `validateDocumentModel`, `assertValidDocumentModel`).
+- `./model` — the document model types only.
+
+## License
+
+Apache-2.0

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -29,19 +29,9 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
-    },
-    "./model": {
-      "bun": "./src/model/document.ts",
-      "types": "./src/model/document.ts",
-      "import": "./dist/model/document.js"
-    }
+    ".": "./src/index.ts",
+    "./model": "./src/model/document.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -34,13 +34,17 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./model": {
       "bun": "./src/model/document.ts",
-      "types": "./src/model/document.ts",
-      "import": "./dist/model/document.js"
+      "import": {
+        "types": "./dist/model/document.d.ts",
+        "default": "./dist/model/document.js"
+      }
     }
   },
   "publishConfig": {
@@ -48,7 +52,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "build": "tsdown",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
@@ -63,6 +67,7 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "tsdown": "catalog:"
   }
 }

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,19 +1,61 @@
 {
   "name": "@stll/docx-core",
   "version": "0.1.0",
-  "private": true,
+  "description": "Typed OOXML/DOCX document model with parsing, validation, and serialization, plus a legal-source compiler that produces DOCX packages.",
+  "keywords": [
+    "document-model",
+    "docx",
+    "legal",
+    "ooxml",
+    "openxml",
+    "serialize",
+    "validate",
+    "word"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/docx-core",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/docx-core"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./model": "./src/model/document.ts"
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
+    },
+    "./model": {
+      "bun": "./src/model/document.ts",
+      "types": "./src/model/document.ts",
+      "import": "./dist/model/document.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/docx-core",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/docx-core",
-    "format": "oxfmt ."
+    "format": "oxfmt .",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "better-result": "catalog:",

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -34,17 +34,13 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     },
     "./model": {
       "bun": "./src/model/document.ts",
-      "import": {
-        "types": "./dist/model/document.d.ts",
-        "default": "./dist/model/document.js"
-      }
+      "types": "./src/model/document.ts",
+      "import": "./dist/model/document.js"
     }
   },
   "publishConfig": {

--- a/packages/docx-core/tsconfig.build.json
+++ b/packages/docx-core/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/docx-core/tsdown.config.ts
+++ b/packages/docx-core/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/model/document.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/packages/docx-utils/README.md
+++ b/packages/docx-utils/README.md
@@ -1,0 +1,33 @@
+# @stll/docx-utils
+
+Low-level helpers for reading and writing DOCX/OOXML zip packages.
+
+The package wraps the mechanical parts of working with a DOCX file: loading and
+repacking the underlying zip, extracting text or binary parts, managing
+relationships and content types, and the OOXML namespace constants those
+operations need.
+
+```ts
+import { loadDocx, extractText, ensureRelationship } from "@stll/docx-utils";
+
+const zip = await loadDocx(bytes);
+const text = await extractText(zip, "word/document.xml");
+```
+
+## Install
+
+```sh
+bun add @stll/docx-utils
+```
+
+## Exports
+
+- `OOXML_NS` / `OoxmlPrefix` — OOXML namespace constants and prefixes.
+- `loadDocx`, `repackZip`, `extractText`, `extractBinary`, `DOCX_COMPRESSION` —
+  zip-level read and write helpers.
+- `findNextRId`, `ensureContentType`, `ensureRelationship` — relationship and
+  content-type management.
+
+## License
+
+Apache-2.0

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -32,8 +32,10 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "publishConfig": {
@@ -41,7 +43,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "build": "tsdown",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
@@ -55,6 +57,7 @@
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "tsdown": "catalog:"
   }
 }

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -1,16 +1,54 @@
 {
   "name": "@stll/docx-utils",
   "version": "0.1.0",
-  "private": true,
+  "description": "Low-level helpers for reading and writing DOCX/OOXML zip packages: text and binary extraction, relationship and content-type management, and namespace constants.",
+  "keywords": [
+    "docx",
+    "ooxml",
+    "openxml",
+    "relationships",
+    "word",
+    "zip"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/docx-utils",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/docx-utils"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
-  "main": "./src/index.ts",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/docx-utils",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/docx-utils",
-    "format": "oxfmt ."
+    "format": "oxfmt .",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "jszip": "catalog:"

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -27,14 +27,8 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -32,10 +32,8 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/docx-utils/tsconfig.build.json
+++ b/packages/docx-utils/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/docx-utils/tsconfig.json
+++ b/packages/docx-utils/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["bun"]
   },
   "include": ["."],
-  "exclude": ["node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/docx-utils/tsdown.config.ts
+++ b/packages/docx-utils/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/packages/template-conditions/README.md
+++ b/packages/template-conditions/README.md
@@ -1,0 +1,42 @@
+# @stll/template-conditions
+
+A document-template marker and condition engine: the `{{...}}` marker grammar,
+an expression parser, numeric/arithmetic compute, a condition-builder
+serializer, and deterministic field-value rendering. Small, side-effect-free
+functions usable on both backend (Bun) and frontend (browser).
+
+Boolean conditions are evaluated through the canonical
+[`@stll/conditions`](https://github.com/stella/stella/tree/main/packages/conditions)
+AST and its single evaluator, so template `{{#if ...}}` conditionals share one
+set of operators and semantics with the rest of the system. This package owns
+the template surface: the marker grammar, the string parser, the named-condition
+resolver, the numeric expression evaluator, and the no-code builder serializer.
+
+```ts
+import { evaluateCondition, scanMarkers } from "@stll/template-conditions";
+
+const branch = evaluateCondition("isCompany and signed", fillData);
+
+for (const marker of scanMarkers(templateText)) {
+  // marker.kind, marker.path, ...
+}
+```
+
+## Install
+
+```sh
+bun add @stll/template-conditions
+```
+
+## Exports (`.`)
+
+- Condition evaluation: `evaluateCondition`, `parseCondition`,
+  `evaluateNumericExpression`, `serializeCondition`, `resolvePath`.
+- Field values: `renderDeterministicFieldValue`, `renderComposite`,
+  `formatDate`.
+- Marker grammar: `scanMarkers`, `classifyMarker`, `markerPattern`,
+  `placeholderPattern`, and the directive-kind constants.
+
+## License
+
+Apache-2.0

--- a/packages/template-conditions/package.json
+++ b/packages/template-conditions/package.json
@@ -28,14 +28,8 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public"
@@ -53,7 +47,7 @@
     "prepack": "bun run build"
   },
   "dependencies": {
-    "@stll/conditions": "workspace:*",
+    "@stll/conditions": "workspace:^",
     "better-result": "catalog:"
   },
   "devDependencies": {

--- a/packages/template-conditions/package.json
+++ b/packages/template-conditions/package.json
@@ -1,20 +1,56 @@
 {
   "name": "@stll/template-conditions",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
+  "description": "A document-template marker and condition engine: {{...}} marker grammar, parse, compute, serialize, field values.",
+  "keywords": [
+    "condition",
+    "field-values",
+    "marker",
+    "parse",
+    "placeholder",
+    "serialize",
+    "template"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/template-conditions",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/template-conditions"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
-    "clean": "git clean -xdf .cache .turbo node_modules",
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test",
     "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
     "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/template-conditions",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/template-conditions",
-    "format": "oxfmt ."
+    "format": "oxfmt .",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "@stll/conditions": "workspace:*",

--- a/packages/template-conditions/package.json
+++ b/packages/template-conditions/package.json
@@ -33,10 +33,8 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/template-conditions/package.json
+++ b/packages/template-conditions/package.json
@@ -33,8 +33,10 @@
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./src/index.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "publishConfig": {
@@ -42,7 +44,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf dist .cache .turbo node_modules",
-    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "build": "tsdown",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test",
     "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
@@ -60,6 +62,7 @@
     "@stll/property-testing": "workspace:*",
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:",
-    "fast-check": "catalog:"
+    "fast-check": "catalog:",
+    "tsdown": "catalog:"
   }
 }

--- a/packages/template-conditions/tsconfig.build.json
+++ b/packages/template-conditions/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/template-conditions/tsconfig.json
+++ b/packages/template-conditions/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["bun"]
   },
   "include": ["."],
-  "exclude": ["node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/template-conditions/tsdown.config.ts
+++ b/packages/template-conditions/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# One-time manual bootstrap publish of the @stll dependency packages.
+#
+# npm trusted publishing (the publish-npm workflow's OIDC flow) can only be
+# configured for a package name that already exists on the registry, so the
+# FIRST publish of each package must be a manual, authenticated publish. After
+# this succeeds, add a trusted publisher per package on npmjs.com (package
+# settings -> Publishing) pointing at this repo + .github/workflows/publish-npm.yml,
+# and use the workflow for every release thereafter.
+#
+# Per package: build, transform the package.json to its published dist shape,
+# `bun publish` (Bun rewrites catalog:/workspace: deps; npm would not), then
+# restore the source-shaped package.json.
+#
+# Requires npm auth (`npm whoami` must succeed) and a clean git tree.
+# Run from the repo root.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is dirty; commit or stash first (this script restores package.json via git)." >&2
+  exit 1
+fi
+
+# conditions before template-conditions (which depends on it); the docx
+# packages are independent.
+packages=(conditions template-conditions docx-core docx-utils)
+
+for p in "${packages[@]}"; do
+  echo "==> publishing @stll/${p}"
+  (cd "packages/${p}" && bun run build)
+  bun scripts/prepare-publish.ts "packages/${p}"
+  (cd "packages/${p}" && bun publish --access public)
+  git checkout -- "packages/${p}/package.json"
+done
+
+echo
+echo "Published. Next: add an npm trusted publisher for each package on npmjs.com,"
+echo "then use the 'Publish npm packages' workflow for subsequent releases."

--- a/scripts/prepare-publish.ts
+++ b/scripts/prepare-publish.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+// Transform a package.json from its in-repo "source" shape to the published
+// "dist" shape, in place.
+//
+// The monorepo consumes these packages from source: `exports` point at
+// `./src/*.ts`, so every consumer (Bun, tgo, Vite) resolves source directly
+// with no aliases or conditions. The published package must instead expose the
+// built artifacts — real `.d.ts` + `.js`, no source — so external consumers do
+// not depend on our `.ts` or our bundler resolution.
+//
+// Run this after `bun run build`, immediately before `bun pm pack` /
+// `bun publish`. It rewrites `exports` (deriving each dist target from the
+// source path), `main`, `types`, and `files`. Restore the working tree
+// afterward (`git checkout -- package.json`) — the publish workflow runs on an
+// ephemeral checkout; the bootstrap script restores explicitly.
+
+import { panic } from "better-result";
+import path from "node:path";
+
+type DistEntry = { types: string; import: string };
+
+const pkgDir =
+  process.argv[2] ??
+  panic("usage: bun scripts/prepare-publish.ts <package-dir>");
+
+const pkgPath = path.resolve(pkgDir, "package.json");
+const pkg = await Bun.file(pkgPath).json();
+
+// "./src/model/document.ts" -> "./dist/model/document"
+const distBase = (srcPath: string): string =>
+  srcPath.replace(/^\.\/src\//u, "./dist/").replace(/\.ts$/u, "");
+
+const distExports: Record<string, DistEntry> = {};
+for (const [subpath, target] of Object.entries(pkg.exports)) {
+  if (typeof target !== "string" || !target.startsWith("./src/")) {
+    panic(
+      `${pkg.name}: expected source export "${subpath}" to be a ./src/*.ts string, got ${JSON.stringify(target)}`,
+    );
+  }
+  const base = distBase(target);
+  distExports[subpath] = { types: `${base}.d.ts`, import: `${base}.js` };
+}
+
+const root =
+  distExports["."] ?? panic(`${pkg.name}: exports must include a "." entry`);
+
+pkg.exports = distExports;
+pkg.main = root.import;
+pkg.types = root.types;
+pkg.files = ["dist", "README.md"];
+
+await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+console.log(
+  `prepared ${pkg.name}@${pkg.version} for publish (exports -> dist)`,
+);


### PR DESCRIPTION
Brings folio's four-package `@stll` dependency closure (`docx-core`, `docx-utils`, `conditions`, `template-conditions`) up to the same publishable setup as `@stll/business-registries`, so folio can be consumed as a standalone npm package.

Per package:
- Dual-condition `exports`: `bun` → `src` (the monorepo keeps consuming source, undisturbed) and `import` → `dist` (built JS for external consumers).
- `tsconfig.build.json` emitting `dist/` with `.js` + `.d.ts`; `build`/`prepack`/`pack:dry-run`/`clean` scripts.
- `files`/`main`/`types`/`publishConfig`/`repository`/metadata; `README`; `private` dropped.

No package is published by this change — it only makes them publishable (there is no publish automation; pushing to npm remains a separate manual step). Verified: all four build, all test suites pass, lint clean, and `packages/folio` typecheck stays green (the monorepo resolves these via the `bun` condition).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package READMEs with installation, usage examples, and export overviews for the document, utility, condition, and template-condition packages.
  * Introduced publish-ready build and packaging support so packages can be built, packaged, and released more reliably.
  * Added a new automated npm publish workflow for selected packages.

* **Documentation**
  * Expanded package metadata and public-facing documentation across the monorepo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->