### PR TITLE
feat(folio): auto-detect RTL base direction for unflagged paragraphs

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -40,6 +40,7 @@ import {
   applyFolioAIEditOperations,
   createFolioAIEditSnapshot,
 } from "../core/ai-edits";
+import { normalizeBaseDirection } from "../core/docx/normalizeBaseDirection";
 import { getCachedNumberingMap } from "../core/docx/numberingParser";
 // ProseMirror editor
 import {
@@ -1252,10 +1253,16 @@ export function DocxEditor({
       return null;
     }
 
-    const doc = structuredClone(history.state);
+    let doc = structuredClone(history.state);
     const pmDoc = pagedEditorRef.current?.getDocument();
     if (pmDoc) {
       doc.package.document.content = pmDoc.package.document.content;
+    } else {
+      // The editor view was never instantiated, so getDocument() returned null
+      // and the PM-layer auto-bidi normalization never reached this clone.
+      // Apply the equivalent model-layer pass so an unflagged RTL-led document
+      // saved without focusing the editor still exports correct `w:bidi`.
+      doc = normalizeBaseDirection(doc);
     }
     // Flush in-flight HF PM edits into the cloned package — the persistent
     // hidden HF EditorViews don't mutate history.state per keystroke

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -37,6 +37,7 @@ import { EditorView } from "prosemirror-view";
 
 import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
+import { ensureBaseDirectionInState } from "../core/prosemirror/extensions/features/AutoBidiDetectionExtension";
 import { ensureParaIdsInState } from "../core/prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
 import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
@@ -149,12 +150,14 @@ function buildInitialState(
   // Header/footer paragraphs share the document's style table, so they get
   // the same style-aware behavior (e.g. Enter after a heading → body text).
   const styleResolverPlugin = createDocumentStylesPlugin(styles);
-  return ensureParaIdsInState(
-    EditorState.create({
-      doc: pmDoc,
-      schema,
-      plugins: [...mgr.getPlugins(), styleResolverPlugin],
-    }),
+  return ensureBaseDirectionInState(
+    ensureParaIdsInState(
+      EditorState.create({
+        doc: pmDoc,
+        schema,
+        plugins: [...mgr.getPlugins(), styleResolverPlugin],
+      }),
+    ),
   );
 }
 

--- a/packages/folio/src/core/controller/hiddenEditorManager.ts
+++ b/packages/folio/src/core/controller/hiddenEditorManager.ts
@@ -28,11 +28,18 @@ import { suppressHiddenEditorScrollToSelection } from "../paged-layout/hiddenEdi
 import { isReadOnlyEditKey } from "../paged-layout/readOnlyEditAttempt";
 import { toProseDoc, createEmptyDoc } from "../prosemirror/conversion";
 import type { ExtensionManager } from "../prosemirror/extensions/ExtensionManager";
+import { ensureBaseDirectionInState } from "../prosemirror/extensions/features/AutoBidiDetectionExtension";
 import { ensureParaIdsInState } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
 import { createDocumentStylesPlugin } from "../prosemirror/plugins/documentStyles";
 import { schema } from "../prosemirror/schema";
 import type { Document, StyleDefinitions } from "../types/document";
 import { createHiddenEditorApi, type HiddenEditorApi } from "./hiddenEditorApi";
+
+// Initial-load normalization. `appendTransaction` does not fire for the seed
+// document, so the paraId allocator and RTL base-direction detection are
+// applied imperatively to freshly created states.
+const normalizeSeedState = (state: EditorState): EditorState =>
+  ensureBaseDirectionInState(ensureParaIdsInState(state));
 
 type YProseMirrorModule = typeof YProseMirror;
 type YjsModule = typeof Yjs;
@@ -263,7 +270,7 @@ export function createHiddenEditorState(
     }
 
     if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
-      const seedState = ensureParaIdsInState(
+      const seedState = normalizeSeedState(
         PMEditorState.create({
           doc: localDoc,
           schema: activeSchema,
@@ -282,7 +289,7 @@ export function createHiddenEditorState(
       activeSchema,
     );
 
-    const initializedState = ensureParaIdsInState(
+    const initializedState = normalizeSeedState(
       PMEditorState.create({
         doc,
         schema: activeSchema,
@@ -301,7 +308,7 @@ export function createHiddenEditorState(
     }
 
     const startedAt = performance.now();
-    const state = ensureParaIdsInState(
+    const state = normalizeSeedState(
       PMEditorState.create({
         doc,
         schema: activeSchema,
@@ -317,7 +324,7 @@ export function createHiddenEditorState(
   }
 
   const startedAt = performance.now();
-  const state = ensureParaIdsInState(
+  const state = normalizeSeedState(
     PMEditorState.create({
       doc: localDoc,
       schema: activeSchema,

--- a/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
@@ -53,6 +53,20 @@ describe("normalizeBaseDirection", () => {
     );
   });
 
+  test("detects RTL inside an insertion (tracked-change) wrapper", () => {
+    const doc = docOf({
+      type: "paragraph",
+      content: [
+        {
+          type: "insertion",
+          info: { id: 1, author: "Reviewer" },
+          content: [{ type: "run", content: [{ type: "text", text: "عربي" }] }],
+        },
+      ],
+    });
+    expect(bidiOf(normalizeBaseDirection(doc), 0)).toBe(true);
+  });
+
   test("detects RTL inside hyperlinked runs", () => {
     const doc = docOf({
       type: "paragraph",

--- a/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
@@ -67,6 +67,35 @@ describe("normalizeBaseDirection", () => {
     expect(bidiOf(normalizeBaseDirection(doc), 0)).toBe(true);
   });
 
+  test("detects RTL inside a move-to (live) wrapper", () => {
+    const doc = docOf({
+      type: "paragraph",
+      content: [
+        {
+          type: "moveTo",
+          info: { id: 2, author: "Reviewer" },
+          content: [{ type: "run", content: [{ type: "text", text: "عربي" }] }],
+        },
+      ],
+    });
+    expect(bidiOf(normalizeBaseDirection(doc), 0)).toBe(true);
+  });
+
+  test("ignores deleted (non-live) text in the save fallback", () => {
+    const doc = docOf({
+      type: "paragraph",
+      content: [
+        {
+          type: "deletion",
+          info: { id: 3, author: "Reviewer" },
+          content: [{ type: "run", content: [{ type: "text", text: "عربي" }] }],
+        },
+        { type: "run", content: [{ type: "text", text: " agreement" }] },
+      ],
+    });
+    expect(bidiOf(normalizeBaseDirection(doc), 0)).toBeUndefined();
+  });
+
   test("detects RTL inside hyperlinked runs", () => {
     const doc = docOf({
       type: "paragraph",

--- a/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Model-level base-direction normalization (the save fallback used when the
+ * editor view was never instantiated, so the PM-layer detector never ran).
+ * Mirrors the editor contract: fill `bidi` only for undecided RTL-led
+ * paragraphs; never override an explicit decision or flag LTR content.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Document, Paragraph } from "../types/document";
+import { normalizeBaseDirection } from "./normalizeBaseDirection";
+
+const para = (text: string, bidi?: boolean): Paragraph => ({
+  type: "paragraph",
+  ...(bidi === undefined ? {} : { formatting: { bidi } }),
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+});
+
+const docOf = (...paragraphs: Paragraph[]): Document => ({
+  package: { document: { content: paragraphs } },
+});
+
+const bidiOf = (doc: Document, index: number): boolean | undefined => {
+  const block = doc.package.document.content.at(index);
+  if (block?.type !== "paragraph") {
+    throw new Error("expected a paragraph");
+  }
+  return block.formatting?.bidi;
+};
+
+describe("normalizeBaseDirection", () => {
+  test("sets bidi=true on an undecided Arabic-led paragraph", () => {
+    expect(bidiOf(normalizeBaseDirection(docOf(para("هذا عقد"))), 0)).toBe(
+      true,
+    );
+  });
+
+  test("leaves a Latin-led paragraph undecided", () => {
+    expect(
+      bidiOf(normalizeBaseDirection(docOf(para("Agreement"))), 0),
+    ).toBeUndefined();
+  });
+
+  test("does not override an explicit LTR (false)", () => {
+    expect(bidiOf(normalizeBaseDirection(docOf(para("عربي", false))), 0)).toBe(
+      false,
+    );
+  });
+
+  test("leaves an explicit RTL (true) untouched", () => {
+    expect(bidiOf(normalizeBaseDirection(docOf(para("عربي", true))), 0)).toBe(
+      true,
+    );
+  });
+
+  test("detects RTL inside hyperlinked runs", () => {
+    const doc = docOf({
+      type: "paragraph",
+      content: [
+        {
+          type: "hyperlink",
+          href: "https://example.test",
+          children: [
+            { type: "run", content: [{ type: "text", text: "عربي" }] },
+          ],
+        },
+      ],
+    });
+    expect(bidiOf(normalizeBaseDirection(doc), 0)).toBe(true);
+  });
+
+  test("normalizes paragraphs nested in table cells", () => {
+    const doc: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [{ type: "tableCell", content: [para("نص عربي")] }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const out = normalizeBaseDirection(doc);
+    const table = out.package.document.content.at(0);
+    if (table?.type !== "table") {
+      throw new Error("expected a table");
+    }
+    const cell = table.rows[0]?.cells[0];
+    const cellPara = cell?.content.at(0);
+    if (cellPara?.type !== "paragraph") {
+      throw new Error("expected a paragraph in the cell");
+    }
+    expect(cellPara.formatting?.bidi).toBe(true);
+  });
+
+  test("does not mutate the input document", () => {
+    const input = docOf(para("هذا عقد"));
+    normalizeBaseDirection(input);
+    expect(bidiOf(input, 0)).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/docx/normalizeBaseDirection.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.ts
@@ -19,6 +19,7 @@ import type {
   Document,
   Hyperlink,
   Paragraph,
+  ParagraphContent,
   Run,
   Table,
 } from "../types/document";
@@ -44,17 +45,38 @@ const hyperlinkText = (link: Hyperlink): string => {
   return text;
 };
 
-const paragraphText = (paragraph: Paragraph): string => {
+// First-strong directional text for model paragraph content. Mirrors the
+// editor's field/SDT-aware detection: it folds in field result text and recurses
+// inline content controls and insertion wrappers (deleted/moved-away content is
+// not live text, so it is skipped). Mutually recursive, hence declarations.
+function paragraphContentText(items: readonly ParagraphContent[]): string {
   let text = "";
-  for (const item of paragraph.content) {
-    if (item.type === "run") {
-      text += runText(item);
-    } else if (item.type === "hyperlink") {
-      text += hyperlinkText(item);
-    }
+  for (const item of items) {
+    text += singleItemText(item);
   }
   return text;
-};
+}
+
+function singleItemText(item: ParagraphContent): string {
+  switch (item.type) {
+    case "run":
+      return runText(item);
+    case "hyperlink":
+      return hyperlinkText(item);
+    case "simpleField":
+    case "insertion":
+      return paragraphContentText(item.content);
+    case "complexField":
+      return paragraphContentText(item.fieldResult);
+    case "inlineSdt":
+      return paragraphContentText(item.content);
+    default:
+      return "";
+  }
+}
+
+const paragraphText = (paragraph: Paragraph): string =>
+  paragraphContentText(paragraph.content);
 
 const normalizeParagraph = (paragraph: Paragraph): Paragraph => {
   // Respect an explicit decision (true = RTL, false = forced LTR); only fill in

--- a/packages/folio/src/core/docx/normalizeBaseDirection.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.ts
@@ -47,8 +47,9 @@ const hyperlinkText = (link: Hyperlink): string => {
 
 // First-strong directional text for model paragraph content. Mirrors the
 // editor's field/SDT-aware detection: it folds in field result text and recurses
-// inline content controls and insertion wrappers (deleted/moved-away content is
-// not live text, so it is skipped). Mutually recursive, hence declarations.
+// inline content controls, insertions and move-to (live) content. Deleted and
+// moved-away content (`deletion`/`moveFrom`) is not live text, so it is skipped.
+// Mutually recursive, hence declarations.
 function paragraphContentText(items: readonly ParagraphContent[]): string {
   let text = "";
   for (const item of items) {
@@ -65,6 +66,7 @@ function singleItemText(item: ParagraphContent): string {
       return hyperlinkText(item);
     case "simpleField":
     case "insertion":
+    case "moveTo":
       return paragraphContentText(item.content);
     case "complexField":
       return paragraphContentText(item.fieldResult);

--- a/packages/folio/src/core/docx/normalizeBaseDirection.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.ts
@@ -10,9 +10,10 @@
  * (`true`/`false`) and LTR paragraphs alone.
  *
  * Detection mirrors the editor's first-strong rule via `detectBaseDirection`.
- * Text extraction is best-effort over the dominant content (runs and
- * hyperlinked runs); inline fields and tracked-change wrappers are treated as
- * neutral here (the editor path covers them when a view exists).
+ * Text extraction walks the live content: runs, hyperlinked runs, simple/complex
+ * field results, and the live tracked-change/control wrappers (`insertion`,
+ * `moveTo`, `inlineSdt`). Non-live content (`deletion` / `moveFrom`) is skipped,
+ * matching the editor path.
  */
 import type {
   BlockContent,

--- a/packages/folio/src/core/docx/normalizeBaseDirection.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.ts
@@ -1,0 +1,116 @@
+/**
+ * Model-level RTL base-direction normalization.
+ *
+ * The in-editor AutoBidiDetection runs on the ProseMirror doc, so it only
+ * reaches a save when `getDocument()` can read the editor view's state. If the
+ * body view was never instantiated, `buildCurrentDocument` falls back to the
+ * untouched `history.state` Document, which would export RTL-led paragraphs
+ * without `w:bidi`. This pass fills the same gap at the model layer: it sets
+ * `bidi` on undecided RTL-led paragraphs while leaving explicit decisions
+ * (`true`/`false`) and LTR paragraphs alone.
+ *
+ * Detection mirrors the editor's first-strong rule via `detectBaseDirection`.
+ * Text extraction is best-effort over the dominant content (runs and
+ * hyperlinked runs); inline fields and tracked-change wrappers are treated as
+ * neutral here (the editor path covers them when a view exists).
+ */
+import type {
+  BlockContent,
+  Document,
+  Hyperlink,
+  Paragraph,
+  Run,
+  Table,
+} from "../types/document";
+import { detectBaseDirection } from "../utils/baseDirection";
+
+const runText = (run: Run): string => {
+  let text = "";
+  for (const piece of run.content) {
+    if (piece.type === "text") {
+      text += piece.text;
+    }
+  }
+  return text;
+};
+
+const hyperlinkText = (link: Hyperlink): string => {
+  let text = "";
+  for (const child of link.children) {
+    if (child.type === "run") {
+      text += runText(child);
+    }
+  }
+  return text;
+};
+
+const paragraphText = (paragraph: Paragraph): string => {
+  let text = "";
+  for (const item of paragraph.content) {
+    if (item.type === "run") {
+      text += runText(item);
+    } else if (item.type === "hyperlink") {
+      text += hyperlinkText(item);
+    }
+  }
+  return text;
+};
+
+const normalizeParagraph = (paragraph: Paragraph): Paragraph => {
+  // Respect an explicit decision (true = RTL, false = forced LTR); only fill in
+  // the undecided case.
+  if (paragraph.formatting?.bidi != null) {
+    return paragraph;
+  }
+  if (detectBaseDirection(paragraphText(paragraph)) !== "rtl") {
+    return paragraph;
+  }
+  return {
+    ...paragraph,
+    formatting: { ...paragraph.formatting, bidi: true },
+  };
+};
+
+const normalizeTable = (table: Table): Table => ({
+  ...table,
+  rows: table.rows.map((row) => ({
+    ...row,
+    cells: row.cells.map((cell) => ({
+      ...cell,
+      content: cell.content.map((block) =>
+        block.type === "paragraph"
+          ? normalizeParagraph(block)
+          : normalizeTable(block),
+      ),
+    })),
+  })),
+});
+
+const normalizeBlocks = (blocks: BlockContent[]): BlockContent[] =>
+  blocks.map((block) => {
+    if (block.type === "paragraph") {
+      return normalizeParagraph(block);
+    }
+    if (block.type === "table") {
+      return normalizeTable(block);
+    }
+    if (block.type === "blockSdt") {
+      return { ...block, content: normalizeBlocks(block.content) };
+    }
+    return block;
+  });
+
+/**
+ * Return a copy of `doc` with `bidi` filled in for undecided RTL-led body
+ * paragraphs (including those nested in tables and block content controls).
+ */
+export const normalizeBaseDirection = (doc: Document): Document => ({
+  ...doc,
+  package: {
+    ...doc.package,
+    document: {
+      ...doc.package.document,
+      content: normalizeBlocks(doc.package.document.content),
+    },
+  },
+});

--- a/packages/folio/src/core/docx/normalizeBaseDirection.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.ts
@@ -94,10 +94,8 @@ const normalizeBlocks = (blocks: BlockContent[]): BlockContent[] =>
     if (block.type === "table") {
       return normalizeTable(block);
     }
-    if (block.type === "blockSdt") {
-      return { ...block, content: normalizeBlocks(block.content) };
-    }
-    return block;
+    // Block content control: recurse into its block children.
+    return { ...block, content: normalizeBlocks(block.content) };
   });
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -2187,9 +2187,9 @@ function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
       return isFieldRun(r) ? (r.fallback ?? "") : "";
     })
     .join("");
-  // First strong directional character decides; nothing strong => honor w:rtl.
-  const dir = detectBaseDirection(text);
-  return dir === null ? true : dir === "rtl";
+  // First strong directional character decides; nothing strong (null) => honor
+  // w:rtl, "rtl" => RTL; only an explicit "ltr" first char stays LTR.
+  return detectBaseDirection(text) !== "ltr";
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -33,6 +33,7 @@ import type {
   TabStop as TabCalcStop,
 } from "../prosemirror/utils/tabCalculator";
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
+import { detectBaseDirection } from "../utils/baseDirection";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
 import {
@@ -2163,17 +2164,6 @@ function bordersFormGroup(a?: ParagraphBorders, b?: ParagraphBorders): boolean {
   );
 }
 
-// Strong-RTL letters, matched by Unicode script so RTL scripts outside the BMP
-// (Adlam U+1E900) and newer blocks (Arabic Extended-B U+0870) are covered
-// without hand-rolling code-point ranges. These eight cover every RTL script in
-// real-world use (Hebrew/Arabic are ~all of it); newer scripts (Yezidi, Garay,
-// …) are omitted because the pinned oxlint/tsc Unicode database rejects their
-// names. Only used to classify the first *letter* (`\p{L}`), so the non-letter
-// members of these scripts (Arabic-Indic digits, combining marks, punctuation)
-// are never tested — they're weak/neutral and skipped upstream.
-const RTL_STRONG_LETTER =
-  /[\p{Script=Hebrew}\p{Script=Arabic}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
-
 /**
  * Decide whether a paragraph without an explicit `w:bidi` flag should still be
  * laid out right-to-left. Only paragraphs that carry at least one `w:rtl` run
@@ -2197,24 +2187,9 @@ function paragraphBaseIsRtl(block: ParagraphBlock): boolean {
       return isFieldRun(r) ? (r.fallback ?? "") : "";
     })
     .join("");
-  // The first strong directional signal, in one native scan: an explicit bidi
-  // mark (RLM U+200F / ALM U+061C => RTL, LRM U+200E => LTR) or the first
-  // letter (`\p{L}`). Digits, combining marks, punctuation and spaces are
-  // weak/neutral and skipped. The first letter's script decides; nothing
-  // strong => honor w:rtl.
-  const match =
-    /(?<rtlMark>\u200F|\u061C)|(?<lrmMark>\u200E)|(?<letter>\p{L})/u.exec(text);
-  if (!match) {
-    return true;
-  }
-  const { rtlMark, lrmMark, letter } = match.groups ?? {};
-  if (rtlMark !== undefined) {
-    return true; // RLM or ALM
-  }
-  if (lrmMark !== undefined) {
-    return false; // LRM
-  }
-  return letter !== undefined && RTL_STRONG_LETTER.test(letter);
+  // First strong directional character decides; nothing strong => honor w:rtl.
+  const dir = detectBaseDirection(text);
+  return dir === null ? true : dir === "rtl";
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -376,6 +376,7 @@ export const readParagraphAttrs = (
     issues,
   );
   optionalBoolean(attrs, "bidi", "paragraph.attrs.bidi", issues);
+  optionalBoolean(attrs, "bidiAuto", "paragraph.attrs.bidiAuto", issues);
   optionalOneOf(
     attrs,
     "sectionBreakType",

--- a/packages/folio/src/core/prosemirror/conversion/bidiTriStateRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/bidiTriStateRoundtrip.test.ts
@@ -81,6 +81,22 @@ describe("fromProseDoc bidi tri-state (changed vs original)", () => {
   });
 });
 
+describe("pageBreakBefore tri-state (same class, fallback path)", () => {
+  test("explicit pageBreakBefore=false is preserved on a new paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { pageBreakBefore: false }, [
+        schema.text("Body"),
+      ]),
+    ]);
+    const out = fromProseDoc(doc);
+    const block = out.package.document.content.at(0);
+    if (block?.type !== "paragraph") {
+      throw new Error("expected a paragraph");
+    }
+    expect(block.formatting?.pageBreakBefore).toBe(false);
+  });
+});
+
 describe("explicit LTR survives serialization (save invariant)", () => {
   test('bidi=false serializes as <w:bidi w:val="0"/>', () => {
     const out = fromProseDoc(paraNode("عربي", false));

--- a/packages/folio/src/core/prosemirror/conversion/bidiTriStateRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/bidiTriStateRoundtrip.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The paragraph `bidi` attribute is tri-state: true (RTL), false (explicit LTR,
+ * serialized as `<w:bidi w:val="0"/>`), and null/undefined (undecided — eligible
+ * for auto-detection). `fromProseDoc` must preserve an explicit `false` rather
+ * than collapse it into "undecided" via a truthiness check.
+ *
+ * Regression guard: previously `if (attrs.bidi)` dropped `false`, so a forced-LTR
+ * Arabic paragraph lost `<w:bidi w:val="0"/>` on save; on reload the seed
+ * auto-detector saw `null` again and re-flipped it back to RTL. These tests lock
+ * the full save invariant end to end (model → serialized XML).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+
+import { serializeParagraph } from "../../docx/serializer/paragraphSerializer";
+import type { Document } from "../../types/document";
+import { schema } from "../schema";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const paraNode = (text: string, bidi: boolean | null) =>
+  schema.node("doc", null, [
+    schema.node("paragraph", { bidi }, [schema.text(text)]),
+  ]);
+
+const firstParagraphBidi = (doc: Document): unknown => {
+  const block = doc.package.document.content.at(0);
+  if (block?.type !== "paragraph") {
+    throw new Error("expected a paragraph");
+  }
+  return block.formatting?.bidi;
+};
+
+describe("fromProseDoc bidi tri-state (new paragraphs, no original)", () => {
+  test("explicit LTR (false) is preserved, not dropped", () => {
+    const out = fromProseDoc(paraNode("عربي", false));
+    expect(firstParagraphBidi(out)).toBe(false);
+  });
+
+  test("explicit RTL (true) is preserved", () => {
+    const out = fromProseDoc(paraNode("عربي", true));
+    expect(firstParagraphBidi(out)).toBe(true);
+  });
+
+  test("undecided (null) is omitted", () => {
+    const out = fromProseDoc(paraNode("Agreement", null));
+    expect(firstParagraphBidi(out)).toBeUndefined();
+  });
+});
+
+describe("fromProseDoc bidi tri-state (changed vs original)", () => {
+  // The real bug: a paragraph imported without bidi (or auto-detected RTL) that
+  // the user forces to LTR. The PM attr (false) now differs from the original,
+  // which is exactly where the old truthiness check deleted it.
+  test("RTL original forced to LTR keeps bidi=false", () => {
+    const original: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { bidi: true },
+              content: [
+                { type: "run", content: [{ type: "text", text: "عربي" }] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const pmDoc = toProseDoc(original);
+    const forcedLtr = EditorState.create({ doc: pmDoc }).tr.setNodeMarkup(
+      0,
+      undefined,
+      { ...pmDoc.child(0).attrs, bidi: false },
+    ).doc;
+
+    const out = fromProseDoc(forcedLtr, original);
+    expect(firstParagraphBidi(out)).toBe(false);
+  });
+});
+
+describe("explicit LTR survives serialization (save invariant)", () => {
+  test('bidi=false serializes as <w:bidi w:val="0"/>', () => {
+    const out = fromProseDoc(paraNode("عربي", false));
+    const block = out.package.document.content.at(0);
+    if (block?.type !== "paragraph") {
+      throw new Error("expected a paragraph");
+    }
+    expect(serializeParagraph(block)).toContain('<w:bidi w:val="0"/>');
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -712,14 +712,20 @@ function assignBooleanToggle(
   orig: ParagraphFormatting,
   key: BooleanToggleKey,
 ): void {
-  // Normalize the undecided sentinel to `undefined`: assigning `undefined`
-  // clears the toggle (serializes as absent) without a dynamic `delete`, while
-  // an explicit `false` is preserved.
+  // Tri-state: `true`/`false` are explicit decisions to keep; `null`/`undefined`
+  // is "undecided" and clears the toggle. `exactOptionalPropertyTypes` forbids
+  // assigning `undefined`, and `no-dynamic-delete` forbids `delete result[key]`,
+  // so the undecided branch clears via `Reflect.deleteProperty`. This preserves
+  // an explicit `false` that a truthiness check would have dropped.
   const value = attrs[key] ?? undefined;
   if (value === (orig[key] ?? undefined)) {
     return;
   }
-  result[key] = value;
+  if (value === undefined) {
+    Reflect.deleteProperty(result, key);
+  } else {
+    result[key] = value;
+  }
 }
 
 function paragraphAttrsToFormatting(

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -857,9 +857,10 @@ function paragraphAttrsToFormatting(
     typeof outlineLevel === "number" ||
     attrs.contextualSpacing ||
     attrs.spacingExplicit ||
-    // Tri-state: an explicit `false` (forced LTR) is meaningful formatting and
-    // must keep the paragraph from short-circuiting to "no formatting".
-    attrs.bidi != null;
+    // Tri-state toggles: an explicit `false` is meaningful formatting and must
+    // keep the paragraph from short-circuiting to "no formatting".
+    attrs.bidi != null ||
+    attrs.pageBreakBefore != null;
 
   if (!hasFormatting) {
     return undefined;
@@ -923,10 +924,13 @@ function paragraphAttrsToFormatting(
   if (attrs.contextualSpacing) {
     f.contextualSpacing = attrs.contextualSpacing;
   }
-  // Preserve an explicit decision, including `false` (forced LTR) so it
-  // serializes as `<w:bidi w:val="0"/>`; only undecided `null` is omitted.
+  // Preserve explicit tri-state decisions, including `false` (which serializes
+  // as `w:val="0"`); only undecided `null` is omitted.
   if (attrs.bidi != null) {
     f.bidi = attrs.bidi;
+  }
+  if (attrs.pageBreakBefore != null) {
+    f.pageBreakBefore = attrs.pageBreakBefore;
   }
   return f;
 }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -698,6 +698,31 @@ function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
   );
 }
 
+// OOXML boolean paragraph toggles are tri-state: `true` (on), `false` (explicit
+// off, serialized as `w:val="0"`), and `null`/`undefined` (inherit). A
+// truthiness check (`if (attrs.key)`) silently collapses explicit `false` into
+// "inherit", dropping the user's decision on save. Branch on `== null` so every
+// toggle routed through here preserves `false` — making that drop impossible to
+// reintroduce per-attribute (the bidi/LTR round-trip depends on it).
+type BooleanToggleKey = "bidi" | "pageBreakBefore";
+
+function assignBooleanToggle(
+  result: ParagraphFormatting,
+  attrs: ParagraphAttrs,
+  orig: ParagraphFormatting,
+  key: BooleanToggleKey,
+): void {
+  const value = attrs[key];
+  if (value === (orig[key] ?? undefined)) {
+    return;
+  }
+  if (value == null) {
+    delete result[key];
+  } else {
+    result[key] = value;
+  }
+}
+
 function paragraphAttrsToFormatting(
   attrs: ParagraphAttrs,
 ): ParagraphFormatting | undefined {
@@ -790,13 +815,7 @@ function paragraphAttrsToFormatting(
         delete result.styleId;
       }
     }
-    if (attrs.pageBreakBefore !== (orig.pageBreakBefore ?? undefined)) {
-      if (attrs.pageBreakBefore) {
-        result.pageBreakBefore = attrs.pageBreakBefore;
-      } else {
-        delete result.pageBreakBefore;
-      }
-    }
+    assignBooleanToggle(result, attrs, orig, "pageBreakBefore");
     if (attrs.spacingExplicit !== orig.spacingExplicit) {
       if (attrs.spacingExplicit) {
         result.spacingExplicit = attrs.spacingExplicit;
@@ -804,13 +823,10 @@ function paragraphAttrsToFormatting(
         delete result.spacingExplicit;
       }
     }
-    if (attrs.bidi !== (orig.bidi ?? undefined)) {
-      if (attrs.bidi) {
-        result.bidi = attrs.bidi;
-      } else {
-        delete result.bidi;
-      }
-    }
+    // Persist an explicit bidi decision, including `false` (LTR forced via
+    // setLtr) so it serializes as `<w:bidi w:val="0"/>` and survives save/reload;
+    // otherwise auto-detection re-flips an Arabic paragraph back to RTL.
+    assignBooleanToggle(result, attrs, orig, "bidi");
 
     return result;
   }
@@ -836,7 +852,9 @@ function paragraphAttrsToFormatting(
     typeof outlineLevel === "number" ||
     attrs.contextualSpacing ||
     attrs.spacingExplicit ||
-    attrs.bidi;
+    // Tri-state: an explicit `false` (forced LTR) is meaningful formatting and
+    // must keep the paragraph from short-circuiting to "no formatting".
+    attrs.bidi != null;
 
   if (!hasFormatting) {
     return undefined;
@@ -900,7 +918,9 @@ function paragraphAttrsToFormatting(
   if (attrs.contextualSpacing) {
     f.contextualSpacing = attrs.contextualSpacing;
   }
-  if (attrs.bidi) {
+  // Preserve an explicit decision, including `false` (forced LTR) so it
+  // serializes as `<w:bidi w:val="0"/>`; only undecided `null` is omitted.
+  if (attrs.bidi != null) {
     f.bidi = attrs.bidi;
   }
   return f;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -712,15 +712,14 @@ function assignBooleanToggle(
   orig: ParagraphFormatting,
   key: BooleanToggleKey,
 ): void {
-  const value = attrs[key];
+  // Normalize the undecided sentinel to `undefined`: assigning `undefined`
+  // clears the toggle (serializes as absent) without a dynamic `delete`, while
+  // an explicit `false` is preserved.
+  const value = attrs[key] ?? undefined;
   if (value === (orig[key] ?? undefined)) {
     return;
   }
-  if (value == null) {
-    delete result[key];
-  } else {
-    result[key] = value;
-  }
+  result[key] = value;
 }
 
 function paragraphAttrsToFormatting(

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -14,6 +14,7 @@ import { DocExtension } from "./core/DocExtension";
 import { HistoryExtension } from "./core/HistoryExtension";
 import { ParagraphExtension } from "./core/ParagraphExtension";
 import { TextExtension } from "./core/TextExtension";
+import { AutoBidiDetectionExtension } from "./features/AutoBidiDetectionExtension";
 import { BaseKeymapExtension } from "./features/BaseKeymapExtension";
 // oxlint-disable-next-line import/no-cycle -- BidiShortcutExtension reaches the singleton schema for runtime command lookup
 import { BidiShortcutExtension } from "./features/BidiShortcutExtension";
@@ -199,6 +200,7 @@ export function createStarterKit(
   add("paraIdAllocator", ParaIdAllocatorExtension());
   add("paragraphChangeTracker", ParagraphChangeTrackerExtension());
   add("bidiShortcut", BidiShortcutExtension());
+  add("autoBidiDetection", AutoBidiDetectionExtension());
   add("contentControlWidgets", ContentControlWidgetsExtension());
 
   return extensions;

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -384,6 +384,10 @@ const paragraphNodeSpec: NodeSpec = {
     defaultTextFormatting: { default: null },
     sectionBreakType: { default: null },
     bidi: { default: null },
+    // Ephemeral, editor-runtime-only: marks a `bidi` value that auto-detection
+    // set (vs an explicit user toggle or imported `w:bidi`). Never serialized to
+    // DOCX or DOM — it only lets auto-detection re-evaluate its own decisions.
+    bidiAuto: { default: null },
     outlineLevel: { default: null },
     bookmarks: { default: null },
     _emptyHyperlinks: { default: null },
@@ -1057,11 +1061,17 @@ export const ParagraphExtension = createNodeExtension({
             // `null` means "no decision" and is reserved for auto-detection;
             // a deliberate LTR must be recorded as `false` so AutoBidiDetection
             // does not re-flip an Arabic paragraph the user set to LTR.
-            return setParagraphAttr("bidi", !currentBidi)(state, dispatch);
+            // Clearing `bidiAuto` marks this as a manual decision, so
+            // auto-detection never revisits it.
+            return setParagraphAttrsCmd({ bidi: !currentBidi, bidiAuto: null })(
+              state,
+              dispatch,
+            );
           },
-        setRtl: () => setParagraphAttr("bidi", true),
-        // Explicit LTR is `false`, not `null`: see toggleBidi above.
-        setLtr: () => setParagraphAttr("bidi", false),
+        // A manual direction choice clears `bidiAuto`, so auto-detection treats
+        // it as authoritative and never re-evaluates it.
+        setRtl: () => setParagraphAttrsCmd({ bidi: true, bidiAuto: null }),
+        setLtr: () => setParagraphAttrsCmd({ bidi: false, bidiAuto: null }),
         setTabs: (tabs: TabStop[]) =>
           setParagraphAttr("tabs", tabs.length > 0 ? tabs : null),
         addTabStop:

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -1053,13 +1053,18 @@ export const ParagraphExtension = createNodeExtension({
               return false;
             }
             const currentBidi = paragraph.attrs["bidi"] || false;
-            return setParagraphAttr("bidi", currentBidi ? null : true)(
+            // Toggle to an explicit value (true/false), never back to `null`.
+            // `null` means "no decision" and is reserved for auto-detection;
+            // a deliberate LTR must be recorded as `false` so AutoBidiDetection
+            // does not re-flip an Arabic paragraph the user set to LTR.
+            return setParagraphAttr("bidi", currentBidi ? false : true)(
               state,
               dispatch,
             );
           },
         setRtl: () => setParagraphAttr("bidi", true),
-        setLtr: () => setParagraphAttr("bidi", null),
+        // Explicit LTR is `false`, not `null`: see toggleBidi above.
+        setLtr: () => setParagraphAttr("bidi", false),
         setTabs: (tabs: TabStop[]) =>
           setParagraphAttr("tabs", tabs.length > 0 ? tabs : null),
         addTabStop:

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -1057,10 +1057,7 @@ export const ParagraphExtension = createNodeExtension({
             // `null` means "no decision" and is reserved for auto-detection;
             // a deliberate LTR must be recorded as `false` so AutoBidiDetection
             // does not re-flip an Arabic paragraph the user set to LTR.
-            return setParagraphAttr("bidi", currentBidi ? false : true)(
-              state,
-              dispatch,
-            );
+            return setParagraphAttr("bidi", !currentBidi)(state, dispatch);
           },
         setRtl: () => setParagraphAttr("bidi", true),
         // Explicit LTR is `false`, not `null`: see toggleBidi above.

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests for AutoBidiDetectionExtension.
  *
- * Contract: a paragraph whose direction is undecided (`bidi == null`) and whose
- * first strong character is RTL gets `bidi: true` — both when seeded on load
- * (`ensureBaseDirectionInState`) and when content is inserted live
- * (`appendTransaction`). An explicit decision (`true`/`false`) is never
- * overridden, and Latin-led paragraphs are left untouched.
+ * Contract: an "auto-managed" paragraph (bidi unset, or previously auto-set via
+ * `bidiAuto`) whose first strong character is RTL gets `bidi: true` + the
+ * ephemeral `bidiAuto: true`, both on load (`ensureBaseDirectionInState`) and on
+ * live edits (`appendTransaction`). Detection includes inline field display
+ * text. An explicit decision (user toggle / import, `bidiAuto` cleared) is never
+ * overridden, and an auto-set value is re-evaluated when the text changes.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -24,8 +25,16 @@ const schema = new Schema({
     paragraph: {
       group: "block",
       content: "inline*",
-      attrs: { bidi: { default: null } },
+      attrs: { bidi: { default: null }, bidiAuto: { default: null } },
       toDOM: () => ["p", 0],
+    },
+    // Inline atom whose rendered text lives in attrs (mirrors the real field).
+    field: {
+      group: "inline",
+      inline: true,
+      atom: true,
+      attrs: { displayText: { default: "" } },
+      toDOM: () => ["span", 0],
     },
     text: { group: "inline" },
   },
@@ -37,12 +46,21 @@ if (!plugin) {
   throw new Error("Expected plugin from AutoBidiDetectionExtension");
 }
 
-const para = (text: string, bidi: boolean | null = null) =>
+type ParaAttrs = { bidi?: boolean | null; bidiAuto?: boolean | null };
+
+const para = (text: string, attrs: ParaAttrs = {}) =>
   schema.node(
     "paragraph",
-    { bidi },
+    { bidi: attrs.bidi ?? null, bidiAuto: attrs.bidiAuto ?? null },
     text.length > 0 ? [schema.text(text)] : [],
   );
+
+// Paragraph led by a field atom whose display text is `fieldText`.
+const fieldLedPara = (fieldText: string, trailing: string) =>
+  schema.node("paragraph", { bidi: null, bidiAuto: null }, [
+    schema.node("field", { displayText: fieldText }),
+    ...(trailing.length > 0 ? [schema.text(trailing)] : []),
+  ]);
 
 const stateOf = (...paras: PMNode[]) =>
   EditorState.create({
@@ -87,13 +105,13 @@ describe("ensureBaseDirectionInState (initial load)", () => {
 
   test("does not override an explicit LTR (false) on Arabic text", () => {
     expect(
-      bidis(ensureBaseDirectionInState(stateOf(para("عربي", false)))),
+      bidis(ensureBaseDirectionInState(stateOf(para("عربي", { bidi: false })))),
     ).toEqual([false]);
   });
 
   test("leaves an already-RTL paragraph as true (idempotent)", () => {
     expect(
-      bidis(ensureBaseDirectionInState(stateOf(para("عربي", true)))),
+      bidis(ensureBaseDirectionInState(stateOf(para("عربي", { bidi: true })))),
     ).toEqual([true]);
   });
 
@@ -102,6 +120,12 @@ describe("ensureBaseDirectionInState (initial load)", () => {
       stateOf(para("English"), para("نص عربي"), para("123 only")),
     );
     expect(bidis(state)).toEqual([null, true, null]);
+  });
+
+  test("detects RTL from an inline field's display text", () => {
+    // node.textContent omits the field atom; detection must fold in displayText.
+    const state = ensureBaseDirectionInState(stateOf(fieldLedPara("عربي", "")));
+    expect(bidis(state)).toEqual([true]);
   });
 });
 
@@ -119,11 +143,30 @@ describe("appendTransaction (live editing)", () => {
   });
 
   test("does not re-flip a paragraph the user set to explicit LTR", () => {
-    // Arabic paragraph the user forced to LTR (false); a further edit must not
-    // re-detect it back to RTL.
-    let state = stateOf(para("عربي", false));
+    // Arabic paragraph the user forced to LTR (false, bidiAuto cleared); a
+    // further edit must not re-detect it back to RTL.
+    let state = stateOf(para("عربي", { bidi: false }));
     state = state.apply(state.tr.insertText(" مزيد", 5));
     expect(bidis(state)).toEqual([false]);
+  });
+
+  test("re-evaluates an auto-set value when the text changes (no sticky RTL)", () => {
+    // Type Arabic into an empty paragraph -> auto RTL.
+    let state = stateOf(para(""));
+    state = state.apply(state.tr.insertText("مرحبا", 1));
+    expect(bidis(state)).toEqual([true]);
+    // Replace all of it with Latin -> the auto value is cleared, not sticky.
+    const end = state.doc.content.size - 1;
+    state = state.apply(state.tr.replaceWith(1, end, schema.text("hello")));
+    expect(bidis(state)).toEqual([null]);
+  });
+
+  test("does not re-evaluate a manual RTL set on Latin text", () => {
+    // User explicitly set RTL (bidiAuto cleared) on Latin content; editing must
+    // leave the explicit decision intact.
+    let state = stateOf(para("Hello", { bidi: true, bidiAuto: null }));
+    state = state.apply(state.tr.insertText(" world", 6));
+    expect(bidis(state)).toEqual([true]);
   });
 
   test("selection-only transactions do not allocate", () => {

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for AutoBidiDetectionExtension.
+ *
+ * Contract: a paragraph whose direction is undecided (`bidi == null`) and whose
+ * first strong character is RTL gets `bidi: true` — both when seeded on load
+ * (`ensureBaseDirectionInState`) and when content is inserted live
+ * (`appendTransaction`). An explicit decision (`true`/`false`) is never
+ * overridden, and Latin-led paragraphs are left untouched.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+import type { Node as PMNode } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+
+import {
+  AutoBidiDetectionExtension,
+  ensureBaseDirectionInState,
+} from "./AutoBidiDetectionExtension";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      attrs: { bidi: { default: null } },
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+  },
+});
+
+const runtime = AutoBidiDetectionExtension().onSchemaReady({ schema });
+const plugin = runtime.plugins?.[0];
+if (!plugin) {
+  throw new Error("Expected plugin from AutoBidiDetectionExtension");
+}
+
+const para = (text: string, bidi: boolean | null = null) =>
+  schema.node(
+    "paragraph",
+    { bidi },
+    text.length > 0 ? [schema.text(text)] : [],
+  );
+
+const stateOf = (...paras: PMNode[]) =>
+  EditorState.create({
+    doc: schema.node("doc", null, paras),
+    plugins: [plugin],
+  });
+
+const bidis = (state: EditorState): (boolean | null)[] => {
+  const out: (boolean | null)[] = [];
+  state.doc.descendants((node) => {
+    if (node.type.name === "paragraph") {
+      out.push(node.attrs["bidi"] as boolean | null);
+    }
+    return false;
+  });
+  return out;
+};
+
+describe("ensureBaseDirectionInState (initial load)", () => {
+  test("sets bidi=true on an Arabic-led paragraph", () => {
+    expect(bidis(ensureBaseDirectionInState(stateOf(para("هذا عقد"))))).toEqual(
+      [true],
+    );
+  });
+
+  test("leaves a Latin-led paragraph undecided", () => {
+    expect(
+      bidis(ensureBaseDirectionInState(stateOf(para("Agreement")))),
+    ).toEqual([null]);
+  });
+
+  test("does not override an explicit LTR (false) on Arabic text", () => {
+    expect(
+      bidis(ensureBaseDirectionInState(stateOf(para("عربي", false)))),
+    ).toEqual([false]);
+  });
+
+  test("leaves an already-RTL paragraph as true (idempotent)", () => {
+    expect(
+      bidis(ensureBaseDirectionInState(stateOf(para("عربي", true)))),
+    ).toEqual([true]);
+  });
+
+  test("mixed: detects per paragraph", () => {
+    const state = ensureBaseDirectionInState(
+      stateOf(para("English"), para("نص عربي"), para("123 only")),
+    );
+    expect(bidis(state)).toEqual([null, true, null]);
+  });
+});
+
+describe("appendTransaction (live editing)", () => {
+  test("typing Arabic into an empty paragraph sets bidi=true", () => {
+    let state = stateOf(para(""));
+    state = state.apply(state.tr.insertText("مرحبا", 1));
+    expect(bidis(state)).toEqual([true]);
+  });
+
+  test("typing Latin leaves bidi undecided", () => {
+    let state = stateOf(para(""));
+    state = state.apply(state.tr.insertText("hello", 1));
+    expect(bidis(state)).toEqual([null]);
+  });
+
+  test("does not re-flip a paragraph the user set to explicit LTR", () => {
+    // Arabic paragraph the user forced to LTR (false); a further edit must not
+    // re-detect it back to RTL.
+    let state = stateOf(para("عربي", false));
+    state = state.apply(state.tr.insertText(" مزيد", 5));
+    expect(bidis(state)).toEqual([false]);
+  });
+
+  test("selection-only transactions do not allocate", () => {
+    let state = stateOf(para("Agreement"));
+    state = state.apply(state.tr.setSelection(state.selection));
+    expect(bidis(state)).toEqual([null]);
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -36,6 +36,13 @@ const schema = new Schema({
       attrs: { displayText: { default: "" } },
       toDOM: () => ["span", 0],
     },
+    // Inline content control holding nested inline content (mirrors inline SDT).
+    inlineSdt: {
+      group: "inline",
+      inline: true,
+      content: "text*",
+      toDOM: () => ["span", 0],
+    },
     text: { group: "inline" },
   },
 });
@@ -60,6 +67,12 @@ const fieldLedPara = (fieldText: string, trailing: string) =>
   schema.node("paragraph", { bidi: null, bidiAuto: null }, [
     schema.node("field", { displayText: fieldText }),
     ...(trailing.length > 0 ? [schema.text(trailing)] : []),
+  ]);
+
+// Paragraph whose only content is an inline content control holding `text`.
+const sdtLedPara = (text: string) =>
+  schema.node("paragraph", { bidi: null, bidiAuto: null }, [
+    schema.node("inlineSdt", null, text.length > 0 ? [schema.text(text)] : []),
   ]);
 
 const stateOf = (...paras: PMNode[]) =>
@@ -127,6 +140,11 @@ describe("ensureBaseDirectionInState (initial load)", () => {
     const state = ensureBaseDirectionInState(stateOf(fieldLedPara("عربي", "")));
     expect(bidis(state)).toEqual([true]);
   });
+
+  test("detects RTL from text inside an inline content control (SDT)", () => {
+    const state = ensureBaseDirectionInState(stateOf(sdtLedPara("عربي")));
+    expect(bidis(state)).toEqual([true]);
+  });
 });
 
 describe("appendTransaction (live editing)", () => {
@@ -167,6 +185,15 @@ describe("appendTransaction (live editing)", () => {
     let state = stateOf(para("Hello", { bidi: true, bidiAuto: null }));
     state = state.apply(state.tr.insertText(" world", 6));
     expect(bidis(state)).toEqual([true]);
+  });
+
+  test("detects the edited paragraph in a multi-paragraph doc (scoped scan)", () => {
+    // Type Arabic into the second (empty) paragraph; only it flips to RTL.
+    let state = stateOf(para("First"), para(""));
+    state = state.apply(
+      state.tr.insertText("مرحبا", state.doc.content.size - 1),
+    );
+    expect(bidis(state)).toEqual([null, true]);
   });
 
   test("selection-only transactions do not allocate", () => {

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -50,6 +50,10 @@ const stateOf = (...paras: PMNode[]) =>
     plugins: [plugin],
   });
 
+// A state built WITHOUT the plugin models a manager that disabled the extension.
+const stateWithoutPlugin = (...paras: PMNode[]) =>
+  EditorState.create({ doc: schema.node("doc", null, paras) });
+
 const bidis = (state: EditorState): (boolean | null)[] => {
   const out: (boolean | null)[] = [];
   state.doc.descendants((node) => {
@@ -71,6 +75,13 @@ describe("ensureBaseDirectionInState (initial load)", () => {
   test("leaves a Latin-led paragraph undecided", () => {
     expect(
       bidis(ensureBaseDirectionInState(stateOf(para("Agreement")))),
+    ).toEqual([null]);
+  });
+
+  test("is a no-op when the extension is disabled (plugin absent)", () => {
+    // Respects `disable: ["autoBidiDetection"]`: no bidi injected on seed.
+    expect(
+      bidis(ensureBaseDirectionInState(stateWithoutPlugin(para("هذا عقد")))),
     ).toEqual([null]);
   });
 

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -153,12 +153,8 @@ describe("ensureBaseDirectionInState (initial load)", () => {
   test("ignores deleted (non-live) text when detecting direction", () => {
     // Deleted Arabic followed by live Latin: the live content is LTR, so the
     // paragraph must not be auto-flipped to RTL by the struck-through text.
-    const deletionMark = schema.marks["deletion"];
-    if (!deletionMark) {
-      throw new Error("expected a deletion mark");
-    }
     const paragraph = schema.node("paragraph", { bidi: null, bidiAuto: null }, [
-      schema.text("عربي", [deletionMark.create()]),
+      schema.text("عربي", [schema.mark("deletion")]),
       schema.text(" agreement"),
     ]);
     const state = ensureBaseDirectionInState(stateOf(paragraph));

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -45,6 +45,10 @@ const schema = new Schema({
     },
     text: { group: "inline" },
   },
+  marks: {
+    // Deleted / moved-away text carries this mark (mirrors the real schema).
+    deletion: { toDOM: () => ["del", 0] },
+  },
 });
 
 const runtime = AutoBidiDetectionExtension().onSchemaReady({ schema });
@@ -144,6 +148,21 @@ describe("ensureBaseDirectionInState (initial load)", () => {
   test("detects RTL from text inside an inline content control (SDT)", () => {
     const state = ensureBaseDirectionInState(stateOf(sdtLedPara("عربي")));
     expect(bidis(state)).toEqual([true]);
+  });
+
+  test("ignores deleted (non-live) text when detecting direction", () => {
+    // Deleted Arabic followed by live Latin: the live content is LTR, so the
+    // paragraph must not be auto-flipped to RTL by the struck-through text.
+    const deletionMark = schema.marks["deletion"];
+    if (!deletionMark) {
+      throw new Error("expected a deletion mark");
+    }
+    const paragraph = schema.node("paragraph", { bidi: null, bidiAuto: null }, [
+      schema.text("عربي", [deletionMark.create()]),
+      schema.text(" agreement"),
+    ]);
+    const state = ensureBaseDirectionInState(stateOf(paragraph));
+    expect(bidis(state)).toEqual([null]);
   });
 });
 

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -94,6 +94,14 @@ const applyBidiUpdates = (
  * bytes; editing the paragraph tracks it and the patch then includes `w:bidi`.
  */
 export const ensureBaseDirectionInState = (state: EditorState): EditorState => {
+  // Respect the extension-disable contract: if a manager was built with
+  // `disable: ["autoBidiDetection"]`, the plugin is absent from the state and
+  // this imperative seed pass must be a no-op too (otherwise a disabled feature
+  // would still materialise — and, on the collaborative path, persist — bidi
+  // attrs). The live `appendTransaction` already only runs when registered.
+  if (!autoBidiDetectionKey.get(state)) {
+    return state;
+  }
   const updates = collectBidiUpdates(state.doc);
   if (updates.length === 0) {
     return state;

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -50,7 +50,8 @@ type BidiUpdate = {
 // text. Text inside hyperlink marks is regular child text, so it is included.
 const paragraphDirectionalText = (node: PMNode): string => {
   let text = "";
-  node.forEach((child) => {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
     if (child.isText) {
       text += child.text ?? "";
     } else if (child.type.name === "field") {
@@ -59,7 +60,7 @@ const paragraphDirectionalText = (node: PMNode): string => {
         text += display;
       }
     }
-  });
+  }
   return text;
 };
 

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -83,6 +83,15 @@ const applyBidiUpdates = (
  * Imperatively apply auto-bidi detection to a freshly built state (initial
  * load: Markdown import, DOCX import, template). `appendTransaction` does not
  * fire for the initial document, so seeded content needs this pass.
+ *
+ * Like the paraId allocator this is `ignoreTrackedChanges`, so a normalized
+ * paragraph the user never edits is not in `changedParaIds`. Full save (the
+ * default; and the only path for Markdown/template/new docs, which have no
+ * original buffer) serializes the whole PM doc, so the flag is written. The
+ * selective-save path (dark `selectiveSave` flag) intentionally preserves
+ * untouched original paragraphs byte-for-byte, so an imported DOCX whose Arabic
+ * arrived without `w:bidi` and is saved without any edit keeps the original
+ * bytes; editing the paragraph tracks it and the patch then includes `w:bidi`.
  */
 export const ensureBaseDirectionInState = (state: EditorState): EditorState => {
   const updates = collectBidiUpdates(state.doc);

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -31,6 +31,8 @@ import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorState } from "prosemirror-state";
 
+import type { DirtyRange } from "../../../paged-layout/incrementalMeasure";
+import { getTransactionDirtyRange } from "../../../paged-layout/transactionDirtyRange";
 import { detectBaseDirection } from "../../../utils/baseDirection";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
@@ -46,12 +48,11 @@ type BidiUpdate = {
 // First-strong detection needs the paragraph's directional text in document
 // order. `node.textContent` skips inline field atoms (MERGEFIELD/REF results
 // keep their rendered text in attrs, not child text), which would mis-detect a
-// field-led paragraph; walk direct inline children and fold in field display
-// text. Text inside hyperlink marks is regular child text, so it is included.
+// field-led paragraph. Walk descendants so text nested in inline content
+// controls (SDT) and hyperlinks is included, and fold in field display text.
 const paragraphDirectionalText = (node: PMNode): string => {
   let text = "";
-  for (let i = 0; i < node.childCount; i++) {
-    const child = node.child(i);
+  node.descendants((child) => {
     if (child.isText) {
       text += child.text ?? "";
     } else if (child.type.name === "field") {
@@ -60,44 +61,71 @@ const paragraphDirectionalText = (node: PMNode): string => {
         text += display;
       }
     }
-  }
+  });
   return text;
 };
 
+// Decide the update (if any) for a single paragraph node.
+const evaluateParagraph = (node: PMNode, pos: number): BidiUpdate | null => {
+  const currentBidi = node.attrs["bidi"] ?? null;
+  const autoManaged = currentBidi === null || node.attrs["bidiAuto"] === true;
+  // Explicit decision (user toggle / imported w:bidi): leave it alone.
+  if (!autoManaged) {
+    return null;
+  }
+
+  const wantRtl = detectBaseDirection(paragraphDirectionalText(node)) === "rtl";
+  const desiredBidi = wantRtl ? true : null;
+  const desiredAuto = wantRtl ? true : null;
+  const unchanged =
+    currentBidi === desiredBidi &&
+    (node.attrs["bidiAuto"] ?? null) === desiredAuto;
+  if (unchanged) {
+    return null;
+  }
+  return {
+    pos,
+    attrs: { ...node.attrs, bidi: desiredBidi, bidiAuto: desiredAuto },
+  };
+};
+
+// Whole-document scan (load/seed, and the rare multi-transaction fallback).
 const collectBidiUpdates = (doc: PMNode): BidiUpdate[] => {
   const updates: BidiUpdate[] = [];
-
   doc.descendants((node, pos) => {
-    // Non-paragraph: recurse — paragraphs nested in tables / cells are in scope.
     if (node.type.name !== "paragraph") {
+      // Recurse — paragraphs nested in tables / cells are in scope.
       return;
     }
-
-    const currentBidi = node.attrs["bidi"] ?? null;
-    const autoManaged = currentBidi === null || node.attrs["bidiAuto"] === true;
-    // Explicit decision (user toggle / imported w:bidi): leave it alone.
-    if (!autoManaged) {
-      return false;
+    const update = evaluateParagraph(node, pos);
+    if (update) {
+      updates.push(update);
     }
-
-    const wantRtl =
-      detectBaseDirection(paragraphDirectionalText(node)) === "rtl";
-    const desiredBidi = wantRtl ? true : null;
-    const desiredAuto = wantRtl ? true : null;
-    const changed =
-      currentBidi !== desiredBidi ||
-      (node.attrs["bidiAuto"] ?? null) !== desiredAuto;
-    if (changed) {
-      updates.push({
-        pos,
-        attrs: { ...node.attrs, bidi: desiredBidi, bidiAuto: desiredAuto },
-      });
-    }
-
     // Paragraphs only contain inline content — skip the subtree.
     return false;
   });
+  return updates;
+};
 
+// Scan only the paragraphs overlapping a transaction's edited range, so a
+// keystroke in a large mostly-LTR document doesn't re-scan every paragraph.
+const collectBidiUpdatesInRange = (
+  doc: PMNode,
+  range: DirtyRange,
+): BidiUpdate[] => {
+  const from = Math.max(0, Math.min(range.from, doc.content.size));
+  const to = Math.max(from, Math.min(range.to, doc.content.size));
+  const seen = new Set<number>();
+  const updates: BidiUpdate[] = [];
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (node.type.name === "paragraph" && !seen.has(pos)) {
+      seen.add(pos);
+      const update = evaluateParagraph(node, pos);
+      if (update) {
+        updates.push(update);
+      }
+    }
+  });
   return updates;
 };
 
@@ -154,7 +182,15 @@ const createAutoBidiDetectionPlugin = (): Plugin =>
         return null;
       }
 
-      const updates = collectBidiUpdates(newState.doc);
+      // Common case: a single transaction — scan only its edited range. For the
+      // rarer multi-transaction batch (positions would span intermediate docs),
+      // fall back to a correct whole-document scan.
+      const [first, ...rest] = transactions;
+      const range =
+        first && rest.length === 0 ? getTransactionDirtyRange(first) : null;
+      const updates = range
+        ? collectBidiUpdatesInRange(newState.doc, range)
+        : collectBidiUpdates(newState.doc);
       if (updates.length === 0) {
         return null;
       }

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -54,7 +54,12 @@ const paragraphDirectionalText = (node: PMNode): string => {
   let text = "";
   node.descendants((child) => {
     if (child.isText) {
-      text += child.text ?? "";
+      // Deleted and moved-away text both carry the `deletion` mark; it is not
+      // live content, so it must not drive base-direction detection.
+      const deleted = child.marks.some((mark) => mark.type.name === "deletion");
+      if (!deleted) {
+        text += child.text ?? "";
+      }
     } else if (child.type.name === "field") {
       const display = child.attrs["displayText"];
       if (typeof display === "string") {

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -14,11 +14,15 @@
  * Detection uses the first-strong-character rule (`detectBaseDirection`), the
  * same logic the layout painter uses for base direction.
  *
- * Clobber safety: we act ONLY when `bidi` is unset (`null`/`undefined`).
- * Explicit user/import decisions are `bidi: true` (RTL) or `bidi: false`
- * (LTR — see `setLtr`), so an Arabic paragraph the user deliberately set to LTR
- * is never re-flipped. We never set `bidi: false` here; LTR-led paragraphs are
- * left untouched (unset already means LTR).
+ * Auto vs. explicit: a paragraph is "auto-managed" when its `bidi` is unset
+ * (`null`) OR was set by this detector (`bidiAuto === true`). Only auto-managed
+ * paragraphs are (re-)evaluated; an explicit user toggle or imported `w:bidi`
+ * sets `bidi` with `bidiAuto` cleared, so it is authoritative and never touched.
+ * Because we re-evaluate our own decisions, replacing an auto-RTL paragraph's
+ * text with Latin clears the flag again (no stale "sticky" RTL).
+ *
+ * `bidiAuto` is an ephemeral editor-runtime attr — it is never serialized to
+ * DOCX or the DOM, so the persisted model still carries only the real `w:bidi`.
  *
  * Mirrors the appendTransaction + ensure-in-state pattern of
  * `ParaIdAllocatorExtension`.
@@ -39,6 +43,26 @@ type BidiUpdate = {
   attrs: Record<string, unknown>;
 };
 
+// First-strong detection needs the paragraph's directional text in document
+// order. `node.textContent` skips inline field atoms (MERGEFIELD/REF results
+// keep their rendered text in attrs, not child text), which would mis-detect a
+// field-led paragraph; walk direct inline children and fold in field display
+// text. Text inside hyperlink marks is regular child text, so it is included.
+const paragraphDirectionalText = (node: PMNode): string => {
+  let text = "";
+  node.forEach((child) => {
+    if (child.isText) {
+      text += child.text ?? "";
+    } else if (child.type.name === "field") {
+      const display = child.attrs["displayText"];
+      if (typeof display === "string") {
+        text += display;
+      }
+    }
+  });
+  return text;
+};
+
 const collectBidiUpdates = (doc: PMNode): BidiUpdate[] => {
   const updates: BidiUpdate[] = [];
 
@@ -48,14 +72,25 @@ const collectBidiUpdates = (doc: PMNode): BidiUpdate[] => {
       return;
     }
 
-    // Only undecided paragraphs are candidates. An explicit true/false (user
-    // toggle or Word import) is authoritative and must not be overridden.
-    if (node.attrs["bidi"] != null) {
+    const currentBidi = node.attrs["bidi"] ?? null;
+    const autoManaged = currentBidi === null || node.attrs["bidiAuto"] === true;
+    // Explicit decision (user toggle / imported w:bidi): leave it alone.
+    if (!autoManaged) {
       return false;
     }
 
-    if (detectBaseDirection(node.textContent) === "rtl") {
-      updates.push({ pos, attrs: { ...node.attrs, bidi: true } });
+    const wantRtl =
+      detectBaseDirection(paragraphDirectionalText(node)) === "rtl";
+    const desiredBidi = wantRtl ? true : null;
+    const desiredAuto = wantRtl ? true : null;
+    const changed =
+      currentBidi !== desiredBidi ||
+      (node.attrs["bidiAuto"] ?? null) !== desiredAuto;
+    if (changed) {
+      updates.push({
+        pos,
+        attrs: { ...node.attrs, bidi: desiredBidi, bidiAuto: desiredAuto },
+      });
     }
 
     // Paragraphs only contain inline content — skip the subtree.

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -1,0 +1,121 @@
+/**
+ * AutoBidiDetection — sets the paragraph `bidi` attribute on RTL-led
+ * paragraphs that arrived without an explicit direction decision.
+ *
+ * Why: Folio only ever rendered/exported RTL when a paragraph already carried
+ * `w:bidi` (from a Word import) or the user toggled it by hand. Content that
+ * never had a flag — AI-generated text, Markdown/HTML/plain-text imports, paste,
+ * or just typing Arabic without the shortcut — stayed left-to-right both in the
+ * editor and in the exported `.docx`. The ProseMirror doc is the single source
+ * of truth for both the layout painter (`toFlowBlocks`) and the serializer
+ * (`fromProseDoc`), so writing the attribute here fixes the editor and the Word
+ * export from one place.
+ *
+ * Detection uses the first-strong-character rule (`detectBaseDirection`), the
+ * same logic the layout painter uses for base direction.
+ *
+ * Clobber safety: we act ONLY when `bidi` is unset (`null`/`undefined`).
+ * Explicit user/import decisions are `bidi: true` (RTL) or `bidi: false`
+ * (LTR — see `setLtr`), so an Arabic paragraph the user deliberately set to LTR
+ * is never re-flipped. We never set `bidi: false` here; LTR-led paragraphs are
+ * left untouched (unset already means LTR).
+ *
+ * Mirrors the appendTransaction + ensure-in-state pattern of
+ * `ParaIdAllocatorExtension`.
+ */
+import type { Node as PMNode } from "prosemirror-model";
+import { Plugin, PluginKey } from "prosemirror-state";
+import type { EditorState } from "prosemirror-state";
+
+import { detectBaseDirection } from "../../../utils/baseDirection";
+import { createExtension } from "../create";
+import type { ExtensionRuntime } from "../types";
+import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
+
+export const autoBidiDetectionKey = new PluginKey("autoBidiDetection");
+
+type BidiUpdate = {
+  pos: number;
+  attrs: Record<string, unknown>;
+};
+
+const collectBidiUpdates = (doc: PMNode): BidiUpdate[] => {
+  const updates: BidiUpdate[] = [];
+
+  doc.descendants((node, pos) => {
+    // Non-paragraph: recurse — paragraphs nested in tables / cells are in scope.
+    if (node.type.name !== "paragraph") {
+      return;
+    }
+
+    // Only undecided paragraphs are candidates. An explicit true/false (user
+    // toggle or Word import) is authoritative and must not be overridden.
+    if (node.attrs["bidi"] != null) {
+      return false;
+    }
+
+    if (detectBaseDirection(node.textContent) === "rtl") {
+      updates.push({ pos, attrs: { ...node.attrs, bidi: true } });
+    }
+
+    // Paragraphs only contain inline content — skip the subtree.
+    return false;
+  });
+
+  return updates;
+};
+
+const applyBidiUpdates = (
+  state: EditorState,
+  updates: BidiUpdate[],
+): EditorState["tr"] => {
+  const tr = state.tr;
+  for (const update of updates) {
+    tr.setNodeMarkup(update.pos, undefined, update.attrs);
+  }
+  ignoreTrackedChanges(tr);
+  tr.setMeta(autoBidiDetectionKey, "applied");
+  tr.setMeta("addToHistory", false);
+  return tr;
+};
+
+/**
+ * Imperatively apply auto-bidi detection to a freshly built state (initial
+ * load: Markdown import, DOCX import, template). `appendTransaction` does not
+ * fire for the initial document, so seeded content needs this pass.
+ */
+export const ensureBaseDirectionInState = (state: EditorState): EditorState => {
+  const updates = collectBidiUpdates(state.doc);
+  if (updates.length === 0) {
+    return state;
+  }
+  return state.apply(applyBidiUpdates(state, updates));
+};
+
+const createAutoBidiDetectionPlugin = (): Plugin =>
+  new Plugin({
+    key: autoBidiDetectionKey,
+    appendTransaction(transactions, _oldState, newState) {
+      // Selection-only / mark-only transactions can't have changed paragraph text.
+      if (!transactions.some((t) => t.docChanged)) {
+        return null;
+      }
+
+      const updates = collectBidiUpdates(newState.doc);
+      if (updates.length === 0) {
+        return null;
+      }
+
+      return applyBidiUpdates(newState, updates);
+    },
+  });
+
+export const AutoBidiDetectionExtension = createExtension({
+  name: "autoBidiDetection",
+  defaultOptions: {},
+  onSchemaReady(): ExtensionRuntime {
+    return {
+      plugins: [createAutoBidiDetectionPlugin()],
+    };
+  },
+});

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -160,6 +160,13 @@ export type ParagraphAttrs = {
 
   // Text direction
   bidi?: boolean;
+  /**
+   * Ephemeral, editor-runtime-only flag: `true` when auto-detection set `bidi`
+   * (as opposed to an explicit user toggle or imported `w:bidi`). Never
+   * serialized to DOCX or DOM; it only lets auto-detection re-evaluate the
+   * paragraphs it previously decided. See AutoBidiDetectionExtension.
+   */
+  bidiAuto?: boolean;
 
   // Outline level for TOC (0-9)
   outlineLevel?: number;

--- a/packages/folio/src/core/utils/baseDirection.test.ts
+++ b/packages/folio/src/core/utils/baseDirection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectBaseDirection } from "./baseDirection";
+
+describe("detectBaseDirection", () => {
+  test("Arabic-led text is RTL", () => {
+    expect(detectBaseDirection("هذا نص عربي")).toBe("rtl");
+  });
+
+  test("Hebrew-led text is RTL", () => {
+    expect(detectBaseDirection("שלום עולם")).toBe("rtl");
+  });
+
+  test("Latin-led text is LTR", () => {
+    expect(detectBaseDirection("Hello world")).toBe("ltr");
+  });
+
+  test("weak/neutral-only text is undecided (null)", () => {
+    expect(detectBaseDirection("123 456 — !!!  ")).toBe(null);
+    expect(detectBaseDirection("")).toBe(null);
+  });
+
+  test("leading digits and punctuation are skipped; first letter decides", () => {
+    expect(detectBaseDirection("123. العربية")).toBe("rtl");
+    expect(detectBaseDirection("(2024) Contract")).toBe("ltr");
+  });
+
+  test("explicit bidi marks override the first letter", () => {
+    const LRM = String.fromCodePoint(8206);
+    const RLM = String.fromCodePoint(8207);
+    // LRM before Arabic forces LTR; RLM before Latin forces RTL.
+    expect(detectBaseDirection(`${LRM}عربي`)).toBe("ltr");
+    expect(detectBaseDirection(`${RLM}Hello`)).toBe("rtl");
+  });
+});

--- a/packages/folio/src/core/utils/baseDirection.ts
+++ b/packages/folio/src/core/utils/baseDirection.ts
@@ -1,0 +1,55 @@
+/**
+ * First-strong base-direction detection (the Unicode `dir="auto"` rule).
+ *
+ * Scans text for the first *strong* directional signal — an explicit bidi
+ * control (RLM / ALM => RTL, LRM => LTR) or the first letter (`\p{L}`) — and
+ * reports the base paragraph direction it implies. Digits, combining marks,
+ * punctuation and whitespace are weak/neutral and skipped. Text with no strong
+ * character returns `null` (undecided; the caller decides the default).
+ *
+ * Shared by the layout painter (paragraph base direction) and the auto-bidi
+ * detector (sets `w:bidi` on Arabic/Hebrew-led paragraphs that arrived without
+ * an explicit direction flag).
+ */
+
+// Strong-RTL letters, matched by Unicode script so RTL scripts outside the BMP
+// (Adlam U+1E900) and newer blocks (Arabic Extended-B U+0870) are covered
+// without hand-rolling code-point ranges. These eight cover every RTL script in
+// real-world use (Hebrew/Arabic are ~all of it); newer scripts (Yezidi, Garay,
+// …) are omitted because the pinned oxlint/tsc Unicode database rejects their
+// names. Only used to classify the first *letter* (`\p{L}`), so the non-letter
+// members of these scripts (Arabic-Indic digits, combining marks, punctuation)
+// are never tested — they're weak/neutral and skipped upstream.
+export const RTL_STRONG_LETTER =
+  /[\p{Script=Hebrew}\p{Script=Arabic}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
+
+const LETTER = /\p{L}/u;
+
+// Explicit bidi controls, by code point (decimal — hex literals trip the
+// numeric-separators lint). RLM U+200F and ALM U+061C force RTL; LRM U+200E
+// forces LTR.
+const RLM = 8207;
+const ALM = 1564;
+const LRM = 8206;
+
+export type BaseDirection = "rtl" | "ltr";
+
+/**
+ * Resolve the first-strong base direction of `text`, or `null` when the text
+ * carries no strong directional character.
+ */
+export function detectBaseDirection(text: string): BaseDirection | null {
+  for (const ch of text) {
+    const cp = ch.codePointAt(0);
+    if (cp === RLM || cp === ALM) {
+      return "rtl";
+    }
+    if (cp === LRM) {
+      return "ltr";
+    }
+    if (LETTER.test(ch)) {
+      return RTL_STRONG_LETTER.test(ch) ? "rtl" : "ltr";
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

Folio only rendered and exported right-to-left when a paragraph already carried an explicit direction flag — either from a Word import or a manual toggle (Ctrl/Cmd+Shift). Paragraphs that arrived without a flag stayed left-to-right in both the editor and the exported `.docx`:

- AI-generated content
- Markdown / plain-text imports
- Pasted content
- Arabic typed without using the direction shortcut

For these, the serializer emitted a bare `<w:p><w:r><w:t>…</w:t></w:r></w:p>` with no `w:bidi`, so Microsoft Word displayed Arabic/Hebrew left-aligned LTR.

## Approach

The ProseMirror document is the single source of truth for both the layout painter (`toFlowBlocks`) and the serializer (`fromProseDoc`), so direction is set there. An undecided paragraph whose first strong character is RTL gets `bidi = true`. That one attribute drives the editor's base direction and emits `<w:bidi/>` on export; Word right-aligns logically from `w:bidi`, so no explicit `w:jc` is needed.

Detection uses the first-strong-character rule (the Unicode `dir="auto"` heuristic) already used by the layout painter for base direction; that scan is extracted into a shared helper.

## Changes

- `utils/baseDirection.ts` — shared `detectBaseDirection` (first-strong scan); `paragraphBaseIsRtl` in the layout painter now reuses it.
- `AutoBidiDetectionExtension` — `appendTransaction` for live edits (typing/paste/AI) + `ensureBaseDirectionInState` for the seed document (initial load, where `appendTransaction` does not fire); wired into the editor and header/footer init paths.
- `setLtr` now records explicit LTR as `bidi = false` (was `null`). `null` means "no decision" and is reserved for auto-detection, so a paragraph the user deliberately set to LTR is never re-flipped.

## Safety / scope

- Acts only when `bidi` is unset; explicit `true`/`false` (user toggle or Word import) is authoritative and never overridden.
- LTR-led paragraphs are left untouched (unset already means LTR); only RTL-led ones are flagged.
- Sets paragraph-level `bidi` only, not per-run `w:rtl`, to avoid mis-marking Latin runs in mixed paragraphs. Word still orders mixed content correctly under the RTL base direction.
- Known edge: copy-pasting a paragraph the user *manually* forced to LTR can lose that override through DOM round-trip and be re-detected as RTL. Rare; the result is the sensible default.

## Tests

- `baseDirection.test.ts` — first-strong detection (Arabic/Hebrew RTL, Latin LTR, weak-only null, leading digits/punctuation skipped, explicit bidi marks).
- `AutoBidiDetectionExtension.test.ts` — seed-load and live-edit detection, explicit-LTR not re-flipped, Latin untouched, selection-only transactions ignored.
- Existing RTL/serializer/layout suites and extension/conversion suites remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic base-direction (bidi) detection for paragraphs, enabled via an extension included in the editor starter kit.
  * Introduced an editor-runtime `bidiAuto` flag to distinguish auto-detected vs explicit bidi.
  * DOCX importing/saving now applies model-level base-direction normalisation when needed.

* **Bug Fixes**
  * Improved bidi detection accuracy (including stronger handling of explicit bidi marks and neutral-only content).
  * Ensured explicit `bidi: false/true/null` preserves correctly across editing and DOCX round-trips.
  * Hidden editor state initialisation and paragraph rendering now consistently normalise base direction.

* **Tests**
  * Expanded Bun tests for bidi detection, editor state seeding, DOCX normalisation, and ProseMirror conversion round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->