### PR TITLE
fix(i18n): gender-agree "New {layout}" view name per locale (ICU select)

### DIFF
--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2883,6 +2883,7 @@
         "table": "جدول",
         "timeline": "خط زمني"
       },
+      "newView": "{layoutType, select, overview {{layout} جديدة} filesystem {{layout} جديدة} other {{layout} جديد}}",
       "noFilterResults": "لا توجد عناصر تطابق عوامل التصفية هذه",
       "noFilterResultsHint": "ستظهر هنا إذا أزلت بعض عوامل التصفية.",
       "removeAdvancedFilter": "إزالة عامل التصفية المتقدم",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2883,7 +2883,6 @@
         "table": "جدول",
         "timeline": "خط زمني"
       },
-      "newView": "{layout} جديدة",
       "noFilterResults": "لا توجد عناصر تطابق عوامل التصفية هذه",
       "noFilterResultsHint": "ستظهر هنا إذا أزلت بعض عوامل التصفية.",
       "removeAdvancedFilter": "إزالة عامل التصفية المتقدم",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2883,6 +2883,7 @@
         "table": "Tabulka",
         "timeline": "Časová osa"
       },
+      "newView": "{layoutType, select, table {Nová {layout}} timeline {Nová {layout}} other {Nový {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Odebrat rozšířený filtr",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2883,7 +2883,6 @@
         "table": "Tabulka",
         "timeline": "Časová osa"
       },
-      "newView": "Nový {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Odebrat rozšířený filtr",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2883,6 +2883,7 @@
         "table": "Tabelle",
         "timeline": "Zeitleiste"
       },
+      "newView": "{layoutType, select, calendar {Neuer {layout}} other {Neue {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2883,7 +2883,6 @@
         "table": "Tabelle",
         "timeline": "Zeitleiste"
       },
-      "newView": "Neue {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2883,7 +2883,6 @@
         "table": "Table",
         "timeline": "Timeline"
       },
-      "newView": "New {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2883,6 +2883,7 @@
         "table": "Table",
         "timeline": "Timeline"
       },
+      "newView": "{layoutType, select, other {New {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2883,7 +2883,6 @@
         "table": "Tabla",
         "timeline": "Línea de tiempo"
       },
-      "newView": "Nueva {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2883,6 +2883,7 @@
         "table": "Tabla",
         "timeline": "Línea de tiempo"
       },
+      "newView": "{layoutType, select, overview {Nuevo {layout}} kanban {Nuevo {layout}} calendar {Nuevo {layout}} other {Nueva {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2883,7 +2883,6 @@
         "table": "Tabel",
         "timeline": "Ajajoon"
       },
-      "newView": "Uus {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2883,6 +2883,7 @@
         "table": "Tabel",
         "timeline": "Ajajoon"
       },
+      "newView": "{layoutType, select, other {Uus {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2883,6 +2883,7 @@
         "table": "Tableau",
         "timeline": "Chronologie"
       },
+      "newView": "{layoutType, select, overview {Nouvel {layout}} filesystem {Nouvelle {layout}} timeline {Nouvelle {layout}} other {Nouveau {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2883,7 +2883,6 @@
         "table": "Tableau",
         "timeline": "Chronologie"
       },
-      "newView": "Nouvelle {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2883,7 +2883,6 @@
         "table": "Táblázat",
         "timeline": "Idővonal"
       },
-      "newView": "Új {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2883,6 +2883,7 @@
         "table": "Táblázat",
         "timeline": "Idővonal"
       },
+      "newView": "{layoutType, select, other {Új {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2883,7 +2883,6 @@
         "table": "Lentelė",
         "timeline": "Laiko juosta"
       },
-      "newView": "Naujas {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2883,6 +2883,7 @@
         "table": "Lentelė",
         "timeline": "Laiko juosta"
       },
+      "newView": "{layoutType, select, other {Naujas {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2883,6 +2883,7 @@
         "table": "Tabula",
         "timeline": "Laika skala"
       },
+      "newView": "{layoutType, select, other {Jauns {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2883,7 +2883,6 @@
         "table": "Tabula",
         "timeline": "Laika skala"
       },
-      "newView": "Jauns {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2886,6 +2886,7 @@ type Messages = {
         "table": "Table";
         "timeline": "Timeline";
       };
+      "newView": "{layoutType, select, other {New {layout}}}";
       "noFilterResults": "No items match these filters";
       "noFilterResultsHint": "They would show up here if you removed some filters.";
       "removeAdvancedFilter": "Remove advanced filter";

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2886,7 +2886,6 @@ type Messages = {
         "table": "Table";
         "timeline": "Timeline";
       };
-      "newView": "New {layout}";
       "noFilterResults": "No items match these filters";
       "noFilterResultsHint": "They would show up here if you removed some filters.";
       "removeAdvancedFilter": "Remove advanced filter";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2883,6 +2883,7 @@
         "table": "Tabela",
         "timeline": "Oś czasu"
       },
+      "newView": "{layoutType, select, table {Nowa {layout}} filesystem {Nowa {layout}} timeline {Nowa {layout}} other {Nowy {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2883,7 +2883,6 @@
         "table": "Tabela",
         "timeline": "Oś czasu"
       },
-      "newView": "Nowy {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2883,7 +2883,6 @@
         "table": "Tabela",
         "timeline": "Linha do tempo"
       },
-      "newView": "Novo {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2883,6 +2883,7 @@
         "table": "Tabela",
         "timeline": "Linha do tempo"
       },
+      "newView": "{layoutType, select, kanban {Novo {layout}} calendar {Novo {layout}} other {Nova {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2883,7 +2883,6 @@
         "table": "Tabuľka",
         "timeline": "Časová os"
       },
-      "newView": "Nový {layout}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2883,6 +2883,7 @@
         "table": "Tabuľka",
         "timeline": "Časová os"
       },
+      "newView": "{layoutType, select, table {Nová {layout}} timeline {Nová {layout}} other {Nový {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -267,9 +267,11 @@ export const ViewSwitcher = ({
                       createView.mutate(
                         {
                           id: viewId,
-                          name: t("workspaces.views.newView", {
-                            layout: t(LAYOUT_LABEL_KEYS[layoutType]),
-                          }),
+                          // Name a new view by its layout type ("Calendar",
+                          // "Table", …). A "New {layout}" template would need a
+                          // gender-agreeing adjective, which can't be done
+                          // correctly across every locale's layout nouns.
+                          name: t(LAYOUT_LABEL_KEYS[layoutType]),
                           layout: defaultLayouts[layoutType],
                         },
                         {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -267,11 +267,13 @@ export const ViewSwitcher = ({
                       createView.mutate(
                         {
                           id: viewId,
-                          // Name a new view by its layout type ("Calendar",
-                          // "Table", …). A "New {layout}" template would need a
-                          // gender-agreeing adjective, which can't be done
-                          // correctly across every locale's layout nouns.
-                          name: t(LAYOUT_LABEL_KEYS[layoutType]),
+                          // `layoutType` lets each locale inflect "New {layout}"
+                          // for the layout noun's gender (ICU select); the name
+                          // stays distinct from the default-view-name set.
+                          name: t("workspaces.views.newView", {
+                            layout: t(LAYOUT_LABEL_KEYS[layoutType]),
+                            layoutType,
+                          }),
                           layout: defaultLayouts[layoutType],
                         },
                         {


### PR DESCRIPTION
## Problem

A new view was named via `newView` = "New {layout}", interpolating the translated layout label after a fixed adjective. The adjective can't agree in gender with a variable noun, and it was hardcoded to one gender in every gendered locale, so it was wrong for layouts of the other gender:

- `ar` "{layout} جديدة" (f) → "تقويم جديدة" (تقويم is masculine)
- `de` "Neue {layout}" (f) → "Neue Kalender" (Kalender is masculine)
- `fr` "Nouvelle {layout}" (f) → "Nouvelle Calendrier"
- `es` "Nueva {layout}" (f), `pt-BR` "Novo {layout}" (m), `cs/sk/pl` "Nový/Nowy {layout}" (m) → wrong for the other gender

Only `en`, `hu`, `et` (no grammatical gender) were correct.

## Approach

Keep the distinct "New {layout}" name (it must stay out of the default-view-name set used by `localizeDefaultViewName`, or user views get treated as auto-created defaults and re-localized) and inflect the adjective per **layout-noun gender** via an ICU `select` on `layoutType`, passed from the call site.

Each locale's `select` keeps its previous adjective as `other`, so any layout not explicitly branched **cannot regress**; explicit branches fix the layouts whose noun gender differs.

- Genders filled: `ar`, `de`, `fr` (incl. elision "Nouvel Aperçu"), `es`, `pt-BR`, `cs`, `sk`, `pl`.
- No grammatical gender: `en`, `hu`, `et` (trivial single-branch select).
- `lt`, `lv` keep their current single-gender form pending native review; the `select` scaffold is in place to add branches.

## Verification
- Rendered outputs spot-checked with `intl-messageformat` across locales (e.g. ar "نظرة عامة جديدة"/"جدول جديد", de "Neuer Kalender", fr "Nouvel Aperçu", pt-BR "Nova Tabela", cs "Nová Tabulka").
- `bun run i18n:check` passes (keys sorted, placeholder parity incl. `{layoutType}`, ICU/quality lint clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved “new view” labels across multiple languages so the wording now matches the selected layout type more accurately.
  * Added layout-type-aware text handling when creating a new view, resulting in more natural labels in the interface.

* **Bug Fixes**
  * Fixed inconsistent grammar in several translations for view creation, especially for different layout variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->