### PR TITLE
fix(folio): respect style-sourced direction in save-fallback bidi normalizer

### DIFF
--- a/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.test.ts
@@ -148,4 +148,69 @@ describe("normalizeBaseDirection", () => {
     normalizeBaseDirection(input);
     expect(bidiOf(input, 0)).toBeUndefined();
   });
+
+  test("respects a style-sourced LTR (w:bidi=0) and does not flip to RTL", () => {
+    const doc: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              name: "Normal",
+              default: true,
+            },
+            {
+              styleId: "LtrForced",
+              type: "paragraph",
+              name: "Ltr Forced",
+              pPr: { bidi: false },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "LtrForced" },
+              content: [
+                { type: "run", content: [{ type: "text", text: "عربي" }] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    // Style forces LTR; the Arabic content must not override it.
+    expect(bidiOf(normalizeBaseDirection(doc), 0)).toBeUndefined();
+  });
+
+  test("still normalizes when the style sets no direction", () => {
+    const doc: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              name: "Normal",
+              default: true,
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "Normal" },
+              content: [
+                { type: "run", content: [{ type: "text", text: "عربي" }] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    expect(bidiOf(normalizeBaseDirection(doc), 0)).toBe(true);
+  });
 });

--- a/packages/folio/src/core/docx/normalizeBaseDirection.ts
+++ b/packages/folio/src/core/docx/normalizeBaseDirection.ts
@@ -1,3 +1,5 @@
+import { createStyleResolver } from "../prosemirror/styles/styleResolver";
+import type { StyleResolver } from "../prosemirror/styles/styleResolver";
 /**
  * Model-level RTL base-direction normalization.
  *
@@ -81,10 +83,20 @@ function singleItemText(item: ParagraphContent): string {
 const paragraphText = (paragraph: Paragraph): string =>
   paragraphContentText(paragraph.content);
 
-const normalizeParagraph = (paragraph: Paragraph): Paragraph => {
-  // Respect an explicit decision (true = RTL, false = forced LTR); only fill in
-  // the undecided case.
-  if (paragraph.formatting?.bidi != null) {
+const normalizeParagraph = (
+  paragraph: Paragraph,
+  styles: StyleResolver,
+): Paragraph => {
+  // Respect an explicit direction decision before normalizing — direct
+  // (`true` = RTL, `false` = forced LTR) OR inherited from the paragraph style
+  // / doc defaults (e.g. a style with `w:bidi w:val="0"` that forces Arabic
+  // text LTR). Only fill in the truly undecided case. Mirrors toProseDoc's
+  // `formatting?.bidi ?? stylePpr?.bidi` resolution.
+  const effectiveBidi =
+    paragraph.formatting?.bidi ??
+    styles.resolveParagraphStyle(paragraph.formatting?.styleId)
+      .paragraphFormatting?.bidi;
+  if (effectiveBidi != null) {
     return paragraph;
   }
   if (detectBaseDirection(paragraphText(paragraph)) !== "rtl") {
@@ -96,7 +108,7 @@ const normalizeParagraph = (paragraph: Paragraph): Paragraph => {
   };
 };
 
-const normalizeTable = (table: Table): Table => ({
+const normalizeTable = (table: Table, styles: StyleResolver): Table => ({
   ...table,
   rows: table.rows.map((row) => ({
     ...row,
@@ -104,36 +116,44 @@ const normalizeTable = (table: Table): Table => ({
       ...cell,
       content: cell.content.map((block) =>
         block.type === "paragraph"
-          ? normalizeParagraph(block)
-          : normalizeTable(block),
+          ? normalizeParagraph(block, styles)
+          : normalizeTable(block, styles),
       ),
     })),
   })),
 });
 
-const normalizeBlocks = (blocks: BlockContent[]): BlockContent[] =>
+const normalizeBlocks = (
+  blocks: BlockContent[],
+  styles: StyleResolver,
+): BlockContent[] =>
   blocks.map((block) => {
     if (block.type === "paragraph") {
-      return normalizeParagraph(block);
+      return normalizeParagraph(block, styles);
     }
     if (block.type === "table") {
-      return normalizeTable(block);
+      return normalizeTable(block, styles);
     }
     // Block content control: recurse into its block children.
-    return { ...block, content: normalizeBlocks(block.content) };
+    return { ...block, content: normalizeBlocks(block.content, styles) };
   });
 
 /**
  * Return a copy of `doc` with `bidi` filled in for undecided RTL-led body
  * paragraphs (including those nested in tables and block content controls).
+ * A paragraph whose direction is set directly OR via its style / doc defaults
+ * is left untouched.
  */
-export const normalizeBaseDirection = (doc: Document): Document => ({
-  ...doc,
-  package: {
-    ...doc.package,
-    document: {
-      ...doc.package.document,
-      content: normalizeBlocks(doc.package.document.content),
+export const normalizeBaseDirection = (doc: Document): Document => {
+  const styles = createStyleResolver(doc.package.styles);
+  return {
+    ...doc,
+    package: {
+      ...doc.package,
+      document: {
+        ...doc.package.document,
+        content: normalizeBlocks(doc.package.document.content, styles),
+      },
     },
-  },
-});
+  };
+};


### PR DESCRIPTION
Follow-up to #903 (Codex review).

## Problem

`normalizeBaseDirection` (the no-view save fallback, used when the editor view was never instantiated) treated only a **direct** `formatting.bidi` as an explicit direction. But a paragraph can inherit direction from its **style** — `toProseDoc` resolves `formatting?.bidi ?? stylePpr?.bidi`. So a DOCX whose paragraph style sets `w:bidi w:val="0"` to force Arabic/Hebrew text LTR (with no direct bidi) would get a direct `bidi: true` injected on save, overriding the style.

## Fix

Resolve the **effective** direction before normalizing — direct `formatting.bidi` first, otherwise the style/doc-defaults `bidi` via the same `StyleResolver` `toProseDoc` uses. Only fill in `bidi` when the paragraph is truly undecided (no direct and no inherited direction).

## Tests
- Style-forced LTR (`w:bidi w:val="0"`) on Arabic text → left undecided (not flipped).
- A paragraph whose style sets no direction → still normalized to RTL.
- All existing normalizer tests (direct decisions, tracked-change liveness, tables, hyperlinks) still pass.