### PR TITLE
fix(i18n): use كانبان for the Kanban view label (Arabic collision)

### DIFF
--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2877,7 +2877,7 @@
       "layouts": {
         "calendar": "تقويم",
         "grid": "شبكة",
-        "kanban": "مخطط الملفات",
+        "kanban": "كانبان",
         "list": "قائمة",
         "overview": "نظرة عامة",
         "table": "جدول",


### PR DESCRIPTION
Follow-up to #902.

`layouts.kanban` was translated as "مخطط الملفات", which contains **الملفات** — the same word used for **Matters** (`common.matters`) — so it read as "Matters chart" and collided with the core entity (Gemini flagged this; same class as the Documents collision already reverted in #902).

Use the standard transliteration **كانبان**: widely recognized, no collision with Matters, and grammatically masculine so the gendered "New {layout}" name (#905) stays correct ("كانبان جديد").

`bun run i18n:check` passes.