### PR TITLE
fix(i18n): gender-agree "New {layout}" for Lithuanian and Latvian

### DIFF
--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2883,7 +2883,7 @@
         "table": "Lentelė",
         "timeline": "Laiko juosta"
       },
-      "newView": "{layoutType, select, other {Naujas {layout}}}",
+      "newView": "{layoutType, select, overview {Nauja {layout}} table {Nauja {layout}} timeline {Nauja {layout}} other {Naujas {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2883,7 +2883,7 @@
         "table": "Tabula",
         "timeline": "Laika skala"
       },
-      "newView": "{layoutType, select, other {Jauns {layout}}}",
+      "newView": "{layoutType, select, table {Jauna {layout}} timeline {Jauna {layout}} other {Jauns {layout}}}",
       "noFilterResults": "No items match these filters",
       "noFilterResultsHint": "They would show up here if you removed some filters.",
       "removeAdvancedFilter": "Remove advanced filter",


### PR DESCRIPTION
Completes the per-locale gender agreement for the "New {layout}" view name (deferred from #905, where lt/lv kept a single-gender fallback).

The "New" adjective now agrees with each layout noun's grammatical gender via the existing ICU `select` on `layoutType`:

- **lt** (`naujas`/`nauja`): feminine — `overview` (Apžvalga), `table` (Lentelė), `timeline` (Laiko juosta); masculine — `filesystem` (Sąrašas), `calendar` (Kalendorius), `kanban`.
- **lv** (`jauns`/`jauna`): feminine — `table` (Tabula), `timeline` (Laika skala); masculine — `overview` (Pārskats), `filesystem` (Saraksts), `calendar` (Kalendārs), `kanban`.

Genders derived from the noun endings (lt -as/-ius = m, -a/-ė = f; lv -s = m, -a = f) and confirmed against Wiktionary. Rendered output verified with `intl-messageformat`; `bun run i18n:check` passes.