### PR TITLE
refactor(folio): model paragraph direction as a discriminated union

### DIFF
--- a/packages/folio/src/core/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/convert/toFlowBlocks.ts
@@ -64,6 +64,7 @@ import {
 } from "../../prosemirror/attrs";
 import { autospacingMatchesBase } from "../../prosemirror/autospacingBase";
 import { runShadingAttrsToShading } from "../../prosemirror/conversion/runShadingMark";
+import { directionIsRtl } from "../../prosemirror/paragraphDirection";
 import type { RunFormattingOverrideAttrs } from "../../prosemirror/schema/marks";
 import type {
   ImageAttrs,
@@ -1649,7 +1650,7 @@ function convertParagraphAttrs(
   if (pmAttrs.runInWithNext) {
     attrs.runInWithNext = true;
   }
-  if (pmAttrs.bidi) {
+  if (directionIsRtl(pmAttrs.direction)) {
     attrs.bidi = true;
   }
   if (pmAttrs.styleId) {

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -27,6 +27,7 @@ import {
   THEME_COLOR_SLOT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
+import { isParagraphDirection } from "../paragraphDirection";
 import type {
   BlockSdtAttrs,
   CharacterSpacingAttrs,
@@ -375,8 +376,17 @@ export const readParagraphAttrs = (
     "paragraph.attrs.contextualSpacing",
     issues,
   );
-  optionalBoolean(attrs, "bidi", "paragraph.attrs.bidi", issues);
-  optionalBoolean(attrs, "bidiAuto", "paragraph.attrs.bidiAuto", issues);
+  const direction = attrs["direction"];
+  if (
+    direction !== undefined &&
+    direction !== null &&
+    !isParagraphDirection(direction)
+  ) {
+    issues.push({
+      path: "paragraph.attrs.direction",
+      message: "Expected a ParagraphDirection.",
+    });
+  }
   optionalOneOf(
     attrs,
     "sectionBreakType",

--- a/packages/folio/src/core/prosemirror/conversion/bidiTriStateRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/bidiTriStateRoundtrip.test.ts
@@ -1,13 +1,13 @@
 /**
- * The paragraph `bidi` attribute is tri-state: true (RTL), false (explicit LTR,
- * serialized as `<w:bidi w:val="0"/>`), and null/undefined (undecided — eligible
- * for auto-detection). `fromProseDoc` must preserve an explicit `false` rather
- * than collapse it into "undecided" via a truthiness check.
+ * `fromProseDoc` maps the paragraph `direction` discriminated union to the
+ * serialized OOXML `w:bidi` tri-state: a manual RTL/LTR decision becomes
+ * `true`/`false` (the latter as `<w:bidi w:val="0"/>`), and an undecided
+ * paragraph is omitted.
  *
- * Regression guard: previously `if (attrs.bidi)` dropped `false`, so a forced-LTR
- * Arabic paragraph lost `<w:bidi w:val="0"/>` on save; on reload the seed
- * auto-detector saw `null` again and re-flipped it back to RTL. These tests lock
- * the full save invariant end to end (model → serialized XML).
+ * Regression guard: a manual LTR (forced via setLtr) must survive save/reload as
+ * `bidi: false`; if it collapsed to "undecided", the seed auto-detector would
+ * re-flip an Arabic paragraph back to RTL. These tests lock the conversion end
+ * to end (PM direction → model → serialized XML).
  */
 
 import { describe, expect, test } from "bun:test";
@@ -15,13 +15,17 @@ import { EditorState } from "prosemirror-state";
 
 import { serializeParagraph } from "../../docx/serializer/paragraphSerializer";
 import type { Document } from "../../types/document";
+import type { ParagraphDirection } from "../paragraphDirection";
 import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
-const paraNode = (text: string, bidi: boolean | null) =>
+const RTL: ParagraphDirection = { source: "manual", value: "rtl" };
+const LTR: ParagraphDirection = { source: "manual", value: "ltr" };
+
+const paraNode = (text: string, direction: ParagraphDirection | null) =>
   schema.node("doc", null, [
-    schema.node("paragraph", { bidi }, [schema.text(text)]),
+    schema.node("paragraph", { direction }, [schema.text(text)]),
   ]);
 
 const firstParagraphBidi = (doc: Document): unknown => {
@@ -32,27 +36,26 @@ const firstParagraphBidi = (doc: Document): unknown => {
   return block.formatting?.bidi;
 };
 
-describe("fromProseDoc bidi tri-state (new paragraphs, no original)", () => {
-  test("explicit LTR (false) is preserved, not dropped", () => {
-    const out = fromProseDoc(paraNode("عربي", false));
-    expect(firstParagraphBidi(out)).toBe(false);
+describe("fromProseDoc direction → bidi (new paragraphs, no original)", () => {
+  test("manual LTR becomes bidi=false (not dropped)", () => {
+    expect(firstParagraphBidi(fromProseDoc(paraNode("عربي", LTR)))).toBe(false);
   });
 
-  test("explicit RTL (true) is preserved", () => {
-    const out = fromProseDoc(paraNode("عربي", true));
-    expect(firstParagraphBidi(out)).toBe(true);
+  test("manual RTL becomes bidi=true", () => {
+    expect(firstParagraphBidi(fromProseDoc(paraNode("عربي", RTL)))).toBe(true);
   });
 
-  test("undecided (null) is omitted", () => {
-    const out = fromProseDoc(paraNode("Agreement", null));
-    expect(firstParagraphBidi(out)).toBeUndefined();
+  test("undecided is omitted", () => {
+    expect(
+      firstParagraphBidi(fromProseDoc(paraNode("Agreement", null))),
+    ).toBeUndefined();
   });
 });
 
-describe("fromProseDoc bidi tri-state (changed vs original)", () => {
-  // The real bug: a paragraph imported without bidi (or auto-detected RTL) that
-  // the user forces to LTR. The PM attr (false) now differs from the original,
-  // which is exactly where the old truthiness check deleted it.
+describe("fromProseDoc direction → bidi (changed vs original)", () => {
+  // An imported RTL paragraph that the user forces to LTR: the direction now
+  // differs from the original, which is where the old truthiness check dropped
+  // the explicit `false`.
   test("RTL original forced to LTR keeps bidi=false", () => {
     const original: Document = {
       package: {
@@ -73,11 +76,10 @@ describe("fromProseDoc bidi tri-state (changed vs original)", () => {
     const forcedLtr = EditorState.create({ doc: pmDoc }).tr.setNodeMarkup(
       0,
       undefined,
-      { ...pmDoc.child(0).attrs, bidi: false },
+      { ...pmDoc.child(0).attrs, direction: LTR },
     ).doc;
 
-    const out = fromProseDoc(forcedLtr, original);
-    expect(firstParagraphBidi(out)).toBe(false);
+    expect(firstParagraphBidi(fromProseDoc(forcedLtr, original))).toBe(false);
   });
 });
 
@@ -88,8 +90,7 @@ describe("pageBreakBefore tri-state (same class, fallback path)", () => {
         schema.text("Body"),
       ]),
     ]);
-    const out = fromProseDoc(doc);
-    const block = out.package.document.content.at(0);
+    const block = fromProseDoc(doc).package.document.content.at(0);
     if (block?.type !== "paragraph") {
       throw new Error("expected a paragraph");
     }
@@ -97,10 +98,11 @@ describe("pageBreakBefore tri-state (same class, fallback path)", () => {
   });
 });
 
-describe("explicit LTR survives serialization (save invariant)", () => {
-  test('bidi=false serializes as <w:bidi w:val="0"/>', () => {
-    const out = fromProseDoc(paraNode("عربي", false));
-    const block = out.package.document.content.at(0);
+describe("manual LTR survives serialization (save invariant)", () => {
+  test('direction=manual ltr serializes as <w:bidi w:val="0"/>', () => {
+    const block = fromProseDoc(
+      paraNode("عربي", LTR),
+    ).package.document.content.at(0);
     if (block?.type !== "paragraph") {
       throw new Error("expected a paragraph");
     }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -97,6 +97,7 @@ import {
   autospacingMatchesBase,
   hasAutospacingBaseSide,
 } from "../autospacingBase";
+import { directionToBidi } from "../paragraphDirection";
 import type { RunFormattingOverrideAttrs } from "../schema/marks";
 import type {
   ParagraphAttrs,
@@ -702,9 +703,9 @@ function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
 // off, serialized as `w:val="0"`), and `null`/`undefined` (inherit). A
 // truthiness check (`if (attrs.key)`) silently collapses explicit `false` into
 // "inherit", dropping the user's decision on save. Branch on `== null` so every
-// toggle routed through here preserves `false` — making that drop impossible to
-// reintroduce per-attribute (the bidi/LTR round-trip depends on it).
-type BooleanToggleKey = "bidi" | "pageBreakBefore";
+// toggle routed through here preserves `false`. (Direction is handled
+// separately via the `direction` discriminated union, not this helper.)
+type BooleanToggleKey = "pageBreakBefore";
 
 function assignBooleanToggle(
   result: ParagraphFormatting,
@@ -828,10 +829,18 @@ function paragraphAttrsToFormatting(
         delete result.spacingExplicit;
       }
     }
-    // Persist an explicit bidi decision, including `false` (LTR forced via
-    // setLtr) so it serializes as `<w:bidi w:val="0"/>` and survives save/reload;
-    // otherwise auto-detection re-flips an Arabic paragraph back to RTL.
-    assignBooleanToggle(result, attrs, orig, "bidi");
+    // Resolve the paragraph direction to the OOXML `w:bidi` tri-state. An
+    // explicit `false` (forced LTR) is preserved so it serializes as
+    // `<w:bidi w:val="0"/>` and survives save/reload; `undefined` (undecided)
+    // clears it.
+    const bidi = directionToBidi(attrs.direction);
+    if (bidi !== (orig.bidi ?? undefined)) {
+      if (bidi === undefined) {
+        delete result.bidi;
+      } else {
+        result.bidi = bidi;
+      }
+    }
 
     return result;
   }
@@ -839,6 +848,7 @@ function paragraphAttrsToFormatting(
   // Fallback: reconstruct formatting from individual attrs (e.g. for
   // newly created paragraphs that don't have _originalFormatting)
   const outlineLevel = Reflect.get(attrs, "outlineLevel");
+  const bidi = directionToBidi(attrs.direction);
   const hasFormatting =
     attrs.alignment ||
     shouldSerializeSpaceBefore ||
@@ -859,7 +869,7 @@ function paragraphAttrsToFormatting(
     attrs.spacingExplicit ||
     // Tri-state toggles: an explicit `false` is meaningful formatting and must
     // keep the paragraph from short-circuiting to "no formatting".
-    attrs.bidi != null ||
+    bidi != null ||
     attrs.pageBreakBefore != null;
 
   if (!hasFormatting) {
@@ -926,8 +936,8 @@ function paragraphAttrsToFormatting(
   }
   // Preserve explicit tri-state decisions, including `false` (which serializes
   // as `w:val="0"`); only undecided `null` is omitted.
-  if (attrs.bidi != null) {
-    f.bidi = attrs.bidi;
+  if (bidi != null) {
+    f.bidi = bidi;
   }
   if (attrs.pageBreakBefore != null) {
     f.pageBreakBefore = attrs.pageBreakBefore;

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -50,6 +50,7 @@ import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
 import { setAutospacingBaseValue } from "../autospacingBase";
 import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
+import { directionFromBidi } from "../paragraphDirection";
 import { schema } from "../schema";
 import type {
   ImagePositionAttrs,
@@ -637,8 +638,9 @@ function paragraphFormattingToAttrs(
     // Outline level (for TOC)
     set("outlineLevel", formatting?.outlineLevel ?? stylePpr?.outlineLevel);
 
-    // Text direction
-    set("bidi", formatting?.bidi ?? stylePpr?.bidi);
+    // Text direction — a direct or style-sourced `w:bidi` is an authoritative
+    // manual decision (auto-detection must not override it).
+    set("direction", directionFromBidi(formatting?.bidi ?? stylePpr?.bidi));
 
     set(
       "defaultTextFormatting",
@@ -676,8 +678,8 @@ function paragraphFormattingToAttrs(
     // Outline level
     set("outlineLevel", formatting?.outlineLevel);
 
-    // Text direction
-    set("bidi", formatting?.bidi);
+    // Text direction — an imported `w:bidi` is an authoritative manual decision.
+    set("direction", directionFromBidi(formatting?.bidi));
 
     // Default run properties (pPr/rPr)
     set(

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -25,6 +25,8 @@ import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
 import { expectParagraphAttrs } from "../../attrs";
 import { autospacingMatchesBase } from "../../autospacingBase";
+import { directionIsRtl } from "../../paragraphDirection";
+import type { ParagraphDirection } from "../../paragraphDirection";
 import type { ParagraphAttrs } from "../../schema/nodes";
 import {
   paragraphAttrsFromResolvedStyle,
@@ -383,11 +385,11 @@ const paragraphNodeSpec: NodeSpec = {
     runInWithNext: { default: null },
     defaultTextFormatting: { default: null },
     sectionBreakType: { default: null },
-    bidi: { default: null },
-    // Ephemeral, editor-runtime-only: marks a `bidi` value that auto-detection
-    // set (vs an explicit user toggle or imported `w:bidi`). Never serialized to
-    // DOCX or DOM — it only lets auto-detection re-evaluate its own decisions.
-    bidiAuto: { default: null },
+    // Base text direction (discriminated union; see paragraphDirection.ts). The
+    // `source` distinguishes an authoritative manual/import decision from a
+    // re-evaluable auto-detected one; only the resolved RTL-ness serializes
+    // (`w:bidi`) or reaches the DOM (`dir`).
+    direction: { default: null },
     outlineLevel: { default: null },
     bookmarks: { default: null },
     _emptyHyperlinks: { default: null },
@@ -489,7 +491,7 @@ const paragraphNodeSpec: NodeSpec = {
       domAttrs["data-list-marker"] = attrs.listMarker;
     }
 
-    if (attrs.bidi) {
+    if (directionIsRtl(attrs.direction)) {
       domAttrs["dir"] = "rtl";
     }
 
@@ -838,7 +840,7 @@ export function getParagraphBidi(state: EditorState): boolean {
   if (paragraph.type.name !== "paragraph") {
     return false;
   }
-  return !!paragraph.attrs["bidi"];
+  return directionIsRtl(paragraph.attrs["direction"]);
 }
 
 // ============================================================================
@@ -1056,22 +1058,20 @@ export const ParagraphExtension = createNodeExtension({
             if (paragraph.type.name !== "paragraph") {
               return false;
             }
-            const currentBidi = paragraph.attrs["bidi"] || false;
-            // Toggle to an explicit value (true/false), never back to `null`.
-            // `null` means "no decision" and is reserved for auto-detection;
-            // a deliberate LTR must be recorded as `false` so AutoBidiDetection
-            // does not re-flip an Arabic paragraph the user set to LTR.
-            // Clearing `bidiAuto` marks this as a manual decision, so
-            // auto-detection never revisits it.
-            return setParagraphAttrsCmd({ bidi: !currentBidi, bidiAuto: null })(
-              state,
-              dispatch,
-            );
+            // Toggle to the opposite explicit direction. A manual decision
+            // (`source: "manual"`) is authoritative, so auto-detection never
+            // revisits it.
+            const next: ParagraphDirection = directionIsRtl(
+              paragraph.attrs["direction"],
+            )
+              ? { source: "manual", value: "ltr" }
+              : { source: "manual", value: "rtl" };
+            return setParagraphAttr("direction", next)(state, dispatch);
           },
-        // A manual direction choice clears `bidiAuto`, so auto-detection treats
-        // it as authoritative and never re-evaluates it.
-        setRtl: () => setParagraphAttrsCmd({ bidi: true, bidiAuto: null }),
-        setLtr: () => setParagraphAttrsCmd({ bidi: false, bidiAuto: null }),
+        setRtl: () =>
+          setParagraphAttr("direction", { source: "manual", value: "rtl" }),
+        setLtr: () =>
+          setParagraphAttr("direction", { source: "manual", value: "ltr" }),
         setTabs: (tabs: TabStop[]) =>
           setParagraphAttr("tabs", tabs.length > 0 ? tabs : null),
         addTabStop:

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.test.ts
@@ -1,12 +1,13 @@
 /**
  * Tests for AutoBidiDetectionExtension.
  *
- * Contract: an "auto-managed" paragraph (bidi unset, or previously auto-set via
- * `bidiAuto`) whose first strong character is RTL gets `bidi: true` + the
- * ephemeral `bidiAuto: true`, both on load (`ensureBaseDirectionInState`) and on
- * live edits (`appendTransaction`). Detection includes inline field display
- * text. An explicit decision (user toggle / import, `bidiAuto` cleared) is never
- * overridden, and an auto-set value is re-evaluated when the text changes.
+ * Contract: an "auto-managed" paragraph (direction undecided, or previously
+ * auto-set as `{ source: "auto" }`) whose first strong character is RTL gets
+ * `{ source: "auto" }`, both on load (`ensureBaseDirectionInState`) and on live
+ * edits (`appendTransaction`). Detection includes inline field display text and
+ * ignores deleted text. A manual decision (`{ source: "manual" }`, from a user
+ * toggle or import) is never overridden, and an auto-set value is re-evaluated
+ * when the text changes.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -14,6 +15,7 @@ import { Schema } from "prosemirror-model";
 import type { Node as PMNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 
+import type { ParagraphDirection } from "../../paragraphDirection";
 import {
   AutoBidiDetectionExtension,
   ensureBaseDirectionInState,
@@ -25,7 +27,7 @@ const schema = new Schema({
     paragraph: {
       group: "block",
       content: "inline*",
-      attrs: { bidi: { default: null }, bidiAuto: { default: null } },
+      attrs: { direction: { default: null } },
       toDOM: () => ["p", 0],
     },
     // Inline atom whose rendered text lives in attrs (mirrors the real field).
@@ -57,25 +59,23 @@ if (!plugin) {
   throw new Error("Expected plugin from AutoBidiDetectionExtension");
 }
 
-type ParaAttrs = { bidi?: boolean | null; bidiAuto?: boolean | null };
-
-const para = (text: string, attrs: ParaAttrs = {}) =>
+const para = (text: string, direction: ParagraphDirection | null = null) =>
   schema.node(
     "paragraph",
-    { bidi: attrs.bidi ?? null, bidiAuto: attrs.bidiAuto ?? null },
+    { direction },
     text.length > 0 ? [schema.text(text)] : [],
   );
 
 // Paragraph led by a field atom whose display text is `fieldText`.
 const fieldLedPara = (fieldText: string, trailing: string) =>
-  schema.node("paragraph", { bidi: null, bidiAuto: null }, [
+  schema.node("paragraph", { direction: null }, [
     schema.node("field", { displayText: fieldText }),
     ...(trailing.length > 0 ? [schema.text(trailing)] : []),
   ]);
 
 // Paragraph whose only content is an inline content control holding `text`.
 const sdtLedPara = (text: string) =>
-  schema.node("paragraph", { bidi: null, bidiAuto: null }, [
+  schema.node("paragraph", { direction: null }, [
     schema.node("inlineSdt", null, text.length > 0 ? [schema.text(text)] : []),
   ]);
 
@@ -89,131 +89,136 @@ const stateOf = (...paras: PMNode[]) =>
 const stateWithoutPlugin = (...paras: PMNode[]) =>
   EditorState.create({ doc: schema.node("doc", null, paras) });
 
-const bidis = (state: EditorState): (boolean | null)[] => {
-  const out: (boolean | null)[] = [];
+// Compact, assertion-friendly tag for a paragraph's direction.
+const dirTag = (direction: ParagraphDirection | null): string => {
+  if (direction == null) {
+    return "none";
+  }
+  if (direction.source === "auto") {
+    return "auto";
+  }
+  return direction.value; // "rtl" | "ltr"
+};
+
+const dirs = (state: EditorState): string[] => {
+  const out: string[] = [];
   state.doc.descendants((node) => {
     if (node.type.name === "paragraph") {
-      out.push(node.attrs["bidi"] as boolean | null);
+      out.push(dirTag(node.attrs["direction"]));
     }
     return false;
   });
   return out;
 };
 
+const RTL = { source: "manual", value: "rtl" } as const;
+const LTR = { source: "manual", value: "ltr" } as const;
+
 describe("ensureBaseDirectionInState (initial load)", () => {
-  test("sets bidi=true on an Arabic-led paragraph", () => {
-    expect(bidis(ensureBaseDirectionInState(stateOf(para("هذا عقد"))))).toEqual(
-      [true],
-    );
+  test("auto-sets an Arabic-led paragraph", () => {
+    expect(dirs(ensureBaseDirectionInState(stateOf(para("هذا عقد"))))).toEqual([
+      "auto",
+    ]);
   });
 
   test("leaves a Latin-led paragraph undecided", () => {
     expect(
-      bidis(ensureBaseDirectionInState(stateOf(para("Agreement")))),
-    ).toEqual([null]);
+      dirs(ensureBaseDirectionInState(stateOf(para("Agreement")))),
+    ).toEqual(["none"]);
   });
 
   test("is a no-op when the extension is disabled (plugin absent)", () => {
-    // Respects `disable: ["autoBidiDetection"]`: no bidi injected on seed.
     expect(
-      bidis(ensureBaseDirectionInState(stateWithoutPlugin(para("هذا عقد")))),
-    ).toEqual([null]);
+      dirs(ensureBaseDirectionInState(stateWithoutPlugin(para("هذا عقد")))),
+    ).toEqual(["none"]);
   });
 
-  test("does not override an explicit LTR (false) on Arabic text", () => {
+  test("does not override a manual LTR on Arabic text", () => {
     expect(
-      bidis(ensureBaseDirectionInState(stateOf(para("عربي", { bidi: false })))),
-    ).toEqual([false]);
+      dirs(ensureBaseDirectionInState(stateOf(para("عربي", LTR)))),
+    ).toEqual(["ltr"]);
   });
 
-  test("leaves an already-RTL paragraph as true (idempotent)", () => {
+  test("leaves a manual RTL paragraph untouched (idempotent)", () => {
     expect(
-      bidis(ensureBaseDirectionInState(stateOf(para("عربي", { bidi: true })))),
-    ).toEqual([true]);
+      dirs(ensureBaseDirectionInState(stateOf(para("عربي", RTL)))),
+    ).toEqual(["rtl"]);
   });
 
   test("mixed: detects per paragraph", () => {
     const state = ensureBaseDirectionInState(
       stateOf(para("English"), para("نص عربي"), para("123 only")),
     );
-    expect(bidis(state)).toEqual([null, true, null]);
+    expect(dirs(state)).toEqual(["none", "auto", "none"]);
   });
 
   test("detects RTL from an inline field's display text", () => {
-    // node.textContent omits the field atom; detection must fold in displayText.
     const state = ensureBaseDirectionInState(stateOf(fieldLedPara("عربي", "")));
-    expect(bidis(state)).toEqual([true]);
+    expect(dirs(state)).toEqual(["auto"]);
   });
 
   test("detects RTL from text inside an inline content control (SDT)", () => {
     const state = ensureBaseDirectionInState(stateOf(sdtLedPara("عربي")));
-    expect(bidis(state)).toEqual([true]);
+    expect(dirs(state)).toEqual(["auto"]);
   });
 
   test("ignores deleted (non-live) text when detecting direction", () => {
-    // Deleted Arabic followed by live Latin: the live content is LTR, so the
-    // paragraph must not be auto-flipped to RTL by the struck-through text.
-    const paragraph = schema.node("paragraph", { bidi: null, bidiAuto: null }, [
+    const paragraph = schema.node("paragraph", { direction: null }, [
       schema.text("عربي", [schema.mark("deletion")]),
       schema.text(" agreement"),
     ]);
-    const state = ensureBaseDirectionInState(stateOf(paragraph));
-    expect(bidis(state)).toEqual([null]);
+    expect(dirs(ensureBaseDirectionInState(stateOf(paragraph)))).toEqual([
+      "none",
+    ]);
   });
 });
 
 describe("appendTransaction (live editing)", () => {
-  test("typing Arabic into an empty paragraph sets bidi=true", () => {
+  test("typing Arabic into an empty paragraph auto-sets RTL", () => {
     let state = stateOf(para(""));
     state = state.apply(state.tr.insertText("مرحبا", 1));
-    expect(bidis(state)).toEqual([true]);
+    expect(dirs(state)).toEqual(["auto"]);
   });
 
-  test("typing Latin leaves bidi undecided", () => {
+  test("typing Latin leaves the paragraph undecided", () => {
     let state = stateOf(para(""));
     state = state.apply(state.tr.insertText("hello", 1));
-    expect(bidis(state)).toEqual([null]);
+    expect(dirs(state)).toEqual(["none"]);
   });
 
-  test("does not re-flip a paragraph the user set to explicit LTR", () => {
-    // Arabic paragraph the user forced to LTR (false, bidiAuto cleared); a
-    // further edit must not re-detect it back to RTL.
-    let state = stateOf(para("عربي", { bidi: false }));
+  test("does not re-flip a paragraph the user set to manual LTR", () => {
+    let state = stateOf(para("عربي", LTR));
     state = state.apply(state.tr.insertText(" مزيد", 5));
-    expect(bidis(state)).toEqual([false]);
+    expect(dirs(state)).toEqual(["ltr"]);
   });
 
   test("re-evaluates an auto-set value when the text changes (no sticky RTL)", () => {
-    // Type Arabic into an empty paragraph -> auto RTL.
     let state = stateOf(para(""));
     state = state.apply(state.tr.insertText("مرحبا", 1));
-    expect(bidis(state)).toEqual([true]);
+    expect(dirs(state)).toEqual(["auto"]);
     // Replace all of it with Latin -> the auto value is cleared, not sticky.
     const end = state.doc.content.size - 1;
     state = state.apply(state.tr.replaceWith(1, end, schema.text("hello")));
-    expect(bidis(state)).toEqual([null]);
+    expect(dirs(state)).toEqual(["none"]);
   });
 
   test("does not re-evaluate a manual RTL set on Latin text", () => {
-    // User explicitly set RTL (bidiAuto cleared) on Latin content; editing must
-    // leave the explicit decision intact.
-    let state = stateOf(para("Hello", { bidi: true, bidiAuto: null }));
+    let state = stateOf(para("Hello", RTL));
     state = state.apply(state.tr.insertText(" world", 6));
-    expect(bidis(state)).toEqual([true]);
+    expect(dirs(state)).toEqual(["rtl"]);
   });
 
   test("detects the edited paragraph in a multi-paragraph doc (scoped scan)", () => {
-    // Type Arabic into the second (empty) paragraph; only it flips to RTL.
     let state = stateOf(para("First"), para(""));
     state = state.apply(
       state.tr.insertText("مرحبا", state.doc.content.size - 1),
     );
-    expect(bidis(state)).toEqual([null, true]);
+    expect(dirs(state)).toEqual(["none", "auto"]);
   });
 
   test("selection-only transactions do not allocate", () => {
     let state = stateOf(para("Agreement"));
     state = state.apply(state.tr.setSelection(state.selection));
-    expect(bidis(state)).toEqual([null]);
+    expect(dirs(state)).toEqual(["none"]);
   });
 });

--- a/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/AutoBidiDetectionExtension.ts
@@ -1,6 +1,6 @@
 /**
- * AutoBidiDetection — sets the paragraph `bidi` attribute on RTL-led
- * paragraphs that arrived without an explicit direction decision.
+ * AutoBidiDetection — sets the paragraph `direction` (to `{ source: "auto" }`)
+ * on RTL-led paragraphs that arrived without an explicit direction decision.
  *
  * Why: Folio only ever rendered/exported RTL when a paragraph already carried
  * `w:bidi` (from a Word import) or the user toggled it by hand. Content that
@@ -14,15 +14,15 @@
  * Detection uses the first-strong-character rule (`detectBaseDirection`), the
  * same logic the layout painter uses for base direction.
  *
- * Auto vs. explicit: a paragraph is "auto-managed" when its `bidi` is unset
- * (`null`) OR was set by this detector (`bidiAuto === true`). Only auto-managed
- * paragraphs are (re-)evaluated; an explicit user toggle or imported `w:bidi`
- * sets `bidi` with `bidiAuto` cleared, so it is authoritative and never touched.
- * Because we re-evaluate our own decisions, replacing an auto-RTL paragraph's
- * text with Latin clears the flag again (no stale "sticky" RTL).
+ * Auto vs. explicit: only "auto-managed" paragraphs are (re-)evaluated — those
+ * whose `direction` is undecided (absent) or was set by this detector
+ * (`source: "auto"`). A manual user toggle or imported `w:bidi`
+ * (`source: "manual"`) is authoritative and never touched. Because the detector
+ * re-evaluates its own decisions, replacing an auto-RTL paragraph's text with
+ * Latin clears it again (no stale "sticky" RTL).
  *
- * `bidiAuto` is an ephemeral editor-runtime attr — it is never serialized to
- * DOCX or the DOM, so the persisted model still carries only the real `w:bidi`.
+ * The `direction` discriminated union is editor-runtime state; only its resolved
+ * RTL-ness serializes (`w:bidi`) — the persisted model keeps the flat tri-state.
  *
  * Mirrors the appendTransaction + ensure-in-state pattern of
  * `ParaIdAllocatorExtension`.
@@ -34,6 +34,8 @@ import type { EditorState } from "prosemirror-state";
 import type { DirtyRange } from "../../../paged-layout/incrementalMeasure";
 import { getTransactionDirtyRange } from "../../../paged-layout/transactionDirtyRange";
 import { detectBaseDirection } from "../../../utils/baseDirection";
+import { directionIsAutoManaged } from "../../paragraphDirection";
+import type { ParagraphDirection } from "../../paragraphDirection";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
@@ -72,26 +74,24 @@ const paragraphDirectionalText = (node: PMNode): string => {
 
 // Decide the update (if any) for a single paragraph node.
 const evaluateParagraph = (node: PMNode, pos: number): BidiUpdate | null => {
-  const currentBidi = node.attrs["bidi"] ?? null;
-  const autoManaged = currentBidi === null || node.attrs["bidiAuto"] === true;
-  // Explicit decision (user toggle / imported w:bidi): leave it alone.
-  if (!autoManaged) {
+  const current = node.attrs["direction"];
+  // Explicit decision (manual toggle / imported w:bidi): leave it alone.
+  if (!directionIsAutoManaged(current)) {
     return null;
   }
 
   const wantRtl = detectBaseDirection(paragraphDirectionalText(node)) === "rtl";
-  const desiredBidi = wantRtl ? true : null;
-  const desiredAuto = wantRtl ? true : null;
-  const unchanged =
-    currentBidi === desiredBidi &&
-    (node.attrs["bidiAuto"] ?? null) === desiredAuto;
-  if (unchanged) {
+  // Auto-managed means `current` is undecided (absent) or `{ source: "auto" }`,
+  // so its RTL-ness is exactly whether it is already auto. No change when that
+  // already matches the detected direction.
+  const currentIsAuto = current?.source === "auto";
+  if (currentIsAuto === wantRtl) {
     return null;
   }
-  return {
-    pos,
-    attrs: { ...node.attrs, bidi: desiredBidi, bidiAuto: desiredAuto },
-  };
+  const desired: ParagraphDirection | null = wantRtl
+    ? { source: "auto" }
+    : null;
+  return { pos, attrs: { ...node.attrs, direction: desired } };
 };
 
 // Whole-document scan (load/seed, and the rare multi-transaction fallback).

--- a/packages/folio/src/core/prosemirror/paragraphDirection.test.ts
+++ b/packages/folio/src/core/prosemirror/paragraphDirection.test.ts
@@ -74,6 +74,8 @@ describe("isParagraphDirection", () => {
     expect(isParagraphDirection({ source: "manual" })).toBe(false);
     expect(isParagraphDirection({ source: "manual", value: "x" })).toBe(false);
     expect(isParagraphDirection({ source: "other" })).toBe(false);
-    expect(isParagraphDirection({ source: "auto", value: "ltr" })).toBe(true);
+    // `auto` must not carry a payload — that is the illegal state this union
+    // is meant to forbid.
+    expect(isParagraphDirection({ source: "auto", value: "ltr" })).toBe(false);
   });
 });

--- a/packages/folio/src/core/prosemirror/paragraphDirection.test.ts
+++ b/packages/folio/src/core/prosemirror/paragraphDirection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  directionFromBidi,
+  directionIsAutoManaged,
+  directionIsRtl,
+  directionToBidi,
+  isParagraphDirection,
+  type ParagraphDirection,
+} from "./paragraphDirection";
+
+const AUTO: ParagraphDirection = { source: "auto" };
+const RTL: ParagraphDirection = { source: "manual", value: "rtl" };
+const LTR: ParagraphDirection = { source: "manual", value: "ltr" };
+
+describe("directionIsRtl", () => {
+  test("auto and manual-rtl are RTL; manual-ltr and undecided are not", () => {
+    expect(directionIsRtl(AUTO)).toBe(true);
+    expect(directionIsRtl(RTL)).toBe(true);
+    expect(directionIsRtl(LTR)).toBe(false);
+    expect(directionIsRtl(null)).toBe(false);
+    expect(directionIsRtl(undefined)).toBe(false);
+  });
+});
+
+describe("directionIsAutoManaged", () => {
+  test("undecided and auto are auto-managed; manual is not", () => {
+    expect(directionIsAutoManaged(null)).toBe(true);
+    expect(directionIsAutoManaged(undefined)).toBe(true);
+    expect(directionIsAutoManaged(AUTO)).toBe(true);
+    expect(directionIsAutoManaged(RTL)).toBe(false);
+    expect(directionIsAutoManaged(LTR)).toBe(false);
+  });
+});
+
+describe("directionToBidi", () => {
+  test("maps to the OOXML w:bidi tri-state", () => {
+    expect(directionToBidi(AUTO)).toBe(true);
+    expect(directionToBidi(RTL)).toBe(true);
+    expect(directionToBidi(LTR)).toBe(false);
+    expect(directionToBidi(null)).toBeUndefined();
+    expect(directionToBidi(undefined)).toBeUndefined();
+  });
+});
+
+describe("directionFromBidi", () => {
+  test("an explicit bidi is a manual decision; absence is undecided", () => {
+    expect(directionFromBidi(true)).toEqual(RTL);
+    expect(directionFromBidi(false)).toEqual(LTR);
+    expect(directionFromBidi(null)).toBeNull();
+    expect(directionFromBidi(undefined)).toBeNull();
+  });
+
+  test("round-trips through directionToBidi", () => {
+    for (const bidi of [true, false] as const) {
+      expect(directionToBidi(directionFromBidi(bidi))).toBe(bidi);
+    }
+  });
+});
+
+describe("isParagraphDirection", () => {
+  test("accepts valid shapes", () => {
+    expect(isParagraphDirection(AUTO)).toBe(true);
+    expect(isParagraphDirection(RTL)).toBe(true);
+    expect(isParagraphDirection(LTR)).toBe(true);
+  });
+
+  test("rejects invalid shapes", () => {
+    expect(isParagraphDirection(null)).toBe(false);
+    expect(isParagraphDirection(undefined)).toBe(false);
+    expect(isParagraphDirection(true)).toBe(false);
+    expect(isParagraphDirection("rtl")).toBe(false);
+    expect(isParagraphDirection({})).toBe(false);
+    expect(isParagraphDirection({ source: "manual" })).toBe(false);
+    expect(isParagraphDirection({ source: "manual", value: "x" })).toBe(false);
+    expect(isParagraphDirection({ source: "other" })).toBe(false);
+    expect(isParagraphDirection({ source: "auto", value: "ltr" })).toBe(true);
+  });
+});

--- a/packages/folio/src/core/prosemirror/paragraphDirection.ts
+++ b/packages/folio/src/core/prosemirror/paragraphDirection.ts
@@ -14,14 +14,6 @@
  * The persisted/serialized model keeps the flat OOXML tri-state
  * (`ParagraphFormatting.bidi: boolean | undefined`); `directionToBidi` /
  * `directionFromBidi` bridge the two at the conversion boundary.
- *
- * Legacy collaborative documents: Yjs fragments persisted before this union
- * carried the old `bidi`/`bidiAuto` PM attrs, which the renamed schema drops on
- * load (ProseMirror ignores attrs it does not declare). Such paragraphs reload
- * as undecided and are re-derived by AutoBidiDetection, so RTL-script content
- * self-heals to `{ source: "auto" }`. There is deliberately no migration; the
- * only lossy case is a paragraph manually forced to LTR over RTL-script text,
- * which reloads undecided and may auto-detect back to RTL.
  */
 export type ParagraphDirection =
   | { source: "auto" }

--- a/packages/folio/src/core/prosemirror/paragraphDirection.ts
+++ b/packages/folio/src/core/prosemirror/paragraphDirection.ts
@@ -1,0 +1,78 @@
+/**
+ * Paragraph base-direction modeled as a discriminated union.
+ *
+ * Replaces the prior `bidi` + `bidiAuto` PM-attribute flag pair, where
+ * combinations such as "auto + ltr" or "auto + undecided" were representable
+ * but never valid. The states are now mutually exclusive:
+ *
+ *   - absent (`null`/`undefined`): undecided — default LTR, eligible for
+ *     auto-detection.
+ *   - `{ source: "auto" }`: auto-detected RTL; re-evaluated as content changes.
+ *   - `{ source: "manual"; value }`: an explicit user toggle or imported
+ *     `w:bidi`; authoritative, never auto-revisited.
+ *
+ * The persisted/serialized model keeps the flat OOXML tri-state
+ * (`ParagraphFormatting.bidi: boolean | undefined`); `directionToBidi` /
+ * `directionFromBidi` bridge the two at the conversion boundary.
+ */
+export type ParagraphDirection =
+  | { source: "auto" }
+  | { source: "manual"; value: "rtl" | "ltr" };
+
+/** Whether the paragraph lays out and exports right-to-left. */
+export const directionIsRtl = (
+  direction: ParagraphDirection | null | undefined,
+): boolean =>
+  direction?.source === "auto" ||
+  (direction?.source === "manual" && direction.value === "rtl");
+
+/**
+ * Auto-managed paragraphs (undecided, or previously auto-set) are the ones
+ * AutoBidiDetection may (re-)evaluate. A manual decision is left untouched.
+ */
+export const directionIsAutoManaged = (
+  direction: ParagraphDirection | null | undefined,
+): boolean => direction == null || direction.source === "auto";
+
+/** Map a direction to the serialized OOXML `w:bidi` tri-state. */
+export const directionToBidi = (
+  direction: ParagraphDirection | null | undefined,
+): boolean | undefined => {
+  if (direction == null) {
+    return undefined;
+  }
+  if (direction.source === "auto") {
+    return true;
+  }
+  return direction.value === "rtl";
+};
+
+/**
+ * Reconstruct a direction from a model `bidi` value (DOCX import / load): an
+ * explicit `true`/`false` is a manual decision, absence is undecided.
+ */
+export const directionFromBidi = (
+  bidi: boolean | null | undefined,
+): ParagraphDirection | null => {
+  if (bidi == null) {
+    return null;
+  }
+  return { source: "manual", value: bidi ? "rtl" : "ltr" };
+};
+
+/** Runtime guard for the PM attribute validator. */
+export const isParagraphDirection = (
+  value: unknown,
+): value is ParagraphDirection => {
+  if (typeof value !== "object" || value === null || !("source" in value)) {
+    return false;
+  }
+  if (value.source === "auto") {
+    return true;
+  }
+  return (
+    value.source === "manual" &&
+    "value" in value &&
+    (value.value === "rtl" || value.value === "ltr")
+  );
+};

--- a/packages/folio/src/core/prosemirror/paragraphDirection.ts
+++ b/packages/folio/src/core/prosemirror/paragraphDirection.ts
@@ -68,7 +68,9 @@ export const isParagraphDirection = (
     return false;
   }
   if (value.source === "auto") {
-    return true;
+    // `auto` carries no payload; reject a stray `value` so the illegal
+    // "auto + ltr/rtl" shape stays unrepresentable.
+    return !("value" in value);
   }
   return (
     value.source === "manual" &&

--- a/packages/folio/src/core/prosemirror/paragraphDirection.ts
+++ b/packages/folio/src/core/prosemirror/paragraphDirection.ts
@@ -14,6 +14,14 @@
  * The persisted/serialized model keeps the flat OOXML tri-state
  * (`ParagraphFormatting.bidi: boolean | undefined`); `directionToBidi` /
  * `directionFromBidi` bridge the two at the conversion boundary.
+ *
+ * Legacy collaborative documents: Yjs fragments persisted before this union
+ * carried the old `bidi`/`bidiAuto` PM attrs, which the renamed schema drops on
+ * load (ProseMirror ignores attrs it does not declare). Such paragraphs reload
+ * as undecided and are re-derived by AutoBidiDetection, so RTL-script content
+ * self-heals to `{ source: "auto" }`. There is deliberately no migration; the
+ * only lossy case is a paragraph manually forced to LTR over RTL-script text,
+ * which reloads undecided and may auto-detect back to RTL.
  */
 export type ParagraphDirection =
   | { source: "auto" }

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -36,6 +36,7 @@ import type {
 } from "../../types/document";
 import type { OutlineStyleAttr } from "../../types/documentEnumValues";
 import type { SpacingExplicit } from "../../types/formatting";
+import type { ParagraphDirection } from "../paragraphDirection";
 
 export type HardBreakAttrs = {
   breakType?: "column";
@@ -158,15 +159,13 @@ export type ParagraphAttrs = {
   // Section break type — marks end of a section
   sectionBreakType?: "nextPage" | "continuous" | "oddPage" | "evenPage";
 
-  // Text direction
-  bidi?: boolean;
   /**
-   * Ephemeral, editor-runtime-only flag: `true` when auto-detection set `bidi`
-   * (as opposed to an explicit user toggle or imported `w:bidi`). Never
-   * serialized to DOCX or DOM; it only lets auto-detection re-evaluate the
-   * paragraphs it previously decided. See AutoBidiDetectionExtension.
+   * Base text direction as a discriminated union (undecided when absent). Maps
+   * to the serialized OOXML `w:bidi` tri-state via `directionToBidi`; the
+   * `source` discriminates an authoritative manual/import decision from a
+   * re-evaluable auto-detected one. See `paragraphDirection.ts`.
    */
-  bidiAuto?: boolean;
+  direction?: ParagraphDirection | null;
 
   // Outline level for TOC (0-9)
   outlineLevel?: number;

--- a/packages/folio/src/core/prosemirror/selectionState.ts
+++ b/packages/folio/src/core/prosemirror/selectionState.ts
@@ -8,6 +8,7 @@ import type { Mark } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 
 import type { TextFormatting, ParagraphFormatting } from "../types/document";
+import { directionIsRtl } from "./paragraphDirection";
 
 // ============================================================================
 // TYPES
@@ -172,7 +173,7 @@ export function extractSelectionState(
     if (paragraph.attrs["tabs"]) {
       paragraphFormatting.tabs = paragraph.attrs["tabs"];
     }
-    if (paragraph.attrs["bidi"]) {
+    if (directionIsRtl(paragraph.attrs["direction"])) {
       paragraphFormatting.bidi = true;
     }
     if (paragraph.attrs["styleId"]) {


### PR DESCRIPTION
## Motivation

The auto-bidi work represented paragraph direction as two PM attributes — `bidi: boolean | null` plus an ephemeral `bidiAuto: boolean | null`. Several combinations were representable but illegal (`bidi:false`+`bidiAuto:true` = "auto LTR"; `bidi:null`+`bidiAuto:true` = "auto undecided"), with the invariant maintained only by discipline. That's the "boolean-flag-set where only some combos are valid" anti-pattern.

## Change

Replace the pair with a single `direction` discriminated union (in `paragraphDirection.ts`), making illegal states unrepresentable:

```ts
type ParagraphDirection =
  | { source: "auto" }                          // auto-detected RTL; re-evaluable
  | { source: "manual"; value: "rtl" | "ltr" }; // user toggle / imported w:bidi; authoritative
// absent = undecided (default LTR, detection-eligible)
```

The persisted/serialized model is unchanged — `ParagraphFormatting.bidi` stays the flat OOXML tri-state. `paragraphDirection.ts` bridges them (`directionToBidi` / `directionFromBidi`) and centralizes `directionIsRtl` / `directionIsAutoManaged`.

Updated every reader: schema (`ParagraphAttrs`), `ParagraphExtension` (NodeSpec attr, `toDOM`, `setRtl`/`setLtr`/`toggleBidi`, `getParagraphBidi`), attrs validation, `toProseDoc`, `fromProseDoc`, `AutoBidiDetection`, `selectionState`, `toFlowBlocks`.

## Notes
- **Pure quality refactor — no functional/behavioral change.** The conversion at import/serialize is identical (`directionFromBidi`/`directionToBidi` mirror the old `formatting.bidi ?? stylePpr.bidi` resolution and the `w:bidi` mapping). An imported/style `w:bidi` is a `manual` decision (authoritative); auto-detected RTL is `auto` (re-evaluable) — same semantics as the old `bidiAuto` flag.
- New `paragraphDirection.test.ts` unit-tests the helpers; the AutoBidi and round-trip tests were updated to the new attr; full folio suite + typecheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paragraph text direction is now handled consistently across editing, import/export, and automatic direction detection.
  * Manual LTR/RTL decisions are preserved, while auto-detection updates only undecided paragraphs.

* **Bug Fixes**
  * Improved RTL handling so direction is reflected correctly in the editor and exported documents.
  * Invalid direction values are now validated more strictly and reported earlier.

* **Tests**
  * Expanded round-trip and OOXML direction coverage to ensure stable behaviour across editor ↔ document conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->