### PR TITLE
fix(ci): widen staging deploy watcher past the infra promote timeout

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,12 +28,10 @@ jobs:
     name: Build + deploy staging
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
-    # Headroom for a cache-miss image build (~15-20 min) plus the
-    # watcher budget below (65 min), which itself must outlast the
-    # infra promote job's own 60-min timeout. Keep this strictly
-    # greater than build + watcher so the job's own timeout never
-    # guillotines the watcher before it can read the infra run's
-    # real conclusion.
+    # Headroom for a cache-miss image build (~15-25 min) plus the
+    # watcher budget below (45 min). Keep this strictly greater than
+    # build + watcher so the job's own timeout never guillotines the
+    # watcher before it can read the infra run's real conclusion.
     timeout-minutes: 90
 
     steps:
@@ -164,15 +162,22 @@ jobs:
 
           watch_run_with_retry() {
             local run_id="$1"
-            # Poll long enough to outlast the infra promote job's own
-            # 60-min timeout-minutes (plus buffer for GitHub to flip the
-            # run to a terminal state). The watcher's job is to surface
-            # the infra run's real conclusion; a shorter budget makes it
-            # give up first and report a misleading "did not complete in
-            # N minutes" while the infra deploy is still legitimately
-            # working (e.g. a slow ECS rollout) and about to report
-            # success or a concrete failure. 390 x 10s = 65 min.
-            local max_attempts=390
+            # Budget is bounded by the GitHub App installation token's
+            # hard 1-hour lifetime: GH_TOKEN is minted in the prior step
+            # and `gh run view` against the infra repo needs it, so
+            # polling past ~1h starts hitting auth failures that this
+            # loop miscounts as transient errors and bails on after only
+            # ~2 min (max_consecutive_errors), masking the infra run's
+            # real status. Stay well under the hour: 270 x 10s = 45 min,
+            # which still covers a realistic promote (image import +
+            # migrate + terraform + a couple of ECS stabilize cycles run
+            # well under that) and far outlasts the old 30-min budget
+            # that gave up before a slow deploy could report its
+            # conclusion. A promote that hangs near the infra job's own
+            # 60-min timeout is surfaced as a watcher timeout here rather
+            # than chased past token expiry. Do NOT raise past ~55 min
+            # without first refreshing the App token inside the loop.
+            local max_attempts=270
             local sleep_seconds=10
             local max_consecutive_errors=12
             local consecutive_errors=0

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,7 +28,13 @@ jobs:
     name: Build + deploy staging
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 75
+    # Headroom for a cache-miss image build (~15-20 min) plus the
+    # watcher budget below (65 min), which itself must outlast the
+    # infra promote job's own 60-min timeout. Keep this strictly
+    # greater than build + watcher so the job's own timeout never
+    # guillotines the watcher before it can read the infra run's
+    # real conclusion.
+    timeout-minutes: 90
 
     steps:
       - name: Resolve synthetic ref
@@ -158,7 +164,15 @@ jobs:
 
           watch_run_with_retry() {
             local run_id="$1"
-            local max_attempts=180
+            # Poll long enough to outlast the infra promote job's own
+            # 60-min timeout-minutes (plus buffer for GitHub to flip the
+            # run to a terminal state). The watcher's job is to surface
+            # the infra run's real conclusion; a shorter budget makes it
+            # give up first and report a misleading "did not complete in
+            # N minutes" while the infra deploy is still legitimately
+            # working (e.g. a slow ECS rollout) and about to report
+            # success or a concrete failure. 390 x 10s = 65 min.
+            local max_attempts=390
             local sleep_seconds=10
             local max_consecutive_errors=12
             local consecutive_errors=0


### PR DESCRIPTION
## Problem

The `Deploy main to staging` workflow's **Dispatch and watch staging promote** step polls the dispatched infra promote run via `watch_run_with_retry`, but its budget was **180 × 10s = 30 min**. That's shorter than:

- the infra promote job's own `timeout-minutes` (60), and
- the deploy's `aws ecs wait services-stable` budget alone (2 cycles × 10 min = 20 min) plus image-import + migrate + terraform.

So a promote that legitimately runs longer than 30 min (e.g. a slow ECS rollout that eventually concludes) trips the **watcher's** deadline first. The staging job then fails with a misleading `Infra run did not complete within 30 minutes` instead of surfacing the infra run's real conclusion and URL — while the infra job is still working and about to report success or a concrete failure.

## Fix

- Widen the watcher to **390 × 10s = 65 min**, comfortably past the infra job's 60-min timeout plus buffer, so the staging job reports the infra run's actual outcome rather than a self-inflicted timeout.
- Raise this job's `timeout-minutes` **75 → 90** so a cache-miss image build can't guillotine the longer watcher.

Diagnosability-only: this makes a slow/failed promote report honestly; it does not change the promote itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the staging deployment timeout to provide more headroom for slower builds and infrastructure promotion steps.
  * Extended the staging promotion watcher window to reduce premature failures when promotions take longer than usual.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->