### PR TITLE
feat(search): Arabic search-key normalization + contacts

### DIFF
--- a/.agents/plans/045-arabic-search-normalization.md
+++ b/.agents/plans/045-arabic-search-normalization.md
@@ -1,0 +1,237 @@
+# Plan: Arabic Search Normalization
+
+Date: 2026-06-29
+
+## Goal
+
+Make search work for Arabic across every search surface by folding
+orthographic variants before matching. Today Arabic search fails
+silently: a query for `أحمد` does not find a record stored as `احمد`,
+and users just conclude the product "can't find things."
+
+## Background
+
+Arabic readers type the same word many visually-distinct ways. The
+normalization classes that matter for matching:
+
+- **Alef variants** `أ إ آ ٱ` → `ا`
+- **Hamza seats** `ؤ ئ ء`
+- **Taa marbuta ↔ haa** `ة` → `ه`
+- **Yaa ↔ alef maqsura** `ى` → `ي`
+- **Tashkeel / harakat** (combining diacritics `U+064B–0652`,
+  superscript alef `U+0670`) — strip
+- **Tatweel / kashida** `U+0640` — remove
+- **Presentation forms** (`U+FB50–FDFF`, `U+FE70–FEFF`) — fold to
+  canonical letters (NFKC)
+- **Arabic-Indic digits** (`U+0660–0669`, `U+06F0–06F9`) → ASCII
+
+A survey of the codebase found **no reusable letter-folding primitive**.
+Some surfaces strip tashkeel; **none** fold the orthographic variants —
+and the variants are the *common* query, not the edge case. Eight search
+surfaces are affected (see Scope).
+
+## Prior-Art Research (2026-06-29)
+
+A verified multi-source research pass (Lucene, CAMeL Tools, PostgreSQL
+docs, Tantivy/Quickwit maintainers) settled the build-vs-adopt question:
+
+- **Build, don't adopt.** No library covers the full class set across our
+  runtimes. The only npm options (`arajs`, `arabic-utils`; both MIT) are
+  partial and unmaintained, and `arajs`'s fold directions were *refuted*
+  as matching the standard — do not trust it.
+- **Vendor the Lucene `ArabicNormalizer` fold table (Apache-2.0)** as the
+  canonical spec, cross-checked against CAMeL Tools (MIT). Fold directions
+  (ة→ه, ى→ي, alef→ا) are settled and agree across all sources.
+- **The Lucene 5-fold set is NOT complete for us.** It covers only the
+  three alef-seat hamzas (أ إ آ), teh-marbuta→heh, alef-maksura→yeh,
+  harakat strip, tatweel removal. Extend it with: alef-wasla (ٱ U+0671,
+  per CAMeL), standalone waw/yeh/bare hamza (ؤ ئ ء), superscript alef
+  (U+0670), presentation-form folding (U+FB50–FDFF, U+FE70–FEFF via NFKC),
+  and Arabic-Indic digits (via `@stll/stdnum`).
+- **Per-runtime implementations are unavoidable** (no shared code across
+  TS + SQL + Tantivy), confirming the one-spec + golden-vectors approach.
+- **Postgres** has no native Arabic FTS dictionary; `unaccent` is
+  Latin-only by construction; ICU collations only sort/compare and cannot
+  produce a folded stored value. Hand-roll the `IMMUTABLE` function.
+- **Tantivy/Quickwit** ship no Arabic analyzer (Quickwit cannot even be
+  configured for one), so pre-normalize text at ingestion using the shared
+  TS normalizer.
+
+## Design Decisions
+
+- **One spec, golden test vectors, per-runtime implementations.** Search
+  spans three runtimes (Postgres SQL, Bun/Node JS, the Quickwit ingestion
+  path). A single shared function cannot run in all three, so the
+  canonical artifact is the **spec + a golden test-vector set**, with a
+  SQL implementation and a TS implementation that are both validated
+  against the same vectors. The golden vectors are the guardrail that
+  keeps the two from drifting.
+- **Copy the standard fold tables; do not invent them.** Base the
+  transform on Lucene's `ArabicNormalizer` (Apache-2.0), cross-checked
+  against CAMeL Tools (MIT) — settled fold directions: alef→ا, ة→ه, ى→ي,
+  strip harakat + tatweel. Extend it for the classes Lucene omits
+  (alef-wasla, waw/yeh/bare hamza, superscript alef, presentation forms,
+  digits). Reuse `@stll/stdnum`'s `normalizeArabicDigits` for the digit
+  class. Note: bare NFKC does *not* fold teh-marbuta or alef-maksura
+  (distinct base letters) — the explicit translate folds are still
+  required on top of NFKC.
+- **Design the fold table as per-language, from day one.** Lucene ships a
+  *separate* `PersianNormalizer`, and Persian/Urdu have conflicting
+  letters (Persian yeh ی U+06CC vs Arabic ي U+064A; Persian kaf ک U+06A9
+  vs Arabic ك U+0643). A single Arabic table would mis-fold `fa`/`ur`, so
+  the package exposes per-language fold tables rather than one global
+  Arabic table — this avoids a rewrite when those locales land.
+- **Normalization is a match-key transform only — never mutate stored or
+  displayed text.** Folding `ة→ه` is lossy and changes meaning. It
+  applies to index/comparison keys; display always renders the original.
+- **Symmetry is mandatory for full-text search.** Index terms and the
+  query must be normalized identically or they cannot match. This is why
+  the FTS surfaces need a reindex/backfill, not just a query-side change.
+- **DB surfaces normalize in SQL; in-memory/client surfaces normalize in
+  TS.** For Postgres, an `IMMUTABLE` `arabic_normalize(text)` function
+  drives both a `GENERATED ... STORED` column and the query expression —
+  so it auto-maintains on write with no write-path changes, and there is
+  one SQL impl for all DB surfaces. The TS normalizer covers the
+  in-memory regex search, the client find-in-page, and the Quickwit
+  ingestion/query path.
+- **Add a structural guardrail after the primitive exists** so the
+  eight-surfaces-drift-apart problem cannot recur, mirroring the existing
+  `no-raw-date-input` oxlint rule.
+
+## Scope
+
+**In scope (the eight surfaces):**
+
+1. Global entity FTS — `apps/api/src/lib/search/query.ts`
+   (`removeSearchDiacritics` / `normalizeTextForLexemes` chokepoint).
+   Also fixes a latent asymmetry: query strips diacritics in JS but the
+   index uses SQL `unaccent` — both sides must use the identical
+   normalizer.
+2. Legal corpus search (Quickwit) —
+   `apps/api/src/lib/legal-search/corpus-index-config.ts` (`default`
+   tokenizer) + `corpus-query.ts`.
+3. Legal PG fallback — `handlers/case-law/decisions/search.ts`,
+   `handlers/legislation/search.ts`,
+   `lib/legal-search/pg-fts-legal-provider.ts`.
+4. Contacts quick search — `handlers/contacts/search.ts` (raw `ILIKE`).
+5. Chat entity-content search —
+   `handlers/chat/tools/execute/workspace-function-registry.ts`
+   (`findHitsInText`, raw regex).
+6. Client case-law find-in-page —
+   `apps/web/src/features/case-law/components/case-viewer/decision-search.ts`
+   (diacritic strip only).
+7. Clauses FTS — `handlers/clauses/search-vector.ts`. **Pre-existing
+   bug**: `to_tsvector('english', …)` (wrong language config + no
+   `unaccent`) is broken for *all* non-English UI languages already
+   shipped (cs/de/pl/…), not just Arabic. Fix as a separate commit.
+
+**Out of scope:**
+
+- Arabic stemming / morphological (root-based) analysis. Normalization is
+  not stemming; light-stemming is a possible future enhancement.
+- Improving `@stll/anonymize-wasm` Arabic PII *matching* quality (surface
+  8, `lib/anonymization-blacklist.ts`). Related but a separate, larger
+  NER effort; this plan only ensures the blacklist call site normalizes
+  its keys consistently if cheap, otherwise tracks it separately.
+- Modifying the `@stll` wasm library internals (aho-corasick, regex-set,
+  fuzzy-search). Their `normalizeDiacritics` flag stays opt-in; we
+  normalize at our call sites instead.
+- Having Arabic legal corpus *content* (Arabic case law/statutes).
+
+## PR Sequencing
+
+Each PR is independently shippable and verifiable. Start with PR1.
+
+### PR1 — Canonical normalizer + low-risk surfaces (start here)
+
+Highest everyday-search value, lowest risk, no reindex.
+
+- Add the **TS normalizer** + golden test-vector set + property tests.
+- Add the **SQL `arabic_normalize()`** `IMMUTABLE` function (migration)
+  and a test asserting SQL output equals TS output over the golden
+  vectors.
+- Wire the surfaces that need no reindex: contacts `ILIKE` (normalized
+  generated column + normalized query), chat `findHitsInText` (normalize
+  both sides in memory), client find-in-page (extend existing TS
+  normalize), and extend the `query.ts` helper.
+- Separate commit: fix the clauses `'english'` → `'simple'` +
+  normalizer bug.
+
+### PR2 — Postgres FTS symmetry + backfill
+
+- Regenerate the entity / legal-PG tsvectors from `arabic_normalize()`
+  (generated STORED column or normalized source), fix the JS/SQL
+  asymmetry, migration + backfill of existing rows.
+
+### PR3 — Quickwit corpus (heaviest; gated)
+
+- Normalize the indexed text field at ingestion + normalize the query in
+  `corpus-query.ts`, both via the TS normalizer; keep an unmodified
+  stored field for display/highlight. Requires a **full corpus reindex**
+  — sequence this once the corpus ingestion pipeline is stable.
+
+### PR4 — Structural guardrail
+
+- Custom oxlint rule (mirroring `no-raw-date-input`) flagging raw
+  `ilike` / `to_tsquery` / `plainto_tsquery` / `new RegExp` on
+  user-search input that bypasses the normalizer.
+
+## Implementation
+
+- **Shared TS normalizer** — new package `@stll/text-normalize`
+  (confirmed), importable by both `apps/api` and `apps/web` so the API and
+  the client run the identical function. Pipeline: NFKC (folds
+  presentation forms) → strip tashkeel + superscript alef → remove tatweel
+  → fold alef variants + alef-wasla + hamza seats + taa-marbuta + yeh →
+  digit normalization (reuse `@stll/stdnum`) → lowercase → collapse
+  whitespace. Exposes a per-language fold table (Arabic first).
+- **SQL `arabic_normalize(text) IMMUTABLE`** — hand-authored timestamped
+  migration (never `drizzle-kit generate`); Postgres `normalize(… NFKC)`
+  + `translate()` + `regexp_replace()` for the fold classes. Drives
+  generated columns + query expressions. Respect squawk migration lint
+  (lock/statement timeouts; explicit short index names).
+- **DB call sites** — replace `unaccent(…)` /  bare `ILIKE` /
+  `to_tsquery('simple', …)` with the `arabic_normalize()`-wrapped
+  equivalents on both index and query sides. Keep all existing tenant /
+  workspace filters intact.
+- **Quickwit (PR3)** — normalize at the ingestion call site and in
+  `corpus-query.ts`; index config keeps `default` tokenizer operating on
+  pre-normalized text.
+- **DB schema** — new generated/normalized columns + GIN indexes for the
+  ILIKE/FTS surfaces; tsvector regeneration. All additive.
+
+## Test Cases
+
+- **Golden vectors** (shared by SQL + TS impls): `أحمد`/`احمد`,
+  `خدمة`/`خدمه`, `يكفى`/`يكفي`, tatweel `مـحـمـد`→`محمد`, a presentation
+  form folding to canonical, digits `٢٠٢٤`/`2024`, mixed Latin+Arabic.
+- **Idempotence** property: `normalize(normalize(x)) === normalize(x)`.
+- **Cross-impl agreement**: SQL `arabic_normalize()` output equals TS
+  output across the golden vectors (DB integration test).
+- **Per-surface**: contacts/entity/legal search returns the record when
+  query and stored value differ only by a normalized class; clauses FTS
+  matches a non-English (e.g. German) term after the `'simple'` fix.
+- **ReDoS check**: the fold is linear `translate`/char-class work; assert
+  no catastrophic backtracking on adversarial input.
+
+## Security Notes
+
+- Search stays workspace/tenant-scoped; normalization does not touch auth.
+  Normalized generated columns must remain inside existing tenant filters
+  (no cross-tenant leakage). Normalizing user input is linear/non-ReDoS.
+
+## Open Questions
+
+- **Hamza-seat fold target** — for ؤ ئ ء Lucene gives no rule. Recommended
+  default for search recall: ؤ→و, ئ→ي, drop standalone ء. Worth confirming
+  with the native legal-Arabic reviewer (one-line table change; golden
+  vectors will pin whatever we choose).
+- **Postgres NFKC presentation-form coverage** — verify empirically that
+  `normalize(text, NFKC)` folds U+FB50–FDFF / U+FE70–FEFF before relying
+  on it in the generated column (first task of PR2's SQL piece; fall back
+  to an explicit translate table if not).
+- **Persian/Urdu fold tables** — out of scope here, but the per-language
+  design must be in place so `fa`/`ur` are additive.
+
+(Resolved: new `@stll/text-normalize` package; anonymisation surface
+deferred to a separate NER-quality effort.)

--- a/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
+++ b/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
@@ -1,11 +1,14 @@
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - retry cleanup only drops the Arabic normalization indexes introduced by this same migration, immediately before rebuilding them concurrently; rollback is to drop these additive indexes and function.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
 -- Search match-key fold for Arabic. Must stay byte-for-byte equal to
 -- @stll/text-normalize's normalizeSearchText (golden vectors pin both).
 -- NFKC folds presentation forms; the regexp strips tatweel (U+0640), the
 -- eight harakat (U+064B-0652) and superscript alef (U+0670); translate
 -- folds alef/hamza/teh-marbuta/yeh variants and Arabic-Indic digits,
--- deleting the trailing standalone hamza (no counterpart in the target).
+-- pins ASCII case folding independently of database collation, and deletes
+-- the standalone hamza (no counterpart in the target).
 CREATE OR REPLACE FUNCTION arabic_normalize(input text)
 RETURNS text
 LANGUAGE sql
@@ -15,19 +18,53 @@ PARALLEL SAFE
 AS $$
   SELECT btrim(
     regexp_replace(
-      lower(
-        translate(
-          regexp_replace(
-            normalize($1, NFKC),
-            '[ـً-ْٰ]',
-            '',
-            'g'
-          ),
-          'آأإٱؤئةى٠١٢٣٤٥٦٧٨٩۰۱۲۳۴۵۶۷۸۹ء',
-          'ااااويهي01234567890123456789'
-        )
+      translate(
+        regexp_replace(
+          normalize($1, NFKC),
+          '[ـً-ْٰ]',
+          '',
+          'g'
+        ),
+        'آأإٱؤئةى٠١٢٣٤٥٦٧٨٩۰۱۲۳۴۵۶۷۸۹ABCDEFGHIJKLMNOPQRSTUVWXYZİء',
+        'ااااويهي01234567890123456789abcdefghijklmnopqrstuvwxyzi'
       ),
-      '\s+', ' ', 'g'
+      U&'[ \0009\000A\000B\000C\000D\00A0\1680\2000-\200A\2028\2029\202F\205F\3000\FEFF]+',
+      ' ',
+      'g'
     )
   )
 $$;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+-- Build the trigram indexes concurrently: contacts can be large enough that
+-- a regular index build would write-lock a user-facing table. Drizzle wraps
+-- pending migrations in one transaction, while PostgreSQL requires CREATE
+-- INDEX CONCURRENTLY to run outside a transaction block.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "contacts_display_name_arabic_norm_trgm_idx";
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_display_name_arabic_norm_trgm_idx"
+  ON "contacts" USING gin (arabic_normalize("display_name") gin_trgm_ops);
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "contacts_first_name_arabic_norm_trgm_idx";
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_first_name_arabic_norm_trgm_idx"
+  ON "contacts" USING gin (arabic_normalize("first_name") gin_trgm_ops);
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "contacts_last_name_arabic_norm_trgm_idx";
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_last_name_arabic_norm_trgm_idx"
+  ON "contacts" USING gin (arabic_normalize("last_name") gin_trgm_ops);
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "contacts_organization_name_arabic_norm_trgm_idx";
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "contacts_organization_name_arabic_norm_trgm_idx"
+  ON "contacts" USING gin (arabic_normalize("organization_name") gin_trgm_ops);
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;
+--> statement-breakpoint
+SET statement_timeout = '5s';

--- a/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
+++ b/apps/api/drizzle/20260629123000_arabic_normalize_function/migration.sql
@@ -1,0 +1,33 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+-- Search match-key fold for Arabic. Must stay byte-for-byte equal to
+-- @stll/text-normalize's normalizeSearchText (golden vectors pin both).
+-- NFKC folds presentation forms; the regexp strips tatweel (U+0640), the
+-- eight harakat (U+064B-0652) and superscript alef (U+0670); translate
+-- folds alef/hamza/teh-marbuta/yeh variants and Arabic-Indic digits,
+-- deleting the trailing standalone hamza (no counterpart in the target).
+CREATE OR REPLACE FUNCTION arabic_normalize(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+  SELECT btrim(
+    regexp_replace(
+      lower(
+        translate(
+          regexp_replace(
+            normalize($1, NFKC),
+            '[ـً-ْٰ]',
+            '',
+            'g'
+          ),
+          'آأإٱؤئةى٠١٢٣٤٥٦٧٨٩۰۱۲۳۴۵۶۷۸۹ء',
+          'ااااويهي01234567890123456789'
+        )
+      ),
+      '\s+', ' ', 'g'
+    )
+  )
+$$;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -75,6 +75,7 @@
     "@stll/permissions": "workspace:*",
     "@stll/skills": "workspace:*",
     "@stll/template-conditions": "workspace:*",
+    "@stll/text-normalize": "workspace:*",
     "@stll/transactional": "workspace:*",
     "@t3-oss/env-core": "catalog:",
     "@valibot/to-json-schema": "^1.7.1",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -371,6 +371,21 @@ export const contacts = p.pgTable(
     p
       .index("contacts_org_org_name_idx")
       .on(table.organizationId, table.organizationName),
+    p
+      .index("contacts_display_name_arabic_norm_trgm_idx")
+      .using("gin", sql`arabic_normalize(${table.displayName}) gin_trgm_ops`),
+    p
+      .index("contacts_first_name_arabic_norm_trgm_idx")
+      .using("gin", sql`arabic_normalize(${table.firstName}) gin_trgm_ops`),
+    p
+      .index("contacts_last_name_arabic_norm_trgm_idx")
+      .using("gin", sql`arabic_normalize(${table.lastName}) gin_trgm_ops`),
+    p
+      .index("contacts_organization_name_arabic_norm_trgm_idx")
+      .using(
+        "gin",
+        sql`arabic_normalize(${table.organizationName}) gin_trgm_ops`,
+      ),
     ...orgPolicies(),
   ],
 );

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -1,4 +1,3 @@
-import { PGlite } from "@electric-sql/pglite";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api-postgres";
 import { eq, sql } from "drizzle-orm";
@@ -16,6 +15,10 @@ import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citati
 import { citationScore } from "@/api/handlers/case-law/citation-score";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  createSchemaPglite,
+  installPgliteSchemaPrerequisites,
+} from "@/api/tests/pglite-schema";
 
 // The materialized citation_authority column must equal citationScore()
 // evaluated at the same instant, so moving the blend out of the per-query
@@ -25,7 +28,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 const allSchema = { ...schema, ...authSchema, ...rlsExports };
 const NOW = new Date("2026-06-05T00:00:00.000Z");
 
-let client: PGlite;
+let client: Awaited<ReturnType<typeof createSchemaPglite>>;
 let db: ReturnType<typeof drizzle>;
 
 const sourceId = createSafeId<"caseLawSource">();
@@ -35,10 +38,11 @@ const regionalCitingId = createSafeId<"caseLawDecision">();
 const orphanId = createSafeId<"caseLawDecision">();
 
 beforeAll(async () => {
-  client = await PGlite.create();
+  client = await createSchemaPglite();
   db = drizzle({ client });
   await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
   await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+  await installPgliteSchemaPrerequisites(db);
   const { sqlStatements } = await pushSchema(allSchema, db);
   for (const statement of sqlStatements) {
     // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)

--- a/apps/api/src/handlers/contacts/search.ts
+++ b/apps/api/src/handlers/contacts/search.ts
@@ -1,6 +1,8 @@
 import { Result } from "better-result";
-import { and, eq, ilike, or } from "drizzle-orm";
+import { and, eq, ilike, or, sql } from "drizzle-orm";
 import { t } from "elysia";
+
+import { normalizeSearchText } from "@stll/text-normalize";
 
 import { contacts } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -19,15 +21,19 @@ const searchContacts = createSafeRootHandler(
     query: searchContactsQuerySchema,
   },
   async function* ({ safeDb, session, query }) {
-    const pattern = `%${escapeLike(query.q)}%`;
+    const normalized = normalizeSearchText(query.q);
+    if (normalized.length === 0) {
+      return Result.ok({ items: [] });
+    }
+    const pattern = `%${escapeLike(normalized)}%`;
 
     const conditions = [
       eq(contacts.organizationId, session.activeOrganizationId),
       or(
-        ilike(contacts.displayName, pattern),
-        ilike(contacts.firstName, pattern),
-        ilike(contacts.lastName, pattern),
-        ilike(contacts.organizationName, pattern),
+        ilike(sql`arabic_normalize(${contacts.displayName})`, pattern),
+        ilike(sql`arabic_normalize(${contacts.firstName})`, pattern),
+        ilike(sql`arabic_normalize(${contacts.lastName})`, pattern),
+        ilike(sql`arabic_normalize(${contacts.organizationName})`, pattern),
       ),
     ];
 

--- a/apps/api/src/handlers/legislation/ingestion.test.ts
+++ b/apps/api/src/handlers/legislation/ingestion.test.ts
@@ -1,4 +1,3 @@
-import { PGlite } from "@electric-sql/pglite";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api-postgres";
 import { eq, sql } from "drizzle-orm";
@@ -11,23 +10,28 @@ import * as schema from "@/api/db/schema";
 import { legislationDocuments, legislationSources } from "@/api/db/schema";
 import { processLegislationDocument } from "@/api/handlers/legislation/ingestion";
 import { createSafeId } from "@/api/lib/branded-types";
+import {
+  createSchemaPglite,
+  installPgliteSchemaPrerequisites,
+} from "@/api/tests/pglite-schema";
 
 // Validates the legislation ingestion entry: store + upsert + source-hash
 // dedup. CORPUS_STORAGE_ENABLED is off in tests, so no S3 is touched.
 
 const allSchema = { ...schema, ...authSchema, ...rlsExports };
 
-let client: PGlite;
+let client: Awaited<ReturnType<typeof createSchemaPglite>>;
 let db: ReturnType<typeof drizzle>;
 let scopedDb: ScopedDb;
 
 const sourceId = createSafeId<"legislationSource">();
 
 beforeAll(async () => {
-  client = await PGlite.create();
+  client = await createSchemaPglite();
   db = drizzle({ client });
   await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
   await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+  await installPgliteSchemaPrerequisites(db);
   const { sqlStatements } = await pushSchema(allSchema, db);
   for (const statement of sqlStatements) {
     // oxlint-disable-next-line no-await-in-loop -- sequential DDL: schema statements must apply in emitted order

--- a/apps/api/src/lib/db/arabic-normalize.test.ts
+++ b/apps/api/src/lib/db/arabic-normalize.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import { normalizeSearchText } from "@stll/text-normalize";
+
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+const MIGRATION_PATH = nodePath.resolve(
+  import.meta.dir,
+  "../../../drizzle/20260629123000_arabic_normalize_function/migration.sql",
+);
+
+// The shared search-key contract: the SQL arabic_normalize() must produce
+// the same match key as the TS normalizeSearchText for every input. The
+// presentation-form inputs also empirically confirm that Postgres
+// normalize(NFKC) folds them the same way String.normalize("NFKC") does.
+const VECTORS: readonly string[] = [
+  "أحمد",
+  "احمد",
+  "إسلام",
+  "آمنة",
+  "خدمة",
+  "يكفى",
+  "مُحَمَّد",
+  "مـحـمـد",
+  "مؤمن",
+  "مسئول",
+  "ء",
+  "السلام عليكم",
+  "٢٠٢٤",
+  "۲۰۲۴",
+  "HELLO Wörld",
+  "  a   b  ",
+  "ﷲ", // U+FDF2 ligature -> الله via NFKC
+  "ﺍﺣﻤﺪ", // presentation forms -> احمد via NFKC
+];
+
+let testDb: TestDatabase;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  const migrationSql = readFileSync(MIGRATION_PATH, "utf-8");
+  for (const statement of migrationSql.split("--> statement-breakpoint")) {
+    const trimmed = statement.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- ordered DDL on one connection
+    await testDb.execute(sql.raw(trimmed));
+  }
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+describe("arabic_normalize SQL function", () => {
+  test("matches normalizeSearchText for every vector", async () => {
+    for (const input of VECTORS) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential queries on one PGlite connection
+      const result = await testDb.execute<{ out: string | null }>(
+        sql`SELECT arabic_normalize(${input}) AS out`,
+      );
+      expect(result.rows.at(0)?.out).toBe(normalizeSearchText(input));
+    }
+  });
+});

--- a/apps/api/src/lib/db/arabic-normalize.test.ts
+++ b/apps/api/src/lib/db/arabic-normalize.test.ts
@@ -33,7 +33,11 @@ const VECTORS: readonly string[] = [
   "٢٠٢٤",
   "۲۰۲۴",
   "HELLO Wörld",
+  "IBRAHIM İBRAHIM",
   "  a   b  ",
+  "a\tb\nc",
+  "a\u00a0b",
+  "a\u2007b\u3000c",
   "ﷲ", // U+FDF2 ligature -> الله via NFKC
   "ﺍﺣﻤﺪ", // presentation forms -> احمد via NFKC
 ];
@@ -45,7 +49,7 @@ beforeAll(async () => {
   const migrationSql = readFileSync(MIGRATION_PATH, "utf-8");
   for (const statement of migrationSql.split("--> statement-breakpoint")) {
     const trimmed = statement.trim();
-    if (trimmed.length === 0) {
+    if (trimmed.length === 0 || !isPortableFunctionStatement(trimmed)) {
       continue;
     }
     // oxlint-disable-next-line no-await-in-loop -- ordered DDL on one connection
@@ -67,4 +71,30 @@ describe("arabic_normalize SQL function", () => {
       expect(result.rows.at(0)?.out).toBe(normalizeSearchText(input));
     }
   });
+
+  test("keeps concurrent index creation retry-safe", () => {
+    const migrationSql = readFileSync(MIGRATION_PATH, "utf-8");
+    const indexNames = [
+      "contacts_display_name_arabic_norm_trgm_idx",
+      "contacts_first_name_arabic_norm_trgm_idx",
+      "contacts_last_name_arabic_norm_trgm_idx",
+      "contacts_organization_name_arabic_norm_trgm_idx",
+    ];
+
+    for (const indexName of indexNames) {
+      expect(migrationSql).toContain(
+        `DROP INDEX CONCURRENTLY IF EXISTS "${indexName}"`,
+      );
+      expect(migrationSql).toContain(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${indexName}"`,
+      );
+    }
+  });
 });
+
+const isPortableFunctionStatement = (statement: string): boolean => {
+  if (statement.includes("CREATE OR REPLACE FUNCTION arabic_normalize")) {
+    return true;
+  }
+  return statement.startsWith("SET ");
+};

--- a/apps/api/src/lib/entity-filters.differential.test.ts
+++ b/apps/api/src/lib/entity-filters.differential.test.ts
@@ -1,4 +1,3 @@
-import { PGlite } from "@electric-sql/pglite";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api-postgres";
 import { and, eq, sql } from "drizzle-orm";
@@ -15,6 +14,10 @@ import { entities, entityVersions, fields, properties } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
 import { applyFilters, buildFilterConditions } from "@/api/lib/entity-filters";
+import {
+  createSchemaPglite,
+  installPgliteSchemaPrerequisites,
+} from "@/api/tests/pglite-schema";
 
 // ── Differential property test ──────────────────────────────
 //
@@ -30,7 +33,7 @@ const allSchema = { ...schema, ...authSchema, ...rlsExports };
 
 type RawDb = ReturnType<typeof drizzle>;
 
-let client: PGlite;
+let client: Awaited<ReturnType<typeof createSchemaPglite>>;
 let db: RawDb;
 
 const ORG_ID = toSafeId<"organization">(Bun.randomUUIDv7());
@@ -91,12 +94,13 @@ const ENTITY_KINDS: readonly EntityKind[] = [
 ];
 
 beforeAll(async () => {
-  client = await PGlite.create();
+  client = await createSchemaPglite();
   db = drizzle({ client });
   const pushDb = drizzle({ client });
 
   await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
   await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+  await installPgliteSchemaPrerequisites(db);
 
   const { sqlStatements } = await pushSchema(allSchema, pushDb);
   // Schema DDL must apply in dependency order, so these run sequentially.

--- a/apps/api/src/tests/pglite-schema.ts
+++ b/apps/api/src/tests/pglite-schema.ts
@@ -1,0 +1,41 @@
+import { PGlite } from "@electric-sql/pglite";
+import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
+import { panic } from "better-result";
+import { sql, type SQL } from "drizzle-orm";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+const ARABIC_NORMALIZE_MIGRATION_PATH = nodePath.resolve(
+  import.meta.dir,
+  "../../drizzle/20260629123000_arabic_normalize_function/migration.sql",
+);
+
+type PgliteSchemaDb = {
+  execute: (query: SQL) => Promise<unknown>;
+};
+
+export const createSchemaPglite = async () =>
+  await PGlite.create({ extensions: { pg_trgm } });
+
+export const installPgliteSchemaPrerequisites = async (
+  db: PgliteSchemaDb,
+): Promise<void> => {
+  await db.execute(sql.raw("CREATE EXTENSION IF NOT EXISTS pg_trgm"));
+  await db.execute(sql.raw(arabicNormalizeFunctionSql()));
+};
+
+const arabicNormalizeFunctionSql = (): string => {
+  const migrationSql = readFileSync(ARABIC_NORMALIZE_MIGRATION_PATH, "utf-8");
+  const statement = migrationSql
+    .split("--> statement-breakpoint")
+    .map((part) => part.trim())
+    .find((part) =>
+      part.includes("CREATE OR REPLACE FUNCTION arabic_normalize"),
+    );
+
+  if (!statement) {
+    panic("arabic_normalize function migration statement not found");
+  }
+
+  return statement;
+};

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -1,4 +1,3 @@
-import { PGlite } from "@electric-sql/pglite";
 import { pushSchema } from "drizzle-kit/api-postgres";
 import { sql, TransactionRollbackError } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
@@ -10,6 +9,10 @@ import { createScopedDb, markRlsDatabase } from "@/api/db/scoped";
 import type { RlsDatabaseMarker, TransactionOf } from "@/api/db/scoped";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  createSchemaPglite,
+  installPgliteSchemaPrerequisites,
+} from "@/api/tests/pglite-schema";
 
 const allSchema = {
   ...schema,
@@ -52,7 +55,7 @@ export type TestDatabase = RawTestDatabase & RlsDatabaseMarker;
 export type TestDatabaseTransaction = TransactionOf<TestDatabase>;
 
 const createTestDb = async (): Promise<TestDatabase> => {
-  const client = await PGlite.create();
+  const client = await createSchemaPglite();
   const testDb = markRlsDatabase(
     drizzle({
       client,
@@ -63,6 +66,7 @@ const createTestDb = async (): Promise<TestDatabase> => {
 
   await testDb.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
   await testDb.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+  await installPgliteSchemaPrerequisites(testDb);
 
   const { sqlStatements } = await pushSchema(allSchema, pushSchemaDb);
   for (const statement of sqlStatements) {

--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,7 @@
         "@stll/permissions": "workspace:*",
         "@stll/skills": "workspace:*",
         "@stll/template-conditions": "workspace:*",
+        "@stll/text-normalize": "workspace:*",
         "@stll/transactional": "workspace:*",
         "@t3-oss/env-core": "catalog:",
         "@valibot/to-json-schema": "^1.7.1",
@@ -607,6 +608,14 @@
         "@types/bun": "catalog:",
         "fast-check": "catalog:",
         "tsdown": "catalog:",
+      },
+    },
+    "packages/text-normalize": {
+      "name": "@stll/text-normalize",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@stll/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
       },
     },
     "packages/transactional": {
@@ -1746,6 +1755,8 @@
     "@stll/stdnum": ["@stll/stdnum@2.1.1", "", {}, "sha512-VV+9w+u3tLYjos2Z0idJBsl+iCmE171u4rhUNEh/QDqljPBjKETKyLkf81Z1sR0QeaAcn3rg+0Y4vauPVU566w=="],
 
     "@stll/template-conditions": ["@stll/template-conditions@workspace:packages/template-conditions"],
+
+    "@stll/text-normalize": ["@stll/text-normalize@workspace:packages/text-normalize"],
 
     "@stll/text-search-wasm": ["@stll/text-search-wasm@1.0.5", "", { "dependencies": { "@stll/aho-corasick-wasm": "^1.0.3", "@stll/fuzzy-search-wasm": "^1.1.1", "@stll/regex-set-wasm": "^1.0.4" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-ZY3nPQ7Zm/KpbeaodQdJMuzShHE9QPJBvRGpZxoGXo7AKOt2t32beZZ6HWG+yvfzMp/loLKY4dGrY8sbIRDf/A=="],
 

--- a/packages/text-normalize/README.md
+++ b/packages/text-normalize/README.md
@@ -1,0 +1,37 @@
+# @stll/text-normalize
+
+Search match-key text normalization. Folds orthographic variants so a
+search query matches text regardless of how it was typed.
+
+The normalized output is a **match key**: it is lossy and intended only
+for indexing and query comparison. Never store or display it in place of
+the original text.
+
+## Arabic
+
+`normalizeSearchText` folds the orthographic variants that make Arabic
+search miss otherwise-identical words:
+
+- alef variants and alef-wasla (`أ إ آ ٱ`) to bare alef `ا`
+- waw-hamza `ؤ` to `و`, yeh-hamza `ئ` to `ي`, standalone hamza `ء` dropped
+- teh marbuta `ة` to heh `ه`
+- alef maksura `ى` to yeh `ي`
+- tashkeel (harakat), superscript alef, and tatweel removed
+- Arabic-Indic and Extended Arabic-Indic digits to ASCII
+
+It also runs NFKC (folding presentation forms) plus lowercase and
+whitespace collapse, so it is a safe pass-through for non-Arabic scripts.
+
+The fold tables are vendored from Lucene's `ArabicNormalizer` (Apache-2.0)
+and cross-checked against CAMeL Tools (MIT), extended for the classes
+Lucene omits.
+
+```ts
+import { normalizeSearchText } from "@stll/text-normalize";
+
+normalizeSearchText("أحمد") === normalizeSearchText("احمد"); // true
+```
+
+The same fold must be reproduced by the PostgreSQL `arabic_normalize()`
+function used for generated search-key columns; the golden vectors in
+`src/normalize.test.ts` pin the shared contract.

--- a/packages/text-normalize/README.md
+++ b/packages/text-normalize/README.md
@@ -19,8 +19,9 @@ search miss otherwise-identical words:
 - tashkeel (harakat), superscript alef, and tatweel removed
 - Arabic-Indic and Extended Arabic-Indic digits to ASCII
 
-It also runs NFKC (folding presentation forms) plus lowercase and
-whitespace collapse, so it is a safe pass-through for non-Arabic scripts.
+It also runs NFKC (folding presentation forms), locale-stable ASCII case
+folding, and whitespace collapse, so it is a safe pass-through for
+non-Arabic scripts.
 
 The fold tables are vendored from Lucene's `ArabicNormalizer` (Apache-2.0)
 and cross-checked against CAMeL Tools (MIT), extended for the classes
@@ -33,5 +34,5 @@ normalizeSearchText("أحمد") === normalizeSearchText("احمد"); // true
 ```
 
 The same fold must be reproduced by the PostgreSQL `arabic_normalize()`
-function used for generated search-key columns; the golden vectors in
-`src/normalize.test.ts` pin the shared contract.
+function used in contacts trigram expression indexes and search predicates;
+the golden vectors in `src/normalize.test.ts` pin the shared contract.

--- a/packages/text-normalize/package.json
+++ b/packages/text-normalize/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@stll/text-normalize",
+  "version": "0.1.0",
+  "description": "Search match-key text normalization — Arabic orthographic variant folding (alef/hamza/teh-marbuta/yeh, tashkeel, tatweel, digits) with per-language fold tables",
+  "keywords": [
+    "arabic",
+    "i18n",
+    "normalization",
+    "search",
+    "text-search",
+    "unicode"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/text-normalize",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/text-normalize"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "pack:dry-run": "bun pm pack --dry-run",
+    "test": "bun test src",
+    "typecheck": "tsgo --noEmit",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/text-normalize",
+    "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/text-normalize",
+    "format": "oxfmt .",
+    "prepack": "bun run build"
+  },
+  "devDependencies": {
+    "@stll/typescript-config": "workspace:*",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/text-normalize/package.json
+++ b/packages/text-normalize/package.json
@@ -33,7 +33,7 @@
     ".": {
       "types": "./src/index.ts",
       "bun": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -1,0 +1,89 @@
+/**
+ * Arabic orthographic fold tables for SEARCH match-key normalization.
+ *
+ * Vendored from Lucene's ArabicNormalizer (Apache-2.0) and cross-checked
+ * against CAMeL Tools (MIT), then extended for the classes Lucene omits:
+ * alef-wasla, waw/yeh/standalone hamza, superscript alef, and Arabic-Indic
+ * digits. Fold directions (alef variants to bare alef, teh-marbuta to heh,
+ * alef-maksura to yeh) are the settled Lucene/CAMeL consensus.
+ *
+ * These folds are lossy match-key transforms: never apply them to stored
+ * or displayed text, only to search keys.
+ */
+
+// One-to-one letter folds (source codepoint to target codepoint).
+export const ARABIC_LETTER_FOLDS: Readonly<Record<string, string>> = {
+  آ: "ا", // آ alef madda       -> ا alef
+  أ: "ا", // أ alef hamza above -> ا alef
+  إ: "ا", // إ alef hamza below -> ا alef
+  ٱ: "ا", // ٱ alef wasla       -> ا alef
+  ؤ: "و", // ؤ waw hamza        -> و waw
+  ئ: "ي", // ئ yeh hamza        -> ي yeh
+  ة: "ه", // ة teh marbuta      -> ه heh
+  ى: "ي", // ى alef maksura     -> ي yeh
+};
+
+// Codepoints folded to nothing (removed). Tatweel, the eight harakat
+// (U+064B–U+0652), superscript alef, and standalone hamza.
+export const ARABIC_REMOVED: readonly string[] = [
+  "ء", // ء standalone hamza
+  "ـ", // ـ tatweel / kashida
+  "ً", // fathatan
+  "ٌ", // dammatan
+  "ٍ", // kasratan
+  "َ", // fatha
+  "ُ", // damma
+  "ِ", // kasra
+  "ّ", // shadda
+  "ْ", // sukun
+  "ٰ", // superscript alef
+];
+
+// Arabic-Indic (U+0660–0669) and Extended Arabic-Indic (U+06F0–06F9)
+// digits to ASCII. Same mapping as @stll/stdnum's internal digit table;
+// inlined here to avoid depending on another package's private util.
+export const ARABIC_DIGIT_FOLDS: Readonly<Record<string, string>> = {
+  "٠": "0",
+  "١": "1",
+  "٢": "2",
+  "٣": "3",
+  "٤": "4",
+  "٥": "5",
+  "٦": "6",
+  "٧": "7",
+  "٨": "8",
+  "٩": "9",
+  "۰": "0",
+  "۱": "1",
+  "۲": "2",
+  "۳": "3",
+  "۴": "4",
+  "۵": "5",
+  "۶": "6",
+  "۷": "7",
+  "۸": "8",
+  "۹": "9",
+};
+
+const FOLD_MAP: ReadonlyMap<string, string> = new Map<string, string>([
+  ...Object.entries(ARABIC_LETTER_FOLDS),
+  ...Object.entries(ARABIC_DIGIT_FOLDS),
+  ...ARABIC_REMOVED.map((char): readonly [string, string] => [char, ""]),
+]);
+
+/**
+ * Apply the Arabic letter, digit, and removal folds codepoint by
+ * codepoint. Non-Arabic characters pass through unchanged.
+ */
+export const applyArabicFolds = (text: string): string => {
+  // Fast path for the single-code-unit calls made character-by-character
+  // when building offset maps; avoids an array allocation per character.
+  if (text.length === 1) {
+    return FOLD_MAP.get(text) ?? text;
+  }
+  const out: string[] = [];
+  for (const char of text) {
+    out.push(FOLD_MAP.get(char) ?? char);
+  }
+  return out.join("");
+};

--- a/packages/text-normalize/src/index.ts
+++ b/packages/text-normalize/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  applyArabicFolds,
+  ARABIC_DIGIT_FOLDS,
+  ARABIC_LETTER_FOLDS,
+  ARABIC_REMOVED,
+} from "./arabic.js";
+export { normalizeSearchText } from "./normalize.js";

--- a/packages/text-normalize/src/normalize.test.ts
+++ b/packages/text-normalize/src/normalize.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeSearchText } from "./normalize.js";
+
+// Each group lists spellings a user might type for the same word. After
+// normalization they must all collapse to a single search key.
+const EQUIVALENCE_GROUPS: readonly (readonly string[])[] = [
+  ["أحمد", "احمد"], // alef-hamza-above vs bare alef
+  ["إسلام", "اسلام"], // alef-hamza-below vs bare alef
+  ["آمنة", "امنه"], // alef-madda + teh-marbuta
+  ["خدمة", "خدمه"], // teh marbuta -> heh
+  ["يكفى", "يكفي"], // alef maksura -> yeh
+  ["مُحَمَّد", "محمد"], // tashkeel stripped
+  ["مـحـمـد", "محمد"], // tatweel removed
+  ["مؤمن", "مومن"], // waw hamza -> waw
+  ["مسئول", "مسيول"], // yeh hamza -> yeh
+  ["٢٠٢٤", "2024"], // Arabic-Indic digits
+  ["۲۰۲۴", "2024"], // Extended Arabic-Indic digits
+];
+
+// Exact outputs pin the contract the SQL arabic_normalize() must
+// reproduce byte-for-byte.
+const GOLDEN: readonly (readonly [string, string])[] = [
+  ["أحمد", "احمد"],
+  ["خدمة", "خدمه"],
+  ["يكفى", "يكفي"],
+  ["مُحَمَّد", "محمد"],
+  ["مـحـمـد", "محمد"],
+  ["مؤمن", "مومن"],
+  ["مسئول", "مسيول"],
+  ["ء", ""], // standalone hamza dropped
+  ["٢٠٢٤", "2024"],
+  ["HELLO Wörld", "hello wörld"], // Latin: NFKC + lowercase only
+  ["  a   b  ", "a b"], // whitespace collapsed and trimmed
+];
+
+describe("normalizeSearchText", () => {
+  test("each equivalence group collapses to one key", () => {
+    for (const group of EQUIVALENCE_GROUPS) {
+      const keys = new Set(group.map(normalizeSearchText));
+      expect(keys.size).toBe(1);
+    }
+  });
+
+  test.each(GOLDEN)("normalize(%p) === %p", (input, expected) => {
+    expect(normalizeSearchText(input)).toBe(expected);
+  });
+
+  test("is idempotent", () => {
+    const samples = [
+      ...EQUIVALENCE_GROUPS.flat(),
+      "السلام عليكم",
+      "Hello World",
+    ];
+    for (const sample of samples) {
+      const once = normalizeSearchText(sample);
+      expect(normalizeSearchText(once)).toBe(once);
+    }
+  });
+
+  test("leaves fold targets (bare alef, waw, yeh, heh) stable", () => {
+    expect(normalizeSearchText("اويه")).toBe("اويه");
+  });
+});

--- a/packages/text-normalize/src/normalize.test.ts
+++ b/packages/text-normalize/src/normalize.test.ts
@@ -30,8 +30,12 @@ const GOLDEN: readonly (readonly [string, string])[] = [
   ["مسئول", "مسيول"],
   ["ء", ""], // standalone hamza dropped
   ["٢٠٢٤", "2024"],
-  ["HELLO Wörld", "hello wörld"], // Latin: NFKC + lowercase only
+  ["HELLO Wörld", "hello wörld"], // Latin: NFKC + ASCII case folding
+  ["IBRAHIM İBRAHIM", "ibrahim ibrahim"], // locale-stable I folding
   ["  a   b  ", "a b"], // whitespace collapsed and trimmed
+  ["a\tb\nc", "a b c"], // ASCII controls collapsed
+  ["a\u00a0b", "a b"], // NBSP collapsed
+  ["a\u2007b\u3000c", "a b c"], // Unicode space separators collapsed
 ];
 
 describe("normalizeSearchText", () => {

--- a/packages/text-normalize/src/normalize.ts
+++ b/packages/text-normalize/src/normalize.ts
@@ -1,0 +1,21 @@
+import { applyArabicFolds } from "./arabic.js";
+
+const WHITESPACE_RE = /\s+/gu;
+
+/**
+ * Canonical search match-key normalizer. Folds Arabic orthographic
+ * variants so a query matches regardless of how the text was typed
+ * (alef/hamza/teh-marbuta/yeh variants, tashkeel, tatweel, Arabic-Indic
+ * digits), and is a harmless NFKC + lowercase pass on other scripts.
+ *
+ * NFKC runs first so presentation forms (U+FB50–FDFF, U+FE70–FEFF) fold
+ * to their canonical letters before the explicit folds apply.
+ *
+ * This MUST stay consistent with the SQL `arabic_normalize()` function;
+ * the golden vectors in normalize.test.ts pin the contract for both.
+ */
+export const normalizeSearchText = (text: string): string =>
+  applyArabicFolds(text.normalize("NFKC"))
+    .toLowerCase()
+    .replace(WHITESPACE_RE, " ")
+    .trim();

--- a/packages/text-normalize/src/normalize.ts
+++ b/packages/text-normalize/src/normalize.ts
@@ -1,12 +1,27 @@
 import { applyArabicFolds } from "./arabic.js";
 
-const WHITESPACE_RE = /\s+/gu;
+const ASCII_UPPERCASE_RE = /[A-Zİ]/gu;
+const SEARCH_WHITESPACE_RE =
+  /[ \t\n\v\f\r\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+/gu;
+
+const foldSearchCase = (text: string): string =>
+  text.replace(ASCII_UPPERCASE_RE, (char) => {
+    if (char === "İ") {
+      return "i";
+    }
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) {
+      return char;
+    }
+    return String.fromCodePoint(codePoint + 32);
+  });
 
 /**
  * Canonical search match-key normalizer. Folds Arabic orthographic
  * variants so a query matches regardless of how the text was typed
  * (alef/hamza/teh-marbuta/yeh variants, tashkeel, tatweel, Arabic-Indic
- * digits), and is a harmless NFKC + lowercase pass on other scripts.
+ * digits), then applies locale-stable ASCII case folding for mixed-script
+ * names.
  *
  * NFKC runs first so presentation forms (U+FB50–FDFF, U+FE70–FEFF) fold
  * to their canonical letters before the explicit folds apply.
@@ -15,7 +30,6 @@ const WHITESPACE_RE = /\s+/gu;
  * the golden vectors in normalize.test.ts pin the contract for both.
  */
 export const normalizeSearchText = (text: string): string =>
-  applyArabicFolds(text.normalize("NFKC"))
-    .toLowerCase()
-    .replace(WHITESPACE_RE, " ")
+  foldSearchCase(applyArabicFolds(text.normalize("NFKC")))
+    .replace(SEARCH_WHITESPACE_RE, " ")
     .trim();

--- a/packages/text-normalize/tsconfig.build.json
+++ b/packages/text-normalize/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/text-normalize/tsconfig.json
+++ b/packages/text-normalize/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@stll/typescript-config/published.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "types": ["bun"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## What

Adds Arabic search-key normalization so search matches text regardless of how it was typed.

- **`@stll/text-normalize`** — a new package that folds Arabic orthographic variants (alef/hamza/teh-marbuta/yeh, tashkeel, tatweel, Arabic-Indic digits, and presentation forms via NFKC). The fold tables are vendored from Lucene's `ArabicNormalizer` and cross-checked against CAMeL Tools, extended for the classes Lucene omits (alef-wasla, the waw/yeh/standalone hamza seats, superscript alef, digits).
- **`arabic_normalize()`** — an `IMMUTABLE` SQL function mirroring the TS normalizer, pinned to it by a cross-implementation golden-vector test (the SQL output must equal the TS output for every vector, including presentation forms).
- **Contacts search** routed through the normalizer on both sides.

## Why

Arabic search fails silently today: a query for `أحمد` does not find a record stored as `احمد`, and the orthographic variants (alef/hamza, teh-marbuta, alef-maksura) are the common case, not the edge case.

## Notes

- Normalization is a **match-key** transform only — lossy, and never applied to stored or displayed text.
- First of a stacked series; later PRs extend the same folding to the in-memory and full-text search surfaces.
- Design notes: `.agents/plans/045-arabic-search-normalization.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Arabic search matching across supported search surfaces using a shared normalisation approach.
  * Added/updated the text normalisation package and documentation to define the search “match key” behaviour.
* **Performance**
  * Rebuilt trigram indexes for Arabic-normalised contact fields to improve Arabic query responsiveness.
* **Bug Fixes**
  * Arabic search now normalises input before matching, and returns no results when the normalised query is empty.
* **Tests**
  * Added cross-checks to keep PostgreSQL and TypeScript normalisation outputs consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->