### PR TITLE
feat(search): fold Arabic variants in in-memory search surfaces

### DIFF
--- a/apps/api/drizzle/20260630100000_arabic_normalize_combining_marks/migration.sql
+++ b/apps/api/drizzle/20260630100000_arabic_normalize_combining_marks/migration.sql
@@ -1,0 +1,30 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+-- Keep the SQL search match-key fold aligned with @stll/text-normalize:
+-- U+0653-U+0655 are decomposed Arabic madda/hamza marks and normalize to
+-- no search-key character, matching composed alef/waw/yeh hamza folds.
+CREATE OR REPLACE FUNCTION arabic_normalize(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+  SELECT btrim(
+    regexp_replace(
+      translate(
+        regexp_replace(
+          normalize($1, NFKC),
+          '[ـً-ٰٕ]',
+          '',
+          'g'
+        ),
+        'آأإٱؤئةى٠١٢٣٤٥٦٧٨٩۰۱۲۳۴۵۶۷۸۹ABCDEFGHIJKLMNOPQRSTUVWXYZİء',
+        'ااااويهي01234567890123456789abcdefghijklmnopqrstuvwxyzi'
+      ),
+      U&'[ \0009\000A\000B\000C\000D\00A0\1680\2000-\200A\2028\2029\202F\205F\3000\FEFF]+',
+      ' ',
+      'g'
+    )
+  )
+$$;

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { findHitsInText } from "./workspace-function-registry";
+
+const OPTIONS = { caseSensitive: false, limit: 5, wholeWord: false };
+
+describe("findHitsInText", () => {
+  test("matches Arabic orthographic variants (teh marbuta)", () => {
+    const result = findHitsInText("عقد خدمة موقع", "خدمه", OPTIONS);
+    expect(result.totalHits).toBe(1);
+  });
+
+  test("folds Arabic-Indic digits but slices snippet from original text", () => {
+    const result = findHitsInText("القيمة ٢٠٢٤ مهمة", "2024", OPTIONS);
+    expect(result.totalHits).toBe(1);
+    // The snippet preserves the original digits, not the folded "2024".
+    expect(result.hits.at(0)?.snippet).toContain("٢٠٢٤");
+  });
+
+  test("returns no hits when the query folds to empty", () => {
+    const result = findHitsInText("نص عربي", "ـ", OPTIONS);
+    expect(result.totalHits).toBe(0);
+    expect(result.hits).toHaveLength(0);
+  });
+
+  test("still matches plain ASCII content", () => {
+    const result = findHitsInText("hello world", "WORLD", OPTIONS);
+    expect(result.totalHits).toBe(1);
+    expect(result.hits.at(0)?.snippet).toContain("world");
+  });
+});

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
@@ -17,6 +17,16 @@ describe("findHitsInText", () => {
     expect(result.hits.at(0)?.snippet).toContain("٢٠٢٤");
   });
 
+  test("bounds snippets by the matched source characters", () => {
+    const result = findHitsInText(`م${"ـ".repeat(300)}نهاية`, "م", {
+      ...OPTIONS,
+      limit: 1,
+    });
+
+    expect(result.totalHits).toBe(1);
+    expect(result.hits.at(0)?.snippet.length).toBeLessThan(250);
+  });
+
   test("returns no hits when the query folds to empty", () => {
     const result = findHitsInText("نص عربي", "ـ", OPTIONS);
     expect(result.totalHits).toBe(0);

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
@@ -27,6 +27,12 @@ describe("findHitsInText", () => {
     expect(result.hits.at(0)?.snippet.length).toBeLessThan(250);
   });
 
+  test("matches decomposed Arabic hamza forms", () => {
+    const result = findHitsInText("أحمد", "احمد", OPTIONS);
+    expect(result.totalHits).toBe(1);
+    expect(result.hits.at(0)?.snippet).toBe("أحمد");
+  });
+
   test("returns no hits when the query folds to empty", () => {
     const result = findHitsInText("نص عربي", "ـ", OPTIONS);
     expect(result.totalHits).toBe(0);

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
@@ -70,7 +70,7 @@ export const findHitsInText = (
   // Match against the Arabic-folded text so a query matches regardless of
   // orthographic variant; snippets are sliced from the original via the
   // offset map so the model reads the text as written.
-  const foldedQuery = applyArabicFolds(query);
+  const foldedQuery = applyArabicFolds(query.normalize("NFKC"));
   if (foldedQuery.length === 0) {
     return { hits: [], totalHits: 0, totalHitsCapped: false, truncated: false };
   }

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
@@ -1,6 +1,11 @@
 import { panic, Result } from "better-result";
 import { and, count, inArray } from "drizzle-orm";
 
+import {
+  applyArabicFolds,
+  applyArabicFoldsWithOffsets,
+} from "@stll/text-normalize";
+
 import type { SafeDb } from "@/api/db";
 import { entityVersions } from "@/api/db/schema";
 import { buildChatSourceDocument } from "@/api/handlers/chat/tools/chat-source-document";
@@ -57,13 +62,22 @@ type SearchResult = {
   truncated: boolean;
 };
 
-const findHitsInText = (
+export const findHitsInText = (
   text: string,
   query: string,
   options: { caseSensitive: boolean; limit: number; wholeWord: boolean },
 ): SearchResult => {
+  // Match against the Arabic-folded text so a query matches regardless of
+  // orthographic variant; snippets are sliced from the original via the
+  // offset map so the model reads the text as written.
+  const foldedQuery = applyArabicFolds(query);
+  if (foldedQuery.length === 0) {
+    return { hits: [], totalHits: 0, totalHitsCapped: false, truncated: false };
+  }
+  const { text: foldedText, sourceIndex } = applyArabicFoldsWithOffsets(text);
+
   const flags = options.caseSensitive ? "g" : "gi";
-  const escaped = escapeRegExp(query);
+  const escaped = escapeRegExp(foldedQuery);
   const pattern = options.wholeWord
     ? `(?:^|[^\\p{L}\\p{N}])(${escaped})(?=$|[^\\p{L}\\p{N}])`
     : `(${escaped})`;
@@ -75,21 +89,25 @@ const findHitsInText = (
   let totalHits = 0;
   let totalHitsCapped = false;
   let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) {
+  while ((match = re.exec(foldedText)) !== null) {
     // Capture group 1 always exists because the pattern wraps the
     // escaped query in `(...)`. Narrowing here keeps the helper
     // self-contained without a runtime branch.
     const captured = match[1] ?? panic("search match missing capture group");
     totalHits++;
     if (hits.length < options.limit) {
-      // Anchor the snippet window around the start of the captured
-      // substring (not `match.index`, which for whole-word matches
-      // includes the leading non-letter/non-digit boundary char).
-      const hitStart = match.index + (match[0].length - captured.length);
+      // Anchor on the start of the captured substring (not `match.index`,
+      // which for whole-word matches includes the leading boundary char),
+      // then map the folded span back to original code-unit offsets so the
+      // snippet is sliced from the unmodified source text.
+      const foldedHitStart = match.index + (match[0].length - captured.length);
+      const hitStart = sourceIndex[foldedHitStart] ?? 0;
+      const hitEnd =
+        sourceIndex[foldedHitStart + captured.length] ?? text.length;
       const snippetStart = Math.max(0, hitStart - SEARCH_SNIPPET_CONTEXT_CHARS);
       const snippetEnd = Math.min(
         text.length,
-        hitStart + captured.length + SEARCH_SNIPPET_CONTEXT_CHARS,
+        hitEnd + SEARCH_SNIPPET_CONTEXT_CHARS,
       );
       hits.push({
         snippet: text.slice(snippetStart, snippetEnd),

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
@@ -51,8 +51,7 @@ const SEARCH_MAX_HITS_SCANNED = 100;
  * a regex pattern, so any regex metacharacter is neutralised.
  */
 const escapeRegExp = (value: string): string =>
-  // eslint-disable-next-line require-unicode-regexp -- u flag rejected by @valibot/to-json-schema elsewhere; keeping policy consistent here.
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  value.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
 type SearchHit = { snippet: string };
 type SearchResult = {
@@ -74,7 +73,11 @@ export const findHitsInText = (
   if (foldedQuery.length === 0) {
     return { hits: [], totalHits: 0, totalHitsCapped: false, truncated: false };
   }
-  const { text: foldedText, sourceIndex } = applyArabicFoldsWithOffsets(text);
+  const {
+    sourceEndIndex,
+    text: foldedText,
+    sourceIndex,
+  } = applyArabicFoldsWithOffsets(text);
 
   const flags = options.caseSensitive ? "g" : "gi";
   const escaped = escapeRegExp(foldedQuery);
@@ -101,9 +104,9 @@ export const findHitsInText = (
       // then map the folded span back to original code-unit offsets so the
       // snippet is sliced from the unmodified source text.
       const foldedHitStart = match.index + (match[0].length - captured.length);
+      const foldedHitEnd = foldedHitStart + captured.length;
       const hitStart = sourceIndex[foldedHitStart] ?? 0;
-      const hitEnd =
-        sourceIndex[foldedHitStart + captured.length] ?? text.length;
+      const hitEnd = sourceEndIndex[foldedHitEnd - 1] ?? text.length;
       const snippetStart = Math.max(0, hitStart - SEARCH_SNIPPET_CONTEXT_CHARS);
       const snippetEnd = Math.min(
         text.length,

--- a/apps/api/src/lib/db/arabic-normalize.test.ts
+++ b/apps/api/src/lib/db/arabic-normalize.test.ts
@@ -8,10 +8,17 @@ import { normalizeSearchText } from "@stll/text-normalize";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
 
-const MIGRATION_PATH = nodePath.resolve(
+const INITIAL_ARABIC_NORMALIZE_MIGRATION_PATH = nodePath.resolve(
   import.meta.dir,
   "../../../drizzle/20260629123000_arabic_normalize_function/migration.sql",
 );
+const ARABIC_NORMALIZE_MIGRATION_PATHS = [
+  INITIAL_ARABIC_NORMALIZE_MIGRATION_PATH,
+  nodePath.resolve(
+    import.meta.dir,
+    "../../../drizzle/20260630100000_arabic_normalize_combining_marks/migration.sql",
+  ),
+];
 
 // The shared search-key contract: the SQL arabic_normalize() must produce
 // the same match key as the TS normalizeSearchText for every input. The
@@ -40,20 +47,24 @@ const VECTORS: readonly string[] = [
   "a\u2007b\u3000c",
   "ﷲ", // U+FDF2 ligature -> الله via NFKC
   "ﺍﺣﻤﺪ", // presentation forms -> احمد via NFKC
+  "أحمد", // decomposed alef + hamza above -> احمد
+  "حٔمد", // uncomposed hamza mark is removed
 ];
 
 let testDb: TestDatabase;
 
 beforeAll(async () => {
   testDb = await getTestDb();
-  const migrationSql = readFileSync(MIGRATION_PATH, "utf-8");
-  for (const statement of migrationSql.split("--> statement-breakpoint")) {
-    const trimmed = statement.trim();
-    if (trimmed.length === 0 || !isPortableFunctionStatement(trimmed)) {
-      continue;
+  for (const migrationPath of ARABIC_NORMALIZE_MIGRATION_PATHS) {
+    const migrationSql = readFileSync(migrationPath, "utf-8");
+    for (const statement of migrationSql.split("--> statement-breakpoint")) {
+      const trimmed = statement.trim();
+      if (trimmed.length === 0 || !isPortableFunctionStatement(trimmed)) {
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- ordered DDL on one connection
+      await testDb.execute(sql.raw(trimmed));
     }
-    // oxlint-disable-next-line no-await-in-loop -- ordered DDL on one connection
-    await testDb.execute(sql.raw(trimmed));
   }
 });
 
@@ -73,7 +84,10 @@ describe("arabic_normalize SQL function", () => {
   });
 
   test("keeps concurrent index creation retry-safe", () => {
-    const migrationSql = readFileSync(MIGRATION_PATH, "utf-8");
+    const migrationSql = readFileSync(
+      INITIAL_ARABIC_NORMALIZE_MIGRATION_PATH,
+      "utf-8",
+    );
     const indexNames = [
       "contacts_display_name_arabic_norm_trgm_idx",
       "contacts_first_name_arabic_norm_trgm_idx",

--- a/apps/api/src/tests/pglite-schema.ts
+++ b/apps/api/src/tests/pglite-schema.ts
@@ -2,13 +2,10 @@ import { PGlite } from "@electric-sql/pglite";
 import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
 import { panic } from "better-result";
 import { sql, type SQL } from "drizzle-orm";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import nodePath from "node:path";
 
-const ARABIC_NORMALIZE_MIGRATION_PATH = nodePath.resolve(
-  import.meta.dir,
-  "../../drizzle/20260629123000_arabic_normalize_function/migration.sql",
-);
+const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../drizzle");
 
 type PgliteSchemaDb = {
   execute: (query: SQL) => Promise<unknown>;
@@ -25,13 +22,24 @@ export const installPgliteSchemaPrerequisites = async (
 };
 
 const arabicNormalizeFunctionSql = (): string => {
-  const migrationSql = readFileSync(ARABIC_NORMALIZE_MIGRATION_PATH, "utf-8");
-  const statement = migrationSql
-    .split("--> statement-breakpoint")
-    .map((part) => part.trim())
-    .find((part) =>
-      part.includes("CREATE OR REPLACE FUNCTION arabic_normalize"),
-    );
+  const statements = readdirSync(DRIZZLE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+    .flatMap((dirName) => {
+      const migrationSql = readFileSync(
+        nodePath.join(DRIZZLE_DIR, dirName, "migration.sql"),
+        "utf-8",
+      );
+      return migrationSql
+        .split("--> statement-breakpoint")
+        .map((part) => part.trim())
+        .filter((part) =>
+          part.includes("CREATE OR REPLACE FUNCTION arabic_normalize"),
+        );
+    });
+
+  const statement = statements.at(-1);
 
   if (!statement) {
     panic("arabic_normalize function migration statement not found");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
     "@stll/money": "workspace:*",
     "@stll/permissions": "workspace:*",
     "@stll/template-conditions": "workspace:*",
+    "@stll/text-normalize": "workspace:*",
     "@stll/ui": "workspace:*",
     "@streamdown/cjk": "^1.0.2",
     "@streamdown/math": "^1.0.2",

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.test.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.test.ts
@@ -64,6 +64,18 @@ describe("buildSearchResults", () => {
     expect(result.matchCount).toBe(1);
   });
 
+  it("folds decomposed Arabic hamza marks copied from OCR", () => {
+    const result = buildSearchResults({
+      pieces: [{ id: "p1", text: "أحمد" }],
+      query: "احمد",
+    });
+
+    expect(result.matchCount).toBe(1);
+    expect(result.rangesByPieceId["p1"]).toEqual([
+      { start: 0, end: 5, matchIndex: 0 },
+    ]);
+  });
+
   it("folds Arabic alef-hamza and teh-marbuta variants", () => {
     const result = buildSearchResults({
       pieces: [{ id: "p1", text: "خدمة أحمد" }],

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.test.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.test.ts
@@ -55,6 +55,30 @@ describe("buildSearchResults", () => {
     ]);
   });
 
+  it("folds Arabic alef-hamza and teh-marbuta variants", () => {
+    const result = buildSearchResults({
+      pieces: [{ id: "p1", text: "خدمة أحمد" }],
+      query: "خدمه احمد",
+    });
+
+    expect(result.matchCount).toBe(1);
+    expect(result.rangesByPieceId["p1"]).toEqual([
+      { start: 0, end: 9, matchIndex: 0 },
+    ]);
+  });
+
+  it("ignores Arabic tatweel and folds Arabic-Indic digits", () => {
+    const result = buildSearchResults({
+      pieces: [{ id: "p1", text: "رقم ٢٠٢٤" }],
+      query: "2024",
+    });
+
+    expect(result.matchCount).toBe(1);
+    expect(result.rangesByPieceId["p1"]).toEqual([
+      { start: 4, end: 8, matchIndex: 0 },
+    ]);
+  });
+
   it("locates matches after astral-plane characters", () => {
     // U+10348 (Gothic letter hwair, "𐍈") is a non-BMP letter
     // encoded as a UTF-16 surrogate pair. `String.indexOf`

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.test.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.test.ts
@@ -55,6 +55,15 @@ describe("buildSearchResults", () => {
     ]);
   });
 
+  it("folds Arabic presentation forms copied from a PDF", () => {
+    const result = buildSearchResults({
+      pieces: [{ id: "p1", text: "ﺍﺣﻤﺪ" }],
+      query: "احمد",
+    });
+
+    expect(result.matchCount).toBe(1);
+  });
+
   it("folds Arabic alef-hamza and teh-marbuta variants", () => {
     const result = buildSearchResults({
       pieces: [{ id: "p1", text: "خدمة أحمد" }],

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
@@ -77,11 +77,11 @@ const normalizeSearchText = (text: string): NormalizedText => {
   };
 
   for (const rawChar of text) {
-    // Fold Arabic variants on the composed char first (alef/hamza,
-    // teh-marbuta, alef-maksura, tatweel, Arabic-Indic digits) — NFD would
-    // otherwise split a composed alef-hamza before the fold can see it —
-    // then strip remaining Latin/Arabic combining diacritics via NFD.
-    const normalizedChar = applyArabicFolds(rawChar)
+    // NFKC folds presentation forms to canonical letters; applyArabicFolds
+    // then folds Arabic variants (before NFD, so a composed alef-hamza is
+    // not split first); NFD + mark removal strips remaining Latin/Arabic
+    // combining diacritics.
+    const normalizedChar = applyArabicFolds(rawChar.normalize("NFKC"))
       .normalize("NFD")
       .replace(DIACRITIC_RE, "");
     const origStart = originalIndex;

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
@@ -1,3 +1,5 @@
+import { applyArabicFolds } from "@stll/text-normalize";
+
 export type SearchPiece = {
   id: string;
   text: string;
@@ -75,7 +77,13 @@ const normalizeSearchText = (text: string): NormalizedText => {
   };
 
   for (const rawChar of text) {
-    const normalizedChar = rawChar.normalize("NFD").replace(DIACRITIC_RE, "");
+    // Fold Arabic variants on the composed char first (alef/hamza,
+    // teh-marbuta, alef-maksura, tatweel, Arabic-Indic digits) — NFD would
+    // otherwise split a composed alef-hamza before the fold can see it —
+    // then strip remaining Latin/Arabic combining diacritics via NFD.
+    const normalizedChar = applyArabicFolds(rawChar)
+      .normalize("NFD")
+      .replace(DIACRITIC_RE, "");
     const origStart = originalIndex;
     const origEnd = originalIndex + rawChar.length;
 

--- a/bun.lock
+++ b/bun.lock
@@ -245,6 +245,7 @@
         "@stll/money": "workspace:*",
         "@stll/permissions": "workspace:*",
         "@stll/template-conditions": "workspace:*",
+        "@stll/text-normalize": "workspace:*",
         "@stll/ui": "workspace:*",
         "@streamdown/cjk": "^1.0.2",
         "@streamdown/math": "^1.0.2",

--- a/packages/text-normalize/package.json
+++ b/packages/text-normalize/package.json
@@ -33,6 +33,7 @@
     ".": {
       "types": "./src/index.ts",
       "bun": "./src/index.ts",
+      "module": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/text-normalize/src/arabic.test.ts
+++ b/packages/text-normalize/src/arabic.test.ts
@@ -4,16 +4,20 @@ import { applyArabicFolds, applyArabicFoldsWithOffsets } from "./arabic.js";
 
 describe("applyArabicFoldsWithOffsets", () => {
   test("folds 1:1 and maps each unit to its source", () => {
-    const { text, sourceIndex } = applyArabicFoldsWithOffsets("أحمد");
+    const { sourceEndIndex, text, sourceIndex } =
+      applyArabicFoldsWithOffsets("أحمد");
     expect(text).toBe("احمد");
     expect(sourceIndex).toEqual([0, 1, 2, 3, 4]);
+    expect(sourceEndIndex).toEqual([1, 2, 3, 4, 4]);
   });
 
   test("drops removed chars; offsets point at the surviving sources", () => {
     // م(0) ـ(1) ح(2) ـ(3) م(4) ـ(5) د(6) -> محمد
-    const { text, sourceIndex } = applyArabicFoldsWithOffsets("مـحـمـد");
+    const { sourceEndIndex, text, sourceIndex } =
+      applyArabicFoldsWithOffsets("مـحـمـد");
     expect(text).toBe("محمد");
     expect(sourceIndex).toEqual([0, 2, 4, 6, 7]);
+    expect(sourceEndIndex).toEqual([1, 3, 5, 7, 7]);
   });
 
   test("maps Arabic-Indic digits", () => {
@@ -43,19 +47,22 @@ describe("applyArabicFoldsWithOffsets", () => {
 
   test("expands a ligature and maps every unit to its source char", () => {
     // ﷲ (U+FDF2) is one code unit; NFKC expands it to الله (4 units).
-    const { text, sourceIndex } = applyArabicFoldsWithOffsets("ﷲ");
+    const { sourceEndIndex, text, sourceIndex } =
+      applyArabicFoldsWithOffsets("ﷲ");
     expect(text).toBe("الله");
     expect(sourceIndex).toEqual([0, 0, 0, 0, 1]);
+    expect(sourceEndIndex).toEqual([1, 1, 1, 1, 1]);
   });
 
   test("a folded match maps back to the original substring", () => {
     const original = "رقم ٢٠٢٤ نهائي";
-    const { text, sourceIndex } = applyArabicFoldsWithOffsets(original);
+    const { sourceEndIndex, text, sourceIndex } =
+      applyArabicFoldsWithOffsets(original);
     const foldedStart = text.indexOf("2024");
     const foldedEnd = foldedStart + "2024".length;
     const origSlice = original.slice(
       sourceIndex[foldedStart],
-      sourceIndex[foldedEnd],
+      sourceEndIndex[foldedEnd - 1],
     );
     expect(origSlice).toBe("٢٠٢٤");
   });

--- a/packages/text-normalize/src/arabic.test.ts
+++ b/packages/text-normalize/src/arabic.test.ts
@@ -37,6 +37,17 @@ describe("applyArabicFoldsWithOffsets", () => {
     }
   });
 
+  test("NFKC-folds Arabic presentation forms", () => {
+    expect(applyArabicFoldsWithOffsets("ﺍﺣﻤﺪ").text).toBe("احمد");
+  });
+
+  test("expands a ligature and maps every unit to its source char", () => {
+    // ﷲ (U+FDF2) is one code unit; NFKC expands it to الله (4 units).
+    const { text, sourceIndex } = applyArabicFoldsWithOffsets("ﷲ");
+    expect(text).toBe("الله");
+    expect(sourceIndex).toEqual([0, 0, 0, 0, 1]);
+  });
+
   test("a folded match maps back to the original substring", () => {
     const original = "رقم ٢٠٢٤ نهائي";
     const { text, sourceIndex } = applyArabicFoldsWithOffsets(original);

--- a/packages/text-normalize/src/arabic.test.ts
+++ b/packages/text-normalize/src/arabic.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import { applyArabicFolds, applyArabicFoldsWithOffsets } from "./arabic.js";
+
+describe("applyArabicFoldsWithOffsets", () => {
+  test("folds 1:1 and maps each unit to its source", () => {
+    const { text, sourceIndex } = applyArabicFoldsWithOffsets("أحمد");
+    expect(text).toBe("احمد");
+    expect(sourceIndex).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("drops removed chars; offsets point at the surviving sources", () => {
+    // م(0) ـ(1) ح(2) ـ(3) م(4) ـ(5) د(6) -> محمد
+    const { text, sourceIndex } = applyArabicFoldsWithOffsets("مـحـمـد");
+    expect(text).toBe("محمد");
+    expect(sourceIndex).toEqual([0, 2, 4, 6, 7]);
+  });
+
+  test("maps Arabic-Indic digits", () => {
+    const { text, sourceIndex } = applyArabicFoldsWithOffsets("٢٠٢٤");
+    expect(text).toBe("2024");
+    expect(sourceIndex).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("preserves astral characters spanning two code units", () => {
+    // 𐍈 (U+10348) is a surrogate pair (2 units); ا is one unit.
+    const { text, sourceIndex } = applyArabicFoldsWithOffsets("𐍈ا");
+    expect(text).toBe("𐍈ا");
+    expect(sourceIndex).toEqual([0, 0, 2, 3]);
+  });
+
+  test("folded text equals applyArabicFolds", () => {
+    for (const input of ["أحمد", "مـحـمـد", "٢٠٢٤", "خدمة", "Hello"]) {
+      expect(applyArabicFoldsWithOffsets(input).text).toBe(
+        applyArabicFolds(input),
+      );
+    }
+  });
+
+  test("a folded match maps back to the original substring", () => {
+    const original = "رقم ٢٠٢٤ نهائي";
+    const { text, sourceIndex } = applyArabicFoldsWithOffsets(original);
+    const foldedStart = text.indexOf("2024");
+    const foldedEnd = foldedStart + "2024".length;
+    const origSlice = original.slice(
+      sourceIndex[foldedStart],
+      sourceIndex[foldedEnd],
+    );
+    expect(origSlice).toBe("٢٠٢٤");
+  });
+});

--- a/packages/text-normalize/src/arabic.test.ts
+++ b/packages/text-normalize/src/arabic.test.ts
@@ -45,6 +45,14 @@ describe("applyArabicFoldsWithOffsets", () => {
     expect(applyArabicFoldsWithOffsets("ﺍﺣﻤﺪ").text).toBe("احمد");
   });
 
+  test("drops decomposed Arabic hamza marks while preserving surrounding offsets", () => {
+    const { sourceEndIndex, text, sourceIndex } =
+      applyArabicFoldsWithOffsets("أحمد");
+    expect(text).toBe("احمد");
+    expect(sourceIndex).toEqual([0, 2, 3, 4, 5]);
+    expect(sourceEndIndex).toEqual([1, 3, 4, 5, 5]);
+  });
+
   test("expands a ligature and maps every unit to its source char", () => {
     // ﷲ (U+FDF2) is one code unit; NFKC expands it to الله (4 units).
     const { sourceEndIndex, text, sourceIndex } =

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -87,3 +87,37 @@ export const applyArabicFolds = (text: string): string => {
   }
   return out.join("");
 };
+
+export type FoldedText = {
+  text: string;
+  // For each UTF-16 code-unit index `i` in `text`, the code-unit index in
+  // the original input where that unit's source character began.
+  // `sourceIndex[text.length]` is the original length (end sentinel), so a
+  // match's [start, end) in folded space maps back to original offsets.
+  sourceIndex: number[];
+};
+
+/**
+ * Like applyArabicFolds, but also returns an offset map so callers that
+ * match against the folded text (e.g. find-in-page) can slice the original
+ * text at the right positions.
+ */
+export const applyArabicFoldsWithOffsets = (input: string): FoldedText => {
+  const parts: string[] = [];
+  const sourceIndex: number[] = [];
+  let originalUnit = 0;
+  for (const char of input) {
+    const replacement = FOLD_MAP.get(char) ?? char;
+    parts.push(replacement);
+    // One offset entry per UTF-16 code unit of the replacement; folds are
+    // BMP, but an unfolded astral passthrough spans two code units.
+    let unit = 0;
+    while (unit < replacement.length) {
+      sourceIndex.push(originalUnit);
+      unit += 1;
+    }
+    originalUnit += char.length;
+  }
+  sourceIndex.push(originalUnit);
+  return { text: parts.join(""), sourceIndex };
+};

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -24,7 +24,8 @@ export const ARABIC_LETTER_FOLDS: Readonly<Record<string, string>> = {
 };
 
 // Codepoints folded to nothing (removed). Tatweel, the eight harakat
-// (U+064B–U+0652), superscript alef, and standalone hamza.
+// (U+064B–U+0652), decomposed hamza/madda marks, superscript alef, and
+// standalone hamza.
 export const ARABIC_REMOVED: readonly string[] = [
   "ء", // ء standalone hamza
   "ـ", // ـ tatweel / kashida
@@ -36,6 +37,9 @@ export const ARABIC_REMOVED: readonly string[] = [
   "ِ", // kasra
   "ّ", // shadda
   "ْ", // sukun
+  "ٓ", // madda above
+  "ٔ", // hamza above
+  "ٕ", // hamza below
   "ٰ", // superscript alef
 ];
 

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -89,6 +89,9 @@ export const applyArabicFolds = (text: string): string => {
 };
 
 export type FoldedText = {
+  // For each UTF-16 code-unit index `i` in `text`, the code-unit index in
+  // the original input immediately after that unit's source character.
+  sourceEndIndex: number[];
   text: string;
   // For each UTF-16 code-unit index `i` in `text`, the code-unit index in
   // the original input where that unit's source character began.
@@ -104,20 +107,24 @@ export type FoldedText = {
  */
 export const applyArabicFoldsWithOffsets = (input: string): FoldedText => {
   const parts: string[] = [];
+  const sourceEndIndex: number[] = [];
   const sourceIndex: number[] = [];
   let originalUnit = 0;
   for (const char of input) {
     const replacement = applyArabicFolds(char.normalize("NFKC"));
+    const originalEnd = originalUnit + char.length;
     parts.push(replacement);
     // One offset entry per UTF-16 code unit of the replacement; folds are
     // BMP, but an unfolded astral passthrough spans two code units.
     let unit = 0;
     while (unit < replacement.length) {
       sourceIndex.push(originalUnit);
+      sourceEndIndex.push(originalEnd);
       unit += 1;
     }
-    originalUnit += char.length;
+    originalUnit = originalEnd;
   }
   sourceIndex.push(originalUnit);
-  return { text: parts.join(""), sourceIndex };
+  sourceEndIndex.push(originalUnit);
+  return { sourceEndIndex, text: parts.join(""), sourceIndex };
 };

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -107,7 +107,7 @@ export const applyArabicFoldsWithOffsets = (input: string): FoldedText => {
   const sourceIndex: number[] = [];
   let originalUnit = 0;
   for (const char of input) {
-    const replacement = FOLD_MAP.get(char) ?? char;
+    const replacement = applyArabicFolds(char.normalize("NFKC"));
     parts.push(replacement);
     // One offset entry per UTF-16 code unit of the replacement; folds are
     // BMP, but an unfolded astral passthrough spans two code units.

--- a/packages/text-normalize/src/index.ts
+++ b/packages/text-normalize/src/index.ts
@@ -1,7 +1,9 @@
 export {
   applyArabicFolds,
+  applyArabicFoldsWithOffsets,
   ARABIC_DIGIT_FOLDS,
   ARABIC_LETTER_FOLDS,
   ARABIC_REMOVED,
 } from "./arabic.js";
+export type { FoldedText } from "./arabic.js";
 export { normalizeSearchText } from "./normalize.js";

--- a/packages/text-normalize/src/normalize.test.ts
+++ b/packages/text-normalize/src/normalize.test.ts
@@ -12,6 +12,7 @@ const EQUIVALENCE_GROUPS: readonly (readonly string[])[] = [
   ["يكفى", "يكفي"], // alef maksura -> yeh
   ["مُحَمَّد", "محمد"], // tashkeel stripped
   ["مـحـمـد", "محمد"], // tatweel removed
+  ["أحمد", "احمد"], // decomposed hamza mark removed
   ["مؤمن", "مومن"], // waw hamza -> waw
   ["مسئول", "مسيول"], // yeh hamza -> yeh
   ["٢٠٢٤", "2024"], // Arabic-Indic digits
@@ -26,6 +27,8 @@ const GOLDEN: readonly (readonly [string, string])[] = [
   ["يكفى", "يكفي"],
   ["مُحَمَّد", "محمد"],
   ["مـحـمـد", "محمد"],
+  ["أحمد", "احمد"],
+  ["حٔمد", "حمد"],
   ["مؤمن", "مومن"],
   ["مسئول", "مسيول"],
   ["ء", ""], // standalone hamza dropped


### PR DESCRIPTION
Stacked on `feat/arabic-search-normalization` (base branch of this PR).

## What

Extends the Arabic fold tables to the two in-memory search surfaces that return match positions:

- **Case-law find-in-page** (`decision-search`) — folds variants inside the existing offset-preserving normalizer. Folding runs on the composed character *before* NFD, so a composed alef-hamza is not split into base + combining mark before the fold can see it.
- **Chat content search** (`findHitsInText`) — adds `applyArabicFoldsWithOffsets` to `@stll/text-normalize` so matches run against the folded text while snippets stay sliced from the original, unmodified source text.

## Why

Both surfaces match against rendered text and report character offsets, so the folding has to be applied without losing the mapping back to original positions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now handles Arabic text more accurately, including common letter variants, presentation forms, digits, and combining marks.
  * Search snippets and match highlighting are now more precise when Arabic characters are normalised.

* **Bug Fixes**
  * Improved search results for Arabic content across case law and workspace search.
  * Prevented empty search queries from returning misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->