### PR TITLE
feat(landing): show more releases per page on changelog

### DIFF
--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -306,7 +306,7 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
 
     type ReleaseKind = "major" | "minor" | "patch";
 
-    const RELEASES_PER_PAGE = 5;
+    const RELEASES_PER_PAGE = 12;
     const GITHUB_RELEASES_PER_PAGE = 100;
     const releasesApiBase = "https://api.github.com/repos/stella/stella/releases";
     const releasesEndpoint =


### PR DESCRIPTION
Bump `RELEASES_PER_PAGE` from 5 to 12 in the changelog page so the feed renders a longer list of releases before pagination. The fetch loop already pulls enough releases from the GitHub API to fill the larger page, and Previous/Next pagination is derived from the same constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The changelog now shows more release entries per page, making it easier to browse older updates without switching pages as often.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->