### PR TITLE
fix(consent): open jurisdiction setup link in a new tab

### DIFF
--- a/apps/web/src/routes/consent.tsx
+++ b/apps/web/src/routes/consent.tsx
@@ -235,6 +235,8 @@ function ConsentPage() {
               <Link
                 className="text-primary text-sm font-medium hover:underline"
                 to="/settings/organization/members"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 {t("consent.completeSetup")}
               </Link>


### PR DESCRIPTION
The OAuth consent screen's "Complete setup" link (shown when an org has no practice jurisdictions configured) used in-app navigation, so clicking it abandoned the in-progress authorization flow.

Open the link in a new tab (`target="_blank"` + `rel="noopener noreferrer"`) so users can configure practice jurisdictions and return to the consent screen to finish granting access.