### PR TITLE
fix(api): authorize permission macro locally instead of via better-auth

### DIFF
--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -8,8 +8,7 @@ import type {
 } from "elysia";
 import { status } from "elysia";
 
-import type { PermissionInput } from "@stll/permissions";
-import { roles } from "@stll/permissions";
+import type { PermissionInput, roles } from "@stll/permissions";
 
 import type { SafeDb, ScopedDb } from "@/api/db";
 import type { UsageActionType, UsageServiceTier } from "@/api/db/schema";
@@ -40,6 +39,7 @@ import {
 } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { getRequestContext } from "@/api/lib/observability/request-context";
+import { hasMemberPermission } from "@/api/lib/permission-authorization";
 import { assertUsageAvailable } from "@/api/lib/usage";
 import { computeUsageUnitCost } from "@/api/lib/usage/action-weights";
 
@@ -348,11 +348,7 @@ const createSafeScopedHandler = <
 ): SafeHandlerDefinition<TConfig, TContext, TResult> => ({
   config,
   handler: async (ctx): Promise<SafeHandlerResult<TResult>> => {
-    const hasPermission = roles[ctx.memberRole.role].authorize(
-      config.permissions,
-    );
-
-    if (!hasPermission.success) {
+    if (!hasMemberPermission(ctx.memberRole, config.permissions)) {
       return toSafeStatusResponse(403, { message: "Forbidden" });
     }
 

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -50,6 +50,10 @@ import { isMemberRole } from "@/api/lib/member-roles";
 import type { MemberRole } from "@/api/lib/member-roles";
 import { enrichRequestContext } from "@/api/lib/observability/request-context";
 import { parseUserAgent } from "@/api/lib/parse-user-agent";
+import {
+  hasMemberPermission,
+  readAuthorizedMemberRole,
+} from "@/api/lib/permission-authorization";
 import { createAuthRateLimitStorage } from "@/api/lib/rate-limit/auth-storage";
 import {
   getMcpResourceUrl,
@@ -807,27 +811,15 @@ export const authMacro = new Elysia({ name: "authMacro" }).macro({
 export const permissionMacro = new Elysia({ name: "permissionMacro" })
   .use(authMacro)
   .macro("permissions", (permissions: PermissionInput) => ({
-    // `validateAuth` resolves the caller's member role (once) before this hook
-    // runs, so the check below reads `ctx.memberRole` instead of a second
-    // session + membership round-trip via better-auth's `hasPermission`. That
-    // round-trip duplicated the authorization the safe-handler factories
-    // already perform; being unguarded, it also let a transient membership read
-    // surface as an uncaught 500 rather than the intended 403.
+    // Reuse authMacro's resolved member role instead of asking better-auth to
+    // perform the same permission check through a second session read.
     validateAuth: true,
     // Without this, when this macro is used with another macro that extends the body,
     // the final merged body would not include the first macro's body extension.
     body: t.Object({}),
     beforeHandle(ctx) {
-      // SAFETY: `validateAuth: true` runs authMacro's resolve before this hook,
-      // and that resolve returns 401 unless a member role is present, so
-      // `memberRole` always exists here at runtime. Elysia's parameterized
-      // macro form does not propagate authMacro's resolved fields into the
-      // hook's ctx type (the documented function-form inference gap), so read
-      // the role through a narrow typed view instead of the untyped ctx.
-      const { memberRole } = ctx as typeof ctx & {
-        memberRole: { role: keyof typeof roles };
-      };
-      if (!roles[memberRole.role].authorize(permissions).success) {
+      const memberRole = readAuthorizedMemberRole(ctx);
+      if (!memberRole || !hasMemberPermission(memberRole, permissions)) {
         return ctx.status(403);
       }
 

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -804,27 +804,36 @@ export const authMacro = new Elysia({ name: "authMacro" }).macro({
   },
 });
 
-export const permissionMacro = new Elysia({ name: "permissionMacro" }).macro({
-  permissions: (permissions: PermissionInput) => ({
+export const permissionMacro = new Elysia({ name: "permissionMacro" })
+  .use(authMacro)
+  .macro("permissions", (permissions: PermissionInput) => ({
+    // `validateAuth` resolves the caller's member role (once) before this hook
+    // runs, so the check below reads `ctx.memberRole` instead of a second
+    // session + membership round-trip via better-auth's `hasPermission`. That
+    // round-trip duplicated the authorization the safe-handler factories
+    // already perform; being unguarded, it also let a transient membership read
+    // surface as an uncaught 500 rather than the intended 403.
+    validateAuth: true,
     // Without this, when this macro is used with another macro that extends the body,
     // the final merged body would not include the first macro's body extension.
     body: t.Object({}),
-    async beforeHandle(ctx) {
-      const hasPermissions = await getAuth().api.hasPermission({
-        headers: ctx.request.headers,
-        body: {
-          permissions,
-        },
-      });
-
-      if (!hasPermissions.success) {
+    beforeHandle(ctx) {
+      // SAFETY: `validateAuth: true` runs authMacro's resolve before this hook,
+      // and that resolve returns 401 unless a member role is present, so
+      // `memberRole` always exists here at runtime. Elysia's parameterized
+      // macro form does not propagate authMacro's resolved fields into the
+      // hook's ctx type (the documented function-form inference gap), so read
+      // the role through a narrow typed view instead of the untyped ctx.
+      const { memberRole } = ctx as typeof ctx & {
+        memberRole: { role: keyof typeof roles };
+      };
+      if (!roles[memberRole.role].authorize(permissions).success) {
         return ctx.status(403);
       }
 
       return undefined;
     },
-  }),
-});
+  }));
 
 const bindWorkspaceRecorder = (
   ctx: {

--- a/apps/api/src/lib/permission-authorization.test.ts
+++ b/apps/api/src/lib/permission-authorization.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import Elysia from "elysia";
+
+import { permissionMacro } from "@/api/lib/auth";
+import {
+  hasMemberPermission,
+  readAuthorizedMemberRole,
+} from "@/api/lib/permission-authorization";
+
+describe("permission authorization", () => {
+  test("reads only known member roles from request context", () => {
+    const contextWithInheritedMemberRole: object = Object.create({
+      memberRole: { role: "owner" },
+    });
+    const memberRoleWithInheritedRole: object = Object.create({
+      role: "owner",
+    });
+
+    expect(readAuthorizedMemberRole({ memberRole: { role: "owner" } })).toEqual(
+      { role: "owner" },
+    );
+    expect(readAuthorizedMemberRole({})).toBeNull();
+    expect(readAuthorizedMemberRole({ memberRole: null })).toBeNull();
+    expect(readAuthorizedMemberRole(contextWithInheritedMemberRole)).toBeNull();
+    expect(
+      readAuthorizedMemberRole({ memberRole: memberRoleWithInheritedRole }),
+    ).toBeNull();
+    expect(
+      readAuthorizedMemberRole({ memberRole: { role: "custom" } }),
+    ).toBeNull();
+    expect(
+      readAuthorizedMemberRole({ memberRole: { role: "constructor" } }),
+    ).toBeNull();
+  });
+
+  test("authorizes from the local role map", () => {
+    expect(
+      hasMemberPermission({ role: "owner" }, { organization: ["delete"] }),
+    ).toBe(true);
+    expect(
+      hasMemberPermission({ role: "member" }, { organization: ["delete"] }),
+    ).toBe(false);
+    expect(
+      hasMemberPermission({ role: "external" }, { workspace: ["read"] }),
+    ).toBe(true);
+  });
+
+  test("permission macro authenticates before checking permissions", async () => {
+    const app = new Elysia()
+      .use(permissionMacro)
+      .get("/protected", () => ({ ok: true }), {
+        permissions: { workspace: ["read"] },
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/protected"),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/api/src/lib/permission-authorization.ts
+++ b/apps/api/src/lib/permission-authorization.ts
@@ -1,0 +1,52 @@
+import type { PermissionInput } from "@stll/permissions";
+import { roles } from "@stll/permissions";
+
+import { isMemberRole } from "@/api/lib/member-roles";
+import type { MemberRole } from "@/api/lib/member-roles";
+
+export type AuthorizedMemberRole = {
+  role: MemberRole;
+};
+
+type MemberRoleContext = {
+  memberRole: unknown;
+};
+
+type RoleContainer = {
+  role: unknown;
+};
+
+const hasOwnMemberRole = (ctx: object): ctx is MemberRoleContext =>
+  Object.hasOwn(ctx, "memberRole");
+
+const hasOwnRole = (memberRole: object): memberRole is RoleContainer =>
+  Object.hasOwn(memberRole, "role");
+
+export const readAuthorizedMemberRole = (
+  ctx: object,
+): AuthorizedMemberRole | null => {
+  if (!hasOwnMemberRole(ctx)) {
+    return null;
+  }
+
+  const { memberRole } = ctx;
+  if (
+    typeof memberRole !== "object" ||
+    memberRole === null ||
+    !hasOwnRole(memberRole)
+  ) {
+    return null;
+  }
+
+  const { role } = memberRole;
+  if (typeof role !== "string" || !isMemberRole(role)) {
+    return null;
+  }
+
+  return { role };
+};
+
+export const hasMemberPermission = (
+  memberRole: AuthorizedMemberRole,
+  permissions: PermissionInput,
+): boolean => roles[memberRole.role].authorize(permissions).success;


### PR DESCRIPTION
## Problem

Every authenticated request to a permission-gated route resolved the caller's membership **twice**:

- `authMacro` resolves the session, looks up the member row `(userId, activeOrganizationId)`, and puts the **member role** into the request context (returning `401` when the user is not a member).
- `permissionMacro.beforeHandle` then called better-auth's `getAuth().api.hasPermission(...)`, which independently re-resolves the session and re-reads the same membership row before checking the role.

That second resolution is redundant: the safe-handler factories (`createSafeHandler` / `createSafeRootHandler`) already re-check the same permission locally via `roles[memberRole.role].authorize(config.permissions)` using the role `authMacro` resolved. So the better-auth round-trip added a duplicate session + membership read per request and nothing else.

It also had a sharp edge. better-auth's `hasPermission` throws `USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION` (a `401`) when its membership read comes back empty, and `beforeHandle` did not catch it. An uncaught throw in an Elysia hook bubbles to the top-level `onError`, which maps any non-Elysia error to a generic **HTTP 500** (`elysia_code: UNKNOWN`). The result: a transient membership read could surface to the client as an internal-server-error rather than the intended auth response, and because the two resolutions are independent they could disagree within a single request.

## Change

Authorize from the member role `authMacro` already resolved, instead of calling better-auth again:

```ts
export const permissionMacro = new Elysia({ name: "permissionMacro" })
  .use(authMacro)
  .macro("permissions", (permissions: PermissionInput) => ({
    validateAuth: true,
    body: t.Object({}),
    beforeHandle(ctx) {
      // memberRole is resolved by authMacro (validateAuth) before this hook runs
      if (!roles[memberRole.role].authorize(permissions).success) {
        return ctx.status(403);
      }
      return undefined;
    },
  }));
```

- Removes the redundant second session + membership lookup, roughly halving per-request auth DB work on gated routes.
- Makes `authMacro`'s single resolution the sole source of truth, so two independent reads can no longer disagree mid-request.
- No uncaught throw path: a member lacking the grant gets a clean `403`; a non-member still gets `401` from `authMacro` upstream.

## Safety

The trust basis is unchanged. `permissions` is the route's static config (never client-supplied), and `memberRole.role` is derived entirely server-side from the validated session and a `member`-table read — the same identity basis better-auth's `hasPermission` used. Membership enforcement is preserved (it moves one layer earlier, into `authMacro`), and the safe handlers still independently re-check the permission, so the in-handler authorization remains as a second layer. The flow is fail-closed: an absent or unrecognised role is rejected with `401`/`403`, never allowed.

## Notes

- `validateAuth: true` inside the macro guarantees `authMacro` runs first, so `memberRole` is present at runtime.
- The narrow `as` view on `ctx` is needed because Elysia's parameterized (function-form) macros don't propagate resolved context fields into the hook's `ctx` type; the value is guaranteed at runtime by `validateAuth`, documented with a `// SAFETY:` comment.

Typecheck and type-aware lint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks for restricted actions, making access decisions faster and more consistent.
  * Requests now authorise using the already-resolved authentication context, reducing delay and unexpected failures.
  * Users without access continue to receive a clear 403 “Forbidden” response.
* **Tests**
  * Added automated coverage for permission authorisation, including validation of authorised member roles and correct permission outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->