### PR TITLE
fix(chat): suppress follow-up suggestions while the ask-user card is live

### DIFF
--- a/apps/web/src/components/chat/ask-user-card.tsx
+++ b/apps/web/src/components/chat/ask-user-card.tsx
@@ -24,6 +24,7 @@ import type {
 } from "@/components/chat/chat-ui-tools";
 import { EntityLink } from "@/components/chat/entity-link";
 import { rehypeAnonSpans } from "@/components/chat/rehype-anon-spans";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 
 type AskUserPart = ToolUIPart<Pick<ChatUITools, "ask-user">>;
 
@@ -41,6 +42,14 @@ type AskUserCardProps = {
    */
   onEditAndRerun?:
     | ((toolCallId: string, output: AskUserOutput) => void | Promise<void>)
+    | undefined;
+  /**
+   * Reports the card's local edit-mode lifecycle to the parent so it can
+   * treat a reopened-for-editing card like a live clarification (e.g. hide
+   * competing follow-up suggestions). Reports `false` on unmount.
+   */
+  onEditingChange?:
+    | ((toolCallId: string, isEditing: boolean) => void)
     | undefined;
   discardsDownstream?: boolean | undefined;
   workspaceId?: string | undefined;
@@ -128,6 +137,7 @@ export const AskUserCard = ({
   part,
   onSubmit,
   onEditAndRerun,
+  onEditingChange,
   discardsDownstream,
   workspaceId,
   restorationPairs,
@@ -206,6 +216,13 @@ export const AskUserCard = ({
   const canRerun = onEditAndRerun !== undefined;
   const isAnswered = answeredOutput !== null || submitted;
   const isDone = isAnswered && !isEditing;
+
+  // Mirror local edit-mode to the parent: a reopened answered card is a live
+  // clarification again, so the parent can suppress competing affordances.
+  useExternalSyncEffect(() => {
+    onEditingChange?.(part.toolCallId, isEditing);
+    return () => onEditingChange?.(part.toolCallId, false);
+  }, [isEditing, onEditingChange, part.toolCallId]);
 
   const setAnswer = useCallback(
     (idx: number, value: string) =>

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -67,6 +67,7 @@ export const ChatThreadMessages = ({
   onSendWithoutAnonymization,
   onAskUserSubmit,
   onAskUserEditAndRerun,
+  onAskUserEditingChange,
   onCreateDocumentResolve,
   onOpenCreatedDocument,
   showThinkingIndicator = false,
@@ -197,6 +198,7 @@ export const ChatThreadMessages = ({
                   }
                   message={message}
                   onAskUserEditAndRerun={onAskUserEditAndRerun}
+                  onAskUserEditingChange={onAskUserEditingChange}
                   onAskUserSubmit={onAskUserSubmit}
                   onCreateDocumentResolve={onCreateDocumentResolve}
                   onOpenCreatedDocument={onOpenCreatedDocument}
@@ -756,6 +758,11 @@ type ChatThreadMessagesProps = {
   onAskUserEditAndRerun?:
     | ((toolCallId: string, output: AskUserOutput) => void | PromiseLike<void>)
     | undefined;
+  /** Mirrors an ask-user card's local edit-mode up to the page so it can
+   *  keep treating a reopened answered card as a live clarification. */
+  onAskUserEditingChange?:
+    | ((toolCallId: string, isEditing: boolean) => void)
+    | undefined;
   onCreateDocumentResolve: (
     toolCallId: string,
     matterId: string,
@@ -854,6 +861,7 @@ const QueuedUserMessages = ({
 type AssistantMessagePartsProps = Pick<
   ChatThreadMessagesProps,
   | "onAskUserEditAndRerun"
+  | "onAskUserEditingChange"
   | "onAskUserSubmit"
   | "onCreateDocumentResolve"
   | "onOpenCreatedDocument"
@@ -879,6 +887,7 @@ const AssistantMessageParts = ({
   isLatestAssistantMessage,
   message,
   onAskUserEditAndRerun,
+  onAskUserEditingChange,
   onAskUserSubmit,
   onCreateDocumentResolve,
   onOpenCreatedDocument,
@@ -911,6 +920,7 @@ const AssistantMessageParts = ({
                   void onAskUserEditAndRerun(toolCallId, output);
                 },
               })}
+              onEditingChange={onAskUserEditingChange}
               onSubmit={(toolCallId, output) => {
                 void onAskUserSubmit(toolCallId, output);
               }}

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
 
 import {
   useMutation,
@@ -213,25 +219,50 @@ export const ChatThreadPage = ({
   const lastMessage = messages.at(-1);
   const lastMessageId = lastMessage?.id ?? null;
   const lastMessageRole = lastMessage?.role ?? null;
-  // A pending ask-user clarification card owns the turn: its own questions
-  // and submit button take precedence over generic follow-up suggestions, so
-  // suppress both the chips and the Tab-to-ask editor hint until it is
-  // answered. Once the card resolves (`output-available`) the assistant's
-  // continuation may live on this same message, so gate on the unanswered
-  // state, not mere presence of the part.
-  const lastMessageHasPendingAskUser =
+  // Ask-user cards report their local "edit answers" mode here: reopening an
+  // answered card turns it back into a live clarification form, which the
+  // persisted part state (`output-available`) does not reflect.
+  const [editingAskUserToolCallIds, setEditingAskUserToolCallIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set<string>());
+  const handleAskUserEditingChange = useCallback(
+    (toolCallId: string, isEditing: boolean) => {
+      setEditingAskUserToolCallIds((prev) => {
+        if (isEditing === prev.has(toolCallId)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        if (isEditing) {
+          next.add(toolCallId);
+        } else {
+          next.delete(toolCallId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+  // An ask-user clarification card owns the turn while it is awaiting input or
+  // being edited: its own questions and submit button take precedence over
+  // generic follow-up suggestions, so suppress both the chips and the
+  // Tab-to-ask editor hint. Once the card resolves (`output-available`) the
+  // assistant's continuation may live on this same message, so gate on the
+  // active state rather than mere presence of the part.
+  const lastMessageHasActiveAskUser =
     lastMessage !== undefined &&
     lastMessage.role === "assistant" &&
     lastMessage.parts.some(
       (part) =>
-        part.type === "tool-ask-user" && part.state !== "output-available",
+        part.type === "tool-ask-user" &&
+        (part.state !== "output-available" ||
+          editingAskUserToolCallIds.has(part.toolCallId)),
     );
   const editorIsEmpty = useIsChatDraftEmpty(threadRef);
   const eligibleForSuggestions =
     editorIsEmpty &&
     lastMessageId !== null &&
     lastMessageRole === "assistant" &&
-    !lastMessageHasPendingAskUser;
+    !lastMessageHasActiveAskUser;
   const { data: suggestedPromptsData } = useQuery(
     chatThreadSuggestedPromptsOptions({
       activeOrganizationId,
@@ -421,6 +452,7 @@ export const ChatThreadPage = ({
                     messages={messages}
                     onLoadOlder={loadOlder}
                     onAskUserEditAndRerun={handleAskUserEditAndRerun}
+                    onAskUserEditingChange={handleAskUserEditingChange}
                     onAskUserSubmit={handleAskUserSubmit}
                     onCreateDocumentResolve={handleCreateDocumentResolve}
                     onOpenCreatedDocument={handleOpenCreatedDocument}

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -213,18 +213,25 @@ export const ChatThreadPage = ({
   const lastMessage = messages.at(-1);
   const lastMessageId = lastMessage?.id ?? null;
   const lastMessageRole = lastMessage?.role ?? null;
-  // The ask-user clarification card owns the turn: its own questions and
-  // submit button take precedence over generic follow-up suggestions, so
-  // suppress both the chips and the Tab-to-ask editor hint while it is live.
-  const lastMessageIsAskUser =
-    lastMessage?.role === "assistant" &&
-    lastMessage.parts.some((part) => part.type === "tool-ask-user");
+  // A pending ask-user clarification card owns the turn: its own questions
+  // and submit button take precedence over generic follow-up suggestions, so
+  // suppress both the chips and the Tab-to-ask editor hint until it is
+  // answered. Once the card resolves (`output-available`) the assistant's
+  // continuation may live on this same message, so gate on the unanswered
+  // state, not mere presence of the part.
+  const lastMessageHasPendingAskUser =
+    lastMessage !== undefined &&
+    lastMessage.role === "assistant" &&
+    lastMessage.parts.some(
+      (part) =>
+        part.type === "tool-ask-user" && part.state !== "output-available",
+    );
   const editorIsEmpty = useIsChatDraftEmpty(threadRef);
   const eligibleForSuggestions =
     editorIsEmpty &&
     lastMessageId !== null &&
     lastMessageRole === "assistant" &&
-    !lastMessageIsAskUser;
+    !lastMessageHasPendingAskUser;
   const { data: suggestedPromptsData } = useQuery(
     chatThreadSuggestedPromptsOptions({
       activeOrganizationId,

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -242,27 +242,28 @@ export const ChatThreadPage = ({
     },
     [],
   );
-  // An ask-user clarification card owns the turn while it is awaiting input or
-  // being edited: its own questions and submit button take precedence over
-  // generic follow-up suggestions, so suppress both the chips and the
-  // Tab-to-ask editor hint. Once the card resolves (`output-available`) the
-  // assistant's continuation may live on this same message, so gate on the
-  // active state rather than mere presence of the part.
-  const lastMessageHasActiveAskUser =
+  // An ask-user clarification card owns the turn, and its own questions and
+  // submit button take precedence over generic follow-up suggestions, so
+  // suppress both the chips and the Tab-to-ask editor hint while one is live.
+  // A card is live when it is still awaiting input (always the last message),
+  // or when any card has been reopened via Edit — including an earlier card
+  // with downstream replies, where the persisted `output-available` state no
+  // longer reflects the live edit-and-rerun form.
+  const lastMessageHasPendingAskUser =
     lastMessage !== undefined &&
     lastMessage.role === "assistant" &&
     lastMessage.parts.some(
       (part) =>
-        part.type === "tool-ask-user" &&
-        (part.state !== "output-available" ||
-          editingAskUserToolCallIds.has(part.toolCallId)),
+        part.type === "tool-ask-user" && part.state !== "output-available",
     );
+  const askUserOwnsTurn =
+    lastMessageHasPendingAskUser || editingAskUserToolCallIds.size > 0;
   const editorIsEmpty = useIsChatDraftEmpty(threadRef);
   const eligibleForSuggestions =
     editorIsEmpty &&
     lastMessageId !== null &&
     lastMessageRole === "assistant" &&
-    !lastMessageHasActiveAskUser;
+    !askUserOwnsTurn;
   const { data: suggestedPromptsData } = useQuery(
     chatThreadSuggestedPromptsOptions({
       activeOrganizationId,

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -210,11 +210,21 @@ export const ChatThreadPage = ({
   // Fetch suggested follow-up prompts for Tab-to-ask (editor) and chips display.
   // Gated by draft store emptiness so the query does not fire when the
   // user is already typing a custom follow-up.
-  const lastMessageId = messages.at(-1)?.id ?? null;
-  const lastMessageRole = messages.at(-1)?.role ?? null;
+  const lastMessage = messages.at(-1);
+  const lastMessageId = lastMessage?.id ?? null;
+  const lastMessageRole = lastMessage?.role ?? null;
+  // The ask-user clarification card owns the turn: its own questions and
+  // submit button take precedence over generic follow-up suggestions, so
+  // suppress both the chips and the Tab-to-ask editor hint while it is live.
+  const lastMessageIsAskUser =
+    lastMessage?.role === "assistant" &&
+    lastMessage.parts.some((part) => part.type === "tool-ask-user");
   const editorIsEmpty = useIsChatDraftEmpty(threadRef);
   const eligibleForSuggestions =
-    editorIsEmpty && lastMessageId !== null && lastMessageRole === "assistant";
+    editorIsEmpty &&
+    lastMessageId !== null &&
+    lastMessageRole === "assistant" &&
+    !lastMessageIsAskUser;
   const { data: suggestedPromptsData } = useQuery(
     chatThreadSuggestedPromptsOptions({
       activeOrganizationId,


### PR DESCRIPTION
When the assistant renders an ask-user clarification card, that card already presents its own questions and submit button. The generic follow-up suggestion chips (and the Tab-to-ask editor hint) were also shown on the same turn, giving two competing "answer next" affordances.

Gate the suggested-prompts query on the last assistant message not carrying a `tool-ask-user` part. While the clarification card is the live message, the suggested-prompts fetch is disabled, so the chips render nothing and the editor hint clears; suggestions resume once a fresh assistant message arrives.