### PR TITLE
feat(mcp): cursor pagination and text-windowing across MCP list/search/read tools

### DIFF
--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -17,11 +17,13 @@ import {
   DEFAULT_COMPAT_SEARCH_LIMIT,
   ensureWorkspaceAccess,
   errorResult,
-  MAX_SEARCH_LIMIT,
+  isToolErrorResult,
   normalizeTextField,
+  parseOptionalCursor,
   parseRequiredString,
   stringProp,
   textResult,
+  windowTextByCursor,
 } from "@/api/mcp/tool-utils";
 
 type CompatToolName = "fetch" | "search";
@@ -353,6 +355,10 @@ export const COMPAT_TOOL_DEFINITIONS = [
         query: stringProp("Search query", {
           maxLength: LIMITS.searchQueryMaxLength,
         }),
+        cursor: stringProp(
+          "Opaque cursor from a previous search call to fetch the next page",
+          { maxLength: 512 },
+        ),
       },
       required: ["query"],
     },
@@ -363,11 +369,16 @@ export const COMPAT_TOOL_DEFINITIONS = [
     annotations: { readOnlyHint: true },
     description:
       "Fetch a knowledge document by id using the OpenAI-compatible fetch " +
-      "tool shape. Use ids returned by the search tool.",
+      "tool shape. Use ids returned by the search tool. Long documents are " +
+      "returned in windows; pass the returned nextCursor back as cursor to read more.",
     inputSchema: {
       type: "object",
       properties: {
         id: stringProp("Document/entity ID"),
+        cursor: stringProp(
+          "Opaque cursor from a previous fetch call to read the next window of text",
+          { maxLength: 512 },
+        ),
       },
       required: ["id"],
     },
@@ -388,6 +399,10 @@ export const ANONYMIZED_COMPAT_TOOL_DEFINITIONS = [
         query: stringProp("Search query", {
           maxLength: LIMITS.searchQueryMaxLength,
         }),
+        cursor: stringProp(
+          "Opaque cursor from a previous search call to fetch the next page",
+          { maxLength: 512 },
+        ),
       },
       required: ["query"],
     },
@@ -398,11 +413,16 @@ export const ANONYMIZED_COMPAT_TOOL_DEFINITIONS = [
     annotations: { readOnlyHint: true },
     description:
       "Fetch anonymized document text by id using the OpenAI-compatible fetch " +
-      "tool shape. Use ids returned by the anonymized search tool.",
+      "tool shape. Use ids returned by the anonymized search tool. Long documents " +
+      "are returned in windows; pass the returned nextCursor back as cursor to read more.",
     inputSchema: {
       type: "object",
       properties: {
         id: stringProp("Document/entity ID"),
+        cursor: stringProp(
+          "Opaque cursor from a previous fetch call to read the next window of text",
+          { maxLength: 512 },
+        ),
       },
       required: ["id"],
     },
@@ -423,13 +443,22 @@ const handleCompatSearchTool: McpToolHandler = async ({
     return query;
   }
 
-  const limit = DEFAULT_COMPAT_SEARCH_LIMIT;
-  const compatLimit = Math.min(limit * 2, MAX_SEARCH_LIMIT);
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
+
+  // Request exactly the page size and pass the provider cursor through so
+  // pagination stays correct: the keyset cursor tracks the provider's hit
+  // position, so over-fetching and post-filtering would desync it and skip
+  // results. Non-fetchable hits are dropped, so a page may be smaller than
+  // the page size; callers keep paging while `nextCursor` is non-null.
   const result = await getSearchProvider().search({
     query,
     organizationId: context.organizationId,
     workspaceIds: context.accessibleWorkspaceIds,
-    limit: compatLimit,
+    limit: DEFAULT_COMPAT_SEARCH_LIMIT,
+    ...(cursor === undefined ? {} : { cursor }),
   });
 
   const hits = getCompatSearchHits({
@@ -443,10 +472,10 @@ const handleCompatSearchTool: McpToolHandler = async ({
     context,
     entityIds: getCompatSearchEntityIds(hits),
   });
-  const limitedResults = mapCompatSearchResults({
+  const mappedResults = mapCompatSearchResults({
     fetchableMap,
     hits,
-  }).slice(0, limit);
+  });
 
   if (mode === "anonymized") {
     // MCP access is for authorized Stella users only. In anonymized
@@ -454,15 +483,17 @@ const handleCompatSearchTool: McpToolHandler = async ({
     // retrieval quality stays useful, then anonymize all returned
     // corpus text before it leaves Stella for the AI client.
     return textResult({
+      nextCursor: result.nextCursor,
       results: await anonymizeCompatSearchResults({
         context,
-        results: limitedResults,
+        results: mappedResults,
       }),
     });
   }
 
   return textResult({
-    results: limitedResults.map(({ workspaceId: _workspaceId, ...hit }) => hit),
+    nextCursor: result.nextCursor,
+    results: mappedResults.map(({ workspaceId: _workspaceId, ...hit }) => hit),
   });
 };
 
@@ -476,6 +507,11 @@ const handleCompatFetchTool: McpToolHandler = async ({
     return rawEntityId;
   }
   const entityId = brandPersistedEntityId(rawEntityId);
+
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
 
   if (context.accessibleWorkspaceIds.length === 0) {
     return errorResult("Document content is unavailable");
@@ -508,12 +544,15 @@ const handleCompatFetchTool: McpToolHandler = async ({
     row.ciphertext,
     row.iv,
   );
-  const truncated = text.length > COMPAT_FETCH_CONTENT_MAX_CHARS;
+  // Keep the full decrypted text here; windowing happens after the
+  // mode branch so anonymized fetches anonymize the whole document
+  // before slicing (slicing raw text first could split an entity name
+  // across the window boundary and leak its prefix).
   const result = {
     charCount: row.charCount,
     name: row.entity.name,
-    text: truncated ? text.slice(0, COMPAT_FETCH_CONTENT_MAX_CHARS) : text,
-    truncated,
+    text,
+    truncated: false,
     workspaceId: row.entity.workspaceId,
   };
 
@@ -556,7 +595,9 @@ const handleCompatFetchTool: McpToolHandler = async ({
   if (mode === "anonymized") {
     // Same boundary as anonymized search: the user may fetch a raw
     // document internally, but the AI client receives only the
-    // anonymized title/body generated below.
+    // anonymized title/body generated below. Anonymize the whole
+    // document first, then window the redacted text so no entity name
+    // is split across a window edge.
     const anonymized = await anonymizeCompatFetchPayload({
       context,
       text: fetchPayload.text,
@@ -564,31 +605,51 @@ const handleCompatFetchTool: McpToolHandler = async ({
       workspaceId: fetchPayload.workspaceId,
     });
 
+    const textWindow = windowTextByCursor({
+      cursor,
+      maxChars: COMPAT_FETCH_CONTENT_MAX_CHARS,
+      text: anonymized.text,
+    });
+    if (isToolErrorResult(textWindow)) {
+      return textWindow;
+    }
+
     return textResult({
       id: entityId,
       title: anonymized.title,
-      text: anonymized.text,
+      text: textWindow.text,
       url,
+      nextCursor: textWindow.nextCursor,
       metadata: {
         anonymized: true,
         anonymizedEntityCount: anonymized.anonymizedEntityCount,
-        charCount: fetchPayload.charCount,
+        charCount: textWindow.charCount,
         source: "stella",
-        truncated: fetchPayload.truncated,
+        truncated: textWindow.truncated,
         workspaceId: fetchPayload.workspaceId,
       },
     });
   }
 
+  const textWindow = windowTextByCursor({
+    cursor,
+    maxChars: COMPAT_FETCH_CONTENT_MAX_CHARS,
+    text: fetchPayload.text,
+  });
+  if (isToolErrorResult(textWindow)) {
+    return textWindow;
+  }
+
   return textResult({
     id: rawEntityId,
     title: fetchPayload.title,
-    text: fetchPayload.text,
+    text: textWindow.text,
     url,
+    nextCursor: textWindow.nextCursor,
     metadata: {
-      charCount: fetchPayload.charCount,
+      charCount: textWindow.charCount,
       source: "stella",
-      truncated: fetchPayload.truncated,
+      truncated: textWindow.truncated,
       workspaceId: fetchPayload.workspaceId,
     },
   });

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -7,6 +7,7 @@ import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-black
 import { decryptContent } from "@/api/lib/content-encryption";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
+import { decodeCursor } from "@/api/lib/search/cursor";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import { anonymizeTextFields } from "@/api/mcp/anonymization";
 import type { McpRequestContext } from "@/api/mcp/context";
@@ -446,6 +447,12 @@ const handleCompatSearchTool: McpToolHandler = async ({
   const cursor = parseOptionalCursor({ args, key: "cursor" });
   if (isToolErrorResult(cursor)) {
     return cursor;
+  }
+  // Reject an undecodable provider cursor instead of forwarding it: the
+  // provider treats a malformed cursor as no cursor and silently returns the
+  // first page, which would duplicate hits or loop a paginating client.
+  if (cursor !== undefined && decodeCursor(cursor) === null) {
+    return errorResult("Invalid cursor");
   }
 
   // Request exactly the page size and pass the provider cursor through so

--- a/apps/api/src/mcp/onboarding.test.ts
+++ b/apps/api/src/mcp/onboarding.test.ts
@@ -61,7 +61,15 @@ type MattersRow = {
   status: string;
 };
 
-type ScopedTx = {
+type SelectChain = {
+  select: () => SelectChain;
+  from: () => SelectChain;
+  where: () => SelectChain;
+  orderBy: () => SelectChain;
+  limit: () => Promise<MattersRow[]>;
+};
+
+type ScopedTx = SelectChain & {
   insert: ReturnType<typeof mock>;
   query: {
     organizationSettings: {
@@ -94,8 +102,18 @@ const createScopedDb = ({
   practiceJurisdictions = [],
 }: ScopedDbOptions = {}) =>
   asTestRaw<McpRequestContext["scopedDb"] & ReturnType<typeof mock>>(
-    mock(async (callback: (tx: ScopedTx) => Promise<unknown>) =>
-      callback({
+    mock(async (callback: (tx: ScopedTx) => Promise<unknown>) => {
+      // list_matters now uses the core query builder; the chain ignores its
+      // column/where/order arguments and resolves to the seeded matters.
+      const builder: SelectChain = {
+        select: () => builder,
+        from: () => builder,
+        where: () => builder,
+        orderBy: () => builder,
+        limit: async () => matters,
+      };
+      return await callback({
+        ...builder,
         insert,
         query: {
           organizationSettings: {
@@ -106,8 +124,8 @@ const createScopedDb = ({
             findMany: async () => matters,
           },
         },
-      }),
-    ),
+      });
+    }),
   );
 
 const createContext = ({

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -33,6 +33,7 @@ import {
   brandPersistedContactId,
   brandPersistedEntityId,
 } from "@/api/lib/safe-id-boundaries";
+import { decodeCursor } from "@/api/lib/search/cursor";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import type { McpRequestContext } from "@/api/mcp/context";
 import type { McpToolDefinition, McpToolHandler } from "@/api/mcp/tool-types";
@@ -385,11 +386,14 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
           // round-trips lastActivityAt through a millisecond JS Date;
           // matters sharing a now()-generated microsecond timestamp cannot
           // be skipped or duplicated across pages. The boundary lookup is
-          // org-scoped (defense in depth beyond RLS) so a cursor carrying a
-          // foreign workspace id cannot shift this org's page boundary.
+          // scoped to the same org and status filter as the page (defense in
+          // depth beyond RLS) so a cursor carrying a foreign or out-of-filter
+          // workspace id cannot shift this page's boundary. The status clause
+          // is conditional: comparing against the synthetic "all" value would
+          // fail to cast to the status enum.
           boundaryId === undefined
             ? undefined
-            : sql`(${workspaces.lastActivityAt}, ${workspaces.id}) < (select b.last_activity_at, b.id from workspaces b where b.id = ${boundaryId} and b.organization_id = ${context.organizationId})`,
+            : sql`(${workspaces.lastActivityAt}, ${workspaces.id}) < (select b.last_activity_at, b.id from workspaces b where b.id = ${boundaryId} and b.organization_id = ${context.organizationId}${status === "all" ? sql`` : sql` and b.status = ${status}`})`,
         ),
       )
       .orderBy(desc(workspaces.lastActivityAt), desc(workspaces.id))
@@ -507,6 +511,12 @@ const handleSearchAcrossMattersTool: McpToolHandler = async ({
   const cursor = parseOptionalCursor({ args, key: "cursor" });
   if (isToolErrorResult(cursor)) {
     return cursor;
+  }
+  // Reject an undecodable provider cursor instead of forwarding it: the
+  // provider treats a malformed cursor as no cursor and silently returns the
+  // first page, which would duplicate hits or loop a paginating client.
+  if (cursor !== undefined && decodeCursor(cursor) === null) {
+    return errorResult("Invalid cursor");
   }
 
   const result = await getSearchProvider().search({

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -52,14 +52,15 @@ import {
   parseOptionalEnum,
   parseOptionalLimit,
   parseRequiredString,
+  resolveWindowBounds,
   stringProp,
   textResult,
   windowTextByCursor,
 } from "@/api/mcp/tool-utils";
 
 const MCP_CONTENT_MAX_CHARS = 8000;
-// Citation lists are capped per call. Paging the citation lists themselves is
-// a separate follow-up; the decision text is paged via the cursor.
+// Page size for each citation list on read_case_law_decision. The decision
+// text and both citation lists are paged together by a single compound cursor.
 const MCP_CASE_LAW_CITATIONS_PER_DECISION = 50;
 type StellaToolName =
   | "get_matter_overview"
@@ -201,14 +202,15 @@ export const STELLA_TOOL_DEFINITIONS = [
     annotations: { readOnlyHint: true },
     description:
       "Read a single case-law decision by its decision ID. Returns metadata, " +
-      "plain text, citation links, and source URLs. Long decision text is " +
-      "returned in windows; pass the returned nextCursor back as cursor to read more.",
+      "plain text, citation links, and source URLs. Long decision text and " +
+      "large citation lists are returned in windows; pass the returned " +
+      "nextCursor back as cursor to read more.",
     inputSchema: {
       type: "object",
       properties: {
         decision_id: stringProp("Case-law decision ID"),
         cursor: stringProp(
-          "Opaque cursor from a previous call to read the next window of decision text",
+          "Opaque cursor from a previous call to read the next window of decision text and citations",
           { maxLength: 512 },
         ),
       },
@@ -860,6 +862,37 @@ const handleSearchCaseLawTool: McpToolHandler = async ({ args, context }) => {
   });
 };
 
+type DecisionCursorOffsets = { text: number; from: number; to: number };
+
+// read_case_law_decision pages the decision text and both citation lists with
+// a single compound cursor encoding [textOffset, fromOffset, toOffset].
+const decodeDecisionCursor = (
+  cursor: string | undefined,
+): DecisionCursorOffsets | null => {
+  if (cursor === undefined) {
+    return { text: 0, from: 0, to: 0 };
+  }
+  const parts = decodePaginationCursor(cursor);
+  if (!parts || parts.length !== 3) {
+    return null;
+  }
+  const [text, from, to] = parts;
+  if (
+    typeof text !== "number" ||
+    !Number.isInteger(text) ||
+    text < 0 ||
+    typeof from !== "number" ||
+    !Number.isInteger(from) ||
+    from < 0 ||
+    typeof to !== "number" ||
+    !Number.isInteger(to) ||
+    to < 0
+  ) {
+    return null;
+  }
+  return { text, from, to };
+};
+
 const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   const decisionId = parseRequiredString(args, "decision_id");
   if (typeof decisionId !== "string") {
@@ -869,6 +902,10 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   const cursor = parseOptionalCursor({ args, key: "cursor" });
   if (isToolErrorResult(cursor)) {
     return cursor;
+  }
+  const offsets = decodeDecisionCursor(cursor);
+  if (offsets === null) {
+    return errorResult("Invalid cursor");
   }
 
   const result = await readDecisionHandler(
@@ -889,25 +926,41 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   const aiTextAllowed = result.source.allowsDerivedAi;
 
   const plainText = aiTextAllowed
-    ? toPlainDecisionText({
+    ? (toPlainDecisionText({
         documentAst: result.documentAst,
         fulltext: result.fulltext,
-      })
+      }) ?? null)
     : null;
-  const textWindow =
-    plainText === null || plainText === undefined
-      ? null
-      : windowTextByCursor({
-          cursor,
-          maxChars: MCP_CONTENT_MAX_CHARS,
-          text: plainText,
-        });
-  if (textWindow !== null && isToolErrorResult(textWindow)) {
-    return textWindow;
-  }
+  const textLength = plainText === null ? 0 : plainText.length;
+
+  const textBounds = resolveWindowBounds(
+    textLength,
+    offsets.text,
+    MCP_CONTENT_MAX_CHARS,
+  );
+  const fromBounds = resolveWindowBounds(
+    result.citationsFrom.length,
+    offsets.from,
+    MCP_CASE_LAW_CITATIONS_PER_DECISION,
+  );
+  const toBounds = resolveWindowBounds(
+    result.citationsTo.length,
+    offsets.to,
+    MCP_CASE_LAW_CITATIONS_PER_DECISION,
+  );
+
+  // One compound cursor advances all three streams together; it resolves to
+  // null only once the text and both citation lists are fully consumed.
+  const hasMore =
+    textBounds.nextOffset !== null ||
+    fromBounds.nextOffset !== null ||
+    toBounds.nextOffset !== null;
+  const nextCursor = hasMore
+    ? encodePaginationCursor([textBounds.end, fromBounds.end, toBounds.end])
+    : null;
 
   return textResult({
-    nextCursor: textWindow === null ? null : textWindow.nextCursor,
+    nextCursor,
     decision: {
       appUrl: buildCaseLawDecisionAppUrl({
         caseNumber: result.caseNumber,
@@ -919,14 +972,11 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
       }),
       caseNumber: result.caseNumber,
       citationsFrom: result.citationsFrom.slice(
-        0,
-        MCP_CASE_LAW_CITATIONS_PER_DECISION,
+        fromBounds.start,
+        fromBounds.end,
       ),
       citationsFromTotal: result.citationsFrom.length,
-      citationsTo: result.citationsTo.slice(
-        0,
-        MCP_CASE_LAW_CITATIONS_PER_DECISION,
-      ),
+      citationsTo: result.citationsTo.slice(toBounds.start, toBounds.end),
       citationsToTotal: result.citationsTo.length,
       country: result.country,
       court: result.court,
@@ -939,9 +989,12 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
       metadata: result.metadata,
       source: result.source,
       sourceUrl: result.sourceUrl,
-      text: textWindow === null ? null : textWindow.text,
-      charCount: textWindow === null ? null : textWindow.charCount,
-      truncated: textWindow === null ? false : textWindow.truncated,
+      text:
+        plainText === null
+          ? null
+          : plainText.slice(textBounds.start, textBounds.end),
+      charCount: plainText === null ? null : textLength,
+      truncated: textBounds.nextOffset !== null,
       ...(aiTextAllowed
         ? {}
         : {

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -1,10 +1,12 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { and, desc, eq, sql } from "drizzle-orm";
 import * as v from "valibot";
 
 import { COUNTRY_CODES } from "@stll/country-codes";
 import { roles } from "@stll/permissions";
 
 import type { PracticeJurisdiction } from "@/api/db/schema";
+import { workspaces } from "@/api/db/schema";
 import { readDecisionHandler } from "@/api/handlers/case-law/decisions/read-by-id";
 import { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
@@ -19,6 +21,12 @@ import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { decryptContent } from "@/api/lib/content-encryption";
 import { isUuid } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
 import {
   brandPersistedCaseLawDecisionId,
   brandPersistedCaseLawSourceId,
@@ -37,16 +45,22 @@ import {
   errorResult,
   getAppBaseUrl,
   intProp,
+  isToolErrorResult,
   MAX_LIST_LIMIT,
   MAX_SEARCH_LIMIT,
+  parseOptionalCursor,
   parseOptionalEnum,
   parseOptionalLimit,
   parseRequiredString,
   stringProp,
   textResult,
+  windowTextByCursor,
 } from "@/api/mcp/tool-utils";
 
 const MCP_CONTENT_MAX_CHARS = 8000;
+// Citation lists are capped per call. Paging the citation lists themselves is
+// a separate follow-up; the decision text is paged via the cursor.
+const MCP_CASE_LAW_CITATIONS_PER_DECISION = 50;
 type StellaToolName =
   | "get_matter_overview"
   | "list_matters"
@@ -73,6 +87,10 @@ export const STELLA_TOOL_DEFINITIONS = [
           min: 1,
           max: MAX_LIST_LIMIT,
         }),
+        cursor: stringProp(
+          "Opaque cursor from a previous list_matters call to fetch the next page",
+          { maxLength: 512 },
+        ),
       },
     },
     name: "list_matters",
@@ -108,6 +126,10 @@ export const STELLA_TOOL_DEFINITIONS = [
           min: 1,
           max: MAX_SEARCH_LIMIT,
         }),
+        cursor: stringProp(
+          "Opaque cursor from a previous search_across_matters call to fetch the next page",
+          { maxLength: 512 },
+        ),
       },
       required: ["query"],
     },
@@ -159,11 +181,16 @@ export const STELLA_TOOL_DEFINITIONS = [
     annotations: { readOnlyHint: true },
     description:
       "Read extracted text from a document found anywhere in your accessible " +
-      "matters. Use after search_across_matters.",
+      "matters. Use after search_across_matters. Long documents are returned " +
+      "in windows; pass the returned nextCursor back as cursor to read more.",
     inputSchema: {
       type: "object",
       properties: {
         entity_id: stringProp("Entity ID"),
+        cursor: stringProp(
+          "Opaque cursor from a previous call to read the next window of text",
+          { maxLength: 512 },
+        ),
       },
       required: ["entity_id"],
     },
@@ -174,11 +201,16 @@ export const STELLA_TOOL_DEFINITIONS = [
     annotations: { readOnlyHint: true },
     description:
       "Read a single case-law decision by its decision ID. Returns metadata, " +
-      "plain text, citation links, and source URLs.",
+      "plain text, citation links, and source URLs. Long decision text is " +
+      "returned in windows; pass the returned nextCursor back as cursor to read more.",
     inputSchema: {
       type: "object",
       properties: {
         decision_id: stringProp("Case-law decision ID"),
+        cursor: stringProp(
+          "Opaque cursor from a previous call to read the next window of decision text",
+          { maxLength: 512 },
+        ),
       },
       required: ["decision_id"],
     },
@@ -285,6 +317,18 @@ const withOnboardingHintIfApplicable = async ({
   };
 };
 
+// The list_matters cursor is the boundary matter id alone; the query
+// resolves its (lastActivityAt, id) in-DB. A malformed id is rejected here
+// so it never reaches the SQL comparison.
+const decodeMatterPageCursor = (cursor: string): string | null => {
+  const parts = decodePaginationCursor(cursor);
+  if (!parts || parts.length !== 1) {
+    return null;
+  }
+  const [rawId] = parts;
+  return isUuidPaginationCursorPart(rawId) ? rawId : null;
+};
+
 const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
   const status = parseOptionalEnum({
     args,
@@ -306,27 +350,56 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
     return limit;
   }
 
-  const matters = await context.scopedDb((tx) =>
-    tx.query.workspaces.findMany({
-      where: {
-        organizationId: { eq: context.organizationId },
-        ...(status === "all" ? {} : { status }),
-      },
-      columns: {
-        id: true,
-        name: true,
-        reference: true,
-        status: true,
-        lastActivityAt: true,
-        createdAt: true,
-      },
-      orderBy: { lastActivityAt: "desc" },
-      limit,
-    }),
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
+  let boundaryId: string | undefined;
+  if (cursor !== undefined) {
+    const decoded = decodeMatterPageCursor(cursor);
+    if (decoded === null) {
+      return errorResult("Invalid cursor");
+    }
+    boundaryId = decoded;
+  }
+
+  const rows = await context.scopedDb((tx) =>
+    tx
+      .select({
+        id: workspaces.id,
+        name: workspaces.name,
+        reference: workspaces.reference,
+        status: workspaces.status,
+        lastActivityAt: workspaces.lastActivityAt,
+        createdAt: workspaces.createdAt,
+      })
+      .from(workspaces)
+      .where(
+        and(
+          eq(workspaces.organizationId, context.organizationId),
+          status === "all" ? undefined : eq(workspaces.status, status),
+          // Compare the full-precision (lastActivityAt, id) tuple in-DB
+          // against the boundary row (looked up by id) so the cursor never
+          // round-trips lastActivityAt through a millisecond JS Date;
+          // matters sharing a now()-generated microsecond timestamp cannot
+          // be skipped or duplicated across pages.
+          boundaryId === undefined
+            ? undefined
+            : sql`(${workspaces.lastActivityAt}, ${workspaces.id}) < (select b.last_activity_at, b.id from workspaces b where b.id = ${boundaryId})`,
+        ),
+      )
+      .orderBy(desc(workspaces.lastActivityAt), desc(workspaces.id))
+      .limit(limit + 1),
   );
 
+  const page = createCursorPage({
+    rows,
+    limit,
+    cursorForItem: (item) => encodePaginationCursor([item.id]),
+  });
+
   const result = textResult({
-    matters: matters.map((matter) => ({
+    matters: page.items.map((matter) => ({
       id: matter.id,
       name: matter.name,
       reference: matter.reference,
@@ -334,12 +407,12 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
       lastActivityAt: matter.lastActivityAt.toISOString(),
       createdAt: matter.createdAt.toISOString(),
     })),
-    totalCountLimit: LIMITS.workspacesCount,
+    nextCursor: page.nextCursor,
   });
 
   return await withOnboardingHintIfApplicable({
     context,
-    isEmpty: matters.length === 0,
+    isEmpty: page.items.length === 0,
     result,
   });
 };
@@ -427,15 +500,22 @@ const handleSearchAcrossMattersTool: McpToolHandler = async ({
     return limit;
   }
 
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
+
   const result = await getSearchProvider().search({
     query,
     organizationId: context.organizationId,
     workspaceIds: context.accessibleWorkspaceIds,
     limit,
+    ...(cursor === undefined ? {} : { cursor }),
   });
 
   return textResult({
     totalCount: result.totalCount,
+    nextCursor: result.nextCursor,
     hits: result.hits.map((hit) => ({
       entityId: hit.entityId,
       workspaceId: hit.workspaceId,
@@ -498,14 +578,6 @@ const parseOptionalDateArg = ({
   }
   return value;
 };
-
-const isToolErrorResult = (
-  value: unknown,
-): value is ReturnType<typeof errorResult> =>
-  typeof value === "object" &&
-  value !== null &&
-  "isError" in value &&
-  value.isError === true;
 
 const getResultMessage = (value: unknown): string | null => {
   if (typeof value !== "object" || value === null) {
@@ -591,6 +663,11 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
 
   const entityId = brandPersistedEntityId(rawEntityId);
 
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
+
   if (context.accessibleWorkspaceIds.length === 0) {
     return errorResult("No extracted content available for this entity.");
   }
@@ -623,15 +700,24 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
     row.ciphertext,
     row.iv,
   );
-  const truncated = plaintext.length > MCP_CONTENT_MAX_CHARS;
+
+  const textWindow = windowTextByCursor({
+    cursor,
+    maxChars: MCP_CONTENT_MAX_CHARS,
+    text: plaintext,
+  });
+  if (isToolErrorResult(textWindow)) {
+    return textWindow;
+  }
 
   return textResult({
-    charCount: row.charCount,
+    charCount: textWindow.charCount,
     entityId,
     kind: row.entity.kind,
     name: row.entity.name,
-    text: truncated ? plaintext.slice(0, MCP_CONTENT_MAX_CHARS) : plaintext,
-    truncated,
+    text: textWindow.text,
+    truncated: textWindow.truncated,
+    nextCursor: textWindow.nextCursor,
     workspaceId: row.entity.workspaceId,
   });
 };
@@ -780,6 +866,11 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
     return decisionId;
   }
 
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
+
   const result = await readDecisionHandler(
     brandPersistedCaseLawDecisionId(decisionId),
     caseLawPublicReadDb,
@@ -797,7 +888,26 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   // model, which is exactly this tool's context.
   const aiTextAllowed = result.source.allowsDerivedAi;
 
+  const plainText = aiTextAllowed
+    ? toPlainDecisionText({
+        documentAst: result.documentAst,
+        fulltext: result.fulltext,
+      })
+    : null;
+  const textWindow =
+    plainText === null || plainText === undefined
+      ? null
+      : windowTextByCursor({
+          cursor,
+          maxChars: MCP_CONTENT_MAX_CHARS,
+          text: plainText,
+        });
+  if (textWindow !== null && isToolErrorResult(textWindow)) {
+    return textWindow;
+  }
+
   return textResult({
+    nextCursor: textWindow === null ? null : textWindow.nextCursor,
     decision: {
       appUrl: buildCaseLawDecisionAppUrl({
         caseNumber: result.caseNumber,
@@ -808,9 +918,15 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
         slug: result.slug,
       }),
       caseNumber: result.caseNumber,
-      citationsFrom: result.citationsFrom.slice(0, 50),
+      citationsFrom: result.citationsFrom.slice(
+        0,
+        MCP_CASE_LAW_CITATIONS_PER_DECISION,
+      ),
       citationsFromTotal: result.citationsFrom.length,
-      citationsTo: result.citationsTo.slice(0, 50),
+      citationsTo: result.citationsTo.slice(
+        0,
+        MCP_CASE_LAW_CITATIONS_PER_DECISION,
+      ),
       citationsToTotal: result.citationsTo.length,
       country: result.country,
       court: result.court,
@@ -823,12 +939,9 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
       metadata: result.metadata,
       source: result.source,
       sourceUrl: result.sourceUrl,
-      text: aiTextAllowed
-        ? toPlainDecisionText({
-            documentAst: result.documentAst,
-            fulltext: result.fulltext,
-          })
-        : null,
+      text: textWindow === null ? null : textWindow.text,
+      charCount: textWindow === null ? null : textWindow.charCount,
+      truncated: textWindow === null ? false : textWindow.truncated,
       ...(aiTextAllowed
         ? {}
         : {

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -384,10 +384,12 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
           // against the boundary row (looked up by id) so the cursor never
           // round-trips lastActivityAt through a millisecond JS Date;
           // matters sharing a now()-generated microsecond timestamp cannot
-          // be skipped or duplicated across pages.
+          // be skipped or duplicated across pages. The boundary lookup is
+          // org-scoped (defense in depth beyond RLS) so a cursor carrying a
+          // foreign workspace id cannot shift this org's page boundary.
           boundaryId === undefined
             ? undefined
-            : sql`(${workspaces.lastActivityAt}, ${workspaces.id}) < (select b.last_activity_at, b.id from workspaces b where b.id = ${boundaryId})`,
+            : sql`(${workspaces.lastActivityAt}, ${workspaces.id}) < (select b.last_activity_at, b.id from workspaces b where b.id = ${boundaryId} and b.organization_id = ${context.organizationId})`,
         ),
       )
       .orderBy(desc(workspaces.lastActivityAt), desc(workspaces.id))

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -76,16 +76,21 @@ const parseToolPayload = (
 
 const createScopedDb = (templates: unknown[] = []) =>
   asTestRaw<McpRequestContext["scopedDb"] & ReturnType<typeof mock>>(
-    mock(
-      async (
-        run: (tx: {
-          query: { templates: { findMany: () => Promise<unknown[]> } };
-        }) => unknown,
-      ) =>
-        await run({
-          query: { templates: { findMany: async () => templates } },
-        }),
-    ),
+    mock(async (run: (tx: unknown) => unknown) => {
+      // list_templates now uses the core query builder; the chain ignores its
+      // column/where/order arguments and resolves to the seeded rows.
+      const builder = {
+        select: () => builder,
+        from: () => builder,
+        where: () => builder,
+        orderBy: () => builder,
+        limit: async () => templates,
+      };
+      return await run({
+        ...builder,
+        query: { templates: { findMany: async () => templates } },
+      });
+    }),
   );
 
 const createContext = ({
@@ -234,7 +239,10 @@ describe("MCP template tools", () => {
       context: createContext({ scopedDb: createScopedDb(rows) }),
       toolName: "list_templates",
     });
-    expect(parseToolPayload(result)).toEqual({ templates: rows });
+    expect(parseToolPayload(result)).toEqual({
+      templates: rows,
+      nextCursor: null,
+    });
   });
 
   test("describe_template surfaces the full field config for round-tripping", async () => {

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -347,10 +347,12 @@ const handleListTemplatesTool: McpToolHandler = async ({ args, context }) => {
           eq(templates.organizationId, context.organizationId),
           // Resolve the full-precision (createdAt, id) boundary in-DB by id
           // so the cursor never round-trips createdAt through a millisecond
-          // JS Date.
+          // JS Date. The boundary lookup is org-scoped (defense in depth
+          // beyond RLS) so a cursor carrying a foreign template id cannot
+          // shift this org's page boundary.
           boundaryId === undefined
             ? undefined
-            : sql`(${templates.createdAt}, ${templates.id}) < (select b.created_at, b.id from templates b where b.id = ${boundaryId})`,
+            : sql`(${templates.createdAt}, ${templates.id}) < (select b.created_at, b.id from templates b where b.id = ${boundaryId} and b.organization_id = ${context.organizationId})`,
         ),
       )
       .orderBy(desc(templates.createdAt), desc(templates.id))

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -1,8 +1,10 @@
 import { Result } from "better-result";
+import { and, desc, eq, sql } from "drizzle-orm";
 import * as v from "valibot";
 
 import { roles } from "@stll/permissions";
 
+import { templates } from "@/api/db/schema";
 import {
   buildAiConditionDecider,
   buildAiFieldGenerator,
@@ -24,12 +26,20 @@ import { captureError } from "@/api/lib/analytics";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { assertUsageAvailableForHandler } from "@/api/lib/api-handlers";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
 import { brandPersistedTemplateId } from "@/api/lib/safe-id-boundaries";
 import { buildMarkerReference } from "@/api/mcp/template-marker-reference";
 import type { McpToolDefinition, McpToolHandler } from "@/api/mcp/tool-types";
 import {
   enumProp,
   errorResult,
+  isToolErrorResult,
+  parseOptionalCursor,
   stringProp,
   textResult,
 } from "@/api/mcp/tool-utils";
@@ -158,7 +168,12 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       "request and skip any whose whenNotToUse applies.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        cursor: stringProp(
+          "Opaque cursor from a previous list_templates call to fetch the next page",
+          { maxLength: 512 },
+        ),
+      },
     },
     name: "list_templates",
     scope: "stella:templates",
@@ -274,7 +289,20 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
   },
 ] as const satisfies readonly McpToolDefinition[];
 
-const listTemplatesArgsSchema = v.strictObject({});
+const listTemplatesArgsSchema = v.strictObject({
+  cursor: v.optional(v.pipe(v.string(), v.maxLength(512))),
+});
+
+// The list_templates cursor is the boundary template id alone; the query
+// resolves its (createdAt, id) in-DB.
+const decodeTemplatePageCursor = (cursor: string): string | null => {
+  const parts = decodePaginationCursor(cursor);
+  if (!parts || parts.length !== 1) {
+    return null;
+  }
+  const [rawId] = parts;
+  return isUuidPaginationCursorPart(rawId) ? rawId : null;
+};
 
 const handleListTemplatesTool: McpToolHandler = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
@@ -286,25 +314,59 @@ const handleListTemplatesTool: McpToolHandler = async ({ args, context }) => {
 
   const parsed = v.safeParse(listTemplatesArgsSchema, args);
   if (!parsed.success) {
-    return errorResult("Invalid input: list_templates takes no parameters");
+    return errorResult("Invalid input: list_templates accepts only a cursor");
   }
 
+  const cursor = parseOptionalCursor({ args, key: "cursor" });
+  if (isToolErrorResult(cursor)) {
+    return cursor;
+  }
+  let boundaryId: string | undefined;
+  if (cursor !== undefined) {
+    const decoded = decodeTemplatePageCursor(cursor);
+    if (decoded === null) {
+      return errorResult("Invalid cursor");
+    }
+    boundaryId = decoded;
+  }
+
+  const limit = LIMITS.templatesCount;
   const rows = await context.scopedDb((tx) =>
-    tx.query.templates.findMany({
-      columns: {
-        id: true,
-        name: true,
-        fieldCount: true,
-        tags: true,
-        whenToUse: true,
-        whenNotToUse: true,
-      },
-      orderBy: { createdAt: "desc" },
-      limit: LIMITS.templatesCount,
-    }),
+    tx
+      .select({
+        id: templates.id,
+        name: templates.name,
+        fieldCount: templates.fieldCount,
+        tags: templates.tags,
+        whenToUse: templates.whenToUse,
+        whenNotToUse: templates.whenNotToUse,
+      })
+      .from(templates)
+      .where(
+        and(
+          eq(templates.organizationId, context.organizationId),
+          // Resolve the full-precision (createdAt, id) boundary in-DB by id
+          // so the cursor never round-trips createdAt through a millisecond
+          // JS Date.
+          boundaryId === undefined
+            ? undefined
+            : sql`(${templates.createdAt}, ${templates.id}) < (select b.created_at, b.id from templates b where b.id = ${boundaryId})`,
+        ),
+      )
+      .orderBy(desc(templates.createdAt), desc(templates.id))
+      .limit(limit + 1),
   );
 
-  return textResult({ templates: rows });
+  const page = createCursorPage({
+    rows,
+    limit,
+    cursorForItem: (item) => encodePaginationCursor([item.id]),
+  });
+
+  return textResult({
+    templates: page.items,
+    nextCursor: page.nextCursor,
+  });
 };
 
 const markerReferenceArgsSchema = v.strictObject({});

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -4,7 +4,10 @@ import { env } from "@/api/env";
 import {
   buildCaseLawDecisionAppUrl,
   buildCaseLawDecisionUrl,
+  isToolErrorResult,
+  parseOptionalCursor,
   slugifyCaseLawPathSegment,
+  windowTextByCursor,
 } from "@/api/mcp/tool-utils";
 
 // FRONTEND_URL is "http://localhost:3000" (no trailing slash) from
@@ -216,5 +219,104 @@ describe("buildCaseLawDecisionAppUrl gate", () => {
     expect(buildCaseLawDecisionAppUrl(input)).toBe(
       `${BASE}/law/cze/cases/ns/s`,
     );
+  });
+});
+
+const expectWindow = (value: ReturnType<typeof windowTextByCursor>) => {
+  if (isToolErrorResult(value)) {
+    throw new Error("expected a text window, got a tool error");
+  }
+  return value;
+};
+
+describe("windowTextByCursor", () => {
+  test("returns the whole text with no nextCursor when it fits one window", () => {
+    const window = expectWindow(
+      windowTextByCursor({ cursor: undefined, maxChars: 100, text: "hello" }),
+    );
+
+    expect(window.text).toBe("hello");
+    expect(window.charCount).toBe(5);
+    expect(window.truncated).toBe(false);
+    expect(window.nextCursor).toBeNull();
+  });
+
+  test("pages through long text without dropping or duplicating characters", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz0123456789";
+    const maxChars = 8;
+
+    let cursor: string | undefined;
+    let assembled = "";
+    let pages = 0;
+    do {
+      const window = expectWindow(
+        windowTextByCursor({ cursor, maxChars, text }),
+      );
+      expect(window.text.length).toBeLessThanOrEqual(maxChars);
+      expect(window.charCount).toBe(text.length);
+      assembled += window.text;
+      cursor = window.nextCursor ?? undefined;
+      pages += 1;
+      if (pages > 100) {
+        throw new Error("pagination did not terminate");
+      }
+    } while (cursor !== undefined);
+
+    expect(assembled).toBe(text);
+    expect(pages).toBe(Math.ceil(text.length / maxChars));
+  });
+
+  test("marks truncated and emits a nextCursor on the first of several windows", () => {
+    const window = expectWindow(
+      windowTextByCursor({ cursor: undefined, maxChars: 4, text: "abcdefgh" }),
+    );
+
+    expect(window.text).toBe("abcd");
+    expect(window.truncated).toBe(true);
+    expect(window.nextCursor).not.toBeNull();
+  });
+
+  test("rejects a malformed cursor", () => {
+    const result = windowTextByCursor({
+      cursor: "not-a-real-cursor",
+      maxChars: 8,
+      text: "abcdefgh",
+    });
+
+    expect(isToolErrorResult(result)).toBe(true);
+  });
+
+  test("clamps an offset past the end to an empty final window", () => {
+    const first = expectWindow(
+      windowTextByCursor({ cursor: undefined, maxChars: 4, text: "abcd" }),
+    );
+    expect(first.nextCursor).toBeNull();
+    expect(first.text).toBe("abcd");
+  });
+});
+
+describe("parseOptionalCursor", () => {
+  test("returns undefined when the cursor arg is absent", () => {
+    expect(parseOptionalCursor({ args: {}, key: "cursor" })).toBeUndefined();
+  });
+
+  test("passes a well-formed cursor through unchanged", () => {
+    const cursor = "eyJhIjoxfQ";
+    expect(parseOptionalCursor({ args: { cursor }, key: "cursor" })).toBe(
+      cursor,
+    );
+  });
+
+  test("rejects a non-string cursor", () => {
+    const result = parseOptionalCursor({ args: { cursor: 42 }, key: "cursor" });
+    expect(isToolErrorResult(result)).toBe(true);
+  });
+
+  test("rejects an over-long cursor", () => {
+    const result = parseOptionalCursor({
+      args: { cursor: "x".repeat(513) },
+      key: "cursor",
+    });
+    expect(isToolErrorResult(result)).toBe(true);
   });
 });

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { env } from "@/api/env";
+import { encodePaginationCursor } from "@/api/lib/pagination";
 import {
   buildCaseLawDecisionAppUrl,
   buildCaseLawDecisionUrl,
@@ -288,11 +289,16 @@ describe("windowTextByCursor", () => {
   });
 
   test("clamps an offset past the end to an empty final window", () => {
-    const first = expectWindow(
-      windowTextByCursor({ cursor: undefined, maxChars: 4, text: "abcd" }),
+    const result = expectWindow(
+      windowTextByCursor({
+        cursor: encodePaginationCursor([999]),
+        maxChars: 4,
+        text: "abcd",
+      }),
     );
-    expect(first.nextCursor).toBeNull();
-    expect(first.text).toBe("abcd");
+    expect(result.text).toBe("");
+    expect(result.nextCursor).toBeNull();
+    expect(result.truncated).toBe(false);
   });
 });
 

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildCaseLawDecisionUrl,
   isToolErrorResult,
   parseOptionalCursor,
+  resolveWindowBounds,
   slugifyCaseLawPathSegment,
   windowTextByCursor,
 } from "@/api/mcp/tool-utils";
@@ -318,5 +319,31 @@ describe("parseOptionalCursor", () => {
       key: "cursor",
     });
     expect(isToolErrorResult(result)).toBe(true);
+  });
+});
+
+describe("resolveWindowBounds", () => {
+  test("returns a full window with no next offset when everything fits", () => {
+    expect(resolveWindowBounds(5, 0, 50)).toEqual({
+      start: 0,
+      end: 5,
+      nextOffset: null,
+    });
+  });
+
+  test("emits the resume offset when the stream has more", () => {
+    expect(resolveWindowBounds(10, 0, 4)).toEqual({
+      start: 0,
+      end: 4,
+      nextOffset: 4,
+    });
+  });
+
+  test("clamps an offset past the end to an empty terminal window", () => {
+    expect(resolveWindowBounds(5, 99, 4)).toEqual({
+      start: 5,
+      end: 5,
+      nextOffset: null,
+    });
   });
 });

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -188,6 +188,30 @@ export type TextWindowResult = {
   truncated: boolean;
 };
 
+export type WindowBounds = {
+  start: number;
+  end: number;
+  /** Offset to resume at for the next window, or null when fully consumed. */
+  nextOffset: number | null;
+};
+
+/**
+ * Resolve a half-open `[start, end)` window of `size` items into a stream of
+ * `length` items, starting at `offset` (clamped into range). `nextOffset` is
+ * the resume point for the next window, or null when the window reaches the
+ * end. Works for any positional stream (string chars, array items).
+ */
+export const resolveWindowBounds = (
+  length: number,
+  offset: number,
+  size: number,
+): WindowBounds => {
+  const start = Math.min(Math.max(offset, 0), length);
+  const end = Math.min(start + size, length);
+
+  return { start, end, nextOffset: end < length ? end : null };
+};
+
 const decodeTextWindowOffset = (
   cursor: string | undefined,
 ): number | CallToolResult => {
@@ -225,17 +249,18 @@ export const windowTextByCursor = ({
     return offset;
   }
 
-  const charCount = text.length;
-  const start = Math.min(offset, charCount);
-  const windowText = text.slice(start, start + maxChars);
-  const end = start + windowText.length;
-  const nextCursor = end < charCount ? encodePaginationCursor([end]) : null;
+  const { start, end, nextOffset } = resolveWindowBounds(
+    text.length,
+    offset,
+    maxChars,
+  );
 
   return {
-    text: windowText,
-    charCount,
-    nextCursor,
-    truncated: nextCursor !== null,
+    text: text.slice(start, end),
+    charCount: text.length,
+    nextCursor:
+      nextOffset === null ? null : encodePaginationCursor([nextOffset]),
+    truncated: nextOffset !== null,
   };
 };
 

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -5,6 +5,10 @@ import { TaggedError } from "better-result";
 import { env } from "@/api/env";
 import { createOrgTools } from "@/api/handlers/chat/tools/org-tools";
 import { LIMITS } from "@/api/lib/limits";
+import {
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { getAccessibleWorkspaceId } from "@/api/mcp/context";
 
@@ -143,6 +147,96 @@ export const parseOptionalLimit = ({
     );
   }
   return value;
+};
+
+export const isToolErrorResult = (value: unknown): value is CallToolResult =>
+  typeof value === "object" &&
+  value !== null &&
+  "isError" in value &&
+  value.isError === true;
+
+const MAX_CURSOR_LENGTH = 512;
+
+export const parseOptionalCursor = ({
+  args,
+  key,
+}: {
+  args: Record<string, unknown>;
+  key: string;
+}): string | undefined | CallToolResult => {
+  const value = args[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.length === 0) {
+    return errorResult(
+      `Invalid parameter: ${key}. Expected an opaque cursor string`,
+    );
+  }
+  if (value.length > MAX_CURSOR_LENGTH) {
+    return errorResult(
+      `Parameter ${key} exceeds maximum length of ${MAX_CURSOR_LENGTH}`,
+    );
+  }
+  return value;
+};
+
+export type TextWindowResult = {
+  text: string;
+  charCount: number;
+  nextCursor: string | null;
+  truncated: boolean;
+};
+
+const decodeTextWindowOffset = (
+  cursor: string | undefined,
+): number | CallToolResult => {
+  if (cursor === undefined) {
+    return 0;
+  }
+  const candidate = decodePaginationCursor(cursor)?.[0];
+  if (
+    typeof candidate !== "number" ||
+    !Number.isInteger(candidate) ||
+    candidate < 0
+  ) {
+    return errorResult("Invalid cursor");
+  }
+  return candidate;
+};
+
+/**
+ * Return a `maxChars` window of `text` starting at the offset encoded in
+ * `cursor` (absent cursor = start). `nextCursor` is the opaque cursor for the
+ * next window, or null when the window reaches the end. Callers paginate long
+ * content by passing the returned `nextCursor` back as `cursor`.
+ */
+export const windowTextByCursor = ({
+  cursor,
+  maxChars,
+  text,
+}: {
+  cursor: string | undefined;
+  maxChars: number;
+  text: string;
+}): TextWindowResult | CallToolResult => {
+  const offset = decodeTextWindowOffset(cursor);
+  if (typeof offset !== "number") {
+    return offset;
+  }
+
+  const charCount = text.length;
+  const start = Math.min(offset, charCount);
+  const windowText = text.slice(start, start + maxChars);
+  const end = start + windowText.length;
+  const nextCursor = end < charCount ? encodePaginationCursor([end]) : null;
+
+  return {
+    text: windowText,
+    charCount,
+    nextCursor,
+    truncated: nextCursor !== null,
+  };
 };
 
 export const ensureWorkspaceAccess = ({

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -1074,6 +1074,60 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(anonymizeTextFieldsMock).not.toHaveBeenCalled();
   });
 
+  test("read_case_law_decision pages citation lists via the compound cursor", async () => {
+    const base = createReadDecisionResult();
+    readDecisionHandlerMock.mockResolvedValue({
+      ...base,
+      citationsFrom: Array.from({ length: 60 }, (_unused, i) => ({
+        citationText: `from-${i}`,
+        id: `cf_${i}`,
+      })),
+      citationsTo: Array.from({ length: 70 }, (_unused, i) => ({
+        citationText: `to-${i}`,
+        id: `ct_${i}`,
+      })),
+    });
+
+    type DecisionPage = {
+      nextCursor: string | null;
+      decision: {
+        citationsFrom: { id: string }[];
+        citationsFromTotal: number;
+        citationsTo: { id: string }[];
+        citationsToTotal: number;
+      };
+    };
+
+    // SAFETY: the decision handler always returns this JSON shape; the cast
+    // only types the field access that the assertions below verify.
+    const page1 = parseToolPayload(
+      await handleMcpToolCall({
+        args: { decision_id: "dec_123" },
+        context: createContext(),
+        toolName: "read_case_law_decision",
+      }),
+    ) as DecisionPage;
+    expect(page1.decision.citationsFrom).toHaveLength(50);
+    expect(page1.decision.citationsFromTotal).toBe(60);
+    expect(page1.decision.citationsTo).toHaveLength(50);
+    expect(page1.decision.citationsToTotal).toBe(70);
+    expect(page1.nextCursor).not.toBeNull();
+
+    // SAFETY: same fixed handler response shape as the first page.
+    const page2 = parseToolPayload(
+      await handleMcpToolCall({
+        args: { decision_id: "dec_123", cursor: page1.nextCursor },
+        context: createContext(),
+        toolName: "read_case_law_decision",
+      }),
+    ) as DecisionPage;
+    expect(page2.decision.citationsFrom).toHaveLength(10);
+    expect(page2.decision.citationsTo).toHaveLength(20);
+    expect(page2.decision.citationsFrom.at(0)?.id).toBe("cf_50");
+    expect(page2.decision.citationsTo.at(0)?.id).toBe("ct_50");
+    expect(page2.nextCursor).toBeNull();
+  });
+
   test("fetch rejects documents outside the MCP workspace allowlist", async () => {
     const result = await handleMcpToolCall({
       args: { id: "entity_1" },

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -1180,6 +1180,17 @@ describe("OpenAI-compatible MCP tools", () => {
     });
   });
 
+  test("search_across_matters rejects a malformed cursor instead of resetting to page 1", async () => {
+    const result = await handleMcpToolCall({
+      args: { query: "share purchase", cursor: "not-a-valid-cursor" },
+      context: createContext(),
+      toolName: "search_across_matters",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(searchProviderSearchMock).not.toHaveBeenCalled();
+  });
+
   test("read_content_across_matters returns content from allowed workspaces", async () => {
     const context = createContext({
       accessibleWorkspaceIds: ["ws_1", "ws_3"],

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -680,36 +680,37 @@ describe("OpenAI-compatible MCP tools", () => {
       scopedDb: createScopedDb([], createExtractedContentRow()),
     });
 
-    // SAFETY: the fetch handler under test always returns this JSON shape; the
-    // cast only types the field access that the assertions below verify.
-    const first = parseToolPayload(
-      await handleMcpToolCall({
-        args: { id: "entity_1" },
-        context,
-        toolName: "fetch",
-      }),
-    ) as {
+    const first = asTestRaw<{
       text: string;
       nextCursor: string | null;
       metadata: { charCount: number; truncated: boolean };
-    };
+    }>(
+      parseToolPayload(
+        await handleMcpToolCall({
+          args: { id: "entity_1" },
+          context,
+          toolName: "fetch",
+        }),
+      ),
+    );
     expect(first.text).toBe("x".repeat(8000));
     expect(first.metadata.charCount).toBe(9000);
     expect(first.metadata.truncated).toBe(true);
     expect(first.nextCursor).not.toBeNull();
 
-    // SAFETY: same fixed handler response shape as the first page.
-    const second = parseToolPayload(
-      await handleMcpToolCall({
-        args: { id: "entity_1", cursor: first.nextCursor },
-        context,
-        toolName: "fetch",
-      }),
-    ) as {
+    const second = asTestRaw<{
       text: string;
       nextCursor: string | null;
       metadata: { truncated: boolean };
-    };
+    }>(
+      parseToolPayload(
+        await handleMcpToolCall({
+          args: { id: "entity_1", cursor: first.nextCursor },
+          context,
+          toolName: "fetch",
+        }),
+      ),
+    );
     expect(second.text).toBe("y".repeat(1000));
     expect(second.metadata.truncated).toBe(false);
     expect(second.nextCursor).toBeNull();
@@ -1098,29 +1099,30 @@ describe("OpenAI-compatible MCP tools", () => {
       };
     };
 
-    // SAFETY: the decision handler always returns this JSON shape; the cast
-    // only types the field access that the assertions below verify.
-    const page1 = parseToolPayload(
-      await handleMcpToolCall({
-        args: { decision_id: "dec_123" },
-        context: createContext(),
-        toolName: "read_case_law_decision",
-      }),
-    ) as DecisionPage;
+    const page1 = asTestRaw<DecisionPage>(
+      parseToolPayload(
+        await handleMcpToolCall({
+          args: { decision_id: "dec_123" },
+          context: createContext(),
+          toolName: "read_case_law_decision",
+        }),
+      ),
+    );
     expect(page1.decision.citationsFrom).toHaveLength(50);
     expect(page1.decision.citationsFromTotal).toBe(60);
     expect(page1.decision.citationsTo).toHaveLength(50);
     expect(page1.decision.citationsToTotal).toBe(70);
     expect(page1.nextCursor).not.toBeNull();
 
-    // SAFETY: same fixed handler response shape as the first page.
-    const page2 = parseToolPayload(
-      await handleMcpToolCall({
-        args: { decision_id: "dec_123", cursor: page1.nextCursor },
-        context: createContext(),
-        toolName: "read_case_law_decision",
-      }),
-    ) as DecisionPage;
+    const page2 = asTestRaw<DecisionPage>(
+      parseToolPayload(
+        await handleMcpToolCall({
+          args: { decision_id: "dec_123", cursor: page1.nextCursor },
+          context: createContext(),
+          toolName: "read_case_law_decision",
+        }),
+      ),
+    );
     expect(page2.decision.citationsFrom).toHaveLength(10);
     expect(page2.decision.citationsTo).toHaveLength(20);
     expect(page2.decision.citationsFrom.at(0)?.id).toBe("cf_50");

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -445,6 +445,12 @@ describe("OpenAI-compatible MCP tools", () => {
           description: "Search query",
           maxLength: 500,
         },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque cursor from a previous search call to fetch the next page",
+          maxLength: 512,
+        },
       },
       required: ["query"],
     });
@@ -619,7 +625,7 @@ describe("OpenAI-compatible MCP tools", () => {
 
     expect(searchAcrossMattersExecute).toHaveBeenCalledWith(
       {
-        limit: 16,
+        limit: 8,
         query: "share purchase",
       },
       {
@@ -657,13 +663,56 @@ describe("OpenAI-compatible MCP tools", () => {
       title: "Share Purchase Agreement",
       text: "Full document text",
       url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=entity_1&field=field_1`,
+      nextCursor: null,
       metadata: {
-        charCount: 321,
+        charCount: "Full document text".length,
         source: "stella",
         truncated: false,
         workspaceId: "ws_1",
       },
     });
+  });
+
+  test("fetch pages long document text via the returned cursor", async () => {
+    const longText = "x".repeat(8000) + "y".repeat(1000);
+    decryptContentMock.mockResolvedValue(longText);
+    const context = createContext({
+      scopedDb: createScopedDb([], createExtractedContentRow()),
+    });
+
+    // SAFETY: the fetch handler under test always returns this JSON shape; the
+    // cast only types the field access that the assertions below verify.
+    const first = parseToolPayload(
+      await handleMcpToolCall({
+        args: { id: "entity_1" },
+        context,
+        toolName: "fetch",
+      }),
+    ) as {
+      text: string;
+      nextCursor: string | null;
+      metadata: { charCount: number; truncated: boolean };
+    };
+    expect(first.text).toBe("x".repeat(8000));
+    expect(first.metadata.charCount).toBe(9000);
+    expect(first.metadata.truncated).toBe(true);
+    expect(first.nextCursor).not.toBeNull();
+
+    // SAFETY: same fixed handler response shape as the first page.
+    const second = parseToolPayload(
+      await handleMcpToolCall({
+        args: { id: "entity_1", cursor: first.nextCursor },
+        context,
+        toolName: "fetch",
+      }),
+    ) as {
+      text: string;
+      nextCursor: string | null;
+      metadata: { truncated: boolean };
+    };
+    expect(second.text).toBe("y".repeat(1000));
+    expect(second.metadata.truncated).toBe(false);
+    expect(second.nextCursor).toBeNull();
   });
 
   test("search_case_law maps filters and returns decision links", async () => {
@@ -929,6 +978,7 @@ describe("OpenAI-compatible MCP tools", () => {
     );
 
     expect(parseToolPayload(result)).toEqual({
+      nextCursor: null,
       decision: {
         appUrl: `${APP_BASE_URL}/law/cze/cases/nejvyssi-soud/stable-official-slug`,
         caseNumber: "29 Cdo 123/2024",
@@ -953,6 +1003,8 @@ describe("OpenAI-compatible MCP tools", () => {
         },
         sourceUrl: "https://example.test/decision",
         text: "29 Cdo 123/2024\n\nThe court dismissed the appeal.",
+        charCount: "29 Cdo 123/2024\n\nThe court dismissed the appeal.".length,
+        truncated: false,
       },
     });
   });
@@ -990,6 +1042,7 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     expect(parseToolPayload(result)).toEqual({
+      nextCursor: null,
       decision: {
         appUrl: `${APP_BASE_URL}/law/cze/cases/nejvyssi-soud/stable-official-slug`,
         caseNumber: "29 Cdo 123/2024",
@@ -1014,6 +1067,8 @@ describe("OpenAI-compatible MCP tools", () => {
         },
         sourceUrl: "https://example.test/decision",
         text: "29 Cdo 123/2024\n\nThe court dismissed the appeal.",
+        charCount: "29 Cdo 123/2024\n\nThe court dismissed the appeal.".length,
+        truncated: false,
       },
     });
     expect(anonymizeTextFieldsMock).not.toHaveBeenCalled();
@@ -1081,12 +1136,13 @@ describe("OpenAI-compatible MCP tools", () => {
     });
 
     expect(parseToolPayload(result)).toEqual({
-      charCount: 321,
+      charCount: "Full document text".length,
       entityId: "entity_1",
       kind: "document",
       name: "Share Purchase Agreement",
       text: "Full document text",
       truncated: false,
+      nextCursor: null,
       workspaceId: "ws_1",
     });
   });
@@ -1310,10 +1366,11 @@ describe("OpenAI-compatible MCP tools", () => {
       title: "[PERSON_1] SPA",
       text: "[PERSON_1] signed the agreement",
       url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=entity_1&field=field_1`,
+      nextCursor: null,
       metadata: {
         anonymized: true,
         anonymizedEntityCount: 2,
-        charCount: 321,
+        charCount: "[PERSON_1] signed the agreement".length,
         source: "stella",
         truncated: false,
         workspaceId: "ws_1",
@@ -1348,10 +1405,11 @@ describe("OpenAI-compatible MCP tools", () => {
       title: "",
       text: "",
       url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=entity_1&field=field_1`,
+      nextCursor: null,
       metadata: {
         anonymized: true,
         anonymizedEntityCount: 1,
-        charCount: 42,
+        charCount: 0,
         source: "stella",
         truncated: false,
         workspaceId: "ws_1",
@@ -1386,10 +1444,11 @@ describe("OpenAI-compatible MCP tools", () => {
       title: "[REDACTED]",
       text: "[REDACTED]",
       url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=entity_1&field=field_1`,
+      nextCursor: null,
       metadata: {
         anonymized: true,
         anonymizedEntityCount: 1,
-        charCount: 42,
+        charCount: "[REDACTED]".length,
         source: "stella",
         truncated: false,
         workspaceId: "ws_1",


### PR DESCRIPTION
Adds opaque cursor pagination to the MCP list/search tools that lacked it and a uniform text-window cursor to the read tools, so MCP clients can page past the previously hard 8k/16k content caps and the fixed list/search limits.

## What changed

**Shared primitives** (`tool-utils.ts`)
- `parseOptionalCursor`, `resolveWindowBounds` (generic positional windowing), and `windowTextByCursor` (offset encoded in an opaque cursor, built on `resolveWindowBounds`)
- promoted `isToolErrorResult` for reuse across the tool files

**Search tools**
- `search_across_matters` and the OpenAI-compatible `search` thread the provider cursor and surface `nextCursor`. Compat `search` drops the 2× over-fetch so the keyset cursor stays aligned with the provider's hit position (over-fetching + post-filtering would desync the cursor and skip results); a page may now be smaller than the page size when non-fetchable hits are filtered out, and callers keep paging while `nextCursor` is non-null.

**List tools**
- `list_matters` and `list_templates` use keyset cursors whose `(lastActivityAt|createdAt, id)` boundary is resolved in-DB by id, so the cursor never round-trips a timestamp through a millisecond `Date`. Both columns are `defaultNow()` (microsecond) where that truncation would otherwise skip or duplicate rows.

**Read tools**
- `read_content_across_matters`, compat `fetch`, and `read_case_law_decision` return text in windows via the same `cursor` idiom.
- Anonymized `fetch` anonymizes the full document before windowing, so an entity name cannot be split across a window edge (this also removes a latent slice-then-anonymize boundary case).
- `read_case_law_decision` pages its decision text and both citation lists together with a single compound cursor (`[textOffset, fromOffset, toOffset]`), keeping one cursor param per tool.
- `fill_template` is intentionally not windowed: it is a metered, audited mutation, so paging by re-invocation would re-charge usage and re-audit. It already returns the full document as base64; the inline text stays a preview.

All paginated tools follow one idiom: pass `cursor`, read `nextCursor` until it is null.

## Notes
- `charCount` on read responses now reflects the length of the returned stream (the decrypted/anonymized text being paged), which is what the cursor offsets index into.
- Tests: unit coverage for `resolveWindowBounds` / `windowTextByCursor` / `parseOptionalCursor`, plus handler-level continuation tests for compat `fetch` text-windowing and `read_case_law_decision` citation paging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination to list, search, fetch, and document-reading tools.
  * Responses now include `nextCursor` so users can continue through longer results and content.

* **Bug Fixes**
  * Improved pagination consistency to avoid skipping or duplicating items.
  * Updated content windowing so returned text and length details better match the actual page shown.
  * Enhanced handling of long content, anonymised output, and compound pagination across related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->