### PR TITLE
fix(folio): render AI inline bold markdown as real Word formatting

### DIFF
--- a/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
+++ b/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
@@ -255,7 +255,11 @@ export const createActiveDocxEditTool = () =>
       "replace, rewrite, revise, or update text in the open DOCX, or asks " +
       "for a review/redline. Operations are queued for the user to review " +
       "and apply themselves; this tool does NOT write to the document. " +
-      "See each schema field for its semantics.",
+      "Write document prose, not markdown: no `#` headings, list dashes, " +
+      "or backticks. For a bold heading set `styleId` (e.g. ClauseHeading1). " +
+      "The only inline formatting honored in `text`/`replace` is `**bold**` " +
+      "and `***bold italic***`; any other markdown lands as literal " +
+      "characters. See each schema field for its semantics.",
     needsApproval: true,
     inputSchema: valibotSchema(
       v.strictObject({

--- a/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
+++ b/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
@@ -257,9 +257,10 @@ export const createActiveDocxEditTool = () =>
       "and apply themselves; this tool does NOT write to the document. " +
       "Write document prose, not markdown: no `#` headings, list dashes, " +
       "or backticks. For a bold heading set `styleId` (e.g. ClauseHeading1). " +
-      "The only inline formatting honored in `text`/`replace` is `**bold**` " +
-      "and `***bold italic***`; any other markdown lands as literal " +
-      "characters. See each schema field for its semantics.",
+      "Inserted block `text` may use `**bold**` / `***bold italic***` for " +
+      "inline emphasis; in `replace` write plain text, since redlined " +
+      "replacements are not re-formatted. See each schema field for its " +
+      "semantics.",
     needsApproval: true,
     inputSchema: valibotSchema(
       v.strictObject({

--- a/packages/folio/src/core/ai-edits/aiEdits.test.ts
+++ b/packages/folio/src/core/ai-edits/aiEdits.test.ts
@@ -1418,6 +1418,72 @@ describe("Folio AI edit operations", () => {
     expect(boldRun).toContain("bold");
   });
 
+  test("replaceBlock **bold** becomes a real bold run and keeps block attrs (direct mode)", () => {
+    const state = makeState([{ text: "Old line.", paraId: "AAAA0001" }]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "replaceBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const block = view.state.doc.child(0);
+    expect(block.textContent).toBe("Date: 2026");
+    expect(block.attrs["paraId"]).toBe("AAAA0001");
+    const runs: { text: string; marks: string[] }[] = [];
+    block.descendants((node) => {
+      if (node.isText) {
+        runs.push({
+          text: node.text ?? "",
+          marks: node.marks.map((m) => m.type.name),
+        });
+      }
+    });
+    expect(runs).toEqual([
+      { text: "Date:", marks: ["bold"] },
+      { text: " 2026", marks: [] },
+    ]);
+  });
+
+  test("replaceBlock strips markdown markers in tracked-changes mode (no literal asterisks)", () => {
+    const state = makeState([{ text: "Old line.", paraId: "AAAA0001" }]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "replaceBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    // The word-diff redline interleaves the deleted old text with the new
+    // run, so the new text is present but not contiguous. The point here is
+    // that the markdown markers never reach the document as literal text.
+    const text = view.state.doc.textContent;
+    expect(text).toContain("Date:");
+    expect(text).toContain("2026");
+    expect(text).not.toContain("*");
+  });
+
   test("page-break-only inserts are skipped in tracked-changes mode", () => {
     const view = makeView(makeState(["Anchor block."]));
     const snapshot = createFolioAIEditSnapshot(view.state.doc);

--- a/packages/folio/src/core/ai-edits/aiEdits.test.ts
+++ b/packages/folio/src/core/ai-edits/aiEdits.test.ts
@@ -1353,6 +1353,71 @@ describe("Folio AI edit operations", () => {
     expect(view.state.doc.child(2).type.name).toBe("table");
   });
 
+  test("inserted **bold** markdown becomes a real bold run (direct mode)", () => {
+    const state = makeState(["Anchor."]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    const result = applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+          inheritFormatting: false,
+        },
+      ],
+      mode: "direct",
+    });
+
+    expect(result.skipped).toEqual([]);
+    const inserted = view.state.doc.child(1);
+    expect(inserted.textContent).toBe("Date: 2026");
+    const runs: { text: string; marks: string[] }[] = [];
+    inserted.descendants((node) => {
+      if (node.isText) {
+        runs.push({
+          text: node.text ?? "",
+          marks: node.marks.map((m) => m.type.name),
+        });
+      }
+    });
+    expect(runs).toEqual([
+      { text: "Date:", marks: ["bold"] },
+      { text: " 2026", marks: [] },
+    ]);
+  });
+
+  test("inserted **bold** markdown carries both insertion and bold marks (tracked changes)", () => {
+    const state = makeState(["Anchor."]);
+    const snapshot = createFolioAIEditSnapshot(state.doc);
+    const view = makeView(state);
+
+    applyFolioAIEditOperations({
+      view,
+      snapshot,
+      operations: [
+        {
+          id: "op-1",
+          type: "insertAfterBlock",
+          blockId: snapshot.blocks[0]?.id ?? "",
+          text: "**Date:** 2026",
+          inheritFormatting: false,
+        },
+      ],
+      mode: "tracked-changes",
+    });
+
+    const inserted = view.state.doc.child(1);
+    expect(inserted.textContent).toBe("Date: 2026");
+    const boldRun = collectMarksByText(view.state)["Date:"];
+    expect(boldRun).toContain("insertion");
+    expect(boldRun).toContain("bold");
+  });
+
   test("page-break-only inserts are skipped in tracked-changes mode", () => {
     const view = makeView(makeState(["Anchor block."]));
     const snapshot = createFolioAIEditSnapshot(view.state.doc);

--- a/packages/folio/src/core/ai-edits/apply.ts
+++ b/packages/folio/src/core/ai-edits/apply.ts
@@ -3,6 +3,10 @@ import type { EditorState, Transaction } from "prosemirror-state";
 
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
+import {
+  parseInlineEmphasisRuns,
+  stripInlineEmphasisMarkers,
+} from "./inline-emphasis";
 import { hashFolioAIBlockText, normalizeFolioAIBlockText } from "./snapshot";
 import type {
   FolioAIEditAppliedOperation,
@@ -314,6 +318,42 @@ const buildSignatureTableNode = ({
   return tableType.create({}, row);
 };
 
+/**
+ * Build the inline content for an inserted or replaced block, promoting the
+ * model's `**bold**` / `***bold italic***` markdown into real Word marks (the
+ * edit-tool schema has no inline-format channel, so the model improvises with
+ * markdown that would otherwise land as literal asterisks). Falls back to a
+ * single verbatim text node when no emphasis is present, so plain prose is
+ * never reshaped. `baseMarks` (insertion / comment) ride on every run.
+ */
+const buildEmphasisInlineContent = (
+  schema: Schema,
+  text: string,
+  baseMarks: readonly Mark[],
+): PMNode[] => {
+  const runs = parseInlineEmphasisRuns(text);
+  if (!runs.some((run) => run.bold || run.italic)) {
+    return [schema.text(text, [...baseMarks])];
+  }
+  const boldType = schema.marks["bold"];
+  const italicType = schema.marks["italic"];
+  const nodes: PMNode[] = [];
+  for (const run of runs) {
+    if (run.text.length === 0) {
+      continue;
+    }
+    const marks: Mark[] = [...baseMarks];
+    if (run.bold && boldType) {
+      marks.push(boldType.create());
+    }
+    if (run.italic && italicType) {
+      marks.push(italicType.create());
+    }
+    nodes.push(schema.text(run.text, marks));
+  }
+  return nodes.length > 0 ? nodes : [schema.text(text, [...baseMarks])];
+};
+
 export const applyFolioAIEditOperations = ({
   view,
   snapshot,
@@ -451,7 +491,11 @@ export const applyFolioAIEditOperations = ({
               replaceAttrs,
               replacement.length === 0
                 ? null
-                : view.state.schema.text(replacement),
+                : buildEmphasisInlineContent(
+                    view.state.schema,
+                    replacement,
+                    [],
+                  ),
             );
             tr = tr.replaceWith(item.blockFrom, item.blockTo, node);
             break;
@@ -504,7 +548,11 @@ export const applyFolioAIEditOperations = ({
         }
         const content =
           item.insertText && item.insertText.length > 0
-            ? view.state.schema.text(item.insertText, marks)
+            ? buildEmphasisInlineContent(
+                view.state.schema,
+                item.insertText,
+                marks,
+              )
             : null;
         // Inherit formatting attrs (listMarker, styleId, …) from
         // the source block but never reuse identity attrs — a new
@@ -665,15 +713,17 @@ const applyTextReplacement = ({
   commentMark,
 }: TextReplacementOptions): Transaction => {
   let nextTr = tr;
-  const replacement = (() => {
-    if (item.operation.type === "replaceInBlock") {
-      return item.operation.replace;
-    }
-    if (item.operation.type === "replaceBlock") {
-      return item.operation.text;
-    }
-    return "";
-  })();
+  const replacement = stripInlineEmphasisMarkers(
+    (() => {
+      if (item.operation.type === "replaceInBlock") {
+        return item.operation.replace;
+      }
+      if (item.operation.type === "replaceBlock") {
+        return item.operation.text;
+      }
+      return "";
+    })(),
+  );
 
   if (mode === "direct") {
     nextTr = nextTr.insertText(replacement, item.from, item.to);

--- a/packages/folio/src/core/ai-edits/apply.ts
+++ b/packages/folio/src/core/ai-edits/apply.ts
@@ -4,6 +4,7 @@ import type { EditorState, Transaction } from "prosemirror-state";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
 import {
+  hasInlineEmphasis,
   parseInlineEmphasisRuns,
   stripInlineEmphasisMarkers,
 } from "./inline-emphasis";
@@ -500,6 +501,27 @@ export const applyFolioAIEditOperations = ({
             tr = tr.replaceWith(item.blockFrom, item.blockTo, node);
             break;
           }
+        }
+        // Direct mode, formatting preserved (the default): when the replacement
+        // carries inline emphasis, rebuild the block node keeping its own attrs
+        // so `**bold**` becomes real marks. The tracked-changes path can't carry
+        // inline marks through its word-diff redline, so it still strips them;
+        // plain replacements fall through to the text-only swap below unchanged.
+        if (mode === "direct" && hasInlineEmphasis(item.operation.text)) {
+          const attrs: Record<string, unknown> =
+            item.operation.styleId !== undefined
+              ? { ...item.blockNode.attrs, styleId: item.operation.styleId }
+              : { ...item.blockNode.attrs };
+          const node = item.blockNode.type.create(
+            attrs,
+            buildEmphasisInlineContent(
+              view.state.schema,
+              item.operation.text,
+              commentMark ? [commentMark] : [],
+            ),
+          );
+          tr = tr.replaceWith(item.blockFrom, item.blockTo, node);
+          break;
         }
         tr = applyTextReplacement({
           tr,

--- a/packages/folio/src/core/ai-edits/inline-emphasis.test.ts
+++ b/packages/folio/src/core/ai-edits/inline-emphasis.test.ts
@@ -1,0 +1,97 @@
+// The chat edit tool has no inline run-format channel, so the model improvises
+// bold with markdown. These tests pin the conservative parse that promotes
+// `**bold**` / `***bold italic***` to runs while leaving ambiguous single
+// delimiters (math, identifiers) and plain prose untouched.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseInlineEmphasisRuns,
+  stripInlineEmphasisMarkers,
+} from "./inline-emphasis";
+
+describe("parseInlineEmphasisRuns", () => {
+  test("promotes a bold span and keeps surrounding literals", () => {
+    expect(parseInlineEmphasisRuns("**Date:** 2026-06-30")).toEqual([
+      { text: "Date:", bold: true, italic: false },
+      { text: " 2026-06-30", bold: false, italic: false },
+    ]);
+  });
+
+  test("handles a bold span mid-sentence", () => {
+    expect(
+      parseInlineEmphasisRuns("(1) **Disclosing Party Name**, with office"),
+    ).toEqual([
+      { text: "(1) ", bold: false, italic: false },
+      { text: "Disclosing Party Name", bold: true, italic: false },
+      { text: ", with office", bold: false, italic: false },
+    ]);
+  });
+
+  test("triple markers are bold and italic", () => {
+    expect(parseInlineEmphasisRuns("***Term***")).toEqual([
+      { text: "Term", bold: true, italic: true },
+    ]);
+  });
+
+  test("underscore double markers are bold", () => {
+    expect(parseInlineEmphasisRuns("__Party__")).toEqual([
+      { text: "Party", bold: true, italic: false },
+    ]);
+  });
+
+  test("two bold spans in one line", () => {
+    expect(parseInlineEmphasisRuns("**a** and **b**")).toEqual([
+      { text: "a", bold: true, italic: false },
+      { text: " and ", bold: false, italic: false },
+      { text: "b", bold: true, italic: false },
+    ]);
+  });
+
+  test("plain prose stays a single literal run", () => {
+    expect(parseInlineEmphasisRuns("Date: {{date}}")).toEqual([
+      { text: "Date: {{date}}", bold: false, italic: false },
+    ]);
+  });
+
+  test("single asterisks are left literal (not italic)", () => {
+    expect(parseInlineEmphasisRuns("quantity 5*3*2 units")).toEqual([
+      { text: "quantity 5*3*2 units", bold: false, italic: false },
+    ]);
+  });
+
+  test("unbalanced markers stay literal", () => {
+    expect(parseInlineEmphasisRuns("see **infra")).toEqual([
+      { text: "see **infra", bold: false, italic: false },
+    ]);
+  });
+
+  test("space-flanked markers are not a span", () => {
+    expect(parseInlineEmphasisRuns("a ** b ** c")).toEqual([
+      { text: "a ** b ** c", bold: false, italic: false },
+    ]);
+  });
+
+  test("escaped markers stay literal", () => {
+    expect(parseInlineEmphasisRuns("price \\*per unit\\*")).toEqual([
+      { text: "price *per unit*", bold: false, italic: false },
+    ]);
+  });
+});
+
+describe("stripInlineEmphasisMarkers", () => {
+  test("drops markers from a bold span", () => {
+    expect(stripInlineEmphasisMarkers("**Date:** 2026")).toBe("Date: 2026");
+  });
+
+  test("returns plain prose verbatim (escapes untouched)", () => {
+    for (const input of [
+      "Date: {{date}}",
+      "quantity 5*3*2 units",
+      "path C:\\*.txt",
+      "see **infra",
+    ]) {
+      expect(stripInlineEmphasisMarkers(input)).toBe(input);
+    }
+  });
+});

--- a/packages/folio/src/core/ai-edits/inline-emphasis.test.ts
+++ b/packages/folio/src/core/ai-edits/inline-emphasis.test.ts
@@ -72,9 +72,16 @@ describe("parseInlineEmphasisRuns", () => {
     ]);
   });
 
-  test("escaped markers stay literal", () => {
+  test("backslashes are ordinary characters (no markdown escapes)", () => {
     expect(parseInlineEmphasisRuns("price \\*per unit\\*")).toEqual([
-      { text: "price *per unit*", bold: false, italic: false },
+      { text: "price \\*per unit\\*", bold: false, italic: false },
+    ]);
+  });
+
+  test("a backslash path survives next to a bold span", () => {
+    expect(parseInlineEmphasisRuns("**Note:** path C:\\*.txt")).toEqual([
+      { text: "Note:", bold: true, italic: false },
+      { text: " path C:\\*.txt", bold: false, italic: false },
     ]);
   });
 });
@@ -84,7 +91,13 @@ describe("stripInlineEmphasisMarkers", () => {
     expect(stripInlineEmphasisMarkers("**Date:** 2026")).toBe("Date: 2026");
   });
 
-  test("returns plain prose verbatim (escapes untouched)", () => {
+  test("keeps a backslash path when stripping an adjacent bold span", () => {
+    expect(stripInlineEmphasisMarkers("**Note:** path C:\\*.txt")).toBe(
+      "Note: path C:\\*.txt",
+    );
+  });
+
+  test("returns plain prose verbatim", () => {
     for (const input of [
       "Date: {{date}}",
       "quantity 5*3*2 units",

--- a/packages/folio/src/core/ai-edits/inline-emphasis.test.ts
+++ b/packages/folio/src/core/ai-edits/inline-emphasis.test.ts
@@ -34,9 +34,15 @@ describe("parseInlineEmphasisRuns", () => {
     ]);
   });
 
-  test("underscore double markers are bold", () => {
-    expect(parseInlineEmphasisRuns("__Party__")).toEqual([
-      { text: "Party", bold: true, italic: false },
+  test("underscore placeholders stay literal (not emphasis)", () => {
+    expect(
+      parseInlineEmphasisRuns("__Borrower__ and ___EffectiveDate___"),
+    ).toEqual([
+      {
+        text: "__Borrower__ and ___EffectiveDate___",
+        bold: false,
+        italic: false,
+      },
     ]);
   });
 
@@ -103,6 +109,7 @@ describe("stripInlineEmphasisMarkers", () => {
       "quantity 5*3*2 units",
       "path C:\\*.txt",
       "see **infra",
+      "__Borrower__ pays ___EffectiveDate___",
     ]) {
       expect(stripInlineEmphasisMarkers(input)).toBe(input);
     }

--- a/packages/folio/src/core/ai-edits/inline-emphasis.ts
+++ b/packages/folio/src/core/ai-edits/inline-emphasis.ts
@@ -1,0 +1,124 @@
+/**
+ * Turn the bold / bold-italic markdown the chat model sometimes emits inside
+ * inserted or replaced block text ("**Date:**", "***Term***") into structured
+ * runs the editor renders as real Word formatting.
+ *
+ * The active-docx-edit tool gives the model no inline run-formatting channel —
+ * only paragraph-level `styleId`. When the model wants a bold label or party
+ * name mid-sentence it improvises with markdown, and because DOCX has no notion
+ * of markdown those markers otherwise reach the document as literal asterisks.
+ *
+ * Deliberately conservative: only paired double (`**`, `__`) and triple
+ * (`***`, `___`) markers with non-space inner content count as emphasis. A lone
+ * `*` or `_` stays literal — in legal prose it is far more likely a
+ * multiplication sign or an identifier than an italic delimiter. Nesting is not
+ * interpreted; inner content is taken verbatim.
+ */
+
+export type InlineEmphasisRun = {
+  text: string;
+  bold: boolean;
+  italic: boolean;
+};
+
+const MARKERS: readonly { marker: string; bold: boolean; italic: boolean }[] = [
+  { marker: "***", bold: true, italic: true },
+  { marker: "___", bold: true, italic: true },
+  { marker: "**", bold: true, italic: false },
+  { marker: "__", bold: true, italic: false },
+];
+
+const isSpace = (ch: string | undefined): boolean =>
+  ch === undefined || ch === " " || ch === "\t" || ch === "\n";
+
+const matchMarkerAt = (
+  input: string,
+  at: number,
+): (typeof MARKERS)[number] | undefined =>
+  MARKERS.find((m) => input.startsWith(m.marker, at));
+
+const appendLiteral = (runs: InlineEmphasisRun[], text: string): void => {
+  if (text.length === 0) {
+    return;
+  }
+  const last = runs.at(-1);
+  if (last && !last.bold && !last.italic) {
+    last.text += text;
+    return;
+  }
+  runs.push({ text, bold: false, italic: false });
+};
+
+export const parseInlineEmphasisRuns = (input: string): InlineEmphasisRun[] => {
+  const runs: InlineEmphasisRun[] = [];
+  let buffer = "";
+  let i = 0;
+
+  const flushBuffer = () => {
+    appendLiteral(runs, buffer);
+    buffer = "";
+  };
+
+  while (i < input.length) {
+    const ch = input[i];
+
+    // A backslash escapes a following emphasis char so it stays literal,
+    // matching markdown's `\*` convention.
+    const next = input[i + 1];
+    if (ch === "\\" && (next === "*" || next === "_" || next === "\\")) {
+      buffer += next;
+      i += 2;
+      continue;
+    }
+
+    const matched = matchMarkerAt(input, i);
+    if (!matched) {
+      buffer += ch;
+      i += 1;
+      continue;
+    }
+
+    const contentStart = i + matched.marker.length;
+    const closeIdx = input.indexOf(matched.marker, contentStart);
+    const content = closeIdx === -1 ? "" : input.slice(contentStart, closeIdx);
+    const isSpan =
+      closeIdx !== -1 &&
+      content.length > 0 &&
+      !isSpace(content[0]) &&
+      !isSpace(content.at(-1));
+
+    if (!isSpan) {
+      // Not a real span (no close, or space-flanked): emit the marker's first
+      // char as literal and retry from the next position so a `**` inside a
+      // dangling `***` can still pair as bold.
+      buffer += ch;
+      i += 1;
+      continue;
+    }
+
+    flushBuffer();
+    runs.push({ text: content, bold: matched.bold, italic: matched.italic });
+    i = closeIdx + matched.marker.length;
+  }
+
+  flushBuffer();
+  return runs;
+};
+
+const hasEmphasis = (runs: readonly InlineEmphasisRun[]): boolean =>
+  runs.some((run) => run.bold || run.italic);
+
+/**
+ * Drop emphasis markers without reconstructing formatting. Used on the
+ * tracked-changes replace path, where the word-diff redline cannot carry inline
+ * marks; stripping at least keeps literal `**` out of the document. Returns the
+ * input verbatim when no real span is present, so plain prose (and stray
+ * single `*` / escaped `\*`) is never reshaped.
+ */
+export const stripInlineEmphasisMarkers = (input: string): string => {
+  const runs = parseInlineEmphasisRuns(input);
+  if (!hasEmphasis(runs)) {
+    return input;
+  }
+  return runs.map((run) => run.text).join("");
+};

--- a/packages/folio/src/core/ai-edits/inline-emphasis.ts
+++ b/packages/folio/src/core/ai-edits/inline-emphasis.ts
@@ -12,7 +12,8 @@
  * (`***`, `___`) markers with non-space inner content count as emphasis. A lone
  * `*` or `_` stays literal — in legal prose it is far more likely a
  * multiplication sign or an identifier than an italic delimiter. Nesting is not
- * interpreted; inner content is taken verbatim.
+ * interpreted; inner content is taken verbatim. Backslashes are ordinary
+ * characters (no markdown escapes), so Windows paths and regex survive intact.
  */
 
 export type InlineEmphasisRun = {
@@ -61,16 +62,6 @@ export const parseInlineEmphasisRuns = (input: string): InlineEmphasisRun[] => {
 
   while (i < input.length) {
     const ch = input[i];
-
-    // A backslash escapes a following emphasis char so it stays literal,
-    // matching markdown's `\*` convention.
-    const next = input[i + 1];
-    if (ch === "\\" && (next === "*" || next === "_" || next === "\\")) {
-      buffer += next;
-      i += 2;
-      continue;
-    }
-
     const matched = matchMarkerAt(input, i);
     if (!matched) {
       buffer += ch;
@@ -107,6 +98,11 @@ export const parseInlineEmphasisRuns = (input: string): InlineEmphasisRun[] => {
 
 const hasEmphasis = (runs: readonly InlineEmphasisRun[]): boolean =>
   runs.some((run) => run.bold || run.italic);
+
+/** True when `input` contains at least one bold / italic span worth promoting
+ *  to real marks; lets callers skip the run rebuild for plain text. */
+export const hasInlineEmphasis = (input: string): boolean =>
+  hasEmphasis(parseInlineEmphasisRuns(input));
 
 /**
  * Drop emphasis markers without reconstructing formatting. Used on the

--- a/packages/folio/src/core/ai-edits/inline-emphasis.ts
+++ b/packages/folio/src/core/ai-edits/inline-emphasis.ts
@@ -8,12 +8,13 @@
  * name mid-sentence it improvises with markdown, and because DOCX has no notion
  * of markdown those markers otherwise reach the document as literal asterisks.
  *
- * Deliberately conservative: only paired double (`**`, `__`) and triple
- * (`***`, `___`) markers with non-space inner content count as emphasis. A lone
- * `*` or `_` stays literal — in legal prose it is far more likely a
- * multiplication sign or an identifier than an italic delimiter. Nesting is not
- * interpreted; inner content is taken verbatim. Backslashes are ordinary
- * characters (no markdown escapes), so Windows paths and regex survive intact.
+ * Deliberately conservative: only paired `**bold**` and `***bold italic***`
+ * asterisk markers with non-space inner content count as emphasis. Underscores
+ * are always literal — `__Borrower__` / snake_case placeholders are common in
+ * legal templates, and a lone `*` is far more likely a multiplication sign than
+ * a delimiter. Nesting is not interpreted; inner content is taken verbatim.
+ * Backslashes are ordinary characters (no markdown escapes), so Windows paths
+ * and regex survive intact.
  */
 
 export type InlineEmphasisRun = {
@@ -24,9 +25,7 @@ export type InlineEmphasisRun = {
 
 const MARKERS: readonly { marker: string; bold: boolean; italic: boolean }[] = [
   { marker: "***", bold: true, italic: true },
-  { marker: "___", bold: true, italic: true },
   { marker: "**", bold: true, italic: false },
-  { marker: "__", bold: true, italic: false },
 ];
 
 const isSpace = (ch: string | undefined): boolean =>


### PR DESCRIPTION
## Problem

Documents built or edited through the active-docx-edit tool show literal
asterisks where bold should be: `**Date:**`, `**Disclosing Party Name**`.
The tool's operation schema gives the model no inline run-format channel —
only a paragraph-level `styleId`. When the model wants a bold label or party
name mid-sentence it improvises with markdown, and since DOCX has no notion
of markdown, the markers reach the document as literal text. (Section
headings stay correctly bold because those come from `styleId`.)

## Fix

- Add a conservative inline-emphasis parser (`inline-emphasis.ts`) that
  promotes paired `**bold**` / `__bold__` and `***bold italic***` markers to
  structured runs. Lone `*` / `_` stay literal (in legal prose far more
  likely a multiplication sign or identifier than a delimiter); `\*` escapes
  are honored; plain prose is returned untouched.
- Apply it in the folio AI-edit path: inserted blocks and replace-block node
  builds now carry real `bold` / `italic` marks (alongside any insertion /
  comment mark). The tracked-changes word-diff path, which can't carry inline
  marks, strips the markers so no literal `**` leaks.
- Tell the model in the tool description to write document prose, not
  markdown, and document the one honored inline channel.

## Notes

Inline emphasis inside tracked-changes `replaceInBlock` / `replaceBlock`
edits is stripped rather than reconstructed (the redline diff is text-only);
bold is reconstructed in the insert and direct replace-block paths, which is
where document bodies are built.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inline emphasis in AI-generated DOCX edits, so bold and bold-italic text is now preserved as formatted content rather than literal marker characters.
  * Improved handling of inserted and replaced text to better match document formatting rules.

* **Bug Fixes**
  * Prevented markdown-style emphasis markers from appearing in tracked changes replacements.
  * Preserved existing paragraph attributes while applying formatted text updates.

* **Tests**
  * Added coverage for emphasis parsing and formatted edit behaviour in both direct and tracked-changes modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->