### PR TITLE
fix: expand Arabic prefix compatibility

### DIFF
--- a/apps/api/src/lib/search/query.test.ts
+++ b/apps/api/src/lib/search/query.test.ts
@@ -47,6 +47,10 @@ describe("search query text", () => {
     );
   });
 
+  test("deduplicates repeated prefix query terms", () => {
+    expect(toPrefixTsQueryText("agreement agreement")).toBe("agreement:*");
+  });
+
   test("keeps legal abbreviations after periods in prefix queries", () => {
     expect(toPrefixTsQueryText("Smith v. Jones")).toBe(
       "Smith:* & v:* & Jones:*",
@@ -55,6 +59,9 @@ describe("search query text", () => {
 
   test("builds a loose fallback so one typo does not hide useful results", () => {
     expect(toLooseTsQueryText("nterim injunctive")).toBe(
+      "nterim:* | injunctive:*",
+    );
+    expect(toLooseTsQueryText("nterim injunctive nterim")).toBe(
       "nterim:* | injunctive:*",
     );
     expect(toLooseTsQueryText("injunctive")).toBeNull();
@@ -256,6 +263,15 @@ describe("search query text", () => {
   test("keeps loose Arabic fallback prefixes compatible with legacy vectors", () => {
     const dialect = new PgDialect();
     const compiled = dialect.sqlToQuery(buildSearchTsQuery("احم agreemnt"));
+
+    expect(compiled.params).toContain(
+      "احم:* | آحم:* | أحم:* | إحم:* | ٱحم:* | agreemnt:*",
+    );
+  });
+
+  test("deduplicates compatible Arabic loose fallback prefixes", () => {
+    const dialect = new PgDialect();
+    const compiled = dialect.sqlToQuery(buildSearchTsQuery("احم agreemnt احم"));
 
     expect(compiled.params).toContain(
       "احم:* | آحم:* | أحم:* | إحم:* | ٱحم:* | agreemnt:*",

--- a/apps/api/src/lib/search/query.test.ts
+++ b/apps/api/src/lib/search/query.test.ts
@@ -180,8 +180,7 @@ describe("search query text", () => {
     expect(compiled.sql).toContain("arabic_normalize");
     expect(compiled.sql).toContain("plainto_tsquery('simple', unaccent($1))");
     expect(compiled.params.filter((param) => param === "خدمة")).toHaveLength(2);
-    expect(compiled.params).toContain("خدمة:*");
-    expect(compiled.params).toContain("خدمه:*");
+    expect(compiled.params).toContain("(خدمة:* | خدمه:*)");
   });
 
   test("keeps advanced Arabic queries compatible with existing indexes", () => {
@@ -243,6 +242,24 @@ describe("search query text", () => {
       "(plainto_tsquery('simple', unaccent($1)) || plainto_tsquery('simple', unaccent($2)) || plainto_tsquery('simple', unaccent($3)) || plainto_tsquery('simple', unaccent($4)) || plainto_tsquery('simple', unaccent($5)))",
     );
     expect(compiled.params).toEqual(["احمد", "آحمد", "أحمد", "إحمد", "ٱحمد"]);
+  });
+
+  test("keeps already-folded Arabic prefixes compatible with legacy vectors", () => {
+    const dialect = new PgDialect();
+    const compiled = dialect.sqlToQuery(buildSearchTsQuery("احم"));
+
+    expect(compiled.params).toContain(
+      "(احم:* | آحم:* | أحم:* | إحم:* | ٱحم:*)",
+    );
+  });
+
+  test("keeps loose Arabic fallback prefixes compatible with legacy vectors", () => {
+    const dialect = new PgDialect();
+    const compiled = dialect.sqlToQuery(buildSearchTsQuery("احم agreemnt"));
+
+    expect(compiled.params).toContain(
+      "احم:* | آحم:* | أحم:* | إحم:* | ٱحم:* | agreemnt:*",
+    );
   });
 
   test("does not duplicate plain tsqueries when folding is a no-op", () => {

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -95,7 +95,7 @@ const toPrefixTsQueryTextForMode = (
   const lexemeGroups = toSearchLexemeGroups(query, mode);
 
   return lexemeGroups.length > 0
-    ? lexemeGroups.map(lexemeGroupToTsQuery).join(" & ")
+    ? [...new Set(lexemeGroups.map(lexemeGroupToTsQuery))].join(" & ")
     : null;
 };
 
@@ -109,9 +109,13 @@ const toLooseTsQueryTextForMode = (
   const lexemeGroups = toSearchLexemeGroups(query, mode);
 
   return lexemeGroups.length > 1
-    ? lexemeGroups
-        .flatMap((lexemes) => lexemes.map((lexeme) => `${lexeme}:*`))
-        .join(" | ")
+    ? [
+        ...new Set(
+          lexemeGroups.flatMap((lexemes) =>
+            lexemes.map((lexeme) => `${lexeme}:*`),
+          ),
+        ),
+      ].join(" | ")
     : null;
 };
 

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -92,10 +92,10 @@ const toPrefixTsQueryTextForMode = (
   query: string,
   mode: ArabicFoldMode,
 ): string | null => {
-  const tokens = toSearchLexemes(query, mode);
+  const lexemeGroups = toSearchLexemeGroups(query, mode);
 
-  return tokens.length > 0
-    ? tokens.map((token) => `${token}:*`).join(" & ")
+  return lexemeGroups.length > 0
+    ? lexemeGroups.map(lexemeGroupToTsQuery).join(" & ")
     : null;
 };
 
@@ -106,10 +106,12 @@ const toLooseTsQueryTextForMode = (
   query: string,
   mode: ArabicFoldMode,
 ): string | null => {
-  const tokens = toSearchLexemes(query, mode);
+  const lexemeGroups = toSearchLexemeGroups(query, mode);
 
-  return tokens.length > 1
-    ? tokens.map((token) => `${token}:*`).join(" | ")
+  return lexemeGroups.length > 1
+    ? lexemeGroups
+        .flatMap((lexemes) => lexemes.map((lexeme) => `${lexeme}:*`))
+        .join(" | ")
     : null;
 };
 
@@ -567,18 +569,16 @@ export const buildSearchTsQuery = (query: string) => {
   const prefixQueries = [
     ...new Set(
       variants.flatMap((variant) => {
-        const legacy = toPrefixTsQueryTextForMode(variant, "legacy");
-        const folded = toPrefixTsQueryTextForMode(variant, "folded");
-        return [legacy, folded].flatMap((prefix) => (prefix ? [prefix] : []));
+        const compatible = toPrefixTsQueryTextForMode(variant, "compatible");
+        return compatible ? [compatible] : [];
       }),
     ),
   ].map((prefix) => sql`to_tsquery('simple', unaccent(${prefix}))`);
   const looseQueries = [
     ...new Set(
       variants.flatMap((variant) => {
-        const legacy = toLooseTsQueryTextForMode(variant, "legacy");
-        const folded = toLooseTsQueryTextForMode(variant, "folded");
-        return [legacy, folded].flatMap((loose) => (loose ? [loose] : []));
+        const compatible = toLooseTsQueryTextForMode(variant, "compatible");
+        return compatible ? [compatible] : [];
       }),
     ),
   ].map((loose) => sql`to_tsquery('simple', unaccent(${loose}))`);


### PR DESCRIPTION
Follow-up to #917. Plain-query prefix and loose fallback branches now use the same bounded compatible Arabic lexeme expansion as advanced search, so already-folded partial prefixes still match legacy vectors.

Verification:
- bun --filter @stll/api test src/lib/search/query.test.ts src/lib/legal-search/pg-fts-query.test.ts
- bun run verify

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arabic search prefix handling so results are grouped more consistently and match legacy behaviour.
  * Fixed loose/fuzzy Arabic search fallbacks to handle mixed Arabic and Latin inputs more reliably.
  * Updated search checks to reflect the new query behaviour for folded and fallback prefix searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->