### PR TITLE
feat: prepare Railway deployment shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: bun run lint:ws
 
+      - name: Railway template shape
+        if: steps.changed-files.outputs.package_checks_required == 'true'
+        run: bun run check:railway-template
+
       - name: Prepare environment
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: |

--- a/.github/workflows/railway-smoke.yml
+++ b/.github/workflows/railway-smoke.yml
@@ -45,7 +45,6 @@ jobs:
           EXPECTED_ENVIRONMENT: ${{ vars.RAILWAY_SMOKE_DEPLOYMENT_ENVIRONMENT || '' }}
           EVENT_NAME: ${{ github.event_name }}
           DEPLOYMENT_ENVIRONMENT: ${{ github.event.deployment.environment || '' }}
-          DEPLOYMENT_SHA: ${{ github.event.deployment.sha || '' }}
         run: |
           set -euo pipefail
 
@@ -66,10 +65,6 @@ jobs:
           api_url="${API_URL_INPUT:-$API_URL_VAR}"
           web_url="${WEB_URL_INPUT:-$WEB_URL_VAR}"
           expected_commit="$EXPECTED_COMMIT_INPUT"
-
-          if [[ -z "$expected_commit" && "$EVENT_NAME" == "deployment_status" ]]; then
-            expected_commit="$DEPLOYMENT_SHA"
-          fi
 
           if [[ -z "$api_url" || -z "$web_url" ]]; then
             echo "::error::Set RAILWAY_SMOKE_API_URL and RAILWAY_SMOKE_WEB_URL repository variables, or pass api_url/web_url when dispatching manually."

--- a/.github/workflows/railway-smoke.yml
+++ b/.github/workflows/railway-smoke.yml
@@ -1,0 +1,104 @@
+name: Railway Smoke
+
+on:
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: "API origin to smoke, for example https://api-production.up.railway.app"
+        required: false
+        type: string
+      web_url:
+        description: "Web origin to smoke, for example https://web-production.up.railway.app"
+        required: false
+        type: string
+      expected_commit:
+        description: "Optional commit SHA expected from /health and /version.json"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: railway-smoke-${{ github.event_name }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Check Railway deployment
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Resolve target
+        id: target
+        env:
+          API_URL_INPUT: ${{ inputs.api_url || '' }}
+          WEB_URL_INPUT: ${{ inputs.web_url || '' }}
+          EXPECTED_COMMIT_INPUT: ${{ inputs.expected_commit || '' }}
+          API_URL_VAR: ${{ vars.RAILWAY_SMOKE_API_URL || '' }}
+          WEB_URL_VAR: ${{ vars.RAILWAY_SMOKE_WEB_URL || '' }}
+          EXPECTED_ENVIRONMENT: ${{ vars.RAILWAY_SMOKE_DEPLOYMENT_ENVIRONMENT || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOYMENT_ENVIRONMENT: ${{ github.event.deployment.environment || '' }}
+          DEPLOYMENT_SHA: ${{ github.event.deployment.sha || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "deployment_status" ]]; then
+            if [[ -z "$EXPECTED_ENVIRONMENT" ]]; then
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Set RAILWAY_SMOKE_DEPLOYMENT_ENVIRONMENT to enable automatic Railway post-deploy smoke checks."
+              exit 0
+            fi
+
+            if [[ "$DEPLOYMENT_ENVIRONMENT" != "$EXPECTED_ENVIRONMENT" ]]; then
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Ignoring deployment environment '${DEPLOYMENT_ENVIRONMENT}'. Expected '${EXPECTED_ENVIRONMENT}'."
+              exit 0
+            fi
+          fi
+
+          api_url="${API_URL_INPUT:-$API_URL_VAR}"
+          web_url="${WEB_URL_INPUT:-$WEB_URL_VAR}"
+          expected_commit="$EXPECTED_COMMIT_INPUT"
+
+          if [[ -z "$expected_commit" && "$EVENT_NAME" == "deployment_status" ]]; then
+            expected_commit="$DEPLOYMENT_SHA"
+          fi
+
+          if [[ -z "$api_url" || -z "$web_url" ]]; then
+            echo "::error::Set RAILWAY_SMOKE_API_URL and RAILWAY_SMOKE_WEB_URL repository variables, or pass api_url/web_url when dispatching manually."
+            exit 1
+          fi
+
+          {
+            echo "run=true"
+            echo "api_url=$api_url"
+            echo "web_url=$web_url"
+            echo "expected_commit=$expected_commit"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.target.outputs.run == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        if: steps.target.outputs.run == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Check Railway smoke deployment
+        if: steps.target.outputs.run == 'true'
+        env:
+          RAILWAY_SMOKE_API_URL: ${{ steps.target.outputs.api_url }}
+          RAILWAY_SMOKE_WEB_URL: ${{ steps.target.outputs.web_url }}
+          RAILWAY_SMOKE_EXPECTED_COMMIT: ${{ steps.target.outputs.expected_commit }}
+        run: bun scripts/check-railway-smoke.ts

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Redis or Valkey, S3-compatible storage, `GOTENBERG_URL`, and Gotenberg
 credentials in `apps/api/.env`. The frontend is a TanStack Start SSR app:
 build and run `apps/web/Dockerfile`, or run `bun --filter @stll/web build`
 followed by `HOST=0.0.0.0 PORT=3002 bun apps/web/start-runtime.js`.
+Railway-specific service configuration is documented in
+[docs/railway.md](docs/railway.md).
 
 ### Prerequisites
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -71,8 +71,10 @@ FROM deps AS runner
 # Defaults to "dev" for local `docker build` outside the release flow.
 ARG STELLA_VERSION=dev
 ARG STELLA_COMMIT_SHA=dev
+ARG RAILWAY_GIT_COMMIT_SHA=dev
 ENV STELLA_VERSION=${STELLA_VERSION}
 ENV STELLA_COMMIT_SHA=${STELLA_COMMIT_SHA}
+ENV RAILWAY_GIT_COMMIT_SHA=${RAILWAY_GIT_COMMIT_SHA}
 ENV STELLA_WORKER_DIR=/\$bunfs/root/workers
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -7,7 +7,14 @@ import type { ProbeOutcome } from "@/api/lib/health/probe-cache";
 import { probeDatabase } from "@/api/lib/health/probe-database";
 
 const APP_VERSION = process.env["STELLA_VERSION"] ?? "dev";
-const APP_COMMIT_SHA = process.env["STELLA_COMMIT_SHA"] ?? "dev";
+const resolveCommitSha = () => {
+  const explicitSha = process.env["STELLA_COMMIT_SHA"];
+  if (explicitSha && explicitSha !== "dev") {
+    return explicitSha;
+  }
+  return process.env["RAILWAY_GIT_COMMIT_SHA"] ?? explicitSha ?? "dev";
+};
+const APP_COMMIT_SHA = resolveCommitSha();
 const BUILD_METADATA = {
   version: APP_VERSION,
   commit: APP_COMMIT_SHA,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -105,7 +105,7 @@ const STATUS_BY_ELYSIA_CODE: Partial<Record<string, number>> = {
 };
 
 const getApiPort = () => {
-  const rawPort = process.env["STELLA_API_PORT"];
+  const rawPort = process.env["STELLA_API_PORT"] ?? process.env["PORT"];
   if (!rawPort) {
     return DEFAULT_API_PORT;
   }

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const createBunRedisClientCalls: unknown[] = [];
+
+void mock.module("bullmq", () => ({
+  createBunRedisClient: (...args: unknown[]) => {
+    createBunRedisClientCalls.push(args);
+    return {};
+  },
+}));
+
+const { createBullMqConnection } = await import("@/api/lib/redis-client");
+
+describe("BullMQ Redis connection", () => {
+  test("lets BullMQ own connection startup", () => {
+    createBunRedisClientCalls.length = 0;
+
+    createBullMqConnection();
+
+    expect(createBunRedisClientCalls).toHaveLength(1);
+    expect(createBunRedisClientCalls[0]).toMatchObject([
+      expect.anything(),
+      { lazyConnect: true },
+    ]);
+  });
+});

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -38,5 +38,7 @@ export const createBullMqConnection = (): ReturnType<
   // reconnecting raw clients, so TLS/options from redisConnectionOptions
   // are preserved by the subclass constructor.
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- bridges BullMQ vs Bun RedisClient structural callback mismatch (see above)
-  return createBunRedisClient(raw as unknown as BunRedisRawClient);
+  return createBunRedisClient(raw as unknown as BunRedisRawClient, {
+    lazyConnect: true,
+  });
 };

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -39,6 +39,8 @@ export const createBullMqConnection = (): ReturnType<
   // are preserved by the subclass constructor.
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- bridges BullMQ vs Bun RedisClient structural callback mismatch (see above)
   return createBunRedisClient(raw as unknown as BunRedisRawClient, {
+    // Railway's Redis proxy can trigger Bun's eager adapter read path before
+    // BullMQ has completed its own readiness flow. Let BullMQ connect lazily.
     lazyConnect: true,
   });
 };

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,6 +34,7 @@ RUN bun install --filter @stll/web --production --frozen-lockfile --ignore-scrip
 FROM deps AS builder
 ARG STELLA_VERSION=dev
 ARG STELLA_COMMIT_SHA=dev
+ARG RAILWAY_GIT_COMMIT_SHA=dev
 ARG PUBLIC_API_URL
 ARG PUBLIC_APP_URL
 ARG PUBLIC_GOOGLE_LOGIN_ENABLED
@@ -64,6 +65,7 @@ ARG VITE_TERMS_URL
 ENV NODE_ENV=production
 ENV STELLA_VERSION=${STELLA_VERSION}
 ENV STELLA_COMMIT_SHA=${STELLA_COMMIT_SHA}
+ENV RAILWAY_GIT_COMMIT_SHA=${RAILWAY_GIT_COMMIT_SHA}
 COPY --from=pruner /app/out/full/ .
 COPY --from=pruner /app/VERSION ./VERSION
 RUN test -n "${PUBLIC_API_URL}" || (echo "PUBLIC_API_URL build arg is required" >&2; exit 1)

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,8 +18,13 @@ const APP_VERSION = readFileSync(
 
 const readCommitSha = () => {
   const explicitSha = process.env["STELLA_COMMIT_SHA"];
-  if (explicitSha) {
+  if (explicitSha && explicitSha !== "dev") {
     return explicitSha;
+  }
+
+  const railwaySha = process.env["RAILWAY_GIT_COMMIT_SHA"];
+  if (railwaySha) {
+    return railwaySha;
   }
 
   try {
@@ -28,7 +33,7 @@ const readCommitSha = () => {
       encoding: "utf-8",
     }).trim();
   } catch {
-    return "dev";
+    return explicitSha ?? "dev";
   }
 };
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -178,10 +178,12 @@ For the default Railway environment, the deployment environment is usually
 and manual dispatch still works.
 
 The smoke checks `api` `/health`, `web` `/health`, and, when GitHub provides a
-deployment SHA, the exact commit reported by API `/health` and web
-`/version.json`. The API and web builds both honor Railway's
-`RAILWAY_GIT_COMMIT_SHA` so source-backed deploys can be tied back to the
-GitHub commit that triggered them.
+manual `expected_commit`, the exact commit reported by API `/health` and web
+`/version.json`. Automatic `deployment_status` runs do not enforce a single
+commit across both services because API-only and web-only changes can deploy
+independently. The API and web builds both honor Railway's
+`RAILWAY_GIT_COMMIT_SHA` so source-backed deploys can be tied back to GitHub
+commits when the stricter manual check is used.
 
 Publish or update the template with:
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -154,6 +154,35 @@ publishing. Check these items before the first publish:
 - Both public domains pass `/health`.
 - The marketplace overview uses `railway/template-readme.md`.
 
+## Source-Backed Smoke Verification
+
+Use `.github/workflows/railway-smoke.yml` to verify the GitHub-backed Railway
+shape after deployment. The workflow has two entry points:
+
+- `deployment_status`: runs after Railway reports a successful GitHub-backed
+  deployment, when `RAILWAY_SMOKE_DEPLOYMENT_ENVIRONMENT` matches the
+  deployment environment.
+- `workflow_dispatch`: runs manually against supplied URLs, useful before
+  publishing or updating the template.
+
+Set these GitHub repository variables for automatic checks:
+
+```bash
+RAILWAY_SMOKE_DEPLOYMENT_ENVIRONMENT=<Railway environment name>
+RAILWAY_SMOKE_API_URL=https://<api-domain>
+RAILWAY_SMOKE_WEB_URL=https://<web-domain>
+```
+
+For the default Railway environment, the deployment environment is usually
+`production`. If the variable is unset, automatic post-deploy checks are skipped
+and manual dispatch still works.
+
+The smoke checks `api` `/health`, `web` `/health`, and, when GitHub provides a
+deployment SHA, the exact commit reported by API `/health` and web
+`/version.json`. The API and web builds both honor Railway's
+`RAILWAY_GIT_COMMIT_SHA` so source-backed deploys can be tied back to the
+GitHub commit that triggered them.
+
 Publish or update the template with:
 
 ```bash

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -172,8 +172,7 @@ Marketplace metadata checklist:
 - Image: use a square transparent stella mark, not the wide repository banner.
 - Description: keep it short and operational; avoid unsupported claims.
 - Enable Template Queue email notifications before publishing.
-- Keep referral, payout, pricing, and private business notes out of public
-  template copy.
+- Keep private business notes out of public template copy.
 
 After publishing, use Railway's generated template code in any README or website
 button:

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,247 @@
+# Railway
+
+This guide documents the intended Railway shape for a self-hosted stella
+deployment. The goal is a template-friendly setup: separate web/API services,
+managed Postgres and Redis, a private Gotenberg service, and a Railway Storage
+Bucket for files. The same shape should be used for the public Railway
+template.
+
+## Services
+
+Create these services in one Railway project:
+
+- `web`: builds from `apps/web/Dockerfile`, public HTTP domain.
+- `api`: builds from `apps/api/Dockerfile`, public HTTP domain.
+- `Postgres`: Railway Postgres 18 or newer.
+- `Redis`: Railway Redis or Valkey.
+- `gotenberg`: image service using `gotenberg/gotenberg:8`, no public domain.
+- Storage bucket, for example `stella-files`.
+
+Point the `api` service at the repository default `railway.json`. Point the
+`web` service config file at `railway/web.railway.json`. Both services use the
+repository root as Docker build context. Railway calls this
+[config as code](https://docs.railway.com/config-as-code); custom config files
+are selected in each service's settings.
+
+## API Variables
+
+Use Railway reference variables for services that live in the same project:
+
+```bash
+NODE_ENV=production
+
+DATABASE_URL=${{Postgres.DATABASE_URL}}
+REDIS_URL=${{Redis.REDIS_URL}}
+
+FRONTEND_URL=https://${{web.RAILWAY_PUBLIC_DOMAIN}}
+BETTER_AUTH_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+PUBLIC_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+
+BETTER_AUTH_SECRET=${{secret(32)}}
+CONTENT_ENCRYPTION_KEY=${{secret(64, "abcdef0123456789")}}
+
+S3_ENDPOINT=<Railway bucket endpoint>
+S3_BUCKET=<Railway bucket name>
+S3_REGION=<Railway bucket region>
+S3_CREDENTIALS_PROVIDER=env
+S3_ACCESS_KEY_ID=<Railway bucket access key id>
+S3_SECRET_ACCESS_KEY=<Railway bucket secret access key>
+
+EMAIL_PROVIDER=smtp
+SMTP_HOST=<smtp host>
+SMTP_PORT=<smtp port>
+SMTP_USERNAME=<smtp username if required>
+SMTP_PASSWORD=<smtp password if required>
+TRANSACTIONAL_EMAIL_FROM=noreply@example.com
+
+GOTENBERG_URL=http://${{gotenberg.RAILWAY_PRIVATE_DOMAIN}}:3000
+GOTENBERG_USERNAME=stella
+GOTENBERG_PASSWORD=${{secret(32)}}
+
+REQUIRE_PERSONAL_AI_KEY=true
+FEATURE_CHAT=true
+FEATURE_DESKTOP_EDITING=true
+```
+
+Do not expose Gotenberg publicly. Configure the `gotenberg` service with:
+
+```bash
+API_ENABLE_BASIC_AUTH=true
+GOTENBERG_API_BASIC_AUTH_USERNAME=${{api.GOTENBERG_USERNAME}}
+GOTENBERG_API_BASIC_AUTH_PASSWORD=${{api.GOTENBERG_PASSWORD}}
+```
+
+The API Docker image now honors Railway's injected `PORT` variable, with
+`STELLA_API_PORT` still available as an explicit override.
+
+For the public template, mark SMTP and storage credential variables as required
+user inputs. Use Railway template variable functions for generated secrets, and
+Railway reference variables for same-project services.
+
+Template editor checklist for `api` variables:
+
+| Variable                   | Source                                              | Prompt user? |
+| -------------------------- | --------------------------------------------------- | ------------ |
+| `DATABASE_URL`             | `${{Postgres.DATABASE_URL}}`                        | No           |
+| `REDIS_URL`                | `${{Redis.REDIS_URL}}`                              | No           |
+| `FRONTEND_URL`             | `https://${{web.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
+| `BETTER_AUTH_URL`          | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
+| `PUBLIC_URL`               | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
+| `BETTER_AUTH_SECRET`       | `${{secret(32)}}`                                   | No           |
+| `CONTENT_ENCRYPTION_KEY`   | `${{secret(64, "abcdef0123456789")}}`               | No           |
+| `SMTP_HOST`                | SMTP relay hostname                                 | Yes          |
+| `SMTP_PORT`                | SMTP relay port                                     | Yes          |
+| `SMTP_USERNAME`            | SMTP username, if required                          | Yes          |
+| `SMTP_PASSWORD`            | SMTP password, if required                          | Yes          |
+| `TRANSACTIONAL_EMAIL_FROM` | Verified sender address                             | Yes          |
+| `S3_ENDPOINT`              | Railway bucket endpoint                             | Yes          |
+| `S3_BUCKET`                | Railway bucket name                                 | Yes          |
+| `S3_REGION`                | Railway bucket region                               | Yes          |
+| `S3_ACCESS_KEY_ID`         | Railway bucket access key ID                        | Yes          |
+| `S3_SECRET_ACCESS_KEY`     | Railway bucket secret access key                    | Yes          |
+| `GOTENBERG_URL`            | `http://${{gotenberg.RAILWAY_PRIVATE_DOMAIN}}:3000` | No           |
+| `GOTENBERG_USERNAME`       | `stella`                                            | No           |
+| `GOTENBERG_PASSWORD`       | `${{secret(32)}}`                                   | No           |
+
+## Web Variables
+
+The web Dockerfile receives these as build arguments. Railway forwards matching
+service variables into the Docker build, so set them before the first deploy:
+
+```bash
+PUBLIC_API_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+PUBLIC_APP_URL=https://${{web.RAILWAY_PUBLIC_DOMAIN}}
+VITE_SELFHOST=true
+
+VITE_FEATURE_CHAT=true
+VITE_FEATURE_DESKTOP_EDITING=true
+```
+
+`PUBLIC_API_URL` maps to `VITE_API_URL`; `PUBLIC_APP_URL` maps to
+`VITE_PUBLIC_APP_URL`. Because these values are baked into the web build,
+changing domains requires redeploying `web`.
+
+## Template Publishing
+
+Build and validate the template from a clean Railway smoke project. The smoke
+project should use the same service names and variable references documented
+above, with source services based on the GitHub repository rather than Docker
+images. GitHub-backed templates are the path Railway uses for automatic update
+notifications.
+
+Use the CLI only after the smoke project has been scrubbed of accidental
+hardcoded secrets:
+
+```bash
+railway templates create \
+  --project stella-railway-smoke \
+  --environment production \
+  --json
+```
+
+Review the unpublished template draft in Railway's template editor before
+publishing. Check these items before the first publish:
+
+- `web` source points at the public GitHub repository on the intended branch.
+- `api` source points at the same repository and branch.
+- `api` config path is the repository default `/railway.json`.
+- `web` config path is `/railway/web.railway.json`.
+- `api`, `web`, Postgres, Redis, Gotenberg, and the storage bucket all deploy
+  from the template into a fresh project.
+- Generated values use `secret(...)`; user-supplied credentials are prompted,
+  not committed.
+- Gotenberg has no public domain.
+- Both public domains pass `/health`.
+- The marketplace overview uses `railway/template-readme.md`.
+
+Publish or update the template with:
+
+```bash
+railway templates publish <template-id-or-code> \
+  --category AI/ML \
+  --description "Self-host stella with web, API, Postgres, Redis, Gotenberg, and file storage." \
+  --readme-file railway/template-readme.md \
+  --json
+```
+
+Marketplace metadata checklist:
+
+- Publish from the official stella Railway workspace, not a personal workspace.
+- Template name: `stella`.
+- Category: `AI/ML`.
+- Image: use a square transparent stella mark, not the wide repository banner.
+- Description: keep it short and operational; avoid unsupported claims.
+- Enable Template Queue email notifications before publishing.
+- Keep referral, payout, pricing, and private business notes out of public
+  template copy.
+
+After publishing, use Railway's generated template code in any README or website
+button:
+
+```md
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/<template-code>?utm_medium=integration&utm_source=button&utm_campaign=stella)
+```
+
+Do not add this button to the repository until the published template code is
+known and a fresh deploy from the published template has passed.
+
+## Updating Template Users
+
+Keep the template's source services GitHub-backed. When changes are merged to
+the repository's root branch, Railway can notify projects deployed from the
+template that an update is available. Users choose when to apply the update.
+
+For stella releases, keep `docs/changelog/` current and call out database
+migrations or required environment changes. Railway users should review those
+notes before applying an upstream template update.
+
+## Migrations
+
+`railway.json` runs `bun src/db/migrate.ts` as the API pre-deploy command. The
+migration entrypoint is included in the API runtime image and uses the same
+`DATABASE_URL` as the server.
+
+If a migration fails, Railway should not promote the API deployment. Fix the
+database/config problem, then redeploy the API service.
+
+## Storage Bucket
+
+Create a Railway Storage Bucket and copy its S3-compatible credential fields
+into the API variables:
+
+- `endpoint` -> `S3_ENDPOINT`
+- `bucketName` -> `S3_BUCKET`
+- `region` -> `S3_REGION`
+- `accessKeyId` -> `S3_ACCESS_KEY_ID`
+- `secretAccessKey` -> `S3_SECRET_ACCESS_KEY`
+
+Keep `S3_CREDENTIALS_PROVIDER=env`. Do not put bucket credentials in the repo.
+
+## Runtime Checks
+
+After a deploy, check:
+
+```bash
+railway status --json
+railway logs --service api --environment production --lines 100 --json
+railway logs --service web --environment production --lines 100 --json
+railway logs --http --service api --environment production --status ">=400" --lines 50 --json
+railway logs --http --service web --environment production --status ">=400" --lines 50 --json
+```
+
+Historical failed or removed deployments in Railway's deployment history are
+not active alerts by themselves. The latest deployment and active instance
+status are the source of truth.
+
+## Desktop Editing
+
+For the signed desktop app linking flow, keep both sides enabled:
+
+```bash
+FEATURE_DESKTOP_EDITING=true
+VITE_FEATURE_DESKTOP_EDITING=true
+```
+
+Users install the signed stella desktop app, open the Railway-hosted web app,
+go to **Settings -> Account -> Desktop**, and click **Connect**. The desktop
+app stores trust for the exact Railway web/API origins.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -16,6 +16,7 @@ services, existing self-hosted services, or a platform such as
 [Dokploy](https://docs.dokploy.com/docs/core). Dokploy's
 [template catalog](https://docs.dokploy.com/docs/templates) is a practical way
 to deploy common dependencies such as Postgres, Valkey or Redis, and MinIO.
+For Railway, see the dedicated [Railway deployment guide](./railway.md).
 
 Deploy the API and Gotenberg with `docker-compose.selfhost.yml` (see below).
 Deploy the web app as its own long-running server process. The web app is a

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "i18n:check": "turbo run i18n:check --",
     "i18n:sync": "turbo run i18n:sync --",
     "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
+    "check:railway-template": "bun scripts/check-railway-template-shape.ts",
     "test": "turbo run test",
     "test:property": "turbo run test:property",
     "verify": "bash scripts/verify.sh",

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/api/Dockerfile",
+    "watchPatterns": [
+      "/apps/api/**",
+      "/apps/legal-atlas-runner/**",
+      "/packages/**",
+      "/bun.lock",
+      "/bunfig.toml",
+      "/package.json",
+      "/turbo.json"
+    ]
+  },
+  "deploy": {
+    "drainingSeconds": 15,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "preDeployCommand": ["bun src/db/migrate.ts"],
+    "restartPolicyMaxRetries": 10,
+    "restartPolicyType": "ON_FAILURE"
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,7 @@
     "builder": "DOCKERFILE",
     "dockerfilePath": "apps/api/Dockerfile",
     "watchPatterns": [
+      "/railway.json",
       "/apps/api/**",
       "/apps/legal-atlas-runner/**",
       "/packages/**",

--- a/railway/template-readme.md
+++ b/railway/template-readme.md
@@ -1,0 +1,89 @@
+# Deploy and Host stella on Railway
+
+stella is an open-source legal workspace for matters, documents, review tables,
+research, chat, and local desktop document editing. This template deploys a
+self-hosted stella stack with a web app, API, Postgres, Redis, private
+Gotenberg document conversion, and S3-compatible file storage.
+
+## About Hosting stella
+
+Hosting stella gives a legal team control over its own workspace and data while
+keeping the application stack deployable as one Railway project. The web service
+serves the TanStack Start SSR app, the API service handles authentication,
+workspace data, document workflows, uploads, background jobs, and desktop
+handoffs, and the supporting services provide database, queue, conversion, and
+file-storage infrastructure.
+
+The template uses Railway private networking for service-to-service traffic and
+public HTTP domains only for the web and API services. Gotenberg is kept private
+because it is an internal document conversion dependency.
+
+## Common Use Cases
+
+- Run a private legal workspace for matters, files, and document review.
+- Self-host legal AI workflows while keeping storage under the deployer's
+  control.
+- Test stella against a production-like stack without assembling services by
+  hand.
+- Use the signed stella desktop app with a self-hosted Railway instance.
+- Evaluate stella before moving to a dedicated production environment.
+
+## Dependencies for stella Hosting
+
+- `web`: TanStack Start SSR frontend.
+- `api`: Bun/Elysia backend.
+- `Postgres`: application database.
+- `Redis`: queues, rate limits, and cross-instance events.
+- `gotenberg`: private document conversion service.
+- Storage bucket: S3-compatible object storage for uploaded files.
+
+### Deployment Dependencies
+
+- SMTP relay credentials are required before the first production login. stella
+  uses email OTPs for sign-in, invitations, and account security emails.
+- File-storage credentials are required for uploads and document workflows.
+- Generated application secrets stay in Railway variables and should not be
+  copied into source control.
+
+Use a production SMTP provider rather than a personal mailbox SMTP account.
+
+### Implementation Details
+
+The API service runs database migrations as a Railway pre-deploy command. If a
+migration fails, Railway should not promote the new API deployment.
+
+The web build bakes in the public API and web origins. If Railway domains or
+custom domains change later, redeploy the web service so the browser bundle uses
+the new origins.
+
+For desktop editing, install the signed stella desktop app, open the
+Railway-hosted web app, go to **Settings -> Account -> Desktop**, and connect
+the self-hosted instance. The desktop app stores trust for the exact web/API
+origins.
+
+## Why Deploy stella on Railway?
+
+Railway keeps the web app, API, database, Redis, document conversion, and file
+storage in one project with managed variables, logs, health checks, and
+deployments. That makes stella easy to try, update, and inspect while preserving
+the self-hosting model: the deployer owns the Railway project and its data.
+
+## After Deploying
+
+1. Open the `web` public domain.
+2. Create the first account with an email address that can receive OTPs.
+3. Confirm the API `/health` endpoint is passing.
+4. Upload a small test document to confirm storage and Gotenberg are reachable.
+5. Connect the signed desktop app if local document editing is needed.
+
+## Updating
+
+This template is based on the GitHub repository source, so Railway can notify
+deployed projects when the upstream template is updated. Review the stella
+changelog before applying updates, especially when database migrations or
+environment changes are included.
+
+## Documentation
+
+See the Railway deployment guide for operational details:
+https://github.com/stella/stella/blob/main/docs/railway.md

--- a/railway/web.railway.json
+++ b/railway/web.railway.json
@@ -4,6 +4,7 @@
     "builder": "DOCKERFILE",
     "dockerfilePath": "apps/web/Dockerfile",
     "watchPatterns": [
+      "/railway/web.railway.json",
       "/apps/web/**",
       "/packages/**",
       "/bun.lock",

--- a/railway/web.railway.json
+++ b/railway/web.railway.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/web/Dockerfile",
+    "watchPatterns": [
+      "/apps/web/**",
+      "/packages/**",
+      "/bun.lock",
+      "/bunfig.toml",
+      "/package.json",
+      "/turbo.json",
+      "/VERSION"
+    ]
+  },
+  "deploy": {
+    "drainingSeconds": 10,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyMaxRetries": 10,
+    "restartPolicyType": "ON_FAILURE"
+  }
+}

--- a/scripts/check-railway-smoke.ts
+++ b/scripts/check-railway-smoke.ts
@@ -1,0 +1,148 @@
+const API_URL_ENV = "RAILWAY_SMOKE_API_URL";
+const WEB_URL_ENV = "RAILWAY_SMOKE_WEB_URL";
+const EXPECTED_COMMIT_ENV = "RAILWAY_SMOKE_EXPECTED_COMMIT";
+const PROBE_ATTEMPTS = 30;
+const PROBE_DELAY_MS = 2000;
+const PROBE_TIMEOUT_MS = 10_000;
+
+class RailwaySmokeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RailwaySmokeError";
+  }
+}
+
+const readRequiredEnv = (name: string) => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new RailwaySmokeError(`${name} is required`);
+  }
+  return stripTrailingSlash(value);
+};
+
+const readOptionalEnv = (name: string) => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    return undefined;
+  }
+  return value;
+};
+
+const stripTrailingSlash = (value: string) => value.replace(/\/+$/u, "");
+
+const appendPath = (baseUrl: string, path: string) =>
+  new URL(path, `${baseUrl}/`).toString();
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const fetchWithTimeout = async (url: string) => {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new RailwaySmokeError(`${url} returned ${response.status}`);
+  }
+  return response;
+};
+
+const checkApiHealth = async (apiUrl: string, expectedCommit?: string) => {
+  const url = appendPath(apiUrl, "/health");
+  const value: unknown = await (await fetchWithTimeout(url)).json();
+  if (!isRecord(value)) {
+    throw new RailwaySmokeError("API /health did not return an object");
+  }
+  if (value["status"] !== "ok") {
+    throw new RailwaySmokeError("API /health did not return status=ok");
+  }
+  expectCommit({ value, expectedCommit, source: "API /health" });
+};
+
+const checkWebHealth = async (webUrl: string) => {
+  await fetchWithTimeout(appendPath(webUrl, "/health"));
+};
+
+const checkWebVersion = async (webUrl: string, expectedCommit: string) => {
+  const url = appendPath(webUrl, "/version.json");
+  const value: unknown = await (await fetchWithTimeout(url)).json();
+  if (!isRecord(value)) {
+    throw new RailwaySmokeError("web /version.json did not return an object");
+  }
+  expectCommit({ value, expectedCommit, source: "web /version.json" });
+};
+
+type ExpectCommitInput = {
+  value: Record<string, unknown>;
+  expectedCommit?: string;
+  source: string;
+};
+
+const expectCommit = ({ value, expectedCommit, source }: ExpectCommitInput) => {
+  if (!expectedCommit) {
+    return;
+  }
+  if (value["commit"] !== expectedCommit) {
+    throw new RailwaySmokeError(
+      `${source} reported commit ${String(value["commit"])}; expected ${expectedCommit}`,
+    );
+  }
+};
+
+const runProbe = async (name: string, probe: () => Promise<void>) => {
+  let lastError: Error | undefined;
+  for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- retry probes must observe the result before deciding whether to wait and try again.
+      await probe();
+      console.log(`${name}: ok`);
+      return;
+    } catch (error) {
+      lastError =
+        error instanceof Error
+          ? error
+          : new RailwaySmokeError(`${name} failed: ${String(error)}`);
+      if (attempt === PROBE_ATTEMPTS) {
+        break;
+      }
+      console.log(`${name}: waiting (${attempt}/${PROBE_ATTEMPTS})`);
+      // eslint-disable-next-line no-await-in-loop -- retries are intentionally sequential to give the deployment time to become healthy.
+      await sleep(PROBE_DELAY_MS);
+    }
+  }
+
+  if (lastError) {
+    throw new RailwaySmokeError(lastError.message);
+  }
+  throw new RailwaySmokeError(`${name} failed`);
+};
+
+const main = async () => {
+  const apiUrl = readRequiredEnv(API_URL_ENV);
+  const webUrl = readRequiredEnv(WEB_URL_ENV);
+  const expectedCommit = readOptionalEnv(EXPECTED_COMMIT_ENV);
+
+  await runProbe("api /health", () => checkApiHealth(apiUrl, expectedCommit));
+  await runProbe("web /health", () => checkWebHealth(webUrl));
+
+  if (expectedCommit) {
+    await runProbe("web /version.json", () =>
+      checkWebVersion(webUrl, expectedCommit),
+    );
+  }
+
+  console.log("railway-smoke: ok");
+};
+
+await main().catch((error: unknown) => {
+  if (error instanceof Error) {
+    console.error(`railway-smoke: ${error.message}`);
+  } else {
+    console.error(`railway-smoke: ${String(error)}`);
+  }
+  process.exit(1);
+});

--- a/scripts/check-railway-smoke.ts
+++ b/scripts/check-railway-smoke.ts
@@ -93,6 +93,10 @@ const expectCommit = ({ value, expectedCommit, source }: ExpectCommitInput) => {
   }
 };
 
+const throwError = (error: Error): never => {
+  throw error;
+};
+
 const runProbe = async (name: string, probe: () => Promise<void>) => {
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt += 1) {
@@ -116,7 +120,7 @@ const runProbe = async (name: string, probe: () => Promise<void>) => {
   }
 
   if (lastError) {
-    throw new RailwaySmokeError(lastError.message);
+    return throwError(lastError);
   }
   throw new RailwaySmokeError(`${name} failed`);
 };

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -1,0 +1,184 @@
+import { existsSync, readFileSync } from "node:fs";
+
+const API_CONFIG_PATH = "railway.json";
+const LEGACY_API_CONFIG_PATH = "railway/api.railway.json";
+const WEB_CONFIG_PATH = "railway/web.railway.json";
+const RAILWAY_DOC_PATH = "docs/railway.md";
+const TEMPLATE_README_PATH = "railway/template-readme.md";
+const DOCKERIGNORE_PATH = ".dockerignore";
+
+const failures: string[] = [];
+
+const readText = (path: string) => readFileSync(path, "utf-8");
+
+const readJson = (path: string): unknown => JSON.parse(readText(path));
+
+const expect = (condition: boolean, message: string) => {
+  if (!condition) {
+    failures.push(message);
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasPath = (
+  value: unknown,
+  key: string,
+): value is Record<string, unknown> => isRecord(value) && key in value;
+
+const getRecord = (value: unknown, key: string): Record<string, unknown> => {
+  if (!hasPath(value, key)) {
+    failures.push(`Missing object key ${key}`);
+    return {};
+  }
+  const next = value[key];
+  if (!isRecord(next)) {
+    failures.push(`Expected ${key} to be an object`);
+    return {};
+  }
+  return next;
+};
+
+const getString = (
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined => {
+  const next = value[key];
+  if (typeof next !== "string") {
+    failures.push(`Expected ${key} to be a string`);
+    return undefined;
+  }
+  return next;
+};
+
+const getStringArray = (
+  value: Record<string, unknown>,
+  key: string,
+): string[] => {
+  const next = value[key];
+  if (!Array.isArray(next) || next.some((item) => typeof item !== "string")) {
+    failures.push(`Expected ${key} to be a string array`);
+    return [];
+  }
+  return next;
+};
+
+const validateServiceConfig = ({
+  path,
+  dockerfilePath,
+  requiredWatchPatterns,
+}: {
+  path: string;
+  dockerfilePath: string;
+  requiredWatchPatterns: string[];
+}) => {
+  const config = readJson(path);
+  const build = getRecord(config, "build");
+  const deploy = getRecord(config, "deploy");
+  const watchPatterns = getStringArray(build, "watchPatterns");
+
+  expect(
+    getString(build, "builder") === "DOCKERFILE",
+    `${path} must use Dockerfile builds`,
+  );
+  expect(
+    getString(build, "dockerfilePath") === dockerfilePath,
+    `${path} must point at ${dockerfilePath}`,
+  );
+  for (const pattern of requiredWatchPatterns) {
+    expect(watchPatterns.includes(pattern), `${path} must watch ${pattern}`);
+  }
+  expect(
+    getString(deploy, "healthcheckPath") === "/health",
+    `${path} must healthcheck /health`,
+  );
+  expect(
+    deploy["restartPolicyType"] === "ON_FAILURE",
+    `${path} must restart on failure`,
+  );
+};
+
+expect(existsSync(API_CONFIG_PATH), "API config must live at /railway.json");
+expect(
+  !existsSync(LEGACY_API_CONFIG_PATH),
+  "Do not keep duplicate API config at /railway/api.railway.json",
+);
+expect(existsSync(WEB_CONFIG_PATH), "Web config must exist");
+
+validateServiceConfig({
+  path: API_CONFIG_PATH,
+  dockerfilePath: "apps/api/Dockerfile",
+  requiredWatchPatterns: ["/apps/api/**", "/packages/**", "/bun.lock"],
+});
+validateServiceConfig({
+  path: WEB_CONFIG_PATH,
+  dockerfilePath: "apps/web/Dockerfile",
+  requiredWatchPatterns: ["/apps/web/**", "/packages/**", "/VERSION"],
+});
+
+const apiDeploy = getRecord(readJson(API_CONFIG_PATH), "deploy");
+expect(
+  JSON.stringify(apiDeploy["preDeployCommand"]) ===
+    JSON.stringify(["bun src/db/migrate.ts"]),
+  "API config must run migrations as a pre-deploy command",
+);
+
+const railwayDoc = readText(RAILWAY_DOC_PATH);
+expect(
+  railwayDoc.includes("`railway.json`"),
+  "Railway docs must reference root API config",
+);
+expect(
+  railwayDoc.includes("`railway/web.railway.json`"),
+  "Railway docs must reference web config",
+);
+expect(
+  !railwayDoc.includes("railway/api.railway.json"),
+  "Railway docs must not reference the removed API config path",
+);
+
+const templateReadme = readText(TEMPLATE_README_PATH);
+for (const heading of [
+  "# Deploy and Host stella on Railway",
+  "## About Hosting stella",
+  "## Common Use Cases",
+  "## Dependencies for stella Hosting",
+  "### Deployment Dependencies",
+  "### Implementation Details",
+  "## Why Deploy stella on Railway?",
+  "## Updating",
+]) {
+  expect(
+    templateReadme.includes(heading),
+    `Template README missing heading: ${heading}`,
+  );
+}
+
+const publicRailwayCopy = [
+  ["Railway docs", railwayDoc],
+  ["template README", templateReadme],
+  ["README", readText("README.md")],
+];
+const privateBusinessPattern = /kickback|referralCode|payout|earnings/iu;
+for (const [label, text] of publicRailwayCopy) {
+  expect(
+    !privateBusinessPattern.test(text),
+    `${label} must not include referral or payout copy`,
+  );
+}
+
+const dockerignore = readText(DOCKERIGNORE_PATH);
+expect(
+  dockerignore.includes("**/.env*"),
+  ".dockerignore must exclude env files from Railway/Docker uploads",
+);
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`railway-template-shape: ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("railway-template-shape: ok");

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -6,6 +6,12 @@ const WEB_CONFIG_PATH = "railway/web.railway.json";
 const RAILWAY_DOC_PATH = "docs/railway.md";
 const TEMPLATE_README_PATH = "railway/template-readme.md";
 const DOCKERIGNORE_PATH = ".dockerignore";
+const RAILWAY_SMOKE_WORKFLOW_PATH = ".github/workflows/railway-smoke.yml";
+const RAILWAY_SMOKE_SCRIPT_PATH = "scripts/check-railway-smoke.ts";
+const API_HEALTH_ROUTE_PATH = "apps/api/src/handlers/health/routes.ts";
+const WEB_VITE_CONFIG_PATH = "apps/web/vite.config.ts";
+const API_DOCKERFILE_PATH = "apps/api/Dockerfile";
+const WEB_DOCKERFILE_PATH = "apps/web/Dockerfile";
 
 const failures: string[] = [];
 
@@ -137,6 +143,10 @@ expect(
   !railwayDoc.includes("railway/api.railway.json"),
   "Railway docs must not reference the removed API config path",
 );
+expect(
+  railwayDoc.includes("## Source-Backed Smoke Verification"),
+  "Railway docs must describe the source-backed smoke workflow",
+);
 
 const templateReadme = readText(TEMPLATE_README_PATH);
 for (const heading of [
@@ -173,6 +183,54 @@ expect(
   dockerignore.includes("**/.env*"),
   ".dockerignore must exclude env files from Railway/Docker uploads",
 );
+
+const railwaySmokeWorkflow = readText(RAILWAY_SMOKE_WORKFLOW_PATH);
+for (const requiredText of [
+  "deployment_status:",
+  "workflow_dispatch:",
+  "RAILWAY_SMOKE_DEPLOYMENT_ENVIRONMENT",
+  "RAILWAY_SMOKE_API_URL",
+  "RAILWAY_SMOKE_WEB_URL",
+  "scripts/check-railway-smoke.ts",
+]) {
+  expect(
+    railwaySmokeWorkflow.includes(requiredText),
+    `Railway smoke workflow must include ${requiredText}`,
+  );
+}
+
+const railwaySmokeScript = readText(RAILWAY_SMOKE_SCRIPT_PATH);
+for (const requiredText of [
+  "RAILWAY_SMOKE_API_URL",
+  "RAILWAY_SMOKE_WEB_URL",
+  "RAILWAY_SMOKE_EXPECTED_COMMIT",
+  "/health",
+  "/version.json",
+]) {
+  expect(
+    railwaySmokeScript.includes(requiredText),
+    `Railway smoke checker must include ${requiredText}`,
+  );
+}
+
+const apiHealthRoute = readText(API_HEALTH_ROUTE_PATH);
+expect(
+  apiHealthRoute.includes("RAILWAY_GIT_COMMIT_SHA"),
+  "API health route must expose Railway source deploy commit SHAs",
+);
+
+const webViteConfig = readText(WEB_VITE_CONFIG_PATH);
+expect(
+  webViteConfig.includes("RAILWAY_GIT_COMMIT_SHA"),
+  "web version manifest must expose Railway source deploy commit SHAs",
+);
+
+for (const path of [API_DOCKERFILE_PATH, WEB_DOCKERFILE_PATH]) {
+  expect(
+    readText(path).includes("RAILWAY_GIT_COMMIT_SHA"),
+    `${path} must preserve Railway source deploy commit SHAs`,
+  );
+}
 
 if (failures.length > 0) {
   for (const failure of failures) {

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -115,12 +115,22 @@ expect(existsSync(WEB_CONFIG_PATH), "Web config must exist");
 validateServiceConfig({
   path: API_CONFIG_PATH,
   dockerfilePath: "apps/api/Dockerfile",
-  requiredWatchPatterns: ["/apps/api/**", "/packages/**", "/bun.lock"],
+  requiredWatchPatterns: [
+    "/railway.json",
+    "/apps/api/**",
+    "/packages/**",
+    "/bun.lock",
+  ],
 });
 validateServiceConfig({
   path: WEB_CONFIG_PATH,
   dockerfilePath: "apps/web/Dockerfile",
-  requiredWatchPatterns: ["/apps/web/**", "/packages/**", "/VERSION"],
+  requiredWatchPatterns: [
+    "/railway/web.railway.json",
+    "/apps/web/**",
+    "/packages/**",
+    "/VERSION",
+  ],
 });
 
 const apiDeploy = getRecord(readJson(API_CONFIG_PATH), "deploy");

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -126,6 +126,7 @@ run_test() {
 
 run_step "AI skill sync" bash scripts/sync-ai-skills.sh --check
 run_step "Workspace hygiene" bun run lint:ws
+run_step "Railway template shape" bun run check:railway-template
 run_step "i18n" bun run i18n:check
 run_step "Release changelog guard" bash scripts/check-release-changelog.sh --base "$base_ref"
 run_step "Lint" run_lint


### PR DESCRIPTION
## Summary

- Add Railway config-as-code and template documentation for the API/web self-host stack.
- Add CI and local guards that keep the Railway template shape from drifting.
- Add a Railway smoke workflow plus runtime compatibility fixes for Railway PORT, Redis startup, and source deploy commit metadata.