### PR TITLE
feat(views): keep visibility menu open on toggle; right-click view tab opens actions

### DIFF
--- a/apps/web/src/components/inspector/use-anchored-menu.tsx
+++ b/apps/web/src/components/inspector/use-anchored-menu.tsx
@@ -27,9 +27,15 @@ export const useAnchoredMenu = ({ children }: { children: ReactNode }) => {
     event.stopPropagation();
     const x = event.clientX;
     const y = event.clientY;
-    setAnchor({
-      getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
-    });
+    const trigger = event.currentTarget;
+    // Keyboard / assistive-tech activations dispatch a click with no
+    // pointer position (clientX/clientY are 0); anchor to the triggering
+    // element so the menu opens beside it instead of the viewport corner.
+    const anchorRect: AnchorRect =
+      x !== 0 || y !== 0
+        ? { getBoundingClientRect: () => new DOMRect(x, y, 0, 0) }
+        : { getBoundingClientRect: () => trigger.getBoundingClientRect() };
+    setAnchor(anchorRect);
     setOpen(true);
   };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -226,7 +226,11 @@ export const ViewSwitcher = ({
                 isRenaming={renamingViewId === view.id}
                 key={view.id}
                 onOpenMenu={(event) =>
-                  viewActions.openFor(view, !isLastOfLayout, event)
+                  viewActions.openFor({
+                    view,
+                    canDelete: !isLastOfLayout,
+                    event,
+                  })
                 }
                 onReorder={handleReorder}
                 onSelect={() => onViewChange(view.id)}
@@ -507,6 +511,10 @@ type ViewActionsTarget = {
   canDelete: boolean;
 };
 
+type OpenViewActionsArgs = ViewActionsTarget & {
+  event: React.MouseEvent<HTMLElement>;
+};
+
 /**
  * Single, shared view-actions menu for the whole switcher. One
  * instance owns the mutations, dialogs, and cursor-anchored menu;
@@ -666,11 +674,7 @@ const useViewActionsMenu = ({
     children: target ? renderItems(target) : null,
   });
 
-  const openFor = (
-    view: WorkspaceView,
-    canDelete: boolean,
-    event: React.MouseEvent<HTMLElement>,
-  ) => {
+  const openFor = ({ view, canDelete, event }: OpenViewActionsArgs) => {
     if (!hasActions) {
       return;
     }
@@ -682,6 +686,7 @@ const useViewActionsMenu = ({
     <>
       {canCreateView && target && (
         <SaveAsTemplateDialog
+          key={target.view.id}
           defaultName={target.view.name}
           layout={target.view.layout}
           onOpenChange={setIsSaveTemplateOpen}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -168,6 +168,11 @@ export const ViewSwitcher = ({
   const { data: views = [] } = useQuery(viewsOptions(workspaceId));
   const createView = useCreateView(workspaceId);
   const reorderViews = useReorderViews(workspaceId);
+  const [renamingViewId, setRenamingViewId] = useState<string | null>(null);
+  const viewActions = useViewActionsMenu({
+    workspaceId,
+    onRenameView: setRenamingViewId,
+  });
   const [isTemplatePickerOpen, setIsTemplatePickerOpen] = useState(false);
   const hasOverviewView = views.some((view) => view.layout.type === "overview");
   const createLayoutOptions = hasOverviewView
@@ -218,11 +223,20 @@ export const ViewSwitcher = ({
 
             return (
               <ViewTab
-                activeViewId={activeViewId}
-                canDelete={!isLastOfLayout}
+                isRenaming={renamingViewId === view.id}
                 key={view.id}
+                onOpenMenu={(event) =>
+                  viewActions.openFor(view, !isLastOfLayout, event)
+                }
                 onReorder={handleReorder}
                 onSelect={() => onViewChange(view.id)}
+                onStartRename={() => setRenamingViewId(view.id)}
+                onStopRename={() =>
+                  setRenamingViewId((current) =>
+                    current === view.id ? null : current,
+                  )
+                }
+                showActions={view.id === activeViewId && viewActions.hasActions}
                 view={view}
                 workspaceId={workspaceId}
               />
@@ -319,46 +333,52 @@ export const ViewSwitcher = ({
           workspaceId={workspaceId}
         />
       )}
+      {viewActions.overlays}
     </div>
   );
 };
 
 type ViewTabProps = {
   workspaceId: string;
-  activeViewId: string;
   view: WorkspaceView;
-  canDelete: boolean;
+  isRenaming: boolean;
+  showActions: boolean;
   onSelect: () => void;
   onReorder: (draggedId: string, targetId: string) => void;
+  onStartRename: () => void;
+  onStopRename: () => void;
+  onOpenMenu: (event: React.MouseEvent<HTMLElement>) => void;
 };
 
 const ViewTab = ({
   workspaceId,
-  activeViewId,
   view,
-  canDelete,
+  isRenaming,
+  showActions,
   onSelect,
   onReorder,
+  onStartRename,
+  onStopRename,
+  onOpenMenu,
 }: ViewTabProps) => {
   const { id, name, layout } = view;
-  const isActive = id === activeViewId;
   const t = useTranslations();
   const canUpdateView = usePermissions({ view: ["update"] });
-  const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(name);
+  const [wasRenaming, setWasRenaming] = useState(isRenaming);
   const [isDropTarget, setIsDropTarget] = useState(false);
   const updateView = useUpdateView(workspaceId);
   const containerRef = useRef<HTMLDivElement>(null);
   const handleReorder = useEffectEvent(onReorder);
-  const tabMenu = useViewTabMenu({
-    workspaceId,
-    view,
-    canDelete,
-    onRename: () => {
-      setIsRenaming(true);
+
+  // Seed the draft from the current name each time rename begins,
+  // since the trigger now lives in the parent (menu or double-click).
+  if (isRenaming !== wasRenaming) {
+    setWasRenaming(isRenaming);
+    if (isRenaming) {
       setRenameValue(name);
-    },
-  });
+    }
+  }
 
   useExternalSyncEffect(() => {
     const el = containerRef.current;
@@ -399,7 +419,7 @@ const ViewTab = ({
   const handleRename = () => {
     const trimmed = renameValue.trim();
     if (trimmed.length === 0 || trimmed === name) {
-      setIsRenaming(false);
+      onStopRename();
       setRenameValue(name);
       return;
     }
@@ -407,13 +427,13 @@ const ViewTab = ({
     updateView.mutate(
       { viewId: id, name: trimmed },
       {
-        onSuccess: () => setIsRenaming(false),
+        onSuccess: () => onStopRename(),
         onError: () => {
           stellaToast.add({
             title: t("errors.failedToRenameView"),
             type: "error",
           });
-          setIsRenaming(false);
+          onStopRename();
           setRenameValue(name);
         },
       },
@@ -429,7 +449,7 @@ const ViewTab = ({
         <InlineEdit
           inputClassName="w-24"
           onCancel={() => {
-            setIsRenaming(false);
+            onStopRename();
             setRenameValue(name);
           }}
           onChange={setRenameValue}
@@ -448,46 +468,55 @@ const ViewTab = ({
       <TabsTab
         className="pe-6.5"
         onClick={onSelect}
-        onContextMenu={tabMenu.openContextMenu}
+        onContextMenu={onOpenMenu}
         onDoubleClick={(e) => {
           if (!canUpdateView) {
             return;
           }
           e.preventDefault();
-          setIsRenaming(true);
-          setRenameValue(name);
+          onStartRename();
         }}
         value={id}
       >
         <Icon className="size-3.5 shrink-0" />
         <span className="max-w-36 truncate">{name}</span>
       </TabsTab>
-      {isActive && tabMenu.triggerButton}
-      {tabMenu.overlays}
+      {showActions && (
+        <Button
+          aria-haspopup="menu"
+          aria-label={t("common.actions")}
+          className="absolute inset-e-0 top-1/2 -translate-y-1/2"
+          onClick={onOpenMenu}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <EllipsisVerticalIcon />
+        </Button>
+      )}
     </div>
   );
 };
 
-type UseViewTabMenuOptions = {
+type UseViewActionsMenuOptions = {
   workspaceId: string;
+  onRenameView: (viewId: string) => void;
+};
+
+type ViewActionsTarget = {
   view: WorkspaceView;
   canDelete: boolean;
-  onRename: () => void;
 };
 
 /**
- * Shared view-tab actions, surfaced both from the three-dot trigger
- * (`triggerButton`) and a cursor-anchored right-click menu
- * (`openContextMenu` + `overlays`), so both gestures open the same
- * rename/duplicate/convert/delete actions.
+ * Single, shared view-actions menu for the whole switcher. One
+ * instance owns the mutations, dialogs, and cursor-anchored menu;
+ * `openFor` retargets it at the right-clicked (or three-dot) view,
+ * so per-tab mounting of mutations and dialogs is avoided.
  */
-const useViewTabMenu = ({
+const useViewActionsMenu = ({
   workspaceId,
-  view,
-  canDelete,
-  onRename,
-}: UseViewTabMenuOptions) => {
-  const { id, name, layout } = view;
+  onRenameView,
+}: UseViewActionsMenuOptions) => {
   const t = useTranslations();
   const canCreateView = usePermissions({ view: ["create"] });
   const canUpdateView = usePermissions({ view: ["update"] });
@@ -495,16 +524,16 @@ const useViewTabMenu = ({
   const createView = useCreateView(workspaceId);
   const convertView = useConvertView(workspaceId);
   const deleteView = useDeleteView(workspaceId);
+  const [target, setTarget] = useState<ViewActionsTarget | null>(null);
   const [isSaveTemplateOpen, setIsSaveTemplateOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [convertPreview, setConvertPreview] = useState<ViewLayoutType | null>(
     null,
   );
 
-  const Icon = layoutIcons[layout.type];
   const hasActions = canUpdateView || canCreateView || canDeleteView;
 
-  const handleDuplicate = () => {
+  const handleDuplicate = (view: WorkspaceView) => {
     const newId = crypto.randomUUID();
     createView.mutate(
       {
@@ -525,9 +554,9 @@ const useViewTabMenu = ({
     );
   };
 
-  const handleDelete = () => {
+  const handleDelete = (viewId: string) => {
     deleteView.mutate(
-      { viewId: id },
+      { viewId },
       {
         onError: () => {
           stellaToast.add({
@@ -539,135 +568,128 @@ const useViewTabMenu = ({
     );
   };
 
-  const items = (
-    <>
-      {canUpdateView && (
-        <MenuItem onClick={onRename}>
-          <PencilIcon />
-          {t("common.rename")}
-        </MenuItem>
-      )}
-      {canCreateView && layout.type !== "overview" && (
-        <MenuItem onClick={handleDuplicate}>
-          <CopyIcon />
-          {t("common.duplicate")}
-        </MenuItem>
-      )}
-      {canCreateView && (
-        <MenuItem onClick={() => setIsSaveTemplateOpen(true)}>
-          <BookmarkPlusIcon />
-          {t("workspaces.views.saveAsTemplate")}
-        </MenuItem>
-      )}
-      {canUpdateView && (
-        <MenuSub
-          onOpenChange={(open) => {
-            if (!open) {
-              setConvertPreview(null);
-            }
-          }}
-        >
-          <MenuSubTrigger>
-            <Icon />
-            {t("common.convertTo")}
-          </MenuSubTrigger>
-          <MenuSubPopup>
-            <MenuPreviewLayout
-              preview={
-                <ViewLayoutPreview
-                  kind={convertPreview}
-                  workspaceId={workspaceId}
-                />
+  const renderItems = ({ view, canDelete }: ViewActionsTarget) => {
+    const { id, layout } = view;
+    const Icon = layoutIcons[layout.type];
+    return (
+      <>
+        {canUpdateView && (
+          <MenuItem onClick={() => onRenameView(id)}>
+            <PencilIcon />
+            {t("common.rename")}
+          </MenuItem>
+        )}
+        {canCreateView && layout.type !== "overview" && (
+          <MenuItem onClick={() => handleDuplicate(view)}>
+            <CopyIcon />
+            {t("common.duplicate")}
+          </MenuItem>
+        )}
+        {canCreateView && (
+          <MenuItem onClick={() => setIsSaveTemplateOpen(true)}>
+            <BookmarkPlusIcon />
+            {t("workspaces.views.saveAsTemplate")}
+          </MenuItem>
+        )}
+        {canUpdateView && (
+          <MenuSub
+            onOpenChange={(open) => {
+              if (!open) {
+                setConvertPreview(null);
               }
-            >
-              {LAYOUT_OPTIONS.filter(
-                (l) => l !== layout.type && l !== "overview",
-              ).map((l) => {
-                const LayoutIcon = layoutIcons[l];
-                return (
-                  <MenuItem
-                    key={l}
-                    onClick={() => {
-                      convertView.mutate(
-                        {
-                          viewId: id,
-                          targetType: l,
-                        },
-                        {
-                          onError: () => {
-                            stellaToast.add({
-                              title: t("errors.failedToChangeViewType"),
-                              type: "error",
-                            });
+            }}
+          >
+            <MenuSubTrigger>
+              <Icon />
+              {t("common.convertTo")}
+            </MenuSubTrigger>
+            <MenuSubPopup>
+              <MenuPreviewLayout
+                preview={
+                  <ViewLayoutPreview
+                    kind={convertPreview}
+                    workspaceId={workspaceId}
+                  />
+                }
+              >
+                {LAYOUT_OPTIONS.filter(
+                  (l) => l !== layout.type && l !== "overview",
+                ).map((l) => {
+                  const LayoutIcon = layoutIcons[l];
+                  return (
+                    <MenuItem
+                      key={l}
+                      onClick={() => {
+                        convertView.mutate(
+                          {
+                            viewId: id,
+                            targetType: l,
                           },
-                        },
-                      );
-                    }}
-                    onFocus={() => setConvertPreview(l)}
-                    onMouseEnter={() => setConvertPreview(l)}
-                  >
-                    <LayoutIcon />
-                    {t(LAYOUT_LABEL_KEYS[l])}
-                  </MenuItem>
-                );
-              })}
-            </MenuPreviewLayout>
-          </MenuSubPopup>
-        </MenuSub>
-      )}
-      {(canUpdateView || canCreateView) && canDeleteView && <MenuSeparator />}
-      {canDeleteView && (
-        <MenuItem
-          disabled={!canDelete}
-          onClick={() => setIsDeleteOpen(true)}
-          variant="destructive"
-        >
-          <Trash2Icon />
-          {t("common.delete")}
-        </MenuItem>
-      )}
-    </>
-  );
+                          {
+                            onError: () => {
+                              stellaToast.add({
+                                title: t("errors.failedToChangeViewType"),
+                                type: "error",
+                              });
+                            },
+                          },
+                        );
+                      }}
+                      onFocus={() => setConvertPreview(l)}
+                      onMouseEnter={() => setConvertPreview(l)}
+                    >
+                      <LayoutIcon />
+                      {t(LAYOUT_LABEL_KEYS[l])}
+                    </MenuItem>
+                  );
+                })}
+              </MenuPreviewLayout>
+            </MenuSubPopup>
+          </MenuSub>
+        )}
+        {(canUpdateView || canCreateView) && canDeleteView && <MenuSeparator />}
+        {canDeleteView && (
+          <MenuItem
+            disabled={!canDelete}
+            onClick={() => setIsDeleteOpen(true)}
+            variant="destructive"
+          >
+            <Trash2Icon />
+            {t("common.delete")}
+          </MenuItem>
+        )}
+      </>
+    );
+  };
 
-  const contextMenu = useAnchoredMenu({ children: items });
+  const contextMenu = useAnchoredMenu({
+    children: target ? renderItems(target) : null,
+  });
 
-  const openContextMenu = (event: React.MouseEvent<HTMLElement>) => {
+  const openFor = (
+    view: WorkspaceView,
+    canDelete: boolean,
+    event: React.MouseEvent<HTMLElement>,
+  ) => {
     if (!hasActions) {
       return;
     }
+    setTarget({ view, canDelete });
     contextMenu.openAt(event);
   };
 
-  const triggerButton = hasActions ? (
-    <Menu>
-      <MenuTrigger
-        aria-label={t("common.actions")}
-        render={
-          <Button
-            className="absolute inset-e-0 top-1/2 -translate-y-1/2"
-            size="icon-xs"
-            variant="ghost"
-          />
-        }
-      >
-        <EllipsisVerticalIcon />
-      </MenuTrigger>
-      <MenuPopup>{items}</MenuPopup>
-    </Menu>
-  ) : null;
-
   const overlays = (
     <>
-      {canCreateView && (
+      {canCreateView && target && (
         <SaveAsTemplateDialog
-          defaultName={name}
-          layout={layout}
+          defaultName={target.view.name}
+          layout={target.view.layout}
           onOpenChange={setIsSaveTemplateOpen}
           open={isSaveTemplateOpen}
           workspaceId={workspaceId}
         />
       )}
-      {canDeleteView && (
+      {canDeleteView && target && (
         <AlertDialog onOpenChange={setIsDeleteOpen} open={isDeleteOpen}>
           <AlertDialogPopup>
             <AlertDialogHeader>
@@ -676,7 +698,7 @@ const useViewTabMenu = ({
               </AlertDialogTitle>
               <AlertDialogDescription>
                 {t("common.deleteConfirmDescription", {
-                  name,
+                  name: target.view.name,
                 })}
               </AlertDialogDescription>
             </AlertDialogHeader>
@@ -685,7 +707,12 @@ const useViewTabMenu = ({
                 {t("common.cancel")}
               </AlertDialogClose>
               <AlertDialogClose
-                render={<Button onClick={handleDelete} variant="destructive" />}
+                render={
+                  <Button
+                    onClick={() => handleDelete(target.view.id)}
+                    variant="destructive"
+                  />
+                }
               >
                 {t("common.delete")}
               </AlertDialogClose>
@@ -697,5 +724,5 @@ const useViewTabMenu = ({
     </>
   );
 
-  return { openContextMenu, triggerButton, overlays };
+  return { hasActions, openFor, overlays };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -32,7 +32,6 @@ import {
   AlertDialogHeader,
   AlertDialogPopup,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@stll/ui/components/alert-dialog";
 import { Button } from "@stll/ui/components/button";
 import {
@@ -50,6 +49,7 @@ import { Tabs, TabsList, TabsTab } from "@stll/ui/components/tabs";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useAnchoredMenu } from "@/components/inspector/use-anchored-menu";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
 import type { TranslationKey } from "@/i18n/types";
@@ -343,15 +343,22 @@ const ViewTab = ({
   const { id, name, layout } = view;
   const isActive = id === activeViewId;
   const t = useTranslations();
-  const canCreateView = usePermissions({ view: ["create"] });
   const canUpdateView = usePermissions({ view: ["update"] });
-  const canDeleteView = usePermissions({ view: ["delete"] });
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(name);
   const [isDropTarget, setIsDropTarget] = useState(false);
   const updateView = useUpdateView(workspaceId);
   const containerRef = useRef<HTMLDivElement>(null);
   const handleReorder = useEffectEvent(onReorder);
+  const tabMenu = useViewTabMenu({
+    workspaceId,
+    view,
+    canDelete,
+    onRename: () => {
+      setIsRenaming(true);
+      setRenameValue(name);
+    },
+  });
 
   useExternalSyncEffect(() => {
     const el = containerRef.current;
@@ -441,6 +448,7 @@ const ViewTab = ({
       <TabsTab
         className="pe-6.5"
         onClick={onSelect}
+        onContextMenu={tabMenu.openContextMenu}
         onDoubleClick={(e) => {
           if (!canUpdateView) {
             return;
@@ -454,37 +462,31 @@ const ViewTab = ({
         <Icon className="size-3.5 shrink-0" />
         <span className="max-w-36 truncate">{name}</span>
       </TabsTab>
-      {isActive && (canUpdateView || canCreateView || canDeleteView) && (
-        <ViewTabMenu
-          canDelete={canDelete}
-          className="absolute inset-e-0 top-1/2 -translate-y-1/2"
-          onRename={() => {
-            setIsRenaming(true);
-            setRenameValue(name);
-          }}
-          view={view}
-          workspaceId={workspaceId}
-        />
-      )}
+      {isActive && tabMenu.triggerButton}
+      {tabMenu.overlays}
     </div>
   );
 };
 
-type ViewTabMenuProps = {
+type UseViewTabMenuOptions = {
   workspaceId: string;
   view: WorkspaceView;
   canDelete: boolean;
   onRename: () => void;
-  className: string;
 };
 
-const ViewTabMenu = ({
+/**
+ * Shared view-tab actions, surfaced both from the three-dot trigger
+ * (`triggerButton`) and a cursor-anchored right-click menu
+ * (`openContextMenu` + `overlays`), so both gestures open the same
+ * rename/duplicate/convert/delete actions.
+ */
+const useViewTabMenu = ({
   workspaceId,
   view,
   canDelete,
   onRename,
-  className,
-}: ViewTabMenuProps) => {
+}: UseViewTabMenuOptions) => {
   const { id, name, layout } = view;
   const t = useTranslations();
   const canCreateView = usePermissions({ view: ["create"] });
@@ -494,11 +496,13 @@ const ViewTabMenu = ({
   const convertView = useConvertView(workspaceId);
   const deleteView = useDeleteView(workspaceId);
   const [isSaveTemplateOpen, setIsSaveTemplateOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [convertPreview, setConvertPreview] = useState<ViewLayoutType | null>(
     null,
   );
 
   const Icon = layoutIcons[layout.type];
+  const hasActions = canUpdateView || canCreateView || canDeleteView;
 
   const handleDuplicate = () => {
     const newId = crypto.randomUUID();
@@ -535,7 +539,124 @@ const ViewTabMenu = ({
     );
   };
 
-  return (
+  const items = (
+    <>
+      {canUpdateView && (
+        <MenuItem onClick={onRename}>
+          <PencilIcon />
+          {t("common.rename")}
+        </MenuItem>
+      )}
+      {canCreateView && layout.type !== "overview" && (
+        <MenuItem onClick={handleDuplicate}>
+          <CopyIcon />
+          {t("common.duplicate")}
+        </MenuItem>
+      )}
+      {canCreateView && (
+        <MenuItem onClick={() => setIsSaveTemplateOpen(true)}>
+          <BookmarkPlusIcon />
+          {t("workspaces.views.saveAsTemplate")}
+        </MenuItem>
+      )}
+      {canUpdateView && (
+        <MenuSub
+          onOpenChange={(open) => {
+            if (!open) {
+              setConvertPreview(null);
+            }
+          }}
+        >
+          <MenuSubTrigger>
+            <Icon />
+            {t("common.convertTo")}
+          </MenuSubTrigger>
+          <MenuSubPopup>
+            <MenuPreviewLayout
+              preview={
+                <ViewLayoutPreview
+                  kind={convertPreview}
+                  workspaceId={workspaceId}
+                />
+              }
+            >
+              {LAYOUT_OPTIONS.filter(
+                (l) => l !== layout.type && l !== "overview",
+              ).map((l) => {
+                const LayoutIcon = layoutIcons[l];
+                return (
+                  <MenuItem
+                    key={l}
+                    onClick={() => {
+                      convertView.mutate(
+                        {
+                          viewId: id,
+                          targetType: l,
+                        },
+                        {
+                          onError: () => {
+                            stellaToast.add({
+                              title: t("errors.failedToChangeViewType"),
+                              type: "error",
+                            });
+                          },
+                        },
+                      );
+                    }}
+                    onFocus={() => setConvertPreview(l)}
+                    onMouseEnter={() => setConvertPreview(l)}
+                  >
+                    <LayoutIcon />
+                    {t(LAYOUT_LABEL_KEYS[l])}
+                  </MenuItem>
+                );
+              })}
+            </MenuPreviewLayout>
+          </MenuSubPopup>
+        </MenuSub>
+      )}
+      {(canUpdateView || canCreateView) && canDeleteView && <MenuSeparator />}
+      {canDeleteView && (
+        <MenuItem
+          disabled={!canDelete}
+          onClick={() => setIsDeleteOpen(true)}
+          variant="destructive"
+        >
+          <Trash2Icon />
+          {t("common.delete")}
+        </MenuItem>
+      )}
+    </>
+  );
+
+  const contextMenu = useAnchoredMenu({ children: items });
+
+  const openContextMenu = (event: React.MouseEvent<HTMLElement>) => {
+    if (!hasActions) {
+      return;
+    }
+    contextMenu.openAt(event);
+  };
+
+  const triggerButton = hasActions ? (
+    <Menu>
+      <MenuTrigger
+        aria-label={t("common.actions")}
+        render={
+          <Button
+            className="absolute inset-e-0 top-1/2 -translate-y-1/2"
+            size="icon-xs"
+            variant="ghost"
+          />
+        }
+      >
+        <EllipsisVerticalIcon />
+      </MenuTrigger>
+      <MenuPopup>{items}</MenuPopup>
+    </Menu>
+  ) : null;
+
+  const overlays = (
     <>
       {canCreateView && (
         <SaveAsTemplateDialog
@@ -546,131 +667,35 @@ const ViewTabMenu = ({
           workspaceId={workspaceId}
         />
       )}
-      <Menu>
-        <MenuTrigger
-          aria-label={t("common.actions")}
-          render={
-            <Button className={className} size="icon-xs" variant="ghost" />
-          }
-        >
-          <EllipsisVerticalIcon />
-        </MenuTrigger>
-        <MenuPopup>
-          {canUpdateView && (
-            <MenuItem onClick={onRename}>
-              <PencilIcon />
-              {t("common.rename")}
-            </MenuItem>
-          )}
-          {canCreateView && layout.type !== "overview" && (
-            <MenuItem onClick={handleDuplicate}>
-              <CopyIcon />
-              {t("common.duplicate")}
-            </MenuItem>
-          )}
-          {canCreateView && (
-            <MenuItem onClick={() => setIsSaveTemplateOpen(true)}>
-              <BookmarkPlusIcon />
-              {t("workspaces.views.saveAsTemplate")}
-            </MenuItem>
-          )}
-          {canUpdateView && (
-            <MenuSub
-              onOpenChange={(open) => {
-                if (!open) {
-                  setConvertPreview(null);
-                }
-              }}
-            >
-              <MenuSubTrigger>
-                <Icon />
-                {t("common.convertTo")}
-              </MenuSubTrigger>
-              <MenuSubPopup>
-                <MenuPreviewLayout
-                  preview={
-                    <ViewLayoutPreview
-                      kind={convertPreview}
-                      workspaceId={workspaceId}
-                    />
-                  }
-                >
-                  {LAYOUT_OPTIONS.filter(
-                    (l) => l !== layout.type && l !== "overview",
-                  ).map((l) => {
-                    const LayoutIcon = layoutIcons[l];
-                    return (
-                      <MenuItem
-                        key={l}
-                        onClick={() => {
-                          convertView.mutate(
-                            {
-                              viewId: id,
-                              targetType: l,
-                            },
-                            {
-                              onError: () => {
-                                stellaToast.add({
-                                  title: t("errors.failedToChangeViewType"),
-                                  type: "error",
-                                });
-                              },
-                            },
-                          );
-                        }}
-                        onFocus={() => setConvertPreview(l)}
-                        onMouseEnter={() => setConvertPreview(l)}
-                      >
-                        <LayoutIcon />
-                        {t(LAYOUT_LABEL_KEYS[l])}
-                      </MenuItem>
-                    );
-                  })}
-                </MenuPreviewLayout>
-              </MenuSubPopup>
-            </MenuSub>
-          )}
-          {(canUpdateView || canCreateView) && canDeleteView && (
-            <MenuSeparator />
-          )}
-          {canDeleteView && (
-            <AlertDialog>
-              <AlertDialogTrigger
-                disabled={!canDelete}
-                nativeButton={false}
-                render={<MenuItem closeOnClick={false} variant="destructive" />}
+      {canDeleteView && (
+        <AlertDialog onOpenChange={setIsDeleteOpen} open={isDeleteOpen}>
+          <AlertDialogPopup>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {t("workspaces.views.deleteView")}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {t("common.deleteConfirmDescription", {
+                  name,
+                })}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogClose render={<Button variant="ghost" />}>
+                {t("common.cancel")}
+              </AlertDialogClose>
+              <AlertDialogClose
+                render={<Button onClick={handleDelete} variant="destructive" />}
               >
-                <Trash2Icon />
                 {t("common.delete")}
-              </AlertDialogTrigger>
-              <AlertDialogPopup>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    {t("workspaces.views.deleteView")}
-                  </AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {t("common.deleteConfirmDescription", {
-                      name,
-                    })}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogClose render={<Button variant="ghost" />}>
-                    {t("common.cancel")}
-                  </AlertDialogClose>
-                  <AlertDialogClose
-                    render={
-                      <Button onClick={handleDelete} variant="destructive" />
-                    }
-                  >
-                    {t("common.delete")}
-                  </AlertDialogClose>
-                </AlertDialogFooter>
-              </AlertDialogPopup>
-            </AlertDialog>
-          )}
-        </MenuPopup>
-      </Menu>
+              </AlertDialogClose>
+            </AlertDialogFooter>
+          </AlertDialogPopup>
+        </AlertDialog>
+      )}
+      {contextMenu.element}
     </>
   );
+
+  return { openContextMenu, triggerButton, overlays };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -223,9 +223,17 @@ export const ViewSwitcher = ({
 
             return (
               <ViewTab
+                actions={
+                  view.id === activeViewId
+                    ? viewActions.renderActions({
+                        view,
+                        canDelete: !isLastOfLayout,
+                      })
+                    : null
+                }
                 isRenaming={renamingViewId === view.id}
                 key={view.id}
-                onOpenMenu={(event) =>
+                onOpenContextMenu={(event) =>
                   viewActions.openFor({
                     view,
                     canDelete: !isLastOfLayout,
@@ -240,7 +248,6 @@ export const ViewSwitcher = ({
                     current === view.id ? null : current,
                   )
                 }
-                showActions={view.id === activeViewId && viewActions.hasActions}
                 view={view}
                 workspaceId={workspaceId}
               />
@@ -346,24 +353,24 @@ type ViewTabProps = {
   workspaceId: string;
   view: WorkspaceView;
   isRenaming: boolean;
-  showActions: boolean;
+  actions: React.ReactNode;
   onSelect: () => void;
   onReorder: (draggedId: string, targetId: string) => void;
   onStartRename: () => void;
   onStopRename: () => void;
-  onOpenMenu: (event: React.MouseEvent<HTMLElement>) => void;
+  onOpenContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
 };
 
 const ViewTab = ({
   workspaceId,
   view,
   isRenaming,
-  showActions,
+  actions,
   onSelect,
   onReorder,
   onStartRename,
   onStopRename,
-  onOpenMenu,
+  onOpenContextMenu,
 }: ViewTabProps) => {
   const { id, name, layout } = view;
   const t = useTranslations();
@@ -472,7 +479,7 @@ const ViewTab = ({
       <TabsTab
         className="pe-6.5"
         onClick={onSelect}
-        onContextMenu={onOpenMenu}
+        onContextMenu={onOpenContextMenu}
         onDoubleClick={(e) => {
           if (!canUpdateView) {
             return;
@@ -485,18 +492,7 @@ const ViewTab = ({
         <Icon className="size-3.5 shrink-0" />
         <span className="max-w-36 truncate">{name}</span>
       </TabsTab>
-      {showActions && (
-        <Button
-          aria-haspopup="menu"
-          aria-label={t("common.actions")}
-          className="absolute inset-e-0 top-1/2 -translate-y-1/2"
-          onClick={onOpenMenu}
-          size="icon-xs"
-          variant="ghost"
-        >
-          <EllipsisVerticalIcon />
-        </Button>
-      )}
+      {actions}
     </div>
   );
 };
@@ -682,6 +678,39 @@ const useViewActionsMenu = ({
     contextMenu.openAt(event);
   };
 
+  // The visible three-dot trigger is a real `MenuTrigger`, so Base UI
+  // anchors the popup to the button and restores focus to it on close
+  // (keyboard/AT included). The cursor-anchored `openFor` path is kept
+  // only for right-click on a tab.
+  const renderActions = ({ view, canDelete }: ViewActionsTarget) => {
+    if (!hasActions) {
+      return null;
+    }
+    return (
+      <Menu
+        onOpenChange={(open) => {
+          if (open) {
+            setTarget({ view, canDelete });
+          }
+        }}
+      >
+        <MenuTrigger
+          aria-label={t("common.actions")}
+          render={
+            <Button
+              className="absolute inset-e-0 top-1/2 -translate-y-1/2"
+              size="icon-xs"
+              variant="ghost"
+            />
+          }
+        >
+          <EllipsisVerticalIcon />
+        </MenuTrigger>
+        <MenuPopup>{renderItems({ view, canDelete })}</MenuPopup>
+      </Menu>
+    );
+  };
+
   const overlays = (
     <>
       {canCreateView && target && (
@@ -729,5 +758,5 @@ const useViewActionsMenu = ({
     </>
   );
 
-  return { hasActions, openFor, overlays };
+  return { openFor, renderActions, overlays };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -943,7 +943,11 @@ const AdditionalDatesControl = ({
           {eligible.map((item) => {
             const isSelected = additionalDatePropertyIds.includes(item.id);
             return (
-              <MenuItem key={item.id} onClick={() => toggleProperty(item.id)}>
+              <MenuItem
+                key={item.id}
+                closeOnClick={false}
+                onClick={() => toggleProperty(item.id)}
+              >
                 <CalendarIcon className="size-3.5" />
                 <span className="flex-1">{item.name}</span>
                 {isSelected && <span className="text-primary">{"\u2713"}</span>}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -705,7 +705,11 @@ const PropertiesToggle = ({
           {metadataFields.map((meta) => {
             const isVisible = !hiddenProperties.includes(meta.id);
             return (
-              <MenuItem key={meta.id} onClick={() => toggleProperty(meta.id)}>
+              <MenuItem
+                key={meta.id}
+                closeOnClick={false}
+                onClick={() => toggleProperty(meta.id)}
+              >
                 <meta.icon className="size-4" />
                 <span className="flex-1">{meta.name}</span>
                 {isVisible && <span className="text-primary">{"\u2713"}</span>}
@@ -723,6 +727,7 @@ const PropertiesToggle = ({
                 return (
                   <MenuItem
                     key={prop.id}
+                    closeOnClick={false}
                     onClick={() => toggleProperty(prop.id)}
                   >
                     <PropertyIcon type={prop.content.type} />
@@ -749,6 +754,7 @@ const PropertiesToggle = ({
                 return (
                   <MenuItem
                     key={prop.id}
+                    closeOnClick={false}
                     onClick={() => toggleProperty(prop.id)}
                   >
                     <PropertyIcon type={prop.content.type} />


### PR DESCRIPTION
## Summary

Two small view-toolbar UX improvements:

- **Property visibility popover (eye icon) stays open while toggling.** Each property-toggle menu item now uses `closeOnClick={false}`, so multiple metadata/property/AI-generated columns can be flipped in one pass; the popover dismisses only on outside click.
- **Right-clicking a view tab opens the same actions menu as the three-dot button.** This works on any view tab, acting on that specific view (rename / duplicate / save as template / convert to / delete).

## Implementation notes

- The tab-menu actions were extracted into a `useViewTabMenu` hook shared by the existing three-dot trigger button and a cursor-anchored context menu built on the existing `useAnchoredMenu` primitive.
- Delete confirmation moved from an `AlertDialogTrigger`-wrapped item to a controlled `AlertDialog`, so the action items are cleanly shared between both surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reworked view tabs to use a shared, cursor-aware actions menu (with right-click context actions and a single active-tab menu).
  * Centralised rename flow: right-click or double-click now initiates rename, with consistent start/stop and commit/cancel behaviour.
* **Bug Fixes**
  * Improved actions-menu positioning, including more reliable anchoring for keyboard and assistive-activation scenarios.
  * “Show/hide” toggles in Columns, Properties, AI-generated properties, and Additional dates no longer close the menu when changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->