### PR TITLE
fix: restrict npm publish dispatch to main

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,8 +10,8 @@ name: Publish npm packages
 # the untrusted build (bun install, prepack, bun pm pack) with NO id-token, so a
 # compromised build/postinstall script cannot mint an OIDC credential. Only the
 # `publish` job — which just downloads the prebuilt tarballs and runs the
-# hardened action — is granted id-token: write, and it runs only when `publish`
-# is ticked.
+# hardened action — is granted id-token: write, and it runs only from main when
+# auto-release or an explicit manual publish requests it.
 #
 # Prerequisite (one-time, per package, by a maintainer on npmjs.com): configure
 # an npm "trusted publisher" for each @stll/* package pointing at this repository
@@ -127,8 +127,9 @@ jobs:
   publish:
     name: Publish @stll/${{ matrix.package }}
     needs: pack
-    # Auto-publish on a version-bump push; on manual dispatch, only when ticked.
-    if: ${{ github.event_name == 'push' || inputs.publish }}
+    # Auto-publish only from main: a version-bump push to main, or a manual
+    # dispatch from main with the publish checkbox ticked.
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Motivation
- Prevent a manual `workflow_dispatch` from non-main refs reaching the OIDC `id-token: write` publish job and thereby publishing unreviewed `@stll/*` artifacts.

### Description
- Update the `publish` job conditional in `.github/workflows/publish-npm.yml` to `if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish) }}`, preserving the `pack` job behavior while ensuring trusted publishing only runs from `refs/heads/main`.

### Testing
- Ran `git diff --check`, validated the YAML `if` expression with `ruby -e 'require "psych"; ...'`, and executed a local Python condition simulator to confirm the publish job is allowed on main pushes and main manual dispatches only, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42d82e85948333895bb8fb9cd52a11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened the release publishing trigger so it only runs from the main branch, and only on a push or when manually enabled.
  * Reduced the chance of unintended package publishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->