### PR TITLE
fix: omit restoration metadata from chat compaction

### DIFF
--- a/apps/api/src/handlers/chat/compaction.test.ts
+++ b/apps/api/src/handlers/chat/compaction.test.ts
@@ -19,8 +19,10 @@ import {
   planModelCompaction,
   renderChatMessagesForCompaction,
   renderModelMessagesForCompaction,
+  shouldCompactChatMessages,
   summarizeChatCompaction,
 } from "./compaction";
+import { ANON_RESTORATIONS_DATA_PART_TYPE } from "./third-party-boundary";
 
 const textMessage = ({
   id,
@@ -182,6 +184,141 @@ describe("chat history compaction", () => {
     expect(transcript).toContain("contract.pdf");
     expect(transcript).toContain("old file attachments are not rehydrated");
     expect(transcript).not.toContain("stella-user-file://file_1");
+  });
+
+  test("omits anonymization restoration metadata from the transcript", () => {
+    const transcript = renderChatMessagesForCompaction([
+      {
+        id: "msg_1",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "The answer references [ORG_1].",
+          },
+          {
+            type: ANON_RESTORATIONS_DATA_PART_TYPE,
+            data: {
+              pairs: [
+                {
+                  placeholder: "[ORG_1]",
+                  original: "Confidential Client LLC",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(transcript).toContain("The answer references [ORG_1].");
+    expect(transcript).not.toContain(ANON_RESTORATIONS_DATA_PART_TYPE);
+    expect(transcript).not.toContain("Confidential Client LLC");
+  });
+
+  test("ignores anonymization restoration metadata when planning compaction", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "The answer references [ORG_1].",
+          },
+          {
+            type: ANON_RESTORATIONS_DATA_PART_TYPE,
+            data: {
+              pairs: [
+                {
+                  placeholder: "[ORG_1]",
+                  original: "Confidential Client LLC ".repeat(1000),
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(shouldCompactChatMessages(messages, 1000)).toBe(false);
+    expect(planChatCompaction({ messages, triggerTokens: 1000 }).type).toBe(
+      "none",
+    );
+  });
+
+  test("drops restoration-only messages from transcript and planning", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "assistant",
+        parts: [
+          {
+            type: ANON_RESTORATIONS_DATA_PART_TYPE,
+            data: {
+              pairs: [
+                {
+                  placeholder: "[ORG_1]",
+                  original: "Confidential Client LLC ".repeat(1000),
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(renderChatMessagesForCompaction(messages)).toBe("");
+    expect(shouldCompactChatMessages(messages, 1)).toBe(false);
+    expect(planChatCompaction({ messages, triggerTokens: 1 }).type).toBe(
+      "none",
+    );
+  });
+
+  test("ignores restoration-only messages when finding the preserved tail", () => {
+    const messages: ChatMessage[] = [
+      textMessage({ id: "msg_1", role: "user", text: "old fact ".repeat(80) }),
+      textMessage({
+        id: "msg_2",
+        role: "assistant",
+        text: "old answer ".repeat(80),
+      }),
+      {
+        id: "msg_3",
+        role: "assistant",
+        parts: [
+          {
+            type: ANON_RESTORATIONS_DATA_PART_TYPE,
+            data: {
+              pairs: [
+                {
+                  placeholder: "[ORG_1]",
+                  original: "Confidential Client LLC",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      textMessage({ id: "msg_4", role: "user", text: "latest question" }),
+    ];
+
+    const plan = planChatCompaction({
+      messages,
+      preserveTokens: 20,
+      triggerTokens: 50,
+    });
+
+    expect(plan.type).toBe("compact");
+    if (plan.type === "none") {
+      return;
+    }
+
+    expect(plan.messagesToSummarize.map((message) => message.id)).toEqual([
+      "msg_1",
+      "msg_2",
+    ]);
+    expect(plan.recentMessages.map((message) => message.id)).toEqual(["msg_4"]);
   });
 
   test("falls back to the recent tail when summary generation fails", async () => {

--- a/apps/api/src/handlers/chat/compaction.ts
+++ b/apps/api/src/handlers/chat/compaction.ts
@@ -3,7 +3,10 @@ import type { LanguageModel, ModelMessage } from "ai";
 import { Result } from "better-result";
 
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
-import { prepareTextForThirdParty } from "@/api/handlers/chat/third-party-boundary";
+import {
+  isProviderInvisiblePart,
+  prepareTextForThirdParty,
+} from "@/api/handlers/chat/third-party-boundary";
 import type {
   ChatCompactionSummary,
   ChatMessage,
@@ -106,7 +109,8 @@ export const planChatCompaction = ({
   preserveTokens = DEFAULT_PRESERVE_TOKENS,
   triggerTokens = DEFAULT_TRIGGER_TOKENS,
 }: PlanChatCompactionOptions): ChatCompactionPlan => {
-  const totalTokens = estimateMessagesTokens(messages);
+  const providerVisibleMessages = getProviderVisibleMessages(messages);
+  const totalTokens = estimateMessagesTokens(providerVisibleMessages);
   if (totalTokens <= triggerTokens) {
     return { totalTokens, type: "none" };
   }
@@ -114,8 +118,8 @@ export const planChatCompaction = ({
   const recentMessages: ChatMessage[] = [];
   let preservedTokens = 0;
 
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages.at(index);
+  for (let index = providerVisibleMessages.length - 1; index >= 0; index -= 1) {
+    const message = providerVisibleMessages.at(index);
     if (!message) {
       continue;
     }
@@ -133,9 +137,9 @@ export const planChatCompaction = ({
     recentMessages.unshift(message);
   }
 
-  const messagesToSummarize = messages.slice(
+  const messagesToSummarize = providerVisibleMessages.slice(
     0,
-    messages.length - recentMessages.length,
+    providerVisibleMessages.length - recentMessages.length,
   );
   if (messagesToSummarize.length === 0) {
     return { totalTokens, type: "none" };
@@ -524,16 +528,26 @@ export const compactModelMessagesForModel = async ({
 
 export const renderChatMessagesForCompaction = (
   messages: readonly ChatMessage[],
-): string =>
-  messages
-    .map((message, index) =>
+): string => {
+  const renderedMessages: string[] = [];
+
+  for (const message of messages) {
+    const visibleParts = getProviderVisibleParts(message);
+    if (visibleParts.length === 0) {
+      continue;
+    }
+
+    renderedMessages.push(
       [
-        `<message index="${index + 1}" role="${message.role}" id="${message.id}">`,
-        ...message.parts.map(renderPartForCompaction),
+        `<message index="${renderedMessages.length + 1}" role="${message.role}" id="${message.id}">`,
+        ...visibleParts.map(renderPartForCompaction),
         "</message>",
       ].join("\n"),
-    )
-    .join("\n\n");
+    );
+  }
+
+  return renderedMessages.join("\n\n");
+};
 
 export const renderModelMessagesForCompaction = (
   messages: readonly ModelMessage[],
@@ -703,11 +717,37 @@ const estimateMessagesTokens = (messages: readonly ChatMessage[]): number =>
     0,
   );
 
-const estimateMessageTokens = (message: ChatMessage): number =>
-  message.parts.reduce(
-    (total, part) => total + estimatePartTokens(part),
-    MESSAGE_OVERHEAD_TOKENS,
-  );
+const estimateMessageTokens = (message: ChatMessage): number => {
+  const visibleParts = getProviderVisibleParts(message);
+  if (visibleParts.length === 0) {
+    return 0;
+  }
+
+  let total = MESSAGE_OVERHEAD_TOKENS;
+
+  for (const part of visibleParts) {
+    total += estimatePartTokens(part);
+  }
+
+  return total;
+};
+
+const getProviderVisibleParts = (message: ChatMessage): ChatMessage["parts"] =>
+  message.parts.filter((part) => !isProviderInvisiblePart(part));
+
+const getProviderVisibleMessages = (
+  messages: readonly ChatMessage[],
+): ChatMessage[] => {
+  const visibleMessages: ChatMessage[] = [];
+
+  for (const message of messages) {
+    if (getProviderVisibleParts(message).length > 0) {
+      visibleMessages.push(message);
+    }
+  }
+
+  return visibleMessages;
+};
 
 const estimatePartTokens = (part: ChatMessage["parts"][number]): number => {
   if (isTextUIPart(part)) {

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -65,7 +65,11 @@ export type ChatThirdPartyBoundary =
       type: "anonymized";
     };
 
-const ANON_RESTORATIONS_DATA_PART_TYPE = "data-stella-anon-restorations";
+export const ANON_RESTORATIONS_DATA_PART_TYPE = "data-stella-anon-restorations";
+
+export const isProviderInvisiblePart = (
+  part: ChatMessage["parts"][number],
+): boolean => part.type === ANON_RESTORATIONS_DATA_PART_TYPE;
 
 export const createChatThirdPartyBoundary = ({
   anonymizeFields,
@@ -521,9 +525,6 @@ const preparePartForThirdParty = ({
 
   return Result.ok(part);
 };
-
-const isProviderInvisiblePart = (part: ChatMessage["parts"][number]): boolean =>
-  part.type === ANON_RESTORATIONS_DATA_PART_TYPE;
 
 const removeProviderInvisibleParts = (
   messages: ChatMessage[],


### PR DESCRIPTION
### Motivation
- The compaction renderer previously serialized all message parts (including provider-invisible `data-stella-anon-restorations`) into the transcript sent to an external summarization model, which can leak original confidential values and bypass the anonymization boundary.
- The change restores the intended boundary by ensuring restoration metadata is never exposed to third-party models during compaction.

### Description
- Export `ANON_RESTORATIONS_DATA_PART_TYPE` from `third-party-boundary.ts` so the discriminator is shared and consistent across codepaths.
- Filter out provider-invisible parts (those with type `data-stella-anon-restorations`) in `renderChatMessagesForCompaction` before rendering parts to the compaction transcript, and add an `isProviderInvisiblePart` helper in `compaction.ts`.
- Add a unit test in `compaction.test.ts` asserting compaction transcripts include visible assistant text but omit the restoration data-part type and any original confidential values.

### Testing
- Ran `git diff --check` to validate the patch formatting and found no issues (passed).
- Attempted to run the compaction unit test via `bun --cwd apps/api test ./src/handlers/chat/compaction.test.ts`, but the run failed due to the test environment resolving `ai/test` (module not found) in the local environment (failure due to missing test dependency resolution, not the patch logic).
- Attempted `bun install` to restore dependencies, but dependency resolution for workspace `catalog:` entries failed in the current environment (dependency installation failed), preventing a full test run and lint check (`oxlint`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39def936c08333beaf81894a2e9530)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history compaction so “provider invisible” and anonymisation restoration metadata parts no longer affect transcript rendering or token estimation.
  * Placeholders remain readable, while sensitive restored values are excluded from generated compaction summaries.
  * Restoration-only messages are omitted from both compaction transcripts and compaction planning results.
* **Tests**
  * Added coverage for anonymisation “restoration metadata” behaviour during chat-history compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->