### PR TITLE
fix: reject symlinked release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,8 +454,18 @@ jobs:
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: |
           manual_notes="docs/changelog/${RELEASE_REF}.md"
-          if [[ ! -f "$manual_notes" ]]; then
+          if [[ -L "$manual_notes" ]]; then
+            echo "Manual release description must be a regular file: ${manual_notes}" >&2
+            exit 1
+          fi
+
+          if [[ ! -e "$manual_notes" ]]; then
             exit 0
+          fi
+
+          if [[ ! -f "$manual_notes" ]]; then
+            echo "Manual release description must be a regular file: ${manual_notes}" >&2
+            exit 1
           fi
 
           {


### PR DESCRIPTION
### Motivation
- The release job prepended `docs/changelog/${RELEASE_REF}.md` into `NOTES.md` using `-f`/`cat`, which follows symlinks and can leak runner credential files into the published GitHub release notes, so the workflow must explicitly refuse symlinked or non-regular manual changelog entries.

### Description
- Modified the `Prepend manual release description` step in `.github/workflows/release.yml` to keep the missing-file no-op (`[[ ! -e ... ]]`) but explicitly reject symlinks and non-regular files with `if [[ -L "$manual_notes" || ! -f "$manual_notes" ]]; then ... exit 1; fi`, before `cat`ing the file into `NOTES.md`.
- No other workflow behavior was changed; regular markdown changelog files are still prepended as before.

### Testing
- Ran `git diff --check` with no whitespace errors and verified the workflow file diff was as intended. 
- Executed a local shell harness that created a symlinked changelog and confirmed the workflow step rejects it (expected failure). 
- Executed a local shell harness with a regular changelog file and confirmed the file is correctly prepended into `NOTES.md` (expected success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a0b2d843c8333a5218d7e2b31f2d8)