### PR TITLE
fix(release): remove registry BuildKit cache from release image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,8 +271,6 @@ jobs:
           file: apps/api/Dockerfile
           platforms: linux/arm64
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-arm64
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-arm64,mode=max
           build-args: |
             STELLA_VERSION=${{ needs.resolve.outputs.version }}
             STELLA_COMMIT_SHA=${{ needs.resolve.outputs.release_sha }}
@@ -323,8 +321,6 @@ jobs:
           file: apps/api/Dockerfile
           platforms: linux/amd64
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64,mode=max
           build-args: |
             STELLA_VERSION=${{ needs.resolve.outputs.version }}
             STELLA_COMMIT_SHA=${{ needs.resolve.outputs.release_sha }}


### PR DESCRIPTION
### Motivation
- Remove mutable registry-backed BuildKit cache import/export from the release image build jobs in `.github/workflows/release.yml` to eliminate a cache-poisoning supply-chain risk while preserving the existing per-architecture digest/push and provenance flow.

### Description
- Deleted the `cache-from` / `cache-to` registry cache lines from the `docker/build-push-action` steps in both `build-arm64` and `build-amd64` so production builds no longer import/export mutable GHCR BuildKit caches; outputs, platforms, build-args, push-by-digest, and provenance steps were left unchanged.

### Testing
- Verified no registry cache directives remain using `rg -n "buildcache|cache-(from|to)" .github/workflows/release.yml`, ran `git diff --check`, and validated YAML parsing with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'` (the environment `python` PyYAML check failed due to missing `PyYAML` but Ruby parsing succeeded); committed the change as `fix: remove release registry build cache` (commit `686c822`).; CC on behalf of @aardvark

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a0efdf8dc8333b0544101a73422e1)