### PR TITLE
fix: keep metered chat streams ledgerable on disconnect

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -122,6 +122,7 @@ import { loadWebSearchProvidersForOrg } from "@/api/lib/web-search/load-org-keys
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const CHAT_COMPACTION_CHECKPOINT_TIMEOUT_MS = 120_000;
+const CHAT_METERED_AI_TIMEOUT_MS = 600_000;
 
 /**
  * Dev model overrides (`body.devModelId`) are local-only: reject them outside
@@ -362,6 +363,17 @@ const sendMessage = createSafeRootHandler(
       workspaceId: workspaceId ?? undefined,
     });
 
+    const isClientConnectionAborted = () => request.signal.aborted;
+
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
     const uploadResult = yield* Result.await(
       uploadMessageFilesWithRollback({
         message: validatedMessage.message,
@@ -459,8 +471,34 @@ const sendMessage = createSafeRootHandler(
       threadId: body.threadId,
     });
 
+    // Metered provider calls must not be directly cancelled by the client
+    // connection. A disconnect can arrive after preflight succeeds but before
+    // the AI SDK emits token usage; allowing that abort to reach the provider
+    // would skip the usage ledger callback while still spending provider work.
+    const createMeteredAIAbortSignal = () =>
+      AbortSignal.timeout(CHAT_METERED_AI_TIMEOUT_MS);
+
+    if (isClientConnectionAborted()) {
+      yield* Result.await(
+        rollbackUnpersistedChatSideEffects({
+          recordAuditEvent,
+          safeDb,
+          threadId: body.threadId,
+          threadState: thread,
+          uploadedFiles: uploadResult.uploadedFiles,
+          userId: user.id,
+        }),
+      );
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
     const messagesForContextResult = await compactMessagesForContext({
-      abortSignal: request.signal,
+      abortSignal: createMeteredAIAbortSignal(),
       boundary: thirdPartyBoundary,
       devModelId: body.devModelId,
       messages: messagesForContextInput,
@@ -652,8 +690,15 @@ const sendMessage = createSafeRootHandler(
       Result.tryPromise({
         try: async () => {
           try {
+            if (isClientConnectionAborted()) {
+              throw new HandlerError({
+                status: 400,
+                message: "Client disconnected before stream started",
+              });
+            }
+
             const chatResponse = await streamChat({
-              abortSignal: request.signal,
+              abortSignal: createMeteredAIAbortSignal(),
               messages: chatContext.hydratedMessages,
               latestMessageId: parsedMessage.message.id,
               onFinish: async ({ isAborted, responseMessage }) => {
@@ -669,7 +714,7 @@ const sendMessage = createSafeRootHandler(
 
                   const persistencePlan = planAssistantFinishPersistence({
                     existingIds: latestMessagePlan.existingIds,
-                    isAborted,
+                    isAborted: isAborted || isClientConnectionAborted(),
                     message: resolvedResponseMessage,
                   });
 
@@ -811,11 +856,13 @@ const sendMessage = createSafeRootHandler(
           }
         },
         catch: (cause) =>
-          new HandlerError({
-            status: 500,
-            message: "Failed to start chat response",
-            cause,
-          }),
+          cause instanceof HandlerError
+            ? cause
+            : new HandlerError({
+                status: 500,
+                message: "Failed to start chat response",
+                cause,
+              }),
       }),
     );
 

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -2,6 +2,7 @@ import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
+  consumeStream,
   hasToolCall,
   stepCountIs,
   streamText,
@@ -647,6 +648,16 @@ export const streamChat = async ({
   });
 
   return createUIMessageStreamResponse({
+    consumeSseStream: async ({ stream: sseStream }) =>
+      await consumeStream({
+        stream: sseStream,
+        onError: (error) => {
+          captureError(error, {
+            threadId,
+            feature: "chat.stream_drain",
+          });
+        },
+      }),
     stream,
   });
 };


### PR DESCRIPTION
### Motivation
- Prevent a client disconnect from aborting provider streams after a successful pre-flight usage check, which allowed authenticated users to avoid ledger debits while still consuming provider resources. 
- Ensure usage is always recordable post-flight so the append-only usage ledger remains consistent and tenant usage enforcement cannot be bypassed by cancelling the client connection.

### Description
- Introduced a server-owned abort signal (`meteredAIAbortSignal = new AbortController().signal`) in `apps/api/src/handlers/chat/send-message.ts` to decouple metered AI provider calls from the client `request.signal`.
- Threaded the server-owned signal into both context compaction (`compactMessagesForContext`) and the main streaming call (`streamChat`) so analytics callbacks (e.g., `onStepFinish` -> `recordStepConsumption`) can run even if the client disconnects.
- Added a short security comment explaining why client aborts must not cancel metered provider calls after preflight.

### Testing
- Ran `git diff --check` to validate no whitespace or diff issues, which passed.
- Verified the change via grep: `rg -n "abortSignal: request\.signal|meteredAIAbortSignal" apps/api/src/handlers/chat/send-message.ts` to confirm the server-owned signal is used in the two call sites, which passed.
- Attempted unit tests with `bun --cwd apps/api test src/lib/analytics/ai.test.ts src/lib/api-handlers.test.ts`, but tests could not run because workspace dependencies were not resolvable (`Cannot find package 'better-result'`) and `bun install` failed to resolve `catalog:` workspace entries; therefore test execution was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44e6647d0c8333b71caca10ed0033a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat request handling when a client disconnects, reducing incorrect follow-up processing.
  * Prevented chat responses from continuing to stream after the connection has already dropped.
  * Made message persistence more reliable by treating client disconnects as an aborted request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->