### PR TITLE
fix: cap Arabic folded search offsets

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts
@@ -39,6 +39,14 @@ describe("findHitsInText", () => {
     expect(result.hits).toHaveLength(0);
   });
 
+  test("caps compatibility-character expansion before scanning", () => {
+    const result = findHitsInText("ﷺ".repeat(30_000), "missing", OPTIONS);
+
+    expect(result.totalHits).toBe(0);
+    expect(result.totalHitsCapped).toBe(true);
+    expect(result.truncated).toBe(true);
+  });
+
   test("still matches plain ASCII content", () => {
     const result = findHitsInText("hello world", "WORLD", OPTIONS);
     expect(result.totalHits).toBe(1);

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
@@ -46,6 +46,13 @@ const SEARCH_SNIPPET_CONTEXT_CHARS = 200;
 const SEARCH_MAX_HITS_SCANNED = 100;
 
 /**
+ * Maximum folded UTF-16 units to materialize per searched entity. NFKC can
+ * expand a single compatibility character into many units, so this caps the
+ * offset maps before regex scanning starts.
+ */
+const SEARCH_MAX_FOLDED_UNITS_SCANNED = 500_000;
+
+/**
  * Escape a literal substring so it can be embedded into a `RegExp`.
  * The caller wants to search for the user's query verbatim, not as
  * a regex pattern, so any regex metacharacter is neutralised.
@@ -76,8 +83,11 @@ export const findHitsInText = (
   const {
     sourceEndIndex,
     text: foldedText,
+    truncated: foldedTextTruncated,
     sourceIndex,
-  } = applyArabicFoldsWithOffsets(text);
+  } = applyArabicFoldsWithOffsets(text, {
+    maxFoldedUnits: SEARCH_MAX_FOLDED_UNITS_SCANNED,
+  });
 
   const flags = options.caseSensitive ? "g" : "gi";
   const escaped = escapeRegExp(foldedQuery);
@@ -134,8 +144,8 @@ export const findHitsInText = (
   return {
     hits,
     totalHits,
-    totalHitsCapped,
-    truncated: hits.length < totalHits,
+    totalHitsCapped: totalHitsCapped || foldedTextTruncated,
+    truncated: foldedTextTruncated || hits.length < totalHits,
   };
 };
 

--- a/packages/text-normalize/src/arabic.test.ts
+++ b/packages/text-normalize/src/arabic.test.ts
@@ -62,6 +62,16 @@ describe("applyArabicFoldsWithOffsets", () => {
     expect(sourceEndIndex).toEqual([1, 1, 1, 1, 1]);
   });
 
+  test("caps folded units before expansion can exhaust offset maps", () => {
+    const { sourceEndIndex, text, truncated, sourceIndex } =
+      applyArabicFoldsWithOffsets("ﷺ".repeat(10), { maxFoldedUnits: 18 });
+
+    expect(text).toBe("صلي الله عليه وسلم");
+    expect(truncated).toBe(true);
+    expect(sourceIndex).toHaveLength(19);
+    expect(sourceEndIndex).toHaveLength(19);
+  });
+
   test("a folded match maps back to the original substring", () => {
     const original = "رقم ٢٠٢٤ نهائي";
     const { sourceEndIndex, text, sourceIndex } =

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -97,6 +97,9 @@ export type FoldedText = {
   // the original input immediately after that unit's source character.
   sourceEndIndex: number[];
   text: string;
+  // True when normalization stopped before consuming the full input because
+  // the folded text reached the caller's scan budget.
+  truncated: boolean;
   // For each UTF-16 code-unit index `i` in `text`, the code-unit index in
   // the original input where that unit's source character began.
   // `sourceIndex[text.length]` is the original length (end sentinel), so a
@@ -104,18 +107,33 @@ export type FoldedText = {
   sourceIndex: number[];
 };
 
+type ApplyArabicFoldsWithOffsetsOptions = {
+  maxFoldedUnits?: number;
+};
+
 /**
  * Like applyArabicFolds, but also returns an offset map so callers that
  * match against the folded text (e.g. find-in-page) can slice the original
  * text at the right positions.
  */
-export const applyArabicFoldsWithOffsets = (input: string): FoldedText => {
+export const applyArabicFoldsWithOffsets = (
+  input: string,
+  options: ApplyArabicFoldsWithOffsetsOptions = {},
+): FoldedText => {
   const parts: string[] = [];
   const sourceEndIndex: number[] = [];
   const sourceIndex: number[] = [];
+  const maxFoldedUnits = options.maxFoldedUnits ?? Number.POSITIVE_INFINITY;
+  let foldedUnits = 0;
   let originalUnit = 0;
+  let truncated = false;
   for (const char of input) {
     const replacement = applyArabicFolds(char.normalize("NFKC"));
+    if (foldedUnits + replacement.length > maxFoldedUnits) {
+      truncated = true;
+      break;
+    }
+
     const originalEnd = originalUnit + char.length;
     parts.push(replacement);
     // One offset entry per UTF-16 code unit of the replacement; folds are
@@ -126,9 +144,10 @@ export const applyArabicFoldsWithOffsets = (input: string): FoldedText => {
       sourceEndIndex.push(originalEnd);
       unit += 1;
     }
+    foldedUnits += replacement.length;
     originalUnit = originalEnd;
   }
   sourceIndex.push(originalUnit);
   sourceEndIndex.push(originalUnit);
-  return { sourceEndIndex, text: parts.join(""), sourceIndex };
+  return { sourceEndIndex, text: parts.join(""), truncated, sourceIndex };
 };

--- a/packages/text-normalize/src/arabic.ts
+++ b/packages/text-normalize/src/arabic.ts
@@ -102,8 +102,9 @@ export type FoldedText = {
   truncated: boolean;
   // For each UTF-16 code-unit index `i` in `text`, the code-unit index in
   // the original input where that unit's source character began.
-  // `sourceIndex[text.length]` is the original length (end sentinel), so a
-  // match's [start, end) in folded space maps back to original offsets.
+  // `sourceIndex[text.length]` is the end of the consumed source prefix (the
+  // full original length when `truncated` is false), so a match's [start, end)
+  // in folded space maps back to original offsets.
   sourceIndex: number[];
 };
 


### PR DESCRIPTION
### Motivation
- Prevent NFKC compatibility-character expansion from inflating folded text and offset maps unboundedly during chat/entity search and causing CPU/memory exhaustion.  
- Ensure search hit caps (`SEARCH_MAX_HITS_SCANNED`) are meaningful by bounding the expensive normalization work that previously ran before scanning.  

### Description
- Add an optional folded-unit budget to `applyArabicFoldsWithOffsets` via `maxFoldedUnits` and return a `truncated` flag when the budget is reached (`packages/text-normalize/src/arabic.ts`).  
- Introduce `SEARCH_MAX_FOLDED_UNITS_SCANNED` and call `applyArabicFoldsWithOffsets(text, { maxFoldedUnits: SEARCH_MAX_FOLDED_UNITS_SCANNED })` in chat search so normalization cannot allocate arbitrarily large folded strings/offset arrays (`apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts`).  
- Propagate fold-budget truncation into the search result by OR-ing `foldedTextTruncated` into `totalHitsCapped` and `truncated`.  
- Add regression tests that exercise compatibility-character expansion truncation in both the normalization helper and the chat search path (`packages/text-normalize/src/arabic.test.ts`, `apps/api/src/handlers/chat/tools/execute/workspace-function-registry.test.ts`).  

### Testing
- Ran dependency install: `bunx bun@1.3.14 install --frozen-lockfile` (succeeded).  
- Unit tests for `@stll/text-normalize` including new truncation case: `bunx bun@1.3.14 --filter @stll/text-normalize test` (passed).  
- Typechecks: `bunx bun@1.3.14 --filter @stll/text-normalize typecheck` and `bunx bun@1.3.14 --filter @stll/api typecheck` (passed).  
- Formatting checks: `oxfmt` checks on modified files passed; repository `oxlint` could not be fully exercised in this container due to the Node/oxlint config mismatch.  
- Note: the API test file requires full API environment variables at import time and therefore fails in a minimal container run; the relevant regression is covered and passing in the `@stll/text-normalize` test suite and exercised in a targeted test added to the API test file (the API test import-time env validation still prevents running the full API test suite without proper env).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4501d50fb8833392e2147dbcb795d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in budget/limit for Arabic-fold text normalisation when processing very large inputs, helping keep matching efficient.
  * Match results now more reliably report when scanning is capped or truncated due to normalisation limits.
* **Bug Fixes**
  * Improved handling of inputs with repeated Arabic compatibility characters to prevent excessive processing and ensure capped/truncated status is accurate.
* **Tests**
  * Added coverage for truncation behaviour in both Arabic folding and search matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->