### PR TITLE
fix: guard template field paths

### DIFF
--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -1167,7 +1167,7 @@ const buildSubmitValues = (
   fields: ResolvedField[],
   conditions: NamedCondition[],
 ): Record<string, unknown> => {
-  const result: Record<string, unknown> = Object.create(null);
+  const result = createNullRecord();
 
   for (const field of fields) {
     // Skip hidden fields
@@ -1182,7 +1182,7 @@ const buildSubmitValues = (
       const arrayValues: Record<string, unknown>[] = [];
 
       for (let i = 0; i < items.length; i++) {
-        const itemObj: Record<string, unknown> = Object.create(null);
+        const itemObj = createNullRecord();
         for (const subField of itemFields) {
           const path = `${field.path}[${i}].${subField.path}`;
           const val = values[path];
@@ -1242,6 +1242,8 @@ const coerceValue = (field: ResolvedField, value: unknown): unknown => {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const createNullRecord = (): Record<string, unknown> => ({ __proto__: null });
+
 const setNestedValue = (
   obj: Record<string, unknown>,
   path: string,
@@ -1264,7 +1266,7 @@ const setNestedValue = (
       current = next;
       continue;
     }
-    const child: Record<string, unknown> = Object.create(null);
+    const child = createNullRecord();
     current[part] = child;
     current = child;
   }

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -15,7 +15,7 @@ import {
 import { useLocale, useTranslations } from "use-intl";
 
 import type { ConditionNode, Operand } from "@stll/conditions";
-import { evaluateCondition } from "@stll/template-conditions";
+import { evaluateCondition, isSafeFieldPath } from "@stll/template-conditions";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import {
@@ -1167,7 +1167,7 @@ const buildSubmitValues = (
   fields: ResolvedField[],
   conditions: NamedCondition[],
 ): Record<string, unknown> => {
-  const result: Record<string, unknown> = {};
+  const result: Record<string, unknown> = Object.create(null);
 
   for (const field of fields) {
     // Skip hidden fields
@@ -1182,11 +1182,15 @@ const buildSubmitValues = (
       const arrayValues: Record<string, unknown>[] = [];
 
       for (let i = 0; i < items.length; i++) {
-        const itemObj: Record<string, unknown> = {};
+        const itemObj: Record<string, unknown> = Object.create(null);
         for (const subField of itemFields) {
           const path = `${field.path}[${i}].${subField.path}`;
           const val = values[path];
-          if (val !== undefined && val !== "") {
+          if (
+            val !== undefined &&
+            val !== "" &&
+            isSafeFieldPath(subField.path)
+          ) {
             itemObj[subField.path] = coerceValue(subField, val);
           }
         }
@@ -1243,6 +1247,10 @@ const setNestedValue = (
   path: string,
   value: unknown,
 ) => {
+  if (!isSafeFieldPath(path)) {
+    return;
+  }
+
   const parts = path.split(".");
   const last = parts.at(-1);
   if (!last) {
@@ -1251,12 +1259,12 @@ const setNestedValue = (
   let current = obj;
 
   for (const part of parts.slice(0, -1)) {
-    const next = current[part];
+    const next = Object.hasOwn(current, part) ? current[part] : undefined;
     if (isRecord(next)) {
       current = next;
       continue;
     }
-    const child: Record<string, unknown> = {};
+    const child: Record<string, unknown> = Object.create(null);
     current[part] = child;
     current = child;
   }

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -82,6 +82,7 @@ import type {
 import { displayLanguageName } from "@stll/locales";
 import {
   isFieldPath,
+  isSafeFieldPath,
   renderDeterministicFieldValue,
   serializeCondition,
 } from "@stll/template-conditions";
@@ -357,16 +358,19 @@ type SlashRows =
   | { view: "fields"; items: StudioField[] }
   | { view: "clauses"; items: SlashClause[] };
 
-/** The new field's path for a "New field" row. The slash query grammar already
- *  mirrors the field-path grammar, so a typed `party.name` / `line-item` is a
- *  valid path and is kept verbatim; only a query that is not itself a valid
- *  path falls back to the sanitizer (`slugify` would strip the `.`/`-` and
- *  mangle the name the user typed). */
+/** The new field's path for a "New field" row. Safe field paths such as
+ *  `party.name` / `line-item` are kept verbatim; unsafe or invalid queries fall
+ *  back to the sanitizer (`slugify` would strip the `.`/`-` and mangle the name
+ *  the user typed). */
 const createFieldPathFromQuery = (trimmed: string): string => {
   if (trimmed === "") {
     return "field";
   }
-  return isFieldPath(trimmed) ? trimmed : sanitizeFieldPath(trimmed);
+  if (isSafeFieldPath(trimmed)) {
+    return trimmed;
+  }
+  const sanitized = sanitizeFieldPath(trimmed);
+  return isSafeFieldPath(sanitized) ? sanitized : "field";
 };
 
 /** The first field path not already taken: `field`, then `field_2`, `field_3`…

--- a/packages/template-conditions/src/index.ts
+++ b/packages/template-conditions/src/index.ts
@@ -211,6 +211,7 @@ export {
   indexPattern,
   isBlockDirectiveKind,
   isFieldPath,
+  isSafeFieldPath,
   markerPattern,
   numPattern,
   placeholderPattern,

--- a/packages/template-conditions/src/markers.test.ts
+++ b/packages/template-conditions/src/markers.test.ts
@@ -5,8 +5,31 @@ import {
   classifyMarker,
   DIRECTIVE_KINDS,
   isBlockDirectiveKind,
+  isFieldPath,
+  isSafeFieldPath,
   scanMarkers,
 } from "./markers.js";
+
+describe("isSafeFieldPath", () => {
+  test("keeps valid dotted marker paths that cannot mutate prototypes", () => {
+    expect(isFieldPath("party.name")).toBe(true);
+    expect(isSafeFieldPath("party.name")).toBe(true);
+    expect(isSafeFieldPath("line-item.value_2")).toBe(true);
+  });
+
+  test("rejects prototype-polluting path segments", () => {
+    const unsafePaths = [
+      "__proto__.polluted",
+      "client.constructor.polluted",
+      "client.prototype.polluted",
+    ];
+
+    for (const path of unsafePaths) {
+      expect(isFieldPath(path)).toBe(true);
+      expect(isSafeFieldPath(path)).toBe(false);
+    }
+  });
+});
 
 describe("classifyMarker", () => {
   test("classifies each directive form", () => {

--- a/packages/template-conditions/src/markers.ts
+++ b/packages/template-conditions/src/markers.ts
@@ -130,9 +130,7 @@ export const isFieldPath = (value: string): boolean =>
 /** Whether `value` is safe to use as a dotted object path. */
 export const isSafeFieldPath = (value: string): boolean =>
   isFieldPath(value) &&
-  value
-    .split(".")
-    .every((segment) => !UNSAFE_FIELD_PATH_SEGMENTS.has(segment));
+  value.split(".").every((segment) => !UNSAFE_FIELD_PATH_SEGMENTS.has(segment));
 const CLAUSE_INNER_RE = /^@clause:(?<name>[^:}\s]+)(?::(?<version>[^}\s]+))?$/u;
 const NUM_INNER_RE = /^@num:(?<key>[\p{L}\p{N}_.-]+)$/u;
 const REF_INNER_RE = /^@ref:(?<key>[\p{L}\p{N}_.-]+)$/u;

--- a/packages/template-conditions/src/markers.ts
+++ b/packages/template-conditions/src/markers.ts
@@ -116,11 +116,23 @@ export const blockDirectiveLinePattern = (): RegExp =>
 
 // Anchored forms used to classify the inner text of one marker.
 const FIELD_PATH_RE = /^[\p{L}\p{N}_.-]+$/u;
+const UNSAFE_FIELD_PATH_SEGMENTS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
 
 /** Whether `value` is a valid field path per the marker grammar (dotted
  *  segments of letters/digits/underscore/dash — no brackets or spaces). */
 export const isFieldPath = (value: string): boolean =>
   FIELD_PATH_RE.test(value);
+
+/** Whether `value` is safe to use as a dotted object path. */
+export const isSafeFieldPath = (value: string): boolean =>
+  isFieldPath(value) &&
+  value
+    .split(".")
+    .every((segment) => !UNSAFE_FIELD_PATH_SEGMENTS.has(segment));
 const CLAUSE_INNER_RE = /^@clause:(?<name>[^:}\s]+)(?::(?<version>[^}\s]+))?$/u;
 const NUM_INNER_RE = /^@num:(?<key>[\p{L}\p{N}_.-]+)$/u;
 const REF_INNER_RE = /^@ref:(?<key>[\p{L}\p{N}_.-]+)$/u;


### PR DESCRIPTION
### Motivation
- Prevent prototype pollution reachable via the new slash-command UX by rejecting dangerous dotted path segments (e.g. `__proto__`, `constructor`, `prototype`) and hardening the dotted-path writer used when building nested fill values.

### Description
- Add `isSafeFieldPath` to the shared marker grammar to reject prototype-polluting path segments while preserving valid marker-path syntax. (packages/template-conditions/src/markers.ts, packages/template-conditions/src/index.ts)
- Use `isSafeFieldPath` when deriving slash-created field paths so unsafe raw queries fall back to sanitization or a safe default. (apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx)
- Harden the form submission payload builder by creating null-prototype containers (`Object.create(null)`), traversing only own properties (`Object.hasOwn`), and refusing to write nested values for unsafe paths. (apps/web/src/routes/_protected.knowledge/-components/template-form.tsx)
- Add regression unit coverage asserting that syntactically valid but unsafe paths such as `__proto__.polluted` are rejected by the new predicate. (packages/template-conditions/src/markers.test.ts)

### Testing
- Added unit tests in `packages/template-conditions/src/markers.test.ts` covering `isSafeFieldPath` behavior. (new test file changes committed)
- Attempted to execute the package tests with `bun --filter @stll/template-conditions test markers.test.ts`, but the run was blocked by local workspace dependency resolution errors (missing workspace/catalog packages such as `better-result`), so the tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a450093a24883339a5774288c462d58)