### PR TITLE
fix: validate chat compaction snapshots

### DIFF
--- a/apps/api/src/handlers/chat/persistent-compaction.test.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.test.ts
@@ -5,6 +5,7 @@ import { toSafeId } from "@/api/lib/branded-types";
 
 import {
   applyChatCompactionCheckpoint,
+  chatCompactionSnapshotMessagesEqual,
   shouldInvalidateChatCompactionCheckpoint,
 } from "./persistent-compaction";
 
@@ -84,6 +85,46 @@ describe("persistent chat compaction", () => {
     });
 
     expect(applied).toBeNull();
+  });
+
+  test("rejects a checkpoint snapshot when message content changed", () => {
+    const id = "11111111-1111-4111-8111-111111111111";
+
+    expect(
+      chatCompactionSnapshotMessagesEqual(
+        [
+          {
+            id: toSafeId<"chatMessage">(id),
+            role: "user",
+            content: {
+              version: 1,
+              data: [{ type: "text", text: "edited" }],
+            },
+          },
+        ],
+        [message(id, "original")],
+      ),
+    ).toBe(false);
+  });
+
+  test("accepts a checkpoint snapshot when message ids and content still match", () => {
+    const id = "11111111-1111-4111-8111-111111111111";
+
+    expect(
+      chatCompactionSnapshotMessagesEqual(
+        [
+          {
+            id: toSafeId<"chatMessage">(id),
+            role: "user",
+            content: {
+              version: 1,
+              data: [{ type: "text", text: "original" }],
+            },
+          },
+        ],
+        [message(id, "original")],
+      ),
+    ).toBe(true);
   });
 
   test("invalidates active checkpoints when a retained message is updated", () => {

--- a/apps/api/src/handlers/chat/persistent-compaction.test.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.test.ts
@@ -127,6 +127,26 @@ describe("persistent chat compaction", () => {
     ).toBe(true);
   });
 
+  test("accepts a checkpoint snapshot when JSON key order differs", () => {
+    const id = "11111111-1111-4111-8111-111111111111";
+
+    expect(
+      chatCompactionSnapshotMessagesEqual(
+        [
+          {
+            id: toSafeId<"chatMessage">(id),
+            role: "user",
+            content: {
+              version: 1,
+              data: [{ text: "original", type: "text" }],
+            },
+          },
+        ],
+        [message(id, "original")],
+      ),
+    ).toBe(true);
+  });
+
   test("invalidates active checkpoints when a retained message is updated", () => {
     expect(
       shouldInvalidateChatCompactionCheckpoint({

--- a/apps/api/src/handlers/chat/persistent-compaction.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.ts
@@ -1,9 +1,9 @@
 import type { LanguageModel } from "ai";
 import { Result } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
 import type { SafeDb, SafeDbError, Transaction } from "@/api/db";
-import { chatThreadCompactions } from "@/api/db/schema";
+import { chatMessages, chatThreadCompactions } from "@/api/db/schema";
 import {
   CHAT_COMPACTION_PROMPT_VERSION,
   createCompactionSummaryMessage,
@@ -14,6 +14,7 @@ import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-bou
 import type {
   ChatCompactionSummary,
   ChatMessage,
+  PersistedChatMessageContent,
 } from "@/api/handlers/chat/types";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -138,6 +139,7 @@ export const markActiveChatCompactionCheckpointStale = async ({
 type PersistChatCompactionCheckpointProps = {
   abortSignal: AbortSignal;
   boundary: ChatThirdPartyBoundary;
+  dataWorkspaceIds: readonly SafeId<"workspace">[];
   messages: ChatMessage[];
   model: LanguageModel;
   onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
@@ -148,6 +150,7 @@ type PersistChatCompactionCheckpointProps = {
 export const persistChatCompactionCheckpoint = async ({
   abortSignal,
   boundary,
+  dataWorkspaceIds,
   messages,
   model,
   onSummaryError,
@@ -179,6 +182,16 @@ export const persistChatCompactionCheckpoint = async ({
   }
 
   const persistResult = await safeDb(async (tx) => {
+    const snapshotIsCurrent = await isChatCompactionSnapshotCurrent({
+      dataWorkspaceIds,
+      messages,
+      threadId,
+      tx,
+    });
+    if (!snapshotIsCurrent) {
+      return;
+    }
+
     await markActiveChatCompactionCheckpointStale({ threadId, tx });
 
     // audit: skip — derived compaction checkpoint cache; no user-authored state change
@@ -203,4 +216,102 @@ export const persistChatCompactionCheckpoint = async ({
   });
 
   return persistResult.andThen(() => Result.ok());
+};
+
+type ChatCompactionSnapshotMessageRow = {
+  id: SafeId<"chatMessage">;
+  role: ChatMessage["role"];
+  content: PersistedChatMessageContent;
+};
+
+type IsChatCompactionSnapshotCurrentProps = {
+  dataWorkspaceIds: readonly SafeId<"workspace">[];
+  messages: readonly ChatMessage[];
+  threadId: SafeId<"chatThread">;
+  tx: Transaction;
+};
+
+const isChatCompactionSnapshotCurrent = async ({
+  dataWorkspaceIds,
+  messages,
+  threadId,
+  tx,
+}: IsChatCompactionSnapshotCurrentProps): Promise<boolean> => {
+  const firstSnapshotMessage = messages.at(0);
+  if (!firstSnapshotMessage) {
+    return false;
+  }
+
+  const thread = await tx.query.chatThreads.findFirst({
+    where: { id: { eq: threadId } },
+    columns: { dataWorkspaceIds: true },
+  });
+  if (
+    !thread ||
+    !workspaceIdsEqual(thread.dataWorkspaceIds, dataWorkspaceIds)
+  ) {
+    return false;
+  }
+
+  const firstPersistedMessage = await tx.query.chatMessages.findFirst({
+    where: {
+      id: { eq: brandPersistedChatMessageId(firstSnapshotMessage.id) },
+      threadId: { eq: threadId },
+    },
+    columns: { createdAt: true, id: true },
+  });
+  if (!firstPersistedMessage) {
+    return false;
+  }
+
+  const rows = await tx
+    .select({
+      id: chatMessages.id,
+      role: chatMessages.role,
+      content: chatMessages.content,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.threadId, threadId),
+        sql`(${chatMessages.createdAt}, ${chatMessages.id}) >= (${firstPersistedMessage.createdAt}, ${firstPersistedMessage.id})`,
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id));
+
+  return chatCompactionSnapshotMessagesEqual(rows, messages);
+};
+
+export const chatCompactionSnapshotMessagesEqual = (
+  rows: readonly ChatCompactionSnapshotMessageRow[],
+  messages: readonly ChatMessage[],
+): boolean => {
+  if (rows.length !== messages.length) {
+    return false;
+  }
+
+  return rows.every((row, index) => {
+    const message = messages.at(index);
+    if (!message) {
+      return false;
+    }
+
+    return (
+      row.id === message.id &&
+      row.role === message.role &&
+      JSON.stringify(row.content.data) === JSON.stringify(message.parts)
+    );
+  });
+};
+
+const workspaceIdsEqual = (
+  left: readonly SafeId<"workspace">[],
+  right: readonly SafeId<"workspace">[],
+): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  const rightIds = new Set(right);
+  return left.every((id) => rightIds.has(id));
 };

--- a/apps/api/src/handlers/chat/persistent-compaction.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.ts
@@ -3,7 +3,11 @@ import { Result } from "better-result";
 import { and, asc, eq, sql } from "drizzle-orm";
 
 import type { SafeDb, SafeDbError, Transaction } from "@/api/db";
-import { chatMessages, chatThreadCompactions } from "@/api/db/schema";
+import {
+  chatMessages,
+  chatThreadCompactions,
+  chatThreads,
+} from "@/api/db/schema";
 import {
   CHAT_COMPACTION_PROMPT_VERSION,
   createCompactionSummaryMessage,
@@ -182,6 +186,8 @@ export const persistChatCompactionCheckpoint = async ({
   }
 
   const persistResult = await safeDb(async (tx) => {
+    await lockChatThreadForCompaction({ threadId, tx });
+
     const snapshotIsCurrent = await isChatCompactionSnapshotCurrent({
       dataWorkspaceIds,
       messages,
@@ -216,6 +222,20 @@ export const persistChatCompactionCheckpoint = async ({
   });
 
   return persistResult.andThen(() => Result.ok());
+};
+
+const lockChatThreadForCompaction = async ({
+  threadId,
+  tx,
+}: {
+  threadId: SafeId<"chatThread">;
+  tx: Transaction;
+}): Promise<void> => {
+  await tx
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .for("update");
 };
 
 type ChatCompactionSnapshotMessageRow = {
@@ -342,10 +362,17 @@ const workspaceIdsEqual = (
   left: readonly SafeId<"workspace">[],
   right: readonly SafeId<"workspace">[],
 ): boolean => {
-  if (left.length !== right.length) {
+  const leftIds = new Set(left);
+  const rightIds = new Set(right);
+
+  if (leftIds.size !== rightIds.size) {
     return false;
   }
 
-  const rightIds = new Set(right);
-  return left.every((id) => rightIds.has(id));
+  for (const id of leftIds) {
+    if (!rightIds.has(id)) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/apps/api/src/handlers/chat/persistent-compaction.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.ts
@@ -277,7 +277,8 @@ const isChatCompactionSnapshotCurrent = async ({
         sql`(${chatMessages.createdAt}, ${chatMessages.id}) >= (${firstPersistedMessage.createdAt}, ${firstPersistedMessage.id})`,
       ),
     )
-    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id));
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
+    .limit(messages.length + 1);
 
   return chatCompactionSnapshotMessagesEqual(rows, messages);
 };
@@ -299,10 +300,43 @@ export const chatCompactionSnapshotMessagesEqual = (
     return (
       row.id === message.id &&
       row.role === message.role &&
-      JSON.stringify(row.content.data) === JSON.stringify(message.parts)
+      jsonEqual(row.content.data, message.parts)
     );
   });
 };
+
+const jsonEqual = (left: unknown, right: unknown): boolean => {
+  if (left === right) {
+    return true;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) {
+      return false;
+    }
+    if (left.length !== right.length) {
+      return false;
+    }
+    return left.every((item, index) => jsonEqual(item, right.at(index)));
+  }
+
+  if (!isJsonRecord(left) || !isJsonRecord(right)) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return leftKeys.every(
+    (key) => Object.hasOwn(right, key) && jsonEqual(left[key], right[key]),
+  );
+};
+
+const isJsonRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const workspaceIdsEqual = (
   left: readonly SafeId<"workspace">[],

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1136,9 +1136,27 @@ const runChatCompactionCheckpoint = async ({
     return;
   }
 
+  const dataScopeResult = await safeDb((tx) =>
+    tx.query.chatThreads.findFirst({
+      where: { id: { eq: threadId } },
+      columns: { dataWorkspaceIds: true },
+    }),
+  );
+  if (Result.isError(dataScopeResult)) {
+    captureError(dataScopeResult.error, {
+      threadId,
+      feature: "chat.compaction_checkpoint_data_scope",
+    });
+    return;
+  }
+  if (!dataScopeResult.value) {
+    return;
+  }
+
   const persistResult = await persistChatCompactionCheckpoint({
     abortSignal,
     boundary,
+    dataWorkspaceIds: dataScopeResult.value.dataWorkspaceIds,
     messages: historyResult.value,
     model,
     onSummaryError: (error) => {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1127,15 +1127,6 @@ const runChatCompactionCheckpoint = async ({
   // checkpoint would be silently dropped. Never feed a synthetic compaction
   // summary message here: its id is not a real chat_messages row and would
   // violate the firstKept/firstSummarized FKs.
-  const historyResult = await loadFullThreadHistory({ safeDb, threadId });
-  if (Result.isError(historyResult)) {
-    captureError(historyResult.error, {
-      threadId,
-      feature: "chat.compaction_checkpoint_history",
-    });
-    return;
-  }
-
   const dataScopeResult = await safeDb((tx) =>
     tx.query.chatThreads.findFirst({
       where: { id: { eq: threadId } },
@@ -1150,6 +1141,15 @@ const runChatCompactionCheckpoint = async ({
     return;
   }
   if (!dataScopeResult.value) {
+    return;
+  }
+
+  const historyResult = await loadFullThreadHistory({ safeDb, threadId });
+  if (Result.isError(historyResult)) {
+    captureError(historyResult.error, {
+      threadId,
+      feature: "chat.compaction_checkpoint_history",
+    });
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Background persistent chat compaction could race with edits/truncations and insert an active checkpoint derived from an obsolete in-memory snapshot, which can resurrect deleted/edited content and leak workspace-scoped data into later model context.
- Compaction must verify the summarized snapshot still matches the durable thread state (messages and `data_workspace_ids`) before staling existing checkpoints and inserting a new active checkpoint.

### Description
- Pass a `dataWorkspaceIds` snapshot from the scheduler into the checkpoint persistence path so the job carries the thread data-scope it summarized. (`send-message.ts`)
- Re-check snapshot freshness inside the DB transaction in `persistChatCompactionCheckpoint` by re-reading the thread `data_workspace_ids` and the persisted message rows, and skip insertion when the stored rows or data scope no longer match the summarized snapshot. (`persistent-compaction.ts`)
- Add helpers `isChatCompactionSnapshotCurrent`, `chatCompactionSnapshotMessagesEqual`, and `workspaceIdsEqual` to implement the transactional freshness gate. (`persistent-compaction.ts`)
- Add unit tests asserting that matching snapshots are accepted and modified message content causes snapshot rejection. (`persistent-compaction.test.ts`)
- Minor import and formatting adjustments to support the new checks. (`persistent-compaction.ts`, `send-message.ts`)

### Testing
- Ran formatter: `bunx oxfmt --write apps/api/src/handlers/chat/send-message.ts apps/api/src/handlers/chat/persistent-compaction.ts` (succeeded).
- Ran quick diff check: `git diff --check` (no whitespace errors reported).
- Added unit tests in `apps/api/src/handlers/chat/persistent-compaction.test.ts` covering `chatCompactionSnapshotMessagesEqual` acceptance and rejection cases, but executing them in this environment failed due to missing workspace dependencies: `bun test apps/api/src/handlers/chat/persistent-compaction.test.ts` errored with `Cannot find package 'better-result'`.
- Typecheck was attempted with `bun run typecheck` but the environment lacked `turbo`, so it could not complete.
- `bun install` failed in this environment due to unresolved workspace `catalog:` dependencies, so full CI/test runs were not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4500944e2883339c4c22037e0f5b76)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat compaction checkpoint handling so it only updates when the saved snapshot still matches the current thread state.
  * Prevents stale checkpoint updates when thread workspace context or message content has changed.
  * Added more reliable comparison of snapshot message content, including nested data and key-order differences.

* **Tests**
  * Added coverage for snapshot comparison to confirm matching and non-matching message cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->