### PR TITLE
fix: unify chat composer action button

### DIFF
--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -22,14 +22,11 @@ import type {
 } from "react";
 
 import {
-  ArrowUpIcon,
   CheckIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   LoaderCircleIcon,
-  RotateCcwIcon,
-  SquareIcon,
   SquarePenIcon,
   UserIcon,
   WandSparklesIcon,
@@ -74,6 +71,7 @@ import {
 } from "@/components/ai-elements/message";
 import { useChatComposerWiring } from "@/components/chat-editor-provider";
 import type { ChatEditorController } from "@/components/chat-editor-provider";
+import { ChatComposerActionButton } from "@/components/chat/chat-composer-action-button";
 import { PromptEditorContent } from "@/components/prompt-editor";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePulse } from "@/hooks/use-pulse";
@@ -1318,9 +1316,9 @@ type PromptBarProps = {
   sendDisabledReason?: "editor-loading" | undefined;
   /**
    * When true the composer keeps accepting input while a response
-   * streams: a send is queued by `useChatSession` and dispatched
-   * once the turn finishes. A dedicated Stop button appears beside
-   * Send instead of the send button morphing into Stop.
+   * streams: pressing Enter queues a send via `useChatSession` and
+   * dispatches it once the turn finishes. The visible primary action
+   * still morphs into Stop so all chat surfaces share one affordance.
    */
   queueWhileGenerating?: boolean | undefined;
 };
@@ -1502,14 +1500,13 @@ export function PromptBar(props: PromptBarProps) {
   const inputDisabled = isSendBlocked;
   const submitDisabled = busy || isSendBlocked;
   // With queuing enabled the composer keeps accepting input while a
-  // response streams — `useChatSession` holds the send until the
-  // turn finishes. The send button stays a send button; a dedicated
-  // Stop button sits beside it instead of the send button morphing.
+  // response streams — `useChatSession` holds Enter-submitted drafts
+  // until the turn finishes. The primary button remains Stop while
+  // streaming, matching the regular chat composer.
   const composerSubmitDisabled = queueWhileGenerating
     ? status === "applying" || isSendBlocked
     : submitDisabled;
-  const morphSendToStop = showStop && !queueWhileGenerating;
-  const showQueueStopButton = showStop && queueWhileGenerating;
+  const morphSendToStop = showStop;
   // After a stop the send arrow becomes Retry until the user starts
   // a new draft (the owner also clears `onRetry` then; the `isEmpty`
   // gate just avoids a one-render flash before that state lands).
@@ -1798,69 +1795,19 @@ export function PromptBar(props: PromptBarProps) {
         </Tooltip>
       )}
 
-      {showQueueStopButton && (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                aria-label={t("chat.stopResponse")}
-                className="rounded-full"
-                onClick={() => onStop()}
-                size="icon-sm"
-                type="button"
-                variant="ghost"
-              >
-                <SquareIcon aria-hidden="true" className="size-3.5" />
-              </Button>
-            }
-          />
-          <TooltipPopup side="top">{t("chat.stopResponse")}</TooltipPopup>
-        </Tooltip>
-      )}
-
       <Tooltip>
         <TooltipTrigger
           render={
-            <Button
-              aria-label={(() => {
-                if (morphSendToStop) {
-                  return t("chat.stopResponse");
-                }
-                if (morphSendToRetry) {
-                  return t("common.retry");
-                }
-                return t("chat.sendPrompt");
-              })()}
-              className="rounded-full"
-              disabled={
-                morphSendToStop || morphSendToRetry
-                  ? false
-                  : composerSubmitDisabled || !canSubmit
-              }
-              onClick={() => {
-                if (morphSendToStop) {
-                  onStop();
-                  return;
-                }
-                if (morphSendToRetry) {
-                  onRetry();
-                  return;
-                }
+            <PromptBarActionButton
+              canSend={!composerSubmitDisabled && canSubmit}
+              morphSendToRetry={morphSendToRetry}
+              morphSendToStop={morphSendToStop}
+              onRetry={onRetry}
+              onSend={() => {
                 void submitDraft();
               }}
-              size="icon"
-              type="button"
-            >
-              {(() => {
-                if (morphSendToStop) {
-                  return <SquareIcon aria-hidden="true" />;
-                }
-                if (morphSendToRetry) {
-                  return <RotateCcwIcon aria-hidden="true" />;
-                }
-                return <ArrowUpIcon aria-hidden="true" />;
-              })()}
-            </Button>
+              onStop={onStop}
+            />
           }
         />
         <TooltipPopup side="top">
@@ -1912,6 +1859,59 @@ export function PromptBar(props: PromptBarProps) {
     </PromptBarShell>
   );
 }
+
+type PromptBarActionButtonProps = {
+  canSend: boolean;
+  morphSendToRetry: boolean;
+  morphSendToStop: boolean;
+  onRetry?: (() => void) | undefined;
+  onSend: () => void;
+  onStop?: (() => void) | undefined;
+};
+
+const PromptBarActionButton = ({
+  canSend,
+  morphSendToRetry,
+  morphSendToStop,
+  onRetry,
+  onSend,
+  onStop,
+}: PromptBarActionButtonProps) => {
+  if (morphSendToStop && onStop !== undefined) {
+    return (
+      <ChatComposerActionButton
+        className="rounded-full"
+        iconClassName="size-4"
+        mode="stop"
+        onStop={onStop}
+        size="icon"
+      />
+    );
+  }
+
+  if (morphSendToRetry && onRetry !== undefined) {
+    return (
+      <ChatComposerActionButton
+        className="rounded-full"
+        iconClassName="size-4"
+        mode="retry"
+        onRetry={onRetry}
+        size="icon"
+      />
+    );
+  }
+
+  return (
+    <ChatComposerActionButton
+      canSend={canSend}
+      className="rounded-full"
+      iconClassName="size-4"
+      mode="send"
+      onSend={onSend}
+      size="icon"
+    />
+  );
+};
 
 // ===========================================================================
 // Thread panel

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -14,7 +14,14 @@
  */
 
 import "@/components/chat-editor.css";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   ComponentProps,
   KeyboardEvent as ReactKeyboardEvent,
@@ -1867,51 +1874,78 @@ type PromptBarActionButtonProps = {
   onRetry?: (() => void) | undefined;
   onSend: () => void;
   onStop?: (() => void) | undefined;
-};
+} & Omit<
+  ComponentProps<typeof ChatComposerActionButton>,
+  | "canSend"
+  | "className"
+  | "iconClassName"
+  | "mode"
+  | "onRetry"
+  | "onSend"
+  | "onStop"
+  | "size"
+>;
 
-const PromptBarActionButton = ({
-  canSend,
-  morphSendToRetry,
-  morphSendToStop,
-  onRetry,
-  onSend,
-  onStop,
-}: PromptBarActionButtonProps) => {
-  if (morphSendToStop && onStop !== undefined) {
+const PromptBarActionButton = forwardRef<
+  HTMLButtonElement,
+  PromptBarActionButtonProps
+>(
+  (
+    {
+      canSend,
+      morphSendToRetry,
+      morphSendToStop,
+      onRetry,
+      onSend,
+      onStop,
+      ...buttonProps
+    },
+    ref,
+  ) => {
+    if (morphSendToStop && onStop !== undefined) {
+      return (
+        <ChatComposerActionButton
+          {...buttonProps}
+          className="rounded-full"
+          iconClassName="size-4"
+          mode="stop"
+          onStop={onStop}
+          ref={ref}
+          size="icon"
+        />
+      );
+    }
+
+    if (morphSendToRetry && onRetry !== undefined) {
+      return (
+        <ChatComposerActionButton
+          {...buttonProps}
+          className="rounded-full"
+          iconClassName="size-4"
+          mode="retry"
+          onRetry={onRetry}
+          ref={ref}
+          size="icon"
+        />
+      );
+    }
+
     return (
       <ChatComposerActionButton
+        {...buttonProps}
+        canSend={canSend}
         className="rounded-full"
         iconClassName="size-4"
-        mode="stop"
-        onStop={onStop}
+        mode="send"
+        onSend={onSend}
+        ref={ref}
         size="icon"
       />
     );
-  }
+  },
+);
 
-  if (morphSendToRetry && onRetry !== undefined) {
-    return (
-      <ChatComposerActionButton
-        className="rounded-full"
-        iconClassName="size-4"
-        mode="retry"
-        onRetry={onRetry}
-        size="icon"
-      />
-    );
-  }
-
-  return (
-    <ChatComposerActionButton
-      canSend={canSend}
-      className="rounded-full"
-      iconClassName="size-4"
-      mode="send"
-      onSend={onSend}
-      size="icon"
-    />
-  );
-};
+PromptBarActionButton.displayName = "PromptBarActionButton";
 
 // ===========================================================================
 // Thread panel

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -34,6 +34,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   LoaderCircleIcon,
+  SquareIcon,
   SquarePenIcon,
   UserIcon,
   WandSparklesIcon,
@@ -1508,17 +1509,12 @@ export function PromptBar(props: PromptBarProps) {
   const submitDisabled = busy || isSendBlocked;
   // With queuing enabled the composer keeps accepting input while a
   // response streams: `useChatSession` holds submitted drafts until the
-  // turn finishes. Keep the primary button as Send once a draft is ready
-  // so click/tap can queue follow-ups, not only keyboard Enter.
+  // turn finishes. Keep Send as the primary action and show Stop beside it.
   const composerSubmitDisabled = queueWhileGenerating
     ? status === "applying" || isSendBlocked
     : submitDisabled;
-  const canQueueDraft =
-    queueWhileGenerating &&
-    isGenerating &&
-    !composerSubmitDisabled &&
-    canSubmit;
-  const morphSendToStop = showStop && !canQueueDraft;
+  const morphSendToStop = showStop && !queueWhileGenerating;
+  const showQueueStopButton = showStop && queueWhileGenerating;
   // After a stop the send arrow becomes Retry until the user starts
   // a new draft (the owner also clears `onRetry` then; the `isEmpty`
   // gate just avoids a one-render flash before that state lands).
@@ -1804,6 +1800,26 @@ export function PromptBar(props: PromptBarProps) {
             }
           />
           <TooltipPopup side="top">{newThreadLabel}</TooltipPopup>
+        </Tooltip>
+      )}
+
+      {showQueueStopButton && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("chat.stopResponse")}
+                className="rounded-full"
+                onClick={() => onStop()}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <SquareIcon aria-hidden="true" className="size-3.5" />
+              </Button>
+            }
+          />
+          <TooltipPopup side="top">{t("chat.stopResponse")}</TooltipPopup>
         </Tooltip>
       )}
 

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1325,8 +1325,8 @@ type PromptBarProps = {
   /**
    * When true the composer keeps accepting input while a response
    * streams: pressing Enter queues a send via `useChatSession` and
-   * dispatches it once the turn finishes. The visible primary action
-   * still morphs into Stop so all chat surfaces share one affordance.
+   * dispatches it once the turn finishes. The primary action stays
+   * Send; a separate Stop button is shown alongside it.
    */
   queueWhileGenerating?: boolean | undefined;
 };

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1507,13 +1507,18 @@ export function PromptBar(props: PromptBarProps) {
   const inputDisabled = isSendBlocked;
   const submitDisabled = busy || isSendBlocked;
   // With queuing enabled the composer keeps accepting input while a
-  // response streams — `useChatSession` holds Enter-submitted drafts
-  // until the turn finishes. The primary button remains Stop while
-  // streaming, matching the regular chat composer.
+  // response streams: `useChatSession` holds submitted drafts until the
+  // turn finishes. Keep the primary button as Send once a draft is ready
+  // so click/tap can queue follow-ups, not only keyboard Enter.
   const composerSubmitDisabled = queueWhileGenerating
     ? status === "applying" || isSendBlocked
     : submitDisabled;
-  const morphSendToStop = showStop;
+  const canQueueDraft =
+    queueWhileGenerating &&
+    isGenerating &&
+    !composerSubmitDisabled &&
+    canSubmit;
+  const morphSendToStop = showStop && !canQueueDraft;
   // After a stop the send arrow becomes Retry until the user starts
   // a new draft (the owner also clears `onRetry` then; the `isEmpty`
   // gate just avoids a one-render flash before that state lands).

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1874,20 +1874,10 @@ type PromptBarActionButtonProps = {
   onRetry?: (() => void) | undefined;
   onSend: () => void;
   onStop?: (() => void) | undefined;
-} & Omit<
-  ComponentProps<typeof ChatComposerActionButton>,
-  | "canSend"
-  | "className"
-  | "iconClassName"
-  | "mode"
-  | "onRetry"
-  | "onSend"
-  | "onStop"
-  | "size"
->;
+} & Omit<ComponentProps<"span">, "children">;
 
 const PromptBarActionButton = forwardRef<
-  HTMLButtonElement,
+  HTMLSpanElement,
   PromptBarActionButtonProps
 >(
   (
@@ -1898,49 +1888,63 @@ const PromptBarActionButton = forwardRef<
       onRetry,
       onSend,
       onStop,
-      ...buttonProps
+      ...triggerProps
     },
     ref,
   ) => {
+    const triggerClassName = triggerProps.className;
+
     if (morphSendToStop && onStop !== undefined) {
       return (
-        <ChatComposerActionButton
-          {...buttonProps}
-          className="rounded-full"
-          iconClassName="size-4"
-          mode="stop"
-          onStop={onStop}
+        <span
+          {...triggerProps}
+          className={cn("inline-flex", triggerClassName)}
           ref={ref}
-          size="icon"
-        />
+        >
+          <ChatComposerActionButton
+            className="rounded-full"
+            iconClassName="size-4"
+            mode="stop"
+            onStop={onStop}
+            size="icon"
+          />
+        </span>
       );
     }
 
     if (morphSendToRetry && onRetry !== undefined) {
       return (
-        <ChatComposerActionButton
-          {...buttonProps}
-          className="rounded-full"
-          iconClassName="size-4"
-          mode="retry"
-          onRetry={onRetry}
+        <span
+          {...triggerProps}
+          className={cn("inline-flex", triggerClassName)}
           ref={ref}
-          size="icon"
-        />
+        >
+          <ChatComposerActionButton
+            className="rounded-full"
+            iconClassName="size-4"
+            mode="retry"
+            onRetry={onRetry}
+            size="icon"
+          />
+        </span>
       );
     }
 
     return (
-      <ChatComposerActionButton
-        {...buttonProps}
-        canSend={canSend}
-        className="rounded-full"
-        iconClassName="size-4"
-        mode="send"
-        onSend={onSend}
+      <span
+        {...triggerProps}
+        className={cn("inline-flex", triggerClassName)}
         ref={ref}
-        size="icon"
-      />
+      >
+        <ChatComposerActionButton
+          canSend={canSend}
+          className="rounded-full"
+          iconClassName="size-4"
+          mode="send"
+          onSend={onSend}
+          size="icon"
+        />
+      </span>
     );
   },
 );

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -1,7 +1,7 @@
 import "./chat-editor.css";
 import { useRef } from "react";
 
-import { ArrowUpIcon, PaperclipIcon, SquareIcon } from "lucide-react";
+import { PaperclipIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
@@ -12,6 +12,7 @@ import type {
   ChatEditorController,
   ChatInputDraft,
 } from "@/components/chat-editor-provider";
+import { ChatComposerActionButton } from "@/components/chat/chat-composer-action-button";
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
 import { PromptEditorContent } from "@/components/prompt-editor";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
@@ -195,38 +196,28 @@ const ChatSubmitButton = ({
   onSend,
   onStop,
 }: ChatSubmitButtonProps) => {
-  const t = useTranslations();
   const isStop = isGenerating && onStop !== undefined;
 
+  if (isStop) {
+    return (
+      <ChatComposerActionButton
+        className="bg-foreground text-background hover:bg-foreground/90 shrink-0"
+        mode="stop"
+        onStop={onStop}
+        size="icon-sm"
+        variant="default"
+      />
+    );
+  }
+
   return (
-    <Button
-      aria-label={isStop ? t("chat.stopResponse") : t("chat.sendPrompt")}
-      className={cn(
-        "bg-foreground text-background hover:bg-foreground/90 shrink-0",
-        !isStop && !canSend && "opacity-50",
-      )}
-      disabled={!isStop && !canSend}
-      onClick={isStop ? onStop : onSend}
+    <ChatComposerActionButton
+      canSend={canSend}
+      className="bg-foreground text-background hover:bg-foreground/90 shrink-0"
+      mode="send"
+      onSend={onSend}
       size="icon-sm"
       variant="default"
-    >
-      <span
-        aria-hidden="true"
-        className="pointer-events-none relative size-3.5"
-      >
-        <SquareIcon
-          className={cn(
-            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
-            isStop ? "scale-100 opacity-100" : "scale-75 opacity-0",
-          )}
-        />
-        <ArrowUpIcon
-          className={cn(
-            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
-            isStop ? "scale-75 opacity-0" : "scale-100 opacity-100",
-          )}
-        />
-      </span>
-    </Button>
+    />
   );
 };

--- a/apps/web/src/components/chat/chat-composer-action-button.tsx
+++ b/apps/web/src/components/chat/chat-composer-action-button.tsx
@@ -1,0 +1,112 @@
+import type { ComponentProps } from "react";
+
+import { ArrowUpIcon, RotateCcwIcon, SquareIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
+
+type ChatComposerActionButtonBaseProps = {
+  className?: string;
+  iconClassName?: string;
+  size?: ComponentProps<typeof Button>["size"];
+  variant?: ComponentProps<typeof Button>["variant"];
+};
+
+type ChatComposerActionButtonProps = ChatComposerActionButtonBaseProps &
+  (
+    | {
+        canSend: boolean;
+        mode: "send";
+        onSend: () => void;
+      }
+    | {
+        mode: "stop";
+        onStop: () => void;
+      }
+    | {
+        mode: "retry";
+        onRetry: () => void;
+      }
+  );
+
+export const ChatComposerActionButton = (
+  props: ChatComposerActionButtonProps,
+) => {
+  const t = useTranslations();
+  const label = (() => {
+    switch (props.mode) {
+      case "send":
+        return t("chat.sendPrompt");
+      case "stop":
+        return t("chat.stopResponse");
+      case "retry":
+        return t("common.retry");
+      default:
+        props satisfies never;
+        return "";
+    }
+  })();
+  const canSend = props.mode !== "send" || props.canSend;
+
+  const handleClick = () => {
+    switch (props.mode) {
+      case "send":
+        props.onSend();
+        return;
+      case "stop":
+        props.onStop();
+        return;
+      case "retry":
+        props.onRetry();
+        return;
+      default:
+        props satisfies never;
+    }
+  };
+
+  return (
+    <Button
+      aria-label={label}
+      className={cn(props.className, !canSend && "opacity-50")}
+      disabled={!canSend}
+      onClick={handleClick}
+      size={props.size}
+      type="button"
+      variant={props.variant}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none relative size-3.5",
+          props.iconClassName,
+        )}
+      >
+        <SquareIcon
+          className={cn(
+            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
+            props.mode === "stop"
+              ? "scale-100 opacity-100"
+              : "scale-75 opacity-0",
+          )}
+        />
+        <RotateCcwIcon
+          className={cn(
+            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
+            props.mode === "retry"
+              ? "scale-100 opacity-100"
+              : "scale-75 opacity-0",
+          )}
+        />
+        <ArrowUpIcon
+          className={cn(
+            "absolute inset-0 mx-0! size-full transition-[opacity,transform] duration-150 ease-out",
+            props.mode === "send"
+              ? "scale-100 opacity-100"
+              : "scale-75 opacity-0",
+          )}
+        />
+      </span>
+    </Button>
+  );
+};

--- a/apps/web/src/components/chat/chat-composer-action-button.tsx
+++ b/apps/web/src/components/chat/chat-composer-action-button.tsx
@@ -1,14 +1,10 @@
-import { forwardRef, useRef } from "react";
 import type { ComponentProps } from "react";
 
 import { ArrowUpIcon, RotateCcwIcon, SquareIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
-
-import { composeRefs } from "@/lib/slot";
 
 type ChatComposerActionButtonBaseProps = {
   className?: string;
@@ -16,17 +12,6 @@ type ChatComposerActionButtonBaseProps = {
   size?: ComponentProps<typeof Button>["size"];
   variant?: ComponentProps<typeof Button>["variant"];
 };
-
-type ButtonForwardProps = Omit<
-  ComponentProps<typeof Button>,
-  | "aria-label"
-  | "children"
-  | "className"
-  | "disabled"
-  | "onClick"
-  | "size"
-  | "variant"
->;
 
 type ChatComposerActionButtonProps = ChatComposerActionButtonBaseProps &
   (
@@ -43,15 +28,12 @@ type ChatComposerActionButtonProps = ChatComposerActionButtonBaseProps &
         mode: "retry";
         onRetry: () => void;
       }
-  ) &
-  ButtonForwardProps;
+  );
 
-export const ChatComposerActionButton = forwardRef<
-  HTMLButtonElement,
-  ChatComposerActionButtonProps
->((props, ref) => {
+export const ChatComposerActionButton = (
+  props: ChatComposerActionButtonProps,
+) => {
   const t = useTranslations();
-  const buttonRef = useRef<HTMLButtonElement>(null);
   const label = (() => {
     switch (props.mode) {
       case "send":
@@ -84,16 +66,13 @@ export const ChatComposerActionButton = forwardRef<
   };
 
   const { className, iconClassName, size, variant } = props;
-  const buttonProps = buttonForwardProps(props);
 
   return (
     <Button
-      {...buttonProps}
       aria-label={label}
       className={cn(className, !canSend && "opacity-50")}
       disabled={!canSend}
-      onClick={containedHandler(buttonRef, handleClick)}
-      ref={composeRefs(buttonRef, ref)}
+      onClick={handleClick}
       size={size}
       type="button"
       variant={variant}
@@ -129,48 +108,4 @@ export const ChatComposerActionButton = forwardRef<
       </span>
     </Button>
   );
-});
-
-ChatComposerActionButton.displayName = "ChatComposerActionButton";
-
-const buttonForwardProps = (
-  props: ChatComposerActionButtonProps,
-): ButtonForwardProps => {
-  if (props.mode === "send") {
-    const {
-      canSend: _canSend,
-      className: _className,
-      iconClassName: _iconClassName,
-      mode: _mode,
-      onSend: _onSend,
-      size: _size,
-      variant: _variant,
-      ...buttonProps
-    } = props;
-    return buttonProps;
-  }
-
-  if (props.mode === "stop") {
-    const {
-      className: _className,
-      iconClassName: _iconClassName,
-      mode: _mode,
-      onStop: _onStop,
-      size: _size,
-      variant: _variant,
-      ...buttonProps
-    } = props;
-    return buttonProps;
-  }
-
-  const {
-    className: _className,
-    iconClassName: _iconClassName,
-    mode: _mode,
-    onRetry: _onRetry,
-    size: _size,
-    variant: _variant,
-    ...buttonProps
-  } = props;
-  return buttonProps;
 };

--- a/apps/web/src/components/chat/chat-composer-action-button.tsx
+++ b/apps/web/src/components/chat/chat-composer-action-button.tsx
@@ -74,6 +74,7 @@ export const ChatComposerActionButton = (
       disabled={!canSend}
       onClick={handleClick}
       size={size}
+      tooltip={false}
       type="button"
       variant={variant}
     >

--- a/apps/web/src/components/chat/chat-composer-action-button.tsx
+++ b/apps/web/src/components/chat/chat-composer-action-button.tsx
@@ -1,10 +1,14 @@
+import { forwardRef, useRef } from "react";
 import type { ComponentProps } from "react";
 
 import { ArrowUpIcon, RotateCcwIcon, SquareIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
+
+import { composeRefs } from "@/lib/slot";
 
 type ChatComposerActionButtonBaseProps = {
   className?: string;
@@ -12,6 +16,17 @@ type ChatComposerActionButtonBaseProps = {
   size?: ComponentProps<typeof Button>["size"];
   variant?: ComponentProps<typeof Button>["variant"];
 };
+
+type ButtonForwardProps = Omit<
+  ComponentProps<typeof Button>,
+  | "aria-label"
+  | "children"
+  | "className"
+  | "disabled"
+  | "onClick"
+  | "size"
+  | "variant"
+>;
 
 type ChatComposerActionButtonProps = ChatComposerActionButtonBaseProps &
   (
@@ -28,12 +43,15 @@ type ChatComposerActionButtonProps = ChatComposerActionButtonBaseProps &
         mode: "retry";
         onRetry: () => void;
       }
-  );
+  ) &
+  ButtonForwardProps;
 
-export const ChatComposerActionButton = (
-  props: ChatComposerActionButtonProps,
-) => {
+export const ChatComposerActionButton = forwardRef<
+  HTMLButtonElement,
+  ChatComposerActionButtonProps
+>((props, ref) => {
   const t = useTranslations();
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const label = (() => {
     switch (props.mode) {
       case "send":
@@ -65,22 +83,24 @@ export const ChatComposerActionButton = (
     }
   };
 
+  const { className, iconClassName, size, variant } = props;
+  const buttonProps = buttonForwardProps(props);
+
   return (
     <Button
+      {...buttonProps}
       aria-label={label}
-      className={cn(props.className, !canSend && "opacity-50")}
+      className={cn(className, !canSend && "opacity-50")}
       disabled={!canSend}
-      onClick={handleClick}
-      size={props.size}
+      onClick={containedHandler(buttonRef, handleClick)}
+      ref={composeRefs(buttonRef, ref)}
+      size={size}
       type="button"
-      variant={props.variant}
+      variant={variant}
     >
       <span
         aria-hidden="true"
-        className={cn(
-          "pointer-events-none relative size-3.5",
-          props.iconClassName,
-        )}
+        className={cn("pointer-events-none relative size-3.5", iconClassName)}
       >
         <SquareIcon
           className={cn(
@@ -109,4 +129,48 @@ export const ChatComposerActionButton = (
       </span>
     </Button>
   );
+});
+
+ChatComposerActionButton.displayName = "ChatComposerActionButton";
+
+const buttonForwardProps = (
+  props: ChatComposerActionButtonProps,
+): ButtonForwardProps => {
+  if (props.mode === "send") {
+    const {
+      canSend: _canSend,
+      className: _className,
+      iconClassName: _iconClassName,
+      mode: _mode,
+      onSend: _onSend,
+      size: _size,
+      variant: _variant,
+      ...buttonProps
+    } = props;
+    return buttonProps;
+  }
+
+  if (props.mode === "stop") {
+    const {
+      className: _className,
+      iconClassName: _iconClassName,
+      mode: _mode,
+      onStop: _onStop,
+      size: _size,
+      variant: _variant,
+      ...buttonProps
+    } = props;
+    return buttonProps;
+  }
+
+  const {
+    className: _className,
+    iconClassName: _iconClassName,
+    mode: _mode,
+    onRetry: _onRetry,
+    size: _size,
+    variant: _variant,
+    ...buttonProps
+  } = props;
+  return buttonProps;
 };


### PR DESCRIPTION
## Summary
- add a shared chat composer action button for send, stop, and retry states
- use the shared action in both the main chat composer and embedded prompt bar
- keep queued draft submission behavior while showing stop as the primary in-flight action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared composer action button for send, stop and retry actions.
  * Unified chat and AI prompt controls to use the same interaction and visual state handling.

* **Bug Fixes**
  * Improved action-state consistency so the correct button behaviour and label are shown during generation.
  * Kept send available alongside stop when queued generation is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->