### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -34,3 +34,34 @@ The `stella-docs` MCP server provides on-demand access to library documentation 
 `WebSearch` directly.
 
 **Setup:** run `bun run setup:mcp` once after cloning.
+
+## Cursor Cloud specific instructions
+
+The base VM already has Bun (`~/.bun/bin`, on `PATH` via `~/.bashrc`) and Docker
+installed; the startup update script runs `bun install`. Standard commands live in
+`README.md`, `CONTRIBUTING.md`, and root `package.json` scripts; the notes below are
+only the non-obvious caveats for this environment.
+
+- **Start the Docker daemon first.** There is no systemd auto-start here, so `docker`
+  commands fail until the daemon runs. Start it once per session in the background
+  (e.g. `sudo dockerd` in a tmux session) and confirm with `docker ps`. The daemon is
+  configured with the `fuse-overlayfs` storage driver and iptables-legacy for
+  docker-in-docker.
+- **Run everything with `bun run dev --no-browser`.** The dev-runner
+  (`packages/scripts/src/dev-runner.ts`) brings up the Docker infra (Postgres 5432,
+  Valkey 6379, MinIO 9000/9001, Gotenberg 3003), copies `apps/{api,web}/.env` from
+  `.env.example`, applies DB migrations, and starts the API (3001) and web (3000). It
+  exits if any child dies, so a single background process covers the whole stack. Use
+  `bun run dev:api` or `bun run dev:web` for a focused loop.
+- **Auth is passwordless email OTP; no SMTP catcher runs.** `EMAIL_PROVIDER=smtp`
+  points at `localhost:1025`, which is not running, so verification emails are not
+  delivered. In dev the OTP is printed to the API log as
+  `[DEV] OTP for <email>: <code>` and is also fetchable via
+  `GET http://localhost:3001/dev-public/last-otp?email=<email>` (dev-only, 404 in
+  prod). Use the log line to complete sign-in/sign-up when testing.
+- **Mock AI is on by default** (`USE_MOCK_AI="true"` in `apps/api/.env.example`), so no
+  AI provider key is needed for local runs.
+- **`bun run verify` / `sync-ai:check` need the `.ai/shared` submodule.** It is not part
+  of the base checkout; run `git submodule update --init .ai/shared` first, otherwise
+  the "AI skill sync" step errors out.
+- Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,3 +379,34 @@ The `stella-docs` MCP server provides on-demand access to library documentation 
 `WebSearch` directly.
 
 **Setup:** run `bun run setup:mcp` once after cloning.
+
+## Cursor Cloud specific instructions
+
+The base VM already has Bun (`~/.bun/bin`, on `PATH` via `~/.bashrc`) and Docker
+installed; the startup update script runs `bun install`. Standard commands live in
+`README.md`, `CONTRIBUTING.md`, and root `package.json` scripts; the notes below are
+only the non-obvious caveats for this environment.
+
+- **Start the Docker daemon first.** There is no systemd auto-start here, so `docker`
+  commands fail until the daemon runs. Start it once per session in the background
+  (e.g. `sudo dockerd` in a tmux session) and confirm with `docker ps`. The daemon is
+  configured with the `fuse-overlayfs` storage driver and iptables-legacy for
+  docker-in-docker.
+- **Run everything with `bun run dev --no-browser`.** The dev-runner
+  (`packages/scripts/src/dev-runner.ts`) brings up the Docker infra (Postgres 5432,
+  Valkey 6379, MinIO 9000/9001, Gotenberg 3003), copies `apps/{api,web}/.env` from
+  `.env.example`, applies DB migrations, and starts the API (3001) and web (3000). It
+  exits if any child dies, so a single background process covers the whole stack. Use
+  `bun run dev:api` or `bun run dev:web` for a focused loop.
+- **Auth is passwordless email OTP; no SMTP catcher runs.** `EMAIL_PROVIDER=smtp`
+  points at `localhost:1025`, which is not running, so verification emails are not
+  delivered. In dev the OTP is printed to the API log as
+  `[DEV] OTP for <email>: <code>` and is also fetchable via
+  `GET http://localhost:3001/dev-public/last-otp?email=<email>` (dev-only, 404 in
+  prod). Use the log line to complete sign-in/sign-up when testing.
+- **Mock AI is on by default** (`USE_MOCK_AI="true"` in `apps/api/.env.example`), so no
+  AI provider key is needed for local runs.
+- **`bun run verify` / `sync-ai:check` need the `.ai/shared` submodule.** It is not part
+  of the base checkout; run `git submodule update --init .ai/shared` first, otherwise
+  the "AI skill sync" step errors out.
+- Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed change

Documents the non-obvious startup/run caveats for developing Stella in a Cursor Cloud VM. Adds a `## Cursor Cloud specific instructions` section to the AI instruction source (`.ai/local/agents.md`) and regenerates the derived `AGENTS.md` via `bun run sync-ai`, so the `sync-ai:check` CI step stays green.

The section covers:
- Starting the Docker daemon (no systemd auto-start in the VM).
- Running the full stack with `bun run dev --no-browser` (dev-runner orchestrates Postgres/Valkey/MinIO/Gotenberg + API 3001 + web 3000).
- Passwordless email OTP auth: no SMTP catcher runs, so read the code from the API log (`[DEV] OTP for <email>: <code>`) or `GET /dev-public/last-otp?email=<email>`.
- Mock AI is on by default; the `.ai/shared` submodule must be initialized for `bun run verify`.

No application code changes.

### Environment verification

The dev environment was set up and exercised end-to-end:
- `bun install`, `bun run lint`, `bun run typecheck`, `bun run test` (3397 pass; 1 pre-existing flaky test in `apps/api` that passes in isolation).
- `bun run dev --no-browser` brought up all four Docker services (healthy) plus API + web.
- Hello-world flow: signed up a new user via email OTP, completed onboarding, and created legal matters.

[stella_signup_and_create_matter.mp4](https://cursor.com/agents/bc-1fbe7f9d-5aea-4de9-8ef7-fbb7b02ededd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstella_signup_and_create_matter.mp4)

Sign-up → OTP → onboarding → create matter ("Series A Financing" for client "Globex Corporation").

[Created matter overview](https://cursor.com/agents/bc-1fbe7f9d-5aea-4de9-8ef7-fbb7b02ededd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_matter_created.webp)

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested (lint/typecheck/test + manual end-to-end app run).
- [ ] DARK MODE SUPPORT | Not applicable (docs only).
- [ ] ISSUE LINKED | No related issue.
- [x] SCREENSHOT INCLUDED | Demo video and screenshot of the running app included.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fbe7f9d-5aea-4de9-8ef7-fbb7b02ededd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fbe7f9d-5aea-4de9-8ef7-fbb7b02ededd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

