### PR TITLE
fix: Enter advances the jurisdiction, catalogue, and AI onboarding steps

### DIFF
--- a/apps/web/src/components/jurisdiction-picker.tsx
+++ b/apps/web/src/components/jurisdiction-picker.tsx
@@ -22,12 +22,14 @@ type JurisdictionPickerProps = {
   selected: readonly PracticeJurisdiction[];
   suggestedCountryCodes?: readonly CountryCode[];
   onChange: (jurisdictions: PracticeJurisdiction[]) => void;
+  autoFocus?: boolean;
 };
 
 export const JurisdictionPicker = ({
   selected,
   suggestedCountryCodes = NO_SUGGESTED_COUNTRY_CODES,
   onChange,
+  autoFocus = false,
 }: JurisdictionPickerProps) => {
   const t = useTranslations();
   const locale = useLocale();
@@ -106,6 +108,7 @@ export const JurisdictionPicker = ({
         </InputGroupAddon>
         <InputGroupInput
           aria-label={t("onboarding.jurisdictionSearchLabel")}
+          autoFocus={autoFocus}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t("onboarding.jurisdictionSearchPlaceholder")}
           value={query}

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { Form } from "@stll/ui/components/form";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { AIConfigProvidersEditor } from "@/components/ai-config-providers-editor";
@@ -314,65 +315,81 @@ export const AIStep = ({
         {t("onboarding.aiSubtitle")}
       </p>
 
-      <div className="mt-8 flex flex-col gap-3">
-        {phase === "providers" ? (
-          <AIConfigProvidersEditor
-            compact
-            onProvidersChange={updateProviders}
-            onSaveRow={(index) => {
-              void saveRow(index);
-            }}
-            providers={providers}
-            rowStatuses={rowStatusList}
-          />
-        ) : (
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex flex-col gap-0.5">
-                <h2 className="text-foreground text-sm font-semibold">
-                  {tOrganization("aiConfig.chooseModelsTitle")}
-                </h2>
-                <p className="text-muted-foreground text-xs">
-                  {tOrganization("aiConfig.chooseModelsSubtitle")}
-                </p>
-              </div>
-              <Button
-                onClick={() => onPhaseChange("providers")}
-                size="sm"
-                type="button"
-                variant="ghost"
-              >
-                {tOrganization("aiConfig.editProviders")}
-              </Button>
-            </div>
-            <AIConfigRoleModelPicker
+      {/* display:contents keeps the existing flex layout; the form only
+          exists so Enter advances the active phase when it is valid.
+          The provider editor's own buttons are type="button", so a
+          key/save keypress never triggers this submit. */}
+      <Form
+        className="contents"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (phase === "providers") {
+            if (canEnterModelsPhase) {
+              onPhaseChange("models");
+            }
+            return;
+          }
+          if (canContinue) {
+            onNext();
+          }
+        }}
+      >
+        <div className="mt-8 flex flex-col gap-3">
+          {phase === "providers" ? (
+            <AIConfigProvidersEditor
               compact
-              onModelChange={setRoleModel}
-              providers={providerValues}
-              roleModels={roleModels}
+              onProvidersChange={updateProviders}
+              onSaveRow={(index) => {
+                void saveRow(index);
+              }}
+              providers={providers}
+              rowStatuses={rowStatusList}
             />
-          </div>
-        )}
-      </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex flex-col gap-0.5">
+                  <h2 className="text-foreground text-sm font-semibold">
+                    {tOrganization("aiConfig.chooseModelsTitle")}
+                  </h2>
+                  <p className="text-muted-foreground text-xs">
+                    {tOrganization("aiConfig.chooseModelsSubtitle")}
+                  </p>
+                </div>
+                <Button
+                  onClick={() => onPhaseChange("providers")}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  {tOrganization("aiConfig.editProviders")}
+                </Button>
+              </div>
+              <AIConfigRoleModelPicker
+                compact
+                onModelChange={setRoleModel}
+                providers={providerValues}
+                roleModels={roleModels}
+              />
+            </div>
+          )}
+        </div>
 
-      <div className="mt-auto flex items-center justify-between gap-3 pt-6">
-        <Button onClick={onSkip} type="button" variant="ghost">
-          {t("onboarding.skipStep")}
-        </Button>
-        {phase === "providers" ? (
-          <Button
-            disabled={!canEnterModelsPhase}
-            onClick={() => onPhaseChange("models")}
-            type="button"
-          >
-            {t("common.next")}
+        <div className="mt-auto flex items-center justify-between gap-3 pt-6">
+          <Button onClick={onSkip} type="button" variant="ghost">
+            {t("onboarding.skipStep")}
           </Button>
-        ) : (
-          <Button disabled={!canContinue} onClick={onNext} type="button">
-            {t("common.next")}
-          </Button>
-        )}
-      </div>
+          {phase === "providers" ? (
+            <Button disabled={!canEnterModelsPhase} type="submit">
+              {t("common.next")}
+            </Button>
+          ) : (
+            <Button disabled={!canContinue} type="submit">
+              {t("common.next")}
+            </Button>
+          )}
+        </div>
+      </Form>
     </>
   );
 };

--- a/apps/web/src/routes/onboarding/-components/steps/catalogue-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/catalogue-step.tsx
@@ -18,6 +18,7 @@ import {
   type LoadedCatalogueEntry,
 } from "@stll/catalogue";
 import { Button } from "@stll/ui/components/button";
+import { Form } from "@stll/ui/components/form";
 import {
   InputGroup,
   InputGroupAddon,
@@ -236,263 +237,278 @@ export const CatalogueStep = ({
         {t("onboarding.catalogueSubtitle")}
       </p>
 
-      {/* Search input + jurisdiction filter inline on the same row.
+      {/* display:contents keeps the fragment's flex layout untouched while
+          still giving Enter native implicit form submission. */}
+      <Form
+        className="contents"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onNext();
+        }}
+      >
+        {/* Search input + jurisdiction filter inline on the same row.
           The dropdown trigger summarises the current selection;
           clicking opens a multi-select checklist with an explicit
           "Vše" reset at the top. */}
-      <div className="mt-6 flex items-center gap-2">
-        <InputGroup className="flex-1">
-          <InputGroupAddon>
-            <SearchIcon className="text-muted-foreground" />
-          </InputGroupAddon>
-          <InputGroupInput
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={t("onboarding.catalogueSearchPlaceholder")}
-            value={query}
-          />
-          {query.length > 0 && (
-            <InputGroupAddon align="inline-end">
-              <Button
-                aria-label={t("onboarding.catalogueClearSearch")}
-                onClick={() => setQuery("")}
-                size="icon-xs"
-                type="button"
-                variant="ghost"
-              >
-                <XIcon />
-              </Button>
+        <div className="mt-6 flex items-center gap-2">
+          <InputGroup className="flex-1">
+            <InputGroupAddon>
+              <SearchIcon className="text-muted-foreground" />
             </InputGroupAddon>
-          )}
-        </InputGroup>
-        <Popover>
-          <PopoverTrigger
-            render={
-              <Button className="shrink-0" type="button" variant="outline" />
-            }
-          >
-            <GlobeIcon className="size-3.5" />
-            {jurisdictionFilter.size === 0
-              ? t("common.all")
-              : [...jurisdictionFilter].sort().join(", ")}
-            <ChevronDownIcon className="size-3.5" />
-          </PopoverTrigger>
-          <PopoverPopup align="end" className="w-60" side="bottom">
-            <div className="border-border border-b p-2">
-              <InputGroup>
-                <InputGroupAddon>
-                  <SearchIcon className="text-muted-foreground" />
-                </InputGroupAddon>
-                <InputGroupInput
-                  autoFocus
-                  onChange={(e) => setFilterQuery(e.target.value)}
-                  placeholder={t("common.search")}
-                  size="sm"
-                  value={filterQuery}
-                />
-              </InputGroup>
-            </div>
-            <div className="flex max-h-[260px] flex-col overflow-y-auto p-1">
-              {/* "ALL" — only shown when not filtering, so the user
+            <InputGroupInput
+              autoFocus
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("onboarding.catalogueSearchPlaceholder")}
+              value={query}
+            />
+            {query.length > 0 && (
+              <InputGroupAddon align="inline-end">
+                <Button
+                  aria-label={t("onboarding.catalogueClearSearch")}
+                  onClick={() => setQuery("")}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <XIcon />
+                </Button>
+              </InputGroupAddon>
+            )}
+          </InputGroup>
+          <Popover>
+            <PopoverTrigger
+              render={
+                <Button className="shrink-0" type="button" variant="outline" />
+              }
+            >
+              <GlobeIcon className="size-3.5" />
+              {jurisdictionFilter.size === 0
+                ? t("common.all")
+                : [...jurisdictionFilter].sort().join(", ")}
+              <ChevronDownIcon className="size-3.5" />
+            </PopoverTrigger>
+            <PopoverPopup align="end" className="w-60" side="bottom">
+              <div className="border-border border-b p-2">
+                <InputGroup>
+                  <InputGroupAddon>
+                    <SearchIcon className="text-muted-foreground" />
+                  </InputGroupAddon>
+                  <InputGroupInput
+                    autoFocus
+                    onChange={(e) => setFilterQuery(e.target.value)}
+                    placeholder={t("common.search")}
+                    size="sm"
+                    value={filterQuery}
+                  />
+                </InputGroup>
+              </div>
+              <div className="flex max-h-[260px] flex-col overflow-y-auto p-1">
+                {/* "ALL" — only shown when not filtering, so the user
                   can quickly reset to the unfiltered view. */}
-              {filterQuery.trim() === "" && (
-                <>
-                  <button
-                    aria-pressed={jurisdictionFilter.size === 0}
-                    className="hover:bg-muted flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors"
-                    onClick={() => setJurisdictionFilter(new Set())}
-                    type="button"
-                  >
-                    <span
-                      className={cn(
-                        "border-border flex size-4 items-center justify-center rounded-sm border",
-                        jurisdictionFilter.size === 0 &&
-                          "border-foreground bg-foreground",
-                      )}
-                    >
-                      {jurisdictionFilter.size === 0 && (
-                        <CheckIcon className="text-background size-3" />
-                      )}
-                    </span>
-                    <span className="text-foreground font-medium">
-                      {t("common.all")}
-                    </span>
-                  </button>
-                  <div className="bg-border my-1 h-px" />
-                </>
-              )}
-              {(() => {
-                const filtered = allJurisdictionCodes.filter((code) =>
-                  code.toLowerCase().includes(filterQuery.trim().toLowerCase()),
-                );
-                if (filtered.length === 0) {
-                  return (
-                    <p className="text-muted-foreground px-2 py-3 text-center text-xs">
-                      {t("common.noResults")}
-                    </p>
-                  );
-                }
-                return filtered.map((code) => {
-                  const active = jurisdictionFilter.has(code);
-                  return (
+                {filterQuery.trim() === "" && (
+                  <>
                     <button
-                      aria-pressed={active}
+                      aria-pressed={jurisdictionFilter.size === 0}
                       className="hover:bg-muted flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors"
-                      key={code}
-                      onClick={() =>
-                        setJurisdictionFilter((prev) => {
-                          const next = new Set(prev);
-                          if (next.has(code)) {
-                            next.delete(code);
-                          } else {
-                            next.add(code);
-                          }
-                          return next;
-                        })
-                      }
+                      onClick={() => setJurisdictionFilter(new Set())}
                       type="button"
                     >
                       <span
                         className={cn(
                           "border-border flex size-4 items-center justify-center rounded-sm border",
-                          active && "border-foreground bg-foreground",
+                          jurisdictionFilter.size === 0 &&
+                            "border-foreground bg-foreground",
                         )}
                       >
-                        {active && (
+                        {jurisdictionFilter.size === 0 && (
                           <CheckIcon className="text-background size-3" />
                         )}
                       </span>
-                      <span className="text-foreground">{code}</span>
+                      <span className="text-foreground font-medium">
+                        {t("common.all")}
+                      </span>
                     </button>
+                    <div className="bg-border my-1 h-px" />
+                  </>
+                )}
+                {(() => {
+                  const filtered = allJurisdictionCodes.filter((code) =>
+                    code
+                      .toLowerCase()
+                      .includes(filterQuery.trim().toLowerCase()),
                   );
-                });
-              })()}
-            </div>
-          </PopoverPopup>
-        </Popover>
-      </div>
-
-      {/* Split list: recommended first, hairline divider with
-          "From the community" heading, then everything else. */}
-      <div className="mt-3 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pe-1">
-        {filteredEntries.length === 0 ? (
-          <div className="flex flex-col items-center gap-3 py-8 text-center">
-            <p className="text-muted-foreground text-xs">
-              {t("common.noResults")}
-            </p>
-            <a
-              className="border-border bg-background hover:bg-muted text-foreground inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
-              href={PROPOSE_TOOL_URL}
-              rel="noreferrer"
-              target="_blank"
-            >
-              {t("onboarding.catalogueProposeTool")}
-              <ExternalLinkIcon className="size-3" />
-            </a>
-          </div>
-        ) : (
-          <>
-            {filteredEntries
-              .filter((entry) => recommendedSet.has(entry.slug))
-              .map((entry) => (
-                <OnboardingCatalogueRow
-                  addLabel={t("common.add")}
-                  entry={entry}
-                  focused={focusedSlug === entry.slug}
-                  key={`${entry.kind}-${entry.slug}`}
-                  onClick={() => handleRowClick(entry)}
-                  onToggleSelection={
-                    pinnedSlugSet.has(entry.slug)
-                      ? undefined
-                      : () => {
-                          if (selectedSet.has(entry.slug)) {
-                            onRemove(entry.slug);
-                          } else {
-                            onAdd(entry.slug);
-                          }
-                        }
+                  if (filtered.length === 0) {
+                    return (
+                      <p className="text-muted-foreground px-2 py-3 text-center text-xs">
+                        {t("common.noResults")}
+                      </p>
+                    );
                   }
-                  removeLabel={t("common.remove")}
-                  selected={selectedSet.has(entry.slug)}
-                />
-              ))}
-            {filteredEntries.some((entry) => !recommendedSet.has(entry.slug)) &&
-              filteredEntries.some((entry) =>
-                recommendedSet.has(entry.slug),
-              ) && (
-                <TextSeparator
-                  className="my-2"
-                  labelClassName="text-[10px] font-medium tracking-wider uppercase"
-                >
-                  {t("onboarding.catalogueCommunityHeading")}
-                </TextSeparator>
-              )}
-            {filteredEntries
-              .filter((entry) => !recommendedSet.has(entry.slug))
-              .map((entry) => (
-                <OnboardingCatalogueRow
-                  addLabel={t("common.add")}
-                  entry={entry}
-                  focused={focusedSlug === entry.slug}
-                  key={`${entry.kind}-${entry.slug}`}
-                  onClick={() => handleRowClick(entry)}
-                  onToggleSelection={
-                    pinnedSlugSet.has(entry.slug)
-                      ? undefined
-                      : () => {
-                          if (selectedSet.has(entry.slug)) {
-                            onRemove(entry.slug);
-                          } else {
-                            onAdd(entry.slug);
-                          }
+                  return filtered.map((code) => {
+                    const active = jurisdictionFilter.has(code);
+                    return (
+                      <button
+                        aria-pressed={active}
+                        className="hover:bg-muted flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors"
+                        key={code}
+                        onClick={() =>
+                          setJurisdictionFilter((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(code)) {
+                              next.delete(code);
+                            } else {
+                              next.add(code);
+                            }
+                            return next;
+                          })
                         }
-                  }
-                  removeLabel={t("common.remove")}
-                  selected={selectedSet.has(entry.slug)}
-                />
-              ))}
-            {jurisdictionFilter.size > 0 && (
-              <div className="flex justify-center py-2">
-                <Button
-                  onClick={() => setJurisdictionFilter(new Set())}
-                  size="sm"
-                  type="button"
-                  variant="link"
-                >
-                  {t("common.showAll")}
-                </Button>
+                        type="button"
+                      >
+                        <span
+                          className={cn(
+                            "border-border flex size-4 items-center justify-center rounded-sm border",
+                            active && "border-foreground bg-foreground",
+                          )}
+                        >
+                          {active && (
+                            <CheckIcon className="text-background size-3" />
+                          )}
+                        </span>
+                        <span className="text-foreground">{code}</span>
+                      </button>
+                    );
+                  });
+                })()}
               </div>
-            )}
-          </>
-        )}
-      </div>
+            </PopoverPopup>
+          </Popover>
+        </div>
 
-      <p className="text-muted-foreground mt-4 text-xs">
-        {t.rich("onboarding.catalogueFootnote", {
-          link: (chunks) => (
-            <a
-              className="hover:text-foreground underline"
-              href={PROPOSE_TOOL_URL}
-              rel="noreferrer"
-              target="_blank"
-            >
-              {chunks}
-            </a>
-          ),
-        })}
-      </p>
+        {/* Split list: recommended first, hairline divider with
+          "From the community" heading, then everything else. */}
+        <div className="mt-3 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pe-1">
+          {filteredEntries.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="text-muted-foreground text-xs">
+                {t("common.noResults")}
+              </p>
+              <a
+                className="border-border bg-background hover:bg-muted text-foreground inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+                href={PROPOSE_TOOL_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                {t("onboarding.catalogueProposeTool")}
+                <ExternalLinkIcon className="size-3" />
+              </a>
+            </div>
+          ) : (
+            <>
+              {filteredEntries
+                .filter((entry) => recommendedSet.has(entry.slug))
+                .map((entry) => (
+                  <OnboardingCatalogueRow
+                    addLabel={t("common.add")}
+                    entry={entry}
+                    focused={focusedSlug === entry.slug}
+                    key={`${entry.kind}-${entry.slug}`}
+                    onClick={() => handleRowClick(entry)}
+                    onToggleSelection={
+                      pinnedSlugSet.has(entry.slug)
+                        ? undefined
+                        : () => {
+                            if (selectedSet.has(entry.slug)) {
+                              onRemove(entry.slug);
+                            } else {
+                              onAdd(entry.slug);
+                            }
+                          }
+                    }
+                    removeLabel={t("common.remove")}
+                    selected={selectedSet.has(entry.slug)}
+                  />
+                ))}
+              {filteredEntries.some(
+                (entry) => !recommendedSet.has(entry.slug),
+              ) &&
+                filteredEntries.some((entry) =>
+                  recommendedSet.has(entry.slug),
+                ) && (
+                  <TextSeparator
+                    className="my-2"
+                    labelClassName="text-[10px] font-medium tracking-wider uppercase"
+                  >
+                    {t("onboarding.catalogueCommunityHeading")}
+                  </TextSeparator>
+                )}
+              {filteredEntries
+                .filter((entry) => !recommendedSet.has(entry.slug))
+                .map((entry) => (
+                  <OnboardingCatalogueRow
+                    addLabel={t("common.add")}
+                    entry={entry}
+                    focused={focusedSlug === entry.slug}
+                    key={`${entry.kind}-${entry.slug}`}
+                    onClick={() => handleRowClick(entry)}
+                    onToggleSelection={
+                      pinnedSlugSet.has(entry.slug)
+                        ? undefined
+                        : () => {
+                            if (selectedSet.has(entry.slug)) {
+                              onRemove(entry.slug);
+                            } else {
+                              onAdd(entry.slug);
+                            }
+                          }
+                    }
+                    removeLabel={t("common.remove")}
+                    selected={selectedSet.has(entry.slug)}
+                  />
+                ))}
+              {jurisdictionFilter.size > 0 && (
+                <div className="flex justify-center py-2">
+                  <Button
+                    onClick={() => setJurisdictionFilter(new Set())}
+                    size="sm"
+                    type="button"
+                    variant="link"
+                  >
+                    {t("common.showAll")}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
 
-      <div className="mt-auto flex items-center justify-between gap-3 pt-8">
-        <Button onClick={onSkip} type="button" variant="ghost">
-          {t("onboarding.skipStep")}
-        </Button>
-        <Button onClick={onNext} type="button">
-          {selectedSet.size === 0
-            ? t("onboarding.continue")
-            : t("onboarding.catalogueContinueWithCount", {
-                count: selectedSet.size,
-              })}
-        </Button>
-      </div>
+        <p className="text-muted-foreground mt-4 text-xs">
+          {t.rich("onboarding.catalogueFootnote", {
+            link: (chunks) => (
+              <a
+                className="hover:text-foreground underline"
+                href={PROPOSE_TOOL_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                {chunks}
+              </a>
+            ),
+          })}
+        </p>
+
+        <div className="mt-auto flex items-center justify-between gap-3 pt-8">
+          <Button onClick={onSkip} type="button" variant="ghost">
+            {t("onboarding.skipStep")}
+          </Button>
+          <Button type="submit">
+            {selectedSet.size === 0
+              ? t("onboarding.continue")
+              : t("onboarding.catalogueContinueWithCount", {
+                  count: selectedSet.size,
+                })}
+          </Button>
+        </div>
+      </Form>
     </>
   );
 };

--- a/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
@@ -5,6 +5,7 @@ import { XIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { Form } from "@stll/ui/components/form";
 import { cn } from "@stll/ui/lib/utils";
 
 import { JurisdictionPicker } from "@/components/jurisdiction-picker";
@@ -42,22 +43,34 @@ export const JurisdictionStep = ({
         {t("onboarding.jurisdictionSubtitle")}
       </p>
 
-      <div className="mt-7 flex min-h-0 flex-1 flex-col gap-4">
-        <JurisdictionPicker
-          onChange={onChange}
-          selected={selected}
-          suggestedCountryCodes={suggestedCountryCodes}
-        />
-      </div>
+      <Form
+        className="mt-7 flex min-h-0 flex-1 flex-col"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (selected.length === 0) {
+            return;
+          }
+          onNext();
+        }}
+      >
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
+          <JurisdictionPicker
+            autoFocus
+            onChange={onChange}
+            selected={selected}
+            suggestedCountryCodes={suggestedCountryCodes}
+          />
+        </div>
 
-      <div className="mt-auto flex items-center justify-between gap-3 pt-8">
-        <Button onClick={onSkip} type="button" variant="ghost">
-          {t("onboarding.skipStep")}
-        </Button>
-        <Button disabled={selected.length === 0} onClick={onNext} type="button">
-          {t("common.next")}
-        </Button>
-      </div>
+        <div className="mt-auto flex items-center justify-between gap-3 pt-8">
+          <Button onClick={onSkip} type="button" variant="ghost">
+            {t("onboarding.skipStep")}
+          </Button>
+          <Button disabled={selected.length === 0} type="submit">
+            {t("common.next")}
+          </Button>
+        </div>
+      </Form>
     </>
   );
 };


### PR DESCRIPTION
## Summary

Only the organization step advanced on <kbd>Enter</kbd>, because it wraps its content in a form with a submit button. The jurisdiction, catalogue, and AI-provider steps used `type="button"` + `onClick` handlers with no surrounding form, so a keypress had nothing to trigger.

Each of these steps now:
- wraps its content in a `<Form>` (using `display:contents` where the existing flex layout must be preserved unchanged),
- switches the primary "continue" button to `type="submit"`,
- autofocuses the search input so a keypress has a focused control to submit from.

The AI-provider step's submit is phase-aware and only advances when the current phase is valid (a saved provider for `providers` → `models`, valid model selection for continue). The shared `ai-config-providers-editor` is untouched; its buttons remain `type="button"`, so entering/saving an API key never triggers the step's submit.

The invite step is intentionally left as-is (its Enter commits an email chip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding steps now support submitting with the Enter key, making it easier to continue through the flow.
  * Search fields in the catalogue and jurisdiction selection can now auto-focus for faster input.

* **Bug Fixes**
  * Improved onboarding navigation so primary actions behave consistently through form submission.
  * The jurisdiction step now only allows continuing when a selection has been made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->