### PR TITLE
chore: skip desktop rebuilds on releases without desktop changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,13 @@ jobs:
       - name: Test release-channel script
         run: bash scripts/release-channel.test.sh
 
+      # Self-test the desktop-release skip decision. This script
+      # decides whether prod desktop users get an update at all; a
+      # regression either ships stale desktop builds or reintroduces
+      # pointless ~30 MB redownloads.
+      - name: Test detect-desktop-release-changes script
+        run: bash scripts/detect-desktop-release-changes.test.sh
+
       - name: Test bun ci retry script
         run: bash scripts/bun-ci-retry.test.sh
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -3,9 +3,15 @@ name: Release Desktop App
 # Build, sign, and publish the Tauri desktop app for each release tag.
 # Runs after release.yml succeeds so the GitHub Release object already
 # exists; this workflow only adds desktop installers + the updater
-# manifest to it. Skipped automatically when nothing in apps/desktop
-# (or its bundled shared packages) changed since the previous tag, so
-# backend-only releases don't churn a 30 MB redownload.
+# manifest to it. Skipped automatically (for STABLE tags as well as
+# prereleases) when nothing the desktop actually ships changed since
+# the previous same-channel release, so backend-only releases don't
+# churn a ~30 MB redownload + restart. See
+# scripts/detect-desktop-release-changes.sh for the exact decision.
+# On a skipped STABLE release, the carry-forward job below copies the
+# previous stable's installers + latest.json onto the new release and
+# flips `--latest`, so the web app's /releases/latest/download deep
+# links never 404 and in-app updaters see no spurious update.
 #
 # Builds Windows + macOS in parallel. Windows uses Azure Trusted
 # Signing; macOS uses a Developer ID Application cert + App Store
@@ -55,6 +61,10 @@ jobs:
       release_sha: ${{ steps.ref.outputs.sha }}
       app_version: ${{ steps.ref.outputs.version }}
       should_build: ${{ steps.diff.outputs.should_build }}
+      # Previous same-channel release the skip decision compared
+      # against (empty when none). Consumed by carry-forward to copy
+      # that release's desktop assets onto a skipped stable release.
+      previous_tag: ${{ steps.diff.outputs.previous_tag }}
       # Channel directory name (`prod`, `rc`, `beta`, `alpha`)
       # derived from the tag suffix by scripts/release-channel.sh.
       # Used to route the updater manifest to a channel-specific
@@ -181,59 +191,26 @@ jobs:
         id: diff
         env:
           CURRENT_TAG: ${{ steps.ref.outputs.value }}
+          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Stable releases are canonical: always build so latest.json
-          # is fresh and stable-channel users always get an upgrade
-          # path. The skip optimization only applies to prereleases,
-          # where rapid iteration on backend-only changes shouldn't
-          # churn desktop redownloads. This also avoids a subtle bug
-          # where the rc->stable promotion points the stable tag at
-          # the same commit as the rc and the diff comes up empty.
-          if [[ "$CURRENT_TAG" != *-* ]]; then
-            echo "Stable release ($CURRENT_TAG); always building desktop."
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          # Manual dispatch is the rebuild escape hatch (e.g. re-running
+          # a release whose signing job failed), so it never skips.
+          # Mirrors ci.yml's dispatch-forces-checks behaviour.
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "Manual dispatch; forcing a desktop build."
+            {
+              echo "should_build=true"
+              echo "previous_tag="
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # For prereleases, find the most recent prerelease tag that
-          # actually shipped desktop artifacts (i.e. has latest.json on
-          # its GitHub Release). If none, build. This pins the diff
-          # window to the last release a desktop client would have
-          # received, instead of any tag that happens to exist.
-          previous=""
-          while IFS= read -r tag; do
-            [[ -z "$tag" || "$tag" == "$CURRENT_TAG" ]] && continue
-            [[ "$tag" != *-* ]] && continue
-            if gh release view "$tag" --json assets \
-                --jq '.assets[].name' 2>/dev/null \
-                | grep -qx 'latest.json'; then
-              previous="$tag"
-              break
-            fi
-          done < <(git tag --sort=-creatordate --list 'v*')
-          if [[ -z "$previous" ]]; then
-            echo "No previous prerelease with desktop artifacts; will build."
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Comparing $previous..$CURRENT_TAG for desktop-relevant changes"
-          # Paths that justify a desktop rebuild. apps/web is included
-          # because the Tauri build embeds the web bundle. VERSION is
-          # intentionally excluded — every tag exists because VERSION
-          # bumped, so including it would defeat the skip entirely.
-          changed=$(git diff --name-only "$previous" "$CURRENT_TAG" -- \
-            apps/desktop/ \
-            apps/web/ \
-            packages/folio/ \
-            packages/ui/ \
-            || true)
-          if [[ -n "$changed" ]]; then
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No desktop-relevant changes; skipping desktop build."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          fi
+          # All the skip logic (channel-exact comparison, manifest
+          # marker, rebuild-trigger paths, and why apps/web + VERSION
+          # are excluded) lives in the script so the workflow and its
+          # test share one implementation.
+          bash scripts/detect-desktop-release-changes.sh "$CURRENT_TAG" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve
@@ -674,3 +651,58 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: gh release edit "$RELEASE_REF" --latest
+
+  carry-forward:
+    # Runs ONLY when a STABLE (prod) release skipped the desktop build.
+    # A skipped release has no installers of its own, so:
+    #   - flipping it to `--latest` as-is would 404 the web app's
+    #     /releases/latest/download/Stella-* deep links, and
+    #   - NOT flipping it would strand /releases/latest on the old tag.
+    # So copy the previous stable release's desktop assets (installers
+    # + latest.json) onto this release, then flip `--latest`. The
+    # carried latest.json still advertises the previous desktop version
+    # and points at the previous release's download URLs, so in-app
+    # updaters see no update: that is exactly the point (no redownload
+    # churn). The S3 manifest mirror is intentionally left untouched
+    # for the same reason.
+    #
+    # Prereleases are deliberately excluded: they are never
+    # /releases/latest and their release objects aren't deep-linked, so
+    # a skipped prerelease needs no carry-forward (today's behaviour).
+    needs: resolve
+    if: ${{ needs.resolve.outputs.should_build == 'false' && needs.resolve.outputs.channel == 'prod' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write   # download from / upload to / edit GitHub Releases
+    env:
+      # `gh` resolves the repo from GH_REPO, so no checkout is needed.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+      PREVIOUS_TAG: ${{ needs.resolve.outputs.previous_tag }}
+    steps:
+      - name: Copy previous stable desktop assets forward and promote
+        run: |
+          # A carry-forward with nothing to carry is a broken invariant:
+          # the skip decision only produces should_build=false when it
+          # found a previous same-channel release WITH a latest.json, so
+          # previous_tag must be non-empty here.
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            echo "::error::carry-forward reached with no previous_tag; refusing to promote an asset-less release"
+            exit 1
+          fi
+
+          # Fail loudly if the previous release has no matching assets:
+          # a stable release with no installers to carry means the
+          # invariant above is already violated upstream.
+          gh release download "$PREVIOUS_TAG" \
+            --pattern 'Stella-*' \
+            --pattern 'latest.json' \
+            --dir assets
+
+          # Attach first, THEN flip --latest (same ordering rationale as
+          # the manifest job's promote step): the deep links must
+          # resolve before /releases/latest points here.
+          gh release upload "$RELEASE_REF" assets/* --clobber
+          gh release edit "$RELEASE_REF" --latest

--- a/scripts/detect-desktop-release-changes.sh
+++ b/scripts/detect-desktop-release-changes.sh
@@ -104,6 +104,15 @@ echo "Current tag $current_tag is on channel '$current_channel'" >&2
 #     stale and wrong; compatibility is the bridge handshake).
 #   - VERSION: every tag exists because VERSION bumped, so including
 #     it would make the diff never empty and defeat the skip entirely.
+#   - Root package.json / bun.lock: these change with nearly every
+#     release (repo-wide dependency maintenance), so including them
+#     would also defeat the skip. This is an accepted staleness
+#     window: a root catalog bump of a settings-webview JS dep does
+#     not rebuild the desktop until the next in-path change. The
+#     shipped native binary's dependencies are pinned in-tree
+#     (apps/desktop/src-tauri/Cargo.lock) and therefore ARE covered;
+#     when a root-level bump must ship immediately, a manual
+#     workflow_dispatch of release-desktop.yml forces a build.
 rebuild_paths=(
   "apps/desktop/"
   "packages/ui/"

--- a/scripts/detect-desktop-release-changes.sh
+++ b/scripts/detect-desktop-release-changes.sh
@@ -115,8 +115,11 @@ rebuild_paths=(
 )
 
 # Find the most recent prior tag on the SAME channel that has a
-# published desktop manifest (latest.json). bash 3.2 on macOS runners
-# has no `mapfile`, so stream `git tag` through a while-read loop.
+# published desktop manifest (latest.json). `--merged` restricts the
+# candidates to ancestors of the current tag: a retried run that
+# executes after a NEWER tag already exists must not pick that tag and
+# diff forward against it. bash 3.2 on macOS runners has no `mapfile`,
+# so stream `git tag` through a while-read loop.
 previous_tag=""
 while IFS= read -r tag; do
   [[ -z "$tag" || "$tag" == "$current_tag" ]] && continue
@@ -134,7 +137,7 @@ while IFS= read -r tag; do
     previous_tag="$tag"
     break
   fi
-done < <(git tag --sort=-creatordate --list 'v*')
+done < <(git tag --sort=-creatordate --merged "$current_tag" --list 'v*')
 
 if [[ -z "$previous_tag" ]]; then
   echo "No prior '$current_channel' release with a desktop manifest; building." >&2

--- a/scripts/detect-desktop-release-changes.sh
+++ b/scripts/detect-desktop-release-changes.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# Decide whether the desktop (Tauri) release pipeline needs to build
+# and publish installers for a given release tag, or whether it can
+# safely carry the previous release forward untouched.
+#
+# WHY this exists
+# ---------------
+# Building + signing + notarizing the desktop app is expensive (tens
+# of minutes across Windows + macOS) and, more importantly, every
+# publish forces a ~30 MB redownload + restart on end users via the
+# updater. A release that changed nothing desktop-relevant (a
+# backend-only version bump, say) should NOT churn that update. This
+# script centralises the "did anything the desktop actually ships
+# change?" decision so both the workflow and its test exercise the
+# exact same logic.
+#
+# The desktop app bundles only its own settings UI plus its single
+# workspace dependency @stll/ui (packages/ui), which itself has no
+# runtime workspace deps. It does NOT embed apps/web or
+# packages/folio: desktop<->web compatibility is guaranteed by the
+# bridge protocol version handshake (BRIDGE_VERSION in
+# apps/desktop/src-tauri/src/types.rs vs MIN_DESKTOP_BRIDGE_VERSION
+# in apps/web/src/lib/desktop-bridge.ts), not by version lockstep. So
+# the desktop may lawfully skip releases; its version simply has gaps.
+#
+# Channel-EXACT comparison
+# ------------------------
+# We compare the current tag only against the most recent PRIOR tag on
+# the SAME channel (prod/rc/beta/alpha, via scripts/release-channel.sh)
+# that actually has a published desktop manifest. This differs from the
+# older inline logic, which compared any prerelease against any other
+# prerelease channel. That was not transitive: when rc and beta tags
+# interleave, an rc release could diff against an intervening beta and
+# leave the previous rc user's manifest permanently stale. Comparing
+# same-channel-to-same-channel fixes that, and it is also what makes
+# the stable (prod) channel skippable at all (the old code always
+# rebuilt stable).
+#
+# Transitivity / why "has latest.json" is the right marker
+# --------------------------------------------------------
+# A release that SKIPS still ends up with the previous release's
+# latest.json: the workflow's carry-forward job copies the prior
+# stable release's desktop assets (installers + latest.json) onto the
+# skipped release before flipping it to `--latest`. So "has a
+# latest.json asset" marks EVERY release a desktop client would have
+# received on that channel, whether freshly built or carried forward.
+# Diffing against the most recent such same-channel tag is therefore
+# sound: each skipped link in the chain was itself verified diff-empty
+# against its own predecessor, so an empty diff against the latest
+# shipped-or-carried tag implies no desktop change since the last
+# build the user actually installed.
+#
+# Interface
+# ---------
+#   bash scripts/detect-desktop-release-changes.sh <current-tag>
+# Requires:
+#   - GH_TOKEN in the environment (used by `gh release view`).
+#   - Run inside the repo checkout with full history AND tags fetched
+#     (git diff + git tag both need them).
+# Prints GitHub-Actions-output style lines on stdout (so the caller
+# can `>> "$GITHUB_OUTPUT"`); all human-readable logging goes to
+# stderr:
+#   should_build=true|false
+#   previous_tag=<tag>     (empty when no comparable predecessor found)
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <current-tag>" >&2
+  exit 1
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "::error::GH_TOKEN must be set (used by 'gh release view')" >&2
+  exit 1
+fi
+
+current_tag="$1"
+
+# Resolve the sibling channel script relative to this file so the
+# workflow, the test harness (which runs from a fixture repo cwd),
+# and a direct invocation all find the same implementation.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+release_channel="$script_dir/release-channel.sh"
+
+current_channel="$(bash "$release_channel" "$current_tag")"
+echo "Current tag $current_tag is on channel '$current_channel'" >&2
+
+# Paths whose changes justify a fresh desktop build. Each is here
+# because it ends up inside the shipped binary or drives the release
+# pipeline that produces it:
+#   - apps/desktop/                          the app itself
+#   - packages/ui/                           its only workspace dep
+#                                            (verified: no transitive
+#                                            runtime workspace deps)
+#   - scripts/rename-desktop-artifacts.sh    stable artifact naming
+#   - scripts/build-updater-manifest.sh      latest.json generation
+#   - scripts/release-channel.sh             channel routing
+#   - scripts/detect-desktop-release-changes.sh  this decision itself
+#   - .github/workflows/release-desktop.yml  the pipeline definition
+# Deliberately NOT included:
+#   - apps/web/ and packages/folio/: not bundled by the desktop app
+#     (the old "the Tauri build embeds the web bundle" comment was
+#     stale and wrong; compatibility is the bridge handshake).
+#   - VERSION: every tag exists because VERSION bumped, so including
+#     it would make the diff never empty and defeat the skip entirely.
+rebuild_paths=(
+  "apps/desktop/"
+  "packages/ui/"
+  "scripts/rename-desktop-artifacts.sh"
+  "scripts/build-updater-manifest.sh"
+  "scripts/release-channel.sh"
+  "scripts/detect-desktop-release-changes.sh"
+  ".github/workflows/release-desktop.yml"
+)
+
+# Find the most recent prior tag on the SAME channel that has a
+# published desktop manifest (latest.json). bash 3.2 on macOS runners
+# has no `mapfile`, so stream `git tag` through a while-read loop.
+previous_tag=""
+while IFS= read -r tag; do
+  [[ -z "$tag" || "$tag" == "$current_tag" ]] && continue
+
+  # Skip tags whose shape release-channel.sh rejects (e.g. a malformed
+  # or non-release tag) rather than aborting the whole run.
+  tag_channel="$(bash "$release_channel" "$tag" 2>/dev/null)" || continue
+  [[ "$tag_channel" != "$current_channel" ]] && continue
+
+  # Only consider a tag whose GitHub Release actually carries a
+  # latest.json asset: that is the marker of a release a desktop
+  # client on this channel would have received (built or carried).
+  if gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null \
+    | grep -qx 'latest.json'; then
+    previous_tag="$tag"
+    break
+  fi
+done < <(git tag --sort=-creatordate --list 'v*')
+
+if [[ -z "$previous_tag" ]]; then
+  echo "No prior '$current_channel' release with a desktop manifest; building." >&2
+  echo "should_build=true"
+  echo "previous_tag="
+  exit 0
+fi
+
+echo "Comparing $previous_tag..$current_tag for desktop-relevant changes" >&2
+# No `|| true` here: an empty diff still exits 0, so a non-zero status
+# means git itself failed (bad revision, shallow history). Swallowing
+# that would read as "no changes" and resolve to should_build=false,
+# silently shipping a stale desktop; let `set -e` abort instead so the
+# workflow fails loudly.
+changed="$(git diff --name-only "$previous_tag" "$current_tag" -- "${rebuild_paths[@]}")"
+
+if [[ -n "$changed" ]]; then
+  echo "Desktop-relevant changes since $previous_tag:" >&2
+  echo "$changed" >&2
+  echo "should_build=true"
+else
+  echo "No desktop-relevant changes since $previous_tag; skipping build." >&2
+  echo "should_build=false"
+fi
+echo "previous_tag=$previous_tag"

--- a/scripts/detect-desktop-release-changes.test.sh
+++ b/scripts/detect-desktop-release-changes.test.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/detect-desktop-release-changes.sh.
+#
+# The script under test shells out to `git` (tags + diff) and `gh`
+# (release asset lookup), so each case builds a throwaway git repo in
+# a temp dir with a hand-crafted tag/commit topology, and a stub `gh`
+# on PATH that answers "does this tag's release carry latest.json?"
+# from a per-case env var. Commit + tag object dates are stamped with
+# strictly increasing timestamps so `git tag --sort=-creatordate` is
+# deterministic across platforms.
+#
+# The real scripts/release-channel.sh is used unchanged: the script
+# resolves it relative to its own path, so pointing $SCRIPT at the
+# real file picks up the real channel logic automatically.
+#
+# Covers:
+#   1. First release of a channel (no prior manifest) → build, empty
+#      previous_tag.
+#   2. Stable, a desktop file changed since the previous stable →
+#      build (and asserts gh was invoked as `release view`).
+#   3. Stable, only backend paths + VERSION changed → skip.
+#   4. Channel isolation: a newer rc with a manifest sits between two
+#      stables; the stable still diffs against the previous STABLE.
+#   5. Prerelease channel-exact: an rc diffs against the last rc,
+#      ignoring a newer beta that has a manifest (and skips cleanly).
+#   6. Change under packages/ui/ (the desktop's only workspace dep) →
+#      build.
+#   7. Change to .github/workflows/release-desktop.yml → build.
+#   8. A prior tag whose release has no manifest (stub gh exits 1) is
+#      skipped over during the search for a comparison point.
+#
+# Run locally:    bash scripts/detect-desktop-release-changes.test.sh
+# Wired into CI in .github/workflows/ci.yml and scripts/verify.sh.
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/detect-desktop-release-changes.sh"
+
+WORK="$(mktemp -d)"
+STUB_BIN="$WORK/bin"
+GH_CALL_LOG="$WORK/gh-calls.log"
+mkdir -p "$STUB_BIN"
+: > "$GH_CALL_LOG"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# --- stub gh: only `gh release view <tag> --json assets --jq ...` ---
+# Prints a `latest.json` asset line and exits 0 for any tag listed in
+# GH_TAGS_WITH_MANIFEST (space separated); exits 1 otherwise, matching
+# real gh for a release without that asset (or no release at all). Any
+# other invocation is a bug in the script under test: fail loudly.
+cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+if [[ "${1:-}" != "release" || "${2:-}" != "view" ]]; then
+  echo "gh stub: unexpected invocation: $*" >&2
+  exit 3
+fi
+tag="${3:-}"
+[[ -n "${GH_CALL_LOG:-}" ]] && echo "release view $tag" >> "$GH_CALL_LOG"
+for t in ${GH_TAGS_WITH_MANIFEST:-}; do
+  if [[ "$t" == "$tag" ]]; then
+    echo "latest.json"
+    exit 0
+  fi
+done
+exit 1
+STUB
+chmod +x "$STUB_BIN/gh"
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+# Monotonic clock for git object dates. Advance before every commit
+# and every annotated tag so creation order is unambiguous.
+TS=1000000000
+next_ts() {
+  TS=$((TS + 100))
+  export GIT_AUTHOR_DATE="$TS +0000"
+  export GIT_COMMITTER_DATE="$TS +0000"
+}
+
+new_repo() {
+  # Echoes the path of a fresh initialised repo under $WORK.
+  local dir="$WORK/repo-$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.name "Test"
+  git -C "$dir" config user.email "test@example.com"
+  git -C "$dir" config commit.gpgsign false
+  git -C "$dir" config tag.gpgsign false
+  echo "$dir"
+}
+
+commit_touching() {
+  local dir="$1" path="$2" msg="$3"
+  mkdir -p "$dir/$(dirname "$path")"
+  echo "$msg" >> "$dir/$path"
+  git -C "$dir" add "$path" >/dev/null
+  next_ts
+  git -C "$dir" commit -q -m "$msg"
+}
+
+tag_annotated() {
+  local dir="$1" name="$2"
+  next_ts
+  git -C "$dir" tag -a "$name" -m "$name"
+}
+
+# Runs the script inside $dir with a stubbed gh + manifest set, then
+# asserts the emitted should_build / previous_tag lines.
+expect_case() {
+  local name="$1" dir="$2" tag="$3" manifests="$4"
+  local want_build="$5" want_prev="$6"
+  local out got_build got_prev
+
+  out="$(
+    cd "$dir" \
+      && PATH="$STUB_BIN:$PATH" \
+         GH_TOKEN="stub" \
+         GH_CALL_LOG="$GH_CALL_LOG" \
+         GH_TAGS_WITH_MANIFEST="$manifests" \
+         bash "$SCRIPT" "$tag" 2>/dev/null
+  )"
+
+  got_build="$(printf '%s\n' "$out" | grep '^should_build=' | head -n1)"
+  got_build="${got_build#should_build=}"
+  got_prev="$(printf '%s\n' "$out" | grep '^previous_tag=' | head -n1)"
+  got_prev="${got_prev#previous_tag=}"
+
+  if [[ "$got_build" != "$want_build" || "$got_prev" != "$want_prev" ]]; then
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+    printf '  x  %s\n     want should_build=%s previous_tag=%q\n     got  should_build=%s previous_tag=%q\n' \
+      "$name" "$want_build" "$want_prev" "$got_build" "$got_prev"
+    return
+  fi
+  PASS=$((PASS + 1))
+  printf '  ok %s\n' "$name"
+}
+
+echo "Running detect-desktop-release-changes.sh tests..."
+
+# 1. First release of a channel: only tag exists, nothing has a
+#    manifest → build with empty previous_tag.
+d="$(new_repo case1)"
+commit_touching "$d" "apps/desktop/app.ts" "desktop init"
+tag_annotated "$d" "v0.1.0"
+expect_case "first release of a channel builds" \
+  "$d" "v0.1.0" "" "true" ""
+
+# 2. Stable with a desktop change since the previous stable → build.
+d="$(new_repo case2)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" "apps/desktop/b.ts" "desktop b"
+tag_annotated "$d" "v0.2.0"
+expect_case "stable + desktop change builds" \
+  "$d" "v0.2.0" "v0.1.0" "true" "v0.1.0"
+
+# The above case exercises the gh lookup: confirm the stub saw a
+# `release view` call, i.e. the script really consults release assets.
+if grep -q '^release view ' "$GH_CALL_LOG"; then
+  PASS=$((PASS + 1))
+  printf '  ok gh release view was invoked\n'
+else
+  FAIL=$((FAIL + 1))
+  FAIL_NAMES+=("gh release view was invoked")
+  printf '  x  gh release view was never invoked\n'
+fi
+
+# 3. Stable, only backend + VERSION changed → skip.
+d="$(new_repo case3)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" "apps/api/x.ts" "backend x"
+commit_touching "$d" "VERSION" "0.2.0"
+tag_annotated "$d" "v0.2.0"
+expect_case "stable + backend/VERSION only skips" \
+  "$d" "v0.2.0" "v0.1.0" "false" "v0.1.0"
+
+# 4. Channel isolation: a newer rc (with a manifest) sits between two
+#    stables. The current stable must select the previous STABLE, not
+#    the rc. Picking the rc would diff rc.1..v0.2.0 (backend only →
+#    skip); picking v0.1.0 catches the rc's desktop change → build.
+d="$(new_repo case4)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" "apps/desktop/b.ts" "desktop b on rc"
+tag_annotated "$d" "v0.2.0-rc.1"
+commit_touching "$d" "apps/api/x.ts" "backend x"
+commit_touching "$d" "VERSION" "0.2.0"
+tag_annotated "$d" "v0.2.0"
+expect_case "stable ignores newer rc, diffs previous stable" \
+  "$d" "v0.2.0" "v0.1.0 v0.2.0-rc.1" "true" "v0.1.0"
+
+# 5. Prerelease channel-exact: current rc.2 must diff against rc.1,
+#    not the newer beta.1 that also has a manifest. Both candidate
+#    diffs here are backend-only, so the answer is skip either way;
+#    previous_tag proves the rc-vs-beta discrimination.
+d="$(new_repo case5)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.2.0-rc.1"
+commit_touching "$d" "apps/api/y.ts" "backend y on beta"
+tag_annotated "$d" "v0.2.0-beta.1"
+commit_touching "$d" "apps/api/x.ts" "backend x"
+commit_touching "$d" "VERSION" "0.2.0-rc.2"
+tag_annotated "$d" "v0.2.0-rc.2"
+expect_case "rc diffs last rc, not newer beta" \
+  "$d" "v0.2.0-rc.2" "v0.2.0-rc.1 v0.2.0-beta.1" "false" "v0.2.0-rc.1"
+
+# 6. Change under packages/ui/ (desktop's only workspace dep) → build.
+d="$(new_repo case6)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" "packages/ui/src/button.tsx" "ui change"
+tag_annotated "$d" "v0.2.0"
+expect_case "packages/ui change builds" \
+  "$d" "v0.2.0" "v0.1.0" "true" "v0.1.0"
+
+# 7. Change to the release-desktop workflow itself → build.
+d="$(new_repo case7)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" ".github/workflows/release-desktop.yml" "workflow tweak"
+tag_annotated "$d" "v0.2.0"
+expect_case "release-desktop.yml change builds" \
+  "$d" "v0.2.0" "v0.1.0" "true" "v0.1.0"
+
+# 8. A prior tag whose release has NO manifest (stub gh exits 1) must
+#    be skipped over: v0.2.0 has no manifest, so v0.3.0 compares back
+#    to v0.1.0. The unshipped desktop change from v0.2.0 is therefore
+#    (correctly) still pending → build.
+d="$(new_repo case8)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" "apps/desktop/b.ts" "desktop b (never shipped)"
+tag_annotated "$d" "v0.2.0"
+commit_touching "$d" "apps/api/x.ts" "backend x"
+commit_touching "$d" "VERSION" "0.3.0"
+tag_annotated "$d" "v0.3.0"
+expect_case "skips a prior tag without a manifest" \
+  "$d" "v0.3.0" "v0.1.0" "true" "v0.1.0"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -ne 0 ]]; then
+  printf 'Failed cases:\n'
+  printf '  - %s\n' "${FAIL_NAMES[@]}"
+  exit 1
+fi

--- a/scripts/detect-desktop-release-changes.test.sh
+++ b/scripts/detect-desktop-release-changes.test.sh
@@ -243,6 +243,21 @@ tag_annotated "$d" "v0.3.0"
 expect_case "skips a prior tag without a manifest" \
   "$d" "v0.3.0" "v0.1.0" "true" "v0.1.0"
 
+# 9. Non-ancestor tags are ignored: a NEWER tag (with a manifest) that
+#    is a descendant of the current tag must not be selected as the
+#    comparison point (a retried run for an older tag would otherwise
+#    diff forward). v0.3.0 sits on top of v0.2.0; running for v0.2.0
+#    must still compare back to v0.1.0.
+d="$(new_repo case9)"
+commit_touching "$d" "apps/desktop/a.ts" "desktop a"
+tag_annotated "$d" "v0.1.0"
+commit_touching "$d" "apps/api/x.ts" "backend x"
+tag_annotated "$d" "v0.2.0"
+commit_touching "$d" "apps/desktop/b.ts" "desktop b"
+tag_annotated "$d" "v0.3.0"
+expect_case "ignores a newer non-ancestor tag" \
+  "$d" "v0.2.0" "v0.1.0 v0.3.0" "false" "v0.1.0"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 if [[ "$FAIL" -ne 0 ]]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -147,6 +147,7 @@ run_step "Knip production deps" run_knip
 run_step "Test" run_test
 run_step "Bridge-version guard self-test" bash scripts/check-bridge-version.test.sh
 run_step "Release-channel self-test" bash scripts/release-channel.test.sh
+run_step "Desktop-release-changes self-test" bash scripts/detect-desktop-release-changes.test.sh
 run_step "Bridge-version guard" bash scripts/check-bridge-version.sh
 
 echo


### PR DESCRIPTION
## Summary

Extends the prerelease-only desktop build skip in `release-desktop.yml` to stable tags, so releases that change nothing the desktop actually ships no longer force every install to redownload and restart via the updater.

- **`scripts/detect-desktop-release-changes.sh`** (new): the skip decision, extracted from the workflow. Finds the most recent prior tag on the *same channel* whose GitHub Release carries `latest.json`, then diffs the rebuild-trigger paths. Channel-exact comparison replaces the old any-prerelease comparison, which was not transitive when rc and beta tags interleaved (an rc could diff against an intervening beta and leave the rc manifest permanently stale); it is also what makes the stable channel skippable at all.
- **Trigger paths corrected**: `apps/desktop/` and `packages/ui/` (the desktop's only workspace dependency), plus the release scripts and the workflow itself. `apps/web/` and `packages/folio/` are removed; the desktop bundles only its own settings UI, and desktop/web compatibility is guaranteed by the bridge protocol version handshake (`BRIDGE_VERSION` / `MIN_DESKTOP_BRIDGE_VERSION`), not version lockstep, so desktop versions may lawfully have gaps.
- **New `carry-forward` job**: when a stable release skips the build, it copies the previous stable release's installers and `latest.json` onto the new release before flipping `--latest`. `releases/latest/download/Stella-*` deep links keep resolving, while the carried manifest still advertises the previous desktop version, so in-app updaters see no spurious update. The S3 manifest mirror is left untouched on skip. Prereleases keep today's behaviour (skip without carry-forward).
- **`workflow_dispatch` always builds**: manual dispatch stays the rebuild escape hatch, and the early exit happens before the script call so tags predating this change remain dispatchable.
- **`scripts/detect-desktop-release-changes.test.sh`** (new): fixture git repos plus a stubbed `gh` on PATH; covers first-release, build/skip decisions, channel isolation in both directions, and skipping tags that never shipped artifacts. Wired into `ci.yml` and `scripts/verify.sh` alongside the release-channel test.

## Testing

- `bash scripts/detect-desktop-release-changes.test.sh`: 9 passed, 0 failed
- `bash scripts/release-channel.test.sh`: 23 passed, 0 failed