### PR TITLE
chore: reduce railway template prompts

### DIFF
--- a/docs/railway.md
+++ b/docs/railway.md
@@ -47,10 +47,10 @@ S3_REGION=${{stella-files.REGION}}
 S3_ACCESS_KEY_ID=${{stella-files.ACCESS_KEY_ID}}
 S3_SECRET_ACCESS_KEY=${{stella-files.SECRET_ACCESS_KEY}}
 
-SMTP_HOST=<smtp host>
+SMTP_HOST=smtp.resend.com
 SMTP_PASSWORD=<smtp password or API key>
-SMTP_PORT=<smtp port>
-SMTP_USERNAME=<smtp username>
+SMTP_PORT=587
+SMTP_USERNAME=resend
 TRANSACTIONAL_EMAIL_FROM=noreply@example.com
 
 GOTENBERG_URL=http://${{gotenberg.RAILWAY_PRIVATE_DOMAIN}}:3000
@@ -61,7 +61,7 @@ GOTENBERG_PASSWORD=${{gotenberg.GOTENBERG_API_BASIC_AUTH_PASSWORD}}
 Do not expose Gotenberg publicly. Configure the `gotenberg` service with:
 
 ```bash
-API_ENABLE_BASIC_AUTH=${{secret(1, "t")}}${{secret(1, "r")}}${{secret(1, "u")}}${{secret(1, "e")}}
+API_ENABLE_BASIC_AUTH=true
 GOTENBERG_API_BASIC_AUTH_USERNAME=${{secret(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")}}
 GOTENBERG_API_BASIC_AUTH_PASSWORD=${{secret(64, "abcdef0123456789")}}
 ```
@@ -69,11 +69,11 @@ GOTENBERG_API_BASIC_AUTH_PASSWORD=${{secret(64, "abcdef0123456789")}}
 The API Docker image now honors Railway's injected `PORT` variable, with
 `STELLA_API_PORT` still available as an explicit override.
 
-For the public template, only SMTP host, port, username, password, and the
-transactional sender address should be required user inputs. Use Railway
-template variable functions for generated secrets and Railway reference
-variables for same-project services. The repository source of truth for this
-shape is `railway/template-manifest.json`.
+For the public template, default the SMTP connection to Resend-compatible SMTP
+settings. Only the SMTP password/API key and transactional sender address should
+be required user inputs. Use Railway template variable functions for generated
+secrets and Railway reference variables for same-project services. The
+repository source of truth for this shape is `railway/template-manifest.json`.
 
 Template editor checklist for `api` variables:
 
@@ -86,10 +86,10 @@ Template editor checklist for `api` variables:
 | `PUBLIC_URL`               | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
 | `BETTER_AUTH_SECRET`       | `${{secret(64, "abcdef0123456789")}}`               | No           |
 | `CONTENT_ENCRYPTION_KEY`   | `${{secret(64, "abcdef0123456789")}}`               | No           |
-| `SMTP_HOST`                | SMTP relay hostname                                 | Yes          |
+| `SMTP_HOST`                | `smtp.resend.com`                                   | No           |
 | `SMTP_PASSWORD`            | SMTP password or API key                            | Yes          |
-| `SMTP_PORT`                | SMTP relay port                                     | Yes          |
-| `SMTP_USERNAME`            | SMTP username                                       | Yes          |
+| `SMTP_PORT`                | `587`                                               | No           |
+| `SMTP_USERNAME`            | `resend`                                            | No           |
 | `TRANSACTIONAL_EMAIL_FROM` | Verified sender address                             | Yes          |
 | `S3_ENDPOINT`              | `${{stella-files.ENDPOINT}}`                        | No           |
 | `S3_BUCKET`                | `${{stella-files.BUCKET}}`                          | No           |
@@ -99,6 +99,22 @@ Template editor checklist for `api` variables:
 | `GOTENBERG_URL`            | `http://${{gotenberg.RAILWAY_PRIVATE_DOMAIN}}:3000` | No           |
 | `GOTENBERG_USERNAME`       | `${{gotenberg.GOTENBERG_API_BASIC_AUTH_USERNAME}}`  | No           |
 | `GOTENBERG_PASSWORD`       | `${{gotenberg.GOTENBERG_API_BASIC_AUTH_PASSWORD}}`  | No           |
+
+Template editor checklist for managed service variables:
+
+| Service     | Variable                              | Source                                                                   | Prompt user? |
+| ----------- | ------------------------------------- | ------------------------------------------------------------------------ | ------------ |
+| `Postgres`  | `PGDATA`                              | `/var/lib/postgresql/data/pgdata`                                        | No           |
+| `Postgres`  | `PGPORT`                              | `5432`                                                                   | No           |
+| `Postgres`  | `POSTGRES_DB`                         | `railway`                                                                | No           |
+| `Postgres`  | `POSTGRES_USER`                       | `postgres`                                                               | No           |
+| `Postgres`  | `SSL_CERT_DAYS`                       | `820`                                                                    | No           |
+| `Postgres`  | `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` | `60`                                                                     | No           |
+| `Redis`     | `REDISPORT`                           | `6379`                                                                   | No           |
+| `Redis`     | `REDISUSER`                           | `default`                                                                | No           |
+| `gotenberg` | `API_ENABLE_BASIC_AUTH`               | `true`                                                                   | No           |
+| `gotenberg` | `GOTENBERG_API_BASIC_AUTH_USERNAME`   | `${{secret(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")}}` | No           |
+| `gotenberg` | `GOTENBERG_API_BASIC_AUTH_PASSWORD`   | `${{secret(64, "abcdef0123456789")}}`                                    | No           |
 
 ## Web Variables
 
@@ -165,11 +181,18 @@ publishing. Check these items before the first publish:
   from the template into a fresh project.
 - Generated values use `secret(...)`; user-supplied credentials are prompted,
   not committed.
-- Only SMTP connection details and `TRANSACTIONAL_EMAIL_FROM` are required user
-  inputs.
+- Only `SMTP_PASSWORD` and `TRANSACTIONAL_EMAIL_FROM` are required user inputs.
+  SMTP host, port, and username should use the template defaults.
 - Gotenberg has no public domain.
 - Both public domains pass `/health`.
 - The marketplace overview uses `railway/template-readme.md`.
+
+After editing the draft variables, validate that only the intended user prompts
+remain:
+
+```bash
+bun run check:railway-template-draft -- --template <template-id>
+```
 
 ## Source-Backed Smoke Verification
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "i18n:check": "turbo run i18n:check --",
     "i18n:sync": "turbo run i18n:sync --",
     "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
+    "check:railway-template-draft": "bun scripts/check-railway-template-draft.ts",
     "check:railway-template": "bun scripts/check-railway-template-shape.ts",
     "sync:railway-template-source": "bun scripts/sync-railway-template-source.ts",
     "test": "turbo run test",

--- a/railway/template-manifest.json
+++ b/railway/template-manifest.json
@@ -14,14 +14,39 @@
     "stella-files": {}
   },
   "services": {
+    "Postgres": {
+      "variables": {
+        "DATABASE_PUBLIC_URL": "postgresql://${{PGUSER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}/${{PGDATABASE}}",
+        "DATABASE_URL": "postgresql://${{PGUSER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:5432/${{PGDATABASE}}",
+        "PGDATA": "/var/lib/postgresql/data/pgdata",
+        "PGDATABASE": "${{POSTGRES_DB}}",
+        "PGHOST": "${{RAILWAY_PRIVATE_DOMAIN}}",
+        "PGPASSWORD": "${{POSTGRES_PASSWORD}}",
+        "PGPORT": "5432",
+        "PGUSER": "${{POSTGRES_USER}}",
+        "POSTGRES_DB": "railway",
+        "POSTGRES_PASSWORD": "${{secret(32, \"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\")}}",
+        "POSTGRES_USER": "postgres",
+        "RAILWAY_DEPLOYMENT_DRAINING_SECONDS": "60",
+        "SSL_CERT_DAYS": "820"
+      }
+    },
+    "Redis": {
+      "variables": {
+        "REDISHOST": "${{RAILWAY_PRIVATE_DOMAIN}}",
+        "REDISPASSWORD": "${{REDIS_PASSWORD}}",
+        "REDISPORT": "6379",
+        "REDISUSER": "default",
+        "REDIS_PASSWORD": "${{secret(32, \"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\")}}",
+        "REDIS_PUBLIC_URL": "redis://default:${{REDIS_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}",
+        "REDIS_URL": "redis://${{REDISUSER}}:${{REDIS_PASSWORD}}@${{REDISHOST}}:${{REDISPORT}}"
+      }
+    },
     "api": {
       "configFile": "/railway.json",
       "publicNetworking": true,
       "requiredUserInputs": {
-        "SMTP_HOST": "SMTP server host for sign-in and invitation emails.",
-        "SMTP_PASSWORD": "SMTP password or API key.",
-        "SMTP_PORT": "SMTP server port.",
-        "SMTP_USERNAME": "SMTP username.",
+        "SMTP_PASSWORD": "SMTP password or API key for sign-in and invitation emails.",
         "TRANSACTIONAL_EMAIL_FROM": "From address for transactional emails."
       },
       "variables": {
@@ -40,10 +65,10 @@
         "S3_ENDPOINT": "${{stella-files.ENDPOINT}}",
         "S3_REGION": "${{stella-files.REGION}}",
         "S3_SECRET_ACCESS_KEY": "${{stella-files.SECRET_ACCESS_KEY}}",
-        "SMTP_HOST": "smtp.example.invalid",
+        "SMTP_HOST": "smtp.resend.com",
         "SMTP_PASSWORD": "smtp-password",
         "SMTP_PORT": "587",
-        "SMTP_USERNAME": "smtp-user",
+        "SMTP_USERNAME": "resend",
         "TRANSACTIONAL_EMAIL_FROM": "noreply@example.invalid"
       }
     },
@@ -58,7 +83,7 @@
     "gotenberg": {
       "publicNetworking": false,
       "variables": {
-        "API_ENABLE_BASIC_AUTH": "${{secret(1, \"t\")}}${{secret(1, \"r\")}}${{secret(1, \"u\")}}${{secret(1, \"e\")}}",
+        "API_ENABLE_BASIC_AUTH": "true",
         "GOTENBERG_API_BASIC_AUTH_PASSWORD": "${{secret(64, \"abcdef0123456789\")}}",
         "GOTENBERG_API_BASIC_AUTH_USERNAME": "${{secret(32, \"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\")}}"
       }

--- a/railway/template-readme.md
+++ b/railway/template-readme.md
@@ -39,14 +39,17 @@ because it is an internal document conversion dependency.
 
 ### Deployment Dependencies
 
-- SMTP relay credentials are required before the first production login. stella
-  uses email OTPs for sign-in, invitations, and account security emails.
+- An SMTP password/API key and verified sender address are required before the
+  first production login. The template defaults to Resend-compatible SMTP
+  settings (`smtp.resend.com`, port `587`, username `resend`). stella uses
+  email OTPs for sign-in, invitations, and account security emails.
 - The Railway storage bucket is provisioned by the template and wired to the
   API with reference variables.
 - Generated application secrets stay in Railway variables and should not be
   copied into source control.
 
-Use a production SMTP provider rather than a personal mailbox SMTP account.
+Use a production transactional email provider rather than a personal mailbox
+SMTP account.
 
 ### Implementation Details
 

--- a/scripts/check-railway-template-draft.ts
+++ b/scripts/check-railway-template-draft.ts
@@ -28,8 +28,18 @@ const failures: string[] = [];
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const readJson = (filePath: string): unknown =>
-  JSON.parse(readFileSync(filePath, "utf-8"));
+const describeError = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+const readJson = (filePath: string): unknown => {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch (error) {
+    throw new RailwayTemplateDraftError(
+      `Failed to read or parse JSON file at ${filePath}: ${describeError(error)}`,
+    );
+  }
+};
 
 const getString = (value: Record<string, unknown>, key: string) => {
   const next = value[key];
@@ -119,22 +129,38 @@ const graphql = async (
   query: string,
   variables: Record<string, unknown>,
 ) => {
-  const response = await fetch(RAILWAY_GRAPHQL_URL, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ query, variables }),
-    signal: AbortSignal.timeout(RAILWAY_GRAPHQL_TIMEOUT_MS),
-  });
+  let response: Response;
+  try {
+    response = await fetch(RAILWAY_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(RAILWAY_GRAPHQL_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new RailwayTemplateDraftError(
+      `Failed to connect to Railway GraphQL API: ${describeError(error)}`,
+    );
+  }
+
   if (!response.ok) {
     throw new RailwayTemplateDraftError(
       `Railway GraphQL request failed with status ${response.status}: ${response.statusText}`,
     );
   }
 
-  const payload: unknown = await response.json();
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new RailwayTemplateDraftError(
+      `Failed to parse Railway GraphQL response as JSON: ${describeError(error)}`,
+    );
+  }
+
   if (!isRecord(payload)) {
     throw new RailwayTemplateDraftError(
       "Railway GraphQL returned invalid JSON",
@@ -200,7 +226,7 @@ const validateServiceVariables = ({
       if (!isRecord(variable)) {
         return false;
       }
-      return variable["isOptional"] === false && !("defaultValue" in variable);
+      return variable["isOptional"] !== true && !("defaultValue" in variable);
     })
     .map(([key]) => key);
 

--- a/scripts/check-railway-template-draft.ts
+++ b/scripts/check-railway-template-draft.ts
@@ -1,0 +1,334 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+const MANIFEST_PATH = "railway/template-manifest.json";
+const RAILWAY_GRAPHQL_URL = "https://backboard.railway.com/graphql/v2";
+const RAILWAY_GRAPHQL_TIMEOUT_MS = 10_000;
+
+class RailwayTemplateDraftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RailwayTemplateDraftError";
+  }
+}
+
+type ServiceTemplate = {
+  requiredUserInputs: Record<string, string>;
+  variables: Record<string, string>;
+};
+
+type TemplateManifest = {
+  services: Record<string, ServiceTemplate>;
+};
+
+const failures: string[] = [];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readJson = (filePath: string): unknown =>
+  JSON.parse(readFileSync(filePath, "utf-8"));
+
+const getString = (value: Record<string, unknown>, key: string) => {
+  const next = value[key];
+  if (typeof next !== "string") {
+    throw new RailwayTemplateDraftError(`${key} must be a string`);
+  }
+  return next;
+};
+
+const readStringRecord = (
+  value: unknown,
+  label: string,
+): Record<string, string> => {
+  if (!isRecord(value)) {
+    throw new RailwayTemplateDraftError(`${label} must be an object`);
+  }
+
+  const result: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item !== "string") {
+      throw new RailwayTemplateDraftError(`${label}.${key} must be a string`);
+    }
+    result[key] = item;
+  }
+  return result;
+};
+
+const readManifest = (): TemplateManifest => {
+  const value = readJson(MANIFEST_PATH);
+  if (!isRecord(value) || !isRecord(value["services"])) {
+    throw new RailwayTemplateDraftError(
+      `${MANIFEST_PATH} must define services`,
+    );
+  }
+
+  const services: Record<string, ServiceTemplate> = {};
+  for (const [serviceName, service] of Object.entries(value["services"])) {
+    if (!isRecord(service)) {
+      throw new RailwayTemplateDraftError(
+        `${MANIFEST_PATH} service ${serviceName} must be an object`,
+      );
+    }
+    services[serviceName] = {
+      requiredUserInputs: readStringRecord(
+        service["requiredUserInputs"] ?? {},
+        `services.${serviceName}.requiredUserInputs`,
+      ),
+      variables: readStringRecord(
+        service["variables"] ?? {},
+        `services.${serviceName}.variables`,
+      ),
+    };
+  }
+
+  return { services };
+};
+
+const readRailwayToken = () => {
+  const fromEnv = process.env["RAILWAY_API_TOKEN"]?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const configPath = path.join(homedir(), ".railway", "config.json");
+  if (!existsSync(configPath)) {
+    throw new RailwayTemplateDraftError(
+      "Set RAILWAY_API_TOKEN or log in with the Railway CLI first",
+    );
+  }
+
+  const config = readJson(configPath);
+  if (
+    !isRecord(config) ||
+    !isRecord(config["user"]) ||
+    typeof config["user"]["accessToken"] !== "string"
+  ) {
+    throw new RailwayTemplateDraftError(
+      "Railway CLI config does not include an access token",
+    );
+  }
+
+  return config["user"]["accessToken"];
+};
+
+const graphql = async (
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+) => {
+  const response = await fetch(RAILWAY_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+    signal: AbortSignal.timeout(RAILWAY_GRAPHQL_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new RailwayTemplateDraftError(
+      `Railway GraphQL request failed with status ${response.status}: ${response.statusText}`,
+    );
+  }
+
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)) {
+    throw new RailwayTemplateDraftError(
+      "Railway GraphQL returned invalid JSON",
+    );
+  }
+  const errors = payload["errors"];
+  if (Array.isArray(errors) && errors.length > 0) {
+    const messages = errors.map((error) => {
+      if (!isRecord(error) || typeof error["message"] !== "string") {
+        return "Unknown Railway GraphQL error";
+      }
+      return error["message"];
+    });
+    throw new RailwayTemplateDraftError(messages.join("; "));
+  }
+  if (!isRecord(payload["data"])) {
+    throw new RailwayTemplateDraftError("Railway GraphQL returned no data");
+  }
+  return payload["data"];
+};
+
+const normalizeTemplateValue = (value: string) =>
+  value.replaceAll(/\$\{\{\s*/gu, "${{").replaceAll(/\s*\}\}/gu, "}}");
+
+const sorted = (items: string[]) => [...items].sort();
+
+const sameStringSet = (left: string[], right: string[]) =>
+  JSON.stringify(sorted(left)) === JSON.stringify(sorted(right));
+
+const findServiceConfig = (
+  servicesConfig: Record<string, unknown>,
+  serviceName: string,
+) => {
+  for (const service of Object.values(servicesConfig)) {
+    if (!isRecord(service) || service["name"] !== serviceName) {
+      continue;
+    }
+    return service;
+  }
+
+  failures.push(`Template draft is missing service ${serviceName}`);
+  return undefined;
+};
+
+const validateServiceVariables = ({
+  draftService,
+  serviceName,
+  template,
+}: {
+  draftService: Record<string, unknown>;
+  serviceName: string;
+  template: ServiceTemplate;
+}) => {
+  const variablesConfig = draftService["variables"];
+  if (!isRecord(variablesConfig)) {
+    failures.push(`Template draft service ${serviceName} has no variables`);
+    return;
+  }
+
+  const expectedPromptKeys = Object.keys(template.requiredUserInputs);
+  const actualPromptKeys = Object.entries(variablesConfig)
+    .filter(([, variable]) => {
+      if (!isRecord(variable)) {
+        return false;
+      }
+      return variable["isOptional"] === false && !("defaultValue" in variable);
+    })
+    .map(([key]) => key);
+
+  if (!sameStringSet(actualPromptKeys, expectedPromptKeys)) {
+    failures.push(
+      `${serviceName} prompts ${sorted(actualPromptKeys).join(", ") || "(none)"}; expected ${sorted(expectedPromptKeys).join(", ") || "(none)"}`,
+    );
+  }
+
+  for (const [key, expectedValue] of Object.entries(template.variables)) {
+    if (expectedPromptKeys.includes(key)) {
+      continue;
+    }
+
+    const variable = variablesConfig[key];
+    if (!isRecord(variable)) {
+      failures.push(`${serviceName}.${key} is missing from the draft`);
+      continue;
+    }
+    if (typeof variable["defaultValue"] !== "string") {
+      failures.push(`${serviceName}.${key} must be prefilled in the draft`);
+      continue;
+    }
+    if (
+      normalizeTemplateValue(variable["defaultValue"]) !==
+      normalizeTemplateValue(expectedValue)
+    ) {
+      failures.push(
+        `${serviceName}.${key} has unexpected draft default ${variable["defaultValue"]}`,
+      );
+    }
+  }
+};
+
+const printUsage = () => {
+  console.log(
+    "Usage: bun scripts/check-railway-template-draft.ts --template <template-id>",
+  );
+};
+
+const main = async () => {
+  const { values } = parseArgs({
+    options: {
+      help: { type: "boolean", short: "h" },
+      template: { type: "string", short: "t" },
+    },
+  });
+
+  if (values.help) {
+    printUsage();
+    return;
+  }
+
+  const templateId = values.template?.trim();
+  if (!templateId) {
+    printUsage();
+    throw new RailwayTemplateDraftError("--template is required");
+  }
+
+  const manifest = readManifest();
+  const token = readRailwayToken();
+  const data = await graphql(
+    token,
+    `
+      query ($id: String!) {
+        template(id: $id) {
+          code
+          id
+          name
+          serializedConfig
+          status
+        }
+      }
+    `,
+    { id: templateId },
+  );
+
+  const template = data["template"];
+  if (template === null || template === undefined) {
+    throw new RailwayTemplateDraftError(
+      `Railway template ${templateId} not found`,
+    );
+  }
+  if (!isRecord(template)) {
+    throw new RailwayTemplateDraftError(
+      `Railway template ${templateId} returned invalid data`,
+    );
+  }
+  if (!isRecord(template["serializedConfig"])) {
+    throw new RailwayTemplateDraftError(
+      `Railway template ${templateId} has no serialized config`,
+    );
+  }
+
+  const servicesConfig = template["serializedConfig"]["services"];
+  if (!isRecord(servicesConfig)) {
+    throw new RailwayTemplateDraftError(
+      `Railway template ${templateId} has no service config`,
+    );
+  }
+
+  for (const [serviceName, serviceTemplate] of Object.entries(
+    manifest.services,
+  )) {
+    const draftService = findServiceConfig(servicesConfig, serviceName);
+    if (!draftService) {
+      continue;
+    }
+    validateServiceVariables({
+      draftService,
+      serviceName,
+      template: serviceTemplate,
+    });
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`railway-template-draft: ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `railway-template-draft: ok (${getString(template, "name")}, ${getString(template, "status")})`,
+  );
+};
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/check-railway-template-draft.ts
+++ b/scripts/check-railway-template-draft.ts
@@ -97,6 +97,28 @@ const readManifest = (): TemplateManifest => {
   return { services };
 };
 
+const readRailwayTokenFromConfig = (config: unknown) => {
+  if (!isRecord(config) || !isRecord(config["user"])) {
+    throw new RailwayTemplateDraftError(
+      "Railway CLI config does not include a user section",
+    );
+  }
+
+  const accessToken = config["user"]["accessToken"];
+  if (typeof accessToken === "string" && accessToken.trim()) {
+    return accessToken;
+  }
+
+  const token = config["user"]["token"];
+  if (typeof token === "string" && token.trim()) {
+    return token;
+  }
+
+  throw new RailwayTemplateDraftError(
+    "Railway CLI config does not include an access token",
+  );
+};
+
 const readRailwayToken = () => {
   const fromEnv = process.env["RAILWAY_API_TOKEN"]?.trim();
   if (fromEnv) {
@@ -111,17 +133,7 @@ const readRailwayToken = () => {
   }
 
   const config = readJson(configPath);
-  if (
-    !isRecord(config) ||
-    !isRecord(config["user"]) ||
-    typeof config["user"]["accessToken"] !== "string"
-  ) {
-    throw new RailwayTemplateDraftError(
-      "Railway CLI config does not include an access token",
-    );
-  }
-
-  return config["user"]["accessToken"];
+  return readRailwayTokenFromConfig(config);
 };
 
 const graphql = async (

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -15,6 +15,8 @@ const WEB_VITE_CONFIG_PATH = "apps/web/vite.config.ts";
 const API_DOCKERFILE_PATH = "apps/api/Dockerfile";
 const WEB_DOCKERFILE_PATH = "apps/web/Dockerfile";
 const railwayTemplateReference = (value: string) => `\${{${value}}}`;
+const railwaySecretReference = (length: number, alphabet: string) =>
+  railwayTemplateReference(`secret(${String(length)}, "${alphabet}")`);
 const railwayPublicUrlReference = (serviceName: string) =>
   `https://${railwayTemplateReference(`${serviceName}.RAILWAY_PUBLIC_DOMAIN`)}`;
 
@@ -324,12 +326,19 @@ expect(
 const apiTemplate = getRecord(templateManifest, "api");
 const webTemplate = getRecord(templateManifest, "web");
 const gotenbergTemplate = getRecord(templateManifest, "gotenberg");
+const postgresTemplate = getRecord(templateManifest, "Postgres");
+const redisTemplate = getRecord(templateManifest, "Redis");
 const apiTemplateVariables = getStringRecord(apiTemplate, "variables");
 const webTemplateVariables = getStringRecord(webTemplate, "variables");
 const gotenbergTemplateVariables = getStringRecord(
   gotenbergTemplate,
   "variables",
 );
+const postgresTemplateVariables = getStringRecord(
+  postgresTemplate,
+  "variables",
+);
+const redisTemplateVariables = getStringRecord(redisTemplate, "variables");
 const apiRequiredUserInputs = getStringRecord(
   apiTemplate,
   "requiredUserInputs",
@@ -348,30 +357,24 @@ expect(
   "Gotenberg must stay private in the template",
 );
 
-const expectedUserInputs = [
-  "SMTP_HOST",
-  "SMTP_PASSWORD",
-  "SMTP_PORT",
-  "SMTP_USERNAME",
-  "TRANSACTIONAL_EMAIL_FROM",
-];
+const expectedUserInputs = ["SMTP_PASSWORD", "TRANSACTIONAL_EMAIL_FROM"];
 expect(
   JSON.stringify(Object.keys(apiRequiredUserInputs).sort()) ===
     JSON.stringify(expectedUserInputs),
-  "Railway template must only require SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USERNAME, and TRANSACTIONAL_EMAIL_FROM",
+  "Railway template must only require SMTP_PASSWORD and TRANSACTIONAL_EMAIL_FROM",
 );
 
 const expectedPlaceholderApiVariables: Record<string, string> = {
-  SMTP_HOST: "smtp.example.invalid",
+  SMTP_HOST: "smtp.resend.com",
   SMTP_PASSWORD: "smtp-password",
   SMTP_PORT: "587",
-  SMTP_USERNAME: "smtp-user",
+  SMTP_USERNAME: "resend",
   TRANSACTIONAL_EMAIL_FROM: "noreply@example.invalid",
 };
 for (const [key, value] of Object.entries(expectedPlaceholderApiVariables)) {
   expect(
     apiTemplateVariables[key] === value,
-    `API template variable ${key} must use the inert placeholder ${value}`,
+    `API template variable ${key} must use the template default ${value}`,
   );
 }
 
@@ -393,6 +396,50 @@ for (const [key, value] of Object.entries(expectedApiReferenceVariables)) {
   );
 }
 
+const expectedPostgresVariables: Record<string, string> = {
+  DATABASE_PUBLIC_URL: `postgresql://${railwayTemplateReference("PGUSER")}:${railwayTemplateReference("POSTGRES_PASSWORD")}@${railwayTemplateReference("RAILWAY_TCP_PROXY_DOMAIN")}:${railwayTemplateReference("RAILWAY_TCP_PROXY_PORT")}/${railwayTemplateReference("PGDATABASE")}`,
+  DATABASE_URL: `postgresql://${railwayTemplateReference("PGUSER")}:${railwayTemplateReference("POSTGRES_PASSWORD")}@${railwayTemplateReference("RAILWAY_PRIVATE_DOMAIN")}:5432/${railwayTemplateReference("PGDATABASE")}`,
+  PGDATA: "/var/lib/postgresql/data/pgdata",
+  PGDATABASE: railwayTemplateReference("POSTGRES_DB"),
+  PGHOST: railwayTemplateReference("RAILWAY_PRIVATE_DOMAIN"),
+  PGPASSWORD: railwayTemplateReference("POSTGRES_PASSWORD"),
+  PGPORT: "5432",
+  PGUSER: railwayTemplateReference("POSTGRES_USER"),
+  POSTGRES_DB: "railway",
+  POSTGRES_PASSWORD: railwaySecretReference(
+    32,
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  ),
+  POSTGRES_USER: "postgres",
+  RAILWAY_DEPLOYMENT_DRAINING_SECONDS: "60",
+  SSL_CERT_DAYS: "820",
+};
+for (const [key, value] of Object.entries(expectedPostgresVariables)) {
+  expect(
+    postgresTemplateVariables[key] === value,
+    `Postgres template variable ${key} must be ${value}`,
+  );
+}
+
+const expectedRedisVariables: Record<string, string> = {
+  REDISHOST: railwayTemplateReference("RAILWAY_PRIVATE_DOMAIN"),
+  REDISPASSWORD: railwayTemplateReference("REDIS_PASSWORD"),
+  REDISPORT: "6379",
+  REDISUSER: "default",
+  REDIS_PASSWORD: railwaySecretReference(
+    32,
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  ),
+  REDIS_PUBLIC_URL: `redis://default:${railwayTemplateReference("REDIS_PASSWORD")}@${railwayTemplateReference("RAILWAY_TCP_PROXY_DOMAIN")}:${railwayTemplateReference("RAILWAY_TCP_PROXY_PORT")}`,
+  REDIS_URL: `redis://${railwayTemplateReference("REDISUSER")}:${railwayTemplateReference("REDIS_PASSWORD")}@${railwayTemplateReference("REDISHOST")}:${railwayTemplateReference("REDISPORT")}`,
+};
+for (const [key, value] of Object.entries(expectedRedisVariables)) {
+  expect(
+    redisTemplateVariables[key] === value,
+    `Redis template variable ${key} must be ${value}`,
+  );
+}
+
 for (const key of ["BETTER_AUTH_SECRET", "CONTENT_ENCRYPTION_KEY"]) {
   expect(
     apiTemplateVariables[key]?.includes("${{secret(") ?? false,
@@ -411,10 +458,8 @@ for (const key of [
 }
 
 expect(
-  gotenbergTemplateVariables["API_ENABLE_BASIC_AUTH"]?.includes(
-    "${{secret(",
-  ) ?? false,
-  "Gotenberg basic auth toggle must be generated instead of prompting users",
+  gotenbergTemplateVariables["API_ENABLE_BASIC_AUTH"] === "true",
+  "Gotenberg basic auth toggle must be prefilled instead of prompting users",
 );
 expect(
   apiTemplateVariables["PUBLIC_URL"] === railwayPublicUrlReference("api"),
@@ -454,11 +499,12 @@ expect(
 
 const forbiddenTemplateVariablePattern =
   /^(?:VITE_)?FEATURE_|^VITE_SELFHOST$|^NODE_ENV$|^EMAIL_PROVIDER$|^S3_CREDENTIALS_PROVIDER$/u;
-for (const [serviceName, variables] of [
+const templateVariableSets: [string, Record<string, string>][] = [
   ["api", apiTemplateVariables],
   ["web", webTemplateVariables],
   ["gotenberg", gotenbergTemplateVariables],
-]) {
+];
+for (const [serviceName, variables] of templateVariableSets) {
   for (const key of Object.keys(variables)) {
     expect(
       !forbiddenTemplateVariablePattern.test(key),

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -503,6 +503,8 @@ const templateVariableSets: [string, Record<string, string>][] = [
   ["api", apiTemplateVariables],
   ["web", webTemplateVariables],
   ["gotenberg", gotenbergTemplateVariables],
+  ["Postgres", postgresTemplateVariables],
+  ["Redis", redisTemplateVariables],
 ];
 for (const [serviceName, variables] of templateVariableSets) {
   for (const key of Object.keys(variables)) {


### PR DESCRIPTION
## Summary

- reduce Railway template user prompts to email password/API key and sender address
- codify managed service defaults for the Railway template manifest and shape check
- add a read-only checker for validating unpublished Railway template drafts
