### PR TITLE
fix: keep matter avatars below group headers

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -93,7 +93,7 @@ export const MatterCard = ({
             render={
               <div
                 className={cn(
-                  "bg-card relative flex flex-col gap-1 overflow-hidden rounded-xl border px-3 py-2 transition-colors",
+                  "bg-card relative isolate flex flex-col gap-1 overflow-hidden rounded-xl border px-3 py-2 transition-colors",
                   isOverdue
                     ? "bg-destructive/[0.04] hover:bg-destructive/[0.08]"
                     : "hover:bg-[var(--matter-tint)]",


### PR DESCRIPTION
## Summary
- isolate matter card stacking so avatar overlays stay within each card and do not paint over client group headers

## Verification
- not run; local checks were stopped to avoid adding load on the machine