### PR TITLE
fix: project chat tool JSON schemas to a provider-safe subset

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -173,6 +173,7 @@ const sendMessage = createSafeRootHandler(
     });
 
     yield* assertDevModelOverride(body.devModelId, orgAIConfig);
+    const externalMcpNullUnionStrategy = "json-schema";
 
     const accessibleWorkspaceIds = activeWorkspaceIds;
     /* eslint-disable no-body-ownership-ids/no-body-ownership-ids -- root handler; resolveChatScope validates against accessibleWorkspaceIds */
@@ -241,6 +242,7 @@ const sendMessage = createSafeRootHandler(
       body.message,
     )
       ? await loadExternalMcpToolsForUser({
+          nullUnionStrategy: externalMcpNullUnionStrategy,
           organizationId: session.activeOrganizationId,
           safeDb,
           userId: user.id,
@@ -618,6 +620,7 @@ const sendMessage = createSafeRootHandler(
     );
 
     const externalMcpTools = await loadExternalMcpToolsForUser({
+      nullUnionStrategy: externalMcpNullUnionStrategy,
       organizationId: session.activeOrganizationId,
       safeDb,
       userId: user.id,

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -9,6 +9,7 @@ import type {
   ChatMiddleware,
   ChatMiddlewareConfig,
   ModelMessage,
+  ServerTool,
   StreamChunk,
   TokenUsage,
   UIMessage,
@@ -79,6 +80,7 @@ import {
   ChatLoopDetectedError,
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
+import { nullUnionStrategyForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import {
   abortControllerFromSignal,
   mergeGenerationOptions,
@@ -86,6 +88,7 @@ import {
   systemPromptsPatch,
 } from "@/api/lib/tanstack-ai-generate";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
+import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
 
 const MAX_TOOL_STEPS = 100;
 const THIRD_PARTY_BOUNDARY_REFUSAL_MESSAGE =
@@ -352,6 +355,93 @@ const chatAttemptTerminalError = (
 ): ChatLoopDetectedError | ChatEmptyCompletionError | null =>
   state.finalLoopDetection ?? state.emptyCompletion;
 
+const projectChatToolSchemasForProvider = ({
+  modelTools,
+  provider,
+}: {
+  modelTools: ReturnType<typeof chatToolMapToArray>;
+  provider: string;
+}): ReturnType<typeof chatToolMapToArray> => {
+  const projectionOptions = {
+    nullUnionStrategy: nullUnionStrategyForTanStackProvider(provider),
+  };
+  const projectedTools: ReturnType<typeof chatToolMapToArray> = [];
+  for (const tool of modelTools) {
+    const projectedTool = { ...tool };
+    if (tool.inputSchema !== undefined) {
+      const inputSchema = projectSchemaInputJsonSchema(
+        tool.inputSchema,
+        projectionOptions,
+      );
+      if (inputSchema !== undefined) {
+        projectedTool.inputSchema = inputSchema;
+      }
+    }
+    if (tool.outputSchema !== undefined) {
+      const outputSchema = projectSchemaInputJsonSchema(
+        tool.outputSchema,
+        projectionOptions,
+      );
+      if (outputSchema !== undefined) {
+        projectedTool.outputSchema = outputSchema;
+      }
+    }
+    projectedTools.push(projectedTool);
+  }
+  return projectedTools;
+};
+
+const projectServerToolsForProvider = ({
+  provider,
+  serverTools,
+}: {
+  provider: string;
+  serverTools: readonly ServerTool[];
+}): ServerTool[] => {
+  const projectionOptions = {
+    nullUnionStrategy: nullUnionStrategyForTanStackProvider(provider),
+  };
+  const projectedTools: ServerTool[] = [];
+  for (const tool of serverTools) {
+    const projectedTool = { ...tool };
+    if (tool.inputSchema !== undefined) {
+      const inputSchema = projectSchemaInputJsonSchema(
+        tool.inputSchema,
+        projectionOptions,
+      );
+      if (inputSchema !== undefined) {
+        projectedTool.inputSchema = inputSchema;
+      }
+    }
+    if (tool.outputSchema !== undefined) {
+      const outputSchema = projectSchemaInputJsonSchema(
+        tool.outputSchema,
+        projectionOptions,
+      );
+      if (outputSchema !== undefined) {
+        projectedTool.outputSchema = outputSchema;
+      }
+    }
+    projectedTools.push(projectedTool);
+  }
+  return projectedTools;
+};
+
+const projectMcpToolSourceSchemasForProvider = ({
+  provider,
+  source,
+}: {
+  provider: string;
+  source: StellaMcpToolSource;
+}): StellaMcpToolSource => ({
+  close: source.close,
+  tools: async (options) =>
+    projectServerToolsForProvider({
+      provider,
+      serverTools: await source.tools(options),
+    }),
+});
+
 type ResolveFallbackTextModelProps = {
   organizationId: SafeId<"organization">;
   orgAIConfig: OrgAIConfig | null;
@@ -615,14 +705,20 @@ const runChatAttempt = async function* ({
   const stream = chat({
     adapter: model.adapter,
     messages: preparedMessages,
-    tools: modelTools,
+    tools: projectChatToolSchemasForProvider({
+      modelTools,
+      provider: model.provider,
+    }),
     ...(externalMcpToolSource
       ? {
           mcp: {
             clients: [
               prepareMcpToolSourceForThirdParty({
                 boundary: thirdPartyBoundary,
-                source: externalMcpToolSource,
+                source: projectMcpToolSourceSchemasForProvider({
+                  provider: model.provider,
+                  source: externalMcpToolSource,
+                }),
               }),
             ],
             connection: "close",

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-normalization.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-normalization.ts
@@ -7,6 +7,42 @@ import {
   CHAT_TOOL_POLICY_KIND,
 } from "@/api/handlers/chat/tools/tool-policy";
 import { namespaceMcpToolName } from "@/api/lib/mcp-upstream/namespace";
+import { logger } from "@/api/lib/observability/logger";
+import { projectToProviderSafeJsonSchema } from "@/api/lib/provider-safe-json-schema";
+
+// External MCP tools arrive with a raw JSON Schema `inputSchema` straight from
+// the upstream server (see `toServerTools` in @tanstack/ai-mcp). Providers such
+// as Gemini reject schemas that carry keywords outside their OpenAPI-3.0
+// subset, so project each one into the portable subset before it backs schema
+// validation and the live `mcp` source. Standard-schema wrappers (which carry
+// `~standard`) are first-party tools already projected at their own seam and
+// are left untouched.
+const isPlainJsonSchema = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  !("~standard" in value);
+
+const projectExternalMcpToolSchema = (tool: ChatTool): ChatTool => {
+  const { inputSchema } = tool;
+  if (!isPlainJsonSchema(inputSchema)) {
+    return tool;
+  }
+
+  const { schema, droppedKeywords } =
+    projectToProviderSafeJsonSchema(inputSchema);
+  if (droppedKeywords.length > 0) {
+    // Telemetry only: never throw. Attribute keys must dodge the API logger's
+    // sensitive-key sanitizer (drops keys matching name/title/etc.), so use
+    // `tool` and `droppedKeywords`, not `toolName`.
+    logger.warn("Projected external MCP tool schema to provider-safe subset", {
+      tool: tool.name,
+      droppedKeywords: droppedKeywords.join(", "),
+    });
+  }
+
+  return { ...tool, inputSchema: schema };
+};
 
 type NormalizeExternalMcpToolsForChatInput = {
   allowedTools: readonly string[] | null;
@@ -39,11 +75,11 @@ export const normalizeExternalMcpToolsForChat = ({
       connectorSlug,
       toolName: rawToolName,
     });
-    loadedTools[exposedToolName] = {
+    loadedTools[exposedToolName] = projectExternalMcpToolSchema({
       ...toolDefinition,
       name: exposedToolName,
       lazy: true,
-    };
+    });
   }
 
   // External MCP tools must always require approval here, regardless of the

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-normalization.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-normalization.ts
@@ -8,36 +8,48 @@ import {
 } from "@/api/handlers/chat/tools/tool-policy";
 import { namespaceMcpToolName } from "@/api/lib/mcp-upstream/namespace";
 import { logger } from "@/api/lib/observability/logger";
+import type { NullUnionStrategy } from "@/api/lib/provider-safe-json-schema";
 import { projectToProviderSafeJsonSchema } from "@/api/lib/provider-safe-json-schema";
 
 // External MCP tools arrive with a raw JSON Schema `inputSchema` straight from
 // the upstream server (see `toServerTools` in @tanstack/ai-mcp). Providers such
 // as Gemini reject schemas that carry keywords outside their OpenAPI-3.0
 // subset, so project each one into the portable subset before it backs schema
-// validation and the live `mcp` source. Standard-schema wrappers (which carry
-// `~standard`) are first-party tools already projected at their own seam and
-// are left untouched.
+// validation and the live `mcp` source. Actual Standard Schema wrappers are
+// first-party tools already projected at their own seam and are left untouched.
 const isPlainJsonSchema = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" &&
-  value !== null &&
-  !Array.isArray(value) &&
-  !("~standard" in value);
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
-const projectExternalMcpToolSchema = (tool: ChatTool): ChatTool => {
+const isStandardSchemaInput = (value: unknown): boolean => {
+  if (!isPlainJsonSchema(value)) {
+    return false;
+  }
+  const standard = value["~standard"];
+  return (
+    isPlainJsonSchema(standard) && typeof standard["validate"] === "function"
+  );
+};
+
+const projectExternalMcpToolSchema = (
+  tool: ChatTool,
+  nullUnionStrategy: NullUnionStrategy,
+): ChatTool => {
   const { inputSchema } = tool;
-  if (!isPlainJsonSchema(inputSchema)) {
+  if (!isPlainJsonSchema(inputSchema) || isStandardSchemaInput(inputSchema)) {
     return tool;
   }
 
-  const { schema, droppedKeywords } =
-    projectToProviderSafeJsonSchema(inputSchema);
+  const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+    inputSchema,
+    {
+      nullUnionStrategy,
+    },
+  );
   if (droppedKeywords.length > 0) {
-    // Telemetry only: never throw. Attribute keys must dodge the API logger's
-    // sensitive-key sanitizer (drops keys matching name/title/etc.), so use
-    // `tool` and `droppedKeywords`, not `toolName`.
+    // Telemetry only: never throw. External MCP metadata is user-configured, so
+    // log only aggregate projection data.
     logger.warn("Projected external MCP tool schema to provider-safe subset", {
-      tool: tool.name,
-      droppedKeywords: droppedKeywords.join(", "),
+      "schema.dropped_keyword_count": droppedKeywords.length,
     });
   }
 
@@ -47,6 +59,7 @@ const projectExternalMcpToolSchema = (tool: ChatTool): ChatTool => {
 type NormalizeExternalMcpToolsForChatInput = {
   allowedTools: readonly string[] | null;
   connectorSlug: string;
+  nullUnionStrategy: NullUnionStrategy;
   tools: readonly ChatTool[];
 };
 
@@ -58,6 +71,7 @@ type NormalizedExternalMcpToolsForChat = {
 export const normalizeExternalMcpToolsForChat = ({
   allowedTools,
   connectorSlug,
+  nullUnionStrategy,
   tools,
 }: NormalizeExternalMcpToolsForChatInput): NormalizedExternalMcpToolsForChat => {
   const allowedToolNames = allowedTools ? new Set(allowedTools) : null;
@@ -75,11 +89,14 @@ export const normalizeExternalMcpToolsForChat = ({
       connectorSlug,
       toolName: rawToolName,
     });
-    loadedTools[exposedToolName] = projectExternalMcpToolSchema({
-      ...toolDefinition,
-      name: exposedToolName,
-      lazy: true,
-    });
+    loadedTools[exposedToolName] = projectExternalMcpToolSchema(
+      {
+        ...toolDefinition,
+        name: exposedToolName,
+        lazy: true,
+      },
+      nullUnionStrategy,
+    );
   }
 
   // External MCP tools must always require approval here, regardless of the

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.test.ts
@@ -26,6 +26,7 @@ describe("external MCP chat tools", () => {
     const normalized = normalizeExternalMcpToolsForChat({
       allowedTools: ["lookup"],
       connectorSlug: "ares",
+      nullUnionStrategy: "json-schema",
       tools: [tool("lookup"), tool("deleteEverything")],
     });
 
@@ -39,6 +40,7 @@ describe("external MCP chat tools", () => {
     const normalized = normalizeExternalMcpToolsForChat({
       allowedTools: null,
       connectorSlug: "public registry",
+      nullUnionStrategy: "json-schema",
       tools: [original],
     });
 
@@ -57,11 +59,60 @@ describe("external MCP chat tools", () => {
     const normalized = normalizeExternalMcpToolsForChat({
       allowedTools: null,
       connectorSlug: "registry",
+      nullUnionStrategy: "json-schema",
       tools: [tool("lookup")],
     });
 
     expect(tool("lookup").needsApproval).toBeUndefined();
     expect(normalized.tools["mcp__registry__lookup"]?.needsApproval).toBe(true);
+  });
+
+  test("projects raw MCP JSON schemas even when they contain a standard-looking key", () => {
+    const normalized = normalizeExternalMcpToolsForChat({
+      allowedTools: null,
+      connectorSlug: "registry",
+      nullUnionStrategy: "openapi",
+      tools: [
+        {
+          ...tool("lookup"),
+          inputSchema: {
+            type: "object",
+            "~standard": {},
+            propertyNames: { type: "string" },
+            properties: {
+              mode: { enum: ["auto", null] },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(normalized.tools["mcp__registry__lookup"]?.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        mode: { enum: ["auto"], nullable: true },
+      },
+    });
+  });
+
+  test("keeps literal-null MCP branches through the JSON Schema validation prepass", () => {
+    const normalized = normalizeExternalMcpToolsForChat({
+      allowedTools: null,
+      connectorSlug: "registry",
+      nullUnionStrategy: "json-schema",
+      tools: [
+        {
+          ...tool("lookup"),
+          inputSchema: {
+            anyOf: [{ type: "string", minLength: 1 }, { const: null }],
+          },
+        },
+      ],
+    });
+
+    expect(normalized.tools["mcp__registry__lookup"]?.inputSchema).toEqual({
+      anyOf: [{ type: "string", minLength: 1 }, { type: "null" }],
+    });
   });
 });
 

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -18,6 +18,7 @@ import {
   loadActiveMcpConnectionsForUser,
 } from "@/api/lib/mcp-upstream/connections";
 import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
+import type { NullUnionStrategy } from "@/api/lib/provider-safe-json-schema";
 
 export type LoadedExternalMcpTools = {
   close: () => Promise<void> | void;
@@ -36,10 +37,12 @@ export type LoadedExternalMcpConnector = {
 };
 
 export const loadExternalMcpToolsForUser = async ({
+  nullUnionStrategy,
   organizationId,
   safeDb,
   userId,
 }: {
+  nullUnionStrategy: NullUnionStrategy;
   organizationId: SafeId<"organization">;
   safeDb: SafeDb;
   userId: SafeId<"user">;
@@ -61,6 +64,7 @@ export const loadExternalMcpToolsForUser = async ({
       clients,
       connectors,
       loadedTools,
+      nullUnionStrategy,
       organizationId,
       row,
       safeDb,
@@ -129,6 +133,7 @@ const loadConnectorTools = async ({
   clients,
   connectors,
   loadedTools,
+  nullUnionStrategy,
   organizationId,
   row,
   safeDb,
@@ -138,6 +143,7 @@ const loadConnectorTools = async ({
   clients: MCPClient[];
   connectors: LoadedExternalMcpConnector[];
   loadedTools: ChatToolMap;
+  nullUnionStrategy: NullUnionStrategy;
   organizationId: SafeId<"organization">;
   row: LoadedMcpConnection;
   safeDb: SafeDb;
@@ -160,6 +166,7 @@ const loadConnectorTools = async ({
     const normalized = normalizeExternalMcpToolsForChat({
       allowedTools: row.allowedTools,
       connectorSlug: row.slug,
+      nullUnionStrategy,
       tools,
     });
     Object.assign(loadedTools, normalized.tools);

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -21,6 +21,8 @@ import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-reg
 import { getChatToolPolicy } from "@/api/handlers/chat/tools/tool-policy";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
+import { PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS } from "@/api/lib/provider-safe-json-schema";
+import type { UrlFetcher, WebSearchProvider } from "@/api/lib/web-search/types";
 
 import { createOrgTools } from "./org-tools";
 import { createSkillTools } from "./skill-tools";
@@ -349,6 +351,129 @@ describe("chat tool schemas", () => {
       needsApproval: false,
       requiresAnonymization: false,
     });
+  });
+
+  test("every registered chat tool serializes to a provider-safe JSON schema", () => {
+    // Construct args so every conditional tool group registers: owner role
+    // (template use + create), active docx edit client, web search enabled with
+    // a resolved provider, and an editable active skill context. BOE, infosoud,
+    // and business-registry tools register by default (no disabled slugs).
+    const webSearchProvider: WebSearchProvider = {
+      name: "tavily",
+      search: async () => ({ results: [] }),
+    };
+    const urlFetcher: UrlFetcher = {
+      name: "jina",
+      fetch: async () => ({
+        url: "",
+        content: "",
+        truncated: false,
+        provider: "jina",
+      }),
+    };
+
+    const tools = getChatTools({
+      orgAIConfig: null,
+      memberRole: "owner",
+      organizationId,
+      refRegistry: createChatRefRegistry(),
+      safeDb: unusedSafeDb,
+      scopedDb: unusedScopedDb,
+      threadId,
+      userId,
+      toolWorkspaceIds: resolveToolWorkspaceIds({
+        pinnedIds: [],
+        accessibleWorkspaceIds: [workspaceId],
+      }),
+      hasActiveDocxEditClient: true,
+      webSearchEnabled: true,
+      webSearchProviders: { webSearchProvider, urlFetcher },
+      activeSkillContext: editableActiveSkillContext,
+      recordAuditEvent: noopAuditRecorder,
+      skillMetadata: [
+        {
+          description: editableActiveSkillContext.description,
+          name: editableActiveSkillContext.toolName,
+          version: editableActiveSkillContext.version,
+        },
+      ],
+    });
+
+    // Sanity: the groups we depend on for coverage are actually present.
+    for (const requiredTool of [
+      "fill_template",
+      "suggest_template_fields",
+      "business_registry_lookup",
+      "web_search",
+      "create-document",
+    ]) {
+      expect(tools).toHaveProperty(requiredTool);
+    }
+
+    const allowedKeywords = new Set<string>(PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS);
+    const isSchemaObject = (value: unknown): value is Record<string, unknown> =>
+      typeof value === "object" && value !== null && !Array.isArray(value);
+
+    const violations: string[] = [];
+    const assertProviderSafe = (
+      node: unknown,
+      path: string,
+      toolName: string,
+    ): void => {
+      if (!isSchemaObject(node)) {
+        return;
+      }
+
+      for (const key of Object.keys(node)) {
+        if (!allowedKeywords.has(key)) {
+          violations.push(
+            `tool "${toolName}" schema at "${path ? `${path}.${key}` : key}" carries non-provider-safe keyword "${key}"`,
+          );
+        }
+      }
+
+      const { properties, items, anyOf, additionalProperties } = node;
+      if (isSchemaObject(properties)) {
+        for (const [name, child] of Object.entries(properties)) {
+          assertProviderSafe(
+            child,
+            `${path ? `${path}.` : ""}properties.${name}`,
+            toolName,
+          );
+        }
+      }
+      if (Array.isArray(items)) {
+        for (const [index, child] of items.entries()) {
+          assertProviderSafe(child, `${path}.items[${index}]`, toolName);
+        }
+      } else if (isSchemaObject(items)) {
+        assertProviderSafe(items, `${path}.items`, toolName);
+      }
+      if (Array.isArray(anyOf)) {
+        for (const [index, child] of anyOf.entries()) {
+          assertProviderSafe(child, `${path}.anyOf[${index}]`, toolName);
+        }
+      }
+      if (isSchemaObject(additionalProperties)) {
+        assertProviderSafe(
+          additionalProperties,
+          `${path}.additionalProperties`,
+          toolName,
+        );
+      }
+    };
+
+    for (const [name, tool] of Object.entries(tools)) {
+      const inputSchema = tool?.inputSchema;
+      if (!inputSchema) {
+        continue;
+      }
+      // Serialize through the exact conversion the runtime hands to providers.
+      const serialized = convertSchemaToJsonSchema(inputSchema);
+      assertProviderSafe(serialized, "", name);
+    }
+
+    expect(violations).toEqual([]);
   });
 
   test("created document output includes the canonical entity mention", () => {

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -1,0 +1,153 @@
+import { convertSchemaToJsonSchema } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+import { projectToProviderSafeJsonSchema } from "@/api/lib/provider-safe-json-schema";
+
+const collectKeywords = (
+  node: unknown,
+  keywords = new Set<string>(),
+): Set<string> => {
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      collectKeywords(entry, keywords);
+    }
+    return keywords;
+  }
+  if (typeof node !== "object" || node === null) {
+    return keywords;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    keywords.add(key);
+    collectKeywords(value, keywords);
+  }
+  return keywords;
+};
+
+describe("projectToProviderSafeJsonSchema", () => {
+  test("drops propertyNames from the fill_template repro while keeping additionalProperties", () => {
+    const input = {
+      type: "object",
+      properties: {
+        templateId: { type: "string" },
+        values: {
+          type: "object",
+          propertyNames: { type: "string" },
+          additionalProperties: {},
+        },
+      },
+      required: ["templateId", "values"],
+    };
+
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(input);
+
+    expect(collectKeywords(schema).has("propertyNames")).toBe(false);
+    expect(droppedKeywords).toContain("properties.values.propertyNames");
+
+    const values = (schema["properties"] as Record<string, unknown>)["values"];
+    expect(values).toEqual({ type: "object", additionalProperties: {} });
+  });
+
+  test("lowers const to enum", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "string",
+      const: "cz",
+    });
+
+    expect(schema).toEqual({ type: "string", enum: ["cz"] });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("lowers oneOf to anyOf and recurses into branches", () => {
+    const { schema } = projectToProviderSafeJsonSchema({
+      oneOf: [
+        { type: "object", properties: { a: { type: "string", const: "x" } } },
+        { type: "number", exclusiveMinimum: 0 },
+      ],
+    });
+
+    expect(schema).toEqual({
+      anyOf: [
+        {
+          type: "object",
+          properties: { a: { type: "string", enum: ["x"] } },
+        },
+        { type: "number" },
+      ],
+    });
+    expect(collectKeywords(schema).has("oneOf")).toBe(false);
+    expect(collectKeywords(schema).has("exclusiveMinimum")).toBe(false);
+  });
+
+  test("lowers a nullable type array to nullable: true", () => {
+    const { schema } = projectToProviderSafeJsonSchema({
+      type: ["string", "null"],
+      description: "maybe a string",
+    });
+
+    expect(schema).toEqual({
+      type: "string",
+      nullable: true,
+      description: "maybe a string",
+    });
+  });
+
+  test("keeps the first entry of a bare type union and records the rest", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: ["string", "number"],
+    });
+
+    expect(schema).toEqual({ type: "string" });
+    expect(droppedKeywords).toEqual(["type[1]"]);
+  });
+
+  test("recurses through items and anyOf", () => {
+    const { schema } = projectToProviderSafeJsonSchema({
+      type: "array",
+      items: {
+        anyOf: [
+          { type: "string", pattern: "^a", propertyNames: { type: "string" } },
+          { type: "integer", minimum: 0 },
+        ],
+      },
+    });
+
+    expect(collectKeywords(schema).has("propertyNames")).toBe(false);
+    const items = schema["items"] as Record<string, unknown>;
+    const branches = items["anyOf"] as Record<string, unknown>[];
+    expect(branches[0]).toEqual({ type: "string", pattern: "^a" });
+    expect(branches[1]).toEqual({ type: "integer", minimum: 0 });
+  });
+
+  test("is idempotent: projecting a projected schema drops nothing", () => {
+    const input = {
+      type: "object",
+      properties: {
+        values: {
+          type: "object",
+          propertyNames: { type: "string" },
+          additionalProperties: {},
+        },
+      },
+      required: ["values"],
+    };
+
+    const once = projectToProviderSafeJsonSchema(input);
+    const twice = projectToProviderSafeJsonSchema(once.schema);
+
+    expect(twice.droppedKeywords).toEqual([]);
+    expect(twice.schema).toEqual(once.schema);
+  });
+
+  test("projects the valibot v.record shape through the tool funnel", () => {
+    const inputSchema = toTanStackToolSchema(
+      v.strictObject({ values: v.record(v.string(), v.unknown()) }),
+    );
+
+    const serialized = convertSchemaToJsonSchema(inputSchema);
+
+    expect(collectKeywords(serialized).has("propertyNames")).toBe(false);
+  });
+});

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -1,9 +1,19 @@
 import { convertSchemaToJsonSchema } from "@tanstack/ai";
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 import * as v from "valibot";
 
+import { propertyConfig } from "@stll/property-testing";
+
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
-import { projectToProviderSafeJsonSchema } from "@/api/lib/provider-safe-json-schema";
+import {
+  projectToProviderSafeJsonSchema,
+  PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
+} from "@/api/lib/provider-safe-json-schema";
+
+const PROVIDER_SAFE_KEYWORDS = new Set<string>(
+  PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
+);
 
 const collectKeywords = (
   node: unknown,
@@ -25,6 +35,86 @@ const collectKeywords = (
   }
   return keywords;
 };
+
+const collectProjectedSchemaKeywords = (
+  node: unknown,
+  keywords = new Set<string>(),
+  parentKeyword: string | null = null,
+): Set<string> => {
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      collectProjectedSchemaKeywords(entry, keywords, parentKeyword);
+    }
+    return keywords;
+  }
+  if (typeof node !== "object" || node === null) {
+    return keywords;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (parentKeyword !== "properties") {
+      keywords.add(key);
+    }
+    collectProjectedSchemaKeywords(value, keywords, key);
+  }
+  return keywords;
+};
+
+const assertOnlyProviderSafeKeywords = (schema: Record<string, unknown>) => {
+  for (const keyword of collectProjectedSchemaKeywords(schema)) {
+    expect(PROVIDER_SAFE_KEYWORDS.has(keyword)).toBe(true);
+  }
+};
+
+const schemaPropertyName = fc.constantFrom("query", "limit", "mode", "kind");
+
+const jsonSchemaLiteral = fc.oneof(
+  fc.string({ maxLength: 12 }),
+  fc.integer({ min: -20, max: 20 }),
+  fc.boolean(),
+  fc.constant(null),
+);
+
+const scalarSchema = fc.oneof(
+  fc.constant({ type: "string" }),
+  fc.constant({ type: "number" }),
+  fc.constant({ type: "boolean" }),
+  fc.record({
+    enum: fc.array(jsonSchemaLiteral, { minLength: 1, maxLength: 4 }),
+  }),
+  fc.record({
+    const: jsonSchemaLiteral,
+    type: fc.constantFrom("string", "number", "boolean"),
+  }),
+);
+
+const objectSchema = fc
+  .dictionary(schemaPropertyName, scalarSchema, { minKeys: 1, maxKeys: 4 })
+  .map((properties) => ({
+    type: "object",
+    properties,
+    propertyNames: { type: "string" },
+    required: Object.keys(properties).slice(0, 2),
+  }));
+
+const schemaWithComposition = fc.oneof(
+  scalarSchema,
+  objectSchema,
+  scalarSchema.map((schema) => ({
+    anyOf: [schema, { type: "null" }, { const: null }, { enum: [null] }],
+  })),
+  objectSchema.map((schema) => ({
+    allOf: [
+      schema,
+      {
+        additionalProperties: false,
+      },
+    ],
+  })),
+  scalarSchema.map((schema) => ({
+    oneOf: [schema, { type: "number", exclusiveMinimum: 0 }],
+  })),
+);
 
 describe("projectToProviderSafeJsonSchema", () => {
   test("drops propertyNames from the fill_template repro while keeping additionalProperties", () => {
@@ -66,6 +156,63 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(droppedKeywords).toEqual([]);
   });
 
+  test("lowers null const to null type for JSON Schema providers", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        const: null,
+      },
+      { nullUnionStrategy: "json-schema" },
+    );
+
+    expect(schema).toEqual({ type: "null" });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("drops const constraints that cannot be lowered to provider-safe enums", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "boolean",
+      const: true,
+    });
+
+    expect(schema).toEqual({ type: "boolean" });
+    expect(droppedKeywords).toEqual(["const"]);
+  });
+
+  test("records const when enum already carries the allowed values", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "string",
+      const: "cz",
+      enum: ["cz", "sk"],
+    });
+
+    expect(schema).toEqual({ type: "string", enum: ["cz", "sk"] });
+    expect(droppedKeywords).toEqual(["const"]);
+  });
+
+  test("preserves enum literals for JSON Schema providers", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        enum: ["ready", true, null, 1],
+      },
+      { nullUnionStrategy: "json-schema" },
+    );
+
+    expect(schema).toEqual({ enum: ["ready", true, null, 1] });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("filters enum literals that OpenAPI provider schemas do not support", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        enum: ["ready", true, null, 1],
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({ enum: ["ready", 1], nullable: true });
+    expect(droppedKeywords).toEqual(["enum[1]"]);
+  });
+
   test("lowers oneOf to anyOf and recurses into branches", () => {
     const { schema } = projectToProviderSafeJsonSchema({
       oneOf: [
@@ -87,44 +234,335 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(collectKeywords(schema).has("exclusiveMinimum")).toBe(false);
   });
 
-  test("lowers a nullable type array to nullable: true", () => {
-    const { schema } = projectToProviderSafeJsonSchema({
-      type: ["string", "null"],
-      description: "maybe a string",
+  test("merges compatible allOf object constraints before projection", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "object",
+      required: ["query"],
+      allOf: [
+        {
+          properties: {
+            query: { type: "string", minLength: 1 },
+          },
+        },
+        {
+          properties: {
+            limit: { type: "number", minimum: 1 },
+          },
+          required: ["limit"],
+        },
+      ],
     });
 
     expect(schema).toEqual({
-      type: "string",
-      nullable: true,
-      description: "maybe a string",
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 1 },
+        limit: { type: "number", minimum: 1 },
+      },
+      required: ["query", "limit"],
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("merges allOf property refinements before projection", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      allOf: [
+        {
+          properties: {
+            query: { minLength: 1 },
+          },
+          required: ["query"],
+        },
+      ],
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 1 },
+      },
+      required: ["query"],
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("keeps merging allOf branches when additionalProperties false is stricter", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "object",
+      additionalProperties: false,
+      allOf: [
+        {
+          additionalProperties: { type: "string" },
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+      ],
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("projects allOf branches before merging their constraints", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        type: "object",
+        allOf: [{ $ref: "#/$defs/base" }],
+        $defs: {
+          base: {
+            properties: {
+              kind: { const: "lookup" },
+              mode: { enum: ["auto", null] },
+            },
+            required: ["kind"],
+          },
+        },
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        kind: { enum: ["lookup"] },
+        mode: { enum: ["auto"], nullable: true },
+      },
+      required: ["kind"],
+    });
+    expect(droppedKeywords).toEqual(["allOf[0].$ref", "$defs"]);
+  });
+
+  test("preserves nullable type arrays for JSON Schema providers", () => {
+    const { schema } = projectToProviderSafeJsonSchema(
+      {
+        type: ["string", "null"],
+        description: "maybe a string",
+      },
+      { nullUnionStrategy: "json-schema" },
+    );
+
+    expect(schema).toEqual({
+      anyOf: [
+        { type: "string", description: "maybe a string" },
+        { type: "null", description: "maybe a string" },
+      ],
     });
   });
 
-  test("lowers a scalar null type to nullable: true", () => {
-    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
-      type: "null",
+  test("lowers nullable anyOf branches to nullable: true in OpenAPI mode", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        anyOf: [{ type: "string", minLength: 1 }, { type: "null" }],
+        description: "optional instructions",
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({
+      type: "string",
+      minLength: 1,
+      description: "optional instructions",
+      nullable: true,
     });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("treats null literal anyOf branches as nullable in OpenAPI mode", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        anyOf: [
+          { type: "string", minLength: 1 },
+          { const: null },
+          { enum: [null] },
+        ],
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({
+      type: "string",
+      minLength: 1,
+      nullable: true,
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("preserves literal-null branches across JSON Schema then OpenAPI projection", () => {
+    const jsonSchemaPass = projectToProviderSafeJsonSchema(
+      {
+        anyOf: [{ type: "string", minLength: 1 }, { const: null }],
+      },
+      { nullUnionStrategy: "json-schema" },
+    );
+    const openApiPass = projectToProviderSafeJsonSchema(jsonSchemaPass.schema, {
+      nullUnionStrategy: "openapi",
+    });
+
+    expect(jsonSchemaPass.schema).toEqual({
+      anyOf: [{ type: "string", minLength: 1 }, { type: "null" }],
+    });
+    expect(openApiPass.schema).toEqual({
+      type: "string",
+      minLength: 1,
+      nullable: true,
+    });
+    expect(jsonSchemaPass.droppedKeywords).toEqual([]);
+    expect(openApiPass.droppedKeywords).toEqual([]);
+  });
+
+  test("merges parent object constraints into anyOf branches without clobbering branch refinements", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        type: "object",
+        properties: {
+          mode: { type: "string" },
+          query: { type: "string" },
+        },
+        required: ["query"],
+        anyOf: [
+          {
+            properties: {
+              query: { minLength: 3 },
+            },
+            required: ["mode"],
+          },
+        ],
+      },
+      { nullUnionStrategy: "json-schema" },
+    );
+
+    expect(schema).toEqual({
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            mode: { type: "string" },
+            query: { type: "string", minLength: 3 },
+          },
+          required: ["query", "mode"],
+        },
+      ],
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("merges parent object constraints before collapsing nullable OpenAPI anyOf branches", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        anyOf: [
+          {
+            properties: {
+              query: { minLength: 3 },
+            },
+          },
+          { const: null },
+        ],
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 3 },
+      },
+      required: ["query"],
+      nullable: true,
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("lowers a scalar null type to nullable: true in OpenAPI mode", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        type: "null",
+      },
+      { nullUnionStrategy: "openapi" },
+    );
 
     expect(schema).toEqual({ nullable: true });
     expect(droppedKeywords).toEqual([]);
   });
 
-  test("lowers a multi-type union with null regardless of position", () => {
-    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
-      type: ["null", "string", "number"],
-    });
+  test("lowers a multi-type union with null in OpenAPI mode", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        type: ["null", "string", "number"],
+      },
+      { nullUnionStrategy: "openapi" },
+    );
 
-    expect(schema).toEqual({ type: "string", nullable: true });
-    expect(droppedKeywords).toEqual(["type[1]"]);
+    expect(schema).toEqual({
+      anyOf: [
+        { type: "string", nullable: true },
+        { type: "number", nullable: true },
+      ],
+    });
+    expect(droppedKeywords).toEqual([]);
   });
 
-  test("keeps the first entry of a bare type union and records the rest", () => {
+  test("lowers a bare type union to anyOf", () => {
     const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
       type: ["string", "number"],
     });
 
+    expect(schema).toEqual({
+      anyOf: [{ type: "string" }, { type: "number" }],
+    });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("drops unsupported type values", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: ["uuid", "string", 1],
+    });
+
     expect(schema).toEqual({ type: "string" });
-    expect(droppedKeywords).toEqual(["type[1]"]);
+    expect(droppedKeywords).toEqual(["type[0]", "type[2]"]);
+  });
+
+  test("re-enters lowerings after collapsing a nullable anyOf branch in OpenAPI mode", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        anyOf: [
+          {
+            type: ["string", "number"],
+            propertyNames: { type: "string" },
+          },
+          { type: "null" },
+        ],
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({
+      anyOf: [
+        { type: "string", nullable: true },
+        { type: "number", nullable: true },
+      ],
+    });
+    expect(droppedKeywords).toEqual([
+      "anyOf[0].propertyNames",
+      "anyOf[1].propertyNames",
+    ]);
   });
 
   test("recurses through items and anyOf", () => {
@@ -148,6 +586,60 @@ describe("projectToProviderSafeJsonSchema", () => {
         ],
       },
     });
+  });
+
+  test("collapses tuple-form items to a single provider-safe schema", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "array",
+      items: [{ type: "string", propertyNames: {} }, { type: "number" }],
+    });
+
+    expect(schema).toEqual({
+      type: "array",
+      items: {
+        anyOf: [{ type: "string" }, { type: "number" }],
+      },
+    });
+    expect(droppedKeywords).toEqual(["items", "items[0].propertyNames"]);
+  });
+
+  test("normalizes boolean schema nodes before returning them", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "object",
+      properties: {
+        allowed: true,
+        forbidden: false,
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        allowed: {},
+        forbidden: {},
+      },
+    });
+    expect(droppedKeywords).toEqual(["properties.forbidden"]);
+  });
+
+  test("dereferences local definitions before dropping unsupported ref keywords", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "object",
+      properties: {
+        id: { $ref: "#/$defs/Id" },
+      },
+      $defs: {
+        Id: { type: "string", minLength: 1 },
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        id: { type: "string", minLength: 1 },
+      },
+    });
+    expect(droppedKeywords).toEqual(["properties.id.$ref", "$defs"]);
   });
 
   test("is idempotent: projecting a projected schema drops nothing", () => {
@@ -178,5 +670,161 @@ describe("projectToProviderSafeJsonSchema", () => {
     const serialized = convertSchemaToJsonSchema(inputSchema);
 
     expect(collectKeywords(serialized).has("propertyNames")).toBe(false);
+  });
+
+  test("property: projection only emits provider-safe schema keywords", () => {
+    fc.assert(
+      fc.property(
+        schemaWithComposition,
+        fc.constantFrom("json-schema", "openapi" as const),
+        (input, nullUnionStrategy) => {
+          const { schema } = projectToProviderSafeJsonSchema(input, {
+            nullUnionStrategy,
+          });
+
+          assertOnlyProviderSafeKeywords(schema);
+        },
+      ),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+
+  test("property: projecting an already projected schema is stable", () => {
+    fc.assert(
+      fc.property(
+        schemaWithComposition,
+        fc.constantFrom("json-schema", "openapi" as const),
+        (input, nullUnionStrategy) => {
+          const first = projectToProviderSafeJsonSchema(input, {
+            nullUnionStrategy,
+          });
+          const second = projectToProviderSafeJsonSchema(first.schema, {
+            nullUnionStrategy,
+          });
+
+          expect(second.schema).toEqual(first.schema);
+          expect(second.droppedKeywords).toEqual([]);
+        },
+      ),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+
+  test("property: OpenAPI enum nulls become nullable instead of disappearing", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(fc.string({ maxLength: 8 }), fc.integer()), {
+          minLength: 1,
+          maxLength: 4,
+        }),
+        fc.boolean(),
+        (values, includeUnsupportedBoolean) => {
+          const enumValues = includeUnsupportedBoolean
+            ? [...values, null, true]
+            : [...values, null];
+          const { schema } = projectToProviderSafeJsonSchema(
+            { enum: enumValues },
+            { nullUnionStrategy: "openapi" },
+          );
+
+          expect(schema["nullable"]).toBe(true);
+          expect(schema["enum"]).toEqual(values);
+        },
+      ),
+      propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("property: compatible allOf property refinements survive projection", () => {
+    fc.assert(
+      fc.property(
+        schemaPropertyName,
+        fc.integer({ min: 1, max: 20 }),
+        fc.boolean(),
+        (propertyName, minLength, closeObject) => {
+          const { schema } = projectToProviderSafeJsonSchema({
+            type: "object",
+            additionalProperties: !closeObject,
+            properties: {
+              [propertyName]: { type: "string" },
+            },
+            allOf: [
+              {
+                additionalProperties: { type: "string" },
+                properties: {
+                  [propertyName]: { minLength },
+                },
+                required: [propertyName],
+              },
+            ],
+          });
+
+          expect(schema).toEqual({
+            type: "object",
+            additionalProperties: closeObject ? false : { type: "string" },
+            properties: {
+              [propertyName]: { type: "string", minLength },
+            },
+            required: [propertyName],
+          });
+        },
+      ),
+      propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("property: OpenAPI nullable allOf object wrappers keep property contracts", () => {
+    fc.assert(
+      fc.property(
+        schemaPropertyName,
+        fc.integer({ min: 1, max: 20 }),
+        (propertyName, minLength) => {
+          const { schema } = projectToProviderSafeJsonSchema(
+            {
+              type: ["object", "null"],
+              allOf: [
+                {
+                  type: "object",
+                  properties: {
+                    [propertyName]: { type: "string", minLength },
+                  },
+                  required: [propertyName],
+                },
+              ],
+            },
+            { nullUnionStrategy: "openapi" },
+          );
+
+          expect(schema).toEqual({
+            type: "object",
+            nullable: true,
+            properties: {
+              [propertyName]: { type: "string", minLength },
+            },
+            required: [propertyName],
+          });
+        },
+      ),
+      propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("property: OpenAPI nullable oneOf branches collapse to nullable schemas", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("string", "number", "boolean" as const),
+        (type) => {
+          const { schema } = projectToProviderSafeJsonSchema(
+            {
+              oneOf: [{ type }, { type: "null" }],
+            },
+            { nullUnionStrategy: "openapi" },
+          );
+
+          expect(schema).toEqual({ type, nullable: true });
+        },
+      ),
+      propertyConfig({ numRuns: 100 }),
+    );
   });
 });

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -94,6 +94,24 @@ describe("projectToProviderSafeJsonSchema", () => {
     });
   });
 
+  test("lowers a scalar null type to nullable: true", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: "null",
+    });
+
+    expect(schema).toEqual({ nullable: true });
+    expect(droppedKeywords).toEqual([]);
+  });
+
+  test("lowers a multi-type union with null regardless of position", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
+      type: ["null", "string", "number"],
+    });
+
+    expect(schema).toEqual({ type: "string", nullable: true });
+    expect(droppedKeywords).toEqual(["type[1]"]);
+  });
+
   test("keeps the first entry of a bare type union and records the rest", () => {
     const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
       type: ["string", "number"],

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -46,8 +46,14 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(collectKeywords(schema).has("propertyNames")).toBe(false);
     expect(droppedKeywords).toContain("properties.values.propertyNames");
 
-    const values = (schema["properties"] as Record<string, unknown>)["values"];
-    expect(values).toEqual({ type: "object", additionalProperties: {} });
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        templateId: { type: "string" },
+        values: { type: "object", additionalProperties: {} },
+      },
+      required: ["templateId", "values"],
+    });
   });
 
   test("lowers const to enum", () => {
@@ -133,10 +139,15 @@ describe("projectToProviderSafeJsonSchema", () => {
     });
 
     expect(collectKeywords(schema).has("propertyNames")).toBe(false);
-    const items = schema["items"] as Record<string, unknown>;
-    const branches = items["anyOf"] as Record<string, unknown>[];
-    expect(branches[0]).toEqual({ type: "string", pattern: "^a" });
-    expect(branches[1]).toEqual({ type: "integer", minimum: 0 });
+    expect(schema).toEqual({
+      type: "array",
+      items: {
+        anyOf: [
+          { type: "string", pattern: "^a" },
+          { type: "integer", minimum: 0 },
+        ],
+      },
+    });
   });
 
   test("is idempotent: projecting a projected schema drops nothing", () => {

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -90,27 +90,35 @@ const applyLowerings = (
     delete next["oneOf"];
   }
 
+  // Gemini's type enum has no "null"; nullability must be expressed via
+  // `nullable: true`. Lower a scalar "null", then any type union: strip
+  // "null" into `nullable`, keep the first remaining type, and record the
+  // rest as dropped.
   const typeValue = next["type"];
-  if (!Array.isArray(typeValue)) {
-    return next;
-  }
-
-  const nonNull = typeValue.filter((entry) => entry !== "null");
-  const hasNull = nonNull.length !== typeValue.length;
-
-  // ["X", "null"] -> type "X" + nullable: true
-  if (hasNull && typeValue.length === 2 && nonNull.length === 1) {
-    next["type"] = nonNull[0];
+  if (typeValue === "null") {
+    delete next["type"];
     if (!("nullable" in next)) {
       next["nullable"] = true;
     }
     return next;
   }
 
-  // Any other type array (bare union, or a union with "null" that is not the
-  // simple nullable case): keep the first entry, record the rest as dropped.
-  next["type"] = typeValue[0];
-  for (let index = 1; index < typeValue.length; index += 1) {
+  if (!Array.isArray(typeValue)) {
+    return next;
+  }
+
+  const nonNull = typeValue.filter((entry) => entry !== "null");
+  if (nonNull.length !== typeValue.length && !("nullable" in next)) {
+    next["nullable"] = true;
+  }
+
+  if (nonNull.length === 0) {
+    delete next["type"];
+    return next;
+  }
+
+  next["type"] = nonNull[0];
+  for (let index = 1; index < nonNull.length; index += 1) {
     dropped.push(`${joinPath(path, "type")}[${index}]`);
   }
   return next;

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -50,6 +50,15 @@ export const PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS = [
 ] as const;
 
 const ALLOWED_KEYWORDS = new Set<string>(PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS);
+const ALLOWED_TYPE_VALUES = new Set([
+  "array",
+  "boolean",
+  "integer",
+  "null",
+  "number",
+  "object",
+  "string",
+]);
 
 type JsonObject = Record<string, unknown>;
 
@@ -58,44 +67,565 @@ export type ProviderSafeJsonSchemaProjection = {
   droppedKeywords: readonly string[];
 };
 
+export type NullUnionStrategy = "json-schema" | "openapi";
+
+export type ProviderSafeJsonSchemaProjectionOptions = {
+  nullUnionStrategy?: NullUnionStrategy;
+};
+
+export const nullUnionStrategyForTanStackProvider = (
+  provider: string,
+): NullUnionStrategy => (provider === "google" ? "openapi" : "json-schema");
+
 const isJsonObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isUnknownArray = (value: unknown): value is unknown[] =>
+  Array.isArray(value);
 
 const joinPath = (path: string, key: string): string =>
   path ? `${path}.${key}` : key;
 
-/**
- * Semantics-preserving rewrites applied before the allowlist filter so common
- * draft-07 shapes survive projection instead of being dropped wholesale.
- */
-const applyLowerings = (
-  node: JsonObject,
-  path: string,
-  dropped: string[],
-): JsonObject => {
-  const next: JsonObject = { ...node };
+const jsonValueEquals = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
 
-  // const: X -> enum: [X]
-  if ("const" in next) {
-    const constValue = next["const"];
-    delete next["const"];
-    if (!("enum" in next)) {
-      next["enum"] = [constValue];
+const decodeJsonPointerSegment = (segment: string): string =>
+  segment.replaceAll("~1", "/").replaceAll("~0", "~");
+
+const resolveLocalJsonPointer = (root: JsonObject, ref: string): unknown => {
+  if (!ref.startsWith("#/")) {
+    return undefined;
+  }
+
+  let current: unknown = root;
+  for (const segment of ref.slice(2).split("/")) {
+    if (!isJsonObject(current)) {
+      return undefined;
+    }
+    current = current[decodeJsonPointerSegment(segment)];
+  }
+  return current;
+};
+
+type ProjectionContext = {
+  root: JsonObject;
+  dropped: string[];
+  nullUnionStrategy: NullUnionStrategy;
+};
+
+type NormalizeSchemaDialectParams = {
+  node: JsonObject;
+  path: string;
+  context: ProjectionContext;
+  seenRefs: ReadonlySet<string>;
+};
+
+type ProjectNodeParams = {
+  node: unknown;
+  path: string;
+  context: ProjectionContext;
+  seenRefs: ReadonlySet<string>;
+};
+
+const withBranchSiblings = (branch: unknown, siblings: JsonObject): unknown => {
+  if (!isJsonObject(branch)) {
+    return branch;
+  }
+
+  const candidate = { ...siblings };
+  if (mergeJsonSchemaObject(candidate, branch)) {
+    return candidate;
+  }
+
+  return { ...siblings, ...branch };
+};
+
+const branchesForTypes = (
+  typeBranches: readonly string[],
+  siblings: JsonObject,
+): JsonObject[] => {
+  const branches: JsonObject[] = [];
+  for (const type of typeBranches) {
+    branches.push({ type, ...siblings });
+  }
+  return branches;
+};
+
+const isAllowedTypeValue = (value: unknown): value is string =>
+  typeof value === "string" && ALLOWED_TYPE_VALUES.has(value);
+
+const normalizeConstKeyword = ({
+  context,
+  next,
+  path,
+}: {
+  context: ProjectionContext;
+  next: JsonObject;
+  path: string;
+}): void => {
+  if (!("const" in next)) {
+    return;
+  }
+
+  const constValue = next["const"];
+  delete next["const"];
+  if (constValue === null && !("enum" in next) && !("type" in next)) {
+    if (context.nullUnionStrategy === "json-schema") {
+      next["type"] = "null";
+      return;
+    }
+
+    next["nullable"] = true;
+    return;
+  }
+
+  if (
+    !("enum" in next) &&
+    (typeof constValue === "string" || typeof constValue === "number")
+  ) {
+    next["enum"] = [constValue];
+    return;
+  }
+
+  context.dropped.push(joinPath(path, "const"));
+};
+
+const filterOpenApiEnumValues = ({
+  context,
+  next,
+  path,
+}: {
+  context: ProjectionContext;
+  next: JsonObject;
+  path: string;
+}): void => {
+  if (!isUnknownArray(next["enum"])) {
+    return;
+  }
+
+  if (context.nullUnionStrategy === "json-schema") {
+    return;
+  }
+
+  const providerSafeValues: unknown[] = [];
+  for (const [index, value] of next["enum"].entries()) {
+    if (typeof value === "string" || typeof value === "number") {
+      providerSafeValues.push(value);
+      continue;
+    }
+    if (value === null) {
+      next["nullable"] = true;
+      continue;
+    }
+    context.dropped.push(`${joinPath(path, "enum")}[${index}]`);
+  }
+
+  if (providerSafeValues.length === 0) {
+    delete next["enum"];
+    return;
+  }
+
+  next["enum"] = providerSafeValues;
+};
+
+const normalizeLiteralKeywords = ({
+  context,
+  next,
+  path,
+}: {
+  context: ProjectionContext;
+  next: JsonObject;
+  path: string;
+}): void => {
+  normalizeConstKeyword({ context, next, path });
+  filterOpenApiEnumValues({ context, next, path });
+};
+
+const stringArrayFrom = (value: unknown): string[] | null => {
+  if (!isUnknownArray(value)) {
+    return null;
+  }
+
+  const strings: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      return null;
+    }
+    strings.push(entry);
+  }
+  return strings;
+};
+
+const typeArrayFrom = (value: unknown): string[] | null => {
+  if (typeof value === "string") {
+    return [value];
+  }
+  return stringArrayFrom(value);
+};
+
+const numberFrom = (value: unknown): number | null =>
+  typeof value === "number" ? value : null;
+
+const mergeRequired = (target: JsonObject, value: unknown): boolean => {
+  const required = stringArrayFrom(value);
+  if (!required) {
+    return false;
+  }
+
+  const existing = stringArrayFrom(target["required"]) ?? [];
+  target["required"] = Array.from(new Set([...existing, ...required]));
+  return true;
+};
+
+const mergeEnum = (target: JsonObject, value: unknown): boolean => {
+  if (!isUnknownArray(value)) {
+    return false;
+  }
+
+  const existing = target["enum"];
+  if (existing === undefined) {
+    target["enum"] = value;
+    return true;
+  }
+  if (!isUnknownArray(existing)) {
+    return false;
+  }
+
+  const intersection = existing.filter((entry) =>
+    value.some((candidate) => jsonValueEquals(candidate, entry)),
+  );
+  if (intersection.length === 0) {
+    return false;
+  }
+
+  target["enum"] = intersection;
+  return true;
+};
+
+const mergeAdditionalProperties = (
+  target: JsonObject,
+  value: unknown,
+): boolean => {
+  const existing = target["additionalProperties"];
+  if (existing === false) {
+    return true;
+  }
+  if (existing === undefined || existing === true) {
+    target["additionalProperties"] = value;
+    return true;
+  }
+  if (value === true || jsonValueEquals(existing, value)) {
+    return true;
+  }
+  if (existing !== false && value === false) {
+    target["additionalProperties"] = false;
+    return true;
+  }
+  return false;
+};
+
+const mergeType = (target: JsonObject, value: unknown): boolean => {
+  const incomingTypes = typeArrayFrom(value);
+  if (!incomingTypes) {
+    return false;
+  }
+
+  const existing = target["type"];
+  if (existing === undefined) {
+    target["type"] = value;
+    return true;
+  }
+
+  const existingTypes = typeArrayFrom(existing);
+  if (!existingTypes) {
+    return false;
+  }
+
+  const incomingTypeSet = new Set(incomingTypes);
+  const sharedTypes = existingTypes.filter((type) => incomingTypeSet.has(type));
+  if (sharedTypes.length === 0) {
+    return false;
+  }
+
+  if (
+    existingTypes.includes("null") &&
+    sharedTypes.some((type) => type !== "null")
+  ) {
+    target["type"] = existing;
+    return true;
+  }
+
+  target["type"] = sharedTypes.length === 1 ? sharedTypes.at(0) : sharedTypes;
+  return true;
+};
+
+const mergeNumberBound = ({
+  mode,
+  target,
+  key,
+  value,
+}: {
+  mode: "max" | "min";
+  target: JsonObject;
+  key: string;
+  value: unknown;
+}): boolean => {
+  const next = numberFrom(value);
+  if (next === null) {
+    return false;
+  }
+
+  const existing = target[key];
+  if (existing === undefined) {
+    target[key] = next;
+    return true;
+  }
+
+  const current = numberFrom(existing);
+  if (current === null) {
+    return false;
+  }
+
+  target[key] =
+    mode === "max" ? Math.max(current, next) : Math.min(current, next);
+  return true;
+};
+
+const mergeJsonSchemaKeyword = ({
+  key,
+  target,
+  value,
+}: {
+  key: string;
+  target: JsonObject;
+  value: unknown;
+}): boolean => {
+  if (key === "properties") {
+    return mergeProperties(target, value);
+  }
+  if (key === "required") {
+    return mergeRequired(target, value);
+  }
+  if (key === "enum") {
+    return mergeEnum(target, value);
+  }
+  if (key === "additionalProperties") {
+    return mergeAdditionalProperties(target, value);
+  }
+  if (key === "type") {
+    return mergeType(target, value);
+  }
+  if (key === "minimum" || key === "minItems" || key === "minLength") {
+    return mergeNumberBound({ key, mode: "max", target, value });
+  }
+  if (key === "maximum" || key === "maxItems" || key === "maxLength") {
+    return mergeNumberBound({ key, mode: "min", target, value });
+  }
+
+  const existing = target[key];
+  if (existing === undefined) {
+    target[key] = value;
+    return true;
+  }
+  return jsonValueEquals(existing, value);
+};
+
+const mergeJsonSchemaObject = (
+  target: JsonObject,
+  source: JsonObject,
+): boolean => {
+  for (const [key, value] of Object.entries(source)) {
+    if (!mergeJsonSchemaKeyword({ key, target, value })) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const mergeProperties = (target: JsonObject, value: unknown): boolean => {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+
+  const existingValue = target["properties"];
+  const properties: JsonObject = isJsonObject(existingValue)
+    ? { ...existingValue }
+    : {};
+
+  for (const [key, propertySchema] of Object.entries(value)) {
+    const existingPropertySchema = properties[key];
+    if (existingPropertySchema === undefined) {
+      properties[key] = propertySchema;
+      continue;
+    }
+    if (
+      !isJsonObject(existingPropertySchema) ||
+      !isJsonObject(propertySchema)
+    ) {
+      if (!jsonValueEquals(existingPropertySchema, propertySchema)) {
+        return false;
+      }
+      continue;
+    }
+
+    const mergedPropertySchema = { ...existingPropertySchema };
+    if (!mergeJsonSchemaObject(mergedPropertySchema, propertySchema)) {
+      return false;
+    }
+    properties[key] = mergedPropertySchema;
+  }
+
+  target["properties"] = properties;
+  return true;
+};
+
+const normalizeAllOfKeyword = ({
+  context,
+  next,
+  path,
+  seenRefs,
+}: {
+  context: ProjectionContext;
+  next: JsonObject;
+  path: string;
+  seenRefs: ReadonlySet<string>;
+}): JsonObject => {
+  if (!isUnknownArray(next["allOf"])) {
+    return next;
+  }
+
+  const droppedKeywordCount = context.dropped.length;
+  const candidate = { ...next };
+  delete candidate["allOf"];
+  for (const [index, branch] of next["allOf"].entries()) {
+    if (!isJsonObject(branch)) {
+      context.dropped.length = droppedKeywordCount;
+      return next;
+    }
+    const projectedBranch = projectNode({
+      node: branch,
+      path: `${joinPath(path, "allOf")}[${index}]`,
+      context,
+      seenRefs,
+    });
+    if (!isJsonObject(projectedBranch)) {
+      context.dropped.length = droppedKeywordCount;
+      return next;
+    }
+    if (!mergeJsonSchemaObject(candidate, projectedBranch)) {
+      context.dropped.length = droppedKeywordCount;
+      return next;
     }
   }
 
-  // oneOf: [...] -> anyOf: [...]
-  if ("oneOf" in next && !("anyOf" in next)) {
-    next["anyOf"] = next["oneOf"];
-    delete next["oneOf"];
+  return candidate;
+};
+
+const isNullOnlySchema = (entry: JsonObject): boolean => {
+  if (entry["type"] === "null" || entry["const"] === null) {
+    return true;
   }
 
-  // Gemini's type enum has no "null"; nullability must be expressed via
-  // `nullable: true`. Lower a scalar "null", then any type union: strip
-  // "null" into `nullable`, keep the first remaining type, and record the
-  // rest as dropped.
+  const entryType = entry["type"];
+  if (
+    isUnknownArray(entryType) &&
+    entryType.length > 0 &&
+    entryType.every((value) => value === "null")
+  ) {
+    return true;
+  }
+
+  const entryEnum = entry["enum"];
+  return (
+    isUnknownArray(entryEnum) &&
+    entryEnum.length > 0 &&
+    entryEnum.every((value) => value === null)
+  );
+};
+
+const normalizeAnyOfKeyword = ({
+  context,
+  next,
+  path,
+  seenRefs,
+}: {
+  context: ProjectionContext;
+  next: JsonObject;
+  path: string;
+  seenRefs: ReadonlySet<string>;
+}): JsonObject => {
+  if (!isUnknownArray(next["anyOf"])) {
+    return next;
+  }
+
+  const anyOf = next["anyOf"];
+  if (context.nullUnionStrategy === "json-schema") {
+    if (Object.keys(next).length <= 1) {
+      return next;
+    }
+
+    const branchSiblings = { ...next };
+    delete branchSiblings["anyOf"];
+    return {
+      anyOf: anyOf.map((branch) => withBranchSiblings(branch, branchSiblings)),
+    };
+  }
+
+  const nonNullBranches = anyOf.filter((entry) => {
+    if (!isJsonObject(entry)) {
+      return true;
+    }
+    return !isNullOnlySchema(entry);
+  });
+
+  if (nonNullBranches.length !== anyOf.length && !("nullable" in next)) {
+    next["nullable"] = true;
+  }
+
+  if (nonNullBranches.length === 0) {
+    delete next["anyOf"];
+    return next;
+  }
+
+  const branchSiblings = { ...next };
+  delete branchSiblings["anyOf"];
+  const branch = nonNullBranches.at(0);
+  if (nonNullBranches.length === 1 && isJsonObject(branch)) {
+    const mergedBranch = withBranchSiblings(branch, branchSiblings);
+    return normalizeSchemaDialect({
+      node: isJsonObject(mergedBranch) ? mergedBranch : branch,
+      path,
+      context,
+      seenRefs,
+    });
+  }
+
+  if (Object.keys(branchSiblings).length > 0) {
+    return {
+      anyOf: nonNullBranches.map((entry) =>
+        withBranchSiblings(entry, branchSiblings),
+      ),
+    };
+  }
+
+  next["anyOf"] = nonNullBranches;
+  return next;
+};
+
+const normalizeTypeKeyword = ({
+  context,
+  next,
+  path,
+}: {
+  context: ProjectionContext;
+  next: JsonObject;
+  path: string;
+}): JsonObject => {
   const typeValue = next["type"];
   if (typeValue === "null") {
+    if (context.nullUnionStrategy === "json-schema") {
+      return next;
+    }
     delete next["type"];
     if (!("nullable" in next)) {
       next["nullable"] = true;
@@ -103,86 +633,254 @@ const applyLowerings = (
     return next;
   }
 
-  if (!Array.isArray(typeValue)) {
+  if (!isUnknownArray(typeValue)) {
+    if (typeValue !== undefined && !isAllowedTypeValue(typeValue)) {
+      delete next["type"];
+      context.dropped.push(joinPath(path, "type"));
+    }
     return next;
   }
 
-  const nonNull = typeValue.filter((entry) => entry !== "null");
-  if (nonNull.length !== typeValue.length && !("nullable" in next)) {
+  const typeBranches: string[] = [];
+  const sawNullType = typeValue.includes("null");
+  for (const [index, entry] of typeValue.entries()) {
+    if (entry === "null") {
+      if (context.nullUnionStrategy === "json-schema") {
+        typeBranches.push(entry);
+      }
+      continue;
+    }
+    if (isAllowedTypeValue(entry)) {
+      typeBranches.push(entry);
+      continue;
+    }
+    context.dropped.push(`${joinPath(path, "type")}[${index}]`);
+  }
+
+  if (
+    context.nullUnionStrategy === "openapi" &&
+    sawNullType &&
+    !("nullable" in next)
+  ) {
     next["nullable"] = true;
   }
 
-  if (nonNull.length === 0) {
+  if (typeBranches.length === 0) {
     delete next["type"];
     return next;
   }
 
-  next["type"] = nonNull[0];
-  for (let index = 1; index < nonNull.length; index += 1) {
-    dropped.push(`${joinPath(path, "type")}[${index}]`);
+  if (typeBranches.length === 1) {
+    next["type"] = typeBranches.at(0);
+    return next;
   }
+
+  const branchSiblings = { ...next };
+  delete branchSiblings["type"];
+  delete next["type"];
+  if (!("anyOf" in next)) {
+    return { anyOf: branchesForTypes(typeBranches, branchSiblings) };
+  }
+
   return next;
 };
 
-const projectChild = (
-  key: string,
-  value: unknown,
-  path: string,
-  dropped: string[],
-): unknown => {
+/**
+ * Semantics-preserving rewrites applied before the allowlist filter so common
+ * draft-07 shapes survive projection instead of being dropped wholesale.
+ */
+const normalizeSchemaDialect = ({
+  node,
+  path,
+  context,
+  seenRefs,
+}: NormalizeSchemaDialectParams): JsonObject => {
+  const next: JsonObject = { ...node };
+
+  normalizeLiteralKeywords({ context, next, path });
+
+  const allOfLowered = normalizeAllOfKeyword({ context, next, path, seenRefs });
+
+  // oneOf: [...] -> anyOf: [...]
+  if ("oneOf" in allOfLowered && !("anyOf" in allOfLowered)) {
+    allOfLowered["anyOf"] = allOfLowered["oneOf"];
+    delete allOfLowered["oneOf"];
+  }
+
+  return normalizeTypeKeyword({
+    context,
+    next: normalizeAnyOfKeyword({
+      context,
+      next: allOfLowered,
+      path,
+      seenRefs,
+    }),
+    path,
+  });
+};
+
+type ProjectChildParams = {
+  key: string;
+  value: unknown;
+  path: string;
+  context: ProjectionContext;
+  seenRefs: ReadonlySet<string>;
+};
+
+const projectChild = ({
+  key,
+  value,
+  path,
+  context,
+  seenRefs,
+}: ProjectChildParams): unknown => {
   if (key === "properties" && isJsonObject(value)) {
     const projectedProperties: JsonObject = {};
     for (const [propertyName, propertySchema] of Object.entries(value)) {
-      projectedProperties[propertyName] = projectNode(
-        propertySchema,
-        joinPath(path, propertyName),
-        dropped,
-      );
+      projectedProperties[propertyName] = projectNode({
+        node: propertySchema,
+        path: joinPath(path, propertyName),
+        context,
+        seenRefs,
+      });
     }
     return projectedProperties;
   }
 
   if (key === "additionalProperties" && isJsonObject(value)) {
-    return projectNode(value, path, dropped);
+    return projectNode({ node: value, path, context, seenRefs });
   }
 
   if (key === "items") {
     if (Array.isArray(value)) {
-      return value.map((entry, index) =>
-        projectNode(entry, `${path}[${index}]`, dropped),
-      );
+      context.dropped.push(path);
+      if (value.length === 0) {
+        return {};
+      }
+      return {
+        anyOf: value.map((entry, index) =>
+          projectNode({
+            node: entry,
+            path: `${path}[${index}]`,
+            context,
+            seenRefs,
+          }),
+        ),
+      };
     }
-    return projectNode(value, path, dropped);
+    return projectNode({ node: value, path, context, seenRefs });
   }
 
   if (key === "anyOf" && Array.isArray(value)) {
     return value.map((entry, index) =>
-      projectNode(entry, `${path}[${index}]`, dropped),
+      projectNode({
+        node: entry,
+        path: `${path}[${index}]`,
+        context,
+        seenRefs,
+      }),
     );
   }
 
   return value;
 };
 
-const projectNode = (
-  node: unknown,
-  path: string,
-  dropped: string[],
-): unknown => {
+const resolveReferencedNode = ({
+  context,
+  node,
+  path,
+  seenRefs,
+}: {
+  context: ProjectionContext;
+  node: JsonObject;
+  path: string;
+  seenRefs: ReadonlySet<string>;
+}): ProjectNodeParams | null => {
+  const ref = node["$ref"];
+  if (typeof ref !== "string" || seenRefs.has(ref)) {
+    return null;
+  }
+
+  const referenced = resolveLocalJsonPointer(context.root, ref);
+  if (!isJsonObject(referenced)) {
+    return null;
+  }
+
+  const overrides = { ...node };
+  delete overrides["$ref"];
+  context.dropped.push(joinPath(path, "$ref"));
+  return {
+    node: { ...referenced, ...overrides },
+    path,
+    context,
+    seenRefs: new Set([...seenRefs, ref]),
+  };
+};
+
+const filterProviderSafeKeywords = ({
+  context,
+  node,
+  path,
+  seenRefs,
+}: {
+  context: ProjectionContext;
+  node: JsonObject;
+  path: string;
+  seenRefs: ReadonlySet<string>;
+}): JsonObject => {
+  const result: JsonObject = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (!ALLOWED_KEYWORDS.has(key)) {
+      context.dropped.push(joinPath(path, key));
+      continue;
+    }
+    result[key] = projectChild({
+      key,
+      value,
+      path: joinPath(path, key),
+      context,
+      seenRefs,
+    });
+  }
+  return result;
+};
+
+const projectNode = ({
+  node,
+  path,
+  context,
+  seenRefs,
+}: ProjectNodeParams): unknown => {
+  if (typeof node === "boolean") {
+    if (!node) {
+      context.dropped.push(path);
+    }
+    return {};
+  }
+
   if (!isJsonObject(node)) {
     return node;
   }
 
-  const lowered = applyLowerings(node, path, dropped);
-  const result: JsonObject = {};
-  for (const [key, value] of Object.entries(lowered)) {
-    if (!ALLOWED_KEYWORDS.has(key)) {
-      dropped.push(joinPath(path, key));
-      continue;
-    }
-    result[key] = projectChild(key, value, joinPath(path, key), dropped);
+  // Provider projection is intentionally staged: resolve local references,
+  // normalize JSON Schema dialect features, then apply the provider allowlist.
+  const referencedNode = resolveReferencedNode({
+    context,
+    node,
+    path,
+    seenRefs,
+  });
+  if (referencedNode) {
+    return projectNode(referencedNode);
   }
-  return result;
+
+  const normalized = normalizeSchemaDialect({ node, path, context, seenRefs });
+  return filterProviderSafeKeywords({
+    node: normalized,
+    path,
+    context,
+    seenRefs,
+  });
 };
 
 /**
@@ -191,9 +889,19 @@ const projectNode = (
  */
 export const projectToProviderSafeJsonSchema = (
   schema: Record<string, unknown>,
+  options: ProviderSafeJsonSchemaProjectionOptions = {},
 ): ProviderSafeJsonSchemaProjection => {
-  const dropped: string[] = [];
-  const projected = projectNode(schema, "", dropped);
+  const context: ProjectionContext = {
+    root: schema,
+    dropped: [],
+    nullUnionStrategy: options.nullUnionStrategy ?? "json-schema",
+  };
+  const projected = projectNode({
+    node: schema,
+    path: "",
+    context,
+    seenRefs: new Set(),
+  });
   const safeSchema = isJsonObject(projected) ? projected : schema;
-  return { schema: safeSchema, droppedKeywords: dropped };
+  return { schema: safeSchema, droppedKeywords: context.dropped };
 };

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -1,0 +1,195 @@
+/**
+ * Provider-safe JSON Schema projection.
+ *
+ * Chat tool JSON Schemas are handed to model providers verbatim by the
+ * TanStack AI adapters (the Gemini adapter does zero sanitization). Google
+ * Gemini's `function_declarations[].parameters` only accepts an OpenAPI-3.0
+ * subset and rejects the whole request at JSON->proto parse time (HTTP 400
+ * `Unknown name "propertyNames"`) when a tool schema carries an unsupported
+ * keyword. One bad tool poisons every chat send.
+ *
+ * This module projects a JSON Schema into a portable subset with an
+ * allowlist (not a blocklist, so new/unknown keywords fail closed). A few
+ * semantics-preserving lowerings run first so common shapes survive
+ * (`const` -> `enum`, `oneOf` -> `anyOf`, nullable type arrays -> `nullable`).
+ * Everything outside the allowlist is dropped and recorded with a dotted path
+ * so logs are actionable.
+ *
+ * Keep this module dependency-free: it operates on plain JSON objects and is
+ * imported by both the first-party valibot funnel and the external-MCP
+ * normalization seam.
+ */
+
+/**
+ * Keywords Gemini's proto parser accepts inside `parameters`. Exported so the
+ * registry CI guard asserts against the same single source of truth.
+ *
+ * `additionalProperties` is empirically accepted; `propertyNames` is not.
+ */
+export const PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS = [
+  "type",
+  "format",
+  "title",
+  "description",
+  "nullable",
+  "enum",
+  "properties",
+  "required",
+  "items",
+  "anyOf",
+  "default",
+  "minimum",
+  "maximum",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "additionalProperties",
+  "example",
+] as const;
+
+type ProviderSafeKeyword = (typeof PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS)[number];
+
+const ALLOWED_KEYWORDS = new Set<string>(PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS);
+
+type JsonObject = Record<string, unknown>;
+
+export type ProviderSafeJsonSchemaProjection = {
+  schema: Record<string, unknown>;
+  droppedKeywords: readonly string[];
+};
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const joinPath = (path: string, key: string): string =>
+  path ? `${path}.${key}` : key;
+
+/**
+ * Semantics-preserving rewrites applied before the allowlist filter so common
+ * draft-07 shapes survive projection instead of being dropped wholesale.
+ */
+const applyLowerings = (
+  node: JsonObject,
+  path: string,
+  dropped: string[],
+): JsonObject => {
+  const next: JsonObject = { ...node };
+
+  // const: X -> enum: [X]
+  if ("const" in next) {
+    const constValue = next["const"];
+    delete next["const"];
+    if (!("enum" in next)) {
+      next["enum"] = [constValue];
+    }
+  }
+
+  // oneOf: [...] -> anyOf: [...]
+  if ("oneOf" in next && !("anyOf" in next)) {
+    next["anyOf"] = next["oneOf"];
+    delete next["oneOf"];
+  }
+
+  const typeValue = next["type"];
+  if (!Array.isArray(typeValue)) {
+    return next;
+  }
+
+  const nonNull = typeValue.filter((entry) => entry !== "null");
+  const hasNull = nonNull.length !== typeValue.length;
+
+  // ["X", "null"] -> type "X" + nullable: true
+  if (hasNull && typeValue.length === 2 && nonNull.length === 1) {
+    next["type"] = nonNull[0];
+    if (!("nullable" in next)) {
+      next["nullable"] = true;
+    }
+    return next;
+  }
+
+  // Any other type array (bare union, or a union with "null" that is not the
+  // simple nullable case): keep the first entry, record the rest as dropped.
+  next["type"] = typeValue[0];
+  for (let index = 1; index < typeValue.length; index += 1) {
+    dropped.push(`${joinPath(path, "type")}[${index}]`);
+  }
+  return next;
+};
+
+const projectChild = (
+  key: string,
+  value: unknown,
+  path: string,
+  dropped: string[],
+): unknown => {
+  if (key === "properties" && isJsonObject(value)) {
+    const projectedProperties: JsonObject = {};
+    for (const [propertyName, propertySchema] of Object.entries(value)) {
+      projectedProperties[propertyName] = projectNode(
+        propertySchema,
+        joinPath(path, propertyName),
+        dropped,
+      );
+    }
+    return projectedProperties;
+  }
+
+  if (key === "additionalProperties" && isJsonObject(value)) {
+    return projectNode(value, path, dropped);
+  }
+
+  if (key === "items") {
+    if (Array.isArray(value)) {
+      return value.map((entry, index) =>
+        projectNode(entry, `${path}[${index}]`, dropped),
+      );
+    }
+    return projectNode(value, path, dropped);
+  }
+
+  if (key === "anyOf" && Array.isArray(value)) {
+    return value.map((entry, index) =>
+      projectNode(entry, `${path}[${index}]`, dropped),
+    );
+  }
+
+  return value;
+};
+
+const projectNode = (
+  node: unknown,
+  path: string,
+  dropped: string[],
+): unknown => {
+  if (!isJsonObject(node)) {
+    return node;
+  }
+
+  const lowered = applyLowerings(node, path, dropped);
+  const result: JsonObject = {};
+  for (const [key, value] of Object.entries(lowered)) {
+    if (!ALLOWED_KEYWORDS.has(key)) {
+      dropped.push(joinPath(path, key));
+      continue;
+    }
+    result[key] = projectChild(key, value, joinPath(path, key), dropped);
+  }
+  return result;
+};
+
+/**
+ * Project a JSON Schema into the provider-safe subset. Pure: returns a fresh
+ * schema plus the dotted paths of every keyword that was dropped.
+ */
+export const projectToProviderSafeJsonSchema = (
+  schema: Record<string, unknown>,
+): ProviderSafeJsonSchemaProjection => {
+  const dropped: string[] = [];
+  const projected = projectNode(schema, "", dropped);
+  const safeSchema = isJsonObject(projected) ? projected : schema;
+  return { schema: safeSchema, droppedKeywords: dropped };
+};
+
+export type { ProviderSafeKeyword };

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -49,8 +49,6 @@ export const PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS = [
   "example",
 ] as const;
 
-type ProviderSafeKeyword = (typeof PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS)[number];
-
 const ALLOWED_KEYWORDS = new Set<string>(PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS);
 
 type JsonObject = Record<string, unknown>;
@@ -191,5 +189,3 @@ export const projectToProviderSafeJsonSchema = (
   const safeSchema = isJsonObject(projected) ? projected : schema;
   return { schema: safeSchema, droppedKeywords: dropped };
 };
-
-export type { ProviderSafeKeyword };

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -5,7 +5,10 @@ import * as v from "valibot";
 import type { CachingDecision } from "@/api/lib/ai-config";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
 import * as realTanStackAIModels from "@/api/lib/tanstack-ai-models";
-import { toTanStackValibotSchema } from "@/api/lib/tanstack-ai-schema";
+import {
+  projectSchemaInputJsonSchema,
+  toTanStackValibotSchema,
+} from "@/api/lib/tanstack-ai-schema";
 
 type CapturedChatOptions = {
   modelOptions?: unknown;
@@ -83,6 +86,27 @@ describe("TanStack AI structured output generation", () => {
     }
     expect(jsonSchema.type).toBe("object");
     expect(jsonSchema.properties).toHaveProperty("answer");
+  });
+
+  test("projects plain JSON schemas even when they contain a standard-looking key", () => {
+    const schema = projectSchemaInputJsonSchema(
+      {
+        type: "object",
+        "~standard": {},
+        propertyNames: { type: "string" },
+        properties: {
+          mode: { enum: ["auto", null] },
+        },
+      },
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        mode: { enum: ["auto"], nullable: true },
+      },
+    });
   });
 
   test("passes converted Valibot schemas to TanStack object generation", async () => {

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -18,6 +18,7 @@ import type {
 import type { TanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { nullUnionStrategyForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import { tanStackCacheControl } from "@/api/lib/tanstack-ai-caching";
 import {
   getTanStackTextModelById,
@@ -332,7 +333,9 @@ export const generateTanStackObjectForRole = async <
   const abortController = options.abortSignal
     ? abortControllerFromSignal(options.abortSignal)
     : undefined;
-  const tanStackOutputSchema = toTanStackValibotSchema(outputSchema);
+  const tanStackOutputSchema = toTanStackValibotSchema(outputSchema, {
+    nullUnionStrategy: nullUnionStrategyForTanStackProvider(model.provider),
+  });
 
   const output = await withStandardServiceTierFallback({
     model,
@@ -417,7 +420,9 @@ const streamTanStackStructuredOutput = async function* <
 }): AsyncIterable<TanStackStructuredOutputEvent<v.InferOutput<TSchema>>> {
   let completed = false;
   let rawJson = "";
-  const tanStackOutputSchema = toTanStackValibotSchema(outputSchema);
+  const tanStackOutputSchema = toTanStackValibotSchema(outputSchema, {
+    nullUnionStrategy: nullUnionStrategyForTanStackProvider(model.provider),
+  });
 
   const stream = iterateWithStandardServiceTierFallback({
     model,

--- a/apps/api/src/lib/tanstack-ai-schema.ts
+++ b/apps/api/src/lib/tanstack-ai-schema.ts
@@ -2,9 +2,11 @@ import type {
   StandardJSONSchemaV1,
   StandardSchemaV1,
 } from "@standard-schema/spec";
+import type { SchemaInput } from "@tanstack/ai";
 import { toStandardJsonSchema } from "@valibot/to-json-schema";
 import type { GenericSchema, InferInput, InferOutput } from "valibot";
 
+import type { ProviderSafeJsonSchemaProjectionOptions } from "@/api/lib/provider-safe-json-schema";
 import { projectToProviderSafeJsonSchema } from "@/api/lib/provider-safe-json-schema";
 
 export type TanStackValibotSchema<TSchema extends GenericSchema> =
@@ -15,6 +17,36 @@ type JsonObject = Record<string, unknown>;
 
 const isJsonObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isProjectableJsonSchemaInput = (
+  value: SchemaInput | undefined,
+): value is StandardJSONSchemaV1 => {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  const schemaObject: JsonObject = value;
+  const standard = schemaObject["~standard"];
+  if (!isJsonObject(standard)) {
+    return false;
+  }
+  const jsonSchema = standard["jsonSchema"];
+  return (
+    isJsonObject(jsonSchema) &&
+    typeof jsonSchema["input"] === "function" &&
+    typeof jsonSchema["output"] === "function"
+  );
+};
+
+const isStandardSchemaInput = (
+  value: SchemaInput | undefined,
+): value is StandardSchemaV1 => {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  const schemaObject: JsonObject = value;
+  const standard = schemaObject["~standard"];
+  return isJsonObject(standard) && typeof standard["validate"] === "function";
+};
 
 const strictifyObjectSchemas = (schema: unknown): unknown => {
   if (!isJsonObject(schema)) {
@@ -58,13 +90,18 @@ const strictifyJsonSchema = (
 // this pure path does not log.
 const toProviderSafeJsonSchema = (
   schema: Record<string, unknown>,
+  options: ProviderSafeJsonSchemaProjectionOptions,
 ): Record<string, unknown> =>
-  projectToProviderSafeJsonSchema(strictifyJsonSchema(schema)).schema;
+  projectToProviderSafeJsonSchema(strictifyJsonSchema(schema), options).schema;
 
 export const toTanStackValibotSchema = <TSchema extends GenericSchema>(
   schema: TSchema,
+  projectionOptions?: ProviderSafeJsonSchemaProjectionOptions,
 ): TanStackValibotSchema<TSchema> => {
   const standardSchema = toStandardJsonSchema(schema);
+  const providerProjectionOptions = projectionOptions ?? {
+    nullUnionStrategy: "json-schema",
+  };
   return {
     ...standardSchema,
     "~standard": {
@@ -73,12 +110,46 @@ export const toTanStackValibotSchema = <TSchema extends GenericSchema>(
         input: (options) =>
           toProviderSafeJsonSchema(
             standardSchema["~standard"].jsonSchema.input(options),
+            providerProjectionOptions,
           ),
         output: (options) =>
           toProviderSafeJsonSchema(
             standardSchema["~standard"].jsonSchema.output(options),
+            providerProjectionOptions,
           ),
       },
     },
   };
+};
+
+export const projectSchemaInputJsonSchema = (
+  schema: SchemaInput | undefined,
+  projectionOptions: ProviderSafeJsonSchemaProjectionOptions,
+): SchemaInput | undefined => {
+  if (isProjectableJsonSchemaInput(schema)) {
+    return {
+      ...schema,
+      "~standard": {
+        ...schema["~standard"],
+        jsonSchema: {
+          input: (options) =>
+            toProviderSafeJsonSchema(
+              schema["~standard"].jsonSchema.input(options),
+              projectionOptions,
+            ),
+          output: (options) =>
+            toProviderSafeJsonSchema(
+              schema["~standard"].jsonSchema.output(options),
+              projectionOptions,
+            ),
+        },
+      },
+    };
+  }
+
+  if (!isJsonObject(schema) || isStandardSchemaInput(schema)) {
+    return schema;
+  }
+
+  return projectToProviderSafeJsonSchema(schema, projectionOptions).schema;
 };

--- a/apps/api/src/lib/tanstack-ai-schema.ts
+++ b/apps/api/src/lib/tanstack-ai-schema.ts
@@ -30,7 +30,14 @@ const strictifyObjectSchemas = (schema: unknown): unknown => {
     next[key] = strictifyObjectSchemas(value);
   }
 
-  if (next["type"] === "object" && next["additionalProperties"] === undefined) {
+  // Nullable object schemas can arrive as a type union (e.g.
+  // ["object", "null"]) before the provider-safe projection lowers them,
+  // so match "object" inside arrays too.
+  const typeValue = next["type"];
+  const isObjectType =
+    typeValue === "object" ||
+    (Array.isArray(typeValue) && typeValue.includes("object"));
+  if (isObjectType && next["additionalProperties"] === undefined) {
     next["additionalProperties"] = false;
   }
 

--- a/apps/api/src/lib/tanstack-ai-schema.ts
+++ b/apps/api/src/lib/tanstack-ai-schema.ts
@@ -5,6 +5,8 @@ import type {
 import { toStandardJsonSchema } from "@valibot/to-json-schema";
 import type { GenericSchema, InferInput, InferOutput } from "valibot";
 
+import { projectToProviderSafeJsonSchema } from "@/api/lib/provider-safe-json-schema";
+
 export type TanStackValibotSchema<TSchema extends GenericSchema> =
   StandardJSONSchemaV1<InferInput<TSchema>, InferOutput<TSchema>> &
     StandardSchemaV1<InferInput<TSchema>, InferOutput<TSchema>>;
@@ -42,6 +44,16 @@ const strictifyJsonSchema = (
   return isJsonObject(strictified) ? strictified : schema;
 };
 
+// Providers (notably Google Gemini) reject tool schemas that carry keywords
+// outside their OpenAPI-3.0 subset. Project into the portable subset after
+// strictification injects `additionalProperties: false`. Dropped keywords here
+// are expected for known valibot shapes (e.g. `v.record` -> `propertyNames`);
+// this pure path does not log.
+const toProviderSafeJsonSchema = (
+  schema: Record<string, unknown>,
+): Record<string, unknown> =>
+  projectToProviderSafeJsonSchema(strictifyJsonSchema(schema)).schema;
+
 export const toTanStackValibotSchema = <TSchema extends GenericSchema>(
   schema: TSchema,
 ): TanStackValibotSchema<TSchema> => {
@@ -52,11 +64,11 @@ export const toTanStackValibotSchema = <TSchema extends GenericSchema>(
       ...standardSchema["~standard"],
       jsonSchema: {
         input: (options) =>
-          strictifyJsonSchema(
+          toProviderSafeJsonSchema(
             standardSchema["~standard"].jsonSchema.input(options),
           ),
         output: (options) =>
-          strictifyJsonSchema(
+          toProviderSafeJsonSchema(
             standardSchema["~standard"].jsonSchema.output(options),
           ),
       },

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -134,7 +134,7 @@ test("authenticated routes render without browser errors", async ({
   context,
   request,
 }) => {
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
 
   const cleanupTasks: (() => Promise<void>)[] = [];
 


### PR DESCRIPTION
## Summary

Google Gemini validates `function_declarations[].parameters` against an OpenAPI 3.0 subset and rejects the entire request at payload-parse time when any tool schema carries an unknown keyword. `@valibot/to-json-schema` emits `propertyNames` for every `v.record(...)`, and the TanStack provider adapters forward tool schemas verbatim, so a single record-typed tool parameter (e.g. `fill_template.values`) fails every chat send routed through the Gemini adapter with a 400.

This adds an allowlist-based projection of all outbound tool JSON Schemas into a provider-portable subset:

- `apps/api/src/lib/provider-safe-json-schema.ts`: recursive projection with semantics-preserving lowerings (`const` → `enum`, `oneOf` → `anyOf`, `["X","null"]` type arrays → `nullable: true`). Keywords outside the allowlist are dropped and recorded with dotted paths, so unknown constructs fail closed instead of poisoning the request.
- Wired into the valibot funnel (`toTanStackValibotSchema`), which covers every first-party chat tool and structured-output schemas.
- Wired into the external MCP normalization seam, where third-party servers hand us arbitrary JSON Schemas; drops are logged for observability.

## Class guard

A new registry test builds the full chat toolset with every conditional group registered and asserts each tool serializes to allowlisted keywords only, naming the tool and offending keyword path on failure. A tool schema construct that a strict provider would reject now fails CI instead of breaking sends at runtime.

Server-side validation of tool call payloads is unchanged; the projection only affects the model-facing schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat tool schemas are now automatically projected into a provider-safe form, improving compatibility for live tool use.
  * Enhanced handling for nullability, `oneOf`/union patterns, and `const`/enumerations when preparing tool definitions.

* **Bug Fixes**
  * Unsupported schema keywords are removed safely, with issues tracked via non-blocking warnings rather than failing requests.

* **Tests**
  * Added coverage to ensure all registered chat tools serialise to provider-safe schemas and that the projection behaves correctly across common JSON Schema shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->