### PR TITLE
feat: constructor-validated groupable SQL fragments and structured DB error codes in logs

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/sitemap.ts
+++ b/apps/api/src/handlers/case-law/decisions/sitemap.ts
@@ -6,6 +6,7 @@ import type { Static } from "elysia";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { groupableSql } from "@/api/lib/groupable-sql";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 
@@ -75,9 +76,17 @@ type SitemapDecisionRow = SitemapDecisionAlternate & {
 // values (e.g. the user-supplied `bucket` in getShardConditions) stay bound.
 // Exported for the grouped-query regression test, which renders each fragment in
 // both the SELECT list and the GROUP BY to assert Postgres accepts the grouping.
-export const decisionYearSql = sql<string>`COALESCE(to_char(${caseLawDecisions.decisionDate}, 'YYYY'), ${sql.raw(`'${SITEMAP_UNDATED_YEAR}'`)})`;
-export const decisionMonthSql = sql<string>`COALESCE(to_char(${caseLawDecisions.decisionDate}, 'MM'), ${sql.raw(`'${SITEMAP_UNDATED_MONTH}'`)})`;
-export const decisionBucketSql = sql<string>`lpad(mod(hashtext(${caseLawDecisions.id}::text)::bigint + 2147483648, ${sql.raw(String(SITEMAP_SHARD_BUCKET_COUNT))})::text, ${sql.raw(String(SITEMAP_SHARD_BUCKET_WIDTH))}, '0')`;
+// `groupableSql` enforces the inlining invariant at construction: a bound
+// constant here would panic at module load rather than fail a live query.
+export const decisionYearSql = groupableSql(
+  sql<string>`COALESCE(to_char(${caseLawDecisions.decisionDate}, 'YYYY'), ${sql.raw(`'${SITEMAP_UNDATED_YEAR}'`)})`,
+);
+export const decisionMonthSql = groupableSql(
+  sql<string>`COALESCE(to_char(${caseLawDecisions.decisionDate}, 'MM'), ${sql.raw(`'${SITEMAP_UNDATED_MONTH}'`)})`,
+);
+export const decisionBucketSql = groupableSql(
+  sql<string>`lpad(mod(hashtext(${caseLawDecisions.id}::text)::bigint + 2147483648, ${sql.raw(String(SITEMAP_SHARD_BUCKET_COUNT))})::text, ${sql.raw(String(SITEMAP_SHARD_BUCKET_WIDTH))}, '0')`,
+);
 
 const getCountryPathSegment = (country: string): string =>
   country.toLowerCase();

--- a/apps/api/src/handlers/entities/read-group-counts.ts
+++ b/apps/api/src/handlers/entities/read-group-counts.ts
@@ -16,6 +16,7 @@ import { tConditionNode } from "@/api/lib/conditions/contract";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { buildFilterConditions } from "@/api/lib/entity-filters";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { groupableSql } from "@/api/lib/groupable-sql";
 
 const STATUS_GROUP_ID = "_status";
 const KIND_GROUP_ID = "_kind";
@@ -29,8 +30,13 @@ const TASK_STATUS_VALUES = [
   "done",
   "cancelled",
 ] as const;
-const TASK_STATUS_SQL_VALUES = TASK_STATUS_VALUES.map(
-  (statusValue) => sql`${statusValue}`,
+// Inline the status literals with `sql.raw` rather than binding them: the
+// enclosing CASE expression is rendered into both the SELECT list and the
+// GROUP BY, and a bound value would get different placeholder numbers per
+// render, making Postgres reject the grouped query. These are fixed code
+// constants, never user input, so inlining is byte-identical and safe.
+const TASK_STATUS_SQL_VALUES = TASK_STATUS_VALUES.map((statusValue) =>
+  sql.raw(`'${statusValue}'`),
 );
 
 const readGroupCountsBodySchema = t.Object({
@@ -95,11 +101,11 @@ const readGroupCounts = createSafeHandler(
       // recognized task status collapse into the uncategorized (null) bucket;
       // mirrors buildStatusGroupCondition's value logic from
       // kanban-group-condition.
-      const statusBucketExpr = sql<string | null>`CASE
+      const statusBucketExpr = groupableSql(sql<string | null>`CASE
         WHEN ${entities.status} IN (${sql.join(TASK_STATUS_SQL_VALUES, sql`, `)})
         THEN ${entities.status}
         ELSE NULL
-      END`;
+      END`);
       const rows = yield* Result.await(
         safeDb((tx) =>
           tx

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -1,5 +1,6 @@
 import { panic } from "better-result";
 import { describe, expect, test } from "bun:test";
+import { DrizzleQueryError } from "drizzle-orm";
 
 import {
   connectionErrorFields,
@@ -216,6 +217,50 @@ describe("errorFingerprint", () => {
     for (const value of Object.values(fingerprint)) {
       expect(value).not.toContain("merger-secret");
     }
+  });
+
+  // A failed Drizzle query wraps the driver's PostgresError as a cause. The
+  // SQLSTATE (here 42803, a GROUP BY error) and schema identifiers are the
+  // actionable, non-PII detail; without them the 5xx fingerprint would carry
+  // only error types and diagnosis would need the RDS server logs.
+  test("surfaces the driver SQLSTATE and schema identifiers, all sanitizer-safe", () => {
+    const cause = Object.assign(new Error("grouping error"), {
+      code: "42803",
+      severity: "ERROR",
+      table: "entities",
+      routine: "check_ungrouped_columns",
+    });
+    const error = new DrizzleQueryError("query failed", [], cause);
+
+    const fingerprint = errorFingerprint(error);
+    expect(fingerprint["error.cause.pg_code"]).toBe("42803");
+    expect(fingerprint["error.cause.pg_table"]).toBe("entities");
+    expect(fingerprint["error.cause.pg_routine"]).toBe(
+      "check_ungrouped_columns",
+    );
+
+    // The whole fingerprint, pg fields included, survives the logger's key
+    // sanitizer unchanged: the SQLSTATE actually reaches the log sink.
+    const sanitized = sanitizeLogAttributes(fingerprint);
+    for (const [key, value] of Object.entries(fingerprint)) {
+      expect(sanitized?.[key]).toBe(value);
+    }
+    expect(sanitized?.["log.attributes_dropped"]).toBeUndefined();
+  });
+
+  test("adds nothing for a non-Postgres error, leaving key-dropping unchanged", () => {
+    const fingerprint = errorFingerprint(new Error("plain"));
+    for (const key of Object.keys(fingerprint)) {
+      expect(key.startsWith("error.cause.pg_")).toBe(false);
+    }
+    // Sensitive keys are still dropped normally; the pg additions do not widen
+    // what the sanitizer keeps.
+    const sanitized = sanitizeLogAttributes({
+      ...fingerprint,
+      userName: "alice",
+    });
+    expect(sanitized?.["userName"]).toBeUndefined();
+    expect(sanitized?.["log.attributes_dropped"]).toBe(1);
   });
 });
 

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -3,6 +3,7 @@ import { appendFile, mkdir, stat, truncate } from "node:fs/promises";
 import path from "node:path";
 
 import { envBase } from "@/api/env-base";
+import { pgErrorFields } from "@/api/lib/pg-error";
 
 /**
  * Extract a safe, structural error identifier for observability.
@@ -342,6 +343,11 @@ export const errorFingerprint = (error: unknown): ErrorFingerprint => {
       fingerprint["error.cause.frame"] = causeFrame;
     }
   }
+  // A Drizzle query failure wraps the driver's PostgresError as a cause; its
+  // SQLSTATE and schema identifiers are the actionable, non-PII detail. Without
+  // this the 5xx fingerprint carries only error types, and diagnosis needs the
+  // RDS server logs.
+  Object.assign(fingerprint, pgErrorFields(error));
   return fingerprint;
 };
 

--- a/apps/api/src/lib/groupable-sql.test.ts
+++ b/apps/api/src/lib/groupable-sql.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { groupableSql } from "@/api/lib/groupable-sql";
+
+const decisions = pgTable("decisions", {
+  id: text("id"),
+  decisionDate: timestamp("decision_date"),
+});
+
+// A grouped SELECT expression is matched by Postgres on rendered text, and
+// drizzle numbers bind placeholders per render, so a bound value inside a
+// fragment used in both the SELECT list and GROUP BY produces a mismatch.
+// `groupableSql` refuses to construct such a fragment.
+
+test("panics on a bare interpolated primitive (drizzle binds it as $n)", () => {
+  expect(() => groupableSql(sql`decision_date >= ${"2020-01-01"}`)).toThrow(
+    /bound/u,
+  );
+});
+
+test("panics on an explicit sql.param(...) value", () => {
+  expect(() => groupableSql(sql`x = ${sql.param("v")}`)).toThrow(/Param/u);
+});
+
+test("panics on an sql.placeholder(...)", () => {
+  expect(() => groupableSql(sql`x = ${sql.placeholder("p")}`)).toThrow(
+    /placeholder/u,
+  );
+});
+
+test("panics on a bound value nested inside a sub-fragment", () => {
+  const inner = sql`${decisions.decisionDate} < ${"2021-01-01"}`;
+  expect(() => groupableSql(sql`(${inner})`)).toThrow(/bound/u);
+});
+
+test("panics on a bound value inside a joined list", () => {
+  const values = ["a", "b"].map((value) => sql`${value}`);
+  expect(() =>
+    groupableSql(sql`status IN (${sql.join(values, sql`, `)})`),
+  ).toThrow(/bound/u);
+});
+
+test("accepts column references and sql.raw-inlined constants", () => {
+  const fragment = groupableSql(
+    sql<string>`COALESCE(to_char(${decisions.decisionDate}, 'YYYY'), ${sql.raw(`'undated'`)})`,
+  );
+  // Returns the same fragment untouched so callers can use it directly.
+  expect(fragment).toBeInstanceOf(sql`x`.constructor);
+});
+
+test("accepts a raw-only fragment", () => {
+  expect(() => groupableSql(sql`${sql.raw("count(*)::int")}`)).not.toThrow();
+});
+
+test("accepts an sql.raw-inlined list join", () => {
+  const values = ["open", "done"].map((value) => sql.raw(`'${value}'`));
+  expect(() =>
+    groupableSql(sql`status IN (${sql.join(values, sql`, `)})`),
+  ).not.toThrow();
+});
+
+test("the migrated sitemap fragments construct without panicking", async () => {
+  const fragments = await import("@/api/handlers/case-law/decisions/sitemap");
+  expect(fragments.decisionYearSql).toBeInstanceOf(sql`x`.constructor);
+  expect(fragments.decisionMonthSql).toBeInstanceOf(sql`x`.constructor);
+  expect(fragments.decisionBucketSql).toBeInstanceOf(sql`x`.constructor);
+});

--- a/apps/api/src/lib/groupable-sql.ts
+++ b/apps/api/src/lib/groupable-sql.ts
@@ -1,0 +1,125 @@
+import { panic } from "better-result";
+import {
+  Column,
+  is,
+  Name,
+  Placeholder,
+  Param,
+  SQL,
+  StringChunk,
+  Table,
+  View,
+} from "drizzle-orm";
+import type { SQLChunk } from "drizzle-orm";
+
+/**
+ * Wrap a drizzle `sql` fragment that is rendered into BOTH a SELECT
+ * expression and a GROUP BY / ORDER BY clause, asserting it carries no
+ * bind parameters.
+ *
+ * Why this exists: Postgres identifies a grouped SELECT expression by its
+ * rendered text, and drizzle numbers bind placeholders per render — the
+ * SELECT copy of a fragment gets `$1`, the GROUP BY copy gets `$3`. A
+ * fragment with a single bound value therefore renders differently in the
+ * two positions, and Postgres rejects the query at runtime with
+ * "column ... must appear in the GROUP BY clause". The type system cannot
+ * see this: both renderings share one TypeScript type.
+ *
+ * `groupableSql` makes that mismatch impossible to construct. It walks the
+ * fragment's chunk tree and `panic()`s if any chunk would render as a bound
+ * placeholder. Only raw SQL text (`StringChunk`, i.e. `sql.raw(...)` and the
+ * template's static parts) and schema identifiers (`Column`, `Table`,
+ * `View`, `Name`) are allowed; nested `SQL` fragments are validated
+ * recursively. Bare interpolated primitives, `sql.param(...)`,
+ * `sql.placeholder(...)`, and any other value chunk are rejected.
+ *
+ * Fragments are module-level (or per-request) constants, so a bound value
+ * fails at construction — module load for the common case — and any test or
+ * boot catches it immediately rather than deferring to a live query.
+ *
+ * Genuinely dynamic values belong outside grouped fragments (e.g. bound in a
+ * WHERE clause). Code constants that must appear inside a grouped fragment
+ * are inlined byte-identically with `sql.raw(...)`.
+ */
+export const groupableSql = <T>(fragment: SQL<T>): SQL<T> => {
+  const boundChunk = findBoundChunk(fragment.queryChunks);
+  if (boundChunk !== undefined) {
+    panic(
+      `groupableSql: fragment "${sketchChunks(fragment.queryChunks)}" contains a bound parameter (${boundChunk}). ` +
+        "A fragment rendered into both a SELECT list and a GROUP BY/ORDER BY clause must carry no bind " +
+        "parameters: Postgres numbers placeholders per render, so the two copies would diverge and the query " +
+        "would fail at runtime. Inline code constants with sql.raw(...) instead.",
+    );
+  }
+
+  return fragment;
+};
+
+// Returns a human-readable description of the first chunk that would render as
+// a bound placeholder, or `undefined` when every chunk is safe. Walks nested
+// SQL fragments and chunk arrays so a bound value at any depth is caught.
+const findBoundChunk = (chunks: readonly SQLChunk[]): string | undefined => {
+  for (const chunk of chunks) {
+    const bound = describeBoundChunk(chunk);
+    if (bound !== undefined) {
+      return bound;
+    }
+  }
+
+  return undefined;
+};
+
+const describeBoundChunk = (chunk: SQLChunk): string | undefined => {
+  if (chunk === undefined || isSafeIdentifierChunk(chunk)) {
+    return undefined;
+  }
+  if (is(chunk, SQL)) {
+    return findBoundChunk(chunk.queryChunks);
+  }
+  if (Array.isArray(chunk)) {
+    return findBoundChunk(chunk);
+  }
+  if (is(chunk, Param)) {
+    return "bound Param";
+  }
+  if (is(chunk, Placeholder)) {
+    return "placeholder";
+  }
+
+  // A bare interpolated primitive (`sql`... ${value}``) is not a drizzle
+  // entity: drizzle binds it as a driver parameter, so it renders as `$n`
+  // just like an explicit Param.
+  return `bound ${typeof chunk} value`;
+};
+
+const isSafeIdentifierChunk = (chunk: SQLChunk): boolean =>
+  is(chunk, StringChunk) ||
+  is(chunk, Column) ||
+  is(chunk, Table) ||
+  is(chunk, View) ||
+  is(chunk, Name);
+
+// Renders a readable outline of a fragment for panic messages: raw text is
+// shown verbatim, identifiers and bound values as placeholders. Never used for
+// SQL generation, so it need not be executable.
+const sketchChunks = (chunks: readonly SQLChunk[]): string =>
+  chunks.map(sketchChunk).join("");
+
+const sketchChunk = (chunk: SQLChunk): string => {
+  if (chunk === undefined) {
+    return "";
+  }
+  if (is(chunk, StringChunk)) {
+    return chunk.value.join("");
+  }
+  if (is(chunk, SQL)) {
+    return sketchChunks(chunk.queryChunks);
+  }
+  if (Array.isArray(chunk)) {
+    return sketchChunks(chunk);
+  }
+  if (isSafeIdentifierChunk(chunk)) {
+    return "⟨identifier⟩";
+  }
+  return "⟨bound⟩";
+};

--- a/apps/api/src/lib/pg-error.test.ts
+++ b/apps/api/src/lib/pg-error.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { DrizzleQueryError } from "drizzle-orm";
 
-import { getPgErrorCode, isPgError, PG_ERROR } from "./pg-error";
+import { getPgErrorCode, isPgError, PG_ERROR, pgErrorFields } from "./pg-error";
 
 const drizzleError = (cause: { errno?: string; code?: string }) =>
   new DrizzleQueryError(
@@ -56,5 +56,90 @@ describe("isPgError", () => {
     expect(isPgError(drizzleError(cause), PG_ERROR.FOREIGN_KEY_VIOLATION)).toBe(
       false,
     );
+  });
+});
+
+// Structural object mirroring the runtime shape of a Bun/pg PostgresError.
+const pgCause = (fields: Record<string, string>): Error =>
+  Object.assign(new Error("database error"), fields);
+
+describe("pgErrorFields", () => {
+  it("surfaces the SQLSTATE from a DrizzleQueryError-wrapped PostgresError", () => {
+    const error = new DrizzleQueryError(
+      "query failed",
+      [],
+      pgCause({
+        code: "42803",
+      }),
+    );
+    expect(pgErrorFields(error)["error.cause.pg_code"]).toBe("42803");
+  });
+
+  it("reads SQLSTATE from `errno` (Bun) over the generic `code` category", () => {
+    const error = new DrizzleQueryError(
+      "query failed",
+      [],
+      pgCause({
+        errno: "23505",
+        code: "ERR_POSTGRES_SERVER_ERROR",
+      }),
+    );
+    expect(pgErrorFields(error)["error.cause.pg_code"]).toBe("23505");
+  });
+
+  it("emits schema identifiers but never row-bearing fields", () => {
+    const error = new DrizzleQueryError(
+      "query failed",
+      [],
+      pgCause({
+        code: "23505",
+        severity: "ERROR",
+        constraint: "users_email_key",
+        table: "users",
+        column: "email",
+        schema: "public",
+        routine: "_bt_check_unique",
+        detail: "Key (email)=(secret@example.com) already exists.",
+        hint: "a hint that could echo values",
+        where: "a plpgsql context line",
+      }),
+    );
+    expect(pgErrorFields(error)).toEqual({
+      "error.cause.pg_code": "23505",
+      "error.cause.pg_severity": "ERROR",
+      "error.cause.pg_constraint": "users_email_key",
+      "error.cause.pg_table": "users",
+      "error.cause.pg_column": "email",
+      "error.cause.pg_schema": "public",
+      "error.cause.pg_routine": "_bt_check_unique",
+    });
+  });
+
+  it("ignores a Node system error whose `code` is not a SQLSTATE", () => {
+    const sys = Object.assign(new Error("socket"), {
+      code: "ECONNRESET",
+      errno: "-54",
+    });
+    expect(pgErrorFields(sys)).toEqual({});
+    expect(
+      pgErrorFields(new DrizzleQueryError("query failed", [], sys)),
+    ).toEqual({});
+  });
+
+  it("returns {} for a non-Postgres error and non-object input", () => {
+    expect(pgErrorFields(new Error("plain"))).toEqual({});
+    expect(pgErrorFields("boom")).toEqual({});
+    expect(pgErrorFields(null)).toEqual({});
+  });
+
+  it("never throws on a hostile cause accessor", () => {
+    const hostile = new Error("hostile");
+    Object.defineProperty(hostile, "cause", {
+      get: () => {
+        throw new Error("cause getter failed");
+      },
+    });
+    expect(() => pgErrorFields(hostile)).not.toThrow();
+    expect(pgErrorFields(hostile)).toEqual({});
   });
 });

--- a/apps/api/src/lib/pg-error.test.ts
+++ b/apps/api/src/lib/pg-error.test.ts
@@ -126,6 +126,26 @@ describe("pgErrorFields", () => {
     ).toEqual({});
   });
 
+  it("ignores five-letter Node system codes that fit the SQLSTATE shape", () => {
+    // EPIPE/EPERM are five chars from the SQLSTATE alphabet; the digit
+    // requirement and the syscall marker must each keep them out.
+    const epipe = Object.assign(new Error("broken pipe"), {
+      code: "EPIPE",
+      errno: -32,
+      syscall: "write",
+    });
+    expect(pgErrorFields(epipe)).toEqual({});
+    expect(
+      pgErrorFields(new DrizzleQueryError("query failed", [], epipe)),
+    ).toEqual({});
+
+    // Even without a syscall marker, an all-letter code is not a SQLSTATE.
+    const eperm = Object.assign(new Error("not permitted"), {
+      code: "EPERM",
+    });
+    expect(pgErrorFields(eperm)).toEqual({});
+  });
+
   it("returns {} for a non-Postgres error and non-object input", () => {
     expect(pgErrorFields(new Error("plain"))).toEqual({});
     expect(pgErrorFields("boom")).toEqual({});

--- a/apps/api/src/lib/pg-error.test.ts
+++ b/apps/api/src/lib/pg-error.test.ts
@@ -115,6 +115,29 @@ describe("pgErrorFields", () => {
     });
   });
 
+  it("continues past SQLSTATE-only wrappers to collect driver schema identifiers", () => {
+    const driver = pgCause({
+      code: "23505",
+      severity: "ERROR",
+      constraint: "users_email_key",
+      table: "users",
+      column: "email",
+    });
+    const drizzle = new DrizzleQueryError("query failed", [], driver);
+    const databaseError = Object.assign(new Error("Database query failed"), {
+      code: "23505",
+      cause: drizzle,
+    });
+
+    expect(pgErrorFields(databaseError)).toEqual({
+      "error.cause.pg_code": "23505",
+      "error.cause.pg_severity": "ERROR",
+      "error.cause.pg_constraint": "users_email_key",
+      "error.cause.pg_table": "users",
+      "error.cause.pg_column": "email",
+    });
+  });
+
   it("ignores a Node system error whose `code` is not a SQLSTATE", () => {
     const sys = Object.assign(new Error("socket"), {
       code: "ECONNRESET",

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -48,3 +48,106 @@ export const PG_ERROR = {
   UNIQUE_VIOLATION: "23505",
   INSUFFICIENT_PRIVILEGE: "42501",
 } as const;
+
+// A SQLSTATE is exactly five characters from the class/subclass alphabet
+// (`0`-`9`, `A`-`Z`). Gating on this shape distinguishes a Postgres driver
+// error from a Node system error that also carries a `.code` (`ECONNRESET`,
+// `ENOENT`), so the cause-chain walk below does not misclassify those.
+const PG_SQLSTATE_PATTERN = /^[0-9A-Z]{5}$/u;
+
+// Schema identifiers Postgres attaches to a server error. These name database
+// objects, never row data, so they are safe to ship to a log sink. `detail`,
+// `hint`, `where`, `internalQuery`, and `query` are deliberately excluded:
+// they can embed the offending row's column values.
+const PG_SAFE_STRING_FIELDS = [
+  { key: "error.cause.pg_severity", property: "severity" },
+  { key: "error.cause.pg_constraint", property: "constraint" },
+  { key: "error.cause.pg_table", property: "table" },
+  { key: "error.cause.pg_column", property: "column" },
+  { key: "error.cause.pg_schema", property: "schema" },
+  { key: "error.cause.pg_routine", property: "routine" },
+] as const;
+
+const MAX_CAUSE_DEPTH = 6;
+
+const readProperty = (value: object, key: string): unknown => {
+  try {
+    return Reflect.get(value, key);
+  } catch {
+    return undefined;
+  }
+};
+
+const readNonEmptyString = (value: object, key: string): string | undefined => {
+  const raw = readProperty(value, key);
+  return typeof raw === "string" && raw !== "" ? raw : undefined;
+};
+
+// Returns a node's SQLSTATE when it is shaped like a Postgres driver error.
+// Bun's `Bun.sql` puts the SQLSTATE in `errno` (`code` is a generic category);
+// pg/PGlite put it in `code`. Prefer `errno`, fall back to `code`, and require
+// the SQLSTATE shape so non-Postgres codes are ignored.
+const sqlStateOf = (node: object): string | undefined => {
+  const errno = readNonEmptyString(node, "errno");
+  if (errno !== undefined && PG_SQLSTATE_PATTERN.test(errno)) {
+    return errno;
+  }
+  const code = readNonEmptyString(node, "code");
+  if (code !== undefined && PG_SQLSTATE_PATTERN.test(code)) {
+    return code;
+  }
+  return undefined;
+};
+
+type PgErrorNode = { error: object; sqlState: string };
+
+const findPgErrorNode = (error: unknown): PgErrorNode | undefined => {
+  const seen = new WeakSet<object>();
+  let current: unknown = error;
+  let depth = 0;
+  while (
+    current !== null &&
+    typeof current === "object" &&
+    depth < MAX_CAUSE_DEPTH &&
+    !seen.has(current)
+  ) {
+    seen.add(current);
+    const sqlState = sqlStateOf(current);
+    if (sqlState !== undefined) {
+      return { error: current, sqlState };
+    }
+    current = readProperty(current, "cause");
+    depth += 1;
+  }
+  return undefined;
+};
+
+/**
+ * Extract safe, structured fields from a Postgres driver error anywhere in an
+ * error's `.cause` chain, for observability. Drizzle wraps the driver error
+ * (`DrizzleQueryError`), so on a failed query the SQLSTATE lives one or more
+ * `.cause` hops down and would otherwise never reach the log sink.
+ *
+ * Returns the SQLSTATE under `error.cause.pg_code` plus any present schema
+ * identifiers (severity, constraint, table, column, schema, routine). Every
+ * key is chosen to NOT match the logger's PII redaction regex, so the fields
+ * survive `sanitizeLogAttributes`. Returns `{}` when no Postgres error is
+ * found. Never throws: property access is fully guarded.
+ */
+export const pgErrorFields = (error: unknown): Record<string, string> => {
+  const node = findPgErrorNode(error);
+  if (node === undefined) {
+    return {};
+  }
+
+  const fields: Record<string, string> = {
+    "error.cause.pg_code": node.sqlState,
+  };
+  for (const { key, property } of PG_SAFE_STRING_FIELDS) {
+    const value = readNonEmptyString(node.error, property);
+    if (value !== undefined) {
+      fields[key] = value;
+    }
+  }
+  return fields;
+};

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -50,10 +50,12 @@ export const PG_ERROR = {
 } as const;
 
 // A SQLSTATE is exactly five characters from the class/subclass alphabet
-// (`0`-`9`, `A`-`Z`). Gating on this shape distinguishes a Postgres driver
-// error from a Node system error that also carries a `.code` (`ECONNRESET`,
-// `ENOENT`), so the cause-chain walk below does not misclassify those.
-const PG_SQLSTATE_PATTERN = /^[0-9A-Z]{5}$/u;
+// (`0`-`9`, `A`-`Z`). Shape alone is not enough: five-letter Node system
+// codes (`EPIPE`, `EPERM`) fit it too, so the check also requires at least
+// one digit (every standard SQLSTATE contains one; Node codes are all
+// letters) and `sqlStateOf` skips nodes carrying `syscall`, which every Node
+// system error has and no Postgres driver error does.
+const PG_SQLSTATE_PATTERN = /^(?=.*[0-9])[0-9A-Z]{5}$/u;
 
 // Schema identifiers Postgres attaches to a server error. These name database
 // objects, never row data, so they are safe to ship to a log sink. `detail`,
@@ -88,6 +90,9 @@ const readNonEmptyString = (value: object, key: string): string | undefined => {
 // pg/PGlite put it in `code`. Prefer `errno`, fall back to `code`, and require
 // the SQLSTATE shape so non-Postgres codes are ignored.
 const sqlStateOf = (node: object): string | undefined => {
+  if (readProperty(node, "syscall") !== undefined) {
+    return undefined;
+  }
   const errno = readNonEmptyString(node, "errno");
   if (errno !== undefined && PG_SQLSTATE_PATTERN.test(errno)) {
     return errno;

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -104,12 +104,24 @@ const sqlStateOf = (node: object): string | undefined => {
   return undefined;
 };
 
-type PgErrorNode = { error: object; sqlState: string };
+const readSafePgStringFields = (node: object): Record<string, string> => {
+  const fields: Record<string, string> = {};
+  for (const { key, property } of PG_SAFE_STRING_FIELDS) {
+    const value = readNonEmptyString(node, property);
+    if (value !== undefined) {
+      fields[key] = value;
+    }
+  }
+  return fields;
+};
 
-const findPgErrorNode = (error: unknown): PgErrorNode | undefined => {
+const collectPgErrorFields = (error: unknown): Record<string, string> => {
   const seen = new WeakSet<object>();
   let current: unknown = error;
   let depth = 0;
+  let sqlState: string | undefined;
+  const fields: Record<string, string> = {};
+
   while (
     current !== null &&
     typeof current === "object" &&
@@ -117,14 +129,20 @@ const findPgErrorNode = (error: unknown): PgErrorNode | undefined => {
     !seen.has(current)
   ) {
     seen.add(current);
-    const sqlState = sqlStateOf(current);
-    if (sqlState !== undefined) {
-      return { error: current, sqlState };
+    const currentSqlState = sqlStateOf(current);
+    sqlState ??= currentSqlState;
+    if (currentSqlState !== undefined) {
+      Object.assign(fields, readSafePgStringFields(current));
     }
     current = readProperty(current, "cause");
     depth += 1;
   }
-  return undefined;
+
+  if (sqlState === undefined) {
+    return {};
+  }
+
+  return { "error.cause.pg_code": sqlState, ...fields };
 };
 
 /**
@@ -139,20 +157,5 @@ const findPgErrorNode = (error: unknown): PgErrorNode | undefined => {
  * survive `sanitizeLogAttributes`. Returns `{}` when no Postgres error is
  * found. Never throws: property access is fully guarded.
  */
-export const pgErrorFields = (error: unknown): Record<string, string> => {
-  const node = findPgErrorNode(error);
-  if (node === undefined) {
-    return {};
-  }
-
-  const fields: Record<string, string> = {
-    "error.cause.pg_code": node.sqlState,
-  };
-  for (const { key, property } of PG_SAFE_STRING_FIELDS) {
-    const value = readNonEmptyString(node.error, property);
-    if (value !== undefined) {
-      fields[key] = value;
-    }
-  }
-  return fields;
-};
+export const pgErrorFields = (error: unknown): Record<string, string> =>
+  collectPgErrorFields(error);


### PR DESCRIPTION
Two structural guards, one commit each.

## groupableSql — bind parameters in grouped fragments become unconstructible

Postgres identifies a grouped SELECT expression by its rendered text, and drizzle numbers bind placeholders per render, so a `sql` fragment with a bound value rendered into both SELECT and GROUP BY diverges (`$1` vs `$3`) and fails at runtime; the type system cannot see it. `groupableSql()` walks the fragment's chunk tree at construction (module load for the common case) and panics unless every chunk is raw SQL text, a schema identifier, or a nested fragment that passes recursively. Notably, in drizzle 1.0.0-rc a bare interpolated primitive is stored as a raw JS value (not a `Param`), so the check is an allowlist rather than a `Param` scan — a Param-only check would under-catch.

Migrated the case-law sitemap fragments, and the sweep found one **live bug of exactly this class**: `statusBucketExpr` in `handlers/entities/read-group-counts.ts` bound the task-status constants into a CASE expression used in both SELECT and GROUP BY (verified render: `IN ($1, $2)` vs `IN ($3, $4)`), so grouping entities by status failed at runtime; existing tests mock the DB and never exercised the path. Fixed by inlining the code constants and wrapping in `groupableSql`.

## Database error codes survive the log sanitizer

The log attribute sanitizer drops keys matching sensitive-name patterns, which also stripped every useful field of a wrapped `PostgresError` — a failed request logged error types but no diagnosable detail. `pgErrorFields()` walks the cause chain (cycle-safe, depth-capped), gates on the 5-char SQLSTATE shape so Node system errors (`ECONNRESET`) are not misclassified, and surfaces only schema-identifier fields under `error.cause.pg_*` keys: `pg_code`, `pg_severity`, `pg_constraint`, `pg_table`, `pg_column`, `pg_schema`, `pg_routine`. Deliberately excluded: `detail`, `hint`, `where`, `internalQuery`, `query`, `position` — those can embed row data. Wired into the shared 5xx serializer used by `request.failed`.

## Tests

51 pass across the guard, sitemap, group-counts, pg-error, and sanitizer suites, including: bound-param fragments panic; the fixed group-counts expression renders identically in both clauses; a `DrizzleQueryError`-wrapped SQLSTATE 42803 survives sanitization while normal key-dropping stays intact.