### PR TITLE
fix: open chat image attachments in an in-page preview

### DIFF
--- a/apps/web/src/components/chat/chat-image-attachment.tsx
+++ b/apps/web/src/components/chat/chat-image-attachment.tsx
@@ -28,7 +28,7 @@ export const ChatImageAttachment = ({
   return (
     <>
       <button
-        aria-label={t("common.preview")}
+        aria-label={`${t("common.preview")}: ${alt}`}
         className="focus-visible:ring-ring cursor-zoom-in rounded-md focus-visible:ring-2 focus-visible:outline-none"
         onClick={() => setOpen(true)}
         type="button"

--- a/apps/web/src/components/chat/chat-image-attachment.tsx
+++ b/apps/web/src/components/chat/chat-image-attachment.tsx
@@ -43,7 +43,7 @@ export const ChatImageAttachment = ({
         />
       </button>
       <Dialog onOpenChange={setOpen} open={open}>
-        <DialogPopup className="max-w-4xl">
+        <DialogPopup bottomStickOnMobile={false} className="max-w-4xl">
           <DialogTitle className="sr-only">{alt}</DialogTitle>
           <DialogPanel className="flex justify-center p-2">
             <img

--- a/apps/web/src/components/chat/chat-image-attachment.tsx
+++ b/apps/web/src/components/chat/chat-image-attachment.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+import { useTranslations } from "use-intl";
+
+import {
+  Dialog,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+
+type ChatImageAttachmentProps = {
+  alt: string;
+  fullSrc: string;
+  thumbnailSrc: string;
+  thumbnailStyle?: React.CSSProperties | undefined;
+};
+
+export const ChatImageAttachment = ({
+  alt,
+  fullSrc,
+  thumbnailSrc,
+  thumbnailStyle,
+}: ChatImageAttachmentProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        aria-label={t("common.preview")}
+        className="focus-visible:ring-ring cursor-zoom-in rounded-md focus-visible:ring-2 focus-visible:outline-none"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        <img
+          alt={alt}
+          className="max-h-32 rounded-md object-cover"
+          height={128}
+          src={thumbnailSrc}
+          style={thumbnailStyle}
+          width={128}
+        />
+      </button>
+      <Dialog onOpenChange={setOpen} open={open}>
+        <DialogPopup className="max-w-4xl">
+          <DialogTitle className="sr-only">{alt}</DialogTitle>
+          <DialogPanel className="flex justify-center p-2">
+            <img
+              alt={alt}
+              className="max-h-[min(70vh,48rem)] w-full object-contain"
+              src={fullSrc}
+            />
+          </DialogPanel>
+        </DialogPopup>
+      </Dialog>
+    </>
+  );
+};

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -293,7 +293,7 @@ describe("chat thread messages", () => {
     expect(html).toContain("/v1/user-files/file_test123/thumbnail");
     expect(html).toContain("background-image");
     expect(html).toContain("data:image/png;base64,AAAA");
-    expect(html).toContain('aria-label="Preview"');
+    expect(html).toContain('aria-label="Preview: evidence.png"');
     expect(html).not.toContain('target="_blank"');
     expect(html).not.toContain('href="/v1/user-files/file_test123/content"');
   });

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -290,10 +290,12 @@ describe("chat thread messages", () => {
       />,
     );
 
-    expect(html).toContain("/v1/user-files/file_test123/content");
     expect(html).toContain("/v1/user-files/file_test123/thumbnail");
     expect(html).toContain("background-image");
     expect(html).toContain("data:image/png;base64,AAAA");
+    expect(html).toContain('aria-label="Preview"');
+    expect(html).not.toContain('target="_blank"');
+    expect(html).not.toContain('href="/v1/user-files/file_test123/content"');
   });
 
   test("shows retry only on the latest assistant response", () => {

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -27,6 +27,7 @@ import {
 import { AnonymizedSpan } from "@/components/chat/anonymized-span";
 import { AskUserCard } from "@/components/chat/ask-user-card";
 import { useChatApproval } from "@/components/chat/chat-approval-context";
+import { ChatImageAttachment } from "@/components/chat/chat-image-attachment";
 import type {
   AskUserOutput,
   ChatAnonRestoration,
@@ -479,24 +480,21 @@ const UserAttachments = ({
             ? (getUserFileThumbnailUrl(url) ?? contentUrl)
             : contentUrl;
           return (
-            <a href={contentUrl} key={key} rel="noreferrer" target="_blank">
-              <img
-                alt={filename ?? t("chat.attachedImage")}
-                className="max-h-32 rounded-md object-cover"
-                height={128}
-                src={imageSrc}
-                style={
-                  placeholder
-                    ? {
-                        backgroundImage: `url("${placeholder}")`,
-                        backgroundSize: "cover",
-                        backgroundPosition: "center",
-                      }
-                    : undefined
-                }
-                width={128}
-              />
-            </a>
+            <ChatImageAttachment
+              alt={filename ?? t("chat.attachedImage")}
+              fullSrc={contentUrl}
+              key={key}
+              thumbnailSrc={imageSrc}
+              thumbnailStyle={
+                placeholder
+                  ? {
+                      backgroundImage: `url("${placeholder}")`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                    }
+                  : undefined
+              }
+            />
           );
         }
 

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -400,7 +400,7 @@ export const ChatThreadPage = ({
         }}
       >
         <div className="relative flex w-full flex-1 flex-col overflow-hidden">
-          <div className="bg-background absolute inset-x-0 top-0 z-10 mx-auto flex w-full max-w-5xl items-center justify-between gap-2 px-4 py-2">
+          <div className="bg-background mx-auto flex w-full max-w-5xl shrink-0 items-center justify-between gap-2 px-4 py-2">
             <div className="flex min-w-0 items-center gap-2">
               <NewChatButton
                 hasMessages={messages.length > 0}
@@ -436,138 +436,134 @@ export const ChatThreadPage = ({
             </div>
           </div>
 
-          <Conversation>
-            <ConversationContent className="mx-auto w-full max-w-5xl gap-3 px-4 pt-14 pb-36">
-              {messages.length === 0 && !isGenerating && !error ? (
-                <div className="m-auto w-full max-w-md px-4">
-                  <PromptSuggestions
-                    onSelect={selectPrompt}
-                    prompts={prompts}
-                  />
-                </div>
-              ) : (
-                <>
-                  <ChatThreadMessages
-                    approvalPendingMessageId={approvalPendingMessageId}
-                    error={error}
-                    hasOlderMessages={olderCursor !== null}
-                    isGenerating={isGenerating}
-                    isLoadingOlder={isLoadingOlder}
-                    loadOlderError={loadOlderError}
-                    messages={messages}
-                    onLoadOlder={loadOlder}
-                    onAskUserEditAndRerun={handleAskUserEditAndRerun}
-                    onAskUserEditingChange={handleAskUserEditingChange}
-                    onAskUserSubmit={handleAskUserSubmit}
-                    onCreateDocumentResolve={handleCreateDocumentResolve}
-                    onOpenCreatedDocument={handleOpenCreatedDocument}
-                    onRemoveQueuedMessage={removeQueuedMessage}
-                    onResend={resendLatestMessage}
-                    onSendWithoutAnonymization={sendWithoutAnonymization}
-                    queuedMessages={queuedMessages}
-                    showThinkingIndicator
-                    streamdownComponents={streamdownComponents}
-                    workspaceId={workspaceId}
-                  />
-                  <ChatThreadRecap
-                    activeOrganizationId={activeOrganizationId}
-                    isGenerating={isGenerating}
-                    key={threadRef.threadId}
-                    lastActivityAt={data.lastActivityAt}
-                    lastMessageId={messages.at(-1)?.id ?? null}
-                    lastMessageRole={messages.at(-1)?.role ?? null}
-                    messageCount={messages.length}
-                    threadRef={threadRef}
-                  />
-                </>
-              )}
-            </ConversationContent>
-            <ConversationScrollButton className="bottom-28" />
-          </Conversation>
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <Conversation className="min-h-0">
+              <ConversationContent className="mx-auto w-full max-w-5xl gap-3 px-4 pb-36">
+                {messages.length === 0 && !isGenerating && !error ? (
+                  <div className="m-auto w-full max-w-md px-4">
+                    <PromptSuggestions
+                      onSelect={selectPrompt}
+                      prompts={prompts}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    <ChatThreadMessages
+                      approvalPendingMessageId={approvalPendingMessageId}
+                      error={error}
+                      hasOlderMessages={olderCursor !== null}
+                      isGenerating={isGenerating}
+                      isLoadingOlder={isLoadingOlder}
+                      loadOlderError={loadOlderError}
+                      messages={messages}
+                      onLoadOlder={loadOlder}
+                      onAskUserEditAndRerun={handleAskUserEditAndRerun}
+                      onAskUserEditingChange={handleAskUserEditingChange}
+                      onAskUserSubmit={handleAskUserSubmit}
+                      onCreateDocumentResolve={handleCreateDocumentResolve}
+                      onOpenCreatedDocument={handleOpenCreatedDocument}
+                      onRemoveQueuedMessage={removeQueuedMessage}
+                      onResend={resendLatestMessage}
+                      onSendWithoutAnonymization={sendWithoutAnonymization}
+                      queuedMessages={queuedMessages}
+                      showThinkingIndicator
+                      streamdownComponents={streamdownComponents}
+                      workspaceId={workspaceId}
+                    />
+                    <ChatThreadRecap
+                      activeOrganizationId={activeOrganizationId}
+                      isGenerating={isGenerating}
+                      key={threadRef.threadId}
+                      lastActivityAt={data.lastActivityAt}
+                      lastMessageId={messages.at(-1)?.id ?? null}
+                      lastMessageRole={messages.at(-1)?.role ?? null}
+                      messageCount={messages.length}
+                      threadRef={threadRef}
+                    />
+                  </>
+                )}
+              </ConversationContent>
+              <ConversationScrollButton className="bottom-28" />
+            </Conversation>
 
-          <ChatAnonymizationLayer
-            editor={controller.editor}
-            enabled={anonymized}
-            workspaceId={workspaceId ?? threadRef.threadId}
-          />
-          {/* Soft fades so messages dissolve into the floating header and
-              composer instead of being clipped at a hard edge. Only when a
+            <ChatAnonymizationLayer
+              editor={controller.editor}
+              enabled={anonymized}
+              workspaceId={workspaceId ?? threadRef.threadId}
+            />
+            {/* Soft fade so messages dissolve into the floating composer
+              instead of being clipped at a hard edge. Only when a
               conversation exists — the centered empty-state suggestions
               must stay crisp, not dimmed by the bottom fade. */}
-          {messages.length > 0 && (
-            <>
-              <div
-                aria-hidden="true"
-                className="from-background pointer-events-none absolute inset-x-0 top-12 mx-auto h-10 w-full max-w-5xl bg-linear-to-b to-transparent"
-              />
+            {messages.length > 0 && (
               <div
                 aria-hidden="true"
                 className="from-background pointer-events-none absolute inset-x-0 bottom-0 mx-auto h-48 w-full max-w-5xl bg-linear-to-t to-transparent"
               />
-            </>
-          )}
-          <div className="absolute inset-x-0 bottom-0 z-10 mx-auto w-full max-w-5xl px-4 pb-4">
-            <SuggestedFollowupChips
-              isGenerating={isGenerating}
-              isEmpty={
-                controller.isEmpty && controller.attachments.length === 0
-              }
-              lastMessageId={messages.at(-1)?.id ?? null}
-              lastMessageRole={messages.at(-1)?.role ?? null}
-              messageCount={messages.length}
-              prompts={suggestedFollowupPrompts}
-              onSelect={(prompt) => {
-                controller.setContent(prompt);
-                void controller.submit(async (draft) => {
+            )}
+            <div className="absolute inset-x-0 bottom-0 z-10 mx-auto w-full max-w-5xl px-4 pb-4">
+              <SuggestedFollowupChips
+                isGenerating={isGenerating}
+                isEmpty={
+                  controller.isEmpty && controller.attachments.length === 0
+                }
+                lastMessageId={messages.at(-1)?.id ?? null}
+                lastMessageRole={messages.at(-1)?.role ?? null}
+                messageCount={messages.length}
+                prompts={suggestedFollowupPrompts}
+                onSelect={(prompt) => {
+                  controller.setContent(prompt);
+                  void controller.submit(async (draft) => {
+                    if (!(await ensureAIAvailable())) {
+                      return;
+                    }
+                    await sendMessage(await buildChatRequestMessage(draft));
+                  });
+                }}
+              />
+              <ChatInputSurface
+                anonymized={anonymized}
+                autoFocus
+                controller={controller}
+                isGenerating={isGenerating}
+                onStop={() => {
+                  stop();
+                }}
+                onSubmit={async (draft) => {
+                  const reservedCommand = matchReservedChatCommand(draft.html);
+                  if (reservedCommand?.id === "new") {
+                    // Abort any live stream first: `chatThreadOptions` keeps the
+                    // in-flight Chat alive in the query cache, so navigating away
+                    // would leave it streaming against the abandoned thread.
+                    stop();
+                    controller.setContent("");
+                    if (threadRef.scope === "workspace") {
+                      void navigate({
+                        to: "/chat/workspaces/$workspaceId/new",
+                        params: { workspaceId: threadRef.workspaceId },
+                        replace: true,
+                      });
+                    } else {
+                      void navigate({
+                        to: "/chat/new",
+                        replace: true,
+                      });
+                    }
+                    return;
+                  }
+                  if (reservedCommand?.id === "model") {
+                    controller.setContent("");
+                    useModelSelectorStore.getState().open();
+                    return;
+                  }
+
                   if (!(await ensureAIAvailable())) {
                     return;
                   }
                   await sendMessage(await buildChatRequestMessage(draft));
-                });
-              }}
-            />
-            <ChatInputSurface
-              anonymized={anonymized}
-              autoFocus
-              controller={controller}
-              isGenerating={isGenerating}
-              onStop={() => {
-                stop();
-              }}
-              onSubmit={async (draft) => {
-                const reservedCommand = matchReservedChatCommand(draft.html);
-                if (reservedCommand?.id === "new") {
-                  // Abort any live stream first: `chatThreadOptions` keeps the
-                  // in-flight Chat alive in the query cache, so navigating away
-                  // would leave it streaming against the abandoned thread.
-                  stop();
-                  controller.setContent("");
-                  if (threadRef.scope === "workspace") {
-                    void navigate({
-                      to: "/chat/workspaces/$workspaceId/new",
-                      params: { workspaceId: threadRef.workspaceId },
-                      replace: true,
-                    });
-                  } else {
-                    void navigate({
-                      to: "/chat/new",
-                      replace: true,
-                    });
-                  }
-                  return;
-                }
-                if (reservedCommand?.id === "model") {
-                  controller.setContent("");
-                  useModelSelectorStore.getState().open();
-                  return;
-                }
-
-                if (!(await ensureAIAvailable())) {
-                  return;
-                }
-                await sendMessage(await buildChatRequestMessage(draft));
-              }}
-            />
+                }}
+              />
+            </div>
           </div>
         </div>
       </ChatApprovalContext>

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -109,11 +109,10 @@ export const ThreadsSheet = ({
       ) : (
         <SheetTrigger
           render={
-            <Button aria-label={triggerLabel} size="sm" variant="ghost" />
+            <Button aria-label={triggerLabel} size="icon-sm" variant="ghost" />
           }
         >
           <MessageSquareIcon className="size-4" />
-          {triggerLabel}
         </SheetTrigger>
       )}
       <SheetPopup side="inline-end">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed change

Clicking a pasted image in chat previously opened the raw presigned S3 URL in a new browser tab. This change opens the full image in a dialog on the same page instead.

Additional follow-ups from review and UX feedback:

- Center the preview dialog on mobile (`bottomStickOnMobile={false}`)
- Stop the thread toolbar from overlaying scrolled image attachments (header is now in normal layout flow; top fade strip removed)
- Show the history control as icon-only in the toolbar
- Include the attachment filename in the preview button's accessible name

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f68b558-d2f9-4b37-918c-4d6157fd1937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f68b558-d2f9-4b37-918c-4d6157fd1937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachments in chat now open in a preview dialog from a clickable thumbnail, allowing quick full-size viewing without leaving the conversation.

* **Bug Fixes**
  * Improved image attachment rendering to use thumbnail URLs (including placeholder behaviour) and ensured the preview control is correctly labelled for accessibility.

* **UI / Layout Updates**
  * Refreshed the chat thread layout for a cleaner conversation structure and adjusted fade/empty-state presentation.
  * Updated the compact toolbar trigger button styling for a better fit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->