### PR TITLE
feat(chat): conversation context meter with per-model compaction windows

### DIFF
--- a/apps/api/src/handlers/chat/chat-prompt.test.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.test.ts
@@ -23,13 +23,22 @@ import type {
   ChatSafePrompt,
   ChatUntrustedPromptSuffix,
 } from "./chat-prompt";
+import type { ChatToolAvailability } from "./chat-prompt";
 import {
   ACTIVE_SKILL_BODY_PROMPT_MAX_CHARS,
   type ActiveChatSkillContext,
 } from "./skills";
+import {
+  FETCH_URL_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME,
+} from "./tools/web-search-tools";
 import type { ChatMessage } from "./types";
 
 const WORKSPACE_ID = toSafeId<"workspace">("ws_prompt_test");
+const FULL_TOOL_AVAILABILITY = {
+  templateAuthoring: true,
+  webResearch: true,
+} as const satisfies ChatToolAvailability;
 const SKILL_METADATA = [
   {
     name: "legal-interpretation",
@@ -366,10 +375,13 @@ describe("chat prompt builders", () => {
   });
 
   test("active-template prompt stays read-only until a snapshot exists", () => {
-    const prompt = buildActiveTemplatePrompt({
-      templateId: toSafeId<"template">("tpl_test"),
-      fileName: "Plna moc.docx",
-    });
+    const prompt = buildActiveTemplatePrompt(
+      {
+        templateId: toSafeId<"template">("tpl_test"),
+        fileName: "Plna moc.docx",
+      },
+      FULL_TOOL_AVAILABILITY,
+    );
 
     expect(prompt).toContain("ACTIVE TEMPLATE");
     expect(prompt).toContain("Plna moc.docx");
@@ -378,19 +390,22 @@ describe("chat prompt builders", () => {
   });
 
   test("active-template prompt wires the suggest-fields and edit flows when a snapshot exists", () => {
-    const prompt = buildActiveTemplatePrompt({
-      templateId: toSafeId<"template">("tpl_test"),
-      fileName: "Plna moc.docx",
-      docxEditSnapshot: {
-        blocks: [
-          {
-            id: "b-1",
-            kind: "paragraph",
-            text: "Zmocnitel: Jan Novak, nar. 1.1.1990",
-          },
-        ],
+    const prompt = buildActiveTemplatePrompt(
+      {
+        templateId: toSafeId<"template">("tpl_test"),
+        fileName: "Plna moc.docx",
+        docxEditSnapshot: {
+          blocks: [
+            {
+              id: "b-1",
+              kind: "paragraph",
+              text: "Zmocnitel: Jan Novak, nar. 1.1.1990",
+            },
+          ],
+        },
       },
-    });
+      FULL_TOOL_AVAILABILITY,
+    );
 
     expect(prompt).toContain("apply-active-docx-edits");
     expect(prompt).toContain("suggest_template_fields");
@@ -401,6 +416,202 @@ describe("chat prompt builders", () => {
     expect(prompt).toContain("cannot honour `insertAfterBlock`");
     // Internal component names must not leak into user-facing prompt.
     expect(prompt).not.toContain("Folio");
+  });
+
+  test("active-template prompt drops the suggest-fields tool for roles without template authoring", () => {
+    const prompt = buildActiveTemplatePrompt(
+      {
+        templateId: toSafeId<"template">("tpl_test"),
+        fileName: "Plna moc.docx",
+        docxEditSnapshot: {
+          blocks: [
+            {
+              id: "b-1",
+              kind: "paragraph",
+              text: "Zmocnitel: Jan Novak, nar. 1.1.1990",
+            },
+          ],
+        },
+      },
+      { templateAuthoring: false, webResearch: true },
+    );
+
+    // A `template: ["use"]`-only role (e.g. intern) never has
+    // `suggest_template_fields` registered; the prompt must not steer
+    // the model to it, but the field-marker workflow via
+    // `apply-active-docx-edits` stays available.
+    expect(prompt).not.toContain("suggest_template_fields");
+    expect(prompt).toContain("FIELD SUGGESTIONS");
+    expect(prompt).toContain("apply-active-docx-edits");
+    expect(prompt).toContain("`{{fieldPath}}` marker verbatim");
+  });
+});
+
+// Class guard: the assembled system prompt must never instruct the
+// model to call a tool that is not registered for that configuration.
+// We build the prompt across an availability matrix, extract every
+// backtick-quoted tool-name-shaped token, and assert each is either a
+// tool that IS registered for that config or an explicit non-tool
+// code span. A future edit that names an unregistered tool (e.g.
+// re-adds a `web_search` pointer to the web-off prompt) fails here.
+describe("system prompt tool-reference guard", () => {
+  // Tools always registered by getChatTools regardless of config, and
+  // referenced by name in the prompt scaffold. `create-document` and
+  // (given an active-template snapshot, which implies
+  // hasActiveDocxEditClient) `apply-active-docx-edits` are always in
+  // the map for the configurations swept here.
+  const ALWAYS_REGISTERED_TOOL_NAMES = new Set([
+    "ask-user",
+    "run-stella-query",
+    "describe-stella-api",
+    "load-skill",
+    "read-skill-resource",
+    "create-document",
+    "apply-active-docx-edits",
+  ]);
+  // Web research tools: registered only when `webResearch` is true.
+  const WEB_RESEARCH_TOOL_NAMES = new Set([
+    WEB_SEARCH_TOOL_NAME,
+    FETCH_URL_TOOL_NAME,
+  ]);
+  const TEMPLATE_AUTHORING_TOOL_NAME = "suggest_template_fields";
+  // Backtick spans that look like a tool name but are not one (schema
+  // fields / plain nouns). Keep this list tight — everything not here
+  // must resolve to a registered tool.
+  const NON_TOOL_CODE_SPANS = new Set([
+    "resources",
+    "mention",
+    // Active-template section: operation fields and result keys.
+    "applied",
+    "find",
+    "replace",
+    "instructions",
+    "severity",
+    "area",
+  ]);
+  // A backtick span is "tool-name-shaped" when it is a bare lowercase
+  // identifier with `-`/`_` separators: excludes `read.*` (dot),
+  // `describe-stella-api({name})` (parens), `[1]` (brackets), and
+  // anything with whitespace or uppercase.
+  const TOOL_NAME_SHAPE = /^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$/u;
+
+  const extractToolNameTokens = (prompt: string): string[] => {
+    const tokens: string[] = [];
+    for (const match of prompt.matchAll(/`([^`]+)`/gu)) {
+      const span = match[1];
+      if (span !== undefined && TOOL_NAME_SHAPE.test(span)) {
+        tokens.push(span);
+      }
+    }
+    return tokens;
+  };
+
+  // Mirrors how buildChatSystemPromptParts appends the active-template
+  // section to the scaffold: core prompt + template appendix in one
+  // assembled string, so the guard sees the same text the model does.
+  const buildAssembledPrompts = (
+    toolAvailability: ChatToolAvailability,
+  ): string[] => {
+    const refRegistry = createChatRefRegistry();
+    const activeTemplateSection = buildActiveTemplatePrompt(
+      {
+        templateId: toSafeId<"template">("tpl_guard"),
+        fileName: "Guard template.docx",
+        docxEditSnapshot: {
+          blocks: [{ id: "b-1", kind: "paragraph", text: "Guard block" }],
+        },
+      },
+      toolAvailability,
+    );
+    return [
+      buildGlobalPrompt({
+        skillMetadata: SKILL_METADATA,
+        toolAvailability,
+        userContext: null,
+      }),
+      buildGlobalPrompt({
+        skillMetadata: [],
+        toolAvailability,
+        userContext: null,
+      }),
+      `${buildWorkspacePromptText({
+        entityCount: 3,
+        refRegistry,
+        skillMetadata: SKILL_METADATA,
+        toolAvailability,
+        userContext: null,
+        workspaceId: WORKSPACE_ID,
+        workspaceName: "Matter Alpha",
+      })}\n\n${activeTemplateSection}`,
+    ];
+  };
+
+  const AVAILABILITY_MATRIX: readonly ChatToolAvailability[] = [
+    { templateAuthoring: true, webResearch: true },
+    { templateAuthoring: true, webResearch: false },
+    { templateAuthoring: false, webResearch: true },
+    { templateAuthoring: false, webResearch: false },
+  ];
+
+  test("every tool named in the prompt is registered for that config", () => {
+    for (const availability of AVAILABILITY_MATRIX) {
+      const registered = new Set(ALWAYS_REGISTERED_TOOL_NAMES);
+      if (availability.webResearch) {
+        for (const name of WEB_RESEARCH_TOOL_NAMES) {
+          registered.add(name);
+        }
+      }
+      if (availability.templateAuthoring) {
+        registered.add(TEMPLATE_AUTHORING_TOOL_NAME);
+      }
+
+      for (const prompt of buildAssembledPrompts(availability)) {
+        for (const token of extractToolNameTokens(prompt)) {
+          const allowed =
+            registered.has(token) || NON_TOOL_CODE_SPANS.has(token);
+          if (!allowed) {
+            throw new Error(
+              `Prompt names \`${token}\` but it is not registered for ` +
+                `${JSON.stringify(availability)} and is not an ` +
+                `allowlisted non-tool span`,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  test("web research tools are named iff they are registered", () => {
+    for (const prompt of buildAssembledPrompts(FULL_TOOL_AVAILABILITY)) {
+      expect(prompt).toContain(`\`${WEB_SEARCH_TOOL_NAME}\``);
+      expect(prompt).toContain(`\`${FETCH_URL_TOOL_NAME}\``);
+    }
+    for (const prompt of buildAssembledPrompts({
+      templateAuthoring: true,
+      webResearch: false,
+    })) {
+      expect(prompt).not.toContain(WEB_SEARCH_TOOL_NAME);
+      expect(prompt).not.toContain(FETCH_URL_TOOL_NAME);
+      // The skill-grounding guidance and the run-stella-query warning
+      // must survive when web research is off.
+      expect(prompt).toContain("EXTERNAL-FACT SOURCING");
+      expect(prompt).toContain("no external source was available");
+    }
+  });
+
+  test("suggest_template_fields is named iff it is registered", () => {
+    const withAuthoring = buildAssembledPrompts(FULL_TOOL_AVAILABILITY);
+    expect(
+      withAuthoring.some((prompt) =>
+        prompt.includes(`\`${TEMPLATE_AUTHORING_TOOL_NAME}\``),
+      ),
+    ).toBe(true);
+    for (const prompt of buildAssembledPrompts({
+      templateAuthoring: false,
+      webResearch: true,
+    })) {
+      expect(prompt).not.toContain(TEMPLATE_AUTHORING_TOOL_NAME);
+    }
   });
 });
 

--- a/apps/api/src/handlers/chat/chat-prompt.test.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.test.ts
@@ -21,9 +21,9 @@ import {
 import type {
   ChatCacheStablePrefix,
   ChatSafePrompt,
+  ChatToolAvailability,
   ChatUntrustedPromptSuffix,
 } from "./chat-prompt";
-import type { ChatToolAvailability } from "./chat-prompt";
 import {
   ACTIVE_SKILL_BODY_PROMPT_MAX_CHARS,
   type ActiveChatSkillContext,
@@ -497,8 +497,8 @@ describe("system prompt tool-reference guard", () => {
 
   const extractToolNameTokens = (prompt: string): string[] => {
     const tokens: string[] = [];
-    for (const match of prompt.matchAll(/`([^`]+)`/gu)) {
-      const span = match[1];
+    for (const match of prompt.matchAll(/`(?<span>[^`]+)`/gu)) {
+      const span = match.groups?.["span"];
       if (span !== undefined && TOOL_NAME_SHAPE.test(span)) {
         tokens.push(span);
       }

--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -24,6 +24,7 @@ import type {
   IncomingActiveTemplate,
   IncomingUserContext,
 } from "@/api/handlers/chat/chat-schema";
+import { estimateTextTokens } from "@/api/handlers/chat/compaction";
 import {
   ACTIVE_SKILL_BODY_PROMPT_MAX_CHARS,
   type ActiveChatSkillContext,
@@ -70,12 +71,49 @@ const buildPromptMentionExample = ({
   id,
 }: BuildPromptMentionExampleProps) => `[${label}](${prefix}${id})`;
 
-const CORE_RULE_SECTIONS = [
+/**
+ * Which conditionally-registered tools this turn actually handed to
+ * the model. The prompt must never instruct the model to call a tool
+ * that is not in the registered `ChatToolMap`; capability flags flow
+ * from the same predicates that gate registration (see
+ * `areWebResearchToolsRegistered` in chat-tools.ts) so the two cannot
+ * drift.
+ */
+export type ChatToolAvailability = {
+  /**
+   * `suggest_template_fields` is registered for this turn: the
+   * caller's role has the `template: ["create"]` grant (see
+   * `areTemplateAuthoringToolsRegistered` in chat-tools.ts).
+   */
+  templateAuthoring: boolean;
+  /** `web_search` + `fetch_url` are registered for this turn. */
+  webResearch: boolean;
+};
+
+const DEFAULT_CHAT_TOOL_AVAILABILITY = {
+  templateAuthoring: true,
+  webResearch: true,
+} as const satisfies ChatToolAvailability;
+
+// EXTERNAL-FACT SOURCING has two shapes: with web research the model
+// is steered to `web_search`/`fetch_url`; without it, to skills and
+// then its own knowledge (with an explicit no-source flag). The
+// run-stella-query warning is identical either way — it is never an
+// external-research tool.
+const EXTERNAL_FACT_SOURCING_WITH_WEB =
+  "EXTERNAL-FACT SOURCING: Always try to ground factual answers in an external source before falling back to your own knowledge. The skill catalog is in this prompt — pick a matching skill and `load-skill` if one fits; otherwise call `web_search` (with `fetch_url` follow-up when snippets are short or contradict). Only when those tools return nothing usable may you answer from your own knowledge, and you MUST flag that you have no source for the claim. Never use `run-stella-query` for external research — that tool reads stella's internal workspace data only. Cite tool-returned sources in the reply.";
+
+const EXTERNAL_FACT_SOURCING_NO_WEB =
+  "EXTERNAL-FACT SOURCING: Ground factual answers in a matching skill when one fits — the skill catalog is in this prompt; `load-skill` before applying it. Web research is not enabled for this thread, so when no skill fits, answer from your own knowledge and explicitly flag that no external source was available in this conversation (the user can enable web search to add one). Never use `run-stella-query` for external research — that tool reads stella's internal workspace data only.";
+
+const buildCoreRuleSections = ({
+  webResearch,
+}: ChatToolAvailability): readonly string[] => [
   "You are an AI inside stella, a legal workspace. Answer directly; skip greetings and persona. For complex or ambiguous tasks, call `ask-user` to gather requirements before acting.",
-  "ASK-USER BOUNDARY: Use `ask-user` only for missing task facts (preferences, jurisdiction, parties, scope). Never use it to request tool-call permission or consent — stella handles approvals outside the model. When you decide to call `ask-user`, do not emit any other tool calls (web_search, run-stella-query, etc.) in the same turn — wait for the user's answer first; otherwise the user sees retrieved data before they have answered the clarifying question and that data may be off-topic. EXCEPTION: `load-skill` may immediately precede `ask-user` in the same turn so the clarifying questions can be informed by the skill's methodology.",
+  "ASK-USER BOUNDARY: Use `ask-user` only for missing task facts (preferences, jurisdiction, parties, scope). Never use it to request tool-call permission or consent — stella handles approvals outside the model. When you decide to call `ask-user`, do not emit any other tool calls (e.g. `run-stella-query`) in the same turn — wait for the user's answer first; otherwise the user sees retrieved data before they have answered the clarifying question and that data may be off-topic. EXCEPTION: `load-skill` may immediately precede `ask-user` in the same turn so the clarifying questions can be informed by the skill's methodology.",
   "REPEATED-QUESTION GUARD: When the user answers a question (even tersely — 'Yes', 'Czechia', 'all parties'), treat the answer as the answer and advance to the next step. Do not re-ask the same question with cosmetic rewording or restate it as confirmation. If their answer leaves a required fact still missing, ask ONLY for that missing fact, never the one they already answered.",
   "TRUTHFULNESS: Never guess, infer, or fabricate document content — retrieve via tools first. Only claim an action occurred when its tool returned success for that action; surface skips, no-ops, and errors plainly.",
-  "EXTERNAL-FACT SOURCING: Always try to ground factual answers in an external source before falling back to your own knowledge. The skill catalog is in this prompt — pick a matching skill and `load-skill` if one fits; otherwise call `web_search` (with `fetch_url` follow-up when snippets are short or contradict). Only when those tools return nothing usable may you answer from your own knowledge, and you MUST flag that you have no source for the claim. Never use `run-stella-query` for external research — that tool reads stella's internal workspace data only. Cite tool-returned sources in the reply.",
+  webResearch ? EXTERNAL_FACT_SOURCING_WITH_WEB : EXTERNAL_FACT_SOURCING_NO_WEB,
   "POST-LOAD-SKILL: After `load-skill` returns, never produce a 'Loaded the X skill' confirmation message. In the SAME turn, do one of: (a) immediately apply the skill's methodology to the user's stated task using the appropriate tool(s) and surface the result as your answer; or (b) if the user's request is bare (just a skill reference) or missing facts the skill explicitly requires (jurisdiction, parties, scope, parameters), call `ask-user` with the SPECIFIC clarifying questions the skill methodology calls for — never generic 'what do you want me to do?'. Read the skill body; ask only for what the skill needs to proceed.",
   "SKILL-RESOURCES: When `load-skill` returns a non-empty `resources` list, treat those paths as part of the skill's methodology — not optional appendices. Before producing the final answer, call `read-skill-resource` on every resource the user's task plausibly depends on (criteria checklists, jurisdictional references, templates the skill prescribes). EMIT ALL READ CALLS IN A SINGLE ASSISTANT TURN — multiple `read-skill-resource` invocations issued together execute in parallel and finish in one round-trip; issuing them across separate turns serializes the reads and multiplies latency. Never claim you 'applied the skill' if you only read the top-level instructions; if you skip resources, say so plainly and offer to re-run with the resources read.",
   "SKILL-REF LINKS: When the user's message contains a markdown link of the form `[name](#stella-skill-ref=slug)`, treat it as an explicit request to use that skill. Call `load-skill` with `skillName: slug` immediately (unless that skill is already loaded in this thread), then follow POST-LOAD-SKILL. Do not echo the link or narrate the load.",
@@ -83,7 +121,7 @@ const CORE_RULE_SECTIONS = [
   "CITATIONS: When a tool returns a stable URL, cite each individual claim inline with its OWN Markdown link — one citation per sentence (or per discrete fact) rather than a single trailing 'Sources:' block. Anchor text should be short (source domain, citation, or `[1]`-style footnote), and each link must point to the specific URL that supports THAT claim. The stella inspector opens these links in-app on click, so prefer them over plain text. Never invent URLs.",
   "LEGAL REFERENCE RESOLUTION: Citation resolvers are exact-match. On a no-match, retry with a broader search tool using citation variants before declaring it unavailable.",
   "USER-FACING LANGUAGE: Speak in legal-work terms; never expose internal names, tool names, or schema identifiers — refer to documents, matters, and folders by their human names. Reply in the user's UI language (see user context); switch only if the user themselves writes a natural-language message in another language. Copy `mention` strings from tool outputs verbatim instead of rewriting refs.",
-] as const;
+];
 
 export type UserContext = IncomingUserContext;
 
@@ -218,6 +256,12 @@ type BuildChatSystemPromptProps = {
   practiceJurisdictions: readonly PracticeJurisdiction[];
   refRegistry: ChatRefRegistry;
   safeDb: SafeDb;
+  /**
+   * The conditionally-registered tools handed to the model this turn.
+   * Prompt text is gated on these flags so it never names a tool that
+   * is absent from the registered `ChatToolMap`.
+   */
+  toolAvailability: ChatToolAvailability;
   userContext: IncomingUserContext | undefined;
   workspaceId: SafeId<"workspace"> | null;
   organizationId?: SafeId<"organization"> | undefined;
@@ -241,6 +285,7 @@ export const buildChatSystemPromptParts = async ({
   practiceJurisdictions,
   refRegistry,
   safeDb,
+  toolAvailability,
   userContext,
   userId,
   workspaceId,
@@ -287,6 +332,7 @@ export const buildChatSystemPromptParts = async ({
         ? buildGlobalPromptParts({
             practiceJurisdictions,
             skillMetadata: promptSkillMetadata,
+            toolAvailability,
             userContext: userContext ?? null,
           })
         : yield* Result.await(
@@ -295,6 +341,7 @@ export const buildChatSystemPromptParts = async ({
               refRegistry,
               safeDb,
               skillMetadata: promptSkillMetadata,
+              toolAvailability,
               userContext: userContext ?? null,
               workspaceId,
             }),
@@ -357,7 +404,10 @@ export const buildChatSystemPromptParts = async ({
         ),
       );
       if (template) {
-        activeTemplateSection = buildActiveTemplatePrompt(activeTemplate);
+        activeTemplateSection = buildActiveTemplatePrompt(
+          activeTemplate,
+          toolAvailability,
+        );
       }
     }
 
@@ -473,37 +523,81 @@ export const extractTitle = (parts: ChatMessage["parts"]) => {
 type BuildGlobalPromptProps = {
   practiceJurisdictions?: readonly PracticeJurisdiction[];
   skillMetadata?: readonly PromptSkillMetadata[] | undefined;
+  toolAvailability?: ChatToolAvailability | undefined;
   userContext: UserContext | null;
 };
 
 export const buildGlobalPrompt = ({
   practiceJurisdictions = [],
   skillMetadata = getChatSkillMetadata(),
+  toolAvailability = DEFAULT_CHAT_TOOL_AVAILABILITY,
   userContext,
 }: BuildGlobalPromptProps) =>
   buildGlobalPromptParts({
     practiceJurisdictions,
     skillMetadata,
+    toolAvailability,
     userContext,
   }).fullPrompt;
 
 export const buildGlobalPromptParts = ({
   practiceJurisdictions = [],
   skillMetadata = getChatSkillMetadata(),
+  toolAvailability = DEFAULT_CHAT_TOOL_AVAILABILITY,
   userContext,
 }: BuildGlobalPromptProps): ChatPromptParts =>
   buildPromptParts({
     practiceJurisdictions,
     requestContextSections: [],
     skillMetadata,
+    toolAvailability,
     userContext,
   });
+
+export type ChatContextPromptEstimate = {
+  /** System-prompt tokens: core rule sections + built-in skill catalog. */
+  promptTokens: number;
+  /** Tool-catalog tokens: the compact `read.*` API surface (`READONLY_API_HINT`). */
+  toolTokens: number;
+};
+
+/**
+ * Token estimate for the cache-stable prompt prefix, split into the
+ * instructions (`promptTokens`) and tool-catalog (`toolTokens`) halves the
+ * context meter renders. Uses the same section builders as `buildPromptParts`
+ * and the shared chars/4 estimator, so it tracks what the send path actually
+ * caches.
+ *
+ * Deliberately excluded (kept cheap and deterministic for the read path, and
+ * documented so the meter's honesty is auditable): org-installed skill
+ * metadata, the workspace "Connected to matter" section, the practice-
+ * jurisdiction line, the user-context block, and the executable tool JSON
+ * schemas passed separately to the provider. These are per-request/per-org and
+ * would require extra DB reads the meter does not otherwise need.
+ */
+export const estimateChatContextPromptTokens = ({
+  toolAvailability = DEFAULT_CHAT_TOOL_AVAILABILITY,
+  skillMetadata = getChatSkillMetadata(),
+}: {
+  toolAvailability?: ChatToolAvailability | undefined;
+  skillMetadata?: readonly PromptSkillMetadata[] | undefined;
+} = {}): ChatContextPromptEstimate => {
+  const instructionsText = joinPromptSections([
+    ...buildCoreRuleSections(toolAvailability),
+    buildSkillCatalogSection(skillMetadata),
+  ]);
+  return {
+    promptTokens: estimateTextTokens(instructionsText),
+    toolTokens: estimateTextTokens(READONLY_API_HINT),
+  };
+};
 
 type BuildWorkspacePromptProps = {
   practiceJurisdictions?: readonly PracticeJurisdiction[];
   refRegistry: ChatRefRegistry;
   safeDb: SafeDb;
   skillMetadata?: readonly PromptSkillMetadata[] | undefined;
+  toolAvailability: ChatToolAvailability;
   userContext: UserContext | null;
   workspaceId: SafeId<"workspace">;
 };
@@ -513,6 +607,7 @@ const buildWorkspacePromptPartsFromDb = async ({
   refRegistry,
   safeDb,
   skillMetadata = getChatSkillMetadata(),
+  toolAvailability,
   userContext,
   workspaceId,
 }: BuildWorkspacePromptProps): Promise<Result<ChatPromptParts, SafeDbError>> =>
@@ -530,6 +625,7 @@ const buildWorkspacePromptPartsFromDb = async ({
         practiceJurisdictions,
         refRegistry,
         skillMetadata,
+        toolAvailability,
         userContext,
         workspaceId,
         workspaceName: workspacePromptData.workspaceName,
@@ -603,6 +699,7 @@ type BuildWorkspacePromptTextProps = {
   practiceJurisdictions?: readonly PracticeJurisdiction[];
   refRegistry: ChatRefRegistry;
   skillMetadata?: readonly PromptSkillMetadata[] | undefined;
+  toolAvailability?: ChatToolAvailability | undefined;
   userContext: UserContext | null;
   workspaceId: SafeId<"workspace">;
   workspaceName: string;
@@ -613,6 +710,7 @@ export const buildWorkspacePromptText = ({
   practiceJurisdictions = [],
   refRegistry,
   skillMetadata = getChatSkillMetadata(),
+  toolAvailability = DEFAULT_CHAT_TOOL_AVAILABILITY,
   userContext,
   workspaceId,
   workspaceName,
@@ -622,6 +720,7 @@ export const buildWorkspacePromptText = ({
     practiceJurisdictions,
     refRegistry,
     skillMetadata,
+    toolAvailability,
     userContext,
     workspaceId,
     workspaceName,
@@ -632,6 +731,7 @@ export const buildWorkspacePromptParts = ({
   practiceJurisdictions = [],
   refRegistry,
   skillMetadata = getChatSkillMetadata(),
+  toolAvailability = DEFAULT_CHAT_TOOL_AVAILABILITY,
   userContext,
   workspaceId,
   workspaceName,
@@ -645,6 +745,7 @@ export const buildWorkspacePromptParts = ({
       workspaceName,
     }),
     skillMetadata,
+    toolAvailability,
     userContext,
   });
 
@@ -743,6 +844,7 @@ const buildEditableBlocksPromptParts = (snapshot: ActiveDocxEditSnapshot) => {
  */
 export const buildActiveTemplatePrompt = (
   activeTemplate: IncomingActiveTemplate,
+  toolAvailability: ChatToolAvailability,
 ) => {
   const safeName = sanitizePromptValue({
     maxLength: 200,
@@ -750,7 +852,9 @@ export const buildActiveTemplatePrompt = (
   });
   const snapshot = activeTemplate.docxEditSnapshot;
   const editingSections =
-    snapshot === undefined ? [] : buildActiveTemplateEditSections(snapshot);
+    snapshot === undefined
+      ? []
+      : buildActiveTemplateEditSections({ snapshot, toolAvailability });
 
   return [
     `ACTIVE TEMPLATE: The user is authoring the reusable document template "${safeName}" in the template studio. It is an org-level template, not a matter document — do not call matter retrieval (\`read.*\`) or \`create-document\` for requests about it; the full text is in the block list below. Plain questions about the template get a normal text answer.`,
@@ -759,15 +863,32 @@ export const buildActiveTemplatePrompt = (
   ].join("\n");
 };
 
-const buildActiveTemplateEditSections = (
-  snapshot: ActiveDocxEditSnapshot,
-): string[] => {
+// FIELD SUGGESTIONS has two shapes: with template authoring the model
+// is steered to `suggest_template_fields` for the analysis pass;
+// without it, straight to `apply-active-docx-edits` replacements.
+const FIELD_SUGGESTIONS_WITH_AUTHORING =
+  "FIELD SUGGESTIONS: When the user asks which literal values should become fillable fields (or uses the suggest-fields preset), first call `suggest_template_fields` with the document text (block texts joined with newlines) and any user guidance as `instructions`. Then apply the suggestions you keep with `apply-active-docx-edits`: one `replaceInBlock` per occurrence, `find` = the exact literalText, `replace` = the `{{fieldPath}}` marker verbatim (e.g. `{{company.name}}`). Reuse the same fieldPath for every occurrence of the same value.";
+
+const FIELD_SUGGESTIONS_NO_AUTHORING =
+  "FIELD SUGGESTIONS: When the user asks which literal values should become fillable fields, propose them with `apply-active-docx-edits`: one `replaceInBlock` per occurrence, `find` = the exact literal text, `replace` = the `{{fieldPath}}` marker verbatim (e.g. `{{company.name}}`). Reuse the same fieldPath for every occurrence of the same value.";
+
+type BuildActiveTemplateEditSectionsProps = {
+  snapshot: ActiveDocxEditSnapshot;
+  toolAvailability: ChatToolAvailability;
+};
+
+const buildActiveTemplateEditSections = ({
+  snapshot,
+  toolAvailability,
+}: BuildActiveTemplateEditSectionsProps): string[] => {
   const { blocks, truncationNotice } = buildEditableBlocksPromptParts(snapshot);
 
   return [
     "TEMPLATE EDITING: When the user asks — in any language — to change, edit, replace, rewrite, fix, correct, review, or revise the template text, you MUST call `apply-active-docx-edits` in the same turn before claiming any work. Operations are queued as in-document suggestions the user accepts or dismisses one by one; NEVER claim the document was changed (only ids in `applied` represent real changes, which this surface does not produce).",
     "SUPPORTED OPERATIONS: only `replaceInBlock` (exact `find`, copied verbatim from the block text), `replaceBlock`, and `deleteBlock`. The template studio cannot honour `insertAfterBlock`, `insertBeforeBlock`, `commentOnBlock`, or `insertSignatureTable` — such operations are skipped; do not emit them and do not promise insertions.",
-    "FIELD SUGGESTIONS: When the user asks which literal values should become fillable fields (or uses the suggest-fields preset), first call `suggest_template_fields` with the document text (block texts joined with newlines) and any user guidance as `instructions`. Then apply the suggestions you keep with `apply-active-docx-edits`: one `replaceInBlock` per occurrence, `find` = the exact literalText, `replace` = the `{{fieldPath}}` marker verbatim (e.g. `{{company.name}}`). Reuse the same fieldPath for every occurrence of the same value.",
+    toolAvailability.templateAuthoring
+      ? FIELD_SUGGESTIONS_WITH_AUTHORING
+      : FIELD_SUGGESTIONS_NO_AUTHORING,
     'ALWAYS set `severity` and `area` on each operation (`severity`: "low" | "medium" | "high"; `area`: short topic label such as "Fields", "Names", "Wording").',
     "After the tool returns, reply with ONE short sentence (in the user's language) covering the count and the goal — the suggestions already render in the document with full context; do not enumerate them.",
     truncationNotice,
@@ -1169,6 +1290,7 @@ type BuildPromptProps = {
   practiceJurisdictions: readonly PracticeJurisdiction[];
   requestContextSections: string[];
   skillMetadata: readonly PromptSkillMetadata[];
+  toolAvailability: ChatToolAvailability;
   userContext: UserContext | null;
 };
 
@@ -1176,13 +1298,14 @@ const buildPromptParts = ({
   practiceJurisdictions,
   requestContextSections,
   skillMetadata,
+  toolAvailability,
   userContext,
 }: BuildPromptProps): ChatPromptParts => {
   const { safeSkillMetadata, untrustedSkillMetadata } =
     splitSkillMetadataForPrompt(skillMetadata);
   const cacheStablePrefix = brandChatCacheStablePrefix(
     joinPromptSections([
-      ...CORE_RULE_SECTIONS,
+      ...buildCoreRuleSections(toolAvailability),
       buildSkillCatalogSection(safeSkillMetadata),
       READONLY_API_HINT,
     ]),

--- a/apps/api/src/handlers/chat/chat-schema.test.ts
+++ b/apps/api/src/handlers/chat/chat-schema.test.ts
@@ -302,6 +302,58 @@ describe("validateMessage", () => {
     expectInvalidChatMessage(result);
   });
 
+  test("accepts an input-complete tool call that carries only arguments", async () => {
+    // The wire/persist shape TanStack actually produces: a valid
+    // `arguments` JSON string and no `input` field. The client derives
+    // `input` from `arguments` at the UI boundary, so the server must
+    // keep accepting arguments-only tool-call parts.
+    const result = await validateMessage({
+      message: {
+        id: chatMessageId("msg_arguments_only_tool_call"),
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-call",
+            id: "tool-call-1",
+            name: "search-documents",
+            arguments: JSON.stringify({ query: "contract" }),
+            state: "input-complete",
+          },
+        ],
+      },
+      safeDb: noDbReads,
+      threadId: chatThreadId("thread_arguments_only_tool_call"),
+      tools: searchTools,
+      userId: userId("user_arguments_only_tool_call"),
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("rejects an input-complete tool call whose arguments fail the tool schema", async () => {
+    const result = await validateMessage({
+      message: {
+        id: chatMessageId("msg_arguments_only_invalid"),
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-call",
+            id: "tool-call-1",
+            name: "search-documents",
+            arguments: JSON.stringify({ query: 123 }),
+            state: "input-complete",
+          },
+        ],
+      },
+      safeDb: noDbReads,
+      threadId: chatThreadId("thread_arguments_only_invalid"),
+      tools: searchTools,
+      userId: userId("user_arguments_only_invalid"),
+    });
+
+    expectInvalidChatMessage(result);
+  });
+
   test("rejects tool call outputs that fail the tool schema", async () => {
     const result = await validateMessage({
       message: {

--- a/apps/api/src/handlers/chat/compaction-budget.ts
+++ b/apps/api/src/handlers/chat/compaction-budget.ts
@@ -1,0 +1,77 @@
+/**
+ * Per-thread compaction budget: resolves the chat model the next send would
+ * use, maps it through the catalog's documented context window, and derives
+ * the compaction trigger plus the proportionally-scaled preserved tail.
+ *
+ * Split from `compaction.ts` (pure token math) so that module stays free of
+ * provider/model-resolution dependencies. Used by both the send path (to gate
+ * and drive checkpointing) and the read path (to size the context meter), so a
+ * thread's meter denominator matches the trigger its next send will apply.
+ */
+import { getContextWindowTokens } from "@stll/ai-catalog";
+
+import {
+  resolveCompactionTriggerTokens,
+  resolvePreserveTokensForTrigger,
+} from "@/api/handlers/chat/compaction";
+import type { OrgAIConfig } from "@/api/lib/ai-config";
+import type { SafeId } from "@/api/lib/branded-types";
+import { getTanStackTextModelInfoForRole } from "@/api/lib/tanstack-ai-models";
+
+export type ChatCompactionBudget = {
+  triggerTokens: number;
+  preserveTokens: number;
+};
+
+type ResolveChatCompactionBudgetOptions = {
+  /** Dev-only model override (`body.devModelId`); absent on the read path. */
+  devModelId?: string | undefined;
+  orgAIConfig: OrgAIConfig | null;
+  organizationId: SafeId<"organization">;
+};
+
+/**
+ * Trigger + preserve budget for a thread, keyed off the resolved chat model's
+ * context window. Never throws: an unconfigured/unsupported chat model degrades
+ * to the historical default trigger so compaction and the meter keep working.
+ */
+export const resolveChatCompactionBudget = (
+  options: ResolveChatCompactionBudgetOptions,
+): ChatCompactionBudget => {
+  const triggerTokens = resolveCompactionTriggerTokens(
+    resolveChatContextWindowTokens(options),
+  );
+  return {
+    triggerTokens,
+    preserveTokens: resolvePreserveTokensForTrigger(triggerTokens),
+  };
+};
+
+const resolveChatContextWindowTokens = (
+  options: ResolveChatCompactionBudgetOptions,
+): number | undefined => {
+  const modelId = resolveChatModelId(options);
+  return modelId === undefined ? undefined : getContextWindowTokens(modelId);
+};
+
+const resolveChatModelId = ({
+  devModelId,
+  orgAIConfig,
+  organizationId,
+}: ResolveChatCompactionBudgetOptions): string | undefined => {
+  if (devModelId) {
+    return devModelId;
+  }
+
+  try {
+    return getTanStackTextModelInfoForRole("chat", orgAIConfig, {
+      organizationId,
+    }).modelId;
+  } catch {
+    // Boundary: `getTanStackTextModelInfoForRole` throws for an
+    // unconfigured/role-unsupported chat model (e.g. BYOK not set up). Budget
+    // resolution is best-effort — fall back to the default trigger via an
+    // undefined window rather than failing the send or the meter.
+    return undefined;
+  }
+};

--- a/apps/api/src/handlers/chat/compaction.test.ts
+++ b/apps/api/src/handlers/chat/compaction.test.ts
@@ -10,14 +10,23 @@ import {
   compactChatMessages,
   compactModelMessagesForModel,
   compactModelMessages,
+  computeThreadContextUsage,
   parseChatCompactionSummary,
   planChatCompaction,
   planModelCompaction,
   renderChatMessagesForCompaction,
   renderModelMessagesForCompaction,
+  resolveCompactionTriggerTokens,
+  resolvePreserveTokensForTrigger,
   shouldCompactChatMessages,
   summarizeChatCompaction,
 } from "./compaction";
+
+// Mirrors the stable estimator contract in compaction.ts. If these change, the
+// exact-value assertions below intentionally fail so the meter math is revisited.
+const MESSAGE_OVERHEAD_TOKENS = 12;
+const FILE_PART_ESTIMATED_TOKENS = 8000;
+const DEFAULT_TRIGGER_TOKENS = 64_000;
 
 const textMessage = ({
   id,
@@ -583,5 +592,189 @@ Answer the latest question.
     ]);
 
     expect(transcript).toContain("[unserializable]");
+  });
+});
+
+describe("thread context usage", () => {
+  const attachmentPart = () =>
+    createChatAttachmentPart({
+      filename: "contract.pdf",
+      mimeType: "application/pdf",
+      url: "stella-user-file://file_1",
+    });
+
+  test("reports an all-zero breakdown for an empty thread", () => {
+    const usage = computeThreadContextUsage({ messages: [], summary: null });
+
+    expect(usage).toEqual({
+      estimatedTokens: 0,
+      triggerTokens: DEFAULT_TRIGGER_TOKENS,
+      cacheStableTokens: 0,
+      summarizedMessageCount: 0,
+      breakdown: {
+        promptTokens: 0,
+        toolTokens: 0,
+        summaryTokens: 0,
+        attachmentTokens: 0,
+        conversationTokens: 0,
+      },
+    });
+  });
+
+  test("counts only conversation tokens for a summary-free text thread", () => {
+    const usage = computeThreadContextUsage({
+      messages: [
+        textMessage({ id: "msg_1", role: "user", text: "hello" }),
+        textMessage({ id: "msg_2", role: "assistant", text: "hi there" }),
+      ],
+      summary: null,
+    });
+
+    // "hello" (5 chars) and "hi there" (8 chars) round up to 2 tokens each,
+    // plus the per-message overhead.
+    const expected = 2 * MESSAGE_OVERHEAD_TOKENS + 2 + 2;
+    expect(usage.breakdown).toEqual({
+      promptTokens: 0,
+      toolTokens: 0,
+      summaryTokens: 0,
+      attachmentTokens: 0,
+      conversationTokens: expected,
+    });
+    expect(usage.estimatedTokens).toBe(expected);
+  });
+
+  test("folds prompt and tool estimates into the sum and cache-stable total", () => {
+    const usage = computeThreadContextUsage({
+      messages: [textMessage({ id: "msg_1", role: "user", text: "hello" })],
+      summary: {
+        summarizedMessageCount: 7,
+        summaryMarkdown: "## Goal\nContinue the analysis.",
+      },
+      promptTokens: 1500,
+      toolTokens: 900,
+    });
+
+    const {
+      promptTokens,
+      toolTokens,
+      summaryTokens,
+      attachmentTokens,
+      conversationTokens,
+    } = usage.breakdown;
+
+    expect(promptTokens).toBe(1500);
+    expect(toolTokens).toBe(900);
+    expect(usage.cacheStableTokens).toBe(2400);
+    expect(usage.summarizedMessageCount).toBe(7);
+    // The invariant the segmented bar relies on: all five parts reconstruct the
+    // whole, now including the cache-stable prefix.
+    expect(usage.estimatedTokens).toBe(
+      promptTokens +
+        toolTokens +
+        summaryTokens +
+        attachmentTokens +
+        conversationTokens,
+    );
+  });
+
+  test("attributes each file part to attachmentTokens, its text to conversation", () => {
+    const usage = computeThreadContextUsage({
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          parts: [
+            { type: "text", content: "see attached" },
+            attachmentPart(),
+            attachmentPart(),
+          ],
+        },
+      ],
+      summary: null,
+    });
+
+    // "see attached" is 12 chars -> 3 tokens, plus the message overhead.
+    expect(usage.breakdown.conversationTokens).toBe(
+      MESSAGE_OVERHEAD_TOKENS + 3,
+    );
+    expect(usage.breakdown.attachmentTokens).toBe(
+      2 * FILE_PART_ESTIMATED_TOKENS,
+    );
+    expect(usage.breakdown.summaryTokens).toBe(0);
+  });
+
+  test("keeps the three parts summing to estimatedTokens with an active summary", () => {
+    const usage = computeThreadContextUsage({
+      messages: [
+        textMessage({ id: "msg_1", role: "user", text: "old context here" }),
+        {
+          id: "msg_2",
+          role: "user",
+          parts: [{ type: "text", content: "see attached" }, attachmentPart()],
+        },
+      ],
+      summary: {
+        summarizedMessageCount: 3,
+        summaryMarkdown: "## Goal\nContinue the analysis.",
+      },
+    });
+
+    const { summaryTokens, conversationTokens, attachmentTokens } =
+      usage.breakdown;
+
+    expect(summaryTokens).toBeGreaterThan(0);
+    expect(conversationTokens).toBeGreaterThan(0);
+    expect(attachmentTokens).toBe(FILE_PART_ESTIMATED_TOKENS);
+    // The invariant the frontend relies on: no reconciliation needed because the
+    // three segments reconstruct the whole.
+    expect(usage.estimatedTokens).toBe(
+      summaryTokens + conversationTokens + attachmentTokens,
+    );
+  });
+
+  test("honors a custom trigger and leaves the estimate independent of it", () => {
+    const usage = computeThreadContextUsage({
+      messages: [textMessage({ id: "msg_1", role: "user", text: "hello" })],
+      summary: null,
+      triggerTokens: 1000,
+    });
+
+    expect(usage.triggerTokens).toBe(1000);
+    expect(usage.estimatedTokens).toBe(MESSAGE_OVERHEAD_TOKENS + 2);
+  });
+});
+
+describe("per-model compaction budget", () => {
+  test("uses half the window, clamped to [64k, 200k]", () => {
+    // 128k window -> 64k (lower clamp), 200k -> 100k, 300k -> 150k,
+    // 400k/1M -> 200k (upper clamp).
+    expect(resolveCompactionTriggerTokens(128_000)).toBe(
+      DEFAULT_TRIGGER_TOKENS,
+    );
+    expect(resolveCompactionTriggerTokens(200_000)).toBe(100_000);
+    expect(resolveCompactionTriggerTokens(300_000)).toBe(150_000);
+    expect(resolveCompactionTriggerTokens(400_000)).toBe(200_000);
+    expect(resolveCompactionTriggerTokens(1_048_576)).toBe(200_000);
+  });
+
+  test("never drops below the default trigger even for tiny windows", () => {
+    expect(resolveCompactionTriggerTokens(32_000)).toBe(DEFAULT_TRIGGER_TOKENS);
+  });
+
+  test("falls back to the default trigger for an unknown window", () => {
+    expect(resolveCompactionTriggerTokens(undefined)).toBe(
+      DEFAULT_TRIGGER_TOKENS,
+    );
+  });
+
+  test("scales the preserved tail proportionally to the trigger", () => {
+    // At the default trigger the preserve budget is unchanged (38k); a 100k
+    // trigger scales it up by the same 100k/64k ratio.
+    expect(resolvePreserveTokensForTrigger(DEFAULT_TRIGGER_TOKENS)).toBe(
+      38_000,
+    );
+    expect(resolvePreserveTokensForTrigger(200_000)).toBe(
+      Math.floor((200_000 * 38_000) / DEFAULT_TRIGGER_TOKENS),
+    );
   });
 });

--- a/apps/api/src/handlers/chat/compaction.ts
+++ b/apps/api/src/handlers/chat/compaction.ts
@@ -26,6 +26,13 @@ const MESSAGE_OVERHEAD_TOKENS = 12;
 const FILE_PART_ESTIMATED_TOKENS = 8000;
 const DEFAULT_TRIGGER_TOKENS = 64_000;
 const DEFAULT_PRESERVE_TOKENS = 38_000;
+/**
+ * Upper bound on the per-model compaction trigger. Even a 1M-token model
+ * checkpoints well before its hard limit: summaries stay cheap, the tail
+ * we resummarize stays bounded, and provider latency/cost stay sane. The
+ * lower bound is `DEFAULT_TRIGGER_TOKENS` (the historical single value).
+ */
+const MAX_TRIGGER_TOKENS = 200_000;
 const MAX_TEXT_PART_CHARS = 8000;
 const MAX_STRUCTURED_PART_CHARS = 4000;
 const MAX_SUMMARY_OUTPUT_TOKENS = 1800;
@@ -110,6 +117,136 @@ export const shouldCompactChatMessages = (
   messages: readonly ChatMessage[],
   triggerTokens: number = DEFAULT_TRIGGER_TOKENS,
 ): boolean => estimateMessagesTokens(messages) > triggerTokens;
+
+/**
+ * Per-model compaction trigger: half the model's documented input window,
+ * clamped to `[DEFAULT_TRIGGER_TOKENS, MAX_TRIGGER_TOKENS]`. Half-window
+ * leaves room for the reply plus the untrusted suffix and tool traffic the
+ * estimate here does not model. An undefined window (unknown model) falls
+ * back to the historical single trigger so behaviour never regresses.
+ */
+export const resolveCompactionTriggerTokens = (
+  contextWindowTokens: number | undefined,
+): number => {
+  if (contextWindowTokens === undefined) {
+    return DEFAULT_TRIGGER_TOKENS;
+  }
+  return Math.min(
+    MAX_TRIGGER_TOKENS,
+    Math.max(DEFAULT_TRIGGER_TOKENS, Math.floor(contextWindowTokens / 2)),
+  );
+};
+
+/**
+ * Scale the preserved-tail budget proportionally to the resolved trigger so
+ * the summarize/keep ratio stays constant as the trigger grows with the
+ * model's window.
+ */
+export const resolvePreserveTokensForTrigger = (
+  triggerTokens: number,
+): number =>
+  Math.floor(
+    (triggerTokens * DEFAULT_PRESERVE_TOKENS) / DEFAULT_TRIGGER_TOKENS,
+  );
+
+export type ThreadContextUsage = {
+  estimatedTokens: number;
+  triggerTokens: number;
+  /** Prompt-cache-stable prefix (instructions + tool catalog). Equal to
+   *  `breakdown.promptTokens + breakdown.toolTokens`. */
+  cacheStableTokens: number;
+  /** Messages folded into the active checkpoint summary; 0 when none. */
+  summarizedMessageCount: number;
+  /** Five parts in legend/render order. They sum to `estimatedTokens`
+   *  exactly, so the segmented bar needs no reconciliation. */
+  breakdown: {
+    promptTokens: number;
+    toolTokens: number;
+    summaryTokens: number;
+    attachmentTokens: number;
+    conversationTokens: number;
+  };
+};
+
+type ComputeThreadContextUsageOptions = {
+  messages: readonly ChatMessage[];
+  /** Active compaction checkpoint carried into the next send, or null when the
+   *  thread has not been summarized yet. Its rendered summary message is what
+   *  the model actually receives, so it is estimated the same way here. */
+  summary: {
+    summarizedMessageCount: number;
+    summaryMarkdown: string;
+  } | null;
+  /** System-prompt estimate (core rules + skill catalog). Supplied by the
+   *  caller from the shared prompt builders; defaults to 0 for pure
+   *  token-math callers/tests. */
+  promptTokens?: number | undefined;
+  /** Tool-catalog estimate (the read.* API surface in the system prompt).
+   *  Supplied by the caller; defaults to 0. */
+  toolTokens?: number | undefined;
+  triggerTokens?: number | undefined;
+};
+
+/**
+ * Estimate the model context a thread's next send would carry, split into the
+ * five parts the composer meter renders: the cache-stable prefix (system
+ * prompt + tool catalog), the active compaction summary, the attachment file
+ * parts, and the conversation text. The message-derived parts reuse the same
+ * estimators as `planChatCompaction`, so the conversation/summary/attachment
+ * split tracks what `shouldCompactChatMessages` sees; the five parts sum to
+ * `estimatedTokens` exactly.
+ */
+export const computeThreadContextUsage = ({
+  messages,
+  summary,
+  promptTokens = 0,
+  toolTokens = 0,
+  triggerTokens = DEFAULT_TRIGGER_TOKENS,
+}: ComputeThreadContextUsageOptions): ThreadContextUsage => {
+  const summaryTokens = summary
+    ? estimateMessageTokens(
+        createCompactionSummaryMessage({
+          summarizedMessageCount: summary.summarizedMessageCount,
+          summary: summary.summaryMarkdown,
+        }),
+      )
+    : 0;
+
+  let conversationTokens = 0;
+  let attachmentTokens = 0;
+  for (const message of messages) {
+    const messageAttachmentTokens =
+      countAttachmentParts(message) * FILE_PART_ESTIMATED_TOKENS;
+    attachmentTokens += messageAttachmentTokens;
+    // The message's non-attachment share (overhead + text/structured parts) is
+    // whatever estimateMessageTokens counts beyond its file parts, so the split
+    // stays exact against the estimator the send path uses.
+    conversationTokens +=
+      estimateMessageTokens(message) - messageAttachmentTokens;
+  }
+
+  return {
+    estimatedTokens:
+      promptTokens +
+      toolTokens +
+      summaryTokens +
+      attachmentTokens +
+      conversationTokens,
+    triggerTokens,
+    cacheStableTokens: promptTokens + toolTokens,
+    summarizedMessageCount: summary?.summarizedMessageCount ?? 0,
+    breakdown: {
+      promptTokens,
+      toolTokens,
+      summaryTokens,
+      attachmentTokens,
+      conversationTokens,
+    },
+  };
+};
+
+const countAttachmentParts = (message: ChatMessage): number =>
+  message.parts.filter(isChatAttachmentPart).length;
 
 export const planChatCompaction = ({
   messages,
@@ -813,7 +950,11 @@ const estimatePartTokens = (part: ChatMessage["parts"][number]): number => {
   return estimateTextTokens(safeStringify(part));
 };
 
-const estimateTextTokens = (text: string): number =>
+/**
+ * Canonical chars/4 token estimate. Shared with the prompt builders so the
+ * meter's prompt/tool parts use the same estimator as the message parts.
+ */
+export const estimateTextTokens = (text: string): number =>
   Math.ceil(text.length / ESTIMATED_CHARS_PER_TOKEN);
 
 const startsWithUserMessage = (

--- a/apps/api/src/handlers/chat/get-messages.ts
+++ b/apps/api/src/handlers/chat/get-messages.ts
@@ -54,6 +54,7 @@ const getMessages = createSafeRootHandler(
             workspaceId: true,
             contextMatterIds: true,
             webSearchEnabled: true,
+            usedAnonymization: true,
           },
         }),
       ),
@@ -132,12 +133,21 @@ const getMessages = createSafeRootHandler(
     // path: the active compaction summary plus the same windowed history the
     // model receives. Computed only here (the initial page); the /older
     // pagination endpoint does not carry it.
-    const checkpoint = yield* Result.await(
+    // Independent reads, fetched in parallel. `isAnonymized` mirrors the
+    // thread's persisted flag: anonymized threads never checkpoint, so the
+    // capped branch bounds this read the same way the send path bounds its
+    // history window (a long anonymized thread must not scan every row just
+    // to render the meter).
+    const [checkpointResult, windowedMessagesResult] = await Promise.all([
       readLatestChatCompaction({ safeDb, threadId }),
-    );
-    const windowedMessages = yield* Result.await(
-      loadWindowedThreadMessages({ safeDb, threadId, isAnonymized: false }),
-    );
+      loadWindowedThreadMessages({
+        safeDb,
+        threadId,
+        isAnonymized: thread.usedAnonymization,
+      }),
+    ]);
+    const checkpoint = yield* checkpointResult;
+    const windowedMessages = yield* windowedMessagesResult;
     // Null for a fresh, empty thread (nothing to meter yet); the frontend
     // renders nothing. Keeping the value nullable also unifies this branch with
     // the missing-thread branch (context: null) into one response type.

--- a/apps/api/src/handlers/chat/get-messages.ts
+++ b/apps/api/src/handlers/chat/get-messages.ts
@@ -1,8 +1,14 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
+import { estimateChatContextPromptTokens } from "@/api/handlers/chat/chat-prompt";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import { computeThreadContextUsage } from "@/api/handlers/chat/compaction";
+import type { ThreadContextUsage } from "@/api/handlers/chat/compaction";
+import { resolveChatCompactionBudget } from "@/api/handlers/chat/compaction-budget";
+import { loadWindowedThreadMessages } from "@/api/handlers/chat/history-window";
 import { loadChatMessagePage } from "@/api/handlers/chat/message-page";
+import { readLatestChatCompaction } from "@/api/handlers/chat/persistent-compaction";
 import { isWebSearchAvailable } from "@/api/handlers/chat/tools/chat-tools";
 import { getDisabledNativeToolSlugs } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -25,6 +31,7 @@ const getMessages = createSafeRootHandler(
   config,
   async function* ({
     activeWorkspaceIds,
+    orgAIConfig,
     params: { threadId },
     query: { allowMissingThread, workspaceId },
     safeDb,
@@ -85,6 +92,7 @@ const getMessages = createSafeRootHandler(
           lastActivityAt: null,
           webSearchAvailable,
           webSearchEnabled: false,
+          context: null,
         });
       }
 
@@ -120,6 +128,55 @@ const getMessages = createSafeRootHandler(
       loadChatMessagePage({ safeDb, threadId, userId: user.id }),
     );
 
+    // Estimate the model context the next send would carry, mirroring the send
+    // path: the active compaction summary plus the same windowed history the
+    // model receives. Computed only here (the initial page); the /older
+    // pagination endpoint does not carry it.
+    const checkpoint = yield* Result.await(
+      readLatestChatCompaction({ safeDb, threadId }),
+    );
+    const windowedMessages = yield* Result.await(
+      loadWindowedThreadMessages({ safeDb, threadId, isAnonymized: false }),
+    );
+    // Null for a fresh, empty thread (nothing to meter yet); the frontend
+    // renders nothing. Keeping the value nullable also unifies this branch with
+    // the missing-thread branch (context: null) into one response type.
+    const hasContext = windowedMessages.length > 0 || checkpoint !== null;
+    // The meter's cache-stable prefix estimate mirrors the send path's stable
+    // prompt: web research steers the core rules through the same two gates the
+    // send path applies (provider availability and the thread's opt-in), and
+    // (unlike template studio) the standalone read path never carries
+    // template-authoring tools. The trigger denominator resolves the same chat
+    // model the next send would use.
+    const { promptTokens, toolTokens } = estimateChatContextPromptTokens({
+      toolAvailability: {
+        templateAuthoring: false,
+        webResearch: webSearchAvailable && thread.webSearchEnabled,
+      },
+    });
+    const { triggerTokens } = resolveChatCompactionBudget({
+      orgAIConfig,
+      organizationId: session.activeOrganizationId,
+    });
+    const context: ThreadContextUsage | null = hasContext
+      ? computeThreadContextUsage({
+          messages: windowedMessages.map((message) => ({
+            id: message.id,
+            role: message.role,
+            parts: message.content.data,
+          })),
+          promptTokens,
+          toolTokens,
+          triggerTokens,
+          summary: checkpoint
+            ? {
+                summarizedMessageCount: checkpoint.summarizedMessageCount,
+                summaryMarkdown: checkpoint.summaryMarkdown,
+              }
+            : null,
+        })
+      : null;
+
     return Result.ok({
       messages: page.messages,
       olderCursor: page.olderCursor,
@@ -127,6 +184,7 @@ const getMessages = createSafeRootHandler(
       lastActivityAt: page.lastActivityAt,
       webSearchAvailable,
       webSearchEnabled: thread.webSearchEnabled,
+      context,
     });
   },
 );

--- a/apps/api/src/handlers/chat/persistent-compaction.ts
+++ b/apps/api/src/handlers/chat/persistent-compaction.ts
@@ -150,8 +150,10 @@ type PersistChatCompactionCheckpointProps = {
   onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
   organizationId: SafeId<"organization">;
   orgAIConfig: OrgAIConfig | null;
+  preserveTokens?: number | undefined;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
+  triggerTokens?: number | undefined;
 };
 
 export const persistChatCompactionCheckpoint = async ({
@@ -163,8 +165,10 @@ export const persistChatCompactionCheckpoint = async ({
   onSummaryError,
   organizationId,
   orgAIConfig,
+  preserveTokens,
   safeDb,
   threadId,
+  triggerTokens,
 }: PersistChatCompactionCheckpointProps): Promise<
   Result<void, HandlerError<422 | 500> | SafeDbError>
 > => {
@@ -176,6 +180,8 @@ export const persistChatCompactionCheckpoint = async ({
     onSummaryError,
     organizationId,
     orgAIConfig,
+    preserveTokens,
+    triggerTokens,
   });
   if (Result.isError(checkpointResult)) {
     return Result.err(checkpointResult.error);

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -20,6 +20,7 @@ import {
 } from "@/api/handlers/chat/chat-prompt";
 import type {
   ChatSafePrompt,
+  ChatToolAvailability,
   ChatUntrustedPromptSuffix,
 } from "@/api/handlers/chat/chat-prompt";
 import type {
@@ -40,6 +41,7 @@ import {
   compactChatMessagesForModel,
   shouldCompactChatMessages,
 } from "@/api/handlers/chat/compaction";
+import { resolveChatCompactionBudget } from "@/api/handlers/chat/compaction-budget";
 import {
   expandThreadDataScope,
   extractAssistantWorkspaceIds,
@@ -79,7 +81,11 @@ import {
   intersectAccessibleWorkspaceIds,
   resolveToolWorkspaceIds,
 } from "@/api/handlers/chat/tools/authorized-workspace-ids";
-import { getChatTools } from "@/api/handlers/chat/tools/chat-tools";
+import {
+  areTemplateAuthoringToolsRegistered,
+  areWebResearchToolsRegistered,
+  getChatTools,
+} from "@/api/handlers/chat/tools/chat-tools";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import {
   buildExternalMcpSystemHint,
@@ -545,6 +551,18 @@ const sendMessage = createSafeRootHandler(
       organizationId: session.activeOrganizationId,
       safeDb,
       sendMode: body.sendMode,
+      // Derived from the same predicates/inputs `getChatTools` uses to
+      // register `web_search`/`fetch_url` and `suggest_template_fields`
+      // below, so the prompt only steers the model to tools that are
+      // actually handed to it.
+      toolAvailability: {
+        templateAuthoring: areTemplateAuthoringToolsRegistered(memberRole.role),
+        webResearch: areWebResearchToolsRegistered({
+          webSearchEnabled: thread.data.webSearchEnabled,
+          webSearchProviders,
+          disabledNativeToolSlugs,
+        }),
+      },
       userContext: body.userContext,
       userId: user.id,
       workspaceId,
@@ -958,6 +976,12 @@ const compactMessagesForContext = async ({
     traceId: Bun.randomUUIDv7(),
   });
 
+  const { triggerTokens, preserveTokens } = resolveChatCompactionBudget({
+    devModelId,
+    orgAIConfig,
+    organizationId,
+  });
+
   return await compactChatMessagesForModel({
     abortSignal,
     aiAnalytics,
@@ -972,6 +996,8 @@ const compactMessagesForContext = async ({
     },
     organizationId,
     orgAIConfig,
+    preserveTokens,
+    triggerTokens,
   });
 };
 
@@ -1027,11 +1053,17 @@ const scheduleChatCompactionCheckpoint = ({
   safeDb,
   threadId,
 }: ScheduleChatCompactionCheckpointProps): void => {
+  const { triggerTokens, preserveTokens } = resolveChatCompactionBudget({
+    devModelId,
+    orgAIConfig,
+    organizationId,
+  });
+
   // Cheap token-estimate gate over the per-send window. For non-anonymized
   // threads (the only ones that schedule a checkpoint) the window now holds the
   // full pre-checkpoint history, so it accurately signals whether compaction is
   // due; the common case is under the trigger and issues no full-history read.
-  if (!shouldCompactChatMessages(messages)) {
+  if (!shouldCompactChatMessages(messages, triggerTokens)) {
     return;
   }
 
@@ -1041,8 +1073,10 @@ const scheduleChatCompactionCheckpoint = ({
     devModelId,
     organizationId,
     orgAIConfig,
+    preserveTokens,
     safeDb,
     threadId,
+    triggerTokens,
   }).catch((error: unknown) => {
     captureError(error, {
       threadId,
@@ -1054,8 +1088,10 @@ const scheduleChatCompactionCheckpoint = ({
 type RunChatCompactionCheckpointProps = ChatCompactionModelProps & {
   abortSignal: AbortSignal;
   boundary: ReturnType<typeof createChatThirdPartyBoundary>;
+  preserveTokens: number;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
+  triggerTokens: number;
 };
 
 const runChatCompactionCheckpoint = async ({
@@ -1064,8 +1100,10 @@ const runChatCompactionCheckpoint = async ({
   devModelId,
   organizationId,
   orgAIConfig,
+  preserveTokens,
   safeDb,
   threadId,
+  triggerTokens,
 }: RunChatCompactionCheckpointProps): Promise<void> => {
   // Summarize from the true start of the conversation. The window passed to
   // the gate above is enough to know a checkpoint is due, but the durable
@@ -1114,8 +1152,10 @@ const runChatCompactionCheckpoint = async ({
     },
     organizationId,
     orgAIConfig,
+    preserveTokens,
     safeDb,
     threadId,
+    triggerTokens,
   });
   if (Result.isError(persistResult)) {
     captureError(persistResult.error, {
@@ -1546,6 +1586,7 @@ type PrepareChatContextProps = {
   refRegistry: ReturnType<typeof createChatRefRegistry>;
   safeDb: SafeDb;
   sendMode: ChatSendMode;
+  toolAvailability: ChatToolAvailability;
   userContext: IncomingUserContext | undefined;
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace"> | null;
@@ -1585,6 +1626,7 @@ const prepareChatContext = async ({
   refRegistry,
   safeDb,
   sendMode,
+  toolAvailability,
   userContext,
   userId,
   workspaceId,
@@ -1613,6 +1655,7 @@ const prepareChatContext = async ({
         practiceJurisdictions,
         refRegistry,
         safeDb,
+        toolAvailability,
         userContext,
         userId,
         workspaceId,

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -69,6 +69,44 @@ export const isWebSearchAvailable = ({
   return webSearchProviderAvailable && !webSearchOrgDisabled;
 };
 
+type WebResearchToolsRegisteredProps = {
+  webSearchEnabled: boolean;
+  webSearchProviders: ResolvedWebSearchProviders;
+  disabledNativeToolSlugs?: readonly string[] | undefined;
+};
+
+/**
+ * Single source of truth for "are `web_search` / `fetch_url`
+ * registered on this turn". `getChatTools` uses it to decide
+ * registration; prompt construction uses it (via the same inputs) to
+ * decide whether to instruct the model to use those tools. Deriving
+ * both from one predicate is what prevents the prompt from naming a
+ * tool the model was never handed.
+ */
+export const areWebResearchToolsRegistered = ({
+  webSearchEnabled,
+  webSearchProviders,
+  disabledNativeToolSlugs,
+}: WebResearchToolsRegisteredProps): boolean =>
+  webSearchEnabled &&
+  webSearchProviders.webSearchProvider !== null &&
+  isWebSearchAvailable({
+    webSearchProviderAvailable: webSearchProviders.webSearchProvider !== null,
+    disabledNativeToolSlugs,
+  });
+
+/**
+ * Single source of truth for "is `suggest_template_fields` registered
+ * on this turn". The tool widens a fill-only role into template
+ * authoring, so it maps to `template: ["create"]` rather than the
+ * broader `["use"]`. `getChatTools` uses this to decide registration;
+ * prompt construction uses it to decide whether the active-template
+ * section may steer the model to the tool.
+ */
+export const areTemplateAuthoringToolsRegistered = (
+  memberRole: keyof typeof roles,
+): boolean => roles[memberRole].authorize({ template: ["create"] }).success;
+
 type WorkspaceTools = ReturnType<typeof createWorkspaceTools>;
 type OrgTools = ReturnType<typeof createOrgTools>;
 type ChatExecutionTools = ReturnType<typeof createChatExecutionTools>;
@@ -244,12 +282,18 @@ export const getChatTools = ({
     organizationId,
     scopedDb,
   });
+  const webResearchAvailable = areWebResearchToolsRegistered({
+    webSearchEnabled,
+    webSearchProviders,
+    disabledNativeToolSlugs,
+  });
   const executionTools = createChatExecutionTools({
     accessibleWorkspaceIds: toolWorkspaceIds,
     organizationId,
     refRegistry,
     safeDb,
     userId,
+    webResearchAvailable,
   });
   const skillTools = createSkillTools({
     activeSkillContext,
@@ -280,14 +324,10 @@ export const getChatTools = ({
     disabledNativeToolSlugs?.includes("infosoud") ?? false;
   const infosoudTools = infosoudDisabled ? {} : createInfosoudTools();
   const { webSearchProvider, urlFetcher } = webSearchProviders;
-  const webSearchToolsAvailable = isWebSearchAvailable({
-    webSearchProviderAvailable: webSearchProvider !== null,
-    disabledNativeToolSlugs,
-  });
   // The `webSearchProvider !== null` re-check narrows the type for
-  // createWebSearchTools; it is implied by webSearchToolsAvailable.
+  // createWebSearchTools; it is implied by `webResearchAvailable`.
   const webSearchTools =
-    webSearchEnabled && webSearchToolsAvailable && webSearchProvider !== null
+    webResearchAvailable && webSearchProvider !== null
       ? createWebSearchTools({ webSearchProvider, urlFetcher })
       : {};
   const activeDocxEditTools = hasActiveDocxEditClient
@@ -334,10 +374,7 @@ export const getChatTools = ({
   // placeholders, i.e. it assists template authoring, not filling. Gate it
   // behind `template: ["create"]` so a fill-only role (e.g. intern, which has
   // `use` but not `create`) cannot reach authoring assistance.
-  const canAuthorTemplates = roles[memberRole].authorize({
-    template: ["create"],
-  }).success;
-  const templateAuthoringTools = canAuthorTemplates
+  const templateAuthoringTools = areTemplateAuthoringToolsRegistered(memberRole)
     ? createTemplateAuthoringTools({
         safeDb,
         organizationId,

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -89,7 +89,6 @@ export const areWebResearchToolsRegistered = ({
   disabledNativeToolSlugs,
 }: WebResearchToolsRegisteredProps): boolean =>
   webSearchEnabled &&
-  webSearchProviders.webSearchProvider !== null &&
   isWebSearchAvailable({
     webSearchProviderAvailable: webSearchProviders.webSearchProvider !== null,
     disabledNativeToolSlugs,

--- a/apps/api/src/handlers/chat/tools/execute/chat-execution-tool-descriptions.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-execution-tool-descriptions.ts
@@ -31,14 +31,7 @@ const RUN_STELLA_QUERY_SCOPE_NO_WEB =
   "NOT a general code sandbox, scratchpad, or way to call external " +
   "APIs, and never submit a no-op program just to 'think out loud'. ";
 
-export const buildRunStellaQueryToolDescription = ({
-  webResearchAvailable,
-}: RunStellaQueryToolDescriptionOptions) =>
-  "SCOPE: stella's internal workspace/organization data only " +
-  "(matters, entities, contacts, etc. via `read.*`). " +
-  (webResearchAvailable
-    ? RUN_STELLA_QUERY_SCOPE_WITH_WEB
-    : RUN_STELLA_QUERY_SCOPE_NO_WEB) +
+const RUN_STELLA_QUERY_USAGE =
   "Call with TypeScript that uses `read.<functionName>(input)`; " +
   "read returned records from `result.items`. The compact " +
   "function catalog is in the system prompt; call " +
@@ -57,3 +50,12 @@ export const buildRunStellaQueryToolDescription = ({
   `${DEFAULT_SANDBOX_LIMITS.maxDurationMs.toLocaleString()}ms, ` +
   `${DEFAULT_SANDBOX_LIMITS.maxHostCalls.toLocaleString()} host calls, ` +
   `${(DEFAULT_SANDBOX_LIMITS.maxReturnBytes / 1024).toLocaleString()} KiB returned.`;
+
+export const buildRunStellaQueryToolDescription = ({
+  webResearchAvailable,
+}: RunStellaQueryToolDescriptionOptions) =>
+  `SCOPE: stella's internal workspace/organization data only (matters, entities, contacts, etc. via \`read.*\`). ${
+    webResearchAvailable
+      ? RUN_STELLA_QUERY_SCOPE_WITH_WEB
+      : RUN_STELLA_QUERY_SCOPE_NO_WEB
+  }${RUN_STELLA_QUERY_USAGE}`;

--- a/apps/api/src/handlers/chat/tools/execute/chat-execution-tool-descriptions.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-execution-tool-descriptions.ts
@@ -9,13 +9,36 @@ export const DESCRIBE_STELLA_API_TOOL_DESCRIPTION =
   "stores records in `result.items`; paginated lists also " +
   "include `result.hasMore` and `result.nextOffset`.";
 
-export const RUN_STELLA_QUERY_TOOL_DESCRIPTION =
+type RunStellaQueryToolDescriptionOptions = {
+  /**
+   * Whether the web research tools (`web_search` / `fetch_url`) are
+   * actually registered for this turn. When they are not, the
+   * description must not point at them — otherwise the model is told
+   * to use a tool it cannot call.
+   */
+  webResearchAvailable: boolean;
+};
+
+// Same "not a code sandbox" warning either way; only the pointer to
+// the web research tools is conditional on their registration.
+const RUN_STELLA_QUERY_SCOPE_WITH_WEB =
+  "NOT a general code sandbox, scratchpad, or way to call external " +
+  "APIs — for legal research, public-web facts, or current events " +
+  "use `web_search`/`fetch_url` instead, and never submit a no-op " +
+  "program just to 'think out loud'. ";
+
+const RUN_STELLA_QUERY_SCOPE_NO_WEB =
+  "NOT a general code sandbox, scratchpad, or way to call external " +
+  "APIs, and never submit a no-op program just to 'think out loud'. ";
+
+export const buildRunStellaQueryToolDescription = ({
+  webResearchAvailable,
+}: RunStellaQueryToolDescriptionOptions) =>
   "SCOPE: stella's internal workspace/organization data only " +
-  "(matters, entities, contacts, etc. via `read.*`). NOT a " +
-  "general code sandbox, scratchpad, or way to call external " +
-  "APIs — for legal research, public-web facts, or current " +
-  "events use `web_search`/`fetch_url` instead, and never " +
-  "submit a no-op program just to 'think out loud'. " +
+  "(matters, entities, contacts, etc. via `read.*`). " +
+  (webResearchAvailable
+    ? RUN_STELLA_QUERY_SCOPE_WITH_WEB
+    : RUN_STELLA_QUERY_SCOPE_NO_WEB) +
   "Call with TypeScript that uses `read.<functionName>(input)`; " +
   "read returned records from `result.items`. The compact " +
   "function catalog is in the system prompt; call " +

--- a/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.test.ts
@@ -1,31 +1,42 @@
 import { describe, expect, test } from "bun:test";
 
-import { RUN_STELLA_QUERY_TOOL_DESCRIPTION } from "@/api/handlers/chat/tools/execute/chat-execution-tool-descriptions";
+import { buildRunStellaQueryToolDescription } from "@/api/handlers/chat/tools/execute/chat-execution-tool-descriptions";
+
+const WITH_WEB = buildRunStellaQueryToolDescription({
+  webResearchAvailable: true,
+});
+const NO_WEB = buildRunStellaQueryToolDescription({
+  webResearchAvailable: false,
+});
 
 describe("chat execution tool descriptions", () => {
   test("scopes run-stella-query to internal data and away from web research", () => {
     // Boundary: model should not abuse this tool for legal research or
     // as a thinking scratchpad — those uses caused real hallucinated
     // no-op programs in chat threads.
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toMatch(
-      /internal workspace.+data/iu,
-    );
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toMatch(/web_search/u);
+    for (const description of [WITH_WEB, NO_WEB]) {
+      expect(description).toMatch(/internal workspace.+data/iu);
+      // The "not a code sandbox / external API" warning holds in both
+      // shapes; only the web pointer is conditional.
+      expect(description).toMatch(/NOT a general code sandbox/u);
+    }
+  });
+
+  test("points at the web tools only when they are registered", () => {
+    // When web research is off for the turn, the tool description must
+    // not name `web_search` / `fetch_url` — the model would be told to
+    // call a tool it was never handed (the bug this guards against).
+    expect(WITH_WEB).toMatch(/web_search/u);
+    expect(WITH_WEB).toMatch(/fetch_url/u);
+    expect(NO_WEB).not.toMatch(/web_search/u);
+    expect(NO_WEB).not.toMatch(/fetch_url/u);
   });
 
   test("requires fresh read calls instead of replaying prior data", () => {
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toMatch(
-      /describe-stella-api\(\{name\}\)/u,
-    );
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toContain("`result.items`");
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toMatch(
-      /MUST fetch current data/u,
-    );
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toMatch(
-      /Do not hardcode.+inline arrays/u,
-    );
-    expect(RUN_STELLA_QUERY_TOOL_DESCRIPTION).toMatch(
-      /paginate.+until `hasMore` is false/u,
-    );
+    expect(WITH_WEB).toMatch(/describe-stella-api\(\{name\}\)/u);
+    expect(WITH_WEB).toContain("`result.items`");
+    expect(WITH_WEB).toMatch(/MUST fetch current data/u);
+    expect(WITH_WEB).toMatch(/Do not hardcode.+inline arrays/u);
+    expect(WITH_WEB).toMatch(/paginate.+until `hasMore` is false/u);
   });
 });

--- a/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.ts
@@ -4,8 +4,8 @@ import * as v from "valibot";
 
 import type { SafeDb } from "@/api/db";
 import {
+  buildRunStellaQueryToolDescription,
   DESCRIBE_STELLA_API_TOOL_DESCRIPTION,
-  RUN_STELLA_QUERY_TOOL_DESCRIPTION,
 } from "@/api/handlers/chat/tools/execute/chat-execution-tool-descriptions";
 import { createReadonlyOrgFunctionRegistry } from "@/api/handlers/chat/tools/execute/org-function-registry";
 import { readonlyOrgFunctionContracts } from "@/api/handlers/chat/tools/execute/org-manifest";
@@ -30,6 +30,12 @@ type CreateChatExecutionToolsProps = {
   refRegistry: ChatRefRegistry;
   safeDb: SafeDb;
   userId: SafeId<"user">;
+  /**
+   * Whether the web research tools are registered for this turn. The
+   * run-stella-query description points at `web_search` / `fetch_url`
+   * only when true, so the prompt never names a tool the model lacks.
+   */
+  webResearchAvailable: boolean;
 };
 
 const readonlyFunctionContracts: readonly ReadonlyFunctionContract[] = [
@@ -98,6 +104,7 @@ export const createChatExecutionTools = ({
   refRegistry,
   safeDb,
   userId,
+  webResearchAvailable,
 }: CreateChatExecutionToolsProps) => {
   const readonlySandboxRegistry = buildReadonlySandboxRegistry({
     accessibleWorkspaceIds,
@@ -155,7 +162,7 @@ export const createChatExecutionTools = ({
 
     "run-stella-query": toolDefinition({
       name: "run-stella-query",
-      description: RUN_STELLA_QUERY_TOOL_DESCRIPTION,
+      description: buildRunStellaQueryToolDescription({ webResearchAvailable }),
       inputSchema: toTanStackToolSchema(
         v.strictObject({
           code: v.pipe(

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -564,7 +564,10 @@ export function AppSidebar(props: AppSidebarProps) {
             </SidebarGroup>
           )}
 
-          <RecentChatsGroup activeOrganizationId={user.activeOrganizationId} />
+          <RecentChatsGroup
+            activeOrganizationId={user.activeOrganizationId}
+            showSeparator={pinned.length > 0 || recents.length > 0}
+          />
         </SidebarContextArea>
       </SidebarContent>
 
@@ -611,8 +614,10 @@ type RecentChatThread =
 
 const RecentChatsGroup = ({
   activeOrganizationId,
+  showSeparator,
 }: {
   activeOrganizationId: string;
+  showSeparator: boolean;
 }) => {
   const t = useTranslations();
   const mounted = useHasMounted();
@@ -657,7 +662,7 @@ const RecentChatsGroup = ({
 
   return (
     <>
-      <SidebarSeparator />
+      {showSeparator && <SidebarSeparator />}
       <SidebarGroup className="min-h-0 flex-1">
         <SidebarGroupLabel>{t("chat.landing.recentChats")}</SidebarGroupLabel>
         <SidebarGroupContent className={SCROLLABLE_GROUP_CONTENT}>

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -1,10 +1,11 @@
 import "./chat-editor.css";
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 
 import { PaperclipIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { useChatComposerWiring } from "@/components/chat-editor-provider";
@@ -13,6 +14,8 @@ import type {
   ChatInputDraft,
 } from "@/components/chat-editor-provider";
 import { ChatComposerActionButton } from "@/components/chat/chat-composer-action-button";
+import { ChatContextMeter } from "@/components/chat/chat-context-meter";
+import type { ChatContextUsage } from "@/components/chat/chat-context-meter";
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
 import { PromptEditorContent } from "@/components/prompt-editor";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
@@ -42,10 +45,12 @@ type ChatInputSurfaceProps = {
    * shield on raw requests or hide it on protected ones.
    */
   anonymized?: boolean;
-};
-
-const captureChatSubmitError = (error: unknown): void => {
-  getAnalytics().captureError(error);
+  /**
+   * Model-context estimate for this thread's next send. Renders a small ring
+   * meter in the footer that opens an explainer popover. Undefined on the
+   * new-chat surface (no thread yet), where nothing is rendered.
+   */
+  contextUsage?: ChatContextUsage | undefined;
 };
 
 export const ChatInputSurface = ({
@@ -58,6 +63,7 @@ export const ChatInputSurface = ({
   isGenerating = false,
   onStop,
   anonymized = false,
+  contextUsage,
 }: ChatInputSurfaceProps) => {
   const t = useTranslations();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -84,11 +90,26 @@ export const ChatInputSurface = ({
   // the response finishes, so overlapping requests can't happen.
   const submitDisabled = disabled;
 
+  // A failed send has already restored the draft (see `submit` in
+  // chat-editor-provider), so the only thing missing is a user-visible
+  // signal. Route it through analytics AND a toast: swallowing the
+  // failure into telemetry alone leaves the send silently lost.
+  const handleSubmitError = useCallback(
+    (error: unknown): void => {
+      getAnalytics().captureError(error);
+      stellaToast.add({
+        title: t("common.somethingWentWrong"),
+        type: "error",
+      });
+    },
+    [t],
+  );
+
   const { submitDraft } = useChatComposerWiring({
     controller,
     inputDisabled,
     onSubmit,
-    onSubmitError: captureChatSubmitError,
+    onSubmitError: handleSubmitError,
     submitDisabled,
   });
 
@@ -172,6 +193,7 @@ export const ChatInputSurface = ({
           type="file"
         />
         <div className="ms-auto flex items-center gap-1">
+          {contextUsage && <ChatContextMeter usage={contextUsage} />}
           <ChatSubmitButton
             canSend={!submitDisabled && canSubmit}
             isGenerating={isGenerating}

--- a/apps/web/src/components/chat/ask-user-card.test.tsx
+++ b/apps/web/src/components/chat/ask-user-card.test.tsx
@@ -5,6 +5,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { IntlProvider } from "use-intl";
 
 import type { AskUserInput, ChatPart } from "@/components/chat/chat-ui-tools";
+import { withParsedToolCallInputs } from "@/components/chat/chat-ui-tools";
 import messages from "@/i18n/langs/en.json";
 import type Messages from "@/i18n/langs/messages.gen";
 
@@ -75,6 +76,45 @@ describe("ask-user clarification card", () => {
     expect(html).toContain('type="text"');
     expect(html).toContain('type="submit"');
     expect(html).toContain(">Submit answers</button>");
+  });
+
+  test("renders questions from an arguments-only part after normalization", () => {
+    // Reproduces the persisted/streamed shape TanStack emits: a valid
+    // `arguments` JSON string and no `input` field. Without the
+    // `withParsedToolCallInputs` boundary fill the card collapses to a
+    // bare "Request clarification" header with no questions.
+    const input: AskUserInput = {
+      analysis: "Need a clarification before continuing.",
+      questions: [
+        {
+          question: "Which jurisdiction should I use?",
+          reason: "The answer changes the legal analysis.",
+        },
+      ],
+    };
+    const argumentsOnlyPart = {
+      arguments: JSON.stringify(input),
+      id: "tool-call-ask-user",
+      state: "input-complete",
+      name: "ask-user",
+      type: "tool-call",
+    } satisfies AskUserPart;
+
+    const [message] = withParsedToolCallInputs([
+      { id: "message-1", parts: [argumentsOnlyPart], role: "assistant" },
+    ]);
+    const normalized = message?.parts[0];
+    if (normalized?.type !== "tool-call" || normalized.name !== "ask-user") {
+      throw new Error("Expected a normalized ask-user tool-call part");
+    }
+
+    const html = renderWithIntl(
+      <AskUserCard onSubmit={() => {}} part={normalized} />,
+    );
+
+    expect(html).toContain("<form");
+    expect(html).toContain('type="submit"');
+    expect(html).toContain("Which jurisdiction should I use?");
   });
 
   test("keeps option chips out of form submission semantics", () => {

--- a/apps/web/src/components/chat/chat-context-meter.tsx
+++ b/apps/web/src/components/chat/chat-context-meter.tsx
@@ -1,0 +1,290 @@
+import { useFormatter, useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Popover,
+  PopoverPopup,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
+
+/** Model-context estimate for a chat thread's next send, as returned by the
+ *  chat-messages endpoint. The five breakdown parts sum to `estimatedTokens`,
+ *  so the segmented bar renders without any reconciliation. `cacheStableTokens`
+ *  (= prompt + tools) is the prompt-cache-stable prefix. */
+export type ChatContextUsage = {
+  estimatedTokens: number;
+  triggerTokens: number;
+  cacheStableTokens: number;
+  summarizedMessageCount: number;
+  breakdown: {
+    promptTokens: number;
+    toolTokens: number;
+    summaryTokens: number;
+    attachmentTokens: number;
+    conversationTokens: number;
+  };
+};
+
+type ChatContextMeterProps = {
+  usage: ChatContextUsage;
+};
+
+// Progressive disclosure: the ring is always shown; the percent label appears
+// only once the context is half full, and the tone escalates near the trigger.
+const PERCENT_LABEL_THRESHOLD = 50;
+const WARNING_THRESHOLD = 80;
+const DANGER_THRESHOLD = 95;
+
+const RING_RADIUS = 6;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+type ContextTone = "muted" | "warning" | "danger";
+
+const TONE_TEXT_CLASS: Record<ContextTone, string> = {
+  muted: "text-muted-foreground",
+  warning: "text-warning",
+  danger: "text-destructive",
+};
+
+// Cache-stable prefix (prompt + tools) uses the two faintest foreground tints;
+// the dynamic parts escalate through primary / info / solid foreground. All
+// semantic tokens, so both themes stay in sync.
+const PROMPT_SWATCH = "bg-foreground-subtle";
+const TOOL_SWATCH = "bg-foreground-ghost";
+const SUMMARY_SWATCH = "bg-primary";
+const ATTACHMENT_SWATCH = "bg-info";
+const CONVERSATION_SWATCH = "bg-foreground";
+
+type ContextPart = {
+  id: string;
+  tokens: number;
+  swatch: string;
+  label: string;
+  cached: boolean;
+};
+
+export const ChatContextMeter = ({ usage }: ChatContextMeterProps) => {
+  const t = useTranslations();
+  const format = useFormatter();
+
+  const percent = Math.min(
+    100,
+    Math.round((usage.estimatedTokens / usage.triggerTokens) * 100),
+  );
+  const tone = contextTone(percent);
+  const showPercent = percent >= PERCENT_LABEL_THRESHOLD;
+  const compact = (value: number) =>
+    format.number(value, { notation: "compact", maximumFractionDigits: 1 });
+
+  const parts = buildContextParts({ t, usage });
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            aria-label={t("chat.contextMeter.triggerLabel", { percent })}
+            className={cn("font-normal", TONE_TEXT_CLASS[tone])}
+            size="xs"
+            variant="ghost"
+          />
+        }
+      >
+        <ContextRing percent={percent} />
+        {showPercent && (
+          <span className="text-xs">
+            {t("chat.contextMeter.percent", { percent })}
+          </span>
+        )}
+      </PopoverTrigger>
+      <PopoverPopup align="end" className="w-96" side="top">
+        <div className="flex flex-col gap-3">
+          <PopoverTitle className="text-sm">
+            {t("chat.contextMeter.title")}
+          </PopoverTitle>
+          <div className="flex items-baseline justify-between gap-2">
+            <span className={cn("text-sm font-medium", TONE_TEXT_CLASS[tone])}>
+              {t("chat.contextMeter.full", { percent })}
+            </span>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {t("chat.contextMeter.tokens", {
+                used: compact(usage.estimatedTokens),
+                total: compact(usage.triggerTokens),
+              })}
+            </span>
+          </div>
+          <ContextBar parts={parts} usage={usage} />
+          <ContextLegend compact={compact} parts={parts} />
+          <div className="text-muted-foreground flex flex-col gap-1 text-xs">
+            <p>{t("chat.contextMeter.autoCompact")}</p>
+            <p>{t("chat.contextMeter.cache")}</p>
+          </div>
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+};
+
+type TranslateFn = ReturnType<typeof useTranslations>;
+
+const buildContextParts = ({
+  t,
+  usage,
+}: {
+  t: TranslateFn;
+  usage: ChatContextUsage;
+}): ContextPart[] => {
+  const { breakdown, summarizedMessageCount } = usage;
+  const summaryLabel =
+    summarizedMessageCount > 0
+      ? t("chat.contextMeter.summaryWithCount", {
+          count: summarizedMessageCount,
+        })
+      : t("chat.contextMeter.summary");
+
+  return [
+    {
+      id: "prompt",
+      tokens: breakdown.promptTokens,
+      swatch: PROMPT_SWATCH,
+      label: t("chat.contextMeter.instructions"),
+      cached: true,
+    },
+    {
+      id: "tools",
+      tokens: breakdown.toolTokens,
+      swatch: TOOL_SWATCH,
+      label: t("chat.contextMeter.tools"),
+      cached: true,
+    },
+    {
+      id: "summary",
+      tokens: breakdown.summaryTokens,
+      swatch: SUMMARY_SWATCH,
+      label: summaryLabel,
+      cached: false,
+    },
+    {
+      id: "attachments",
+      tokens: breakdown.attachmentTokens,
+      swatch: ATTACHMENT_SWATCH,
+      label: t("chat.contextMeter.attachments"),
+      cached: false,
+    },
+    {
+      id: "conversation",
+      tokens: breakdown.conversationTokens,
+      swatch: CONVERSATION_SWATCH,
+      label: t("chat.contextMeter.conversation"),
+      cached: false,
+    },
+  ];
+};
+
+const contextTone = (percent: number): ContextTone => {
+  if (percent >= DANGER_THRESHOLD) {
+    return "danger";
+  }
+  if (percent >= WARNING_THRESHOLD) {
+    return "warning";
+  }
+  return "muted";
+};
+
+const ContextRing = ({ percent }: { percent: number }) => {
+  const filled = (RING_CIRCUMFERENCE * percent) / 100;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5 -rotate-90"
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <circle
+        className="stroke-current opacity-20"
+        cx="8"
+        cy="8"
+        r={RING_RADIUS}
+        strokeWidth="2"
+      />
+      <circle
+        className="stroke-current"
+        cx="8"
+        cy="8"
+        r={RING_RADIUS}
+        strokeDasharray={`${filled} ${RING_CIRCUMFERENCE}`}
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+};
+
+type ContextBarProps = {
+  parts: ContextPart[];
+  usage: ChatContextUsage;
+};
+
+const ContextBar = ({ parts, usage }: ContextBarProps) => {
+  // Normalize against the larger of the trigger and the estimate so the
+  // segments never overflow the track, even once the estimate crosses the
+  // trigger (where the ring percent is already clamped to 100).
+  const denominator = Math.max(usage.triggerTokens, usage.estimatedTokens);
+  const width = (tokens: number) =>
+    denominator === 0 ? "0%" : `${(tokens / denominator) * 100}%`;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="bg-muted flex h-1.5 overflow-hidden rounded-full"
+    >
+      {parts
+        .filter((part) => part.tokens > 0)
+        .map((part) => (
+          <div
+            className={part.swatch}
+            key={part.id}
+            style={{ width: width(part.tokens) }}
+          />
+        ))}
+    </div>
+  );
+};
+
+type ContextLegendProps = {
+  compact: (value: number) => string;
+  parts: ContextPart[];
+};
+
+const ContextLegend = ({ compact, parts }: ContextLegendProps) => {
+  const t = useTranslations();
+  const visibleParts = parts.filter((part) => part.tokens > 0);
+  if (visibleParts.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {visibleParts.map((part) => (
+        <li className="flex items-center gap-2 py-0.5 text-xs" key={part.id}>
+          <span
+            aria-hidden="true"
+            className={cn("size-2 shrink-0 rounded-full", part.swatch)}
+          />
+          <span className="text-foreground">{part.label}</span>
+          {part.cached && (
+            <span className="bg-muted text-muted-foreground rounded-sm px-1 leading-tight">
+              {t("chat.contextMeter.cached")}
+            </span>
+          )}
+          <span className="text-muted-foreground ms-auto tabular-nums">
+            {compact(part.tokens)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/apps/web/src/components/chat/chat-ui-tools.test.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.test.ts
@@ -13,7 +13,9 @@ import {
   isChatTurnInFlight,
   isPublicOfficialChatToolName,
   isToolApprovedByGrant,
+  withParsedToolCallInputs,
 } from "@/components/chat/chat-ui-tools";
+import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 
 describe("chat tool titles", () => {
   test("maps stella API tools to translation keys", () => {
@@ -452,6 +454,109 @@ describe("isChatTurnInFlight", () => {
 
   test("is idle without an active request or running tool call", () => {
     expect(isChatTurnInFlight({ status: "ready", messages: [] })).toBe(false);
+  });
+});
+
+describe("withParsedToolCallInputs", () => {
+  const askUserArguments = JSON.stringify({
+    analysis: "Which company did you mean?",
+    questions: [
+      {
+        default: "Alza.cz a.s.",
+        question: "Which entity should I look up?",
+        options: ["Alza.cz a.s.", "Alzashop.com"],
+      },
+    ],
+  });
+
+  const argumentsOnlyMessages = (part: ChatPart): PersistedChatMessage[] => [
+    { id: "message-1", parts: [part], role: "assistant" },
+  ];
+
+  test("derives input from arguments on an input-complete tool call", () => {
+    // Exactly the persisted/streamed shape TanStack produces: a valid
+    // `arguments` JSON string with no `input` field.
+    const part = {
+      arguments: askUserArguments,
+      id: "tool-call-1",
+      name: "ask-user",
+      state: "input-complete",
+      type: "tool-call",
+    } satisfies ChatPart;
+
+    const [message] = withParsedToolCallInputs(argumentsOnlyMessages(part));
+    const normalized = message?.parts[0];
+    if (normalized?.type !== "tool-call" || normalized.name !== "ask-user") {
+      throw new Error("Expected a normalized ask-user tool-call part");
+    }
+
+    expect(normalized.input).toEqual({
+      analysis: "Which company did you mean?",
+      questions: [
+        {
+          default: "Alza.cz a.s.",
+          question: "Which entity should I look up?",
+          options: ["Alza.cz a.s.", "Alzashop.com"],
+        },
+      ],
+    });
+  });
+
+  test("leaves input undefined for invalid JSON arguments without throwing", () => {
+    const part = {
+      arguments: '{"questions":[',
+      id: "tool-call-1",
+      name: "ask-user",
+      state: "input-complete",
+      type: "tool-call",
+    } satisfies ChatPart;
+
+    const [message] = withParsedToolCallInputs(argumentsOnlyMessages(part));
+    const normalized = message?.parts[0];
+    if (normalized?.type !== "tool-call") {
+      throw new Error("Expected a tool-call part");
+    }
+
+    expect(normalized.input).toBeUndefined();
+    // The part is unchanged, so its reference is preserved.
+    expect(normalized).toBe(part);
+  });
+
+  test("does not parse arguments while the tool call is still streaming", () => {
+    const part = {
+      arguments: '{"questions":[{"quest',
+      id: "tool-call-1",
+      name: "ask-user",
+      state: "input-streaming",
+      type: "tool-call",
+    } satisfies ChatPart;
+
+    const [message] = withParsedToolCallInputs(argumentsOnlyMessages(part));
+    const normalized = message?.parts[0];
+    if (normalized?.type !== "tool-call") {
+      throw new Error("Expected a tool-call part");
+    }
+
+    expect(normalized.input).toBeUndefined();
+    expect(normalized).toBe(part);
+  });
+
+  test("preserves an already-populated input and message identity", () => {
+    const part = {
+      arguments: JSON.stringify({ query: "consumer credit" }),
+      id: "tool-call-1",
+      input: { query: "consumer credit" },
+      name: "mcp__salvia__search_decisions",
+      state: "input-complete",
+      type: "tool-call",
+    } satisfies ChatPart;
+    const messages = argumentsOnlyMessages(part);
+
+    const result = withParsedToolCallInputs(messages);
+
+    // Nothing to fill: the message object keeps its reference so
+    // downstream memoization is not invalidated.
+    expect(result[0]).toBe(messages[0]);
   });
 });
 

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -455,6 +455,81 @@ export const isChatTurnInFlight = ({
   return hasRunningToolCallInLatestAssistantMessage({ messages });
 };
 
+/**
+ * Parse a completed tool-call part's raw `arguments` JSON.
+ *
+ * Arguments stream in incrementally, so the part carries no usable
+ * payload while it is `awaiting-input` / `input-streaming`; parsing is
+ * skipped for those states. Invalid or empty JSON yields `undefined`
+ * rather than throwing (JSON boundary, so a local try/catch is fine).
+ */
+const parseCompletedToolCallArguments = (part: ChatToolCallPart): unknown => {
+  if (part.state === "awaiting-input" || part.state === "input-streaming") {
+    return undefined;
+  }
+  const raw = part.arguments.trim();
+  if (raw.length === 0) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+};
+
+const withParsedToolCallInput = (part: ChatPart): ChatPart => {
+  if (part.type !== "tool-call" || part.input !== undefined) {
+    return part;
+  }
+  const input = parseCompletedToolCallArguments(part);
+  if (input === undefined) {
+    return part;
+  }
+  // SAFETY: `arguments` is validated against the tool's inputSchema on
+  // the server (validateToolCallPart) before the part is streamed or
+  // persisted, so its parsed form conforms to this part's `input` type.
+  // `JSON.parse` is read as `unknown` above; this narrows it back onto
+  // the discriminated tool-call union without widening the part.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- parsed arguments conform to the tool inputSchema (validated server-side)
+  return { ...part, input } as ChatToolCallPart;
+};
+
+/**
+ * Fill each tool-call part's typed `input` from its raw `arguments`.
+ *
+ * TanStack's stream processor and its persisted-message projection
+ * only ever populate `arguments` (the raw JSON string) on a tool-call
+ * part; `input` is optional at the type level and never set at runtime
+ * (the parsed value stays inside the processor as `parsedArguments`).
+ * Reading `part.input` directly therefore always yields `undefined` —
+ * identically in live streaming, transcript re-send, and reload from
+ * persistence.
+ *
+ * Deriving `input` here, once, at the single point where messages
+ * leave the chat runtime for the UI (`useChatSession`), gives every
+ * consumer (ask-user / create-document / approval cards, generic
+ * tool-call card, active-DOCX-edit recovery) a parsed `input` without
+ * scattering `JSON.parse` across components. Messages and parts that
+ * need no change are returned by reference so downstream memoization
+ * and referential-equality checks stay stable.
+ */
+export const withParsedToolCallInputs = (
+  messages: readonly PersistedChatMessage[],
+): PersistedChatMessage[] =>
+  messages.map((message) => {
+    let partsChanged = false;
+    const parts = message.parts.map((part) => {
+      const nextPart = withParsedToolCallInput(part);
+      if (nextPart !== part) {
+        partsChanged = true;
+      }
+      return nextPart;
+    });
+    // eslint-disable-next-line oxc/no-map-spread -- immutable per-message rebuild, only when a tool-call input was filled; preserves refs otherwise
+    return partsChanged ? { ...message, parts } : message;
+  });
+
 export const getUserMessageHtmlHistory = (
   messages: readonly PersistedChatMessage[],
 ) => {

--- a/apps/web/src/components/chat/needs-matter-card.tsx
+++ b/apps/web/src/components/chat/needs-matter-card.tsx
@@ -60,9 +60,10 @@ export const NeedsMatterCard = ({
   } = useChatMatters();
   const t = useTranslations();
 
-  // Streaming-tolerant input read. While the model is producing the
-  // tool call, TanStack populates `part.input` incrementally; show
-  // whatever has arrived so far.
+  // Streaming-tolerant input read. `part.input` is derived from the
+  // part's `arguments` at the session boundary (see
+  // `withParsedToolCallInputs`) once the tool call reaches
+  // `input-complete`; show whatever has arrived so far.
   const partialInput =
     part.state === "input-streaming" ||
     part.state === "input-complete" ||

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -60,6 +60,7 @@
     "catalogue.setup.account",
     "catalogue.setup.apiKey",
     "chat.approval.deny",
+    "chat.contextMeter.tools",
     "chat.createDocument.continue",
     "chat.createDocument.created",
     "chat.landing.prompts",
@@ -108,6 +109,7 @@
     "knowledge.playbooks.severity.medium",
     "knowledge.sections.prompts.title",
     "knowledge.sections.templates.title",
+    "knowledge.sections.tools.title",
     "navigation.chat",
     "navigation.myTodos",
     "navigation.templates",
@@ -286,6 +288,12 @@
     ],
     "catalogue.configuration": [
       "fr"
+    ],
+    "chat.contextMeter.instructions": [
+      "fr"
+    ],
+    "chat.contextMeter.tools": [
+      "de"
     ],
     "chat.folioCitationFallback": [
       "es",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "إلغاء الرسالة المُدرجة في قائمة الانتظار",
     "caseLawGreeting": "اسأل عن هذا القرار — نصّه الكامل متاح هنا.",
     "chatAbout": "تحدّث عن هذا",
+    "contextMeter": {
+      "attachments": "المستندات المرفقة",
+      "autoCompact": "عند 100% تلخّص stella الرسائل الأقدم تلقائيًا لإتاحة مساحة.",
+      "cache": "المتابعات السريعة تعيد استخدام المحادثة المخزَّنة مؤقتًا حتى الآن. الجزء الثابت (تعليمات النظام والأدوات) مخزَّن مؤقتًا دائمًا.",
+      "cached": "مخزَّن مؤقتًا",
+      "conversation": "المحادثة",
+      "full": "ممتلئة بنسبة {percent}%",
+      "instructions": "تعليمات النظام",
+      "percent": "{percent}%",
+      "summary": "ملخّص الرسائل الأقدم",
+      "summaryWithCount": "ملخّص {count} من الرسائل الأقدم",
+      "title": "سياق المحادثة",
+      "tokens": "~{used} / {total} رمز",
+      "tools": "الأدوات",
+      "triggerLabel": "سياق المحادثة: ممتلئة بنسبة {percent}%"
+    },
     "contextPlaceholder": "تحدّث عن {context}، / للمهارات، @ لإضافة سياق",
     "createDocument": {
       "continue": "إنشاء مستند",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Zrušit zařazenou zprávu",
     "caseLawGreeting": "Zeptejte se na toto rozhodnutí — plný text je k dispozici.",
     "chatAbout": "Vložit do AI chatu",
+    "contextMeter": {
+      "attachments": "Připojené dokumenty",
+      "autoCompact": "Při 100 % stella automaticky shrne starší zprávy, aby uvolnila místo.",
+      "cache": "Rychlé navázání využívá dosavadní konverzaci z mezipaměti. Pevná část (systémové pokyny, nástroje) je v mezipaměti vždy.",
+      "cached": "v mezipaměti",
+      "conversation": "Konverzace",
+      "full": "{percent} % zaplněno",
+      "instructions": "Systémové pokyny",
+      "percent": "{percent} %",
+      "summary": "Shrnutí starších zpráv",
+      "summaryWithCount": "Shrnutí {count} starších zpráv",
+      "title": "Kontext konverzace",
+      "tokens": "~{used} / {total} tokenů",
+      "tools": "Nástroje",
+      "triggerLabel": "Kontext konverzace: {percent} % zaplněno"
+    },
     "contextPlaceholder": "Chat o {context}, / pro dovednosti, @ pro přidání kontextu",
     "createDocument": {
       "continue": "Vytvořit dokument",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Eingereihte Nachricht abbrechen",
     "caseLawGreeting": "Stelle Fragen zu dieser Entscheidung — der vollständige Text ist hier verfügbar.",
     "chatAbout": "In AI-Chat einfügen",
+    "contextMeter": {
+      "attachments": "Angehängte Dokumente",
+      "autoCompact": "Bei 100 % fasst stella ältere Nachrichten automatisch zusammen, um Platz zu schaffen.",
+      "cache": "Schnelle Rückfragen nutzen die zwischengespeicherte bisherige Unterhaltung. Der feste Teil (Systemanweisungen, Tools) ist immer zwischengespeichert.",
+      "cached": "zwischengespeichert",
+      "conversation": "Unterhaltung",
+      "full": "{percent} % voll",
+      "instructions": "Systemanweisungen",
+      "percent": "{percent} %",
+      "summary": "Zusammenfassung älterer Nachrichten",
+      "summaryWithCount": "Zusammenfassung von {count} älteren Nachrichten",
+      "title": "Kontext der Unterhaltung",
+      "tokens": "~{used} / {total} Tokens",
+      "tools": "Tools",
+      "triggerLabel": "Kontext der Unterhaltung: {percent} % voll"
+    },
     "contextPlaceholder": "Chat über {context}, / für Skills, @ für Kontext",
     "createDocument": {
       "continue": "Dokument erstellen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Ask about this decision — its full text is available here.",
     "chatAbout": "Chat about this",
+    "contextMeter": {
+      "attachments": "Attached documents",
+      "autoCompact": "At 100% stella automatically summarizes older messages to free space.",
+      "cache": "Quick follow-ups reuse the cached conversation so far. The fixed part (system instructions, tools) is always cached.",
+      "cached": "cached",
+      "conversation": "Conversation",
+      "full": "{percent}% full",
+      "instructions": "System instructions",
+      "percent": "{percent}%",
+      "summary": "Summary of older messages",
+      "summaryWithCount": "Summary of {count} older messages",
+      "title": "Conversation context",
+      "tokens": "~{used} / {total} tokens",
+      "tools": "Tools",
+      "triggerLabel": "Conversation context: {percent}% full"
+    },
     "contextPlaceholder": "Chat about {context}, / for skills, @ to add context",
     "createDocument": {
       "continue": "Create document",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Cancelar mensaje en cola",
     "caseLawGreeting": "Pregunta sobre esta decisión — el texto completo está disponible aquí.",
     "chatAbout": "Insertar en chat de IA",
+    "contextMeter": {
+      "attachments": "Documentos adjuntos",
+      "autoCompact": "Al 100 % stella resume automáticamente los mensajes más antiguos para liberar espacio.",
+      "cache": "Las continuaciones rápidas reutilizan la conversación almacenada en caché. La parte fija (instrucciones del sistema, herramientas) siempre está en caché.",
+      "cached": "en caché",
+      "conversation": "Conversación",
+      "full": "{percent}% lleno",
+      "instructions": "Instrucciones del sistema",
+      "percent": "{percent}%",
+      "summary": "Resumen de los mensajes más antiguos",
+      "summaryWithCount": "Resumen de {count} mensajes más antiguos",
+      "title": "Contexto de la conversación",
+      "tokens": "~{used} de {total} tokens",
+      "tools": "Herramientas",
+      "triggerLabel": "Contexto de la conversación: {percent}% lleno"
+    },
     "contextPlaceholder": "Chat sobre {context}, / para skills, @ para añadir contexto",
     "createDocument": {
       "continue": "Crear documento",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Tühista järjekorras sõnum",
     "caseLawGreeting": "Esita küsimusi selle otsuse kohta — täistekst on siin saadaval.",
     "chatAbout": "Lisa AI vestlusesse",
+    "contextMeter": {
+      "attachments": "Manustatud dokumendid",
+      "autoCompact": "100% juures teeb stella vanematest sõnumitest automaatselt kokkuvõtte, et ruumi vabastada.",
+      "cache": "Kiired jätkud kasutavad vahemällu salvestatud senist vestlust. Püsiv osa (süsteemi juhised, tööriistad) on alati vahemälus.",
+      "cached": "vahemälus",
+      "conversation": "Vestlus",
+      "full": "{percent}% täis",
+      "instructions": "Süsteemi juhised",
+      "percent": "{percent}%",
+      "summary": "Vanemate sõnumite kokkuvõte",
+      "summaryWithCount": "{count} vanema sõnumi kokkuvõte",
+      "title": "Vestluse kontekst",
+      "tokens": "~{used} / {total} tokenit",
+      "tools": "Tööriistad",
+      "triggerLabel": "Vestluse kontekst: {percent}% täis"
+    },
     "contextPlaceholder": "Vestle teemal {context}, / oskuste jaoks, @ konteksti lisamiseks",
     "createDocument": {
       "continue": "Loo dokument",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Annuler le message en file d’attente",
     "caseLawGreeting": "Pose des questions sur cette décision — le texte complet est disponible ici.",
     "chatAbout": "Insérer dans le chat IA",
+    "contextMeter": {
+      "attachments": "Documents joints",
+      "autoCompact": "À 100 %, stella résume automatiquement les anciens messages pour libérer de la place.",
+      "cache": "Les suites rapides réutilisent la discussion mise en cache. La partie fixe (instructions système, outils) est toujours en cache.",
+      "cached": "en cache",
+      "conversation": "Discussion",
+      "full": "{percent} % plein",
+      "instructions": "Instructions système",
+      "percent": "{percent} %",
+      "summary": "Résumé des anciens messages",
+      "summaryWithCount": "Résumé de {count} anciens messages",
+      "title": "Contexte de la discussion",
+      "tokens": "~{used} / {total} jetons",
+      "tools": "Outils",
+      "triggerLabel": "Contexte de la discussion : {percent} % plein"
+    },
     "contextPlaceholder": "Chat sur {context}, / pour les skills, @ pour ajouter du contexte",
     "createDocument": {
       "continue": "Créer le document",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Sorba állított üzenet visszavonása",
     "caseLawGreeting": "Kérdezz erről a határozatról — a teljes szöveg itt elérhető.",
     "chatAbout": "Beszúrás az AI chatbe",
+    "contextMeter": {
+      "attachments": "Csatolt dokumentumok",
+      "autoCompact": "100%-nál a stella automatikusan összefoglalja a korábbi üzeneteket, hogy helyet szabadítson fel.",
+      "cache": "A gyors folytatások a gyorsítótárazott eddigi beszélgetést használják újra. A rögzített rész (rendszerutasítások, eszközök) mindig gyorsítótárban van.",
+      "cached": "gyorsítótárban",
+      "conversation": "Beszélgetés",
+      "full": "{percent}% megtelt",
+      "instructions": "Rendszerutasítások",
+      "percent": "{percent}%",
+      "summary": "Korábbi üzenetek összefoglalója",
+      "summaryWithCount": "{count} korábbi üzenet összefoglalója",
+      "title": "Beszélgetés kontextusa",
+      "tokens": "~{used} / {total} token",
+      "tools": "Eszközök",
+      "triggerLabel": "Beszélgetés kontextusa: {percent}% megtelt"
+    },
     "contextPlaceholder": "Chat erről: {context}, / a skillekhez, @ kontextus hozzáadásához",
     "createDocument": {
       "continue": "Dokumentum létrehozása",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Atšaukti eilėje esančią žinutę",
     "caseLawGreeting": "Klausk apie šį sprendimą — visas tekstas pasiekiamas čia.",
     "chatAbout": "Įterpti į AI pokalbį",
+    "contextMeter": {
+      "attachments": "Pridėti dokumentai",
+      "autoCompact": "Pasiekus 100%, stella automatiškai apibendrina senesnes žinutes, kad atlaisvintų vietos.",
+      "cache": "Greiti tęsiniai pakartotinai naudoja podėlyje saugomą ligšiolinį pokalbį. Pastovioji dalis (sistemos instrukcijos, įrankiai) podėlyje saugoma visada.",
+      "cached": "podėlyje",
+      "conversation": "Pokalbis",
+      "full": "Užpildyta {percent}%",
+      "instructions": "Sistemos instrukcijos",
+      "percent": "{percent}%",
+      "summary": "Senesnių žinučių santrauka",
+      "summaryWithCount": "{count} senesnių žinučių santrauka",
+      "title": "Pokalbio kontekstas",
+      "tokens": "~{used} / {total} tokenų",
+      "tools": "Įrankiai",
+      "triggerLabel": "Pokalbio kontekstas: užpildyta {percent}%"
+    },
     "contextPlaceholder": "Pokalbis apie {context}, / įgūdžiams, @ kontekstui pridėti",
     "createDocument": {
       "continue": "Sukurti dokumentą",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Atcelt rindā gaidošo ziņojumu",
     "caseLawGreeting": "Uzdod jautājumus par šo lēmumu — pilns teksts ir pieejams šeit.",
     "chatAbout": "Ievietot AI čatā",
+    "contextMeter": {
+      "attachments": "Pievienotie dokumenti",
+      "autoCompact": "Sasniedzot 100%, stella automātiski apkopo vecākos ziņojumus, lai atbrīvotu vietu.",
+      "cache": "Ātri turpinājumi atkārtoti izmanto kešatmiņā saglabāto līdzšinējo sarunu. Fiksētā daļa (sistēmas norādes, rīki) kešatmiņā ir vienmēr.",
+      "cached": "kešatmiņā",
+      "conversation": "Saruna",
+      "full": "Aizpildīts par {percent}%",
+      "instructions": "Sistēmas norādes",
+      "percent": "{percent}%",
+      "summary": "Vecāko ziņojumu kopsavilkums",
+      "summaryWithCount": "{count} vecāko ziņojumu kopsavilkums",
+      "title": "Sarunas konteksts",
+      "tokens": "~{used} / {total} tokeni",
+      "tools": "Rīki",
+      "triggerLabel": "Sarunas konteksts: aizpildīts par {percent}%"
+    },
     "contextPlaceholder": "Tērzēt par {context}, / prasmēm, @ konteksta pievienošanai",
     "createDocument": {
       "continue": "Izveidot dokumentu",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -376,6 +376,22 @@ type Messages = {
     "cancelQueuedMessage": "Cancel queued message";
     "caseLawGreeting": "Ask about this decision — its full text is available here.";
     "chatAbout": "Chat about this";
+    "contextMeter": {
+      "attachments": "Attached documents";
+      "autoCompact": "At 100% stella automatically summarizes older messages to free space.";
+      "cache": "Quick follow-ups reuse the cached conversation so far. The fixed part (system instructions, tools) is always cached.";
+      "cached": "cached";
+      "conversation": "Conversation";
+      "full": "{percent}% full";
+      "instructions": "System instructions";
+      "percent": "{percent}%";
+      "summary": "Summary of older messages";
+      "summaryWithCount": "Summary of {count} older messages";
+      "title": "Conversation context";
+      "tokens": "~{used} / {total} tokens";
+      "tools": "Tools";
+      "triggerLabel": "Conversation context: {percent}% full";
+    };
     "contextPlaceholder": "Chat about {context}, / for skills, @ to add context";
     "createDocument": {
       "continue": "Create document";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Anuluj wiadomość w kolejce",
     "caseLawGreeting": "Zapytaj mnie o to orzeczenie — mam dostęp do pełnej treści.",
     "chatAbout": "Omów na czacie",
+    "contextMeter": {
+      "attachments": "Załączone dokumenty",
+      "autoCompact": "Przy 100% stella automatycznie podsumowuje starsze wiadomości, aby zwolnić miejsce.",
+      "cache": "Szybkie kontynuacje wykorzystują dotychczasową rozmowę z pamięci podręcznej. Stała część (instrukcje systemowe, narzędzia) jest w pamięci podręcznej zawsze.",
+      "cached": "w pamięci podręcznej",
+      "conversation": "Rozmowa",
+      "full": "{percent}% zapełnienia",
+      "instructions": "Instrukcje systemowe",
+      "percent": "{percent}%",
+      "summary": "Podsumowanie starszych wiadomości",
+      "summaryWithCount": "Podsumowanie {count} starszych wiadomości",
+      "title": "Kontekst rozmowy",
+      "tokens": "~{used} / {total} tokenów",
+      "tools": "Narzędzia",
+      "triggerLabel": "Kontekst rozmowy: {percent}% zapełnienia"
+    },
     "contextPlaceholder": "Czat o {context}, / dla umiejętności, @ aby dodać kontekst",
     "createDocument": {
       "continue": "Utwórz dokument",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Cancelar mensagem na fila",
     "caseLawGreeting": "Pergunte sobre esta decisão; o texto completo está disponível aqui.",
     "chatAbout": "Converse sobre isso",
+    "contextMeter": {
+      "attachments": "Documentos anexados",
+      "autoCompact": "Aos 100%, a stella resume automaticamente as mensagens mais antigas para liberar espaço.",
+      "cache": "Continuações rápidas reutilizam a conversa em cache. A parte fixa (instruções do sistema, ferramentas) fica sempre em cache.",
+      "cached": "em cache",
+      "conversation": "Conversa",
+      "full": "{percent}% cheio",
+      "instructions": "Instruções do sistema",
+      "percent": "{percent}%",
+      "summary": "Resumo das mensagens mais antigas",
+      "summaryWithCount": "Resumo de {count} mensagens mais antigas",
+      "title": "Contexto da conversa",
+      "tokens": "~{used} de {total} tokens",
+      "tools": "Ferramentas",
+      "triggerLabel": "Contexto da conversa: {percent}% cheio"
+    },
     "contextPlaceholder": "Converse sobre {context}, / para habilidades, @ para adicionar contexto",
     "createDocument": {
       "continue": "Criar documento",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -373,6 +373,22 @@
     "cancelQueuedMessage": "Zrušiť správu v poradí",
     "caseLawGreeting": "Spýtajte sa na toto rozhodnutie — plný text je k dispozícii.",
     "chatAbout": "Vložiť do AI chatu",
+    "contextMeter": {
+      "attachments": "Pripojené dokumenty",
+      "autoCompact": "Pri 100 % stella automaticky zhrnie staršie správy, aby uvoľnila miesto.",
+      "cache": "Rýchle pokračovanie využíva doterajšiu konverzáciu z vyrovnávacej pamäte. Pevná časť (systémové pokyny, nástroje) je vo vyrovnávacej pamäti vždy.",
+      "cached": "vo vyrovnávacej pamäti",
+      "conversation": "Konverzácia",
+      "full": "{percent} % zaplnené",
+      "instructions": "Systémové pokyny",
+      "percent": "{percent} %",
+      "summary": "Zhrnutie starších správ",
+      "summaryWithCount": "Zhrnutie {count} starších správ",
+      "title": "Kontext konverzácie",
+      "tokens": "~{used} / {total} tokenov",
+      "tools": "Nástroje",
+      "triggerLabel": "Kontext konverzácie: {percent} % zaplnené"
+    },
     "contextPlaceholder": "Chat o {context}, / pre zručnosti, @ na pridanie kontextu",
     "createDocument": {
       "continue": "Vytvoriť dokument",

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -524,6 +524,7 @@ export const ChatThreadPage = ({
               <ChatInputSurface
                 anonymized={anonymized}
                 autoFocus
+                contextUsage={data.context ?? undefined}
                 controller={controller}
                 isGenerating={isGenerating}
                 onStop={() => {

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -33,6 +33,7 @@ import {
   isApprovalToolName,
   isExternalMcpToolName,
   isToolApprovalGrant,
+  withParsedToolCallInputs,
 } from "@/components/chat/chat-ui-tools";
 import { openEntityInInspector } from "@/components/chat/entity-open";
 import type { NeedsMatterMatter } from "@/components/chat/needs-matter-card";
@@ -167,7 +168,16 @@ export const useChatSession = ({
     chat.getSnapshot,
     chat.getSnapshot,
   );
-  const { error, messages, sessionGenerating, status } = snapshot;
+  const { error, sessionGenerating, status } = snapshot;
+  // TanStack only populates a tool-call part's raw `arguments`; its
+  // typed `input` is filled here, once, as messages leave the runtime
+  // for the UI, so every consumer reads a parsed `input` the same way
+  // across live streaming, transcript re-send, and reload. Memoized on
+  // the runtime's message identity; unchanged messages keep their refs.
+  const messages = useMemo(
+    () => withParsedToolCallInputs(snapshot.messages),
+    [snapshot.messages],
+  );
   const sendChatMessage = useCallback(
     async (message: ChatUserMessageInput, options?: ChatSendMessageOptions) => {
       await sendThreadChatMessage(chat, message, options);

--- a/apps/web/src/routes/_protected.chat/-queries.test.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.test.ts
@@ -1,3 +1,4 @@
+import { replaceEqualDeep } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -727,5 +728,74 @@ describe("chat runtime", () => {
     await responseRequested;
     releaseResponse();
     await started.stream;
+  });
+});
+
+describe("chat runtime identity across query refetch", () => {
+  // Shape a `ChatThreadFetched`-like value: a live runtime plus the
+  // post-turn context estimate that changes every turn. Each queryFn run
+  // creates and registers a fresh runtime, so consecutive fetches carry
+  // distinct runtime identities.
+  const buildFetched = (estimatedTokens: number) => ({
+    chat: createChatRuntime({
+      context: undefined,
+      initialMessages: [],
+      key: { scope: "global", threadId: toChatThreadId("thread-shared") },
+      onError: () => {},
+      onFinish: () => {},
+    }),
+    olderCursor: null as string | null,
+    contextMatterIds: [] as string[],
+    lastActivityAt: null as string | null,
+    webSearchAvailable: false,
+    webSearchEnabled: false,
+    context: {
+      estimatedTokens,
+      triggerTokens: 200_000,
+      breakdown: {
+        summaryTokens: 0,
+        conversationTokens: estimatedTokens,
+        attachmentTokens: 0,
+      },
+    },
+  });
+
+  test("structural sharing would strip the runtime's send capability", async () => {
+    const prev = buildFetched(100);
+    const next = buildFetched(200);
+
+    // This is exactly what TanStack's default structural sharing does on a
+    // refetch. Because `context` changed it rebuilds the parent, and because
+    // the runtime's method closures differ across runs it rebuilds `chat`
+    // into a fresh `{}` copy: neither the previous nor the freshly registered
+    // runtime, and (via `Object.keys`) without the runtime's `Symbol` brand.
+    const shared = replaceEqualDeep(prev, next);
+
+    expect(shared.chat).not.toBe(prev.chat);
+    expect(shared.chat).not.toBe(next.chat);
+
+    // The rebuilt copy was never registered in the send-capability WeakMap,
+    // so sending through it panics ("Missing thread send capability"). This
+    // is the corruption `chatThreadOptions`' `structuralSharing: false` avoids
+    // by handing the registered runtime back verbatim.
+    await expect(
+      sendThreadChatMessage(
+        shared.chat,
+        createOutgoingMessage("22222222-2222-4222-8222-2222222222aa"),
+      ),
+    ).rejects.toThrow("Missing thread send capability");
+  });
+
+  test("chatThreadOptions opts out of structural sharing", () => {
+    const options = chatThreadOptions({
+      activeOrganizationId: "org-A",
+      key: { scope: "global", threadId: toChatThreadId("thread-opts") },
+      context: { allowMissingThread: true },
+    });
+
+    // Guards the invariant: the query data embeds a `ChatRuntime` whose
+    // identity and `Symbol` brand must survive every refetch, so this query
+    // must never run through `replaceEqualDeep`.
+    expect(options.structuralSharing).toBe(false);
   });
 });

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -12,6 +12,7 @@ import { panic } from "better-result";
 import { CHAT_SEND_MODE, isChatSendMode } from "@stll/anonymize-chat";
 import type { ChatSendMode } from "@stll/anonymize-chat";
 
+import type { ChatContextUsage } from "@/components/chat/chat-context-meter";
 import type {
   ChatClientTools,
   ChatMessageMetadata,
@@ -289,6 +290,9 @@ type ThreadFetch = {
   lastActivityAt: string | null;
   webSearchAvailable: boolean;
   webSearchEnabled: boolean;
+  /** Model-context estimate for the next send; null for a missing or empty
+   *  thread (nothing to meter yet). */
+  context: ChatContextUsage | null;
 };
 
 export type ChatUserMessageInput = MultimodalContent & {
@@ -404,6 +408,7 @@ const fetchThreadMessages = async (
         lastActivityAt: null,
         webSearchAvailable: false,
         webSearchEnabled: false,
+        context: null,
       };
     }
 
@@ -417,6 +422,7 @@ const fetchThreadMessages = async (
     lastActivityAt: response.data.lastActivityAt,
     webSearchAvailable: response.data.webSearchAvailable,
     webSearchEnabled: response.data.webSearchEnabled,
+    context: response.data.context,
   };
 };
 
@@ -1179,6 +1185,11 @@ export type ChatThreadFetched = {
    * fetch_url tools to the model.
    */
   webSearchEnabled: boolean;
+  /**
+   * Model-context estimate for the next send, driving the composer
+   * meter. Null for a missing or empty thread (nothing to meter yet).
+   */
+  context: ChatContextUsage | null;
 };
 
 type FileChatThreadOptionsArgs = {
@@ -1225,6 +1236,21 @@ export const chatThreadOptions = ({
   queryOptions({
     staleTime: STALE_TIME.FIVETEEN.MINUTES,
     gcTime: STALE_TIME.FIVETEEN.MINUTES,
+    // The query data carries a live `ChatRuntime`: a plain object with a
+    // `Symbol` brand key and function-valued methods, registered by object
+    // identity in `threadSendMessageByRuntime`. TanStack's default
+    // structural sharing (`replaceEqualDeep`) walks the data on every
+    // refetch and, because the runtime's method closures differ across
+    // queryFn runs, rebuilds `data.chat` into a fresh `{}` copy. That copy
+    // is a distinct identity the WeakMap never saw, and `Object.keys`
+    // iteration drops the `Symbol` brand, so `sendThreadChatMessage` would
+    // panic with "Missing thread send capability". Each queryFn run already
+    // creates and registers a new runtime (see `onFinish` invalidation and
+    // the `seededChat` re-seed in useChatSession), so there is nothing for
+    // structural sharing to preserve here: hand the registered runtime back
+    // verbatim. INVARIANT: any query whose data embeds a `ChatRuntime` must
+    // opt out of structural sharing.
+    structuralSharing: false,
     queryKey: chatKeys.thread(activeOrganizationId, {
       ...key,
       allowMissingThread: context.allowMissingThread,
@@ -1238,6 +1264,7 @@ export const chatThreadOptions = ({
         lastActivityAt,
         webSearchAvailable,
         webSearchEnabled,
+        context: contextUsage,
       } = await fetchThreadMessages(key, {
         allowMissingThread: context.allowMissingThread,
       });
@@ -1264,6 +1291,7 @@ export const chatThreadOptions = ({
         lastActivityAt,
         webSearchAvailable,
         webSearchEnabled,
+        context: contextUsage,
       };
     },
   });

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -6,6 +6,9 @@ import {
   BYOK_DEFAULT_MODELS,
   BYOK_DOCUMENT_INPUT_MODEL_OPTIONS,
   BYOK_MODEL_OPTIONS,
+  CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CONTEXT_WINDOW_TOKENS,
+  getContextWindowTokens,
   isBYOKModelRoleSupported,
   isBYOKProviderRoleSupported,
   DEFAULT_MODELS,
@@ -144,4 +147,35 @@ describe("MODEL_RATES economic ordering", () => {
       expect(Number.isFinite(rate.outputPerMTok)).toBe(true);
     });
   }
+});
+
+describe("CONTEXT_WINDOW_TOKENS", () => {
+  // Every metered first-party model must declare a window, or the
+  // per-model compaction trigger silently degrades to the conservative
+  // default for a model users actively pick.
+  test("covers every model with a ledger rate", () => {
+    for (const modelId of Object.keys(MODEL_RATES)) {
+      expect(CONTEXT_WINDOW_TOKENS[modelId]).toBeGreaterThan(0);
+    }
+  });
+
+  test("windows are never below the conservative default", () => {
+    for (const window of Object.values(CONTEXT_WINDOW_TOKENS)) {
+      expect(window).toBeGreaterThanOrEqual(DEFAULT_CONTEXT_WINDOW_TOKENS);
+    }
+  });
+
+  test("falls back to the default for unlisted model IDs", () => {
+    expect(getContextWindowTokens("speakleash/Bielik-11B-v2.3-Instruct")).toBe(
+      DEFAULT_CONTEXT_WINDOW_TOKENS,
+    );
+    expect(getContextWindowTokens("default")).toBe(
+      DEFAULT_CONTEXT_WINDOW_TOKENS,
+    );
+  });
+
+  test("returns the documented window for a listed model ID", () => {
+    expect(getContextWindowTokens("claude-sonnet-4-6")).toBe(200_000);
+    expect(getContextWindowTokens("gpt-5.4")).toBe(400_000);
+  });
 });

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -495,3 +495,84 @@ export const MODEL_RATES: Readonly<Record<string, ModelRate>> = {
   },
 } satisfies Record<OfferedFirstPartyModelId, ModelRate> &
   Record<string, ModelRate>;
+
+/**
+ * Documented input context-window sizes (in tokens) per model ID.
+ *
+ * Keys are the canonical model IDs stella resolves for the provider
+ * adapters (the same forms used in `MODEL_RATES`, `BYOK_MODEL_OPTIONS`,
+ * and `DEFAULT_MODELS`, including OpenRouter provider-prefixed slugs and
+ * AWS Bedrock IDs). Values are the providers' publicly documented input
+ * windows; where a provider offers a larger beta window we intentionally
+ * take the conservative default (e.g. Claude's standard 200K rather than
+ * the 1M beta) so context budgeting never overpromises.
+ *
+ * Consumers must go through `getContextWindowTokens`, which falls back to
+ * `DEFAULT_CONTEXT_WINDOW_TOKENS` for any unlisted ID. Unlike
+ * `MODEL_RATES`, the nightly `model-catalog-upstream` check does not
+ * validate this map, so an unknown model degrades to the conservative
+ * default rather than failing CI.
+ */
+export const CONTEXT_WINDOW_TOKENS: Readonly<Record<string, number>> = {
+  // Google Gemini: 1M-token input window across the current lineup.
+  "gemini-2.5-flash": 1_048_576,
+  "gemini-2.5-pro": 1_048_576,
+  "gemini-3.1-flash-lite": 1_048_576,
+  "gemini-3.5-flash": 1_048_576,
+  "gemini-3.1-pro-preview": 1_048_576,
+  // OpenAI: GPT-4o family 128K; GPT-5 family 400K input.
+  "gpt-4o-mini": 128_000,
+  "gpt-4o": 128_000,
+  "gpt-5.2": 400_000,
+  "gpt-5.4-nano": 400_000,
+  "gpt-5.4-mini": 400_000,
+  "gpt-5.4": 400_000,
+  "gpt-5.5": 400_000,
+  // Anthropic Claude: standard 200K window (1M is beta-gated; not assumed).
+  "claude-haiku-4-5-20251001": 200_000,
+  "claude-sonnet-4-6": 200_000,
+  "claude-opus-4-6": 200_000,
+  "claude-opus-4-7": 200_000,
+  "claude-opus-4-8": 200_000,
+  "claude-fable-5": 200_000,
+  // Mistral: 128K across the offered text/vision models.
+  "mistral-small-latest": 128_000,
+  "mistral-large-latest": 128_000,
+  "mistral-medium-latest": 128_000,
+  "mistral-medium-3-5": 128_000,
+  "magistral-medium-latest": 128_000,
+  "magistral-small-latest": 128_000,
+  "pixtral-large-latest": 128_000,
+  // OpenRouter provider-prefixed slugs mirror their upstream windows.
+  "google/gemini-3.1-pro-preview": 1_048_576,
+  "google/gemini-3.5-flash": 1_048_576,
+  "google/gemini-3.1-flash-lite": 1_048_576,
+  "anthropic/claude-opus-4.8": 200_000,
+  "anthropic/claude-sonnet-4.6": 200_000,
+  "openai/gpt-5.5": 400_000,
+  "openai/gpt-5.4-mini": 400_000,
+  // AWS Bedrock IDs.
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
+  "us.amazon.nova-pro-v1:0": 300_000, // Nova Pro/Lite: 300K input.
+  "us.amazon.nova-lite-v1:0": 300_000,
+  "us.amazon.nova-micro-v1:0": 128_000, // Nova Micro: 128K input.
+  "openai.gpt-oss-120b-1:0": 128_000, // gpt-oss on Bedrock: 128K.
+  "openai.gpt-oss-20b-1:0": 128_000,
+  "us.deepseek.r1-v1:0": 128_000, // DeepSeek-R1: 128K.
+};
+
+/**
+ * Conservative window assumed for any model ID absent from
+ * `CONTEXT_WINDOW_TOKENS` (custom deployments, OpenAI-compatible
+ * endpoints, brand-new IDs not yet catalogued).
+ */
+export const DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
+
+/**
+ * Documented input context window for a model ID, or the conservative
+ * default for unlisted IDs. Callers must never index
+ * `CONTEXT_WINDOW_TOKENS` directly.
+ */
+export const getContextWindowTokens = (modelId: string): number =>
+  CONTEXT_WINDOW_TOKENS[modelId] ?? DEFAULT_CONTEXT_WINDOW_TOKENS;

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -542,6 +542,7 @@ export const CONTEXT_WINDOW_TOKENS: Readonly<Record<string, number>> = {
   "mistral-medium-3-5": 128_000,
   "magistral-medium-latest": 128_000,
   "magistral-small-latest": 128_000,
+  "magistral-small": 128_000,
   "pixtral-large-latest": 128_000,
   // OpenRouter provider-prefixed slugs mirror their upstream windows.
   "google/gemini-3.1-pro-preview": 1_048_576,


### PR DESCRIPTION
## Summary

Adds a context-usage meter to the chat composer and deepens the compaction model behind it, plus a set of chat correctness fixes found while building it.

### Context meter
- The chat messages GET (initial page only) returns an estimated context breakdown for the thread's next send: system instructions, tools, compaction summary, attached documents, and conversation, with an exact-sum invariant. Estimates reuse the same chars-per-token estimators the compaction path uses; the instructions/tools figures are derived from the prompt's cache-stable prefix, so the UI's "cached" badges reflect what is actually cached.
- Composer footer gains a small ring (progressive disclosure: percent label from 50%, warning tone from 80%) opening a popover: usage bar, per-part legend with cached-prefix badges and summarized-message count, and two footer notes (auto-summarization at 100%, prefix caching). Localized in all 13 languages.

### Per-model compaction windows
- `@stll/ai-catalog` gains `CONTEXT_WINDOW_TOKENS` (documented per entry). The compaction trigger becomes `clamp(floor(window / 2), 64k, 200k)` resolved from the thread's chat model on both the send and read paths; the preserve budget scales proportionally. Unknown models fall back to the previous 64k behaviour.

### Fixes
- Tool-call parts now hydrate their typed `input` from the raw `arguments` JSON at the single boundary where messages leave the chat runtime, so interactive tool cards (ask-user) render their questions in live streaming, transcript re-send, and reload alike. Regression tests cover the arguments-only persisted shape and invalid JSON.
- The system prompt and the run-stella-query description now derive tool references from the same predicates that register the tools (web research, template authoring). A guard test sweeps the availability matrix and asserts every backtick-quoted tool name in the assembled prompt is registered for that configuration.
- The thread query opts out of TanStack Query structural sharing: its data embeds the chat runtime, and `replaceEqualDeep` rebuilds objects on refetch, which breaks identity-keyed capabilities. Regression tests pin both the hazard and the opt-out.
- Failed sends surface an error toast instead of telemetry only.
- Sidebar: the recent-chats separator renders only when a matters section sits above it.

### Follow-ups (not in this PR)
- Place an explicit provider cache breakpoint at the conversation tail for providers that require one, so conversation history benefits from prompt caching there too.
- Template studio: decide whether the suggest-fields preset should be hidden for roles without template-create rights (the prompt now degrades gracefully either way).

## Verification
- api: chat handler suite (343 tests) and typecheck green after rebase; ai-catalog tests green.
- web: chat component and query tests green; i18n:check (typegen, locale sync, glossary, lint) green.
- Manually exercised in the dev app: meter states, popover, ask-user card answer/edit flow, multi-turn sends, compaction threshold display.