### PR TITLE
fix: reuse loading copy for template states

### DIFF
--- a/apps/api/src/mcp/egress.test.ts
+++ b/apps/api/src/mcp/egress.test.ts
@@ -1,5 +1,5 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { toSafeId } from "@/api/lib/branded-types";
 import type { McpRequestContext } from "@/api/mcp/context";
@@ -9,12 +9,15 @@ import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const anonymizeTextFieldsMock = mock();
 const loadAnonymizationGazetteerEntriesMock = mock();
+const realAnonymizationBlacklist =
+  await import("@/api/lib/anonymization-blacklist");
 
 void mock.module("@/api/mcp/anonymization", () => ({
   anonymizeTextFields: anonymizeTextFieldsMock,
 }));
 
 void mock.module("@/api/lib/anonymization-blacklist", () => ({
+  ...realAnonymizationBlacklist,
   loadAnonymizationGazetteerEntries: loadAnonymizationGazetteerEntriesMock,
 }));
 
@@ -51,6 +54,10 @@ const parsePayload = (result: CallToolResult) =>
   }>(parseText(result));
 
 describe("finalizeMcpEgress", () => {
+  afterAll(() => {
+    mock.restore();
+  });
+
   beforeEach(() => {
     anonymizeTextFieldsMock.mockReset();
     loadAnonymizationGazetteerEntriesMock.mockReset();

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -19,6 +19,8 @@ const loadOrgAIConfigMock = mock();
 const captureErrorMock = mock();
 const anonymizeTextFieldsMock = mock();
 const loadAnonymizationGazetteerEntriesMock = mock();
+const realAnonymizationBlacklist =
+  await import("@/api/lib/anonymization-blacklist");
 
 void mock.module("@/api/lib/analytics", () => ({
   captureError: captureErrorMock,
@@ -31,6 +33,7 @@ void mock.module("@/api/mcp/anonymization", () => ({
 }));
 
 void mock.module("@/api/lib/anonymization-blacklist", () => ({
+  ...realAnonymizationBlacklist,
   loadAnonymizationGazetteerEntries: loadAnonymizationGazetteerEntriesMock,
 }));
 

--- a/apps/web/src/i18n/glossary.json
+++ b/apps/web/src/i18n/glossary.json
@@ -868,6 +868,41 @@
         "fr": "colonne",
         "pt-BR": "coluna"
       }
+    },
+    {
+      "id": "loading",
+      "en": "Loading",
+      "note": "Standalone loading-state label. Use each locale's loading/status copy; do not use analysis/discovery wording for this key.",
+      "keyTriggers": ["common.loading"],
+      "forbidden": {
+        "en": ["Analyzing..."],
+        "ar": ["جارٍ التحليل..."],
+        "cs": ["Analyzování..."],
+        "sk": ["Analyzovanie..."],
+        "pl": ["Analizowanie..."],
+        "de": ["Analyse..."],
+        "et": ["Analüüsimine..."],
+        "hu": ["Elemzés..."],
+        "lt": ["Analizuojama..."],
+        "lv": ["Analizē..."],
+        "es": ["Analizando..."],
+        "fr": ["Analyse..."],
+        "pt-BR": ["Analisando..."]
+      },
+      "translations": {
+        "ar": "جارٍ التحميل",
+        "cs": "Načítám",
+        "sk": "Načítavam",
+        "pl": "Ładowanie",
+        "de": "Wird geladen …",
+        "et": "Laadimine",
+        "hu": "Betöltés",
+        "lt": "Įkeliama",
+        "lv": "Ielādē",
+        "es": "Cargando",
+        "fr": "Chargement",
+        "pt-BR": "Carregando"
+      }
     }
   ]
 }

--- a/apps/web/src/i18n/i18n-check-baseline.json
+++ b/apps/web/src/i18n/i18n-check-baseline.json
@@ -168,7 +168,6 @@
     "templates.conditionValue",
     "templates.createDocument",
     "templates.deleteFailed",
-    "templates.discovering",
     "templates.fieldLabel",
     "templates.previewSectionBody",
     "templates.saveFailed",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "نهاية الحلقة",
     "directiveEndIf": "نهاية الشرط",
     "directiveIf": "إذا: {expression}",
-    "discovering": "جارٍ التحليل...",
     "discoveryFailed": "تعذّر تحليل القالب",
     "downloadAnyway": "التنزيل على أي حال",
     "downloadDocx": "تنزيل DOCX",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Konec smyčky",
     "directiveEndIf": "Konec pokud",
     "directiveIf": "Pokud: {expression}",
-    "discovering": "Analyzování...",
     "discoveryFailed": "Nepodařilo se analyzovat vzor",
     "downloadAnyway": "Přesto stáhnout",
     "downloadDocx": "Stáhnout DOCX",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Schleife beenden",
     "directiveEndIf": "Wenn beenden",
     "directiveIf": "Wenn: {expression}",
-    "discovering": "Analyse...",
     "discoveryFailed": "Vorlage konnte nicht analysiert werden",
     "downloadAnyway": "Trotzdem herunterladen",
     "downloadDocx": "DOCX herunterladen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "End loop",
     "directiveEndIf": "End if",
     "directiveIf": "If: {expression}",
-    "discovering": "Analyzing...",
     "discoveryFailed": "Failed to analyze template",
     "downloadAnyway": "Download anyway",
     "downloadDocx": "Download DOCX",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Fin del bucle",
     "directiveEndIf": "Fin del condicional",
     "directiveIf": "Si: {expression}",
-    "discovering": "Analizando...",
     "discoveryFailed": "No se pudo analizar la plantilla",
     "downloadAnyway": "Descargar de todos modos",
     "downloadDocx": "Descargar DOCX",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Tsükli lõpp",
     "directiveEndIf": "Tingimuse lõpp",
     "directiveIf": "Kui: {expression}",
-    "discovering": "Analüüsimine...",
     "discoveryFailed": "Malli analüüsimine ebaõnnestus",
     "downloadAnyway": "Laadi ikkagi alla",
     "downloadDocx": "Laadi alla DOCX",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Fin de boucle",
     "directiveEndIf": "Fin de condition",
     "directiveIf": "Si : {expression}",
-    "discovering": "Analyse...",
     "discoveryFailed": "Impossible d'analyser le modèle",
     "downloadAnyway": "Télécharger quand même",
     "downloadDocx": "Télécharger en DOCX",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Ciklus vége",
     "directiveEndIf": "Ha vége",
     "directiveIf": "Ha: {expression}",
-    "discovering": "Elemzés...",
     "discoveryFailed": "Nem sikerült elemezni a sablont",
     "downloadAnyway": "Letöltés így is",
     "downloadDocx": "Letöltés DOCX-ként",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Kilpos pabaiga",
     "directiveEndIf": "Sąlygos pabaiga",
     "directiveIf": "Jei: {expression}",
-    "discovering": "Analizuojama...",
     "discoveryFailed": "Nepavyko išanalizuoti šablono",
     "downloadAnyway": "Vis tiek atsisiųsti",
     "downloadDocx": "Atsisiųsti DOCX",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Cikla beigas",
     "directiveEndIf": "Nosacījuma beigas",
     "directiveIf": "Ja: {expression}",
-    "discovering": "Analizē...",
     "discoveryFailed": "Neizdevās analizēt veidni",
     "downloadAnyway": "Tomēr lejupielādēt",
     "downloadDocx": "Lejupielādēt DOCX",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2184,7 +2184,6 @@ type Messages = {
     "directiveEndEach": "End loop";
     "directiveEndIf": "End if";
     "directiveIf": "If: {expression}";
-    "discovering": "Analyzing...";
     "discoveryFailed": "Failed to analyze template";
     "downloadAnyway": "Download anyway";
     "downloadDocx": "Download DOCX";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Koniec pętli",
     "directiveEndIf": "Koniec warunku",
     "directiveIf": "Jeśli: {expression}",
-    "discovering": "Analizowanie...",
     "discoveryFailed": "Nie udało się przeanalizować szablonu",
     "downloadAnyway": "Pobierz mimo to",
     "downloadDocx": "Pobierz DOCX",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Fim da repetição",
     "directiveEndIf": "Fim do se",
     "directiveIf": "Se: {expression}",
-    "discovering": "Analisando...",
     "discoveryFailed": "Falha ao analisar o modelo",
     "downloadAnyway": "Baixar mesmo assim",
     "downloadDocx": "Baixar DOCX",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2181,7 +2181,6 @@
     "directiveEndEach": "Koniec cyklu",
     "directiveEndIf": "Koniec podmienky",
     "directiveIf": "Ak: {expression}",
-    "discovering": "Analyzovanie...",
     "discoveryFailed": "Nepodarilo sa analyzovať vzor",
     "downloadAnyway": "Aj tak stiahnuť",
     "downloadDocx": "Stiahnuť DOCX",

--- a/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
@@ -147,9 +147,7 @@ export const TemplateClausesTab = ({ templateId }: TemplateClausesTabProps) => {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">
-          {t("templates.discovering")}
-        </p>
+        <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
       </div>
     );
   }

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -331,7 +331,7 @@ export const TemplateList = ({
                 >
                   <PlusIcon />
                   {discovering
-                    ? t("templates.discovering")
+                    ? t("common.loading")
                     : t("templates.newTemplate")}
                 </Button>
                 <input

--- a/apps/web/src/routes/_protected.knowledge/-components/template-preview.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-preview.tsx
@@ -276,7 +276,7 @@ const SectionDivider = ({ label }: { label: string }) => (
 const protectedRouteApi = getRouteApi("/_protected");
 
 export const TemplatePreview = ({ templateId }: { templateId: string }) => {
-  const t = useTranslations("templates");
+  const t = useTranslations();
   const activeOrganizationId = protectedRouteApi.useRouteContext({
     select: (ctx) => ctx.user.activeOrganizationId,
   });
@@ -288,7 +288,7 @@ export const TemplatePreview = ({ templateId }: { templateId: string }) => {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">{t("discovering")}</p>
+        <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
       </div>
     );
   }
@@ -296,7 +296,9 @@ export const TemplatePreview = ({ templateId }: { templateId: string }) => {
   if (isError || !data || data instanceof Response || !("paragraphs" in data)) {
     return (
       <div className="flex items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">{t("previewFailed")}</p>
+        <p className="text-muted-foreground text-sm">
+          {t("templates.previewFailed")}
+        </p>
       </div>
     );
   }
@@ -306,7 +308,9 @@ export const TemplatePreview = ({ templateId }: { templateId: string }) => {
   if (paragraphs.length === 0) {
     return (
       <div className="flex items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">{t("previewEmpty")}</p>
+        <p className="text-muted-foreground text-sm">
+          {t("templates.previewEmpty")}
+        </p>
       </div>
     );
   }
@@ -333,12 +337,12 @@ export const TemplatePreview = ({ templateId }: { templateId: string }) => {
 
         const sectionLabel = (() => {
           if (source === "header") {
-            return t("previewSectionHeader");
+            return t("templates.previewSectionHeader");
           }
           if (source === "footer") {
-            return t("previewSectionFooter");
+            return t("templates.previewSectionFooter");
           }
-          return t("previewSectionBody");
+          return t("templates.previewSectionBody");
         })();
 
         return (

--- a/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
@@ -202,9 +202,7 @@ export const TemplateUpload = ({
               variant="outline"
             >
               <UploadIcon />
-              {loading
-                ? t("templates.discovering")
-                : t("templates.browseFiles")}
+              {loading ? t("common.loading") : t("templates.browseFiles")}
             </Button>
             <Button
               disabled={loading}

--- a/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
@@ -98,9 +98,7 @@ export const TemplateVersionsTab = ({
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">
-          {t("templates.discovering")}
-        </p>
+        <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
       </div>
     );
   }

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -282,9 +282,7 @@ function RouteComponent() {
   if (creating) {
     return (
       <div className="flex flex-1 items-center justify-center p-8">
-        <p className="text-muted-foreground text-sm">
-          {t("templates.discovering")}
-        </p>
+        <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
       </div>
     );
   }
@@ -363,9 +361,7 @@ const TemplateDetail = ({
     <div className="flex min-h-0 flex-1 flex-col">
       {state === "loading" && (
         <div className="flex flex-1 items-center justify-center p-8">
-          <p className="text-muted-foreground text-sm">
-            {t("templates.discovering")}
-          </p>
+          <p className="text-muted-foreground text-sm">{t("common.loading")}</p>
         </div>
       )}
 

--- a/packages/scripts/src/i18n-lint.test.ts
+++ b/packages/scripts/src/i18n-lint.test.ts
@@ -485,4 +485,34 @@ describe("terminology: real glossary covers migrated Team-scope keys", () => {
       ),
     ).toEqual([]);
   });
+
+  const loadingRegressions = [
+    { locale: "en", value: "Analyzing..." },
+    { locale: "ar", value: "جارٍ التحليل..." },
+    { locale: "cs", value: "Analyzování..." },
+    { locale: "sk", value: "Analyzovanie..." },
+    { locale: "pl", value: "Analizowanie..." },
+    { locale: "de", value: "Analyse..." },
+    { locale: "et", value: "Analüüsimine..." },
+    { locale: "hu", value: "Elemzés..." },
+    { locale: "lt", value: "Analizuojama..." },
+    { locale: "lv", value: "Analizē..." },
+    { locale: "es", value: "Analizando..." },
+    { locale: "fr", value: "Analyse..." },
+    { locale: "pt-BR", value: "Analisando..." },
+  ];
+
+  for (const { locale, value } of loadingRegressions) {
+    test(`${locale} standalone Loading cannot regress to analysis copy`, () => {
+      expect(
+        findForbiddenTerms(
+          "Loading",
+          value,
+          locale,
+          realRules,
+          "common.loading",
+        ),
+      ).toEqual([value]);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- reuse `common.loading` for template loading states and remove the duplicate `templates.discovering` key
- add existing-glossary forbidden-term bans so standalone `common.loading` cannot regress to analysis/discovery wording across locales
- restore API MCP test mocks so the full test suite is stable when anonymization blacklist helpers are imported

## Verification
- `bun run i18n:check`
- `bun test packages/scripts/src/i18n-lint.test.ts packages/scripts/src/glossary-gen.test.ts`
- `bun run lint && bun run format && bun run typecheck && bun run test`
- pre-push hook: format, i18n, affected typecheck

## Security
- No production security-sensitive code changed; API changes are test-only mock isolation.