### PR TITLE
fix: align shift-select patch type with RowSelectionState

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
@@ -3,7 +3,7 @@ import type React from "react";
 
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
-import { flexRender } from "@tanstack/react-table";
+import { flexRender, type RowSelectionState } from "@tanstack/react-table";
 import {
   row_getIsExpanded,
   row_getIsSelected,
@@ -718,7 +718,7 @@ const SelectRowContent = ({
       const start = Math.min(lastSelectedIndex.current, index);
       const end = Math.max(lastSelectedIndex.current, index);
       const rows = table.getRowModel().rows;
-      const patch: Record<string, boolean> = {};
+      const patch: RowSelectionState = {};
       for (let i = start; i <= end; i++) {
         const r = rows[i];
         if (r) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `@stll/web` typecheck failure introduced by the TanStack Table `RowSelectionState` type tightening (`Record<string, true>` instead of `Record<string, boolean>`).

The shift-click range selection path in `row-cells.tsx` built a `Record<string, boolean>` patch and spread it into `setRowSelection`, which no longer satisfies `Updater<RowSelectionState>`.

## Changes

- Type the shift-select patch as `RowSelectionState` (values are already `true` only).
- Import `RowSelectionState` from `@tanstack/react-table`.

## Testing

- `bun --filter @stll/web typecheck` passes locally.

Unblocks CI for #989 and any other PRs hitting the same typecheck step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b01e4a-36fb-4231-b5bc-5cd854c1c2b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b01e4a-36fb-4231-b5bc-5cd854c1c2b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal table selection typing to improve type safety.
  * No user-facing behaviour changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->