### PR TITLE
fix: reject invalid timezone ids in timer start and expense creation

### DIFF
--- a/apps/api/src/handlers/expenses/create.test.ts
+++ b/apps/api/src/handlers/expenses/create.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import createExpense from "./create";
+
+type CreateExpenseCtx = Parameters<typeof createExpense.handler>[0];
+
+const createContext = ({
+  safeDb,
+}: {
+  safeDb: CreateExpenseCtx["safeDb"];
+}): CreateExpenseCtx =>
+  asTestRaw<CreateExpenseCtx>({
+    body: {
+      matterId: toSafeId<"entity">("matter_test"),
+      dateIncurred: "2026-07-01",
+      timezoneId: "Not/A_Real_Zone",
+      amount: 10_000,
+      currency: "USD",
+      category: "filing_fee",
+      description: "test",
+    },
+    safeDb,
+    workspaceId: toSafeId<"workspace">("workspace_test"),
+    memberRole: { role: "owner" },
+    session: {
+      activeOrganizationId: toSafeId<"organization">("org_test"),
+    },
+    user: { id: toSafeId<"user">("user_test") },
+    recordAuditEvent: async () => {},
+  });
+
+describe("createExpense (timezone validation)", () => {
+  test("rejects an invalid IANA timezone id with a 400 instead of throwing", async () => {
+    const { getCallCount, safeDb } = createScopedDbMock({
+      query: {
+        entities: {
+          findFirst: () => {
+            throw new Error(
+              "should not query the matter for an invalid timezone",
+            );
+          },
+        },
+      },
+    });
+
+    const result = await createExpense.handler(createContext({ safeDb }));
+
+    expect(result).toEqual({
+      code: 400,
+      response: {
+        message: "Invalid timezone identifier",
+      },
+    });
+    expect(getCallCount()).toBe(0);
+  });
+});

--- a/apps/api/src/handlers/expenses/create.ts
+++ b/apps/api/src/handlers/expenses/create.ts
@@ -11,6 +11,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { cents } from "@/api/lib/money";
+import { formatTodayInTimeZone } from "@/api/lib/timezone";
 
 const createExpenseBodySchema = t.Object({
   matterId: tSafeId("entity"),
@@ -41,11 +42,9 @@ const createExpense = createSafeHandler(
     body,
     recordAuditEvent,
   }) {
-    const now = new Date();
-    // en-CA locale formats dates as YYYY-MM-DD (ISO 8601)
-    const todayStr = new Intl.DateTimeFormat("en-CA", {
-      timeZone: body.timezoneId,
-    }).format(now);
+    const todayStr = yield* formatTodayInTimeZone({
+      timezoneId: body.timezoneId,
+    });
     const dateIncurred = new Date(`${body.dateIncurred}T00:00:00`);
     const today = new Date(`${todayStr}T00:00:00`);
 

--- a/apps/api/src/handlers/time-entries/create.ts
+++ b/apps/api/src/handlers/time-entries/create.ts
@@ -13,6 +13,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { cents } from "@/api/lib/money";
+import { formatTodayInTimeZone } from "@/api/lib/timezone";
 
 const createTimeEntryBodySchema = t.Object({
   matterId: tSafeId("entity"),
@@ -47,20 +48,9 @@ export const createTimeEntryHandler = async function* ({
   recordAuditEvent,
   body,
 }: CreateTimeEntryHandlerProps) {
-  const now = new Date();
-  let todayStr: string;
-  try {
-    todayStr = new Intl.DateTimeFormat("en-CA", {
-      timeZone: body.timezoneId,
-    }).format(now);
-  } catch {
-    return Result.err(
-      new HandlerError({
-        status: 400,
-        message: "Invalid timezone identifier",
-      }),
-    );
-  }
+  const todayStr = yield* formatTodayInTimeZone({
+    timezoneId: body.timezoneId,
+  });
   const dateWorked = new Date(`${body.dateWorked}T00:00:00`);
   const today = new Date(`${todayStr}T00:00:00`);
 

--- a/apps/api/src/handlers/time-entries/timer-start.test.ts
+++ b/apps/api/src/handlers/time-entries/timer-start.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import timerStart from "./timer-start";
+
+type TimerStartCtx = Parameters<typeof timerStart.handler>[0];
+
+const createContext = ({
+  safeDb,
+}: {
+  safeDb: TimerStartCtx["safeDb"];
+}): TimerStartCtx =>
+  asTestRaw<TimerStartCtx>({
+    body: {
+      matterId: toSafeId<"entity">("matter_test"),
+      timezoneId: "Not/A_Real_Zone",
+      rateAtEntry: 10_000,
+      currency: "USD",
+    },
+    safeDb,
+    workspaceId: toSafeId<"workspace">("workspace_test"),
+    memberRole: { role: "owner" },
+    session: {
+      activeOrganizationId: toSafeId<"organization">("org_test"),
+    },
+    user: { id: toSafeId<"user">("user_test") },
+    recordAuditEvent: async () => {},
+  });
+
+describe("timerStart (timezone validation)", () => {
+  test("rejects an invalid IANA timezone id with a 400 instead of throwing", async () => {
+    const { getCallCount, safeDb } = createScopedDbMock({
+      $count: () => {
+        throw new Error(
+          "should not query the active timer count for an invalid timezone",
+        );
+      },
+      query: {
+        entities: {
+          findFirst: () => {
+            throw new Error(
+              "should not query the matter for an invalid timezone",
+            );
+          },
+        },
+      },
+    });
+
+    const result = await timerStart.handler(createContext({ safeDb }));
+
+    expect(result).toEqual({
+      code: 400,
+      response: {
+        message: "Invalid timezone identifier",
+      },
+    });
+    expect(getCallCount()).toBe(0);
+  });
+});

--- a/apps/api/src/handlers/time-entries/timer-start.ts
+++ b/apps/api/src/handlers/time-entries/timer-start.ts
@@ -13,6 +13,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { cents } from "@/api/lib/money";
+import { formatTodayInTimeZone } from "@/api/lib/timezone";
 
 const timerStartBodySchema = t.Object({
   matterId: tSafeId("entity"),
@@ -36,6 +37,12 @@ const timerStart = createSafeHandler(
     body,
     recordAuditEvent,
   }) {
+    const now = new Date();
+    const todayStr = yield* formatTodayInTimeZone({
+      timezoneId: body.timezoneId,
+      now,
+    });
+
     // Check active timer limit
     const activeTimerCount = yield* Result.await(
       safeDb((tx) =>
@@ -81,12 +88,6 @@ const timerStart = createSafeHandler(
         }),
       );
     }
-
-    const now = new Date();
-    // en-CA locale formats dates as YYYY-MM-DD (ISO 8601)
-    const todayStr = new Intl.DateTimeFormat("en-CA", {
-      timeZone: body.timezoneId,
-    }).format(now);
 
     // Advisory lock + count + insert in one transaction to
     // prevent TOCTOU on the workspace time entry limit.

--- a/apps/api/src/lib/timezone.ts
+++ b/apps/api/src/lib/timezone.ts
@@ -1,0 +1,30 @@
+import { Result } from "better-result";
+
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+type FormatTodayInTimeZoneProps = {
+  timezoneId: string;
+  now?: Date;
+};
+
+/**
+ * Formats "today" as an ISO (YYYY-MM-DD) date string in the given IANA
+ * timezone id. `Intl.DateTimeFormat` throws a `RangeError` for an invalid
+ * timezone id, so this wraps the call in a `Result` and surfaces a 400
+ * `HandlerError` instead of letting the exception reach the client as an
+ * unhandled 500.
+ */
+export const formatTodayInTimeZone = ({
+  timezoneId,
+  now = new Date(),
+}: FormatTodayInTimeZoneProps): Result<string, HandlerError<400>> =>
+  Result.try({
+    // en-CA locale formats dates as YYYY-MM-DD (ISO 8601)
+    try: () =>
+      new Intl.DateTimeFormat("en-CA", { timeZone: timezoneId }).format(now),
+    catch: () =>
+      new HandlerError({
+        status: 400,
+        message: "Invalid timezone identifier",
+      }),
+  });


### PR DESCRIPTION
An invalid IANA timezone id reached `Intl.DateTimeFormat` unguarded in timer start and expense creation, turning bad input into a 500. Both paths (and the previously fixed time-entry creation) now share a `formatTodayInTimeZone` helper returning a 400 before any DB work.