### PR TITLE
feat: mute the matters nav icon to match neighbouring entries

### DIFF
--- a/apps/web/src/components/matter-icon.tsx
+++ b/apps/web/src/components/matter-icon.tsx
@@ -91,10 +91,12 @@ export const MatterIcon = (props: MatterIconProps) => {
 
 // Stable component reference for config-driven renderers (the primary nav,
 // the onboarding sidebar preview) that store an icon component and render
-// it as `<Icon className={...} />`. Represents the "all matters"
-// navigation affordance (the tri-plane stack).
+// it as `<Icon className={...} />`. Paints the muted mono glyph so the
+// matters entry reads like its neighbouring nav icons (search, chat,
+// contacts) rather than singling itself out with the tri-plane colour;
+// a specific matter still gets its colour wherever one is actually named.
 export const MattersNavIcon = ({
   className,
 }: {
   className?: string | undefined;
-}) => <MatterIcon className={className} variant="all" />;
+}) => <MatterIcon className={className} variant="none" />;


### PR DESCRIPTION
Renders the matters (Spisy) sidebar entry with the muted mono layers glyph (`variant="none"`) instead of the coloured tri-plane `variant="all"`, so it reads like its neighbouring nav icons (search, chat, knowledge, contacts) rather than singling itself out.

Routed through the sanctioned muted arm of `MatterIcon`, so the `no-direct-matter-glyph` guard stays intact: a specific matter is still unrepresentable without its colour; only the "all matters" nav affordance goes mono. The onboarding sidebar preview, which shares `MattersNavIcon`, mutes with it and stays in sync with the real sidebar.