### PR TITLE
docs(meta): sync ai-shared — orchestrate subtasks to cheaper subagent tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,9 @@ details unless they are already public in the repository.
   manual discipline
 - Conventional Commits: `feat:`, `chore:`, `fix:`, `docs:`
 - Rebase feature branches onto main (linear history)
+- Enable `git rerere` (`git config --global rerere.enabled true`, plus
+  `rerere.autoupdate true` to auto-stage what it resolves) so conflict
+  resolutions are recorded and auto-replayed across repeated or long rebases
 - Fail fast: validate at boundaries, return/throw early
 - Minimize brace nesting: invert conditions, early returns
 - Use named constants, not string literals for domain values
@@ -60,6 +63,12 @@ details unless they are already public in the repository.
 - Avoid spread in loop accumulators (use `.push()`)
 - If you encounter a pre-existing bug or lint error while working on something else,
   fix it (separate commit)
+- Orchestrate across model tiers when your harness supports subagents and model
+  selection: delegate well-scoped, mechanical, or independently verifiable subtasks
+  (edits, searches, refactors, test runs) to a subagent on the cheapest model that
+  does them correctly; keep planning, cross-cutting design, security-sensitive work,
+  and final review on the primary model. If your tooling has no subagents or model
+  selection, ignore this.
 
 ## Design Principles
 


### PR DESCRIPTION
Bumps the `.ai/shared` submodule to the current `main` (`c08a6f3`) and regenerates `AGENTS.md`.

New Meta Preferences guidance: when a harness supports subagents and model selection, delegate well-scoped, mechanical, or independently verifiable subtasks to a cheaper model and keep planning, cross-cutting design, security-sensitive work, and final review on the primary model; gated so tools without subagents/model selection ignore it. The submodule bump also brings in the upstream `git rerere` bullet.

Docs-only: `AGENTS.md` is regenerated from the module fragments, no source changes.