### PR TITLE
feat: add anonymization canary corpus and text-field spec foundation

### DIFF
--- a/apps/api/src/mcp/egress-canary.test.ts
+++ b/apps/api/src/mcp/egress-canary.test.ts
@@ -1,0 +1,1531 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import type { McpRequestContext } from "@/api/mcp/context";
+import type { McpEgressPlan } from "@/api/mcp/tool-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+/**
+ * Registry-driven canary corpus over the MCP anonymized surface (plan 049,
+ * Phase 0). This is the structural guard for the bug class both shipped
+ * leaks shared: a tool's `textFields` declaration and its handler's actual
+ * `McpStructuredTextField` pushes are hand-maintained twins with nothing
+ * forcing them to describe the same fields (Wave 1: `read_document` declared
+ * `versions[].label`/`description` but never pushed them; Wave 4: a
+ * fail-closed guard in `readClauseDetail` could skip a push entirely).
+ *
+ * Mechanics: for every tool the registry marks `exposure: "anonymize"`, a
+ * fixture seeds a unique per-declared-field token into the handler's backing
+ * store (a minimal scopedDb/safeDb test double, or a mocked plain backing
+ * function for a handful of workspace/template lookups), calls the real
+ * exported tool handler directly (`<MODULE>_TOOL_HANDLERS.<name>`, bypassing
+ * only the outer schema/permission dispatch in `tools.ts`), and runs the
+ * result through the real, unmocked `finalizeMcpEgress` in anonymized mode.
+ * Two assertions close the loop: (a) no seed token survives anywhere in the
+ * serialized result (no leak), and (b) every seed token was actually queued
+ * into an `anonymizeTextFields` call (proving the declared field was really
+ * pushed by production code, not merely documented). Checking (b) against the
+ * anonymizer's call arguments rather than walking the output by path string
+ * sidesteps a real wrinkle found while building this: several declared paths
+ * (e.g. `fields[].value`) do not literally address the JSON the handler
+ * returns (the real shape nests under `fields[].content.value`); the
+ * declared strings are documentation of intent, not a parseable path
+ * grammar, so a literal path-walker would be exactly as fragile here as the
+ * design brief's Option A predicts.
+ *
+ * `CANARY_COVERED_TOOL_NAMES` is checked against the live registry
+ * enumeration in the completeness test below: a tool added to the anonymized
+ * surface without a matching entry here fails a red build, closing the
+ * "someone forgot" gap the design brief calls out for Option C.
+ *
+ * Known, stated blind spot: `read_document`'s `compare_with_version_id`
+ * (diff) branch loads DOCX bytes from S3 through `loadEntityVersionDocxText`
+ * and diffs them with `buildLineDiffSegments`. Driving that for real needs an
+ * actual DOCX fixture and an S3 double, which is out of scope for this
+ * corpus; that one sub-case (`diff.segments[].text`) is exercised at the
+ * egress-plan level instead of through the real handler (see the dedicated
+ * test below). Every other declared field on every other tool, including
+ * both compat variants, runs through the real production handler.
+ */
+
+// --- Shared anonymization/backing-handler mocks -----------------------
+
+type AnonymizeTextFieldsInput = {
+  fields: readonly string[];
+  gazetteerEntries?: unknown;
+  organizationId?: unknown;
+  scopedDb?: unknown;
+  workspaceId?: unknown;
+};
+
+const anonymizeTextFieldsMock = mock(
+  async ({ fields }: AnonymizeTextFieldsInput) => ({
+    entityCount: fields.length,
+    fields: fields.map((_field, index) => `[ANON_${index}]`),
+  }),
+);
+
+const loadAnonymizationGazetteerEntriesMock = mock(async () => []);
+
+const decryptContentMock = mock(async () => "");
+
+type SearchProviderHit = {
+  entityId: string;
+  headline?: string | null;
+  kind?: string;
+  title: string;
+  workspaceId: string;
+  workspaceName?: string;
+};
+
+const searchProviderSearchMock = mock(
+  async (): Promise<{
+    hits: SearchProviderHit[];
+    nextCursor: string | null;
+    totalCount: number;
+  }> => ({ hits: [], nextCursor: null, totalCount: 0 }),
+);
+
+const readWorkspaceHandlerMock = mock();
+const readOverviewHandlerMock = mock();
+const readWorkspaceContactsHandlerMock = mock();
+const readWorkspaceMembersHandlerMock = mock();
+const describeStoredTemplateMock = mock();
+
+const realAnonymizationBlacklist =
+  await import("@/api/lib/anonymization-blacklist");
+const realContentEncryption = await import("@/api/lib/content-encryption");
+const realTemplateFillService =
+  await import("@/api/handlers/templates/template-fill-service");
+
+void mock.module("@/api/mcp/anonymization", () => ({
+  anonymizeTextFields: anonymizeTextFieldsMock,
+}));
+
+void mock.module("@/api/lib/anonymization-blacklist", () => ({
+  ...realAnonymizationBlacklist,
+  loadAnonymizationGazetteerEntries: loadAnonymizationGazetteerEntriesMock,
+}));
+
+void mock.module("@/api/lib/content-encryption", () => ({
+  ...realContentEncryption,
+  decryptContent: decryptContentMock,
+}));
+
+void mock.module("@/api/lib/search/provider", () => ({
+  getSearchProvider: () => ({ search: searchProviderSearchMock }),
+}));
+
+void mock.module("@/api/handlers/workspaces/read-by-id", () => ({
+  readWorkspaceHandler: readWorkspaceHandlerMock,
+}));
+
+void mock.module("@/api/handlers/workspaces/read-overview", () => ({
+  readOverviewHandler: readOverviewHandlerMock,
+}));
+
+void mock.module("@/api/handlers/workspaces/workspace-contacts-read", () => ({
+  readWorkspaceContactsHandler: readWorkspaceContactsHandlerMock,
+}));
+
+void mock.module("@/api/handlers/workspaces/workspace-members-read", () => ({
+  readWorkspaceMembersHandler: readWorkspaceMembersHandlerMock,
+}));
+
+void mock.module("@/api/handlers/templates/template-fill-service", () => ({
+  ...realTemplateFillService,
+  describeStoredTemplate: describeStoredTemplateMock,
+}));
+
+const { finalizeMcpEgress } = await import("@/api/mcp/egress");
+const { ANONYMIZED_MCP_TOOL_DEFINITIONS } =
+  await import("@/api/mcp/static-tool-definitions");
+const { COMPAT_TOOL_HANDLERS } = await import("@/api/mcp/compat-tools");
+const { STELLA_TOOL_HANDLERS } = await import("@/api/mcp/stella-tools");
+const { DOCUMENT_TOOL_HANDLERS } = await import("@/api/mcp/document-tools");
+const { MATTER_TOOL_HANDLERS } = await import("@/api/mcp/matter-tools");
+const { TEMPLATE_TOOL_HANDLERS } = await import("@/api/mcp/template-tools");
+const { BILLING_TOOL_HANDLERS } = await import("@/api/mcp/billing-tools");
+const { KNOWLEDGE_TOOL_HANDLERS } = await import("@/api/mcp/knowledge-tools");
+
+// --- Fixture harness ----------------------------------------------------
+
+/** A unique, greppable token for one tool's one declared textFields entry. */
+const mkSeed = (tool: string, index: number): string =>
+  `SEED_${tool}_${index}_TOKEN`;
+
+type ChainableRows = {
+  from: (...args: unknown[]) => ChainableRows;
+  where: (...args: unknown[]) => ChainableRows;
+  orderBy: (...args: unknown[]) => ChainableRows;
+  innerJoin: (...args: unknown[]) => ChainableRows;
+  leftJoin: (...args: unknown[]) => ChainableRows;
+  limit: (...args: unknown[]) => Promise<readonly unknown[]>;
+};
+
+/**
+ * A drizzle-shaped select chain covering every query in this corpus that
+ * terminates at `.limit()`: every non-terminal method (`from`, `where`,
+ * `orderBy`, the joins) returns the same synchronous builder, and the
+ * terminal `.limit()` resolves to `rows`. The one query with no page limit
+ * (the `loadUserNames` join inside `list_time_entries`) uses the bespoke
+ * builder next to its call site instead, since a method cannot be both a
+ * synchronous, further-chainable step and an awaitable terminus.
+ */
+const chainableRows = (rows: readonly unknown[]): ChainableRows => {
+  const builder: ChainableRows = {
+    from: () => builder,
+    where: () => builder,
+    orderBy: () => builder,
+    innerJoin: () => builder,
+    leftJoin: () => builder,
+    limit: async () => rows,
+  };
+  return builder;
+};
+
+/**
+ * A `tx.select` stand-in for a join query with no page limit, terminating at
+ * `.where()` (the compat `search` tool's fetchable-entity join). Mirrors
+ * `chainableRows` but with an awaitable terminal `.where()` instead of
+ * `.limit()`.
+ */
+const chainableJoinRows = (rows: readonly unknown[]) => ({
+  from: () => ({
+    innerJoin: () => ({
+      leftJoin: () => ({ where: async () => rows }),
+    }),
+  }),
+});
+
+/**
+ * A `tx.select` stand-in for `list_time_entries`, whose handler runs two
+ * distinct select queries against one scopedDb double inside a single call:
+ * the entries page (terminates at `.limit()`), then a join resolving each
+ * entry's user display name (terminates at `.where()`, no page limit). Each
+ * call to the returned function advances to the next query, in the order
+ * the handler issues them; the counter lives on a boxed object the factory
+ * closes over so repeated calls advance correctly.
+ */
+const createEntriesAndUserNamesSelect = ({
+  entryRows,
+  userNameRows,
+}: {
+  entryRows: readonly unknown[];
+  userNameRows: readonly unknown[];
+}) => {
+  const state = { call: 0 };
+  return (..._args: unknown[]) => {
+    state.call += 1;
+    if (state.call === 1) {
+      return chainableRows(entryRows);
+    }
+    return {
+      from: () => ({
+        innerJoin: () => ({
+          where: async () => userNameRows,
+        }),
+      }),
+    };
+  };
+};
+
+const buildContext = ({
+  memberRole = "owner",
+  organizationId = "org_1",
+  tx = {},
+  workspaceIds = ["ws_1"],
+}: {
+  memberRole?: McpRequestContext["memberRole"];
+  organizationId?: string;
+  tx?: unknown;
+  workspaceIds?: readonly string[];
+} = {}): McpRequestContext => {
+  const { safeDb, scopedDb } = createScopedDbMock(tx);
+  return {
+    accessibleWorkspaceIds: workspaceIds.map((id) => toSafeId<"workspace">(id)),
+    accessibleWorkspaceIdSet: new Set(workspaceIds),
+    accessibleWorkspaceStatusById: new Map(
+      workspaceIds.map((id) => [id, "active"]),
+    ),
+    memberRole,
+    organizationId: toSafeId<"organization">(organizationId),
+    recordAuditEvent: asTestRaw(mock(async () => undefined)),
+    safeDb,
+    scopedDb,
+    userId: toSafeId<"user">("user_1"),
+  };
+};
+
+const parseResultText = (result: CallToolResult): string => {
+  const item = result.content.at(0);
+  if (!item || item.type !== "text") {
+    throw new Error("Expected a text MCP response");
+  }
+  return item.text;
+};
+
+/** Runs a handler's response through the real anonymized egress pipeline. */
+const finalize = async (
+  context: McpRequestContext,
+  response: Awaited<ReturnType<typeof COMPAT_TOOL_HANDLERS.search>>,
+) => await finalizeMcpEgress({ context, mode: "anonymized", response });
+
+const expectNoSeedLeak = (
+  result: CallToolResult,
+  seeds: readonly string[],
+): void => {
+  const text = parseResultText(result);
+  for (const seed of seeds) {
+    expect(
+      text,
+      `Seed ${seed} leaked into the anonymized result`,
+    ).not.toContain(seed);
+  }
+};
+
+/**
+ * The precise, surgical replacement for a path-walker: every declared field
+ * must have actually reached an `anonymizeTextFields` call, proving the
+ * handler queued it for redaction rather than merely documenting it in
+ * `textFields`. A seed missing here reproduces the Wave 1 class of bug
+ * (declared, never pushed) without needing to resolve the declared path
+ * string against the handler's real JSON shape.
+ */
+const expectSeedsQueuedForAnonymization = (seeds: readonly string[]): void => {
+  const queued = anonymizeTextFieldsMock.mock.calls.flatMap(
+    (call) => call[0].fields,
+  );
+  for (const seed of seeds) {
+    expect(queued, `Expected ${seed} to be queued for anonymization`).toContain(
+      seed,
+    );
+  }
+};
+
+beforeEach(() => {
+  anonymizeTextFieldsMock.mockClear();
+  loadAnonymizationGazetteerEntriesMock.mockReset();
+  loadAnonymizationGazetteerEntriesMock.mockResolvedValue([]);
+  decryptContentMock.mockReset();
+  searchProviderSearchMock.mockReset();
+  searchProviderSearchMock.mockResolvedValue({
+    hits: [],
+    nextCursor: null,
+    totalCount: 0,
+  });
+  readWorkspaceHandlerMock.mockReset();
+  readOverviewHandlerMock.mockReset();
+  readWorkspaceContactsHandlerMock.mockReset();
+  readWorkspaceMembersHandlerMock.mockReset();
+  describeStoredTemplateMock.mockReset();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+/**
+ * Tools this file has a canary fixture for, checked below against every
+ * `exposure: "anonymize"` tool the live registry advertises. A tool added to
+ * the anonymized surface without an entry here fails the build instead of
+ * shipping unguarded.
+ */
+const CANARY_COVERED_TOOL_NAMES = new Set([
+  "search",
+  "fetch",
+  "list_matters",
+  "search_across_matters",
+  "read_content_across_matters",
+  "read_contact",
+  "list_templates",
+  "list_documents",
+  "read_document",
+  "list_properties",
+  "list_tasks",
+  "list_clauses",
+  "list_playbooks",
+  "list_time_entries",
+  "list_invoices",
+]);
+
+describe("MCP anonymization canary corpus", () => {
+  test("every anonymize-mode tool in the registry has a canary fixture", () => {
+    const anonymizeToolNames = ANONYMIZED_MCP_TOOL_DEFINITIONS.filter(
+      (tool) => tool.anonymized.exposure === "anonymize",
+    ).map((tool) => tool.name);
+
+    const missing = anonymizeToolNames.filter(
+      (name) => !CANARY_COVERED_TOOL_NAMES.has(name),
+    );
+
+    expect(
+      missing,
+      "A tool joined the anonymized surface without a canary fixture in " +
+        "egress-canary.test.ts. Add one before merging.",
+    ).toEqual([]);
+
+    // Guards the guard: a typo'd or stale name in the covered set that no
+    // longer matches a real anonymize-mode tool would otherwise hide a gap.
+    const extra = [...CANARY_COVERED_TOOL_NAMES].filter(
+      (name) => !anonymizeToolNames.includes(name),
+    );
+    expect(
+      extra,
+      "CANARY_COVERED_TOOL_NAMES names a tool that is not (or no longer) " +
+        "anonymize-mode in the registry.",
+    ).toEqual([]);
+  });
+
+  // --- compat: search / fetch -------------------------------------------
+
+  test("compat search anonymizes result titles", async () => {
+    const tool = "search";
+    const titleSeed = mkSeed(tool, 0);
+    searchProviderSearchMock.mockResolvedValue({
+      hits: [
+        {
+          entityId: "entity_1",
+          workspaceId: "ws_1",
+          title: titleSeed,
+        },
+      ],
+      nextCursor: null,
+      totalCount: 1,
+    });
+    const tx = {
+      select: () =>
+        chainableJoinRows([
+          { entityId: "entity_1", workspaceId: "ws_1", fieldId: "field_1" },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await COMPAT_TOOL_HANDLERS.search({
+      args: { query: "q" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [titleSeed]);
+    expectSeedsQueuedForAnonymization([titleSeed]);
+  });
+
+  test("compat fetch anonymizes title and text", async () => {
+    const tool = "fetch";
+    const titleSeed = mkSeed(tool, 0);
+    const textSeed = mkSeed(tool, 1);
+    decryptContentMock.mockResolvedValue(textSeed);
+    const tx = {
+      query: {
+        entities: { findFirst: async () => null },
+        extractedContent: {
+          findFirst: async () => ({
+            charCount: textSeed.length,
+            ciphertext: "cipher",
+            iv: "iv",
+            entity: { name: titleSeed, workspaceId: "ws_1" },
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await COMPAT_TOOL_HANDLERS.fetch({
+      args: { id: "entity_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [titleSeed, textSeed]);
+    expectSeedsQueuedForAnonymization([titleSeed, textSeed]);
+  });
+
+  // --- stella-tools --------------------------------------------------------
+
+  test("list_matters (list mode) anonymizes matter names", async () => {
+    const tool = "list_matters";
+    const nameSeed = mkSeed(tool, 0);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            id: "ws_1",
+            name: nameSeed,
+            reference: "REF-1",
+            status: "active",
+            lastActivityAt: new Date("2026-01-01"),
+            createdAt: new Date("2026-01-01"),
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await STELLA_TOOL_HANDLERS.list_matters({
+      args: {},
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [nameSeed]);
+    expectSeedsQueuedForAnonymization([nameSeed]);
+  });
+
+  test("list_matters (detail mode) anonymizes matter, overview, contacts, and members", async () => {
+    const tool = "list_matters";
+    const matterNameSeed = mkSeed(tool, 1);
+    const clientNameSeed = mkSeed(tool, 2);
+    const recentNameSeed = mkSeed(tool, 3);
+    const createdBySeed = mkSeed(tool, 4);
+    const assignedToSeed = mkSeed(tool, 5);
+    const contactDisplayNameSeed = mkSeed(tool, 6);
+    const memberNameSeed = mkSeed(tool, 7);
+
+    readWorkspaceHandlerMock.mockResolvedValue({
+      id: "ws_1",
+      name: matterNameSeed,
+      reference: "REF-1",
+      status: "active",
+      client: { displayName: clientNameSeed },
+    });
+    readOverviewHandlerMock.mockResolvedValue({
+      entityCount: 1,
+      documentCount: 1,
+      taskCount: 0,
+      recentEntities: [
+        {
+          entityId: "entity_1",
+          name: recentNameSeed,
+          kind: "document",
+          status: null,
+          priority: null,
+          dueDate: null,
+          mimeType: null,
+          fieldId: null,
+          propertyId: null,
+          pdfFileId: null,
+          encrypted: false,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: null,
+          createdBy: createdBySeed,
+          createdByImage: null,
+          createdByDeletedAt: null,
+          assignedTo: assignedToSeed,
+          assignedToImage: null,
+          assignedToDeletedAt: null,
+        },
+      ],
+    });
+    readWorkspaceContactsHandlerMock.mockResolvedValue([
+      {
+        id: "wc_1",
+        role: "client",
+        contact: {
+          id: "contact_1",
+          type: "person",
+          displayName: contactDisplayNameSeed,
+        },
+      },
+    ]);
+    readWorkspaceMembersHandlerMock.mockResolvedValue([
+      {
+        id: "wm_1",
+        userId: "user_2",
+        createdAt: new Date("2026-01-01"),
+        user: {
+          id: "user_2",
+          name: memberNameSeed,
+          email: "member@example.test",
+          image: null,
+        },
+      },
+    ]);
+
+    const context = buildContext();
+    const response = await STELLA_TOOL_HANDLERS.list_matters({
+      args: { matter_id: "ws_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      matterNameSeed,
+      clientNameSeed,
+      recentNameSeed,
+      createdBySeed,
+      assignedToSeed,
+      contactDisplayNameSeed,
+      memberNameSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("search_across_matters anonymizes hit name, headline, and workspace name", async () => {
+    const tool = "search_across_matters";
+    const nameSeed = mkSeed(tool, 0);
+    const headlineSeed = mkSeed(tool, 1);
+    const workspaceNameSeed = mkSeed(tool, 2);
+    searchProviderSearchMock.mockResolvedValue({
+      hits: [
+        {
+          entityId: "entity_1",
+          workspaceId: "ws_1",
+          title: nameSeed,
+          headline: headlineSeed,
+          workspaceName: workspaceNameSeed,
+          kind: "document",
+        },
+      ],
+      nextCursor: null,
+      totalCount: 1,
+    });
+    const context = buildContext();
+
+    const response = await STELLA_TOOL_HANDLERS.search_across_matters({
+      args: { query: "q" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [nameSeed, headlineSeed, workspaceNameSeed];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("read_content_across_matters anonymizes entity name and text", async () => {
+    const tool = "read_content_across_matters";
+    const nameSeed = mkSeed(tool, 0);
+    const textSeed = mkSeed(tool, 1);
+    decryptContentMock.mockResolvedValue(textSeed);
+    const tx = {
+      query: {
+        extractedContent: {
+          findFirst: async () => ({
+            ciphertext: "cipher",
+            iv: "iv",
+            entity: { kind: "document", name: nameSeed, workspaceId: "ws_1" },
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await STELLA_TOOL_HANDLERS.read_content_across_matters({
+      args: { entity_id: "entity_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [nameSeed, textSeed]);
+    expectSeedsQueuedForAnonymization([nameSeed, textSeed]);
+  });
+
+  test("read_contact anonymizes name, org, email, and phone fields", async () => {
+    const tool = "read_contact";
+    const displayNameSeed = mkSeed(tool, 0);
+    const firstNameSeed = mkSeed(tool, 1);
+    const lastNameSeed = mkSeed(tool, 2);
+    const organizationNameSeed = mkSeed(tool, 3);
+    const emailSeed = mkSeed(tool, 4);
+    const phoneSeed = mkSeed(tool, 5);
+    const tx = {
+      query: {
+        contacts: {
+          findFirst: async () => ({
+            id: "contact_1",
+            type: "person",
+            displayName: displayNameSeed,
+            firstName: firstNameSeed,
+            lastName: lastNameSeed,
+            organizationName: organizationNameSeed,
+            emails: [{ label: "work", address: emailSeed }],
+            phones: [{ label: "mobile", number: phoneSeed }],
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await STELLA_TOOL_HANDLERS.read_contact({
+      args: { contact_id: "contact_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      displayNameSeed,
+      firstNameSeed,
+      lastNameSeed,
+      organizationNameSeed,
+      emailSeed,
+      phoneSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  // --- document-tools ------------------------------------------------------
+
+  test("list_documents anonymizes document names", async () => {
+    const tool = "list_documents";
+    const nameSeed = mkSeed(tool, 0);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            createdAt: "2026-01-01T00:00:00.000000",
+            id: "doc_1",
+            name: nameSeed,
+            kind: "document",
+            parentId: null,
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await DOCUMENT_TOOL_HANDLERS.list_documents({
+      args: { matter_id: "ws_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [nameSeed]);
+    expectSeedsQueuedForAnonymization([nameSeed]);
+  });
+
+  test("read_document (default + version history) anonymizes name, field values, and version labels", async () => {
+    const tool = "read_document";
+    const nameSeed = mkSeed(tool, 0);
+    const fieldValueSeed = mkSeed(tool, 1);
+    const versionLabelSeed = mkSeed(tool, 3);
+    const versionDescriptionSeed = mkSeed(tool, 4);
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => ({
+            workspaceId: "ws_1",
+            kind: "document",
+            name: nameSeed,
+            currentVersionId: "ver_current",
+          }),
+        },
+        fields: {
+          findMany: async () => [
+            {
+              id: "field_1",
+              propertyId: "prop_1",
+              content: { version: 1, type: "text", value: fieldValueSeed },
+            },
+          ],
+        },
+      },
+      select: () =>
+        chainableRows([
+          {
+            id: "ver_2",
+            versionNumber: 2,
+            stamp: null,
+            label: versionLabelSeed,
+            description: versionDescriptionSeed,
+            createdAt: new Date("2026-01-01"),
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await DOCUMENT_TOOL_HANDLERS.read_document({
+      args: { entity_id: "entity_1", include_versions: true },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      nameSeed,
+      fieldValueSeed,
+      versionLabelSeed,
+      versionDescriptionSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("read_document (specific version) anonymizes that version's field values", async () => {
+    const tool = "read_document";
+    const versionFieldValueSeed = mkSeed(tool, 2);
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => ({
+            workspaceId: "ws_1",
+            kind: "document",
+            name: "Doc",
+            currentVersionId: "ver_current",
+          }),
+        },
+        entityVersions: {
+          findFirst: async () => ({
+            id: "ver_1",
+            versionNumber: 1,
+            stamp: null,
+            label: null,
+            description: null,
+            createdAt: new Date("2026-01-01"),
+          }),
+        },
+        fields: {
+          findMany: async () => [
+            {
+              id: "field_2",
+              propertyId: "prop_2",
+              content: {
+                version: 1,
+                type: "text",
+                value: versionFieldValueSeed,
+              },
+            },
+          ],
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await DOCUMENT_TOOL_HANDLERS.read_document({
+      args: { entity_id: "entity_1", version_id: "ver_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [versionFieldValueSeed]);
+    expectSeedsQueuedForAnonymization([versionFieldValueSeed]);
+  });
+
+  // read_document's compare_with_version_id branch diffs two DOCX versions
+  // loaded from S3 (loadEntityVersionDocxText -> buildLineDiffSegments).
+  // Driving that for real needs an actual DOCX fixture and an S3 double,
+  // which this corpus does not attempt (see the file-level blind-spot note).
+  // This sub-case is exercised at the egress-plan level instead: the plan
+  // shape below mirrors exactly what the diff branch builds
+  // (`document-tools.ts`'s `handleReadDocumentTool`, compare branch).
+  test("read_document (diff, egress-plan level) anonymizes diff segment text", async () => {
+    const tool = "read_document";
+    const diffSeed = mkSeed(tool, 5);
+    const payload = {
+      entityId: "entity_1",
+      name: "Doc",
+      diff: {
+        baseVersionId: "ver_a",
+        targetVersionId: "ver_b",
+        segments: [{ kind: "unchanged" as const, text: diffSeed }],
+      },
+    };
+    const plan: McpEgressPlan = {
+      egress: "structured",
+      payload,
+      textFields: [
+        {
+          apply: (value: string) => {
+            payload.diff.segments[0]!.text = value;
+          },
+          value: diffSeed,
+          workspaceId: "ws_1",
+        },
+      ],
+    };
+    const context = buildContext();
+
+    const result = await finalizeMcpEgress({
+      context,
+      mode: "anonymized",
+      response: plan,
+    });
+
+    expectNoSeedLeak(result, [diffSeed]);
+    expectSeedsQueuedForAnonymization([diffSeed]);
+  });
+
+  test("list_properties anonymizes property names", async () => {
+    const tool = "list_properties";
+    const nameSeed = mkSeed(tool, 0);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            createdAt: "2026-01-01T00:00:00.000000",
+            id: "prop_1",
+            name: nameSeed,
+            content: { type: "text" },
+            status: "active",
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await DOCUMENT_TOOL_HANDLERS.list_properties({
+      args: { matter_id: "ws_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [nameSeed]);
+    expectSeedsQueuedForAnonymization([nameSeed]);
+  });
+
+  // --- matter-tools --------------------------------------------------------
+
+  test("list_tasks (list mode) anonymizes task names", async () => {
+    const tool = "list_tasks";
+    const nameSeed = mkSeed(tool, 0);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            createdAt: "2026-01-01T00:00:00.000000",
+            id: "task_1",
+            name: nameSeed,
+            status: "open",
+            priority: "high",
+            dueDate: null,
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await MATTER_TOOL_HANDLERS.list_tasks({
+      args: { matter_id: "ws_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [nameSeed]);
+    expectSeedsQueuedForAnonymization([nameSeed]);
+  });
+
+  test("list_tasks (detail mode) anonymizes name, location, assignees, and linked entity names", async () => {
+    const tool = "list_tasks";
+    const nameSeed = mkSeed(tool, 1);
+    const locationSeed = mkSeed(tool, 2);
+    const assigneeNameSeed = mkSeed(tool, 3);
+    const linkedEntityNameSeed = mkSeed(tool, 4);
+    const tx = {
+      query: {
+        entities: {
+          findFirst: async () => ({
+            id: "task_1",
+            workspaceId: "ws_1",
+            kind: "task",
+            name: nameSeed,
+            status: "open",
+            priority: "high",
+            dueDate: null,
+            startAt: null,
+            endAt: null,
+            location: locationSeed,
+            agendaKind: null,
+          }),
+        },
+        taskAssignees: {
+          findMany: async () => [
+            {
+              role: "assignee",
+              user: { id: "user_2", name: assigneeNameSeed },
+            },
+          ],
+        },
+        entityLinks: {
+          findMany: async (input?: {
+            where?: { sourceEntityId?: unknown; targetEntityId?: unknown };
+          }) =>
+            input?.where?.sourceEntityId === undefined
+              ? []
+              : [
+                  {
+                    id: "link_1",
+                    linkType: "related",
+                    sourceEntityId: "task_1",
+                    targetEntityId: "doc_1",
+                    sourceEntity: {
+                      id: "task_1",
+                      name: nameSeed,
+                      kind: "task",
+                    },
+                    targetEntity: {
+                      id: "doc_1",
+                      name: linkedEntityNameSeed,
+                      kind: "document",
+                    },
+                  },
+                ],
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await MATTER_TOOL_HANDLERS.list_tasks({
+      args: { task_id: "task_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      nameSeed,
+      locationSeed,
+      assigneeNameSeed,
+      linkedEntityNameSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  // --- template-tools ------------------------------------------------------
+
+  test("list_templates (list mode) anonymizes name, usage guidance", async () => {
+    const tool = "list_templates";
+    const nameSeed = mkSeed(tool, 0);
+    const whenToUseSeed = mkSeed(tool, 1);
+    const whenNotToUseSeed = mkSeed(tool, 2);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            id: "tpl_1",
+            name: nameSeed,
+            fieldCount: 2,
+            tags: [],
+            whenToUse: whenToUseSeed,
+            whenNotToUse: whenNotToUseSeed,
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await TEMPLATE_TOOL_HANDLERS.list_templates({
+      args: {},
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [nameSeed, whenToUseSeed, whenNotToUseSeed];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("list_templates (detail mode) anonymizes template name and field label/hint/aiPrompt", async () => {
+    const tool = "list_templates";
+    const nameSeed = mkSeed(tool, 3);
+    const labelSeed = mkSeed(tool, 4);
+    const hintSeed = mkSeed(tool, 5);
+    const aiPromptSeed = mkSeed(tool, 6);
+    describeStoredTemplateMock.mockResolvedValue({
+      name: nameSeed,
+      fields: [
+        {
+          path: "field1",
+          label: labelSeed,
+          inputType: "text",
+          required: false,
+          hint: hintSeed,
+          options: null,
+          formats: null,
+          aiPrompt: aiPromptSeed,
+          aiAdapt: false,
+          optionsFrom: null,
+          dateFormat: null,
+          parts: null,
+          format: null,
+        },
+      ],
+      conditions: [],
+      computed: [],
+    });
+    const context = buildContext();
+
+    const response = await TEMPLATE_TOOL_HANDLERS.list_templates({
+      args: { template_id: "tpl_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [nameSeed, labelSeed, hintSeed, aiPromptSeed];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  // --- billing-tools -------------------------------------------------------
+
+  test("list_time_entries (list mode) anonymizes narrative, invoice narrative, and user name", async () => {
+    const tool = "list_time_entries";
+    const narrativeSeed = mkSeed(tool, 0);
+    const invoiceNarrativeSeed = mkSeed(tool, 1);
+    const userNameSeed = mkSeed(tool, 2);
+    const tx = {
+      select: createEntriesAndUserNamesSelect({
+        entryRows: [
+          {
+            id: "te_1",
+            entityId: "entity_1",
+            userId: "user_2",
+            dateWorked: "2026-01-01",
+            durationMinutes: 60,
+            billedMinutes: 60,
+            rateAtEntry: 100,
+            currency: "EUR",
+            narrative: narrativeSeed,
+            invoiceNarrative: invoiceNarrativeSeed,
+            billable: true,
+            noCharge: false,
+            status: "draft",
+          },
+        ],
+        userNameRows: [{ id: "user_2", name: userNameSeed }],
+      }),
+    };
+    const context = buildContext({ tx });
+
+    const response = await BILLING_TOOL_HANDLERS.list_time_entries({
+      args: { matter_id: "ws_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [narrativeSeed, invoiceNarrativeSeed, userNameSeed];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("list_time_entries (detail mode) anonymizes narrative, invoice narrative, and user name", async () => {
+    const tool = "list_time_entries";
+    const narrativeSeed = mkSeed(tool, 3);
+    const invoiceNarrativeSeed = mkSeed(tool, 4);
+    const userNameSeed = mkSeed(tool, 5);
+    const tx = {
+      query: {
+        timeEntries: {
+          findFirst: async () => ({ workspaceId: "ws_1" }),
+        },
+      },
+      select: createEntriesAndUserNamesSelect({
+        entryRows: [
+          {
+            id: "te_2",
+            entityId: "entity_1",
+            userId: "user_3",
+            dateWorked: "2026-01-01",
+            durationMinutes: 30,
+            billedMinutes: 30,
+            rateAtEntry: 100,
+            currency: "EUR",
+            narrative: narrativeSeed,
+            invoiceNarrative: invoiceNarrativeSeed,
+            billable: true,
+            noCharge: false,
+            status: "draft",
+          },
+        ],
+        userNameRows: [{ id: "user_3", name: userNameSeed }],
+      }),
+    };
+    const context = buildContext({ tx });
+
+    const response = await BILLING_TOOL_HANDLERS.list_time_entries({
+      args: { time_entry_id: "te_2" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [narrativeSeed, invoiceNarrativeSeed, userNameSeed];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("list_invoices (list mode) anonymizes invoice reference", async () => {
+    const tool = "list_invoices";
+    const referenceSeed = mkSeed(tool, 0);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            id: "inv_1",
+            invoiceNumber: "INV-1",
+            reference: referenceSeed,
+            status: "draft",
+            invoiceDate: "2026-01-01",
+            dueDate: "2026-02-01",
+            currency: "EUR",
+            totalAmount: 1000,
+            createdAtCursor: new Date("2026-01-01"),
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await BILLING_TOOL_HANDLERS.list_invoices({
+      args: { matter_id: "ws_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [referenceSeed]);
+    expectSeedsQueuedForAnonymization([referenceSeed]);
+  });
+
+  test("list_invoices (detail mode) anonymizes reference, notes, and nested time-entry/expense fields", async () => {
+    const tool = "list_invoices";
+    const referenceSeed = mkSeed(tool, 1);
+    const notesSeed = mkSeed(tool, 2);
+    const teNarrativeSeed = mkSeed(tool, 3);
+    const teInvoiceNarrativeSeed = mkSeed(tool, 4);
+    const teEntityNameSeed = mkSeed(tool, 5);
+    const exDescriptionSeed = mkSeed(tool, 6);
+    const exInvoiceDescriptionSeed = mkSeed(tool, 7);
+    const exEntityNameSeed = mkSeed(tool, 8);
+    const tx = {
+      query: {
+        invoices: {
+          findFirst: async () => ({
+            id: "inv_2",
+            workspaceId: "ws_1",
+            invoiceNumber: "INV-2",
+            reference: referenceSeed,
+            status: "draft",
+            invoiceDate: "2026-01-01",
+            dueDate: "2026-02-01",
+            currency: "EUR",
+            totalAmount: 2000,
+            notes: notesSeed,
+            paidAt: null,
+            createdAt: new Date("2026-01-01"),
+            updatedAt: new Date("2026-01-01"),
+            timeEntries: [
+              {
+                id: "te_1",
+                matterId: "entity_1",
+                dateWorked: "2026-01-01",
+                billedMinutes: 60,
+                rateAtEntry: 100,
+                currency: "EUR",
+                narrative: teNarrativeSeed,
+                invoiceNarrative: teInvoiceNarrativeSeed,
+                status: "invoiced",
+                matter: { id: "entity_1", name: teEntityNameSeed },
+              },
+            ],
+            expenses: [
+              {
+                id: "ex_1",
+                matterId: "entity_2",
+                dateIncurred: "2026-01-01",
+                amount: 100,
+                currency: "EUR",
+                category: "travel",
+                description: exDescriptionSeed,
+                invoiceDescription: exInvoiceDescriptionSeed,
+                billable: true,
+                markup: 0,
+                matter: { id: "entity_2", name: exEntityNameSeed },
+              },
+            ],
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await BILLING_TOOL_HANDLERS.list_invoices({
+      args: { invoice_id: "inv_2" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      referenceSeed,
+      notesSeed,
+      teNarrativeSeed,
+      teInvoiceNarrativeSeed,
+      teEntityNameSeed,
+      exDescriptionSeed,
+      exInvoiceDescriptionSeed,
+      exEntityNameSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  // --- knowledge-tools -------------------------------------------------------
+
+  test("list_clauses (list mode) anonymizes clause and category title/description", async () => {
+    const tool = "list_clauses";
+    const clauseTitleSeed = mkSeed(tool, 0);
+    const clauseDescriptionSeed = mkSeed(tool, 1);
+    const categoryNameSeed = mkSeed(tool, 2);
+    const categoryDescriptionSeed = mkSeed(tool, 3);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            id: "c1",
+            title: clauseTitleSeed,
+            categoryId: null,
+            language: "en",
+            description: clauseDescriptionSeed,
+            currentVersion: 1,
+            createdAt: new Date("2026-01-01"),
+            updatedAt: new Date("2026-01-01"),
+          },
+        ]),
+      query: {
+        clauseCategories: {
+          findMany: async () => [
+            {
+              id: "cat_1",
+              parentId: null,
+              name: categoryNameSeed,
+              description: categoryDescriptionSeed,
+              sortOrder: 0,
+              createdAt: new Date("2026-01-01"),
+              updatedAt: new Date("2026-01-01"),
+            },
+          ],
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
+      args: { include_categories: true },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      clauseTitleSeed,
+      clauseDescriptionSeed,
+      categoryNameSeed,
+      categoryDescriptionSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("list_clauses (clause detail) anonymizes title, description, usage notes, body, and variants", async () => {
+    const tool = "list_clauses";
+    const titleSeed = mkSeed(tool, 4);
+    const descriptionSeed = mkSeed(tool, 5);
+    const usageNotesSeed = mkSeed(tool, 6);
+    const bodySeed = mkSeed(tool, 7);
+    const variantLabelSeed = mkSeed(tool, 8);
+    const variantBodySeed = mkSeed(tool, 9);
+    const tx = {
+      query: {
+        clauses: {
+          findFirst: async () => ({
+            id: "c2",
+            title: titleSeed,
+            categoryId: null,
+            description: descriptionSeed,
+            usageNotes: usageNotesSeed,
+            language: "en",
+            body: [{ text: bodySeed }],
+            metadata: null,
+            currentVersion: 1,
+            createdBy: "user_1",
+            createdAt: new Date("2026-01-01"),
+            updatedAt: new Date("2026-01-01"),
+            variants: [
+              {
+                id: "var_1",
+                label: variantLabelSeed,
+                body: [{ text: variantBodySeed }],
+                sortOrder: 0,
+                createdAt: new Date("2026-01-01"),
+              },
+            ],
+            versions: [],
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
+      args: { clause_id: "c2" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      titleSeed,
+      descriptionSeed,
+      usageNotesSeed,
+      bodySeed,
+      variantLabelSeed,
+      variantBodySeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("list_clauses (version detail) anonymizes the version body", async () => {
+    const tool = "list_clauses";
+    const versionBodySeed = mkSeed(tool, 10);
+    const tx = {
+      query: {
+        clauses: { findFirst: async () => ({ id: "c2" }) },
+        clauseVersions: {
+          findFirst: async () => ({
+            id: "cv_1",
+            version: 1,
+            body: [{ text: versionBodySeed }],
+            createdAt: new Date("2026-01-01"),
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
+      args: { clause_id: "c2", version_id: "cv_1" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    expectNoSeedLeak(result, [versionBodySeed]);
+    expectSeedsQueuedForAnonymization([versionBodySeed]);
+  });
+
+  // Wave 4 precedent: `readClauseDetail` fails closed when a clause/variant
+  // body does not structurally match `ClauseBody` (`isClauseBody`), instead
+  // of pushing the raw value through. An empty array fails the `length > 0`
+  // check in `isClauseBody`, the smallest input that trips the guard.
+  test("list_clauses fails closed (no leak) when a clause body has an unrecognized format", async () => {
+    const titleSeed = mkSeed("list_clauses_fail_closed", 0);
+    const tx = {
+      query: {
+        clauses: {
+          findFirst: async () => ({
+            id: "c3",
+            title: titleSeed,
+            categoryId: null,
+            description: null,
+            usageNotes: null,
+            language: "en",
+            body: [],
+            metadata: null,
+            currentVersion: 1,
+            createdBy: "user_1",
+            createdAt: new Date("2026-01-01"),
+            updatedAt: new Date("2026-01-01"),
+            variants: [],
+            versions: [],
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await KNOWLEDGE_TOOL_HANDLERS.list_clauses({
+      args: { clause_id: "c3" },
+      context,
+    });
+
+    expect(response).toEqual({
+      content: [
+        { type: "text", text: "Clause body has an unrecognized format" },
+      ],
+      isError: true,
+    });
+    // Belt-and-braces: even though the handler already returned a finished
+    // error result here (never reaching finalizeMcpEgress), confirm the
+    // pipeline agrees nothing was queued for anonymization.
+    expectSeedsQueuedForAnonymization([]);
+  });
+
+  test("list_playbooks (list mode) anonymizes item name and description", async () => {
+    const tool = "list_playbooks";
+    const nameSeed = mkSeed(tool, 0);
+    const descriptionSeed = mkSeed(tool, 1);
+    const tx = {
+      select: () =>
+        chainableRows([
+          {
+            id: "pb_1",
+            name: nameSeed,
+            description: descriptionSeed,
+            createdAt: new Date("2026-01-01"),
+            updatedAt: new Date("2026-01-01"),
+          },
+        ]),
+    };
+    const context = buildContext({ tx });
+
+    const response = await KNOWLEDGE_TOOL_HANDLERS.list_playbooks({
+      args: {},
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [nameSeed, descriptionSeed];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+
+  test("list_playbooks (detail) anonymizes name, description, and position issue/question/guidance/standard fields", async () => {
+    const tool = "list_playbooks";
+    const nameSeed = mkSeed(tool, 2);
+    const descriptionSeed = mkSeed(tool, 3);
+    const issueSeed = mkSeed(tool, 4);
+    const questionSeed = mkSeed(tool, 5);
+    const guidanceSeed = mkSeed(tool, 6);
+    const preferredSeed = mkSeed(tool, 7);
+    const fallbackTextSeed = mkSeed(tool, 8);
+    const tx = {
+      query: {
+        playbookDefinitions: {
+          findFirst: async () => ({
+            id: "pb_2",
+            name: nameSeed,
+            description: descriptionSeed,
+            scope: "organization",
+            positions: {
+              items: [
+                {
+                  issue: issueSeed,
+                  ask: { question: questionSeed },
+                  guidance: guidanceSeed,
+                  standard: {
+                    source: "inline",
+                    preferred: preferredSeed,
+                    fallbacks: [{ label: "fallback", text: fallbackTextSeed }],
+                  },
+                },
+              ],
+            },
+            createdAt: new Date("2026-01-01"),
+            updatedAt: new Date("2026-01-01"),
+          }),
+        },
+      },
+    };
+    const context = buildContext({ tx });
+
+    const response = await KNOWLEDGE_TOOL_HANDLERS.list_playbooks({
+      args: { playbook_id: "pb_2" },
+      context,
+    });
+    const result = await finalize(context, response);
+
+    const seeds = [
+      nameSeed,
+      descriptionSeed,
+      issueSeed,
+      questionSeed,
+      guidanceSeed,
+      preferredSeed,
+      fallbackTextSeed,
+    ];
+    expectNoSeedLeak(result, seeds);
+    expectSeedsQueuedForAnonymization(seeds);
+  });
+});

--- a/apps/api/src/mcp/egress-canary.test.ts
+++ b/apps/api/src/mcp/egress-canary.test.ts
@@ -812,13 +812,14 @@ describe("MCP anonymization canary corpus", () => {
   test("read_document (diff, egress-plan level) anonymizes diff segment text", async () => {
     const tool = "read_document";
     const diffSeed = mkSeed(tool, 5);
+    const diffSegment = { kind: "unchanged" as const, text: diffSeed };
     const payload = {
       entityId: "entity_1",
       name: "Doc",
       diff: {
         baseVersionId: "ver_a",
         targetVersionId: "ver_b",
-        segments: [{ kind: "unchanged" as const, text: diffSeed }],
+        segments: [diffSegment],
       },
     };
     const plan: McpEgressPlan = {
@@ -827,7 +828,7 @@ describe("MCP anonymization canary corpus", () => {
       textFields: [
         {
           apply: (value: string) => {
-            payload.diff.segments[0]!.text = value;
+            diffSegment.text = value;
           },
           value: diffSeed,
           workspaceId: "ws_1",
@@ -1436,10 +1437,9 @@ describe("MCP anonymization canary corpus", () => {
       ],
       isError: true,
     });
-    // Belt-and-braces: even though the handler already returned a finished
-    // error result here (never reaching finalizeMcpEgress), confirm the
-    // pipeline agrees nothing was queued for anonymization.
-    expectSeedsQueuedForAnonymization([]);
+    // Belt-and-braces: the handler returned a finished error result (never
+    // reaching finalizeMcpEgress), so the anonymizer must never have run.
+    expect(anonymizeTextFieldsMock.mock.calls.length).toBe(0);
   });
 
   test("list_playbooks (list mode) anonymizes item name and description", async () => {

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -644,7 +644,11 @@ const readMatterOverview: McpToolHandler = async ({ args, context }) => {
     value: matter.clientName,
     workspaceId,
   });
-  for (const entity of overview.recentEntities) {
+  // Iterate the entities actually served in the payload, not the source
+  // `overview.recentEntities`: the avatar-URL strip above copies each entity
+  // into a new object, so writing an anonymized value back onto the source
+  // entity would land on a stale reference the response never serializes.
+  for (const entity of overviewWithoutAvatarUrls.recentEntities) {
     collectAnonymizableField({
       apply: (value) => {
         entity.name = value;

--- a/apps/api/src/mcp/text-field-spec.test.ts
+++ b/apps/api/src/mcp/text-field-spec.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  defineTextFieldSpec,
+  deriveTextFieldPaths,
+  runTextFieldSpecs,
+} from "@/api/mcp/text-field-spec";
+
+describe("deriveTextFieldPaths", () => {
+  test("mechanically derives the documented path list from a spec list", () => {
+    const specs = [
+      defineTextFieldSpec({
+        path: "matters[].name",
+        items: (payload: { matters: { name: string }[] }) => payload.matters,
+        scope: () => "org_1",
+        read: (item) => item.name,
+        apply: (item, value) => {
+          item.name = value;
+        },
+      }),
+      defineTextFieldSpec({
+        path: "matter.clientName",
+        items: (payload: { matter: { clientName: string | null } }) => [
+          payload.matter,
+        ],
+        scope: () => "org_1",
+        read: (item) => item.clientName,
+        apply: (item, value) => {
+          item.clientName = value;
+        },
+      }),
+    ];
+
+    expect(deriveTextFieldPaths(specs)).toEqual([
+      "matters[].name",
+      "matter.clientName",
+    ]);
+  });
+
+  test("an empty spec list derives an empty path list", () => {
+    expect(deriveTextFieldPaths([])).toEqual([]);
+  });
+});
+
+describe("runTextFieldSpecs", () => {
+  test("per-item scope: each item anonymizes under its own id", () => {
+    type Hit = { name: string; workspaceId: string };
+    const payload = {
+      hits: [
+        { name: "John Smith SPA", workspaceId: "ws_1" },
+        { name: "Jane Doe NDA", workspaceId: "ws_2" },
+      ],
+    };
+    const spec = defineTextFieldSpec({
+      path: "hits[].name",
+      items: (p: typeof payload) => p.hits,
+      scope: (hit: Hit) => hit.workspaceId,
+      read: (hit: Hit) => hit.name,
+      apply: (hit: Hit, value) => {
+        hit.name = value;
+      },
+    });
+
+    const fields = runTextFieldSpecs([spec], payload);
+
+    expect(
+      fields.map((f) => ({ value: f.value, workspaceId: f.workspaceId })),
+    ).toEqual([
+      { value: "John Smith SPA", workspaceId: "ws_1" },
+      { value: "Jane Doe NDA", workspaceId: "ws_2" },
+    ]);
+
+    fields[0]?.apply("[PERSON_1] SPA");
+    fields[1]?.apply("[PERSON_2] NDA");
+    expect(payload.hits[0]?.name).toBe("[PERSON_1] SPA");
+    expect(payload.hits[1]?.name).toBe("[PERSON_2] NDA");
+  });
+
+  test("org-constant scope: every item shares one fixed scope regardless of item content", () => {
+    type TemplateField = { label: string | null };
+    const payload = {
+      fields: [{ label: "Party name" }, { label: "Effective date" }],
+    };
+    const spec = defineTextFieldSpec({
+      path: "fields[].label",
+      items: (p: typeof payload) => p.fields,
+      scope: () => "org_1",
+      read: (field: TemplateField) => field.label,
+      apply: (field: TemplateField, value) => {
+        field.label = value;
+      },
+    });
+
+    const fields = runTextFieldSpecs([spec], payload);
+
+    expect(fields).toHaveLength(2);
+    expect(fields.every((f) => f.workspaceId === "org_1")).toBe(true);
+  });
+
+  test("skip-null: a null or empty value is never queued", () => {
+    type Entry = { narrative: string | null };
+    const payload = {
+      entries: [
+        { narrative: "Call with client" },
+        { narrative: null },
+        { narrative: "" },
+      ],
+    };
+    const spec = defineTextFieldSpec({
+      path: "entries[].narrative",
+      items: (p: typeof payload) => p.entries,
+      scope: () => "ws_1",
+      read: (entry: Entry) => entry.narrative,
+      apply: (entry: Entry, value) => {
+        entry.narrative = value;
+      },
+    });
+
+    const fields = runTextFieldSpecs([spec], payload);
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0]?.value).toBe("Call with client");
+  });
+
+  test("array write-back: apply writes into the owning array by index, not the (primitive) item", () => {
+    const payload = { values: ["Acme Corp", "Beta LLC"] };
+    const spec = defineTextFieldSpec({
+      path: "values[]",
+      items: (p: typeof payload) => p.values,
+      scope: () => "ws_1",
+      read: (value: string) => value,
+      apply: (_item, value, index) => {
+        payload.values[index] = value;
+      },
+    });
+
+    const fields = runTextFieldSpecs([spec], payload);
+    for (const field of fields) {
+      field.apply(`[REDACTED_${field.value}]`);
+    }
+
+    expect(payload.values).toEqual([
+      "[REDACTED_Acme Corp]",
+      "[REDACTED_Beta LLC]",
+    ]);
+  });
+
+  test("a spec whose items() returns an empty array queues nothing", () => {
+    const payload = { matters: [] as { name: string }[] };
+    const spec = defineTextFieldSpec({
+      path: "matters[].name",
+      items: (p: typeof payload) => p.matters,
+      scope: () => "org_1",
+      read: (item: { name: string }) => item.name,
+      apply: (item: { name: string }, value) => {
+        item.name = value;
+      },
+    });
+
+    expect(runTextFieldSpecs([spec], payload)).toEqual([]);
+  });
+
+  test("multiple specs over one payload combine in declaration order", () => {
+    const payload = {
+      matter: { name: "Acme Corp", clientName: "Acme Client" },
+    };
+    const nameSpec = defineTextFieldSpec({
+      path: "matter.name",
+      items: (p: typeof payload) => [p.matter],
+      scope: () => "ws_1",
+      read: (item: (typeof payload)["matter"]) => item.name,
+      apply: (item: (typeof payload)["matter"], value) => {
+        item.name = value;
+      },
+    });
+    const clientNameSpec = defineTextFieldSpec({
+      path: "matter.clientName",
+      items: (p: typeof payload) => [p.matter],
+      scope: () => "ws_1",
+      read: (item: (typeof payload)["matter"]) => item.clientName,
+      apply: (item: (typeof payload)["matter"], value) => {
+        item.clientName = value;
+      },
+    });
+
+    const fields = runTextFieldSpecs([nameSpec, clientNameSpec], payload);
+
+    expect(fields.map((f) => f.value)).toEqual(["Acme Corp", "Acme Client"]);
+  });
+});

--- a/apps/api/src/mcp/text-field-spec.ts
+++ b/apps/api/src/mcp/text-field-spec.ts
@@ -1,0 +1,94 @@
+import type {
+  McpStructuredTextField,
+  McpTextFieldSpec,
+} from "@/api/mcp/tool-types";
+
+/**
+ * Foundation helpers for `McpTextFieldSpec` (design brief plan 049, Phase 1
+ * of Option B). A tool would author one `McpTextFieldSpec<TPayload>[]` per
+ * response shape; `deriveTextFieldPaths` turns that list into the
+ * documentation-only path list a registry entry declares today, and
+ * `runTextFieldSpecs` turns it into the `McpStructuredTextField[]` push list
+ * `finalizeMcpEgress` already consumes, replacing the four duplicated
+ * `pushTextField`/`collectAnonymizableField` helpers module by module.
+ *
+ * No tool module is migrated to this in this commit (see plan 049 Phases
+ * 2+); this file has no consumer yet beyond its own unit tests.
+ */
+
+/**
+ * A spec list's documented `textFields` path list, mechanically derived from
+ * the specs so the declaration cannot name a field the specs don't cover,
+ * nor omit one they do. Typed structurally on just `path` (not the full
+ * `McpTextFieldSpec<TPayload>`): `path` does not depend on `TPayload`, and
+ * requiring one shared `TPayload` here would reject the realistic case of
+ * inspecting specs from more than one tool (each with its own payload shape)
+ * in the same call, over the contravariant-parameter variance of `items`.
+ */
+export const deriveTextFieldPaths = (
+  specs: readonly { path: string }[],
+): readonly string[] => specs.map((spec) => spec.path);
+
+/**
+ * Runs every spec's `items` extractor against the live payload and collects
+ * one `McpStructuredTextField` per non-null, non-empty value (P4 skip-null,
+ * centralized here instead of duplicated per module). `apply` closes over
+ * the exact item `items` produced, so the write-back lands on the same
+ * object reference `items` read from - as long as `items` itself reads from
+ * the payload the caller is about to serve (not a copy of it), the anonymized
+ * value is guaranteed to reach the served response.
+ */
+export const runTextFieldSpecs = <TPayload>(
+  specs: readonly McpTextFieldSpec<TPayload>[],
+  payload: TPayload,
+): McpStructuredTextField[] => {
+  const fields: McpStructuredTextField[] = [];
+
+  for (const spec of specs) {
+    const items = spec.items(payload);
+    for (const [index, item] of items.entries()) {
+      const value = spec.read(item, index);
+      if (typeof value !== "string" || value.length === 0) {
+        continue;
+      }
+      fields.push({
+        apply: (next) => {
+          spec.apply(item, next, index);
+        },
+        value,
+        workspaceId: spec.scope(item, index),
+      });
+    }
+  }
+
+  return fields;
+};
+
+/**
+ * Authors one `McpTextFieldSpec` with a concrete item shape (`TItem`), then
+ * stores it item-shape-erased as `McpTextFieldSpec<TPayload>` so a tool's
+ * spec list can mix fields over different item shapes (a matter, a recent
+ * entity, a contact card, ...) in one array.
+ *
+ * SAFETY: the erasure only ever discards the `TItem` parameter type on
+ * `scope`/`read`/`apply` (from `TItem` to `unknown`) and only ever widens
+ * `items`'s return element type the same way. Every value `runTextFieldSpecs`
+ * later hands back into `scope`/`read`/`apply` came from calling this same
+ * spec's own `items(payload)`, so it is always genuinely a `TItem`; nothing
+ * outside this module ever constructs an `unknown` value and feeds it
+ * through the erased type. Type erasure over a closed pair of a producer and
+ * its own consumers (never an argument to attacker-controlled or otherwise
+ * unrelated code) is a standard, sound existential-type encoding. (A
+ * bivariant method-shorthand signature would avoid the cast entirely, but
+ * this repo's `method-signature-style` lint rule forbids method shorthand in
+ * type literals, so the cast is the sanctioned way to express this here.)
+ */
+export const defineTextFieldSpec = <TPayload, TItem>(spec: {
+  path: string;
+  items: (payload: TPayload) => readonly TItem[];
+  scope: (item: TItem, index: number) => string;
+  read: (item: TItem, index: number) => string | null | undefined;
+  apply: (item: TItem, value: string, index: number) => void;
+}): McpTextFieldSpec<TPayload> =>
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- sound item-shape erasure, see the SAFETY note above
+  spec as McpTextFieldSpec<TPayload>;

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -187,3 +187,48 @@ export type McpToolHandler = ({
   args: Record<string, unknown>;
   context: McpRequestContext;
 }) => Promise<McpToolResponse>;
+
+/**
+ * Foundation for expressing one anonymizable text field as code instead of a
+ * hand-written `textFields` path string (design brief plan 049, Option B).
+ * `items` extracts the field's target items live from the actual payload
+ * object a handler is about to return, so a write-back through `apply`
+ * always lands on the object reference the client receives - this closes,
+ * structurally, the specific class of bug where a push closure mutates a
+ * copy the served payload was built from instead of the served object
+ * itself (see the `readMatterOverview` fix in `stella-tools.ts` for a real,
+ * shipped instance of exactly that mistake).
+ *
+ * `path` stays a human/agent-facing documentation string, mirroring today's
+ * hand-written `textFields` entries; `deriveTextFieldPaths` in
+ * `text-field-spec.ts` turns a spec list into that documented list
+ * mechanically, so the declaration and the code that actually walks the
+ * payload can no longer name different fields.
+ *
+ * `TItem` is intentionally not a parameter of this public type: one tool's
+ * spec list mixes fields over different item shapes (a matter, a recent
+ * entity, a contact card, ...), so a list of specs for one tool is
+ * necessarily item-shape-heterogeneous. Author a spec through
+ * `defineTextFieldSpec` (generic over `TItem`) in `text-field-spec.ts`,
+ * which stores it here item-shape-erased.
+ *
+ * This type has no consumer yet: wiring a real tool's `textFields` through
+ * a spec is a per-module migration, out of scope for this foundational
+ * commit (see plan 049 Phases 2+).
+ */
+export type McpTextFieldSpec<TPayload> = {
+  /** Documentation-only path, mirroring today's hand-written textFields entries. */
+  path: string;
+  /** Extracts this field's target items live from the payload about to be returned. */
+  items: (payload: TPayload) => readonly unknown[];
+  /**
+   * Anonymization scope for one item: a real workspace id for
+   * matter/document-shaped items, or the organization id for org-scoped
+   * items (contacts, templates, clauses).
+   */
+  scope: (item: unknown, index: number) => string;
+  /** Reads the current text value off one item; null/undefined/empty is skipped. */
+  read: (item: unknown, index: number) => string | null | undefined;
+  /** Writes the redacted value back onto the item (or an owning array, by index). */
+  apply: (item: unknown, value: string, index: number) => void;
+};

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "as-casts": {
-    "count": 124,
+    "count": 125,
     "files": {
       "apps/api/src/db-url.ts": 1,
       "apps/api/src/handlers/case-law/citation-authority.ts": 1,
@@ -42,6 +42,7 @@
       "apps/api/src/lib/validated-org-user-id.ts": 1,
       "apps/api/src/mcp/document-tools.ts": 1,
       "apps/api/src/mcp/stella-tools.ts": 1,
+      "apps/api/src/mcp/text-field-spec.ts": 1,
       "apps/api/src/scripts/resolve-citations.ts": 2,
       "apps/api/src/tests/helpers/test-tool-set.ts": 5,
       "apps/web/src/app-providers.tsx": 1,
@@ -165,8 +166,6 @@
       "apps/api/src/mcp/stella-tools.ts": 3,
       "apps/api/src/mcp/template-tools.ts": 1,
       "apps/web/src/components/ai-suggestions/file-chat-overlay.tsx": 2,
-      "apps/web/src/components/ai-suggestions/host.logic.ts": 1,
-      "apps/web/src/components/ai-suggestions/host.tsx": 1,
       "apps/web/src/components/ai-suggestions/playbook-review-store.ts": 1,
       "apps/web/src/components/ai-suggestions/review-panel.impl.tsx": 3,
       "apps/web/src/components/ai-suggestions/review-store.ts": 1,
@@ -241,6 +240,7 @@
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx": 2,
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/group-columns.ts": 1,
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx": 3,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/export-report-dialog.tsx": 2,
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx": 3,
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications.ts": 1,
       "apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts": 3,


### PR DESCRIPTION
Registry-enumerated canary tests: every anonymize-mode tool gets a fixture that seeds a unique token into each declared text field, drives the real handler through the real egress pipeline, and asserts no token survives AND every token was actually queued for redaction. A live tool without a fixture (or a stale fixture entry) fails the suite, so future tools cannot ship unguarded.

- first run caught a shipping defect: `list_matters` detail mode wrote redacted recent-entity fields back onto a stale copy the response never serializes; fixed in its own commit against the served payload
- adds the text-field spec foundation (`deriveTextFieldPaths`/`runTextFieldSpecs`), unconsumed yet — module migrations follow separately; its `items` extraction reads targets from the served payload, structurally closing the stale-copy class
- one deliberate as-cast ratchet bump (124 -> 125) with a SAFETY note; the bivariant alternative is blocked by the method-signature-style lint rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded anonymisation coverage with a new canary-style test suite that validates redaction across all anonymise-mode tools and nested content.
  * Added typed helpers for defining text fields to anonymise, improving consistency of what gets queued for redaction.
* **Bug Fixes**
  * Fixed anonymisation in the matter overview “recent entities” path to ensure redacted updates are applied to the exact response data.
* **Tests**
  * Added a dedicated test suite for text-field specification utilities, covering path derivation, scope handling, and safe write-back behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->