### PR TITLE
feat: scaffold the stella CLI package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -389,6 +389,20 @@
         "@types/bun": "catalog:",
       },
     },
+    "packages/cli": {
+      "name": "@stll/cli",
+      "version": "0.1.0",
+      "bin": {
+        "stella": "./dist/cli.js",
+      },
+      "dependencies": {
+        "@stricli/core": "^1.2.8",
+      },
+      "devDependencies": {
+        "@stll/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
+      },
+    },
     "packages/conditions": {
       "name": "@stll/conditions",
       "version": "0.1.0",
@@ -1686,6 +1700,8 @@
 
     "@stll/catalogue": ["@stll/catalogue@workspace:packages/catalogue"],
 
+    "@stll/cli": ["@stll/cli@workspace:packages/cli"],
+
     "@stll/collab": ["@stll/collab@workspace:apps/collab"],
 
     "@stll/conditions": ["@stll/conditions@workspace:packages/conditions"],
@@ -1755,6 +1771,8 @@
     "@streamdown/math": ["@streamdown/math@1.0.2", "", { "dependencies": { "katex": "^0.16.27", "rehype-katex": "^7.0.1", "remark-math": "^6.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g=="],
 
     "@streamdown/mermaid": ["@streamdown/mermaid@1.0.2", "", { "dependencies": { "mermaid": "^11.12.2" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-Fr/4sBWnAeSnxM3PcrV/+DiZe5oPMq9gOkUIAH7ZauJeuwrZ/DVzD4g0zlav6AH0axh2m/sOfrfLtY5aLT7niw=="],
+
+    "@stricli/core": ["@stricli/core@1.2.8", "", {}, "sha512-zqEZu9x+UAAZrzQlfD/iDXIyb6Y3560MzfvFpNfWXJdZuJ0SSxGOGse+0P/5kwlufsSXQF8Wn5jK1NZF4vcqnw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@stll/cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Stella command-line client",
+  "keywords": [
+    "cli",
+    "legal",
+    "stella"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/cli",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/cli"
+  },
+  "bin": {
+    "stella": "./dist/cli.js"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "scripts": {
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "rm -rf dist && tsgo -p tsconfig.build.json",
+    "test": "bun test src",
+    "typecheck": "tsgo --noEmit",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/cli",
+    "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/cli",
+    "format": "oxfmt ."
+  },
+  "dependencies": {
+    "@stricli/core": "^1.2.8"
+  },
+  "devDependencies": {
+    "@stll/typescript-config": "workspace:*",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const CLI_ENTRYPOINT = path.join(import.meta.dirname, "cli.ts");
+
+describe("stella CLI shell", () => {
+  test("--version prints the package version", () => {
+    const result = Bun.spawnSync({
+      cmd: ["bun", CLI_ENTRYPOINT, "--version"],
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe(packageJson.version);
+  });
+
+  test("--help exits 0", () => {
+    const result = Bun.spawnSync({
+      cmd: ["bun", CLI_ENTRYPOINT, "--help"],
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("Stella command-line client");
+  });
+
+  test("tools list stub reports it is not yet implemented", () => {
+    const result = Bun.spawnSync({
+      cmd: ["bun", CLI_ENTRYPOINT, "tools", "list"],
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe(
+      "stella tools list: not yet implemented",
+    );
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+// Application shell for the `stella` CLI (spec 051, Phase 1 scaffold only).
+//
+// No generator, no auth, no real domain commands yet: `stella tools list` is a
+// stub that proves the stricli route-map wires up end to end. Real commands
+// arrive once `generateRouteMap` (spec S5.2) and the Annotation Table (spec
+// S1) ship in a later phase, folding into `generatedRouteMap` from
+// `./generated/route-map.js`.
+
+import {
+  buildApplication,
+  buildCommand,
+  buildRouteMap,
+  run,
+} from "@stricli/core";
+
+import packageJson from "../package.json" with { type: "json" };
+import type { Context } from "./context.js";
+
+const toolsListCommand = buildCommand({
+  docs: {
+    brief: "List the CLI commands generated from the stella MCP tool registry",
+  },
+  func(this: Context): void {
+    this.process.stdout.write("stella tools list: not yet implemented\n");
+  },
+  parameters: {},
+});
+
+const toolsRoute = buildRouteMap({
+  docs: { brief: "Inspect the generated command registry" },
+  routes: { list: toolsListCommand },
+});
+
+const rootRoute = buildRouteMap({
+  docs: { brief: "Stella command-line client" },
+  routes: { tools: toolsRoute },
+});
+
+const app = buildApplication(rootRoute, {
+  name: "stella",
+  versionInfo: { currentVersion: packageJson.version },
+});
+
+// Server resolution and stored auth are out of scope for this phase (spec
+// 051 covers both in later phases); the context carries their final shape
+// with placeholder values until then.
+const buildContext = (): Context => ({
+  process,
+  serverUrl: "",
+  token: undefined,
+});
+
+void run(app, process.argv.slice(2), buildContext());

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,0 +1,14 @@
+// Shared stricli application context (spec 051 S5.1): a single `Context` type
+// threaded through every command. Auth resolution, the real server client, and
+// scope prechecks are out of scope for this phase; this is the minimal typed
+// sketch a later phase fills in.
+
+import type { CommandContext } from "@stricli/core";
+
+/** Context every generated (and hand-written) command receives. */
+export type Context = CommandContext & {
+  /** Resolved server origin the CLI is targeting (spec S5.5 provenance pin). */
+  readonly serverUrl: string;
+  /** Stored auth token for the current server origin, if any (auth: out of scope for this phase). */
+  readonly token: string | undefined;
+};

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -1,0 +1,15 @@
+// Placeholder for the committed, generated route tree (spec 051 S5.2, build-time
+// call site). The real file is produced by a codegen script that projects
+// `DEFAULT_MCP_TOOL_DEFINITIONS` through `generateRouteMap` and serializes the
+// result here; drift then shows up as a PR diff instead of a runtime surprise.
+//
+// Neither the codegen script nor `generateRouteMap` exist yet (Phase 1 scaffolds
+// the package shell only), so this module exports an empty route with no
+// children until Phase 3 wires the generator up.
+
+import type { RouteNode } from "../route-types.js";
+
+export const generatedRouteMap: RouteNode = {
+  kind: "route",
+  children: {},
+};

--- a/packages/cli/src/route-types.ts
+++ b/packages/cli/src/route-types.ts
@@ -1,0 +1,101 @@
+// Data shapes for the JSON-Schema -> stricli route-map generator.
+//
+// This module is types only (spec 051 S5.1). The generator itself
+// (`generateRouteMap`), the annotation table (S1), and every domain command
+// are out of scope for this phase; see `src/generated/route-map.ts` for the
+// placeholder the real generator will replace.
+
+/** A JSON Schema fragment, as emitted by the MCP tool registry's prop builders. */
+export type JsonSchema = Record<string, unknown>;
+
+/** The MCP scope strings a tool annotation can require (client-side precheck only). */
+export type ToolScope =
+  | "read"
+  | "matters_write"
+  | "documents_write"
+  | "knowledge_write"
+  | "search"
+  | "onboarding"
+  | "templates"
+  | "billing_write"
+  | "admin_read"
+  | "admin_write";
+
+/** Wire fields from `tools/list` (build-time: projected from `DEFAULT_MCP_TOOL_DEFINITIONS`). */
+export type RegistryToolListing = {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+  };
+};
+
+/** One required-enum subcommand produced by a discriminator split (spec S2). */
+export type DiscriminatorSubcommand = {
+  command: string;
+  destructive?: true;
+  include?: readonly string[];
+  required?: readonly string[];
+};
+
+/** Baked-in per-tool annotation (spec S1), keyed by tool name and merged with the listing. */
+export type ToolAnnotation = {
+  command: readonly string[];
+  excluded?: true;
+  scope?: ToolScope;
+  itemsKey?: string;
+  singleReadWhen?: string;
+  columns?: readonly string[];
+  windowedText?: true;
+  paginationless?: true;
+  inputOnly?: readonly string[];
+  discriminator?: {
+    prop: string;
+    subcommands: Record<string, DiscriminatorSubcommand>;
+  };
+  flagRename?: Record<string, string>;
+};
+
+/** One generated CLI flag, derived from an `inputSchema` prop (spec S3). */
+export type FlagSpec = {
+  flag: string;
+  prop: string;
+  kind:
+    | "string"
+    | "int"
+    | "number"
+    | "boolean"
+    | "enum"
+    | "nullable-string"
+    | "string-array"
+    | "int-array"
+    | "enum-array";
+  required: boolean;
+  enum?: readonly string[];
+  min?: number;
+  max?: number;
+  repeatable: boolean;
+  default?: unknown;
+};
+
+/** The generator's per-leaf output before handing to stricli's `buildCommand`. */
+export type LeafCommandSpec = {
+  commandPath: readonly string[];
+  toolName: string;
+  discriminatorInject?: Record<string, string>;
+  flags: readonly FlagSpec[];
+  inputOnly: readonly string[];
+  paginated: boolean;
+  windowedText: boolean;
+  itemsKey?: string;
+  destructive: boolean;
+  scope?: ToolScope;
+  inputSchema: JsonSchema;
+};
+
+/** stricli assembly: `LeafCommandSpec[]` folds into a nested route tree. */
+export type RouteNode =
+  | { kind: "leaf"; spec: LeafCommandSpec }
+  | { kind: "route"; children: Record<string, RouteNode> };

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@stll/typescript-config/published.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "types": ["bun"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
New private workspace package `@stll/cli` (`stella` binary): stricli app shell with `--version`/`--help`, the route-map type surface the future generator emits into, a typed context placeholder, and smoke tests. No generator, no auth, no publish wiring yet — the package stays `private: true`.