### PR TITLE
refactor: derive template and stella tool text fields from typed specs

### DIFF
--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -7,6 +7,7 @@ import { roles } from "@stll/permissions";
 
 import type { PracticeJurisdiction } from "@/api/db/schema";
 import { workspaces } from "@/api/db/schema";
+import type { ContactEmail, ContactPhone } from "@/api/db/schema-validators";
 import { readDecisionHandler } from "@/api/handlers/case-law/decisions/read-by-id";
 import { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
@@ -37,8 +38,13 @@ import {
 import { decodeCursor } from "@/api/lib/search/cursor";
 import { getSearchProvider } from "@/api/lib/search/provider";
 import type { McpRequestContext } from "@/api/mcp/context";
+import {
+  defineTextFieldSpec,
+  deriveTextFieldPaths,
+  runTextFieldSpecs,
+} from "@/api/mcp/text-field-spec";
 import type {
-  McpStructuredTextField,
+  McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
 } from "@/api/mcp/tool-types";
@@ -78,26 +84,349 @@ type StellaToolName =
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
+// --- Text-field specs (plan 049, Option B) --------------------------------
+
 /**
- * Queue one anonymizable text field onto a structured egress plan, skipping
- * null/empty values (no PII to redact, and an empty batch entry is wasted
- * work). `apply` writes the anonymized value back into the payload.
+ * list_matters, list mode: one matter per row, scoped under its own matter id
+ * (a matter's workspace id IS its anonymization scope). Both fields already
+ * ride in the served payload, so no external attribution is needed.
  */
-const collectAnonymizableField = ({
-  apply,
-  fields,
-  value,
-  workspaceId,
-}: {
-  apply: (value: string) => void;
-  fields: McpStructuredTextField[];
-  value: string | null | undefined;
-  workspaceId: string;
-}): void => {
-  if (typeof value === "string" && value.length > 0) {
-    fields.push({ apply, value, workspaceId });
-  }
+type ListedMatter = { id: string; name: string; reference: string };
+type ListMattersListPayload = { matters: readonly ListedMatter[] };
+
+const LIST_MATTERS_LIST_TEXT_FIELD_SPECS: readonly McpTextFieldSpec<ListMattersListPayload>[] =
+  [
+    defineTextFieldSpec({
+      path: "matters[].name",
+      items: (payload: ListMattersListPayload) => payload.matters,
+      scope: (matter: ListedMatter) => matter.id,
+      read: (matter: ListedMatter) => matter.name,
+      apply: (matter: ListedMatter, value) => {
+        matter.name = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "matters[].reference",
+      items: (payload: ListMattersListPayload) => payload.matters,
+      scope: (matter: ListedMatter) => matter.id,
+      read: (matter: ListedMatter) => matter.reference,
+      apply: (matter: ListedMatter, value) => {
+        matter.reference = value;
+      },
+    }),
+  ];
+
+/**
+ * list_matters, detail mode (one matter's overview): every field below
+ * belongs to the one matter this response describes, so `payload.matter.id`
+ * is the anonymization scope throughout — including the nested
+ * entity/contact/member cards, which carry no workspace id of their own on
+ * the wire. Each nested item selector pairs the item with that scope id
+ * read straight off the payload, so no request-scoped closure is needed.
+ */
+type MatterOverviewMatter = {
+  clientName: string | null;
+  id: string;
+  name: string;
+  reference: string;
 };
+type MatterOverviewEntity = {
+  assignedTo: string | null;
+  createdBy: string | null;
+  name: string;
+};
+type MatterOverviewContact = { displayName: string };
+type MatterOverviewMember = { name: string };
+type MatterOverviewPayload = {
+  contacts: readonly MatterOverviewContact[];
+  matter: MatterOverviewMatter;
+  members: readonly MatterOverviewMember[];
+  overview: { recentEntities: readonly MatterOverviewEntity[] };
+};
+
+const matterOverviewMatterItems = (
+  payload: MatterOverviewPayload,
+): readonly [MatterOverviewMatter] => [payload.matter];
+
+type EntityWithScope = { entity: MatterOverviewEntity; workspaceId: string };
+const matterOverviewEntityItems = (
+  payload: MatterOverviewPayload,
+): readonly EntityWithScope[] =>
+  payload.overview.recentEntities.map((entity) => ({
+    entity,
+    workspaceId: payload.matter.id,
+  }));
+
+type ContactWithScope = {
+  contact: MatterOverviewContact;
+  workspaceId: string;
+};
+const matterOverviewContactItems = (
+  payload: MatterOverviewPayload,
+): readonly ContactWithScope[] =>
+  payload.contacts.map((contact) => ({
+    contact,
+    workspaceId: payload.matter.id,
+  }));
+
+type MemberWithScope = { member: MatterOverviewMember; workspaceId: string };
+const matterOverviewMemberItems = (
+  payload: MatterOverviewPayload,
+): readonly MemberWithScope[] =>
+  payload.members.map((member) => ({
+    member,
+    workspaceId: payload.matter.id,
+  }));
+
+const MATTER_OVERVIEW_TEXT_FIELD_SPECS: readonly McpTextFieldSpec<MatterOverviewPayload>[] =
+  [
+    defineTextFieldSpec({
+      path: "matter.name",
+      items: matterOverviewMatterItems,
+      scope: (matter: MatterOverviewMatter) => matter.id,
+      read: (matter: MatterOverviewMatter) => matter.name,
+      apply: (matter: MatterOverviewMatter, value) => {
+        matter.name = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "matter.reference",
+      items: matterOverviewMatterItems,
+      scope: (matter: MatterOverviewMatter) => matter.id,
+      read: (matter: MatterOverviewMatter) => matter.reference,
+      apply: (matter: MatterOverviewMatter, value) => {
+        matter.reference = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "matter.clientName",
+      items: matterOverviewMatterItems,
+      scope: (matter: MatterOverviewMatter) => matter.id,
+      read: (matter: MatterOverviewMatter) => matter.clientName,
+      apply: (matter: MatterOverviewMatter, value) => {
+        matter.clientName = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "overview.recentEntities[].name",
+      items: matterOverviewEntityItems,
+      scope: (item: EntityWithScope) => item.workspaceId,
+      read: (item: EntityWithScope) => item.entity.name,
+      apply: (item: EntityWithScope, value) => {
+        item.entity.name = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "overview.recentEntities[].createdBy",
+      items: matterOverviewEntityItems,
+      scope: (item: EntityWithScope) => item.workspaceId,
+      read: (item: EntityWithScope) => item.entity.createdBy,
+      apply: (item: EntityWithScope, value) => {
+        item.entity.createdBy = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "overview.recentEntities[].assignedTo",
+      items: matterOverviewEntityItems,
+      scope: (item: EntityWithScope) => item.workspaceId,
+      read: (item: EntityWithScope) => item.entity.assignedTo,
+      apply: (item: EntityWithScope, value) => {
+        item.entity.assignedTo = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "contacts[].displayName",
+      items: matterOverviewContactItems,
+      scope: (item: ContactWithScope) => item.workspaceId,
+      read: (item: ContactWithScope) => item.contact.displayName,
+      apply: (item: ContactWithScope, value) => {
+        item.contact.displayName = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "members[].name",
+      items: matterOverviewMemberItems,
+      scope: (item: MemberWithScope) => item.workspaceId,
+      read: (item: MemberWithScope) => item.member.name,
+      apply: (item: MemberWithScope, value) => {
+        item.member.name = value;
+      },
+    }),
+  ];
+
+/**
+ * search_across_matters: hits span multiple matters, each already carrying
+ * its own `workspaceId` on the wire (P2 per-item attribution).
+ */
+type SearchAcrossMattersHit = {
+  headline: string | null;
+  name: string;
+  workspaceId: string;
+  workspaceName: string | null;
+};
+type SearchAcrossMattersPayload = { hits: readonly SearchAcrossMattersHit[] };
+
+const SEARCH_ACROSS_MATTERS_TEXT_FIELD_SPECS: readonly McpTextFieldSpec<SearchAcrossMattersPayload>[] =
+  [
+    defineTextFieldSpec({
+      path: "hits[].name",
+      items: (payload: SearchAcrossMattersPayload) => payload.hits,
+      scope: (hit: SearchAcrossMattersHit) => hit.workspaceId,
+      read: (hit: SearchAcrossMattersHit) => hit.name,
+      apply: (hit: SearchAcrossMattersHit, value) => {
+        hit.name = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "hits[].headline",
+      items: (payload: SearchAcrossMattersPayload) => payload.hits,
+      scope: (hit: SearchAcrossMattersHit) => hit.workspaceId,
+      read: (hit: SearchAcrossMattersHit) => hit.headline,
+      apply: (hit: SearchAcrossMattersHit, value) => {
+        hit.headline = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "hits[].workspaceName",
+      items: (payload: SearchAcrossMattersPayload) => payload.hits,
+      scope: (hit: SearchAcrossMattersHit) => hit.workspaceId,
+      read: (hit: SearchAcrossMattersHit) => hit.workspaceName,
+      apply: (hit: SearchAcrossMattersHit, value) => {
+        hit.workspaceName = value;
+      },
+    }),
+  ];
+
+/**
+ * read_content_across_matters: a single document, windowed after
+ * anonymization (P8). The window co-declaration in the handler is untouched;
+ * only the `name`/`text` textFields construction migrates here. `workspaceId`
+ * already rides in the payload (stripped by nothing — this tool has no
+ * compat-style field-stripping), so it is read straight off the item.
+ */
+type ReadContentAcrossMattersPayload = {
+  name: string;
+  text: string;
+  workspaceId: string;
+};
+
+const READ_CONTENT_ACROSS_MATTERS_TEXT_FIELD_SPECS: readonly McpTextFieldSpec<ReadContentAcrossMattersPayload>[] =
+  [
+    defineTextFieldSpec({
+      path: "name",
+      items: (payload: ReadContentAcrossMattersPayload) => [payload],
+      scope: (item: ReadContentAcrossMattersPayload) => item.workspaceId,
+      read: (item: ReadContentAcrossMattersPayload) => item.name,
+      apply: (item: ReadContentAcrossMattersPayload, value) => {
+        item.name = value;
+      },
+    }),
+    defineTextFieldSpec({
+      path: "text",
+      items: (payload: ReadContentAcrossMattersPayload) => [payload],
+      scope: (item: ReadContentAcrossMattersPayload) => item.workspaceId,
+      read: (item: ReadContentAcrossMattersPayload) => item.text,
+      apply: (item: ReadContentAcrossMattersPayload, value) => {
+        item.text = value;
+      },
+    }),
+  ];
+
+/**
+ * read_contact: contacts are organization-scoped (no owning workspace), so
+ * `organizationId` is the anonymization scope for every field. Unlike the
+ * per-item/per-matter cases above, `organizationId` is not part of the served
+ * payload, so it is threaded in as a builder argument. `STELLA_TOOL_DEFINITIONS`
+ * below calls this same builder with a placeholder id purely to derive the
+ * documented `textFields` path list — `deriveTextFieldPaths` only reads each
+ * spec's static `path`, never `scope`, so the placeholder never affects the
+ * declaration.
+ */
+type ContactPayload = {
+  displayName: string;
+  emails: readonly ContactEmail[];
+  firstName: string | null;
+  lastName: string | null;
+  organizationName: string | null;
+  phones: readonly ContactPhone[];
+};
+
+const buildContactTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<ContactPayload>[] => [
+  defineTextFieldSpec({
+    path: "displayName",
+    items: (payload: ContactPayload) => [payload],
+    scope: () => organizationId,
+    read: (item: ContactPayload) => item.displayName,
+    apply: (item: ContactPayload, value) => {
+      item.displayName = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "firstName",
+    items: (payload: ContactPayload) => [payload],
+    scope: () => organizationId,
+    read: (item: ContactPayload) => item.firstName,
+    apply: (item: ContactPayload, value) => {
+      item.firstName = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "lastName",
+    items: (payload: ContactPayload) => [payload],
+    scope: () => organizationId,
+    read: (item: ContactPayload) => item.lastName,
+    apply: (item: ContactPayload, value) => {
+      item.lastName = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "organizationName",
+    items: (payload: ContactPayload) => [payload],
+    scope: () => organizationId,
+    read: (item: ContactPayload) => item.organizationName,
+    apply: (item: ContactPayload, value) => {
+      item.organizationName = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "emails[].label",
+    items: (payload: ContactPayload) => payload.emails,
+    scope: () => organizationId,
+    read: (email: ContactEmail) => email.label,
+    apply: (email: ContactEmail, value) => {
+      email.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "emails[].address",
+    items: (payload: ContactPayload) => payload.emails,
+    scope: () => organizationId,
+    read: (email: ContactEmail) => email.address,
+    apply: (email: ContactEmail, value) => {
+      email.address = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "phones[].label",
+    items: (payload: ContactPayload) => payload.phones,
+    scope: () => organizationId,
+    read: (phone: ContactPhone) => phone.label,
+    apply: (phone: ContactPhone, value) => {
+      phone.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "phones[].number",
+    items: (payload: ContactPayload) => payload.phones,
+    scope: () => organizationId,
+    read: (phone: ContactPhone) => phone.number,
+    apply: (phone: ContactPhone, value) => {
+      phone.number = value;
+    },
+  }),
+];
 
 export const STELLA_TOOL_DEFINITIONS = [
   {
@@ -131,14 +460,8 @@ export const STELLA_TOOL_DEFINITIONS = [
     anonymized: {
       exposure: "anonymize",
       textFields: [
-        "matters[].name",
-        "matter.name",
-        "matter.clientName",
-        "overview.recentEntities[].name",
-        "overview.recentEntities[].createdBy",
-        "overview.recentEntities[].assignedTo",
-        "contacts[].displayName",
-        "members[].name",
+        ...deriveTextFieldPaths(LIST_MATTERS_LIST_TEXT_FIELD_SPECS),
+        ...deriveTextFieldPaths(MATTER_OVERVIEW_TEXT_FIELD_SPECS),
       ],
     },
     name: "list_matters",
@@ -168,7 +491,7 @@ export const STELLA_TOOL_DEFINITIONS = [
     },
     anonymized: {
       exposure: "anonymize",
-      textFields: ["hits[].name", "hits[].headline", "hits[].workspaceName"],
+      textFields: deriveTextFieldPaths(SEARCH_ACROSS_MATTERS_TEXT_FIELD_SPECS),
     },
     name: "search_across_matters",
     scope: "stella:search",
@@ -235,7 +558,12 @@ export const STELLA_TOOL_DEFINITIONS = [
       },
       required: ["entity_id"],
     },
-    anonymized: { exposure: "anonymize", textFields: ["name", "text"] },
+    anonymized: {
+      exposure: "anonymize",
+      textFields: deriveTextFieldPaths(
+        READ_CONTENT_ACROSS_MATTERS_TEXT_FIELD_SPECS,
+      ),
+    },
     name: "read_content_across_matters",
     scope: "stella:read",
   },
@@ -278,14 +606,9 @@ export const STELLA_TOOL_DEFINITIONS = [
     },
     anonymized: {
       exposure: "anonymize",
-      textFields: [
-        "displayName",
-        "firstName",
-        "lastName",
-        "organizationName",
-        "emails[].address",
-        "phones[].number",
-      ],
+      // Placeholder org id: derivation only ever reads `.path`, see
+      // `buildContactTextFieldSpecs`'s doc comment above.
+      textFields: deriveTextFieldPaths(buildContactTextFieldSpecs("")),
     },
     name: "read_contact",
     scope: "stella:read",
@@ -499,31 +822,13 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
     });
   }
 
-  const textFields: McpStructuredTextField[] = [];
-  for (const matter of matters) {
-    collectAnonymizableField({
-      apply: (value) => {
-        matter.name = value;
-      },
-      fields: textFields,
-      value: matter.name,
-      workspaceId: matter.id,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        matter.reference = value;
-      },
-      fields: textFields,
-      value: matter.reference,
-      workspaceId: matter.id,
-    });
-  }
+  const payload = { matters, nextCursor: page.nextCursor };
+  const textFields = runTextFieldSpecs(
+    LIST_MATTERS_LIST_TEXT_FIELD_SPECS,
+    payload,
+  );
 
-  return {
-    egress: "structured",
-    payload: { matters, nextCursor: page.nextCursor },
-    textFields,
-  };
+  return { egress: "structured", payload, textFields };
 };
 
 // Detail branch of list_matters: one matter's overview (counts, recent
@@ -618,82 +923,17 @@ const readMatterOverview: McpToolHandler = async ({ args, context }) => {
 
   // Everything below belongs to one matter, so it all anonymizes under this
   // single workspace scope. Ids/status/dates pass through; user-authored
-  // matter references and free-text party/person names are redacted.
-  const textFields: McpStructuredTextField[] = [];
-  collectAnonymizableField({
-    apply: (value) => {
-      matter.name = value;
-    },
-    fields: textFields,
-    value: matter.name,
-    workspaceId,
-  });
-  collectAnonymizableField({
-    apply: (value) => {
-      matter.reference = value;
-    },
-    fields: textFields,
-    value: matter.reference,
-    workspaceId,
-  });
-  collectAnonymizableField({
-    apply: (value) => {
-      matter.clientName = value;
-    },
-    fields: textFields,
-    value: matter.clientName,
-    workspaceId,
-  });
-  // Iterate the entities actually served in the payload, not the source
-  // `overview.recentEntities`: the avatar-URL strip above copies each entity
-  // into a new object, so writing an anonymized value back onto the source
-  // entity would land on a stale reference the response never serializes.
-  for (const entity of overviewWithoutAvatarUrls.recentEntities) {
-    collectAnonymizableField({
-      apply: (value) => {
-        entity.name = value;
-      },
-      fields: textFields,
-      value: entity.name,
-      workspaceId,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        entity.createdBy = value;
-      },
-      fields: textFields,
-      value: entity.createdBy,
-      workspaceId,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        entity.assignedTo = value;
-      },
-      fields: textFields,
-      value: entity.assignedTo,
-      workspaceId,
-    });
-  }
-  for (const contactCard of contactCards) {
-    collectAnonymizableField({
-      apply: (value) => {
-        contactCard.displayName = value;
-      },
-      fields: textFields,
-      value: contactCard.displayName,
-      workspaceId,
-    });
-  }
-  for (const memberCard of memberCards) {
-    collectAnonymizableField({
-      apply: (value) => {
-        memberCard.name = value;
-      },
-      fields: textFields,
-      value: memberCard.name,
-      workspaceId,
-    });
-  }
+  // matter references and free-text party/person names are redacted. The
+  // entity/contact/member item selectors above read `payload.matter.id` for
+  // the scope and `payload.overview.recentEntities` (not the source
+  // `overview.recentEntities`) for the entities — the avatar-URL strip above
+  // copies each entity into a new object, so extracting items from the
+  // object actually placed in the payload (not the pre-strip source) is what
+  // keeps the write-back landing on the object the response serializes.
+  const textFields = runTextFieldSpecs(
+    MATTER_OVERVIEW_TEXT_FIELD_SPECS,
+    payload,
+  );
 
   return { egress: "structured", payload, textFields };
 };
@@ -750,43 +990,17 @@ const handleSearchAcrossMattersTool: McpToolHandler = async ({
   // Hits span multiple matters; each anonymizes under its own workspace scope.
   // `workspaceName` embeds the matter name (party names), so it is redacted
   // alongside the hit name and headline to stay consistent with list_matters.
-  const textFields: McpStructuredTextField[] = [];
-  for (const hit of hits) {
-    collectAnonymizableField({
-      apply: (value) => {
-        hit.name = value;
-      },
-      fields: textFields,
-      value: hit.name,
-      workspaceId: hit.workspaceId,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        hit.headline = value;
-      },
-      fields: textFields,
-      value: hit.headline,
-      workspaceId: hit.workspaceId,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        hit.workspaceName = value;
-      },
-      fields: textFields,
-      value: hit.workspaceName,
-      workspaceId: hit.workspaceId,
-    });
-  }
-
-  return {
-    egress: "structured",
-    payload: {
-      totalCount: result.totalCount,
-      nextCursor: result.nextCursor,
-      hits,
-    },
-    textFields,
+  const payload = {
+    totalCount: result.totalCount,
+    nextCursor: result.nextCursor,
+    hits,
   };
+  const textFields = runTextFieldSpecs(
+    SEARCH_ACROSS_MATTERS_TEXT_FIELD_SPECS,
+    payload,
+  );
+
+  return { egress: "structured", payload, textFields };
 };
 
 const parseOptionalStringArg = ({
@@ -982,22 +1196,10 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
   return {
     egress: "structured",
     payload,
-    textFields: [
-      {
-        apply: (value) => {
-          payload.name = value;
-        },
-        value: payload.name,
-        workspaceId,
-      },
-      {
-        apply: (value) => {
-          payload.text = value;
-        },
-        value: payload.text,
-        workspaceId,
-      },
-    ],
+    textFields: runTextFieldSpecs(
+      READ_CONTENT_ACROSS_MATTERS_TEXT_FIELD_SPECS,
+      payload,
+    ),
     window: {
       cursor,
       maxChars: MCP_CONTENT_MAX_CHARS,
@@ -1327,7 +1529,6 @@ const handleReadContactTool: McpToolHandler = async ({ args, context }) => {
   // Contacts are organization-scoped (no owning workspace), so the org id is
   // the anonymization scope. The placeholder card is intentional and consistent
   // with how chat anonymizes contact fields.
-  const workspaceId = context.organizationId;
   const payload = {
     contactId: contact.id,
     type: contact.type,
@@ -1341,75 +1542,10 @@ const handleReadContactTool: McpToolHandler = async ({ args, context }) => {
     phones: contact.phones ?? [],
   };
 
-  const textFields: McpStructuredTextField[] = [];
-  collectAnonymizableField({
-    apply: (value) => {
-      payload.displayName = value;
-    },
-    fields: textFields,
-    value: payload.displayName,
-    workspaceId,
-  });
-  collectAnonymizableField({
-    apply: (value) => {
-      payload.firstName = value;
-    },
-    fields: textFields,
-    value: payload.firstName,
-    workspaceId,
-  });
-  collectAnonymizableField({
-    apply: (value) => {
-      payload.lastName = value;
-    },
-    fields: textFields,
-    value: payload.lastName,
-    workspaceId,
-  });
-  collectAnonymizableField({
-    apply: (value) => {
-      payload.organizationName = value;
-    },
-    fields: textFields,
-    value: payload.organizationName,
-    workspaceId,
-  });
-  for (const email of payload.emails) {
-    collectAnonymizableField({
-      apply: (value) => {
-        email.label = value;
-      },
-      fields: textFields,
-      value: email.label,
-      workspaceId,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        email.address = value;
-      },
-      fields: textFields,
-      value: email.address,
-      workspaceId,
-    });
-  }
-  for (const phone of payload.phones) {
-    collectAnonymizableField({
-      apply: (value) => {
-        phone.label = value;
-      },
-      fields: textFields,
-      value: phone.label,
-      workspaceId,
-    });
-    collectAnonymizableField({
-      apply: (value) => {
-        phone.number = value;
-      },
-      fields: textFields,
-      value: phone.number,
-      workspaceId,
-    });
-  }
+  const textFields = runTextFieldSpecs(
+    buildContactTextFieldSpecs(context.organizationId),
+    payload,
+  );
 
   return { egress: "structured", payload, textFields };
 };

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -10,12 +10,13 @@ import {
   buildAiFieldGenerator,
   buildAiOccurrenceAdapter,
 } from "@/api/handlers/docx/ai-field-generator";
-import type { FieldMeta } from "@/api/handlers/docx/types";
+import type { FieldMeta, FieldPart } from "@/api/handlers/docx/types";
 import { INPUT_TYPES, isFieldMeta } from "@/api/handlers/docx/types";
 import { validateDocxBuffer } from "@/api/handlers/entities/validate-docx-buffer";
 import { configureTemplateFields } from "@/api/handlers/templates/configure-template-fields-service";
 import { createStoredTemplate } from "@/api/handlers/templates/create-template-service";
 import { recordTemplateFill } from "@/api/handlers/templates/record-use";
+import type { DescribeTemplateResult } from "@/api/handlers/templates/template-fill-service";
 import {
   describeStoredTemplate,
   fillStoredTemplateWithText,
@@ -34,8 +35,13 @@ import {
 import { brandPersistedTemplateId } from "@/api/lib/safe-id-boundaries";
 import { hasTanStackInstanceProvider } from "@/api/lib/tanstack-ai-models";
 import type { McpRequestContext } from "@/api/mcp/context";
+import {
+  defineTextFieldSpec,
+  deriveTextFieldPaths,
+  runTextFieldSpecs,
+} from "@/api/mcp/text-field-spec";
 import type {
-  McpStructuredTextField,
+  McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
 } from "@/api/mcp/tool-types";
@@ -154,6 +160,191 @@ const fieldsOverlayProp = {
   items: fieldConfigItemSchema,
 } as const;
 
+// --- Text-field specs (plan 049, Option B) --------------------------------
+//
+// Both anonymize-mode branches of list_templates are org-scoped: templates
+// have no owning workspace, so `organizationId` is the anonymization scope
+// for every field below. `organizationId` is not part of either served
+// payload, so (unlike a per-item workspace id already sitting in the
+// payload) it must be threaded in as a builder argument rather than read off
+// an item. `TEMPLATE_TOOL_DEFINITIONS` below calls these same builders with a
+// placeholder id purely to derive the documented `textFields` path list:
+// `deriveTextFieldPaths` only reads each spec's static `path`, never `scope`,
+// so the placeholder never affects the declaration.
+
+type TemplateListItem = {
+  name: string;
+  tags: string[] | null;
+  whenNotToUse: string | null;
+  whenToUse: string | null;
+};
+
+type TemplateListPayload = { templates: readonly TemplateListItem[] };
+
+/** Every tag on every listed template, paired with its own index into the
+ * owning `tags` array so `apply` writes back through that same array
+ * reference rather than a detached copy. */
+const templateTagItems = (
+  payload: TemplateListPayload,
+): readonly { index: number; tags: string[] }[] =>
+  payload.templates.flatMap((template) => {
+    const tags = template.tags;
+    return tags ? tags.map((_tag, index) => ({ index, tags })) : [];
+  });
+
+const buildTemplateListTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<TemplateListPayload>[] => [
+  defineTextFieldSpec({
+    path: "templates[].name",
+    items: (payload: TemplateListPayload) => payload.templates,
+    scope: () => organizationId,
+    read: (template: TemplateListItem) => template.name,
+    apply: (template: TemplateListItem, value) => {
+      template.name = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "templates[].whenToUse",
+    items: (payload: TemplateListPayload) => payload.templates,
+    scope: () => organizationId,
+    read: (template: TemplateListItem) => template.whenToUse,
+    apply: (template: TemplateListItem, value) => {
+      template.whenToUse = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "templates[].whenNotToUse",
+    items: (payload: TemplateListPayload) => payload.templates,
+    scope: () => organizationId,
+    read: (template: TemplateListItem) => template.whenNotToUse,
+    apply: (template: TemplateListItem, value) => {
+      template.whenNotToUse = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "templates[].tags[]",
+    items: templateTagItems,
+    scope: () => organizationId,
+    read: (item: { index: number; tags: string[] }) => item.tags[item.index],
+    apply: (item: { index: number; tags: string[] }, value) => {
+      item.tags[item.index] = value;
+    },
+  }),
+];
+
+// Detail-mode payload: the success variant of `describeStoredTemplate`'s
+// result (the error variant is handled and returned before a spec ever runs).
+type TemplateDetailSuccess = Extract<
+  DescribeTemplateResult,
+  { fields: unknown[] }
+>;
+type TemplateDetailField = TemplateDetailSuccess["fields"][number];
+
+const templateFieldOptionItems = (
+  payload: TemplateDetailSuccess,
+): readonly { index: number; options: string[] }[] =>
+  payload.fields.flatMap((field) => {
+    const options = field.options;
+    return options ? options.map((_option, index) => ({ index, options })) : [];
+  });
+
+const templateFieldPartItems = (
+  payload: TemplateDetailSuccess,
+): readonly FieldPart[] => payload.fields.flatMap((field) => field.parts ?? []);
+
+const templateFieldPartOptionItems = (
+  payload: TemplateDetailSuccess,
+): readonly { index: number; options: string[] }[] =>
+  templateFieldPartItems(payload).flatMap((part) => {
+    const options = part.options;
+    return options ? options.map((_option, index) => ({ index, options })) : [];
+  });
+
+const templateFieldFormatItems = (
+  payload: TemplateDetailSuccess,
+): readonly { key: string; template: string }[] =>
+  payload.fields.flatMap((field) => field.formats ?? []);
+
+const buildTemplateDetailTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<TemplateDetailSuccess>[] => [
+  defineTextFieldSpec({
+    path: "name",
+    items: (payload: TemplateDetailSuccess) => [payload],
+    scope: () => organizationId,
+    read: (payload: TemplateDetailSuccess) => payload.name,
+    apply: (payload: TemplateDetailSuccess, value) => {
+      payload.name = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].label",
+    items: (payload: TemplateDetailSuccess) => payload.fields,
+    scope: () => organizationId,
+    read: (field: TemplateDetailField) => field.label,
+    apply: (field: TemplateDetailField, value) => {
+      field.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].hint",
+    items: (payload: TemplateDetailSuccess) => payload.fields,
+    scope: () => organizationId,
+    read: (field: TemplateDetailField) => field.hint,
+    apply: (field: TemplateDetailField, value) => {
+      field.hint = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].aiPrompt",
+    items: (payload: TemplateDetailSuccess) => payload.fields,
+    scope: () => organizationId,
+    read: (field: TemplateDetailField) => field.aiPrompt,
+    apply: (field: TemplateDetailField, value) => {
+      field.aiPrompt = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].options[]",
+    items: templateFieldOptionItems,
+    scope: () => organizationId,
+    read: (item: { index: number; options: string[] }) =>
+      item.options[item.index],
+    apply: (item: { index: number; options: string[] }, value) => {
+      item.options[item.index] = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].parts[].label",
+    items: templateFieldPartItems,
+    scope: () => organizationId,
+    read: (part: FieldPart) => part.label,
+    apply: (part: FieldPart, value) => {
+      part.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].parts[].options[]",
+    items: templateFieldPartOptionItems,
+    scope: () => organizationId,
+    read: (item: { index: number; options: string[] }) =>
+      item.options[item.index],
+    apply: (item: { index: number; options: string[] }, value) => {
+      item.options[item.index] = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "fields[].formats[].template",
+    items: templateFieldFormatItems,
+    scope: () => organizationId,
+    read: (format: { key: string; template: string }) => format.template,
+    apply: (format: { key: string; template: string }, value) => {
+      format.template = value;
+    },
+  }),
+];
+
 export const TEMPLATE_TOOL_DEFINITIONS = [
   {
     annotations: { readOnlyHint: true },
@@ -182,14 +373,11 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
     },
     anonymized: {
       exposure: "anonymize",
+      // Placeholder org id: derivation only ever reads `.path`, see the
+      // builders' doc comment above.
       textFields: [
-        "templates[].name",
-        "templates[].whenToUse",
-        "templates[].whenNotToUse",
-        "name",
-        "fields[].label",
-        "fields[].hint",
-        "fields[].aiPrompt",
+        ...deriveTextFieldPaths(buildTemplateListTextFieldSpecs("")),
+        ...deriveTextFieldPaths(buildTemplateDetailTextFieldSpecs("")),
       ],
     },
     name: "list_templates",
@@ -344,152 +532,16 @@ const handleListTemplatesTool: McpToolHandler = async ({ args, context }) => {
     cursorForItem: (item) => encodePaginationCursor([item.id]),
   });
 
-  const templateList = page.items;
-
   // Templates are organization-scoped, so the org id is the anonymization
-  // scope. Only the org-authored free text (name, usage guidance) is redacted;
-  // ids, field counts, and tags pass through.
-  const workspaceId = context.organizationId;
-  const textFields: McpStructuredTextField[] = [];
-  for (const template of templateList) {
-    pushTemplateTextField({
-      apply: (value) => {
-        template.name = value;
-      },
-      fields: textFields,
-      value: template.name,
-      workspaceId,
-    });
-    pushTemplateTextField({
-      apply: (value) => {
-        template.whenToUse = value;
-      },
-      fields: textFields,
-      value: template.whenToUse,
-      workspaceId,
-    });
-    pushTemplateTextField({
-      apply: (value) => {
-        template.whenNotToUse = value;
-      },
-      fields: textFields,
-      value: template.whenNotToUse,
-      workspaceId,
-    });
-    const tags = template.tags ?? [];
-    for (const [index, tag] of tags.entries()) {
-      pushTemplateTextField({
-        apply: (value) => {
-          tags[index] = value;
-        },
-        fields: textFields,
-        value: tag,
-        workspaceId,
-      });
-    }
-  }
+  // scope. Only the org-authored free text (name, usage guidance, tags) is
+  // redacted; ids and field counts pass through.
+  const payload = { templates: page.items, nextCursor: page.nextCursor };
+  const textFields = runTextFieldSpecs(
+    buildTemplateListTextFieldSpecs(context.organizationId),
+    payload,
+  );
 
-  return {
-    egress: "structured",
-    payload: { templates: templateList, nextCursor: page.nextCursor },
-    textFields,
-  };
-};
-
-/**
- * Queue one anonymizable template text field, skipping null/empty values.
- * Templates carry org-authored free text (name, usage guidance, field labels
- * and prompts); everything else on the surface is structural.
- */
-const pushTemplateTextField = ({
-  apply,
-  fields,
-  value,
-  workspaceId,
-}: {
-  apply: (value: string) => void;
-  fields: McpStructuredTextField[];
-  value: string | null | undefined;
-  workspaceId: string;
-}): void => {
-  if (typeof value === "string" && value.length > 0) {
-    fields.push({ apply, value, workspaceId });
-  }
-};
-
-type TemplateAnonymizableField = {
-  formats?: { template: string }[] | null | undefined;
-  lookup?: { formats: { template: string }[] } | null | undefined;
-  options?: string[] | null | undefined;
-  parts?:
-    | {
-        label?: string | null | undefined;
-        options?: string[] | null | undefined;
-      }[]
-    | null
-    | undefined;
-};
-
-const pushTemplateFieldNestedTextFields = ({
-  field,
-  fields,
-  workspaceId,
-}: {
-  field: TemplateAnonymizableField;
-  fields: McpStructuredTextField[];
-  workspaceId: string;
-}): void => {
-  if (field.options) {
-    for (const [index, option] of field.options.entries()) {
-      pushTemplateTextField({
-        apply: (value) => {
-          field.options?.splice(index, 1, value);
-        },
-        fields,
-        value: option,
-        workspaceId,
-      });
-    }
-  }
-
-  if (field.parts) {
-    for (const part of field.parts) {
-      pushTemplateTextField({
-        apply: (value) => {
-          part.label = value;
-        },
-        fields,
-        value: part.label,
-        workspaceId,
-      });
-      if (part.options) {
-        for (const [index, option] of part.options.entries()) {
-          pushTemplateTextField({
-            apply: (value) => {
-              part.options?.splice(index, 1, value);
-            },
-            fields,
-            value: option,
-            workspaceId,
-          });
-        }
-      }
-    }
-  }
-
-  const formats = field.formats ?? field.lookup?.formats;
-  if (formats) {
-    for (const format of formats) {
-      pushTemplateTextField({
-        apply: (value) => {
-          format.template = value;
-        },
-        fields,
-        value: format.template,
-        workspaceId,
-      });
-    }
-  }
+  return { egress: "structured", payload, textFields };
 };
 
 const describeTemplateArgsSchema = v.strictObject({
@@ -516,47 +568,10 @@ const describeTemplateDetail: McpToolHandler = async ({ args, context }) => {
   // Redact the org-authored template name and each field's label/hint/aiPrompt;
   // field paths, input types, options, and condition/formula expressions are
   // structural and pass through. Template = org scope.
-  const workspaceId = context.organizationId;
-  const textFields: McpStructuredTextField[] = [];
-  pushTemplateTextField({
-    apply: (value) => {
-      result.name = value;
-    },
-    fields: textFields,
-    value: result.name,
-    workspaceId,
-  });
-  for (const field of result.fields) {
-    pushTemplateTextField({
-      apply: (value) => {
-        field.label = value;
-      },
-      fields: textFields,
-      value: field.label,
-      workspaceId,
-    });
-    pushTemplateTextField({
-      apply: (value) => {
-        field.hint = value;
-      },
-      fields: textFields,
-      value: field.hint,
-      workspaceId,
-    });
-    pushTemplateTextField({
-      apply: (value) => {
-        field.aiPrompt = value;
-      },
-      fields: textFields,
-      value: field.aiPrompt,
-      workspaceId,
-    });
-    pushTemplateFieldNestedTextFields({
-      field,
-      fields: textFields,
-      workspaceId,
-    });
-  }
+  const textFields = runTextFieldSpecs(
+    buildTemplateDetailTextFieldSpecs(context.organizationId),
+    result,
+  );
 
   return { egress: "structured", payload: result, textFields };
 };

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -91,7 +91,7 @@
     }
   },
   "nullish-array-fallback": {
-    "count": 314,
+    "count": 315,
     "files": {
       "apps/api/src/handlers/case-law/court-weights.ts": 2,
       "apps/api/src/handlers/case-law/decisions/search.ts": 5,
@@ -164,7 +164,7 @@
       "apps/api/src/lib/workflow/get-execution-plan.ts": 2,
       "apps/api/src/lib/workflow/verdict-engine.ts": 1,
       "apps/api/src/mcp/stella-tools.ts": 3,
-      "apps/api/src/mcp/template-tools.ts": 1,
+      "apps/api/src/mcp/template-tools.ts": 2,
       "apps/web/src/components/ai-suggestions/file-chat-overlay.tsx": 2,
       "apps/web/src/components/ai-suggestions/playbook-review-store.ts": 1,
       "apps/web/src/components/ai-suggestions/review-panel.impl.tsx": 3,


### PR DESCRIPTION
Second module pair of the egress spec migration (plan 049): template and stella tool anonymization fields become typed specs with derived `textFields` declarations. The derivation surfaced five fields that were already anonymized but never declared (matter references, template tags, contact email/phone labels) — now documented by construction. The windowed read tool keeps its window block untouched; the canary suite is unchanged and green. One justified nullish-fallback ratchet bump (optional-array flatteners, lint-forced).