### PR TITLE
refactor: derive document and knowledge tool text fields from typed specs

### DIFF
--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -38,9 +38,15 @@ import {
   brandPersistedPropertyId,
 } from "@/api/lib/safe-id-boundaries";
 import { buildLineDiffSegments } from "@/api/lib/text-diff";
+import type { VersionDiffSegment } from "@/api/lib/text-diff";
 import type { McpRequestContext } from "@/api/mcp/context";
+import {
+  defineTextFieldSpec,
+  deriveTextFieldPaths,
+  runTextFieldSpecs,
+} from "@/api/mcp/text-field-spec";
 import type {
-  McpStructuredTextField,
+  McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
 } from "@/api/mcp/tool-types";
@@ -78,6 +84,344 @@ const SETTABLE_VALUE_TYPES = [
   "date",
   "int",
 ] as const;
+
+// --- Text-field specs (plan 049, Option B) --------------------------------
+
+/**
+ * Normalized read/write pair over one field's tenant-authored text unit. A
+ * `FieldContent`'s text-bearing value is not always a lone scalar: a
+ * multi-select holds several array-indexed values, a clip holds two named
+ * fields (snippet, citation), and a "changed" diff segment holds several
+ * inline runs. Every text-bearing shape becomes one unit apiece; a single
+ * `McpTextFieldSpec` then just iterates `TextUnit`s without re-deriving the
+ * union's shape at every call site.
+ */
+type TextUnit = {
+  read: () => string | null | undefined;
+  write: (value: string) => void;
+};
+
+/** One entity/version field row as fetched from the DB — text-field specs
+ * only ever touch `content`. */
+type EntityFieldRow = { content: FieldContent };
+
+/**
+ * The former `pushFieldContentTexts` helper's full discriminated-union walk,
+ * narrowed here once: `text`/`single-select` are a scalar unit; `multi-select`
+ * yields one unit per array index, writing back through the same array
+ * reference; `clip` yields its snippet and citation as two named units;
+ * `file` yields its fileName. `date`/`int`/`error`/`pending`/`unsupported`
+ * carry no tenant-authored text and contribute nothing.
+ */
+const fieldContentTextUnits = (
+  fields: readonly EntityFieldRow[],
+): readonly TextUnit[] =>
+  fields.flatMap(({ content }): TextUnit[] => {
+    if (content.type === "text") {
+      return [
+        {
+          read: () => content.value,
+          write: (value) => {
+            content.value = value;
+          },
+        },
+      ];
+    }
+    if (content.type === "single-select") {
+      return [
+        {
+          read: () => content.value,
+          write: (value) => {
+            content.value = value;
+          },
+        },
+      ];
+    }
+    if (content.type === "multi-select") {
+      const values = content.value;
+      return values.map((_value, index) => ({
+        read: () => values[index],
+        write: (value: string) => {
+          values[index] = value;
+        },
+      }));
+    }
+    if (content.type === "clip") {
+      return [
+        {
+          read: () => content.snippet,
+          write: (value) => {
+            content.snippet = value;
+          },
+        },
+        {
+          read: () => content.citation,
+          write: (value) => {
+            content.citation = value;
+          },
+        },
+      ];
+    }
+    if (content.type === "file") {
+      return [
+        {
+          read: () => content.fileName,
+          write: (value) => {
+            content.fileName = value;
+          },
+        },
+      ];
+    }
+    return [];
+  });
+
+/**
+ * Same union-walk shape as `fieldContentTextUnits`, over a line-diff's
+ * segments: a "changed" segment's several inline runs each become one unit;
+ * every other segment kind is a single scalar unit over its own `text`.
+ */
+const diffSegmentTextUnits = (
+  segments: readonly VersionDiffSegment[],
+): readonly TextUnit[] =>
+  segments.flatMap((segment): TextUnit[] => {
+    if (segment.kind === "changed") {
+      return segment.runs.map((run) => ({
+        read: () => run.text,
+        write: (value: string) => {
+          run.text = value;
+        },
+      }));
+    }
+    return [
+      {
+        read: () => segment.text,
+        write: (value: string) => {
+          segment.text = value;
+        },
+      },
+    ];
+  });
+
+/**
+ * One anonymize-mode spec over a flat list of `TextUnit`s, shared by every
+ * field-values path (`fields[].value`, `version.fields[].value`) and the diff
+ * path (`diff.segments[].text`) below.
+ */
+const textUnitTextFieldSpec = <TPayload>({
+  path,
+  units,
+  workspaceId,
+}: {
+  path: string;
+  units: (payload: TPayload) => readonly TextUnit[];
+  workspaceId: string;
+}): McpTextFieldSpec<TPayload> =>
+  defineTextFieldSpec({
+    path,
+    items: units,
+    scope: () => workspaceId,
+    read: (unit: TextUnit) => unit.read(),
+    apply: (unit: TextUnit, value) => {
+      unit.write(value);
+    },
+  });
+
+/**
+ * One anonymize-mode spec over a single `{ name: string }`-shaped payload,
+ * shared across read_document's default/version/diff branches (P1: the whole
+ * branch response shares one resolved `workspaceId`).
+ */
+const nameTextFieldSpec = <TPayload extends { name: string }>(
+  workspaceId: string,
+): McpTextFieldSpec<TPayload> =>
+  defineTextFieldSpec({
+    path: "name",
+    items: (payload: TPayload) => [payload],
+    scope: () => workspaceId,
+    read: (item: TPayload) => item.name,
+    apply: (item: TPayload, value) => {
+      item.name = value;
+    },
+  });
+
+// --- list_documents / list_properties -------------------------------------
+
+type NamedListItem = { name: string };
+
+const DOCUMENT_LIST_TEXT_FIELD_PATH = "documents[].name";
+
+const documentListTextFieldSpecs = (
+  workspaceId: string,
+): readonly McpTextFieldSpec<{ documents: readonly NamedListItem[] }>[] => [
+  defineTextFieldSpec({
+    path: DOCUMENT_LIST_TEXT_FIELD_PATH,
+    items: (payload) => payload.documents,
+    scope: () => workspaceId,
+    read: (item) => item.name,
+    apply: (item, value) => {
+      item.name = value;
+    },
+  }),
+];
+
+const PROPERTY_LIST_TEXT_FIELD_PATH = "properties[].name";
+
+const propertyListTextFieldSpecs = (
+  workspaceId: string,
+): readonly McpTextFieldSpec<{ properties: readonly NamedListItem[] }>[] => [
+  defineTextFieldSpec({
+    path: PROPERTY_LIST_TEXT_FIELD_PATH,
+    items: (payload) => payload.properties,
+    scope: () => workspaceId,
+    read: (item) => item.name,
+    apply: (item, value) => {
+      item.name = value;
+    },
+  }),
+];
+
+// --- read_document ---------------------------------------------------------
+
+/** Version-history fields this surface redacts. See `VersionHistoryEntry`
+ * below for the full row shape fetched from the DB. */
+type VersionHistoryTextItem = {
+  label: string | null;
+  description: string | null;
+};
+
+type ReadDocumentDefaultPayload = {
+  name: string;
+  fields: readonly EntityFieldRow[];
+  versions?: readonly VersionHistoryTextItem[];
+};
+
+/** `versions` is only present when `include_versions` was requested — a
+ * genuine absence, not a structural invariant, so this reads as an explicit
+ * presence check rather than a `?? []` fallback. */
+const readDocumentVersionHistoryItems = (
+  payload: ReadDocumentDefaultPayload,
+): readonly VersionHistoryTextItem[] => {
+  if (payload.versions === undefined) {
+    return [];
+  }
+  return payload.versions;
+};
+
+/**
+ * Default branch (current version): the entity's own name, its field values
+ * (full `FieldContent` union recursion via `fieldContentTextUnits`), and,
+ * when `include_versions` was requested, each version-history entry's label
+ * and description — the exact fields Wave 1 declared but never pushed;
+ * deriving the declaration from this same spec closes that gap structurally.
+ */
+const readDocumentDefaultTextFieldSpecs = (
+  workspaceId: string,
+): readonly McpTextFieldSpec<ReadDocumentDefaultPayload>[] => [
+  nameTextFieldSpec<ReadDocumentDefaultPayload>(workspaceId),
+  textUnitTextFieldSpec({
+    path: "fields[].value",
+    units: (payload: ReadDocumentDefaultPayload) =>
+      fieldContentTextUnits(payload.fields),
+    workspaceId,
+  }),
+  defineTextFieldSpec({
+    path: "versions[].label",
+    items: readDocumentVersionHistoryItems,
+    scope: () => workspaceId,
+    read: (item) => item.label,
+    apply: (item, value) => {
+      item.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "versions[].description",
+    items: readDocumentVersionHistoryItems,
+    scope: () => workspaceId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+];
+
+type ReadDocumentVersionDetailPayload = {
+  name: string;
+  version: {
+    label: string | null;
+    description: string | null;
+    fields: readonly EntityFieldRow[];
+  };
+};
+
+/**
+ * version_id branch: the entity name, the requested version's own
+ * label/description (pushed by the original handler but never declared —
+ * another instance of the declared-vs-pushed drift this migration closes),
+ * and that version's field values.
+ */
+const readDocumentVersionDetailTextFieldSpecs = (
+  workspaceId: string,
+): readonly McpTextFieldSpec<ReadDocumentVersionDetailPayload>[] => [
+  nameTextFieldSpec<ReadDocumentVersionDetailPayload>(workspaceId),
+  defineTextFieldSpec({
+    path: "version.label",
+    items: (payload: ReadDocumentVersionDetailPayload) => [payload.version],
+    scope: () => workspaceId,
+    read: (item) => item.label,
+    apply: (item, value) => {
+      item.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "version.description",
+    items: (payload: ReadDocumentVersionDetailPayload) => [payload.version],
+    scope: () => workspaceId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+  textUnitTextFieldSpec({
+    path: "version.fields[].value",
+    units: (payload: ReadDocumentVersionDetailPayload) =>
+      fieldContentTextUnits(payload.version.fields),
+    workspaceId,
+  }),
+];
+
+type ReadDocumentDiffPayload = {
+  name: string;
+  diff: { segments: readonly VersionDiffSegment[] };
+};
+
+/**
+ * compare_with_version_id branch: the entity name and every diff segment's
+ * text (a "changed" segment's several inline runs, or the segment's own text
+ * for every other kind).
+ */
+const readDocumentDiffTextFieldSpecs = (
+  workspaceId: string,
+): readonly McpTextFieldSpec<ReadDocumentDiffPayload>[] => [
+  nameTextFieldSpec<ReadDocumentDiffPayload>(workspaceId),
+  textUnitTextFieldSpec({
+    path: "diff.segments[].text",
+    units: (payload: ReadDocumentDiffPayload) =>
+      diffSegmentTextUnits(payload.diff.segments),
+    workspaceId,
+  }),
+];
+
+// read_document's three branches (default/version/diff) never populate the
+// same response at once, but each has its own payload shape, so the declared
+// path list is the union of all three specs' paths (deduped: `name` is
+// shared by every branch).
+const READ_DOCUMENT_TEXT_FIELD_PATHS = [
+  ...new Set([
+    ...deriveTextFieldPaths(readDocumentDefaultTextFieldSpecs("")),
+    ...deriveTextFieldPaths(readDocumentVersionDetailTextFieldSpecs("")),
+    ...deriveTextFieldPaths(readDocumentDiffTextFieldSpecs("")),
+  ]),
+];
 
 export const DOCUMENT_TOOL_DEFINITIONS = [
   {
@@ -117,7 +461,10 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
       },
       required: ["matter_id"],
     },
-    anonymized: { exposure: "anonymize", textFields: ["documents[].name"] },
+    anonymized: {
+      exposure: "anonymize",
+      textFields: [DOCUMENT_LIST_TEXT_FIELD_PATH],
+    },
     name: "list_documents",
     scope: "stella:read",
   },
@@ -153,14 +500,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     },
     anonymized: {
       exposure: "anonymize",
-      textFields: [
-        "name",
-        "fields[].value",
-        "version.fields[].value",
-        "versions[].label",
-        "versions[].description",
-        "diff.segments[].text",
-      ],
+      textFields: READ_DOCUMENT_TEXT_FIELD_PATHS,
     },
     name: "read_document",
     scope: "stella:read",
@@ -259,7 +599,10 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
       },
       required: ["matter_id"],
     },
-    anonymized: { exposure: "anonymize", textFields: ["properties[].name"] },
+    anonymized: {
+      exposure: "anonymize",
+      textFields: [PROPERTY_LIST_TEXT_FIELD_PATH],
+    },
     name: "list_properties",
     scope: "stella:read",
   },
@@ -306,123 +649,6 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     scope: "stella:documents_write",
   },
 ] as const satisfies readonly McpToolDefinition[];
-
-/**
- * Queue one anonymizable text field onto a structured egress plan, skipping
- * null/empty values. `apply` writes the anonymized value back into the payload.
- */
-const pushTextField = ({
-  apply,
-  fields: sink,
-  value,
-  workspaceId,
-}: {
-  apply: (value: string) => void;
-  fields: McpStructuredTextField[];
-  value: string | null | undefined;
-  workspaceId: string;
-}): void => {
-  if (typeof value === "string" && value.length > 0) {
-    sink.push({ apply, value, workspaceId });
-  }
-};
-
-/** Anonymize a field's tenant-authored text in place (values, file names). */
-const pushFieldContentTexts = ({
-  content,
-  fields: sink,
-  workspaceId,
-}: {
-  content: FieldContent;
-  fields: McpStructuredTextField[];
-  workspaceId: string;
-}): void => {
-  if (content.type === "text") {
-    pushTextField({
-      apply: (value) => {
-        content.value = value;
-      },
-      fields: sink,
-      value: content.value,
-      workspaceId,
-    });
-    return;
-  }
-  if (content.type === "single-select") {
-    pushTextField({
-      apply: (value) => {
-        content.value = value;
-      },
-      fields: sink,
-      value: content.value,
-      workspaceId,
-    });
-    return;
-  }
-  if (content.type === "multi-select") {
-    const values = content.value;
-    for (const [index, value] of values.entries()) {
-      pushTextField({
-        apply: (next) => {
-          values[index] = next;
-        },
-        fields: sink,
-        value,
-        workspaceId,
-      });
-    }
-    return;
-  }
-  if (content.type === "clip") {
-    pushTextField({
-      apply: (value) => {
-        content.snippet = value;
-      },
-      fields: sink,
-      value: content.snippet,
-      workspaceId,
-    });
-    pushTextField({
-      apply: (value) => {
-        content.citation = value;
-      },
-      fields: sink,
-      value: content.citation,
-      workspaceId,
-    });
-    return;
-  }
-  if (content.type === "file") {
-    pushTextField({
-      apply: (value) => {
-        content.fileName = value;
-      },
-      fields: sink,
-      value: content.fileName,
-      workspaceId,
-    });
-  }
-};
-
-type EntityFieldRow = { content: FieldContent };
-
-const pushEntityFieldsTexts = ({
-  entityFields,
-  fields: sink,
-  workspaceId,
-}: {
-  entityFields: EntityFieldRow[];
-  fields: McpStructuredTextField[];
-  workspaceId: string;
-}): void => {
-  for (const field of entityFields) {
-    pushFieldContentTexts({
-      content: field.content,
-      fields: sink,
-      workspaceId,
-    });
-  }
-};
 
 /** Entity kind the document tools operate on (same set list_documents surfaces). */
 type DocumentEntityKind = (typeof LISTABLE_ENTITY_KINDS)[number];
@@ -651,23 +877,13 @@ const handleListDocumentsTool: McpToolHandler = async ({ args, context }) => {
 
   const documents = page.items.map(({ createdAt: _createdAt, ...doc }) => doc);
 
-  const textFields: McpStructuredTextField[] = [];
-  for (const doc of documents) {
-    pushTextField({
-      apply: (value) => {
-        doc.name = value;
-      },
-      fields: textFields,
-      value: doc.name,
-      workspaceId,
-    });
-  }
+  const payload = { documents, nextCursor: page.nextCursor };
+  const textFields = runTextFieldSpecs(
+    documentListTextFieldSpecs(workspaceId),
+    payload,
+  );
 
-  return {
-    egress: "structured",
-    payload: { documents, nextCursor: page.nextCursor },
-    textFields,
-  };
+  return { egress: "structured", payload, textFields };
 };
 
 // Version-history cursor is [versionNumber, versionId]; keyset paginates
@@ -713,9 +929,9 @@ const readDocumentArgsSchema = v.pipe(
 
 /**
  * One version-history entry. `label` and `description` are tenant-authored, so
- * both must be pushed through `pushTextField` on the anonymized surface; typing
- * them concretely (rather than `unknown[]` at the call site) is what makes that
- * omission visible.
+ * both must be redacted through `readDocumentDefaultTextFieldSpecs` on the
+ * anonymized surface; typing them concretely (rather than `unknown[]` at the
+ * call site) is what makes that omission visible.
  */
 type VersionHistoryEntry = {
   id: SafeId<"entityVersion">;
@@ -875,38 +1091,10 @@ const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
       diff: { baseVersionId, targetVersionId, segments },
     };
 
-    const textFields: McpStructuredTextField[] = [];
-    pushTextField({
-      apply: (value) => {
-        payload.name = value;
-      },
-      fields: textFields,
-      value: payload.name,
-      workspaceId,
-    });
-    for (const segment of segments) {
-      if (segment.kind === "changed") {
-        for (const run of segment.runs) {
-          pushTextField({
-            apply: (value) => {
-              run.text = value;
-            },
-            fields: textFields,
-            value: run.text,
-            workspaceId,
-          });
-        }
-        continue;
-      }
-      pushTextField({
-        apply: (value) => {
-          segment.text = value;
-        },
-        fields: textFields,
-        value: segment.text,
-        workspaceId,
-      });
-    }
+    const textFields = runTextFieldSpecs(
+      readDocumentDiffTextFieldSpecs(workspaceId),
+      payload,
+    );
 
     return { egress: "structured", payload, textFields };
   }
@@ -953,36 +1141,10 @@ const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
         fields: versionFields,
       },
     };
-    const textFields: McpStructuredTextField[] = [];
-    pushTextField({
-      apply: (value) => {
-        payload.name = value;
-      },
-      fields: textFields,
-      value: payload.name,
-      workspaceId,
-    });
-    pushTextField({
-      apply: (value) => {
-        payload.version.label = value;
-      },
-      fields: textFields,
-      value: payload.version.label,
-      workspaceId,
-    });
-    pushTextField({
-      apply: (value) => {
-        payload.version.description = value;
-      },
-      fields: textFields,
-      value: payload.version.description,
-      workspaceId,
-    });
-    pushEntityFieldsTexts({
-      entityFields: versionFields,
-      fields: textFields,
-      workspaceId,
-    });
+    const textFields = runTextFieldSpecs(
+      readDocumentVersionDetailTextFieldSpecs(workspaceId),
+      payload,
+    );
     return { egress: "structured", payload, textFields };
   }
 
@@ -1022,43 +1184,14 @@ const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
       : {}),
   };
 
-  const textFields: McpStructuredTextField[] = [];
-  pushTextField({
-    apply: (value) => {
-      payload.name = value;
-    },
-    fields: textFields,
-    value: payload.name,
-    workspaceId,
-  });
-  pushEntityFieldsTexts({
-    entityFields: current.fields,
-    fields: textFields,
-    workspaceId,
-  });
-  // Version history carries tenant-authored label/description. payload.versions
-  // holds the same entry references, so writing back here anonymizes the
-  // payload in place, matching the specific-version branch above.
-  if (versionHistory) {
-    for (const version of versionHistory.versions) {
-      pushTextField({
-        apply: (value) => {
-          version.label = value;
-        },
-        fields: textFields,
-        value: version.label,
-        workspaceId,
-      });
-      pushTextField({
-        apply: (value) => {
-          version.description = value;
-        },
-        fields: textFields,
-        value: version.description,
-        workspaceId,
-      });
-    }
-  }
+  // Version history carries tenant-authored label/description; payload.versions
+  // holds the same entry references runTextFieldSpecs reads from, so the
+  // write-back anonymizes the served payload in place, matching the
+  // specific-version branch above.
+  const textFields = runTextFieldSpecs(
+    readDocumentDefaultTextFieldSpecs(workspaceId),
+    payload,
+  );
 
   return { egress: "structured", payload, textFields };
 };
@@ -1626,23 +1759,13 @@ const handleListPropertiesTool: McpToolHandler = async ({ args, context }) => {
     status: property.status,
   }));
 
-  const textFields: McpStructuredTextField[] = [];
-  for (const property of propertyList) {
-    pushTextField({
-      apply: (value) => {
-        property.name = value;
-      },
-      fields: textFields,
-      value: property.name,
-      workspaceId,
-    });
-  }
+  const payload = { properties: propertyList, nextCursor: page.nextCursor };
+  const textFields = runTextFieldSpecs(
+    propertyListTextFieldSpecs(workspaceId),
+    payload,
+  );
 
-  return {
-    egress: "structured",
-    payload: { properties: propertyList, nextCursor: page.nextCursor },
-    textFields,
-  };
+  return { egress: "structured", payload, textFields };
 };
 
 const setFieldValueContentSchema = v.variant("type", [

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -11,10 +11,14 @@ import {
   getClauseVersionHandler,
   listClausesHandler,
 } from "@/api/handlers/clauses/read";
-import type { ClauseBody } from "@/api/handlers/clauses/types";
+import type { ClauseBody, ClauseRun } from "@/api/handlers/clauses/types";
 import { isClauseBody } from "@/api/handlers/clauses/types";
 import { updateClauseHandler } from "@/api/handlers/clauses/update";
 import { materializePlaybookRun } from "@/api/handlers/playbooks/materialize-run";
+import type {
+  Position,
+  PositionStandard,
+} from "@/api/handlers/playbooks/positions";
 import {
   getPlaybookDefinitionHandler,
   listPlaybookDefinitionsHandler,
@@ -31,8 +35,13 @@ import {
 } from "@/api/lib/safe-id-boundaries";
 import { startWorkflow } from "@/api/lib/workflow-queue";
 import type { McpRequestContext } from "@/api/mcp/context";
+import {
+  defineTextFieldSpec,
+  deriveTextFieldPaths,
+  runTextFieldSpecs,
+} from "@/api/mcp/text-field-spec";
 import type {
-  McpStructuredTextField,
+  McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
 } from "@/api/mcp/tool-types";
@@ -118,6 +127,358 @@ const clauseBodyProp = {
   items: clauseParagraphItemSchema,
 } as const;
 
+// --- Text-field specs (plan 049, Option B) --------------------------------
+//
+// Every anonymize-mode field below is organization-scoped: clauses and
+// playbooks have no owning workspace, so `organizationId` is the
+// anonymization scope everywhere. `organizationId` is not part of either
+// served payload, so it is threaded in as a builder argument; the
+// definitions below call these same builders with a placeholder id purely to
+// derive the documented `textFields` path list — `deriveTextFieldPaths` only
+// reads each spec's static `path`, never `scope`, so the placeholder never
+// affects the declaration.
+
+/**
+ * Normalized read/write pair over one tenant-authored text unit. A clause
+ * body paragraph's text and its optional inline runs' text both become one
+ * unit apiece, so `clauseBodyTextFieldSpec` below can redact a whole body
+ * (paragraphs + runs) as a single spec instead of re-deriving that shape at
+ * every call site (clause body, clause variant bodies, standalone version
+ * body).
+ */
+type TextUnit = {
+  read: () => string | null | undefined;
+  write: (value: string) => void;
+};
+
+/** A paragraph's inline runs, or an empty list when it has none. */
+const clauseParagraphRuns = (
+  paragraph: ClauseBody[number],
+): readonly ClauseRun[] => {
+  if (paragraph.runs === undefined) {
+    return [];
+  }
+  return paragraph.runs;
+};
+
+const clauseBodyTextUnits = (body: ClauseBody): readonly TextUnit[] =>
+  body.flatMap((paragraph): TextUnit[] => [
+    {
+      read: () => paragraph.text,
+      write: (value) => {
+        paragraph.text = value;
+      },
+    },
+    ...clauseParagraphRuns(paragraph).map((run) => ({
+      read: () => run.text,
+      write: (value: string) => {
+        run.text = value;
+      },
+    })),
+  ]);
+
+/**
+ * One anonymize-mode spec over a whole `ClauseBody`, parameterized on the
+ * `path` (`clause.body[].text` / `clause.variants[].body[].text` /
+ * `version.body[].text`) and the `body` accessor for the branch's payload
+ * shape. Every call site runs this only after its own `isClauseBody` guard
+ * has passed (see the fail-closed control flow in `readClauseDetail`).
+ */
+const clauseBodyTextFieldSpec = <TPayload>({
+  body,
+  organizationId,
+  path,
+}: {
+  body: (payload: TPayload) => ClauseBody;
+  organizationId: string;
+  path: string;
+}): McpTextFieldSpec<TPayload> =>
+  defineTextFieldSpec({
+    path,
+    items: (payload: TPayload) => clauseBodyTextUnits(body(payload)),
+    scope: () => organizationId,
+    read: (unit: TextUnit) => unit.read(),
+    apply: (unit: TextUnit, value) => {
+      unit.write(value);
+    },
+  });
+
+const CLAUSE_BODY_TEXT_FIELD_PATH = "clause.body[].text";
+const CLAUSE_VARIANT_BODY_TEXT_FIELD_PATH = "clause.variants[].body[].text";
+const CLAUSE_VERSION_BODY_TEXT_FIELD_PATH = "version.body[].text";
+
+// --- list_clauses ----------------------------------------------------------
+
+type ClauseListItem = { title: string; description: string | null };
+type ClauseCategoryItem = { name: string; description: string | null };
+
+const clauseListTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<{ clauses: readonly ClauseListItem[] }>[] => [
+  defineTextFieldSpec({
+    path: "clauses[].title",
+    items: (payload) => payload.clauses,
+    scope: () => organizationId,
+    read: (item) => item.title,
+    apply: (item, value) => {
+      item.title = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "clauses[].description",
+    items: (payload) => payload.clauses,
+    scope: () => organizationId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+];
+
+const categoryListTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<{
+  categories: readonly ClauseCategoryItem[];
+}>[] => [
+  defineTextFieldSpec({
+    path: "categories[].name",
+    items: (payload) => payload.categories,
+    scope: () => organizationId,
+    read: (item) => item.name,
+    apply: (item, value) => {
+      item.name = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "categories[].description",
+    items: (payload) => payload.categories,
+    scope: () => organizationId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+];
+
+type ClauseCoreItem = {
+  title: string;
+  description: string | null;
+  usageNotes: string | null;
+};
+
+/** Clause detail: title/description/usageNotes. Pushed unconditionally
+ * before either `isClauseBody` guard in `readClauseDetail` runs — matching
+ * the original handler, where these are pushed first and only discarded (via
+ * the guard's early error return) if the body turns out malformed. */
+const clauseCoreTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<{ clause: ClauseCoreItem }>[] => [
+  defineTextFieldSpec({
+    path: "clause.title",
+    items: (payload) => [payload.clause],
+    scope: () => organizationId,
+    read: (item) => item.title,
+    apply: (item, value) => {
+      item.title = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "clause.description",
+    items: (payload) => [payload.clause],
+    scope: () => organizationId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "clause.usageNotes",
+    items: (payload) => [payload.clause],
+    scope: () => organizationId,
+    read: (item) => item.usageNotes,
+    apply: (item, value) => {
+      item.usageNotes = value;
+    },
+  }),
+];
+
+type ClauseVariantLabelItem = { label: string };
+
+const variantLabelTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<{ variant: ClauseVariantLabelItem }>[] => [
+  defineTextFieldSpec({
+    path: "clause.variants[].label",
+    items: (payload) => [payload.variant],
+    scope: () => organizationId,
+    read: (item) => item.label,
+    apply: (item, value) => {
+      item.label = value;
+    },
+  }),
+];
+
+const LIST_CLAUSES_TEXT_FIELD_PATHS = [
+  ...deriveTextFieldPaths(clauseListTextFieldSpecs("")),
+  ...deriveTextFieldPaths(categoryListTextFieldSpecs("")),
+  ...deriveTextFieldPaths(clauseCoreTextFieldSpecs("")),
+  CLAUSE_BODY_TEXT_FIELD_PATH,
+  ...deriveTextFieldPaths(variantLabelTextFieldSpecs("")),
+  CLAUSE_VARIANT_BODY_TEXT_FIELD_PATH,
+  CLAUSE_VERSION_BODY_TEXT_FIELD_PATH,
+];
+
+// --- list_playbooks ---------------------------------------------------------
+
+type PlaybookListItem = { name: string; description: string | null };
+
+const playbookListTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<{ items: readonly PlaybookListItem[] }>[] => [
+  defineTextFieldSpec({
+    path: "items[].name",
+    items: (payload) => payload.items,
+    scope: () => organizationId,
+    read: (item) => item.name,
+    apply: (item, value) => {
+      item.name = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "items[].description",
+    items: (payload) => payload.items,
+    scope: () => organizationId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+];
+
+type PlaybookInlineStandard = Extract<PositionStandard, { source: "inline" }>;
+type PlaybookInlineFallback = NonNullable<
+  PlaybookInlineStandard["fallbacks"]
+>[number];
+
+const playbookInlineStandardItems = (
+  positions: readonly Position[],
+): readonly PlaybookInlineStandard[] =>
+  positions.flatMap((position) =>
+    position.standard.source === "inline" ? [position.standard] : [],
+  );
+
+const playbookStandardFallbacks = (
+  standard: PlaybookInlineStandard,
+): readonly PlaybookInlineFallback[] => {
+  if (standard.fallbacks === undefined) {
+    return [];
+  }
+  return standard.fallbacks;
+};
+
+const playbookInlineFallbackItems = (
+  positions: readonly Position[],
+): readonly PlaybookInlineFallback[] =>
+  playbookInlineStandardItems(positions).flatMap(playbookStandardFallbacks);
+
+type PlaybookDetailPayload = {
+  playbook: {
+    name: string;
+    description: string | null;
+    positions: { items: readonly Position[] };
+  };
+};
+
+/**
+ * Every redactable field on one playbook detail response: the playbook's own
+ * name/description, each position's issue/ask.question/guidance, and — only
+ * for an inline standard (`source === "inline"`, resolved structurally, same
+ * discriminant the handler already checks) — its preferred language and each
+ * fallback's label and text. `standard.fallbacks[].label` was pushed by the
+ * original handler but never declared (the same declared-vs-pushed drift the
+ * `read_document` migration also fixed); deriving the declaration from this
+ * spec closes that gap here too.
+ */
+const playbookDetailTextFieldSpecs = (
+  organizationId: string,
+): readonly McpTextFieldSpec<PlaybookDetailPayload>[] => [
+  defineTextFieldSpec({
+    path: "playbook.name",
+    items: (payload) => [payload.playbook],
+    scope: () => organizationId,
+    read: (item) => item.name,
+    apply: (item, value) => {
+      item.name = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.description",
+    items: (payload) => [payload.playbook],
+    scope: () => organizationId,
+    read: (item) => item.description,
+    apply: (item, value) => {
+      item.description = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.positions.items[].issue",
+    items: (payload) => payload.playbook.positions.items,
+    scope: () => organizationId,
+    read: (item) => item.issue,
+    apply: (item, value) => {
+      item.issue = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.positions.items[].ask.question",
+    items: (payload) => payload.playbook.positions.items,
+    scope: () => organizationId,
+    read: (item) => item.ask.question,
+    apply: (item, value) => {
+      item.ask.question = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.positions.items[].guidance",
+    items: (payload) => payload.playbook.positions.items,
+    scope: () => organizationId,
+    read: (item) => item.guidance,
+    apply: (item, value) => {
+      item.guidance = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.positions.items[].standard.preferred",
+    items: (payload) =>
+      playbookInlineStandardItems(payload.playbook.positions.items),
+    scope: () => organizationId,
+    read: (item) => item.preferred,
+    apply: (item, value) => {
+      item.preferred = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.positions.items[].standard.fallbacks[].label",
+    items: (payload) =>
+      playbookInlineFallbackItems(payload.playbook.positions.items),
+    scope: () => organizationId,
+    read: (item) => item.label,
+    apply: (item, value) => {
+      item.label = value;
+    },
+  }),
+  defineTextFieldSpec({
+    path: "playbook.positions.items[].standard.fallbacks[].text",
+    items: (payload) =>
+      playbookInlineFallbackItems(payload.playbook.positions.items),
+    scope: () => organizationId,
+    read: (item) => item.text,
+    apply: (item, value) => {
+      item.text = value;
+    },
+  }),
+];
+
 export const KNOWLEDGE_TOOL_DEFINITIONS = [
   {
     annotations: { readOnlyHint: true },
@@ -159,19 +520,7 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
     },
     anonymized: {
       exposure: "anonymize",
-      textFields: [
-        "clauses[].title",
-        "clauses[].description",
-        "categories[].name",
-        "categories[].description",
-        "clause.title",
-        "clause.description",
-        "clause.usageNotes",
-        "clause.body[].text",
-        "clause.variants[].label",
-        "clause.variants[].body[].text",
-        "version.body[].text",
-      ],
+      textFields: LIST_CLAUSES_TEXT_FIELD_PATHS,
     },
     name: "list_clauses",
     scope: "stella:read",
@@ -266,15 +615,8 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
     anonymized: {
       exposure: "anonymize",
       textFields: [
-        "items[].name",
-        "items[].description",
-        "playbook.name",
-        "playbook.description",
-        "playbook.positions.items[].issue",
-        "playbook.positions.items[].ask.question",
-        "playbook.positions.items[].guidance",
-        "playbook.positions.items[].standard.preferred",
-        "playbook.positions.items[].standard.fallbacks[].text",
+        ...deriveTextFieldPaths(playbookListTextFieldSpecs("")),
+        ...deriveTextFieldPaths(playbookDetailTextFieldSpecs("")),
       ],
     },
     name: "list_playbooks",
@@ -299,26 +641,6 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
     scope: "stella:knowledge_write",
   },
 ] as const satisfies readonly McpToolDefinition[];
-
-/**
- * Queue one anonymizable text field onto a structured egress plan, skipping
- * null/empty values. `apply` writes the anonymized value back into the payload.
- */
-const pushTextField = ({
-  apply,
-  fields: sink,
-  value,
-  workspaceId,
-}: {
-  apply: (value: string) => void;
-  fields: McpStructuredTextField[];
-  value: string | null | undefined;
-  workspaceId: string;
-}): void => {
-  if (typeof value === "string" && value.length > 0) {
-    sink.push({ apply, value, workspaceId });
-  }
-};
 
 /**
  * Wrap the request-scoped recorder so audit rows written by the reused backing
@@ -351,40 +673,6 @@ const crossFieldOrGeneric = (
 ): string =>
   issues.find((issue) => issue.type === "partial_check")?.message ??
   genericMessage;
-
-/** Anonymize each paragraph's text and inline-run text in a clause body. */
-const pushClauseBodyTexts = ({
-  body,
-  fields: sink,
-  workspaceId,
-}: {
-  body: ClauseBody;
-  fields: McpStructuredTextField[];
-  workspaceId: string;
-}): void => {
-  for (const paragraph of body) {
-    pushTextField({
-      apply: (value) => {
-        paragraph.text = value;
-      },
-      fields: sink,
-      value: paragraph.text,
-      workspaceId,
-    });
-    if (paragraph.runs) {
-      for (const run of paragraph.runs) {
-        pushTextField({
-          apply: (value) => {
-            run.text = value;
-          },
-          fields: sink,
-          value: run.text,
-          workspaceId,
-        });
-      }
-    }
-  }
-};
 
 // --- list_clauses -------------------------------------------------------
 
@@ -460,15 +748,22 @@ const readClauseDetail = async ({
       return errorResult(result.error.message);
     }
     const version = result.value;
+    // Fail-closed (P7): a malformed version body aborts before any push runs,
+    // exactly the Wave 4 fix — kept as inline control flow, unchanged.
     if (!isClauseBody(version.body)) {
       return errorResult("Clause body has an unrecognized format");
     }
-    const textFields: McpStructuredTextField[] = [];
-    pushClauseBodyTexts({
-      body: version.body,
-      fields: textFields,
-      workspaceId: organizationId,
-    });
+    const textFields = runTextFieldSpecs(
+      [
+        clauseBodyTextFieldSpec({
+          path: CLAUSE_VERSION_BODY_TEXT_FIELD_PATH,
+          body: (payload: { version: { body: ClauseBody } }) =>
+            payload.version.body,
+          organizationId,
+        }),
+      ],
+      { version },
+    );
     return { egress: "structured", payload: { version }, textFields } as const;
   }
 
@@ -479,56 +774,55 @@ const readClauseDetail = async ({
     return errorResult(result.error.message);
   }
   const clause = result.value;
-  const textFields: McpStructuredTextField[] = [];
-  pushTextField({
-    apply: (value) => {
-      clause.title = value;
+  // title/description/usageNotes are queued unconditionally, matching the
+  // original handler: if the body guard below fails, this response (and these
+  // fields) is discarded via the early error return before it ever reaches a
+  // caller, same as before.
+  const textFields = runTextFieldSpecs(
+    clauseCoreTextFieldSpecs(organizationId),
+    {
+      clause,
     },
-    fields: textFields,
-    value: clause.title,
-    workspaceId: organizationId,
-  });
-  pushTextField({
-    apply: (value) => {
-      clause.description = value;
-    },
-    fields: textFields,
-    value: clause.description,
-    workspaceId: organizationId,
-  });
-  pushTextField({
-    apply: (value) => {
-      clause.usageNotes = value;
-    },
-    fields: textFields,
-    value: clause.usageNotes,
-    workspaceId: organizationId,
-  });
+  );
+  // Fail-closed (P7): kept as inline control flow, unchanged, at the same
+  // point relative to the pushes above and below.
   if (!isClauseBody(clause.body)) {
     return errorResult("Clause body has an unrecognized format");
   }
-  pushClauseBodyTexts({
-    body: clause.body,
-    fields: textFields,
-    workspaceId: organizationId,
-  });
+  textFields.push(
+    ...runTextFieldSpecs(
+      [
+        clauseBodyTextFieldSpec({
+          path: CLAUSE_BODY_TEXT_FIELD_PATH,
+          body: (payload: { body: ClauseBody }) => payload.body,
+          organizationId,
+        }),
+      ],
+      { body: clause.body },
+    ),
+  );
   for (const variant of clause.variants) {
-    pushTextField({
-      apply: (value) => {
-        variant.label = value;
-      },
-      fields: textFields,
-      value: variant.label,
-      workspaceId: organizationId,
-    });
+    textFields.push(
+      ...runTextFieldSpecs(variantLabelTextFieldSpecs(organizationId), {
+        variant,
+      }),
+    );
+    // Fail-closed (P7): kept inline inside the variant loop, unchanged.
     if (!isClauseBody(variant.body)) {
       return errorResult("Clause body has an unrecognized format");
     }
-    pushClauseBodyTexts({
-      body: variant.body,
-      fields: textFields,
-      workspaceId: organizationId,
-    });
+    textFields.push(
+      ...runTextFieldSpecs(
+        [
+          clauseBodyTextFieldSpec({
+            path: CLAUSE_VARIANT_BODY_TEXT_FIELD_PATH,
+            body: (payload: { body: ClauseBody }) => payload.body,
+            organizationId,
+          }),
+        ],
+        { body: variant.body },
+      ),
+    );
   }
   return { egress: "structured", payload: { clause }, textFields } as const;
 };
@@ -598,55 +892,21 @@ const handleListClausesTool: McpToolHandler = async ({ args, context }) => {
       ? categoriesResult.value.categories
       : undefined;
 
-  const textFields: McpStructuredTextField[] = [];
-  for (const clause of clauses) {
-    pushTextField({
-      apply: (value) => {
-        clause.title = value;
-      },
-      fields: textFields,
-      value: clause.title,
-      workspaceId: organizationId,
-    });
-    pushTextField({
-      apply: (value) => {
-        clause.description = value;
-      },
-      fields: textFields,
-      value: clause.description,
-      workspaceId: organizationId,
-    });
-  }
-  if (categories) {
-    for (const category of categories) {
-      pushTextField({
-        apply: (value) => {
-          category.name = value;
-        },
-        fields: textFields,
-        value: category.name,
-        workspaceId: organizationId,
-      });
-      pushTextField({
-        apply: (value) => {
-          category.description = value;
-        },
-        fields: textFields,
-        value: category.description,
-        workspaceId: organizationId,
-      });
-    }
-  }
-
-  return {
-    egress: "structured",
-    payload: {
-      clauses,
-      ...(categories ? { categories } : {}),
-      nextCursor: listed.value.nextCursor,
-    },
-    textFields,
+  const payload = {
+    clauses,
+    ...(categories ? { categories } : {}),
+    nextCursor: listed.value.nextCursor,
   };
+  const textFields = [
+    ...runTextFieldSpecs(clauseListTextFieldSpecs(organizationId), payload),
+    ...(categories
+      ? runTextFieldSpecs(categoryListTextFieldSpecs(organizationId), {
+          categories,
+        })
+      : []),
+  ];
+
+  return { egress: "structured", payload, textFields };
 };
 
 // --- save_clause --------------------------------------------------------
@@ -932,80 +1192,10 @@ const readPlaybookDetail = async ({
   }
   const playbook = result.value;
 
-  const textFields: McpStructuredTextField[] = [];
-  pushTextField({
-    apply: (value) => {
-      playbook.name = value;
-    },
-    fields: textFields,
-    value: playbook.name,
-    workspaceId: organizationId,
-  });
-  pushTextField({
-    apply: (value) => {
-      playbook.description = value;
-    },
-    fields: textFields,
-    value: playbook.description,
-    workspaceId: organizationId,
-  });
-  for (const position of playbook.positions.items) {
-    pushTextField({
-      apply: (value) => {
-        position.issue = value;
-      },
-      fields: textFields,
-      value: position.issue,
-      workspaceId: organizationId,
-    });
-    pushTextField({
-      apply: (value) => {
-        position.ask.question = value;
-      },
-      fields: textFields,
-      value: position.ask.question,
-      workspaceId: organizationId,
-    });
-    pushTextField({
-      apply: (value) => {
-        position.guidance = value;
-      },
-      fields: textFields,
-      value: position.guidance,
-      workspaceId: organizationId,
-    });
-    if (position.standard.source === "inline") {
-      const standard = position.standard;
-      pushTextField({
-        apply: (value) => {
-          standard.preferred = value;
-        },
-        fields: textFields,
-        value: standard.preferred,
-        workspaceId: organizationId,
-      });
-      if (standard.fallbacks !== undefined) {
-        for (const fallback of standard.fallbacks) {
-          pushTextField({
-            apply: (value) => {
-              fallback.label = value;
-            },
-            fields: textFields,
-            value: fallback.label,
-            workspaceId: organizationId,
-          });
-          pushTextField({
-            apply: (value) => {
-              fallback.text = value;
-            },
-            fields: textFields,
-            value: fallback.text,
-            workspaceId: organizationId,
-          });
-        }
-      }
-    }
-  }
+  const textFields = runTextFieldSpecs(
+    playbookDetailTextFieldSpecs(organizationId),
+    { playbook },
+  );
 
   return { egress: "structured", payload: { playbook }, textFields } as const;
 };
@@ -1049,31 +1239,13 @@ const handleListPlaybooksTool: McpToolHandler = async ({ args, context }) => {
   }
   const items = listed.value.items;
 
-  const textFields: McpStructuredTextField[] = [];
-  for (const item of items) {
-    pushTextField({
-      apply: (value) => {
-        item.name = value;
-      },
-      fields: textFields,
-      value: item.name,
-      workspaceId: organizationId,
-    });
-    pushTextField({
-      apply: (value) => {
-        item.description = value;
-      },
-      fields: textFields,
-      value: item.description,
-      workspaceId: organizationId,
-    });
-  }
+  const payload = { items, nextCursor: listed.value.nextCursor };
+  const textFields = runTextFieldSpecs(
+    playbookListTextFieldSpecs(organizationId),
+    payload,
+  );
 
-  return {
-    egress: "structured",
-    payload: { items, nextCursor: listed.value.nextCursor },
-    textFields,
-  };
+  return { egress: "structured", payload, textFields };
 };
 
 // --- run_playbook -------------------------------------------------------


### PR DESCRIPTION
Final module pair of the egress spec migration (plan 049): document and knowledge tool anonymization fields become typed specs with derived declarations. The FieldContent union walk keeps full narrowing (now a TextUnit producer feeding one spec per field group); every fail-closed clause-body guard stays inline at its original position. Derivation surfaced two more pushed-but-undeclared fields (single-version label/description, playbook fallback labels), now documented by construction. Canary suite unchanged and green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved anonymised document and knowledge responses across listings and detailed views.
  * More text in document names, properties, clauses, playbooks, and document content is now consistently hidden when exported or viewed through MCP tools.

* **Bug Fixes**
  * Made anonymisation more reliable for mixed content, including document diffs and version details.
  * Reduced the chance of sensitive text appearing in list and detail results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->