### PR TITLE
feat: add a registry adapter layer for chat code-mode tools

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/ref-registry.ts
+++ b/apps/api/src/handlers/chat/tools/execute/ref-registry.ts
@@ -39,7 +39,7 @@ const escapeMarkdownLinkLabel = (label: string) =>
 const createEntityRefKey = ({ entityId, workspaceId }: EntityTarget) =>
   `${workspaceId}:${entityId}`;
 
-type EntityTarget = {
+export type EntityTarget = {
   entityId: SafeId<"entity">;
   workspaceId: SafeId<"workspace">;
 };
@@ -140,6 +140,15 @@ export type ChatRefRegistry = {
   resolveEntityRefs: (
     refs: string[],
   ) => Result<SafeId<"entity">[], ChatToolError>;
+  /**
+   * Like `resolveEntityRefs`, but keeps each ref's owning workspace id
+   * alongside its entity id. Callers that need to mint a ref for a
+   * *different* entity known to share the resolved ref's workspace (e.g. a
+   * task's linked entities) use this instead of discarding the workspace id.
+   */
+  resolveEntityRefTargets: (
+    refs: string[],
+  ) => Result<EntityTarget[], ChatToolError>;
   resolveMatterRefs: (
     refs: string[],
   ) => Result<SafeId<"workspace">[], ChatToolError>;
@@ -440,6 +449,12 @@ export const createChatRefRegistry = (): ChatRefRegistry => {
 
       return Result.ok(resolved.value.map(({ entityId }) => entityId));
     },
+    resolveEntityRefTargets: (refs: string[]) =>
+      resolveRefs({
+        kind: "entity",
+        refs,
+        state: entityState,
+      }),
     resolveContactRefs: (refs: string[]) =>
       resolveRefs({
         kind: "contact",

--- a/apps/api/src/handlers/chat/tools/registry-adapter/mcp-chat-context.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/mcp-chat-context.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import type { ChatRegistryContextDeps } from "./mcp-chat-context";
+import { buildMcpContextFromChat } from "./mcp-chat-context";
+
+const workspaceOne = toSafeId<"workspace">("ws_1");
+const workspaceTwo = toSafeId<"workspace">("ws_2");
+
+const buildDeps = (
+  overrides: Partial<ChatRegistryContextDeps> = {},
+): ChatRegistryContextDeps => {
+  const { safeDb, scopedDb } = createScopedDbMock({});
+  return {
+    organizationId: toSafeId<"organization">("org_1"),
+    userId: toSafeId<"user">("user_1"),
+    memberRole: "owner",
+    safeDb,
+    scopedDb,
+    toolWorkspaceIds: resolveToolWorkspaceIds({
+      accessibleWorkspaceIds: [workspaceOne, workspaceTwo],
+      pinnedIds: [],
+    }),
+    ...overrides,
+  };
+};
+
+describe("buildMcpContextFromChat", () => {
+  test("maps every McpRequestContext field from chat-resolved state", () => {
+    const deps = buildDeps();
+    const context = buildMcpContextFromChat(deps);
+
+    expect(context.accessibleWorkspaceIds).toEqual([
+      workspaceOne,
+      workspaceTwo,
+    ]);
+    expect([...context.accessibleWorkspaceIdSet]).toEqual([
+      workspaceOne,
+      workspaceTwo,
+    ]);
+    // No status carried by chat's authorized ids, and read tools never consult
+    // it: every authorized workspace defaults to "active".
+    expect(context.accessibleWorkspaceStatusById).toEqual(
+      new Map([
+        [workspaceOne, "active"],
+        [workspaceTwo, "active"],
+      ]),
+    );
+    expect(context.memberRole).toBe(deps.memberRole);
+    expect(context.organizationId).toBe(deps.organizationId);
+    expect(context.userId).toBe(deps.userId);
+    expect(context.safeDb).toBe(deps.safeDb);
+    expect(context.scopedDb).toBe(deps.scopedDb);
+  });
+
+  test("copies the workspace id list instead of aliasing the input", () => {
+    const deps = buildDeps();
+    const context = buildMcpContextFromChat(deps);
+    expect(context.accessibleWorkspaceIds).not.toBe(deps.toolWorkspaceIds);
+  });
+
+  test("threads a supplied audit recorder through, and no-ops when absent", async () => {
+    const recorder = asTestRaw<AuditRecorder & ReturnType<typeof mock>>(
+      mock(async () => undefined),
+    );
+    expect(
+      buildMcpContextFromChat(buildDeps({ recordAuditEvent: recorder }))
+        .recordAuditEvent,
+    ).toBe(recorder);
+
+    // Absent recorder resolves to a callable no-op, never undefined.
+    const noop = buildMcpContextFromChat(
+      buildDeps({ recordAuditEvent: undefined }),
+    ).recordAuditEvent;
+    expect(typeof noop).toBe("function");
+    const settled = noop(asTestRaw(null), asTestRaw({ action: "noop" }));
+    expect(settled).toBeInstanceOf(Promise);
+    await settled;
+  });
+
+  test("uses a supplied per-workspace status override when the writer path needs it", () => {
+    const context = buildMcpContextFromChat(
+      buildDeps({
+        workspaceStatusById: new Map([[workspaceTwo, "archived"]]),
+      }),
+    );
+    expect(context.accessibleWorkspaceStatusById.get(workspaceOne)).toBe(
+      "active",
+    );
+    expect(context.accessibleWorkspaceStatusById.get(workspaceTwo)).toBe(
+      "archived",
+    );
+  });
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/mcp-chat-context.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/mcp-chat-context.ts
@@ -1,0 +1,96 @@
+import type { SafeDb, ScopedDb } from "@/api/db";
+import type { AuthorizedToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { AccessibleWorkspace } from "@/api/lib/auth";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { MemberRole } from "@/api/lib/member-roles";
+import type { McpRequestContext } from "@/api/mcp/context";
+
+/**
+ * Everything a chat request has already resolved that an `McpRequestContext`
+ * needs. These are the same values `getChatTools` threads into the execution
+ * tools today (`chat-tools.ts`), just gathered into one shape. Typed against the
+ * adapter's own contract (not chat's live types) so this step can widen inputs
+ * without touching live chat.
+ */
+export type ChatRegistryContextDeps = {
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  memberRole: MemberRole;
+  safeDb: SafeDb;
+  scopedDb: ScopedDb;
+  /**
+   * The request's authorized workspace set. `getChatTools` already resolves
+   * this via `resolveToolWorkspaceIds` (pins intersected with the accessible
+   * set), so it is the correct source for `accessibleWorkspaceIds`.
+   */
+  toolWorkspaceIds: AuthorizedToolWorkspaceIds;
+  /**
+   * Optional, like chat's own `getChatTools` param. Read tools do not mutate,
+   * so there is nothing to audit today; it is threaded through so any future
+   * logging inside a projected handler is not silently dropped, and defaults to
+   * a no-op when chat does not supply one.
+   */
+  recordAuditEvent?: AuditRecorder | undefined;
+  /**
+   * Optional per-workspace status. Chat's `AuthorizedToolWorkspaceIds` is a
+   * bare id list and carries no status; every projected read tool gates
+   * workspace access on the id set alone (`ensureWorkspaceAccess`) and never
+   * consults `accessibleWorkspaceStatusById` (only write tools do, via
+   * `ensureActiveWorkspace` / `getWorkspaceStatus`). So this defaults to
+   * "active" for every authorized workspace: a value that is never read on the
+   * read path. It is accepted here so the write-tool driver (a later step) can
+   * supply real statuses without reshaping this adapter.
+   */
+  workspaceStatusById?:
+    | ReadonlyMap<string, AccessibleWorkspace["status"]>
+    | undefined;
+};
+
+// eslint-disable-next-line promise-function-async -- read tools never record audit events; this returns a resolved promise directly, and `async` would only add a redundant wrapper with nothing to await (which `require-await` then rejects)
+const NO_OP_AUDIT_RECORDER: AuditRecorder = () => Promise.resolve();
+
+const deriveWorkspaceStatusMap = ({
+  toolWorkspaceIds,
+  workspaceStatusById,
+}: ChatRegistryContextDeps): Map<string, AccessibleWorkspace["status"]> => {
+  const statusById = new Map<string, AccessibleWorkspace["status"]>();
+  for (const workspaceId of toolWorkspaceIds) {
+    statusById.set(
+      workspaceId,
+      workspaceStatusById?.get(workspaceId) ?? "active",
+    );
+  }
+  return statusById;
+};
+
+/**
+ * Project a chat request's already-resolved session/workspace state onto the
+ * `McpRequestContext` the registry handlers expect. A thin mapping, not a new
+ * resolution path: no DB query, no membership lookup.
+ *
+ * Scope/feature gating is deliberately NOT applied here. MCP dispatch gates a
+ * tool on its `ToolScope` (the caller's OAuth scope) and its
+ * `McpToolFeatureFlag` (a deploy flag). OAuth scopes have no meaning for a
+ * session-authed chat turn: reaching `getChatTools` already means the request
+ * passed the coarser workspace/role authorization that governs reads, so scope
+ * gating is dropped. Feature-flag gating still matters (a tool's backing surface
+ * can be off on this deployment) and is re-checked in the orchestrator, not
+ * here, where the tool name is known.
+ */
+export const buildMcpContextFromChat = (
+  deps: ChatRegistryContextDeps,
+): McpRequestContext => {
+  const accessibleWorkspaceIds = [...deps.toolWorkspaceIds];
+  return {
+    accessibleWorkspaceIds,
+    accessibleWorkspaceIdSet: new Set(accessibleWorkspaceIds),
+    accessibleWorkspaceStatusById: deriveWorkspaceStatusMap(deps),
+    memberRole: deps.memberRole,
+    organizationId: deps.organizationId,
+    recordAuditEvent: deps.recordAuditEvent ?? NO_OP_AUDIT_RECORDER,
+    safeDb: deps.safeDb,
+    scopedDb: deps.scopedDb,
+    userId: deps.userId,
+  };
+};

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -1,0 +1,392 @@
+import type { DEFAULT_MCP_TOOL_DEFINITIONS } from "@/api/mcp/static-tool-definitions";
+
+/**
+ * The read-only slice of the MCP registry, derived structurally from the single
+ * source of truth. `DEFAULT_MCP_TOOL_DEFINITIONS` is declared `as const`, so its
+ * element union carries each tool's literal `access`, and filtering by
+ * `{ access: "read" }` yields exactly the read-tool name union. A newly added
+ * read tool widens this union, which makes the `satisfies` on
+ * `READ_TOOL_REF_FIELD_MAP` below fail typecheck until an explicit ref decision
+ * is recorded for it: the same class-guard shape the anonymized projection uses.
+ */
+type ReadToolDefinition = Extract<
+  (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
+  { access: "read" }
+>;
+
+export type RegistryReadToolName = ReadToolDefinition["name"];
+
+/**
+ * The four tenant-content id kinds the chat ref registry mediates
+ * (`createChatRefRegistry`). Every other id a registry handler emits (user,
+ * task-link, invoice, time-entry, template, clause, playbook, audit-log,
+ * usage-plan, or public case-law/BOE corpus id) is a handle the model may pass
+ * back verbatim, not a tenant-content reference, so it stays outside this set.
+ */
+export type RegistryRefKind = "matter" | "entity" | "contact" | "property";
+
+type SimpleRefKind = Exclude<RegistryRefKind, "entity">;
+
+/**
+ * How an entity output ref recovers its owning workspace id, which
+ * `toEntityRef` needs alongside the entity id. MCP handlers name these fields
+ * differently per tool (a sibling `workspaceId`, a fixed `matter.id`, or the
+ * tool's resolved `matter_id` input), so the source is declared per field
+ * rather than guessed from key names.
+ */
+export type EntityWorkspaceSource =
+  | { from: "sibling"; key: string }
+  | { from: "outputPath"; path: string }
+  | { from: "inputParam"; param: string }
+  // The output entity IS the request's own entity input; the orchestrator
+  // reuses the ref it dehydrated on the way in, so no workspace lookup runs.
+  | { from: "inputEntity"; param: string };
+
+/**
+ * One UUID-bearing output path and the tenant ref kind it carries. `path` uses
+ * the same `a.b` / `a[].b` grammar as the egress text-field specs. Entity
+ * fields additionally declare where their owning workspace id lives.
+ */
+export type OutputRefField =
+  | { kind: SimpleRefKind; path: string }
+  | { kind: "entity"; path: string; workspace: EntityWorkspaceSource };
+
+/** One input parameter that accepts a chat ref, and the id kind it resolves to. */
+export type InputRefParam = { kind: RegistryRefKind; param: string };
+
+export type RegistryRefFieldMapEntry = {
+  /**
+   * Whether chat may project this read tool at all. `false` marks a read tool
+   * deliberately kept off the chat surface (rationale in the entry's comment);
+   * the orchestrator refuses to dispatch it, so a tool that cannot satisfy the
+   * "no tenant UUID reaches the model" invariant by static field mapping is
+   * never reachable from chat.
+   */
+  chatProjectable: boolean;
+  inputRefs: readonly InputRefParam[];
+  outputRefs: readonly OutputRefField[];
+  /**
+   * UUID-bearing output paths intentionally left un-refed, each with a
+   * rationale in a comment. Forces an explicit decision per tool: an id here is
+   * either a non-tenant handle (user/invoice/template/audit/public-corpus id)
+   * or an entity id whose owning workspace is not statically recoverable and is
+   * deferred to the manifest-swap step. Documentation only; never walked.
+   */
+  passthroughIdPaths: readonly string[];
+};
+
+/**
+ * Per-tool ref decision for every read tool in the MCP registry. Keyed by the
+ * derived `RegistryReadToolName` union via `satisfies`, so the map is
+ * exhaustive by construction: a read tool with no entry here cannot compile.
+ */
+export const READ_TOOL_REF_FIELD_MAP = {
+  // --- OpenAI-compat shims: not projected to chat ---------------------------
+  // `fetch`/`search` duplicate read_content_across_matters /
+  // search_across_matters and additionally emit `url` (and `metadata`) fields
+  // that embed raw workspace/entity UUIDs inside a string the ref walker cannot
+  // rewrite without reparsing URLs. Chat projects the native equivalents
+  // instead, so these are kept off the chat surface.
+  fetch: {
+    chatProjectable: false,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "id (entity handle)",
+      "url (embeds workspace + entity UUIDs)",
+    ],
+  },
+  search: {
+    chatProjectable: false,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "results[].id (entity handle)",
+      "results[].url (embeds workspace + entity UUIDs)",
+    ],
+  },
+
+  // --- Matters / contacts / content -----------------------------------------
+  list_matters: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    outputRefs: [
+      { kind: "matter", path: "matters[].id" },
+      { kind: "matter", path: "matter.id" },
+      { kind: "contact", path: "contacts[].contactId" },
+      {
+        kind: "entity",
+        path: "overview.recentEntities[].id",
+        // Detail mode: every recent entity belongs to the one matter this
+        // response describes, so its workspace is the payload's `matter.id`.
+        workspace: { from: "outputPath", path: "matter.id" },
+      },
+    ],
+    passthroughIdPaths: [
+      "contacts[].workspaceContactId (matter-contact link handle, no chat ref kind)",
+      "members[].userId (user handle, no chat ref kind)",
+      "nextCursor (opaque base64 cursor; not UUID-formatted)",
+    ],
+  },
+  search_across_matters: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [
+      { kind: "matter", path: "hits[].workspaceId" },
+      {
+        kind: "entity",
+        path: "hits[].entityId",
+        workspace: { from: "sibling", key: "workspaceId" },
+      },
+    ],
+    passthroughIdPaths: [],
+  },
+  read_content_across_matters: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "entity", param: "entity_id" }],
+    outputRefs: [
+      { kind: "matter", path: "workspaceId" },
+      {
+        kind: "entity",
+        path: "entityId",
+        workspace: { from: "sibling", key: "workspaceId" },
+      },
+    ],
+    passthroughIdPaths: [],
+  },
+  read_contact: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "contact", param: "contact_id" }],
+    outputRefs: [{ kind: "contact", path: "contactId" }],
+    passthroughIdPaths: [],
+  },
+
+  // --- Documents / properties -----------------------------------------------
+  list_documents: {
+    chatProjectable: true,
+    inputRefs: [
+      { kind: "matter", param: "matter_id" },
+      { kind: "entity", param: "parent_id" },
+    ],
+    outputRefs: [
+      {
+        kind: "entity",
+        path: "documents[].id",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+      {
+        kind: "entity",
+        path: "documents[].parentId",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+    ],
+    passthroughIdPaths: [
+      "nextCursor (opaque [createdAt, id] cursor; embeds an entity id, not UUID-formatted)",
+    ],
+  },
+  read_document: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "entity", param: "entity_id" }],
+    outputRefs: [
+      {
+        kind: "entity",
+        path: "entityId",
+        workspace: { from: "inputEntity", param: "entity_id" },
+      },
+      { kind: "property", path: "fields[].propertyId" },
+      { kind: "property", path: "version.fields[].propertyId" },
+    ],
+    passthroughIdPaths: [
+      "version.id / versions[].id (entity-version handles, no chat ref kind)",
+      "fields[].id (field row handles, no chat ref kind)",
+    ],
+  },
+  list_properties: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    outputRefs: [{ kind: "property", path: "properties[].id" }],
+    passthroughIdPaths: [
+      "nextCursor (opaque [createdAt, id] cursor; not UUID-formatted)",
+    ],
+  },
+
+  // --- Tasks -----------------------------------------------------------------
+  list_tasks: {
+    chatProjectable: true,
+    inputRefs: [
+      { kind: "matter", param: "matter_id" },
+      { kind: "entity", param: "task_id" },
+    ],
+    outputRefs: [
+      {
+        kind: "entity",
+        path: "tasks[].id",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+      {
+        kind: "entity",
+        path: "task.taskId",
+        workspace: { from: "inputEntity", param: "task_id" },
+      },
+    ],
+    passthroughIdPaths: [
+      // A linked entity's owning workspace is the task's matter, which detail
+      // mode does not surface and does not require `matter_id` to reach. Minting
+      // its ref needs the extra lookup the manifest-swap step adds; deferred.
+      "task.links[].entity.id (linked entity id; owning workspace not statically recoverable)",
+      "task.assignees[].userId (user handle, no chat ref kind)",
+      "task.links[].linkId (entity-link handle, no chat ref kind)",
+    ],
+  },
+
+  // --- Knowledge: org-scoped handles, no tenant refs ------------------------
+  // Clause and playbook ids are org-scoped library handles the model passes
+  // back verbatim; they are not one of the four tenant ref kinds.
+  list_clauses: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "clauses[].id / clause.id (clause handle)",
+      "clause.variants[].id, version ids, category ids (library handles)",
+    ],
+  },
+  list_playbooks: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: ["items[].id / playbook.id (playbook handle)"],
+  },
+
+  // --- Billing: entity refs on line items, rest are billing handles ---------
+  list_time_entries: {
+    chatProjectable: true,
+    inputRefs: [
+      { kind: "matter", param: "matter_id" },
+      { kind: "entity", param: "entity_id" },
+    ],
+    outputRefs: [
+      {
+        kind: "entity",
+        path: "entries[].entityId",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+      {
+        kind: "entity",
+        path: "entry.entityId",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+    ],
+    passthroughIdPaths: [
+      "entries[].id / entry.id (time-entry handles)",
+      "entries[].userId / entry.userId (user handles)",
+      "nextCursor (opaque [dateWorked, id] cursor; not UUID-formatted)",
+    ],
+  },
+  resolve_rate: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    outputRefs: [],
+    passthroughIdPaths: [],
+  },
+  list_invoices: {
+    chatProjectable: true,
+    inputRefs: [{ kind: "matter", param: "matter_id" }],
+    outputRefs: [
+      {
+        kind: "entity",
+        path: "invoice.timeEntries[].entityId",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+      {
+        kind: "entity",
+        path: "invoice.timeEntries[].entity.id",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+      {
+        kind: "entity",
+        path: "invoice.expenses[].entityId",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+      {
+        kind: "entity",
+        path: "invoice.expenses[].entity.id",
+        workspace: { from: "inputParam", param: "matter_id" },
+      },
+    ],
+    passthroughIdPaths: [
+      "invoices[].id / invoice.id (invoice handles)",
+      "invoice.timeEntries[].id, invoice.expenses[].id (line-item handles)",
+      "nextCursor (opaque [createdAt, id] cursor; not UUID-formatted)",
+    ],
+  },
+  get_usage: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "entitlement.id, policy.id (org billing-plan ids, not tenant refs)",
+    ],
+  },
+
+  // --- Public corpora: public ids, no tenant refs ---------------------------
+  search_case_law: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "results[].decisionId, source_id (public case-law corpus ids)",
+    ],
+  },
+  read_case_law_decision: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "decision.decisionId, decision_id (public case-law corpus ids)",
+    ],
+  },
+  search_legislation: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "lawId, blockId (public BOE statute ids, not tenant refs)",
+    ],
+  },
+  lookup_business_registry: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [],
+  },
+
+  // --- Templates: org-scoped template handles -------------------------------
+  list_templates: {
+    chatProjectable: true,
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "templates[].id / template_id (org template handle, no chat ref kind)",
+    ],
+  },
+
+  // --- Audit log: not projected to chat -------------------------------------
+  // Excluded from the anonymized surface (`dynamic_tenant_payload`) for the
+  // same reason it cannot be safely ref-mediated: `metadata`/`changes` are
+  // free-form JSON that may embed any tenant id or tenant text under keys the
+  // walker cannot enumerate, and `nextCursor` embeds the audit-log id verbatim.
+  // Static field mapping cannot guarantee no tenant UUID leaks, so it stays off
+  // the chat surface until a payload-shaping step handles it.
+  list_audit_log: {
+    chatProjectable: false,
+    // `resource_id` is polymorphic (its kind depends on `resource_type`), so it
+    // is deliberately not declared as any single ref kind; the tool is off the
+    // chat surface anyway, so no input dehydration runs.
+    inputRefs: [],
+    outputRefs: [],
+    passthroughIdPaths: [
+      "items[].workspaceId, items[].resourceId (polymorphic), metadata, changes (unenumerable tenant payload)",
+    ],
+  },
+} as const satisfies Record<RegistryReadToolName, RegistryRefFieldMapEntry>;

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -72,11 +72,18 @@ export type RegistryRefFieldMapEntry = {
   inputRefs: readonly InputRefParam[];
   outputRefs: readonly OutputRefField[];
   /**
-   * UUID-bearing output paths intentionally left un-refed, each with a
-   * rationale in a comment. Forces an explicit decision per tool: an id here is
-   * either a non-tenant handle (user/invoice/template/audit/public-corpus id)
-   * or an entity id whose owning workspace is not statically recoverable and is
-   * deferred to the manifest-swap step. Documentation only; never walked.
+   * UUID-bearing output paths intentionally left un-refed. Each path uses the
+   * same `a.b` / `a[].b` grammar as `outputRefs`. Forces an explicit decision
+   * per tool: an id here is either a non-tenant handle (user/invoice/
+   * template/audit/public-corpus id) or an entity id whose owning workspace is
+   * not statically recoverable and is deferred to the manifest-swap step.
+   *
+   * Load-bearing, not documentation: `findUndeclaredUuidPath`
+   * (`ref-mediation.ts`) walks the hydrated payload and allows a surviving
+   * raw uuid only at one of these exact paths. An `outputRefs` path is
+   * deliberately NOT part of this allowlist — hydration must have already
+   * rewritten it to a chat ref, so a uuid still there means hydration missed
+   * it, which fails closed the same as an undeclared path.
    */
   passthroughIdPaths: readonly string[];
 };
@@ -92,23 +99,24 @@ export const READ_TOOL_REF_FIELD_MAP = {
   // search_across_matters and additionally emit `url` (and `metadata`) fields
   // that embed raw workspace/entity UUIDs inside a string the ref walker cannot
   // rewrite without reparsing URLs. Chat projects the native equivalents
-  // instead, so these are kept off the chat surface.
+  // instead, so these are kept off the chat surface: `chatProjectable: false`
+  // makes the paths below inert (the orchestrator refuses the tool before the
+  // backstop ever walks its payload), they are listed only so the shape stays
+  // documented if that ever changes.
   fetch: {
     chatProjectable: false,
     inputRefs: [],
     outputRefs: [],
-    passthroughIdPaths: [
-      "id (entity handle)",
-      "url (embeds workspace + entity UUIDs)",
-    ],
+    passthroughIdPaths: ["id", "url", "workspaceId"],
   },
   search: {
     chatProjectable: false,
     inputRefs: [],
     outputRefs: [],
     passthroughIdPaths: [
-      "results[].id (entity handle)",
-      "results[].url (embeds workspace + entity UUIDs)",
+      "results[].id",
+      "results[].url",
+      "results[].workspaceId",
     ],
   },
 
@@ -132,10 +140,13 @@ export const READ_TOOL_REF_FIELD_MAP = {
         workspace: { from: "outputPath", path: "matter.id" },
       },
     ],
+    // Matter-contact link ids and workspace member (user) ids are handles
+    // with no chat ref kind; `nextCursor` is an opaque base64 cursor (not
+    // UUID-formatted).
     passthroughIdPaths: [
-      "contacts[].workspaceContactId (matter-contact link handle, no chat ref kind)",
-      "members[].userId (user handle, no chat ref kind)",
-      "nextCursor (opaque base64 cursor; not UUID-formatted)",
+      "contacts[].workspaceContactId",
+      "members[].userId",
+      "nextCursor",
     ],
   },
   search_across_matters: {
@@ -190,9 +201,8 @@ export const READ_TOOL_REF_FIELD_MAP = {
         workspace: { from: "inputParam", param: "matter_id" },
       },
     ],
-    passthroughIdPaths: [
-      "nextCursor (opaque [createdAt, id] cursor; embeds an entity id, not UUID-formatted)",
-    ],
+    // Opaque `[createdAt, id]` cursor; embeds an entity id, not UUID-formatted.
+    passthroughIdPaths: ["nextCursor"],
   },
   read_document: {
     chatProjectable: true,
@@ -206,18 +216,27 @@ export const READ_TOOL_REF_FIELD_MAP = {
       { kind: "property", path: "fields[].propertyId" },
       { kind: "property", path: "version.fields[].propertyId" },
     ],
+    // Entity-version handles (`version.id`/`versions[].id`, the specific-
+    // version branch's own `version.fields[].id`, and the diff branch's
+    // `diff.baseVersionId`/`diff.targetVersionId`), field-row handles
+    // (`fields[].id`), and `versionsNextCursor`, an opaque
+    // `[versionNumber, entityVersionId]` cursor — none carry a chat ref kind.
     passthroughIdPaths: [
-      "version.id / versions[].id (entity-version handles, no chat ref kind)",
-      "fields[].id (field row handles, no chat ref kind)",
+      "version.id",
+      "versions[].id",
+      "version.fields[].id",
+      "fields[].id",
+      "diff.baseVersionId",
+      "diff.targetVersionId",
+      "versionsNextCursor",
     ],
   },
   list_properties: {
     chatProjectable: true,
     inputRefs: [{ kind: "matter", param: "matter_id" }],
     outputRefs: [{ kind: "property", path: "properties[].id" }],
-    passthroughIdPaths: [
-      "nextCursor (opaque [createdAt, id] cursor; not UUID-formatted)",
-    ],
+    // Opaque `[createdAt, id]` cursor; not UUID-formatted.
+    passthroughIdPaths: ["nextCursor"],
   },
 
   // --- Tasks -----------------------------------------------------------------
@@ -252,9 +271,13 @@ export const READ_TOOL_REF_FIELD_MAP = {
         workspace: { from: "inputEntityWorkspace", param: "task_id" },
       },
     ],
+    // Assignee ids are user handles, link ids are entity-link handles
+    // (neither carries a chat ref kind); `nextCursor` is an opaque
+    // `[createdAt, id]` cursor embedding an entity id, not UUID-formatted.
     passthroughIdPaths: [
-      "task.assignees[].userId (user handle, no chat ref kind)",
-      "task.links[].linkId (entity-link handle, no chat ref kind)",
+      "task.assignees[].userId",
+      "task.links[].linkId",
+      "nextCursor",
     ],
   },
 
@@ -265,16 +288,39 @@ export const READ_TOOL_REF_FIELD_MAP = {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
+    // Clause, category, variant, and clause-version ids are org-scoped
+    // library handles; `clause.createdBy` is the authoring user's id (a
+    // `text` column, not a uuid column, but declared defensively in case a
+    // deployment's user ids happen to be uuid-shaped); `nextCursor` is an
+    // opaque `${isoDate}|${clauseId}` cursor.
     passthroughIdPaths: [
-      "clauses[].id / clause.id (clause handle)",
-      "clause.variants[].id, version ids, category ids (library handles)",
+      "clauses[].id",
+      "clauses[].categoryId",
+      "clause.id",
+      "clause.categoryId",
+      "clause.variants[].id",
+      "clause.versions[].id",
+      "clause.createdBy",
+      "categories[].id",
+      "categories[].parentId",
+      "version.id",
+      "nextCursor",
     ],
   },
   list_playbooks: {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
-    passthroughIdPaths: ["items[].id / playbook.id (playbook handle)"],
+    // Playbook ids are org-scoped library handles; a position's `sourceId` is
+    // a client-supplied stable id; a "clause"-sourced standard's `clauseId`
+    // is the same clause-library handle `list_clauses` declares.
+    passthroughIdPaths: [
+      "items[].id",
+      "playbook.id",
+      "playbook.positions.items[].sourceId",
+      "playbook.positions.items[].standard.clauseId",
+      "nextCursor",
+    ],
   },
 
   // --- Billing: entity refs on line items, rest are billing handles ---------
@@ -296,10 +342,14 @@ export const READ_TOOL_REF_FIELD_MAP = {
         workspace: { from: "inputParam", param: "matter_id" },
       },
     ],
+    // Time-entry ids and user ids carry no chat ref kind; `nextCursor` is an
+    // opaque `[dateWorked, id]` cursor, not UUID-formatted.
     passthroughIdPaths: [
-      "entries[].id / entry.id (time-entry handles)",
-      "entries[].userId / entry.userId (user handles)",
-      "nextCursor (opaque [dateWorked, id] cursor; not UUID-formatted)",
+      "entries[].id",
+      "entry.id",
+      "entries[].userId",
+      "entry.userId",
+      "nextCursor",
     ],
   },
   resolve_rate: {
@@ -333,19 +383,23 @@ export const READ_TOOL_REF_FIELD_MAP = {
         workspace: { from: "inputParam", param: "matter_id" },
       },
     ],
+    // Invoice ids and line-item ids (time entry / expense) carry no chat ref
+    // kind; `nextCursor` is an opaque `[createdAt, id]` cursor, not
+    // UUID-formatted.
     passthroughIdPaths: [
-      "invoices[].id / invoice.id (invoice handles)",
-      "invoice.timeEntries[].id, invoice.expenses[].id (line-item handles)",
-      "nextCursor (opaque [createdAt, id] cursor; not UUID-formatted)",
+      "invoices[].id",
+      "invoice.id",
+      "invoice.timeEntries[].id",
+      "invoice.expenses[].id",
+      "nextCursor",
     ],
   },
   get_usage: {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
-    passthroughIdPaths: [
-      "entitlement.id, policy.id (org billing-plan ids, not tenant refs)",
-    ],
+    // Org billing-plan ids, not tenant refs.
+    passthroughIdPaths: ["entitlement.id", "policy.id"],
   },
 
   // --- Public corpora: public ids, no tenant refs ---------------------------
@@ -353,24 +407,42 @@ export const READ_TOOL_REF_FIELD_MAP = {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
-    passthroughIdPaths: [
-      "results[].decisionId, source_id (public case-law corpus ids)",
-    ],
+    // Public case-law corpus id; `source_id` is a request input, never an
+    // output field, so it needs no output-path declaration here.
+    passthroughIdPaths: ["results[].decisionId", "nextCursor"],
   },
   read_case_law_decision: {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
+    // Public case-law corpus ids (decision, citation, and source ids);
+    // `decision.metadata` is free-form jsonb straight from the public court
+    // source and cannot be enumerated by path (same unenumerable-payload
+    // caveat as `list_audit_log`'s `metadata`/`changes`, just over public
+    // rather than tenant data).
     passthroughIdPaths: [
-      "decision.decisionId, decision_id (public case-law corpus ids)",
+      "decision.decisionId",
+      "decision.citationsFrom[].id",
+      "decision.citationsFrom[].citedDecisionId",
+      "decision.citationsTo[].id",
+      "decision.citationsTo[].citingDecisionId",
+      "decision.source.id",
+      "nextCursor",
     ],
   },
   search_legislation: {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
+    // Public BOE statute ids, not tenant refs. Never actually UUID-formatted
+    // (`lawId` is schema-validated against the `BOE-*` id pattern; `blockId`
+    // and `data[].identificador` are declared defensively since `blockId` is
+    // an unvalidated request-argument echo).
     passthroughIdPaths: [
-      "lawId, blockId (public BOE statute ids, not tenant refs)",
+      "lawId",
+      "blockId",
+      "law.lawId",
+      "data[].identificador",
     ],
   },
   lookup_business_registry: {
@@ -385,9 +457,10 @@ export const READ_TOOL_REF_FIELD_MAP = {
     chatProjectable: true,
     inputRefs: [],
     outputRefs: [],
-    passthroughIdPaths: [
-      "templates[].id / template_id (org template handle, no chat ref kind)",
-    ],
+    // Org template handle; `template_id` is a request input, not an output
+    // field, so it needs no output-path declaration. Detail mode's describe
+    // payload carries no id fields at all.
+    passthroughIdPaths: ["templates[].id", "nextCursor"],
   },
 
   // --- Audit log: not projected to chat -------------------------------------
@@ -404,8 +477,10 @@ export const READ_TOOL_REF_FIELD_MAP = {
     // chat surface anyway, so no input dehydration runs.
     inputRefs: [],
     outputRefs: [],
-    passthroughIdPaths: [
-      "items[].workspaceId, items[].resourceId (polymorphic), metadata, changes (unenumerable tenant payload)",
-    ],
+    // `items[].resourceId` is polymorphic and `metadata`/`changes` are
+    // unenumerable free-form tenant JSON, so no path list here could make
+    // this payload safe to walk. Moot in practice: `chatProjectable: false`
+    // means the backstop never runs against this tool's output at all.
+    passthroughIdPaths: ["items[].workspaceId", "items[].resourceId"],
   },
 } as const satisfies Record<RegistryReadToolName, RegistryRefFieldMapEntry>;

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -38,6 +38,12 @@ export type EntityWorkspaceSource =
   | { from: "sibling"; key: string }
   | { from: "outputPath"; path: string }
   | { from: "inputParam"; param: string }
+  // The output entity is a *different* entity than the request's own entity
+  // input named by `param`, but is validated (at write time, outside this
+  // orchestrator) to share its workspace, e.g. a task's linked entities. The
+  // workspace is the one already resolved when `param`'s ref was dehydrated,
+  // not a fresh lookup.
+  | { from: "inputEntityWorkspace"; param: string }
   // The output entity IS the request's own entity input; the orchestrator
   // reuses the ref it dehydrated on the way in, so no workspace lookup runs.
   | { from: "inputEntity"; param: string };
@@ -116,7 +122,11 @@ export const READ_TOOL_REF_FIELD_MAP = {
       { kind: "contact", path: "contacts[].contactId" },
       {
         kind: "entity",
-        path: "overview.recentEntities[].id",
+        // The overview handler's item field is `entityId`, not `id`
+        // (`readOverviewHandler` returns `{ entityId: e.id, ... }`); the path
+        // must match the actual key or the walker silently skips every slot
+        // and the raw entity uuid reaches the model.
+        path: "overview.recentEntities[].entityId",
         // Detail mode: every recent entity belongs to the one matter this
         // response describes, so its workspace is the payload's `matter.id`.
         workspace: { from: "outputPath", path: "matter.id" },
@@ -228,12 +238,21 @@ export const READ_TOOL_REF_FIELD_MAP = {
         path: "task.taskId",
         workspace: { from: "inputEntity", param: "task_id" },
       },
+      {
+        kind: "entity",
+        path: "task.links[].entity.id",
+        // Entity links are validated same-workspace at creation:
+        // `createEntityLinkHandler` (entity-links-create.ts, shared by the
+        // HTTP route and save_task) looks up both the source and target
+        // entities scoped to one ambient `workspaceId` before inserting the
+        // link row, so a linked entity always belongs to the task's own
+        // workspace. Detail mode only reaches this path via `task_id`
+        // (list mode's `tasks[]` carries no `links`), so the workspace
+        // already resolved for that input entity is the correct source.
+        workspace: { from: "inputEntityWorkspace", param: "task_id" },
+      },
     ],
     passthroughIdPaths: [
-      // A linked entity's owning workspace is the task's matter, which detail
-      // mode does not surface and does not require `matter_id` to reach. Minting
-      // its ref needs the extra lookup the manifest-swap step adds; deferred.
-      "task.links[].entity.id (linked entity id; owning workspace not statically recoverable)",
       "task.assignees[].userId (user handle, no chat ref kind)",
       "task.links[].linkId (entity-link handle, no chat ref kind)",
     ],

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
@@ -1,0 +1,189 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  containsRawUuid,
+  dehydrateInputRefs,
+  hydrateOutputRefs,
+} from "./ref-mediation";
+
+const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
+const ENTITY_UUID = "c09ec856-d945-5ecc-82e3-bb5382165f34";
+const PROPERTY_UUID = "37286c24-6145-572e-ad27-15a1d4454d59";
+const CONTACT_UUID = "6111c8e9-1404-5b6f-8a9a-0e3a93e8179a";
+
+const EMPTY_DEHYDRATION = {
+  args: {},
+  resolvedMatterParams: {},
+  dehydratedEntityRefs: new Map<string, string>(),
+};
+
+describe("registry ref mediation", () => {
+  test("matter refs round-trip: dehydrate input, hydrate output, no UUID survives", () => {
+    const registry = createChatRefRegistry();
+    const matterRef = registry.toMatterRef(toSafeId<"workspace">(WS_UUID));
+    expect(matterRef).toBe("mat_1");
+
+    const dehydrated = dehydrateInputRefs({
+      args: { matter_id: matterRef },
+      refRegistry: registry,
+      toolName: "list_matters",
+    }).unwrap();
+    expect(dehydrated.args["matter_id"]).toBe(WS_UUID);
+    expect(dehydrated.resolvedMatterParams["matter_id"]).toBe(
+      toSafeId<"workspace">(WS_UUID),
+    );
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: EMPTY_DEHYDRATION,
+      output: { matters: [{ id: WS_UUID, name: "Acme" }], nextCursor: null },
+      refRegistry: registry,
+      toolName: "list_matters",
+    });
+    expect(hydrated).toEqual({
+      matters: [{ id: matterRef, name: "Acme" }],
+      nextCursor: null,
+    });
+    expect(containsRawUuid(hydrated)).toBe(false);
+  });
+
+  test("entity refs round-trip via a sibling workspace id", () => {
+    const registry = createChatRefRegistry();
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: EMPTY_DEHYDRATION,
+      output: {
+        hits: [{ entityId: ENTITY_UUID, workspaceId: WS_UUID, name: "Brief" }],
+      },
+      refRegistry: registry,
+      toolName: "search_across_matters",
+    });
+    // The entity ref is minted from (entityId, sibling workspaceId); the
+    // workspace id itself becomes a matter ref. Neither UUID survives.
+    expect(hydrated).toEqual({
+      hits: [{ entityId: "ent_1", workspaceId: "mat_1", name: "Brief" }],
+    });
+    expect(containsRawUuid(hydrated)).toBe(false);
+
+    // Inverse: the same entity ref dehydrates back to its UUID on input.
+    const dehydrated = dehydrateInputRefs({
+      args: { entity_id: "ent_1" },
+      refRegistry: registry,
+      toolName: "read_content_across_matters",
+    }).unwrap();
+    expect(dehydrated.args["entity_id"]).toBe(ENTITY_UUID);
+  });
+
+  test("contact refs round-trip: dehydrate input, hydrate output", () => {
+    const registry = createChatRefRegistry();
+    const contactRef = registry.toContactRef(toSafeId<"contact">(CONTACT_UUID));
+
+    const dehydrated = dehydrateInputRefs({
+      args: { contact_id: contactRef },
+      refRegistry: registry,
+      toolName: "read_contact",
+    }).unwrap();
+    expect(dehydrated.args["contact_id"]).toBe(CONTACT_UUID);
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: EMPTY_DEHYDRATION,
+      output: { contactId: CONTACT_UUID, displayName: "Jane" },
+      refRegistry: registry,
+      toolName: "read_contact",
+    });
+    expect(hydrated).toEqual({ contactId: contactRef, displayName: "Jane" });
+    expect(containsRawUuid(hydrated)).toBe(false);
+  });
+
+  test("property refs hydrate and resolve back through the registry", () => {
+    const registry = createChatRefRegistry();
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: EMPTY_DEHYDRATION,
+      output: { properties: [{ id: PROPERTY_UUID, name: "Amount" }] },
+      refRegistry: registry,
+      toolName: "list_properties",
+    });
+    expect(hydrated).toEqual({
+      properties: [{ id: "prop_1", name: "Amount" }],
+    });
+    expect(registry.resolvePropertyRefs(["prop_1"]).unwrap()).toEqual([
+      toSafeId<"property">(PROPERTY_UUID),
+    ]);
+  });
+
+  test("an output entity that is the request's own input reuses its ref without a workspace lookup", () => {
+    const registry = createChatRefRegistry();
+    const entityRef = registry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
+    });
+
+    const dehydrated = dehydrateInputRefs({
+      args: { entity_id: entityRef },
+      refRegistry: registry,
+      toolName: "read_document",
+    }).unwrap();
+    expect(dehydrated.dehydratedEntityRefs.get(ENTITY_UUID)).toBe(entityRef);
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: dehydrated,
+      output: {
+        entityId: ENTITY_UUID,
+        name: "Contract",
+        fields: [{ propertyId: PROPERTY_UUID }],
+      },
+      refRegistry: registry,
+      toolName: "read_document",
+    });
+    expect(hydrated).toEqual({
+      entityId: entityRef,
+      name: "Contract",
+      fields: [{ propertyId: "prop_1" }],
+    });
+    expect(containsRawUuid(hydrated)).toBe(false);
+  });
+
+  test("an entity output ref draws its workspace from the resolved matter input", () => {
+    const registry = createChatRefRegistry();
+    const matterRef = registry.toMatterRef(toSafeId<"workspace">(WS_UUID));
+
+    const dehydrated = dehydrateInputRefs({
+      args: { matter_id: matterRef },
+      refRegistry: registry,
+      toolName: "list_documents",
+    }).unwrap();
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: dehydrated,
+      output: {
+        documents: [{ id: ENTITY_UUID, parentId: null, name: "Draft" }],
+        nextCursor: null,
+      },
+      refRegistry: registry,
+      toolName: "list_documents",
+    });
+    expect(hydrated).toEqual({
+      documents: [{ id: "ent_1", parentId: null, name: "Draft" }],
+      nextCursor: null,
+    });
+    expect(containsRawUuid(hydrated)).toBe(false);
+  });
+
+  test("an unknown ref surfaces the registry's ChatToolError", () => {
+    const result = dehydrateInputRefs({
+      args: { matter_id: "mat_999" },
+      refRegistry: createChatRefRegistry(),
+      toolName: "list_matters",
+    });
+    expect(Result.isError(result)).toBe(true);
+  });
+
+  test("containsRawUuid flags an un-hydrated payload", () => {
+    expect(containsRawUuid({ id: WS_UUID })).toBe(true);
+    expect(containsRawUuid({ id: "mat_1" })).toBe(false);
+  });
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
@@ -12,12 +12,14 @@ import {
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
 const ENTITY_UUID = "c09ec856-d945-5ecc-82e3-bb5382165f34";
+const LINKED_ENTITY_UUID = "1e7f7f2a-9b2b-4c40-8ab1-2f5b6c7d8e9f";
 const PROPERTY_UUID = "37286c24-6145-572e-ad27-15a1d4454d59";
 const CONTACT_UUID = "6111c8e9-1404-5b6f-8a9a-0e3a93e8179a";
 
 const EMPTY_DEHYDRATION = {
   args: {},
   resolvedMatterParams: {},
+  resolvedEntityParams: {},
   dehydratedEntityRefs: new Map<string, string>(),
 };
 
@@ -171,6 +173,70 @@ describe("registry ref mediation", () => {
       nextCursor: null,
     });
     expect(containsRawUuid(hydrated)).toBe(false);
+  });
+
+  test("list_tasks: a linked entity ref draws its workspace from the task_id input, not the reuse map", () => {
+    const registry = createChatRefRegistry();
+    const taskRef = registry.toEntityRef({
+      entityId: toSafeId<"entity">(ENTITY_UUID),
+      workspaceId: toSafeId<"workspace">(WS_UUID),
+    });
+
+    const dehydrated = dehydrateInputRefs({
+      args: { task_id: taskRef },
+      refRegistry: registry,
+      toolName: "list_tasks",
+    }).unwrap();
+    expect(dehydrated.args["task_id"]).toBe(ENTITY_UUID);
+    expect(dehydrated.resolvedEntityParams["task_id"]).toBe(
+      toSafeId<"workspace">(WS_UUID),
+    );
+
+    const hydrated = hydrateOutputRefs({
+      dehydration: dehydrated,
+      output: {
+        task: {
+          taskId: ENTITY_UUID,
+          name: "Draft reply",
+          links: [
+            {
+              linkId: "link-1",
+              linkType: "related",
+              direction: "outgoing",
+              entity: {
+                id: LINKED_ENTITY_UUID,
+                name: "Exhibit A",
+                kind: "document",
+              },
+            },
+          ],
+        },
+      },
+      refRegistry: registry,
+      toolName: "list_tasks",
+    });
+
+    // The task's own id reuses its input ref; the linked entity (a different
+    // uuid) mints a new ref scoped to the same workspace, not the task's own
+    // ref and not an un-hydrated raw uuid.
+    expect(hydrated).toEqual({
+      task: {
+        taskId: taskRef,
+        name: "Draft reply",
+        links: [
+          {
+            linkId: "link-1",
+            linkType: "related",
+            direction: "outgoing",
+            entity: { id: "ent_2", name: "Exhibit A", kind: "document" },
+          },
+        ],
+      },
+    });
+    expect(containsRawUuid(hydrated)).toBe(false);
+    expect(registry.resolveEntityRefs(["ent_2"]).unwrap()).toEqual([
+      toSafeId<"entity">(LINKED_ENTITY_UUID),
+    ]);
   });
 
   test("an unknown ref surfaces the registry's ChatToolError", () => {

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.test.ts
@@ -7,6 +7,7 @@ import { toSafeId } from "@/api/lib/branded-types";
 import {
   containsRawUuid,
   dehydrateInputRefs,
+  findUndeclaredUuidPath,
   hydrateOutputRefs,
 } from "./ref-mediation";
 
@@ -251,5 +252,84 @@ describe("registry ref mediation", () => {
   test("containsRawUuid flags an un-hydrated payload", () => {
     expect(containsRawUuid({ id: WS_UUID })).toBe(true);
     expect(containsRawUuid({ id: "mat_1" })).toBe(false);
+  });
+
+  describe("findUndeclaredUuidPath", () => {
+    const INVOICE_UUID = "9c9f2a9e-2f0a-4b7a-9a0e-2e7a1a2b3c4d";
+    const LINE_ITEM_UUID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
+    // A list_invoices-style detail-branch payload, post-hydration: the
+    // entity refs `hydrateOutputRefs` mints for the invoice's tenant
+    // content (an `outputRefs` path) already read as chat refs, while the
+    // invoice id and the time-entry's own id are non-tenant handles the
+    // map declares in `passthroughIdPaths` and never mediates.
+    const invoiceFixture = {
+      invoice: {
+        id: INVOICE_UUID,
+        status: "draft",
+        timeEntries: [
+          {
+            id: LINE_ITEM_UUID,
+            entityId: "ent_1",
+            entity: { id: "ent_1", name: "Brief" },
+          },
+        ],
+        expenses: [],
+      },
+    };
+
+    test("a list_invoices-style fixture with only declared passthrough ids passes", () => {
+      expect(
+        findUndeclaredUuidPath({
+          payload: invoiceFixture,
+          toolName: "list_invoices",
+        }),
+      ).toBeUndefined();
+    });
+
+    test("a rogue uuid at an undeclared path fails closed with that path", () => {
+      const doctored = {
+        invoice: {
+          ...invoiceFixture.invoice,
+          // Not one of list_invoices's outputRefs or passthroughIdPaths: an
+          // ordinary field nothing stops from holding a raw uuid.
+          notes: WS_UUID,
+        },
+      };
+
+      expect(
+        findUndeclaredUuidPath({
+          payload: doctored,
+          toolName: "list_invoices",
+        }),
+      ).toBe("invoice.notes");
+    });
+
+    test("a uuid surviving at a declared outputRefs path fails closed (simulated hydration miss)", () => {
+      // `invoice.timeEntries[].entityId` is a declared `outputRefs` entity
+      // path: `hydrateOutputRefs` should always have rewritten it to a chat
+      // ref. Leaving it a raw uuid simulates a hydration miss (an
+      // unresolved workspace source, say), which the passthrough allowlist
+      // must NOT paper over: `outputRefs` paths are deliberately excluded
+      // from it.
+      const doctored = {
+        invoice: {
+          ...invoiceFixture.invoice,
+          timeEntries: [
+            {
+              id: LINE_ITEM_UUID,
+              entityId: ENTITY_UUID,
+              entity: { id: "ent_1", name: "Brief" },
+            },
+          ],
+        },
+      };
+
+      expect(
+        findUndeclaredUuidPath({
+          payload: doctored,
+          toolName: "list_invoices",
+        }),
+      ).toBe("invoice.timeEntries[].entityId");
+    });
   });
 });

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -101,6 +101,15 @@ export type DehydratedInput = {
   args: Record<string, unknown>;
   /** Resolved workspace uuid per matter input param, for entity output refs. */
   resolvedMatterParams: Record<string, SafeId<"workspace">>;
+  /**
+   * Resolved workspace uuid per entity input param, for output entities that
+   * are *different* from the input entity but share its workspace (e.g. a
+   * task's linked entities). `resolvedMatterParams` covers the reverse case
+   * (workspace named directly); this covers the entity-ref case, where the
+   * workspace is recovered from the ref the caller already resolved rather
+   * than from a fresh lookup.
+   */
+  resolvedEntityParams: Record<string, SafeId<"workspace">>;
   /** entity uuid -> the ref it was dehydrated from, for reuse on output. */
   dehydratedEntityRefs: Map<string, string>;
 };
@@ -126,6 +135,7 @@ export const dehydrateInputRefs = ({
 }): Result<DehydratedInput, ChatToolError> => {
   const nextArgs = { ...args };
   const resolvedMatterParams: Record<string, SafeId<"workspace">> = {};
+  const resolvedEntityParams: Record<string, SafeId<"workspace">> = {};
   const dehydratedEntityRefs = new Map<string, string>();
 
   for (const { kind, param } of READ_TOOL_REF_FIELD_MAP[toolName].inputRefs) {
@@ -147,12 +157,13 @@ export const dehydrateInputRefs = ({
       continue;
     }
     if (kind === "entity") {
-      const resolved = refRegistry.resolveEntityRefs([raw]);
+      const resolved = refRegistry.resolveEntityRefTargets([raw]);
       if (Result.isError(resolved)) {
         return Result.err(resolved.error);
       }
-      const entityId = takeSingle(resolved.value);
+      const { entityId, workspaceId } = takeSingle(resolved.value);
       nextArgs[param] = entityId;
+      resolvedEntityParams[param] = workspaceId;
       dehydratedEntityRefs.set(entityId, raw);
       continue;
     }
@@ -171,6 +182,7 @@ export const dehydrateInputRefs = ({
   return Result.ok({
     args: nextArgs,
     resolvedMatterParams,
+    resolvedEntityParams,
     dehydratedEntityRefs,
   });
 };
@@ -197,8 +209,12 @@ const resolveEntityWorkspaceUuid = ({
   if (source.from === "inputParam") {
     return dehydration.resolvedMatterParams[source.param];
   }
+  if (source.from === "inputEntityWorkspace") {
+    return dehydration.resolvedEntityParams[source.param];
+  }
   // "inputEntity": the output entity is the request's own entity input, so its
   // ref is minted from the reuse map below, never from a workspace lookup.
+  source.from satisfies "inputEntity";
   return undefined;
 };
 

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -1,0 +1,326 @@
+import { panic, Result } from "better-result";
+
+import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import {
+  brandPersistedContactId,
+  brandPersistedEntityId,
+  brandPersistedPropertyId,
+  brandPersistedWorkspaceId,
+} from "@/api/lib/safe-id-boundaries";
+
+import type {
+  EntityWorkspaceSource,
+  OutputRefField,
+  RegistryReadToolName,
+} from "./ref-field-map";
+import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const UUID_ANYWHERE_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/iu;
+
+const isUuidString = (value: unknown): value is string =>
+  typeof value === "string" && UUID_REGEX.test(value);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * A verbatim-UUID guard for the "no tenant UUID reaches the model" invariant.
+ * After ref hydration a projected read tool's payload must serialize without any
+ * raw UUID: every tenant id is a ref and every non-tenant handle in the map's
+ * `passthroughIdPaths` is documented as either non-UUID-formatted (opaque
+ * cursors) or an out-of-band handle. Tests assert this holds.
+ */
+export const containsRawUuid = (value: unknown): boolean =>
+  UUID_ANYWHERE_REGEX.test(JSON.stringify(value));
+
+// --- path grammar -----------------------------------------------------------
+// Paths use the same `a.b` / `a[].b` shape as the egress text-field specs. A
+// step is one dotted token; a `[]` suffix means "descend into the array at this
+// key, then continue into each item". The final step is always a scalar key.
+
+type PathStep = { key: string; array: boolean };
+
+const parsePath = (path: string): readonly PathStep[] =>
+  path.split(".").map((token) => {
+    const array = token.endsWith("[]");
+    return { key: array ? token.slice(0, -2) : token, array };
+  });
+
+/**
+ * Visit every `(container, key)` slot a path resolves to, mutating in place. The
+ * caller owns the parsed JSON payload, so in-place edits are safe. Missing or
+ * wrong-typed intermediates are skipped rather than thrown: a tool's optional
+ * branch (list vs. detail) simply produces no slots for the other branch's
+ * paths.
+ */
+const visitPathSlots = (
+  root: unknown,
+  steps: readonly PathStep[],
+  visit: (container: Record<string, unknown>, key: string) => void,
+): void => {
+  const [step, ...rest] = steps;
+  if (step === undefined || !isRecord(root)) {
+    return;
+  }
+  if (rest.length === 0) {
+    visit(root, step.key);
+    return;
+  }
+  const child = root[step.key];
+  if (step.array) {
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        visitPathSlots(item, rest, visit);
+      }
+    }
+    return;
+  }
+  visitPathSlots(child, rest, visit);
+};
+
+/** Read the first scalar a (non-array) absolute path resolves to. */
+const readScalarAtPath = (root: unknown, path: string): unknown => {
+  let cursor: unknown = root;
+  for (const step of parsePath(path)) {
+    if (!isRecord(cursor)) {
+      return undefined;
+    }
+    cursor = cursor[step.key];
+  }
+  return cursor;
+};
+
+// --- input dehydration ------------------------------------------------------
+
+export type DehydratedInput = {
+  args: Record<string, unknown>;
+  /** Resolved workspace uuid per matter input param, for entity output refs. */
+  resolvedMatterParams: Record<string, SafeId<"workspace">>;
+  /** entity uuid -> the ref it was dehydrated from, for reuse on output. */
+  dehydratedEntityRefs: Map<string, string>;
+};
+
+const takeSingle = <T>(values: readonly T[]): T =>
+  values.at(0) ?? panic("resolved ref list is unexpectedly empty");
+
+/**
+ * Replace every input ref arg (`mat_N`/`ent_N`/`contact_N`/`prop_N`) with the
+ * real UUID the registry handler expects, via the chat ref registry. An unknown
+ * ref surfaces as the registry's own `ChatToolError`. Records the resolved
+ * workspace ids and entity refs so output hydration can mint entity refs and
+ * reuse the request's own entity ref.
+ */
+export const dehydrateInputRefs = ({
+  toolName,
+  args,
+  refRegistry,
+}: {
+  toolName: RegistryReadToolName;
+  args: Record<string, unknown>;
+  refRegistry: ChatRefRegistry;
+}): Result<DehydratedInput, ChatToolError> => {
+  const nextArgs = { ...args };
+  const resolvedMatterParams: Record<string, SafeId<"workspace">> = {};
+  const dehydratedEntityRefs = new Map<string, string>();
+
+  for (const { kind, param } of READ_TOOL_REF_FIELD_MAP[toolName].inputRefs) {
+    const raw = args[param];
+    if (typeof raw !== "string") {
+      // The param is optional and absent (or already a non-ref value); nothing
+      // to resolve.
+      continue;
+    }
+
+    if (kind === "matter") {
+      const resolved = refRegistry.resolveMatterRefs([raw]);
+      if (Result.isError(resolved)) {
+        return Result.err(resolved.error);
+      }
+      const workspaceId = takeSingle(resolved.value);
+      nextArgs[param] = workspaceId;
+      resolvedMatterParams[param] = workspaceId;
+      continue;
+    }
+    if (kind === "entity") {
+      const resolved = refRegistry.resolveEntityRefs([raw]);
+      if (Result.isError(resolved)) {
+        return Result.err(resolved.error);
+      }
+      const entityId = takeSingle(resolved.value);
+      nextArgs[param] = entityId;
+      dehydratedEntityRefs.set(entityId, raw);
+      continue;
+    }
+    // `contact` is the only remaining input ref kind across the read tools; no
+    // read tool declares a `property` input ref (only the write tool
+    // set_field_value does). Adding one would widen `kind` here and break this
+    // `satisfies`, forcing the extra branch to be written.
+    kind satisfies "contact";
+    const resolved = refRegistry.resolveContactRefs([raw]);
+    if (Result.isError(resolved)) {
+      return Result.err(resolved.error);
+    }
+    nextArgs[param] = takeSingle(resolved.value);
+  }
+
+  return Result.ok({
+    args: nextArgs,
+    resolvedMatterParams,
+    dehydratedEntityRefs,
+  });
+};
+
+// --- output hydration -------------------------------------------------------
+
+const resolveEntityWorkspaceUuid = ({
+  container,
+  dehydration,
+  root,
+  source,
+}: {
+  container: Record<string, unknown>;
+  dehydration: DehydratedInput;
+  root: unknown;
+  source: EntityWorkspaceSource;
+}): unknown => {
+  if (source.from === "sibling") {
+    return container[source.key];
+  }
+  if (source.from === "outputPath") {
+    return readScalarAtPath(root, source.path);
+  }
+  if (source.from === "inputParam") {
+    return dehydration.resolvedMatterParams[source.param];
+  }
+  // "inputEntity": the output entity is the request's own entity input, so its
+  // ref is minted from the reuse map below, never from a workspace lookup.
+  return undefined;
+};
+
+const hydrateEntitySlot = ({
+  container,
+  dehydration,
+  key,
+  refRegistry,
+  root,
+  source,
+}: {
+  container: Record<string, unknown>;
+  dehydration: DehydratedInput;
+  key: string;
+  refRegistry: ChatRefRegistry;
+  root: unknown;
+  source: EntityWorkspaceSource;
+}): void => {
+  const value = container[key];
+  if (!isUuidString(value)) {
+    return;
+  }
+
+  // The output entity IS one the request named on input: reuse the ref already
+  // minted for it, so no workspace lookup is needed.
+  const reused = dehydration.dehydratedEntityRefs.get(value);
+  if (reused !== undefined) {
+    container[key] = reused;
+    return;
+  }
+
+  const workspaceUuid = resolveEntityWorkspaceUuid({
+    container,
+    dehydration,
+    root,
+    source,
+  });
+  if (!isUuidString(workspaceUuid)) {
+    // Owning workspace not recoverable for this field (a deferred case, tracked
+    // in the map's passthroughIdPaths); leave the id untouched rather than mint
+    // a ref against a guessed workspace.
+    return;
+  }
+
+  container[key] = refRegistry.toEntityRef({
+    entityId: brandPersistedEntityId(value),
+    workspaceId: brandPersistedWorkspaceId(workspaceUuid),
+  });
+};
+
+const hydrateSimpleSlot = ({
+  container,
+  field,
+  key,
+  refRegistry,
+}: {
+  container: Record<string, unknown>;
+  field: Extract<OutputRefField, { kind: "matter" | "contact" | "property" }>;
+  key: string;
+  refRegistry: ChatRefRegistry;
+}): void => {
+  const value = container[key];
+  if (!isUuidString(value)) {
+    return;
+  }
+  if (field.kind === "matter") {
+    container[key] = refRegistry.toMatterRef(brandPersistedWorkspaceId(value));
+    return;
+  }
+  if (field.kind === "contact") {
+    container[key] = refRegistry.toContactRef(brandPersistedContactId(value));
+    return;
+  }
+  container[key] = refRegistry.toPropertyRef(brandPersistedPropertyId(value));
+};
+
+/**
+ * Rewrite every tenant UUID a projected read tool emits into its chat ref, in
+ * place, driven by the tool's declared output ref fields. The payload is the
+ * caller-owned JSON.parsed object, so it is mutated and returned. Fields the map
+ * leaves un-refed (non-tenant handles, deferred entity ids) are untouched.
+ */
+export const hydrateOutputRefs = ({
+  toolName,
+  output,
+  refRegistry,
+  dehydration,
+}: {
+  toolName: RegistryReadToolName;
+  output: unknown;
+  refRegistry: ChatRefRegistry;
+  dehydration: DehydratedInput;
+}): unknown => {
+  const { outputRefs } = READ_TOOL_REF_FIELD_MAP[toolName];
+
+  // Entity refs first: an entity's `sibling`/`outputPath` workspace source reads
+  // a workspace UUID that a matter ref in the same payload would otherwise
+  // overwrite with a `mat_N` ref before the entity ref is minted.
+  for (const field of outputRefs) {
+    if (field.kind !== "entity") {
+      continue;
+    }
+    visitPathSlots(output, parsePath(field.path), (container, key) => {
+      hydrateEntitySlot({
+        container,
+        dehydration,
+        key,
+        refRegistry,
+        root: output,
+        source: field.workspace,
+      });
+    });
+  }
+
+  for (const field of outputRefs) {
+    if (field.kind === "entity") {
+      continue;
+    }
+    visitPathSlots(output, parsePath(field.path), (container, key) => {
+      hydrateSimpleSlot({ container, field, key, refRegistry });
+    });
+  }
+
+  return output;
+};

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-mediation.ts
@@ -38,6 +38,75 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 export const containsRawUuid = (value: unknown): boolean =>
   UUID_ANYWHERE_REGEX.test(JSON.stringify(value));
 
+// --- path-aware UUID backstop ------------------------------------------------
+
+export type UuidPathHit = { path: string; value: string };
+
+/**
+ * Walk every string leaf in a payload, recording the normalized path (dot-
+ * joined, arrays collapsed to `[]`, the same `a.b` / `a[].b` grammar
+ * `outputRefs`/`passthroughIdPaths` use) of every value that matches the UUID
+ * pattern anywhere in the string. A substring match (not just a bare-UUID
+ * exact match) so a UUID embedded inside a longer string (a url, free text)
+ * is still caught, matching the whole-payload check this replaces.
+ */
+const walkUuidPaths = (
+  node: unknown,
+  path: readonly string[],
+  hits: UuidPathHit[],
+): void => {
+  if (typeof node === "string") {
+    if (UUID_ANYWHERE_REGEX.test(node)) {
+      hits.push({ path: path.join("."), value: node });
+    }
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walkUuidPaths(item, path, hits);
+    }
+    return;
+  }
+  if (!isRecord(node)) {
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const segment = Array.isArray(value) ? `${key}[]` : key;
+    walkUuidPaths(value, [...path, segment], hits);
+  }
+};
+
+/** Every UUID-matching string value in a payload, with its normalized path. */
+export const collectUuidPaths = (payload: unknown): readonly UuidPathHit[] => {
+  const hits: UuidPathHit[] = [];
+  walkUuidPaths(payload, [], hits);
+  return hits;
+};
+
+/**
+ * Find the first UUID surviving in a hydrated read-tool payload at a path the
+ * tool's ref-field-map entry does not license. Only `passthroughIdPaths`
+ * grants a path permission to still hold a raw UUID (a declared non-tenant
+ * handle); an `outputRefs` path is deliberately excluded from this allowlist,
+ * since `hydrateOutputRefs` should have already rewritten it to a chat ref —
+ * a UUID still there means hydration missed it, which fails closed the same
+ * as a wholly undeclared path. Returns the offending path, never the value,
+ * so callers can log it without leaking the id it is refusing.
+ */
+export const findUndeclaredUuidPath = ({
+  toolName,
+  payload,
+}: {
+  toolName: RegistryReadToolName;
+  payload: unknown;
+}): string | undefined => {
+  const allowedPaths = new Set<string>(
+    READ_TOOL_REF_FIELD_MAP[toolName].passthroughIdPaths,
+  );
+  return collectUuidPaths(payload).find((hit) => !allowedPaths.has(hit.path))
+    ?.path;
+};
+
 // --- path grammar -----------------------------------------------------------
 // Paths use the same `a.b` / `a[].b` shape as the egress text-field specs. A
 // step is one dotted token; a `[]` suffix means "descend into the array at this

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ScopedDb } from "@/api/db";
 import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
@@ -9,9 +9,16 @@ import type { McpRequestContext } from "@/api/mcp/context";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
-import { buildMcpContextFromChat } from "./mcp-chat-context";
-import { containsRawUuid, dehydrateInputRefs } from "./ref-mediation";
-import { runRegistryReadTool } from "./run-registry-tool";
+const captureErrorMock = mock();
+void mock.module("@/api/lib/analytics", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
+}));
+
+const { buildMcpContextFromChat } = await import("./mcp-chat-context");
+const { containsRawUuid, dehydrateInputRefs } = await import("./ref-mediation");
+const { runRegistryReadTool } = await import("./run-registry-tool");
 
 const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
 const OTHER_WS_UUID = "4e919658-a448-5354-8e3a-e99911214d2c";
@@ -49,6 +56,10 @@ const buildContext = ({
   });
 
 describe("runRegistryReadTool", () => {
+  beforeEach(() => {
+    captureErrorMock.mockClear();
+  });
+
   test("runs list_matters end-to-end: output UUIDs become refs, input ref dehydrates", async () => {
     const registry = createChatRefRegistry();
     const rows = [
@@ -109,13 +120,13 @@ describe("runRegistryReadTool", () => {
     }
   });
 
-  test("fails closed when a raw uuid survives ref hydration in an unmapped field", async () => {
+  test("fails closed when a raw uuid survives ref hydration at an undeclared path", async () => {
     const registry = createChatRefRegistry();
     // Doctored: `reference` is an ordinary free-text field the ref map never
     // mediates (it is not one of `list_matters`'s `outputRefs` or
     // `passthroughIdPaths`), but nothing stops it from holding a raw uuid.
-    // The backstop must catch this survivor even though no per-field ref
-    // rule exists for it.
+    // The path-aware backstop must catch this survivor at its exact path even
+    // though no per-field ref rule exists for it.
     const rows = [
       {
         id: WS_UUID,
@@ -139,6 +150,18 @@ describe("runRegistryReadTool", () => {
       expect(result.error.message).not.toContain(WS_UUID);
       expect(result.error.message).not.toContain(OTHER_WS_UUID);
     }
+    // Telemetry carries the offending path so the survivor is traceable, but
+    // never the leaked value itself.
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) }),
+      {
+        source: "run-registry-tool",
+        toolName: "list_matters",
+        path: "matters[].reference",
+      },
+    );
+    const [, telemetryContext] = captureErrorMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(telemetryContext)).not.toContain(OTHER_WS_UUID);
   });
 
   test("refuses a read tool the ref map keeps off the chat surface", async () => {

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -109,6 +109,38 @@ describe("runRegistryReadTool", () => {
     }
   });
 
+  test("fails closed when a raw uuid survives ref hydration in an unmapped field", async () => {
+    const registry = createChatRefRegistry();
+    // Doctored: `reference` is an ordinary free-text field the ref map never
+    // mediates (it is not one of `list_matters`'s `outputRefs` or
+    // `passthroughIdPaths`), but nothing stops it from holding a raw uuid.
+    // The backstop must catch this survivor even though no per-field ref
+    // rule exists for it.
+    const rows = [
+      {
+        id: WS_UUID,
+        name: "Acme",
+        reference: OTHER_WS_UUID,
+        status: "active",
+        lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ];
+
+    const result = await runRegistryReadTool({
+      args: {},
+      context: buildContext({ scopedDb: selectScopedDb(rows) }),
+      refRegistry: registry,
+      toolName: "list_matters",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.message).not.toContain(WS_UUID);
+      expect(result.error.message).not.toContain(OTHER_WS_UUID);
+    }
+  });
+
   test("refuses a read tool the ref map keeps off the chat surface", async () => {
     const result = await runRegistryReadTool({
       args: {},

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.test.ts
@@ -1,0 +1,125 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import type { ScopedDb } from "@/api/db";
+import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { McpRequestContext } from "@/api/mcp/context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
+
+import { buildMcpContextFromChat } from "./mcp-chat-context";
+import { containsRawUuid, dehydrateInputRefs } from "./ref-mediation";
+import { runRegistryReadTool } from "./run-registry-tool";
+
+const WS_UUID = "0dc54d0c-10d7-501d-897e-e801dbd0998c";
+const OTHER_WS_UUID = "4e919658-a448-5354-8e3a-e99911214d2c";
+
+/** A scopedDb whose select chain resolves to the seeded matter rows. */
+const selectScopedDb = (rows: readonly unknown[]): ScopedDb =>
+  asTestRaw<ScopedDb>(async (run: (tx: unknown) => unknown) => {
+    const builder = {
+      select: () => builder,
+      from: () => builder,
+      where: () => builder,
+      orderBy: () => builder,
+      limit: async () => rows,
+    };
+    return await run(builder);
+  });
+
+const buildContext = ({
+  accessibleWorkspaceIds = [toSafeId<"workspace">(WS_UUID)],
+  scopedDb = selectScopedDb([]),
+}: {
+  accessibleWorkspaceIds?: ReturnType<typeof toSafeId<"workspace">>[];
+  scopedDb?: ScopedDb;
+} = {}): McpRequestContext =>
+  buildMcpContextFromChat({
+    memberRole: "owner",
+    organizationId: toSafeId<"organization">("org_1"),
+    safeDb: toSafeDbMock(scopedDb),
+    scopedDb,
+    toolWorkspaceIds: resolveToolWorkspaceIds({
+      accessibleWorkspaceIds,
+      pinnedIds: [],
+    }),
+    userId: toSafeId<"user">("user_1"),
+  });
+
+describe("runRegistryReadTool", () => {
+  test("runs list_matters end-to-end: output UUIDs become refs, input ref dehydrates", async () => {
+    const registry = createChatRefRegistry();
+    const rows = [
+      {
+        id: WS_UUID,
+        name: "Acme",
+        reference: "REF-1",
+        status: "active",
+        lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ];
+
+    const result = await runRegistryReadTool({
+      args: {},
+      context: buildContext({ scopedDb: selectScopedDb(rows) }),
+      refRegistry: registry,
+      toolName: "list_matters",
+    });
+
+    expect(Result.isError(result)).toBe(false);
+    const payload = result.unwrap();
+    // The matter's workspace UUID is replaced by its chat ref in the output.
+    expect(payload).toMatchObject({
+      matters: [{ id: "mat_1", name: "Acme", reference: "REF-1" }],
+    });
+    // The whole model-facing payload is free of raw UUIDs.
+    expect(containsRawUuid(payload)).toBe(false);
+
+    // A ref arg dehydrates back to its UUID before the handler sees it. The
+    // registry already minted mat_1 while hydrating the output above.
+    const dehydrated = dehydrateInputRefs({
+      args: { matter_id: "mat_1" },
+      refRegistry: registry,
+      toolName: "list_matters",
+    }).unwrap();
+    expect(dehydrated.args["matter_id"]).toBe(WS_UUID);
+  });
+
+  test("maps an isError registry result to a ChatToolError", async () => {
+    const registry = createChatRefRegistry();
+    // A ref to a workspace that is NOT in the accessible set: detail mode
+    // rejects it as not-found/not-accessible before touching the DB.
+    const matterRef = registry.toMatterRef(
+      toSafeId<"workspace">(OTHER_WS_UUID),
+    );
+
+    const result = await runRegistryReadTool({
+      args: { matter_id: matterRef },
+      context: buildContext(),
+      refRegistry: registry,
+      toolName: "list_matters",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.message).toContain("not accessible");
+    }
+  });
+
+  test("refuses a read tool the ref map keeps off the chat surface", async () => {
+    const result = await runRegistryReadTool({
+      args: {},
+      context: buildContext(),
+      refRegistry: createChatRefRegistry(),
+      toolName: "list_audit_log",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.message).toContain("not available in chat");
+    }
+  });
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -1,0 +1,162 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { panic, Result } from "better-result";
+
+import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import { BILLING_TOOL_HANDLERS } from "@/api/mcp/billing-tools";
+import { COMPAT_TOOL_HANDLERS } from "@/api/mcp/compat-tools";
+import type { McpRequestContext } from "@/api/mcp/context";
+import { DOCUMENT_TOOL_HANDLERS } from "@/api/mcp/document-tools";
+import { finalizeMcpEgress } from "@/api/mcp/egress";
+import { isMcpToolFeatureEnabled } from "@/api/mcp/gateway/list-tools";
+import { KNOWLEDGE_TOOL_HANDLERS } from "@/api/mcp/knowledge-tools";
+import { MATTER_TOOL_HANDLERS } from "@/api/mcp/matter-tools";
+import { RESEARCH_ADMIN_TOOL_HANDLERS } from "@/api/mcp/research-admin-tools";
+import { getStaticMcpToolDefinition } from "@/api/mcp/static-tool-definitions";
+import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
+import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
+import type { McpToolHandler } from "@/api/mcp/tool-types";
+
+import type { RegistryReadToolName } from "./ref-field-map";
+import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
+import { dehydrateInputRefs, hydrateOutputRefs } from "./ref-mediation";
+
+/**
+ * The read-only registry handlers chat may drive, gathered from the per-domain
+ * exports and keyed by `RegistryReadToolName` via `satisfies`. Exhaustive by
+ * construction (a second class-guard beside the ref-field map): a read tool with
+ * no handler wired here cannot compile.
+ */
+const REGISTRY_READ_TOOL_HANDLERS = {
+  fetch: COMPAT_TOOL_HANDLERS.fetch,
+  search: COMPAT_TOOL_HANDLERS.search,
+  list_matters: STELLA_TOOL_HANDLERS.list_matters,
+  read_case_law_decision: STELLA_TOOL_HANDLERS.read_case_law_decision,
+  read_contact: STELLA_TOOL_HANDLERS.read_contact,
+  read_content_across_matters: STELLA_TOOL_HANDLERS.read_content_across_matters,
+  search_case_law: STELLA_TOOL_HANDLERS.search_case_law,
+  search_across_matters: STELLA_TOOL_HANDLERS.search_across_matters,
+  list_templates: TEMPLATE_TOOL_HANDLERS.list_templates,
+  list_documents: DOCUMENT_TOOL_HANDLERS.list_documents,
+  read_document: DOCUMENT_TOOL_HANDLERS.read_document,
+  list_properties: DOCUMENT_TOOL_HANDLERS.list_properties,
+  list_tasks: MATTER_TOOL_HANDLERS.list_tasks,
+  lookup_business_registry: MATTER_TOOL_HANDLERS.lookup_business_registry,
+  list_clauses: KNOWLEDGE_TOOL_HANDLERS.list_clauses,
+  list_playbooks: KNOWLEDGE_TOOL_HANDLERS.list_playbooks,
+  list_time_entries: BILLING_TOOL_HANDLERS.list_time_entries,
+  resolve_rate: BILLING_TOOL_HANDLERS.resolve_rate,
+  list_invoices: BILLING_TOOL_HANDLERS.list_invoices,
+  get_usage: BILLING_TOOL_HANDLERS.get_usage,
+  search_legislation: RESEARCH_ADMIN_TOOL_HANDLERS.search_legislation,
+  list_audit_log: RESEARCH_ADMIN_TOOL_HANDLERS.list_audit_log,
+} satisfies Record<RegistryReadToolName, McpToolHandler>;
+
+const firstTextContent = (result: CallToolResult): string => {
+  const item = result.content.at(0);
+  return item?.type === "text" ? item.text : "";
+};
+
+/**
+ * A finished registry result is a single text content block holding the
+ * handler's JSON payload (`textResult`). Parse it back into the plain object the
+ * chat sandbox expects, mapping a malformed body to a `ChatToolError`. The
+ * try/catch is a boundary parse of an already-serialized payload, not control
+ * flow.
+ */
+const parsePayload = (
+  result: CallToolResult,
+): Result<unknown, ChatToolError> => {
+  try {
+    // JSON.parse is typed `any`; pin it to `unknown` so the payload stays
+    // opaque until ref hydration walks it (no `as` cast).
+    const parsed: unknown = JSON.parse(firstTextContent(result));
+    return Result.ok(parsed);
+  } catch {
+    return Result.err(
+      new ChatToolError({
+        message: "The tool returned a response that could not be read.",
+      }),
+    );
+  }
+};
+
+export type RunRegistryReadToolProps = {
+  toolName: RegistryReadToolName;
+  args: Record<string, unknown>;
+  context: McpRequestContext;
+  refRegistry: ChatRefRegistry;
+};
+
+/**
+ * Run one read-only MCP registry tool as a chat tool.
+ *
+ * 1. Refuse a tool the ref-field map keeps off the chat surface, or one whose
+ *    deploy feature flag is off (feature gating still applies to chat; OAuth
+ *    scope gating does not, see `buildMcpContextFromChat`).
+ * 2. Dehydrate ref args to real UUIDs.
+ * 3. Run the handler and finalize its egress in DEFAULT mode (chat is not the
+ *    anonymized surface).
+ * 4. Map an `isError` result into a `ChatToolError`; otherwise parse the JSON
+ *    payload, hydrate its tenant UUIDs into chat refs, and return the object.
+ */
+export const runRegistryReadTool = async ({
+  toolName,
+  args,
+  context,
+  refRegistry,
+}: RunRegistryReadToolProps): Promise<Result<unknown, ChatToolError>> => {
+  if (!READ_TOOL_REF_FIELD_MAP[toolName].chatProjectable) {
+    return Result.err(
+      new ChatToolError({
+        message: `Tool ${toolName} is not available in chat.`,
+      }),
+    );
+  }
+
+  const staticDefinition =
+    getStaticMcpToolDefinition(toolName) ??
+    panic(`Read tool ${toolName} is missing from the static registry`);
+  if (!isMcpToolFeatureEnabled(staticDefinition.feature)) {
+    return Result.err(
+      new ChatToolError({
+        message: "This feature is not enabled on this deployment.",
+      }),
+    );
+  }
+
+  const dehydrated = dehydrateInputRefs({ args, refRegistry, toolName });
+  if (Result.isError(dehydrated)) {
+    return Result.err(dehydrated.error);
+  }
+
+  const response = await REGISTRY_READ_TOOL_HANDLERS[toolName]({
+    args: dehydrated.value.args,
+    context,
+  });
+  const finished = await finalizeMcpEgress({
+    context,
+    mode: "default",
+    response,
+  });
+
+  if (finished.isError === true) {
+    return Result.err(
+      new ChatToolError({ message: firstTextContent(finished) }),
+    );
+  }
+
+  const payload = parsePayload(finished);
+  if (Result.isError(payload)) {
+    return Result.err(payload.error);
+  }
+
+  return Result.ok(
+    hydrateOutputRefs({
+      dehydration: dehydrated.value,
+      output: payload.value,
+      refRegistry,
+      toolName,
+    }),
+  );
+};

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { panic, Result } from "better-result";
 
 import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
+import { captureError } from "@/api/lib/analytics";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import { BILLING_TOOL_HANDLERS } from "@/api/mcp/billing-tools";
 import { COMPAT_TOOL_HANDLERS } from "@/api/mcp/compat-tools";
@@ -19,7 +20,11 @@ import type { McpToolHandler } from "@/api/mcp/tool-types";
 
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
-import { dehydrateInputRefs, hydrateOutputRefs } from "./ref-mediation";
+import {
+  containsRawUuid,
+  dehydrateInputRefs,
+  hydrateOutputRefs,
+} from "./ref-mediation";
 
 /**
  * The read-only registry handlers chat may drive, gathered from the per-domain
@@ -56,6 +61,13 @@ const firstTextContent = (result: CallToolResult): string => {
   const item = result.content.at(0);
   return item?.type === "text" ? item.text : "";
 };
+
+/** Fallback for an `isError` result whose content carries no text block. */
+const DEFAULT_TOOL_ERROR_MESSAGE = "Tool execution failed.";
+
+/** Surfaced to the model when a hydrated payload still carries a raw uuid. */
+const ANONYMIZATION_FAILURE_MESSAGE =
+  "Tool output failed anonymization of internal identifiers.";
 
 /**
  * A finished registry result is a single text content block holding the
@@ -141,9 +153,8 @@ export const runRegistryReadTool = async ({
   });
 
   if (finished.isError === true) {
-    return Result.err(
-      new ChatToolError({ message: firstTextContent(finished) }),
-    );
+    const message = firstTextContent(finished) || DEFAULT_TOOL_ERROR_MESSAGE;
+    return Result.err(new ChatToolError({ message }));
   }
 
   const payload = parsePayload(finished);
@@ -151,12 +162,24 @@ export const runRegistryReadTool = async ({
     return Result.err(payload.error);
   }
 
-  return Result.ok(
-    hydrateOutputRefs({
-      dehydration: dehydrated.value,
-      output: payload.value,
-      refRegistry,
-      toolName,
-    }),
-  );
+  const hydrated = hydrateOutputRefs({
+    dehydration: dehydrated.value,
+    output: payload.value,
+    refRegistry,
+    toolName,
+  });
+
+  // Runtime backstop for the "no tenant UUID reaches the model" invariant: the
+  // ref-field map is documentation the type system cannot fully enforce (a
+  // wrong or missing path silently skips hydration), so re-check the finished
+  // payload rather than trusting the static mapping alone. A survivor fails
+  // closed instead of leaking the id; the error message never repeats the
+  // payload, so it cannot itself leak the value it is refusing.
+  if (containsRawUuid(hydrated)) {
+    const error = new ChatToolError({ message: ANONYMIZATION_FAILURE_MESSAGE });
+    captureError(error, { source: "run-registry-tool", toolName });
+    return Result.err(error);
+  }
+
+  return Result.ok(hydrated);
 };

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -21,8 +21,8 @@ import type { McpToolHandler } from "@/api/mcp/tool-types";
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import {
-  containsRawUuid,
   dehydrateInputRefs,
+  findUndeclaredUuidPath,
   hydrateOutputRefs,
 } from "./ref-mediation";
 
@@ -172,12 +172,19 @@ export const runRegistryReadTool = async ({
   // Runtime backstop for the "no tenant UUID reaches the model" invariant: the
   // ref-field map is documentation the type system cannot fully enforce (a
   // wrong or missing path silently skips hydration), so re-check the finished
-  // payload rather than trusting the static mapping alone. A survivor fails
-  // closed instead of leaking the id; the error message never repeats the
-  // payload, so it cannot itself leak the value it is refusing.
-  if (containsRawUuid(hydrated)) {
+  // payload path-by-path rather than trusting the static mapping alone. A
+  // UUID surviving anywhere the tool's `passthroughIdPaths` does not license
+  // fails closed instead of leaking; the error message never repeats the
+  // payload or the path, so it cannot itself leak the value it is refusing,
+  // while the offending path (never the value) still reaches telemetry.
+  const offendingPath = findUndeclaredUuidPath({ toolName, payload: hydrated });
+  if (offendingPath !== undefined) {
     const error = new ChatToolError({ message: ANONYMIZATION_FAILURE_MESSAGE });
-    captureError(error, { source: "run-registry-tool", toolName });
+    captureError(error, {
+      source: "run-registry-tool",
+      toolName,
+      path: offendingPath,
+    });
     return Result.err(error);
   }
 


### PR DESCRIPTION
Isolated adapter layer (no live wiring yet) letting chat consume MCP registry read tools: a context mapping from chat's resolved deps to `McpRequestContext`, ref mediation that dehydrates sequential refs to ids on input and hydrates ids back to refs on output (exhaustively typed over the read-tool union, so a new read tool cannot ship without a ref decision), and result shaping from `CallToolResult` into chat's typed error conventions. Tools whose payloads embed ids in URLs or unenumerable JSON are marked non-projectable and refused. Tests assert no raw UUID survives hydration on any path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat read-only tool outputs are now mediated to return human-friendly references rather than raw UUIDs.
  * Ref-based tool inputs are automatically resolved before tool execution, including entity ref context.
  * Improved “workspace status” projection and optional audit recording support in chat tool registry context.

* **Bug Fixes**
  * Fail-closed safeguards now detect and block raw UUID leakage at undeclared output paths.
  * Enhanced handling of inaccessible workspaces and chat-ineligible tools (safer “unavailable in chat” responses).

* **Tests**
  * Added coverage for ref mediation, hydration/dehydration round-trips, and security regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->