### PR TITLE
feat: add PKCE loopback authentication to the stella CLI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -397,6 +397,8 @@
       },
       "dependencies": {
         "@stricli/core": "^1.2.8",
+        "better-result": "catalog:",
+        "valibot": "catalog:",
       },
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,9 @@
     "format": "oxfmt ."
   },
   "dependencies": {
-    "@stricli/core": "^1.2.8"
+    "@stricli/core": "^1.2.8",
+    "better-result": "catalog:",
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",

--- a/packages/cli/src/auth/browser-open.ts
+++ b/packages/cli/src/auth/browser-open.ts
@@ -27,13 +27,18 @@ export const openInBrowser = async (url: string): Promise<boolean> => {
       stdin: "ignore",
       stdout: "ignore",
     });
-    const exited = await Promise.race([
-      proc.exited,
-      new Promise<number>((resolve) => {
-        setTimeout(() => resolve(-1), OPEN_TIMEOUT_MS);
-      }),
-    ]);
-    return exited === 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const exited = await Promise.race([
+        proc.exited,
+        new Promise<number>((resolve) => {
+          timer = setTimeout(() => resolve(-1), OPEN_TIMEOUT_MS);
+        }),
+      ]);
+      return exited === 0;
+    } finally {
+      clearTimeout(timer);
+    }
   } catch {
     return false;
   }

--- a/packages/cli/src/auth/browser-open.ts
+++ b/packages/cli/src/auth/browser-open.ts
@@ -1,0 +1,40 @@
+// Best-effort system-browser launch. Never throws: the printed URL is always
+// the fallback (see `login.ts`), so a failure here is not fatal.
+
+const OPEN_TIMEOUT_MS = 5000;
+
+const openCommandFor = (
+  platform: NodeJS.Platform,
+): readonly string[] | undefined => {
+  if (platform === "darwin") {
+    return ["open"];
+  }
+  if (platform === "win32") {
+    return ["cmd", "/c", "start", ""];
+  }
+  return ["xdg-open"];
+};
+
+export const openInBrowser = async (url: string): Promise<boolean> => {
+  const command = openCommandFor(process.platform);
+  if (!command) {
+    return false;
+  }
+
+  try {
+    const proc = Bun.spawn([...command, url], {
+      stderr: "ignore",
+      stdin: "ignore",
+      stdout: "ignore",
+    });
+    const exited = await Promise.race([
+      proc.exited,
+      new Promise<number>((resolve) => {
+        setTimeout(() => resolve(-1), OPEN_TIMEOUT_MS);
+      }),
+    ]);
+    return exited === 0;
+  } catch {
+    return false;
+  }
+};

--- a/packages/cli/src/auth/cli-config.ts
+++ b/packages/cli/src/auth/cli-config.ts
@@ -49,7 +49,14 @@ export const readCliConfig = async (configDir: string): Promise<CliConfig> => {
     return EMPTY_CONFIG;
   }
 
-  const raw: unknown = await file.json();
+  // A corrupt or empty config file must degrade to defaults, not crash
+  // every CLI invocation at context construction.
+  let raw: unknown;
+  try {
+    raw = await file.json();
+  } catch {
+    return EMPTY_CONFIG;
+  }
   const parsed = v.safeParse(cliConfigSchema, raw);
   return parsed.success ? parsed.output : EMPTY_CONFIG;
 };

--- a/packages/cli/src/auth/cli-config.ts
+++ b/packages/cli/src/auth/cli-config.ts
@@ -1,0 +1,96 @@
+// Non-secret CLI configuration: the default server origin and, per server,
+// the dynamically-registered OAuth client id (a public client id is not a
+// secret; there is no client_secret for `token_endpoint_auth_method: "none"`
+// clients). Stored separately from `credential-store.ts`'s file, which holds
+// tokens and is mode 0600.
+
+import path from "node:path";
+import * as v from "valibot";
+
+import { defaultConfigDir, resolveConfigDir } from "./config-dir.js";
+import type { ConfigPathOverrides } from "./config-dir.js";
+
+export { defaultConfigDir, resolveConfigDir };
+export type { ConfigPathOverrides };
+
+// Hand-written rather than `v.InferOutput<typeof schema>`: this package
+// builds with `isolatedDeclarations` (it is a publishable `@stll` package),
+// which requires every module-scope binding reachable from an exported
+// symbol to carry an explicit type. Decoupling the wire schema from the
+// domain type also means a schema/type drift shows up as a type error at
+// the `v.parse`/`v.safeParse` call site instead of silently at the alias.
+export type CliConfig = {
+  readonly version: 1;
+  readonly defaultServerUrl?: string | undefined;
+  readonly oauthClients: Readonly<
+    Record<string, { readonly clientId: string; readonly registeredAt: number }>
+  >;
+};
+
+const oauthClientEntrySchema = v.strictObject({
+  clientId: v.string(),
+  registeredAt: v.number(),
+});
+
+const cliConfigSchema = v.strictObject({
+  version: v.literal(1),
+  defaultServerUrl: v.optional(v.string()),
+  oauthClients: v.record(v.string(), oauthClientEntrySchema),
+});
+
+const EMPTY_CONFIG: CliConfig = { oauthClients: {}, version: 1 };
+
+export const configFilePath = (configDir: string): string =>
+  path.join(configDir, "config.json");
+
+export const readCliConfig = async (configDir: string): Promise<CliConfig> => {
+  const file = Bun.file(configFilePath(configDir));
+  if (!(await file.exists())) {
+    return EMPTY_CONFIG;
+  }
+
+  const raw: unknown = await file.json();
+  const parsed = v.safeParse(cliConfigSchema, raw);
+  return parsed.success ? parsed.output : EMPTY_CONFIG;
+};
+
+export const writeCliConfig = async (
+  configDir: string,
+  config: CliConfig,
+): Promise<void> => {
+  await Bun.write(
+    configFilePath(configDir),
+    `${JSON.stringify(config, null, 2)}\n`,
+  );
+};
+
+export const setDefaultServerUrl = async (
+  configDir: string,
+  serverUrl: string,
+): Promise<void> => {
+  const config = await readCliConfig(configDir);
+  await writeCliConfig(configDir, { ...config, defaultServerUrl: serverUrl });
+};
+
+export const getRegisteredClientId = async (
+  configDir: string,
+  serverUrl: string,
+): Promise<string | undefined> => {
+  const config = await readCliConfig(configDir);
+  return config.oauthClients[serverUrl]?.clientId;
+};
+
+export const setRegisteredClientId = async (
+  configDir: string,
+  serverUrl: string,
+  clientId: string,
+): Promise<void> => {
+  const config = await readCliConfig(configDir);
+  await writeCliConfig(configDir, {
+    ...config,
+    oauthClients: {
+      ...config.oauthClients,
+      [serverUrl]: { clientId, registeredAt: Date.now() },
+    },
+  });
+};

--- a/packages/cli/src/auth/config-dir.ts
+++ b/packages/cli/src/auth/config-dir.ts
@@ -1,0 +1,27 @@
+// Shared `~/.config/stella` (XDG) directory resolution, used by both
+// `cli-config.ts` (non-secret config) and `credential-store.ts` (secrets).
+
+import os from "node:os";
+import path from "node:path";
+
+import { XDG_CONFIG_HOME } from "../env.js";
+
+export type ConfigPathOverrides = {
+  readonly xdgConfigHome?: string | undefined;
+  readonly homeDir: string;
+};
+
+/** `$XDG_CONFIG_HOME/stella` or `~/.config/stella`, per the XDG base dir spec. */
+export const resolveConfigDir = (overrides: ConfigPathOverrides): string => {
+  const base =
+    overrides.xdgConfigHome && overrides.xdgConfigHome.length > 0
+      ? overrides.xdgConfigHome
+      : path.join(overrides.homeDir, ".config");
+  return path.join(base, "stella");
+};
+
+export const defaultConfigDir = (): string =>
+  resolveConfigDir({
+    homeDir: os.homedir(),
+    xdgConfigHome: XDG_CONFIG_HOME,
+  });

--- a/packages/cli/src/auth/constants.ts
+++ b/packages/cli/src/auth/constants.ts
@@ -1,0 +1,85 @@
+// Shared literal constants for the `stella auth` flow (spec 051 Phase 2).
+//
+// Several of these intentionally duplicate values owned by `apps/api`
+// (`apps/api/src/mcp/constants.ts`, `apps/api/src/lib/auth.ts`). `packages/cli`
+// cannot import from `apps/api` (apps depend on packages, never the reverse),
+// and the MCP tool registry does not yet expose these as data the CLI could
+// fetch at runtime. This is the same hand-duplication already accepted for
+// `ToolScope` in `../route-types.ts`; keep both sides in sync by hand until a
+// shared package exists.
+
+/** Mirrors `apps/api/src/mcp/constants.ts`'s `MCP_HTTP_PATH`. */
+const MCP_HTTP_PATH = "/mcp";
+
+/**
+ * The OAuth resource (`RFC 8707`) the CLI requests. Passing `resource` at the
+ * token endpoint is what makes better-auth's oauth-provider mint a JWT-format
+ * access token (see `checkResource`/`isJwtAccessToken` in
+ * `@better-auth/oauth-provider`); without it the server returns an opaque
+ * token that the CLI cannot decode for `stella auth whoami`.
+ */
+export const getMcpResourceUrl = (serverUrl: string): string =>
+  new URL(MCP_HTTP_PATH, serverUrl).toString();
+
+/**
+ * Candidate RFC 8414 authorization-server-metadata paths, tried in order.
+ * The first is the spec's root-issuer convention; the second matches
+ * better-auth's actual (default `/api/auth`) mount point, which is what
+ * stella's own server uses today. Self-hosted forks that change
+ * `advanced.basePath` are covered as long as they keep one of these two
+ * shapes; forks using a third convention are a follow-up, not a Phase 2 gap.
+ */
+export const AUTHORIZATION_SERVER_METADATA_PATHS = [
+  "/.well-known/oauth-authorization-server",
+  "/api/auth/.well-known/oauth-authorization-server",
+] as const;
+
+/**
+ * Loopback redirect URI registered with the OAuth client. Deliberately has no
+ * port: better-auth's redirect-uri matcher (`isLoopbackIP` in
+ * `@better-auth/core/utils/host`) only compares hostname/pathname/protocol/
+ * search for loopback hosts, never the port (RFC 8252 S7.3). Registering a
+ * portless URI once lets every login reuse the same client registration with
+ * a fresh ephemeral port each run.
+ */
+export const LOOPBACK_REDIRECT_PATH = "/callback";
+export const LOOPBACK_REDIRECT_URI: string = `http://127.0.0.1${LOOPBACK_REDIRECT_PATH}`;
+
+/** Default scopes requested when `stella auth login` is run without `--scopes`. */
+export const CLI_DEFAULT_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "stella:read",
+  "stella:search",
+] as const;
+
+/** Every OAuth scope `stella auth login --scopes` is documented to accept. */
+export const CLI_KNOWN_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "stella:search",
+  "stella:read",
+  "stella:templates",
+  "stella:documents_write",
+  "stella:matters_write",
+  "stella:knowledge_write",
+  "stella:billing_write",
+  "stella:admin_read",
+  "stella:admin_write",
+  "stella:onboarding",
+  "stella:skills",
+  "stella:external_mcps",
+] as const;
+
+export const CLIENT_NAME = "stella-cli";
+
+/** `--server` resolution: env var name, checked between the flag and the config file. */
+export const SERVER_URL_ENV_VAR = "STELLA_SERVER_URL";
+
+/** How long the CLI waits for the browser round-trip before giving up. */
+export const LOGIN_TIMEOUT_MS: number = 5 * 60 * 1000;
+
+/** Network timeout for every discovery/registration/token request the CLI makes. */
+export const AUTH_FETCH_TIMEOUT_MS = 10_000;

--- a/packages/cli/src/auth/credential-store.test.ts
+++ b/packages/cli/src/auth/credential-store.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  credentialsFilePath,
+  findCredentialByOrgHint,
+  findCredentialByOrgId,
+  findDefaultCredential,
+  listCredentialsForServer,
+  readCredentialFile,
+  removeCredential,
+  resolveConfigDir,
+  setDefaultOrg,
+  upsertCredential,
+  writeCredentialFile,
+} from "./credential-store.js";
+import type { StoredCredential } from "./credential-store.js";
+
+const buildCredential = (
+  overrides: Partial<StoredCredential> = {},
+): StoredCredential => ({
+  accessToken: "access-token",
+  clientId: "client-id",
+  createdAt: 1000,
+  expiresAt: 2000,
+  orgId: "org-1",
+  scope: "openid stella:read",
+  serverUrl: "https://stella.example",
+  tokenType: "Bearer",
+  updatedAt: 1000,
+  ...overrides,
+});
+
+describe("resolveConfigDir", () => {
+  test("prefers XDG_CONFIG_HOME when set", () => {
+    expect(
+      resolveConfigDir({
+        homeDir: "/home/alice",
+        xdgConfigHome: "/custom/xdg",
+      }),
+    ).toBe(path.join("/custom/xdg", "stella"));
+  });
+
+  test("falls back to ~/.config when XDG_CONFIG_HOME is unset", () => {
+    expect(resolveConfigDir({ homeDir: "/home/alice" })).toBe(
+      path.join("/home/alice", ".config", "stella"),
+    );
+  });
+
+  test("treats an empty XDG_CONFIG_HOME as unset", () => {
+    expect(
+      resolveConfigDir({ homeDir: "/home/alice", xdgConfigHome: "" }),
+    ).toBe(path.join("/home/alice", ".config", "stella"));
+  });
+});
+
+describe("credential file round-trip (tmp XDG dir)", () => {
+  let configDir: string;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(path.join(os.tmpdir(), "stella-cli-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(configDir, { force: true, recursive: true });
+  });
+
+  test("readCredentialFile returns an empty file when none exists yet", async () => {
+    const file = await readCredentialFile(configDir);
+    expect(file).toEqual({
+      credentials: [],
+      defaultOrgByServer: {},
+      version: 1,
+    });
+  });
+
+  test("round-trips a written credential file exactly", async () => {
+    const credential = buildCredential();
+    const written = upsertCredential(
+      await readCredentialFile(configDir),
+      credential,
+    );
+    await writeCredentialFile(configDir, written);
+
+    const reread = await readCredentialFile(configDir);
+    expect(reread).toEqual(written);
+  });
+
+  test("writes the credentials file with mode 0600", async () => {
+    await writeCredentialFile(
+      configDir,
+      upsertCredential(await readCredentialFile(configDir), buildCredential()),
+    );
+
+    const stats = await stat(credentialsFilePath(configDir));
+    // eslint-disable-next-line no-bitwise -- masking the permission bits out of `stat().mode` requires `&`; there is no non-bitwise API for this
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  test("tightens an existing file's permissions on rewrite", async () => {
+    await writeCredentialFile(
+      configDir,
+      upsertCredential(await readCredentialFile(configDir), buildCredential()),
+    );
+    await chmod(credentialsFilePath(configDir), 0o644);
+
+    await writeCredentialFile(
+      configDir,
+      upsertCredential(
+        await readCredentialFile(configDir),
+        buildCredential({ orgId: "org-2" }),
+      ),
+    );
+
+    const stats = await stat(credentialsFilePath(configDir));
+    // eslint-disable-next-line no-bitwise -- masking the permission bits out of `stat().mode` requires `&`; there is no non-bitwise API for this
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  test("ignores a malformed credentials file instead of throwing", async () => {
+    await Bun.write(credentialsFilePath(configDir), "not json");
+    const file = await readCredentialFile(configDir);
+    expect(file).toEqual({
+      credentials: [],
+      defaultOrgByServer: {},
+      version: 1,
+    });
+  });
+});
+
+describe("credential store data operations", () => {
+  const empty = {
+    credentials: [],
+    defaultOrgByServer: {},
+    version: 1 as const,
+  };
+
+  test("upsertCredential sets the first credential for a server as its default", () => {
+    const credential = buildCredential();
+    const file = upsertCredential(empty, credential);
+    expect(file.defaultOrgByServer[credential.serverUrl]).toBe(
+      credential.orgId,
+    );
+  });
+
+  test("upsertCredential does not change the default when adding a second org", () => {
+    const first = buildCredential({ orgId: "org-1" });
+    const second = buildCredential({ orgId: "org-2" });
+    const file = upsertCredential(upsertCredential(empty, first), second);
+    expect(file.defaultOrgByServer[first.serverUrl]).toBe("org-1");
+    expect(file.credentials).toHaveLength(2);
+  });
+
+  test("upsertCredential replaces an existing (serverUrl, orgId) pair rather than duplicating", () => {
+    const original = buildCredential({ accessToken: "old-token" });
+    const updated = buildCredential({ accessToken: "new-token" });
+    const file = upsertCredential(upsertCredential(empty, original), updated);
+    expect(file.credentials).toHaveLength(1);
+    expect(file.credentials.at(0)?.accessToken).toBe("new-token");
+  });
+
+  test("findCredentialByOrgId matches on the exact (serverUrl, orgId) pair", () => {
+    const credential = buildCredential();
+    const file = upsertCredential(empty, credential);
+    expect(
+      findCredentialByOrgId(file, credential.serverUrl, credential.orgId),
+    ).toEqual(credential);
+    expect(
+      findCredentialByOrgId(file, credential.serverUrl, "other-org"),
+    ).toBeUndefined();
+  });
+
+  test("findCredentialByOrgHint matches by orgId or by the unverified orgLabel", () => {
+    const credential = buildCredential({ orgLabel: "acme" });
+    const file = upsertCredential(empty, credential);
+    expect(findCredentialByOrgHint(file, credential.serverUrl, "acme")).toEqual(
+      credential,
+    );
+    expect(
+      findCredentialByOrgHint(file, credential.serverUrl, credential.orgId),
+    ).toEqual(credential);
+    expect(
+      findCredentialByOrgHint(file, credential.serverUrl, "nope"),
+    ).toBeUndefined();
+  });
+
+  test("findDefaultCredential resolves via defaultOrgByServer", () => {
+    const first = buildCredential({ orgId: "org-1" });
+    const second = buildCredential({ orgId: "org-2" });
+    const file = setDefaultOrg(
+      upsertCredential(upsertCredential(empty, first), second),
+      first.serverUrl,
+      "org-2",
+    );
+    expect(findDefaultCredential(file, first.serverUrl)?.orgId).toBe("org-2");
+  });
+
+  test("listCredentialsForServer only returns credentials for that server", () => {
+    const here = buildCredential({ serverUrl: "https://a.example" });
+    const there = buildCredential({ serverUrl: "https://b.example" });
+    const file = upsertCredential(upsertCredential(empty, here), there);
+    expect(listCredentialsForServer(file, "https://a.example")).toEqual([here]);
+  });
+
+  test("removeCredential promotes another credential to default when the default is removed", () => {
+    const first = buildCredential({ orgId: "org-1" });
+    const second = buildCredential({ orgId: "org-2" });
+    const file = upsertCredential(upsertCredential(empty, first), second);
+
+    const afterRemoval = removeCredential(file, first.serverUrl, "org-1");
+    expect(afterRemoval.credentials).toHaveLength(1);
+    expect(afterRemoval.defaultOrgByServer[first.serverUrl]).toBe("org-2");
+  });
+
+  test("removeCredential clears the default when no credential remains for that server", () => {
+    const credential = buildCredential();
+    const file = upsertCredential(empty, credential);
+    const afterRemoval = removeCredential(
+      file,
+      credential.serverUrl,
+      credential.orgId,
+    );
+    expect(afterRemoval.credentials).toHaveLength(0);
+    expect(
+      afterRemoval.defaultOrgByServer[credential.serverUrl],
+    ).toBeUndefined();
+  });
+
+  test("removeCredential leaves the default alone when removing a non-default org", () => {
+    const first = buildCredential({ orgId: "org-1" });
+    const second = buildCredential({ orgId: "org-2" });
+    const file = upsertCredential(upsertCredential(empty, first), second);
+    const afterRemoval = removeCredential(file, first.serverUrl, "org-2");
+    expect(afterRemoval.defaultOrgByServer[first.serverUrl]).toBe("org-1");
+  });
+});

--- a/packages/cli/src/auth/credential-store.ts
+++ b/packages/cli/src/auth/credential-store.ts
@@ -1,0 +1,225 @@
+// Token storage.
+//
+// OS keychain is the target end state (see the design brief and
+// `apps/desktop/src-tauri/src/keychain.rs`'s policy precedent), but wiring a
+// native keyring binding is real native-dependency surface (napi-rs
+// prebuilds, per-platform CI, etc.) that this phase deliberately does not
+// pull in without a separate flag-and-discuss. The XDG file is the only
+// backend today; `--no-keychain` (see `../commands/login.ts`) is accepted
+// and threaded through for forward compatibility but is currently a no-op,
+// since there is nothing else to fall back from yet.
+//
+// One credential per (serverUrl, orgId) pair, mode 0600, analogous to the
+// `aws`/`gh` multi-profile credential file pattern.
+
+import { Result } from "better-result";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import * as v from "valibot";
+
+import { defaultConfigDir, resolveConfigDir } from "./config-dir.js";
+import type { ConfigPathOverrides } from "./config-dir.js";
+
+export { defaultConfigDir, resolveConfigDir };
+export type { ConfigPathOverrides };
+
+const CREDENTIALS_FILE_MODE = 0o600;
+
+// Hand-written rather than `v.InferOutput<typeof schema>`: this package
+// builds with `isolatedDeclarations` (see `cli-config.ts` for the full
+// rationale), which requires every exported type to be self-contained
+// rather than derived from an unannotated schema expression.
+export type StoredCredential = {
+  readonly serverUrl: string;
+  readonly orgId: string;
+  /**
+   * Best-effort label the user passed via `--org` at login time. Not
+   * cryptographically verified against the token (see `login.ts` for why:
+   * the server has no cheap org-slug-lookup endpoint and org selection
+   * happens entirely in the browser). Purely a display/lookup convenience.
+   */
+  readonly orgLabel?: string | undefined;
+  readonly clientId: string;
+  readonly accessToken: string;
+  readonly refreshToken?: string | undefined;
+  readonly scope: string;
+  readonly tokenType: string;
+  readonly expiresAt: number;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+};
+
+export type CredentialFile = {
+  readonly version: 1;
+  /** serverUrl -> orgId, the org used when a command targets a server without an explicit `--org`. */
+  readonly defaultOrgByServer: Readonly<Record<string, string>>;
+  readonly credentials: readonly StoredCredential[];
+};
+
+const storedCredentialSchema = v.strictObject({
+  serverUrl: v.string(),
+  orgId: v.string(),
+  orgLabel: v.optional(v.string()),
+  clientId: v.string(),
+  accessToken: v.string(),
+  refreshToken: v.optional(v.string()),
+  scope: v.string(),
+  tokenType: v.string(),
+  expiresAt: v.number(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});
+
+const credentialFileSchema = v.strictObject({
+  version: v.literal(1),
+  defaultOrgByServer: v.record(v.string(), v.string()),
+  credentials: v.array(storedCredentialSchema),
+});
+
+const EMPTY_FILE: CredentialFile = {
+  credentials: [],
+  defaultOrgByServer: {},
+  version: 1,
+};
+
+export const credentialsFilePath = (configDir: string): string =>
+  path.join(configDir, "credentials.json");
+
+export const readCredentialFile = async (
+  configDir: string,
+): Promise<CredentialFile> => {
+  const filePath = credentialsFilePath(configDir);
+
+  const raw = await Result.tryPromise(
+    async () => await readFile(filePath, "utf-8"),
+  );
+  if (Result.isError(raw)) {
+    return EMPTY_FILE;
+  }
+
+  const parsedJson = Result.try((): unknown => JSON.parse(raw.value));
+  if (Result.isError(parsedJson)) {
+    return EMPTY_FILE;
+  }
+
+  const parsed = v.safeParse(credentialFileSchema, parsedJson.value);
+  return parsed.success ? parsed.output : EMPTY_FILE;
+};
+
+export const writeCredentialFile = async (
+  configDir: string,
+  file: CredentialFile,
+): Promise<void> => {
+  const filePath = credentialsFilePath(configDir);
+  await mkdir(configDir, { mode: 0o700, recursive: true });
+  await writeFile(filePath, `${JSON.stringify(file, null, 2)}\n`, {
+    mode: CREDENTIALS_FILE_MODE,
+  });
+  // `writeFile`'s `mode` option only applies when the file is created; force
+  // it on every write so a pre-existing looser-permission file gets fixed.
+  await chmod(filePath, CREDENTIALS_FILE_MODE);
+};
+
+const credentialKey = (serverUrl: string, orgId: string): string =>
+  `${serverUrl}::${orgId}`;
+
+export const findCredentialByOrgId = (
+  file: CredentialFile,
+  serverUrl: string,
+  orgId: string,
+): StoredCredential | undefined =>
+  file.credentials.find(
+    (credential) =>
+      credentialKey(credential.serverUrl, credential.orgId) ===
+      credentialKey(serverUrl, orgId),
+  );
+
+/** Matches on org id first, then the unverified `orgLabel`. */
+export const findCredentialByOrgHint = (
+  file: CredentialFile,
+  serverUrl: string,
+  orgHint: string,
+): StoredCredential | undefined =>
+  file.credentials.find(
+    (credential) =>
+      credential.serverUrl === serverUrl &&
+      (credential.orgId === orgHint || credential.orgLabel === orgHint),
+  );
+
+export const findDefaultCredential = (
+  file: CredentialFile,
+  serverUrl: string,
+): StoredCredential | undefined => {
+  const defaultOrgId = file.defaultOrgByServer[serverUrl];
+  if (defaultOrgId) {
+    return findCredentialByOrgId(file, serverUrl, defaultOrgId);
+  }
+  return file.credentials.find(
+    (credential) => credential.serverUrl === serverUrl,
+  );
+};
+
+export const listCredentialsForServer = (
+  file: CredentialFile,
+  serverUrl: string,
+): readonly StoredCredential[] =>
+  file.credentials.filter((credential) => credential.serverUrl === serverUrl);
+
+/** Inserts or replaces the (serverUrl, orgId) credential; sets it as the server's default if none was set. */
+export const upsertCredential = (
+  file: CredentialFile,
+  credential: StoredCredential,
+): CredentialFile => {
+  const withoutExisting = file.credentials.filter(
+    (existing) =>
+      credentialKey(existing.serverUrl, existing.orgId) !==
+      credentialKey(credential.serverUrl, credential.orgId),
+  );
+
+  const defaultOrgByServer = file.defaultOrgByServer[credential.serverUrl]
+    ? file.defaultOrgByServer
+    : { ...file.defaultOrgByServer, [credential.serverUrl]: credential.orgId };
+
+  return {
+    ...file,
+    credentials: [...withoutExisting, credential],
+    defaultOrgByServer,
+  };
+};
+
+export const removeCredential = (
+  file: CredentialFile,
+  serverUrl: string,
+  orgId: string,
+): CredentialFile => {
+  const credentials = file.credentials.filter(
+    (existing) =>
+      credentialKey(existing.serverUrl, existing.orgId) !==
+      credentialKey(serverUrl, orgId),
+  );
+
+  if (file.defaultOrgByServer[serverUrl] !== orgId) {
+    return { ...file, credentials };
+  }
+
+  // The removed credential was the server's default; drop it and, if
+  // another credential remains for that server, promote it in one step
+  // (destructuring-omit instead of `delete`, per repo convention).
+  const { [serverUrl]: _removedDefault, ...remainingDefaults } =
+    file.defaultOrgByServer;
+  const nextDefault = credentials.find((c) => c.serverUrl === serverUrl);
+  const defaultOrgByServer = nextDefault
+    ? { ...remainingDefaults, [serverUrl]: nextDefault.orgId }
+    : remainingDefaults;
+
+  return { ...file, credentials, defaultOrgByServer };
+};
+
+export const setDefaultOrg = (
+  file: CredentialFile,
+  serverUrl: string,
+  orgId: string,
+): CredentialFile => ({
+  ...file,
+  defaultOrgByServer: { ...file.defaultOrgByServer, [serverUrl]: orgId },
+});

--- a/packages/cli/src/auth/ensure-fresh-credential.test.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { readCredentialFile, upsertCredential } from "./credential-store.js";
+import type { CredentialFile, StoredCredential } from "./credential-store.js";
+import { ensureFreshCredential } from "./ensure-fresh-credential.js";
+import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
+
+const buildCredential = (
+  overrides: Partial<StoredCredential> = {},
+): StoredCredential => ({
+  accessToken: "old-access-token",
+  clientId: "client-id",
+  createdAt: 0,
+  expiresAt: 10_000,
+  orgId: "org-1",
+  refreshToken: "old-refresh-token",
+  scope: "openid stella:read",
+  serverUrl: "https://stella.example",
+  tokenType: "Bearer",
+  updatedAt: 0,
+  ...overrides,
+});
+
+/** A mock `/oauth2/token` endpoint whose response depends on the test scenario, plus a request counter. */
+const startMockProvider = (
+  handleTokenRequest: (body: URLSearchParams) => Response,
+) => {
+  let requestCount = 0;
+  const server = Bun.serve({
+    fetch: async (request) => {
+      requestCount += 1;
+      const body = new URLSearchParams(await request.text());
+      return handleTokenRequest(body);
+    },
+    hostname: "127.0.0.1",
+    port: 0,
+  });
+
+  const metadata: AuthorizationServerMetadata = {
+    authorization_endpoint: `http://127.0.0.1:${server.port}/oauth2/authorize`,
+    issuer: `http://127.0.0.1:${server.port}`,
+    token_endpoint: `http://127.0.0.1:${server.port}/oauth2/token`,
+  };
+
+  return {
+    close: () => {
+      void server.stop(true);
+    },
+    getRequestCount: () => requestCount,
+    metadata,
+  };
+};
+
+describe("ensureFreshCredential", () => {
+  let configDir: string;
+  let credentialFile: CredentialFile;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(
+      path.join(os.tmpdir(), "stella-cli-refresh-test-"),
+    );
+    credentialFile = { credentials: [], defaultOrgByServer: {}, version: 1 };
+  });
+
+  afterEach(async () => {
+    await rm(configDir, { force: true, recursive: true });
+  });
+
+  test("returns the credential unchanged (no network call) when it is not near expiry", async () => {
+    const provider = startMockProvider(
+      () => new Response("should not be called", { status: 500 }),
+    );
+    try {
+      const credential = buildCredential({ expiresAt: Date.now() + 60_000 });
+      const result = await ensureFreshCredential({
+        configDir,
+        credential,
+        credentialFile,
+        metadata: provider.metadata,
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.value).toEqual(credential);
+      }
+      expect(provider.getRequestCount()).toBe(0);
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("refreshes and persists an expired credential when a refresh token is available", async () => {
+    const provider = startMockProvider(
+      (body) =>
+        new Response(
+          JSON.stringify(
+            body.get("grant_type") === "refresh_token" &&
+              body.get("refresh_token") === "old-refresh-token"
+              ? {
+                  access_token: "new-access-token",
+                  expires_in: 900,
+                  refresh_token: "new-refresh-token",
+                  scope: "openid stella:read",
+                  token_type: "Bearer",
+                }
+              : { error: "invalid_grant" },
+          ),
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        ),
+    );
+
+    try {
+      const credential = buildCredential({ expiresAt: Date.now() - 1000 });
+      const now = Date.now();
+      const result = await ensureFreshCredential({
+        configDir,
+        credential,
+        credentialFile: upsertCredential(credentialFile, credential),
+        metadata: provider.metadata,
+        now,
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.value.accessToken).toBe("new-access-token");
+        expect(result.value.refreshToken).toBe("new-refresh-token");
+        expect(result.value.expiresAt).toBe(now + 900 * 1000);
+      }
+      expect(provider.getRequestCount()).toBe(1);
+
+      const persisted = await readCredentialFile(configDir);
+      expect(persisted.credentials.at(0)?.accessToken).toBe("new-access-token");
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("surfaces a refresh failure from the provider as an error", async () => {
+    const provider = startMockProvider(
+      () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          headers: { "Content-Type": "application/json" },
+          status: 400,
+        }),
+    );
+
+    try {
+      const credential = buildCredential({ expiresAt: Date.now() - 1000 });
+      const result = await ensureFreshCredential({
+        configDir,
+        credential,
+        credentialFile: upsertCredential(credentialFile, credential),
+        metadata: provider.metadata,
+      });
+
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.error._tag).toBe("TokenRefreshError");
+      }
+      expect(provider.getRequestCount()).toBe(1);
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("errors without a network call when the credential is expired and has no refresh token", async () => {
+    const provider = startMockProvider(
+      () => new Response("should not be called", { status: 500 }),
+    );
+    try {
+      const credential = buildCredential({
+        expiresAt: Date.now() - 1000,
+        refreshToken: undefined,
+      });
+      const result = await ensureFreshCredential({
+        configDir,
+        credential,
+        credentialFile: upsertCredential(credentialFile, credential),
+        metadata: provider.metadata,
+      });
+
+      expect(result.status).toBe("error");
+      if (result.status === "error") {
+        expect(result.error._tag).toBe("NoRefreshTokenError");
+      }
+      expect(provider.getRequestCount()).toBe(0);
+    } finally {
+      provider.close();
+    }
+  });
+});

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -1,0 +1,85 @@
+// Token refresh state machine: called proactively (context/whoami resolution)
+// and reactively (a future Phase 3+ HTTP client on a 401) to keep a stored
+// credential usable without forcing a full re-login.
+//
+// Today's server config issues no refresh tokens at all (the oauthProvider's
+// `scopes` list has no `offline_access`, which is what
+// `@better-auth/oauth-provider` gates refresh-token issuance on — see
+// `packages/cli/src/auth/login.ts`'s module comment and the design brief).
+// This function is still exercised end-to-end against a mocked provider
+// (see `ensure-fresh-credential.test.ts`) so it is ready the moment that
+// scope is added server-side; until then every credential this CLI stores
+// simply has no `refreshToken` and expires after `ACCESS_TOKEN_EXPIRES_IN`.
+
+import { Result } from "better-result";
+
+import { getMcpResourceUrl } from "./constants.js";
+import { upsertCredential, writeCredentialFile } from "./credential-store.js";
+import type { CredentialFile, StoredCredential } from "./credential-store.js";
+import { NoRefreshTokenError } from "./errors.js";
+import type { CliAuthError } from "./errors.js";
+import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
+import { refreshAccessToken } from "./token-exchange.js";
+
+/** How much of a credential's remaining lifetime triggers a proactive refresh. */
+const REFRESH_SKEW_MS = 30_000;
+
+export type EnsureFreshCredentialInput = {
+  readonly configDir: string;
+  readonly credential: StoredCredential;
+  readonly credentialFile: CredentialFile;
+  readonly metadata: AuthorizationServerMetadata;
+  readonly now?: number;
+};
+
+/**
+ * Returns a credential guaranteed usable "now" (with `REFRESH_SKEW_MS` of
+ * slack), refreshing and persisting it first if it is expired or about to
+ * expire. Errors when the credential is expired and either has no refresh
+ * token or the refresh call itself fails — both cases mean the caller must
+ * fall back to `stella auth login`.
+ */
+export const ensureFreshCredential = async (
+  input: EnsureFreshCredentialInput,
+): Promise<Result<StoredCredential, CliAuthError>> => {
+  const now = input.now ?? Date.now();
+  if (input.credential.expiresAt - REFRESH_SKEW_MS > now) {
+    return Result.ok(input.credential);
+  }
+
+  if (!input.credential.refreshToken) {
+    return Result.err(
+      new NoRefreshTokenError({
+        message:
+          "The stored access token has expired and no refresh token is available. Run `stella auth login` again.",
+      }),
+    );
+  }
+
+  const refreshed = await refreshAccessToken({
+    clientId: input.credential.clientId,
+    metadata: input.metadata,
+    refreshToken: input.credential.refreshToken,
+    resource: getMcpResourceUrl(input.credential.serverUrl),
+  });
+  if (Result.isError(refreshed)) {
+    return Result.err(refreshed.error);
+  }
+
+  const updated: StoredCredential = {
+    ...input.credential,
+    accessToken: refreshed.value.access_token,
+    expiresAt: now + refreshed.value.expires_in * 1000,
+    refreshToken:
+      refreshed.value.refresh_token ?? input.credential.refreshToken,
+    scope: refreshed.value.scope ?? input.credential.scope,
+    updatedAt: now,
+  };
+
+  await writeCredentialFile(
+    input.configDir,
+    upsertCredential(input.credentialFile, updated),
+  );
+
+  return Result.ok(updated);
+};

--- a/packages/cli/src/auth/errors.ts
+++ b/packages/cli/src/auth/errors.ts
@@ -1,0 +1,165 @@
+// Tagged errors for the `stella auth` flow (see AGENTS.md "Error Handling":
+// tagged errors over bare `Error`, one `message: string` field on every one).
+//
+// Hand-rolled rather than `better-result`'s `TaggedError(tag)<Props>()`
+// factory: that factory's `class Foo extends TaggedError("Foo")<Props>() {}`
+// shape requires a call expression in the `extends` clause, which
+// `isolatedDeclarations` (this package builds with it — see
+// `cli-config.ts`) rejects outright (`TS9021`). `CliBaseError<Tag>` below
+// gives the same discriminated-union/`_tag` shape without a factory call.
+// Every subclass also declares its own literal `name` field (oxlint's
+// `unicorn/custom-error-definition` checks each class individually, not
+// through inheritance).
+
+export class CliBaseError<Tag extends string> extends Error {
+  override readonly name: Tag;
+  readonly _tag: Tag;
+
+  constructor(tag: Tag, message: string) {
+    super(message);
+    // eslint-disable-next-line unicorn/custom-error-definition -- generic base, never instantiated directly; every concrete subclass sets its own literal `name` too
+    this.name = tag;
+    this._tag = tag;
+  }
+}
+
+export class OAuthMetadataError extends CliBaseError<"OAuthMetadataError"> {
+  override readonly name = "OAuthMetadataError";
+  readonly serverUrl: string;
+  override readonly cause?: unknown;
+
+  constructor(props: { message: string; serverUrl: string; cause?: unknown }) {
+    super("OAuthMetadataError", props.message);
+    this.serverUrl = props.serverUrl;
+    this.cause = props.cause;
+  }
+}
+
+export class ClientRegistrationError extends CliBaseError<"ClientRegistrationError"> {
+  override readonly name = "ClientRegistrationError";
+  override readonly cause?: unknown;
+
+  constructor(props: { message: string; cause?: unknown }) {
+    super("ClientRegistrationError", props.message);
+    this.cause = props.cause;
+  }
+}
+
+export class TokenExchangeError extends CliBaseError<"TokenExchangeError"> {
+  override readonly name = "TokenExchangeError";
+  readonly oauthError?: string | undefined;
+  override readonly cause?: unknown;
+
+  constructor(props: {
+    message: string;
+    oauthError?: string | undefined;
+    cause?: unknown;
+  }) {
+    super("TokenExchangeError", props.message);
+    this.oauthError = props.oauthError;
+    this.cause = props.cause;
+  }
+}
+
+export class TokenRefreshError extends CliBaseError<"TokenRefreshError"> {
+  override readonly name = "TokenRefreshError";
+  readonly oauthError?: string | undefined;
+  override readonly cause?: unknown;
+
+  constructor(props: {
+    message: string;
+    oauthError?: string | undefined;
+    cause?: unknown;
+  }) {
+    super("TokenRefreshError", props.message);
+    this.oauthError = props.oauthError;
+    this.cause = props.cause;
+  }
+}
+
+export class LoopbackTimeoutError extends CliBaseError<"LoopbackTimeoutError"> {
+  override readonly name = "LoopbackTimeoutError";
+
+  constructor(props: { message: string }) {
+    super("LoopbackTimeoutError", props.message);
+  }
+}
+
+export class LoopbackCallbackError extends CliBaseError<"LoopbackCallbackError"> {
+  override readonly name = "LoopbackCallbackError";
+  readonly oauthError: string;
+  readonly oauthErrorDescription?: string | undefined;
+
+  constructor(props: {
+    message: string;
+    oauthError: string;
+    oauthErrorDescription?: string | undefined;
+  }) {
+    super("LoopbackCallbackError", props.message);
+    this.oauthError = props.oauthError;
+    this.oauthErrorDescription = props.oauthErrorDescription;
+  }
+}
+
+export class ManualCallbackParseError extends CliBaseError<"ManualCallbackParseError"> {
+  override readonly name = "ManualCallbackParseError";
+
+  constructor(props: { message: string }) {
+    super("ManualCallbackParseError", props.message);
+  }
+}
+
+export class ServerUrlNotConfiguredError extends CliBaseError<"ServerUrlNotConfiguredError"> {
+  override readonly name = "ServerUrlNotConfiguredError";
+
+  constructor(props: { message: string }) {
+    super("ServerUrlNotConfiguredError", props.message);
+  }
+}
+
+export class CredentialNotFoundError extends CliBaseError<"CredentialNotFoundError"> {
+  override readonly name = "CredentialNotFoundError";
+  readonly serverUrl: string;
+  readonly org?: string | undefined;
+
+  constructor(props: {
+    message: string;
+    serverUrl: string;
+    org?: string | undefined;
+  }) {
+    super("CredentialNotFoundError", props.message);
+    this.serverUrl = props.serverUrl;
+    this.org = props.org;
+  }
+}
+
+export class MissingOrgClaimError extends CliBaseError<"MissingOrgClaimError"> {
+  override readonly name = "MissingOrgClaimError";
+  readonly serverUrl: string;
+
+  constructor(props: { message: string; serverUrl: string }) {
+    super("MissingOrgClaimError", props.message);
+    this.serverUrl = props.serverUrl;
+  }
+}
+
+export class NoRefreshTokenError extends CliBaseError<"NoRefreshTokenError"> {
+  override readonly name = "NoRefreshTokenError";
+
+  constructor(props: { message: string }) {
+    super("NoRefreshTokenError", props.message);
+  }
+}
+
+export type CliAuthError =
+  | OAuthMetadataError
+  | ClientRegistrationError
+  | TokenExchangeError
+  | TokenRefreshError
+  | LoopbackTimeoutError
+  | LoopbackCallbackError
+  | ManualCallbackParseError
+  | ServerUrlNotConfiguredError
+  | CredentialNotFoundError
+  | MissingOrgClaimError
+  | NoRefreshTokenError;

--- a/packages/cli/src/auth/jwt.ts
+++ b/packages/cli/src/auth/jwt.ts
@@ -1,0 +1,56 @@
+// Local (unverified) decode of the access token for `stella auth whoami`.
+//
+// The provider only mints a JWT-format access token when the CLI requests a
+// `resource` at the token endpoint (see `constants.ts#getMcpResourceUrl`);
+// its authenticity was already established by receiving it directly from the
+// token endpoint over TLS, so `whoami` decodes locally rather than making a
+// server round trip, per the design brief. There is no cheap endpoint to
+// resolve `org_id` back to an org slug/name (`/oauth2/userinfo` only returns
+// `sub`/`email`/`name`/`picture`), so `whoami` reports the id verbatim.
+
+import { Result } from "better-result";
+import * as v from "valibot";
+
+// Hand-written rather than `v.InferOutput<typeof schema>` (see
+// `cli-config.ts` for why: this package builds with `isolatedDeclarations`).
+export type AccessTokenClaims = {
+  readonly sub: string;
+  readonly org_id?: string | undefined;
+  readonly scope?: string | undefined;
+  readonly exp: number;
+  readonly iat?: number | undefined;
+  readonly aud?: string | readonly string[] | undefined;
+};
+
+const accessTokenClaimsSchema = v.strictObject({
+  sub: v.string(),
+  org_id: v.optional(v.string()),
+  scope: v.optional(v.string()),
+  exp: v.number(),
+  iat: v.optional(v.number()),
+  aud: v.optional(v.union([v.string(), v.array(v.string())])),
+});
+
+/**
+ * Decodes a JWT's payload segment without verifying its signature. Returns
+ * `undefined` for opaque (non-JWT) tokens or malformed payloads.
+ */
+export const decodeAccessTokenClaims = (
+  accessToken: string,
+): AccessTokenClaims | undefined => {
+  const segments = accessToken.split(".");
+  const payloadSegment = segments.length === 3 ? segments.at(1) : undefined;
+  if (!payloadSegment) {
+    return undefined;
+  }
+
+  const decoded = Result.try((): unknown =>
+    JSON.parse(Buffer.from(payloadSegment, "base64url").toString("utf-8")),
+  );
+  if (Result.isError(decoded)) {
+    return undefined;
+  }
+
+  const parsed = v.safeParse(accessTokenClaimsSchema, decoded.value);
+  return parsed.success ? parsed.output : undefined;
+};

--- a/packages/cli/src/auth/login.ts
+++ b/packages/cli/src/auth/login.ts
@@ -1,0 +1,307 @@
+// Orchestrates `stella auth login`: PKCE authorization-code flow against
+// stella's own oauthProvider, with a loopback listener as the primary
+// transport and a manual URL/code paste as the fallback for headless
+// environments (see module comments in `loopback-listener.ts` and
+// `manual-callback.ts`).
+
+import { Result } from "better-result";
+import { createInterface } from "node:readline/promises";
+
+import { openInBrowser } from "./browser-open.js";
+import { getRegisteredClientId, setRegisteredClientId } from "./cli-config.js";
+import {
+  getMcpResourceUrl,
+  LOGIN_TIMEOUT_MS,
+  LOOPBACK_REDIRECT_URI,
+} from "./constants.js";
+import {
+  readCredentialFile,
+  setDefaultOrg,
+  upsertCredential,
+  writeCredentialFile,
+} from "./credential-store.js";
+import type { StoredCredential } from "./credential-store.js";
+import { MissingOrgClaimError } from "./errors.js";
+import type { CliAuthError, LoopbackTimeoutError } from "./errors.js";
+import { decodeAccessTokenClaims } from "./jwt.js";
+import {
+  startLoopbackListener,
+  toLoopbackCallbackError,
+} from "./loopback-listener.js";
+import type { LoopbackCallback } from "./loopback-listener.js";
+import { parseManualCallbackInput } from "./manual-callback.js";
+import { registerLoopbackClient } from "./oauth-client-registration.js";
+import { discoverAuthorizationServerMetadata } from "./oauth-metadata.js";
+import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
+import { createOAuthState, createPkcePair } from "./pkce.js";
+import { resolveServerUrl } from "./server-resolution.js";
+import { exchangeAuthorizationCode } from "./token-exchange.js";
+
+export type LoginOptions = {
+  readonly configDir: string;
+  readonly orgHint: string | undefined;
+  readonly registrationScopes: readonly string[];
+  readonly requestedScopes: readonly string[];
+  readonly serverFlag: string | undefined;
+};
+
+export type LoginSuccess = {
+  readonly serverUrl: string;
+  readonly orgId: string;
+  readonly grantedScopes: string;
+  readonly expiresAt: number;
+  readonly hasRefreshToken: boolean;
+};
+
+type Io = {
+  readonly print: (line: string) => void;
+  readonly promptLine: (question: string) => Promise<string>;
+};
+
+const buildIo = (process: NodeJS.Process): Io => ({
+  print: (line) => {
+    process.stdout.write(`${line}\n`);
+  },
+  promptLine: async (question) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    try {
+      return await rl.question(question);
+    } finally {
+      rl.close();
+    }
+  },
+});
+
+const buildAuthorizeUrl = (input: {
+  authorizationEndpoint: string;
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  scopes: readonly string[];
+  state: string;
+}): string => {
+  const url = new URL(input.authorizationEndpoint);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", input.clientId);
+  url.searchParams.set("redirect_uri", input.redirectUri);
+  url.searchParams.set("code_challenge", input.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", input.state);
+  if (input.scopes.length > 0) {
+    url.searchParams.set("scope", input.scopes.join(" "));
+  }
+  return url.toString();
+};
+
+/** Gets the cached loopback client id for `serverUrl`, registering one if none exists yet. */
+const getOrRegisterClient = async (
+  configDir: string,
+  serverUrl: string,
+  metadata: AuthorizationServerMetadata,
+  registrationScopes: readonly string[],
+): Promise<Result<string, CliAuthError>> => {
+  const cached = await getRegisteredClientId(configDir, serverUrl);
+  if (cached) {
+    return Result.ok(cached);
+  }
+
+  const registered = await registerLoopbackClient(metadata, registrationScopes);
+  if (Result.isError(registered)) {
+    return registered;
+  }
+
+  await setRegisteredClientId(configDir, serverUrl, registered.value);
+  return Result.ok(registered.value);
+};
+
+const isLoopbackCallback = (
+  value: LoopbackCallback | LoopbackTimeoutError,
+): value is LoopbackCallback => "kind" in value;
+
+type AuthorizationCode = {
+  readonly code: string;
+  readonly redirectUri: string;
+};
+
+const awaitManualCode = async (
+  io: Io,
+  redirectUri: string,
+  expectedState: string,
+): Promise<Result<AuthorizationCode, CliAuthError>> => {
+  const pasted = await io.promptLine("Paste the redirected URL or code: ");
+  const parsed = parseManualCallbackInput(pasted);
+  if (Result.isError(parsed)) {
+    return Result.err(parsed.error);
+  }
+
+  if (parsed.value.state && parsed.value.state !== expectedState) {
+    return Result.err(
+      toLoopbackCallbackError({ error: "invalid_state", kind: "error" }),
+    );
+  }
+
+  return Result.ok({ code: parsed.value.code, redirectUri });
+};
+
+/**
+ * Waits for the loopback callback, falling back to manual paste if the
+ * listener never fires. `redirectUri` must be whichever URI was actually
+ * used to build the authorize request (the listener's port-specific one, or
+ * the portless default when no listener could be started) — the token
+ * endpoint later requires an exact match (RFC 6749 S4.1.3).
+ */
+const awaitAuthorizationCode = async (
+  io: Io,
+  authorizeUrl: string,
+  redirectUri: string,
+  listener: ReturnType<typeof startLoopbackListener>,
+  expectedState: string,
+): Promise<Result<AuthorizationCode, CliAuthError>> => {
+  io.print("Opening the stella sign-in page in your browser:");
+  io.print(`  ${authorizeUrl}`);
+  void openInBrowser(authorizeUrl);
+
+  if (!listener) {
+    io.print(
+      "Could not start a local listener; complete sign-in in any browser, then paste the redirected URL (or just the code) below.",
+    );
+    return awaitManualCode(io, redirectUri, expectedState);
+  }
+
+  const result = await listener.waitForCallback(LOGIN_TIMEOUT_MS);
+  listener.close();
+
+  if (!isLoopbackCallback(result)) {
+    // Timed out waiting locally: the browser most likely isn't reachable
+    // from this machine (SSH/remote dev/agent sandbox). Fall back to manual.
+    io.print(
+      "Timed out waiting for the browser. If you're running headless, complete sign-in in any browser, then paste the redirected URL (or just the code) below.",
+    );
+    return awaitManualCode(io, redirectUri, expectedState);
+  }
+
+  if (result.kind === "error") {
+    return Result.err(toLoopbackCallbackError(result));
+  }
+
+  if (result.state !== expectedState) {
+    return Result.err(
+      toLoopbackCallbackError({ error: "invalid_state", kind: "error" }),
+    );
+  }
+
+  return Result.ok({ code: result.code, redirectUri });
+};
+
+// Sequential steps with different Ok types chained via `Result.gen` +
+// `yield* Result.await(...)` (see AGENTS.md's Error Handling conventions):
+// this avoids re-wrapping every intermediate error result by hand.
+export const login = async (
+  process: NodeJS.Process,
+  options: LoginOptions,
+): Promise<Result<LoginSuccess, CliAuthError>> =>
+  await Result.gen(async function* loginGen() {
+    const io = buildIo(process);
+
+    const serverUrl = yield* Result.await(
+      resolveServerUrl(options.configDir, options.serverFlag),
+    );
+    const metadata = yield* Result.await(
+      discoverAuthorizationServerMetadata(serverUrl),
+    );
+    const clientId = yield* Result.await(
+      getOrRegisterClient(
+        options.configDir,
+        serverUrl,
+        metadata,
+        options.registrationScopes,
+      ),
+    );
+
+    const { codeChallenge, codeVerifier } = createPkcePair();
+    const state = createOAuthState();
+
+    if (options.orgHint) {
+      io.print(
+        `If prompted to select an organization in the browser, choose: ${options.orgHint} (the CLI cannot preselect it for you; org selection happens in the browser UI).`,
+      );
+    }
+
+    // Start the listener before building the authorize URL: the redirect_uri
+    // sent to the authorization server must be whichever one the browser
+    // will actually be redirected back to (the listener's ephemeral port, or
+    // the portless default if binding failed), and it must stay identical
+    // through to the token exchange.
+    const listener = startLoopbackListener();
+    const redirectUri = listener?.redirectUri ?? LOOPBACK_REDIRECT_URI;
+
+    const authorizeUrl = buildAuthorizeUrl({
+      authorizationEndpoint: metadata.authorization_endpoint,
+      clientId,
+      codeChallenge,
+      redirectUri,
+      scopes: options.requestedScopes,
+      state,
+    });
+
+    const callback = yield* Result.await(
+      awaitAuthorizationCode(io, authorizeUrl, redirectUri, listener, state),
+    );
+
+    const token = yield* Result.await(
+      exchangeAuthorizationCode({
+        clientId,
+        code: callback.code,
+        codeVerifier,
+        metadata,
+        redirectUri: callback.redirectUri,
+        resource: getMcpResourceUrl(serverUrl),
+      }),
+    );
+
+    const claims = decodeAccessTokenClaims(token.access_token);
+    if (!claims?.org_id) {
+      return Result.err(
+        new MissingOrgClaimError({
+          message:
+            "The access token has no org_id claim, so the CLI cannot tell which organization was granted. Re-run `stella auth login` and make sure an organization is active when you reach the consent screen.",
+          serverUrl,
+        }),
+      );
+    }
+
+    const now = Date.now();
+    const credential: StoredCredential = {
+      accessToken: token.access_token,
+      clientId,
+      createdAt: now,
+      expiresAt: now + token.expires_in * 1000,
+      orgId: claims.org_id,
+      ...(options.orgHint ? { orgLabel: options.orgHint } : {}),
+      refreshToken: token.refresh_token,
+      scope: token.scope ?? options.requestedScopes.join(" "),
+      serverUrl,
+      tokenType: token.token_type,
+      updatedAt: now,
+    };
+
+    const existingFile = await readCredentialFile(options.configDir);
+    const withCredential = upsertCredential(existingFile, credential);
+    const withDefaultOrg = setDefaultOrg(
+      withCredential,
+      serverUrl,
+      credential.orgId,
+    );
+    await writeCredentialFile(options.configDir, withDefaultOrg);
+
+    return Result.ok({
+      expiresAt: credential.expiresAt,
+      grantedScopes: credential.scope,
+      hasRefreshToken: Boolean(credential.refreshToken),
+      orgId: credential.orgId,
+      serverUrl,
+    });
+  });

--- a/packages/cli/src/auth/loopback-listener.test.ts
+++ b/packages/cli/src/auth/loopback-listener.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import { startLoopbackListener } from "./loopback-listener.js";
+
+describe("startLoopbackListener", () => {
+  test("binds an ephemeral 127.0.0.1 port and reports it in redirectUri", () => {
+    const listener = startLoopbackListener();
+    try {
+      expect(listener).toBeDefined();
+      expect(listener?.port).toBeGreaterThan(0);
+      expect(listener?.redirectUri).toBe(
+        `http://127.0.0.1:${listener?.port}/callback`,
+      );
+    } finally {
+      listener?.close();
+    }
+  });
+
+  test("delivers a success callback parsed from the redirect query string", async () => {
+    const listener = startLoopbackListener();
+    if (!listener) {
+      throw new Error("listener failed to bind");
+    }
+
+    try {
+      const pending = listener.waitForCallback(5000);
+      const response = await fetch(
+        `${listener.redirectUri}?code=abc123&state=xyz789`,
+      );
+      expect(response.status).toBe(200);
+
+      const callback = await pending;
+      expect(callback).toEqual({
+        code: "abc123",
+        kind: "success",
+        state: "xyz789",
+      });
+    } finally {
+      listener.close();
+    }
+  });
+
+  test("delivers an error callback with error_description when the provider redirects an error", async () => {
+    const listener = startLoopbackListener();
+    if (!listener) {
+      throw new Error("listener failed to bind");
+    }
+
+    try {
+      const pending = listener.waitForCallback(5000);
+      const url = new URL(listener.redirectUri);
+      url.searchParams.set("error", "access_denied");
+      url.searchParams.set("error_description", "user declined consent");
+      url.searchParams.set("state", "xyz789");
+      await fetch(url);
+
+      const callback = await pending;
+      expect(callback).toEqual({
+        error: "access_denied",
+        errorDescription: "user declined consent",
+        kind: "error",
+        state: "xyz789",
+      });
+    } finally {
+      listener.close();
+    }
+  });
+
+  test("responds 400 and does not resolve when code or state is missing", async () => {
+    const listener = startLoopbackListener();
+    if (!listener) {
+      throw new Error("listener failed to bind");
+    }
+
+    try {
+      const response = await fetch(`${listener.redirectUri}?code=abc123`);
+      expect(response.status).toBe(400);
+    } finally {
+      listener.close();
+    }
+  });
+
+  test("responds 404 for a path other than the callback path", async () => {
+    const listener = startLoopbackListener();
+    if (!listener) {
+      throw new Error("listener failed to bind");
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${listener.port}/other`);
+      expect(response.status).toBe(404);
+    } finally {
+      listener.close();
+    }
+  });
+
+  test("waitForCallback times out with a LoopbackTimeoutError when nothing arrives", async () => {
+    const listener = startLoopbackListener();
+    if (!listener) {
+      throw new Error("listener failed to bind");
+    }
+
+    try {
+      const result = await listener.waitForCallback(20);
+      if (!(result instanceof Error)) {
+        throw new Error("expected a LoopbackTimeoutError");
+      }
+      expect(result.name).toBe("LoopbackTimeoutError");
+    } finally {
+      listener.close();
+    }
+  });
+});

--- a/packages/cli/src/auth/loopback-listener.ts
+++ b/packages/cli/src/auth/loopback-listener.ts
@@ -1,0 +1,141 @@
+// Ephemeral 127.0.0.1 listener for the loopback redirect (RFC 8252).
+//
+// Binds port 0 (OS-assigned) so concurrent logins and busy dev machines never
+// collide. The registered client's redirect_uri has no port (see
+// `constants.ts#LOOPBACK_REDIRECT_URI`); better-auth's loopback exemption
+// matches on hostname/pathname/protocol/search only, so any ephemeral port
+// still satisfies the registered redirect_uri.
+
+import { LOOPBACK_REDIRECT_PATH } from "./constants.js";
+import { LoopbackCallbackError, LoopbackTimeoutError } from "./errors.js";
+
+export type LoopbackCallback =
+  | { readonly kind: "success"; readonly code: string; readonly state: string }
+  | {
+      readonly kind: "error";
+      readonly error: string;
+      readonly errorDescription?: string;
+      readonly state?: string;
+    };
+
+export type LoopbackListener = {
+  readonly port: number;
+  readonly redirectUri: string;
+  readonly waitForCallback: (
+    timeoutMs: number,
+  ) => Promise<LoopbackCallback | LoopbackTimeoutError>;
+  readonly close: () => void;
+};
+
+const renderCallbackPage = (ok: boolean): string =>
+  `<!doctype html><html><head><meta charset="utf-8"><title>stella CLI</title></head>` +
+  `<body><p>${ok ? "Signed in. You can close this tab and return to the terminal." : "Sign-in failed. Return to the terminal for details."}</p></body></html>`;
+
+const raceWithTimeout = async (
+  received: Promise<LoopbackCallback>,
+  timeoutMs: number,
+): Promise<LoopbackCallback | LoopbackTimeoutError> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<LoopbackTimeoutError>((resolve) => {
+    timer = setTimeout(() => {
+      resolve(
+        new LoopbackTimeoutError({
+          message: `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the browser sign-in to complete.`,
+        }),
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([received, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
+/**
+ * Starts the loopback HTTP listener. Returns `undefined` if binding fails
+ * (sandboxed/offline environments) so callers can fall back to the manual
+ * paste flow instead of crashing.
+ */
+export const startLoopbackListener = (): LoopbackListener | undefined => {
+  let deliver: ((callback: LoopbackCallback) => void) | undefined;
+  const received = new Promise<LoopbackCallback>((resolve) => {
+    deliver = resolve;
+  });
+
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname !== LOOPBACK_REDIRECT_PATH) {
+          return new Response("Not found", { status: 404 });
+        }
+
+        const error = url.searchParams.get("error");
+        if (error) {
+          const errorDescription = url.searchParams.get("error_description");
+          const state = url.searchParams.get("state");
+          deliver?.({
+            error,
+            kind: "error",
+            ...(errorDescription ? { errorDescription } : {}),
+            ...(state ? { state } : {}),
+          });
+          return new Response(renderCallbackPage(false), {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+        if (!code || !state) {
+          return new Response("Missing code or state", { status: 400 });
+        }
+
+        deliver?.({ code, kind: "success", state });
+        return new Response(renderCallbackPage(true), {
+          headers: { "Content-Type": "text/html" },
+        });
+      },
+      hostname: "127.0.0.1",
+      port: 0,
+    });
+  } catch {
+    return undefined;
+  }
+
+  // `Server.port` is typed optional to cover unix-socket servers; a
+  // `hostname`+`port: 0` TCP server (as configured above) always reports a
+  // real port, so this fallback is unreachable in practice.
+  const listenerPort = server.port ?? 0;
+
+  return {
+    // `Server.stop()` returns a `Promise<void>` that resolves once in-flight
+    // connections drain; the CLI doesn't need to wait for that; it just
+    // needs the port freed and no more callbacks delivered.
+    close: () => {
+      void server.stop(true);
+    },
+    port: listenerPort,
+    redirectUri: `http://127.0.0.1:${listenerPort}${LOOPBACK_REDIRECT_PATH}`,
+    waitForCallback: async (timeoutMs) =>
+      await raceWithTimeout(received, timeoutMs),
+  };
+};
+
+/** Converts a listener callback into the `TaggedError` shape the login flow expects. */
+export const toLoopbackCallbackError = (
+  callback: Extract<LoopbackCallback, { kind: "error" }>,
+): LoopbackCallbackError =>
+  new LoopbackCallbackError({
+    message:
+      callback.error === "set_organization"
+        ? "Your account needs an active organization before granting stella CLI access. Complete organization setup in the browser (create or select one), then re-run `stella auth login`."
+        : (callback.errorDescription ?? callback.error),
+    oauthError: callback.error,
+    oauthErrorDescription: callback.errorDescription,
+  });

--- a/packages/cli/src/auth/manage.ts
+++ b/packages/cli/src/auth/manage.ts
@@ -1,0 +1,154 @@
+// `stella auth whoami` / `logout` / `switch`: read-mostly operations against
+// the credential store, resolved for whichever server is currently active.
+
+import { Result } from "better-result";
+
+import {
+  findCredentialByOrgHint,
+  findDefaultCredential,
+  listCredentialsForServer,
+  readCredentialFile,
+  removeCredential,
+  setDefaultOrg,
+  writeCredentialFile,
+} from "./credential-store.js";
+import type { StoredCredential } from "./credential-store.js";
+import { CredentialNotFoundError } from "./errors.js";
+import type { CliAuthError } from "./errors.js";
+import { decodeAccessTokenClaims } from "./jwt.js";
+import type { AccessTokenClaims } from "./jwt.js";
+
+const resolveCredential = async (
+  configDir: string,
+  serverUrl: string,
+  orgHint: string | undefined,
+): Promise<
+  Result<
+    { credential: StoredCredential; allForServer: readonly StoredCredential[] },
+    CliAuthError
+  >
+> => {
+  const file = await readCredentialFile(configDir);
+  const allForServer = listCredentialsForServer(file, serverUrl);
+
+  const credential = orgHint
+    ? findCredentialByOrgHint(file, serverUrl, orgHint)
+    : findDefaultCredential(file, serverUrl);
+
+  if (!credential) {
+    const guidance =
+      orgHint && allForServer.length > 0
+        ? `Not signed in to "${orgHint}" on ${serverUrl}. Known orgs here: ${allForServer.map((c) => c.orgLabel ?? c.orgId).join(", ")}.`
+        : `Not signed in to ${serverUrl}. Run \`stella auth login\`${orgHint ? ` --org ${orgHint}` : ""}.`;
+    return Result.err(
+      new CredentialNotFoundError({
+        message: guidance,
+        org: orgHint,
+        serverUrl,
+      }),
+    );
+  }
+
+  return Result.ok({ allForServer, credential });
+};
+
+export type WhoamiInfo = {
+  readonly serverUrl: string;
+  readonly orgId: string;
+  readonly orgLabel: string | undefined;
+  readonly scope: string;
+  readonly expiresAt: number;
+  readonly isExpired: boolean;
+  readonly hasRefreshToken: boolean;
+  readonly claims: AccessTokenClaims | undefined;
+};
+
+export const whoami = async (
+  configDir: string,
+  serverUrl: string,
+  orgHint: string | undefined,
+): Promise<Result<WhoamiInfo, CliAuthError>> => {
+  const resolved = await resolveCredential(configDir, serverUrl, orgHint);
+  if (Result.isError(resolved)) {
+    return Result.err(resolved.error);
+  }
+  const { credential } = resolved.value;
+
+  return Result.ok({
+    claims: decodeAccessTokenClaims(credential.accessToken),
+    expiresAt: credential.expiresAt,
+    hasRefreshToken: Boolean(credential.refreshToken),
+    isExpired: credential.expiresAt <= Date.now(),
+    orgId: credential.orgId,
+    orgLabel: credential.orgLabel,
+    scope: credential.scope,
+    serverUrl: credential.serverUrl,
+  });
+};
+
+export const logout = async (
+  configDir: string,
+  serverUrl: string,
+  orgHint: string | undefined,
+): Promise<Result<{ orgId: string }, CliAuthError>> => {
+  const file = await readCredentialFile(configDir);
+  const allForServer = listCredentialsForServer(file, serverUrl);
+
+  if (allForServer.length === 0) {
+    return Result.err(
+      new CredentialNotFoundError({
+        message: `Not signed in to ${serverUrl}.`,
+        serverUrl,
+      }),
+    );
+  }
+
+  let target: StoredCredential | undefined;
+  if (orgHint) {
+    target = findCredentialByOrgHint(file, serverUrl, orgHint);
+  } else if (allForServer.length === 1) {
+    target = allForServer.at(0);
+  }
+
+  if (!target) {
+    return Result.err(
+      new CredentialNotFoundError({
+        message: `Multiple organizations are signed in on ${serverUrl} (${allForServer.map((c) => c.orgLabel ?? c.orgId).join(", ")}); pass --org to pick one.`,
+        serverUrl,
+      }),
+    );
+  }
+
+  await writeCredentialFile(
+    configDir,
+    removeCredential(file, serverUrl, target.orgId),
+  );
+  return Result.ok({ orgId: target.orgId });
+};
+
+export const switchOrg = async (
+  configDir: string,
+  serverUrl: string,
+  orgHint: string,
+): Promise<Result<{ orgId: string }, CliAuthError>> => {
+  const file = await readCredentialFile(configDir);
+  const target = findCredentialByOrgHint(file, serverUrl, orgHint);
+
+  if (!target) {
+    const allForServer = listCredentialsForServer(file, serverUrl);
+    const known = allForServer.map((c) => c.orgLabel ?? c.orgId).join(", ");
+    return Result.err(
+      new CredentialNotFoundError({
+        message: `Not signed in to "${orgHint}" on ${serverUrl}.${known ? ` Known orgs here: ${known}.` : ""} Run \`stella auth login --org ${orgHint}\` first.`,
+        org: orgHint,
+        serverUrl,
+      }),
+    );
+  }
+
+  await writeCredentialFile(
+    configDir,
+    setDefaultOrg(file, serverUrl, target.orgId),
+  );
+  return Result.ok({ orgId: target.orgId });
+};

--- a/packages/cli/src/auth/manual-callback.test.ts
+++ b/packages/cli/src/auth/manual-callback.test.ts
@@ -1,0 +1,58 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { parseManualCallbackInput } from "./manual-callback.js";
+
+describe("parseManualCallbackInput", () => {
+  test("parses a full redirected URL", () => {
+    const result = parseManualCallbackInput(
+      "http://127.0.0.1:54321/callback?code=abc123&state=xyz789",
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value).toEqual({ code: "abc123", state: "xyz789" });
+    }
+  });
+
+  test("trims surrounding whitespace from a pasted URL", () => {
+    const result = parseManualCallbackInput(
+      "  http://127.0.0.1/callback?code=abc123&state=xyz789  \n",
+    );
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("accepts a bare authorization code with no URL", () => {
+    const result = parseManualCallbackInput("abc123");
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value).toEqual({ code: "abc123", state: undefined });
+    }
+  });
+
+  test("rejects empty input", () => {
+    expect(Result.isError(parseManualCallbackInput(""))).toBe(true);
+    expect(Result.isError(parseManualCallbackInput("   "))).toBe(true);
+  });
+
+  test("surfaces an error= query parameter from the redirected URL", () => {
+    const result = parseManualCallbackInput(
+      "http://127.0.0.1/callback?error=access_denied&error_description=user+declined",
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.message).toBe("user declined");
+    }
+  });
+
+  test("rejects a URL with no code parameter", () => {
+    const result = parseManualCallbackInput(
+      "http://127.0.0.1/callback?state=xyz789",
+    );
+    expect(Result.isError(result)).toBe(true);
+  });
+
+  test("rejects an unparseable URL-like string", () => {
+    const result = parseManualCallbackInput("http://");
+    expect(Result.isError(result)).toBe(true);
+  });
+});

--- a/packages/cli/src/auth/manual-callback.ts
+++ b/packages/cli/src/auth/manual-callback.ts
@@ -1,0 +1,65 @@
+// Headless fallback: the user completes the OAuth flow in any browser (not
+// necessarily one reachable from the CLI's machine) and pastes back either
+// the full redirected URL or the bare `code` value.
+
+import { Result } from "better-result";
+
+import { ManualCallbackParseError } from "./errors.js";
+
+export type ParsedManualCallback = {
+  readonly code: string;
+  /** `undefined` when the user pasted a bare code and no state could be checked. */
+  readonly state: string | undefined;
+};
+
+/**
+ * Parses manual-paste input. Accepts a full redirect URL (`http://127.0.0.1/
+ * callback?code=...&state=...`) or a bare authorization code.
+ */
+export const parseManualCallbackInput = (
+  input: string,
+): Result<ParsedManualCallback, ManualCallbackParseError> => {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return Result.err(
+      new ManualCallbackParseError({ message: "No input provided" }),
+    );
+  }
+
+  if (!trimmed.includes("://")) {
+    return Result.ok({ code: trimmed, state: undefined });
+  }
+
+  const parsedUrl = Result.try(() => new URL(trimmed));
+  if (Result.isError(parsedUrl)) {
+    return Result.err(
+      new ManualCallbackParseError({
+        message: `Could not parse "${trimmed}" as a URL or a bare authorization code`,
+      }),
+    );
+  }
+
+  const error = parsedUrl.value.searchParams.get("error");
+  if (error) {
+    const description = parsedUrl.value.searchParams.get("error_description");
+    return Result.err(
+      new ManualCallbackParseError({
+        message: description ?? error,
+      }),
+    );
+  }
+
+  const code = parsedUrl.value.searchParams.get("code");
+  if (!code) {
+    return Result.err(
+      new ManualCallbackParseError({
+        message: "The pasted URL has no `code` query parameter",
+      }),
+    );
+  }
+
+  return Result.ok({
+    code,
+    state: parsedUrl.value.searchParams.get("state") ?? undefined,
+  });
+};

--- a/packages/cli/src/auth/oauth-client-registration.ts
+++ b/packages/cli/src/auth/oauth-client-registration.ts
@@ -1,0 +1,76 @@
+// Dynamic client registration (RFC 7591) against a `registration_endpoint`
+// better-auth's oauth-provider exposes with `allowDynamicClientRegistration`
+// and `allowUnauthenticatedClientRegistration` both enabled (see
+// `apps/api/src/lib/auth.ts`). Unauthenticated registration always resolves
+// to a public client (`token_endpoint_auth_method: "none"`) server-side
+// regardless of what the request asks for, so the CLI's request body is
+// mostly documentation of intent.
+
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import {
+  AUTH_FETCH_TIMEOUT_MS,
+  CLIENT_NAME,
+  LOOPBACK_REDIRECT_URI,
+} from "./constants.js";
+import { ClientRegistrationError } from "./errors.js";
+import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
+
+const registrationResponseSchema = v.looseObject({
+  client_id: v.string(),
+});
+
+/** Registers a fresh public loopback client with the requested scopes. */
+export const registerLoopbackClient = async (
+  metadata: AuthorizationServerMetadata,
+  scopes: readonly string[],
+): Promise<Result<string, ClientRegistrationError>> => {
+  if (!metadata.registration_endpoint) {
+    return Result.err(
+      new ClientRegistrationError({
+        message:
+          "The server does not advertise a registration_endpoint (allowDynamicClientRegistration is off). A pre-registered loopback client id would need to be configured out of band; this is a server-side gap, not something the CLI can work around.",
+      }),
+    );
+  }
+
+  const body = {
+    client_name: CLIENT_NAME,
+    grant_types: ["authorization_code", "refresh_token"],
+    redirect_uris: [LOOPBACK_REDIRECT_URI],
+    response_types: ["code"],
+    scope: scopes.join(" "),
+    token_endpoint_auth_method: "none",
+    type: "native",
+  };
+
+  return await Result.tryPromise({
+    catch: (cause) =>
+      cause instanceof ClientRegistrationError
+        ? cause
+        : new ClientRegistrationError({
+            cause,
+            message: "Failed to register the stella CLI as an OAuth client",
+          }),
+    try: async () => {
+      const response = await fetch(metadata.registration_endpoint ?? "", {
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new ClientRegistrationError({
+          message: `registration_endpoint responded ${response.status}: ${text}`,
+        });
+      }
+
+      const json: unknown = await response.json();
+      const parsed = v.parse(registrationResponseSchema, json);
+      return parsed.client_id;
+    },
+  });
+};

--- a/packages/cli/src/auth/oauth-metadata.ts
+++ b/packages/cli/src/auth/oauth-metadata.ts
@@ -1,0 +1,81 @@
+// RFC 8414 authorization-server-metadata discovery.
+
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import {
+  AUTH_FETCH_TIMEOUT_MS,
+  AUTHORIZATION_SERVER_METADATA_PATHS,
+} from "./constants.js";
+import { OAuthMetadataError } from "./errors.js";
+
+// Hand-written rather than `v.InferOutput<typeof schema>` (see
+// `cli-config.ts` for why: this package builds with `isolatedDeclarations`).
+export type AuthorizationServerMetadata = {
+  readonly issuer: string;
+  readonly authorization_endpoint: string;
+  readonly token_endpoint: string;
+  readonly registration_endpoint?: string | undefined;
+  readonly code_challenge_methods_supported?: readonly string[] | undefined;
+  readonly scopes_supported?: readonly string[] | undefined;
+  readonly token_endpoint_auth_methods_supported?:
+    | readonly string[]
+    | undefined;
+};
+
+const authorizationServerMetadataSchema = v.strictObject({
+  issuer: v.pipe(v.string(), v.url()),
+  authorization_endpoint: v.pipe(v.string(), v.url()),
+  token_endpoint: v.pipe(v.string(), v.url()),
+  registration_endpoint: v.optional(v.pipe(v.string(), v.url())),
+  code_challenge_methods_supported: v.optional(v.array(v.string())),
+  scopes_supported: v.optional(v.array(v.string())),
+  token_endpoint_auth_methods_supported: v.optional(v.array(v.string())),
+});
+
+const fetchCandidate = async (
+  url: string,
+): Promise<AuthorizationServerMetadata | undefined> => {
+  const attempt = await Result.tryPromise(async () => {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
+    });
+    return response.ok ? await response.json() : undefined;
+  });
+  if (Result.isError(attempt) || attempt.value === undefined) {
+    return undefined;
+  }
+
+  const parsed = v.safeParse(authorizationServerMetadataSchema, attempt.value);
+  return parsed.success ? parsed.output : undefined;
+};
+
+/**
+ * Discovers the OAuth authorization-server metadata for `serverUrl` by
+ * trying both the RFC 8414 root-issuer path and better-auth's actual mount
+ * path (see `AUTHORIZATION_SERVER_METADATA_PATHS`), in order. The two
+ * candidates are unrolled explicitly (not looped) so the second request
+ * only ever fires once the first has definitively failed.
+ */
+export const discoverAuthorizationServerMetadata = async (
+  serverUrl: string,
+): Promise<Result<AuthorizationServerMetadata, OAuthMetadataError>> => {
+  const origin = serverUrl.replace(/\/$/u, "");
+  const [rootPath, mountedPath] = AUTHORIZATION_SERVER_METADATA_PATHS;
+
+  const found =
+    (await fetchCandidate(`${origin}${rootPath}`)) ??
+    (await fetchCandidate(`${origin}${mountedPath}`));
+
+  if (found) {
+    return Result.ok(found);
+  }
+
+  return Result.err(
+    new OAuthMetadataError({
+      message: `Could not discover OAuth authorization server metadata at ${serverUrl}. Pass --server pointing at the stella API origin (not the web app), and confirm the server exposes ${AUTHORIZATION_SERVER_METADATA_PATHS.join(" or ")}.`,
+      serverUrl,
+    }),
+  );
+};

--- a/packages/cli/src/auth/pkce.test.ts
+++ b/packages/cli/src/auth/pkce.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createOAuthState,
+  createPkcePair,
+  generateCodeChallenge,
+} from "./pkce.js";
+
+// RFC 7636 Appendix B's worked example: a fixed verifier and its known-good
+// S256 challenge. Pinning this catches any accidental change to the hash
+// algorithm/encoding (e.g. swapping base64 for base64url) that unit tests
+// against freshly-generated values would never notice.
+const RFC_7636_APPENDIX_B_VERIFIER =
+  "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+const RFC_7636_APPENDIX_B_CHALLENGE =
+  "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+describe("generateCodeChallenge", () => {
+  test("matches the RFC 7636 Appendix B worked example", () => {
+    expect(generateCodeChallenge(RFC_7636_APPENDIX_B_VERIFIER)).toBe(
+      RFC_7636_APPENDIX_B_CHALLENGE,
+    );
+  });
+
+  test("is deterministic for a given verifier", () => {
+    const verifier = createPkcePair().codeVerifier;
+    expect(generateCodeChallenge(verifier)).toBe(
+      generateCodeChallenge(verifier),
+    );
+  });
+});
+
+describe("createPkcePair", () => {
+  test("codeVerifier uses only the RFC 7636 unreserved charset", () => {
+    const { codeVerifier } = createPkcePair();
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9\-._~]+$/u);
+  });
+
+  test("codeVerifier length falls within RFC 7636's 43-128 bound", () => {
+    const { codeVerifier } = createPkcePair();
+    expect(codeVerifier.length).toBeGreaterThanOrEqual(43);
+    expect(codeVerifier.length).toBeLessThanOrEqual(128);
+  });
+
+  test("codeChallenge is the S256 hash of codeVerifier", () => {
+    const { codeChallenge, codeVerifier } = createPkcePair();
+    expect(codeChallenge).toBe(generateCodeChallenge(codeVerifier));
+  });
+
+  test("generates a fresh verifier on every call", () => {
+    const first = createPkcePair();
+    const second = createPkcePair();
+    expect(first.codeVerifier).not.toBe(second.codeVerifier);
+  });
+});
+
+describe("createOAuthState", () => {
+  test("generates a fresh value on every call", () => {
+    expect(createOAuthState()).not.toBe(createOAuthState());
+  });
+
+  test("uses a URL-safe charset (no query-string escaping needed)", () => {
+    expect(createOAuthState()).toMatch(/^[A-Za-z0-9\-_]+$/u);
+  });
+});

--- a/packages/cli/src/auth/pkce.ts
+++ b/packages/cli/src/auth/pkce.ts
@@ -1,0 +1,34 @@
+// PKCE (RFC 7636) helpers for the loopback authorization-code flow.
+//
+// Mirrors the existing repo convention for PKCE generation
+// (`apps/api/src/handlers/mcp-connectors/oauth.ts`'s `createPkce`): random
+// bytes via Web Crypto, S256 challenge via `Bun.CryptoHasher` per the
+// "prefer Bun-native APIs" convention.
+
+const VERIFIER_BYTES = 32;
+const STATE_BYTES = 32;
+
+const randomBase64Url = (byteLength: number): string => {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString("base64url");
+};
+
+export type PkcePair = {
+  readonly codeVerifier: string;
+  readonly codeChallenge: string;
+};
+
+/** Generates a fresh PKCE verifier/challenge pair (S256). */
+export const createPkcePair = (): PkcePair => {
+  const codeVerifier = randomBase64Url(VERIFIER_BYTES);
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  return { codeChallenge, codeVerifier };
+};
+
+/** Derives the S256 code challenge for a given verifier (exported for tests/vectors). */
+export const generateCodeChallenge = (codeVerifier: string): string =>
+  new Bun.CryptoHasher("sha256").update(codeVerifier).digest("base64url");
+
+/** Generates a random `state` parameter used to bind the callback to this login attempt. */
+export const createOAuthState = (): string => randomBase64Url(STATE_BYTES);

--- a/packages/cli/src/auth/scopes.test.ts
+++ b/packages/cli/src/auth/scopes.test.ts
@@ -1,0 +1,32 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { parseScopesFlag } from "./scopes.js";
+
+describe("parseScopesFlag", () => {
+  test("splits a comma-separated list", () => {
+    const result = parseScopesFlag("openid,profile,stella:read");
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value).toEqual(["openid", "profile", "stella:read"]);
+    }
+  });
+
+  test("trims whitespace around each scope and drops empty entries", () => {
+    const result = parseScopesFlag(" openid , , stella:read ");
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value).toEqual(["openid", "stella:read"]);
+    }
+  });
+
+  test("rejects an entirely empty value", () => {
+    expect(Result.isError(parseScopesFlag(""))).toBe(true);
+    expect(Result.isError(parseScopesFlag(" , , "))).toBe(true);
+  });
+
+  test("rejects a scope token containing internal whitespace", () => {
+    const result = parseScopesFlag("openid,stella read");
+    expect(Result.isError(result)).toBe(true);
+  });
+});

--- a/packages/cli/src/auth/scopes.ts
+++ b/packages/cli/src/auth/scopes.ts
@@ -1,0 +1,50 @@
+// `--scopes` parsing. Validity of individual scope names is ultimately the
+// server's call (`opts.scopes` in `oauthProvider`, see the design brief's
+// "let a feature-disabled call fail with the server's actual error"
+// principle applied to scopes): this only rejects obviously-malformed input
+// (empty, containing whitespace) before it reaches a URL query string.
+
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import { CliBaseError } from "./errors.js";
+
+class InvalidScopeInputError extends CliBaseError<"InvalidScopeInputError"> {
+  override readonly name = "InvalidScopeInputError";
+
+  constructor(message: string) {
+    super("InvalidScopeInputError", message);
+  }
+}
+
+const scopeTokenSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1),
+  v.regex(/^\S+$/u, "Scope names cannot contain whitespace"),
+);
+
+export const parseScopesFlag = (
+  input: string,
+): Result<readonly string[], InvalidScopeInputError> => {
+  const tokens = input
+    .split(",")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) {
+    return Result.err(new InvalidScopeInputError("--scopes was empty"));
+  }
+
+  const parsed = v.safeParse(v.array(scopeTokenSchema), tokens);
+  if (!parsed.success) {
+    return Result.err(
+      new InvalidScopeInputError(
+        `Invalid --scopes value: ${parsed.issues.map((issue) => issue.message).join("; ")}`,
+      ),
+    );
+  }
+
+  return Result.ok(parsed.output);
+};
+
+export { InvalidScopeInputError };

--- a/packages/cli/src/auth/server-resolution.ts
+++ b/packages/cli/src/auth/server-resolution.ts
@@ -1,0 +1,37 @@
+// `--server` resolution: no hosted-SaaS URL is baked in (self-hosting is
+// first-class; the CLI must not silently assume a build-time origin).
+// Priority: `--server` flag > `STELLA_SERVER_URL` env var > the last server
+// `stella auth login` succeeded against (`config.json#defaultServerUrl`).
+
+import { Result } from "better-result";
+
+import { STELLA_SERVER_URL } from "../env.js";
+import { readCliConfig } from "./cli-config.js";
+import { SERVER_URL_ENV_VAR } from "./constants.js";
+import { ServerUrlNotConfiguredError } from "./errors.js";
+
+const normalizeServerUrl = (input: string): string => input.replace(/\/$/u, "");
+
+export const resolveServerUrl = async (
+  configDir: string,
+  flagValue: string | undefined,
+): Promise<Result<string, ServerUrlNotConfiguredError>> => {
+  if (flagValue) {
+    return Result.ok(normalizeServerUrl(flagValue));
+  }
+
+  if (STELLA_SERVER_URL) {
+    return Result.ok(normalizeServerUrl(STELLA_SERVER_URL));
+  }
+
+  const config = await readCliConfig(configDir);
+  if (config.defaultServerUrl) {
+    return Result.ok(normalizeServerUrl(config.defaultServerUrl));
+  }
+
+  return Result.err(
+    new ServerUrlNotConfiguredError({
+      message: `No server configured. Pass --server <url>, set ${SERVER_URL_ENV_VAR}, or run \`stella auth login --server <url>\` once to set the default.`,
+    }),
+  );
+};

--- a/packages/cli/src/auth/token-exchange.ts
+++ b/packages/cli/src/auth/token-exchange.ts
@@ -1,0 +1,165 @@
+// `/oauth2/token` grant handling: authorization_code exchange and
+// refresh_token rotation.
+
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import { AUTH_FETCH_TIMEOUT_MS } from "./constants.js";
+import { TokenExchangeError, TokenRefreshError } from "./errors.js";
+import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
+
+// Hand-written rather than `v.InferOutput<typeof schema>` (see
+// `cli-config.ts` for why: this package builds with `isolatedDeclarations`).
+export type TokenResponse = {
+  readonly access_token: string;
+  readonly expires_in: number;
+  readonly refresh_token?: string | undefined;
+  readonly scope?: string | undefined;
+  readonly token_type: string;
+};
+
+const tokenResponseSchema = v.looseObject({
+  access_token: v.string(),
+  expires_in: v.number(),
+  refresh_token: v.optional(v.string()),
+  scope: v.optional(v.string()),
+  token_type: v.string(),
+});
+
+const oauthErrorBodySchema = v.looseObject({
+  error: v.string(),
+  error_description: v.optional(v.string()),
+});
+
+const describeTokenEndpointError = async (
+  response: Response,
+): Promise<{ error?: string; message: string }> => {
+  const text = await response.text();
+  const fallback = {
+    message:
+      text.length > 0 ? text : `token endpoint responded ${response.status}`,
+  };
+
+  const parsedJson = Result.try((): unknown => JSON.parse(text));
+  if (Result.isError(parsedJson)) {
+    return fallback;
+  }
+
+  const parsed = v.safeParse(oauthErrorBodySchema, parsedJson.value);
+  if (!parsed.success) {
+    return fallback;
+  }
+
+  return {
+    error: parsed.output.error,
+    message: parsed.output.error_description ?? parsed.output.error,
+  };
+};
+
+export type ExchangeAuthorizationCodeInput = {
+  readonly metadata: AuthorizationServerMetadata;
+  readonly clientId: string;
+  readonly code: string;
+  readonly codeVerifier: string;
+  readonly redirectUri: string;
+  readonly resource: string;
+};
+
+export const exchangeAuthorizationCode = async ({
+  clientId,
+  code,
+  codeVerifier,
+  metadata,
+  redirectUri,
+  resource,
+}: ExchangeAuthorizationCodeInput): Promise<
+  Result<TokenResponse, TokenExchangeError>
+> => {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    code,
+    code_verifier: codeVerifier,
+    grant_type: "authorization_code",
+    redirect_uri: redirectUri,
+    resource,
+  });
+
+  return await Result.tryPromise({
+    catch: (cause) =>
+      cause instanceof TokenExchangeError
+        ? cause
+        : new TokenExchangeError({
+            cause,
+            message: "Failed to exchange the authorization code for a token",
+          }),
+    try: async () => {
+      const response = await fetch(metadata.token_endpoint, {
+        body,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        method: "POST",
+        signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        const described = await describeTokenEndpointError(response);
+        throw new TokenExchangeError({
+          message: described.message,
+          oauthError: described.error,
+        });
+      }
+
+      return v.parse(tokenResponseSchema, await response.json());
+    },
+  });
+};
+
+export type RefreshAccessTokenInput = {
+  readonly metadata: AuthorizationServerMetadata;
+  readonly clientId: string;
+  readonly refreshToken: string;
+  readonly resource: string;
+};
+
+export const refreshAccessToken = async ({
+  clientId,
+  metadata,
+  refreshToken,
+  resource,
+}: RefreshAccessTokenInput): Promise<
+  Result<TokenResponse, TokenRefreshError>
+> => {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    resource,
+  });
+
+  return await Result.tryPromise({
+    catch: (cause) =>
+      cause instanceof TokenRefreshError
+        ? cause
+        : new TokenRefreshError({
+            cause,
+            message: "Failed to refresh the access token",
+          }),
+    try: async () => {
+      const response = await fetch(metadata.token_endpoint, {
+        body,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        method: "POST",
+        signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        const described = await describeTokenEndpointError(response);
+        throw new TokenRefreshError({
+          message: described.message,
+          oauthError: described.error,
+        });
+      }
+
+      return v.parse(tokenResponseSchema, await response.json());
+    },
+  });
+};

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,11 +1,8 @@
 #!/usr/bin/env bun
-// Application shell for the `stella` CLI (spec 051, Phase 1 scaffold only).
-//
-// No generator, no auth, no real domain commands yet: `stella tools list` is a
-// stub that proves the stricli route-map wires up end to end. Real commands
-// arrive once `generateRouteMap` (spec S5.2) and the Annotation Table (spec
-// S1) ship in a later phase, folding into `generatedRouteMap` from
-// `./generated/route-map.js`.
+// Application shell for the `stella` CLI (spec 051). `stella auth *` (Phase 2)
+// is real; the generated domain-command tree (Phase 3+) is still a stub
+// (`stella tools list`), folding into `generatedRouteMap` from
+// `./generated/route-map.js` once `generateRouteMap` (spec S5.2) ships.
 
 import {
   buildApplication,
@@ -13,8 +10,17 @@ import {
   buildRouteMap,
   run,
 } from "@stricli/core";
+import type { StricliProcess } from "@stricli/core";
+import { Result } from "better-result";
 
 import packageJson from "../package.json" with { type: "json" };
+import { defaultConfigDir } from "./auth/cli-config.js";
+import {
+  findDefaultCredential,
+  readCredentialFile,
+} from "./auth/credential-store.js";
+import { resolveServerUrl } from "./auth/server-resolution.js";
+import { authRoute } from "./commands/auth.js";
 import type { Context } from "./context.js";
 
 const toolsListCommand = buildCommand({
@@ -34,21 +40,52 @@ const toolsRoute = buildRouteMap({
 
 const rootRoute = buildRouteMap({
   docs: { brief: "Stella command-line client" },
-  routes: { tools: toolsRoute },
+  routes: { auth: authRoute, tools: toolsRoute },
 });
 
 const app = buildApplication(rootRoute, {
   name: "stella",
+  // Renders (and accepts) multi-word flags as kebab-case, e.g. the
+  // `keychain` flag's auto-generated negation as `--no-keychain` rather
+  // than `--noKeychain` — matches the documented command surface and every
+  // other kebab-case CLI convention (gh, npm, docker).
+  scanner: { caseStyle: "allow-kebab-for-camel" },
   versionInfo: { currentVersion: packageJson.version },
 });
 
-// Server resolution and stored auth are out of scope for this phase (spec
-// 051 covers both in later phases); the context carries their final shape
-// with placeholder values until then.
-const buildContext = (): Context => ({
-  process,
-  serverUrl: "",
-  token: undefined,
-});
+// Resolved once per invocation, ahead of flag parsing (stricli's async
+// `forCommand` context builder): `stella auth *` commands ignore
+// `serverUrl`/`token` and resolve their own from flags (they can target a
+// server other than "the current one," e.g. during first-time setup); every
+// future generated command reads these directly instead of re-resolving.
+const buildContext = async (): Promise<Context> => {
+  const configDir = defaultConfigDir();
+  const serverUrlResult = await resolveServerUrl(configDir, undefined);
+  const serverUrl = Result.isOk(serverUrlResult)
+    ? serverUrlResult.value
+    : undefined;
 
-void run(app, process.argv.slice(2), buildContext());
+  const token = serverUrl
+    ? findDefaultCredential(await readCredentialFile(configDir), serverUrl)
+        ?.accessToken
+    : undefined;
+
+  return { configDir, process, serverUrl, token };
+};
+
+// SAFETY: Node's `process.exitCode` type allows an explicit `undefined`
+// value (not just "absent"), which conflicts with stricli's own
+// `StricliProcess.exitCode?: string | number | null` under this package's
+// `exactOptionalPropertyTypes`. The real process object satisfies
+// `StricliProcess` at runtime regardless (it has every field stricli reads
+// or writes); this is a type-only mismatch between two independently-typed
+// libraries, not an actual runtime risk. Passing the real `process` (rather
+// than a constructed stand-in) matters: stricli sets `context.process.exitCode`
+// on it directly, and that must land on the process that is actually exiting.
+// eslint-disable-next-line no-unsafe-type-assertion -- see SAFETY comment above
+const stricliProcess = process as unknown as StricliProcess & typeof process;
+
+void run(app, process.argv.slice(2), {
+  forCommand: buildContext,
+  process: stricliProcess,
+});

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,232 @@
+// `stella auth login|logout|whoami|switch` (spec 051 Phase 2).
+
+import { buildCommand, buildRouteMap } from "@stricli/core";
+import type { RouteMap } from "@stricli/core";
+import { Result } from "better-result";
+
+import { CLI_DEFAULT_SCOPES, CLI_KNOWN_SCOPES } from "../auth/constants.js";
+import { login } from "../auth/login.js";
+import { logout, switchOrg, whoami } from "../auth/manage.js";
+import { parseScopesFlag } from "../auth/scopes.js";
+import { resolveServerUrl } from "../auth/server-resolution.js";
+import type { Context } from "../context.js";
+
+const parseString = (input: string): string => input;
+
+const stringFlag = (brief: string) =>
+  ({ brief, kind: "parsed", optional: true, parse: parseString }) as const;
+
+const requiredStringFlag = (brief: string) =>
+  ({ brief, kind: "parsed", parse: parseString }) as const;
+
+const formatDate = (epochMs: number): string => new Date(epochMs).toISOString();
+
+type LoginFlags = {
+  readonly keychain: boolean;
+  readonly org: string | undefined;
+  readonly scopes: string | undefined;
+  readonly server: string | undefined;
+};
+
+type ServerOrgFlags = {
+  readonly org: string | undefined;
+  readonly server: string | undefined;
+};
+
+type SwitchFlags = {
+  readonly org: string;
+  readonly server: string | undefined;
+};
+
+const loginCommand = buildCommand<LoginFlags, [], Context>({
+  docs: {
+    brief: "Sign in to a stella server via the browser (PKCE loopback flow)",
+    fullDescription:
+      "Opens the stella sign-in page in your default browser and waits for the redirect on an ephemeral localhost port. If the browser can't reach this machine (SSH/remote/headless), paste the redirected URL or the bare authorization code back into the prompt instead.",
+  },
+  func: async function func(this: Context, flags) {
+    let requestedScopes: readonly string[] = CLI_DEFAULT_SCOPES;
+    if (flags.scopes) {
+      const parsedScopes = parseScopesFlag(flags.scopes);
+      if (Result.isError(parsedScopes)) {
+        return new Error(parsedScopes.error.message);
+      }
+      requestedScopes = parsedScopes.value;
+    }
+
+    if (!flags.keychain) {
+      this.process.stdout.write(
+        "Note: --no-keychain has no effect yet; credentials are always stored at ~/.config/stella/credentials.json (mode 0600). OS keychain support is a follow-up.\n",
+      );
+    }
+
+    const result = await login(this.process, {
+      configDir: this.configDir,
+      orgHint: flags.org,
+      registrationScopes: CLI_KNOWN_SCOPES,
+      requestedScopes,
+      serverFlag: flags.server,
+    });
+
+    if (Result.isError(result)) {
+      return new Error(result.error.message);
+    }
+
+    const refreshNote = result.value.hasRefreshToken
+      ? ""
+      : "No refresh token was issued (the server has not enabled offline_access yet); re-run `stella auth login` once this token expires.\n";
+    const lines = [
+      `Signed in to ${result.value.serverUrl} (org ${result.value.orgId}).`,
+      `Granted scopes: ${result.value.grantedScopes}`,
+      `Access token expires: ${formatDate(result.value.expiresAt)}`,
+    ];
+    this.process.stdout.write(`${lines.join("\n")}\n${refreshNote}`);
+    return undefined;
+  },
+  parameters: {
+    flags: {
+      keychain: {
+        brief:
+          "Use the OS keychain for storage (currently always falls back to the XDG credentials file; see --help)",
+        default: true,
+        kind: "boolean",
+      },
+      org: stringFlag(
+        "Organization slug to select in the browser when prompted (label only, not enforced server-side; see --help)",
+      ),
+      scopes: stringFlag(
+        `Comma-separated OAuth scopes to request (default: ${CLI_DEFAULT_SCOPES.join(",")})`,
+      ),
+      server: stringFlag("Stella API origin to sign in to"),
+    },
+  },
+});
+
+const whoamiCommand = buildCommand<ServerOrgFlags, [], Context>({
+  docs: { brief: "Show the signed-in organization, scopes, and token expiry" },
+  func: async function func(this: Context, flags) {
+    const serverUrlResult = await resolveServerUrl(
+      this.configDir,
+      flags.server,
+    );
+    if (Result.isError(serverUrlResult)) {
+      return new Error(serverUrlResult.error.message);
+    }
+
+    const result = await whoami(
+      this.configDir,
+      serverUrlResult.value,
+      flags.org,
+    );
+    if (Result.isError(result)) {
+      return new Error(result.error.message);
+    }
+
+    const info = result.value;
+    const lines = [
+      `Server: ${info.serverUrl}`,
+      `Organization: ${info.orgLabel ? `${info.orgLabel} (${info.orgId})` : info.orgId}`,
+      `Scopes: ${info.scope}`,
+      `Expires: ${formatDate(info.expiresAt)}${info.isExpired ? " (expired)" : ""}`,
+      `Refresh token: ${info.hasRefreshToken ? "yes" : "no"}`,
+    ];
+    if (info.claims?.sub) {
+      lines.push(`Subject: ${info.claims.sub}`);
+    }
+    this.process.stdout.write(`${lines.join("\n")}\n`);
+    return undefined;
+  },
+  parameters: {
+    flags: {
+      org: stringFlag(
+        "Organization to inspect (default: this server's default org)",
+      ),
+      server: stringFlag(
+        "Stella API origin to inspect (default: resolved server)",
+      ),
+    },
+  },
+});
+
+const logoutCommand = buildCommand<ServerOrgFlags, [], Context>({
+  docs: { brief: "Remove a stored stella credential" },
+  func: async function func(this: Context, flags) {
+    const serverUrlResult = await resolveServerUrl(
+      this.configDir,
+      flags.server,
+    );
+    if (Result.isError(serverUrlResult)) {
+      return new Error(serverUrlResult.error.message);
+    }
+
+    const result = await logout(
+      this.configDir,
+      serverUrlResult.value,
+      flags.org,
+    );
+    if (Result.isError(result)) {
+      return new Error(result.error.message);
+    }
+
+    this.process.stdout.write(
+      `Signed out of ${serverUrlResult.value} (org ${result.value.orgId}).\n`,
+    );
+    return undefined;
+  },
+  parameters: {
+    flags: {
+      org: stringFlag(
+        "Organization to sign out of (default: the only signed-in org)",
+      ),
+      server: stringFlag(
+        "Stella API origin to sign out of (default: resolved server)",
+      ),
+    },
+  },
+});
+
+const switchCommand = buildCommand<SwitchFlags, [], Context>({
+  docs: {
+    brief:
+      "Switch the default organization for a server (no re-auth if already signed in)",
+  },
+  func: async function func(this: Context, flags) {
+    const serverUrlResult = await resolveServerUrl(
+      this.configDir,
+      flags.server,
+    );
+    if (Result.isError(serverUrlResult)) {
+      return new Error(serverUrlResult.error.message);
+    }
+
+    const result = await switchOrg(
+      this.configDir,
+      serverUrlResult.value,
+      flags.org,
+    );
+    if (Result.isError(result)) {
+      return new Error(result.error.message);
+    }
+
+    this.process.stdout.write(
+      `Default organization for ${serverUrlResult.value} is now ${result.value.orgId}.\n`,
+    );
+    return undefined;
+  },
+  parameters: {
+    flags: {
+      org: requiredStringFlag("Organization to switch to"),
+      server: stringFlag("Stella API origin (default: resolved server)"),
+    },
+  },
+});
+
+export const authRoute: RouteMap<Context> = buildRouteMap({
+  docs: { brief: "Manage stella authentication" },
+  routes: {
+    login: loginCommand,
+    logout: logoutCommand,
+    switch: switchCommand,
+    whoami: whoamiCommand,
+  },
+});

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,14 +1,29 @@
 // Shared stricli application context (spec 051 S5.1): a single `Context` type
-// threaded through every command. Auth resolution, the real server client, and
-// scope prechecks are out of scope for this phase; this is the minimal typed
-// sketch a later phase fills in.
+// threaded through every command. Generated (Phase 3+) commands read
+// `serverUrl`/`token` directly instead of re-resolving them; hand-written
+// `stella auth` commands (this phase) resolve their own server/org from
+// flags since they operate on a specific (possibly not-yet-configured)
+// server rather than "the" current one.
 
 import type { CommandContext } from "@stricli/core";
 
 /** Context every generated (and hand-written) command receives. */
 export type Context = CommandContext & {
-  /** Resolved server origin the CLI is targeting (spec S5.5 provenance pin). */
-  readonly serverUrl: string;
-  /** Stored auth token for the current server origin, if any (auth: out of scope for this phase). */
+  /**
+   * Real Node/Bun process, not just stricli's minimal `WritableStreams`:
+   * `stella auth login`'s manual-paste fallback needs `stdin`, and server
+   * resolution reads `env`.
+   */
+  readonly process: NodeJS.Process;
+  /** `~/.config/stella` (or `$XDG_CONFIG_HOME/stella`), resolved once per invocation. */
+  readonly configDir: string;
+  /** Resolved server origin (`--server`/env/config; see `auth/server-resolution.ts`), if any. */
+  readonly serverUrl: string | undefined;
+  /**
+   * The default org's stored access token for `serverUrl`, if signed in.
+   * Not proactively refreshed here — a Phase 3+ HTTP client wrapper should
+   * call `auth/ensure-fresh-credential.ts` reactively on a 401, matching
+   * `stella auth whoami`'s "no extra server calls unless needed" stance.
+   */
   readonly token: string | undefined;
 };

--- a/packages/cli/src/env.ts
+++ b/packages/cli/src/env.ts
@@ -1,0 +1,13 @@
+// Centralizes every `process.env` read for `@stll/cli` (the
+// `forbid-process-env-outside-env-ts` lint rule requires reads to live in an
+// `env.ts`-named module; see `oxlint.config.ts`). Both variables are
+// optional: the CLI never hard-requires an env var to start (self-hosting
+// first-class — `--server`/`credentials.json` always work without either).
+
+/** XDG base-directory override for `~/.config/stella`; see `auth/config-dir.ts`. */
+export const XDG_CONFIG_HOME: string | undefined =
+  process.env["XDG_CONFIG_HOME"];
+
+/** Default `--server` origin when neither the flag nor a saved config exists; see `auth/server-resolution.ts`. */
+export const STELLA_SERVER_URL: string | undefined =
+  process.env["STELLA_SERVER_URL"];


### PR DESCRIPTION
`stella auth login|logout|whoami|switch`: authorization-code + PKCE (S256) against the existing oauthProvider via dynamic public-client registration, loopback listener on an ephemeral port with a manual paste fallback for headless use, credentials per (server, org) in an XDG file (0600). No server changes; no hosted URL hardcoded (`--server` flag, env, saved config).

- the refresh state machine is implemented and tested but dormant: the provider's scope list has no `offline_access`, so no client currently receives refresh tokens — a separate server-side PR adds the scope
- one SAFETY-commented type-only cast bridging Node's and stricli's `process` ambient types