### PR TITLE
fix: bootstrap the stella RLS role in the migration entrypoint

### DIFF
--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -28,7 +28,29 @@ if (!url) {
 
 const client = new SQL({ url, max: 1 });
 
+// Bootstrap the `stella` RLS role before migrating. Managed-provider fresh
+// databases (no `docker-entrypoint-initdb.d`) never run
+// `docker/postgres/init.sql`, so the migrator owns role bootstrap; the RLS
+// migrations only GRANT to `stella` and would fail with `role "stella" does
+// not exist` on a clean DB. Keep this in parity with
+// `docker/postgres/init.sql` (init.sql stays the fast path for local
+// containers). Guard with a `pg_roles` lookup inside a DO block: there is no
+// `CREATE ROLE IF NOT EXISTS`, and a bare `CREATE ROLE` would error when the
+// role already exists (local dev, prod, reruns). `unaccent` is not bootstrapped
+// here: the migration that uses it self-runs `CREATE EXTENSION IF NOT EXISTS
+// unaccent`. `stella_ingestion` likewise self-creates in its own migration.
+const bootstrapRoleSql = `
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stella') THEN
+    CREATE ROLE stella NOLOGIN;
+  END IF;
+END
+$$;
+`;
+
 try {
+  await client.unsafe(bootstrapRoleSql);
   await migrate(drizzle({ client }), {
     // cwd is the migrate task's workingDirectory (/app/apps/api); mirrors
     // the path that assert-migrations-applied.ts checks at startup.

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -36,14 +36,21 @@ const client = new SQL({ url, max: 1 });
 // `docker/postgres/init.sql` (init.sql stays the fast path for local
 // containers). Guard with a `pg_roles` lookup inside a DO block: there is no
 // `CREATE ROLE IF NOT EXISTS`, and a bare `CREATE ROLE` would error when the
-// role already exists (local dev, prod, reruns). `unaccent` is not bootstrapped
+// role already exists (local dev, prod, reruns). The inner exception handler
+// absorbs the duplicate-role race if two bootstraps ever run concurrently;
+// the existence check alone is check-then-act. `unaccent` is not bootstrapped
 // here: the migration that uses it self-runs `CREATE EXTENSION IF NOT EXISTS
 // unaccent`. `stella_ingestion` likewise self-creates in its own migration.
 const bootstrapRoleSql = `
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'stella') THEN
-    CREATE ROLE stella NOLOGIN;
+    BEGIN
+      CREATE ROLE stella NOLOGIN;
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
   END IF;
 END
 $$;

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,8 +1,10 @@
 -- RLS runtime role. The connection user (`postgres` locally per
 -- docker-compose.yml; the provider's master role on managed DBs)
 -- runs `SET LOCAL ROLE stella` per transaction. Privileges live in
--- migration `20260510140000_document_rls_role_bootstrap`. On managed
--- providers, create this role via the dashboard before migrations.
+-- migration `20260510140000_document_rls_role_bootstrap`. This file is the
+-- fast path for local containers only; managed providers have no init.sql,
+-- so the migration entrypoint (`apps/api/src/db/migrate.ts`) bootstraps this
+-- role idempotently. Keep the two in parity.
 CREATE ROLE stella NOLOGIN;
 
 CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -281,7 +281,9 @@ notes before applying an upstream template update.
 
 `railway.json` runs `bun src/db/migrate.ts` as the API pre-deploy command. The
 migration entrypoint is included in the API runtime image and uses the same
-`DATABASE_URL` as the server.
+`DATABASE_URL` as the server. It bootstraps the `stella` RLS role idempotently
+before applying migrations, so a fresh managed Postgres needs no manual role
+setup.
 
 If a migration fails, Railway should not promote the API deployment. Fix the
 database/config problem, then redeploy the API service.


### PR DESCRIPTION
## Summary

Fresh managed-Postgres databases have no `docker-entrypoint-initdb.d`, so `docker/postgres/init.sql` never runs and the `stella` RLS role does not exist when migrations replay from scratch. The first RLS migration that grants to `stella` then fails with `role "stella" does not exist` (42704), blocking the pre-deploy migration step on any fresh self-hosted deploy.

- `apps/api/src/db/migrate.ts`: bootstrap the `stella` NOLOGIN role idempotently (pg_roles-guarded DO block) on the migration connection before running the migrator, keeping parity with `docker/postgres/init.sql`.
- `docker/postgres/init.sql`: update the comment; init.sql is the local fast path, the migrator owns bootstrap on managed providers.
- `docs/railway.md`: note that no manual role setup is needed on fresh databases.

`unaccent` and `stella_ingestion` need no bootstrap; their migrations self-create them (`CREATE EXTENSION IF NOT EXISTS` / `CREATE ROLE` in first-run-only migrations).

## Testing

- Reasoned through the three cases for the DO block: existing role (local dev, prod) short-circuits; fresh DB creates the role before the first RLS grant; single `max: 1` pre-deploy connection, so no concurrent bootstrap.
- Fresh-deploy verification happens via a Railway template deploy after merge.