### PR TITLE
fix: keep Railway config files out of repo-root auto-discovery

### DIFF
--- a/docs/railway.md
+++ b/docs/railway.md
@@ -17,11 +17,22 @@ Create these services in one Railway project:
 - `gotenberg`: image service using `gotenberg/gotenberg:8`, no public domain.
 - Storage bucket, for example `stella-files`.
 
-Point the `api` service at the repository default `railway.json`. Point the
+Point the `api` service config file at `railway/api.railway.json`. Point the
 `web` service config file at `railway/web.railway.json`. Both services use the
 repository root as Docker build context. Railway calls this
 [config as code](https://docs.railway.com/config-as-code); custom config files
 are selected in each service's settings.
+
+The repository root must not contain a `railway.json` or `railway.toml` file.
+Railway auto-discovers a config file at the repository root and applies it to
+every GitHub-sourced service in a template, which would hijack each service's
+build (for example, forcing `web` to build the API Dockerfile). Keeping both
+service configs under `railway/` avoids that root auto-discovery. Because
+serialized template config drops per-service config-file paths, the marketplace
+template instead carries explicit per-service `build` settings in
+`railway/template-manifest.json`. Those `build` settings must stay in sync with
+the `build` blocks in each service's config file; `check:railway-template-draft`
+enforces that the published template's per-service build matches the manifest.
 
 ## API Variables
 
@@ -185,8 +196,10 @@ publishing. Check these items before the first publish:
 
 - `web` source points at the public GitHub repository on the intended branch.
 - `api` source points at the same repository and branch.
-- `api` config path is the repository default `/railway.json`.
+- `api` config path is `/railway/api.railway.json`.
 - `web` config path is `/railway/web.railway.json`.
+- No `railway.json` or `railway.toml` exists at the repository root, so Railway
+  does not auto-apply a root config to every GitHub-sourced service.
 - `api`, `web`, Postgres, Redis, Gotenberg, and the storage bucket all deploy
   from the template into a fresh project.
 - Generated values use `secret(...)`; no deploy-time user credentials are
@@ -279,7 +292,8 @@ notes before applying an upstream template update.
 
 ## Migrations
 
-`railway.json` runs `bun src/db/migrate.ts` as the API pre-deploy command. The
+`railway/api.railway.json` runs `bun src/db/migrate.ts` as the API pre-deploy
+command. The
 migration entrypoint is included in the API runtime image and uses the same
 `DATABASE_URL` as the server.
 

--- a/railway/api.railway.json
+++ b/railway/api.railway.json
@@ -4,7 +4,7 @@
     "builder": "DOCKERFILE",
     "dockerfilePath": "apps/api/Dockerfile",
     "watchPatterns": [
-      "/railway.json",
+      "/railway/api.railway.json",
       "/apps/api/**",
       "/apps/legal-atlas-runner/**",
       "/packages/**",

--- a/railway/template-manifest.json
+++ b/railway/template-manifest.json
@@ -43,7 +43,11 @@
       }
     },
     "api": {
-      "configFile": "/railway.json",
+      "configFile": "/railway/api.railway.json",
+      "build": {
+        "builder": "DOCKERFILE",
+        "dockerfilePath": "apps/api/Dockerfile"
+      },
       "publicNetworking": true,
       "requiredUserInputs": {},
       "variables": {
@@ -68,6 +72,10 @@
     },
     "web": {
       "configFile": "/railway/web.railway.json",
+      "build": {
+        "builder": "DOCKERFILE",
+        "dockerfilePath": "apps/web/Dockerfile"
+      },
       "publicNetworking": true,
       "variables": {
         "PUBLIC_API_URL": "https://${{api.RAILWAY_PUBLIC_DOMAIN}}",

--- a/scripts/check-railway-template-draft.ts
+++ b/scripts/check-railway-template-draft.ts
@@ -14,13 +14,20 @@ class RailwayTemplateDraftError extends Error {
   }
 }
 
+type ServiceBuild = {
+  builder: string;
+  dockerfilePath: string;
+};
+
 type ServiceTemplate = {
   requiredUserInputs: Record<string, string>;
   variables: Record<string, string>;
+  build?: ServiceBuild;
 };
 
 type TemplateManifest = {
   services: Record<string, ServiceTemplate>;
+  buckets: string[];
 };
 
 const failures: string[] = [];
@@ -67,6 +74,32 @@ const readStringRecord = (
   return result;
 };
 
+const readServiceBuild = (
+  value: unknown,
+  label: string,
+): ServiceBuild | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new RailwayTemplateDraftError(`${label} must be an object`);
+  }
+  return {
+    builder: getString(value, "builder"),
+    dockerfilePath: getString(value, "dockerfilePath"),
+  };
+};
+
+const readManifestBuckets = (value: unknown): string[] => {
+  if (value === undefined) {
+    return [];
+  }
+  if (!isRecord(value)) {
+    throw new RailwayTemplateDraftError(`${MANIFEST_PATH} buckets must be an object`);
+  }
+  return Object.keys(value);
+};
+
 const readManifest = (): TemplateManifest => {
   const value = readJson(MANIFEST_PATH);
   if (!isRecord(value) || !isRecord(value["services"])) {
@@ -91,10 +124,14 @@ const readManifest = (): TemplateManifest => {
         service["variables"] ?? {},
         `services.${serviceName}.variables`,
       ),
+      build: readServiceBuild(
+        service["build"],
+        `services.${serviceName}.build`,
+      ),
     };
   }
 
-  return { services };
+  return { services, buckets: readManifestBuckets(value["buckets"]) };
 };
 
 const readRailwayTokenFromConfig = (config: unknown) => {
@@ -273,6 +310,55 @@ const validateServiceVariables = ({
   }
 };
 
+const validateServiceBuild = ({
+  draftService,
+  serviceName,
+  build,
+}: {
+  draftService: Record<string, unknown>;
+  serviceName: string;
+  build: ServiceBuild;
+}) => {
+  const buildConfig = draftService["build"];
+  if (!isRecord(buildConfig)) {
+    failures.push(`${serviceName} has no build config in the template draft`);
+    return;
+  }
+
+  if (buildConfig["builder"] !== build.builder) {
+    failures.push(
+      `${serviceName}.build.builder is ${String(buildConfig["builder"])}; expected ${build.builder}`,
+    );
+  }
+  if (buildConfig["dockerfilePath"] !== build.dockerfilePath) {
+    failures.push(
+      `${serviceName}.build.dockerfilePath is ${String(buildConfig["dockerfilePath"])}; expected ${build.dockerfilePath}`,
+    );
+  }
+};
+
+const validateBuckets = (
+  serializedConfig: Record<string, unknown>,
+  expectedBuckets: string[],
+) => {
+  const bucketsConfig = serializedConfig["buckets"];
+  const actualNames = new Set<string>();
+  if (isRecord(bucketsConfig)) {
+    for (const [key, bucket] of Object.entries(bucketsConfig)) {
+      actualNames.add(key);
+      if (isRecord(bucket) && typeof bucket["name"] === "string") {
+        actualNames.add(bucket["name"]);
+      }
+    }
+  }
+
+  for (const name of expectedBuckets) {
+    if (!actualNames.has(name)) {
+      failures.push(`Template draft is missing bucket ${name}`);
+    }
+  }
+};
+
 const printUsage = () => {
   console.log(
     "Usage: bun scripts/check-railway-template-draft.ts --template <template-id>",
@@ -327,13 +413,14 @@ const main = async () => {
       `Railway template ${templateId} returned invalid data`,
     );
   }
-  if (!isRecord(template["serializedConfig"])) {
+  const serializedConfig = template["serializedConfig"];
+  if (!isRecord(serializedConfig)) {
     throw new RailwayTemplateDraftError(
       `Railway template ${templateId} has no serialized config`,
     );
   }
 
-  const servicesConfig = template["serializedConfig"]["services"];
+  const servicesConfig = serializedConfig["services"];
   if (!isRecord(servicesConfig)) {
     throw new RailwayTemplateDraftError(
       `Railway template ${templateId} has no service config`,
@@ -352,7 +439,16 @@ const main = async () => {
       serviceName,
       template: serviceTemplate,
     });
+    if (serviceTemplate.build) {
+      validateServiceBuild({
+        draftService,
+        serviceName,
+        build: serviceTemplate.build,
+      });
+    }
   }
+
+  validateBuckets(serializedConfig, manifest.buckets);
 
   if (failures.length > 0) {
     for (const failure of failures) {

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 
-const API_CONFIG_PATH = "railway.json";
-const LEGACY_API_CONFIG_PATH = "railway/api.railway.json";
+const API_CONFIG_PATH = "railway/api.railway.json";
+const ROOT_RAILWAY_CONFIG_PATHS = ["railway.json", "railway.toml"];
 const WEB_CONFIG_PATH = "railway/web.railway.json";
 const RAILWAY_DOC_PATH = "docs/railway.md";
 const TEMPLATE_README_PATH = "railway/template-readme.md";
@@ -145,11 +145,16 @@ const validateServiceConfig = ({
   );
 };
 
-expect(existsSync(API_CONFIG_PATH), "API config must live at /railway.json");
 expect(
-  !existsSync(LEGACY_API_CONFIG_PATH),
-  "Do not keep duplicate API config at /railway/api.railway.json",
+  existsSync(API_CONFIG_PATH),
+  "API config must live at /railway/api.railway.json",
 );
+for (const rootConfigPath of ROOT_RAILWAY_CONFIG_PATHS) {
+  expect(
+    !existsSync(rootConfigPath),
+    `Root config file /${rootConfigPath} must not exist: Railway auto-discovers repo-root config files and applies them to every GitHub-sourced template service, hijacking per-service config`,
+  );
+}
 expect(existsSync(WEB_CONFIG_PATH), "Web config must exist");
 expect(existsSync(TEMPLATE_MANIFEST_PATH), "Template manifest must exist");
 
@@ -157,7 +162,7 @@ validateServiceConfig({
   path: API_CONFIG_PATH,
   dockerfilePath: "apps/api/Dockerfile",
   requiredWatchPatterns: [
-    "/railway.json",
+    "/railway/api.railway.json",
     "/apps/api/**",
     "/packages/**",
     "/bun.lock",
@@ -183,16 +188,16 @@ expect(
 
 const railwayDoc = readText(RAILWAY_DOC_PATH);
 expect(
-  railwayDoc.includes("`railway.json`"),
-  "Railway docs must reference root API config",
+  railwayDoc.includes("`railway/api.railway.json`"),
+  "Railway docs must reference the API config path",
 );
 expect(
   railwayDoc.includes("`railway/web.railway.json`"),
   "Railway docs must reference web config",
 );
 expect(
-  !railwayDoc.includes("railway/api.railway.json"),
-  "Railway docs must not reference the removed API config path",
+  railwayDoc.includes("repository root must not contain a `railway.json`"),
+  "Railway docs must document the repo-root config invariant (no railway.json/railway.toml)",
 );
 expect(
   railwayDoc.includes("## Source-Backed Smoke Verification"),
@@ -345,8 +350,8 @@ const apiRequiredUserInputs = getStringRecord(
 );
 
 expect(
-  getString(apiTemplate, "configFile") === "/railway.json",
-  "API template service must point at /railway.json",
+  getString(apiTemplate, "configFile") === "/railway/api.railway.json",
+  "API template service must point at /railway/api.railway.json",
 );
 expect(
   getString(webTemplate, "configFile") === "/railway/web.railway.json",


### PR DESCRIPTION
## Summary

Railway auto-discovers `railway.json`/`railway.toml` at the repository root and applies it to every GitHub-sourced service rooted there. In the marketplace template this hijacks the `web` service: file-based config overrides per-service build settings, so `web` builds `apps/api/Dockerfile`. Railway templates cannot carry per-service config-file paths (the serialized template config drops them), so the template instead carries explicit per-service `build` configuration, and the repository root must stay free of Railway config files.

- Move `railway.json` to `railway/api.railway.json` (self watch-pattern updated); both service config files now live under `railway/`.
- `scripts/check-railway-template-shape.ts`: assert the api config's new path and fail if `railway.json`/`railway.toml` exists at the repo root.
- `railway/template-manifest.json`: record the intended `build` (builder + dockerfilePath) for `api` and `web` alongside the existing variables.
- `scripts/check-railway-template-draft.ts`: validate the live template's per-service `build` config and provisioned buckets against the manifest, so a regenerated template that silently drops them fails the check.
- `docs/railway.md`: document the no-root-config invariant and the template build-config sync.

## Testing

- `bun run check:railway-template` passes (new root-config invariant enforced).
- `bun run check:railway-template-draft -- --template <id>` passes against the published template, which carries matching `build` sections and the `stella-files` bucket; the new validations were confirmed to compare real fields, not skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Railway template guidance to use separate config files for API and web services.
  * Added checks to keep template deployment settings aligned across documentation and configuration.

* **Bug Fixes**
  * Prevented root Railway config files from being picked up during builds.
  * Improved validation so service rebuilds now follow the correct per-service config file.

* **Tests**
  * Strengthened template checks to verify service build settings, config paths, and bucket configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->