### PR TITLE
fix(ci): sync v-tag protection ruleset to GitHub

### DIFF
--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -1,0 +1,90 @@
+name: Sync Branch Protection
+
+# Applies checked-in ruleset JSON to the live GitHub repository
+# rulesets. Run after changing `.github/branch-protection/*.json`
+# so the weekly audit workflow stays green.
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected-config-path:
+        description: Path to the ruleset JSON to apply
+        type: choice
+        options:
+          - .github/branch-protection/ruleset-main.json
+          - .github/branch-protection/tags-v.json
+        default: .github/branch-protection/tags-v.json
+
+concurrency:
+  group: sync-branch-protection
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
+          private-key: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
+
+      - name: Apply ruleset
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          EXPECTED_PATH: ${{ inputs.expected-config-path }}
+        shell: bash --noprofile --norc -eo pipefail {0}
+        run: |
+          if [ ! -f "${EXPECTED_PATH}" ]; then
+            echo "::error::Expected config not found: ${EXPECTED_PATH}"
+            exit 1
+          fi
+
+          EXPECTED_NAME=$(jq -r '.name' "${EXPECTED_PATH}")
+          echo "Syncing ruleset: ${EXPECTED_NAME}"
+
+          MATCHED_ID=$(
+            gh api "repos/${REPO}/rulesets" \
+              --paginate \
+              --slurp \
+              | jq --arg name "${EXPECTED_NAME}" '[add // [] | .[] | select(.name == $name) | .id] | first'
+          )
+
+          if [ -z "${MATCHED_ID}" ] || [ "${MATCHED_ID}" = "null" ]; then
+            echo "::error::Ruleset '${EXPECTED_NAME}' not found on GitHub."
+            exit 1
+          fi
+
+          jq '{
+            name,
+            target,
+            enforcement,
+            conditions,
+            rules,
+            bypass_actors
+          }' "${EXPECTED_PATH}" > ruleset-payload.json
+
+          echo "::group::Payload"
+          jq . ruleset-payload.json
+          echo "::endgroup::"
+
+          gh api --method PUT "repos/${REPO}/rulesets/${MATCHED_ID}" \
+            --input ruleset-payload.json \
+            > live-updated.json
+
+          echo "::group::Live ruleset (after sync)"
+          jq . live-updated.json
+          echo "::endgroup::"
+
+          echo "Synced ruleset '${EXPECTED_NAME}' (id ${MATCHED_ID})."

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - .github/branch-protection/**
+      - .github/workflows/sync-branch-protection.yml
   workflow_dispatch:
     inputs:
       expected-config-path:
@@ -39,8 +40,10 @@ jobs:
           - .github/branch-protection/ruleset-main.json
           - .github/branch-protection/tags-v.json
 
-    # On push, only sync configs touched by the commit. On manual
-    # dispatch, sync the selected config only.
+    # On push, sync configs touched by the commit. When the sync
+    # workflow itself changes, apply every checked-in ruleset so a
+    # prior config-only merge cannot leave live GitHub behind.
+    # On manual dispatch, sync the selected config only.
     if: >-
       github.event_name == 'workflow_dispatch'
       && matrix.expected-config-path == inputs.expected-config-path
@@ -48,6 +51,8 @@ jobs:
       && (
         contains(github.event.head_commit.modified, matrix.expected-config-path)
         || contains(github.event.head_commit.added, matrix.expected-config-path)
+        || contains(github.event.head_commit.modified, '.github/workflows/sync-branch-protection.yml')
+        || contains(github.event.head_commit.added, '.github/workflows/sync-branch-protection.yml')
       )
 
     steps:

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -40,21 +40,6 @@ jobs:
           - .github/branch-protection/ruleset-main.json
           - .github/branch-protection/tags-v.json
 
-    # On push, sync configs touched by the commit. When the sync
-    # workflow itself changes, apply every checked-in ruleset so a
-    # prior config-only merge cannot leave live GitHub behind.
-    # On manual dispatch, sync the selected config only.
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      && matrix.expected-config-path == inputs.expected-config-path
-      || github.event_name == 'push'
-      && (
-        contains(github.event.head_commit.modified, matrix.expected-config-path)
-        || contains(github.event.head_commit.added, matrix.expected-config-path)
-        || contains(github.event.head_commit.modified, '.github/workflows/sync-branch-protection.yml')
-        || contains(github.event.head_commit.added, '.github/workflows/sync-branch-protection.yml')
-      )
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -67,6 +52,20 @@ jobs:
           private-key: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
 
       - name: Apply ruleset
+        # On push, sync configs touched by the commit. When the sync
+        # workflow itself changes, apply every checked-in ruleset so a
+        # prior config-only merge cannot leave live GitHub behind.
+        # On manual dispatch, sync the selected config only.
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && matrix.expected-config-path == inputs.expected-config-path
+          || github.event_name == 'push'
+          && (
+            contains(github.event.head_commit.modified, matrix.expected-config-path)
+            || contains(github.event.head_commit.added, matrix.expected-config-path)
+            || contains(github.event.head_commit.modified, '.github/workflows/sync-branch-protection.yml')
+            || contains(github.event.head_commit.added, '.github/workflows/sync-branch-protection.yml')
+          )
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -5,6 +5,10 @@ name: Sync Branch Protection
 # so the weekly audit workflow stays green.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - .github/branch-protection/**
   workflow_dispatch:
     inputs:
       expected-config-path:
@@ -28,6 +32,24 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        expected-config-path:
+          - .github/branch-protection/ruleset-main.json
+          - .github/branch-protection/tags-v.json
+
+    # On push, only sync configs touched by the commit. On manual
+    # dispatch, sync the selected config only.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      && matrix.expected-config-path == inputs.expected-config-path
+      || github.event_name == 'push'
+      && (
+        contains(github.event.head_commit.modified, matrix.expected-config-path)
+        || contains(github.event.head_commit.added, matrix.expected-config-path)
+      )
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,7 +65,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
-          EXPECTED_PATH: ${{ inputs.expected-config-path }}
+          EXPECTED_PATH: ${{ matrix.expected-config-path }}
         shell: bash --noprofile --norc -eo pipefail {0}
         run: |
           if [ ! -f "${EXPECTED_PATH}" ]; then

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,9 +26,6 @@
     "README.md"
   ],
   "type": "module",
-  "engines": {
-    "node": ">=20"
-  },
   "sideEffects": false,
   "exports": {
     ".": "./src/cli.ts"
@@ -56,5 +53,8 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed change

The weekly `audit-branch-protection` job failed on `audit-tag` because PR #938 updated `.github/branch-protection/tags-v.json` (added a `creation` rule and release-app bypass) but the live GitHub ruleset was never applied.

Live GitHub is missing:
- the `creation` rule (anyone with tag-push rights could still mint `v*` tags)
- the Integration bypass for the release app (`actor_id` 3569952)

This PR adds `sync-branch-protection.yml`, a workflow that applies checked-in ruleset JSON via the branch-protection GitHub App.

- On push to `main` that changes `.github/branch-protection/**`, only the touched configs are synced.
- When this sync workflow itself lands on `main`, all checked-in rulesets are applied (remediating the current `tags-v.json` drift automatically on merge).
- `workflow_dispatch` remains available for manual remediation.

Also includes a pre-existing `packages/cli/package.json` format fix caught by the pre-push hook.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [ ] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a79f66bc-d102-4d96-be84-43361baa095a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a79f66bc-d102-4d96-be84-43361baa095a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to keep live branch protection/rulesets in sync with repository configuration files.
  * Enabled manual selection of a specific ruleset configuration for syncing.
* **Bug Fixes**
  * Improved sync reliability by preventing overlapping runs and providing clear failure when a matching live ruleset cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->