### PR TITLE
fix: Railway api version stamping and Redis cold-start connect retries

### DIFF
--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -5,16 +5,8 @@ import { HealthCheckError } from "@/api/lib/errors/tagged-errors";
 import { createProbeCache } from "@/api/lib/health/probe-cache";
 import type { ProbeOutcome } from "@/api/lib/health/probe-cache";
 import { probeDatabase } from "@/api/lib/health/probe-database";
-import { APP_VERSION } from "@/api/lib/version";
+import { APP_COMMIT_SHA, APP_VERSION } from "@/api/lib/version";
 
-const resolveCommitSha = () => {
-  const explicitSha = process.env["STELLA_COMMIT_SHA"];
-  if (explicitSha && explicitSha !== "dev") {
-    return explicitSha;
-  }
-  return process.env["RAILWAY_GIT_COMMIT_SHA"] ?? explicitSha ?? "dev";
-};
-const APP_COMMIT_SHA = resolveCommitSha();
 const BUILD_METADATA = {
   version: APP_VERSION,
   commit: APP_COMMIT_SHA,

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -5,8 +5,8 @@ import { HealthCheckError } from "@/api/lib/errors/tagged-errors";
 import { createProbeCache } from "@/api/lib/health/probe-cache";
 import type { ProbeOutcome } from "@/api/lib/health/probe-cache";
 import { probeDatabase } from "@/api/lib/health/probe-database";
+import { APP_VERSION } from "@/api/lib/version";
 
-const APP_VERSION = process.env["STELLA_VERSION"] ?? "dev";
 const resolveCommitSha = () => {
   const explicitSha = process.env["STELLA_COMMIT_SHA"];
   if (explicitSha && explicitSha !== "dev") {

--- a/apps/api/src/lib/analytics/posthog.ts
+++ b/apps/api/src/lib/analytics/posthog.ts
@@ -5,8 +5,8 @@ import type {
   Analytics,
   ServerAnalyticsCaptureParams,
 } from "@/api/lib/analytics/types";
+import { APP_VERSION } from "@/api/lib/version";
 
-const APP_VERSION = process.env["STELLA_VERSION"] ?? "dev";
 const APP_COMMIT_SHA = process.env["STELLA_COMMIT_SHA"] ?? "dev";
 const ALLOWED_EVENTS = new Set<ServerAnalyticsCaptureParams["event"]>(
   Object.values(SERVER_ANALYTICS_EVENTS),

--- a/apps/api/src/lib/analytics/posthog.ts
+++ b/apps/api/src/lib/analytics/posthog.ts
@@ -5,9 +5,8 @@ import type {
   Analytics,
   ServerAnalyticsCaptureParams,
 } from "@/api/lib/analytics/types";
-import { APP_VERSION } from "@/api/lib/version";
+import { APP_COMMIT_SHA, APP_VERSION } from "@/api/lib/version";
 
-const APP_COMMIT_SHA = process.env["STELLA_COMMIT_SHA"] ?? "dev";
 const ALLOWED_EVENTS = new Set<ServerAnalyticsCaptureParams["event"]>(
   Object.values(SERVER_ANALYTICS_EVENTS),
 );

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -38,9 +38,8 @@ describe("connectWithColdStartRetries", () => {
       }
     };
 
-    await expect(
-      connectWithColdStartRetries(connectOnce),
-    ).resolves.toBeUndefined();
+    // Resolving without throwing is the assertion; a rejection fails the test.
+    await connectWithColdStartRetries(connectOnce);
     expect(calls).toBe(3);
   });
 
@@ -52,7 +51,14 @@ describe("connectWithColdStartRetries", () => {
       throw originalError;
     };
 
-    const rejection = connectWithColdStartRetries(connectOnce);
-    await expect(rejection).rejects.toBe(originalError);
+    let caught: unknown;
+    try {
+      await connectWithColdStartRetries(connectOnce);
+    } catch (error) {
+      caught = error;
+    }
+    // Identity check: the retries-exhausted rethrow must preserve the
+    // original error object, not wrap it.
+    expect(caught).toBe(originalError);
   });
 });

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -5,11 +5,12 @@ const createBunRedisClientCalls: unknown[] = [];
 void mock.module("bullmq", () => ({
   createBunRedisClient: (...args: unknown[]) => {
     createBunRedisClientCalls.push(args);
-    return {};
+    return { connect: async () => undefined };
   },
 }));
 
-const { createBullMqConnection } = await import("@/api/lib/redis-client");
+const { connectWithColdStartRetries, createBullMqConnection } =
+  await import("@/api/lib/redis-client");
 
 describe("BullMQ Redis connection", () => {
   test("lets BullMQ own connection startup", () => {
@@ -22,5 +23,36 @@ describe("BullMQ Redis connection", () => {
       expect.anything(),
       { lazyConnect: true },
     ]);
+  });
+});
+
+describe("connectWithColdStartRetries", () => {
+  test("resolves once a transient cold-start failure recovers", async () => {
+    let calls = 0;
+    const connectOnce = async () => {
+      calls += 1;
+      if (calls < 3) {
+        throw Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        });
+      }
+    };
+
+    await expect(
+      connectWithColdStartRetries(connectOnce),
+    ).resolves.toBeUndefined();
+    expect(calls).toBe(3);
+  });
+
+  test("rethrows the original error once retries are exhausted", async () => {
+    const originalError = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    const connectOnce = async () => {
+      throw originalError;
+    };
+
+    const rejection = connectWithColdStartRetries(connectOnce);
+    await expect(rejection).rejects.toBe(originalError);
   });
 });

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -1,7 +1,10 @@
+import { Result } from "better-result";
 import { type BunRedisRawClient, createBunRedisClient } from "bullmq";
-import { type RedisOptions, RedisClient } from "bun";
+import { type RedisOptions, RedisClient, sleep } from "bun";
 
 import { env } from "@/api/env";
+import { connectionErrorFields } from "@/api/lib/errors/utils";
+import { logger } from "@/api/lib/observability/logger";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
 
 type StellaRedisClient = RedisClient & {
@@ -21,6 +24,54 @@ export const createRedisClient = (
   overrides?: RedisOptions,
 ): StellaRedisClient => new ConfiguredRedisClient(env.REDIS_URL, overrides);
 
+// On a Railway cold start the API container can win the race against its
+// own Redis/Valkey service, so the very first connection attempt hits
+// ECONNREFUSED/ENOTFOUND before Redis is accepting connections. BullMQ's
+// RedisConnection calls `client.connect()` once (see `waitUntilReady` for
+// the initial "wait" status) and rejects loudly through `worker.on("error")`
+// on the first failure, with no retry of its own for that initial attempt.
+// Retry a handful of times with a short capped backoff so that expected,
+// self-recovering cold-start blips log at warn instead of paging as an
+// error; once retries are exhausted the error is rethrown so BullMQ's own
+// (unchanged) error handling still surfaces a persistent outage loudly.
+const COLD_START_CONNECT_RETRY_DELAYS_MS = [200, 500, 1000, 2000];
+
+export const connectWithColdStartRetries = async (
+  connectOnce: () => Promise<void>,
+): Promise<void> => {
+  for (let attempt = 0; ; attempt += 1) {
+    // catch returns the raw cause unchanged so a final, retries-exhausted
+    // rethrow preserves the original error identity (code, syscall, class)
+    // for whichever consumer's `worker.on("error")` handler logs it loudly.
+    // oxlint-disable-next-line no-await-in-loop -- each retry must observe whether the connection came up before deciding to wait and try again
+    const result = await Result.tryPromise({
+      try: connectOnce,
+      catch: (cause: unknown) => cause,
+    });
+    if (result.isOk()) {
+      return;
+    }
+    const delayMs = COLD_START_CONNECT_RETRY_DELAYS_MS[attempt];
+    if (delayMs === undefined) {
+      throw result.error;
+    }
+    logger.warn(
+      "redis.cold_start_reconnect",
+      connectionErrorFields(result.error),
+    );
+    // oxlint-disable-next-line no-await-in-loop -- retries are intentionally sequential backoff, not parallel work
+    await sleep(delayMs);
+  }
+};
+
+const withColdStartConnectRetries = (
+  connection: ReturnType<typeof createBunRedisClient>,
+): ReturnType<typeof createBunRedisClient> => {
+  const connectOnce = connection.connect.bind(connection);
+  connection.connect = () => connectWithColdStartRetries(connectOnce);
+  return connection;
+};
+
 /**
  * Build a BullMQ connection wrapped around a freshly-constructed Bun
  * RedisClient. BullMQ's adapter assigns onconnect/onclose on the raw
@@ -38,9 +89,10 @@ export const createBullMqConnection = (): ReturnType<
   // reconnecting raw clients, so TLS/options from redisConnectionOptions
   // are preserved by the subclass constructor.
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- bridges BullMQ vs Bun RedisClient structural callback mismatch (see above)
-  return createBunRedisClient(raw as unknown as BunRedisRawClient, {
+  const connection = createBunRedisClient(raw as unknown as BunRedisRawClient, {
     // Railway's Redis proxy can trigger Bun's eager adapter read path before
     // BullMQ has completed its own readiness flow. Let BullMQ connect lazily.
     lazyConnect: true,
   });
+  return withColdStartConnectRetries(connection);
 };

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -68,7 +68,9 @@ const withColdStartConnectRetries = (
   connection: ReturnType<typeof createBunRedisClient>,
 ): ReturnType<typeof createBunRedisClient> => {
   const connectOnce = connection.connect.bind(connection);
-  connection.connect = () => connectWithColdStartRetries(connectOnce);
+  connection.connect = async () => {
+    await connectWithColdStartRetries(connectOnce);
+  };
   return connection;
 };
 

--- a/apps/api/src/lib/version.test.ts
+++ b/apps/api/src/lib/version.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveStamp } from "@/api/lib/version";
+
+describe("resolveStamp", () => {
+  let savedRailwaySha: string | undefined;
+
+  beforeEach(() => {
+    savedRailwaySha = process.env["RAILWAY_GIT_COMMIT_SHA"];
+    delete process.env["RAILWAY_GIT_COMMIT_SHA"];
+  });
+
+  afterEach(() => {
+    if (savedRailwaySha === undefined) {
+      delete process.env["RAILWAY_GIT_COMMIT_SHA"];
+    } else {
+      process.env["RAILWAY_GIT_COMMIT_SHA"] = savedRailwaySha;
+    }
+  });
+
+  test("explicit build-arg value wins over the Railway fallback", () => {
+    process.env["RAILWAY_GIT_COMMIT_SHA"] = "railway-sha";
+    expect(resolveStamp("v1.2.3")).toBe("v1.2.3");
+  });
+
+  test("the Dockerfile default 'dev' defers to the Railway commit SHA", () => {
+    process.env["RAILWAY_GIT_COMMIT_SHA"] = "railway-sha";
+    expect(resolveStamp("dev")).toBe("railway-sha");
+    expect(resolveStamp(undefined)).toBe("railway-sha");
+  });
+
+  test("empty string is treated as absent, not as a version", () => {
+    process.env["RAILWAY_GIT_COMMIT_SHA"] = "railway-sha";
+    expect(resolveStamp("")).toBe("railway-sha");
+
+    process.env["RAILWAY_GIT_COMMIT_SHA"] = "";
+    expect(resolveStamp("")).toBe("dev");
+  });
+
+  test("falls back to 'dev' outside any release flow", () => {
+    expect(resolveStamp(undefined)).toBe("dev");
+    expect(resolveStamp("dev")).toBe("dev");
+  });
+});

--- a/apps/api/src/lib/version.ts
+++ b/apps/api/src/lib/version.ts
@@ -1,0 +1,14 @@
+// The API version reported by `/health` and tagged onto PostHog events.
+// ECS/prod release builds pass an explicit `STELLA_VERSION` Docker build arg.
+// Railway's source-based builds do not set that, but Railway always exposes
+// `RAILWAY_GIT_COMMIT_SHA` to the build, so fall back to it before defaulting
+// to "dev" for a local `docker build` outside either release flow.
+const resolveAppVersion = () => {
+  const explicitVersion = process.env["STELLA_VERSION"];
+  if (explicitVersion && explicitVersion !== "dev") {
+    return explicitVersion;
+  }
+  return process.env["RAILWAY_GIT_COMMIT_SHA"] ?? explicitVersion ?? "dev";
+};
+
+export const APP_VERSION = resolveAppVersion();

--- a/apps/api/src/lib/version.ts
+++ b/apps/api/src/lib/version.ts
@@ -1,14 +1,20 @@
-// The API version reported by `/health` and tagged onto PostHog events.
-// ECS/prod release builds pass an explicit `STELLA_VERSION` Docker build arg.
-// Railway's source-based builds do not set that, but Railway always exposes
-// `RAILWAY_GIT_COMMIT_SHA` to the build, so fall back to it before defaulting
-// to "dev" for a local `docker build` outside either release flow.
-const resolveAppVersion = () => {
-  const explicitVersion = process.env["STELLA_VERSION"];
-  if (explicitVersion && explicitVersion !== "dev") {
-    return explicitVersion;
+// Build stamps reported by `/health` and tagged onto PostHog events.
+// ECS/prod release builds pass explicit `STELLA_VERSION` and
+// `STELLA_COMMIT_SHA` Docker build args. Railway's source-based builds do
+// not set those, but Railway always exposes `RAILWAY_GIT_COMMIT_SHA` to the
+// build, so fall back to it before defaulting to "dev" for a local
+// `docker build` outside either release flow.
+//
+// The resolver treats "" and "dev" as absent: the Dockerfile defaults both
+// build args to "dev", and an empty string (e.g. an unset CI variable
+// interpolating to "") must not shadow the Railway fallback or the "dev"
+// default. `||` (not `??`) is deliberate for the same reason.
+export const resolveStamp = (explicit: string | undefined) => {
+  if (explicit && explicit !== "dev") {
+    return explicit;
   }
-  return process.env["RAILWAY_GIT_COMMIT_SHA"] ?? explicitVersion ?? "dev";
+  return process.env["RAILWAY_GIT_COMMIT_SHA"] || explicit || "dev";
 };
 
-export const APP_VERSION = resolveAppVersion();
+export const APP_VERSION = resolveStamp(process.env["STELLA_VERSION"]);
+export const APP_COMMIT_SHA = resolveStamp(process.env["STELLA_COMMIT_SHA"]);

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1262,6 +1262,11 @@ export default defineConfig({
               "apps/api/src/lib/s3.ts",
               "apps/api/src/lib/scheduler/runner.ts",
               "apps/api/src/lib/subprocess.ts",
+              // Shared APP_VERSION resolution for routes.ts and posthog.ts
+              // above; reads STELLA_VERSION/RAILWAY_GIT_COMMIT_SHA directly
+              // rather than through env.ts so it stays side-effect-free at
+              // import time, matching the two call sites it replaces.
+              "apps/api/src/lib/version.ts",
               "apps/web/e2e/helpers/api.ts",
               "apps/web/e2e/staging/global-setup.ts",
               // Test-only helper: reads PROPERTY_TEST_NUM_RUNS_FACTOR and CI

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,9 +26,6 @@
     "README.md"
   ],
   "type": "module",
-  "engines": {
-    "node": ">=20"
-  },
   "sideEffects": false,
   "exports": {
     ".": "./src/cli.ts"
@@ -56,5 +53,8 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -11,6 +11,7 @@ const RAILWAY_SMOKE_WORKFLOW_PATH = ".github/workflows/railway-smoke.yml";
 const RAILWAY_SMOKE_SCRIPT_PATH = "scripts/check-railway-smoke.ts";
 const RAILWAY_SYNC_SCRIPT_PATH = "scripts/sync-railway-template-source.ts";
 const API_HEALTH_ROUTE_PATH = "apps/api/src/handlers/health/routes.ts";
+const API_VERSION_MODULE_PATH = "apps/api/src/lib/version.ts";
 const WEB_VITE_CONFIG_PATH = "apps/web/vite.config.ts";
 const API_DOCKERFILE_PATH = "apps/api/Dockerfile";
 const WEB_DOCKERFILE_PATH = "apps/web/Dockerfile";
@@ -292,10 +293,16 @@ for (const requiredText of [
   );
 }
 
+const apiVersionModule = readText(API_VERSION_MODULE_PATH);
+expect(
+  apiVersionModule.includes("RAILWAY_GIT_COMMIT_SHA"),
+  "API version module must expose Railway source deploy commit SHAs",
+);
+
 const apiHealthRoute = readText(API_HEALTH_ROUTE_PATH);
 expect(
-  apiHealthRoute.includes("RAILWAY_GIT_COMMIT_SHA"),
-  "API health route must expose Railway source deploy commit SHAs",
+  apiHealthRoute.includes("@/api/lib/version"),
+  "API health route must report build stamps from the shared version module",
 );
 
 const webViteConfig = readText(WEB_VITE_CONFIG_PATH);


### PR DESCRIPTION
Two small follow-ups for Railway-based deployments of the api.

## Version stamping

On Railway builds, `/health` reported `version: "dev"`: release builds pass an explicit `STELLA_VERSION` build arg, but source-based Railway builds do not, and the Dockerfile bakes `ENV STELLA_VERSION=dev` as the default. The `commit` field already fell back to `RAILWAY_GIT_COMMIT_SHA`; `version` never did.

- New shared `apps/api/src/lib/version.ts` resolves `APP_VERSION` as `STELLA_VERSION` → `RAILWAY_GIT_COMMIT_SHA` → `"dev"`. The `!== "dev"` guard is required because the baked env default would otherwise short-circuit the fallback.
- `/health` and the PostHog client now import the shared constant instead of each duplicating `process.env["STELLA_VERSION"] ?? "dev"`.
- `oxlint.config.ts`: allowlisted the new module for `forbid-process-env-outside-env-ts`, same as the two call sites it replaces (it must stay side-effect-free at import time, so it does not go through `env.ts`).

No Dockerfile change needed: `ARG RAILWAY_GIT_COMMIT_SHA` is already threaded into the image, and `scripts/check-railway-smoke.ts` compares the (already correct) `commit` field.

## Redis cold-start connect retries

On a cold start the api container can win the race against its Redis/Valkey service: BullMQ's `RedisConnection` calls the adapter's `connect()` exactly once during `waitUntilReady`, so a single `ECONNREFUSED` surfaces as a loud `worker.on("error")` log even though the connection recovers moments later.

- `createBullMqConnection()` now wraps the initial `connect()` with up to 4 retries on a short capped backoff (200/500/1000/2000 ms), logging transient failures at `warn` via the existing `connectionErrorFields` helper.
- Once retries are exhausted, the original error is rethrown unchanged (identity preserved), so the existing per-worker error handlers still report a persistent outage loudly. None of the worker files change.
- Tests cover both paths: recovery after transient failures, and original-error rethrow after exhaustion.

## Testing

- `bun --filter @stll/api test src/lib/redis-client.test.ts` (3 pass, real backoff timing exercised)
- `bun --filter @stll/api test src/lib/analytics/posthog.test.ts` (1 pass)
- Regression-checked adjacent suites using the same connection factory: `workflow-queue.test.ts`, `account-deletion-cleanup-queue.test.ts`, `scheduler/bullmq.test.ts`, `errors/utils.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved application version reporting across health checks and analytics, making build and deployment information more consistent.
  * Added more resilient Redis connection handling during startup, helping the service recover better from brief connection failures.

* **Bug Fixes**
  * Health checks now continue to return the same response format while using a more reliable version source.
  * Redis cold-start connection attempts now retry automatically before failing, reducing transient startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->