### PR TITLE
chore: fix verify baseline failures

### DIFF
--- a/apps/api/src/tests/setup-env.ts
+++ b/apps/api/src/tests/setup-env.ts
@@ -12,6 +12,18 @@ process.env["S3_REGION"] ??= "us-east-1";
 process.env["S3_ACCESS_KEY_ID"] ??= "minioadmin";
 process.env["S3_SECRET_ACCESS_KEY"] ??= "minioadmin";
 
+// Bun auto-loads the developer-local (gitignored) apps/api/.env into
+// `bun test`. Real social-provider credentials there flip the auth
+// capabilities endpoint to `available` and break the hermetic
+// "unavailable when not configured" test in
+// handlers/auth/metadata.test.ts. Force the unconfigured baseline; no
+// test needs live provider credentials.
+delete process.env["GOOGLE_AUTH_CLIENT_ID"];
+delete process.env["GOOGLE_AUTH_CLIENT_SECRET"];
+delete process.env["MICROSOFT_AUTH_CLIENT_ID"];
+delete process.env["MICROSOFT_AUTH_CLIENT_SECRET"];
+delete process.env["MICROSOFT_AUTH_TENANT_ID"];
+
 process.env["REDIS_URL"] ??= "redis://localhost:6379";
 process.env["BETTER_AUTH_SECRET"] ??= "x".repeat(32);
 process.env["BETTER_AUTH_URL"] ??= "http://localhost:3001";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,9 +26,6 @@
     "README.md"
   ],
   "type": "module",
-  "engines": {
-    "node": ">=20"
-  },
   "sideEffects": false,
   "exports": {
     ".": "./src/cli.ts"
@@ -56,5 +53,8 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
Fixes the one reproducible `bun run verify` baseline failure and documents the triage of three other reported failures that turned out to be local-environment artifacts, not repository bugs.

## Fixed here

### `auth capabilities > reports social providers as unavailable when provider credentials are not configured` fails locally

Bun auto-loads the developer-local (gitignored) `apps/api/.env` into `bun test`. When that file contains real `GOOGLE_AUTH_*` / `MICROSOFT_AUTH_*` credentials, the `/auth/capabilities` endpoint truthfully reports the providers as available, and the test's `v.literal(false)` assertions fail. The endpoint behavior and the test expectation are both correct; the test's stated precondition ("credentials are not configured") was simply never enforced, so the suite's outcome depended on gitignored local state. CI never hit this because it seeds `.env` from `.env.example`, which leaves the provider variables unset.

Fix: delete the five social-provider variables in the shared test preload (`apps/api/src/tests/setup-env.ts`), which runs before any test module imports the env schema. No test needs live provider credentials (verified by grep across `apps/api/src/**/*.test.ts`).

### `bun run format -- --check` fails on `packages/cli/package.json`

The npm-publish changes for `@stll/cli` landed with `engines` placed ahead of oxfmt's canonical key position, so the format check (and the pre-push format hook) fails on a clean checkout of `main`. Running `oxfmt` restores the expected ordering; no content change.

## Triaged, no repo change needed

- `bun run typecheck` failing in `@stll/cli` with an unresolved `@stricli/core`: stale `node_modules` (install predated the CLI changes). `@stricli/core` is declared in `packages/cli/package.json` and present in `bun.lock`; a fresh `bun install` makes typecheck pass (31/31 tasks).
- `bun run lint` reporting 98 unused `eslint-disable` directives in `apps/web`: same stale `node_modules` (older oxlint). After a fresh install, lint passes with 0 warnings and 0 errors across all 31 packages.
- Verify extras ("AI skill sync" and "workspace hygiene"): local checkout drift. The `.ai/shared` submodule working copy was behind the committed pointer (`git submodule update --init` resolves it; at the recorded pointer `scripts/sync-ai-skills.sh --check` passes), and an untracked leftover `packages/folio/` directory (only `.turbo/` logs, `.cache/tsbuildinfo.json`, and a stray `node_modules/marked` remaining after the migration to the published `@stll/folio-core`/`@stll/folio-react` packages in #959) tripped the workspace-hygiene check until deleted.
