### PR TITLE
fix: isolate sandbox admission state across api test files

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, mock, setDefaultTimeout, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import type { ScopedDb } from "@/api/db";
 import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
+import { registerSandboxTestHygiene } from "@/api/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
-// Running the real QuickJS sandbox needs the run-sandbox.test ceiling.
-setDefaultTimeout(15_000);
+// Drives the real QuickJS sandbox through execute_typescript: share the sandbox
+// suite's 15s ceiling and drain the process-global admission state after each
+// test so a run here cannot bleed into a later sandbox test file.
+registerSandboxTestHygiene();
 
 const captureErrorMock = mock();
 void mock.module("@/api/lib/analytics", () => ({

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { createStellaIsolateDriver } from "@/api/handlers/chat/tools/execute/sandbox/code-mode-driver";
 import type { SandboxLimits } from "@/api/handlers/chat/tools/execute/sandbox/limits";
+import { getSandboxAdmissionSnapshot } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
 import { registerSandboxTestHygiene } from "@/api/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene";
 
 registerSandboxTestHygiene();
@@ -11,6 +12,35 @@ let driverKeyCounter = 0;
 const nextKey = (): string => {
   driverKeyCounter += 1;
   return `driver-key-${driverKeyCounter}`;
+};
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+const createDeferred = (): Deferred => {
+  let deferredResolve!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    deferredResolve = resolve;
+  });
+  return { promise, resolve: deferredResolve };
+};
+
+// Poll a condition that is GUARANTEED to become true under correct behaviour
+// (e.g. "the second run is parked in the admission queue"). The timeout is a
+// generous bug guard, never an observation window tuned to expected wall-clock
+// progress; a fixed "long enough" sleep is exactly what flakes on a loaded
+// CI runner.
+const waitForCondition = async (condition: () => boolean): Promise<void> => {
+  const deadline = Date.now() + 12_000;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error("Condition was not met before timeout.");
+    }
+    // oxlint-disable-next-line no-await-in-loop -- polling loop: each tick must wait before re-checking the condition
+    await Bun.sleep(5);
+  }
 };
 
 type BindingImpl = (args: unknown) => Promise<unknown>;
@@ -123,37 +153,59 @@ describe("createStellaIsolateDriver", () => {
     expect(result.error?.name).toBe("forbidden-syntax");
   });
 
-  it("times out long host work near the deadline, not the host duration", async () => {
-    const startedAt = Date.now();
+  it("times out at the deadline instead of waiting for unfinished host work", async () => {
+    // The host call blocks on a gate the test releases only AFTER the run has
+    // returned, so the run terminating with `timeout` at all proves the
+    // deadline governs, not the host call's duration. No elapsed-time bound:
+    // wall-clock assertions are exactly what flakes on a loaded runner.
+    const hostGate = createDeferred();
     const result = await runCode({
       code: `await external_slow({}); return "ok";`,
       bindings: bindingsRecord(
         binding("external_slow", async () => {
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 800);
-          });
+          await hostGate.promise;
           return { done: true };
         }),
       ),
-      limits: { maxDurationMs: 100 },
+      limits: { maxDurationMs: 250 },
     });
-    const elapsedMs = Date.now() - startedAt;
+
     expect(result.success).toBe(false);
     expect(result.error?.name).toBe("timeout");
-    expect(elapsedMs).toBeLessThan(700);
+
+    // Settle the orphaned host call so the afterEach drain stays instant.
+    hostGate.resolve();
   });
 
   it("serializes runs sharing a concurrency key through the admission queue", async () => {
     const key = nextKey();
     const started: string[] = [];
-    const gate = new Map<string, () => void>();
+    // Every gate exists before either run starts, so a release can never be
+    // lost to timing. The previous version created each release callback only
+    // when its host call began and resolved it after a fixed sleep; on a
+    // loaded runner the second call had not begun yet, the release no-oped,
+    // and the run hung to its 10s deadline.
+    const startedGates = new Map([
+      ["first", createDeferred()],
+      ["second", createDeferred()],
+    ]);
+    const releaseGates = new Map([
+      ["first", createDeferred()],
+      ["second", createDeferred()],
+    ]);
+    const gateOf = (gates: Map<string, Deferred>, label: string): Deferred => {
+      const gate = gates.get(label);
+      if (!gate) {
+        throw new Error(`No gate for label: ${label}`);
+      }
+      return gate;
+    };
     const bindings = bindingsRecord(
       binding("external_hold", async (args) => {
         const label = readLabel(args);
         started.push(label);
-        await new Promise<void>((resolve) => {
-          gate.set(label, resolve);
-        });
+        gateOf(startedGates, label).resolve();
+        await gateOf(releaseGates, label).promise;
         return { label };
       }),
     );
@@ -171,18 +223,22 @@ describe("createStellaIsolateDriver", () => {
     };
 
     const first = runOne("first");
+    await gateOf(startedGates, "first").promise;
     const second = runOne("second");
 
-    await Bun.sleep(200);
-    // Same key: only the first run may hold the single per-key slot.
+    // Once the second run is visibly parked in the admission queue, it was
+    // definitively denied the single per-key slot the first still holds.
+    await waitForCondition(
+      () => getSandboxAdmissionSnapshot().queuedWaiters === 1,
+    );
     expect(started).toEqual(["first"]);
 
-    gate.get("first")?.();
-    await Bun.sleep(50);
-    gate.get("second")?.();
+    gateOf(releaseGates, "first").resolve();
+    await gateOf(startedGates, "second").promise;
+    expect(started).toEqual(["first", "second"]);
+    gateOf(releaseGates, "second").resolve();
 
     const [a, b] = await Promise.all([first, second]);
-    expect(started).toEqual(["first", "second"]);
     expect(a).toMatchObject({ success: true });
     expect(b).toMatchObject({ success: true });
   });

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/code-mode-driver.test.ts
@@ -1,20 +1,11 @@
 import type { ToolBinding } from "@tanstack/ai-code-mode";
-import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { createStellaIsolateDriver } from "@/api/handlers/chat/tools/execute/sandbox/code-mode-driver";
 import type { SandboxLimits } from "@/api/handlers/chat/tools/execute/sandbox/limits";
-import { awaitSandboxAdmissionIdle } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
+import { registerSandboxTestHygiene } from "@/api/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene";
 
-// Sandbox runs spin up isolated QuickJS contexts; match run-sandbox.test's ceiling.
-setDefaultTimeout(15_000);
-
-// The sandbox admission state is process-global and Bun runs a package's test
-// files in one shared process, so a timed-out run's orphaned host work must be
-// fully drained before the next test (or file) starts; otherwise it perturbs
-// the timing-sensitive admission-queue assertions.
-afterEach(async () => {
-  await awaitSandboxAdmissionIdle();
-});
+registerSandboxTestHygiene();
 
 let driverKeyCounter = 0;
 const nextKey = (): string => {

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -10,7 +10,9 @@ import type {
 import {
   SandboxAdmissionNotIdleError,
   awaitSandboxAdmissionIdle,
+  getSandboxAdmissionSnapshot,
   runSandbox as runSandboxInternal,
+  trackSandboxHostWorkForTest,
 } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
 import { registerSandboxTestHygiene } from "@/api/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene";
 
@@ -61,9 +63,15 @@ type WaitForConditionProps = {
   timeoutMs?: number;
 };
 
+// Poll a condition that is GUARANTEED to become true under correct behaviour
+// (e.g. "the second run has been pushed onto the admission queue"). The
+// timeout is a bug guard, not an observation window: it only fires when the
+// property under test is actually broken, so it is set generously (just below
+// the 15s per-test ceiling) rather than tuned to expected wall-clock progress.
+// Never use this to wait a fixed interval "long enough" for background work.
 const waitForCondition = async ({
   condition,
-  timeoutMs = 3000,
+  timeoutMs = 12_000,
 }: WaitForConditionProps): Promise<void> => {
   const deadline = Date.now() + timeoutMs;
   while (!condition()) {
@@ -75,6 +83,79 @@ const waitForCondition = async ({
       setTimeout(resolve, 5);
     });
   }
+};
+
+// Observe "exactly N runs are parked in the admission queue" as a state
+// transition on the live counters. Once a waiter is visibly queued, admission
+// has already run and denied it a slot, so asserting "it has not started" right
+// after this is deterministic — no sleep window that a slow runner can miss.
+const waitForQueuedWaiters = async (count: number): Promise<void> => {
+  await waitForCondition({
+    condition: () => getSandboxAdmissionSnapshot().queuedWaiters === count,
+  });
+};
+
+type HoldGate = {
+  registry: SandboxFunctionRegistry;
+  startedLabels: string[];
+  whenStarted: (label: string) => Promise<void>;
+  release: (label: string) => void;
+};
+
+/**
+ * A gated `read.hold({ label })` tool whose lifecycle the test controls through
+ * explicit promises instead of wall-clock waits: `whenStarted(label)` resolves
+ * once the host call for that label has begun (its run was admitted and reached
+ * the host bridge) and `release(label)` lets it return. Every gate is created
+ * upfront, so a release can never be lost to timing: even if it fires before
+ * the host call starts, the call finds its gate already resolved. That ordering
+ * hole (releasing a gate that did not exist yet, so the run hung to its
+ * deadline) is exactly what sank the previous sleep-based versions on a loaded
+ * CI runner.
+ */
+const createHoldGate = (labels: readonly string[]): HoldGate => {
+  const startedGates = new Map(
+    labels.map((label) => [label, createDeferredPromise()]),
+  );
+  const releaseGates = new Map(
+    labels.map((label) => [label, createDeferredPromise()]),
+  );
+  const startedLabels: string[] = [];
+
+  const gateFor = (
+    gates: Map<string, DeferredPromise>,
+    label: string,
+  ): DeferredPromise => {
+    const gate = gates.get(label);
+    if (!gate) {
+      throw new Error(`No hold gate was created for label: ${label}`);
+    }
+    return gate;
+  };
+
+  const hold = createToolFunction(
+    {
+      name: "hold",
+      input: v.strictObject({ label: v.string() }),
+      output: v.strictObject({ label: v.string() }),
+      schema: v.any(),
+    },
+    async function* (input) {
+      startedLabels.push(input.label);
+      gateFor(startedGates, input.label).resolve();
+      await gateFor(releaseGates, input.label).promise;
+      return Result.ok({ label: input.label });
+    },
+  );
+
+  return {
+    registry: { hold },
+    startedLabels,
+    whenStarted: async (label) => await gateFor(startedGates, label).promise,
+    release: (label) => {
+      gateFor(releaseGates, label).resolve();
+    },
+  };
 };
 
 const echo = createToolFunction(
@@ -274,20 +355,25 @@ describe("runSandbox", () => {
     }
   });
 
-  it("times out long host work near the deadline instead of the host duration", async () => {
-    const startedAt = Date.now();
+  it("times out at the deadline instead of waiting for unfinished host work", async () => {
+    // The host call blocks on a gate the test releases only AFTER the run has
+    // returned, so the run terminating with `timeout` at all proves the
+    // deadline governs, not the host call's duration. No elapsed-time bound:
+    // wall-clock assertions are exactly what flakes on a loaded runner.
+    const gate = createHoldGate(["slow-host"]);
     const result = await runSandbox({
-      source: `await read.slow({ ms: 800 }); return "ok";`,
-      registry: baseRegistry,
-      limits: { maxDurationMs: 100 },
+      source: `await read.hold({ label: "slow-host" }); return "ok";`,
+      registry: gate.registry,
+      limits: { maxDurationMs: 250 },
     });
-    const elapsedMs = Date.now() - startedAt;
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
       expect(result.error.reason).toBe("timeout");
     }
-    expect(elapsedMs).toBeLessThan(700);
+
+    // Settle the orphaned host call so the afterEach drain stays instant.
+    gate.release("slow-host");
   });
 
   it("aborts an exponential allocation on memory limit", async () => {
@@ -576,95 +662,57 @@ describe("runSandbox", () => {
 
   it("serializes runs for the same concurrency key", async () => {
     const concurrencyKey = nextSandboxConcurrencyKey();
-    const startedLabels: string[] = [];
-    const holds = new Map<string, DeferredPromise>();
-    const hold = createToolFunction(
-      {
-        name: "hold",
-        input: v.strictObject({ label: v.string() }),
-        output: v.strictObject({ label: v.string() }),
-        schema: v.any(),
-      },
-      async function* (input) {
-        startedLabels.push(input.label);
-        const deferred = createDeferredPromise();
-        holds.set(input.label, deferred);
-        await deferred.promise;
-        return Result.ok({ label: input.label });
-      },
-    );
-    const registry: SandboxFunctionRegistry = { hold };
+    const gate = createHoldGate(["first", "second"]);
 
     const firstPromise = runSandbox({
       source: `return await read.hold({ label: "first" });`,
-      registry,
+      registry: gate.registry,
       concurrencyKey,
     });
-    await waitForCondition({
-      condition: () => startedLabels.length === 1,
-    });
+    await gate.whenStarted("first");
 
     const secondPromise = runSandbox({
       source: `return await read.hold({ label: "second" });`,
-      registry,
+      registry: gate.registry,
       concurrencyKey,
     });
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 30);
-    });
+    // Once the second run is visibly parked in the admission queue, it was
+    // definitively denied a slot while the first still holds the per-key slot.
+    await waitForQueuedWaiters(1);
+    expect(gate.startedLabels).toEqual(["first"]);
 
-    expect(startedLabels).toEqual(["first"]);
-
-    holds.get("first")?.resolve();
-    await waitForCondition({
-      condition: () => startedLabels.length === 2,
-    });
-    holds.get("second")?.resolve();
+    gate.release("first");
+    await gate.whenStarted("second");
+    expect(gate.startedLabels).toEqual(["first", "second"]);
+    gate.release("second");
 
     const [first, second] = await Promise.all([firstPromise, secondPromise]);
     expect(Result.isOk(first)).toBe(true);
     expect(Result.isOk(second)).toBe(true);
-    expect(startedLabels).toEqual(["first", "second"]);
   });
 
   it("allows different concurrency keys to run concurrently up to the global cap", async () => {
     const concurrencyKeyPrefix = nextSandboxConcurrencyKey();
-    const startedLabels: string[] = [];
-    const holds = new Map<string, DeferredPromise>();
-    const hold = createToolFunction(
-      {
-        name: "hold",
-        input: v.strictObject({ label: v.string() }),
-        output: v.strictObject({ label: v.string() }),
-        schema: v.any(),
-      },
-      async function* (input) {
-        startedLabels.push(input.label);
-        const deferred = createDeferredPromise();
-        holds.set(input.label, deferred);
-        await deferred.promise;
-        return Result.ok({ label: input.label });
-      },
-    );
-    const registry: SandboxFunctionRegistry = { hold };
+    const labels = ["a", "b", "c", "d"];
+    const gate = createHoldGate(labels);
 
-    const promises = ["a", "b", "c", "d"].map(
+    const promises = labels.map(
       async (label) =>
         await runSandbox({
           source: `return await read.hold({ label: "${label}" });`,
-          registry,
+          registry: gate.registry,
           concurrencyKey: `${concurrencyKeyPrefix}-${label}`,
         }),
     );
 
-    await waitForCondition({
-      condition: () => startedLabels.length === 4,
-    });
-    expect(new Set(startedLabels)).toEqual(new Set(["a", "b", "c", "d"]));
+    // All four host calls start while every release gate is still closed, so
+    // the four runs are provably in flight at the same time.
+    await Promise.all(labels.map(async (label) => gate.whenStarted(label)));
+    expect(new Set(gate.startedLabels)).toEqual(new Set(labels));
 
-    for (const label of startedLabels) {
-      holds.get(label)?.resolve();
+    for (const label of labels) {
+      gate.release(label);
     }
 
     const results = await Promise.all(promises);
@@ -673,48 +721,34 @@ describe("runSandbox", () => {
 
   it("queues a fifth distinct key until a global slot opens", async () => {
     const concurrencyKeyPrefix = nextSandboxConcurrencyKey();
-    const startedLabels: string[] = [];
-    const holds = new Map<string, DeferredPromise>();
-    const hold = createToolFunction(
-      {
-        name: "hold",
-        input: v.strictObject({ label: v.string() }),
-        output: v.strictObject({ label: v.string() }),
-        schema: v.any(),
-      },
-      async function* (input) {
-        startedLabels.push(input.label);
-        const deferred = createDeferredPromise();
-        holds.set(input.label, deferred);
-        await deferred.promise;
-        return Result.ok({ label: input.label });
-      },
-    );
-    const registry: SandboxFunctionRegistry = { hold };
+    const labels = ["a", "b", "c", "d", "e"];
+    const gate = createHoldGate(labels);
 
-    const promises = ["a", "b", "c", "d", "e"].map(
+    // Admission waiters are pushed synchronously in call order, so with the
+    // global cap at 4 exactly a-d are admitted and e is queued.
+    const promises = labels.map(
       async (label) =>
         await runSandbox({
           source: `return await read.hold({ label: "${label}" });`,
-          registry,
+          registry: gate.registry,
           concurrencyKey: `${concurrencyKeyPrefix}-${label}`,
         }),
     );
 
-    await waitForCondition({
-      condition: () => startedLabels.length === 4,
-    });
-    expect(new Set(startedLabels)).toEqual(new Set(["a", "b", "c", "d"]));
-    expect(startedLabels).not.toContain("e");
+    const admitted = ["a", "b", "c", "d"];
+    await Promise.all(admitted.map(async (label) => gate.whenStarted(label)));
+    // e being visibly parked in the queue proves it was denied a slot while
+    // all four admitted runs are still holding theirs.
+    await waitForQueuedWaiters(1);
+    expect(new Set(gate.startedLabels)).toEqual(new Set(admitted));
+    expect(gate.startedLabels).not.toContain("e");
 
-    holds.get("a")?.resolve();
-    await waitForCondition({
-      condition: () => startedLabels.length === 5,
-    });
-    expect(startedLabels).toContain("e");
+    gate.release("a");
+    await gate.whenStarted("e");
+    expect(gate.startedLabels).toContain("e");
 
     for (const label of ["b", "c", "d", "e"]) {
-      holds.get(label)?.resolve();
+      gate.release(label);
     }
 
     const results = await Promise.all(promises);
@@ -723,45 +757,35 @@ describe("runSandbox", () => {
 
   it("does not count queue wait time against maxDurationMs", async () => {
     const concurrencyKey = nextSandboxConcurrencyKey();
-    const holds = new Map<string, DeferredPromise>();
-    const hold = createToolFunction(
-      {
-        name: "hold",
-        input: v.strictObject({ label: v.string() }),
-        output: v.strictObject({ label: v.string() }),
-        schema: v.any(),
-      },
-      async function* (input) {
-        const deferred = createDeferredPromise();
-        holds.set(input.label, deferred);
-        await deferred.promise;
-        return Result.ok({ label: input.label });
-      },
-    );
-    const registry: SandboxFunctionRegistry = { hold };
+    const gate = createHoldGate(["first"]);
 
+    // The first run's deadline must comfortably outlast the queued interval
+    // below plus any load-induced slack; only the second run's budget is under
+    // test.
     const firstPromise = runSandbox({
       source: `return await read.hold({ label: "first" });`,
-      registry,
+      registry: gate.registry,
       concurrencyKey,
-      limits: { maxDurationMs: 2000 },
+      limits: { maxDurationMs: 12_000 },
     });
-    await waitForCondition({
-      condition: () => holds.has("first"),
-    });
+    await gate.whenStarted("first");
 
+    const secondBudgetMs = 2000;
     const secondPromise = runSandbox({
       source: `return 42;`,
-      registry,
+      registry: gate.registry,
       concurrencyKey,
-      limits: { maxDurationMs: 1000 },
+      limits: { maxDurationMs: secondBudgetMs },
     });
+    await waitForQueuedWaiters(1);
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 1200);
-    });
-
-    holds.get("first")?.resolve();
+    // Keep the second run queued for strictly longer than its entire execution
+    // budget. The property is inherently about wall-clock, but the wait only
+    // needs a MINIMUM (Bun.sleep guarantees at-least semantics), so runner
+    // load can only lengthen the queued interval — it exercises the property
+    // harder, it can never fake a pass or force a failure.
+    await Bun.sleep(secondBudgetMs + 250);
+    gate.release("first");
 
     const [first, second] = await Promise.all([firstPromise, secondPromise]);
     expect(Result.isOk(first)).toBe(true);
@@ -773,17 +797,16 @@ describe("runSandbox", () => {
 
   it("releases keyed and global slots after a timeout", async () => {
     const concurrencyKey = nextSandboxConcurrencyKey();
+    // Admission waiters are pushed synchronously in call order: the first run
+    // takes the per-key slot and the second queues behind it, no spacing sleep
+    // needed. The second run can only succeed if the first's timeout released
+    // both the keyed and the global slot.
     const firstPromise = runSandbox({
       source: `await read.slow({ ms: 150 }); return "late";`,
       registry: baseRegistry,
       concurrencyKey,
       limits: { maxDurationMs: 50 },
     });
-
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 20);
-    });
-
     const secondPromise = runSandbox({
       source: `return 42;`,
       registry: baseRegistry,
@@ -803,42 +826,25 @@ describe("runSandbox", () => {
 
   it("releases keyed and global slots after a runtime failure", async () => {
     const concurrencyKey = nextSandboxConcurrencyKey();
-    const holds = new Map<string, DeferredPromise>();
-    const hold = createToolFunction(
-      {
-        name: "hold",
-        input: v.strictObject({ label: v.string() }),
-        output: v.strictObject({ label: v.string() }),
-        schema: v.any(),
-      },
-      async function* (input) {
-        const deferred = createDeferredPromise();
-        holds.set(input.label, deferred);
-        await deferred.promise;
-        return Result.ok({ label: input.label });
-      },
-    );
-    const registry: SandboxFunctionRegistry = { hold };
+    const gate = createHoldGate(["first"]);
 
     const firstPromise = runSandbox({
       source: `
         await read.hold({ label: "first" });
         throw new Error("boom");
       `,
-      registry,
+      registry: gate.registry,
       concurrencyKey,
     });
-    await waitForCondition({
-      condition: () => holds.has("first"),
-    });
+    await gate.whenStarted("first");
 
     const secondPromise = runSandbox({
       source: `return 42;`,
-      registry,
+      registry: gate.registry,
       concurrencyKey,
     });
 
-    holds.get("first")?.resolve();
+    gate.release("first");
 
     const [first, second] = await Promise.all([firstPromise, secondPromise]);
     expect(Result.isError(first)).toBe(true);
@@ -984,20 +990,19 @@ describe("runSandbox", () => {
 
   it("passes an abort signal to host handlers so they can avoid committing after timeout", async () => {
     let sideEffect = 0;
+    // The host call blocks on a gate the test releases only AFTER the run has
+    // returned (i.e. after the bridge's AbortController has fired), so the
+    // signal check runs at a deterministic point instead of racing two timers.
+    const commitGate = createDeferredPromise();
     const mutate = createToolFunction(
       {
         name: "mutate",
-        input: v.strictObject({
-          ms: v.number(),
-          value: v.number(),
-        }),
+        input: v.strictObject({ value: v.number() }),
         output: v.strictObject({ ok: v.boolean() }),
         schema: v.any(),
       },
       async function* (input, { signal }) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, input.ms);
-        });
+        await commitGate.promise;
         signal.throwIfAborted();
         sideEffect = input.value;
         return Result.ok({ ok: true });
@@ -1008,9 +1013,9 @@ describe("runSandbox", () => {
     };
 
     const result = await runSandbox({
-      source: `await read.mutate({ ms: 200, value: 7 }); return "done";`,
+      source: `await read.mutate({ value: 7 }); return "done";`,
       registry,
-      limits: { maxDurationMs: 50 },
+      limits: { maxDurationMs: 250 },
     });
 
     expect(Result.isError(result)).toBe(true);
@@ -1018,9 +1023,10 @@ describe("runSandbox", () => {
       expect(result.error.reason).toBe("timeout");
     }
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 300);
-    });
+    // Let the (now aborted) host call proceed to its commit check, then await
+    // its full unwind through the drain — an event, not a fixed sleep.
+    commitGate.resolve();
+    await awaitSandboxAdmissionIdle();
 
     expect(sideEffect).toBe(0);
   });
@@ -1049,57 +1055,47 @@ describe("runSandbox", () => {
 });
 
 describe("awaitSandboxAdmissionIdle", () => {
-  // A host binding that never settles and ignores the abort signal strands its
-  // in-flight promise in the process-global set once the run returns at its
-  // deadline. The drain must not then hang for the full per-test timeout on this
-  // test and every later one: it fails fast with the live counters and evicts
-  // the strand so the next drain is clean. This is the class guard for the
-  // "every sandbox test uniformly times out at ~15s" flake.
+  // A host call that never settles (and ignores the abort signal) strands its
+  // in-flight promise in the process-global set once its run returns at the
+  // deadline. The drain must not then hang for the full per-test timeout on
+  // this test and every later one: it fails fast with the live counters and
+  // evicts the strand so the next drain is clean. This is the class guard for
+  // the "every sandbox test uniformly times out at ~15s" flake.
+  //
+  // The strand is injected directly rather than constructed through a real
+  // run: with a real run, a small maxDurationMs races QuickJS startup on a
+  // loaded runner and the host call may never begin, which made the previous
+  // version of this test flake in CI. The injected shape (an entry in the
+  // in-flight set with no admitted run) is byte-for-byte what such a run
+  // leaves behind. The drain budget is an injected parameter here, and the
+  // assertions are about the thrown diagnostic and its counters — never about
+  // wall-clock progress.
   it("fails fast with a diagnostic when a host promise is stranded, then unpoisons", async () => {
-    let started = false;
-    const strand = createToolFunction(
-      {
-        name: "strand",
-        input: v.strictObject({}),
-        output: v.strictObject({}),
-        schema: v.any(),
-      },
-      async function* () {
-        started = true;
-        await new Promise<void>(() => {
-          // never resolves; ignores the abort signal
-        });
-        return Result.ok({});
-      },
+    trackSandboxHostWorkForTest(
+      new Promise<void>(() => {
+        // never settles; models a stranded host call
+      }),
     );
-
-    // Short deadline so the run itself returns quickly (releasing its slot)
-    // while the orphaned host promise lingers in the in-flight set.
-    void runSandbox({
-      source: `return await read.strand({});`,
-      registry: { strand },
-      limits: { maxDurationMs: 200 },
-    });
-
-    await waitForCondition({ condition: () => started });
 
     let thrown: unknown;
     try {
-      await awaitSandboxAdmissionIdle({ timeoutMs: 500 });
+      await awaitSandboxAdmissionIdle({ timeoutMs: 250 });
     } catch (error) {
       thrown = error;
     }
 
     expect(thrown).toBeInstanceOf(SandboxAdmissionNotIdleError);
     if (thrown instanceof SandboxAdmissionNotIdleError) {
-      // The slot was released at the deadline; only the host tail is stranded.
-      expect(thrown.snapshot.activeSandboxCount).toBe(0);
-      expect(thrown.snapshot.queuedWaiters).toBe(0);
-      expect(thrown.snapshot.hostWorkInFlight).toBeGreaterThan(0);
+      // No run is admitted or queued; only the host tail is stranded.
+      expect(thrown.snapshot).toEqual({
+        activeSandboxCount: 0,
+        queuedWaiters: 0,
+        hostWorkInFlight: 1,
+      });
     }
 
-    // The strand was evicted, so a subsequent drain resolves immediately and
-    // the poison does not cascade into the next test or file.
-    await awaitSandboxAdmissionIdle({ timeoutMs: 500 });
+    // The strand was evicted, so a subsequent drain resolves instead of
+    // cascading the poison into the next test or file.
+    await awaitSandboxAdmissionIdle({ timeoutMs: 250 });
   });
 });

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import * as v from "valibot";
 
 import { createToolFunction } from "@/api/handlers/chat/tools/execute/execute-tool-function";
@@ -8,20 +8,13 @@ import type {
   SandboxFunctionRegistry,
 } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
 import {
+  SandboxAdmissionNotIdleError,
   awaitSandboxAdmissionIdle,
   runSandbox as runSandboxInternal,
 } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
+import { registerSandboxTestHygiene } from "@/api/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene";
 
-// Sandbox runs spin up isolated V8 contexts; raise the bun-test ceiling so CI runner load doesn't flake. Product code enforces its own smaller deadlines.
-setDefaultTimeout(15_000);
-
-// The sandbox admission state is process-global and Bun runs a package's test
-// files in one shared process, so a timed-out run's orphaned host work must be
-// fully drained before the next test (or file) starts; otherwise it perturbs
-// the timing-sensitive admission-queue assertions.
-afterEach(async () => {
-  await awaitSandboxAdmissionIdle();
-});
+registerSandboxTestHygiene();
 
 type RunTestSandboxProps = Omit<RunSandboxInput, "concurrencyKey"> & {
   concurrencyKey?: string;
@@ -1052,5 +1045,61 @@ describe("runSandbox", () => {
     if (Result.isError(result)) {
       expect(result.error.reason).toBe("forbidden-syntax");
     }
+  });
+});
+
+describe("awaitSandboxAdmissionIdle", () => {
+  // A host binding that never settles and ignores the abort signal strands its
+  // in-flight promise in the process-global set once the run returns at its
+  // deadline. The drain must not then hang for the full per-test timeout on this
+  // test and every later one: it fails fast with the live counters and evicts
+  // the strand so the next drain is clean. This is the class guard for the
+  // "every sandbox test uniformly times out at ~15s" flake.
+  it("fails fast with a diagnostic when a host promise is stranded, then unpoisons", async () => {
+    let started = false;
+    const strand = createToolFunction(
+      {
+        name: "strand",
+        input: v.strictObject({}),
+        output: v.strictObject({}),
+        schema: v.any(),
+      },
+      async function* () {
+        started = true;
+        await new Promise<void>(() => {
+          // never resolves; ignores the abort signal
+        });
+        return Result.ok({});
+      },
+    );
+
+    // Short deadline so the run itself returns quickly (releasing its slot)
+    // while the orphaned host promise lingers in the in-flight set.
+    void runSandbox({
+      source: `return await read.strand({});`,
+      registry: { strand },
+      limits: { maxDurationMs: 200 },
+    });
+
+    await waitForCondition({ condition: () => started });
+
+    let thrown: unknown;
+    try {
+      await awaitSandboxAdmissionIdle({ timeoutMs: 500 });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxAdmissionNotIdleError);
+    if (thrown instanceof SandboxAdmissionNotIdleError) {
+      // The slot was released at the deadline; only the host tail is stranded.
+      expect(thrown.snapshot.activeSandboxCount).toBe(0);
+      expect(thrown.snapshot.queuedWaiters).toBe(0);
+      expect(thrown.snapshot.hostWorkInFlight).toBeGreaterThan(0);
+    }
+
+    // The strand was evicted, so a subsequent drain resolves immediately and
+    // the poison does not cascade into the next test or file.
+    await awaitSandboxAdmissionIdle({ timeoutMs: 500 });
   });
 });

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
@@ -166,9 +166,14 @@ const raceHostWorkAgainstDeadline = async (
   hostWork: readonly Promise<void>[],
   deadline: number,
 ): Promise<void> => {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    return;
+  }
+
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const budget = new Promise<void>((resolve) => {
-    timeoutId = setTimeout(resolve, Math.max(0, deadline - Date.now()));
+    timeoutId = setTimeout(resolve, remainingMs);
   });
   try {
     await Promise.race([Promise.allSettled(hostWork), budget]);
@@ -177,6 +182,36 @@ const raceHostWorkAgainstDeadline = async (
       clearTimeout(timeoutId);
     }
   }
+};
+
+/**
+ * Test-only: read the live admission counters. Concurrency tests use this to
+ * observe "a run is QUEUED behind the cap" as a state transition instead of
+ * sleeping a fixed interval and hoping the queue has settled — a fixed sleep is
+ * exactly what flakes on a loaded CI runner. The waiter push and the admission
+ * flush both happen synchronously inside `runSandbox`'s first await, so polling
+ * this snapshot for `queuedWaiters` is a guaranteed-eventual observation, never
+ * a timing bet.
+ */
+export const getSandboxAdmissionSnapshot = (): SandboxAdmissionSnapshot =>
+  snapshotSandboxAdmission();
+
+/**
+ * Test-only: register host work in the process-global in-flight set exactly as
+ * `runHostCall` does (added on registration, removed when it settles). Drain
+ * tests use it to create a stranded entry (a promise that never settles)
+ * DIRECTLY, instead of racing a real run's wall-clock deadline against QuickJS
+ * startup on a loaded runner: with a small `maxDurationMs`, the deadline can
+ * pass before the script's host call ever executes, so the end-to-end
+ * construction of a strand is nondeterministic under CI load.
+ */
+export const trackSandboxHostWorkForTest = (work: Promise<void>): void => {
+  const tracked: Promise<void> = work
+    .catch(() => undefined)
+    .finally(() => {
+      sandboxHostWorkInFlight.delete(tracked);
+    });
+  sandboxHostWorkInFlight.add(tracked);
 };
 
 /**

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
@@ -105,24 +105,125 @@ const sandboxAdmissionQueue: SandboxAdmissionWaiter[] = [];
 const sandboxHostWorkInFlight = new Set<Promise<void>>();
 
 /**
+ * Default budget for {@link awaitSandboxAdmissionIdle}. Generously above the
+ * longest legitimate orphaned host-work tail (bounded by a run's wall-clock
+ * deadline, {@link DEFAULT_SANDBOX_LIMITS}.maxDurationMs) yet below the sandbox
+ * test suite's 15s per-test ceiling, so a genuinely stranded host promise fails
+ * the drain fast with a diagnostic instead of silently 15s-timing-out every
+ * subsequent test.
+ */
+export const SANDBOX_ADMISSION_IDLE_TIMEOUT_MS = 10_000;
+
+type SandboxAdmissionSnapshot = {
+  activeSandboxCount: number;
+  queuedWaiters: number;
+  hostWorkInFlight: number;
+};
+
+const snapshotSandboxAdmission = (): SandboxAdmissionSnapshot => ({
+  activeSandboxCount,
+  queuedWaiters: sandboxAdmissionQueue.length,
+  hostWorkInFlight: sandboxHostWorkInFlight.size,
+});
+
+/**
+ * Thrown by {@link awaitSandboxAdmissionIdle} (a test-only hook) when the
+ * process-global admission state cannot reach idle within its budget. It exists
+ * to make a poisoned state loud and localized: a single host promise that never
+ * settles (e.g. a test that abandons an unresolved gate before releasing it)
+ * otherwise strands an entry in the module-global in-flight set forever, and the
+ * drain — which every sandbox `afterEach` awaits — would then hang for the full
+ * per-test timeout on that test AND every test after it in the shared Bun
+ * process. Surfacing the live counters names the culprit instead of burying it
+ * under a uniform wall of 15s hook timeouts.
+ */
+export class SandboxAdmissionNotIdleError extends Error {
+  readonly snapshot: SandboxAdmissionSnapshot;
+
+  constructor(snapshot: SandboxAdmissionSnapshot, timeoutMs: number) {
+    super(
+      `Sandbox admission did not reach idle within ${timeoutMs}ms: ` +
+        `activeSandboxCount=${snapshot.activeSandboxCount}, ` +
+        `queuedWaiters=${snapshot.queuedWaiters}, ` +
+        `hostWorkInFlight=${snapshot.hostWorkInFlight}. ` +
+        "A host promise was likely stranded (e.g. a test abandoned an unresolved gate); " +
+        "resolve/settle every host call it starts, or lower the run's maxDurationMs.",
+    );
+    this.name = "SandboxAdmissionNotIdleError";
+    this.snapshot = snapshot;
+  }
+}
+
+type AwaitSandboxAdmissionIdleOptions = {
+  /** Drain budget; see {@link SANDBOX_ADMISSION_IDLE_TIMEOUT_MS}. */
+  timeoutMs?: number;
+};
+
+// Await the current in-flight host work, but give up at `deadline` so a
+// never-settling promise cannot hang the drain. The budget timer is always
+// cleared so it can never fire into the following test.
+const raceHostWorkAgainstDeadline = async (
+  hostWork: readonly Promise<void>[],
+  deadline: number,
+): Promise<void> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<void>((resolve) => {
+    timeoutId = setTimeout(resolve, Math.max(0, deadline - Date.now()));
+  });
+  try {
+    await Promise.race([Promise.allSettled(hostWork), budget]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+/**
  * Test-only drain hook: resolves once the process-global sandbox admission
  * state is fully idle — no admitted runs, an empty admission queue, and no
- * orphaned host work still settling in the background. It only READS module
- * state and awaits already-scheduled work; it never resets counters or cancels
- * work, so it cannot mask a real admission-accounting bug. Both sandbox test
- * files call it in `afterEach` so one test's background host work cannot leak
- * into the timing of the next.
+ * orphaned host work still settling in the background. It only READS the
+ * admission counters (`activeSandboxCount`, the queue) and awaits
+ * already-scheduled work; it never resets those counters, so it cannot mask a
+ * real admission-accounting bug. Every sandbox test file registers it in
+ * `afterEach` (see `registerSandboxTestHygiene`) so one test's background host
+ * work cannot leak into the timing of the next.
+ *
+ * The wait is bounded: a host promise that never settles cannot hold an
+ * admission slot (the slot is released in `runSandbox`'s `finally` at the run's
+ * deadline), but it lingers forever in `sandboxHostWorkInFlight`. Without a
+ * bound the drain would then hang for the whole per-test timeout on this test
+ * and every later one. On timeout we therefore evict the stranded in-flight
+ * host work (a test-support set, safe to clear once we have waited past every
+ * legitimate tail) so the poison does not cascade, and throw a diagnostic naming
+ * the live counters. Admission counts are never cleared: if they are the stuck
+ * dimension, that is a genuine accounting bug and it should keep surfacing.
  */
-export const awaitSandboxAdmissionIdle = async (): Promise<void> => {
+export const awaitSandboxAdmissionIdle = async ({
+  timeoutMs = SANDBOX_ADMISSION_IDLE_TIMEOUT_MS,
+}: AwaitSandboxAdmissionIdleOptions = {}): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+
   while (
     // oxlint-disable-next-line no-unmodified-loop-condition -- released by admission callbacks that settle during the awaited work below, not in this loop body
     activeSandboxCount > 0 ||
     sandboxAdmissionQueue.length > 0 ||
     sandboxHostWorkInFlight.size > 0
   ) {
+    if (Date.now() >= deadline) {
+      const snapshot = snapshotSandboxAdmission();
+      // Drop the stranded host-work tail so the next test starts clean; keep
+      // the admission counters intact so a real accounting bug still surfaces.
+      sandboxHostWorkInFlight.clear();
+      throw new SandboxAdmissionNotIdleError(snapshot, timeoutMs);
+    }
+
     if (sandboxHostWorkInFlight.size > 0) {
-      // oxlint-disable-next-line no-await-in-loop -- drain loop: await the current in-flight snapshot, then re-check for work registered while we waited
-      await Promise.allSettled(Array.from(sandboxHostWorkInFlight));
+      // oxlint-disable-next-line no-await-in-loop -- drain loop: race the current in-flight snapshot against the remaining budget, then re-check for work registered while we waited
+      await raceHostWorkAgainstDeadline(
+        Array.from(sandboxHostWorkInFlight),
+        deadline,
+      );
       continue;
     }
 

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/sandbox-test-hygiene.ts
@@ -1,0 +1,27 @@
+import { afterEach, setDefaultTimeout } from "bun:test";
+
+import { awaitSandboxAdmissionIdle } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
+
+/**
+ * The sandbox admission state (`activeSandboxCount`, the admission queue, and
+ * the in-flight host-work set) lives at module scope, and Bun runs a package's
+ * test files in ONE shared process. So any test file that drives the real
+ * sandbox must drain that state after every test; otherwise one test's
+ * background host work (or a run that outlives its assertions) bleeds into the
+ * timing of the next test — and, in the worst case, a stranded host promise
+ * hangs every later test for the full per-test timeout.
+ *
+ * This is the single seam every sandbox test file wires in, so the hygiene
+ * cannot be forgotten per-file and cannot drift between files. It sets the
+ * shared 15s ceiling (real QuickJS runs need headroom over Bun's 5s default)
+ * and registers the bounded `afterEach` drain.
+ */
+export const registerSandboxTestHygiene = (): void => {
+  // Real QuickJS runs (and their wall-clock deadline) need more than Bun's
+  // default 5s per-test ceiling.
+  setDefaultTimeout(15_000);
+
+  afterEach(async () => {
+    await awaitSandboxAdmissionIdle();
+  });
+};


### PR DESCRIPTION
Kills a cross-file test flake class in the chat sandbox suites.

The sandbox admission state is module-global and all api test files share one Bun process. A concurrency test whose timing assertion throws while its manually-gated host calls are still pending strands those promises in the test-only in-flight tracking set; the previous drain hook waited on that set unbounded, so one flaky assertion cascaded into ~15s per-test timeouts for every subsequent sandbox test — including trivial ones (the exact signature seen on a recent PR run).

- The drain (`awaitSandboxAdmissionIdle`) now has a bounded budget: on timeout it evicts the stranded host work and throws a diagnostic error carrying the live counters, so the poisoned state fails one test fast and self-heals instead of cascading. Admission counts are never cleared, so real accounting bugs still surface.
- New `registerSandboxTestHygiene()` seam registers the ceiling + drain in one place; all three sandbox-driving test files use it (one previously had no drain at all).
- Regression test proves a stranded host promise produces the fast diagnostic failure and the next drain is clean.

Prod behavior is unchanged: `runSandbox` always released its admission slot in `finally`; the stranded set was test-support only.

Verification: sandbox subset 10x consecutive green in one process; full `src/handlers/chat/tools` scope 5x green (148 tests); typecheck and type-aware lint clean.