### PR TITLE
fix(api): auto-heal org AI configs pinned to dropped catalog models

### DIFF
--- a/apps/api/src/lib/ai-config.test.ts
+++ b/apps/api/src/lib/ai-config.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import { BYOK_DEFAULT_MODELS } from "@stll/ai-catalog";
+
+import { normalizeOrgAIConfig } from "@/api/lib/ai-config";
+import type { OrgAIConfig } from "@/api/lib/ai-config";
+
+const googleProvider = {
+  provider: "google",
+  apiKey: "test-key",
+  region: "global",
+} as const;
+
+const mistralProvider = {
+  provider: "mistral",
+  apiKey: "test-key",
+  region: "global",
+} as const;
+
+describe("normalizeOrgAIConfig auto-heal", () => {
+  test("rewrites models dropped by a catalog bump to the same-provider default", () => {
+    const config: OrgAIConfig = {
+      providers: [googleProvider],
+      overrideModels: {
+        fast: { provider: "google", modelId: "gemini-2.5-flash-lite" },
+        chat: { provider: "google", modelId: "gemini-3-flash-preview" },
+        reasoning: { provider: "google", modelId: "gemini-3-pro-preview" },
+        pdf: { provider: "google", modelId: "gemini-3-flash-preview" },
+      },
+    };
+
+    const healed = normalizeOrgAIConfig(config).overrideModels;
+
+    expect(healed.fast).toEqual({
+      provider: "google",
+      modelId: BYOK_DEFAULT_MODELS.google.fast,
+    });
+    expect(healed.chat).toEqual({
+      provider: "google",
+      modelId: BYOK_DEFAULT_MODELS.google.chat,
+    });
+    expect(healed.reasoning).toEqual({
+      provider: "google",
+      modelId: BYOK_DEFAULT_MODELS.google.reasoning,
+    });
+    expect(healed.pdf).toEqual({
+      provider: "google",
+      modelId: BYOK_DEFAULT_MODELS.google.pdf,
+    });
+  });
+
+  test("leaves still-offered models untouched", () => {
+    const config: OrgAIConfig = {
+      providers: [googleProvider],
+      overrideModels: {
+        fast: { provider: "google", modelId: BYOK_DEFAULT_MODELS.google.fast },
+        chat: { provider: "google", modelId: BYOK_DEFAULT_MODELS.google.chat },
+        reasoning: {
+          provider: "google",
+          modelId: BYOK_DEFAULT_MODELS.google.reasoning,
+        },
+        pdf: { provider: "google", modelId: BYOK_DEFAULT_MODELS.google.pdf },
+      },
+    };
+
+    expect(normalizeOrgAIConfig(config).overrideModels).toEqual(
+      config.overrideModels,
+    );
+  });
+
+  test("leaves mistral + pdf unhealable selection as-is (no document-capable model)", () => {
+    const staleMistralPdf = {
+      provider: "mistral",
+      modelId: "mistral-large-latest",
+    } as const;
+    const config: OrgAIConfig = {
+      providers: [mistralProvider],
+      overrideModels: {
+        fast: { provider: "mistral", modelId: "some-retired-mistral-id" },
+        chat: { provider: "mistral", modelId: "some-retired-mistral-id" },
+        reasoning: { provider: "mistral", modelId: "some-retired-mistral-id" },
+        pdf: staleMistralPdf,
+      },
+    };
+
+    const healed = normalizeOrgAIConfig(config).overrideModels;
+
+    // fast/chat/reasoning heal on the same provider...
+    expect(healed.fast.modelId).toBe(BYOK_DEFAULT_MODELS.mistral.fast);
+    expect(healed.chat.modelId).toBe(BYOK_DEFAULT_MODELS.mistral.chat);
+    expect(healed.reasoning.modelId).toBe(
+      BYOK_DEFAULT_MODELS.mistral.reasoning,
+    );
+    // ...but pdf cannot be healed to the same provider, so it is untouched.
+    expect(healed.pdf).toEqual(staleMistralPdf);
+  });
+
+  test("leaves a non-BYOK provider selection untouched", () => {
+    // A provider with no first-class BYOK adapter (e.g. huggingface) has
+    // nothing to heal to on the same provider, so the selection passes
+    // through and surfaces via generation-time validation instead.
+    const staleHuggingFace = {
+      provider: "huggingface",
+      modelId: "speakleash/Bielik-11B-v2.3-Instruct",
+    } as const;
+    const config: OrgAIConfig = {
+      providers: [googleProvider],
+      overrideModels: {
+        fast: staleHuggingFace,
+        chat: { provider: "google", modelId: BYOK_DEFAULT_MODELS.google.chat },
+        reasoning: {
+          provider: "google",
+          modelId: BYOK_DEFAULT_MODELS.google.reasoning,
+        },
+        pdf: { provider: "google", modelId: BYOK_DEFAULT_MODELS.google.pdf },
+      },
+    };
+
+    expect(normalizeOrgAIConfig(config).overrideModels.fast).toEqual(
+      staleHuggingFace,
+    );
+  });
+});

--- a/apps/api/src/lib/ai-config.ts
+++ b/apps/api/src/lib/ai-config.ts
@@ -1,4 +1,8 @@
-import type { AIProvider, ModelRole } from "@stll/ai-catalog";
+import {
+  BYOK_MODEL_OPTIONS,
+  resolveWorkingBYOKModelForRole,
+} from "@stll/ai-catalog";
+import type { AIProvider, BYOKProvider, ModelRole } from "@stll/ai-catalog";
 
 import type { UsageServiceTier } from "@/api/db/schema";
 
@@ -148,7 +152,53 @@ export const normalizeOrgAIProviderConfig = (
   }
 };
 
+const isBYOKProviderId = (provider: AIProvider): provider is BYOKProvider =>
+  provider in BYOK_MODEL_OPTIONS;
+
+/**
+ * Auto-heal a per-role model selection so it resolves to a model that
+ * actually works on the SAME provider. A catalog bump can drop a model
+ * id that an org previously pinned; the stored config still decrypts
+ * (the id is any non-empty string), but generation would 400 (PDF
+ * role) or forward a retired id to the provider (other roles). When
+ * the pinned model is no longer offered, fall back to the provider's
+ * per-role default.
+ *
+ * Left unchanged when: the model is still offered; the provider is not
+ * a BYOK provider (nothing to heal to on the same provider); or the
+ * provider has no valid model for the role at all (mistral + pdf,
+ * which has no document-capable model). Those residual cases are
+ * surfaced by generation-time validation rather than silently rerouted
+ * to a different provider.
+ */
+const healOverrideModel = (
+  role: ModelRole,
+  selection: OrgAIModelSelection,
+): OrgAIModelSelection => {
+  if (!isBYOKProviderId(selection.provider)) {
+    return selection;
+  }
+  const working = resolveWorkingBYOKModelForRole({
+    provider: selection.provider,
+    modelId: selection.modelId,
+    role,
+  });
+  if (!working || working === selection.modelId) {
+    return selection;
+  }
+  return { provider: selection.provider, modelId: working };
+};
+
+const healOverrideModels = (
+  overrideModels: Record<ModelRole, OrgAIModelSelection>,
+): Record<ModelRole, OrgAIModelSelection> => ({
+  fast: healOverrideModel("fast", overrideModels.fast),
+  chat: healOverrideModel("chat", overrideModels.chat),
+  reasoning: healOverrideModel("reasoning", overrideModels.reasoning),
+  pdf: healOverrideModel("pdf", overrideModels.pdf),
+});
+
 export const normalizeOrgAIConfig = (config: OrgAIConfig): OrgAIConfig => ({
   providers: config.providers.map(normalizeOrgAIProviderConfig),
-  overrideModels: config.overrideModels,
+  overrideModels: healOverrideModels(config.overrideModels),
 });

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_MODELS,
   MODEL_RATES,
   MODEL_ROLES,
+  resolveWorkingBYOKModelForRole,
   TANSTACK_AI_PROVIDERS,
 } from "./index";
 
@@ -123,6 +124,89 @@ describe("anthropic adaptive thinking", () => {
         BYOK_MODEL_OPTIONS.anthropic.some((offered) => offered.includes(model)),
       ).toBe(true);
     }
+  });
+});
+
+describe("resolveWorkingBYOKModelForRole", () => {
+  test("keeps a still-offered model unchanged", () => {
+    const modelId = BYOK_MODEL_OPTIONS.google[0];
+    expect(
+      resolveWorkingBYOKModelForRole({
+        provider: "google",
+        modelId,
+        role: "chat",
+      }),
+    ).toBe(modelId);
+  });
+
+  test("heals a dropped model to the provider's per-role default", () => {
+    // `gemini-3-flash-preview` was a prior-catalog id, no longer offered.
+    expect(
+      resolveWorkingBYOKModelForRole({
+        provider: "google",
+        modelId: "gemini-3-flash-preview",
+        role: "reasoning",
+      }),
+    ).toBe(BYOK_DEFAULT_MODELS.google.reasoning);
+  });
+
+  test("heals a dropped model on the pdf role to a document-capable default", () => {
+    const healed = resolveWorkingBYOKModelForRole({
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+      role: "pdf",
+    });
+    expect(healed).toBe(BYOK_DEFAULT_MODELS.google.pdf);
+    expect(BYOK_DOCUMENT_INPUT_MODEL_OPTIONS.google).toContain(
+      BYOK_DEFAULT_MODELS.google.pdf,
+    );
+  });
+
+  test("every BYOK default is offered for its role (except mistral+pdf)", () => {
+    // resolveWorkingBYOKModelForRole only returns null when even the
+    // per-role default is not offered. That must stay a one-off
+    // (mistral+pdf, which has no document-capable model): if a future
+    // catalog edit drops a default from BYOK_MODEL_OPTIONS, healing would
+    // silently stop and leave a stale model pinned. Catch that here.
+    for (const provider of TANSTACK_AI_PROVIDERS) {
+      for (const role of MODEL_ROLES) {
+        const modelId = BYOK_DEFAULT_MODELS[provider][role];
+        const resolved = resolveWorkingBYOKModelForRole({
+          provider,
+          modelId,
+          role,
+        });
+        if (provider === "mistral" && role === "pdf") {
+          expect(resolved).toBeNull();
+        } else {
+          expect(resolved).toBe(modelId);
+        }
+      }
+    }
+  });
+
+  test("returns null for mistral + pdf: no document-capable model exists", () => {
+    // The TanStack Mistral adapter exposes no `document` input modality,
+    // so not even the default can serve the pdf role. Same-provider
+    // healing is impossible; the caller must leave the selection as-is.
+    expect(BYOK_DOCUMENT_INPUT_MODEL_OPTIONS.mistral).toHaveLength(0);
+    expect(
+      resolveWorkingBYOKModelForRole({
+        provider: "mistral",
+        modelId: "mistral-large-latest",
+        role: "pdf",
+      }),
+    ).toBeNull();
+  });
+
+  test("mistral non-pdf roles still heal on the same provider", () => {
+    expect(
+      resolveWorkingBYOKModelForRole({
+        provider: "mistral",
+        modelId: "some-retired-mistral-id",
+        role: "chat",
+      }),
+    ).toBe(BYOK_DEFAULT_MODELS.mistral.chat);
   });
 });
 

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -304,6 +304,62 @@ export const isBYOKModelRoleSupported = ({
 };
 
 /**
+ * Whether a model id is currently offered for this provider+role: it
+ * must be in the curated catalog for the provider AND satisfy the
+ * role's input-modality constraint (PDF needs a document-capable
+ * model). This is the runtime allowlist, so a model dropped by a
+ * catalog bump stops being valid here even though it is still a
+ * non-empty string in a stored org config.
+ */
+const isOfferedBYOKModelForRole = ({
+  provider,
+  modelId,
+  role,
+}: {
+  provider: BYOKProvider;
+  modelId: string;
+  role: ModelRole;
+}): boolean => {
+  const offered: readonly string[] = BYOK_MODEL_OPTIONS[provider];
+  return (
+    offered.includes(modelId) &&
+    isBYOKModelRoleSupported({ provider, modelId, role })
+  );
+};
+
+/**
+ * Resolve a model id that will actually work for this provider+role,
+ * keeping the SAME provider. Returns the caller's model unchanged when
+ * it is still offered; otherwise falls back to the provider's per-role
+ * default (`BYOK_DEFAULT_MODELS`). Returns `null` only when the
+ * provider has no valid model for the role at all — the sole case
+ * today is `mistral` + `pdf`, because the TanStack Mistral adapter
+ * exposes no `document` input modality, so no Mistral model (not even
+ * the default) can serve the PDF role.
+ *
+ * Used to auto-heal org AI configs whose pinned model was removed by a
+ * catalog bump, so generation resolves to a supported model instead of
+ * 400-ing (or forwarding a retired id to the provider).
+ */
+export const resolveWorkingBYOKModelForRole = ({
+  provider,
+  modelId,
+  role,
+}: {
+  provider: BYOKProvider;
+  modelId: string;
+  role: ModelRole;
+}): string | null => {
+  if (isOfferedBYOKModelForRole({ provider, modelId, role })) {
+    return modelId;
+  }
+  const fallback = BYOK_DEFAULT_MODELS[provider][role];
+  return isOfferedBYOKModelForRole({ provider, modelId: fallback, role })
+    ? fallback
+    : null;
+};
+
+/**
  * Anthropic models that use the adaptive-thinking request shape
  * (`thinking: { type: "adaptive" }`). Newer Claude models reject the
  * legacy budget-based form, so every Opus 4.6+/Sonnet 4.6/Fable entry


### PR DESCRIPTION
## What

When a catalog update removes a BYOK model id, an org that previously pinned that model in its per-role `overrideModels` keeps a config that still decrypts (the stored `modelId` is any non-empty string) but no longer resolves cleanly:

- the **pdf** role (the only role whose model is validated) returns a 400 at generation time;
- **fast/chat/reasoning** forward the retired id straight to the provider.

## Change

`normalizeOrgAIConfig` is the single choke point every decrypt path runs through. It now reconciles each role's selection to a model that works on the **same provider**:

- keep the pinned model when it is still offered for that provider + role;
- otherwise fall back to `BYOK_DEFAULT_MODELS[provider][role]` (tier-appropriate: a reasoning pin heals to the provider's reasoning default, a flash-lite pin to its fast default, and the pdf fallback is document-capable);
- leave the selection untouched when it cannot be healed on the same provider: an unsupported provider, or `mistral` + `pdf`, which has no document-capable model. Those keep flowing through the existing generation-time validation rather than being silently rerouted to a different provider.

Stored blobs are not rewritten; healing happens on read, and persists the next time the org saves its config.

## Details

- Adds `resolveWorkingBYOKModelForRole` to `@stll/ai-catalog` (returns the working model id, or `null` when the provider has no valid model for the role).
- Wires it into `normalizeOrgAIConfig` in `apps/api/src/lib/ai-config.ts`.
- Tests in both packages, including the `mistral` + `pdf` no-op case and the still-offered-model no-op case.

## Test

`bun --filter @stll/ai-catalog test` and `bun --filter @stll/api test src/lib/ai-config.test.ts` pass; the existing ai-config crypto/loader/model tests are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stored AI model selections now automatically recover when a chosen model is no longer available, switching to a working same-provider default where possible.
  * PDF/document-capable model choices are validated more strictly, helping ensure document-related roles stay usable.

* **Bug Fixes**
  * Preserved valid model selections when they are still supported.
  * Left unsupported PDF settings unchanged when no suitable replacement exists, while still healing other roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->