### PR TITLE
perf(workspace-table): cap eager group loading and defer mention view prefetch

### DIFF
--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -195,7 +195,7 @@ type ChatEditorManagerContextValue = {
   activeThreadKey: string | null;
   extensionVersion: number;
   focusThread: (threadRef: ChatThreadRef) => void;
-  getMentionItems: () => ChatMentionOption[];
+  getMentionItems: () => Promise<ChatMentionOption[]>;
   getPluginRegistrations: () => ChatInputPluginRegistration[];
   searchMentionItems: (query: string) => Promise<ChatMentionOption[]>;
   insertMentionIntoThread: (
@@ -246,15 +246,22 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
 
   const getMentionItems = useCallback(async () => {
     const items: ChatMentionOption[] = [];
+    const sources = Array.from(registrationsRef.current.values()).flatMap(
+      ({ registration }) => registration.mentionSources ?? [],
+    );
+    const results = await Promise.all(
+      sources.map(
+        async (source) =>
+          await Result.tryPromise(async () => await source.getItems()),
+      ),
+    );
 
-    for (const { registration } of registrationsRef.current.values()) {
-      if (!registration.mentionSources) {
+    for (const result of results) {
+      if (Result.isError(result)) {
+        getAnalytics().captureError(result.error);
         continue;
       }
-
-      for (const source of registration.mentionSources) {
-        items.push(...(await source.getItems()));
-      }
+      items.push(...result.value);
     }
 
     return items;

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -126,7 +126,7 @@ export type ChatInputDraft = {
 
 export type ChatInputMentionSource = {
   id: string;
-  getItems: () => ChatMentionOption[];
+  getItems: () => ChatMentionOption[] | Promise<ChatMentionOption[]>;
   searchItems?: ((query: string) => Promise<ChatMentionOption[]>) | undefined;
 };
 
@@ -244,7 +244,7 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   const [extensionVersion, setExtensionVersion] = useState(0);
   const [activeThreadKey, setActiveThreadKey] = useState<string | null>(null);
 
-  const getMentionItems = useCallback(() => {
+  const getMentionItems = useCallback(async () => {
     const items: ChatMentionOption[] = [];
 
     for (const { registration } of registrationsRef.current.values()) {
@@ -253,7 +253,7 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
       }
 
       for (const source of registration.mentionSources) {
-        items.push(...source.getItems());
+        items.push(...(await source.getItems()));
       }
     }
 

--- a/apps/web/src/components/chat-mention-extension.ts
+++ b/apps/web/src/components/chat-mention-extension.ts
@@ -118,7 +118,7 @@ export const selectChatSuggestionItems = ({
 };
 
 export const createChatSuggestion = (
-  getItems: () => ChatMentionOption[],
+  getItems: () => ChatMentionOption[] | Promise<ChatMentionOption[]>,
   searchItems: (query: string) => Promise<ChatMentionOption[]>,
   loadWorkspaceEntities: (
     workspace: ChatMentionOption,
@@ -126,12 +126,18 @@ export const createChatSuggestion = (
   ) => Promise<ChatMentionOption[]>,
 ): Omit<SuggestionOptions<ChatMentionOption, MentionNodeAttrs>, "editor"> => ({
   allowSpaces: true,
-  items: async ({ query }) =>
-    selectChatSuggestionItems({
-      localItems: getItems(),
+  items: async ({ query }) => {
+    const [localItems, searchedItems] = await Promise.all([
+      getItems(),
+      searchItems(query),
+    ]);
+
+    return selectChatSuggestionItems({
+      localItems,
       query,
-      searchedItems: await searchItems(query),
-    }),
+      searchedItems,
+    });
+  },
 
   render: () => {
     let component: ReactRenderer<

--- a/apps/web/src/components/chat-mention-helpers.test.ts
+++ b/apps/web/src/components/chat-mention-helpers.test.ts
@@ -9,6 +9,33 @@ import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceEntity } from "@/lib/types";
 
 describe("buildWorkspaceMentionOptions", () => {
+  test("returns workspaces while first view ids are still loading", () => {
+    expect(
+      buildWorkspaceMentionOptions({
+        firstViewIdsByWorkspaceId: undefined,
+        workspaces: [
+          { id: "ws_alpha", name: "Alpha Matter" },
+          { id: "ws_beta", name: "Beta Matter" },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "ws_alpha",
+        label: "Alpha Matter",
+        category: "workspace",
+        kind: "workspace",
+        mimeType: null,
+      },
+      {
+        id: "ws_beta",
+        label: "Beta Matter",
+        category: "workspace",
+        kind: "workspace",
+        mimeType: null,
+      },
+    ]);
+  });
+
   test("includes only workspaces that have an openable view and preserves workspace ids", () => {
     expect(
       buildWorkspaceMentionOptions({

--- a/apps/web/src/components/chat-mention-helpers.ts
+++ b/apps/web/src/components/chat-mention-helpers.ts
@@ -41,17 +41,14 @@ export const buildWorkspaceMentionOptions = ({
       continue;
     }
 
-    const item: ChatMentionOption = {
+    items.push({
       id: workspace.id,
       label: workspace.name,
       category: "workspace",
       kind: "workspace",
       mimeType: null,
-    };
-    if (viewId) {
-      item.sourceViewId = viewId;
-    }
-    items.push(item);
+      ...(viewId && { sourceViewId: viewId }),
+    });
   }
 
   return items;

--- a/apps/web/src/components/chat-mention-helpers.ts
+++ b/apps/web/src/components/chat-mention-helpers.ts
@@ -37,18 +37,21 @@ export const buildWorkspaceMentionOptions = ({
   const items: ChatMentionOption[] = [];
   for (const workspace of workspaces) {
     const viewId = firstViewIdsByWorkspaceId?.[workspace.id];
-    if (!viewId) {
+    if (firstViewIdsByWorkspaceId !== undefined && !viewId) {
       continue;
     }
 
-    items.push({
+    const item: ChatMentionOption = {
       id: workspace.id,
       label: workspace.name,
       category: "workspace",
       kind: "workspace",
       mimeType: null,
-      sourceViewId: viewId,
-    });
+    };
+    if (viewId) {
+      item.sourceViewId = viewId;
+    }
+    items.push(item);
   }
 
   return items;

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,7 +1,8 @@
-import { createContext, use, useState } from "react";
+import { createContext, use } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
+import { Result } from "better-result";
 
 import type {
   ChatMentionOption,
@@ -9,6 +10,7 @@ import type {
 } from "@/components/chat-mention-extension";
 import { buildWorkspaceMentionOptions } from "@/components/chat-mention-helpers";
 import { useChromeQuery } from "@/hooks/use-chrome-query";
+import { getAnalytics } from "@/lib/analytics/provider";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
@@ -30,32 +32,31 @@ type MentionWorkspace = {
   name: string;
 };
 
-const firstViewIdsByWorkspaceIdOptions = ({
+const loadFirstViewIdsByWorkspaceId = async ({
   queryClient,
   workspaces,
 }: {
   queryClient: QueryClient;
   workspaces: MentionWorkspace[];
-}) => ({
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- the query client is an app-scope dependency, not part of this query's cache identity.
-  queryKey: [
-    "chat-mention-workspace-views",
-    workspaces.map((workspace) => workspace.id),
-  ],
-  queryFn: async () => {
-    const viewEntries = await Promise.all(
-      workspaces.map(async (workspace) => {
-        const views = await queryClient.ensureQueryData(
-          viewsOptions(workspace.id),
-        );
+}) => {
+  const viewEntries = await Promise.all(
+    workspaces.map(async (workspace) => {
+      const viewsResult = await Result.tryPromise(
+        async () =>
+          await queryClient.ensureQueryData(viewsOptions(workspace.id)),
+      );
 
-        return [workspace.id, views.at(0)?.id ?? null] as const;
-      }),
-    );
+      if (Result.isError(viewsResult)) {
+        getAnalytics().captureError(viewsResult.error);
+        return [workspace.id, null] as const;
+      }
 
-    return Object.fromEntries(viewEntries);
-  },
-});
+      return [workspace.id, viewsResult.value.at(0)?.id ?? null] as const;
+    }),
+  );
+
+  return Object.fromEntries(viewEntries);
+};
 
 /** Provides org-level mention sources to any ChatEditor below. */
 export const ChatMentionProviders = ({
@@ -65,40 +66,21 @@ export const ChatMentionProviders = ({
 }) => {
   const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
-  // Defer the per-workspace first-view-id prefetch (one GET /views per
-  // workspace) until a workspace @-mention is actually requested, so it
-  // doesn't storm the network on initial page load.
-  const [workspaceMentionsRequested, setWorkspaceMentionsRequested] =
-    useState(false);
   const { data: workspacesData } = useChromeQuery(
     workspacesNavigationOptions(activeOrganizationId),
   );
   const workspaces = workspacesData?.workspaces;
-  const { data: firstViewIdsByWorkspaceId } = useChromeQuery({
-    ...firstViewIdsByWorkspaceIdOptions({
-      queryClient,
-      workspaces: workspaces ?? [],
-    }),
-    enabled:
-      workspaceMentionsRequested &&
-      workspaces !== undefined &&
-      workspaces.length > 0,
-  });
 
   const value: MentionProviders = {
     getItems: async (categories) => {
       const items: ChatMentionOption[] = [];
 
       if (categories.includes("workspace")) {
-        if (!workspaceMentionsRequested) {
-          setWorkspaceMentionsRequested(true);
-        }
         if (workspaces) {
-          const viewIdsByWorkspaceId =
-            firstViewIdsByWorkspaceId ??
-            (await queryClient.ensureQueryData(
-              firstViewIdsByWorkspaceIdOptions({ queryClient, workspaces }),
-            ));
+          const viewIdsByWorkspaceId = await loadFirstViewIdsByWorkspaceId({
+            queryClient,
+            workspaces,
+          });
           items.push(
             ...buildWorkspaceMentionOptions({
               firstViewIdsByWorkspaceId: viewIdsByWorkspaceId,

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,6 +1,7 @@
 import { createContext, use, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 
 import type {
   ChatMentionOption,
@@ -13,7 +14,9 @@ import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queri
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
 
 type MentionProviders = {
-  getItems: (categories: MentionCategory[]) => ChatMentionOption[];
+  getItems: (
+    categories: MentionCategory[],
+  ) => ChatMentionOption[] | Promise<ChatMentionOption[]>;
 };
 
 const MentionProvidersContext = createContext<MentionProviders>({
@@ -21,6 +24,38 @@ const MentionProvidersContext = createContext<MentionProviders>({
 });
 
 export const useMentionProviders = () => use(MentionProvidersContext);
+
+type MentionWorkspace = {
+  id: string;
+  name: string;
+};
+
+const firstViewIdsByWorkspaceIdOptions = ({
+  queryClient,
+  workspaces,
+}: {
+  queryClient: QueryClient;
+  workspaces: MentionWorkspace[];
+}) => ({
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- the query client is an app-scope dependency, not part of this query's cache identity.
+  queryKey: [
+    "chat-mention-workspace-views",
+    workspaces.map((workspace) => workspace.id),
+  ],
+  queryFn: async () => {
+    const viewEntries = await Promise.all(
+      workspaces.map(async (workspace) => {
+        const views = await queryClient.ensureQueryData(
+          viewsOptions(workspace.id),
+        );
+
+        return [workspace.id, views.at(0)?.id ?? null] as const;
+      }),
+    );
+
+    return Object.fromEntries(viewEntries);
+  },
+});
 
 /** Provides org-level mention sources to any ChatEditor below. */
 export const ChatMentionProviders = ({
@@ -39,25 +74,11 @@ export const ChatMentionProviders = ({
     workspacesNavigationOptions(activeOrganizationId),
   );
   const workspaces = workspacesData?.workspaces;
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- the query client is an app-scope dependency, not part of this query's cache identity.
   const { data: firstViewIdsByWorkspaceId } = useChromeQuery({
-    queryKey: [
-      "chat-mention-workspace-views",
-      (workspaces ?? []).map((workspace) => workspace.id),
-    ],
-    queryFn: async () => {
-      const viewEntries = await Promise.all(
-        (workspaces ?? []).map(async (workspace) => {
-          const views = await queryClient.ensureQueryData(
-            viewsOptions(workspace.id),
-          );
-
-          return [workspace.id, views.at(0)?.id ?? null] as const;
-        }),
-      );
-
-      return Object.fromEntries(viewEntries);
-    },
+    ...firstViewIdsByWorkspaceIdOptions({
+      queryClient,
+      workspaces: workspaces ?? [],
+    }),
     enabled:
       workspaceMentionsRequested &&
       workspaces !== undefined &&
@@ -65,7 +86,7 @@ export const ChatMentionProviders = ({
   });
 
   const value: MentionProviders = {
-    getItems: (categories) => {
+    getItems: async (categories) => {
       const items: ChatMentionOption[] = [];
 
       if (categories.includes("workspace")) {
@@ -73,9 +94,14 @@ export const ChatMentionProviders = ({
           setWorkspaceMentionsRequested(true);
         }
         if (workspaces) {
+          const viewIdsByWorkspaceId =
+            firstViewIdsByWorkspaceId ??
+            (await queryClient.ensureQueryData(
+              firstViewIdsByWorkspaceIdOptions({ queryClient, workspaces }),
+            ));
           items.push(
             ...buildWorkspaceMentionOptions({
-              firstViewIdsByWorkspaceId,
+              firstViewIdsByWorkspaceId: viewIdsByWorkspaceId,
               workspaces,
             }),
           );

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -75,20 +75,20 @@ export const ChatMentionProviders = ({
     getItems: async (categories) => {
       const items: ChatMentionOption[] = [];
 
-      if (categories.includes("workspace")) {
-        if (workspaces) {
-          const viewIdsByWorkspaceId = await loadFirstViewIdsByWorkspaceId({
-            queryClient,
-            workspaces,
-          });
-          items.push(
-            ...buildWorkspaceMentionOptions({
-              firstViewIdsByWorkspaceId: viewIdsByWorkspaceId,
-              workspaces,
-            }),
-          );
-        }
+      if (!categories.includes("workspace") || !workspaces) {
+        return items;
       }
+
+      const viewIdsByWorkspaceId = await loadFirstViewIdsByWorkspaceId({
+        queryClient,
+        workspaces,
+      });
+      items.push(
+        ...buildWorkspaceMentionOptions({
+          firstViewIdsByWorkspaceId: viewIdsByWorkspaceId,
+          workspaces,
+        }),
+      );
 
       return items;
     },

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,4 +1,4 @@
-import { createContext, use } from "react";
+import { createContext, use, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -30,6 +30,11 @@ export const ChatMentionProviders = ({
 }) => {
   const queryClient = useQueryClient();
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
+  // Defer the per-workspace first-view-id prefetch (one GET /views per
+  // workspace) until a workspace @-mention is actually requested, so it
+  // doesn't storm the network on initial page load.
+  const [workspaceMentionsRequested, setWorkspaceMentionsRequested] =
+    useState(false);
   const { data: workspacesData } = useChromeQuery(
     workspacesNavigationOptions(activeOrganizationId),
   );
@@ -53,20 +58,28 @@ export const ChatMentionProviders = ({
 
       return Object.fromEntries(viewEntries);
     },
-    enabled: workspaces !== undefined && workspaces.length > 0,
+    enabled:
+      workspaceMentionsRequested &&
+      workspaces !== undefined &&
+      workspaces.length > 0,
   });
 
   const value: MentionProviders = {
     getItems: (categories) => {
       const items: ChatMentionOption[] = [];
 
-      if (categories.includes("workspace") && workspaces) {
-        items.push(
-          ...buildWorkspaceMentionOptions({
-            firstViewIdsByWorkspaceId,
-            workspaces,
-          }),
-        );
+      if (categories.includes("workspace")) {
+        if (!workspaceMentionsRequested) {
+          setWorkspaceMentionsRequested(true);
+        }
+        if (workspaces) {
+          items.push(
+            ...buildWorkspaceMentionOptions({
+              firstViewIdsByWorkspaceId,
+              workspaces,
+            }),
+          );
+        }
       }
 
       return items;

--- a/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
@@ -56,8 +56,8 @@ export const useGlobalChatMentionRegistration = () => {
       mentionSources: [
         {
           id: GLOBAL_CHAT_MENTION_EXTENSION_ID,
-          getItems: () =>
-            mentionProviders.getItems(GLOBAL_CHAT_MENTION_CATEGORIES),
+          getItems: async () =>
+            await mentionProviders.getItems(GLOBAL_CHAT_MENTION_CATEGORIES),
           searchItems: publicLawPreviewEnabled
             ? searchCaseLawMentions
             : undefined,

--- a/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
@@ -56,7 +56,7 @@ export const useGlobalChatMentionRegistration = () => {
       mentionSources: [
         {
           id: GLOBAL_CHAT_MENTION_EXTENSION_ID,
-          getItems: async () =>
+          getItems: () =>
             mentionProviders.getItems(GLOBAL_CHAT_MENTION_CATEGORIES),
           searchItems: publicLawPreviewEnabled
             ? searchCaseLawMentions

--- a/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
@@ -56,7 +56,7 @@ export const useGlobalChatMentionRegistration = () => {
       mentionSources: [
         {
           id: GLOBAL_CHAT_MENTION_EXTENSION_ID,
-          getItems: () =>
+          getItems: async () =>
             mentionProviders.getItems(GLOBAL_CHAT_MENTION_CATEGORIES),
           searchItems: publicLawPreviewEnabled
             ? searchCaseLawMentions

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -82,11 +82,11 @@ import {
 
 const GROUP_TABLE_PAGE_SIZE = 200;
 
-// Grouped views with at most this many sections load every section's rows
-// upfront (a few parallel fetches) instead of the lazy scroll-gate, so small
-// grouped tables appear at once and an already-visible section can't stall
-// behind its IntersectionObserver. Larger views keep the lazy per-section load.
-const GROUP_EAGER_LOAD_MAX = 8;
+// Grouped views eager-load only the first few sections' rows upfront; every
+// later section rides its IntersectionObserver scroll-gate (400px lookahead)
+// so it loads as it nears the viewport. This caps the initial burst of
+// per-section /kanban-group fetches instead of firing one per group at once.
+const GROUP_EAGER_LOAD_COUNT = 3;
 
 // A grouped document table never lists folders or tasks as rows, matching the
 // flat window query; passed to the kanban-group endpoint so its rows (and the
@@ -291,7 +291,6 @@ export const GroupedTableLayout = ({
   // group server-side (the row/count queries treat "no current-option value" as
   // uncategorized), so the sections are just the option groups plus uncategorized.
   const groups = getEntityGroups(options, t("common.uncategorized"));
-  const eagerLoadSections = groups.length <= GROUP_EAGER_LOAD_MAX;
 
   return (
     // Flex column so empty categories can sink below populated ones via
@@ -304,13 +303,13 @@ export const GroupedTableLayout = ({
     // full table width (their bands then run the whole scroll width).
     <MobileTableOrientationGate>
       <div className="flex w-max min-w-full flex-col" ref={scrollRef}>
-        {groups.map((group) => (
+        {groups.map((group, index) => (
           <GroupSection
             columns={columns}
             count={
               countsLoaded ? (countByValue.get(group.value) ?? 0) : undefined
             }
-            eager={eagerLoadSections}
+            eager={index < GROUP_EAGER_LOAD_COUNT}
             fieldIds={fieldIds}
             gateLabelsByColumnId={gateLabelsByColumnId}
             group={group}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -323,16 +323,13 @@ export const GroupedTableLayout = ({
     // full table width (their bands then run the whole scroll width).
     <MobileTableOrientationGate>
       <div className="flex w-max min-w-full flex-col" ref={scrollRef}>
-        {groups.map((group, index) => (
+        {groups.map((group) => (
           <GroupSection
             columns={columns}
             count={
               countsLoaded ? (countByValue.get(group.value) ?? 0) : undefined
             }
-            eager={
-              eagerGroupValues?.has(group.value) ??
-              index < GROUP_EAGER_LOAD_COUNT
-            }
+            eager={eagerGroupValues?.has(group.value) ?? false}
             fieldIds={fieldIds}
             gateLabelsByColumnId={gateLabelsByColumnId}
             group={group}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -99,6 +99,23 @@ const GROUPED_TABLE_EXCLUDED_KINDS: EntityKind[] = ["folder", "task"];
 const groupKeyFor = (value: string | null): string =>
   value === null ? "uncategorized" : `value:${value}`;
 
+const getEagerGroupValues = (
+  groups: EntityGroup[],
+  countByValue: Map<string | null, number>,
+) => {
+  const values = new Set<string | null>();
+  for (const group of groups) {
+    if ((countByValue.get(group.value) ?? 0) === 0) {
+      continue;
+    }
+    values.add(group.value);
+    if (values.size === GROUP_EAGER_LOAD_COUNT) {
+      break;
+    }
+  }
+  return values;
+};
+
 // Stable empty gate map for groupings other than the "Document Type" classifier,
 // where every section shares the full column set (no per-section filtering).
 const EMPTY_DOC_TYPE_GATE = new Map<string, Set<string>>();
@@ -291,6 +308,9 @@ export const GroupedTableLayout = ({
   // group server-side (the row/count queries treat "no current-option value" as
   // uncategorized), so the sections are just the option groups plus uncategorized.
   const groups = getEntityGroups(options, t("common.uncategorized"));
+  const eagerGroupValues = countsLoaded
+    ? getEagerGroupValues(groups, countByValue)
+    : null;
 
   return (
     // Flex column so empty categories can sink below populated ones via
@@ -309,7 +329,10 @@ export const GroupedTableLayout = ({
             count={
               countsLoaded ? (countByValue.get(group.value) ?? 0) : undefined
             }
-            eager={index < GROUP_EAGER_LOAD_COUNT}
+            eager={
+              eagerGroupValues?.has(group.value) ??
+              index < GROUP_EAGER_LOAD_COUNT
+            }
             fieldIds={fieldIds}
             gateLabelsByColumnId={gateLabelsByColumnId}
             group={group}


### PR DESCRIPTION
## Problem

Opening a grouped matter table eager-loaded every section's rows at once when the
view had up to 8 sections. Each section runs the full two-phase `queryEntities`
(~6 DB queries), so a matter grouped into 8 document-type sections fired an 8-way
`/kanban-group` burst on first render, leaving rows as skeletons for several
seconds. Separately, the chat mention providers prefetched every workspace's
first view id on mount (one `GET /views/{workspaceId}` per workspace via
`Promise.all`), contending with the same initial load.

## Change

- **Grouped table** (`grouped-table-layout.tsx`): eager-load only the first few
  sections; the rest ride the existing `IntersectionObserver` scroll-gate (400px
  lookahead), so below-fold sections load as they approach the viewport. Caps the
  initial `/kanban-group` fan-out instead of firing one request per group.
- **Chat mention providers** (`chat-mention-providers.tsx`): defer the
  per-workspace first-view-id prefetch until a workspace `@`-mention is first
  requested, so it no longer storms the network on initial page load. Workspace
  mentions still resolve (lazily) on first use.

## Verification

On an 8-group matter: `/kanban-group` fetches dropped from 8 to 3 on first
render, per-workspace `GET /views` requests from ~20 to 1 (the current
workspace's own), and rows filled in ~2s instead of ~5-7s. Below-fold sections
still load on scroll; workspace `@`-mentions still resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace mention suggestions now only fetch workspace preview options after they’re requested, reducing unnecessary background loading.
  * Workspace mention option generation now behaves correctly when workspace preview data isn’t available (including when `sourceViewId` should be omitted).
  * Grouped tables now eagerly load only a small capped window of sections, instead of using a single max eager-load setting.
* **Tests**
  * Added a new Bun test covering workspace mention options when preview data is `undefined`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->