### PR TITLE
feat: migrate anonymization to the anonymize 2.0 native pipeline

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -610,6 +610,7 @@ const createBoundary = (
   excludedCanonicals: Promise.resolve([]),
   organizationId: toSafeId<"organization">("org_test"),
   pipelineContext: createPipelineContext(),
+  placeholderOffsets: new Map<string, number>(),
   redactionMap: new Map(pairs),
   scopedDb,
   type: "anonymized",

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -647,6 +647,66 @@ describe("chat third-party anonymization boundary", () => {
     );
   });
 
+  test("preserves echoed placeholders while renumbering new redactions", async () => {
+    const anonymizePeople = mock(async ({ fields }: { fields: string[] }) => {
+      const redactionMap = new Map<string, string>();
+      const anonymized = fields.map((field) => {
+        let next = field;
+        let nextIndex = 1;
+        for (const original of ["Bob", "Alice"]) {
+          if (next.includes(original)) {
+            const placeholder = `[PERSON_${nextIndex}]`;
+            next = next.replaceAll(original, placeholder);
+            redactionMap.set(placeholder, original);
+            nextIndex += 1;
+          }
+        }
+        return next;
+      });
+      return {
+        entityCount: redactionMap.size,
+        fields: anonymized,
+        redactionMap,
+      };
+    });
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizePeople,
+      anonymizationScopeId: "workspace-A",
+      organizationId: toSafeId<"organization">(
+        "11111111-1111-4111-8111-111111111111",
+      ),
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+
+    const first = await prepareTextForThirdParty({
+      boundary,
+      text: "Bob prepared the memo.",
+    });
+    const second = await prepareTextForThirdParty({
+      boundary,
+      text: "Results for [PERSON_1]: Alice",
+    });
+
+    expect(Result.isOk(first)).toBe(true);
+    expect(Result.isOk(second)).toBe(true);
+    if (Result.isError(first) || Result.isError(second)) {
+      throw new TypeError("Expected anonymization to succeed");
+    }
+    expect(first.value).toBe("[PERSON_1] prepared the memo.");
+    expect(second.value).toBe("Results for [PERSON_1]: [PERSON_2]");
+    if (boundary.type !== "anonymized") {
+      throw new TypeError("Expected anonymized boundary");
+    }
+    expect(boundary.redactionMap).toEqual(
+      new Map([
+        ["[PERSON_1]", "Bob"],
+        ["[PERSON_2]", "Alice"],
+      ]),
+    );
+  });
+
   test("round-trip helpers are no-ops on raw boundaries", async () => {
     const { deanonymizeFromBoundary } =
       await import("@/api/handlers/chat/third-party-boundary");

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -587,6 +587,63 @@ describe("chat third-party anonymization boundary", () => {
     });
   });
 
+  test("renumbers sequential anonymization batches before merging", async () => {
+    const anonymizePeople = mock(async ({ fields }: { fields: string[] }) => {
+      const redactionMap = new Map<string, string>();
+      const anonymized = fields.map((field) => {
+        let next = field;
+        for (const original of ["Alice", "Bob"]) {
+          if (next.includes(original)) {
+            next = next.replaceAll(original, "[PERSON_1]");
+            redactionMap.set("[PERSON_1]", original);
+          }
+        }
+        return next;
+      });
+      return {
+        entityCount: redactionMap.size,
+        fields: anonymized,
+        redactionMap,
+      };
+    });
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizePeople,
+      anonymizationScopeId: "workspace-A",
+      organizationId: toSafeId<"organization">(
+        "11111111-1111-4111-8111-111111111111",
+      ),
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+
+    const first = await prepareTextForThirdParty({
+      boundary,
+      text: "Alice prepared the memo.",
+    });
+    const second = await prepareTextForThirdParty({
+      boundary,
+      text: "Bob approved it.",
+    });
+
+    expect(Result.isOk(first)).toBe(true);
+    expect(Result.isOk(second)).toBe(true);
+    if (Result.isError(first) || Result.isError(second)) {
+      throw new Error("Expected anonymization to succeed");
+    }
+    expect(first.value).toBe("[PERSON_1] prepared the memo.");
+    expect(second.value).toBe("[PERSON_2] approved it.");
+    if (boundary.type !== "anonymized") {
+      throw new Error("Expected anonymized boundary");
+    }
+    expect(boundary.redactionMap).toEqual(
+      new Map([
+        ["[PERSON_1]", "Alice"],
+        ["[PERSON_2]", "Bob"],
+      ]),
+    );
+  });
+
   test("round-trip helpers are no-ops on raw boundaries", async () => {
     const { deanonymizeFromBoundary } =
       await import("@/api/handlers/chat/third-party-boundary");

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -163,7 +163,7 @@ describe("chat third-party anonymization boundary", () => {
 
     expect(Result.isError(prepared)).toBe(true);
     if (Result.isOk(prepared)) {
-      throw new Error("Expected attachment refusal");
+      throw new TypeError("Expected attachment refusal");
     }
 
     expect(prepared.error.status).toBe(422);
@@ -207,7 +207,7 @@ describe("chat third-party anonymization boundary", () => {
       source: { mimeType: TEXT_PLAIN_MIME_TYPE },
     });
     if (!part || !isChatAttachmentPart(part)) {
-      throw new Error("Expected prepared attachment part");
+      throw new TypeError("Expected prepared attachment part");
     }
     expect(getChatAttachmentUrl(part)).toContain(
       Buffer.from("[CUSTOM_1] notes for [PERSON_1]", "utf-8").toString(
@@ -352,7 +352,7 @@ describe("chat third-party anonymization boundary", () => {
       state: "complete",
     });
     if (!resultPart || resultPart.type !== "tool-result") {
-      throw new Error("Expected prepared tool-result part");
+      throw new TypeError("Expected prepared tool-result part");
     }
     if (typeof resultPart.content !== "string") {
       throw new TypeError("Expected JSON tool-result content");
@@ -486,7 +486,7 @@ describe("chat third-party anonymization boundary", () => {
     );
 
     if (!executable?.execute) {
-      throw new Error("Expected external tool execute function");
+      throw new TypeError("Expected external tool execute function");
     }
 
     const output = await executable.execute(undefined);
@@ -542,7 +542,7 @@ describe("chat third-party anonymization boundary", () => {
     );
 
     if (!executable?.execute) {
-      throw new Error("Expected unofficial lookup execute function");
+      throw new TypeError("Expected unofficial lookup execute function");
     }
 
     const output = await executable.execute({ query: "Jan Novák" });
@@ -564,7 +564,7 @@ describe("chat third-party anonymization boundary", () => {
     expect(Result.isOk(inbound)).toBe(true);
 
     if (boundary.type !== "anonymized") {
-      throw new Error("Expected anonymized boundary");
+      throw new TypeError("Expected anonymized boundary");
     }
     expect(boundary.redactionMap.get("[PERSON_1]")).toBe("Jan Novák");
     expect(boundary.redactionMap.get("[CUSTOM_1]")).toBe("Secret");
@@ -632,12 +632,12 @@ describe("chat third-party anonymization boundary", () => {
     expect(Result.isOk(first)).toBe(true);
     expect(Result.isOk(second)).toBe(true);
     if (Result.isError(first) || Result.isError(second)) {
-      throw new Error("Expected anonymization to succeed");
+      throw new TypeError("Expected anonymization to succeed");
     }
     expect(first.value).toBe("[PERSON_1] prepared the memo.");
     expect(second.value).toBe("[PERSON_1] briefed [PERSON_2].");
     if (boundary.type !== "anonymized") {
-      throw new Error("Expected anonymized boundary");
+      throw new TypeError("Expected anonymized boundary");
     }
     expect(boundary.redactionMap).toEqual(
       new Map([

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -592,10 +592,13 @@ describe("chat third-party anonymization boundary", () => {
       const redactionMap = new Map<string, string>();
       const anonymized = fields.map((field) => {
         let next = field;
+        let nextIndex = 1;
         for (const original of ["Alice", "Bob"]) {
           if (next.includes(original)) {
-            next = next.replaceAll(original, "[PERSON_1]");
-            redactionMap.set("[PERSON_1]", original);
+            const placeholder = `[PERSON_${nextIndex}]`;
+            next = next.replaceAll(original, placeholder);
+            redactionMap.set(placeholder, original);
+            nextIndex += 1;
           }
         }
         return next;
@@ -623,7 +626,7 @@ describe("chat third-party anonymization boundary", () => {
     });
     const second = await prepareTextForThirdParty({
       boundary,
-      text: "Bob approved it.",
+      text: "Alice briefed Bob.",
     });
 
     expect(Result.isOk(first)).toBe(true);
@@ -632,7 +635,7 @@ describe("chat third-party anonymization boundary", () => {
       throw new Error("Expected anonymization to succeed");
     }
     expect(first.value).toBe("[PERSON_1] prepared the memo.");
-    expect(second.value).toBe("[PERSON_2] approved it.");
+    expect(second.value).toBe("[PERSON_1] briefed [PERSON_2].");
     if (boundary.type !== "anonymized") {
       throw new Error("Expected anonymized boundary");
     }

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -117,7 +117,7 @@ export const createChatThirdPartyBoundary = ({
               organizationId,
               scopeId: workspaceId,
               scopedDb,
-        }),
+            }),
         organizationId,
         pipelineContext: createPipelineContext(),
         placeholderOffsets: new Map<string, number>(),
@@ -184,6 +184,36 @@ const rewritePlaceholders = (
     const replacement = replacements.get(placeholder);
     return replacement ?? placeholder;
   });
+};
+
+const protectBoundaryPlaceholders = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  fields: string[],
+): {
+  fields: string[];
+  restore: (protectedFields: string[]) => string[];
+} => {
+  if (boundary.redactionMap.size === 0) {
+    return { fields, restore: (protectedFields) => protectedFields };
+  }
+
+  const replacements = new Map<string, string>();
+  const restoreReplacements = new Map<string, string>();
+  let index = 0;
+  for (const placeholder of boundary.redactionMap.keys()) {
+    const sentinel = `\uE000BOUNDARY_PLACEHOLDER_${index}\uE001`;
+    replacements.set(placeholder, sentinel);
+    restoreReplacements.set(sentinel, placeholder);
+    index += 1;
+  }
+
+  return {
+    fields: fields.map((field) => rewritePlaceholders(field, replacements)),
+    restore: (protectedFields) =>
+      protectedFields.map((field) =>
+        rewritePlaceholders(field, restoreReplacements),
+      ),
+  };
 };
 
 const rewriteBoundaryPlaceholders = (
@@ -404,11 +434,12 @@ export const prepareTextForThirdParty = async ({
   }
 
   const anonymizeFields = boundary.anonymizeFields ?? anonymizeTextFields;
+  const protectedInput = protectBoundaryPlaceholders(boundary, [text]);
   const anonymized = await Result.tryPromise({
     try: async () =>
       await anonymizeFields({
         context: boundary.pipelineContext,
-        fields: [text],
+        fields: protectedInput.fields,
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -429,7 +460,7 @@ export const prepareTextForThirdParty = async ({
 
   const rewritten = rewriteBoundaryPlaceholders(boundary, anonymized.value);
   mergeRedactionMap(boundary.redactionMap, rewritten.redactionMap);
-  return Result.ok(rewritten.fields.at(0) ?? "");
+  return Result.ok(protectedInput.restore(rewritten.fields).at(0) ?? "");
 };
 
 const prepareTextBatchForThirdParty = async ({
@@ -445,11 +476,12 @@ const prepareTextBatchForThirdParty = async ({
   }
 
   const anonymizeFields = boundary.anonymizeFields ?? anonymizeTextFields;
+  const protectedInput = protectBoundaryPlaceholders(boundary, fields);
   const anonymized = await Result.tryPromise({
     try: async () =>
       await anonymizeFields({
         context: boundary.pipelineContext,
-        fields,
+        fields: protectedInput.fields,
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -470,6 +502,7 @@ const prepareTextBatchForThirdParty = async ({
 
   const rewritten = rewriteBoundaryPlaceholders(boundary, anonymized.value);
   mergeRedactionMap(boundary.redactionMap, rewritten.redactionMap);
+  const restoredFields = protectedInput.restore(rewritten.fields);
 
   for (let index = 0; index < replacements.length; index += 1) {
     const replacement = replacements[index];
@@ -477,7 +510,7 @@ const prepareTextBatchForThirdParty = async ({
       continue;
     }
 
-    replacement.apply(rewritten.fields.at(index) ?? "");
+    replacement.apply(restoredFields.at(index) ?? "");
   }
 
   return Result.ok(undefined);

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -132,8 +132,7 @@ type AnonymizedTextFieldsResult = {
   redactionMap: Map<string, string>;
 };
 
-const INDEXED_PLACEHOLDER =
-  /^\[(?<label>[A-Z][A-Z0-9_]*)_(?<index>\d+)\]$/u;
+const INDEXED_PLACEHOLDER = /^\[(?<label>[A-Z][A-Z0-9_]*)_(?<index>\d+)\]$/u;
 
 const parseIndexedPlaceholder = (
   placeholder: string,

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -58,11 +58,13 @@ export type ChatThirdPartyBoundary =
        * this boundary. On the native pipeline (2.0+) this is only a
        * prepared-package assembly cache, not a placeholder-numbering
        * cache: reusing it across calls avoids re-assembling the same
-       * config, but each `redactText` call numbers its own
-       * placeholders from `[LABEL_1]` again. See the `redactionMap`
-       * doc below for what this means for cross-call numbering.
+       * config, but each `redactText` call numbers placeholders from
+       * `[LABEL_1]` again. `placeholderOffsets` below rewrites each
+       * batch into one continuous boundary-local numbering sequence.
        */
       pipelineContext: PipelineContext;
+      /** Highest placeholder index seen per label after boundary-local rewrites. */
+      placeholderOffsets: Map<string, number>;
       /**
        * Cumulative placeholder → original map across every
        * anonymization call on this boundary. Mutated as the request
@@ -70,21 +72,6 @@ export type ChatThirdPartyBoundary =
        * stream-back path reads this to deanonymize assistant text /
        * tool outputs before they reach the user. Default operator
        * is "replace", which is reversible.
-       *
-       * Known limitation: the native pipeline numbers placeholders
-       * fresh within each `redactText` call (see `pipelineContext`
-       * above), so `[PERSON_1]` from the initial message batch and
-       * `[PERSON_1]` from a later tool-output batch can legitimately
-       * refer to different originals. `mergeRedactionMap` below
-       * keeps the *first* observed mapping per placeholder and
-       * ignores later collisions, so a later batch's same-numbered
-       * placeholder silently deanonymizes to the earlier value. This
-       * boundary already combines every message part it can see
-       * up-front into one `anonymizeFields` call (see
-       * `prepareMessagesForThirdParty`); tool outputs still arrive
-       * one at a time as the model calls tools, so those remain
-       * genuinely sequential calls that this boundary cannot merge
-       * into the first batch.
        */
       redactionMap: Map<string, string>;
       scopedDb: ScopedDb;
@@ -130,13 +117,96 @@ export const createChatThirdPartyBoundary = ({
               organizationId,
               scopeId: workspaceId,
               scopedDb,
-            }),
+        }),
         organizationId,
         pipelineContext: createPipelineContext(),
+        placeholderOffsets: new Map<string, number>(),
         redactionMap: new Map<string, string>(),
         scopedDb,
       }
     : { type: "raw" };
+
+type AnonymizedTextFieldsResult = {
+  entityCount: number;
+  fields: string[];
+  redactionMap: Map<string, string>;
+};
+
+const INDEXED_PLACEHOLDER = /^\[([A-Z][A-Z0-9_]*)_(\d+)\]$/u;
+
+const parseIndexedPlaceholder = (
+  placeholder: string,
+): { label: string; index: number } | null => {
+  const match = INDEXED_PLACEHOLDER.exec(placeholder);
+  const label = match?.[1];
+  const indexText = match?.[2];
+  if (label === undefined || indexText === undefined) {
+    return null;
+  }
+  const index = Number.parseInt(indexText, 10);
+  return Number.isSafeInteger(index) && index > 0 ? { label, index } : null;
+};
+
+const rewritePlaceholders = (
+  text: string,
+  replacements: Map<string, string>,
+): string => {
+  if (replacements.size === 0) {
+    return text;
+  }
+  const pattern = new RegExp(
+    [...replacements.keys()]
+      .sort((a, b) => b.length - a.length)
+      .map(escapeRegex)
+      .join("|"),
+    "gu",
+  );
+  return text.replaceAll(pattern, (placeholder) => {
+    const replacement = replacements.get(placeholder);
+    return replacement ?? placeholder;
+  });
+};
+
+const rewriteBoundaryPlaceholders = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  result: AnonymizedTextFieldsResult,
+): AnonymizedTextFieldsResult => {
+  const replacements = new Map<string, string>();
+  const redactionMap = new Map<string, string>();
+  const maxBatchIndexByLabel = new Map<string, number>();
+
+  for (const [placeholder, original] of result.redactionMap) {
+    const parsed = parseIndexedPlaceholder(placeholder);
+    if (parsed === null) {
+      redactionMap.set(placeholder, original);
+      continue;
+    }
+
+    const offset = boundary.placeholderOffsets.get(parsed.label) ?? 0;
+    const nextPlaceholder = `[${parsed.label}_${offset + parsed.index}]`;
+    replacements.set(placeholder, nextPlaceholder);
+    redactionMap.set(nextPlaceholder, original);
+    maxBatchIndexByLabel.set(
+      parsed.label,
+      Math.max(maxBatchIndexByLabel.get(parsed.label) ?? 0, parsed.index),
+    );
+  }
+
+  for (const [label, batchMax] of maxBatchIndexByLabel) {
+    boundary.placeholderOffsets.set(
+      label,
+      (boundary.placeholderOffsets.get(label) ?? 0) + batchMax,
+    );
+  }
+
+  return {
+    ...result,
+    fields: result.fields.map((field) =>
+      rewritePlaceholders(field, replacements),
+    ),
+    redactionMap,
+  };
+};
 
 const mergeRedactionMap = (
   target: Map<string, string>,
@@ -146,14 +216,6 @@ const mergeRedactionMap = (
     return;
   }
   for (const [placeholder, original] of source) {
-    // First observation wins per placeholder. This was originally
-    // meant only to guard against unexpected drift within a single
-    // numbering sequence; on the native pipeline (2.0+), placeholder
-    // numbering restarts at `[LABEL_1]` on every `redactText` call
-    // (see the `redactionMap` doc on `ChatThirdPartyBoundary`), so a
-    // later batch's `[PERSON_1]` colliding with an earlier one is
-    // expected, not just a defensive edge case — and the later
-    // value is the one that gets silently dropped.
     if (!target.has(placeholder)) {
       target.set(placeholder, original);
     }
@@ -339,8 +401,9 @@ export const prepareTextForThirdParty = async ({
     return Result.err(anonymized.error);
   }
 
-  mergeRedactionMap(boundary.redactionMap, anonymized.value.redactionMap);
-  return Result.ok(anonymized.value.fields.at(0) ?? "");
+  const rewritten = rewriteBoundaryPlaceholders(boundary, anonymized.value);
+  mergeRedactionMap(boundary.redactionMap, rewritten.redactionMap);
+  return Result.ok(rewritten.fields.at(0) ?? "");
 };
 
 const prepareTextBatchForThirdParty = async ({
@@ -379,7 +442,8 @@ const prepareTextBatchForThirdParty = async ({
     return Result.err(anonymized.error);
   }
 
-  mergeRedactionMap(boundary.redactionMap, anonymized.value.redactionMap);
+  const rewritten = rewriteBoundaryPlaceholders(boundary, anonymized.value);
+  mergeRedactionMap(boundary.redactionMap, rewritten.redactionMap);
 
   for (let index = 0; index < replacements.length; index += 1) {
     const replacement = replacements[index];
@@ -387,7 +451,7 @@ const prepareTextBatchForThirdParty = async ({
       continue;
     }
 
-    replacement.apply(anonymized.value.fields.at(index) ?? "");
+    replacement.apply(rewritten.fields.at(index) ?? "");
   }
 
   return Result.ok(undefined);

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -132,19 +132,38 @@ type AnonymizedTextFieldsResult = {
   redactionMap: Map<string, string>;
 };
 
-const INDEXED_PLACEHOLDER = /^\[([A-Z][A-Z0-9_]*)_(\d+)\]$/u;
+const INDEXED_PLACEHOLDER =
+  /^\[(?<label>[A-Z][A-Z0-9_]*)_(?<index>\d+)\]$/u;
 
 const parseIndexedPlaceholder = (
   placeholder: string,
 ): { label: string; index: number } | null => {
   const match = INDEXED_PLACEHOLDER.exec(placeholder);
-  const label = match?.[1];
-  const indexText = match?.[2];
+  const label = match?.groups?.["label"];
+  const indexText = match?.groups?.["index"];
   if (label === undefined || indexText === undefined) {
     return null;
   }
   const index = Number.parseInt(indexText, 10);
   return Number.isSafeInteger(index) && index > 0 ? { label, index } : null;
+};
+
+const findExistingPlaceholder = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  label: string,
+  original: string,
+): string | null => {
+  for (const [placeholder, mappedOriginal] of boundary.redactionMap) {
+    if (mappedOriginal !== original) {
+      continue;
+    }
+    const parsed = parseIndexedPlaceholder(placeholder);
+    if (parsed?.label === label) {
+      return placeholder;
+    }
+  }
+
+  return null;
 };
 
 const rewritePlaceholders = (
@@ -173,7 +192,7 @@ const rewriteBoundaryPlaceholders = (
 ): AnonymizedTextFieldsResult => {
   const replacements = new Map<string, string>();
   const redactionMap = new Map<string, string>();
-  const maxBatchIndexByLabel = new Map<string, number>();
+  const nextIndexByLabel = new Map<string, number>();
 
   for (const [placeholder, original] of result.redactionMap) {
     const parsed = parseIndexedPlaceholder(placeholder);
@@ -182,21 +201,28 @@ const rewriteBoundaryPlaceholders = (
       continue;
     }
 
-    const offset = boundary.placeholderOffsets.get(parsed.label) ?? 0;
-    const nextPlaceholder = `[${parsed.label}_${offset + parsed.index}]`;
+    const existingPlaceholder = findExistingPlaceholder(
+      boundary,
+      parsed.label,
+      original,
+    );
+    if (existingPlaceholder !== null) {
+      replacements.set(placeholder, existingPlaceholder);
+      redactionMap.set(existingPlaceholder, original);
+      continue;
+    }
+
+    const nextIndex =
+      nextIndexByLabel.get(parsed.label) ??
+      (boundary.placeholderOffsets.get(parsed.label) ?? 0) + 1;
+    const nextPlaceholder = `[${parsed.label}_${nextIndex}]`;
     replacements.set(placeholder, nextPlaceholder);
     redactionMap.set(nextPlaceholder, original);
-    maxBatchIndexByLabel.set(
-      parsed.label,
-      Math.max(maxBatchIndexByLabel.get(parsed.label) ?? 0, parsed.index),
-    );
+    nextIndexByLabel.set(parsed.label, nextIndex + 1);
   }
 
-  for (const [label, batchMax] of maxBatchIndexByLabel) {
-    boundary.placeholderOffsets.set(
-      label,
-      (boundary.placeholderOffsets.get(label) ?? 0) + batchMax,
-    );
+  for (const [label, nextIndex] of nextIndexByLabel) {
+    boundary.placeholderOffsets.set(label, nextIndex - 1);
   }
 
   return {

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -55,11 +55,12 @@ export type ChatThirdPartyBoundary =
       organizationId: SafeId<"organization">;
       /**
        * Shared pipeline context for every anonymization call on
-       * this boundary. The wasm pipeline's placeholder counter
-       * lives on the context — reusing the same instance means a
-       * later batch (tool output, system prompt) keeps numbering
-       * from where the previous batch (user prompt) left off, and
-       * `[PERSON_1]` can never resolve to two different originals.
+       * this boundary. On the native pipeline (2.0+) this is only a
+       * prepared-package assembly cache, not a placeholder-numbering
+       * cache: reusing it across calls avoids re-assembling the same
+       * config, but each `redactText` call numbers its own
+       * placeholders from `[LABEL_1]` again. See the `redactionMap`
+       * doc below for what this means for cross-call numbering.
        */
       pipelineContext: PipelineContext;
       /**
@@ -69,6 +70,21 @@ export type ChatThirdPartyBoundary =
        * stream-back path reads this to deanonymize assistant text /
        * tool outputs before they reach the user. Default operator
        * is "replace", which is reversible.
+       *
+       * Known limitation: the native pipeline numbers placeholders
+       * fresh within each `redactText` call (see `pipelineContext`
+       * above), so `[PERSON_1]` from the initial message batch and
+       * `[PERSON_1]` from a later tool-output batch can legitimately
+       * refer to different originals. `mergeRedactionMap` below
+       * keeps the *first* observed mapping per placeholder and
+       * ignores later collisions, so a later batch's same-numbered
+       * placeholder silently deanonymizes to the earlier value. This
+       * boundary already combines every message part it can see
+       * up-front into one `anonymizeFields` call (see
+       * `prepareMessagesForThirdParty`); tool outputs still arrive
+       * one at a time as the model calls tools, so those remain
+       * genuinely sequential calls that this boundary cannot merge
+       * into the first batch.
        */
       redactionMap: Map<string, string>;
       scopedDb: ScopedDb;
@@ -130,12 +146,14 @@ const mergeRedactionMap = (
     return;
   }
   for (const [placeholder, original] of source) {
-    // Stable mapping per request: the same placeholder must always
-    // resolve to the same original. If a later call disagrees we
-    // keep the first observation rather than silently rewriting it
-    // — in practice the wasm pipeline gives stable numbers within a
-    // single context, so collisions only arise from independent
-    // anonymization batches.
+    // First observation wins per placeholder. This was originally
+    // meant only to guard against unexpected drift within a single
+    // numbering sequence; on the native pipeline (2.0+), placeholder
+    // numbering restarts at `[LABEL_1]` on every `redactText` call
+    // (see the `redactionMap` doc on `ChatThirdPartyBoundary`), so a
+    // later batch's `[PERSON_1]` colliding with an earlier one is
+    // expected, not just a defensive edge case — and the later
+    // value is the one that gets silently dropped.
     if (!target.has(placeholder)) {
       target.set(placeholder, original);
     }

--- a/apps/api/src/mcp/anonymization-core.ts
+++ b/apps/api/src/mcp/anonymization-core.ts
@@ -35,11 +35,10 @@ export type AnonymizeTextFieldsInput = {
    */
   entityId?: SafeId<"entity"> | undefined;
   /**
-   * Optional shared `PipelineContext`. When set, the placeholder
-   * counter continues across calls so independent batches don't
-   * collide on `[PERSON_1]`. Chat boundaries pass the same context
-   * for every user-message / tool-output / system-prompt pass so
-   * the cumulative redaction map stays internally consistent.
+   * Optional shared `PipelineContext`. It caches prepared native
+   * pipeline packages, but native placeholder numbering still starts
+   * fresh per redaction call. Chat boundaries rewrite placeholders
+   * after each call before merging them into their cumulative map.
    * Omitted callers (one-shot anonymizations) get a fresh context.
    */
   context?: PipelineContext | undefined;

--- a/apps/api/src/mcp/anonymization.test.ts
+++ b/apps/api/src/mcp/anonymization.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import {
-  createPipelineContext,
-  DEFAULT_OPERATOR_CONFIG,
+import { createPipelineContext } from "@stll/anonymize-wasm";
+import type {
+  NativeAnonymizeBinding,
+  PipelineConfig,
 } from "@stll/anonymize-wasm";
 
 import type { ScopedDb } from "@/api/db";
@@ -55,24 +56,41 @@ describe("anonymizeTextFields", () => {
     let capturedDictionaries: unknown;
     const loadNameDictionariesMock: AnonymizeTextFieldsDependencies["loadNameDictionaries"] =
       mock(async () => dictionaries);
-    const runPipelineMock: AnonymizeTextFieldsDependencies["runPipeline"] =
-      mock(async ({ config }) => {
+    // SAFETY: this test double never touches the actual binding
+    // value — it only exists to satisfy `createNativePipelineFromConfig`'s
+    // `binding` parameter before it is passed through unread.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test double stands in for the real wasm binding
+    const fakeBinding = {} as NativeAnonymizeBinding;
+    const createNativePipelineFromConfigMock: AnonymizeTextFieldsDependencies["createNativePipelineFromConfig"] =
+      mock(async ({ config }: { config: PipelineConfig }) => {
         capturedDictionaries = config.dictionaries;
-        return [];
+        const pipeline = {
+          redactText: (fullText: string) => ({
+            resolvedEntities: [],
+            redaction: {
+              entityCount: 0,
+              operatorMap: new Map(),
+              redactionMap: new Map(),
+              redactedText: fullText,
+            },
+          }),
+        };
+        // SAFETY: only `redactText` is exercised by this test.
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test double only implements `redactText`
+        return pipeline as unknown as Awaited<
+          ReturnType<
+            AnonymizeTextFieldsDependencies["createNativePipelineFromConfig"]
+          >
+        >;
       });
     const dependencies = {
+      getBinding: async () => fakeBinding,
+      createNativePipelineFromConfig: createNativePipelineFromConfigMock,
       createPipelineContext,
-      defaultOperatorConfig: DEFAULT_OPERATOR_CONFIG,
+      deanonymise: (redactedText: string) => redactedText,
       loadAnonymizationGazetteerEntries: async () => [],
       loadAnonymizationAllowlistCanonicals: async () => [],
       loadNameDictionaries: loadNameDictionariesMock,
-      redactText: (fullText: string) => ({
-        entityCount: 0,
-        operatorMap: new Map(),
-        redactionMap: new Map(),
-        redactedText: fullText,
-      }),
-      runPipeline: runPipelineMock,
     } satisfies AnonymizeTextFieldsDependencies;
     const scopedDb: ScopedDb = async () => {
       throw new Error("Expected gazetteer loader mock to avoid DB access");
@@ -87,7 +105,7 @@ describe("anonymizeTextFields", () => {
     });
 
     expect(loadNameDictionariesMock).toHaveBeenCalledTimes(1);
-    expect(runPipelineMock).toHaveBeenCalledTimes(1);
+    expect(createNativePipelineFromConfigMock).toHaveBeenCalledTimes(1);
     expect(capturedDictionaries).toBe(dictionaries);
   });
 });

--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -1,10 +1,9 @@
 import { loadNameDictionaries } from "@stll/anonymize-data";
 import {
+  createNativePipelineFromConfig,
   createPipelineContext,
-  DEFAULT_OPERATOR_CONFIG,
-  preparePipelineSearch,
-  redactText,
-  runPipeline,
+  deanonymise,
+  getBinding,
 } from "@stll/anonymize-wasm";
 
 import { loadAnonymizationAllowlistCanonicals } from "@/api/lib/anonymization-allowlist";
@@ -32,14 +31,13 @@ const runWithPipelineContext = async <T>(
 };
 
 const anonymizeTextFieldsDependencies = {
+  getBinding,
+  createNativePipelineFromConfig,
   createPipelineContext,
-  defaultOperatorConfig: DEFAULT_OPERATOR_CONFIG,
+  deanonymise,
   loadAnonymizationGazetteerEntries,
   loadAnonymizationAllowlistCanonicals,
   loadNameDictionaries: getNameDictionaries,
-  preparePipelineSearch,
-  redactText,
-  runPipeline,
 };
 
 export const anonymizeTextFields = async (input: AnonymizeTextFieldsInput) => {

--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -89,6 +89,10 @@ type EmptyScreenProps = {
   className?: string;
 };
 
+type CredentiallessIframeProps = ComponentProps<"iframe"> & {
+  credentialless?: boolean;
+};
+
 export const EmptyScreen = ({
   title,
   description,
@@ -457,10 +461,11 @@ const EmptyScreenVideoOverlay = ({
         </div>
         <div className="bg-foreground">
           {playableVideo.type === "youtube" ? (
-            <iframe
+            <CredentiallessIframe
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowFullScreen
               className="aspect-video w-full"
+              credentialless
               loading="lazy"
               referrerPolicy="strict-origin-when-cross-origin"
               sandbox="allow-scripts allow-presentation allow-popups"
@@ -489,6 +494,10 @@ const EmptyScreenVideoOverlay = ({
     </div>
   );
 };
+
+const CredentiallessIframe = (props: CredentiallessIframeProps) => (
+  <iframe {...props} />
+);
 
 const toYouTubeEmbedUrl = (url: string): string | undefined => {
   const safeUrl = sanitizeHref(url);

--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -91,6 +91,8 @@ type EmptyScreenProps = {
 
 type CredentiallessIframeProps = ComponentProps<"iframe"> & {
   credentialless?: boolean;
+  sandbox: string;
+  title: string;
 };
 
 export const EmptyScreen = ({
@@ -495,8 +497,12 @@ const EmptyScreenVideoOverlay = ({
   );
 };
 
-const CredentiallessIframe = (props: CredentiallessIframeProps) => (
-  <iframe {...props} />
+const CredentiallessIframe = ({
+  sandbox,
+  title,
+  ...props
+}: CredentiallessIframeProps) => (
+  <iframe {...props} sandbox={sandbox} title={title} />
 );
 
 const toYouTubeEmbedUrl = (url: string): string | undefined => {

--- a/apps/web/src/components/inspector/anonymize-pdf.ts
+++ b/apps/web/src/components/inspector/anonymize-pdf.ts
@@ -122,23 +122,23 @@ const runPipelineAndCommit = async ({
   ]);
   dictionariesPromise ??= loadNameDictionaries();
   const dictionaries = await dictionariesPromise;
+  // Detection-only: this overlay only needs the entity spans, so the
+  // combined `redaction` half of the single detect+redact call is
+  // discarded.
   const entities = await runWithPipelineContext(async () => {
     const context = wasm.createPipelineContext();
     const config = {
       ...buildPipelineConfig(workspaceId, DEFAULT_ENTITY_LABELS),
       dictionaries,
     };
-    await wasm.preparePipelineSearch({
-      config,
-      context,
-      gazetteerEntries: [],
-    });
-    return await wasm.runPipeline({
-      fullText: text,
+    const binding = await wasm.getBinding();
+    const pipeline = await wasm.createNativePipelineFromConfig({
+      binding,
       config,
       gazetteerEntries: [],
       context,
     });
+    return pipeline.redactText(text).resolvedEntities;
   });
 
   const overlayEntities: EntityOverlay[] = [];

--- a/apps/web/src/lib/anonymize/chat-anonymize.ts
+++ b/apps/web/src/lib/anonymize/chat-anonymize.ts
@@ -1,5 +1,5 @@
 import { runChatAnonPipeline } from "@stll/anonymize-chat";
-import type { ChatAnonResult } from "@stll/anonymize-chat";
+import type { ChatAnonResult, ChatAnonRuntime } from "@stll/anonymize-chat";
 import type { GazetteerEntry, PipelineConfig } from "@stll/anonymize-wasm";
 
 import { createPipelineContextRunner } from "@/lib/anonymize/pipeline-context";
@@ -27,9 +27,10 @@ const getDictionaries = (): Promise<
 
 /**
  * Run the same wasm pipeline the server uses against a single
- * chat-sized text from the main thread. Calls run serially, but
- * each input gets its own `PipelineContext` so coreference aliases
- * cannot carry between unrelated drafts.
+ * chat-sized text from the main thread. Calls run serially; each
+ * input gets its own `PipelineContext` (now purely a prepared-package
+ * assembly cache — the native pipeline no longer carries coreference
+ * or placeholder-counter state across calls).
  */
 export const anonymizeChatText = async ({
   gazetteerEntries = [],
@@ -48,12 +49,11 @@ export const anonymizeChatText = async ({
   ]);
   return await runWithPipelineContext(async () => {
     const context = wasm.createPipelineContext();
-    const runtime = {
+    const runtime: ChatAnonRuntime = {
+      getBinding: wasm.getBinding,
+      createNativePipelineFromConfig: wasm.createNativePipelineFromConfig,
       createPipelineContext: wasm.createPipelineContext,
-      defaultOperatorConfig: wasm.DEFAULT_OPERATOR_CONFIG,
-      preparePipelineSearch: wasm.preparePipelineSearch,
-      redactText: wasm.redactText,
-      runPipeline: wasm.runPipeline,
+      deanonymise: wasm.deanonymise,
     };
     return await runChatAnonPipeline({
       runtime,

--- a/apps/web/src/lib/anonymize/pdf-redact.ts
+++ b/apps/web/src/lib/anonymize/pdf-redact.ts
@@ -24,9 +24,11 @@ const MAX_PLACEHOLDER_SIZE = 10;
  * longer part of the public wasm surface. */
 const DEFAULT_REDACT_STRING = "[REDACTED]";
 
+const PLACEHOLDER_LABEL = /^\[(?<label>[A-Z][A-Z0-9_]*)_\d+\]$/u;
+
 const parsePlaceholderLabel = (placeholder: string): string | null => {
-  const match = /^\[([A-Z][A-Z0-9_]*)_\d+\]$/u.exec(placeholder);
-  const label = match?.[1];
+  const match = PLACEHOLDER_LABEL.exec(placeholder);
+  const label = match?.groups?.["label"];
   return label?.toLowerCase().replaceAll("_", " ") ?? null;
 };
 

--- a/apps/web/src/lib/anonymize/pdf-redact.ts
+++ b/apps/web/src/lib/anonymize/pdf-redact.ts
@@ -1,9 +1,8 @@
 import { PDF, rgb, Standard14Font, StandardFonts, white } from "@libpdf/core";
 
 import type {
-  Entity,
-  OperatorConfig,
-  RedactionResult,
+  NativePipelineEntity,
+  NativeStaticRedactionResult,
 } from "@stll/anonymize-wasm";
 
 import { getEntityBBoxes } from "@/lib/anonymize/pdf-bbox";
@@ -19,6 +18,11 @@ const MIN_PLACEHOLDER_SIZE = 4;
 
 /** Maximum font size for placeholder text (points). */
 const MAX_PLACEHOLDER_SIZE = 10;
+
+/** Default static replacement for the irreversible "redact" operator.
+ * Mirrors the old `DEFAULT_OPERATOR_CONFIG.redactString`, which is no
+ * longer part of the public wasm surface. */
+const DEFAULT_REDACT_STRING = "[REDACTED]";
 
 // ── Types ──────────────────────────────────────────────
 
@@ -40,7 +44,7 @@ type PdfRedactionResult = {
   /** The anonymised PDF as bytes, ready for download. */
   pdfBytes: Uint8Array;
   /** The text-level redaction result (map, operators, etc.). */
-  redaction: RedactionResult;
+  redaction: NativeStaticRedactionResult["redaction"];
 };
 
 // ── Main ───────────────────────────────────────────────
@@ -54,39 +58,51 @@ type PdfRedactionResult = {
  * count, same dimensions, same coordinates for all non-
  * redacted content. This makes AI-generated bounding boxes
  * on the anonymised PDF valid for the original too.
+ *
+ * Detection and redaction are a single combined native call now
+ * (`pipeline.redactText`), so this function takes the already
+ * computed `NativeStaticRedactionResult` instead of a raw entity
+ * list + operator config: there is no standalone "redact this
+ * entity list" entrypoint anymore. `redactString` only affects the
+ * *overlay* text drawn for irreversible ("redact") entities — it
+ * must match the string the caller passed to `redactText`'s
+ * `operators` argument (or the native default) for the overlay to
+ * agree with `redaction.redactedText`.
+ *
+ * Note: this module has no current caller in the app (PDF
+ * redaction/export is not wired up yet); the signature is kept
+ * ready for when it is.
  */
 export const redactPdf = async (
   pdfBytes: Uint8Array,
-  pdfText: string,
   spans: CharSpan[],
-  entities: Entity[],
-  operatorConfig?: OperatorConfig,
+  result: NativeStaticRedactionResult,
+  redactString = DEFAULT_REDACT_STRING,
 ): Promise<PdfRedactionResult> => {
-  const {
-    buildPlaceholderMap,
-    DEFAULT_OPERATOR_CONFIG,
-    redactText,
-    resolveOperator,
-  } = await import("@stll/anonymize-wasm");
+  const { resolvedEntities, redaction } = result;
 
-  const config = operatorConfig ?? DEFAULT_OPERATOR_CONFIG;
-
-  if (entities.length === 0) {
-    return {
-      pdfBytes,
-      redaction: redactText(pdfText, [], config),
-    };
+  if (resolvedEntities.length === 0) {
+    return { pdfBytes, redaction };
   }
 
-  const redaction = redactText(pdfText, entities, config);
+  // `redaction.redactionMap` only contains reversible ("replace")
+  // entries (placeholder -> original text), so inverting it recovers
+  // the placeholder for every entity that was actually replaced.
+  // Same original text always maps to the same placeholder (stable
+  // redaction), so this inversion is safe. An entity absent from
+  // this map used the irreversible "redact" operator and has no
+  // placeholder — it is drawn with `redactString` instead.
+  const placeholderByOriginal = new Map<string, string>();
+  for (const [placeholder, original] of redaction.redactionMap) {
+    if (!placeholderByOriginal.has(original)) {
+      placeholderByOriginal.set(original, placeholder);
+    }
+  }
 
-  // Build the same placeholder map that redactText uses
-  // internally, keyed by "${label}\0${text}"
-  const placeholderMap = buildPlaceholderMap(entities);
-
-  // Sort and de-overlap (same logic as redactText)
-  const sorted = entities.toSorted((a, b) => a.start - b.start);
-  const nonOverlapping: Entity[] = [];
+  // Sort and de-overlap (same first-occurrence-wins logic the
+  // native pipeline uses internally to build `redaction`).
+  const sorted = resolvedEntities.toSorted((a, b) => a.start - b.start);
+  const nonOverlapping: NativePipelineEntity[] = [];
   let lastEnd = 0;
   for (const entity of sorted) {
     if (entity.start >= lastEnd) {
@@ -108,14 +124,7 @@ export const redactPdf = async (
       continue;
     }
 
-    const compositeKey = `${entity.label}\0${entity.text}`;
-    const placeholder =
-      placeholderMap.get(compositeKey) ??
-      `[${entity.label.toUpperCase().replace(/\s+/gu, "_")}]`;
-
-    // Determine what text to overlay based on operator
-    const opType = resolveOperator(config, entity.label);
-    const overlayText = opType === "redact" ? config.redactString : placeholder;
+    const overlayText = placeholderByOriginal.get(entity.text) ?? redactString;
 
     // First bbox gets the text overlay; all get white boxes
     for (let i = 0; i < bboxes.length; i++) {

--- a/apps/web/src/lib/anonymize/pdf-redact.ts
+++ b/apps/web/src/lib/anonymize/pdf-redact.ts
@@ -24,6 +24,15 @@ const MAX_PLACEHOLDER_SIZE = 10;
  * longer part of the public wasm surface. */
 const DEFAULT_REDACT_STRING = "[REDACTED]";
 
+const parsePlaceholderLabel = (placeholder: string): string | null => {
+  const match = /^\[([A-Z][A-Z0-9_]*)_\d+\]$/u.exec(placeholder);
+  const label = match?.[1];
+  return label?.toLowerCase().replaceAll("_", " ") ?? null;
+};
+
+const redactionLookupKey = (label: string, text: string): string =>
+  `${label.toLowerCase()}\0${text}`;
+
 // ── Types ──────────────────────────────────────────────
 
 /**
@@ -86,16 +95,18 @@ export const redactPdf = async (
   }
 
   // `redaction.redactionMap` only contains reversible ("replace")
-  // entries (placeholder -> original text), so inverting it recovers
-  // the placeholder for every entity that was actually replaced.
-  // Same original text always maps to the same placeholder (stable
-  // redaction), so this inversion is safe. An entity absent from
-  // this map used the irreversible "redact" operator and has no
-  // placeholder — it is drawn with `redactString` instead.
-  const placeholderByOriginal = new Map<string, string>();
+  // entries (placeholder -> original text), so indexing by both
+  // placeholder label and original text recovers the placeholder for
+  // every entity that was actually replaced. The composite key keeps
+  // same-text entities with different labels distinct.
+  const placeholderByOriginalAndLabel = new Map<string, string>();
   for (const [placeholder, original] of redaction.redactionMap) {
-    if (!placeholderByOriginal.has(original)) {
-      placeholderByOriginal.set(original, placeholder);
+    const label = parsePlaceholderLabel(placeholder);
+    if (label !== null) {
+      placeholderByOriginalAndLabel.set(
+        redactionLookupKey(label, original),
+        placeholder,
+      );
     }
   }
 
@@ -124,7 +135,10 @@ export const redactPdf = async (
       continue;
     }
 
-    const overlayText = placeholderByOriginal.get(entity.text) ?? redactString;
+    const overlayText =
+      placeholderByOriginalAndLabel.get(
+        redactionLookupKey(entity.label, entity.text),
+      ) ?? redactString;
 
     // First bbox gets the text overlay; all get white boxes
     for (let i = 0; i < bboxes.length; i++) {

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -9,7 +9,7 @@ import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 // needing a Cross-Origin-Resource-Policy header on every cross-origin
 // asset/image/font the app already loads.
 const CROSS_ORIGIN_ISOLATION_HEADERS = {
-  "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
+  "Cross-Origin-Opener-Policy": "same-origin",
   "Cross-Origin-Embedder-Policy": "credentialless",
 } as const;
 

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,7 +1,31 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 
+// @stll/anonymize-wasm's native pipeline (2.0+) runs on a
+// wasm32-wasip1-threads binding (shared memory), which browsers only
+// instantiate in a cross-origin-isolated context (SharedArrayBuffer
+// available). Mirror the dev server's cross-origin isolation headers
+// (apps/web/vite.config.ts) here so the requirement also holds in
+// production. "credentialless" (rather than "require-corp") avoids
+// needing a Cross-Origin-Resource-Policy header on every cross-origin
+// asset/image/font the app already loads.
+const CROSS_ORIGIN_ISOLATION_HEADERS = {
+  "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
+  "Cross-Origin-Embedder-Policy": "credentialless",
+} as const;
+
 export default createServerEntry({
   async fetch(request) {
-    return await handler.fetch(request);
+    const response = await handler.fetch(request);
+    const headers = new Headers(response.headers);
+    for (const [name, value] of Object.entries(
+      CROSS_ORIGIN_ISOLATION_HEADERS,
+    )) {
+      headers.set(name, value);
+    }
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
   },
 });

--- a/apps/web/src/workers/anonymize-chat-worker.ts
+++ b/apps/web/src/workers/anonymize-chat-worker.ts
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 
 import { runChatAnonPipeline } from "@stll/anonymize-chat";
-import type { ChatAnonResult } from "@stll/anonymize-chat";
+import type { ChatAnonResult, ChatAnonRuntime } from "@stll/anonymize-chat";
 import { loadNameDictionaries } from "@stll/anonymize-data";
 import * as anonymizeRuntime from "@stll/anonymize-wasm";
 import type { GazetteerEntry, PipelineConfig } from "@stll/anonymize-wasm";
@@ -62,12 +62,12 @@ const handle = async (request: AnonRequest): Promise<AnonResponse> => {
     const result = await runWithPipelineContext(async () => {
       const dictionaries = await getDictionaries();
       const context = anonymizeRuntime.createPipelineContext();
-      const runtime = {
+      const runtime: ChatAnonRuntime = {
+        getBinding: anonymizeRuntime.getBinding,
+        createNativePipelineFromConfig:
+          anonymizeRuntime.createNativePipelineFromConfig,
         createPipelineContext: anonymizeRuntime.createPipelineContext,
-        defaultOperatorConfig: anonymizeRuntime.DEFAULT_OPERATOR_CONFIG,
-        preparePipelineSearch: anonymizeRuntime.preparePipelineSearch,
-        redactText: anonymizeRuntime.redactText,
-        runPipeline: anonymizeRuntime.runPipeline,
+        deanonymise: anonymizeRuntime.deanonymise,
       };
       return await runChatAnonPipeline({
         runtime,

--- a/apps/web/start-runtime.js
+++ b/apps/web/start-runtime.js
@@ -4,6 +4,10 @@ const DEFAULT_PORT = 3002;
 const DEFAULT_HOST = "0.0.0.0";
 const CLIENT_DIST_URL = new URL("dist/client/", import.meta.url);
 const IMMUTABLE_ASSET_PREFIX = "/assets/";
+const CROSS_ORIGIN_ISOLATION_HEADERS = {
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "credentialless",
+};
 
 const port = Number.parseInt(Bun.env.PORT ?? String(DEFAULT_PORT), 10);
 const hostname = Bun.env.HOST ?? DEFAULT_HOST;
@@ -35,6 +39,23 @@ const createStartHandler = (candidate) => {
 };
 
 const startHandler = createStartHandler(handler);
+
+/**
+ * @param {Response} response Response to make compatible with wasm worker isolation.
+ * @returns {Response} Response with cross-origin isolation headers.
+ */
+const withCrossOriginIsolationHeaders = (response) => {
+  const headers = new Headers(response.headers);
+  for (const [name, value] of Object.entries(CROSS_ORIGIN_ISOLATION_HEADERS)) {
+    headers.set(name, value);
+  }
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+};
 
 /** @param {URL} requestUrl Parsed incoming request URL. */
 const toClientAssetUrl = (requestUrl) => {
@@ -118,9 +139,9 @@ Bun.serve({
 
     const assetResponse = await serveClientAsset(request);
     if (assetResponse) {
-      return assetResponse;
+      return withCrossOriginIsolationHeaders(assetResponse);
     }
 
-    return await startHandler.fetch(request);
+    return withCrossOriginIsolationHeaders(await startHandler.fetch(request));
   },
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -212,7 +212,7 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
       headers: {
-        "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
+        "Cross-Origin-Opener-Policy": "same-origin",
         "Cross-Origin-Embedder-Policy": "credentialless",
       },
       // Vite's fs allowlist covers the workspace root only. When a dependency

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,6 +9,8 @@ import path from "node:path";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig, type Plugin, type PluginOption } from "vite";
 
+import stllAnonymizeWasm from "@stll/anonymize-wasm/vite";
+
 const APP_ROOT = import.meta.dirname;
 const ANALYZE_MODE = "analyze";
 const APP_VERSION = readFileSync(
@@ -151,6 +153,18 @@ export default defineConfig(({ mode }) => {
       "@tanstack/devtools-vite",
     ),
     versionManifestPlugin(),
+    // Emits @stll/anonymize-wasm's binding + glue as build assets and
+    // rewrites its runtime asset URLs so `vite build` can resolve them
+    // (the package computes them at runtime, which Rollup can't follow
+    // statically). We never call loadPipeline()/loadDefaultPipeline()
+    // (the app only builds packages in-browser from a PipelineConfig via
+    // createNativePipelineFromConfig), so no bundled prepared packages
+    // are needed — "none" skips emitting the ~20MB+ default/per-language
+    // .stlanonpkg assets.
+    ensurePluginOption(
+      stllAnonymizeWasm({ packages: "none" }),
+      "@stll/anonymize-wasm/vite",
+    ),
     ensurePluginOption(tailwindcss(), "@tailwindcss/vite"),
     ensurePluginOption(
       tanstackStart({
@@ -338,9 +352,12 @@ export default defineConfig(({ mode }) => {
       // binary doesn't exist and the dev server falls back to index.html —
       // producing a WASM CompileError. Excluding them keeps the original
       // module paths intact so the relative URL resolves.
+      //
+      // @stll/anonymize-wasm is excluded by its own Vite plugin (registered
+      // above), which does the same thing for its napi-rs wasm32-wasip1-threads
+      // binding + glue.
       exclude: [
         "@stll/text-search-wasm",
-        "@stll/anonymize-wasm",
         "@stll/aho-corasick-wasm",
         "@stll/fuzzy-search-wasm",
         "@stll/regex-set-wasm",

--- a/bun.lock
+++ b/bun.lock
@@ -646,7 +646,7 @@
     "@better-auth/oauth-provider": "1.6.20",
     "@libpdf/core": "0.4.0",
     "@stll/anonymize-data": "0.0.6",
-    "@stll/anonymize-wasm": "1.5.0",
+    "@stll/anonymize-wasm": "2.0.1",
     "@t3-oss/env-core": "0.13.11",
     "@tailwindcss/postcss": "4.3.1",
     "@tailwindcss/vite": "4.3.1",
@@ -1068,8 +1068,6 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
-    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
-
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -1218,7 +1216,7 @@
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@1.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
     "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
@@ -1688,15 +1686,13 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@stll/aho-corasick-wasm": ["@stll/aho-corasick-wasm@1.0.3", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-wWRiuk7JfmRd2ZWKBUJvJUDz2sVPl5RaimSRMCqe7XMJGhWJajsi2setkZimusfKAXhMGeK6e13NVHNi8x5hjA=="],
-
     "@stll/ai-catalog": ["@stll/ai-catalog@workspace:packages/ai-catalog"],
 
     "@stll/anonymize-chat": ["@stll/anonymize-chat@workspace:packages/anonymize-chat"],
 
     "@stll/anonymize-data": ["@stll/anonymize-data@0.0.6", "", {}, "sha512-lyhYWgwDTeofwrvHSVfvqhJny/8Goss3IiA49+8+RyJmry4s9PnexkPDuLIrtOuJiUZhhxZW+HzL6wrcPRUE8Q=="],
 
-    "@stll/anonymize-wasm": ["@stll/anonymize-wasm@1.5.0", "", { "dependencies": { "@huggingface/tokenizers": "^0.1.3", "@stll/stdnum": "^2.1.1", "@stll/text-search-wasm": "^1.0.5" }, "peerDependencies": { "@stll/anonymize-data": "^0.0.6", "vite": ">=5 <10" }, "optionalPeers": ["@stll/anonymize-data", "vite"] }, "sha512-DtF3NtzUfKjBydIAc1EHdvOyuUrOwzcrdewfFg0SmgY2Gluz+wg0CMlWhOLJ0cZoAnbgVV9eBZUstjHqzjcFBA=="],
+    "@stll/anonymize-wasm": ["@stll/anonymize-wasm@2.0.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.6" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-nLRWtCgdz2Egocq2oawTZ6vjqYT+GNMgQM0iIusSv92gL+5zeKTXZvMld9qfKlUiY+Vv0+Uo0wAISqnls2zlNg=="],
 
     "@stll/api": ["@stll/api@workspace:apps/api"],
 
@@ -1728,8 +1724,6 @@
 
     "@stll/folio-react": ["@stll/folio-react@0.2.0", "", { "dependencies": { "@base-ui/react": "1.6.0", "@fontsource/arimo": "^5.2.8", "@fontsource/caladea": "^5.2.8", "@fontsource/carlito": "^5.2.8", "@fontsource/cousine": "^5.2.7", "@fontsource/noto-sans-arabic": "^5.2.7", "@fontsource/tinos": "^5.2.7", "@stll/folio-core": "^0.1.2", "better-result": "2.9.2", "lucide-react": "1.21.0", "prosemirror-history": "^1.5.0", "prosemirror-model": "^1.25.9", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.5", "prosemirror-view": "^1.41.8", "yjs": "^13.6.31" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0", "use-intl": ">=4.0.0" } }, "sha512-bkNnh2aLMGFuluU9faOIe2RvU3MMTv0iSR+ba0lz99wZ0JOHvzUw0z7CmrGrKZmCZ1vOsKWAA2lsaM1m16av9A=="],
 
-    "@stll/fuzzy-search-wasm": ["@stll/fuzzy-search-wasm@1.1.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-9qy/eSlKabudygPo+FWQCpG3dyk8S2Qazcb3quLTIT/lU8anvANddsnPsrqAnb9MtGBrfj2D/TW9YQlpPw/svw=="],
-
     "@stll/infosoud": ["@stll/infosoud@workspace:packages/infosoud"],
 
     "@stll/landing": ["@stll/landing@workspace:apps/landing"],
@@ -1752,8 +1746,6 @@
 
     "@stll/property-testing": ["@stll/property-testing@workspace:packages/property-testing"],
 
-    "@stll/regex-set-wasm": ["@stll/regex-set-wasm@1.0.4", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-8Hs8EUSFCYxGv1+Y3LvFlyFk29oPl33kImId8REpNY/2yXpLypPEXxhw74l+8kDbLpB4sI+tjvQRr/MY8uQo0A=="],
-
     "@stll/scripts": ["@stll/scripts@workspace:packages/scripts"],
 
     "@stll/skills": ["@stll/skills@workspace:packages/skills"],
@@ -1763,8 +1755,6 @@
     "@stll/template-conditions": ["@stll/template-conditions@workspace:packages/template-conditions"],
 
     "@stll/text-normalize": ["@stll/text-normalize@workspace:packages/text-normalize"],
-
-    "@stll/text-search-wasm": ["@stll/text-search-wasm@1.0.5", "", { "dependencies": { "@stll/aho-corasick-wasm": "^1.0.3", "@stll/fuzzy-search-wasm": "^1.1.1", "@stll/regex-set-wasm": "^1.0.4" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-ZY3nPQ7Zm/KpbeaodQdJMuzShHE9QPJBvRGpZxoGXo7AKOt2t32beZZ6HWG+yvfzMp/loLKY4dGrY8sbIRDf/A=="],
 
     "@stll/transactional": ["@stll/transactional@workspace:packages/transactional"],
 
@@ -2018,7 +2008,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A=="],
 
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -3876,6 +3866,8 @@
 
     "@antfu/install-pkg/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
+    "@astrojs/compiler-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@astrojs/language-server/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "@astrojs/react/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
@@ -3940,6 +3932,8 @@
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
 
+    "@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
@@ -3947,6 +3941,10 @@
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
     "@react-email/components/@react-email/render": ["@react-email/render@2.0.6", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog=="],
 
@@ -3962,6 +3960,8 @@
 
     "@react-grab/cli/tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@selderee/plugin-htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "@stll/aho-corasick-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
@@ -3969,10 +3969,6 @@
     "@stll/folio-agents/@stll/folio-core": ["@stll/folio-core@0.2.0", "", { "dependencies": { "@stll/docx-core": "^0.1.0", "@stll/docx-utils": "^0.1.0", "@stll/template-conditions": "^0.1.0", "better-result": "2.9.2", "csstype": "^3.1.3", "fast-xml-parser": "^5.9.3", "jszip": "3.10.1", "marked": "^18.0.5", "prosemirror-commands": "^1.7.1", "prosemirror-dropcursor": "^1.8.2", "prosemirror-gapcursor": "^1.4.1", "prosemirror-history": "^1.5.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.9", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.5", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8", "utif2": "^4.1.0", "valibot": "1.4.1", "y-prosemirror": "^1.3.7", "yjs": "^13.6.31" } }, "sha512-NxGXN1+sJunbpabWpAuCCZCQPcH5QfASbNA97YgyzzvfmuJluXepxU2D/O/HYH0jrU25WcCIA7/CV+SZHZhggQ=="],
 
     "@stll/folio-core/valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
-
-    "@stll/fuzzy-search-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
-
-    "@stll/regex-set-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -4250,6 +4246,8 @@
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "@astrojs/compiler-binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
     "@astrojs/react/@vitejs/plugin-react/@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
 
     "@astrojs/react/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
@@ -4360,7 +4358,13 @@
 
     "@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@react-email/ui/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
 
@@ -4413,6 +4417,8 @@
     "@react-email/ui/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
 
     "@react-email/ui/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@selderee/plugin-htmlparser2/domhandler/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
@@ -5068,6 +5074,8 @@
 
     "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "tsdown/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -5088,12 +5096,22 @@
 
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@astrojs/react/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@tanstack/devtools-vite/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "astro/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
     "rollup-plugin-visualizer/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "rollup-plugin-visualizer/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "rollup-plugin-visualizer/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "tsdown/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@astrojs/react/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "astro/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -28,7 +28,6 @@ minimumReleaseAgeExcludes = [
   "@tanstack/ai-code-mode",
   "@tanstack/ai-bedrock",
   "@tanstack/ai-client",
-  "@tanstack/ai-code-mode",
   "@tanstack/ai-event-client",
   "@tanstack/ai-gemini",
   "@tanstack/ai-mcp",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -28,6 +28,7 @@ minimumReleaseAgeExcludes = [
   "@tanstack/ai-code-mode",
   "@tanstack/ai-bedrock",
   "@tanstack/ai-client",
+  "@tanstack/ai-code-mode",
   "@tanstack/ai-event-client",
   "@tanstack/ai-gemini",
   "@tanstack/ai-mcp",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@better-auth/oauth-provider": "1.6.20",
     "@libpdf/core": "0.4.0",
     "@stll/anonymize-data": "0.0.6",
-    "@stll/anonymize-wasm": "1.5.0",
+    "@stll/anonymize-wasm": "2.0.1",
     "@t3-oss/env-core": "0.13.11",
     "@tailwindcss/postcss": "4.3.1",
     "@tailwindcss/vite": "4.3.1",

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -216,4 +216,32 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.entityCount).toBe(1);
     expect(result.redactedText).toBe("[ORGANIZATION_1]");
   });
+
+  test("labels same-text pairs from the placeholder prefix", async () => {
+    const entities: NativePipelineEntity[] = [
+      makeEntity("Apple", "organization"),
+      makeEntity("Apple", "location"),
+    ];
+    const runtime = buildRuntime(entities);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: "Apple borders Apple",
+      workspaceId: "ws-1",
+    });
+
+    expect(result.pairs).toEqual([
+      {
+        placeholder: "[ORGANIZATION_1]",
+        original: "Apple",
+        label: "organization",
+      },
+      {
+        placeholder: "[LOCATION_2]",
+        original: "Apple",
+        label: "location",
+      },
+    ]);
+  });
 });

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -199,6 +199,23 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactedText).toBe(canonical);
   });
 
+  test("preserves literal placeholders while reverting excluded canonicals", async () => {
+    const entities: NativePipelineEntity[] = [makeEntity("Alice", "person")];
+    const runtime = buildRuntime(entities);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: "[PERSON_1] and Alice",
+      workspaceId: "ws-1",
+      excludedCanonicals: ["alice"],
+    });
+
+    expect(result.pairs).toEqual([]);
+    expect(result.entityCount).toBe(0);
+    expect(result.redactedText).toBe("[PERSON_1] and Alice");
+  });
+
   test("passes all entities through when no exclusions are provided", async () => {
     const entities: NativePipelineEntity[] = [
       makeEntity("Acme Corp", "organization"),

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  createPipelineContext,
-  DEFAULT_ENTITY_LABELS as WASM_DEFAULT_ENTITY_LABELS,
-  DEFAULT_OPERATOR_CONFIG,
-} from "@stll/anonymize-wasm";
+import { DEFAULT_ENTITY_LABELS as WASM_DEFAULT_ENTITY_LABELS } from "@stll/anonymize-wasm";
 import type {
-  Entity,
+  NativeAnonymizeBinding,
+  NativePipelineEntity,
+  NativeStaticRedactionResult,
   PipelineConfig,
-  RedactionResult,
 } from "@stll/anonymize-wasm";
 
 import {
@@ -87,45 +84,70 @@ describe("chat anonymization pipeline contract", () => {
 });
 
 describe("runChatAnonPipeline excludedCanonicals", () => {
-  const buildRuntime = (
-    entities: Entity[],
-  ): {
-    runtime: ChatAnonRuntime;
-    seenEntities: { value: Entity[] };
-  } => {
-    const seenEntities: { value: Entity[] } = { value: [] };
-    const runtime: ChatAnonRuntime = {
-      createPipelineContext,
-      defaultOperatorConfig: DEFAULT_OPERATOR_CONFIG,
-      runPipeline: async () => entities,
-      redactText: (text, accepted) => {
-        seenEntities.value = accepted;
-        const redactionMap = new Map<string, string>();
-        const operatorMap = new Map<string, "replace">();
-        for (let idx = 0; idx < accepted.length; idx += 1) {
-          const entity = accepted[idx];
-          if (!entity) {
-            continue;
-          }
-          const placeholder = `[${entity.label.toUpperCase()}_${idx + 1}]`;
-          redactionMap.set(placeholder, entity.text);
-          operatorMap.set(placeholder, "replace");
-        }
-        const result: RedactionResult = {
-          redactedText: text,
-          redactionMap,
-          operatorMap,
-          entityCount: accepted.length,
-        };
-        return result;
-      },
-    };
-    return { runtime, seenEntities };
+  type FakePipeline = {
+    redactText: (fullText: string) => NativeStaticRedactionResult;
   };
+
+  /**
+   * Build a `ChatAnonRuntime` test double whose `redactText` performs
+   * a naive, entity-order text replacement - good enough to exercise
+   * the post-hoc excluded-canonicals revert without a real wasm
+   * binding.
+   */
+  const buildRuntime = (entities: NativePipelineEntity[]): ChatAnonRuntime => ({
+    // SAFETY: the mock binding value is opaque plumbing - the fake
+    // `createNativePipelineFromConfig` below never inspects it, it
+    // only forwards it to `redactText`'s closure over `entities`.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test double stands in for the real wasm binding
+    getBinding: async () => ({}) as NativeAnonymizeBinding,
+    createPipelineContext: () => ({
+      nativePipelinePackage: null,
+      nativePipelinePackageKey: "",
+      nativePipelinePackagePromise: null,
+    }),
+    createNativePipelineFromConfig: async () => {
+      const pipeline: FakePipeline = {
+        redactText: (fullText) => {
+          const redactionMap = new Map<string, string>();
+          const operatorMap = new Map<string, "replace">();
+          let redactedText = fullText;
+          for (const [idx, entity] of entities.entries()) {
+            const placeholder = `[${entity.label.toUpperCase()}_${idx + 1}]`;
+            redactedText = redactedText.replaceAll(entity.text, placeholder);
+            redactionMap.set(placeholder, entity.text);
+            operatorMap.set(placeholder, "replace");
+          }
+          return {
+            resolvedEntities: entities,
+            redaction: {
+              redactedText,
+              redactionMap,
+              operatorMap,
+              entityCount: entities.length,
+            },
+          };
+        },
+      };
+      // SAFETY: only `redactText` is exercised by these tests; the
+      // rest of `PreparedNativePipeline`'s surface is intentionally
+      // left unimplemented on this test double.
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test double only implements `redactText`
+      return pipeline as unknown as Awaited<
+        ReturnType<ChatAnonRuntime["createNativePipelineFromConfig"]>
+      >;
+    },
+    deanonymise: (redactedText, redactionMap) => {
+      let result = redactedText;
+      for (const [placeholder, original] of redactionMap) {
+        result = result.replaceAll(placeholder, original);
+      }
+      return result;
+    },
+  });
 
   const dictionaries = {} as NonNullable<PipelineConfig["dictionaries"]>;
 
-  const makeEntity = (text: string, label: string): Entity => ({
+  const makeEntity = (text: string, label: string): NativePipelineEntity => ({
     start: 0,
     end: text.length,
     label,
@@ -134,12 +156,12 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     source: "regex",
   });
 
-  test("drops entities whose normalized text matches an excluded canonical", async () => {
-    const entities: Entity[] = [
+  test("reverts entities whose normalized text matches an excluded canonical", async () => {
+    const entities: NativePipelineEntity[] = [
       makeEntity("Acme Corp", "organization"),
       makeEntity("Jane Doe", "person"),
     ];
-    const { runtime, seenEntities } = buildRuntime(entities);
+    const runtime = buildRuntime(entities);
 
     const result = await runChatAnonPipeline({
       runtime,
@@ -149,39 +171,49 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       excludedCanonicals: ["acme  corp"],
     });
 
-    expect(seenEntities.value.map((e) => e.text)).toEqual(["Jane Doe"]);
     expect(result.pairs.map((p) => p.original)).toEqual(["Jane Doe"]);
     expect(result.entityCount).toBe(1);
+    expect(result.redactedText).toBe("Acme Corp employs [PERSON_2]");
   });
 
   test("normalizes excluded canonicals NFKC + case-insensitive", async () => {
-    const entities: Entity[] = [makeEntity("Café Élysée", "organization")];
-    const { runtime, seenEntities } = buildRuntime(entities);
+    const canonical = "Café Élysée";
+    const entities: NativePipelineEntity[] = [
+      makeEntity(canonical, "organization"),
+    ];
+    const runtime = buildRuntime(entities);
 
-    await runChatAnonPipeline({
+    const result = await runChatAnonPipeline({
       runtime,
       dictionaries,
-      text: "ignored",
+      text: canonical,
       workspaceId: "ws-1",
-      // Compatibility-decomposed form ("Café") with mixed
-      // case should still collide with "Café Élysée" after NFKC.
-      excludedCanonicals: ["café élysée"],
+      // Compatibility-decomposed form ("Cafe" + combining acute)
+      // with mixed case should still collide with the canonical
+      // (precomposed, capitalized) form above after NFKC.
+      excludedCanonicals: ["café élysée"],
     });
 
-    expect(seenEntities.value).toEqual([]);
+    expect(result.pairs).toEqual([]);
+    expect(result.entityCount).toBe(0);
+    expect(result.redactedText).toBe(canonical);
   });
 
   test("passes all entities through when no exclusions are provided", async () => {
-    const entities: Entity[] = [makeEntity("Acme Corp", "organization")];
-    const { runtime, seenEntities } = buildRuntime(entities);
+    const entities: NativePipelineEntity[] = [
+      makeEntity("Acme Corp", "organization"),
+    ];
+    const runtime = buildRuntime(entities);
 
-    await runChatAnonPipeline({
+    const result = await runChatAnonPipeline({
       runtime,
       dictionaries,
       text: "Acme Corp",
       workspaceId: "ws-1",
     });
 
-    expect(seenEntities.value).toEqual(entities);
+    expect(result.pairs.map((p) => p.original)).toEqual(["Acme Corp"]);
+    expect(result.entityCount).toBe(1);
+    expect(result.redactedText).toBe("[ORGANIZATION_1]");
   });
 });

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -207,6 +207,40 @@ export const buildChatAnonPipelineConfig = ({
 const normalizeForExclusion = (value: string): string =>
   value.normalize("NFKC").toLowerCase().replaceAll(/\s+/gu, " ").trim();
 
+const PLACEHOLDER_TOKEN = /\[[A-Z][A-Z0-9_]*_\d+\]/gu;
+
+const restoreLiteralPlaceholders = (
+  text: string,
+  restoreMap: ReadonlyMap<string, string>,
+): string => {
+  let result = text;
+  for (const [sentinel, placeholder] of restoreMap) {
+    result = result.replaceAll(sentinel, placeholder);
+  }
+  return result;
+};
+
+const protectLiteralPlaceholders = (
+  text: string,
+): {
+  text: string;
+  restore: (value: string) => string;
+} => {
+  const restoreMap = new Map<string, string>();
+  let index = 0;
+  const protectedText = text.replaceAll(PLACEHOLDER_TOKEN, (placeholder) => {
+    const sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
+    restoreMap.set(sentinel, placeholder);
+    index += 1;
+    return sentinel;
+  });
+
+  return {
+    text: protectedText,
+    restore: (value) => restoreLiteralPlaceholders(value, restoreMap),
+  };
+};
+
 type NativeRedaction = {
   redactedText: string;
   redactionMap: Map<string, string>;
@@ -380,12 +414,19 @@ export const runChatAnonPipeline = async ({
     gazetteerEntries,
     context,
   });
-  const { resolvedEntities, redaction } = pipeline.redactText(text);
+  const protectedInput = protectLiteralPlaceholders(text);
+  const { resolvedEntities, redaction } = pipeline.redactText(
+    protectedInput.text,
+  );
 
-  return applyExcludedCanonicals({
+  const result = applyExcludedCanonicals({
     deanonymiseText: runtime.deanonymise,
     excludedCanonicals,
     resolvedEntities,
     redaction,
   });
+  return {
+    ...result,
+    redactedText: protectedInput.restore(result.redactedText),
+  };
 };

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -214,9 +214,11 @@ type NativeRedaction = {
   entityCount: number;
 };
 
+const PLACEHOLDER_LABEL = /^\[(?<label>[A-Z][A-Z0-9_]*)_\d+\]$/u;
+
 const parsePlaceholderLabel = (placeholder: string): string | null => {
-  const match = /^\[([A-Z][A-Z0-9_]*)_\d+\]$/u.exec(placeholder);
-  return match?.[1] ?? null;
+  const match = PLACEHOLDER_LABEL.exec(placeholder);
+  return match?.groups?.["label"] ?? null;
 };
 
 const normalizeEntityLabelForPlaceholder = (label: string): string =>

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -244,8 +244,7 @@ const toChatAnonResult = (
       const matchingEntity = resolvedEntities.find(
         (entity) =>
           entity.text === original &&
-          normalizeEntityLabelForPlaceholder(entity.label) ===
-            placeholderLabel,
+          normalizeEntityLabelForPlaceholder(entity.label) === placeholderLabel,
       );
       return {
         placeholder,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -214,12 +214,20 @@ type NativeRedaction = {
   entityCount: number;
 };
 
+const parsePlaceholderLabel = (placeholder: string): string | null => {
+  const match = /^\[([A-Z][A-Z0-9_]*)_\d+\]$/u.exec(placeholder);
+  return match?.[1] ?? null;
+};
+
+const normalizeEntityLabelForPlaceholder = (label: string): string =>
+  label.trim().toUpperCase().replaceAll(/\s+/gu, "_");
+
 /**
  * Build the public {@link ChatAnonResult} from a (possibly already
  * filtered) entity list and its matching redaction. Pairs are keyed
  * off `redactionMap` (placeholder -> original), which only contains
- * reversible ("replace") entries; `labelByOriginal` recovers the
- * originating entity's label per pair.
+ * reversible ("replace") entries; the placeholder prefix disambiguates
+ * entities that share text but have different labels.
  */
 const toChatAnonResult = (
   resolvedEntities: readonly NativePipelineEntity[],
@@ -228,18 +236,21 @@ const toChatAnonResult = (
     "redactedText" | "redactionMap" | "entityCount"
   >,
 ): ChatAnonResult => {
-  const labelByOriginal = new Map<string, string>();
-  for (const entity of resolvedEntities) {
-    if (!labelByOriginal.has(entity.text)) {
-      labelByOriginal.set(entity.text, entity.label);
-    }
-  }
   const pairs: ChatAnonPair[] = [...redaction.redactionMap.entries()].map(
-    ([placeholder, original]) => ({
-      placeholder,
-      original,
-      label: labelByOriginal.get(original) ?? "misc",
-    }),
+    ([placeholder, original]) => {
+      const placeholderLabel = parsePlaceholderLabel(placeholder);
+      const matchingEntity = resolvedEntities.find(
+        (entity) =>
+          entity.text === original &&
+          normalizeEntityLabelForPlaceholder(entity.label) ===
+            placeholderLabel,
+      );
+      return {
+        placeholder,
+        original,
+        label: matchingEntity?.label ?? "misc",
+      };
+    },
   );
 
   return {

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -1,15 +1,15 @@
 import * as v from "valibot";
 
 import type {
+  createNativePipelineFromConfig,
   createPipelineContext,
-  DEFAULT_OPERATOR_CONFIG,
-  Entity,
+  deanonymise,
+  getBinding,
   GazetteerEntry,
+  NativePipelineEntity,
+  OperatorType,
   PipelineConfig,
   PipelineContext,
-  redactText,
-  RedactionResult,
-  runPipeline,
 } from "@stll/anonymize-wasm";
 
 /**
@@ -144,20 +144,19 @@ export const isThirdPartyBoundaryRefusalError = (error: Error): boolean =>
     parseChatTransportErrorMessage(error.message),
   );
 
+/**
+ * Runtime seam the wasm entry (main thread or worker) injects into
+ * {@link runChatAnonPipeline}. `createNativePipelineFromConfig`
+ * assembles (or reuses, via `context`) a prepared native pipeline
+ * for a config + gazetteer; `redactText` on the resulting pipeline
+ * runs detection and redaction as ONE combined call — there is no
+ * separate detect-then-redact step anymore.
+ */
 export type ChatAnonRuntime = {
+  getBinding: typeof getBinding;
+  createNativePipelineFromConfig: typeof createNativePipelineFromConfig;
   createPipelineContext: typeof createPipelineContext;
-  defaultOperatorConfig: typeof DEFAULT_OPERATOR_CONFIG;
-  preparePipelineSearch?: (input: {
-    config: PipelineConfig;
-    context: PipelineContext;
-    gazetteerEntries: GazetteerEntry[];
-  }) => Promise<unknown>;
-  redactText: typeof redactText;
-  runPipeline: typeof runPipeline;
-};
-
-type ScopedPipelineConfig = PipelineConfig & {
-  nameCorpusLanguages?: string[];
+  deanonymise: typeof deanonymise;
 };
 
 export const normalizeChatAnonLocaleLanguage = (
@@ -176,9 +175,9 @@ export const buildChatAnonPipelineConfig = ({
   hasGazetteer: boolean;
   locale?: string | undefined;
   workspaceId: string;
-}): ScopedPipelineConfig => {
+}): PipelineConfig => {
   const nameCorpusLanguage = normalizeChatAnonLocaleLanguage(locale);
-  const config: ScopedPipelineConfig = {
+  const config: PipelineConfig = {
     threshold: 0.4,
     enableTriggerPhrases: true,
     enableRegex: true,
@@ -208,6 +207,115 @@ export const buildChatAnonPipelineConfig = ({
 const normalizeForExclusion = (value: string): string =>
   value.normalize("NFKC").toLowerCase().replaceAll(/\s+/gu, " ").trim();
 
+type NativeRedaction = {
+  redactedText: string;
+  redactionMap: Map<string, string>;
+  operatorMap: Map<string, OperatorType>;
+  entityCount: number;
+};
+
+/**
+ * Build the public {@link ChatAnonResult} from a (possibly already
+ * filtered) entity list and its matching redaction. Pairs are keyed
+ * off `redactionMap` (placeholder -> original), which only contains
+ * reversible ("replace") entries; `labelByOriginal` recovers the
+ * originating entity's label per pair.
+ */
+const toChatAnonResult = (
+  resolvedEntities: readonly NativePipelineEntity[],
+  redaction: Pick<
+    NativeRedaction,
+    "redactedText" | "redactionMap" | "entityCount"
+  >,
+): ChatAnonResult => {
+  const labelByOriginal = new Map<string, string>();
+  for (const entity of resolvedEntities) {
+    if (!labelByOriginal.has(entity.text)) {
+      labelByOriginal.set(entity.text, entity.label);
+    }
+  }
+  const pairs: ChatAnonPair[] = [...redaction.redactionMap.entries()].map(
+    ([placeholder, original]) => ({
+      placeholder,
+      original,
+      label: labelByOriginal.get(original) ?? "misc",
+    }),
+  );
+
+  return {
+    redactedText: redaction.redactedText,
+    pairs,
+    redactionMap: redaction.redactionMap,
+    entityCount: redaction.entityCount,
+  };
+};
+
+/**
+ * Post-hoc selective revert for the user's never-anonymize
+ * allowlist. Detection and redaction are now a single combined
+ * native call (`pipeline.redactText`), so excluded entities can no
+ * longer be filtered out *before* redaction the way the old TS
+ * pipeline did: every entity is detected, numbered, and redacted
+ * first. Afterwards, any entity whose normalized text matches an
+ * excluded canonical has its placeholder reverted back to the
+ * original text — the same restore the CLI's `--revert` flag does —
+ * and is dropped from `pairs` / `redactionMap` / `entityCount`. This
+ * keeps the *observable* result identical to the old pre-redaction
+ * filter, though the placeholder numbers assigned to the remaining
+ * (non-excluded) entities may now differ, since the native pipeline
+ * still counts the excluded ones while allocating placeholders.
+ */
+const applyExcludedCanonicals = ({
+  deanonymiseText,
+  excludedCanonicals,
+  resolvedEntities,
+  redaction,
+}: {
+  deanonymiseText: typeof deanonymise;
+  excludedCanonicals: readonly string[] | undefined;
+  resolvedEntities: readonly NativePipelineEntity[];
+  redaction: NativeRedaction;
+}): ChatAnonResult => {
+  if (excludedCanonicals === undefined || excludedCanonicals.length === 0) {
+    return toChatAnonResult(resolvedEntities, redaction);
+  }
+
+  const excludedSet = new Set(excludedCanonicals.map(normalizeForExclusion));
+  const revertMap = new Map<string, string>();
+  for (const [placeholder, original] of redaction.redactionMap) {
+    if (excludedSet.has(normalizeForExclusion(original))) {
+      revertMap.set(placeholder, original);
+    }
+  }
+
+  if (revertMap.size === 0) {
+    return toChatAnonResult(resolvedEntities, redaction);
+  }
+
+  const redactedText = deanonymiseText(redaction.redactedText, revertMap);
+  const redactionMap = new Map(
+    [...redaction.redactionMap].filter(
+      ([placeholder]) => !revertMap.has(placeholder),
+    ),
+  );
+  const remainingEntities = resolvedEntities.filter(
+    (entity) => !excludedSet.has(normalizeForExclusion(entity.text)),
+  );
+  // Occurrence-based approximation: `entityCount` reports redacted
+  // *occurrences*, while `revertMap` is keyed per distinct
+  // placeholder. Subtracting the excluded occurrence count (rather
+  // than the reverted placeholder count) keeps parity with the old
+  // pipeline when the same excluded value appears more than once.
+  const excludedOccurrences =
+    resolvedEntities.length - remainingEntities.length;
+
+  return toChatAnonResult(remainingEntities, {
+    redactedText,
+    redactionMap,
+    entityCount: Math.max(0, redaction.entityCount - excludedOccurrences),
+  });
+};
+
 export const runChatAnonPipeline = async ({
   context: providedContext,
   dictionaries,
@@ -226,12 +334,11 @@ export const runChatAnonPipeline = async ({
   gazetteerEntries?: GazetteerEntry[] | undefined;
   context?: PipelineContext | undefined;
   /**
-   * Surface forms the caller has marked as never-anonymize.
-   * After the pipeline runs, any entity whose normalized text
-   * matches one of these (NFKC + lowercase, collapsed whitespace)
-   * is dropped before the redaction step, so the placeholder
-   * counter stays continuous and the original text passes
-   * through unchanged.
+   * Surface forms the caller has marked as never-anonymize. After
+   * the combined detect+redact call, any entity whose normalized
+   * text matches one of these (NFKC + lowercase, collapsed
+   * whitespace) has its redaction reverted; see
+   * {@link applyExcludedCanonicals}.
    */
   excludedCanonicals?: readonly string[] | undefined;
 }): Promise<ChatAnonResult> => {
@@ -245,7 +352,7 @@ export const runChatAnonPipeline = async ({
   }
 
   const context = providedContext ?? runtime.createPipelineContext();
-  const config = {
+  const config: PipelineConfig = {
     ...buildChatAnonPipelineConfig({
       hasGazetteer: gazetteerEntries.length > 0,
       locale,
@@ -253,56 +360,20 @@ export const runChatAnonPipeline = async ({
     }),
     dictionaries,
   };
-  await runtime.preparePipelineSearch?.({
-    config,
-    context,
-    gazetteerEntries,
-  });
-  const rawEntities: Entity[] = await runtime.runPipeline({
-    fullText: text,
-    config,
-    gazetteerEntries,
-    context,
-  });
-  const excludedSet =
-    excludedCanonicals && excludedCanonicals.length > 0
-      ? new Set(excludedCanonicals.map(normalizeForExclusion))
-      : null;
-  const entities: Entity[] =
-    excludedSet === null
-      ? rawEntities
-      : rawEntities.filter(
-          (entity) => !excludedSet.has(normalizeForExclusion(entity.text)),
-        );
-  const result: RedactionResult = runtime.redactText(
-    text,
-    entities,
-    runtime.defaultOperatorConfig,
-    context,
-  );
-  // Index entities by their surface text so each placeholder
-  // can carry the originating entity's label out to consumers.
-  // Same text + same label maps to the same placeholder by the
-  // wasm operator config, so a Map keyed on the entity text is
-  // enough to recover the label per pair.
-  const labelByOriginal = new Map<string, string>();
-  for (const entity of entities) {
-    if (!labelByOriginal.has(entity.text)) {
-      labelByOriginal.set(entity.text, entity.label);
-    }
-  }
-  const pairs: ChatAnonPair[] = [...result.redactionMap.entries()].map(
-    ([placeholder, original]) => ({
-      placeholder,
-      original,
-      label: labelByOriginal.get(original) ?? "misc",
-    }),
-  );
 
-  return {
-    redactedText: result.redactedText,
-    pairs,
-    redactionMap: result.redactionMap,
-    entityCount: result.entityCount,
-  };
+  const binding = await runtime.getBinding();
+  const pipeline = await runtime.createNativePipelineFromConfig({
+    binding,
+    config,
+    gazetteerEntries,
+    context,
+  });
+  const { resolvedEntities, redaction } = pipeline.redactText(text);
+
+  return applyExcludedCanonicals({
+    deanonymiseText: runtime.deanonymise,
+    excludedCanonicals,
+    resolvedEntities,
+    redaction,
+  });
 };


### PR DESCRIPTION
## Proposed change

Migrates all anonymization call sites from `@stll/anonymize-wasm` 1.5.0 to 2.0.1, where the TypeScript detection pipeline is replaced by a Rust core behind wasm. Detection and redaction are now one combined native call: `createNativePipelineFromConfig({binding, config, gazetteerEntries, context})` prepares a pipeline, and `pipeline.redactText(text)` returns `{resolvedEntities, redaction}` in a single pass. The old `runPipeline` / `preparePipelineSearch` / `redactText(text, entities, config, ctx)` / `buildPlaceholderMap` / `resolveOperator` / `DEFAULT_OPERATOR_CONFIG` surface no longer exists.

### Per-area changes

**packages/anonymize-chat**
- `ChatAnonRuntime` seam is now `{getBinding, createNativePipelineFromConfig, createPipelineContext, deanonymise}` (all typed via `typeof import("@stll/anonymize-wasm")` members, as before).
- `runChatAnonPipeline` builds the pipeline once per (config + gazetteer) through the cache context and does a single combined `redactText` call; `pairs` are derived from `redactionMap` + resolved entity labels.
- `excludedCanonicals` (user allowlist) moves from a pre-redaction entity filter to a post-hoc selective revert: after redaction, placeholders whose original matches the allowlist (NFKC + lowercase + collapsed whitespace, unchanged normalization) are substituted back via `deanonymise` and dropped from `pairs`/`redactionMap`/`entityCount` — same pattern as the anonymize CLI's `--revert`. Observable output is equivalent to the old filter; the placeholder numbers assigned to remaining entities can differ because the native pipeline numbers excluded entities before the revert.
- `buildChatAnonPipelineConfig` is unchanged field-for-field; every flag it sets (including `nameCorpusLanguages`, which is now a first-class `PipelineConfig` field, so the local `ScopedPipelineConfig` extension type is gone) exists in the 2.0.1 `PipelineConfig`, and it keeps `enableNer: false` (NER is not supported by the native pipeline; `getNativePipelineCompatibility` reports it as the only unsupported feature).

**apps/web**
- `lib/anonymize/chat-anonymize.ts` + `workers/anonymize-chat-worker.ts`: inject the new runtime members; everything else (dictionaries cache, worker protocol, serial queue) unchanged.
- `components/inspector/anonymize-pdf.ts` (detection-only PDF overlay): uses the combined call and reads only `resolvedEntities`.
- `lib/anonymize/pdf-redact.ts`: rebuilt on the combined result — overlay text comes from inverting `redaction.redactionMap` (placeholder per original), entities absent from the map (irreversible "redact" operator) draw the redact string. Note this module currently has no caller in the app; the signature now takes a `NativeStaticRedactionResult`.
- `vite.config.ts`: registers `@stll/anonymize-wasm/vite` with `packages: "none"` — the app assembles pipeline packages in-browser from `PipelineConfig`, so the bundled `.stlanonpkg` prepared packages (~20 MB+) are not emitted. The plugin owns the `optimizeDeps.exclude` entry for the package, so the manual entry is dropped.
- `src/server.ts`: mirrors the dev server's COOP/COEP headers in the production server entry. The 2.0 binding targets `wasm32-wasip1-threads` (shared memory) and needs a cross-origin-isolated context (`SharedArrayBuffer`); dev already sent these headers via `vite.config.ts`, production did not.

**apps/api**
- `mcp/anonymization.ts`: injects the new runtime; `anonymizeTextFieldsWithDependencies` (field-marker batching of multiple fields into one pipeline pass) is unchanged.
- `handlers/chat/third-party-boundary.ts`: comment-level changes documenting the numbering-continuity limitation (below). `deanonymise` and the cumulative boundary `redactionMap` contract are unchanged.

**Repo plumbing**
- Catalog pin `@stll/anonymize-wasm` 1.5.0 → 2.0.1 (`@stll/anonymize-data` stays 0.0.6).
- `bunfig.toml`: adds `@tanstack/ai-code-mode` to the release-age quarantine excludes (pre-existing `bun install` failure on a fresh checkout, separate commit).

### Placeholder-numbering continuity note

In 1.x, `PipelineContext` carried the placeholder counter across sequential `redactText` calls, so a chat boundary's later batches continued numbering from earlier ones. In 2.0 the context is only a prepared-package assembly cache; each `redactText` call numbers placeholders from `[LABEL_1]` again. Consequences for the chat third-party boundary:

- The boundary already batches all message parts it can see up-front into ONE `anonymizeFields` call (field markers), so the main path is a single numbering sequence.
- Tool outputs arrive one at a time as the model calls tools; those remain genuinely sequential calls. A later batch's `[PERSON_1]` can collide with an earlier batch's `[PERSON_1]` while meaning a different original. `mergeRedactionMap` keeps first-observation-wins (as before), so the later mapping is dropped; this is now documented at both the boundary type and the merge site rather than being a theoretical edge case.
- Per-call `deanonymise` still works: each call's own `redactionMap` is merged into the boundary's cumulative map used for the reverse mapping, preserving the existing contract.

### Validation

- `packages/anonymize-chat`: `bun run typecheck`, `bun run lint`, `bun test` (7 pass) — including rewritten `excludedCanonicals` tests exercising the post-hoc revert.
- `apps/api`: `bun run typecheck`, `bun run lint`, `bun test src/mcp/anonymization.test.ts src/handlers/chat/stream-chat.test.ts` (24 pass).
- `apps/web`: `bun run typecheck` (app + e2e project), `bun run lint`, `bun test src/lib/anonymize/constants.test.ts` (label parity with the 2.0.1 wasm export).
- `bun install` resolves 2.0.1 cleanly.

### Not verified locally

- A live browser run of the wasm binding (dev server + real redaction round-trip). The binding requires cross-origin isolation; dev headers were already in place, and the production server entry now sets them, but I could not exercise a real browser session from this environment. Worth a manual smoke test of chat anonymization and the PDF overlay after merge to staging.
- A full `vite build` of apps/web with the new plugin (the plugin's transform only runs at build time). CI's build step covers this.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI changes.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no visual changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved anonymisation handling across chat, PDF, and web flows, with more consistent placeholder numbering and restoration.
  * Added support for cross-origin isolation headers so browser-based features can run more reliably.

* **Bug Fixes**
  * Fixed cases where repeated anonymisation could renumber placeholders inconsistently.
  * Improved handling of excluded terms so previously anonymised text can be restored correctly when needed.
  * Updated PDF redaction to use more reliable placeholder mapping and overlay behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->