### PR TITLE
fix(ci): make staging smoke wait for revision

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -233,7 +233,7 @@ jobs:
     name: Verify staging deploy
     needs: build-and-deploy
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
 
@@ -272,6 +272,7 @@ jobs:
         env:
           E2E_API_URL: https://api-staging.stll.app
           SMOKE_SESSION_SECRET: ${{ secrets.SMOKE_SESSION_SECRET }}
+          EXPECTED_COMMIT: ${{ github.sha }}
 
       - name: Upload Playwright report
         if: failure()

--- a/apps/api/src/handlers/views/table-export.test.ts
+++ b/apps/api/src/handlers/views/table-export.test.ts
@@ -620,7 +620,9 @@ describe("table export", () => {
       ),
       propertyConfig({ numRuns: 50 }),
     );
-  });
+    // 50 zip builds + parses can exceed Bun's default 5s timeout on loaded
+    // CI runners; keep the invariant broad while making runtime deterministic.
+  }, 20_000);
 
   test("merges a graded position into one column with its verdict tier and rationale", () => {
     const verdictTool: PropertyTool = {

--- a/apps/api/src/scripts/post-deploy-smoke.test.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.test.ts
@@ -5,6 +5,7 @@ import {
   buildChatSmokeBody,
   evaluateChatStreamPrefix,
   evaluateChatStreamContentType,
+  evaluateHealthRevision,
   evaluateHttpCheck,
   isExpectedChatBusinessResponse,
   isServerError,
@@ -96,6 +97,53 @@ describe("evaluateHttpCheck", () => {
         mode: "chatSend",
       }).ok,
     ).toBe(false);
+  });
+});
+
+describe("evaluateHealthRevision", () => {
+  test("passes plain health checks when no expected commit is set", () => {
+    expect(
+      evaluateHealthRevision({
+        body: { commit: "old" },
+        expectedCommit: undefined,
+        status: 200,
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("requires the expected commit when provided", () => {
+    expect(
+      evaluateHealthRevision({
+        body: { commit: "abc123" },
+        expectedCommit: "abc123",
+        status: 200,
+      }).ok,
+    ).toBe(true);
+    expect(
+      evaluateHealthRevision({
+        body: { commit: "old" },
+        expectedCommit: "abc123",
+        status: 200,
+      }).ok,
+    ).toBe(false);
+    expect(
+      evaluateHealthRevision({
+        body: { status: "ok" },
+        expectedCommit: "abc123",
+        status: 200,
+      }).ok,
+    ).toBe(false);
+  });
+
+  test("fails on non-2xx health responses before checking commit", () => {
+    const check = evaluateHealthRevision({
+      body: { commit: "abc123" },
+      expectedCommit: "abc123",
+      status: 503,
+    });
+
+    expect(check.ok).toBe(false);
+    expect(check.detail).toBe("503 (expected 2xx)");
   });
 });
 

--- a/apps/api/src/scripts/post-deploy-smoke.ts
+++ b/apps/api/src/scripts/post-deploy-smoke.ts
@@ -28,6 +28,10 @@ import * as v from "valibot";
 const SMOKE_SESSION_TIMEOUT_MS = 15_000;
 const READ_CHECK_TIMEOUT_MS = 15_000;
 const CHAT_SEND_TIMEOUT_MS = 60_000;
+const REVISION_READINESS_TIMEOUT_MS = 600_000;
+const REVISION_READINESS_INTERVAL_MS = 5000;
+const REVISION_READINESS_LOG_INTERVAL_MS = 30_000;
+const REVISION_READINESS_STABLE_SAMPLES = 3;
 // Cap how much of the chat SSE stream we read while looking for an
 // early error frame. A healthy turn streams far more than this; we only
 // need the opening frames to tell "started streaming" from "failed".
@@ -241,6 +245,59 @@ export const evaluateChatStreamPrefix = (prefix: string): EvaluatedCheck => {
 export const allChecksPassed = (checks: EvaluatedCheck[]): boolean =>
   checks.every((check) => check.ok);
 
+type HealthRevisionInput = {
+  body: unknown;
+  expectedCommit: string | undefined;
+  status: number;
+};
+
+const getObjectProperty = (value: unknown, property: string): unknown => {
+  if (typeof value !== "object" || value === null || !(property in value)) {
+    return undefined;
+  }
+  return Reflect.get(value, property);
+};
+
+const getCommitFromHealthBody = (body: unknown): string | null => {
+  const commit = getObjectProperty(body, "commit");
+  if (typeof commit === "string") {
+    return commit;
+  }
+  return null;
+};
+
+export const evaluateHealthRevision = ({
+  body,
+  expectedCommit,
+  status,
+}: HealthRevisionInput): EvaluatedCheck => {
+  const httpCheck = evaluateHttpCheck({
+    name: "GET /health",
+    status,
+    mode: CHECK_MODE.okOnly,
+  });
+  if (!httpCheck.ok || !expectedCommit) {
+    return httpCheck;
+  }
+
+  const commit = getCommitFromHealthBody(body);
+  if (commit === expectedCommit) {
+    return {
+      name: "GET /health",
+      ok: true,
+      detail: `${String(status)} serving ${commit}`,
+    };
+  }
+
+  return {
+    name: "GET /health",
+    ok: false,
+    detail: commit
+      ? `${String(status)} serving stale commit ${commit}`
+      : `${String(status)} without a commit marker`,
+  };
+};
+
 const sessionCookieHeader = (session: SmokeSession): string =>
   `${session.cookieName}=${session.cookieValue}`;
 
@@ -316,10 +373,78 @@ const readHealth = async (baseUrl: string): Promise<EvaluatedCheck> => {
   const response = await fetch(`${baseUrl}/health`, {
     signal: AbortSignal.timeout(READ_CHECK_TIMEOUT_MS),
   });
-  return evaluateHttpCheck({
-    name: "GET /health",
+  return evaluateHealthRevision({
+    body: response.ok ? await response.json().catch(() => null) : null,
+    expectedCommit: process.env["EXPECTED_COMMIT"],
     status: response.status,
-    mode: CHECK_MODE.okOnly,
+  });
+};
+
+const sleep = async (ms: number): Promise<void> =>
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const writeReadinessLog = (message: string): void => {
+  process.stdout.write(`[api-readiness] ${message}\n`);
+};
+
+const waitForApiRevision = async (baseUrl: string): Promise<void> => {
+  const expectedCommit = process.env["EXPECTED_COMMIT"];
+  if (!expectedCommit) {
+    return;
+  }
+
+  const deadline = Date.now() + REVISION_READINESS_TIMEOUT_MS;
+  let consecutive = 0;
+  let lastDetail = "no readiness samples collected";
+  let nextPeriodicLogAt = 0;
+
+  writeReadinessLog(
+    `waiting for ${expectedCommit} for up to ${
+      REVISION_READINESS_TIMEOUT_MS / 1000
+    }s`,
+  );
+
+  while (Date.now() < deadline) {
+    let check: EvaluatedCheck;
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- readiness must be sampled sequentially to build a stable streak
+      check = await readHealth(baseUrl);
+    } catch (error) {
+      check = {
+        name: "GET /health",
+        ok: false,
+        detail: `request failed: ${errorMessage(error)}`,
+      };
+    }
+
+    const now = Date.now();
+    consecutive = check.ok ? consecutive + 1 : 0;
+    if (check.detail !== lastDetail || now >= nextPeriodicLogAt) {
+      writeReadinessLog(
+        `${check.ok ? "ready" : "waiting"} (${check.detail}); stable samples ${String(
+          consecutive,
+        )}/${String(REVISION_READINESS_STABLE_SAMPLES)}`,
+      );
+      nextPeriodicLogAt = now + REVISION_READINESS_LOG_INTERVAL_MS;
+    }
+    lastDetail = check.detail;
+
+    if (consecutive >= REVISION_READINESS_STABLE_SAMPLES) {
+      writeReadinessLog(`ready after ${String(consecutive)} stable samples`);
+      return;
+    }
+
+    // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: wait between readiness samples
+    await sleep(REVISION_READINESS_INTERVAL_MS);
+  }
+
+  throw new PostDeploySmokeError({
+    message:
+      `API did not stably serve ${expectedCommit} within ` +
+      `${String(REVISION_READINESS_TIMEOUT_MS / 1000)}s. ` +
+      `Last sample: ${lastDetail}`,
   });
 };
 
@@ -485,6 +610,8 @@ const main = async (): Promise<void> => {
         "SMOKE_SESSION_SECRET is required to authenticate the post-deploy smoke",
     });
   }
+
+  await waitForApiRevision(baseUrl);
 
   const session = await mintSmokeSession(baseUrl, secret);
   const cookie = sessionCookieHeader(session);

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -12,8 +12,9 @@ type SmokeSession = {
 const API_URL = process.env["E2E_API_URL"] ?? "https://api-staging.stll.app";
 const WEB_URL = process.env["E2E_WEB_URL"] ?? "https://staging.stll.app";
 
-const READINESS_TIMEOUT_MS = 300_000;
+const READINESS_TIMEOUT_MS = 600_000;
 const READINESS_INTERVAL_MS = 5000;
+const READINESS_LOG_INTERVAL_MS = 30_000;
 // Require several consecutive expected-commit samples before proceeding:
 // during rollover the ALB serves old and new tasks side by side, so a
 // single new-commit hit does not mean later browser traffic avoids the
@@ -31,48 +32,155 @@ type Origin = {
   // The web origin's version.json may be absent on the revision being
   // replaced (it predates this marker), so a missing marker counts as
   // ready: the API gate covers the dominant rollover race regardless.
-  isReady: (expectedCommit: string | undefined) => Promise<boolean>;
+  sample: (expectedCommit: string | undefined) => Promise<ReadinessSample>;
 };
 
-const fetchCommit = async (url: string): Promise<string | null | undefined> => {
+type VersionProbe =
+  | {
+      type: "ok";
+      commit: string | null;
+    }
+  | {
+      type: "missing-marker";
+    }
+  | {
+      type: "http-error";
+      status: number;
+    }
+  | {
+      type: "invalid-json";
+    }
+  | {
+      message: string;
+      type: "network-error";
+    };
+
+type ReadinessSample = {
+  detail: string;
+  label: string;
+  ready: boolean;
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const fetchCommit = async (url: string): Promise<VersionProbe> => {
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
     if (response.status === 404) {
-      return null;
+      return { type: "missing-marker" };
     }
     if (!response.ok) {
-      return undefined;
+      return { type: "http-error", status: response.status };
     }
-    const { commit } = (await response.json()) as { commit?: string };
-    return commit;
+    const body: unknown = await response.json();
+    if (!isObject(body)) {
+      return { type: "invalid-json" };
+    }
+    const commit = body["commit"];
+    if (typeof commit === "string") {
+      return { type: "ok", commit };
+    }
+    if (commit === undefined || commit === null) {
+      return { type: "ok", commit: null };
+    }
+    return { type: "invalid-json" };
   } catch {
     // Connection reset/timeout during rollover; treated as not-ready.
-    return undefined;
+    return { type: "network-error", message: "request failed or timed out" };
   }
+};
+
+const sampleRevision = async ({
+  allowMissingMarker,
+  expectedCommit,
+  label,
+  url,
+}: {
+  allowMissingMarker: boolean;
+  expectedCommit: string | undefined;
+  label: string;
+  url: string;
+}): Promise<ReadinessSample> => {
+  const probe = await fetchCommit(url);
+  if (probe.type === "http-error") {
+    return {
+      detail: `HTTP ${String(probe.status)}`,
+      label,
+      ready: false,
+    };
+  }
+  if (probe.type === "invalid-json") {
+    return { detail: "invalid JSON body", label, ready: false };
+  }
+  if (probe.type === "network-error") {
+    return { detail: probe.message, label, ready: false };
+  }
+  if (probe.type === "missing-marker") {
+    return {
+      detail: allowMissingMarker
+        ? "version marker missing; accepted"
+        : "version marker missing",
+      label,
+      ready: allowMissingMarker,
+    };
+  }
+
+  if (!expectedCommit) {
+    return {
+      detail: probe.commit ? `healthy commit ${probe.commit}` : "healthy",
+      label,
+      ready: true,
+    };
+  }
+
+  if (probe.commit === expectedCommit) {
+    return { detail: `commit ${probe.commit}`, label, ready: true };
+  }
+
+  return {
+    detail: probe.commit
+      ? `stale commit ${probe.commit}`
+      : "commit missing from response",
+    label,
+    ready: false,
+  };
 };
 
 const ORIGINS: Origin[] = [
   {
     label: "api",
-    isReady: async (expectedCommit) => {
-      const commit = await fetchCommit(`${API_URL}/health`);
-      if (commit === undefined) {
-        return false;
-      }
-      return !expectedCommit || commit === expectedCommit;
-    },
+    sample: async (expectedCommit) =>
+      await sampleRevision({
+        allowMissingMarker: false,
+        expectedCommit,
+        label: "api",
+        url: `${API_URL}/health`,
+      }),
   },
   {
     label: "web",
-    isReady: async (expectedCommit) => {
-      const commit = await fetchCommit(`${WEB_URL}/version.json`);
-      if (commit === undefined) {
-        return false;
-      }
-      return !expectedCommit || commit === null || commit === expectedCommit;
-    },
+    sample: async (expectedCommit) =>
+      await sampleRevision({
+        allowMissingMarker: true,
+        expectedCommit,
+        label: "web",
+        url: `${WEB_URL}/version.json`,
+      }),
   },
 ];
+
+const formatReadinessSamples = (samples: ReadinessSample[]): string =>
+  samples
+    .map(
+      (sample) =>
+        `${sample.label}: ${sample.ready ? "ready" : "waiting"} (${sample.detail})`,
+    )
+    .join("; ");
+
+const writeReadinessLog = (message: string): void => {
+  process.stdout.write(`[staging-readiness] ${message}\n`);
+};
 
 // Block until both the API and the web origin stably serve the deployed
 // revision. verify-staging fires the moment the promote returns, while
@@ -85,14 +193,35 @@ const waitForDeployedRevision = async (): Promise<void> => {
   const expectedCommit = process.env["EXPECTED_COMMIT"];
   const deadline = Date.now() + READINESS_TIMEOUT_MS;
   let consecutive = 0;
+  let lastSummary = "no readiness samples collected";
+  let nextPeriodicLogAt = 0;
+
+  writeReadinessLog(
+    `waiting for ${expectedCommit ?? "healthy staging"} for up to ${
+      READINESS_TIMEOUT_MS / 1000
+    }s`,
+  );
 
   while (Date.now() < deadline) {
     // oxlint-disable-next-line no-await-in-loop -- sequential readiness sampling: each sample must follow the prior interval to build a streak
-    const readiness = await Promise.all(
-      ORIGINS.map(async (origin) => await origin.isReady(expectedCommit)),
+    const samples = await Promise.all(
+      ORIGINS.map(async (origin) => await origin.sample(expectedCommit)),
     );
-    consecutive = readiness.every(Boolean) ? consecutive + 1 : 0;
+    const summary = formatReadinessSamples(samples);
+    const now = Date.now();
+    consecutive = samples.every((sample) => sample.ready) ? consecutive + 1 : 0;
+    if (summary !== lastSummary || now >= nextPeriodicLogAt) {
+      writeReadinessLog(
+        `${summary}; stable samples ${String(consecutive)}/${String(
+          READINESS_STABLE_SAMPLES,
+        )}`,
+      );
+      nextPeriodicLogAt = now + READINESS_LOG_INTERVAL_MS;
+    }
+    lastSummary = summary;
+
     if (consecutive >= READINESS_STABLE_SAMPLES) {
+      writeReadinessLog(`ready after ${String(consecutive)} stable samples`);
       return;
     }
     // oxlint-disable-next-line no-await-in-loop -- sequential poll backoff: wait between readiness samples
@@ -101,7 +230,7 @@ const waitForDeployedRevision = async (): Promise<void> => {
 
   throw new Error(
     `Staging did not stably serve ${expectedCommit ?? "a healthy revision"} ` +
-      `within ${READINESS_TIMEOUT_MS / 1000}s`,
+      `within ${READINESS_TIMEOUT_MS / 1000}s. Last sample: ${lastSummary}`,
   );
 };
 

--- a/apps/web/e2e/staging/global-setup.ts
+++ b/apps/web/e2e/staging/global-setup.ts
@@ -62,7 +62,7 @@ type ReadinessSample = {
 };
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const fetchCommit = async (url: string): Promise<VersionProbe> => {
   try {
@@ -73,7 +73,7 @@ const fetchCommit = async (url: string): Promise<VersionProbe> => {
     if (!response.ok) {
       return { type: "http-error", status: response.status };
     }
-    const body: unknown = await response.json();
+    const body: unknown = await response.json().catch(() => null);
     if (!isObject(body)) {
       return { type: "invalid-json" };
     }


### PR DESCRIPTION
Summary:
- add commit-aware readiness logging to staging web smoke
- wait for the expected API revision before post-deploy chat smoke mints a session
- extend the staging verification job budget for longer convergence windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging deployment readiness checks to reduce false positives from stale revisions.
  * Added commit-matching validation for API health checks so staging waits for the expected build before proceeding.
  * Increased staging verification timeouts and added clearer progress logging during readiness checks.

* **Tests**
  * Expanded automated coverage for API health revision validation and updated existing timing-related test guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->