### PR TITLE
fix(ai-catalog): refresh mistral-medium-latest rates after upstream repricing

### DIFF
--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -526,8 +526,8 @@ export const MODEL_RATES: Readonly<Record<string, ModelRate>> = {
     outputPerMTok: 150_000,
   },
   "mistral-medium-latest": {
-    inputPerMTok: 40_000,
-    outputPerMTok: 200_000,
+    inputPerMTok: 150_000,
+    outputPerMTok: 750_000,
   },
   "mistral-medium-3-5": {
     inputPerMTok: 150_000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed change

Fixes the failing [Model Catalog Upstream Check](https://github.com/stella/stella/actions/runs/28920180275) workflow.

Mistral repriced `mistral-medium-latest` on models.dev from $0.40/$2.00 to $1.50/$7.50 per MTok. The stale `MODEL_RATES` entry triggered a `RATE DRIFT` failure in the nightly catalog validation.

Updated `mistral-medium-latest` rates to match upstream pricing (150_000 / 750_000 micro-units per MTok), consistent with the existing `mistral-medium-3-5` entry.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | `bun run check:model-catalog` passes; ai-catalog and rate-check unit tests pass.
- [ ] DARK MODE SUPPORT | N/A (catalog rate table only).
- [ ] ISSUE LINKED | N/A (scheduled workflow failure).
- [ ] SCREENSHOT INCLUDED | N/A.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69e4e106-b823-4501-a9fd-feaa97810a14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69e4e106-b823-4501-a9fd-feaa97810a14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the per-token rates for the `mistral-medium-latest` model, affecting both input and output pricing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->