### PR TITLE
fix: package anonymize wasm assets in api image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -98,16 +98,16 @@ COPY --chown=stella:stella --from=builder /app/apps/api/drizzle /app/apps/api/dr
 RUN mkdir -p '/$bunfs/root'
 COPY --chown=stella:stella --from=builder /app/runtime-workers /\$bunfs/root/workers
 COPY --chown=stella:stella --from=builder /app/apps/api/src/lib/file-scan/yara /\$bunfs/root/yara
+# @stll/anonymize-wasm resolves its native glue, WASM, and prepared pipeline
+# packages relative to `dist/wasm.mjs`; Bun's compiled binary resolves those
+# bundled asset URLs under `$bunfs/root/native`.
 COPY --chown=stella:stella --from=deps \
-    /app/node_modules/@stll/aho-corasick-wasm/dist/*.wasm \
-    /app/node_modules/@stll/fuzzy-search-wasm/dist/*.wasm \
-    /app/node_modules/@stll/regex-set-wasm/dist/*.wasm \
-    /\$bunfs/root/
+    /app/node_modules/@stll/anonymize-wasm/dist/native/ \
+    /\$bunfs/root/native/
 # quickjs-emscripten loads this WASM file at runtime from the
 # compiled Bun binary's `$bunfs/root` asset directory.
 COPY --chown=stella:stella --from=deps \
     /app/node_modules/@jitl/quickjs-wasmfile-release-asyncify/dist/emscripten-module.wasm \
-    /app/node_modules/@stll/aho-corasick-wasm/dist/wasi-worker-browser.mjs \
     /\$bunfs/root/
 WORKDIR /app/apps/api
 


### PR DESCRIPTION
## Summary
- copy @stll/anonymize-wasm native runtime assets into the compiled API image asset root
- remove stale text-search wasm asset copies that are no longer installed by the filtered API dependency layer

## Verification
- docker build --target runner -f apps/api/Dockerfile .
- git diff --check

Note: local pre-push format and i18n checks passed; the local typecheck hook was interrupted after several minutes, so GitHub checks should provide the final signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the application image to include the correct runtime assets, helping ensure the service starts and runs reliably.
  * Replaced older bundled WebAssembly files with the current asset layout, reducing the risk of missing or incompatible runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->