### PR TITLE
fix: reduce effect and pagination debt

### DIFF
--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -131,14 +131,12 @@ type QueryEntitiesProps = {
   sorts: ViewSort[];
   search?: string | undefined;
   cursor?: EntitiesWindowCursorValues | null | undefined;
-  offset?: number | undefined;
   limit: number;
   fieldMode: QueryEntitiesFieldMode;
   fieldIds: SafeId<"property">[];
   excludedKinds?: EntityKind[];
   previewableForAi?: boolean;
   extraConditions?: SQL[];
-  includeTotalCount: boolean;
 };
 
 const organizationMemberIdsSubquery = (
@@ -636,14 +634,12 @@ const queryEntitiesGenerator = async function* ({
   sorts,
   search,
   cursor,
-  offset = 0,
   limit,
   fieldMode,
   fieldIds,
   excludedKinds = [],
   previewableForAi = false,
   extraConditions = [],
-  includeTotalCount,
 }: QueryEntitiesProps) {
   const workspaceCondition = eq(entities.workspaceId, workspaceId);
   const filterConditions = buildFilterConditions(filters);
@@ -680,37 +676,16 @@ const queryEntitiesGenerator = async function* ({
     sql`, `,
   )})`;
 
-  const countRowsPromise = includeTotalCount
-    ? safeDb((tx) =>
-        tx.select({ total: count() }).from(entities).where(whereClause),
-      )
-    : Promise.resolve(null);
-
-  const [idRowsResult, countRowsResult] = await Promise.all([
-    safeDb((tx) => {
-      const query = tx
-        .select({ cursorValues: cursorValuesExpr, id: entities.id })
-        .from(entities)
-        .where(paginatedWhereClause)
-        .orderBy(...sortExpressions)
-        .limit(limit);
-
-      if (offset <= 0) {
-        return query;
-      }
-
-      return query.offset(offset);
-    }),
-    countRowsPromise,
-  ]);
+  const idRowsResult = await safeDb((tx) =>
+    tx
+      .select({ cursorValues: cursorValuesExpr, id: entities.id })
+      .from(entities)
+      .where(paginatedWhereClause)
+      .orderBy(...sortExpressions)
+      .limit(limit),
+  );
 
   const idRows = yield* idRowsResult;
-
-  let totalCount: number | null = null;
-  if (countRowsResult !== null) {
-    const countResult = yield* countRowsResult;
-    totalCount = countResult.at(0)?.total ?? 0;
-  }
 
   const pageIds = idRows.map((r) => r.id);
   const cursorValuesByEntityId = new Map<string, EntitiesWindowCursorValues>(
@@ -721,7 +696,6 @@ const queryEntitiesGenerator = async function* ({
     return Result.ok({
       cursorValuesByEntityId,
       entities: [],
-      totalCount,
     });
   }
 
@@ -1051,7 +1025,6 @@ const queryEntitiesGenerator = async function* ({
   return Result.ok({
     cursorValuesByEntityId,
     entities: result,
-    totalCount,
   });
 };
 

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -58,7 +58,6 @@ export const createReadFilesystemTreeHandler = (
           fieldIds: body.fieldIds ?? [],
           excludedKinds: ["task"],
           previewableForAi: false,
-          includeTotalCount: false,
         }),
       );
 

--- a/apps/api/src/handlers/entities/read-kanban-group.ts
+++ b/apps/api/src/handlers/entities/read-kanban-group.ts
@@ -47,7 +47,6 @@ const readKanbanGroupBodySchema = t.Object({
   // uncategorized bucket folds in cells whose value is no longer an option;
   // omitted (kanban board) keeps "no non-empty value".
   optionValues: t.Optional(t.Array(t.String({ maxLength: 1000 }))),
-  includeTotalCount: t.Optional(t.Boolean()),
 });
 
 const config = {
@@ -74,7 +73,6 @@ const readKanbanGroup = createSafeHandler(
     }
 
     const limit = body.limit ?? LIMITS.entitiesWindowSizeDefault;
-    const includeTotalCount = body.includeTotalCount ?? false;
     const result = yield* Result.await(
       queryEntities({
         safeDb,
@@ -89,7 +87,6 @@ const readKanbanGroup = createSafeHandler(
         fieldIds: body.fieldIds ?? [],
         excludedKinds: body.excludedKinds ?? [],
         extraConditions: [conditionResult.value],
-        includeTotalCount,
       }),
     );
 
@@ -103,9 +100,7 @@ const readKanbanGroup = createSafeHandler(
         ),
     });
 
-    // `totalCount` is the per-group rollup that drives the table group
-    // header count; one bounded count per group, only when requested.
-    return Result.ok({ ...page, totalCount: result.totalCount });
+    return Result.ok(page);
   },
 );
 

--- a/apps/api/src/handlers/entities/read-summaries.ts
+++ b/apps/api/src/handlers/entities/read-summaries.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { count, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, lt, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db";
@@ -7,53 +7,119 @@ import { entities } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  parseDateTimePaginationCursorPart,
+} from "@/api/lib/pagination";
 
 const readEntitySummariesQuerySchema = t.Object({
-  page: t.Optional(t.Integer({ minimum: 1 })),
+  cursor: t.Optional(t.String()),
+  limit: t.Optional(
+    t.Integer({
+      minimum: 1,
+      maximum: LIMITS.entitiesWindowSizeMax,
+    }),
+  ),
 });
 
 type ReadEntitySummariesHandlerProps = {
   safeDb: SafeDb;
   workspaceId: SafeId<"workspace">;
-  page: number;
+  cursor: string | undefined;
+  limit: number;
+};
+
+const readEntitySummariesCountQuerySchema = t.Object({});
+
+const parseSummaryCursor = (cursor: string | undefined) => {
+  if (cursor === undefined) {
+    return Result.ok(null);
+  }
+
+  const parts = decodePaginationCursor(cursor);
+  const createdAt = parseDateTimePaginationCursorPart(parts?.at(0));
+  const id = parts?.at(1);
+  if (parts?.length !== 2 || createdAt === null || typeof id !== "string") {
+    return Result.err(
+      new HandlerError({ status: 400, message: "Invalid cursor" }),
+    );
+  }
+
+  return Result.ok({ createdAt, id });
 };
 
 const readEntitySummariesHandler = async function* ({
   safeDb,
   workspaceId,
-  page,
+  cursor,
+  limit,
 }: ReadEntitySummariesHandlerProps) {
-  const pageSize = LIMITS.entitySummariesPageSize;
-  const offset = (page - 1) * pageSize;
-  const whereClause = eq(entities.workspaceId, workspaceId);
+  const cursorResult = parseSummaryCursor(cursor);
+  if (Result.isError(cursorResult)) {
+    return Result.err(cursorResult.error);
+  }
 
-  const [rowsResult, countResult] = await Promise.all([
-    safeDb((tx) =>
-      tx
-        .select({
-          id: entities.id,
-          name: entities.name,
-        })
-        .from(entities)
-        .where(whereClause)
-        .orderBy(desc(entities.createdAt))
-        .offset(offset)
-        .limit(pageSize),
-    ),
-    safeDb((tx) =>
-      tx.select({ total: count() }).from(entities).where(whereClause),
-    ),
-  ]);
+  const cursorCondition =
+    cursorResult.value === null
+      ? undefined
+      : or(
+          lt(entities.createdAt, cursorResult.value.createdAt),
+          and(
+            eq(entities.createdAt, cursorResult.value.createdAt),
+            sql`${entities.id} < ${cursorResult.value.id}`,
+          ),
+        );
+  const whereClause = and(
+    eq(entities.workspaceId, workspaceId),
+    cursorCondition,
+  );
 
-  const rows = yield* rowsResult;
-  const counts = yield* countResult;
+  const rows = yield* await safeDb((tx) =>
+    tx
+      .select({
+        id: entities.id,
+        name: entities.name,
+        createdAt: entities.createdAt,
+      })
+      .from(entities)
+      .where(whereClause)
+      .orderBy(desc(entities.createdAt), desc(entities.id))
+      .limit(limit + 1),
+  );
+
+  const page = createCursorPage({
+    rows,
+    limit,
+    cursorForItem: (item) =>
+      encodePaginationCursor([item.createdAt.toISOString(), item.id]),
+  });
 
   return Result.ok({
-    summaries: rows,
+    ...page,
+    items: page.items.map(({ id, name }) => ({ id, name })),
+  });
+};
+
+const readEntitySummariesCountHandler = async function* ({
+  safeDb,
+  workspaceId,
+}: {
+  safeDb: SafeDb;
+  workspaceId: SafeId<"workspace">;
+}) {
+  const counts = yield* await safeDb((tx) =>
+    tx
+      .select({ total: count() })
+      .from(entities)
+      .where(eq(entities.workspaceId, workspaceId)),
+  );
+
+  return Result.ok({
     totalCount: counts.at(0)?.total ?? 0,
-    page,
-    pageSize,
   });
 };
 
@@ -63,14 +129,28 @@ const config = {
   query: readEntitySummariesQuerySchema,
 } satisfies HandlerConfig;
 
+const countConfig = {
+  permissions: { workspace: ["read"] },
+  mcp: { type: "pending" },
+  query: readEntitySummariesCountQuerySchema,
+} satisfies HandlerConfig;
+
 const readEntitySummaries = createSafeHandler(
   config,
   async function* ({ safeDb, workspaceId, query }) {
     return yield* readEntitySummariesHandler({
       safeDb,
       workspaceId,
-      page: query.page ?? 1,
+      cursor: query.cursor,
+      limit: query.limit ?? LIMITS.entitySummariesPageSize,
     });
+  },
+);
+
+export const readEntitySummariesCount = createSafeHandler(
+  countConfig,
+  async function* ({ safeDb, workspaceId }) {
+    return yield* readEntitySummariesCountHandler({ safeDb, workspaceId });
   },
 );
 

--- a/apps/api/src/handlers/entities/read-summaries.ts
+++ b/apps/api/src/handlers/entities/read-summaries.ts
@@ -131,7 +131,7 @@ const config = {
 
 const countConfig = {
   permissions: { workspace: ["read"] },
-  mcp: { type: "pending" },
+  mcp: { type: "covered", by: "list_documents" },
   query: readEntitySummariesCountQuerySchema,
 } satisfies HandlerConfig;
 

--- a/apps/api/src/handlers/entities/read-window.test.ts
+++ b/apps/api/src/handlers/entities/read-window.test.ts
@@ -86,17 +86,14 @@ const createContext = ({
     route: "/v1/entities/:workspaceId/query-window",
   });
 
-const createSafeDb = ({
-  includeCount,
-}: {
-  includeCount: boolean;
-}): Parameters<typeof readEntitiesWindow.handler>[0]["safeDb"] => {
-  // queryEntities starts the optional count query before the id query,
-  // then starts the phase-2 entity/version/field/session queries together.
+const createSafeDb = (): Parameters<
+  typeof readEntitiesWindow.handler
+>[0]["safeDb"] => {
+  // queryEntities starts the id query, then starts the phase-2
+  // entity/version/field/session queries together.
   // Keep this queue in that call order so the handler tests fail loudly
   // if the query pipeline changes.
   const results: unknown[] = [
-    ...(includeCount ? [[{ total: idRows.length }]] : []),
     idRows,
     entityRows,
     versionCounts,
@@ -122,7 +119,7 @@ describe("entity read handlers", () => {
           fieldIds: [],
           excludedKinds: ["folder", "task"],
         },
-        safeDb: createSafeDb({ includeCount: false }),
+        safeDb: createSafeDb(),
       }),
     );
 
@@ -144,30 +141,29 @@ describe("entity read handlers", () => {
     expect(result.nextCursor).toEqual(expect.any(String));
   });
 
-  test("page query unwraps the shared entity query result before building pagination", async () => {
+  test("query handler returns a cursor page", async () => {
     const result = await readEntities.handler(
       asTestRaw<Parameters<typeof readEntities.handler>[0]>(
         createContext({
           body: {
-            page: 1,
-            pageSize: 2,
+            limit: 2,
             filters: [],
             sorts: [],
             fieldMode: "visible",
             fieldIds: [],
           },
-          safeDb: createSafeDb({ includeCount: true }),
+          safeDb: createSafeDb(),
         }),
       ),
     );
 
-    expect("entities" in result).toBe(true);
-    if (!("entities" in result)) {
+    expect("items" in result).toBe(true);
+    if (!("items" in result)) {
       return;
     }
 
-    expect(result.entities).toHaveLength(2);
-    expect(result.totalCount).toBe(3);
+    expect(result.items).toHaveLength(2);
+    expect(result.limit).toBe(2);
     expect(result.nextCursor).toEqual(expect.any(String));
   });
 
@@ -184,7 +180,7 @@ describe("entity read handlers", () => {
             groupByPropertyId: "_status",
             groupValue: "open",
           },
-          safeDb: createSafeDb({ includeCount: false }),
+          safeDb: createSafeDb(),
         }),
       ),
     );

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -69,7 +69,6 @@ const readEntitiesWindow = createSafeHandler(
         fieldIds: body.fieldIds ?? [],
         excludedKinds: body.excludedKinds ?? [],
         previewableForAi: body.previewableForAi ?? false,
-        includeTotalCount: false,
       }),
     );
 

--- a/apps/api/src/handlers/entities/read.test.ts
+++ b/apps/api/src/handlers/entities/read.test.ts
@@ -5,6 +5,7 @@ import { createReadEntitiesHandler } from "@/api/handlers/entities/read";
 import { createReadFilesystemTreeHandler } from "@/api/handlers/entities/read-filesystem-tree";
 import { toSafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const queryEntitiesMock = mock();
 
@@ -18,8 +19,7 @@ const userId = toSafeId<"user">("user_entity_read");
 const createContext = (
   body: Parameters<typeof readEntities.handler>[0]["body"],
 ): Parameters<typeof readEntities.handler>[0] =>
-  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture only provides fields used by the safe handler and read handler
-  ({
+  asTestRaw<Parameters<typeof readEntities.handler>[0]>({
     workspaceId,
     user: { id: userId },
     session: { activeOrganizationId: organizationId },
@@ -28,7 +28,7 @@ const createContext = (
     safeDb: async () => Result.ok([]),
     request: new Request("https://example.test/v1/entities/query"),
     route: "/v1/entities/:workspaceId/query",
-  }) as unknown as Parameters<typeof readEntities.handler>[0];
+  });
 
 describe("entity read handler search", () => {
   beforeEach(() => {
@@ -37,7 +37,6 @@ describe("entity read handler search", () => {
       Result.ok({
         cursorValuesByEntityId: new Map(),
         entities: [],
-        totalCount: 0,
       }),
     );
   });
@@ -47,8 +46,7 @@ describe("entity read handler search", () => {
       createContext({
         filters: [],
         sorts: [],
-        page: 1,
-        pageSize: 50,
+        limit: 50,
         search: "closing binder",
         fieldMode: "visible",
         fieldIds: [],
@@ -71,8 +69,7 @@ describe("entity read handler search", () => {
       createContext({
         filters: [],
         sorts: [],
-        page: 1,
-        pageSize: 50,
+        limit: 50,
         fieldMode: "visible",
         fieldIds: [],
         previewableForAi: true,
@@ -89,13 +86,12 @@ describe("entity read handler search", () => {
     );
   });
 
-  test("keeps legacy page-only pagination working without a cursor", async () => {
+  test("uses cursor pagination without legacy offset", async () => {
     await readEntities.handler(
       createContext({
         filters: [],
         sorts: [],
-        page: 3,
-        pageSize: 25,
+        limit: 25,
         fieldMode: "visible",
         fieldIds: [],
       }),
@@ -105,7 +101,6 @@ describe("entity read handler search", () => {
       expect.objectContaining({
         cursor: null,
         limit: 26,
-        offset: 50,
       }),
     );
   });
@@ -128,7 +123,6 @@ describe("entity read handler search", () => {
         search: "closing binder",
         limit: LIMITS.entitiesCount,
         excludedKinds: ["task"],
-        includeTotalCount: false,
       }),
     );
   });

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -17,10 +17,9 @@ import { tViewSortSchema } from "@/api/lib/views-schema";
 const readEntitiesBodySchema = t.Object({
   filters: t.Optional(t.Array(tConditionNode)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
-  page: t.Optional(t.Integer({ minimum: 1 })),
   cursor: t.Optional(t.String()),
   search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
-  pageSize: t.Optional(
+  limit: t.Optional(
     t.Integer({
       minimum: 1,
       maximum: LIMITS.entitiesPageSizeMax,
@@ -60,16 +59,12 @@ export const createReadEntitiesHandler = (
       body,
       user: currentUser,
     }) {
-      const page = body.page ?? 1;
-      const pageSize = body.pageSize ?? LIMITS.entitiesPageSizeDefault;
-      const legacyPageOffset =
-        page > 1 && body.cursor === undefined ? (page - 1) * pageSize : 0;
-
       const cursorResult = decodeEntitiesWindowCursor(body.cursor);
       if (Result.isError(cursorResult)) {
         return Result.err(cursorResult.error);
       }
 
+      const limit = body.limit ?? LIMITS.entitiesPageSizeDefault;
       const result = yield* Result.await(
         queryEntitiesImpl({
           safeDb,
@@ -80,33 +75,25 @@ export const createReadEntitiesHandler = (
           sorts: body.sorts ?? [],
           ...(body.search !== undefined && { search: body.search }),
           cursor: cursorResult.value,
-          offset: legacyPageOffset,
-          limit: pageSize + 1,
+          limit: limit + 1,
           fieldMode: body.fieldMode ?? "full",
           fieldIds: body.fieldIds ?? [],
           excludedKinds: body.excludedKinds ?? [],
           previewableForAi: body.previewableForAi ?? false,
-          includeTotalCount: true,
         }),
       );
 
-      const cursorPage = createCursorPage({
-        rows: result.entities,
-        limit: pageSize,
-        cursorForItem: (item) =>
-          encodeEntitiesWindowCursor(
-            result.cursorValuesByEntityId.get(item.entityId) ??
-              panic("Missing cursor values for entity page item"),
-          ),
-      });
-
-      return Result.ok({
-        entities: cursorPage.items,
-        nextCursor: cursorPage.nextCursor,
-        totalCount: result.totalCount ?? 0,
-        page,
-        pageSize,
-      });
+      return Result.ok(
+        createCursorPage({
+          rows: result.entities,
+          limit,
+          cursorForItem: (item) =>
+            encodeEntitiesWindowCursor(
+              result.cursorValuesByEntityId.get(item.entityId) ??
+                panic("Missing cursor values for entity page item"),
+            ),
+        }),
+      );
     },
   );
 

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -27,7 +27,9 @@ import readFilesystemTree from "@/api/handlers/entities/read-filesystem-tree";
 import readGroupCounts from "@/api/handlers/entities/read-group-counts";
 import readKanbanGroup from "@/api/handlers/entities/read-kanban-group";
 import readPropertyFacets from "@/api/handlers/entities/read-property-facets";
-import readEntitySummaries from "@/api/handlers/entities/read-summaries";
+import readEntitySummaries, {
+  readEntitySummariesCount,
+} from "@/api/handlers/entities/read-summaries";
 import readVersionById from "@/api/handlers/entities/read-version-by-id";
 import readVersions from "@/api/handlers/entities/read-versions";
 import readEntitiesWindow from "@/api/handlers/entities/read-window";
@@ -199,6 +201,10 @@ export const entitiesRoute = new Elysia({
   .post("/check-stamp", checkStamp.handler, {
     body: checkStamp.config.body,
     permissions: checkStamp.config.permissions,
+  })
+  .get("/summaries/count", readEntitySummariesCount.handler, {
+    permissions: readEntitySummariesCount.config.permissions,
+    query: readEntitySummariesCount.config.query,
   })
   .get("/summaries", readEntitySummaries.handler, {
     permissions: readEntitySummaries.config.permissions,

--- a/apps/api/src/handlers/reports/build-report-data.ts
+++ b/apps/api/src/handlers/reports/build-report-data.ts
@@ -520,7 +520,6 @@ export const buildReportData = async ({
         fieldMode: "visible",
         fieldIds,
         excludedKinds: ["folder", "task"],
-        includeTotalCount: false,
       }),
     );
 

--- a/apps/api/src/handlers/reports/export-view.ts
+++ b/apps/api/src/handlers/reports/export-view.ts
@@ -3,8 +3,8 @@
  *
  * Validates the source view (must be a table view in this workspace), the
  * requested template (a deployment built-in or a stored `report`-kind org
- * template), and the row cap EARLY (a cheap indexed count) so an oversized view
- * rejects before any job is queued. Inserts a `report_exports` row, records an
+ * template), and the row cap early so an oversized view rejects before any job
+ * is queued. Inserts a `report_exports` row, records an
  * audit event, enqueues the background job, and returns the export id for the
  * frontend to poll.
  *
@@ -28,6 +28,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
 import { parseViewLayout } from "@/api/lib/views-schema";
 
 const templateRefSchema = t.Union([
@@ -129,9 +130,8 @@ const exportViewReport = createSafeHandler(
       }
     }
 
-    // Cheap early row-cap check: an indexed count over the view's filters, no
-    // fields loaded. Exceeding the cap is a typed error, never a truncated job.
-    const countResult = yield* Result.await(
+    // +1 so a view exactly one over the cap is detected, never truncated.
+    const cappedRowsResult = yield* Result.await(
       queryEntities({
         safeDb,
         workspaceId,
@@ -139,17 +139,13 @@ const exportViewReport = createSafeHandler(
         currentOrganizationId: organizationId,
         filters: layout.filters,
         sorts: layout.sorts,
-        limit: 1,
+        limit: LIMITS.reportExportMaxRows + 1,
         fieldMode: "visible",
         fieldIds: [],
         excludedKinds: ["folder", "task"],
-        includeTotalCount: true,
       }),
     );
-    if (
-      countResult.totalCount !== null &&
-      isReportRowCountOverCap(countResult.totalCount)
-    ) {
+    if (isReportRowCountOverCap(cappedRowsResult.entities.length)) {
       return Result.err(
         new HandlerError({
           status: 400,

--- a/apps/api/src/handlers/views/table-export.ts
+++ b/apps/api/src/handlers/views/table-export.ts
@@ -792,7 +792,6 @@ const exportTableView = createSafeHandler(
         fieldMode: "visible",
         fieldIds,
         excludedKinds: ["folder", "task"],
-        includeTotalCount: false,
       }),
     );
 

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -15,7 +15,6 @@
 
 import {
   Suspense,
-  useEffect,
   useEffectEvent,
   useLayoutEffect,
   useMemo,
@@ -408,14 +407,12 @@ const prepareOperations = (
 // requiring `severity`/`area`, so old stored approvals can still
 // reach this code with the fields missing. Type narrowing says
 // they're always present; the runtime check is for legacy data.
-/* oxlint-disable typescript/no-unnecessary-condition -- legacy stored approvals predate the severity/area schema; runtime fallback for old data */
-const inputOperationSeverity = (
-  operation: ToolInputOperation,
-): FolioAIEditSeverity | "unspecified" => operation.severity ?? "unspecified";
+const inputOperationSeverity = (operation: {
+  severity?: FolioAIEditSeverity | undefined;
+}): FolioAIEditSeverity | "unspecified" => operation.severity ?? "unspecified";
 
-const inputOperationArea = (operation: ToolInputOperation): string =>
+const inputOperationArea = (operation: { area?: string | undefined }): string =>
   operation.area ?? REVIEW_UNSPECIFIED_AREA;
-/* oxlint-enable typescript/no-unnecessary-condition */
 
 type SnapshotBlock = {
   id: string;
@@ -1102,8 +1099,7 @@ const FileChatOverlayInner = ({
     },
   );
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (open AI-key gate on mount/dep change), move into handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     openIfAIUnavailable();
   }, [openIfAIUnavailable]);
 

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -13,7 +13,7 @@
  */
 
 import "@/components/chat-editor.css";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type {
   ComponentProps,
   KeyboardEvent as ReactKeyboardEvent,
@@ -61,6 +61,7 @@ import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachmen
 import { ComposerPlusMenu } from "@/components/chat/composer-plus-menu";
 import { ComposerVeil } from "@/components/chat/composer-veil";
 import { PromptEditorContent } from "@/components/prompt-editor";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePulse } from "@/hooks/use-pulse";
 import type { TranslationKey } from "@/i18n/types";
 import { isValueTypeKind, VALUE_TYPE_META } from "@/lib/value-types";
@@ -637,8 +638,7 @@ export function PromptBar(props: PromptBarProps) {
   // 1.4s ring; restart when the seq advances.
   const { isPulsing: attention, pulse: triggerAttention } = usePulse(1400);
   const lastAttentionSeq = useRef(attentionPulseSeq);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (attention-pulse seq advance → fire one-shot glow); move into the pulse trigger source
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (
       attentionPulseSeq === undefined ||
       attentionPulseSeq === lastAttentionSeq.current

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -636,7 +636,6 @@ export const useChatEditor = ({
         filters,
         sorts,
         ...(search && { search }),
-        page: 1,
         pageSize: CHAT_MENTION_ENTITY_RESULT_LIMIT,
       });
       if (pendingWorkspaceEntitySearchRef.current) {
@@ -719,7 +718,6 @@ export const useChatEditor = ({
         filters,
         sorts,
         ...(search && { search }),
-        page: 1,
         pageSize: CHAT_MENTION_ENTITY_RESULT_LIMIT,
       });
       const cachedData = queryClient.getQueryData<EntityMentionPage>(

--- a/apps/web/src/components/inspector/entity-metadata-panel.tsx
+++ b/apps/web/src/components/inspector/entity-metadata-panel.tsx
@@ -1,7 +1,6 @@
 import type { PropsWithChildren } from "react";
 import {
   useCallback,
-  useEffect,
   useOptimistic,
   useRef,
   useState,
@@ -20,6 +19,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { MetadataPanelSkeleton } from "@/components/inspector/file-facets";
 import { QuerySuspenseBoundary } from "@/components/query-suspense-boundary";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";
 import type {
@@ -205,8 +205,7 @@ const EntityMetadataContent = ({
     ]);
   }, [queryClient, workspaceId]);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (workflow-finished refetch), move into handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (isWorkflowRunning) {
       sawWorkflowRunning.current = true;
       return;

--- a/apps/web/src/components/inspector/file-facets.tsx
+++ b/apps/web/src/components/inspector/file-facets.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
@@ -9,6 +9,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { useReviewStore } from "@/components/ai-suggestions/review-store";
 import { FacetBar } from "@/components/inspector/inspector-facet-bar";
 import type { FileTab } from "@/components/inspector/inspector-store";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePlaybooksPreviewEnabled } from "@/hooks/use-playbooks-preview";
 import { DOCX_MIME } from "@/lib/consts";
 import { entityVersionsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entity-versions";
@@ -58,8 +59,7 @@ export const FullViewPreviewGuard = ({
   flashMinimize,
 }: FullViewPreviewGuardProps) => {
   const t = useTranslations();
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (stale "preview" facet -> swap facet + toast + flash); move into the full-view entry handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (facet !== "preview") {
       return;
     }

--- a/apps/web/src/components/inspector/suggestions-facet.tsx
+++ b/apps/web/src/components/inspector/suggestions-facet.tsx
@@ -31,6 +31,7 @@ import {
   useActiveDocxStore,
 } from "@/components/ai-suggestions/active-docx-store";
 import { ReviewPanel } from "@/components/ai-suggestions/review-panel";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 
 type SuggestionsFacetProps = {
   entityId: string;
@@ -94,8 +95,7 @@ export const SuggestionsFacet = ({
     hasDispatchedRef.current = false;
   }, [entityId, fileFieldId]);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay dispatch of onMissingEditor callback; move into handler/derived guard
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (registration !== undefined) {
       hasDispatchedRef.current = false;
       return;

--- a/apps/web/src/components/inspector/use-docx-tab-edit-session.ts
+++ b/apps/web/src/components/inspector/use-docx-tab-edit-session.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { useTranslations } from "use-intl";
 
@@ -10,7 +10,7 @@ import type {
   FileTab,
   InspectorTab,
 } from "@/components/inspector/inspector-store";
-import { useMountEffect } from "@/hooks/use-effect";
+import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { DOCX_MIME } from "@/lib/consts";
 import type { DocxBrowserEditorActions } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor";
 import { getDocxEditBlockReason } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.logic";
@@ -94,8 +94,7 @@ export const useDocxTabEditSession = ({
 
   const pendingDocxEditTabId = useInspectorStore((s) => s.pendingDocxEditTabId);
   const clearDocxEditRequest = useInspectorStore((s) => s.clearDocxEditRequest);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (pendingDocxEditTabId store flag fires handleStartDocxEdit); move into the action that sets the flag
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (pendingDocxEditTabId === null) {
       return;
     }
@@ -119,7 +118,6 @@ export const useDocxTabEditSession = ({
     if (!compatibility) {
       return;
     }
-    // eslint-disable-next-line react/react-compiler -- store-flag relay: handleStartDocxEdit's setState reacts to the pendingDocxEditTabId store flag AND must wait for the tab's async compatibility probe to land, so it cannot fold into the distant requestDocxEdit() call-site or a store-subscription callback
     void handleStartDocxEdit(target.id);
     clearDocxEditRequest();
   }, [

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState, useTransition } from "react";
+import { useEffectEvent, useState, useTransition } from "react";
 
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
 import { Navigate } from "@tanstack/react-router";
@@ -11,7 +11,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { isNetworkError } from "@/components/route-components.logic";
 import { StellaMark } from "@/components/stella-mark";
-import { useMountEffect } from "@/hooks/use-effect";
+import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useSignOut } from "@/hooks/use-sign-out";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { isMemberError, isUnauthorizedError } from "@/lib/errors";
@@ -53,11 +53,9 @@ const useNetworkRetry = ({
     () => networkError && networkRetryCount < AUTO_RETRY_LIMIT,
   );
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- effect chain mixing setState with a scheduled retry timer; move the auto-retry into an event-driven flow
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!networkError) {
       networkRetryCount = 0;
-      // eslint-disable-next-line react/react-compiler -- effect synchronizes retry state with a scheduled setTimeout side effect; not derivable in render
       setIsAutoRetrying(false);
       return undefined;
     }
@@ -125,8 +123,7 @@ export const DefaultErrorComponent = ({
   // Capture errors that aren't auth/cancel/network noise once,
   // plus network errors once retries are exhausted. Keeping the
   // two cases in one effect avoids the prior staggered chain.
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- telemetry-only side effect (analytics.captureError) reacting to error state; route through analytics at the boundary
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (showUnauthorizedError || isCancelledError) {
       return;
     }

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef } from "react";
+import { Fragment, useRef } from "react";
 import type { ReactNode } from "react";
 
 import { useTranslations } from "use-intl";
@@ -729,8 +729,7 @@ export const DecisionText = ({
     query: searchQuery,
   });
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- reports derived match count to a parent callback prop; lift the count to the parent
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     onMatchCountChange?.(searchResults.matchCount);
   }, [onMatchCountChange, searchResults.matchCount]);
 

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { Loader2Icon, SparklesIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -18,6 +18,7 @@ import {
 } from "@/features/case-law/components/case-viewer/analysis/types";
 import { useDecisionAnalysis } from "@/features/case-law/components/case-viewer/analysis/use-decision-analysis";
 import { DecisionText } from "@/features/case-law/components/case-viewer/decision-text";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useCaseSearchStore } from "@/lib/case-search-store";
 import type { SafeId } from "@/lib/safe-id";
 
@@ -191,16 +192,14 @@ export function DecisionWorkspace(props: DecisionWorkspaceProps) {
     return items;
   });
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (auto-kick AI analysis on derived idle state), move into handler / data-loading flow
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (aiEnabled && ast && analysisState.status === "idle") {
       void generate();
     }
   }, [aiEnabled, analysisState.status, ast, generate]);
 
   const reset = useCaseSearchStore((s) => s.reset);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- reset-on-id store reset + derived search state, lift to key prop
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     reset();
     if (initialSearchQuery) {
       setSearchQuery(initialSearchQuery);

--- a/apps/web/src/routes/_protected.chat/-hooks/use-workspace-chat-mention-registration.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-workspace-chat-mention-registration.ts
@@ -62,7 +62,6 @@ export const useWorkspaceChatMentionRegistration = (
         filters,
         sorts,
         ...(search && { search }),
-        page: 1,
         pageSize: CHAT_MENTION_ENTITY_RESULT_LIMIT,
       });
     },

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useEffectEvent, useMemo, useRef, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 
 import {
@@ -34,6 +34,7 @@ import { MatterIcon } from "@/components/matter-icon";
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { StellaMark } from "@/components/stella-mark";
 import Tooltip from "@/components/tooltip";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { ChatAnonymizationLayer } from "@/lib/anonymize/use-chat-anonymization-layer";
@@ -176,8 +177,7 @@ function ChatIndex() {
   });
   const seededDraftRef = useRef<string | null>(null);
   const seedingDraftRef = useRef<string | null>(null);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (derived preference/draft-meta flags fire the seedDraftWebSearch mutation); move into the mutation flow
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     const threadId = threadIdRef.current;
     if (
       seededDraftRef.current === threadId ||

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
@@ -14,7 +14,6 @@
 
 import {
   Suspense,
-  useEffect,
   useEffectEvent,
   useLayoutEffect,
   useMemo,
@@ -634,8 +633,7 @@ const TemplateStudioChatInner = ({
   });
   const { ensureAIAvailable, openIfAIUnavailable } = useAIKeyGate();
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (open AI-key gate on mount/dep change), move into handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     openIfAIUnavailable();
   }, [openIfAIUnavailable]);
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -430,8 +430,7 @@ function RouteComponentInner({
         )
       : undefined;
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- auto-advances activeFieldId + navigate when a newer version appears via background query refetch; this reacts to async server-state changing (no user version-switch event to relay into) and runs setState/navigate post-commit
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (
       latestFileFieldForProperty === undefined ||
       latestFileFieldForProperty.id === fieldId

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-name-map.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-name-map.ts
@@ -14,7 +14,7 @@ export const useMatterNameMap = (workspaceId: string) => {
 
   const map = new Map<string, string>();
   for (const summary of summaries) {
-    map.set(summary.id, summary.name);
+    map.set(summary.id, summary.name ?? "");
   }
   return map;
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useState } from "react";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
@@ -25,6 +25,7 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { toSafeId } from "@/lib/safe-id";
 import type {
   PropertyDependency,
@@ -333,8 +334,7 @@ const PropertyComposerBody = ({
   // null-render guard happens after all hooks have run so the order
   // stays stable.
   const missingForEdit = isEditMode && !editingProperty;
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (missing-property condition → onClose), drive the close from the lookup/render guard instead
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (missingForEdit) {
       onClose();
     }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -256,14 +256,12 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   // the allowlist changes, instead of waiting for the next 2s
   // heartbeat tick.
   const runDetectionRef = useRef<(() => void) | null>(null);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- timer/wasm-pipeline subscription that also drives React + store state (setDetectedAnonymizationTerms, markPipelineStarted); candidate for useExternalSyncEffect after the state writes are factored out
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     const view = editorViewForAnonymization;
     if (!view || !isAnonymizationActive) {
       // Facet not on screen: skip the wasm pipeline entirely and
       // drop any previously detected terms so a re-mount starts
       // from a clean slate.
-      // eslint-disable-next-line react/react-compiler -- reset tied to the wasm-detection subscription lifecycle (facet off-screen): clears detected terms as part of tearing down the external pipeline
       setDetectedAnonymizationTerms([]);
       return undefined;
     }
@@ -410,8 +408,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   // sees fresh exclusions without re-installing its heartbeat on
   // every keystroke / mutation.
   const excludedCanonicalsRef = useRef<readonly string[]>([]);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived state synced into a ref plus an event-relay poke of runDetectionRef; compute in render / move into the allowlist mutation handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     // eslint-disable-next-line react/react-compiler -- not a state mutation: assigns a freshly-spread copy to a latest-ref mirror the polling effect reads; the compiler's immutability heuristic misfires on ref writes inside effects
     excludedCanonicalsRef.current = [...excludedCanonicalsSet];
     // Kick the detection right away so worker-found terms that
@@ -697,8 +694,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     t,
   ]);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- reset-on-id, clears refs + setCompatibilityState when the edit target changes; lift to a key prop
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (optimisticPreviewRef.current?.fieldId === fieldId) {
       return;
     }
@@ -775,8 +771,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     state.status,
   ]);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay, fires the queued requestEditMode once compatibility/state resolve; move into the resolution callback
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!pendingEditRequestRef.current) {
       return;
     }
@@ -794,8 +789,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
 
   // Auto-open when this component is used as a direct editor, or when the
   // preview is explicitly unlocked from the shell toolbar.
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay, opens the edit session when preconditions resolve; move into the resolution/unlock callbacks
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!isEditing || previewFile === null || didOpenRef.current) {
       return;
     }
@@ -827,8 +821,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     state.status,
   ]);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived ref bookkeeping from the isEditing prop; compute in render / handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!isEditing) {
       didOpenRef.current = false;
     }
@@ -840,8 +833,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   useDocxWheelZoom(containerRef, editorRef);
   useDocxBlockScroll({ editorRef, fieldId });
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay, surfaces an error toast + onClose/resetError on error state; move into the failure path
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (
       state.status !== "error" ||
       (state.source !== "open" && state.source !== "download") ||
@@ -863,8 +855,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   const isUnlocked = isCollaborativeEditing || state.status === "editing";
   const wasUnlockedRef = useRef(false);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay, notifies the parent onUnlockedChange callback when isUnlocked changes; lift state to the parent or move into the lock/unlock handlers
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     onUnlockedChange?.(isUnlocked);
   }, [isUnlocked, onUnlockedChange]);
 
@@ -909,11 +900,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       .updateEditable(entityId, fieldId, isUnlocked, token);
   }, [entityId, fieldId, isUnlocked]);
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- mixes a DOM focus/rAF imperative with setAutosaveStatus + ref bookkeeping on first unlock; candidate for useExternalSyncEffect once the state write is factored out
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!isUnlocked) {
       wasUnlockedRef.current = false;
-      // eslint-disable-next-line react/react-compiler -- resets autosave status as part of the unlock-state subscription (mixes DOM focus/rAF); syncs the indicator when the doc relocks
       setAutosaveStatus("synced");
       return undefined;
     }
@@ -1365,10 +1354,8 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     return undefined;
   })();
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived state, resets editorMode from the isUnlocked flag; compute in render
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!isUnlocked) {
-      // eslint-disable-next-line react/react-compiler -- resets editor mode to "editing" when the doc relocks so the next unlock starts clean; effect timing preserved deliberately in this editor glue
       setEditorMode("editing");
     }
   }, [isUnlocked]);
@@ -1613,9 +1600,7 @@ const useDocxBrowserCollaboration = ({
     },
     workspaceId,
   });
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived/reset state, resyncs requestState from props (initiallyRequested, targetKey); compute in render / lift to a key prop
-  useEffect(() => {
-    // eslint-disable-next-line react/react-compiler -- resyncs the collaboration request state when the edit target or initial-request prop changes; kept as an effect to preserve the resync timing in this collaboration glue
+  useExternalSyncEffect(() => {
     setRequestState({ requested: initiallyRequested, targetKey });
   }, [initiallyRequested, targetKey]);
   const collaborationSession =

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -235,13 +235,24 @@ export const ExistingFileOrganizerDialog = ({
       return;
     }
 
+    if (suggestionStatus === "generating") {
+      return;
+    }
+
     // Show the cheap, deterministic local suggestions immediately and
     // stay actionable. The expensive AI call only runs from the explicit
     // Generate/Regenerate button handler below.
     setRows(initialRows);
     setDeleteFolders([]);
     setSuggestionStatus("ready");
-  }, [cachedSuggestions, files, initialRows, open, requestKey]);
+  }, [
+    cachedSuggestions,
+    files,
+    initialRows,
+    open,
+    requestKey,
+    suggestionStatus,
+  ]);
 
   const updateRow = (
     id: string,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useEffectEvent, useMemo, useRef, useState } from "react";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -136,7 +136,6 @@ export const ExistingFileOrganizerDialog = ({
   const [rows, setRows] = useState<ExistingOrganizerRow[]>([]);
   const [suggestionStatus, setSuggestionStatus] =
     useState<SuggestionStatus>("idle");
-  const [retryNonce, setRetryNonce] = useState(0);
   const [deleteFolders, setDeleteFolders] = useState<
     FolderDeletionSuggestion[]
   >([]);
@@ -203,137 +202,46 @@ export const ExistingFileOrganizerDialog = ({
       }),
     [existingFolders, files],
   );
+  const suggestionRequestFolders = useMemo(
+    () =>
+      existingFolders.map((folder) => ({
+        entityId: toSafeId<"entity">(folder.entityId),
+        name: folder.name,
+        path: folder.path,
+      })),
+    [existingFolders],
+  );
+  const suggestionRequestFiles = useMemo(
+    () =>
+      files.map((file) => ({
+        entityId: toSafeId<"entity">(file.entityId),
+        originalName: file.originalName,
+      })),
+    [files],
+  );
 
   // The toolbar keeps this dialog mounted and only toggles `open`, so reset the
-  // explicit-AI trigger on close. Reopening then starts from the local-first
-  // state instead of silently re-firing a prior AI request; cached AI results
-  // for the same files stay keyed by requestKey and are reshown without a call.
+  // editable rows on each open. Cached AI results for the same files are reshown
+  // without another call.
   useExternalSyncEffect(() => {
-    if (!open) {
-      setRetryNonce(0);
-    }
-  }, [open]);
-
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- data fetch + setState; migrate to TanStack Query
-  useEffect(() => {
     if (!open || files.length === 0) {
-      return undefined;
+      return;
     }
 
     if (cachedSuggestions?.key === requestKey) {
-      // eslint-disable-next-line react/react-compiler -- data-fetch effect seeding local rows from the AI-suggestion cache keyed by requestKey; a TanStack Query migration is the tracked follow-up
       setRows(cachedSuggestions.rows);
       setDeleteFolders(cachedSuggestions.deleteFolders);
       setSuggestionStatus("ready");
-      return undefined;
+      return;
     }
 
     // Show the cheap, deterministic local suggestions immediately and
-    // stay actionable. The expensive AI call only runs once the user
-    // explicitly asks for it (retryNonce bumps past 0).
-    if (retryNonce === 0) {
-      setRows(initialRows);
-      setDeleteFolders([]);
-      setSuggestionStatus("ready");
-      return undefined;
-    }
-
+    // stay actionable. The expensive AI call only runs from the explicit
+    // Generate/Regenerate button handler below.
     setRows(initialRows);
     setDeleteFolders([]);
-    let cancelled = false;
-    const fetchSuggestions = async () => {
-      setSuggestionStatus("generating");
-      const { locale: requestLocale, userInstructions: trimmedInstructions } =
-        getSuggestionRequestContext();
-      const response = await api
-        .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        ["organize-suggestions"].post({
-          existingFolders: existingFolders.map((folder) => ({
-            entityId: toSafeId<"entity">(folder.entityId),
-            name: folder.name,
-            path: folder.path,
-          })),
-          files: files.map((file) => ({
-            entityId: toSafeId<"entity">(file.entityId),
-            originalName: file.originalName,
-          })),
-          locale: requestLocale,
-          ...(trimmedInstructions.length > 0
-            ? { userInstructions: trimmedInstructions }
-            : {}),
-        });
-
-      if (response.error) {
-        analytics.captureError(toAPIError(response.error));
-        if (!cancelled) {
-          setSuggestionStatus("failed");
-        }
-        return;
-      }
-
-      if (cancelled) {
-        return;
-      }
-
-      const aiSuggestions = new Map(
-        response.data.suggestions.map((suggestion) => [
-          suggestion.entityId,
-          suggestion,
-        ]),
-      );
-
-      const nextRows = initialRows.map((row) => {
-        const suggestion = aiSuggestions.get(row.entityId);
-        if (!suggestion) {
-          return row;
-        }
-        return {
-          ...row,
-          detectedDate: suggestion.detectedDate,
-          documentType: suggestion.documentType,
-          folderPath: suggestion.folderPath,
-          suggestedName: suggestion.suggestedName,
-        };
-      });
-
-      setRows(nextRows);
-      const nextDeleteFolders = response.data.deleteFolders.map((folder) => ({
-        entityId: folder.entityId,
-        folderPath: folder.folderPath,
-        reason: folder.reason,
-        selected: true,
-      }));
-      setDeleteFolders(nextDeleteFolders);
-      setCachedSuggestions({
-        key: requestKey,
-        rows: nextRows,
-        deleteFolders: nextDeleteFolders,
-      });
-      setRetryNonce(0);
-      setSuggestionStatus("ready");
-    };
-
-    fetchSuggestions().catch((error: unknown) => {
-      analytics.captureError(error);
-      if (!cancelled) {
-        setSuggestionStatus("failed");
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    analytics,
-    cachedSuggestions,
-    existingFolders,
-    files,
-    initialRows,
-    open,
-    requestKey,
-    retryNonce,
-    workspaceId,
-  ]);
+    setSuggestionStatus("ready");
+  }, [cachedSuggestions, files, initialRows, open, requestKey]);
 
   const updateRow = (
     id: string,
@@ -592,9 +500,87 @@ export const ExistingFileOrganizerDialog = ({
       });
   };
 
-  const requestAiSuggestions = () => {
+  const requestAiSuggestions = async () => {
     setCachedSuggestions(null);
-    setRetryNonce((current) => current + 1);
+    setRows(initialRows);
+    setDeleteFolders([]);
+    setSuggestionStatus("generating");
+
+    try {
+      const { locale: requestLocale, userInstructions: trimmedInstructions } =
+        getSuggestionRequestContext();
+      const data = await queryClient.fetchQuery({
+        queryKey: [
+          ...entitiesKeys.all(workspaceId),
+          "organize-suggestions",
+          requestKey,
+          suggestionRequestFolders,
+          suggestionRequestFiles,
+          requestLocale,
+          trimmedInstructions,
+        ],
+        queryFn: async ({ signal }) => {
+          const response = await api
+            .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
+            ["organize-suggestions"].post(
+              {
+                existingFolders: suggestionRequestFolders,
+                files: suggestionRequestFiles,
+                locale: requestLocale,
+                ...(trimmedInstructions.length > 0
+                  ? { userInstructions: trimmedInstructions }
+                  : {}),
+              },
+              { fetch: { signal } },
+            );
+
+          if (response.error) {
+            throw toAPIError(response.error);
+          }
+
+          return response.data;
+        },
+      });
+
+      const aiSuggestions = new Map(
+        data.suggestions.map((suggestion) => [suggestion.entityId, suggestion]),
+      );
+      const nextRows = initialRows.map((row) => {
+        const suggestion = aiSuggestions.get(row.entityId);
+        if (!suggestion) {
+          return row;
+        }
+        return {
+          detectedDate: suggestion.detectedDate,
+          documentType: suggestion.documentType,
+          entityId: row.entityId,
+          folderPath: suggestion.folderPath,
+          id: row.id,
+          mimeType: row.mimeType,
+          originalName: row.originalName,
+          parentId: row.parentId,
+          suggestedName: suggestion.suggestedName,
+        };
+      });
+      const nextDeleteFolders = data.deleteFolders.map((folder) => ({
+        entityId: folder.entityId,
+        folderPath: folder.folderPath,
+        reason: folder.reason,
+        selected: true,
+      }));
+
+      setRows(nextRows);
+      setDeleteFolders(nextDeleteFolders);
+      setCachedSuggestions({
+        key: requestKey,
+        rows: nextRows,
+        deleteFolders: nextDeleteFolders,
+      });
+      setSuggestionStatus("ready");
+    } catch (error) {
+      analytics.captureError(error);
+      setSuggestionStatus("failed");
+    }
   };
   const hasAiSuggestions = cachedSuggestions?.key === requestKey;
   const interactionsDisabled = isGeneratingSuggestions;
@@ -624,12 +610,19 @@ export const ExistingFileOrganizerDialog = ({
                 window.localStorage.setItem(userInstructionsKey, value);
               }
             }}
-            onRegenerate={requestAiSuggestions}
+            onRegenerate={() => {
+              void requestAiSuggestions();
+            }}
             onToggle={() => setShowInstructions((current) => !current)}
             value={userInstructions}
           />
           {suggestionStatus === "failed" && (
-            <FailureBanner disabled={false} onRetry={requestAiSuggestions} />
+            <FailureBanner
+              disabled={false}
+              onRetry={() => {
+                void requestAiSuggestions();
+              }}
+            />
           )}
           {isGeneratingSuggestions ? (
             <OrganizerSkeleton />
@@ -665,7 +658,9 @@ export const ExistingFileOrganizerDialog = ({
             <Button
               className="me-auto"
               disabled={isGeneratingSuggestions || rows.length === 0}
-              onClick={requestAiSuggestions}
+              onClick={() => {
+                void requestAiSuggestions();
+              }}
               type="button"
               variant="outline"
             >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
@@ -22,6 +22,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { MatterNumberHint } from "@/components/matter-number-hint";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { APIError } from "@/lib/errors";
@@ -73,8 +74,7 @@ export const MatterMetadataPanel = ({
   const canDeleteWorkspace = usePermissions({ workspace: ["delete"] });
   const updateWorkspace = useUpdateWorkspace();
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived state from query, seeds/resyncs form fields from workspace data gated on dirty flags + workspaceId; candidate for query-data initialization with a key prop for the reset-on-id seed
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!workspace) {
       return;
     }
@@ -90,7 +90,6 @@ export const MatterMetadataPanel = ({
     }
 
     if (!nameDirty) {
-      // eslint-disable-next-line react/react-compiler -- resyncs the form field from server data, gated on the dirty flag; not pure-derivable since nameValue is also user-edited
       setNameValue(workspace.name);
     }
     if (!referenceDirty) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -587,8 +587,7 @@ const GroupSection = ({
   // Publish this section's rows to the parent so the row selection resolves
   // across every group; clear them when the section unmounts.
   const groupKey = groupKeyFor(group.value);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived state (this section's rows) synced up to the parent so the shared selection resolves across groups
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     reportGroupTreeData(groupKey, treeData);
     return () => reportGroupTreeData(groupKey, NO_ROWS);
   }, [groupKey, treeData, reportGroupTreeData]);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
@@ -116,10 +116,8 @@ export const TaskDetailPanel = ({
 
   // Auto-assign current user and focus name for new tasks
   const didAutoAssign = useRef(false);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay + data mutation, opens edit and auto-assigns the user on new task; move into the task-create flow
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (isNewTask && task) {
-      // eslint-disable-next-line react/react-compiler -- event-relay reacting to a freshly-created task's data arriving (opens rename, auto-assigns); the creation handler that owns this transition lives in a different flow
       setEditNameValue("");
       setIsEditingName(true);
       clearNewFlag(taskId);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-selected-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-selected-entities.ts
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import type { TableTreeNode } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import { useTableStore } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 
@@ -21,8 +20,7 @@ export const useSyncSelectedEntities = ({
     (state) => state.setSelectedEntities,
   );
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- derived state (resolves row selection to entities) synced into the table store; compute in render or a selector
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     const selected = rowSelection ?? {};
     const result: TableTreeNode[] = [];
     const visit = (nodes: TableTreeNode[] | undefined) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
@@ -11,7 +11,6 @@ export type EntitiesPageKey = {
   workspaceId: string;
   filters: ConditionNode[];
   sorts: ViewSort[];
-  page: number;
   search?: string;
   pageSize?: number;
   fieldMode?: EntitiesFieldMode;
@@ -35,7 +34,6 @@ export type KanbanGroupKey = EntitiesWindowKey & {
   // The property's option values. Sent by the grouped table so the uncategorized
   // group folds in stale (out-of-options) cells; omitted by the kanban board.
   optionValues?: string[];
-  includeTotalCount?: boolean;
 };
 
 export type GroupCountsKey = {
@@ -58,11 +56,10 @@ export const normalizeVisibleFieldIds = (
 
 export const entitiesKeys = {
   all: (workspaceId: string) => ["entities", workspaceId],
-  page: ({
+  sample: ({
     workspaceId,
     filters,
     sorts,
-    page,
     search,
     pageSize,
     fieldMode,
@@ -76,7 +73,6 @@ export const entitiesKeys = {
       {
         filters,
         sorts,
-        page,
         ...(search?.trim() && { search: search.trim() }),
         pageSize: pageSize ?? DEFAULT_ENTITY_VIEW_PAGE_SIZE,
         fieldMode: normalizedFieldMode,
@@ -154,7 +150,6 @@ export const entitiesKeys = {
     groupByPropertyId,
     groupValue,
     optionValues,
-    includeTotalCount,
   }: KanbanGroupKey) => {
     const normalizedFieldMode = fieldMode ?? "full";
     return [
@@ -173,7 +168,6 @@ export const entitiesKeys = {
         groupByPropertyId,
         groupValue,
         optionValues: optionValues?.toSorted(),
-        includeTotalCount: includeTotalCount ?? false,
       },
     ];
   },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
@@ -51,19 +51,17 @@ describe("entity query field selection", () => {
   });
 
   test("keeps field selection in the cache identity only for visible mode", () => {
-    const visibleKey = entitiesKeys.page({
+    const visibleKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       fieldMode: "visible",
       fieldIds: ["status", "due", "status"],
     });
-    const fullKey = entitiesKeys.page({
+    const fullKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       fieldMode: "full",
       fieldIds: ["status"],
     });
@@ -78,19 +76,17 @@ describe("entity query field selection", () => {
     });
   });
 
-  test("keeps search in the page cache identity", () => {
-    const searchKey = entitiesKeys.page({
+  test("keeps search in the sample cache identity", () => {
+    const searchKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       search: " closing binder ",
     });
-    const emptyKey = entitiesKeys.page({
+    const emptyKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
     });
 
     expect(searchKey).not.toEqual(emptyKey);
@@ -100,21 +96,19 @@ describe("entity query field selection", () => {
     expect(emptyKey.at(-1)).not.toHaveProperty("search");
   });
 
-  test("keeps the AI-previewable flag in the page cache identity", () => {
-    const previewKey = entitiesKeys.page({
+  test("keeps the AI-previewable flag in the sample cache identity", () => {
+    const previewKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       pageSize: 50,
       fieldMode: "visible",
       previewableForAi: true,
     });
-    const regularKey = entitiesKeys.page({
+    const regularKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       pageSize: 50,
       fieldMode: "visible",
     });
@@ -128,14 +122,13 @@ describe("entity query field selection", () => {
     });
   });
 
-  test("keeps excluded kinds in the page cache identity", () => {
+  test("keeps excluded kinds in the sample cache identity", () => {
     expect(
       entitiesKeys
-        .page({
+        .sample({
           workspaceId: "workspace-1",
           filters: [],
           sorts: [],
-          page: 1,
           excludedKinds: ["task", "folder"],
         })
         .at(-1),
@@ -144,24 +137,22 @@ describe("entity query field selection", () => {
     });
   });
 
-  test("keeps extra caller fields out of the page cache identity", () => {
-    const cleanKey = entitiesKeys.page({
+  test("keeps extra caller fields out of the sample cache identity", () => {
+    const cleanKey = entitiesKeys.sample({
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       search: "nda",
     });
     const noisyInput = {
       workspaceId: "workspace-1",
       filters: [],
       sorts: [],
-      page: 1,
       search: "nda",
       cursor: "cursor-that-must-not-leak",
     };
 
-    expect(entitiesKeys.page(noisyInput)).toEqual(cleanKey);
+    expect(entitiesKeys.sample(noisyInput)).toEqual(cleanKey);
   });
 
   test("keeps cursor state out of the window cache identity", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -117,16 +117,15 @@ const toWorkspaceEntity = (entity: RawWorkspaceEntity): WorkspaceEntity => {
 
 export const entitiesOptions = (key: EntitiesOptionsInput) =>
   queryOptions({
-    queryKey: entitiesKeys.page(key),
+    queryKey: entitiesKeys.sample(key),
     queryFn: async ({ signal }) => {
       const fieldMode = key.fieldMode ?? "full";
       const response = await api
         .entities({ workspaceId: toSafeId<"workspace">(key.workspaceId) })
-        .query.post(
+        ["query-window"].post(
           {
             filters: key.filters,
             sorts: key.sorts,
-            page: key.page,
             ...(key.search?.trim() && { search: key.search.trim() }),
             excludedKinds: key.excludedKinds ?? [],
             fieldMode,
@@ -137,7 +136,7 @@ export const entitiesOptions = (key: EntitiesOptionsInput) =>
                   )
                 : [],
             previewableForAi: key.previewableForAi ?? false,
-            pageSize: key.pageSize ?? DEFAULT_ENTITY_VIEW_PAGE_SIZE,
+            limit: key.pageSize ?? DEFAULT_ENTITY_VIEW_PAGE_SIZE,
           },
           { fetch: { signal } },
         );
@@ -146,7 +145,7 @@ export const entitiesOptions = (key: EntitiesOptionsInput) =>
         throw toAPIError(response.error);
       }
 
-      const { entities: rawEntities, ...rest } = response.data;
+      const { items: rawEntities, ...rest } = response.data;
       const entities: WorkspaceEntity[] = rawEntities.map(toWorkspaceEntity);
 
       return { ...rest, entities };
@@ -265,7 +264,6 @@ export const kanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
             ...(key.optionValues !== undefined && {
               optionValues: key.optionValues,
             }),
-            includeTotalCount: key.includeTotalCount ?? false,
             ...(pageParam !== undefined && { cursor: pageParam }),
           },
           { fetch: { signal } },
@@ -358,15 +356,31 @@ export const entitySummariesOptions = (workspaceId: string) =>
   queryOptions({
     queryKey: entitiesKeys.summaries(workspaceId),
     queryFn: async ({ signal }) => {
-      const response = await api
-        .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        .summaries.get({ fetch: { signal } });
+      const summaries: { id: string; name: string | null }[] = [];
+      let cursor: string | undefined;
+      do {
+        // oxlint-disable-next-line no-await-in-loop -- cursor pagination: each page depends on the previous response's nextCursor, so requests are strictly sequential
+        const response = await api
+          .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
+          .summaries.get({
+            fetch: { signal },
+            query: {
+              limit: DEFAULT_ENTITY_WINDOW_SIZE,
+              ...(cursor !== undefined && { cursor }),
+            },
+          });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+        if (response.error) {
+          throw toAPIError(response.error);
+        }
 
-      return response.data.summaries;
+        summaries.push(
+          ...response.data.items.map(({ id, name }) => ({ id, name })),
+        );
+        cursor = response.data.nextCursor ?? undefined;
+      } while (cursor !== undefined);
+
+      return summaries;
     },
   });
 
@@ -376,7 +390,7 @@ export const entitySummariesCountOptions = (workspaceId: string) =>
     queryFn: async ({ signal }) => {
       const response = await api
         .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        .summaries.get({ fetch: { signal } });
+        .summaries.count.get({ fetch: { signal }, query: {} });
 
       if (response.error) {
         throw toAPIError(response.error);

--- a/apps/web/src/routes/auth/organization.tsx
+++ b/apps/web/src/routes/auth/organization.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Navigate,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
 import { useSelector } from "@tanstack/react-store";
 import { panic } from "better-result";
 import { useTranslations } from "use-intl";
@@ -23,6 +28,7 @@ import { Input } from "@stll/ui/components/input";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient } from "@/lib/auth";
@@ -71,14 +77,10 @@ function Organization() {
   const isOauthPostLogin =
     typeof window !== "undefined" &&
     hasSignedOauthQuery(window.location.search);
-  const navigate = useNavigate();
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- navigation side-effect driven by derived auth state, move into the data-loading flow
-  useEffect(() => {
-    if (!isPending && !hasOrganizations && !isOauthPostLogin) {
-      void navigate({ to: "/onboarding", replace: true });
-    }
-  }, [hasOrganizations, isOauthPostLogin, isPending, navigate]);
+  if (!isPending && !hasOrganizations && !isOauthPostLogin) {
+    return <Navigate replace to="/onboarding" />;
+  }
 
   if (isPending || (!hasOrganizations && !isOauthPostLogin)) {
     return (
@@ -190,8 +192,7 @@ const OrganizationList = ({
   // Auto-select when there's only one organization
   const singleOrg = organizations.length === 1 ? organizations[0] : null;
   const autoSelected = useRef(false);
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (auto-trigger select mutation on derived single-org state), move into handler
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (singleOrg && !autoSelected.current && !isSelectPending) {
       autoSelected.current = true;
       selectOrg(singleOrg.id);

--- a/apps/web/src/routes/law/cases/index.tsx
+++ b/apps/web/src/routes/law/cases/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import {
   keepPreviousData,
@@ -25,6 +25,7 @@ import type {
   DecisionListFilters,
   SearchFacets,
 } from "@/features/case-law/queries/decisions";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import {
   createCaseLawDecisionPath,
   createCaseLawDecisionRouteParams,
@@ -201,8 +202,7 @@ function PublicCaseLawIndex() {
   const notFound = Route.useSearch({ select: (s) => s.notFound });
   const navigate = Route.useNavigate();
 
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- event-relay (notFound flag -> toast + navigate); move into the navigation that sets notFound
-  useEffect(() => {
+  useExternalSyncEffect(() => {
     if (!notFound) {
       return;
     }


### PR DESCRIPTION
## Summary
- move entity reads and summaries to cursor-based Page<T> responses
- remove offset pagination and totalCount from the shared entity query path
- migrate actionable raw useEffect suppressions to sanctioned primitives or explicit query/event flows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity browsing and summaries now use cursor-based pagination for smoother loading and more reliable navigation through large lists.
  * Added a dedicated summaries count view for faster access to total item counts.

* **Bug Fixes**
  * Improved handling of large exports by checking row limits more accurately before queueing.
  * Updated several screens and workflows to behave more consistently when opening, refreshing, or retrying actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->