### PR TITLE
fix: classify case law browse endpoints

### DIFF
--- a/apps/api/src/handlers/case-law/public-routes.ts
+++ b/apps/api/src/handlers/case-law/public-routes.ts
@@ -24,7 +24,7 @@ import { tSafeId } from "@/api/lib/custom-schema";
 
 const listDecisions = createSafePublicHandler(
   {
-    mcp: { type: "covered", by: "search_case_law" },
+    mcp: { type: "internal", reason: "public_indexing" },
     query: listDecisionsQuerySchema,
   },
   async function* ({ query }) {
@@ -39,7 +39,7 @@ const listDecisions = createSafePublicHandler(
 );
 
 const listDecisionFacets = createSafePublicHandler(
-  { mcp: { type: "covered", by: "search_case_law" } },
+  { mcp: { type: "internal", reason: "public_indexing" } },
   async function* () {
     const response = yield* Result.await(
       Result.tryPromise(


### PR DESCRIPTION
## Summary

- classify queryless case law browse and facet endpoints as public indexing surfaces instead of search-covered endpoints
- keep the MCP coverage baseline at zero pending endpoints

## Verification

- bun apps/api/scripts/mcp-coverage-guard.ts