### PR TITLE
feat(chat): split thread query into pure data fetch and runtime registry

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -84,6 +84,7 @@ import { useModelSelectorStore } from "@/lib/model-selector-store";
 import { matchReservedChatCommand } from "@/lib/reserved-chat-commands";
 import { SuggestedFollowupChips } from "@/routes/_protected.chat/-components/suggested-followup-chips";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
+import { useChatThreadRuntime } from "@/routes/_protected.chat/-hooks/use-chat-thread-runtime";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
 import type {
@@ -1031,30 +1032,33 @@ const FileChatOverlayInner = ({
     ? ACTIVE_FILE_BLOCKED_APPROVAL_TOOLS
     : undefined;
 
+  const chatThreadContext = {
+    allowMissingThread: true,
+    getContextMatterIds,
+    getSendMode,
+    getUserContext,
+    ...(activeExternal ? { getActiveExternal: () => getActiveExternal() } : {}),
+    ...(activeFile ? { getActiveFile: () => getActiveFile() } : {}),
+    ...(hasDocxEditSurface
+      ? {
+          handleActiveDocxEditToolCall: (input: ApplyActiveDocxEditsInput) =>
+            handleActiveDocxEditToolCall(input),
+        }
+      : {}),
+  };
   const { data } = useSuspenseQuery(
     chatThreadOptions({
       activeOrganizationId,
       key: threadRef,
-      context: {
-        allowMissingThread: true,
-        getContextMatterIds,
-        getSendMode,
-        getUserContext,
-        ...(activeExternal
-          ? { getActiveExternal: () => getActiveExternal() }
-          : {}),
-        ...(activeFile ? { getActiveFile: () => getActiveFile() } : {}),
-        ...(hasDocxEditSurface
-          ? {
-              handleActiveDocxEditToolCall: (
-                input: ApplyActiveDocxEditsInput,
-              ) => handleActiveDocxEditToolCall(input),
-            }
-          : {}),
-      },
+      context: chatThreadContext,
     }),
   );
-  const { chat } = data;
+  const chat = useChatThreadRuntime({
+    activeOrganizationId,
+    context: chatThreadContext,
+    data,
+    key: threadRef,
+  });
   // Seed the picker once per thread. Prefer the server's persisted set;
   // for a brand-new file thread (empty set) fall back to the file's own
   // matter so "the matter this file lives in" is the default context. A

--- a/apps/web/src/components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/components/inspector/chat-tab-panel.tsx
@@ -77,6 +77,7 @@ import { matchReservedChatCommand } from "@/lib/reserved-chat-commands";
 import { toSafeId } from "@/lib/safe-id";
 import { SuggestedFollowupChips } from "@/routes/_protected.chat/-components/suggested-followup-chips";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
+import { useChatThreadRuntime } from "@/routes/_protected.chat/-hooks/use-chat-thread-runtime";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
 import {
@@ -189,21 +190,27 @@ export const ChatTabPanel = ({
   // doesn't exist server-side until the first message lands. Allow
   // the missing-thread response so the GET doesn't 404 on a fresh
   // tab; the thread will be created idempotently on the first send.
+  const chatThreadContext = {
+    allowMissingThread: true,
+    getUserContext,
+    getActiveDecision,
+    ...(tabActiveSkill ? { getActiveSkill } : {}),
+    getContextMatterIds,
+    getSendMode,
+  };
   const { data } = useSuspenseQuery(
     chatThreadOptions({
       activeOrganizationId,
       key: threadRef,
-      context: {
-        allowMissingThread: true,
-        getUserContext,
-        getActiveDecision,
-        ...(tabActiveSkill ? { getActiveSkill } : {}),
-        getContextMatterIds,
-        getSendMode,
-      },
+      context: chatThreadContext,
     }),
   );
-  const { chat } = data;
+  const chat = useChatThreadRuntime({
+    activeOrganizationId,
+    context: chatThreadContext,
+    data,
+    key: threadRef,
+  });
 
   const {
     error,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -11,6 +11,7 @@ import {
 import { createAnalyticsValue } from "@/lib/analytics/provider";
 import { STALE_TIME } from "@/lib/consts";
 import { installPDFDocumentCleanup } from "@/lib/pdf/hooks/use-pdf-document";
+import { installChatRuntimeCleanup } from "@/routes/_protected.chat/-queries";
 import { routeTree } from "@/routeTree.gen";
 
 enableMapSet();
@@ -25,6 +26,7 @@ export function getRouter() {
     },
   });
   installPDFDocumentCleanup(queryClient);
+  installChatRuntimeCleanup(queryClient);
 
   const router = createRouter({
     routeTree,

--- a/apps/web/src/routes/_protected.chat/$threadId.tsx
+++ b/apps/web/src/routes/_protected.chat/$threadId.tsx
@@ -3,8 +3,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { toChatThreadId } from "@/lib/chat-thread-ref";
-// oxlint-disable-next-line require-loader-prefetch/require-loader-prefetch -- chatThreadOptions builds the ChatRuntime from component-provided context getters (auth user, matter ids, send mode); a loader prefetch would cache a stub-context runtime under the same key and the first send would bypass anonymization. Fixing needs the queryFn split into a pure data fetch plus in-component runtime construction
+import { ensureRouteQueryData } from "@/lib/react-query";
 import { ChatThreadPage } from "@/routes/_protected.chat/-components/chat-thread-page";
+import { chatThreadOptions } from "@/routes/_protected.chat/-queries";
 
 export const Route = createFileRoute("/_protected/chat/$threadId")({
   component: ThreadRoute,
@@ -13,6 +14,36 @@ export const Route = createFileRoute("/_protected/chat/$threadId")({
   // 1s — it only appears when the load actually stalls, avoiding a flash
   // between two consecutive chats.
   pendingMs: 1000,
+  loader: async ({ context, params }) => {
+    // Prime the pure thread-data query the page suspends on so the fetch
+    // starts during navigation instead of after the component mounts and
+    // suspends. `context` here is a key-shape stub only (no live getters):
+    // `chatThreadOptions` never builds a `ChatRuntime` from it — the
+    // component builds that separately, from its own live getters, via
+    // `useChatThreadRuntime`. See that factory's docs.
+    const options = chatThreadOptions({
+      activeOrganizationId: context.user.activeOrganizationId,
+      key: {
+        scope: "global",
+        threadId: toChatThreadId(params.threadId),
+      },
+      context: { allowMissingThread: true },
+    });
+    // Cached data — fresh, stale, or invalidated — renders immediately;
+    // the component's own observer background-refetches stale entries
+    // after mount and the runtime registry's idle reconcile picks the
+    // refetched messages up. Awaiting a refetch here would block first
+    // paint on a warm navigation and, worse, clobber the "move to main"
+    // seeding: `buildMaximizeTabAction` seeds this key with the inspector
+    // tab's unpersisted `contextMatterIds` and then invalidates, so an
+    // awaited refetch would replace the seed with the server's (possibly
+    // empty) set before the page's matter picker ever saw it. The loader
+    // only fills a cold cache.
+    if (context.queryClient.getQueryData(options.queryKey) !== undefined) {
+      return;
+    }
+    await ensureRouteQueryData(context.queryClient, options);
+  },
 });
 
 function ThreadRoute() {

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -61,6 +61,7 @@ import { ChatThreadRecap } from "@/routes/_protected.chat/-components/chat-threa
 import { SuggestedFollowupChips } from "@/routes/_protected.chat/-components/suggested-followup-chips";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
+import { useChatThreadRuntime } from "@/routes/_protected.chat/-hooks/use-chat-thread-runtime";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
 import {
@@ -120,23 +121,29 @@ export const ChatThreadPage = ({
   const getContextMatterIds = useEffectEvent(() => contextMatterIds ?? []);
   const getSendMode = useEffectEvent(() => getChatSendMode(threadRef));
 
+  // A thread can be opened (e.g. via "Move to main" from the inspector)
+  // before its first message has reached the server, so the row may not
+  // exist yet. The fetch handles missing threads gracefully; the row is
+  // created on first send.
+  const chatThreadContext = {
+    allowMissingThread: true,
+    getUserContext,
+    getContextMatterIds,
+    getSendMode,
+  };
   const { data } = useSuspenseQuery(
     chatThreadOptions({
       activeOrganizationId,
       key: threadRef,
-      // A thread can be opened (e.g. via "Move to main" from the
-      // inspector) before its first message has reached the server,
-      // so the row may not exist yet. The fetch handles missing
-      // threads gracefully; the row is created on first send.
-      context: {
-        allowMissingThread: true,
-        getUserContext,
-        getContextMatterIds,
-        getSendMode,
-      },
+      context: chatThreadContext,
     }),
   );
-  const { chat } = data;
+  const chat = useChatThreadRuntime({
+    activeOrganizationId,
+    context: chatThreadContext,
+    data,
+    key: threadRef,
+  });
   useExternalSyncEffect(() => {
     if (seededForThreadId === threadRef.threadId) {
       return;

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-thread-runtime.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-thread-runtime.ts
@@ -1,0 +1,60 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import type { ChatThreadRef } from "@/lib/chat-thread-ref";
+import {
+  acquireChatRuntime,
+  type ChatRuntime,
+  type ChatThreadFetched,
+  type ChatThreadOptionsContext,
+} from "@/routes/_protected.chat/-queries";
+
+type UseChatThreadRuntimeArgs = {
+  activeOrganizationId: string;
+  context: ChatThreadOptionsContext | undefined;
+  /** The pure-data result of `useSuspenseQuery(chatThreadOptions(...))`. */
+  data: ChatThreadFetched;
+  key: ChatThreadRef;
+};
+
+/**
+ * Resolve the live `ChatRuntime` for a mounted thread surface.
+ *
+ * `chatThreadOptions` only ever fetches pure thread data (see its docs),
+ * so a route loader can prefetch it without any component mounted. The
+ * runtime — the streaming TanStack `ChatClient` whose fetcher closes over
+ * THIS surface's live `context` getters — is built here, at the point a
+ * real component renders with real getters, and shared through
+ * `acquireChatRuntime`'s module-level registry so:
+ *   - navigating away from a streaming thread and back reattaches to the
+ *     SAME runtime with the stream still going (the registry entry
+ *     outlives this component's mount/unmount), and
+ *   - a thread whose stream was started by the `/chat` route-handoff
+ *     sender (before this component ever mounted) is picked up here
+ *     instead of a second, competing runtime being built.
+ *
+ * Called on every render (not gated behind `useState`/effects):
+ * `acquireChatRuntime` is a cheap registry lookup on every call after the
+ * first, so this stays correct if `context`'s getters change identity
+ * across renders without needing extra synchronization. When a background
+ * refetch (window-refocus staleness, cross-tab invalidation) delivers
+ * `data` with a newer freshness signal to an IDLE thread, the acquire
+ * call reconciles: the runtime is rebuilt from the fresh messages (new
+ * identity, so `useChatSession`'s seeded paging state resets too). A busy
+ * (streaming) runtime is never rebuilt — see `acquireChatRuntime`.
+ */
+export const useChatThreadRuntime = ({
+  activeOrganizationId,
+  context,
+  data,
+  key,
+}: UseChatThreadRuntimeArgs): ChatRuntime => {
+  const queryClient = useQueryClient();
+
+  return acquireChatRuntime({
+    activeOrganizationId,
+    context,
+    data,
+    key,
+    queryClient,
+  });
+};

--- a/apps/web/src/routes/_protected.chat/-queries.test.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.test.ts
@@ -1,4 +1,4 @@
-import { replaceEqualDeep } from "@tanstack/react-query";
+import { QueryClient, replaceEqualDeep } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -8,13 +8,16 @@ import { toChatThreadId } from "@/lib/chat-thread-ref";
 import { toSafeId, type SafeId } from "@/lib/safe-id";
 import {
   __resetChatRequestStateForTests,
+  acquireChatRuntime,
   buildSendRequestBody,
   chatKeys,
   chatThreadOptions,
   createChatRuntime,
+  installChatRuntimeCleanup,
   matchesChatThreadAcrossScopes,
   mergeGroupedChatThreadPages,
   sendThreadChatMessage,
+  type ChatThreadFetched,
 } from "@/routes/_protected.chat/-queries";
 
 const createMessage = (id = "message-A"): PersistedChatMessage => ({
@@ -795,9 +798,631 @@ describe("chat runtime identity across query refetch", () => {
       context: { allowMissingThread: true },
     });
 
-    // Guards the invariant: the query data embeds a `ChatRuntime` whose
-    // identity and `Symbol` brand must survive every refetch, so this query
-    // must never run through `replaceEqualDeep`.
+    // Guards the known requirement: this query keeps
+    // `structuralSharing: false` (each refetch hands back a fresh object;
+    // see the option's inline comment for the history and rationale).
     expect(options.structuralSharing).toBe(false);
+  });
+});
+
+describe("acquireChatRuntime reconcile", () => {
+  const previousFetch = globalThis.fetch;
+  type FetchHandler = (
+    ...args: Parameters<typeof fetch>
+  ) => ReturnType<typeof fetch>;
+  const createFetchMock = (handler: FetchHandler): typeof fetch =>
+    Object.assign(handler, { preconnect: previousFetch.preconnect });
+
+  beforeEach(() => {
+    __resetChatRequestStateForTests();
+    globalThis.fetch = previousFetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = previousFetch;
+  });
+
+  const threadId = toChatThreadId("thread-acquire");
+  const threadRef = { scope: "global", threadId } as const;
+  const activeOrganizationId = "org_test";
+
+  const buildThreadData = (
+    overrides: Partial<ChatThreadFetched> = {},
+  ): ChatThreadFetched => ({
+    messages: [],
+    olderCursor: null,
+    contextMatterIds: [],
+    lastActivityAt: null,
+    webSearchAvailable: false,
+    webSearchEnabled: false,
+    context: null,
+    ...overrides,
+  });
+
+  const newerThreadData = () =>
+    buildThreadData({
+      lastActivityAt: "2026-07-08T10:00:00.000Z",
+      messages: [
+        createMessage("message-A"),
+        {
+          id: assistantMessageId,
+          role: "assistant",
+          parts: [{ type: "text", content: "Ahoj!" }],
+        },
+      ],
+    });
+
+  const createFinishedSseChunks = () => [
+    { type: "RUN_STARTED", threadId, runId: "run-A" },
+    {
+      type: "TEXT_MESSAGE_START",
+      messageId: assistantMessageId,
+      role: "assistant",
+    },
+    {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: assistantMessageId,
+      delta: "Ahoj!",
+    },
+    { type: "TEXT_MESSAGE_END", messageId: assistantMessageId },
+    { type: "RUN_FINISHED", threadId, runId: "run-A", finishReason: "stop" },
+  ];
+
+  test("reattaches to the same runtime when the freshness signal is unchanged", () => {
+    const queryClient = new QueryClient();
+    const data = buildThreadData();
+
+    const first = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data,
+      key: threadRef,
+      queryClient,
+    });
+    const second = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data: buildThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+
+    expect(second).toBe(first);
+  });
+
+  test("rebuilds an idle runtime from the current caller's live getters when newer data arrives", async () => {
+    const queryClient = new QueryClient();
+    const requests: unknown[] = [];
+    globalThis.fetch = createFetchMock(async (_input, init) => {
+      requests.push(parseJsonRequestBody(init));
+      return createSseResponse(createFinishedSseChunks());
+    });
+
+    const first = acquireChatRuntime({
+      activeOrganizationId,
+      context: {
+        allowMissingThread: true,
+        getSendMode: () => CHAT_SEND_MODE.rawOverride,
+      },
+      data: buildThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+
+    // A background refetch delivered messages the idle runtime never saw:
+    // the acquire must rebuild, seeded from the fresh transcript, wired to
+    // THIS caller's getters.
+    const rebuilt = acquireChatRuntime({
+      activeOrganizationId,
+      context: {
+        allowMissingThread: true,
+        getSendMode: () => CHAT_SEND_MODE.anonymized,
+      },
+      data: newerThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+
+    expect(rebuilt).not.toBe(first);
+    expect(rebuilt.getSnapshot().messages).toMatchObject([
+      { id: "message-A", role: "user" },
+      { id: assistantMessageId, role: "assistant" },
+    ]);
+
+    // The next send resolves its mode through the rebuilt runtime's
+    // context. `anonymized` cannot come from the missing-getter fallback
+    // (that fallback is `rawOverride`), so this proves the current
+    // caller's live getter won.
+    await sendThreadChatMessage(
+      rebuilt,
+      createOutgoingMessage("22222222-2222-4222-8222-2222222222b1"),
+    );
+    expect(requests.at(0)).toMatchObject({
+      sendMode: CHAT_SEND_MODE.anonymized,
+      threadId,
+    });
+  });
+
+  test("keeps a mid-stream runtime even when newer data arrives, then rebuilds after the post-turn refetch", async () => {
+    const queryClient = new QueryClient();
+    let markResponseRequested: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    const responseRequested = new Promise<void>((resolve) => {
+      markResponseRequested = resolve;
+    });
+    let releaseResponse: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    globalThis.fetch = createFetchMock(async () => {
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+        markResponseRequested();
+      });
+      return createSseResponse(createFinishedSseChunks());
+    });
+
+    // Mirrors the /chat route-handoff: the landing page registers the
+    // runtime and starts the stream BEFORE navigating.
+    const preSendData = buildThreadData();
+    const handoff = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data: preSendData,
+      key: threadRef,
+      queryClient,
+    });
+    const started = handoff.startRouteHandoffMessage(
+      createOutgoingMessage("22222222-2222-4222-8222-2222222222b2"),
+    );
+    await responseRequested;
+
+    // The destination page acquires while the stream is in flight — even
+    // with a diverged freshness signal it must reattach, never rebuild
+    // (invariant: an in-flight stream survives navigation).
+    const reattached = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data: newerThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+    expect(reattached).toBe(handoff);
+
+    releaseResponse();
+    await started.stream;
+
+    // Between the turn's onFinish (which only invalidates) and its
+    // refetch landing, the component re-renders from the runtime's final
+    // stream updates while the CACHED data is still pre-send. That
+    // acquire must reattach (stale data equals the entry's frozen
+    // build-time seed), keeping the finished turn on screen instead of
+    // rebuilding a runtime from pre-send messages.
+    const beforeRefetch = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data: preSendData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(beforeRefetch).toBe(handoff);
+
+    // Once the invalidation's refetch lands, the fresh data's signal
+    // diverges from the frozen seed and the now-idle runtime is rebuilt
+    // from server-authoritative messages with the current caller's
+    // getters (this is where a handoff runtime sheds the landing page's
+    // getters).
+    const afterRefetch = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data: newerThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+    expect(afterRefetch).not.toBe(handoff);
+  });
+
+  test("keeps distinct runtimes per context capability set and sweeps them all on query GC", () => {
+    const queryClient = new QueryClient();
+    installChatRuntimeCleanup(queryClient);
+    const data = buildThreadData();
+
+    // Both contexts map to the SAME pure-data query key: contextKind
+    // ignores `getActiveDecision`, so both are "plain". Without the
+    // capability fingerprint they would collide in the registry and the
+    // decision-carrying surface could inherit a runtime whose sends omit
+    // activeDecision.
+    const plainOptions = chatThreadOptions({
+      activeOrganizationId,
+      key: threadRef,
+      context: { allowMissingThread: true },
+    });
+    const decisionContext = {
+      allowMissingThread: true,
+      getActiveDecision: () => ({ decisionId: "decision-A" }),
+    };
+    expect(
+      chatThreadOptions({
+        activeOrganizationId,
+        key: threadRef,
+        context: decisionContext,
+      }).queryKey,
+    ).toEqual(plainOptions.queryKey);
+
+    const plainRuntime = acquireChatRuntime({
+      activeOrganizationId,
+      context: { allowMissingThread: true },
+      data,
+      key: threadRef,
+      queryClient,
+    });
+    const decisionRuntime = acquireChatRuntime({
+      activeOrganizationId,
+      context: decisionContext,
+      data,
+      key: threadRef,
+      queryClient,
+    });
+    expect(decisionRuntime).not.toBe(plainRuntime);
+
+    // Each capability set reattaches to its own entry.
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: { allowMissingThread: true },
+        data,
+        key: threadRef,
+        queryClient,
+      }),
+    ).toBe(plainRuntime);
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: decisionContext,
+        data,
+        key: threadRef,
+        queryClient,
+      }),
+    ).toBe(decisionRuntime);
+
+    // GC of the shared pure-data query sweeps BOTH entries: a fresh
+    // acquire on either capability set builds a new runtime.
+    queryClient.setQueryData(plainOptions.queryKey, data);
+    queryClient.removeQueries({ queryKey: plainOptions.queryKey });
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: { allowMissingThread: true },
+        data,
+        key: threadRef,
+        queryClient,
+      }),
+    ).not.toBe(plainRuntime);
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: decisionContext,
+        data,
+        key: threadRef,
+        queryClient,
+      }),
+    ).not.toBe(decisionRuntime);
+  });
+
+  test("reattaches a busy runtime across capability fingerprints, then rebuilds per fingerprint after the refetch", async () => {
+    const queryClient = new QueryClient();
+    let markResponseRequested: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    const responseRequested = new Promise<void>((resolve) => {
+      markResponseRequested = resolve;
+    });
+    let releaseResponse: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    globalThis.fetch = createFetchMock(async () => {
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+        markResponseRequested();
+      });
+      return createSseResponse(createFinishedSseChunks());
+    });
+
+    const staleData = buildThreadData();
+    const plainContext = { allowMissingThread: true };
+    // Inspector-like context: `getActiveDecision` changes the registry
+    // fingerprint but not the query key.
+    const decisionContext = {
+      allowMissingThread: true,
+      getActiveDecision: () => ({ decisionId: "decision-A" }),
+    };
+
+    // A stale idle entry already exists under the PLAIN fingerprint (a
+    // previous main-page visit), then the inspector surface builds its
+    // own runtime and starts a stream.
+    const idlePlain = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    const streaming = acquireChatRuntime({
+      activeOrganizationId,
+      context: decisionContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(streaming).not.toBe(idlePlain);
+    const started = streaming.startRouteHandoffMessage(
+      createOutgoingMessage("22222222-2222-4222-8222-2222222222b3"),
+    );
+    await responseRequested;
+
+    // "Move to main" mid-stream: the destination page acquires under the
+    // plain fingerprint with still-stale data. Busyness must override
+    // capability splitting — even though the page has its own idle
+    // seed-equal entry, the live stream wins and stays visible.
+    const reattached = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(reattached).toBe(streaming);
+
+    releaseResponse();
+    await started.stream;
+
+    // After the turn finished and the invalidation's refetch delivered
+    // fresh data, the plain surface rebuilds under its OWN fingerprint
+    // with its own getters.
+    const rebuiltPlain = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: newerThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+    expect(rebuiltPlain).not.toBe(streaming);
+    expect(rebuiltPlain).not.toBe(idlePlain);
+
+    // No leak: the rebuild explicitly dropped the superseded (idle,
+    // diverged-seed) decision-fingerprint entry. Probe with the STALE
+    // data — a surviving entry would reattach seed-equal and hand the
+    // finished foreign runtime back.
+    const decisionAfter = acquireChatRuntime({
+      activeOrganizationId,
+      context: decisionContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(decisionAfter).not.toBe(streaming);
+  });
+
+  test("reattaches a busy runtime across different query keys for the same thread", async () => {
+    const queryClient = new QueryClient();
+    let markResponseRequested: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    const responseRequested = new Promise<void>((resolve) => {
+      markResponseRequested = resolve;
+    });
+    let releaseResponse: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    globalThis.fetch = createFetchMock(async () => {
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+        markResponseRequested();
+      });
+      return createSseResponse(createFinishedSseChunks());
+    });
+
+    const staleData = buildThreadData();
+    const plainContext = { allowMissingThread: true };
+    // `getActiveSkill` flips contextKind, so this surface's PURE-DATA
+    // query key differs from the plain one — the busy reattach must
+    // match on thread identity, not on the query key.
+    const skillContext = {
+      allowMissingThread: true,
+      getActiveSkill: () => ({ skillName: "Summarize" }),
+    };
+    expect(
+      chatThreadOptions({
+        activeOrganizationId,
+        key: threadRef,
+        context: skillContext,
+      }).queryKey,
+    ).not.toEqual(
+      chatThreadOptions({
+        activeOrganizationId,
+        key: threadRef,
+        context: plainContext,
+      }).queryKey,
+    );
+
+    const streaming = acquireChatRuntime({
+      activeOrganizationId,
+      context: skillContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    const started = streaming.startRouteHandoffMessage(
+      createOutgoingMessage("22222222-2222-4222-8222-2222222222b4"),
+    );
+    await responseRequested;
+
+    const reattached = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(reattached).toBe(streaming);
+
+    releaseResponse();
+    await started.stream;
+  });
+
+  test("aliases a foreign busy reattach so the post-finish stale render keeps the finished turn", async () => {
+    const queryClient = new QueryClient();
+    let markResponseRequested: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    const responseRequested = new Promise<void>((resolve) => {
+      markResponseRequested = resolve;
+    });
+    let releaseResponse: () => void = () => {
+      throw new Error("Chat response was not requested");
+    };
+    globalThis.fetch = createFetchMock(async () => {
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+        markResponseRequested();
+      });
+      return createSseResponse(createFinishedSseChunks());
+    });
+
+    const staleData = buildThreadData();
+    const plainContext = { allowMissingThread: true };
+    const skillContext = {
+      allowMissingThread: true,
+      getActiveSkill: () => ({ skillName: "Summarize" }),
+    };
+
+    // No prior entry under the plain key: the mid-stream acquire hits
+    // the cross-key busy scan and records an alias under it.
+    const streaming = acquireChatRuntime({
+      activeOrganizationId,
+      context: skillContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    const started = streaming.startRouteHandoffMessage(
+      createOutgoingMessage("22222222-2222-4222-8222-2222222222b5"),
+    );
+    await responseRequested;
+    const reattached = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(reattached).toBe(streaming);
+
+    releaseResponse();
+    await started.stream;
+
+    // Post-finish, pre-refetch: the plain surface re-renders with STALE
+    // cached data. Without the alias this would be a registry miss (the
+    // runtime is idle now, so the busy scan finds nothing) and a rebuild
+    // from pre-send messages — wiping the finished turn. The alias makes
+    // it a seed-equal exact hit instead.
+    const afterFinishStale = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    expect(afterFinishStale).toBe(streaming);
+
+    // Once the refetch lands, the plain surface rebuilds under its own
+    // fingerprint from fresh messages...
+    const rebuiltPlain = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: newerThreadData(),
+      key: threadRef,
+      queryClient,
+    });
+    expect(rebuiltPlain).not.toBe(streaming);
+    // ...replacing the alias (a fresh seed-equal acquire reattaches to
+    // the rebuilt runtime, not the finished foreign one)...
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: plainContext,
+        data: newerThreadData(),
+        key: threadRef,
+        queryClient,
+      }),
+    ).toBe(rebuiltPlain);
+    // ...and dropping the superseded SOURCE entry: probing the skill
+    // context with the stale data must build fresh, not resurrect the
+    // finished runtime.
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: skillContext,
+        data: staleData,
+        key: threadRef,
+        queryClient,
+      }),
+    ).not.toBe(streaming);
+  });
+
+  test("GC sweep removes only the entries of the removed query key", () => {
+    const queryClient = new QueryClient();
+    installChatRuntimeCleanup(queryClient);
+    const staleData = buildThreadData();
+    const plainContext = { allowMissingThread: true };
+    const skillContext = {
+      allowMissingThread: true,
+      getActiveSkill: () => ({ skillName: "Summarize" }),
+    };
+    const plainOptions = chatThreadOptions({
+      activeOrganizationId,
+      key: threadRef,
+      context: plainContext,
+    });
+
+    const plainRuntime = acquireChatRuntime({
+      activeOrganizationId,
+      context: plainContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+    const skillRuntime = acquireChatRuntime({
+      activeOrganizationId,
+      context: skillContext,
+      data: staleData,
+      key: threadRef,
+      queryClient,
+    });
+
+    // Remove only the PLAIN query: its entry is swept, but the sibling
+    // query key's entry for the same thread must survive (the sweep is
+    // query-key-scoped; only the busy scan and the rebuild cleanup work
+    // on thread identity).
+    queryClient.setQueryData(plainOptions.queryKey, staleData);
+    queryClient.removeQueries({ queryKey: plainOptions.queryKey });
+
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: plainContext,
+        data: staleData,
+        key: threadRef,
+        queryClient,
+      }),
+    ).not.toBe(plainRuntime);
+    expect(
+      acquireChatRuntime({
+        activeOrganizationId,
+        context: skillContext,
+        data: staleData,
+        key: threadRef,
+        queryClient,
+      }),
+    ).toBe(skillRuntime);
   });
 });

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -19,7 +19,10 @@ import type {
   ChatUITools,
   PersistedChatMessage,
 } from "@/components/chat/chat-ui-tools";
-import { sanitizeHydratedRunningToolCalls } from "@/components/chat/chat-ui-tools";
+import {
+  hasRunningToolCallInLatestAssistantMessage,
+  sanitizeHydratedRunningToolCalls,
+} from "@/components/chat/chat-ui-tools";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { apiUrl } from "@/lib/api-url";
@@ -116,7 +119,7 @@ export type ApplyActiveDocxEditsInput =
 export type ApplyActiveDocxEditsOutput =
   ChatUITools[typeof APPLY_ACTIVE_DOCX_EDITS_TOOL_NAME]["output"];
 
-type ChatThreadOptionsContext = {
+export type ChatThreadOptionsContext = {
   allowMissingThread?: boolean | undefined;
   getActiveDecision?: (() => ActiveDecisionContext | undefined) | undefined;
   getActiveExternal?: (() => ActiveExternalContext | undefined) | undefined;
@@ -1161,21 +1164,32 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
 /**
- * Test-only escape hatch. The module-level cache is intentionally
- * not cleared automatically; this helper resets it between unit
+ * Test-only escape hatch. The module-level caches are intentionally
+ * not cleared automatically; this helper resets them between unit
  * tests so each one starts hermetically.
  */
 export const __resetChatRequestStateForTests = (): void => {
   activeTurnSendModes.clear();
+  chatRuntimeRegistry.clear();
 };
 
 export type ChatThreadFetched = {
-  chat: ChatRuntime;
+  /**
+   * Sanitized initial history for this thread (running tool-call
+   * parts left by a stream that died mid-call are dropped — see
+   * `sanitizeHydratedRunningToolCalls`). Pure server data: this
+   * query never builds a `ChatRuntime` (see `chatThreadOptions`
+   * docs below), so a route loader can prefetch it safely. Callers
+   * that need a live runtime pass this array as `initialMessages`
+   * to `acquireChatRuntime` / `useChatThreadRuntime`.
+   */
+  messages: PersistedChatMessage[];
   /**
    * Cursor for the page of messages immediately older than the
-   * oldest message in `chat`. Null when the thread's full history
-   * is already loaded. Consumers seed local load-older state from
-   * this and replace it with each older-page response's cursor.
+   * oldest message in `messages`. Null when the thread's full
+   * history is already loaded. Consumers seed local load-older
+   * state from this and replace it with each older-page response's
+   * cursor.
    */
   olderCursor: string | null;
   /**
@@ -1241,6 +1255,91 @@ export type ChatThreadOptionsArgs = ChatThreadOptionsInput & {
   activeOrganizationId: string;
 };
 
+/**
+ * Cache-identity key shared by `chatThreadOptions`' `queryKey` and the
+ * runtime registry below. Keeping both derivations behind this one
+ * helper guarantees a query cache entry and its registered `ChatRuntime`
+ * are always addressed by the exact same (org, thread, allowMissingThread,
+ * contextKind) tuple — they can drift in content, never in identity.
+ */
+const chatThreadCacheKey = ({
+  activeOrganizationId,
+  context,
+  key,
+}: {
+  activeOrganizationId: string;
+  context: ChatThreadOptionsContext | undefined;
+  key: ChatThreadKey;
+}) =>
+  chatKeys.thread(activeOrganizationId, {
+    ...key,
+    allowMissingThread: context?.allowMissingThread,
+    contextKind: getChatRuntimeContextKind(context),
+  });
+
+/**
+ * Durable identity of the THREAD a registry entry streams into: org +
+ * scope (+ workspaceId for workspace scope) + threadId, and nothing
+ * else. Deliberately excludes `allowMissingThread`, `contextKind`, and
+ * the transport version — those vary per SURFACE (they are query-cache
+ * concerns), while a live stream belongs to the thread itself: the
+ * cross-fingerprint busy reattach and the rebuild-time cleanup of
+ * superseded entries must see every entry for the thread regardless of
+ * which surface's query key it was registered under. JSON-encoded so
+ * user-controlled ids cannot collide with a separator.
+ */
+const chatThreadIdentity = ({
+  activeOrganizationId,
+  key,
+}: {
+  activeOrganizationId: string;
+  key: ChatThreadKey;
+}): string =>
+  key.scope === "global"
+    ? JSON.stringify([activeOrganizationId, key.scope, key.threadId])
+    : JSON.stringify([
+        activeOrganizationId,
+        key.scope,
+        key.workspaceId,
+        key.threadId,
+      ]);
+
+// Every context capability (getter/handler) that changes what a runtime
+// SENDS. `allowMissingThread` is excluded: it shapes the fetch, not the
+// send, and is already part of the query key.
+const CHAT_CONTEXT_CAPABILITY_KEYS = [
+  "getActiveDecision",
+  "getActiveExternal",
+  "getActiveFile",
+  "getActiveSkill",
+  "getActiveTemplate",
+  "getContextMatterIds",
+  "getSendMode",
+  "getUserContext",
+  "handleActiveDocxEditToolCall",
+] as const satisfies readonly (keyof ChatThreadOptionsContext)[];
+
+/**
+ * Deterministic encoding of WHICH capabilities a context carries (fixed
+ * declaration order, presence only). Registry identity is deliberately
+ * STRICTER than cache identity: the pure-data query is context-free, so
+ * distinct surfaces may share one cache entry (and the query key must
+ * stay stable for invalidation targeting), but a runtime's send path
+ * uses exactly the getters present at build time. `contextKind` in the
+ * query key only records the FIRST matched kind and ignores getters like
+ * `getActiveDecision` entirely, so two surfaces with different
+ * capability sets can share a query key; without this fingerprint an
+ * idle runtime built by the capability-poorer surface could be reused
+ * seed-equal by the richer one, and its sends would silently omit that
+ * context.
+ */
+const chatContextCapabilityFingerprint = (
+  context: ChatThreadOptionsContext | undefined,
+): string =>
+  CHAT_CONTEXT_CAPABILITY_KEYS.filter(
+    (capability) => context?.[capability] !== undefined,
+  ).join(",");
+
 export const chatThreadOptions = ({
   activeOrganizationId,
   key,
@@ -1249,70 +1348,413 @@ export const chatThreadOptions = ({
   queryOptions({
     staleTime: STALE_TIME.FIVETEEN.MINUTES,
     gcTime: STALE_TIME.FIVETEEN.MINUTES,
-    // The query data carries a live `ChatRuntime`: a plain object with a
-    // `Symbol` brand key and function-valued methods, registered by object
-    // identity in `threadSendMessageByRuntime`. TanStack's default
-    // structural sharing (`replaceEqualDeep`) walks the data on every
-    // refetch and, because the runtime's method closures differ across
-    // queryFn runs, rebuilds `data.chat` into a fresh `{}` copy. That copy
-    // is a distinct identity the WeakMap never saw, and `Object.keys`
-    // iteration drops the `Symbol` brand, so `sendThreadChatMessage` would
-    // panic with "Missing thread send capability". Each queryFn run already
-    // creates and registers a new runtime (see `onFinish` invalidation and
-    // the `seededChat` re-seed in useChatSession), so there is nothing for
-    // structural sharing to preserve here: hand the registered runtime back
-    // verbatim. INVARIANT: any query whose data embeds a `ChatRuntime` must
-    // opt out of structural sharing.
+    // This query fetches PURE thread data — messages, cursor, matter ids,
+    // web-search flags, context estimate — and nothing else. It never
+    // builds a `ChatRuntime`, on purpose: a route loader can call
+    // `ensureRouteQueryData(chatThreadOptions(...))` before any chat
+    // component has mounted, with no live `getUserContext` /
+    // `getContextMatterIds` / `getSendMode` getters available yet. If
+    // queryFn built the runtime here, a loader-triggered fetch would bake
+    // in a stub context for the runtime's entire lifetime (until the next
+    // invalidation) — including the first `sendMode` resolution, which
+    // would silently fall back to `CHAT_SEND_MODE.rawOverride` and drop
+    // the user's anonymization choice. See `acquireChatRuntime` /
+    // `useChatThreadRuntime`: the runtime is always built at the point a
+    // component (or the `/chat` route-handoff sender) actually holds live
+    // getters, never here.
+    //
+    // `structuralSharing: false` is kept even though this query's data no
+    // longer embeds a `ChatRuntime` (the historical reason it was added —
+    // see the "chat runtime identity across query refetch" tests). Every
+    // refetch of this query still means "the server's authoritative
+    // messages changed"; handing back a fresh object each time (instead of
+    // walking it for structural equality) keeps that signal simple and
+    // costs nothing since nothing here is expensive to diff.
     structuralSharing: false,
-    queryKey: chatKeys.thread(activeOrganizationId, {
-      ...key,
-      allowMissingThread: context.allowMissingThread,
-      contextKind: getChatRuntimeContextKind(context),
-    }),
-    queryFn: async ({ client: queryClient }): Promise<ChatThreadFetched> => {
-      const {
-        messages,
-        olderCursor,
-        contextMatterIds,
-        lastActivityAt,
-        webSearchAvailable,
-        webSearchEnabled,
-        context: contextUsage,
-      } = await fetchThreadMessages(key, {
+    queryKey: chatThreadCacheKey({ activeOrganizationId, context, key }),
+    queryFn: async (): Promise<ChatThreadFetched> => {
+      const fetched = await fetchThreadMessages(key, {
         allowMissingThread: context.allowMissingThread,
       });
 
-      const chat = createChatRuntime({
-        context,
+      return {
+        ...fetched,
         // Thread hydration is the one place persisted messages enter a
         // fresh runtime with no live turn; drop any tool-call part left
         // running by a stream that died mid call so the session does not
         // load already wedged as "generating". See
         // `sanitizeHydratedRunningToolCalls`.
-        initialMessages: sanitizeHydratedRunningToolCalls(messages),
-        key,
-        onError: (error) => {
-          getAnalytics().captureError(error);
-        },
-        onFinish: () => {
-          void Promise.all([
-            invalidateChatThread({ queryClient, threadRef: key }),
-            invalidateGroupedChatThreads(queryClient),
-          ]);
-        },
-      });
-
-      return {
-        chat,
-        olderCursor,
-        contextMatterIds,
-        lastActivityAt,
-        webSearchAvailable,
-        webSearchEnabled,
-        context: contextUsage,
+        messages: sanitizeHydratedRunningToolCalls(fetched.messages),
       };
     },
   });
+
+/**
+ * Server-authoritative freshness signal a runtime was seeded with,
+ * remembered alongside its registry entry so a later acquire can tell
+ * whether the incoming pure-data fetch carries anything the runtime was
+ * not BUILT from. Both fields together are the signal: `lastActivityAt`
+ * alone cannot distinguish two states of a thread edited within the same
+ * timestamp resolution, and the last message id alone cannot see a
+ * truncate-and-replay that lands back on the same tail message.
+ *
+ * INVARIANT: captured once at build time and never updated afterwards —
+ * deliberately, even though the runtime's own transcript advances as
+ * turns stream. That staleness is what drives replacement: after a turn
+ * finishes, `onFinish` only invalidates the pure-data query (it does NOT
+ * evict — see the registry docs for the race that eviction caused);
+ * until the refetch lands, acquire compares the stale cached data
+ * against this equally stale build-time seed → equal → reattach, and the
+ * runtime keeps showing the finished turn it holds internally. Once the
+ * refetch lands, the fresh data's signal diverges from this frozen seed
+ * → idle rebuild from server-authoritative messages. Updating the seed
+ * on stream progress would break exactly that divergence detection.
+ */
+type ChatRuntimeSeedSignal = {
+  lastActivityAt: string | null;
+  lastMessageId: string | null;
+};
+
+type ChatRuntimeRegistryEntry = {
+  runtime: ChatRuntime;
+  seed: ChatRuntimeSeedSignal;
+  /**
+   * Stringified query key of the pure-data query this entry belongs to.
+   * The registry key is this string PLUS the context-capability
+   * fingerprint, so one query key can own several entries; the GC sweep
+   * in `installChatRuntimeCleanup` uses this field to find all of them
+   * (and ONLY them — a removed query must not sweep entries registered
+   * under a sibling query key for the same thread).
+   */
+  queryKeyString: string;
+  /**
+   * Durable thread identity (see `chatThreadIdentity`), shared by every
+   * entry for the thread across query keys and fingerprints. The busy
+   * cross-fingerprint reattach and the rebuild-time cleanup of
+   * superseded entries match on this, never on `queryKeyString`.
+   */
+  threadIdentity: string;
+};
+
+const toChatRuntimeSeedSignal = (
+  data: ChatThreadFetched,
+): ChatRuntimeSeedSignal => ({
+  lastActivityAt: data.lastActivityAt,
+  lastMessageId: data.messages.at(-1)?.id ?? null,
+});
+
+const seedSignalsEqual = (
+  left: ChatRuntimeSeedSignal,
+  right: ChatRuntimeSeedSignal,
+): boolean =>
+  left.lastActivityAt === right.lastActivityAt &&
+  left.lastMessageId === right.lastMessageId;
+
+/**
+ * Whether a runtime has live work in flight that a rebuild would kill:
+ * an active stream (`status` submitted/streaming, `isLoading` covers a
+ * locally-pending optimistic send whose response has not started yet),
+ * a server-side generation session (`sessionGenerating`), or a running
+ * tool call awaiting its result/approval in the latest assistant turn
+ * (which `status` alone does not cover — between tool hops the client
+ * is technically "ready"). A busy runtime is never replaced; once its
+ * turn finishes and the `onFinish` invalidation's refetch lands, the
+ * idle reconcile in `acquireChatRuntime` rebuilds it.
+ */
+const isChatRuntimeBusy = (runtime: ChatRuntime): boolean => {
+  const snapshot = runtime.getSnapshot();
+  return (
+    snapshot.isLoading ||
+    snapshot.sessionGenerating ||
+    snapshot.status === "submitted" ||
+    snapshot.status === "streaming" ||
+    hasRunningToolCallInLatestAssistantMessage({
+      messages: snapshot.messages,
+    })
+  );
+};
+
+/**
+ * Live `ChatRuntime` instances, keyed by cache identity (see
+ * `chatThreadCacheKey`) PLUS context-capability fingerprint (see
+ * `chatContextCapabilityFingerprint`). A runtime is built lazily, from
+ * whichever caller's live context getters are on hand the first time its
+ * key is resolved, and then reused:
+ *   - across a component unmount/remount (thread revisit within the pure
+ *     data query's `gcTime`) so an in-flight stream stays attached — see
+ *     `useChatThreadRuntime`;
+ *   - across the `/chat` landing page's route-handoff send, which calls
+ *     `acquireChatRuntime` directly (no mounted component yet) to start
+ *     the stream before navigating; the destination route's first render
+ *     resolves the same key (identical capability set) and reattaches
+ *     instead of building a second, competing runtime;
+ *   - across SURFACES while a stream is live: a busy runtime is
+ *     reattached even from a different capability fingerprint or query
+ *     key (moving a chat between the inspector and the main page
+ *     mid-stream) — see `findBusyChatRuntimeEntryForThread` and the
+ *     alias mechanism in `acquireChatRuntime`.
+ *
+ * A hit is NOT unconditional: when the runtime is idle and the incoming
+ * pure-data fetch carries a signal that diverges from the entry's frozen
+ * build-time seed, the entry is rebuilt from the current caller's live
+ * getters and fresh messages — see `acquireChatRuntime`. That one rule
+ * covers both refresh paths:
+ *   - a background refetch (window-refocus staleness, cross-tab/device
+ *     invalidation) picked up messages the runtime never saw;
+ *   - this runtime's own finished turn: `onFinish` only INVALIDATES the
+ *     pure-data query — it must not evict, because the component
+ *     re-renders from the runtime's final stream updates BEFORE the
+ *     refetch lands, and an evicted entry would make that render's
+ *     acquire (still holding pre-send cached data) rebuild from stale
+ *     messages, wiping the just-finished turn off the screen until (or
+ *     unless) the refetch wins. With the entry left in place, that
+ *     interim acquire sees stale-data-equals-stale-seed → reattach, and
+ *     the post-refetch acquire sees the divergence → rebuild from
+ *     server-authoritative messages with the mounted caller's getters.
+ *
+ * Entries are swept when TanStack garbage-collects the matching
+ * pure-data query (see `installChatRuntimeCleanup`) so a thread opened
+ * once and never revisited doesn't hold its runtime — and every message
+ * it ever streamed — in memory indefinitely.
+ */
+const chatRuntimeRegistry = new Map<string, ChatRuntimeRegistryEntry>();
+
+/**
+ * Registry key: query-key string + capability fingerprint. IDLE entries
+ * never cross capability sets even when they share a pure-data cache
+ * entry; BUSY entries do — see `findBusyChatRuntimeEntryForThread`.
+ */
+const toChatRuntimeRegistryKey = (
+  queryKeyString: string,
+  context: ChatThreadOptionsContext | undefined,
+): string => `${queryKeyString}#${chatContextCapabilityFingerprint(context)}`;
+
+/**
+ * BUSYNESS OVERRIDES CAPABILITY SPLITTING. The fingerprint keeps idle
+ * runtimes from crossing capability sets because what matters there is
+ * the NEXT send: it must be configured by the acquiring surface's own
+ * getters. A busy runtime is different — its in-flight turn was already
+ * configured by the surface that started it, so reattaching another
+ * surface to it for display cannot mis-scope anything, while NOT
+ * reattaching would hide a live stream: moving a chat between surfaces
+ * mid-stream (inspector "move to main"/"move to side") lands on a
+ * surface whose fingerprint differs (the inspector always passes
+ * `getActiveDecision`; the page does not), and an exact-fingerprint
+ * lookup alone would miss the streaming runtime and rebuild from stale
+ * data. Once the turn finishes, `onFinish` invalidates, the refetch
+ * diverges the seed, and the idle reconcile rebuilds under the
+ * acquiring surface's own fingerprint with its own getters — capability
+ * purity is restored at exactly the moment it matters again.
+ *
+ * Matched on THREAD identity, not query key: the query key embeds
+ * `contextKind` (and `allowMissingThread`), so an inspector surface
+ * opened with `getActiveSkill` registers under an "active-skill" query
+ * key while the main page acquires the same thread under the "plain"
+ * one — a query-key-scoped scan would miss that live stream entirely.
+ *
+ * Sends are serialized per thread in the UI, so two busy entries for
+ * one thread should not occur; if state ever degrades to that, the
+ * first entry in Map insertion order wins, deterministically.
+ */
+const findBusyChatRuntimeEntryForThread = (
+  threadIdentity: string,
+): ChatRuntimeRegistryEntry | undefined => {
+  for (const entry of chatRuntimeRegistry.values()) {
+    if (
+      entry.threadIdentity === threadIdentity &&
+      isChatRuntimeBusy(entry.runtime)
+    ) {
+      return entry;
+    }
+  }
+  return undefined;
+};
+
+const isChatThreadQueryKey = (queryKey: unknown): boolean =>
+  Array.isArray(queryKey) &&
+  queryKey.at(0) === "chat" &&
+  queryKey.at(2) === "thread";
+
+const chatRuntimeCleanupInstalledClients = new WeakSet<QueryClient>();
+
+/**
+ * Wire `chatRuntimeRegistry` eviction to the query cache's own GC.
+ * Idempotent per `QueryClient` (mirrors `installPDFDocumentCleanup`);
+ * call once, e.g. wherever the app's `QueryClient` is constructed.
+ */
+export const installChatRuntimeCleanup = (queryClient: QueryClient): void => {
+  if (chatRuntimeCleanupInstalledClients.has(queryClient)) {
+    return;
+  }
+  chatRuntimeCleanupInstalledClients.add(queryClient);
+
+  queryClient.getQueryCache().subscribe((event) => {
+    if (
+      event.type !== "removed" ||
+      !isChatThreadQueryKey(event.query.queryKey)
+    ) {
+      return;
+    }
+    // One query key can own several registry entries (one per context
+    // capability fingerprint), so sweep by the entry's recorded query
+    // key rather than deleting a single map key. Deleting during Map
+    // iteration is safe per spec.
+    const removedKeyString = JSON.stringify(event.query.queryKey);
+    for (const [registryKey, entry] of chatRuntimeRegistry) {
+      if (entry.queryKeyString === removedKeyString) {
+        chatRuntimeRegistry.delete(registryKey);
+      }
+    }
+  });
+};
+
+export type AcquireChatRuntimeArgs = {
+  activeOrganizationId: string;
+  context: ChatThreadOptionsContext | undefined;
+  /**
+   * The pure-data result of the matching `chatThreadOptions` query.
+   * Seeds a freshly built runtime (`messages` are already sanitized by
+   * the queryFn) and provides the freshness signal for the idle
+   * reconcile on a registry hit.
+   */
+  data: ChatThreadFetched;
+  key: ChatThreadKey;
+  queryClient: QueryClient;
+};
+
+/**
+ * Resolve the live `ChatRuntime` for a thread, building and registering
+ * one from `context`'s live getters on a registry miss. See
+ * `chatRuntimeRegistry`'s docs for the full reuse/replacement lifecycle.
+ *
+ * Reattach priority, reconciled against `data`'s freshness signal:
+ *   1. Busy runtime under the caller's exact registry key: returned
+ *      unconditionally, regardless of signal. Never replace mid-stream —
+ *      this is what keeps an in-flight chat alive across navigation, and
+ *      what makes the `/chat` route-handoff work: the handoff sender
+ *      registers the runtime and starts the stream BEFORE navigating, so
+ *      the destination page's acquire (identical fingerprint) lands here
+ *      and reattaches instead of rebuilding.
+ *   2. Busy runtime under ANY other registry key for the same THREAD
+ *      (any fingerprint, any query key — the inspector's active-skill
+ *      surface and the main page's plain surface use different query
+ *      keys for one thread): returned unconditionally — see
+ *      `findBusyChatRuntimeEntryForThread` (busyness overrides
+ *      capability splitting). Checked BEFORE the idle exact reattach so
+ *      a stale idle entry left under the acquiring surface's own key can
+ *      never shadow a live stream running under a foreign one. The
+ *      reattach also records an ALIAS entry under the ACQUIRER's
+ *      registry key — same runtime object, the source entry's seed — so
+ *      that after the stream finishes but before the refetch lands, the
+ *      acquirer's stale-data render takes the idle seed-equal exact hit
+ *      (priority 3) instead of missing and rebuilding from pre-send
+ *      messages (the finding-1 race, reintroduced through this path
+ *      without the alias). Idempotent across renders: once the alias
+ *      exists, subsequent busy renders resolve it at priority 1.
+ *   3. Idle exact-key runtime, signal equal to the entry's build-time
+ *      seed: returned as-is. This covers a plain revisit AND the window
+ *      between a turn's `onFinish` (which only invalidates) and its
+ *      refetch landing: cached data is still pre-send, the frozen seed
+ *      is too, so the runtime — which holds the finished turn
+ *      internally — is kept and the transcript never flickers back.
+ *   4. Rebuild: the refetch (or a cross-tab/device background refetch)
+ *      delivered messages the exact-key runtime was not built from, or
+ *      no entry exists. Build from the CURRENT caller's live getters and
+ *      fresh sanitized messages (the pre-registry design rebuilt on
+ *      every queryFn run; this is the idle-only equivalent). This is
+ *      also the moment a busy-reattached foreign runtime — or a
+ *      route-handoff runtime — sheds its originating surface's getters
+ *      in favour of the mounted caller's. Superseded same-thread entries
+ *      (idle, diverged seed — finished streams whose data has been
+ *      refetched, including both a busy-reattach's SOURCE entry and any
+ *      ALIAS of it under other keys) are explicitly deleted here so one
+ *      thread does not accumulate a dead entry per fingerprint;
+ *      seed-equal entries are kept — they belong to a concurrently
+ *      mounted surface built from the same fresh data.
+ */
+export const acquireChatRuntime = ({
+  activeOrganizationId,
+  context,
+  data,
+  key,
+  queryClient,
+}: AcquireChatRuntimeArgs): ChatRuntime => {
+  const queryKeyString = JSON.stringify(
+    chatThreadCacheKey({ activeOrganizationId, context, key }),
+  );
+  const registryKey = toChatRuntimeRegistryKey(queryKeyString, context);
+  const threadIdentity = chatThreadIdentity({ activeOrganizationId, key });
+  const seed = toChatRuntimeSeedSignal(data);
+  const existing = chatRuntimeRegistry.get(registryKey);
+  // Priority 1: busy runtime under the exact registry key.
+  if (existing !== undefined && isChatRuntimeBusy(existing.runtime)) {
+    return existing.runtime;
+  }
+  // Priority 2: busy runtime under any other registry key for this
+  // thread. Record an alias under the acquirer's key (same runtime, the
+  // source's seed) so the post-finish stale render reattaches via the
+  // seed-equal exact hit instead of rebuilding from pre-send messages.
+  // Overwrites a stale idle exact entry on purpose: the user is looking
+  // at the streaming runtime now, so a later seed-equal hit must return
+  // it, not the pre-stream leftover.
+  const busyEntry = findBusyChatRuntimeEntryForThread(threadIdentity);
+  if (busyEntry !== undefined) {
+    chatRuntimeRegistry.set(registryKey, {
+      runtime: busyEntry.runtime,
+      seed: busyEntry.seed,
+      queryKeyString,
+      threadIdentity,
+    });
+    return busyEntry.runtime;
+  }
+  // Priority 3: idle exact-key reattach on an unchanged signal.
+  if (existing !== undefined && seedSignalsEqual(existing.seed, seed)) {
+    return existing.runtime;
+  }
+  // Priority 4: rebuild. Every entry for this thread is idle here (the
+  // busy scan above found none), so drop superseded same-thread entries —
+  // idle, diverged seed — before registering the replacement; the `set`
+  // at the end replaces the exact-key entry atomically.
+  for (const [staleKey, entry] of chatRuntimeRegistry) {
+    if (
+      staleKey !== registryKey &&
+      entry.threadIdentity === threadIdentity &&
+      !seedSignalsEqual(entry.seed, seed)
+    ) {
+      chatRuntimeRegistry.delete(staleKey);
+    }
+  }
+
+  const runtime = createChatRuntime({
+    context,
+    initialMessages: data.messages,
+    key,
+    onError: (error) => {
+      getAnalytics().captureError(error);
+    },
+    onFinish: () => {
+      // Invalidate only — do NOT evict the registry entry here. The
+      // component re-renders from the runtime's final stream updates
+      // before this invalidation's refetch lands; with the entry gone
+      // that render's acquire would be a registry MISS against still
+      // stale cached data and would rebuild from pre-send messages,
+      // wiping the finished turn until the refetch wins (or forever if
+      // it fails). Kept in place, the entry reattaches seed-equal until
+      // the refetch lands, then the idle reconcile replaces it.
+      void Promise.all([
+        invalidateChatThread({ queryClient, threadRef: key }),
+        invalidateGroupedChatThreads(queryClient),
+      ]);
+    },
+  });
+  chatRuntimeRegistry.set(registryKey, {
+    runtime,
+    seed,
+    queryKeyString,
+    threadIdentity,
+  });
+  return runtime;
+};
 
 type ChatThreadRecapFetched = {
   recap: string | null;

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -60,6 +60,7 @@ import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
 import {
+  acquireChatRuntime,
   chatThreadOptions,
   groupedChatThreadsOptions,
   invalidateGroupedChatThreads,
@@ -397,26 +398,47 @@ function ChatIndex() {
                 if (!(await ensureAIAvailable())) {
                   return;
                 }
-                // Build the request payload first, then resolve the
-                // Chat<> instance from the cache; the thread route
-                // reads the *same* cached instance, so kicking off
-                // `sendMessage` here lets the thread page observe
-                // the in-flight stream as soon as it mounts.
-                const [message, { chat }] = await Promise.all([
+                // Build the request payload and fetch the pure thread data
+                // in parallel, then resolve (and register) the Chat<>
+                // runtime from this component's own live getters; the
+                // thread route resolves the *same* registered runtime (see
+                // `acquireChatRuntime` — this context carries the exact
+                // capability set ChatThreadPage passes, so both map to
+                // the same registry fingerprint), and kicking off the
+                // send here lets the thread page observe the in-flight
+                // stream as soon as it mounts. The stream started below
+                // also makes the runtime BUSY before the destination
+                // page's acquire runs, so its idle-reconcile can never
+                // rebuild the handoff runtime out from under the live
+                // stream — it always takes the mid-stream reattach
+                // branch. The runtime keeps THIS page's getters until the
+                // turn's onFinish invalidation refetches the thread
+                // query; the destination page's post-refetch acquire then
+                // sees the diverged seed signal and rebuilds with its own
+                // getters.
+                const chatThreadContext = {
+                  allowMissingThread: true,
+                  getUserContext,
+                  getContextMatterIds,
+                  getSendMode,
+                };
+                const [message, threadData] = await Promise.all([
                   buildChatRequestMessage(draft),
                   queryClient.ensureQueryData(
                     chatThreadOptions({
                       activeOrganizationId,
                       key: threadRef,
-                      context: {
-                        allowMissingThread: true,
-                        getUserContext,
-                        getContextMatterIds,
-                        getSendMode,
-                      },
+                      context: chatThreadContext,
                     }),
                   ),
                 ]);
+                const chat = acquireChatRuntime({
+                  activeOrganizationId,
+                  context: chatThreadContext,
+                  data: threadData,
+                  key: threadRef,
+                  queryClient,
+                });
 
                 // Start the stream before navigation and require
                 // the user message to be locally visible. If the

--- a/apps/web/src/routes/_protected.chat/workspaces/$workspaceId/$threadId.tsx
+++ b/apps/web/src/routes/_protected.chat/workspaces/$workspaceId/$threadId.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { toChatThreadId } from "@/lib/chat-thread-ref";
-// oxlint-disable-next-line require-loader-prefetch/require-loader-prefetch -- chatThreadOptions builds the ChatRuntime from component-provided context getters (auth user, matter ids, send mode); a loader prefetch would cache a stub-context runtime under the same key and the first send would bypass anonymization. Fixing needs the queryFn split into a pure data fetch plus in-component runtime construction
+import { ensureRouteQueryData } from "@/lib/react-query";
 import { ChatThreadPage } from "@/routes/_protected.chat/-components/chat-thread-page";
 import { useWorkspaceChatMentionRegistration } from "@/routes/_protected.chat/-hooks/use-workspace-chat-mention-registration";
+import { chatThreadOptions } from "@/routes/_protected.chat/-queries";
 
 export const Route = createFileRoute(
   "/_protected/chat/workspaces/$workspaceId/$threadId",
@@ -13,6 +14,27 @@ export const Route = createFileRoute(
   // pending splash so consecutive thread navigations don't flash
   // a logo loader between two cached chats.
   pendingMs: 1000,
+  loader: async ({ context, params }) => {
+    // Prime the pure thread-data query the page suspends on; see the
+    // sibling `/_protected/chat/$threadId` loader for why `context` here
+    // is a key-shape stub and never seeds a `ChatRuntime`, and why the
+    // loader only fills a COLD cache (cached data renders immediately and
+    // background-refetches; awaiting here would clobber the maximize-tab
+    // `contextMatterIds` seeding).
+    const options = chatThreadOptions({
+      activeOrganizationId: context.user.activeOrganizationId,
+      key: {
+        scope: "workspace",
+        threadId: toChatThreadId(params.threadId),
+        workspaceId: params.workspaceId,
+      },
+      context: { allowMissingThread: true },
+    });
+    if (context.queryClient.getQueryData(options.queryKey) !== undefined) {
+      return;
+    }
+    await ensureRouteQueryData(context.queryClient, options);
+  },
 });
 
 function WorkspaceThreadRoute() {

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
@@ -80,6 +80,7 @@ import { toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 import { inputTypeValueKind } from "@/lib/value-types";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
+import { useChatThreadRuntime } from "@/routes/_protected.chat/-hooks/use-chat-thread-runtime";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
 import {
@@ -586,19 +587,25 @@ const TemplateStudioChatInner = ({
   // No `handleActiveDocxEditToolCall` in the context: the transport
   // never invokes it (the approve path below client-executes the tool),
   // and `getActiveTemplate` already keys the cache as "active-template".
+  const chatThreadContext = {
+    allowMissingThread: true,
+    getUserContext,
+    getSendMode,
+    getActiveTemplate: () => getActiveTemplate(),
+  };
   const { data } = useSuspenseQuery(
     chatThreadOptions({
       activeOrganizationId,
       key: threadRef,
-      context: {
-        allowMissingThread: true,
-        getUserContext,
-        getSendMode,
-        getActiveTemplate: () => getActiveTemplate(),
-      },
+      context: chatThreadContext,
     }),
   );
-  const { chat } = data;
+  const chat = useChatThreadRuntime({
+    activeOrganizationId,
+    context: chatThreadContext,
+    data,
+    key: threadRef,
+  });
 
   const {
     error,


### PR DESCRIPTION
Follow-up to #1056, which left two `require-loader-prefetch` suppressions on the chat thread routes because the fix needed a design change rather than a loader edit. This is that change.

## Problem

`chatThreadOptions`' queryFn built the `ChatRuntime` inline, closing over component-provided context getters (auth user, matter ids, send mode). A route-loader prefetch would therefore cache a runtime built from a stub context under the same query key, and `resolveChatRequestSendMode`'s `rawOverride` fallback would silently bypass the anonymization setting on the first send of a freshly navigated thread. So the routes could not prefetch, and every cold navigation to a chat thread paid a render-fetch waterfall.

## Design

- **Pure data query.** `chatThreadOptions` now fetches messages/cursor/flags only and never touches the context getters, so `ensureRouteQueryData` in a loader is safe by construction: there is no code path that bakes a stub context into a runtime.
- **Runtime registry.** Runtimes live in a module-level `Map` keyed by the same cache-identity tuple as the query (one shared `chatThreadCacheKey` helper, so the two can never drift). They are built exclusively where live getters exist: a mounted component (`useChatThreadRuntime`) or the `/chat` route-handoff sender, which registers the runtime and starts the stream before navigating so the destination page reattaches to it.
- **Reattach vs. reconcile.** A busy runtime (streaming, submitted, optimistic send pending, or a running tool call between hops) is always reattached: an in-flight stream survives navigation unconditionally. An idle entry whose seed signal (`lastActivityAt` + last message id) diverges from freshly fetched data is rebuilt from the current caller's live getters, preserving the previous rebuild-on-refetch behavior for background refetches (refocus staleness, broadcast invalidations).
- **Lifecycle.** `onFinish` evicts its own entry (identity-guarded so a late finish from a superseded runtime cannot evict its successor) and then invalidates the pure-data query; query-cache GC sweeps leftovers via `installChatRuntimeCleanup` (mirrors `installPDFDocumentCleanup`), so an opened-and-abandoned thread does not hold its messages in memory indefinitely.
- `structuralSharing: false` stays on the query (comment updated with the current rationale).

Both chat thread routes now prefetch in their loaders, which also satisfies `require-loader-prefetch`; the two suppressions are removed. All four `chatThreadOptions` consumers (thread page, inspector chat tab, file chat overlay, template studio chat) migrated to the shared hook.

## Tests

New `acquireChatRuntime` reconcile suite: same-signal reattach keeps identity; idle-plus-newer rebuild produces a new runtime whose next send provably carries the second caller's send mode (not the fallback); a mid-stream runtime with a diverged signal is kept until its own `onFinish`, then rebuilt. Full web suite: 819 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat screens now prime thread data in advance so pages mount with less waiting.
  * Chat UI now consistently uses a dedicated live chat runtime hook to power active thread behaviour.
* **Bug Fixes**
  * Improved handling of in-progress chat streams across navigation, including running tool-call activity.
  * Reduced stale or inconsistent rendering by reattaching to the correct runtime based on current thread data and capabilities; sanitised partially-finished tool calls on hydration.
* **Chores**
  * Added automatic chat runtime cleanup during router initialisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->