### PR TITLE
chore: clean architectural migration debt

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,6 +1,6 @@
 # Stella API
 
-The Stella backend API built with [Elysia](https://elysiajs.com/) and [Rivet](https://www.rivet.dev/).
+The Stella backend API built with [Elysia](https://elysiajs.com/).
 
 ## Getting Started
 
@@ -17,8 +17,3 @@ bun --filter @stll/api dev
 ```
 
 The API serves on [http://localhost:3001](http://localhost:3001) by default.
-The Rivet dashboard serves on [http://localhost:6420](http://localhost:6420) by default.
-
-## Good to know
-
-You can find data stored by Rivet in `~/.local/share`. Whenever you update the rivet version you need to clear the stored data.

--- a/apps/api/src/handlers/skills/list.ts
+++ b/apps/api/src/handlers/skills/list.ts
@@ -1,13 +1,26 @@
 import { Result } from "better-result";
-import { and, desc, eq, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { listSkillMetadata, listSkillResources } from "@stll/skills";
 
-import { agentSkills, AGENT_SKILL_SCOPES } from "@/api/db/schema";
+import {
+  agentSkills,
+  AGENT_SKILL_SCOPES,
+  type AgentSkillScope,
+} from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
+import { brandPersistedAgentSkillId } from "@/api/lib/safe-id-boundaries";
 
 const listSkillsQuerySchema = t.Object({
   limit: t.Optional(
@@ -16,7 +29,7 @@ const listSkillsQuerySchema = t.Object({
       maximum: LIMITS.agentSkillsPageSizeMax,
     }),
   ),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
 });
 
 const config = {
@@ -25,11 +38,46 @@ const config = {
   query: listSkillsQuerySchema,
 } satisfies HandlerConfig;
 
+type SkillCursor = {
+  enabled: boolean;
+  scope: AgentSkillScope;
+  name: string;
+  id: SafeId<"agentSkill">;
+};
+
+const isAgentSkillScope = (value: unknown): value is AgentSkillScope => {
+  for (const scope of AGENT_SKILL_SCOPES) {
+    if (value === scope) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const decodeSkillCursor = (cursor: string): SkillCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const enabled = parts?.at(0);
+  const scope = parts?.at(1);
+  const name = parts?.at(2);
+  const id = parts?.at(3);
+
+  if (
+    typeof enabled !== "boolean" ||
+    !isAgentSkillScope(scope) ||
+    typeof name !== "string" ||
+    !isUuidPaginationCursorPart(id)
+  ) {
+    return null;
+  }
+
+  return { enabled, scope, name, id: brandPersistedAgentSkillId(id) };
+};
+
 const listSkills = createSafeRootHandler(
   config,
   async function* ({ safeDb, session, user, memberRole, query }) {
     const limit = query.limit ?? LIMITS.agentSkillsPageSizeDefault;
-    const offset = query.offset ?? 0;
 
     const visibilityFilter = and(
       eq(agentSkills.organizationId, session.activeOrganizationId),
@@ -38,6 +86,44 @@ const listSkills = createSafeRootHandler(
         eq(agentSkills.userId, user.id),
       ),
     );
+    const conditions = [visibilityFilter];
+
+    if (query.cursor) {
+      const cursor = decodeSkillCursor(query.cursor);
+
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const sameEnabledCursorCondition = or(
+        and(
+          eq(agentSkills.enabled, cursor.enabled),
+          gt(agentSkills.scope, cursor.scope),
+        ),
+        and(
+          eq(agentSkills.enabled, cursor.enabled),
+          eq(agentSkills.scope, cursor.scope),
+          gt(agentSkills.name, cursor.name),
+        ),
+        and(
+          eq(agentSkills.enabled, cursor.enabled),
+          eq(agentSkills.scope, cursor.scope),
+          eq(agentSkills.name, cursor.name),
+          gt(agentSkills.id, cursor.id),
+        ),
+      );
+
+      const cursorCondition = cursor.enabled
+        ? or(eq(agentSkills.enabled, false), sameEnabledCursorCondition)
+        : sameEnabledCursorCondition;
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
+
     const installedRows = yield* Result.await(
       safeDb((tx) =>
         tx
@@ -65,19 +151,22 @@ const listSkills = createSafeRootHandler(
             createdAt: agentSkills.createdAt,
           })
           .from(agentSkills)
-          .where(visibilityFilter)
+          .where(and(...conditions))
           .orderBy(
             desc(agentSkills.enabled),
-            agentSkills.scope,
-            agentSkills.name,
-            agentSkills.id,
+            asc(agentSkills.scope),
+            asc(agentSkills.name),
+            asc(agentSkills.id),
           )
-          .limit(limit + 1)
-          .offset(offset),
+          .limit(limit + 1),
       ),
     );
-    const hasMore = installedRows.length > limit;
-    const installed = hasMore ? installedRows.slice(0, limit) : installedRows;
+    const installedPage = createCursorPage({
+      rows: installedRows,
+      limit,
+      cursorForItem: (item) =>
+        encodePaginationCursor([item.enabled, item.scope, item.name, item.id]),
+    });
 
     return Result.ok({
       canManageTeam: ["admin", "owner"].includes(memberRole.role),
@@ -94,8 +183,9 @@ const listSkills = createSafeRootHandler(
         enabled: true,
         resourceCount: listSkillResources(skill.name).length,
       })),
-      installed,
-      nextOffset: hasMore ? offset + installed.length : null,
+      installed: installedPage.items,
+      limit: installedPage.limit,
+      nextCursor: installedPage.nextCursor,
     });
   },
 );

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -99,6 +99,10 @@ export const brandPersistedAuditLogId = (
   auditLogId: string,
 ): SafeId<"auditLog"> => toSafeId<"auditLog">(auditLogId);
 
+export const brandPersistedAgentSkillId = (
+  agentSkillId: string,
+): SafeId<"agentSkill"> => toSafeId<"agentSkill">(agentSkillId);
+
 export const brandPersistedBillingCodeId = (
   billingCodeId: string,
 ): SafeId<"billingCode"> => toSafeId<"billingCode">(billingCodeId);

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-model.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-model.ts
@@ -13,11 +13,11 @@ import {
 } from "@/routes/_protected.knowledge/-components/template-studio-store";
 import {
   defaultCompositeFormat,
-  type EditableField,
   type EditableLookupFormat,
   type EditablePart,
   type FieldValidation,
   isLookupRegistry,
+  type TemplateEditableField,
 } from "@/routes/_protected.knowledge/-components/template-wizard";
 // ── Manifest <-> state ───────────────────────────────────
 
@@ -31,7 +31,7 @@ const INPUT_TYPE_VALUES = [
 
 export const isInputType = (
   value: string,
-): value is EditableField["inputType"] =>
+): value is TemplateEditableField["inputType"] =>
   INPUT_TYPE_VALUES.some((type) => type === value);
 
 const trimChar = (value: string, ch: string): string => {
@@ -243,7 +243,7 @@ const parseEditableLookupFormats = (raw: unknown): EditableLookupFormat[] => {
 
 type ManifestField = {
   path: string;
-  inputType: EditableField["inputType"];
+  inputType: TemplateEditableField["inputType"];
   label?: string;
   required?: boolean;
   options?: string[];
@@ -253,12 +253,12 @@ type ManifestField = {
   parts?: EditablePart[];
   format?: string;
   optionsFrom?: string;
-  lookup?: EditableField["lookup"];
+  lookup?: TemplateEditableField["lookup"];
   formula?: string;
   condition?: string;
   conditionAst?: ConditionNode;
   hint?: string;
-  dateFormat?: EditableField["dateFormat"];
+  dateFormat?: TemplateEditableField["dateFormat"];
   validation?: FieldValidation;
 };
 

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-store.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-store.ts
@@ -4,7 +4,7 @@ import type { TemplateRecipeDefinition } from "@stll/api/types";
 import type { DirectiveRange, TemplatePreviewValue } from "@stll/folio-react";
 
 import type { ReplacementSpec } from "@/routes/_protected.knowledge/-components/template-studio-suggestions";
-import type { EditableField } from "@/routes/_protected.knowledge/-components/template-wizard";
+import type { TemplateEditableField } from "@/routes/_protected.knowledge/-components/template-wizard";
 
 // The Studio's editable manifest data + live document selection. Lives in a
 // module-level store (not the inspector tab payload, which must be
@@ -12,7 +12,7 @@ import type { EditableField } from "@/routes/_protected.knowledge/-components/te
 // History tab — rendered in the global inspector, a separate React tree — share
 // one source of truth. Only one template is authored at a time.
 
-export type StudioField = EditableField & {
+export type StudioField = TemplateEditableField & {
   aiPrompt: string | undefined;
   /** Person fills a stub; AI rewords it per occurrence to fit the context. */
   aiAdapt: boolean;

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -101,7 +101,7 @@ import {
   type StudioField,
 } from "@/routes/_protected.knowledge/-components/template-studio-store";
 import { filledByForFieldMeta } from "@/routes/_protected.knowledge/-components/template-studio-suggestions";
-import type { EditableField } from "@/routes/_protected.knowledge/-components/template-wizard";
+import type { TemplateEditableField } from "@/routes/_protected.knowledge/-components/template-wizard";
 import {
   clausesOptions as clauseLibraryOptions,
   knowledgeKeys,
@@ -390,7 +390,7 @@ type GestureEnrichment =
   | {
       status: "ready";
       label: string | undefined;
-      inputType: EditableField["inputType"] | undefined;
+      inputType: TemplateEditableField["inputType"] | undefined;
       aiPrompt: string | undefined;
       fieldPath: string | undefined;
     };

--- a/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
@@ -96,7 +96,7 @@ export const FIELD_TYPE_CHOICES = [
 
 /** What the type picker (and the field row) shows: "company" when a lookup
  *  is configured, the manifest input type otherwise. */
-const fieldTypeChoice = (field: EditableField): InputType | "company" =>
+const fieldTypeChoice = (field: TemplateEditableField): InputType | "company" =>
   field.lookup === undefined ? field.inputType : "company";
 
 export const PART_INPUT_TYPES = ["text", "select"] as const;
@@ -171,7 +171,7 @@ export type EditablePart = {
   pattern?: string | undefined;
 };
 
-export type EditableField = {
+export type TemplateEditableField = {
   path: string;
   kind: string;
   label: string;
@@ -271,7 +271,7 @@ const inferInputType = (field: ResolvedField): InputType => {
 
 export const buildEditableFields = (
   fields: readonly ResolvedField[],
-): EditableField[] =>
+): TemplateEditableField[] =>
   fields.map((f) => ({
     path: f.path,
     kind: f.kind,
@@ -323,7 +323,7 @@ export const defaultCompositeFormat = (
 };
 
 export const compositeManifestProps = (
-  field: EditableField,
+  field: TemplateEditableField,
 ): CompositeManifestProps => {
   const parts = (field.parts ?? []).filter((part) => part.key.trim() !== "");
   // An untyped format defaults to all parts joined by spaces, so a composite
@@ -361,7 +361,7 @@ export const compositeManifestProps = (
  * invalid empty lookup.
  */
 export const lookupManifestProps = (
-  field: EditableField,
+  field: TemplateEditableField,
 ): EditableLookup | undefined => {
   if (
     field.lookup === undefined ||
@@ -392,7 +392,9 @@ export const lookupManifestProps = (
  * The manifest shape of a field's fill hint: the trimmed text, with a blank
  * one normalized away. Kept short — the input enforces {@link HINT_MAX_LENGTH}.
  */
-export const hintManifestProps = (field: EditableField): string | undefined => {
+export const hintManifestProps = (
+  field: TemplateEditableField,
+): string | undefined => {
   const hint = field.hint?.trim() ?? "";
   return hint === "" ? undefined : hint;
 };
@@ -403,7 +405,7 @@ export const hintManifestProps = (field: EditableField): string | undefined => {
  * different value).
  */
 export const dateFormatManifestProps = (
-  field: EditableField,
+  field: TemplateEditableField,
 ): TemplateDateFormat | undefined => {
   if (
     field.inputType !== "date" ||
@@ -423,7 +425,7 @@ export const dateFormatManifestProps = (
  * composite configuration takes precedence and suppresses the formula.
  */
 export const formulaManifestProps = (
-  field: EditableField,
+  field: TemplateEditableField,
 ): string | undefined => {
   if (field.formula === undefined || field.parts !== undefined) {
     return undefined;
@@ -459,7 +461,7 @@ export const ConfigureStep = ({
   const [expandedField, setExpandedField] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  const updateField = (path: string, patch: Partial<EditableField>) => {
+  const updateField = (path: string, patch: Partial<TemplateEditableField>) => {
     setFields((prev) =>
       prev.map((f) => (f.path === path ? { ...f, ...patch } : f)),
     );
@@ -764,8 +766,8 @@ const CompositePartsEditor = ({
   field,
   onUpdate,
 }: {
-  field: EditableField;
-  onUpdate: (patch: Partial<EditableField>) => void;
+  field: TemplateEditableField;
+  onUpdate: (patch: Partial<TemplateEditableField>) => void;
 }) => {
   const t = useTranslations();
   const parts = field.parts ?? [];
@@ -933,8 +935,8 @@ const OptionsFromFieldControl = ({
   onUpdate,
   siblingPaths,
 }: {
-  field: EditableField;
-  onUpdate: (patch: Partial<EditableField>) => void;
+  field: TemplateEditableField;
+  onUpdate: (patch: Partial<TemplateEditableField>) => void;
   siblingPaths?: readonly string[] | undefined;
 }) => {
   const t = useTranslations();
@@ -1192,8 +1194,8 @@ const CompanyLookupConfig = ({
   field,
   onUpdate,
 }: {
-  field: EditableField;
-  onUpdate: (patch: Partial<EditableField>) => void;
+  field: TemplateEditableField;
+  onUpdate: (patch: Partial<TemplateEditableField>) => void;
 }) => {
   const t = useTranslations();
   const locale = useLocale();
@@ -1492,8 +1494,8 @@ const DateFormatConfigControl = ({
   onUpdate,
   defaultLocale,
 }: {
-  field: EditableField;
-  onUpdate: (patch: Partial<EditableField>) => void;
+  field: TemplateEditableField;
+  onUpdate: (patch: Partial<TemplateEditableField>) => void;
   /** Locale preselected before the user picks one — the template's primary
    *  language when the host knows it, the app locale otherwise. */
   defaultLocale: string;
@@ -1573,8 +1575,8 @@ const FormulaConfigControl = ({
   field,
   onUpdate,
 }: {
-  field: EditableField;
-  onUpdate: (patch: Partial<EditableField>) => void;
+  field: TemplateEditableField;
+  onUpdate: (patch: Partial<TemplateEditableField>) => void;
 }) => {
   const t = useTranslations();
 
@@ -1634,8 +1636,8 @@ export const FieldConfigEditor = ({
   hideFormulaControl = false,
   defaultDateLocale,
 }: {
-  field: EditableField;
-  onUpdate: (patch: Partial<EditableField>) => void;
+  field: TemplateEditableField;
+  onUpdate: (patch: Partial<TemplateEditableField>) => void;
   /** Embedded in the Studio's field face: the face header already shows the
    *  path, and the wizard's chevron-row indent doesn't apply. */
   embedded?: boolean;

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -570,8 +570,8 @@ export const skillsOptions = (organizationId: string) =>
     queryFn: async ({ pageParam, signal }) => {
       const response = await api.skills.get({
         query: {
+          ...(pageParam ? { cursor: pageParam } : {}),
           limit: SKILLS_PAGE_SIZE,
-          offset: pageParam,
         },
         fetch: { signal },
       });
@@ -580,8 +580,8 @@ export const skillsOptions = (organizationId: string) =>
       }
       return response.data;
     },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -568,11 +568,14 @@ export const skillsOptions = (organizationId: string) =>
       limit: SKILLS_PAGE_SIZE,
     }),
     queryFn: async ({ pageParam, signal }) => {
+      const query: { limit: number; cursor?: string } = {
+        limit: SKILLS_PAGE_SIZE,
+      };
+      if (pageParam !== "") {
+        query.cursor = pageParam;
+      }
       const response = await api.skills.get({
-        query: {
-          ...(pageParam ? { cursor: pageParam } : {}),
-          limit: SKILLS_PAGE_SIZE,
-        },
+        query,
         fetch: { signal },
       });
       if (response.error) {
@@ -580,8 +583,8 @@ export const skillsOptions = (organizationId: string) =>
       }
       return response.data;
     },
-    initialPageParam: null as string | null,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    initialPageParam: "",
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
@@ -17,7 +17,6 @@ import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-quer
 
 /**
  * Returns a function that starts an AI extraction workflow via REST.
- * Replaces the old `useWorkflowActor().startWorkflow()` Rivet call.
  */
 export const useStartWorkflow = (workspaceId: string) => {
   const queryClient = useQueryClient();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -208,8 +208,7 @@ function RouteComponent() {
     previewClearTimersRef.current.set(key, nextTimer);
   };
 
-  // Subscribe to workspace SSE events for real-time query
-  // invalidation (replaces the Rivet sync actor for this workspace).
+  // Subscribe to workspace SSE events for real-time query invalidation.
   useWorkspaceSSE(workspaceId, { onEvent: handleWorkspaceSSEEvent });
 
   // Register the matter's entities as `@`-mention sources for any

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1695,22 +1695,7 @@ export default defineConfig({
       files: ["apps/api/src/handlers/**/*.ts"],
       rules: {
         "no-body-ownership-ids/no-body-ownership-ids": "error",
-        "no-offset-pagination/no-offset-pagination": [
-          "error",
-          {
-            // Legacy offset-paginated list endpoints. New list endpoints must
-            // use cursor pagination and return Page<T>.
-            allowedFiles: [
-              "apps/api/src/handlers/billing-codes/read.ts",
-              "apps/api/src/handlers/expenses/read.ts",
-              "apps/api/src/handlers/invoices/read.ts",
-              "apps/api/src/handlers/rates/entries-read.ts",
-              "apps/api/src/handlers/rates/read.ts",
-              "apps/api/src/handlers/skills/list.ts",
-              "apps/api/src/handlers/time-entries/read.ts",
-            ],
-          },
-        ],
+        "no-offset-pagination/no-offset-pagination": "error",
         "no-raw-user-id-schema/no-raw-user-id-schema": "error",
         "no-untyped-updates/no-untyped-updates": "error",
         "security-guards/no-unscoped-user-query": "error",


### PR DESCRIPTION
## Summary
- remove stale Rivet references from live docs and comments
- migrate the skills list endpoint and web query from offset pagination to cursor pagination
- remove the stale offset-pagination lint allowlist and rename the template manifest field type to avoid EditableField ambiguity

## Validation
- targeted oxlint on touched files passed before push
- @stll/api typecheck passed before push
- full local checks were not completed to avoid overloading the machine; CI should run the full suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills lists now load with cursor-based pagination for smoother browsing and more reliable results.
  * The web app’s skills loading flow now supports the new paging behaviour.

* **Bug Fixes**
  * Improved handling of invalid pagination tokens to prevent broken list requests.
  * Real-time workspace updates and form editing now use a more consistent field structure.

* **Documentation**
  * Updated backend setup notes and removed outdated references.

* **Chores**
  * Tightened linting rules to discourage offset-based pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->