### PR TITLE
fix: guard Railway template-source credentials

### DIFF
--- a/.github/workflows/railway-template-source.yml
+++ b/.github/workflows/railway-template-source.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Check Railway template-source runtime credentials
         env:
+          RAILWAY_PROJECT_TOKEN: ${{ secrets.RAILWAY_PROJECT_TOKEN }}
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
           RAILWAY_TEMPLATE_PROJECT_ID: ${{ inputs.project_id || vars.RAILWAY_TEMPLATE_PROJECT_ID }}
           RAILWAY_TEMPLATE_ENVIRONMENT: ${{ inputs.environment || vars.RAILWAY_TEMPLATE_ENVIRONMENT || 'production' }}

--- a/.github/workflows/railway-template-source.yml
+++ b/.github/workflows/railway-template-source.yml
@@ -1,0 +1,46 @@
+name: Railway Template Source
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: "Railway template-source project ID. Defaults to RAILWAY_TEMPLATE_PROJECT_ID."
+        required: false
+        type: string
+      environment:
+        description: "Railway environment name or ID."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: railway-template-source
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Check template-source runtime credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Check Railway template-source runtime credentials
+        env:
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_TEMPLATE_PROJECT_ID: ${{ inputs.project_id || vars.RAILWAY_TEMPLATE_PROJECT_ID }}
+          RAILWAY_TEMPLATE_ENVIRONMENT: ${{ inputs.environment || vars.RAILWAY_TEMPLATE_ENVIRONMENT || 'production' }}
+        run: bun run check:railway-template-source-runtime

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -95,47 +95,47 @@ shape is `railway/template-manifest.json`.
 
 Template editor checklist for `api` variables:
 
-| Variable                   | Source                                              | Prompt user? |
-| -------------------------- | --------------------------------------------------- | ------------ |
-| `DATABASE_URL`             | `${{Postgres.DATABASE_URL}}`                        | No           |
-| `REDIS_URL`                | `${{Redis.REDIS_URL}}`                              | No           |
-| `FRONTEND_URL`             | `https://${{web.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
-| `BETTER_AUTH_URL`          | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
-| `PUBLIC_URL`               | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`            | No           |
-| `BETTER_AUTH_SECRET`       | `${{secret(64, "abcdef0123456789")}}`               | No           |
-| `CONTENT_ENCRYPTION_KEY`   | `${{secret(64, "abcdef0123456789")}}`               | No           |
-| `SELFHOST_LOCAL_PASSWORD_AUTH` | `true`                                          | No           |
-| `SELFHOST_BOOTSTRAP_TOKEN` | `${{secret(40, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")}}` | No           |
-| `EMAIL_PROVIDER`           | Optional: `smtp` or `ses`                           | No           |
-| `SMTP_HOST`                | Optional SMTP host                                  | No           |
-| `SMTP_PASSWORD`            | Optional SMTP password or API key                   | No           |
-| `SMTP_PORT`                | Optional SMTP port                                  | No           |
-| `SMTP_USERNAME`            | Optional SMTP username                              | No           |
-| `TRANSACTIONAL_EMAIL_FROM` | Optional verified sender address                    | No           |
-| `S3_ENDPOINT`              | `${{stella-files.ENDPOINT}}`                        | No           |
-| `S3_BUCKET`                | `${{stella-files.BUCKET}}`                          | No           |
-| `S3_REGION`                | `${{stella-files.REGION}}`                          | No           |
-| `S3_ACCESS_KEY_ID`         | `${{stella-files.ACCESS_KEY_ID}}`                   | No           |
-| `S3_SECRET_ACCESS_KEY`     | `${{stella-files.SECRET_ACCESS_KEY}}`               | No           |
-| `GOTENBERG_URL`            | `http://${{gotenberg.RAILWAY_PRIVATE_DOMAIN}}:3000` | No           |
-| `GOTENBERG_USERNAME`       | `${{gotenberg.GOTENBERG_API_BASIC_AUTH_USERNAME}}`  | No           |
-| `GOTENBERG_PASSWORD`       | `${{gotenberg.GOTENBERG_API_BASIC_AUTH_PASSWORD}}`  | No           |
+| Variable                       | Source                                                                              | Prompt user? |
+| ------------------------------ | ----------------------------------------------------------------------------------- | ------------ |
+| `DATABASE_URL`                 | `${{Postgres.DATABASE_URL}}`                                                        | No           |
+| `REDIS_URL`                    | `${{Redis.REDIS_URL}}`                                                              | No           |
+| `FRONTEND_URL`                 | `https://${{web.RAILWAY_PUBLIC_DOMAIN}}`                                            | No           |
+| `BETTER_AUTH_URL`              | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`                                            | No           |
+| `PUBLIC_URL`                   | `https://${{api.RAILWAY_PUBLIC_DOMAIN}}`                                            | No           |
+| `BETTER_AUTH_SECRET`           | `${{secret(64, "abcdef0123456789")}}`                                               | No           |
+| `CONTENT_ENCRYPTION_KEY`       | `${{secret(64, "abcdef0123456789")}}`                                               | No           |
+| `SELFHOST_LOCAL_PASSWORD_AUTH` | `true`                                                                              | No           |
+| `SELFHOST_BOOTSTRAP_TOKEN`     | `${{secret(40, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")}}` | No           |
+| `EMAIL_PROVIDER`               | Optional: `smtp` or `ses`                                                           | No           |
+| `SMTP_HOST`                    | Optional SMTP host                                                                  | No           |
+| `SMTP_PASSWORD`                | Optional SMTP password or API key                                                   | No           |
+| `SMTP_PORT`                    | Optional SMTP port                                                                  | No           |
+| `SMTP_USERNAME`                | Optional SMTP username                                                              | No           |
+| `TRANSACTIONAL_EMAIL_FROM`     | Optional verified sender address                                                    | No           |
+| `S3_ENDPOINT`                  | `${{stella-files.ENDPOINT}}`                                                        | No           |
+| `S3_BUCKET`                    | `${{stella-files.BUCKET}}`                                                          | No           |
+| `S3_REGION`                    | `${{stella-files.REGION}}`                                                          | No           |
+| `S3_ACCESS_KEY_ID`             | `${{stella-files.ACCESS_KEY_ID}}`                                                   | No           |
+| `S3_SECRET_ACCESS_KEY`         | `${{stella-files.SECRET_ACCESS_KEY}}`                                               | No           |
+| `GOTENBERG_URL`                | `http://${{gotenberg.RAILWAY_PRIVATE_DOMAIN}}:3000`                                 | No           |
+| `GOTENBERG_USERNAME`           | `${{gotenberg.GOTENBERG_API_BASIC_AUTH_USERNAME}}`                                  | No           |
+| `GOTENBERG_PASSWORD`           | `${{gotenberg.GOTENBERG_API_BASIC_AUTH_PASSWORD}}`                                  | No           |
 
 Template editor checklist for managed service variables:
 
-| Service     | Variable                              | Source                                                                   | Prompt user? |
-| ----------- | ------------------------------------- | ------------------------------------------------------------------------ | ------------ |
-| `Postgres`  | `PGDATA`                              | `/var/lib/postgresql/data/pgdata`                                        | No           |
-| `Postgres`  | `PGPORT`                              | `5432`                                                                   | No           |
-| `Postgres`  | `POSTGRES_DB`                         | `railway`                                                                | No           |
-| `Postgres`  | `POSTGRES_USER`                       | `postgres`                                                               | No           |
-| `Postgres`  | `SSL_CERT_DAYS`                       | `820`                                                                    | No           |
-| `Postgres`  | `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` | `60`                                                                     | No           |
-| `Redis`     | `REDISPORT`                           | `6379`                                                                   | No           |
-| `Redis`     | `REDISUSER`                           | `default`                                                                | No           |
-| `gotenberg` | `API_ENABLE_BASIC_AUTH`               | `true`                                                                   | No           |
+| Service     | Variable                              | Source                                                                    | Prompt user? |
+| ----------- | ------------------------------------- | ------------------------------------------------------------------------- | ------------ |
+| `Postgres`  | `PGDATA`                              | `/var/lib/postgresql/data/pgdata`                                         | No           |
+| `Postgres`  | `PGPORT`                              | `5432`                                                                    | No           |
+| `Postgres`  | `POSTGRES_DB`                         | `railway`                                                                 | No           |
+| `Postgres`  | `POSTGRES_USER`                       | `postgres`                                                                | No           |
+| `Postgres`  | `SSL_CERT_DAYS`                       | `820`                                                                     | No           |
+| `Postgres`  | `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` | `60`                                                                      | No           |
+| `Redis`     | `REDISPORT`                           | `6379`                                                                    | No           |
+| `Redis`     | `REDISUSER`                           | `default`                                                                 | No           |
+| `gotenberg` | `API_ENABLE_BASIC_AUTH`               | `true`                                                                    | No           |
 | `gotenberg` | `GOTENBERG_API_BASIC_AUTH_USERNAME`   | `${{secret(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")}}` | No           |
-| `gotenberg` | `GOTENBERG_API_BASIC_AUTH_PASSWORD`   | `${{secret(64, "abcdef0123456789")}}`                                    | No           |
+| `gotenberg` | `GOTENBERG_API_BASIC_AUTH_PASSWORD`   | `${{secret(64, "abcdef0123456789")}}`                                     | No           |
 
 ## Web Variables
 
@@ -218,6 +218,42 @@ remain:
 ```bash
 bun run check:railway-template-draft -- --template <template-id>
 ```
+
+## Template Source Drift Guard
+
+The template-source project must keep same-project references such as
+`${{Postgres.DATABASE_URL}}` and `${{stella-files.ACCESS_KEY_ID}}` as Railway
+references. Do not copy rendered values from the Railway UI into app services:
+rendered database, Redis, bucket, or Gotenberg credentials can drift after a
+service is recreated or a secret rotates, causing later deployments to fail
+even though older deployments keep running.
+
+`.github/workflows/railway-template-source.yml` runs a non-mutating rendered
+credential check on a schedule and by manual dispatch. It verifies that the
+rendered API variables match the rendered Postgres, Redis, and Gotenberg
+credentials. Configure these GitHub settings:
+
+```bash
+RAILWAY_API_TOKEN=<Railway token with read access to the template-source project>
+RAILWAY_TEMPLATE_PROJECT_ID=<template-source-project-id>
+RAILWAY_TEMPLATE_ENVIRONMENT=production
+```
+
+Run the same check locally with:
+
+```bash
+bun run check:railway-template-source-runtime -- \
+  --project <template-source-project-id> \
+  --environment production
+```
+
+This check intentionally uses rendered variables: it catches the class of
+failures where a live source project stores template functions such as
+`secret(...)` directly and Railway expands each nested reference differently.
+Use `sync:railway-template-source` to compare the checked-in manifest before
+generating a draft, but do not apply generated-secret template functions to a
+live deployable source project unless you are also reinitializing the dependent
+service state from scratch.
 
 ## Source-Backed Smoke Verification
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -234,7 +234,9 @@ rendered API variables match the rendered Postgres, Redis, and Gotenberg
 credentials. Configure these GitHub settings:
 
 ```bash
-RAILWAY_API_TOKEN=<Railway token with read access to the template-source project>
+RAILWAY_PROJECT_TOKEN=<Railway project token for the template-source project>
+# Or use an account/team API token instead:
+RAILWAY_API_TOKEN=<Railway account or team API token>
 RAILWAY_TEMPLATE_PROJECT_ID=<template-source-project-id>
 RAILWAY_TEMPLATE_ENVIRONMENT=production
 ```

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
     "check:railway-template-draft": "bun scripts/check-railway-template-draft.ts",
     "check:railway-template": "bun scripts/check-railway-template-shape.ts",
+    "check:railway-template-source-runtime": "bun scripts/sync-railway-template-source.ts --check-rendered-credentials",
     "sync:railway-template-source": "bun scripts/sync-railway-template-source.ts",
     "test": "turbo run test",
     "test:property": "turbo run test:property",

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -8,6 +8,8 @@ const TEMPLATE_README_PATH = "railway/template-readme.md";
 const TEMPLATE_MANIFEST_PATH = "railway/template-manifest.json";
 const DOCKERIGNORE_PATH = ".dockerignore";
 const RAILWAY_SMOKE_WORKFLOW_PATH = ".github/workflows/railway-smoke.yml";
+const RAILWAY_TEMPLATE_SOURCE_WORKFLOW_PATH =
+  ".github/workflows/railway-template-source.yml";
 const RAILWAY_SMOKE_SCRIPT_PATH = "scripts/check-railway-smoke.ts";
 const RAILWAY_SYNC_SCRIPT_PATH = "scripts/sync-railway-template-source.ts";
 const API_HEALTH_ROUTE_PATH = "apps/api/src/handlers/health/routes.ts";
@@ -213,6 +215,10 @@ expect(
     railwayDoc.includes("networking, or config files"),
   "Railway docs must require manual review of non-variable template shape",
 );
+expect(
+  railwayDoc.includes("## Template Source Drift Guard"),
+  "Railway docs must describe the template-source drift guard",
+);
 
 const railwaySyncScript = readText(RAILWAY_SYNC_SCRIPT_PATH);
 expect(
@@ -223,6 +229,25 @@ expect(
   railwaySyncScript.includes("Dry run found variable drift."),
   "Railway sync script must fail dry runs with variable drift",
 );
+expect(
+  railwaySyncScript.includes("unrendered = true"),
+  "Railway sync script must compare unrendered variables so same-project references cannot flatten to literals",
+);
+expect(
+  railwaySyncScript.includes("skipDeploys: true"),
+  "Railway sync script must not trigger deploys while syncing template-source variables",
+);
+for (const requiredText of [
+  "check-rendered-credentials",
+  "rendered credentials ok",
+  "rendered credentials disagree",
+  "Gotenberg password",
+]) {
+  expect(
+    railwaySyncScript.includes(requiredText),
+    `Railway sync script must include rendered credential guard text: ${requiredText}`,
+  );
+}
 
 const templateReadme = readText(TEMPLATE_README_PATH);
 for (const heading of [
@@ -276,6 +301,23 @@ for (const requiredText of [
   expect(
     railwaySmokeWorkflow.includes(requiredText),
     `Railway smoke workflow must include ${requiredText}`,
+  );
+}
+
+const railwayTemplateSourceWorkflow = readText(
+  RAILWAY_TEMPLATE_SOURCE_WORKFLOW_PATH,
+);
+for (const requiredText of [
+  "schedule:",
+  "workflow_dispatch:",
+  "RAILWAY_API_TOKEN",
+  "RAILWAY_TEMPLATE_PROJECT_ID",
+  "RAILWAY_TEMPLATE_ENVIRONMENT",
+  "check:railway-template-source-runtime",
+]) {
+  expect(
+    railwayTemplateSourceWorkflow.includes(requiredText),
+    `Railway template-source workflow must include ${requiredText}`,
   );
 }
 

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -240,6 +240,7 @@ expect(
 for (const requiredText of [
   "check-rendered-credentials",
   "Project-Access-Token",
+  "projectToken",
   "RAILWAY_PROJECT_TOKEN",
   "rendered credentials ok",
   "rendered credentials disagree",

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -239,6 +239,8 @@ expect(
 );
 for (const requiredText of [
   "check-rendered-credentials",
+  "Project-Access-Token",
+  "RAILWAY_PROJECT_TOKEN",
   "rendered credentials ok",
   "rendered credentials disagree",
   "Gotenberg password",
@@ -310,6 +312,7 @@ const railwayTemplateSourceWorkflow = readText(
 for (const requiredText of [
   "schedule:",
   "workflow_dispatch:",
+  "RAILWAY_PROJECT_TOKEN",
   "RAILWAY_API_TOKEN",
   "RAILWAY_TEMPLATE_PROJECT_ID",
   "RAILWAY_TEMPLATE_ENVIRONMENT",

--- a/scripts/sync-railway-template-source.ts
+++ b/scripts/sync-railway-template-source.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 import { parseArgs } from "node:util";
 
 const MANIFEST_PATH = "railway/template-manifest.json";
@@ -8,6 +8,12 @@ const RAILWAY_GRAPHQL_URL = "https://backboard.railway.com/graphql/v2";
 const RAILWAY_GRAPHQL_TIMEOUT_MS = 10_000;
 const DEFAULT_ENVIRONMENT = "production";
 const TEMPLATE_FUNCTION_PATTERN = /\$\{\{\s*(?:secret|randomInt)\(/u;
+const SERVICE_NAMES = {
+  api: "api",
+  gotenberg: "gotenberg",
+  postgres: "Postgres",
+  redis: "Redis",
+} as const;
 
 class RailwayTemplateSyncError extends Error {
   constructor(message: string) {
@@ -63,8 +69,8 @@ type VariableCollectionUpsertData = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const readJson = (path: string): unknown =>
-  JSON.parse(readFileSync(path, "utf-8"));
+const readJson = (filePath: string): unknown =>
+  JSON.parse(readFileSync(filePath, "utf-8"));
 
 const readStringRecord = (
   value: unknown,
@@ -114,7 +120,7 @@ const readRailwayToken = () => {
     return fromEnv;
   }
 
-  const configPath = join(homedir(), ".railway", "config.json");
+  const configPath = path.join(homedir(), ".railway", "config.json");
   if (!existsSync(configPath)) {
     throw new RailwayTemplateSyncError(
       "Set RAILWAY_API_TOKEN or log in with the Railway CLI first",
@@ -155,6 +161,9 @@ const graphql = async <TData>(
     );
   }
 
+  // SAFETY: Railway GraphQL validates the response shape for the query; callers
+  // provide the matching data type for the query document they pass here.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   const payload = (await response.json()) as GraphqlResponse<TData>;
   if (payload.errors && payload.errors.length > 0) {
     throw new RailwayTemplateSyncError(
@@ -246,11 +255,13 @@ const readVariables = async ({
   projectId,
   environmentId,
   serviceId,
+  unrendered = true,
 }: {
   token: string;
   projectId: string;
   environmentId: string;
   serviceId: string;
+  unrendered?: boolean;
 }) => {
   const data = await graphql<VariablesQueryData>(
     token,
@@ -259,19 +270,34 @@ const readVariables = async ({
         $projectId: String!
         $environmentId: String!
         $serviceId: String!
+        $unrendered: Boolean!
       ) {
         variables(
           projectId: $projectId
           environmentId: $environmentId
           serviceId: $serviceId
-          unrendered: true
+          unrendered: $unrendered
         )
       }
     `,
-    { projectId, environmentId, serviceId },
+    { environmentId, projectId, serviceId, unrendered },
   );
 
   return data.variables;
+};
+
+const requireServiceId = (
+  serviceIdsByName: Map<string, string>,
+  serviceName: string,
+  projectName: string,
+) => {
+  const serviceId = serviceIdsByName.get(serviceName);
+  if (!serviceId) {
+    throw new RailwayTemplateSyncError(
+      `Service ${serviceName} not found in ${projectName}`,
+    );
+  }
+  return serviceId;
 };
 
 const writeVariables = async ({
@@ -340,10 +366,134 @@ const hasTemplateFunction = (variables: Record<string, string>) =>
     TEMPLATE_FUNCTION_PATTERN.test(value),
   );
 
+const extractUrlPassword = (value: string | undefined, label: string) => {
+  if (!value) {
+    throw new RailwayTemplateSyncError(`${label} is missing`);
+  }
+
+  try {
+    const url = new URL(value);
+    if (!url.password) {
+      throw new RailwayTemplateSyncError(`${label} has no password`);
+    }
+    return decodeURIComponent(url.password);
+  } catch (error) {
+    if (error instanceof RailwayTemplateSyncError) {
+      throw error;
+    }
+    throw new RailwayTemplateSyncError(`${label} is not a valid URL`);
+  }
+};
+
+const assertSameSecret = (
+  label: string,
+  values: Record<string, string | undefined>,
+) => {
+  const entries = Object.entries(values);
+  if (entries.length === 0) {
+    throw new RailwayTemplateSyncError(`${label} has no values to compare`);
+  }
+
+  const first = entries.at(0);
+  if (!first) {
+    throw new RailwayTemplateSyncError(`${label} has no values to compare`);
+  }
+  const [firstKey, firstValue] = first;
+  if (!firstValue) {
+    throw new RailwayTemplateSyncError(`${label} missing ${firstKey}`);
+  }
+
+  for (const [key, value] of entries.slice(1)) {
+    if (!value) {
+      throw new RailwayTemplateSyncError(`${label} missing ${key}`);
+    }
+    if (value !== firstValue) {
+      throw new RailwayTemplateSyncError(
+        `${label} rendered credentials disagree: ${firstKey} does not match ${key}`,
+      );
+    }
+  }
+};
+
+const checkRenderedCredentials = async ({
+  token,
+  projectId,
+  resolvedProject,
+}: {
+  token: string;
+  projectId: string;
+  resolvedProject: ResolvedProject;
+}) => {
+  const readRendered = async (serviceName: string) =>
+    await readVariables({
+      environmentId: resolvedProject.environmentId,
+      projectId,
+      serviceId: requireServiceId(
+        resolvedProject.serviceIdsByName,
+        serviceName,
+        resolvedProject.projectName,
+      ),
+      token,
+      unrendered: false,
+    });
+
+  const postgres = await readRendered(SERVICE_NAMES.postgres);
+  const redis = await readRendered(SERVICE_NAMES.redis);
+  const api = await readRendered(SERVICE_NAMES.api);
+  const gotenberg = await readRendered(SERVICE_NAMES.gotenberg);
+
+  assertSameSecret("Postgres password", {
+    "Postgres.DATABASE_PUBLIC_URL password": extractUrlPassword(
+      postgres["DATABASE_PUBLIC_URL"],
+      "Postgres.DATABASE_PUBLIC_URL",
+    ),
+    "Postgres.DATABASE_URL password": extractUrlPassword(
+      postgres["DATABASE_URL"],
+      "Postgres.DATABASE_URL",
+    ),
+    "Postgres.PGPASSWORD": postgres["PGPASSWORD"],
+    "Postgres.POSTGRES_PASSWORD": postgres["POSTGRES_PASSWORD"],
+    "api.DATABASE_URL password": extractUrlPassword(
+      api["DATABASE_URL"],
+      "api.DATABASE_URL",
+    ),
+  });
+
+  assertSameSecret("Redis password", {
+    "Redis.REDIS_PUBLIC_URL password": extractUrlPassword(
+      redis["REDIS_PUBLIC_URL"],
+      "Redis.REDIS_PUBLIC_URL",
+    ),
+    "Redis.REDIS_URL password": extractUrlPassword(
+      redis["REDIS_URL"],
+      "Redis.REDIS_URL",
+    ),
+    "Redis.REDISPASSWORD": redis["REDISPASSWORD"],
+    "Redis.REDIS_PASSWORD": redis["REDIS_PASSWORD"],
+    "api.REDIS_URL password": extractUrlPassword(
+      api["REDIS_URL"],
+      "api.REDIS_URL",
+    ),
+  });
+
+  assertSameSecret("Gotenberg username", {
+    "api.GOTENBERG_USERNAME": api["GOTENBERG_USERNAME"],
+    "gotenberg.GOTENBERG_API_BASIC_AUTH_USERNAME":
+      gotenberg["GOTENBERG_API_BASIC_AUTH_USERNAME"],
+  });
+
+  assertSameSecret("Gotenberg password", {
+    "api.GOTENBERG_PASSWORD": api["GOTENBERG_PASSWORD"],
+    "gotenberg.GOTENBERG_API_BASIC_AUTH_PASSWORD":
+      gotenberg["GOTENBERG_API_BASIC_AUTH_PASSWORD"],
+  });
+};
+
 const main = async () => {
   const {
     values: {
       apply,
+      "check-rendered-credentials": checkRenderedCredentialsOnly,
       environment,
       project,
       prune,
@@ -352,6 +502,7 @@ const main = async () => {
   } = parseArgs({
     options: {
       apply: { type: "boolean" },
+      "check-rendered-credentials": { type: "boolean" },
       environment: { type: "string" },
       project: { type: "string" },
       prune: { type: "boolean" },
@@ -377,18 +528,23 @@ const main = async () => {
       DEFAULT_ENVIRONMENT,
   });
 
+  if (checkRenderedCredentialsOnly) {
+    await checkRenderedCredentials({ projectId, resolvedProject, token });
+    console.log("railway-template-source: rendered credentials ok");
+    return;
+  }
+
   console.log(
     `railway-template-source: ${apply ? "apply variables" : "dry-run variables"} ${resolvedProject.projectName}/${resolvedProject.environmentName}`,
   );
 
   let hasDrift = false;
   for (const [serviceName, service] of Object.entries(manifest.services)) {
-    const serviceId = resolvedProject.serviceIdsByName.get(serviceName);
-    if (!serviceId) {
-      throw new RailwayTemplateSyncError(
-        `Service ${serviceName} not found in ${resolvedProject.projectName}`,
-      );
-    }
+    const serviceId = requireServiceId(
+      resolvedProject.serviceIdsByName,
+      serviceName,
+      resolvedProject.projectName,
+    );
 
     if (apply && hasTemplateFunction(service.variables) && !templateSource) {
       throw new RailwayTemplateSyncError(

--- a/scripts/sync-railway-template-source.ts
+++ b/scripts/sync-railway-template-source.ts
@@ -59,12 +59,22 @@ type ProjectQueryData = {
 };
 
 type VariablesQueryData = {
-  variables: Record<string, string>;
+  variables: unknown;
 };
 
 type VariableCollectionUpsertData = {
   variableCollectionUpsert: boolean;
 };
+
+type RailwayAuth =
+  | {
+      type: "bearer";
+      token: string;
+    }
+  | {
+      type: "project";
+      token: string;
+    };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -114,16 +124,21 @@ const readManifest = (): TemplateManifest => {
   return { services };
 };
 
-const readRailwayToken = () => {
+const readRailwayAuth = (): RailwayAuth => {
+  const fromProjectEnv = process.env["RAILWAY_PROJECT_TOKEN"]?.trim();
+  if (fromProjectEnv) {
+    return { token: fromProjectEnv, type: "project" };
+  }
+
   const fromEnv = process.env["RAILWAY_API_TOKEN"]?.trim();
   if (fromEnv) {
-    return fromEnv;
+    return { token: fromEnv, type: "bearer" };
   }
 
   const configPath = path.join(homedir(), ".railway", "config.json");
   if (!existsSync(configPath)) {
     throw new RailwayTemplateSyncError(
-      "Set RAILWAY_API_TOKEN or log in with the Railway CLI first",
+      "Set RAILWAY_PROJECT_TOKEN, set RAILWAY_API_TOKEN, or log in with the Railway CLI first",
     );
   }
 
@@ -138,19 +153,27 @@ const readRailwayToken = () => {
     );
   }
 
-  return config["user"]["accessToken"];
+  return { token: config["user"]["accessToken"], type: "bearer" };
+};
+
+const authHeaders = (auth: RailwayAuth): Record<string, string> => {
+  if (auth.type === "project") {
+    return { "Project-Access-Token": auth.token };
+  }
+
+  return { authorization: `Bearer ${auth.token}` };
 };
 
 const graphql = async <TData>(
-  token: string,
+  auth: RailwayAuth,
   query: string,
   variables: Record<string, unknown>,
 ) => {
   const response = await fetch(RAILWAY_GRAPHQL_URL, {
     method: "POST",
     headers: {
-      authorization: `Bearer ${token}`,
       "content-type": "application/json",
+      ...authHeaders(auth),
     },
     body: JSON.stringify({ query, variables }),
     signal: AbortSignal.timeout(RAILWAY_GRAPHQL_TIMEOUT_MS),
@@ -184,16 +207,16 @@ type ResolvedProject = {
 };
 
 const resolveProject = async ({
-  token,
+  auth,
   projectId,
   environment,
 }: {
-  token: string;
+  auth: RailwayAuth;
   projectId: string;
   environment: string;
 }): Promise<ResolvedProject> => {
   const data = await graphql<ProjectQueryData>(
-    token,
+    auth,
     `
       query ($projectId: String!) {
         project(id: $projectId) {
@@ -251,20 +274,20 @@ const resolveProject = async ({
 };
 
 const readVariables = async ({
-  token,
+  auth,
   projectId,
   environmentId,
   serviceId,
   unrendered = true,
 }: {
-  token: string;
+  auth: RailwayAuth;
   projectId: string;
   environmentId: string;
   serviceId: string;
   unrendered?: boolean;
 }) => {
   const data = await graphql<VariablesQueryData>(
-    token,
+    auth,
     `
       query (
         $projectId: String!
@@ -283,7 +306,7 @@ const readVariables = async ({
     { environmentId, projectId, serviceId, unrendered },
   );
 
-  return data.variables;
+  return readStringRecord(data.variables, "Railway variables");
 };
 
 const requireServiceId = (
@@ -301,14 +324,14 @@ const requireServiceId = (
 };
 
 const writeVariables = async ({
-  token,
+  auth,
   projectId,
   environmentId,
   serviceId,
   variables,
   prune,
 }: {
-  token: string;
+  auth: RailwayAuth;
   projectId: string;
   environmentId: string;
   serviceId: string;
@@ -316,7 +339,7 @@ const writeVariables = async ({
   prune: boolean;
 }) => {
   const data = await graphql<VariableCollectionUpsertData>(
-    token,
+    auth,
     `
       mutation ($input: VariableCollectionUpsertInput!) {
         variableCollectionUpsert(input: $input)
@@ -416,11 +439,11 @@ const assertSameSecret = (
 };
 
 const checkRenderedCredentials = async ({
-  token,
+  auth,
   projectId,
   resolvedProject,
 }: {
-  token: string;
+  auth: RailwayAuth;
   projectId: string;
   resolvedProject: ResolvedProject;
 }) => {
@@ -433,14 +456,16 @@ const checkRenderedCredentials = async ({
         serviceName,
         resolvedProject.projectName,
       ),
-      token,
+      auth,
       unrendered: false,
     });
 
-  const postgres = await readRendered(SERVICE_NAMES.postgres);
-  const redis = await readRendered(SERVICE_NAMES.redis);
-  const api = await readRendered(SERVICE_NAMES.api);
-  const gotenberg = await readRendered(SERVICE_NAMES.gotenberg);
+  const [postgres, redis, api, gotenberg] = await Promise.all([
+    readRendered(SERVICE_NAMES.postgres),
+    readRendered(SERVICE_NAMES.redis),
+    readRendered(SERVICE_NAMES.api),
+    readRendered(SERVICE_NAMES.gotenberg),
+  ]);
 
   assertSameSecret("Postgres password", {
     "Postgres.DATABASE_PUBLIC_URL password": extractUrlPassword(
@@ -518,9 +543,9 @@ const main = async () => {
   }
 
   const manifest = readManifest();
-  const token = readRailwayToken();
+  const auth = readRailwayAuth();
   const resolvedProject = await resolveProject({
-    token,
+    auth,
     projectId,
     environment:
       environment ??
@@ -529,7 +554,7 @@ const main = async () => {
   });
 
   if (checkRenderedCredentialsOnly) {
-    await checkRenderedCredentials({ projectId, resolvedProject, token });
+    await checkRenderedCredentials({ auth, projectId, resolvedProject });
     console.log("railway-template-source: rendered credentials ok");
     return;
   }
@@ -554,7 +579,7 @@ const main = async () => {
 
     // eslint-disable-next-line no-await-in-loop -- diff output is intentionally ordered by service for operator review.
     const current = await readVariables({
-      token,
+      auth,
       projectId,
       environmentId: resolvedProject.environmentId,
       serviceId,
@@ -581,7 +606,7 @@ const main = async () => {
     if (apply) {
       // eslint-disable-next-line no-await-in-loop -- service variable writes are intentionally sequential to keep Railway changes easy to audit.
       await writeVariables({
-        token,
+        auth,
         projectId,
         environmentId: resolvedProject.environmentId,
         serviceId,

--- a/scripts/sync-railway-template-source.ts
+++ b/scripts/sync-railway-template-source.ts
@@ -58,6 +58,27 @@ type ProjectQueryData = {
   } | null;
 };
 
+type ProjectTokenQueryData = {
+  projectToken: {
+    environment: {
+      name: string;
+      serviceInstances: {
+        edges: {
+          node: {
+            serviceId: string;
+            serviceName: string;
+          };
+        }[];
+      };
+    };
+    environmentId: string;
+    project: {
+      name: string;
+    };
+    projectId: string;
+  };
+};
+
 type VariablesQueryData = {
   variables: unknown;
 };
@@ -202,8 +223,74 @@ const graphql = async <TData>(
 type ResolvedProject = {
   environmentId: string;
   environmentName: string;
+  projectId: string;
   projectName: string;
   serviceIdsByName: Map<string, string>;
+};
+
+const resolveProjectToken = async ({
+  auth,
+  environment,
+  projectId,
+}: {
+  auth: RailwayAuth;
+  environment: string;
+  projectId?: string;
+}): Promise<ResolvedProject> => {
+  const data = await graphql<ProjectTokenQueryData>(
+    auth,
+    `
+      query {
+        projectToken {
+          projectId
+          environmentId
+          project {
+            name
+          }
+          environment {
+            name
+            serviceInstances {
+              edges {
+                node {
+                  serviceId
+                  serviceName
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    {},
+  );
+
+  if (projectId && data.projectToken.projectId !== projectId) {
+    throw new RailwayTemplateSyncError(
+      "RAILWAY_PROJECT_TOKEN is scoped to a different project than --project",
+    );
+  }
+
+  if (
+    data.projectToken.environmentId !== environment &&
+    data.projectToken.environment.name !== environment
+  ) {
+    throw new RailwayTemplateSyncError(
+      "RAILWAY_PROJECT_TOKEN is scoped to a different environment than --environment",
+    );
+  }
+
+  return {
+    environmentId: data.projectToken.environmentId,
+    environmentName: data.projectToken.environment.name,
+    projectId: data.projectToken.projectId,
+    projectName: data.projectToken.project.name,
+    serviceIdsByName: new Map(
+      data.projectToken.environment.serviceInstances.edges.map((edge) => [
+        edge.node.serviceName,
+        edge.node.serviceId,
+      ]),
+    ),
+  };
 };
 
 const resolveProject = async ({
@@ -212,9 +299,19 @@ const resolveProject = async ({
   environment,
 }: {
   auth: RailwayAuth;
-  projectId: string;
+  projectId?: string;
   environment: string;
 }): Promise<ResolvedProject> => {
+  if (auth.type === "project") {
+    return resolveProjectToken({ auth, environment, projectId });
+  }
+
+  if (!projectId) {
+    throw new RailwayTemplateSyncError(
+      "Pass --project or set RAILWAY_TEMPLATE_PROJECT_ID",
+    );
+  }
+
   const data = await graphql<ProjectQueryData>(
     auth,
     `
@@ -263,6 +360,7 @@ const resolveProject = async ({
   return {
     environmentId: selectedEnvironment.id,
     environmentName: selectedEnvironment.name,
+    projectId: data.project.id,
     projectName: data.project.name,
     serviceIdsByName: new Map(
       selectedEnvironment.serviceInstances.edges.map((edge) => [
@@ -440,17 +538,15 @@ const assertSameSecret = (
 
 const checkRenderedCredentials = async ({
   auth,
-  projectId,
   resolvedProject,
 }: {
   auth: RailwayAuth;
-  projectId: string;
   resolvedProject: ResolvedProject;
 }) => {
   const readRendered = async (serviceName: string) =>
     await readVariables({
       environmentId: resolvedProject.environmentId,
-      projectId,
+      projectId: resolvedProject.projectId,
       serviceId: requireServiceId(
         resolvedProject.serviceIdsByName,
         serviceName,
@@ -535,15 +631,9 @@ const main = async () => {
     },
   });
 
-  const projectId = project ?? process.env["RAILWAY_TEMPLATE_PROJECT_ID"];
-  if (!projectId) {
-    throw new RailwayTemplateSyncError(
-      "Pass --project or set RAILWAY_TEMPLATE_PROJECT_ID",
-    );
-  }
-
   const manifest = readManifest();
   const auth = readRailwayAuth();
+  const projectId = project ?? process.env["RAILWAY_TEMPLATE_PROJECT_ID"];
   const resolvedProject = await resolveProject({
     auth,
     projectId,
@@ -554,7 +644,7 @@ const main = async () => {
   });
 
   if (checkRenderedCredentialsOnly) {
-    await checkRenderedCredentials({ auth, projectId, resolvedProject });
+    await checkRenderedCredentials({ auth, resolvedProject });
     console.log("railway-template-source: rendered credentials ok");
     return;
   }
@@ -580,7 +670,7 @@ const main = async () => {
     // eslint-disable-next-line no-await-in-loop -- diff output is intentionally ordered by service for operator review.
     const current = await readVariables({
       auth,
-      projectId,
+      projectId: resolvedProject.projectId,
       environmentId: resolvedProject.environmentId,
       serviceId,
     });
@@ -607,7 +697,7 @@ const main = async () => {
       // eslint-disable-next-line no-await-in-loop -- service variable writes are intentionally sequential to keep Railway changes easy to audit.
       await writeVariables({
         auth,
-        projectId,
+        projectId: resolvedProject.projectId,
         environmentId: resolvedProject.environmentId,
         serviceId,
         variables: service.variables,


### PR DESCRIPTION
Adds a non-mutating Railway template-source runtime check that verifies rendered service credentials stay consistent across the API, Postgres, Redis, and Gotenberg services.\n\nAlso wires the guard into a scheduled/manual GitHub workflow and extends the existing Railway template shape check so the guard, workflow, unrendered manifest comparison, and skip-deploy sync behavior stay in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated Railway template source check that runs on a schedule or manually to help detect credential drift.
  * Added a local command to verify rendered credentials across services.

* **Documentation**
  * Expanded Railway docs with a new drift-guard guide and refreshed the template editor checklist layout.

* **Bug Fixes**
  * Improved validation of Railway template settings and service credential consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->