### PR TITLE
fix: update entity route network baseline

### DIFF
--- a/apps/web/e2e/network-baseline.json
+++ b/apps/web/e2e/network-baseline.json
@@ -1373,7 +1373,7 @@
       "GET /v1/views/:id": 1,
       "GET /v1/workspaces/:id": 1,
       "GET /v1/workspaces/:id/anonymization-terms": 1,
-      "GET /v1/workspaces/:id/events": 1,
+      "GET /v1/workspaces/:id/events": 2,
       "GET /v1/workspaces/:id/overview": 1,
       "GET /v1/workspaces/:id/workflow": 1,
       "GET /v1/workspaces/navigation": 1,


### PR DESCRIPTION
## Summary
- update the entity detail route-smoke network baseline for the workspace SSE events request count

## Verification
- parsed apps/web/e2e/network-baseline.json
- did not run local lint or typecheck per request

CC on behalf of @sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the expected network activity for the workspace entity view to account for an additional events request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->