### PR TITLE
fix(chat): composer runtime bugs — web-search toggle, stop during tool calls, editor render loop

### DIFF
--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -191,9 +191,15 @@ export type ChatEditorController = {
   ) => Promise<void>;
 };
 
+// The stable manager API: every field is a `useCallback`, so the whole value
+// keeps one identity for the provider's lifetime. `extensionVersion` — the one
+// value that changes as registrations come and go — deliberately lives in a
+// SEPARATE context (`ChatEditorExtensionVersionContext`) rather than here.
+// Folding it in would rebuild this value on every register/unregister and
+// re-render every consumer of the API (including the mention-registration
+// hooks, whose effects would then re-register and bump the version again — an
+// update loop that trips React's max-update-depth guard under load).
 type ChatEditorManagerContextValue = {
-  activeThreadKey: string | null;
-  extensionVersion: number;
   focusThread: (threadRef: ChatThreadRef) => void;
   getMentionItems: () => Promise<ChatMentionOption[]>;
   getPluginRegistrations: () => ChatInputPluginRegistration[];
@@ -211,6 +217,12 @@ type ChatEditorManagerContextValue = {
 
 const ChatEditorManagerContext =
   createContext<ChatEditorManagerContextValue | null>(null);
+
+// Carries only the registration version counter. Bumped on every
+// register/unregister and consumed solely by the editor's plugin-sync effect
+// (via `useChatEditorExtensionVersion`), so a bump re-renders that one
+// subscriber instead of every holder of the manager API.
+const ChatEditorExtensionVersionContext = createContext<number>(0);
 
 const isSuggestionPluginState = (
   value: unknown,
@@ -242,7 +254,6 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   const registrationsRef = useRef(new Map<string, RegisteredExtension>());
   const activeEditorRef = useRef<ActiveChatEditorHandle | null>(null);
   const [extensionVersion, setExtensionVersion] = useState(0);
-  const [activeThreadKey, setActiveThreadKey] = useState<string | null>(null);
 
   const getMentionItems = useCallback(async () => {
     const items: ChatMentionOption[] = [];
@@ -335,7 +346,6 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
 
   const registerActiveEditor = useCallback((handle: ActiveChatEditorHandle) => {
     activeEditorRef.current = handle;
-    setActiveThreadKey(handle.threadKey);
 
     return () => {
       if (activeEditorRef.current?.threadKey !== handle.threadKey) {
@@ -343,9 +353,6 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
       }
 
       activeEditorRef.current = null;
-      setActiveThreadKey((current) =>
-        current === handle.threadKey ? null : current,
-      );
     };
   }, []);
 
@@ -377,8 +384,6 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
 
   const contextValue = useMemo<ChatEditorManagerContextValue>(
     () => ({
-      activeThreadKey,
-      extensionVersion,
       focusThread,
       getMentionItems,
       getPluginRegistrations,
@@ -388,8 +393,6 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
       searchMentionItems,
     }),
     [
-      activeThreadKey,
-      extensionVersion,
       focusThread,
       getMentionItems,
       getPluginRegistrations,
@@ -402,7 +405,9 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
 
   return (
     <ChatEditorManagerContext value={contextValue}>
-      {children}
+      <ChatEditorExtensionVersionContext value={extensionVersion}>
+        {children}
+      </ChatEditorExtensionVersionContext>
     </ChatEditorManagerContext>
   );
 };
@@ -428,6 +433,12 @@ export const useChatEditorManager = () => {
 
   return context;
 };
+
+// Subscribes only to the registration version, so the editor's plugin-sync
+// effect re-runs when extensions change without dragging the whole manager API
+// into the volatile-value subscription (see `ChatEditorExtensionVersionContext`).
+const useChatEditorExtensionVersion = () =>
+  use(ChatEditorExtensionVersionContext);
 
 type UseChatComposerWiringOptions = {
   controller: ChatEditorController;
@@ -559,12 +570,12 @@ export const useChatEditor = ({
   sentMessageHistoryHtmlRef.current = sentMessageHistoryHtml ?? [];
   const threadKey = getChatThreadKey(threadRef);
   const {
-    extensionVersion,
     getMentionItems,
     getPluginRegistrations,
     registerActiveEditor,
     searchMentionItems,
   } = useChatEditorManager();
+  const extensionVersion = useChatEditorExtensionVersion();
   const draft = useChatDraftStore(
     (state) => state.draftsByThreadKey[threadKey] ?? null,
   );

--- a/apps/web/src/components/chat/chat-ui-tools.test.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.test.ts
@@ -13,7 +13,7 @@ import {
   isPublicOfficialChatToolName,
   isToolApprovedByGrant,
   isUnresolvedFolioAgentDocToolCallPart,
-  sanitizeHydratedRunningToolCalls,
+  sanitizeRunningToolCalls,
   selectUnresolvedFolioAgentDocToolCallParts,
   withParsedToolCallInputs,
 } from "@/components/chat/chat-ui-tools";
@@ -673,7 +673,7 @@ describe("isChatTurnInFlight", () => {
   });
 });
 
-describe("sanitizeHydratedRunningToolCalls", () => {
+describe("sanitizeRunningToolCalls", () => {
   const runningToolPart = {
     arguments: JSON.stringify({ query: "consumer credit" }),
     id: "tool-call-1",
@@ -688,7 +688,7 @@ describe("sanitizeHydratedRunningToolCalls", () => {
       { id: "message-1", parts: [runningToolPart], role: "assistant" },
     ];
 
-    const sanitized = sanitizeHydratedRunningToolCalls(messages);
+    const sanitized = sanitizeRunningToolCalls(messages);
     const part = sanitized[0]?.parts[0];
     if (part?.type !== "tool-call") {
       throw new Error("Expected a tool-call part");
@@ -711,7 +711,7 @@ describe("sanitizeHydratedRunningToolCalls", () => {
       },
     ];
 
-    const sanitized = sanitizeHydratedRunningToolCalls(messages);
+    const sanitized = sanitizeRunningToolCalls(messages);
     const part = sanitized[0]?.parts[0];
     if (part?.type !== "tool-call") {
       throw new Error("Expected a tool-call part");
@@ -741,7 +741,7 @@ describe("sanitizeHydratedRunningToolCalls", () => {
     ];
 
     // Long-lived by design: the message keeps its reference (no change).
-    expect(sanitizeHydratedRunningToolCalls(messages)[0]).toBe(messages[0]);
+    expect(sanitizeRunningToolCalls(messages)[0]).toBe(messages[0]);
   });
 
   test("leaves an approval-requested tool call untouched", () => {
@@ -763,7 +763,7 @@ describe("sanitizeHydratedRunningToolCalls", () => {
       },
     ];
 
-    expect(sanitizeHydratedRunningToolCalls(messages)[0]).toBe(messages[0]);
+    expect(sanitizeRunningToolCalls(messages)[0]).toBe(messages[0]);
   });
 
   test("leaves a completed tool call untouched", () => {
@@ -785,11 +785,11 @@ describe("sanitizeHydratedRunningToolCalls", () => {
       },
     ];
 
-    expect(sanitizeHydratedRunningToolCalls(messages)[0]).toBe(messages[0]);
+    expect(sanitizeRunningToolCalls(messages)[0]).toBe(messages[0]);
   });
 
   test("is a no-op for an empty thread or a user-last transcript", () => {
-    expect(sanitizeHydratedRunningToolCalls([])).toEqual([]);
+    expect(sanitizeRunningToolCalls([])).toEqual([]);
 
     const messages: PersistedChatMessage[] = [
       {
@@ -804,7 +804,7 @@ describe("sanitizeHydratedRunningToolCalls", () => {
       },
     ];
 
-    const sanitized = sanitizeHydratedRunningToolCalls(messages);
+    const sanitized = sanitizeRunningToolCalls(messages);
     // Nothing running anywhere: every message keeps its reference.
     expect(sanitized[0]).toBe(messages[0]);
     expect(sanitized[1]).toBe(messages[1]);

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -600,26 +600,29 @@ const toTerminalIfRunningToolPart = (part: ChatPart): ChatPart => {
 };
 
 /**
- * Rewrite dead running tool-call parts to a terminal errored state when a
- * thread is hydrated from persistence.
+ * Rewrite running tool-call parts that can no longer complete into a
+ * terminal errored state, clearing `isRunningToolPart` — and therefore
+ * `hasRunningToolCallInLatestAssistantMessage` / `isGenerating` — so the
+ * composer leaves its stop/spinner state instead of wedging there forever.
  *
- * The server only persists finalized turns (a turn is written at stream
- * end, not mid-stream) and a freshly built runtime drives no live turn, so
- * every running tool-call part in server-loaded messages belongs to a turn
- * whose stream died before finishing (API process restart / deploy / crash
- * mid tool call). Left untouched, such a part keeps
- * `hasRunningToolCallInLatestAssistantMessage` — and therefore
- * `isGenerating` — stuck true on every reload, wedging the composer in a
- * stop/spinner state no live request can ever clear.
+ * Applied on the two triggers that strand a tool part mid-run with no event
+ * that would ever finalize it:
  *
- * Live-turn parts never flow through here: streaming updates reach the UI
- * through the runtime's message subscription, not this hydration path, so a
- * mid-flight tool call is never sanitized. `ask-user` / `create-document`
- * and approval-flow parts are long-lived by design and already excluded by
- * `isRunningToolPart`. Messages and parts left unchanged are returned by
- * reference so downstream memoization stays stable.
+ *  - Hydration from persistence: the server only persists finalized turns
+ *    (written at stream end, not mid-stream), so any running tool-call part
+ *    in server-loaded messages belongs to a turn whose stream died before
+ *    finishing (API restart / deploy / crash mid tool call).
+ *  - Explicit stop: the AI SDK's `stop()` aborts the live request but never
+ *    rewrites message parts, so a tool part caught mid-input would keep the
+ *    turn "generating" forever. The runtime's `stop` applies this right
+ *    after aborting.
+ *
+ * `ask-user` / `create-document` and approval-flow parts are long-lived by
+ * design and already excluded by `isRunningToolPart`. Messages and parts
+ * left unchanged are returned by reference so downstream memoization stays
+ * stable.
  */
-export const sanitizeHydratedRunningToolCalls = (
+export const sanitizeRunningToolCalls = (
   messages: readonly PersistedChatMessage[],
 ): PersistedChatMessage[] =>
   messages.map((message) => {

--- a/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
@@ -92,8 +92,10 @@ export const ChatWebSearchToggle = ({
       return { previous };
     },
     onError: (error, _nextEnabled, context) => {
-      for (const [key, data] of context?.previous ?? []) {
-        queryClient.setQueryData(key, data);
+      if (context) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
       }
       stellaToast.add({
         title: userErrorFromThrown(error, t("errors.actionFailed")),

--- a/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
@@ -1,3 +1,4 @@
+import type { Query } from "@tanstack/react-query";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { GlobeIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -31,7 +32,29 @@ export const ChatWebSearchToggle = ({
     (state) => state.setEnabledPreference,
   );
 
-  const { mutate, isPending } = useMutation({
+  // Every cached query for this thread (the thread page's `chatThreadOptions`
+  // and the new-chat hero's draft-meta both sit under the same
+  // `chat/<org>/thread/<scope>/<…ids>` prefix) that carries a
+  // `webSearchEnabled` field. Flipping them in `onMutate` turns the icon on/off
+  // instantly and smoothly instead of snapping only once the PATCH round-trips.
+  const matchesThisThread = (queryKey: readonly unknown[]): boolean => {
+    if (
+      queryKey.at(0) !== "chat" ||
+      queryKey.at(2) !== "thread" ||
+      queryKey.at(3) !== threadRef.scope
+    ) {
+      return false;
+    }
+    if (threadRef.scope === "global") {
+      return queryKey.at(4) === threadRef.threadId;
+    }
+    return (
+      queryKey.at(4) === threadRef.workspaceId &&
+      queryKey.at(5) === threadRef.threadId
+    );
+  };
+
+  const { mutate } = useMutation({
     mutationFn: async (nextEnabled: boolean) => {
       const response = await api.chat
         .threads({ threadId: toSafeId<"chatThread">(threadRef.threadId) })
@@ -49,14 +72,32 @@ export const ChatWebSearchToggle = ({
       }
       return response.data;
     },
-    onSuccess: () => {
-      void invalidateChatThread({ queryClient, threadRef });
+    onMutate: async (nextEnabled) => {
+      const filters = {
+        predicate: (q: Query) => matchesThisThread(q.queryKey),
+      };
+      await queryClient.cancelQueries(filters);
+      const previous = queryClient.getQueriesData(filters);
+      queryClient.setQueriesData(filters, (old) =>
+        old && typeof old === "object" && "webSearchEnabled" in old
+          ? { ...old, webSearchEnabled: nextEnabled }
+          : old,
+      );
+      return { previous };
     },
-    onError: (error) => {
+    onError: (error, _nextEnabled, context) => {
+      for (const [key, data] of context?.previous ?? []) {
+        queryClient.setQueryData(key, data);
+      }
       stellaToast.add({
         title: userErrorFromThrown(error, t("errors.actionFailed")),
         type: "error",
       });
+    },
+    // Reconcile against the server on both paths: confirm the optimistic flip
+    // on success, or land the rolled-back truth after an error.
+    onSettled: () => {
+      void invalidateChatThread({ queryClient, threadRef });
     },
   });
 
@@ -73,10 +114,11 @@ export const ChatWebSearchToggle = ({
           aria-pressed={enabled}
           // Quiet status-row control: muted at rest, borderless, only the
           // usual ghost hover surface. The enabled state speaks through
-          // the info-tinted icon, not a filled chip.
-          className="text-muted-foreground hover:text-foreground"
+          // the info-tinted icon, not a filled chip. `transition-colors`
+          // eases the on/off tint so the optimistic flip reads as a smooth
+          // turn-on rather than a blip.
+          className="text-muted-foreground hover:text-foreground transition-colors"
           data-pressed={enabled ? "" : undefined}
-          disabled={isPending}
           onClick={() => {
             const next = !enabled;
             setEnabledPreference(next);
@@ -87,6 +129,7 @@ export const ChatWebSearchToggle = ({
         >
           <GlobeIcon
             className={cn(
+              "transition-colors",
               size === "icon-xs" ? "size-3.5" : "size-4",
               enabled && "text-info",
             )}

--- a/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx
@@ -55,6 +55,9 @@ export const ChatWebSearchToggle = ({
   };
 
   const { mutate } = useMutation({
+    scope: {
+      id: `chat-web-search-toggle:${threadRef.scope}:${threadRef.threadId}`,
+    },
     mutationFn: async (nextEnabled: boolean) => {
       const response = await api.chat
         .threads({ threadId: toSafeId<"chatThread">(threadRef.threadId) })
@@ -79,7 +82,10 @@ export const ChatWebSearchToggle = ({
       await queryClient.cancelQueries(filters);
       const previous = queryClient.getQueriesData(filters);
       queryClient.setQueriesData(filters, (old) =>
-        old && typeof old === "object" && "webSearchEnabled" in old
+        old !== undefined &&
+        old !== null &&
+        typeof old === "object" &&
+        "webSearchEnabled" in old
           ? { ...old, webSearchEnabled: nextEnabled }
           : old,
       );

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -33,7 +33,7 @@ import {
   isApprovalToolName,
   isExternalMcpToolName,
   isToolApprovalGrant,
-  sanitizeHydratedRunningToolCalls,
+  sanitizeRunningToolCalls,
   withParsedToolCallInputs,
 } from "@/components/chat/chat-ui-tools";
 import { openEntityInInspector } from "@/components/chat/entity-open";
@@ -273,7 +273,7 @@ export const useChatSession = ({
     // the live turn — so rewriting their dead running tool-call parts is
     // unconditionally safe. `current` is NOT sanitized: its tail may be a
     // live streaming turn.
-    const prepend = sanitizeHydratedRunningToolCalls(older.messages).filter(
+    const prepend = sanitizeRunningToolCalls(older.messages).filter(
       (message) => !existingIds.has(message.id),
     );
     if (prepend.length > 0) {

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -21,7 +21,7 @@ import type {
 } from "@/components/chat/chat-ui-tools";
 import {
   hasRunningToolCallInLatestAssistantMessage,
-  sanitizeHydratedRunningToolCalls,
+  sanitizeRunningToolCalls,
 } from "@/components/chat/chat-ui-tools";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -961,6 +961,22 @@ export const createChatRuntime = ({
     },
     stop: () => {
       client.stop();
+      // `client.stop()` aborts the live request but never rewrites message
+      // parts, so a tool-call part caught mid-run stays in a running state and
+      // keeps `hasRunningToolCallInLatestAssistantMessage` — and thus
+      // `isGenerating` — stuck true, wedging the composer on Stop/spinner with
+      // the tool card spinning forever. When the aborted turn had a running
+      // tool call, finalize it the same way the hydration path does so the
+      // turn actually ends.
+      if (
+        hasRunningToolCallInLatestAssistantMessage({
+          messages: snapshot.messages,
+        })
+      ) {
+        const sanitized = sanitizeRunningToolCalls(snapshot.messages);
+        client.setMessagesManually(sanitized);
+        setSnapshot({ messages: sanitized });
+      }
     },
     subscribe: (listener) => {
       listeners.add(listener);
@@ -1201,7 +1217,7 @@ export type ChatThreadFetched = {
   /**
    * Sanitized initial history for this thread (running tool-call
    * parts left by a stream that died mid-call are dropped — see
-   * `sanitizeHydratedRunningToolCalls`). Pure server data: this
+   * `sanitizeRunningToolCalls`). Pure server data: this
    * query never builds a `ChatRuntime` (see `chatThreadOptions`
    * docs below), so a route loader can prefetch it safely. Callers
    * that need a live runtime pass this array as `initialMessages`
@@ -1308,7 +1324,7 @@ export const fileChatThreadOptions = ({
           context: stubContext,
         }).queryKey,
         {
-          messages: sanitizeHydratedRunningToolCalls(fetched.messages),
+          messages: sanitizeRunningToolCalls(fetched.messages),
           olderCursor: fetched.olderCursor,
           contextMatterIds: fetched.contextMatterIds,
           lastActivityAt: fetched.lastActivityAt,
@@ -1470,8 +1486,8 @@ export const chatThreadOptions = ({
         // fresh runtime with no live turn; drop any tool-call part left
         // running by a stream that died mid call so the session does not
         // load already wedged as "generating". See
-        // `sanitizeHydratedRunningToolCalls`.
-        messages: sanitizeHydratedRunningToolCalls(fetched.messages),
+        // `sanitizeRunningToolCalls`.
+        messages: sanitizeRunningToolCalls(fetched.messages),
       };
     },
   });


### PR DESCRIPTION
Three independent chat-composer runtime bug fixes, all pre-existing on `main`
(surfaced while testing #1058). A fourth fix — the context-meter baseline —
depends on #1058's per-thread model selection, so it rides with that PR rather
than this one.

## 1. Web-search toggle turned on with a delayed blip
`chat-web-search-toggle.tsx`: the globe reflected the new state only after the
`PATCH` round-tripped and the thread query refetched, and it dimmed via
`disabled` while in flight — so it snapped late instead of turning on smoothly.
It now flips the cached `webSearchEnabled` optimistically in `onMutate`
(rollback on error) across the shared `chat/<org>/thread/<scope>/…` key prefix,
so both the thread page and the new-chat hero update instantly; the request no
longer disables the button; and `transition-colors` eases the tint.

## 2. Stop did nothing while tool calls were running
`chat-ui-tools.ts`, `-queries.ts`, `use-chat-session.ts`: `client.stop()` aborts
the live request but never rewrites message parts, so a tool-call part caught
mid-run stays in a running state and keeps
`hasRunningToolCallInLatestAssistantMessage` — and therefore `isGenerating` —
stuck true. The composer wedged on Stop with the tool card spinning forever. On
stop, running tool-call parts are now rewritten to their terminal state, the
same normalization the hydration path already applies. `sanitizeHydratedRunningToolCalls`
is generalized to `sanitizeRunningToolCalls` since it now serves both hydration
and explicit stop.

## 3. "Maximum update depth exceeded" in the composer during streaming
`chat-editor-provider.tsx`: the editor manager folded a monotonic
`extensionVersion` counter and a write-only, never-read `activeThreadKey` into
its memoized context value. Every extension register/unregister bumped the
version → gave the context a new identity → re-rendered the mention-registration
hooks → re-fired their effects → registered again → bumped again. That feedback
loop is damped at rest but exceeds React's nested-update cap under the rapid
re-renders of an active stream. `extensionVersion` now lives in its own context
consumed only by the plugin-sync effect, and the dead `activeThreadKey` is
removed, so the stable-API context no longer changes identity on version bumps
and the loop can't form. (This is the concrete instance of the render-loop class
that #1076 adds structural guards for.)

Each fix was verified end-to-end in the running app, including the stop fix
against a live `execute_typescript` tool call and the render-loop fix under an
active tool-call stream.
