### PR TITLE
feat: date/timezone footgun guards + ratchet

### DIFF
--- a/apps/api/src/handlers/feedback/intake.ts
+++ b/apps/api/src/handlers/feedback/intake.ts
@@ -62,7 +62,9 @@ const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const UNKNOWN_IP_KEY = "unknown";
 
 // Content dedup window: an identical report inside a day is a resend, not new
-// signal.
+// signal. Fixed-duration TTL, not calendar math — the ratchet flags this ms
+// literal (scripts/ratchet.ts, `raw-date-parsing`) but converting it to
+// `addDays` would make the window drift across a DST transition.
 const DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
 
 const INTAKE_FOOTER =

--- a/apps/api/src/lib/dates.test.ts
+++ b/apps/api/src/lib/dates.test.ts
@@ -14,11 +14,11 @@ import { addDays, isIsoDateString, parseIsoDateLocal } from "./dates";
 let originalTz: string | undefined;
 
 beforeEach(() => {
-  originalTz = process.env["TZ"];
+  originalTz = process.env.TZ;
 });
 
 afterEach(() => {
-  process.env["TZ"] = originalTz ?? "";
+  process.env.TZ = originalTz ?? "";
 });
 
 describe("isIsoDateString", () => {
@@ -36,7 +36,7 @@ describe("isIsoDateString", () => {
 
 describe("parseIsoDateLocal", () => {
   test("does not shift a day west of UTC (the new Date(string) bug)", () => {
-    process.env["TZ"] = "Pacific/Honolulu"; // UTC-10, west of UTC
+    process.env.TZ = "Pacific/Honolulu"; // UTC-10, west of UTC
 
     // The footgun this guards against: `new Date("2024-01-01")` parses as
     // UTC midnight, which renders as Dec 31 in a west-of-UTC timezone.
@@ -50,7 +50,7 @@ describe("parseIsoDateLocal", () => {
   });
 
   test("lands on the intended day east of UTC too", () => {
-    process.env["TZ"] = "Pacific/Auckland"; // UTC+12/+13
+    process.env.TZ = "Pacific/Auckland"; // UTC+12/+13
 
     const parsed = parseIsoDateLocal("2024-06-15");
     expect(parsed?.getFullYear()).toBe(2024);
@@ -73,7 +73,7 @@ describe("parseIsoDateLocal", () => {
 
 describe("addDays", () => {
   test("crosses a spring-forward DST transition without overshooting", () => {
-    process.env["TZ"] = "America/New_York";
+    process.env.TZ = "America/New_York";
     // 2024-03-10 02:00 -> 03:00: the 10th is a 23-hour day.
     const start = new Date(2024, 2, 9, 12, 0, 0);
 
@@ -89,7 +89,7 @@ describe("addDays", () => {
   });
 
   test("crosses a fall-back DST transition without undershooting", () => {
-    process.env["TZ"] = "America/New_York";
+    process.env.TZ = "America/New_York";
     // 2024-11-03 02:00 -> 01:00: the 3rd is a 25-hour day.
     const start = new Date(2024, 10, 2, 12, 0, 0);
 

--- a/apps/api/src/lib/dates.test.ts
+++ b/apps/api/src/lib/dates.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { addDays, isIsoDateString, parseIsoDateLocal } from "./dates";
+
+// Date's local-time methods read `process.env.TZ` on every call in Bun (and
+// Node), so flipping it around a test reproduces the exact footgun in a
+// deterministic CI environment instead of depending on the runner's host TZ.
+//
+// Always REASSIGN, never `delete process.env["TZ"]`: deleting the key mid
+// process poisons Bun's cached local-time resolver for the rest of the
+// process (every later Date falls back to UTC, even after a fresh
+// assignment) — reassigning to `""` restores the same "no override"
+// behavior without tripping that cache bug.
+let originalTz: string | undefined;
+
+beforeEach(() => {
+  originalTz = process.env["TZ"];
+});
+
+afterEach(() => {
+  process.env["TZ"] = originalTz ?? "";
+});
+
+describe("isIsoDateString", () => {
+  test("accepts YYYY-MM-DD", () => {
+    expect(isIsoDateString("2024-01-01")).toBe(true);
+  });
+
+  test("rejects non-ISO shapes", () => {
+    expect(isIsoDateString("01/01/2024")).toBe(false);
+    expect(isIsoDateString("2024-1-1")).toBe(false);
+    expect(isIsoDateString("2024-01-01T00:00:00Z")).toBe(false);
+    expect(isIsoDateString("")).toBe(false);
+  });
+});
+
+describe("parseIsoDateLocal", () => {
+  test("does not shift a day west of UTC (the new Date(string) bug)", () => {
+    process.env["TZ"] = "Pacific/Honolulu"; // UTC-10, west of UTC
+
+    // The footgun this guards against: `new Date("2024-01-01")` parses as
+    // UTC midnight, which renders as Dec 31 in a west-of-UTC timezone.
+    expect(new Date("2024-01-01").getDate()).toBe(31);
+
+    // `parseIsoDateLocal` must land on the intended calendar day instead.
+    const parsed = parseIsoDateLocal("2024-01-01");
+    expect(parsed?.getFullYear()).toBe(2024);
+    expect(parsed?.getMonth()).toBe(0);
+    expect(parsed?.getDate()).toBe(1);
+  });
+
+  test("lands on the intended day east of UTC too", () => {
+    process.env["TZ"] = "Pacific/Auckland"; // UTC+12/+13
+
+    const parsed = parseIsoDateLocal("2024-06-15");
+    expect(parsed?.getFullYear()).toBe(2024);
+    expect(parsed?.getMonth()).toBe(5);
+    expect(parsed?.getDate()).toBe(15);
+  });
+
+  test("rejects a calendar date that does not exist", () => {
+    expect(parseIsoDateLocal("2024-02-30")).toBeNull();
+    expect(parseIsoDateLocal("2024-13-01")).toBeNull();
+    expect(parseIsoDateLocal("2024-00-10")).toBeNull();
+  });
+
+  test("rejects malformed strings", () => {
+    expect(parseIsoDateLocal("not-a-date")).toBeNull();
+    expect(parseIsoDateLocal("2024-01-01T00:00:00Z")).toBeNull();
+    expect(parseIsoDateLocal("")).toBeNull();
+  });
+});
+
+describe("addDays", () => {
+  test("crosses a spring-forward DST transition without overshooting", () => {
+    process.env["TZ"] = "America/New_York";
+    // 2024-03-10 02:00 -> 03:00: the 10th is a 23-hour day.
+    const start = new Date(2024, 2, 9, 12, 0, 0);
+
+    // The footgun this guards against: a fixed 24h millisecond step
+    // overshoots the wall clock on a 23-hour day.
+    const naive = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+    expect(naive.getDate()).toBe(10);
+    expect(naive.getHours()).toBe(13); // overshot noon by an hour
+
+    const next = addDays(start, 1);
+    expect(next.getDate()).toBe(10);
+    expect(next.getHours()).toBe(12); // stays on the intended wall-clock hour
+  });
+
+  test("crosses a fall-back DST transition without undershooting", () => {
+    process.env["TZ"] = "America/New_York";
+    // 2024-11-03 02:00 -> 01:00: the 3rd is a 25-hour day.
+    const start = new Date(2024, 10, 2, 12, 0, 0);
+
+    const naive = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+    expect(naive.getDate()).toBe(3);
+    expect(naive.getHours()).toBe(11); // undershot noon by an hour
+
+    const next = addDays(start, 1);
+    expect(next.getDate()).toBe(3);
+    expect(next.getHours()).toBe(12);
+  });
+
+  test("rolls over a month/year boundary", () => {
+    // Read back via local getters (not `toISOString`, which reprojects
+    // through UTC and would make this assertion depend on the host TZ).
+    const next = addDays(new Date(2024, 11, 31), 1);
+    expect(next.getFullYear()).toBe(2025);
+    expect(next.getMonth()).toBe(0);
+    expect(next.getDate()).toBe(1);
+  });
+
+  test("subtracts with a negative n", () => {
+    const prev = addDays(new Date(2024, 0, 1), -1);
+    expect(prev.getFullYear()).toBe(2023);
+    expect(prev.getMonth()).toBe(11);
+    expect(prev.getDate()).toBe(31);
+  });
+});

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -1,0 +1,68 @@
+// Small, dependency-free guards against the two most common date footguns:
+// UTC/local-midnight drift when parsing a bare calendar-date string, and
+// DST-unsafe day arithmetic via millisecond math. See the mirrored
+// `apps/web/src/lib/dates.ts` for the frontend-side copy — there is no
+// shared cross-app package for this yet, so the two stay independent.
+
+const ISO_DATE_PATTERN = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u;
+
+/**
+ * True when `value` has the `YYYY-MM-DD` shape `parseIsoDateLocal` accepts.
+ * Does not check that the date exists on the calendar (e.g. "2024-02-30"
+ * passes this guard but `parseIsoDateLocal` still rejects it).
+ */
+export const isIsoDateString = (value: string): boolean =>
+  ISO_DATE_PATTERN.test(value);
+
+/**
+ * Parse a `YYYY-MM-DD` calendar-date string as LOCAL midnight.
+ *
+ * `new Date("2024-01-01")` parses as UTC midnight per the ECMAScript spec;
+ * rendering it in any timezone west of UTC (e.g. US, most of the Americas)
+ * shows the previous day. This builds the `Date` from the individual parts
+ * instead, so it always lands on the intended calendar day in the local
+ * timezone.
+ *
+ * Returns `null` for a malformed string or a day/month that does not exist
+ * on the calendar, instead of silently rolling over (e.g. "2024-02-30").
+ */
+export const parseIsoDateLocal = (value: string): Date | null => {
+  const match = ISO_DATE_PATTERN.exec(value);
+  const yearStr = match?.groups?.["year"];
+  const monthStr = match?.groups?.["month"];
+  const dayStr = match?.groups?.["day"];
+  if (!yearStr || !monthStr || !dayStr) {
+    return null;
+  }
+
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  const date = new Date(year, month - 1, day);
+
+  // `Date` rolls over out-of-range parts (e.g. Feb 30 -> Mar 2) instead of
+  // throwing; reject anything that didn't round-trip to the input date.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+};
+
+/**
+ * Add `n` calendar days to `date`, DST-safe.
+ *
+ * Adding `n * 24 * 60 * 60 * 1000` milliseconds breaks across a DST
+ * transition: the transition day is 23 or 25 hours, so a fixed 24h step
+ * over- or under-shoots the intended calendar day. This adds to the
+ * day-of-month part instead and lets `Date` resolve the wall-clock time,
+ * so the result always lands on the correct calendar date `n` days later.
+ */
+export const addDays = (date: Date, n: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + n);
+  return result;
+};

--- a/apps/api/src/lib/desktop-edit-sessions.ts
+++ b/apps/api/src/lib/desktop-edit-sessions.ts
@@ -43,7 +43,10 @@ type DesktopEditSessionAuthorizationResult =
       status: "permission-revoked";
     };
 
-/** Session tokens expire after 24 hours. Each checkpoint extends by this amount. */
+/** Session tokens expire after 24 hours. Each checkpoint extends by this amount.
+ *  Fixed-duration TTL, not calendar math — the ratchet flags this ms literal
+ *  (scripts/ratchet.ts, `raw-date-parsing`) but converting it to `addDays`
+ *  would make expiry drift by an hour across a DST transition. */
 export const SESSION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 
 export const computeTokenExpiresAt = () =>

--- a/apps/api/src/lib/report-export-recovery.ts
+++ b/apps/api/src/lib/report-export-recovery.ts
@@ -30,7 +30,10 @@ import { reportExports } from "@/api/db/schema";
 /** A `running` row this old lost its worker to a hard death. */
 const STUCK_RUNNING_MS = 30 * 60 * 1000;
 /** A `queued` row this old lost its job to queue data loss; anything younger
- *  may simply be backlogged and must be left for the worker. */
+ *  may simply be backlogged and must be left for the worker.
+ *  Fixed-duration threshold, not calendar math — the ratchet flags this ms
+ *  literal (scripts/ratchet.ts, `raw-date-parsing`) but converting it to
+ *  `addDays` would make the threshold drift across a DST transition. */
 const STUCK_QUEUED_MS = 24 * 60 * 60 * 1000;
 const STUCK_EXPORT_ERROR =
   "Report export did not complete in time and was marked failed. Please try again.";

--- a/apps/web/src/lib/dates.test.ts
+++ b/apps/web/src/lib/dates.test.ts
@@ -14,11 +14,11 @@ import { addDays, isIsoDateString, parseIsoDateLocal } from "./dates";
 let originalTz: string | undefined;
 
 beforeEach(() => {
-  originalTz = process.env["TZ"];
+  originalTz = process.env.TZ;
 });
 
 afterEach(() => {
-  process.env["TZ"] = originalTz ?? "";
+  process.env.TZ = originalTz ?? "";
 });
 
 describe("isIsoDateString", () => {
@@ -36,7 +36,7 @@ describe("isIsoDateString", () => {
 
 describe("parseIsoDateLocal", () => {
   test("does not shift a day west of UTC (the new Date(string) bug)", () => {
-    process.env["TZ"] = "Pacific/Honolulu"; // UTC-10, west of UTC
+    process.env.TZ = "Pacific/Honolulu"; // UTC-10, west of UTC
 
     // The footgun this guards against: `new Date("2024-01-01")` parses as
     // UTC midnight, which renders as Dec 31 in a west-of-UTC timezone.
@@ -50,7 +50,7 @@ describe("parseIsoDateLocal", () => {
   });
 
   test("lands on the intended day east of UTC too", () => {
-    process.env["TZ"] = "Pacific/Auckland"; // UTC+12/+13
+    process.env.TZ = "Pacific/Auckland"; // UTC+12/+13
 
     const parsed = parseIsoDateLocal("2024-06-15");
     expect(parsed?.getFullYear()).toBe(2024);
@@ -73,7 +73,7 @@ describe("parseIsoDateLocal", () => {
 
 describe("addDays", () => {
   test("crosses a spring-forward DST transition without overshooting", () => {
-    process.env["TZ"] = "America/New_York";
+    process.env.TZ = "America/New_York";
     // 2024-03-10 02:00 -> 03:00: the 10th is a 23-hour day.
     const start = new Date(2024, 2, 9, 12, 0, 0);
 
@@ -89,7 +89,7 @@ describe("addDays", () => {
   });
 
   test("crosses a fall-back DST transition without undershooting", () => {
-    process.env["TZ"] = "America/New_York";
+    process.env.TZ = "America/New_York";
     // 2024-11-03 02:00 -> 01:00: the 3rd is a 25-hour day.
     const start = new Date(2024, 10, 2, 12, 0, 0);
 

--- a/apps/web/src/lib/dates.test.ts
+++ b/apps/web/src/lib/dates.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { addDays, isIsoDateString, parseIsoDateLocal } from "./dates";
+
+// Date's local-time methods read `process.env.TZ` on every call in Bun (and
+// Node), so flipping it around a test reproduces the exact footgun in a
+// deterministic CI environment instead of depending on the runner's host TZ.
+//
+// Always REASSIGN, never `delete process.env["TZ"]`: deleting the key mid
+// process poisons Bun's cached local-time resolver for the rest of the
+// process (every later Date falls back to UTC, even after a fresh
+// assignment) — reassigning to `""` restores the same "no override"
+// behavior without tripping that cache bug.
+let originalTz: string | undefined;
+
+beforeEach(() => {
+  originalTz = process.env["TZ"];
+});
+
+afterEach(() => {
+  process.env["TZ"] = originalTz ?? "";
+});
+
+describe("isIsoDateString", () => {
+  test("accepts YYYY-MM-DD", () => {
+    expect(isIsoDateString("2024-01-01")).toBe(true);
+  });
+
+  test("rejects non-ISO shapes", () => {
+    expect(isIsoDateString("01/01/2024")).toBe(false);
+    expect(isIsoDateString("2024-1-1")).toBe(false);
+    expect(isIsoDateString("2024-01-01T00:00:00Z")).toBe(false);
+    expect(isIsoDateString("")).toBe(false);
+  });
+});
+
+describe("parseIsoDateLocal", () => {
+  test("does not shift a day west of UTC (the new Date(string) bug)", () => {
+    process.env["TZ"] = "Pacific/Honolulu"; // UTC-10, west of UTC
+
+    // The footgun this guards against: `new Date("2024-01-01")` parses as
+    // UTC midnight, which renders as Dec 31 in a west-of-UTC timezone.
+    expect(new Date("2024-01-01").getDate()).toBe(31);
+
+    // `parseIsoDateLocal` must land on the intended calendar day instead.
+    const parsed = parseIsoDateLocal("2024-01-01");
+    expect(parsed?.getFullYear()).toBe(2024);
+    expect(parsed?.getMonth()).toBe(0);
+    expect(parsed?.getDate()).toBe(1);
+  });
+
+  test("lands on the intended day east of UTC too", () => {
+    process.env["TZ"] = "Pacific/Auckland"; // UTC+12/+13
+
+    const parsed = parseIsoDateLocal("2024-06-15");
+    expect(parsed?.getFullYear()).toBe(2024);
+    expect(parsed?.getMonth()).toBe(5);
+    expect(parsed?.getDate()).toBe(15);
+  });
+
+  test("rejects a calendar date that does not exist", () => {
+    expect(parseIsoDateLocal("2024-02-30")).toBeNull();
+    expect(parseIsoDateLocal("2024-13-01")).toBeNull();
+    expect(parseIsoDateLocal("2024-00-10")).toBeNull();
+  });
+
+  test("rejects malformed strings", () => {
+    expect(parseIsoDateLocal("not-a-date")).toBeNull();
+    expect(parseIsoDateLocal("2024-01-01T00:00:00Z")).toBeNull();
+    expect(parseIsoDateLocal("")).toBeNull();
+  });
+});
+
+describe("addDays", () => {
+  test("crosses a spring-forward DST transition without overshooting", () => {
+    process.env["TZ"] = "America/New_York";
+    // 2024-03-10 02:00 -> 03:00: the 10th is a 23-hour day.
+    const start = new Date(2024, 2, 9, 12, 0, 0);
+
+    // The footgun this guards against: a fixed 24h millisecond step
+    // overshoots the wall clock on a 23-hour day.
+    const naive = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+    expect(naive.getDate()).toBe(10);
+    expect(naive.getHours()).toBe(13); // overshot noon by an hour
+
+    const next = addDays(start, 1);
+    expect(next.getDate()).toBe(10);
+    expect(next.getHours()).toBe(12); // stays on the intended wall-clock hour
+  });
+
+  test("crosses a fall-back DST transition without undershooting", () => {
+    process.env["TZ"] = "America/New_York";
+    // 2024-11-03 02:00 -> 01:00: the 3rd is a 25-hour day.
+    const start = new Date(2024, 10, 2, 12, 0, 0);
+
+    const naive = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+    expect(naive.getDate()).toBe(3);
+    expect(naive.getHours()).toBe(11); // undershot noon by an hour
+
+    const next = addDays(start, 1);
+    expect(next.getDate()).toBe(3);
+    expect(next.getHours()).toBe(12);
+  });
+
+  test("rolls over a month/year boundary", () => {
+    // Read back via local getters (not `toISOString`, which reprojects
+    // through UTC and would make this assertion depend on the host TZ).
+    const next = addDays(new Date(2024, 11, 31), 1);
+    expect(next.getFullYear()).toBe(2025);
+    expect(next.getMonth()).toBe(0);
+    expect(next.getDate()).toBe(1);
+  });
+
+  test("subtracts with a negative n", () => {
+    const prev = addDays(new Date(2024, 0, 1), -1);
+    expect(prev.getFullYear()).toBe(2023);
+    expect(prev.getMonth()).toBe(11);
+    expect(prev.getDate()).toBe(31);
+  });
+});

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -1,0 +1,68 @@
+// Small, dependency-free guards against the two most common date footguns:
+// UTC/local-midnight drift when parsing a bare calendar-date string, and
+// DST-unsafe day arithmetic via millisecond math. See the mirrored
+// `apps/api/src/lib/dates.ts` for the backend-side copy — there is no
+// shared cross-app package for this yet, so the two stay independent.
+
+const ISO_DATE_PATTERN = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u;
+
+/**
+ * True when `value` has the `YYYY-MM-DD` shape `parseIsoDateLocal` accepts.
+ * Does not check that the date exists on the calendar (e.g. "2024-02-30"
+ * passes this guard but `parseIsoDateLocal` still rejects it).
+ */
+export const isIsoDateString = (value: string): boolean =>
+  ISO_DATE_PATTERN.test(value);
+
+/**
+ * Parse a `YYYY-MM-DD` calendar-date string as LOCAL midnight.
+ *
+ * `new Date("2024-01-01")` parses as UTC midnight per the ECMAScript spec;
+ * rendering it in any timezone west of UTC (e.g. US, most of the Americas)
+ * shows the previous day. This builds the `Date` from the individual parts
+ * instead, so it always lands on the intended calendar day in the local
+ * timezone.
+ *
+ * Returns `null` for a malformed string or a day/month that does not exist
+ * on the calendar, instead of silently rolling over (e.g. "2024-02-30").
+ */
+export const parseIsoDateLocal = (value: string): Date | null => {
+  const match = ISO_DATE_PATTERN.exec(value);
+  const yearStr = match?.groups?.["year"];
+  const monthStr = match?.groups?.["month"];
+  const dayStr = match?.groups?.["day"];
+  if (!yearStr || !monthStr || !dayStr) {
+    return null;
+  }
+
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  const date = new Date(year, month - 1, day);
+
+  // `Date` rolls over out-of-range parts (e.g. Feb 30 -> Mar 2) instead of
+  // throwing; reject anything that didn't round-trip to the input date.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+};
+
+/**
+ * Add `n` calendar days to `date`, DST-safe.
+ *
+ * Adding `n * 24 * 60 * 60 * 1000` milliseconds breaks across a DST
+ * transition: the transition day is 23 or 25 hours, so a fixed 24h step
+ * over- or under-shoots the intended calendar day. This adds to the
+ * day-of-month part instead and lets `Date` resolve the wall-clock time,
+ * so the result always lands on the correct calendar date `n` days later.
+ */
+export const addDays = (date: Date, n: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + n);
+  return result;
+};

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -311,5 +311,36 @@
       "apps/web/src/routes/auth/organization.tsx": 2,
       "apps/web/src/routes/consent.tsx": 1
     }
+  },
+  "raw-date-parsing": {
+    "count": 41,
+    "files": {
+      "apps/api/src/handlers/case-law/citation-score.ts": 2,
+      "apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts": 1,
+      "apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts": 1,
+      "apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts": 2,
+      "apps/api/src/handlers/case-law/ingestion/status.ts": 1,
+      "apps/api/src/handlers/entities/query-entities.ts": 1,
+      "apps/api/src/handlers/expenses/create.ts": 2,
+      "apps/api/src/handlers/feedback/intake.ts": 1,
+      "apps/api/src/handlers/tasks/calendar.ts": 2,
+      "apps/api/src/handlers/time-entries/create.ts": 2,
+      "apps/api/src/lib/desktop-edit-sessions.ts": 1,
+      "apps/api/src/lib/pagination.ts": 1,
+      "apps/api/src/lib/report-export-recovery.ts": 1,
+      "apps/api/src/lib/scheduler/schedule.ts": 1,
+      "apps/api/src/mcp/research-admin-tools.ts": 1,
+      "apps/web/src/components/search-dialog.tsx": 2,
+      "apps/web/src/components/selfhost-update-banner.tsx": 1,
+      "apps/web/src/lib/desktop-bridge.ts": 2,
+      "apps/web/src/lib/search.ts": 4,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx": 3,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.logic.ts": 1,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx": 1,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts": 2,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-components/import-organizer.logic.ts": 1,
+      "apps/web/src/routes/_protected.workspaces/$workspaceId/-utils.ts": 1,
+      "apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx": 3
+    }
   }
 }

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -123,9 +123,17 @@ const findUnescapedQuote = (
 // state across lines. Returns the remaining code (literal contents replaced
 // by a single space, so word boundaries around the literal still hold) plus
 // the state to pass into the next line.
+//
+// `keepDelimiters` blanks only the INTERIOR of the literal, leaving the
+// opening/closing quote characters in place (`"foo"` -> `" "` rather than
+// ` `). Most counters don't need this — the quote chars are noise — but
+// `countRawDateParsing` matches on the opening quote itself
+// (`new Date("`), which a full blank would erase along with the rest of
+// the string it's trying to detect.
 const stripStringLiterals = (
   raw: string,
   state: LiteralScanState,
+  keepDelimiters = false,
 ): { code: string; state: LiteralScanState } => {
   let out = "";
   let i = 0;
@@ -135,7 +143,7 @@ const stripStringLiterals = (
     if (close === -1) {
       return { code: out, state };
     }
-    out += BLANKED_LITERAL;
+    out += keepDelimiters ? `${BLANKED_LITERAL}\`` : BLANKED_LITERAL;
     i = close + 1;
   }
 
@@ -152,7 +160,9 @@ const stripStringLiterals = (
         }
         break;
       }
-      out += BLANKED_LITERAL;
+      out += keepDelimiters
+        ? `${ch}${BLANKED_LITERAL}${raw[close]}`
+        : BLANKED_LITERAL;
       i = close + 1;
       continue;
     }
@@ -171,8 +181,13 @@ const stripStringLiterals = (
 const stripLine = (
   raw: string,
   state: LiteralScanState,
+  keepDelimiters = false,
 ): { code: string; state: LiteralScanState } => {
-  const { code, state: nextState } = stripStringLiterals(raw, state);
+  const { code, state: nextState } = stripStringLiterals(
+    raw,
+    state,
+    keepDelimiters,
+  );
   return { code: code.replace(LINE_COMMENT_TAIL, ""), state: nextState };
 };
 
@@ -254,30 +269,44 @@ const countPresence = (): number => 1;
 // Raw date/timezone footguns: `new Date("YYYY-MM-DD")` parses as UTC
 // midnight (an off-by-one day once rendered west of UTC), `Date.parse(...)`
 // of a non-ISO string is engine-dependent, and day-length millisecond
-// arithmetic (`24 * 60 * 60 * 1000`, `86_400_000`/`86400000`) breaks across
-// a DST transition (the clocks-change day is 23 or 25 hours, not 24). Use
-// `parseIsoDateLocal` / `addDays` from `apps/{api,web}/src/lib/dates.ts`
-// instead.
+// arithmetic used for CALENDAR math (`24 * 60 * 60 * 1000`,
+// `86_400_000`/`86400000`) breaks across a DST transition (the clocks-change
+// day is 23 or 25 hours, not 24). Use `parseIsoDateLocal` / `addDays` from
+// `apps/{api,web}/src/lib/dates.ts` for calendar/date-boundary work instead.
 //
-// Line-based, like the counters above: a comment line is skipped and a
-// trailing `//` tail is dropped, but (unlike `countAsCasts`) string/template
-// contents are NOT blanked first, because the string quote characters
-// themselves are part of what this counter matches (`new Date("`). Accepted
-// fidelity limit: a `//` sitting inside an earlier string on the same line
-// would truncate the line before a later match — rare for date-parsing code
-// and consistent with this file's other documented tradeoffs.
+// NOT a footgun: the same millisecond literal used as a fixed-duration span
+// (a TTL, a timeout, a "how many ms have elapsed" comparison) rather than a
+// calendar offset. `Date.now() + 24 * 60 * 60 * 1000` for a token that must
+// expire exactly 86,400,000ms after issuance is correct — converting it to
+// `addDays` would make the expiry drift by an hour across a DST transition,
+// which is the opposite of what this ratchet wants. This counter can't tell
+// the two apart lexically (that requires understanding whether the result
+// feeds a calendar boundary or a raw duration comparison), so it flags both;
+// treat a flagged fixed-duration constant as a false positive to leave alone,
+// not a violation to "fix" into calendar arithmetic.
+//
+// Line-based, like the counters above, and (like `countAsCasts`) runs
+// through `stripLine` so a `//` sitting inside an earlier string on the same
+// line (e.g. a URL) can't truncate the line before a later real match.
+// Unlike the other counters, it passes `keepDelimiters: true` — the string
+// quote characters themselves are part of what `RAW_DATE_STRING_ARG` matches
+// (`new Date("`), so only the literal's interior is blanked, not the quotes.
 const RAW_DATE_STRING_ARG = /\bnew\s+Date\(\s*["`]/gu;
 const DATE_PARSE_CALL = /\bDate\.parse\(/gu;
 const DAY_MS_ARITHMETIC_EXPR = /24\s*\*\s*60\s*\*\s*60\s*\*\s*1000\b/gu;
 const DAY_MS_LITERAL = /\b86_400_000\b|\b86400000\b/gu;
+const KEEP_QUOTE_DELIMITERS = true;
 
 const countRawDateParsing = (content: string): number => {
   let total = 0;
+  let literalState = NO_OPEN_TEMPLATE;
+
   for (const raw of content.split("\n")) {
-    if (COMMENT_LINE.test(raw)) {
+    const { code, state } = stripLine(raw, literalState, KEEP_QUOTE_DELIMITERS);
+    literalState = state;
+    if (COMMENT_LINE.test(code)) {
       continue;
     }
-    const code = raw.replace(LINE_COMMENT_TAIL, "");
     total += (code.match(RAW_DATE_STRING_ARG) ?? []).length;
     total += (code.match(DATE_PARSE_CALL) ?? []).length;
     total += (code.match(DAY_MS_ARITHMETIC_EXPR) ?? []).length;
@@ -344,7 +373,7 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
   {
     id: "raw-date-parsing",
     description:
-      'string-literal date parsing (`new Date("...")`, `new Date(`...`)`, `Date.parse(...)`) and day-length ms arithmetic literals (`24 * 60 * 60 * 1000`, `86_400_000`/`86400000`) in app source (excl. tests/gen); prefer `parseIsoDateLocal`/`addDays` from apps/{api,web}/src/lib/dates.ts',
+      'string-literal date parsing (`new Date("...")`, `new Date(`...`)`, `Date.parse(...)`) and day-length ms arithmetic used for CALENDAR math (`24 * 60 * 60 * 1000`, `86_400_000`/`86400000`) in app source (excl. tests/gen); prefer `parseIsoDateLocal`/`addDays` from apps/{api,web}/src/lib/dates.ts for date-boundary work. The same ms literal used as a fixed-duration TTL/timeout (not a calendar offset) is correct as-is and must NOT be converted to calendar-day arithmetic — that would introduce DST drift. The counter cannot distinguish the two lexically, so it flags both; a flagged fixed-duration constant is a known false positive, not a violation.',
     include: APP_SOURCE_GLOBS,
     exclude: isExcludedSource,
     count: countRawDateParsing,
@@ -623,12 +652,15 @@ const RAW_DATE_FIXTURE_LINES = [
   "const i = new Date(existingDate); // copying a Date instance is safe",
   '// new Date("2024-01-01") mentioned in a comment must not count',
   "const j = parseIsoDateLocal(iso); // helper call is safe",
+  'const withUrl = "see http://example.com for details"; const k = new Date("2024-01-01"); // "//" earlier in the line must not hide this real match',
 ];
 const SELF_TEST_RAW_DATE = `${RAW_DATE_FIXTURE_LINES.join("\n")}\n`;
-// Expected: a(1) + b(1) + c(1) + d(1) + e(1) + f(1) = 6. The no-arg/parts/
-// copy Date constructors, the safe helper call, and the comment mention are
-// all excluded.
-const EXPECTED_RAW_DATE = 6;
+// Expected: a(1) + b(1) + c(1) + d(1) + e(1) + f(1) + k(1) = 7. The no-arg/
+// parts/copy Date constructors, the safe helper call, and the comment
+// mention are all excluded. `k` proves the earlier `http://` string (with
+// its own `//`) does not truncate the line before the real `new Date(...)`
+// call further along it — the false-negative class `stripLine` fixes.
+const EXPECTED_RAW_DATE = 7;
 
 const writeFixture = (root: string, rel: string, content: string): void => {
   const full = path.join(root, rel);

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -251,6 +251,41 @@ const countDirectErrorMessageDisplay = (content: string): number => {
 // one barrel (presence metric).
 const countPresence = (): number => 1;
 
+// Raw date/timezone footguns: `new Date("YYYY-MM-DD")` parses as UTC
+// midnight (an off-by-one day once rendered west of UTC), `Date.parse(...)`
+// of a non-ISO string is engine-dependent, and day-length millisecond
+// arithmetic (`24 * 60 * 60 * 1000`, `86_400_000`/`86400000`) breaks across
+// a DST transition (the clocks-change day is 23 or 25 hours, not 24). Use
+// `parseIsoDateLocal` / `addDays` from `apps/{api,web}/src/lib/dates.ts`
+// instead.
+//
+// Line-based, like the counters above: a comment line is skipped and a
+// trailing `//` tail is dropped, but (unlike `countAsCasts`) string/template
+// contents are NOT blanked first, because the string quote characters
+// themselves are part of what this counter matches (`new Date("`). Accepted
+// fidelity limit: a `//` sitting inside an earlier string on the same line
+// would truncate the line before a later match — rare for date-parsing code
+// and consistent with this file's other documented tradeoffs.
+const RAW_DATE_STRING_ARG = /\bnew\s+Date\(\s*["`]/gu;
+const DATE_PARSE_CALL = /\bDate\.parse\(/gu;
+const DAY_MS_ARITHMETIC_EXPR = /24\s*\*\s*60\s*\*\s*60\s*\*\s*1000\b/gu;
+const DAY_MS_LITERAL = /\b86_400_000\b|\b86400000\b/gu;
+
+const countRawDateParsing = (content: string): number => {
+  let total = 0;
+  for (const raw of content.split("\n")) {
+    if (COMMENT_LINE.test(raw)) {
+      continue;
+    }
+    const code = raw.replace(LINE_COMMENT_TAIL, "");
+    total += (code.match(RAW_DATE_STRING_ARG) ?? []).length;
+    total += (code.match(DATE_PARSE_CALL) ?? []).length;
+    total += (code.match(DAY_MS_ARITHMETIC_EXPR) ?? []).length;
+    total += (code.match(DAY_MS_LITERAL) ?? []).length;
+  }
+  return total;
+};
+
 // --- Metric table -----------------------------------------------------------
 
 type FileCounter = (content: string) => number;
@@ -305,6 +340,14 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
       file.includes("apps/web/src/routes/dev/") ||
       file.startsWith("apps/web/src/workers/"),
     count: countDirectErrorMessageDisplay,
+  },
+  {
+    id: "raw-date-parsing",
+    description:
+      'string-literal date parsing (`new Date("...")`, `new Date(`...`)`, `Date.parse(...)`) and day-length ms arithmetic literals (`24 * 60 * 60 * 1000`, `86_400_000`/`86400000`) in app source (excl. tests/gen); prefer `parseIsoDateLocal`/`addDays` from apps/{api,web}/src/lib/dates.ts',
+    include: APP_SOURCE_GLOBS,
+    exclude: isExcludedSource,
+    count: countRawDateParsing,
   },
 ];
 
@@ -568,6 +611,25 @@ const SELF_TEST_DIRECT_ERROR = `${DIRECT_ERROR_FIXTURE_LINES.join("\n")}\n`;
 // string literal, and comment are excluded.
 const EXPECTED_DIRECT_ERROR = 4;
 
+const RAW_DATE_FIXTURE_LINES = [
+  'const a = new Date("2024-01-01");',
+  "const b = new Date(`2024-01-01`);",
+  "const c = Date.parse(rawInput);",
+  "const d = now.getTime() + 24 * 60 * 60 * 1000;",
+  "const e = now.getTime() + 86_400_000;",
+  "const f = now.getTime() + 86400000;",
+  "const g = new Date(); // no-arg constructor is safe, must not count",
+  "const h = new Date(year, month - 1, day); // date-parts ctor is safe",
+  "const i = new Date(existingDate); // copying a Date instance is safe",
+  '// new Date("2024-01-01") mentioned in a comment must not count',
+  "const j = parseIsoDateLocal(iso); // helper call is safe",
+];
+const SELF_TEST_RAW_DATE = `${RAW_DATE_FIXTURE_LINES.join("\n")}\n`;
+// Expected: a(1) + b(1) + c(1) + d(1) + e(1) + f(1) = 6. The no-arg/parts/
+// copy Date constructors, the safe helper call, and the comment mention are
+// all excluded.
+const EXPECTED_RAW_DATE = 6;
+
 const writeFixture = (root: string, rel: string, content: string): void => {
   const full = path.join(root, rel);
   mkdirSync(path.dirname(full), { recursive: true });
@@ -588,6 +650,7 @@ const runSelfTest = (): number => {
     );
     writeFixture(root, "apps/api/src/db/index.ts", "export const x = 1;\n");
     writeFixture(root, "apps/web/src/lib/index.tsx", "export const y = 2;\n");
+    writeFixture(root, "apps/api/src/raw-date.ts", SELF_TEST_RAW_DATE);
     // Excluded companions: these must NOT be counted.
     writeFixture(
       root,
@@ -595,6 +658,7 @@ const runSelfTest = (): number => {
       "const z = value as Widget;\n",
     );
     writeFixture(root, "apps/web/src/types.gen.ts", "const g = x as Y;\n");
+    writeFixture(root, "apps/api/src/raw-date.test.ts", SELF_TEST_RAW_DATE);
 
     const snapshot = scanAll(root);
 
@@ -630,6 +694,16 @@ const runSelfTest = (): number => {
       failures.push(
         `direct-error-message-display counted ${directErrorMetric.count}, expected ${EXPECTED_DIRECT_ERROR}`,
       );
+    }
+
+    const rawDateMetric = snapshot["raw-date-parsing"];
+    if (rawDateMetric.count !== EXPECTED_RAW_DATE) {
+      failures.push(
+        `raw-date-parsing counted ${rawDateMetric.count}, expected ${EXPECTED_RAW_DATE}`,
+      );
+    }
+    if ("apps/api/src/raw-date.test.ts" in rawDateMetric.files) {
+      failures.push("raw-date-parsing did not exclude a .test.ts file");
     }
 
     // Diff behavior: equal passes, a rise regresses, a fall is a drop.


### PR DESCRIPTION
## Summary

The codebase has ~376 argument-taking `new Date(...)` call sites and no date library. Three known bug classes:

- `new Date("YYYY-MM-DD")` parses as UTC midnight per the ECMAScript spec; rendering it in any timezone west of UTC shows the previous calendar day.
- `Date.parse(...)` of a non-ISO string is engine-dependent (unspecified by the spec).
- Day arithmetic via `n * 24 * 60 * 60 * 1000` breaks across a DST transition, since the transition day is 23 or 25 hours, not 24.

In a legal-workspace product, a date-offset bug (a filing deadline or hearing date shown a day early/late) is top severity.

This PR is deliberately **not** a mass migration of existing call sites — it adds guards and a visibility mechanism, and leaves current code untouched:

- `parseIsoDateLocal`, `addDays`, and `isIsoDateString` — small, dependency-free, DST-safe pure helpers, added in `apps/web/src/lib/dates.ts` and mirrored in `apps/api/src/lib/dates.ts` (no shared cross-app date package exists yet, so the two stay independent copies for now).
- A `raw-date-parsing` ratchet metric in `scripts/ratchet.ts` that counts string-literal `new Date("...")` / `` new Date(`...`) `` / `Date.parse(...)` calls and day-length ms-arithmetic literals (`24 * 60 * 60 * 1000`, `86_400_000`/`86400000`) in app source. Current baseline: 41 occurrences across 26 files — it can only shrink from here, catching new instances of the footgun in CI going forward.

## Test plan

- [x] `bun scripts/ratchet.ts --self-test` passes (new fixture proves the counter counts exactly what it claims, including the tests/gen exclusion)
- [x] `bun scripts/ratchet.ts --write` regenerated the baseline (41 across 26 files, committed)
- [x] `bun --filter @stll/web test src/lib/dates.test.ts` — 10/10 pass, including DST spring-forward/fall-back and UTC-shift edge cases
- [x] `bun --filter @stll/api test src/lib/dates.test.ts` — 10/10 pass (mirrored suite)
- [x] `bunx oxfmt -c .oxfmtrc.json` on all changed files
- [x] pre-commit lint/format hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared date utilities for strict `YYYY-MM-DD` validation, local date parsing and calendar-day adjustments.
  - Date calculations now remain accurate across daylight-saving changes, month and year boundaries, and date subtraction.
  - Invalid or malformed calendar dates are rejected consistently.

- **Bug Fixes**
  - Improved date handling to prevent timezone-related date shifts and daylight-saving drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->