### PR TITLE
chore: bump @stll/cli to 0.2.0

### DIFF
--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -73,7 +73,7 @@ export const MCP_ALLOWED_HEADERS = [
 // one stderr hint. Bump this line when publishing a new @stll/cli. The header
 // name is mirrored (by design, no shared module) in
 // `packages/cli/src/cli-version-nudge.ts`.
-export const STELLA_CLI_LATEST_VERSION = "0.1.2";
+export const STELLA_CLI_LATEST_VERSION = "0.2.0";
 export const STELLA_CLI_LATEST_HEADER = "x-stella-cli-latest";
 
 export const MCP_EXPOSE_HEADERS = [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/cli",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Stella command-line client",
   "keywords": [
     "cli",

--- a/packages/cli/src/generated/cli-version.ts
+++ b/packages/cli/src/generated/cli-version.ts
@@ -3,4 +3,4 @@
 // The running CLI's own version, baked in at codegen time so the update nudge
 // (spec 051 addendum) never reads package.json from the published dist.
 
-export const CLI_VERSION = "0.1.2";
+export const CLI_VERSION = "0.2.0";


### PR DESCRIPTION
## Summary

Publishes the plan-049 CLI surface: 281 commands (44 curated + 237 capability), request-id receipts, `--dry-run`, `--no-input`, JSONL streaming, the `stella:chat` scope, and the new exit codes (8 permission_denied, 9 usage_limited, 10 conflict).

- `packages/cli/package.json` 0.1.2 → 0.2.0 (publish-npm.yml triggers on this path; OIDC trusted publishing, idempotent)
- `cli-version.ts` regenerated via codegen (idempotent)
- `STELLA_CLI_LATEST_VERSION` → 0.2.0 (update-nudge header)

## Verification

- `bun --filter @stll/cli test` (272 pass), `bun --filter @stll/cli build`
- codegen idempotent; type-aware oxlint + oxfmt clean; `bun --filter @stll/api typecheck` exit 0