### PR TITLE
feat: dev-only render-storm canary around the app root

### DIFF
--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from "react-dom/client";
 import { CancelledError } from "@tanstack/react-query";
 import { StartClient } from "@tanstack/react-start/client";
 
+import { RenderStormCanary } from "@/components/render-storm-canary";
 import { initializeI18n } from "@/i18n/i18n-store";
 import { installPreloadErrorRecovery } from "@/lib/preload-error-recovery";
 import { isPublicSsrPath } from "@/lib/public-ssr-paths";
@@ -13,7 +14,9 @@ const hydrate = () => {
     hydrateRoot(
       document,
       <StrictMode>
-        <StartClient />
+        <RenderStormCanary>
+          <StartClient />
+        </RenderStormCanary>
       </StrictMode>,
       {
         onCaughtError: (error) => {

--- a/apps/web/src/components/render-storm-canary.tsx
+++ b/apps/web/src/components/render-storm-canary.tsx
@@ -1,0 +1,67 @@
+import { Profiler, useState } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
+
+import type {
+  RenderStormDetails,
+  RenderStormPhase,
+} from "@/lib/render-storm-canary";
+import { createRenderStormMonitor } from "@/lib/render-storm-canary";
+
+const RENDER_STORM_CANARY_PROFILER_ID = "render-storm-canary";
+
+/**
+ * Dev-only render-loop detector. Wraps the app root in a React `<Profiler>`
+ * that counts commits per second; a sustained storm (see the lib module
+ * "render-storm-canary" under apps/web/src/lib for thresholds and
+ * calibration) emits a single `console.error`, which the e2e
+ * `browserErrors` fixture (apps/web/e2e/helpers/test.ts) turns into a CI
+ * failure on ANY spec, not just one dedicated to a specific past
+ * regression. Damped near-loops (hundreds of re-renders/sec that never
+ * trip React's own "Maximum update depth exceeded" throw) ship silently
+ * without this.
+ *
+ * `import.meta.env.DEV` is statically replaced at build time, so the
+ * unreachable branch below (and everything it alone references —
+ * RenderStormProfiler, the monitor, the emitter) is dead-code-eliminated
+ * from production bundles.
+ */
+export const RenderStormCanary = ({
+  children,
+}: PropsWithChildren): ReactNode => {
+  if (!import.meta.env.DEV) {
+    return children;
+  }
+
+  return <RenderStormProfiler>{children}</RenderStormProfiler>;
+};
+
+const formatPhaseBreakdown = (
+  phaseCounts: Record<RenderStormPhase, number>,
+): string =>
+  Object.entries(phaseCounts)
+    .filter(([, count]) => count > 0)
+    .map(([phase, count]) => `${phase}=${count}`)
+    .join(", ");
+
+const emitRenderStormError = (details: RenderStormDetails) => {
+  // eslint-disable-next-line no-console -- dev-only render-storm canary; this is the one sanctioned diagnostic emitter whose entire purpose is to be caught by the e2e browserErrors fixture as a CI-failing signal
+  console.error(
+    `[render-storm] sustained render storm detected: ~${details.commitsPerSecond} commits/sec ` +
+      `(phases: ${formatPhaseBreakdown(details.phaseCounts)}). A component is re-rendering ` +
+      "far above legitimate streaming rates (~20/s) without tripping React's own " +
+      '"Maximum update depth exceeded" guard. Find the state update that re-triggers ' +
+      "itself and break the loop.",
+  );
+};
+
+const RenderStormProfiler = ({ children }: PropsWithChildren) => {
+  const [monitor] = useState(() =>
+    createRenderStormMonitor(emitRenderStormError),
+  );
+
+  return (
+    <Profiler id={RENDER_STORM_CANARY_PROFILER_ID} onRender={monitor.onRender}>
+      {children}
+    </Profiler>
+  );
+};

--- a/apps/web/src/lib/render-storm-canary.test.ts
+++ b/apps/web/src/lib/render-storm-canary.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createRenderStormMonitor,
+  evaluateStormWindow,
+  RENDER_STORM_SUSTAINED_WINDOWS_REQUIRED,
+  RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND,
+  RENDER_STORM_WINDOW_MS,
+} from "./render-storm-canary";
+
+describe("evaluateStormWindow", () => {
+  it("resets the streak when a window is under threshold", () => {
+    const result = evaluateStormWindow(20, 80, 0);
+    expect(result).toEqual({ consecutiveStormWindows: 0, isStorm: false });
+  });
+
+  it("treats a count exactly at threshold as not over it", () => {
+    const result = evaluateStormWindow(80, 80, 1);
+    expect(result).toEqual({ consecutiveStormWindows: 0, isStorm: false });
+  });
+
+  it("starts a streak on the first over-threshold window without reporting a storm", () => {
+    const result = evaluateStormWindow(200, 80, 0);
+    expect(result).toEqual({ consecutiveStormWindows: 1, isStorm: false });
+  });
+
+  it("reports a storm once the streak reaches the sustained-windows requirement", () => {
+    const first = evaluateStormWindow(200, 80, 0);
+    const second = evaluateStormWindow(200, 80, first.consecutiveStormWindows);
+    expect(second).toEqual({ consecutiveStormWindows: 2, isStorm: true });
+    expect(second.consecutiveStormWindows).toBeGreaterThanOrEqual(
+      RENDER_STORM_SUSTAINED_WINDOWS_REQUIRED,
+    );
+  });
+
+  it("keeps reporting a storm while the streak continues past the requirement", () => {
+    const result = evaluateStormWindow(200, 80, 2);
+    expect(result).toEqual({ consecutiveStormWindows: 3, isStorm: true });
+  });
+
+  it("resets an in-progress streak the moment a window drops back under threshold", () => {
+    const result = evaluateStormWindow(10, 80, 5);
+    expect(result).toEqual({ consecutiveStormWindows: 0, isStorm: false });
+  });
+});
+
+describe("createRenderStormMonitor", () => {
+  const PHASE = "update" as const;
+
+  it("does not emit for commits that never exceed the threshold", () => {
+    const emitted: unknown[] = [];
+    const monitor = createRenderStormMonitor((details) => {
+      emitted.push(details);
+    });
+
+    let time = 0;
+    // ~20 commits/sec for 3 windows worth of time — legitimate streaming rate.
+    for (let window = 0; window < 3; window += 1) {
+      for (let commit = 0; commit < 20; commit += 1) {
+        monitor.onRender("app", PHASE, 1, 1, time, time);
+        time += RENDER_STORM_WINDOW_MS / 20;
+      }
+    }
+
+    expect(emitted).toEqual([]);
+  });
+
+  it("emits once a storm sustains for the required consecutive windows", () => {
+    const emitted: { commitsPerSecond: number }[] = [];
+    const monitor = createRenderStormMonitor((details) => {
+      emitted.push(details);
+    });
+
+    let time = 0;
+    const commitsPerWindow = RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND + 50;
+    // Window 1: over threshold, no emission yet (streak length 1).
+    // Window 2: over threshold again, closes window 1 and reports the storm.
+    // A final commit closes window 2 and evaluates it.
+    for (let window = 0; window < 3; window += 1) {
+      for (let commit = 0; commit < commitsPerWindow; commit += 1) {
+        monitor.onRender("app", PHASE, 1, 1, time, time);
+        time += RENDER_STORM_WINDOW_MS / commitsPerWindow;
+      }
+      time = (window + 1) * RENDER_STORM_WINDOW_MS;
+    }
+    // One more commit far enough ahead to force the last window closed.
+    monitor.onRender("app", PHASE, 1, 1, time, time + RENDER_STORM_WINDOW_MS);
+
+    expect(emitted.length).toBeGreaterThanOrEqual(1);
+    expect(emitted[0]?.commitsPerSecond).toBeGreaterThan(
+      RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND,
+    );
+  });
+
+  it("rate-limits repeat emissions to at most one per RENDER_STORM_ERROR_RATE_LIMIT_MS", () => {
+    const emitted: unknown[] = [];
+    const monitor = createRenderStormMonitor((details) => {
+      emitted.push(details);
+    });
+
+    const commitsPerWindow = RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND + 50;
+    let time = 0;
+    // Ten consecutive storming windows, well past the rate-limit interval.
+    for (let window = 0; window < 10; window += 1) {
+      for (let commit = 0; commit < commitsPerWindow; commit += 1) {
+        monitor.onRender("app", PHASE, 1, 1, time, time);
+        time += RENDER_STORM_WINDOW_MS / commitsPerWindow;
+      }
+      time = (window + 1) * RENDER_STORM_WINDOW_MS;
+    }
+    monitor.onRender("app", PHASE, 1, 1, time, time + RENDER_STORM_WINDOW_MS);
+
+    // 10 windows spanning ~10s at the rate limit boundary should emit far
+    // fewer than once per window.
+    expect(emitted.length).toBeLessThan(10);
+    expect(emitted.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("tracks phase counts for the window that triggers the storm", () => {
+    const emitted: { phaseCounts: Record<string, number> }[] = [];
+    const monitor = createRenderStormMonitor((details) => {
+      emitted.push(details);
+    });
+
+    let time = 0;
+    const commitsPerWindow = RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND + 20;
+    for (let window = 0; window < 2; window += 1) {
+      for (let commit = 0; commit < commitsPerWindow; commit += 1) {
+        monitor.onRender("app", "nested-update", 1, 1, time, time);
+        time += RENDER_STORM_WINDOW_MS / commitsPerWindow;
+      }
+      time = (window + 1) * RENDER_STORM_WINDOW_MS;
+    }
+    monitor.onRender("app", PHASE, 1, 1, time, time + RENDER_STORM_WINDOW_MS);
+
+    expect(emitted.length).toBeGreaterThanOrEqual(1);
+    expect(emitted[0]?.phaseCounts["nested-update"]).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/render-storm-canary.test.ts
+++ b/apps/web/src/lib/render-storm-canary.test.ts
@@ -84,7 +84,7 @@ describe("createRenderStormMonitor", () => {
       time = (window + 1) * RENDER_STORM_WINDOW_MS;
     }
     // One more commit far enough ahead to force the last window closed.
-    monitor.onRender("app", PHASE, 1, 1, time, time + RENDER_STORM_WINDOW_MS);
+    monitor.onRender("app", PHASE, 1, 1, time, time + 1);
 
     expect(emitted.length).toBeGreaterThanOrEqual(1);
     expect(emitted[0]?.commitsPerSecond).toBeGreaterThan(
@@ -108,7 +108,7 @@ describe("createRenderStormMonitor", () => {
       }
       time = (window + 1) * RENDER_STORM_WINDOW_MS;
     }
-    monitor.onRender("app", PHASE, 1, 1, time, time + RENDER_STORM_WINDOW_MS);
+    monitor.onRender("app", PHASE, 1, 1, time, time + 1);
 
     // 10 windows spanning ~10s at the rate limit boundary should emit far
     // fewer than once per window.
@@ -131,9 +131,39 @@ describe("createRenderStormMonitor", () => {
       }
       time = (window + 1) * RENDER_STORM_WINDOW_MS;
     }
-    monitor.onRender("app", PHASE, 1, 1, time, time + RENDER_STORM_WINDOW_MS);
+    monitor.onRender("app", PHASE, 1, 1, time, time + 1);
 
     expect(emitted.length).toBeGreaterThanOrEqual(1);
     expect(emitted[0]?.phaseCounts["nested-update"]).toBeGreaterThan(0);
+  });
+
+  it("does not treat bursts separated by idle time as sustained throughput", () => {
+    const emitted: unknown[] = [];
+    const monitor = createRenderStormMonitor((details) => {
+      emitted.push(details);
+    });
+
+    const commitsPerBurst = RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND + 20;
+    for (let commit = 0; commit < commitsPerBurst; commit += 1) {
+      monitor.onRender("app", PHASE, 1, 1, commit, commit);
+    }
+
+    const afterFirstIdle = 30_000;
+    monitor.onRender("app", PHASE, 1, 1, afterFirstIdle, afterFirstIdle);
+    for (let commit = 1; commit < commitsPerBurst; commit += 1) {
+      monitor.onRender(
+        "app",
+        PHASE,
+        1,
+        1,
+        afterFirstIdle + commit,
+        afterFirstIdle + commit,
+      );
+    }
+
+    const afterSecondIdle = 60_000;
+    monitor.onRender("app", PHASE, 1, 1, afterSecondIdle, afterSecondIdle);
+
+    expect(emitted).toEqual([]);
   });
 });

--- a/apps/web/src/lib/render-storm-canary.ts
+++ b/apps/web/src/lib/render-storm-canary.ts
@@ -1,0 +1,154 @@
+// Pure windowing logic for the dev-only render-storm canary
+// (@/components/render-storm-canary). Kept separate from the React
+// component and its console.error emitter so the decision logic is
+// unit-testable without a DOM or React renderer.
+
+export type RenderStormPhase = "mount" | "nested-update" | "update";
+
+export type RenderStormPhaseCounts = Record<RenderStormPhase, number>;
+
+export const createEmptyPhaseCounts = (): RenderStormPhaseCounts => ({
+  mount: 0,
+  "nested-update": 0,
+  update: 0,
+});
+
+// React's own "Maximum update depth exceeded" throw only fires once a loop
+// hits its hard recursion limit; a *damped* near-loop (a component that
+// keeps re-triggering its own update without ever quite reaching that limit)
+// re-renders hundreds of times per second and ships silently. This canary
+// exists to turn that class of bug into a CI-failing console.error via the
+// e2e browserErrors fixture.
+//
+// Calibration: chat response streaming legitimately commits ~20 times/sec
+// (SSE chunks land roughly every 50ms and each chunk is its own commit).
+// A damped render loop commits at least in the hundreds/sec range, so 80
+// commits/sec sustained across two consecutive 1s windows sits ~4x above
+// real streaming traffic (comfortable headroom against jitter/GC pauses)
+// while staying well below the loop floor.
+export const RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND = 80;
+
+// Window length the commit counter buckets into. Windows are commit-driven
+// (closed by the next commit once this much time has elapsed since the
+// window opened), not a timer, so a storm is detected without needing an
+// effect or interval — see createRenderStormMonitor below.
+export const RENDER_STORM_WINDOW_MS = 1000;
+
+// A single over-threshold window can be a legitimate burst (e.g. a big
+// paginated list mounting). Two consecutive over-threshold windows is what
+// distinguishes a *sustained* storm from a one-off burst.
+export const RENDER_STORM_SUSTAINED_WINDOWS_REQUIRED = 2;
+
+// The canary itself must not spam the console once a storm is underway:
+// one console.error per storm episode, then at most one more per this
+// interval for as long as the storm continues.
+export const RENDER_STORM_ERROR_RATE_LIMIT_MS = 10_000;
+
+export type StormWindowResult = {
+  consecutiveStormWindows: number;
+  isStorm: boolean;
+};
+
+/**
+ * Decide whether the window that just closed continues, starts, or resets a
+ * storm streak, and whether the streak has now become a reportable storm
+ * (two consecutive over-threshold windows). Pure and side-effect free so it
+ * can be unit-tested without a Profiler or a DOM.
+ */
+export const evaluateStormWindow = (
+  commitsInWindow: number,
+  threshold: number,
+  previousConsecutiveStormWindows: number,
+): StormWindowResult => {
+  const isOverThreshold = commitsInWindow > threshold;
+  const consecutiveStormWindows = isOverThreshold
+    ? previousConsecutiveStormWindows + 1
+    : 0;
+
+  return {
+    consecutiveStormWindows,
+    isStorm: consecutiveStormWindows >= RENDER_STORM_SUSTAINED_WINDOWS_REQUIRED,
+  };
+};
+
+export type RenderStormDetails = {
+  commitsPerSecond: number;
+  phaseCounts: RenderStormPhaseCounts;
+};
+
+export type RenderStormOnRender = (
+  id: string,
+  phase: RenderStormPhase,
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+) => void;
+
+export type RenderStormMonitor = {
+  onRender: RenderStormOnRender;
+};
+
+/**
+ * Stateful driver around evaluateStormWindow: buckets Profiler commits into
+ * commit-driven 1s windows, tracks the phase breakdown of the window that
+ * triggered a storm, and rate-limits `emitStorm` to one call per storm
+ * episode (then at most one per RENDER_STORM_ERROR_RATE_LIMIT_MS while the
+ * storm persists).
+ */
+export const createRenderStormMonitor = (
+  emitStorm: (details: RenderStormDetails) => void,
+): RenderStormMonitor => {
+  let windowStart: number | undefined;
+  let commitsInWindow = 0;
+  let phaseCountsInWindow = createEmptyPhaseCounts();
+  let consecutiveStormWindows = 0;
+  // -Infinity, not 0: a real commitTime of 0 is possible (performance.now()
+  // at app start), and seeding this at 0 would suppress the very first
+  // storm for RENDER_STORM_ERROR_RATE_LIMIT_MS after boot instead of
+  // reporting it immediately.
+  let lastErrorEmittedAt = Number.NEGATIVE_INFINITY;
+
+  const closeWindow = (now: number) => {
+    const result = evaluateStormWindow(
+      commitsInWindow,
+      RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND,
+      consecutiveStormWindows,
+    );
+    consecutiveStormWindows = result.consecutiveStormWindows;
+
+    const canEmit =
+      now - lastErrorEmittedAt >= RENDER_STORM_ERROR_RATE_LIMIT_MS;
+    if (result.isStorm && canEmit) {
+      lastErrorEmittedAt = now;
+      emitStorm({
+        commitsPerSecond: commitsInWindow,
+        phaseCounts: phaseCountsInWindow,
+      });
+    }
+
+    commitsInWindow = 0;
+    phaseCountsInWindow = createEmptyPhaseCounts();
+    windowStart = now;
+  };
+
+  const onRender: RenderStormOnRender = (
+    _id,
+    phase,
+    _actualDuration,
+    _baseDuration,
+    _startTime,
+    commitTime,
+  ) => {
+    if (windowStart === undefined) {
+      windowStart = commitTime;
+    } else if (commitTime - windowStart >= RENDER_STORM_WINDOW_MS) {
+      closeWindow(commitTime);
+    }
+
+    commitsInWindow += 1;
+    phaseCountsInWindow[phase] += 1;
+  };
+
+  return { onRender };
+};

--- a/apps/web/src/lib/render-storm-canary.ts
+++ b/apps/web/src/lib/render-storm-canary.ts
@@ -109,9 +109,13 @@ export const createRenderStormMonitor = (
   // reporting it immediately.
   let lastErrorEmittedAt = Number.NEGATIVE_INFINITY;
 
-  const closeWindow = (now: number) => {
+  const closeWindow = (now: number, startedAt: number) => {
+    const elapsedMs = now - startedAt;
+    const commitsPerSecond = Math.round(
+      (commitsInWindow / elapsedMs) * RENDER_STORM_WINDOW_MS,
+    );
     const result = evaluateStormWindow(
-      commitsInWindow,
+      commitsPerSecond,
       RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND,
       consecutiveStormWindows,
     );
@@ -122,7 +126,7 @@ export const createRenderStormMonitor = (
     if (result.isStorm && canEmit) {
       lastErrorEmittedAt = now;
       emitStorm({
-        commitsPerSecond: commitsInWindow,
+        commitsPerSecond,
         phaseCounts: phaseCountsInWindow,
       });
     }
@@ -143,7 +147,7 @@ export const createRenderStormMonitor = (
     if (windowStart === undefined) {
       windowStart = commitTime;
     } else if (commitTime - windowStart >= RENDER_STORM_WINDOW_MS) {
-      closeWindow(commitTime);
+      closeWindow(commitTime, windowStart);
     }
 
     commitsInWindow += 1;


### PR DESCRIPTION
## Summary

Dev-only render-storm canary: a `<Profiler>` wrapper around the app root (`apps/web/src/client.tsx`) counts React commits per second and emits a single rate-limited `console.error("[render-storm] ...")` on a sustained storm. The e2e `browserErrors` fixture (`apps/web/e2e/helpers/test.ts`) already fails any test on `console.error`, so this turns every existing e2e spec into a render-loop detector with no per-spec changes.

React's own "Maximum update depth exceeded" throw only fires when a loop hits the hard synchronous limit; a damped near-loop (a component re-rendering hundreds of times per second via async self-triggered updates) ships silently. This canary catches that class.

## Design

- `apps/web/src/lib/render-storm-canary.ts`: pure windowing logic. Profiler commits are bucketed into commit-driven 1s windows; a window is "over threshold" above `RENDER_STORM_THRESHOLD_COMMITS_PER_SECOND = 80`, and a storm is reported after 2 consecutive over-threshold windows. Calibration: chat response streaming legitimately commits ~20/s (one commit per ~50ms chunk); damped loops run at hundreds/s, so 80/s sustained 2s sits ~4x above real streaming with headroom against bursts (e.g. big list mounts get one window for free).
- One `console.error` per storm episode, rate-limited to at most one per 10s while a storm persists, with commits/sec and the Profiler phase breakdown (`mount` / `update` / `nested-update`) in the message.
- `apps/web/src/components/render-storm-canary.tsx`: the `<RenderStormCanary>` wrapper. Gated by a plain `import.meta.env.DEV` conditional, so the Profiler, monitor, and emitter are dead-code-eliminated from production bundles. The e2e CI job runs the web app via `vite dev` (`.github/workflows/ci.yml`), so DEV covers CI.
- No effects needed: the monitor is module-level state driven purely by the Profiler `onRender` callback; windows close on the next commit after 1s elapses rather than on a timer.

## Verification

- Unit tests (`bun:test`, pure logic, no DOM): 10 tests covering streak reset, threshold boundary (exactly 80 does not trip), sustained-window requirement, rate limiting, and phase tracking. Full `@stll/web` suite: 876 pass.
- Negative proof: `chat.spec.ts` (full streamed assistant reply through the mock provider) and `smoke.spec.ts` pass with the canary mounted; streaming at ~20 commits/s does not trip it.
- Positive proof: a temporary probe component on the chat route (async `setTimeout(0)` self-incrementing state; never trips React's own depth guard) made `chat.spec.ts` fail via the `browserErrors` fixture with `[render-storm] sustained render storm detected: ~6250 commits/sec (phases: update=6250)`. The probe was removed and the spec re-run to green; it is not part of this diff.
