### PR TITLE
feat: per-endpoint response payload-size budgets in the network baseline

### DIFF
--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -91,9 +91,9 @@ const isTrackedApiRequest = (request: Request, apiOrigin: string): boolean => {
 };
 
 const isStreamedResponse = (response: Response): boolean =>
-  (response.headers()["content-type"] ?? "").includes(
-    STREAMED_RESPONSE_CONTENT_TYPE,
-  );
+  (response.headers()["content-type"] ?? "")
+    .toLowerCase()
+    .includes(STREAMED_RESPONSE_CONTENT_TYPE);
 
 // Playwright's body() rejects for a response that never finishes (aborted or
 // redirected mid-navigation); that is a legitimate outcome here, not a bug in

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -18,6 +18,14 @@ const TRACKED_RESOURCE_TYPES = new Set(["fetch", "xhr", "eventsource"]);
 // an N+1 regression fail per route+endpoint, not just per HTTP fan-out.
 const DB_QUERIES_HEADER = "x-db-queries";
 
+// The API sends real-time channels (chat streaming, workspace events, the
+// autocomplete stream) as `text/event-stream` connections that stay open for
+// the life of the page instead of returning a fixed payload. Their "size" is
+// unbounded by design, so the response-size dimension excludes them entirely
+// rather than budgeting a snapshot of however many bytes happened to have
+// streamed by the time the `response` event fired.
+const STREAMED_RESPONSE_CONTENT_TYPE = "text/event-stream";
+
 const BASELINE_PATH = path.resolve(
   import.meta.dirname,
   "../network-baseline.json",
@@ -36,13 +44,22 @@ export type NetworkCapture = {
     pathname: string;
     dbQueries: number | null;
     dbQueryHeaderMissing: boolean;
+    // Response body size in bytes; null for a streamed response (excluded by
+    // content-type, see STREAMED_RESPONSE_CONTENT_TYPE) or one whose body
+    // Playwright never resolved (see responseBytesUnavailable).
+    responseBytes: number | null;
+    // True only when Playwright saw a non-streamed response and reading its
+    // body failed (e.g. aborted/redirected mid-navigation).
+    responseBytesUnavailable: boolean;
   }[];
   intervals: { start: number; end: number }[];
 };
 
 export type NetworkCollector = {
   trackPage: (page: Page) => () => void;
-  capture: () => NetworkCapture;
+  // Async: waits for in-flight response-body reads so response sizes are
+  // populated before the caller summarizes the capture.
+  capture: () => Promise<NetworkCapture>;
 };
 
 type NetworkCollectorOptions = {
@@ -60,6 +77,10 @@ type NetworkRecord = {
   // True only when Playwright saw a response and that response did not expose
   // the dev/test query-count header.
   dbQueryHeaderMissing: boolean;
+  // Response body length in bytes; null until the async body read resolves,
+  // and permanently null for a streamed (SSE) response.
+  responseBytes: number | null;
+  responseBytesUnavailable: boolean;
 };
 
 const isTrackedApiRequest = (request: Request, apiOrigin: string): boolean => {
@@ -69,12 +90,36 @@ const isTrackedApiRequest = (request: Request, apiOrigin: string): boolean => {
   return new URL(request.url()).origin === apiOrigin;
 };
 
+const isStreamedResponse = (response: Response): boolean =>
+  (response.headers()["content-type"] ?? "").includes(
+    STREAMED_RESPONSE_CONTENT_TYPE,
+  );
+
+// Playwright's body() rejects for a response that never finishes (aborted or
+// redirected mid-navigation); that is a legitimate outcome here, not a bug in
+// the collector, so it is caught and recorded rather than left to reject the
+// whole route walk.
+const readResponseBytes = async (
+  response: Response,
+  record: NetworkRecord,
+): Promise<void> => {
+  try {
+    const body = await response.body();
+    record.responseBytes = body.length;
+  } catch {
+    record.responseBytesUnavailable = true;
+  }
+};
+
 export const createNetworkCollector = (
   options: NetworkCollectorOptions = {},
 ): NetworkCollector => {
   const apiOrigin = options.apiOrigin ?? new URL(DEFAULT_API_URL).origin;
   const records: NetworkRecord[] = [];
   const byRequest = new Map<Request, NetworkRecord>();
+  // Body reads are async (Playwright must finish downloading the response),
+  // so capture() awaits these before reading responseBytes off the records.
+  const pendingBodyReads: Promise<void>[] = [];
 
   return {
     trackPage: (page) => {
@@ -89,6 +134,8 @@ export const createNetworkCollector = (
           end: null,
           dbQueries: null,
           dbQueryHeaderMissing: false,
+          responseBytes: null,
+          responseBytesUnavailable: false,
         };
         records.push(record);
         byRequest.set(request, record);
@@ -109,9 +156,14 @@ export const createNetworkCollector = (
         const header = response.headers()[DB_QUERIES_HEADER];
         if (header !== undefined) {
           record.dbQueries = Number(header);
+        } else {
+          record.dbQueryHeaderMissing = true;
+        }
+
+        if (isStreamedResponse(response)) {
           return;
         }
-        record.dbQueryHeaderMissing = true;
+        pendingBodyReads.push(readResponseBytes(response, record));
       };
 
       page.on("request", onRequest);
@@ -127,17 +179,27 @@ export const createNetworkCollector = (
       };
     },
 
-    capture: () => {
+    capture: async () => {
+      await Promise.all(pendingBodyReads);
       // A still-pending request can only be the tail of a chain (nothing waited
       // on its response yet), so closing it at "now" never inflates the depth.
       const now = Date.now();
       return {
         requests: records.map(
-          ({ method, pathname, dbQueries, dbQueryHeaderMissing }) => ({
+          ({
             method,
             pathname,
             dbQueries,
             dbQueryHeaderMissing,
+            responseBytes,
+            responseBytesUnavailable,
+          }) => ({
+            method,
+            pathname,
+            dbQueries,
+            dbQueryHeaderMissing,
+            responseBytes,
+            responseBytesUnavailable,
           }),
         ),
         intervals: records.map(({ start, end }) => ({
@@ -220,6 +282,11 @@ export type RouteNetworkMetrics = {
   dbQueries: Record<string, number>;
   // Per request key, how many completed responses omitted `x-db-queries`.
   missingDbQueryCounts: Record<string, number>;
+  // Per request key, the max response body size (bytes) observed this run.
+  // Streamed (SSE) responses and keys whose body never resolved are absent.
+  responseSizes: Record<string, number>;
+  // Per request key, how many non-streamed responses failed to yield a body.
+  missingResponseSizeCounts: Record<string, number>;
 };
 
 export type NetworkBaselineEntry = {
@@ -229,6 +296,9 @@ export type NetworkBaselineEntry = {
   requestCounts?: Record<string, number>;
   // Optional so baselines written before the counter existed still parse.
   dbQueries?: Record<string, number>;
+  // Optional so baselines written before the response-size dimension existed
+  // still parse. Bytes, rounded up to the next KiB by the writer.
+  responseSizes?: Record<string, number>;
 };
 
 export type NetworkBaseline = Record<string, NetworkBaselineEntry>;
@@ -238,6 +308,8 @@ export const summarizeCapture = (
 ): RouteNetworkMetrics => {
   const dbQueries: Record<string, number> = {};
   const missingDbQueryCounts: Record<string, number> = {};
+  const responseSizes: Record<string, number> = {};
+  const missingResponseSizeCounts: Record<string, number> = {};
   const requestCounts: Record<string, number> = {};
   for (const request of capture.requests) {
     const key = requestKey(request);
@@ -245,10 +317,22 @@ export const summarizeCapture = (
     if (request.dbQueryHeaderMissing) {
       missingDbQueryCounts[key] = (missingDbQueryCounts[key] ?? 0) + 1;
     }
-    if (request.dbQueries === null || Number.isNaN(request.dbQueries)) {
-      continue;
+    if (request.dbQueries !== null && !Number.isNaN(request.dbQueries)) {
+      dbQueries[key] = Math.max(dbQueries[key] ?? 0, request.dbQueries);
     }
-    dbQueries[key] = Math.max(dbQueries[key] ?? 0, request.dbQueries);
+    if (request.responseBytesUnavailable) {
+      missingResponseSizeCounts[key] =
+        (missingResponseSizeCounts[key] ?? 0) + 1;
+    }
+    if (
+      request.responseBytes !== null &&
+      !Number.isNaN(request.responseBytes)
+    ) {
+      responseSizes[key] = Math.max(
+        responseSizes[key] ?? 0,
+        request.responseBytes,
+      );
+    }
   }
   return {
     requests: Object.keys(requestCounts).sort(),
@@ -259,6 +343,14 @@ export const summarizeCapture = (
     dbQueries,
     missingDbQueryCounts: Object.fromEntries(
       Object.entries(missingDbQueryCounts).sort(([a], [b]) =>
+        a.localeCompare(b),
+      ),
+    ),
+    responseSizes: Object.fromEntries(
+      Object.entries(responseSizes).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+    missingResponseSizeCounts: Object.fromEntries(
+      Object.entries(missingResponseSizeCounts).sort(([a], [b]) =>
         a.localeCompare(b),
       ),
     ),
@@ -393,6 +485,46 @@ const pushDbQueryProblems = ({
   }
 };
 
+const pushResponseSizeProblems = ({
+  route,
+  entry,
+  metrics,
+  problems,
+}: {
+  route: string;
+  entry: NetworkBaselineEntry;
+  metrics: RouteNetworkMetrics;
+  problems: string[];
+}) => {
+  const baselineSizes = entry.responseSizes ?? {};
+  for (const key of Object.keys(baselineSizes)) {
+    if (metrics.missingResponseSizeCounts[key] === undefined) {
+      continue;
+    }
+    problems.push(
+      `Response size missing on ${route}: ${key}\n` +
+        `  This request has a committed response-size budget, but Playwright\n` +
+        `  could not read the response body (aborted or redirected mid-\n` +
+        `  navigation is the usual cause). Re-run the suite; if it persists,\n` +
+        `  investigate before trusting this route's payload-size budget.`,
+    );
+  }
+  for (const [key, observed] of Object.entries(metrics.responseSizes)) {
+    const budget = baselineSizes[key];
+    if (budget === undefined || observed <= responseSizeAllowance(budget)) {
+      continue;
+    }
+    problems.push(
+      `Response payload grew on ${route}: ${key} ran ${formatBytes(budget)} -> ${formatBytes(observed)}\n` +
+        `  The endpoint now returns more bytes for the same page — the classic\n` +
+        `  cause is a handler returning full rows instead of the minimal\n` +
+        `  projection callers actually use ("Return minimal data" in\n` +
+        `  AGENTS.md). Trim the response shape or, if the extra payload is\n` +
+        `  genuinely required, ${WRITE_HINT}.`,
+    );
+  }
+};
+
 const pushImprovementNotices = ({
   route,
   entry,
@@ -428,6 +560,27 @@ const pushImprovementNotices = ({
 // without masking the failure mode it exists for.
 export const dbQueryAllowance = (budget: number): number =>
   budget + Math.max(2, Math.ceil(budget * 0.15));
+
+// Response bodies wobble run to run: generated ids, timestamps, and
+// locale-formatted numbers all shift byte counts by a few percent without
+// signaling a real regression. +20% headroom absorbs that jitter while still
+// catching an endpoint that starts returning full rows instead of the
+// minimal projection the repo convention requires.
+const RESPONSE_SIZE_ALLOWANCE_MULTIPLIER = 1.2;
+
+export const responseSizeAllowance = (budgetBytes: number): number =>
+  Math.ceil(budgetBytes * RESPONSE_SIZE_ALLOWANCE_MULTIPLIER);
+
+const BYTES_PER_KIB = 1024;
+
+// Budgets are stored rounded up to the next KiB so a one-byte jitter in a
+// freshly written baseline does not immediately eat into the +20% allowance
+// above it.
+const roundUpToKiB = (bytes: number): number =>
+  Math.ceil(bytes / BYTES_PER_KIB) * BYTES_PER_KIB;
+
+const formatBytes = (bytes: number): string =>
+  `${(bytes / BYTES_PER_KIB).toFixed(1)} KiB`;
 
 const requestCountBudget = (
   entry: NetworkBaselineEntry,
@@ -477,6 +630,9 @@ export const diffNetworkBaseline = (
     // hits, timing) and re-noticing it every run would be noise; tightening
     // happens via a deliberate rewrite.
     pushDbQueryProblems({ route, entry, metrics, problems });
+    // Same one-directional policy as DB-query budgets: a smaller payload is
+    // never a failure, only a growth beyond the allowance is.
+    pushResponseSizeProblems({ route, entry, metrics, problems });
     pushImprovementNotices({ route, entry, metrics, notices });
   }
 
@@ -525,7 +681,9 @@ const isNetworkBaselineEntry = (
     isStringArray(value["requests"]) &&
     (value["requestCounts"] === undefined ||
       isNumberRecord(value["requestCounts"])) &&
-    (value["dbQueries"] === undefined || isNumberRecord(value["dbQueries"]))
+    (value["dbQueries"] === undefined || isNumberRecord(value["dbQueries"])) &&
+    (value["responseSizes"] === undefined ||
+      isNumberRecord(value["responseSizes"]))
   );
 };
 
@@ -567,6 +725,15 @@ export const mergeNetworkBaseline = (
         dbQueries[key] = Math.max(dbQueries[key] ?? 0, count);
       }
     }
+    const responseSizes: Record<string, number> = {};
+    for (const source of [
+      previous?.responseSizes ?? {},
+      metrics.responseSizes,
+    ]) {
+      for (const [key, bytes] of Object.entries(source)) {
+        responseSizes[key] = Math.max(responseSizes[key] ?? 0, bytes);
+      }
+    }
     merged[route] = {
       depth: Math.max(metrics.depth, previous?.depth ?? 0),
       requests: [...new Set([...metrics.requests, ...previousRequests])].sort(),
@@ -575,6 +742,13 @@ export const mergeNetworkBaseline = (
       ),
       dbQueries: Object.fromEntries(
         Object.entries(dbQueries).sort(([a], [b]) => a.localeCompare(b)),
+      ),
+      // Rounded up to the next KiB here (the writer), not at measurement time,
+      // so the raw max observed across write runs is what gets rounded once.
+      responseSizes: Object.fromEntries(
+        Object.entries(responseSizes)
+          .map(([key, bytes]) => [key, roundUpToKiB(bytes)] as const)
+          .sort(([a], [b]) => a.localeCompare(b)),
       ),
     };
   }

--- a/apps/web/e2e/network-baseline.json
+++ b/apps/web/e2e/network-baseline.json
@@ -33,6 +33,17 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/skills": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/chat/threads/:id/messages": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/chat/$threadId": {
@@ -78,6 +89,20 @@
       "GET /v1/skills": 6,
       "GET /v1/usage/entitlement": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/chat/threads/:id/messages": 1024,
+      "GET /v1/chat/threads/:id/title": 1024,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/usage/entitlement": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/chat/new": {
@@ -123,6 +148,20 @@
       "GET /v1/skills": 6,
       "GET /v1/usage/entitlement": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/chat/threads/:id/messages": 1024,
+      "GET /v1/chat/threads/:id/title": 1024,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/usage/entitlement": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/chat/workspaces/$workspaceId/$threadId": {
@@ -171,6 +210,21 @@
       "GET /v1/usage/entitlement": 6,
       "GET /v1/views/:id": 8,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/chat/threads/:id/messages": 1024,
+      "GET /v1/chat/threads/:id/title": 1024,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/usage/entitlement": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/chat/workspaces/$workspaceId/new": {
@@ -219,6 +273,21 @@
       "GET /v1/usage/entitlement": 6,
       "GET /v1/views/:id": 8,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/chat/threads/:id/messages": 1024,
+      "GET /v1/chat/threads/:id/title": 1024,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/usage/entitlement": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/contacts": {
@@ -255,6 +324,17 @@
       "GET /v1/mcp/connectors": 8,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/contacts": 10240,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/contacts/$contactId": {
@@ -291,6 +371,17 @@
       "GET /v1/contacts/:id": 9,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/get-full-organization": 3072,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/contacts/:id": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/dev/autocomplete": {
@@ -321,6 +412,15 @@
       "GET /v1/chat/threads": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/knowledge": {
@@ -351,6 +451,15 @@
       "GET /v1/chat/threads": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/knowledge/clauses": {
@@ -387,6 +496,17 @@
       "GET /v1/clauses": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/clause-categories": 2048,
+      "GET /v1/clauses": 9216,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/knowledge/mcp target": {
@@ -426,6 +546,18 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/skills/seed": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/catalogue": 71680,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/skills/seed": 1024
     }
   },
   "/knowledge/playbooks": {
@@ -459,6 +591,16 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/playbooks": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/playbooks": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/knowledge/prompts target": {
@@ -498,6 +640,18 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/skills/seed": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/catalogue": 71680,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/skills/seed": 1024
     }
   },
   "/knowledge/skills target": {
@@ -537,6 +691,18 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/skills/seed": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/catalogue": 71680,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/skills/seed": 1024
     }
   },
   "/knowledge/templates": {
@@ -573,6 +739,17 @@
       "GET /v1/template-categories": 6,
       "GET /v1/templates": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/template-categories": 1024,
+      "GET /v1/templates": 4096,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/knowledge/tools": {
@@ -612,6 +789,18 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/skills/seed": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/catalogue": 71680,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/skills/seed": 1024
     }
   },
   "/settings target": {
@@ -645,6 +834,16 @@
       "GET /v1/chat/threads": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/list-sessions": 3072,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/account/beta": {
@@ -675,6 +874,15 @@
       "GET /v1/chat/threads": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/account/connections": {
@@ -708,6 +916,16 @@
       "GET /v1/me/oauth-connections": 3,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/me/oauth-connections": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/account/desktop": {
@@ -738,6 +956,15 @@
       "GET /v1/chat/threads": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/account/profile": {
@@ -771,6 +998,16 @@
       "GET /v1/chat/threads": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/list-sessions": 3072,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/organization target": {
@@ -807,6 +1044,17 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/get-full-organization": 3072,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/organization/ai": {
@@ -849,6 +1097,19 @@
       "GET /v1/organization-settings/deepl-config": 6,
       "GET /v1/organization-settings/web-search-config": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/organization-settings/ai-config": 1024,
+      "GET /v1/organization-settings/deepl-config": 1024,
+      "GET /v1/organization-settings/web-search-config": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/organization/anonymization": {
@@ -882,6 +1143,16 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/organization-settings/anonymization-blacklist": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/organization-settings/anonymization-blacklist": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/organization/catalogue target": {
@@ -921,6 +1192,18 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/skills/seed": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/catalogue": 71680,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/skills/seed": 1024
     }
   },
   "/settings/organization/document-types": {
@@ -954,6 +1237,16 @@
       "GET /v1/document-types": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/document-types": 3072,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/organization/matter-numbering": {
@@ -990,6 +1283,17 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/organization-settings/preview": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/organization-settings/preview": 1024
     }
   },
   "/settings/organization/members": {
@@ -1026,6 +1330,17 @@
       "GET /v1/organization-settings": 6,
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/get-full-organization": 3072,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/settings/organization/usage": {
@@ -1059,6 +1374,16 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/usage/entitlement": 6,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/usage/entitlement": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/todos": {
@@ -1095,6 +1420,17 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces": 10,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/my-tasks": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces": 87040,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/workspaces": {
@@ -1128,6 +1464,16 @@
       "GET /v1/organization-settings/ai-availability": 4,
       "GET /v1/workspaces": 10,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/workspaces": 87040,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/workspaces/$workspaceId target": {
@@ -1188,6 +1534,24 @@
       "GET /v1/workspaces/:id/overview": 7,
       "GET /v1/workspaces/:id/workflow": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/get-full-organization": 3072,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/time-entries/:id": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/members": 1024,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/workspaces/$workspaceId/$viewId": {
@@ -1248,6 +1612,24 @@
       "GET /v1/workspaces/:id/overview": 7,
       "GET /v1/workspaces/:id/workflow": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/get-full-organization": 3072,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/time-entries/:id": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/members": 1024,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/workspaces/$workspaceId/$viewId/document": {
@@ -1326,6 +1708,30 @@
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/chat/workspaces/:id/file-thread": 13,
       "POST /v1/workspaces/:id/justifications/query": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/entities/:id/entity/:id": 1024,
+      "GET /v1/entities/:id/entity/:id/versions": 1024,
+      "GET /v1/files/:id/url/:id": 1024,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/organization-settings/deepl": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/anonymization-terms": 1024,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/chat/workspaces/:id/file-thread": 1024,
+      "POST /v1/workspaces/:id/justifications/query": 1024
     }
   },
   "/workspaces/$workspaceId/entities/$entityId": {
@@ -1403,6 +1809,30 @@
       "GET /v1/workspaces/navigation": 6,
       "POST /v1/chat/workspaces/:id/file-thread": 13,
       "POST /v1/workspaces/:id/justifications/query": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/entities/:id/entity/:id": 1024,
+      "GET /v1/entities/:id/entity/:id/versions": 1024,
+      "GET /v1/files/:id/url/:id": 1024,
+      "GET /v1/mcp/connectors": 5120,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/organization-settings/deepl": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/skills": 4096,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/anonymization-terms": 1024,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480,
+      "POST /v1/chat/workspaces/:id/file-thread": 1024,
+      "POST /v1/workspaces/:id/justifications/query": 1024
     }
   },
   "/workspaces/$workspaceId/expenses": {
@@ -1459,6 +1889,23 @@
       "GET /v1/workspaces/:id/overview": 7,
       "GET /v1/workspaces/:id/workflow": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/entities/:id/summaries": 1024,
+      "GET /v1/expenses/:id": 1024,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/workspaces/$workspaceId/invoices": {
@@ -1512,6 +1959,22 @@
       "GET /v1/workspaces/:id/overview": 7,
       "GET /v1/workspaces/:id/workflow": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/invoices/:id": 1024,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   },
   "/workspaces/$workspaceId/timesheets target": {
@@ -1571,6 +2034,24 @@
       "GET /v1/workspaces/:id/overview": 7,
       "GET /v1/workspaces/:id/workflow": 4,
       "GET /v1/workspaces/navigation": 6
+    },
+    "responseSizes": {
+      "GET /api/auth/get-session": 1024,
+      "GET /api/auth/organization/get-active-member-role": 1024,
+      "GET /api/auth/organization/get-full-organization": 3072,
+      "GET /api/auth/organization/list": 1024,
+      "GET /health": 1024,
+      "GET /v1/chat/threads": 4096,
+      "GET /v1/organization-settings": 1024,
+      "GET /v1/organization-settings/ai-availability": 1024,
+      "GET /v1/properties/:id": 1024,
+      "GET /v1/time-entries/:id": 1024,
+      "GET /v1/views/:id": 1024,
+      "GET /v1/workspaces/:id": 6144,
+      "GET /v1/workspaces/:id/members": 1024,
+      "GET /v1/workspaces/:id/overview": 1024,
+      "GET /v1/workspaces/:id/workflow": 1024,
+      "GET /v1/workspaces/navigation": 20480
     }
   }
 }

--- a/apps/web/e2e/specs/network-metrics.unit.spec.ts
+++ b/apps/web/e2e/specs/network-metrics.unit.spec.ts
@@ -8,6 +8,7 @@ import {
   diffNetworkBaseline,
   mergeNetworkBaseline,
   normalizeApiPath,
+  responseSizeAllowance,
   waterfallDepth,
 } from "../helpers/network";
 
@@ -101,12 +102,16 @@ const metrics = (
     requests.map((request) => [request, 1]),
   ),
   missingDbQueryCounts: Record<string, number> = {},
+  responseSizes: Record<string, number> = {},
+  missingResponseSizeCounts: Record<string, number> = {},
 ): RouteNetworkMetrics => ({
   requests: [...requests].sort(),
   requestCounts,
   depth,
   dbQueries,
   missingDbQueryCounts,
+  responseSizes,
+  missingResponseSizeCounts,
 });
 
 test.describe("diffNetworkBaseline", () => {
@@ -331,6 +336,106 @@ test.describe("diffNetworkBaseline", () => {
     );
     expect(problems).toEqual([]);
   });
+
+  const sizeBaseline: NetworkBaseline = {
+    "/contacts": {
+      depth: 2,
+      requests: ["GET /v1/contacts"],
+      responseSizes: { "GET /v1/contacts": 1024 },
+    },
+  };
+  const sizeMetrics = (bytes: number, missing: Record<string, number> = {}) =>
+    metrics(
+      ["GET /v1/contacts"],
+      2,
+      {},
+      undefined,
+      {},
+      { "GET /v1/contacts": bytes },
+      missing,
+    );
+
+  test("a grown response size beyond the allowance is a problem", () => {
+    // responseSizeAllowance(1024) = ceil(1024 * 1.2) = 1229.
+    const { problems } = diffNetworkBaseline(
+      sizeBaseline,
+      new Map([["/contacts", sizeMetrics(1300)]]),
+    );
+    expect(problems.some((p) => p.includes("Response payload grew"))).toBe(
+      true,
+    );
+  });
+
+  test("response-size growth within the +20% allowance passes", () => {
+    expect(responseSizeAllowance(1024)).toBe(1229);
+    const { problems } = diffNetworkBaseline(
+      sizeBaseline,
+      new Map([["/contacts", sizeMetrics(1200)]]),
+    );
+    expect(problems).toEqual([]);
+  });
+
+  test("a smaller response size passes silently", () => {
+    const { problems } = diffNetworkBaseline(
+      sizeBaseline,
+      new Map([["/contacts", sizeMetrics(10)]]),
+    );
+    expect(problems).toEqual([]);
+  });
+
+  test("a response size for a key without a budget is not a problem", () => {
+    const { problems } = diffNetworkBaseline(
+      sizeBaseline,
+      new Map([
+        [
+          "/contacts",
+          metrics(
+            ["GET /v1/contacts"],
+            2,
+            {},
+            undefined,
+            {},
+            { "GET /v1/contacts": 1024, "GET /health": 50 },
+          ),
+        ],
+      ]),
+    );
+    expect(problems).toEqual([]);
+  });
+
+  test("a missing response size for a budgeted key is a problem", () => {
+    const { problems } = diffNetworkBaseline(
+      sizeBaseline,
+      new Map([
+        [
+          "/contacts",
+          metrics(
+            ["GET /v1/contacts"],
+            2,
+            {},
+            undefined,
+            {},
+            {},
+            { "GET /v1/contacts": 1 },
+          ),
+        ],
+      ]),
+    );
+    expect(problems.some((p) => p.includes("Response size missing"))).toBe(
+      true,
+    );
+  });
+
+  test("a request without a measured size is not a missing response-size count", () => {
+    // Mirrors "a request without a response is not a missing db-query count":
+    // no measurement attempt (e.g. a streamed response, excluded entirely by
+    // network.ts's isStreamedResponse) is not the same as a failed one.
+    const { problems } = diffNetworkBaseline(
+      sizeBaseline,
+      new Map([["/contacts", metrics(["GET /v1/contacts"], 2)]]),
+    );
+    expect(problems).toEqual([]);
+  });
 });
 
 test.describe("mergeNetworkBaseline", () => {
@@ -345,6 +450,7 @@ test.describe("mergeNetworkBaseline", () => {
         requests: ["GET /v1/contacts"],
         requestCounts: { "GET /v1/contacts": 1 },
         dbQueries: {},
+        responseSizes: {},
       },
     });
   });
@@ -366,6 +472,7 @@ test.describe("mergeNetworkBaseline", () => {
           "GET /v1/views/:id": 1,
         },
         dbQueries: {},
+        responseSizes: {},
       },
     });
   });
@@ -412,6 +519,60 @@ test.describe("mergeNetworkBaseline", () => {
     expect(merged["/contacts"]?.dbQueries).toEqual({
       "GET /health": 0,
       "GET /v1/contacts": 5,
+    });
+  });
+
+  test("response sizes merge to the per-key max, rounded up to the next KiB", () => {
+    const existing: NetworkBaseline = {
+      "/contacts": {
+        depth: 2,
+        requests: ["GET /v1/contacts"],
+        responseSizes: { "GET /v1/contacts": 2048, "GET /health": 1024 },
+      },
+    };
+    const merged = mergeNetworkBaseline(
+      existing,
+      new Map([
+        [
+          "/contacts",
+          metrics(
+            ["GET /v1/contacts"],
+            2,
+            {},
+            undefined,
+            {},
+            { "GET /v1/contacts": 3000 },
+          ),
+        ],
+      ]),
+    );
+    expect(merged["/contacts"]?.responseSizes).toEqual({
+      "GET /health": 1024,
+      // 3000 raw bytes rounds up to 3072 (3 KiB), same width as the writer
+      // rounds a brand-new measurement to.
+      "GET /v1/contacts": 3072,
+    });
+  });
+
+  test("a brand-new response size is rounded up to the next KiB", () => {
+    const merged = mergeNetworkBaseline(
+      null,
+      new Map([
+        [
+          "/contacts",
+          metrics(
+            ["GET /v1/contacts"],
+            2,
+            {},
+            undefined,
+            {},
+            { "GET /v1/contacts": 1 },
+          ),
+        ],
+      ]),
+    );
+    expect(merged["/contacts"]?.responseSizes).toEqual({
+      "GET /v1/contacts": 1024,
     });
   });
 

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -358,7 +358,7 @@ const smokeRouteTarget = async ({
     // last step is browserErrors.assertEmpty), so the manifest reflects the
     // fully-rendered route. Stored under the template it received; redirect
     // targets already arrive as "<template> target".
-    results.set(route.template, summarizeCapture(network.capture()));
+    results.set(route.template, summarizeCapture(await network.capture()));
   } finally {
     detachNetwork();
     detachPage();


### PR DESCRIPTION
## What

Adds a per-endpoint **response payload-size** dimension to the existing e2e network baseline (`apps/web/e2e/network-baseline.json`), alongside the request manifest, waterfall depth, request counts, and DB-query budgets. A handler that starts returning full rows instead of the minimal projection ("Return minimal data") now fails the route-smoke suite instead of regressing invisibly.

## How

Mirrors the `dbQueries` dimension end to end:

- **Collection:** the network collector reads each tracked API response's body via Playwright (`response.body()`) and records its byte length. Body reads are async, so `capture()` is now async and awaits the in-flight reads before summarizing.
- **Streamed responses are excluded** by content-type (`text/event-stream`): SSE channels (workspace events, chat streaming) stay open for the life of the page, so their "size" is unbounded by design. They remain in the request manifest; they just carry no size budget. The committed baseline shows this: `GET /v1/workspaces/:id/events` appears in `requests` with no `responseSizes` entry.
- **Aggregation:** per request key, max across occurrences on a route; `write` mode merges per-key max with the existing baseline, exactly like `dbQueries`.
- **Tolerance:** the check fails only when the observed size exceeds the budget by more than **+20%** (`responseSizeAllowance`). Payload bytes wobble run to run (generated ids, timestamps), and a real "returns full rows now" regression is a step change well past 20%. Same one-directional policy as the other dimensions: smaller payloads never fail.
- **Budget rounding:** the writer rounds budgets up to the next KiB so a one-byte jitter in a fresh baseline does not immediately eat into the allowance.
- A budgeted request whose body Playwright could not read (aborted mid-navigation) is reported as a distinct problem, mirroring the missing `x-db-queries` header check.

Unit coverage extends `network-metrics.unit.spec.ts` with diff/merge/rounding cases (42 tests, all passing).

## Baseline regeneration

Per the repo's performance conventions, reseeding a baseline needs explicit justification: **this write only ADDS the new `responseSizes` dimension.** I diffed the regenerated JSON against `main` per dimension: the pre-existing dimensions (`requests`, `requestCounts`, `depth`, `dbQueries`) are **byte-identical to main** for every route (the baseline commit is 481 insertions, 0 deletions). The route-smoke suite was then re-run without write mode against the committed baseline and passed with zero problems.

## Findings

No oversized endpoints (nothing near 1 MiB on any smoke route). Largest budgets, as future trim candidates rather than blockers:

- `GET /v1/workspaces` — 85 KiB (on `/workspaces` and `/todos`)
- `GET /v1/catalogue` — 70 KiB (knowledge/tools routes)
- `GET /v1/workspaces/navigation` — 20 KiB (all workspace routes)
