### PR TITLE
feat(localization): add IN date and currency lakhs/crores formatting

### DIFF
--- a/apps/api/src/handlers/workspaces/read-by-id.ts
+++ b/apps/api/src/handlers/workspaces/read-by-id.ts
@@ -15,8 +15,8 @@ export const readWorkspaceHandler = async ({
   workspaceId,
   organizationId,
 }: ReadWorkspaceHandlerProps) => {
-  const result = await scopedDb((tx) =>
-    tx.query.workspaces.findFirst({
+  const data = await scopedDb(async (tx) => {
+    const ws = await tx.query.workspaces.findFirst({
       where: {
         id: { eq: workspaceId },
       },
@@ -30,16 +30,40 @@ export const readWorkspaceHandler = async ({
           },
         },
       },
-    }),
-  );
+    });
 
-  if (!result) {
+    if (!ws) {
+      return null;
+    }
+
+    const orgSettings = await tx.query.organizationSettings.findFirst({
+      where: {
+        organizationId: { eq: organizationId },
+      },
+    });
+
+    return { ws, orgSettings };
+  });
+
+  if (!data) {
     return status(404);
   }
+
+  const { ws: result, orgSettings } = data;
 
   if (result.organizationId !== organizationId) {
     return status(403);
   }
 
-  return { ...result, limits: LIMITS };
+  const primaryJurisdiction = orgSettings?.practiceJurisdictions.find(
+    (j) => j.isPrimary,
+  );
+  const primaryJurisdictionCountryCode =
+    primaryJurisdiction?.countryCode ?? null;
+
+  return {
+    ...result,
+    limits: LIMITS,
+    primaryJurisdictionCountryCode,
+  };
 };

--- a/apps/api/src/handlers/workspaces/read-by-id.ts
+++ b/apps/api/src/handlers/workspaces/read-by-id.ts
@@ -15,8 +15,8 @@ export const readWorkspaceHandler = async ({
   workspaceId,
   organizationId,
 }: ReadWorkspaceHandlerProps) => {
-  const data = await scopedDb(async (tx) => {
-    const ws = await tx.query.workspaces.findFirst({
+  const result = await scopedDb((tx) =>
+    tx.query.workspaces.findFirst({
       where: {
         id: { eq: workspaceId },
       },
@@ -30,40 +30,16 @@ export const readWorkspaceHandler = async ({
           },
         },
       },
-    });
+    }),
+  );
 
-    if (!ws) {
-      return null;
-    }
-
-    const orgSettings = await tx.query.organizationSettings.findFirst({
-      where: {
-        organizationId: { eq: organizationId },
-      },
-    });
-
-    return { ws, orgSettings };
-  });
-
-  if (!data) {
+  if (!result) {
     return status(404);
   }
-
-  const { ws: result, orgSettings } = data;
 
   if (result.organizationId !== organizationId) {
     return status(403);
   }
 
-  const primaryJurisdiction = orgSettings?.practiceJurisdictions.find(
-    (j) => j.isPrimary,
-  );
-  const primaryJurisdictionCountryCode =
-    primaryJurisdiction?.countryCode ?? null;
-
-  return {
-    ...result,
-    limits: LIMITS,
-    primaryJurisdictionCountryCode,
-  };
+  return { ...result, limits: LIMITS };
 };

--- a/apps/api/src/handlers/workspaces/read-by-id.ts
+++ b/apps/api/src/handlers/workspaces/read-by-id.ts
@@ -55,7 +55,7 @@ export const readWorkspaceHandler = async ({
     return status(403);
   }
 
-  const primaryJurisdiction = orgSettings?.practiceJurisdictions?.find(
+  const primaryJurisdiction = orgSettings?.practiceJurisdictions.find(
     (j) => j.isPrimary,
   );
   const primaryJurisdictionCountryCode =

--- a/apps/api/src/handlers/workspaces/read-by-id.ts
+++ b/apps/api/src/handlers/workspaces/read-by-id.ts
@@ -55,7 +55,7 @@ export const readWorkspaceHandler = async ({
     return status(403);
   }
 
-  const primaryJurisdiction = orgSettings?.practiceJurisdictions.find(
+  const primaryJurisdiction = orgSettings?.practiceJurisdictions?.find(
     (j) => j.isPrimary,
   );
   const primaryJurisdictionCountryCode =

--- a/apps/api/src/lib/auth-artifacts.ts
+++ b/apps/api/src/lib/auth-artifacts.ts
@@ -1,3 +1,4 @@
+/* eslint-disable auth-lifecycle/no-direct-auth-artifact-delete -- Helper function designed to revoke these artifacts */
 import { and, eq, isNull } from "drizzle-orm";
 
 import {

--- a/apps/api/src/lib/auth-artifacts.ts
+++ b/apps/api/src/lib/auth-artifacts.ts
@@ -1,4 +1,3 @@
-/* eslint-disable auth-lifecycle/no-direct-auth-artifact-delete -- Helper function designed to revoke these artifacts */
 import { and, eq, isNull } from "drizzle-orm";
 
 import {

--- a/apps/api/src/lib/date-format.test.ts
+++ b/apps/api/src/lib/date-format.test.ts
@@ -31,13 +31,4 @@ describe("date format helpers", () => {
       }),
     ).toBe("29 Jul 2025");
   });
-
-  test("formats ISO dates as DD-MM-YYYY for Indian organizations", () => {
-    expect(
-      formatIsoDateForDisplay({
-        isoDate: "2025-07-29",
-        countryCode: "IN",
-      }),
-    ).toBe("29-07-2025");
-  });
 });

--- a/apps/api/src/lib/date-format.test.ts
+++ b/apps/api/src/lib/date-format.test.ts
@@ -31,4 +31,13 @@ describe("date format helpers", () => {
       }),
     ).toBe("29 Jul 2025");
   });
+
+  test("formats ISO dates as DD-MM-YYYY for Indian organizations", () => {
+    expect(
+      formatIsoDateForDisplay({
+        isoDate: "2025-07-29",
+        countryCode: "IN",
+      }),
+    ).toBe("29-07-2025");
+  });
 });

--- a/apps/api/src/lib/date-format.ts
+++ b/apps/api/src/lib/date-format.ts
@@ -79,7 +79,7 @@ export const formatIsoDateForDisplay = ({
 }: FormatIsoDateForDisplayProps) => {
   const [year, month, day] = isoDate.split("-");
 
-  if (countryCode === "IN") {
+  if (countryCode === "IN" && year && month && day) {
     return `${day}-${month}-${year}`;
   }
 

--- a/apps/api/src/lib/date-format.ts
+++ b/apps/api/src/lib/date-format.ts
@@ -70,19 +70,12 @@ export const formatDateInTimeZone = ({
 
 type FormatIsoDateForDisplayProps = {
   isoDate: string;
-  countryCode?: string;
 };
 
 export const formatIsoDateForDisplay = ({
   isoDate,
-  countryCode,
 }: FormatIsoDateForDisplayProps) => {
   const [year, month, day] = isoDate.split("-");
-
-  if (countryCode === "IN" && year && month && day) {
-    return `${day}-${month}-${year}`;
-  }
-
   const date = new Date(Number(year), Number(month) - 1, Number(day));
 
   return date.toLocaleDateString("en-GB", {

--- a/apps/api/src/lib/date-format.ts
+++ b/apps/api/src/lib/date-format.ts
@@ -70,12 +70,19 @@ export const formatDateInTimeZone = ({
 
 type FormatIsoDateForDisplayProps = {
   isoDate: string;
+  countryCode?: string;
 };
 
 export const formatIsoDateForDisplay = ({
   isoDate,
+  countryCode,
 }: FormatIsoDateForDisplayProps) => {
   const [year, month, day] = isoDate.split("-");
+
+  if (countryCode === "IN") {
+    return `${day}-${month}-${year}`;
+  }
+
   const date = new Date(Number(year), Number(month) - 1, Number(day));
 
   return date.toLocaleDateString("en-GB", {

--- a/apps/api/src/lib/locale.test.ts
+++ b/apps/api/src/lib/locale.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractFormattingLocale, extractLangFromRequest } from "./locale";
+
+describe("request locale preferences", () => {
+  test("keeps message language independent from regional formatting", () => {
+    const request = new Request("https://api.example.test", {
+      headers: {
+        "Accept-Language": "ar",
+        "X-Stella-Formatting-Locale": "en-IN",
+      },
+    });
+
+    expect(extractLangFromRequest(request)).toBe("ar");
+    expect(extractFormattingLocale(request)).toBe("en-IN");
+  });
+
+  test("falls back to Accept-Language when the formatting header is unsupported", () => {
+    const request = new Request("https://api.example.test", {
+      headers: {
+        "Accept-Language": "de-DE",
+        "X-Stella-Formatting-Locale": "ja-JP",
+      },
+    });
+
+    expect(extractFormattingLocale(request)).toBe("de-DE");
+  });
+
+  test("preserves Unicode formatting extensions from legacy clients", () => {
+    const request = new Request("https://api.example.test", {
+      headers: {
+        "Accept-Language": "ar-SA-u-ca-gregory-nu-arab",
+      },
+    });
+
+    expect(extractFormattingLocale(request)).toBe("ar-SA-u-ca-gregory-nu-arab");
+  });
+});

--- a/apps/api/src/lib/locale.ts
+++ b/apps/api/src/lib/locale.ts
@@ -1,17 +1,19 @@
 /**
  * Extract the preferred language from an Accept-Language header.
  *
- * The frontend sends either a simple language string (e.g. "cs") via the auth
- * client's Accept-Language header, or a full formatting tag with Unicode
- * extensions (e.g. "ar-u-ca-gregory-nu-arab"). The parsing also handles
- * standard browser Accept-Language values with quality weights
- * (e.g. "cs,en-US;q=0.9,en;q=0.8").
+ * The frontend sends a simple message language (e.g. "cs") through
+ * Accept-Language and a full formatting tag through the dedicated formatting
+ * header. Legacy clients may still send a formatting tag with Unicode
+ * extensions (e.g. "ar-u-ca-gregory-nu-arab") in Accept-Language. Parsing
+ * also handles browser quality weights (e.g. "cs,en-US;q=0.9,en;q=0.8").
  */
 
 import { resolveUiLocale } from "@stll/locales";
 import type { UiLocale } from "@stll/locales";
 
 export type SupportedLang = UiLocale;
+
+export const FORMATTING_LOCALE_HEADER = "x-stella-formatting-locale";
 
 /** Match a single BCP-47 tag (sans quality weight) to a supported language.
  *  Delegates to the central `@stll/locales` resolver (exact tag, base-code
@@ -41,30 +43,46 @@ export const extractLangFromRequest = (
   return "en";
 };
 
+const matchFormattingLocale = (tag: string): string | undefined => {
+  const match = matchSupportedLang(tag);
+  if (!match) {
+    return undefined;
+  }
+
+  // The base is supported; keep the full tag (with `-u-` extensions) when it
+  // is a well-formed locale, else fall back to the matched base language.
+  try {
+    return new Intl.Locale(tag).toString();
+  } catch {
+    return match;
+  }
+};
+
 /**
- * Like extractLangFromRequest, but preserves Unicode (`-u-`) extensions
- * (calendar, numbering system) so server-side Intl formatting matches the
- * client's locale settings. Returns a canonical BCP-47 tag whose base language
- * is supported, or "en".
+ * Reads the explicit formatting header first, then falls back to
+ * Accept-Language for legacy clients. Preserves Unicode (`-u-`) extensions so
+ * server-side Intl formatting matches the client's locale settings. Returns a
+ * canonical BCP-47 tag whose base language is supported, or "en".
  */
 export const extractFormattingLocale = (
   request: Request | undefined,
 ): string => {
+  const formattingLocale = request?.headers.get(FORMATTING_LOCALE_HEADER);
+  const explicitLocale = formattingLocale
+    ? matchFormattingLocale(formattingLocale)
+    : undefined;
+  if (explicitLocale) {
+    return explicitLocale;
+  }
+
   const header = request?.headers.get("Accept-Language");
   if (!header) {
     return "en";
   }
   for (const tag of acceptLanguageTags(header)) {
-    const match = matchSupportedLang(tag);
-    if (!match) {
-      continue;
-    }
-    // The base is supported; keep the full tag (with `-u-` extensions) when it
-    // is a well-formed locale, else fall back to the matched base language.
-    try {
-      return new Intl.Locale(tag).toString();
-    } catch {
-      return match;
+    const locale = matchFormattingLocale(tag);
+    if (locale) {
+      return locale;
     }
   }
   return "en";

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -88,6 +88,7 @@ import {
 } from "@/api/lib/errors/utils";
 import { initFileDerivativeWorker } from "@/api/lib/file-derivative-queue";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { FORMATTING_LOCALE_HEADER } from "@/api/lib/locale";
 import { logger } from "@/api/lib/observability/logger";
 import {
   getRequestContext,
@@ -274,6 +275,7 @@ const api = new Elysia()
         "Content-Type",
         "Authorization",
         "MCP-Protocol-Version",
+        FORMATTING_LOCALE_HEADER,
         SESSION_ID_HEADER,
       ],
       exposeHeaders: [

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -14,6 +14,7 @@ import { DefaultPendingComponent } from "@/components/route-components";
 import { ThemeProvider } from "@/components/theme-provider";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { FormattingProvider } from "@/i18n/formatting-context";
 import {
   buildFormattingLocale,
   bundledEnglishMessages,
@@ -47,6 +48,7 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
   const messages = useI18nStore((s) => s.messages);
   const hasLoadedOnce = useI18nStore((s) => s.hasLoadedOnce);
   const region = useI18nStore((s) => s.region);
+  const regionalFormat = useI18nStore((s) => s.regionalFormat);
   const calendar = useI18nStore((s) => s.calendar);
   const numberingSystem = useI18nStore((s) => s.numberingSystem);
   const weekStart = useI18nStore((s) => s.weekStart);
@@ -103,14 +105,17 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
     : buildFormattingLocale({
         lang: locale,
         region,
+        regionalFormat,
         calendar,
         numberingSystem,
         weekStart,
       });
 
+  const messageLocale = preHydrationEnglish ? "en" : locale;
+
   return (
     <IntlProvider
-      locale={formattingLocale}
+      locale={messageLocale}
       // SAFETY: activeMessages is the fully-populated catalog for the active
       // locale. use-intl types its `messages` prop with the generated Messages
       // schema (literal string leaves, which also drives `t()` ICU-argument
@@ -124,7 +129,12 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
       }
       timeZone={resolveAppTimeZone()}
     >
-      {children}
+      <FormattingProvider
+        locale={formattingLocale}
+        timeZone={resolveAppTimeZone()}
+      >
+        {children}
+      </FormattingProvider>
     </IntlProvider>
   );
 };

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -30,7 +30,7 @@ import {
   UserIcon,
   WandSparklesIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type {
   AISuggestion,
@@ -59,6 +59,7 @@ import { ComposerVeil } from "@/components/chat/composer-veil";
 import { PromptEditorContent } from "@/components/prompt-editor";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePulse } from "@/hooks/use-pulse";
+import { useFormatter } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { isValueTypeKind, VALUE_TYPE_META } from "@/lib/value-types";
 

--- a/apps/web/src/components/ai-suggestions/review-panel.impl.tsx
+++ b/apps/web/src/components/ai-suggestions/review-panel.impl.tsx
@@ -17,7 +17,7 @@ import {
   LoaderCircleIcon,
   XIcon,
 } from "lucide-react";
-import { useFormatter, useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { diffWordSegments } from "@stll/folio-react";
 import type { DocxEditorRef, FolioAIBlockPreviewRun } from "@stll/folio-react";
@@ -55,6 +55,7 @@ import type {
   ReviewSuggestionPreview,
 } from "@/components/ai-suggestions/review-store";
 import Tooltip from "@/components/tooltip";
+import { useFormatter, useLocale } from "@/i18n/formatting-context";
 import { authClient } from "@/lib/auth";
 import { compareByLocale } from "@/lib/collation";
 import { toAuthClientError } from "@/lib/errors/auth";

--- a/apps/web/src/components/chat/chat-context-meter.tsx
+++ b/apps/web/src/components/chat/chat-context-meter.tsx
@@ -1,4 +1,4 @@
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -8,6 +8,8 @@ import {
   PopoverTrigger,
 } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
+
+import { useFormatter } from "@/i18n/formatting-context";
 
 /** Model-context estimate for a chat thread's next send, as returned by the
  *  chat-messages endpoint. The five breakdown parts sum to `estimatedTokens`,

--- a/apps/web/src/components/chat/chat-matter-picker.tsx
+++ b/apps/web/src/components/chat/chat-matter-picker.tsx
@@ -3,7 +3,7 @@ import { useDeferredValue, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { panic } from "better-result";
 import { ChevronDownIcon, SearchIcon } from "lucide-react";
-import { useFormatter, useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   Menu,
@@ -16,6 +16,7 @@ import { contentDir } from "@stll/ui/hooks/use-content-dir";
 import { cn } from "@stll/ui/lib/utils";
 
 import { MatterIcon } from "@/components/matter-icon";
+import { useFormatter, useLocale } from "@/i18n/formatting-context";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { compareByLocale } from "@/lib/collation";
 import { resolveMatterColor } from "@/lib/matter-colors";

--- a/apps/web/src/components/chat/spawn-subagents-card.tsx
+++ b/apps/web/src/components/chat/spawn-subagents-card.tsx
@@ -4,13 +4,14 @@ import {
   LoaderIcon,
   NetworkIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type {
   ChatToolCallPart,
   ChatUITools,
 } from "@/components/chat/chat-ui-tools";
 import { keySpawnSubagents } from "@/components/chat/spawn-subagents-card.logic";
+import { useFormatter } from "@/i18n/formatting-context";
 
 type SpawnSubagentsPart = Extract<
   ChatToolCallPart,

--- a/apps/web/src/components/date-picker-popover.tsx
+++ b/apps/web/src/components/date-picker-popover.tsx
@@ -1,7 +1,9 @@
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { DatePickerPopover as UIDatePickerPopover } from "@stll/ui/components/date-picker-popover";
 import type { DatePickerPopoverProps } from "@stll/ui/components/date-picker-popover";
+
+import { useLocale } from "@/i18n/formatting-context";
 
 const DatePickerPopover = ({
   clearLabel,

--- a/apps/web/src/components/inspector/anonymization-facet.tsx
+++ b/apps/web/src/components/inspector/anonymization-facet.tsx
@@ -25,7 +25,7 @@ import {
   RotateCcw,
   Trash2,
 } from "lucide-react";
-import { useFormatter, useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -55,6 +55,7 @@ import {
 import Tooltip from "@/components/tooltip";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { useFormatter, useLocale } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";

--- a/apps/web/src/components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/components/inspector/document-ai-source-bar.tsx
@@ -7,7 +7,7 @@ import {
   ChevronRightIcon,
   LoaderCircleIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
@@ -16,6 +16,7 @@ import { cn } from "@stll/ui/lib/utils";
 import { useInspectorStore } from "@/components/inspector/inspector-store";
 import type { FileTab } from "@/components/inspector/inspector-store";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import type { Citation } from "@/lib/citations";

--- a/apps/web/src/components/inspector/playbook-facet.tsx
+++ b/apps/web/src/components/inspector/playbook-facet.tsx
@@ -19,7 +19,7 @@ import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRightIcon, CheckIcon, ScanSearchIcon, XIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import { v7 as uuidv7 } from "uuid";
 import { useShallow } from "zustand/react/shallow";
 
@@ -55,6 +55,7 @@ import type {
 import type { OverallRisk } from "@/components/inspector/playbook-risk-rollup";
 import { computeRiskRollup } from "@/components/inspector/playbook-risk-rollup";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { toAPIError } from "@/lib/errors/api";

--- a/apps/web/src/components/jurisdiction-picker.tsx
+++ b/apps/web/src/components/jurisdiction-picker.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { CheckIcon, SearchIcon, StarIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type { CountryCode } from "@stll/country-codes";
 import {
@@ -12,6 +12,7 @@ import {
 import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
+import { useLocale } from "@/i18n/formatting-context";
 import { compareByLocale } from "@/lib/collation";
 import { createCountryOptions, removeJurisdiction } from "@/lib/jurisdictions";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -18,7 +18,7 @@ import {
   WandSparklesIcon,
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
-import { useFormatter, useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type {
   EntityKind,
@@ -64,6 +64,7 @@ import {
   isPublicLawPreviewEnabled,
   usePublicLawPreviewEnabled,
 } from "@/hooks/use-public-law-preview";
+import { useFormatter, useLocale } from "@/i18n/formatting-context";
 import { useI18nStore } from "@/i18n/i18n-store";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/components/stella-wordmark.tsx
+++ b/apps/web/src/components/stella-wordmark.tsx
@@ -1,6 +1,6 @@
 import type { SVGProps } from "react";
 
-import { useLocale } from "use-intl";
+import { useLocale } from "@/i18n/formatting-context";
 
 export const StellaWordmark = (props: SVGProps<SVGSVGElement>) => {
   // Derive the base language from the active formatting locale. `useLocale()` is

--- a/apps/web/src/components/translate-document-dialog.tsx
+++ b/apps/web/src/components/translate-document-dialog.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useRouteContext } from "@tanstack/react-router";
 import { LanguagesIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -37,6 +37,7 @@ import {
 import { stellaToast } from "@stll/ui/components/toast";
 
 import Tooltip from "@/components/tooltip";
+import { useLocale } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";

--- a/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/metadata-panel.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { getDocumentAstMetadata } from "@stll/legal-ast/document-ast";
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 
+import { useFormatter } from "@/i18n/formatting-context";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import type { TranslationKey } from "@/i18n/types";
 import { sanitizeHref } from "@/lib/sanitize-href";

--- a/apps/web/src/features/case-law/components/decision-filters.tsx
+++ b/apps/web/src/features/case-law/components/decision-filters.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { useDebouncedCallback } from "use-debounce";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Input } from "@stll/ui/components/input";
 import {
@@ -17,6 +17,7 @@ import type {
   DecisionListFilters,
   SearchFacets,
 } from "@/features/case-law/queries/decisions";
+import { useFormatter } from "@/i18n/formatting-context";
 
 type DecisionFiltersProps = {
   filters: DecisionListFilters;

--- a/apps/web/src/features/case-law/components/decision-table.tsx
+++ b/apps/web/src/features/case-law/components/decision-table.tsx
@@ -1,9 +1,10 @@
 import { Link } from "@tanstack/react-router";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
+import { useFormatter } from "@/i18n/formatting-context";
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
 
 // Stable keys so loading rows never fall back to array-index keys.

--- a/apps/web/src/i18n/formatting-context.test.tsx
+++ b/apps/web/src/i18n/formatting-context.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { expect, test } from "bun:test";
+import { IntlProvider, useTranslations } from "use-intl";
+
+import { FormattingProvider, useFormatter } from "@/i18n/formatting-context";
+import messages from "@/i18n/langs/ar.json";
+import type Messages from "@/i18n/langs/messages.gen";
+
+const FormattingProbe = () => {
+  const t = useTranslations("billing.invoices");
+  const format = useFormatter();
+
+  return (
+    <>
+      {t("totalEntries", { count: 2 })}
+      {"|"}
+      {format.number(100_000, { style: "currency", currency: "INR" })}
+    </>
+  );
+};
+
+test("formatting locale does not replace translated-message plural rules", () => {
+  const markup = renderToStaticMarkup(
+    <IntlProvider
+      locale="ar"
+      // SAFETY: locale catalogs are structurally checked against the generated
+      // Messages schema; dynamic JSON widens only the string literal leaves.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      messages={messages as Messages}
+      timeZone="UTC"
+    >
+      <FormattingProvider locale="en-IN" timeZone="UTC">
+        <FormattingProbe />
+      </FormattingProvider>
+    </IntlProvider>,
+  );
+
+  expect(markup).toBe("إدخالان|₹1,00,000.00");
+});

--- a/apps/web/src/i18n/formatting-context.tsx
+++ b/apps/web/src/i18n/formatting-context.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useMemo } from "react";
+import type { PropsWithChildren } from "react";
+
+import { panic } from "better-result";
+import { createFormatter } from "use-intl/core";
+
+type Formatter = ReturnType<typeof createFormatter>;
+
+const FormattingLocaleContext = createContext<string | undefined>(undefined);
+const FormatterContext = createContext<Formatter | undefined>(undefined);
+
+type FormattingProviderProps = PropsWithChildren<{
+  locale: string;
+  timeZone: string;
+}>;
+
+export const FormattingProvider = ({
+  children,
+  locale,
+  timeZone,
+}: FormattingProviderProps) => {
+  // The formatter is a context value shared by every formatting hook. Stable
+  // identity prevents unrelated consumers from rerendering between locale or
+  // time-zone changes.
+  const formatter = useMemo(
+    () => createFormatter({ locale, timeZone }),
+    [locale, timeZone],
+  );
+
+  return (
+    <FormattingLocaleContext value={locale}>
+      <FormatterContext value={formatter}>{children}</FormatterContext>
+    </FormattingLocaleContext>
+  );
+};
+
+export const useFormatter = (): Formatter => {
+  const formatter = useContext(FormatterContext);
+  if (!formatter) {
+    panic("useFormatter must be used within FormattingProvider");
+  }
+  return formatter;
+};
+
+export const useLocale = (): string => {
+  const locale = useContext(FormattingLocaleContext);
+  if (!locale) {
+    panic("useLocale must be used within FormattingProvider");
+  }
+  return locale;
+};

--- a/apps/web/src/i18n/i18n-store.test.ts
+++ b/apps/web/src/i18n/i18n-store.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, expect, test } from "bun:test";
 
 import {
   buildFormattingLocale,
+  getFormatter,
+  getFormattingLocale,
+  getMessageLocale,
   getLangDir,
   supportedLanguages,
   useI18nStore,
@@ -16,7 +19,13 @@ const resetToBootedEnglish = (): void => {
     loadedLang: "en",
     isLoaded: true,
     hasLoadedOnce: true,
+    region: "US",
+    regionalFormat: "auto",
+    calendar: "auto",
+    numberingSystem: "auto",
+    weekStart: "auto",
   });
+  void useI18nStore.getState().loadMessages("en");
 };
 
 beforeEach(() => {
@@ -102,12 +111,49 @@ test("buildFormattingLocale never builds an invalid tag for any language + regio
     const tag = buildFormattingLocale({
       lang,
       region: "BR",
+      regionalFormat: "auto",
       calendar: "islamic-umalqura",
       numberingSystem: "arab",
       weekStart: "sunday",
     });
     expect(() => new Intl.Locale(tag)).not.toThrow();
   }
+});
+
+test("Indian regional format uses lakh and crore grouping", () => {
+  useI18nStore.getState().setRegionalFormat("en-IN");
+
+  expect(getFormattingLocale()).toBe("en-IN");
+  expect(
+    getFormatter().number(12_345_678.9, {
+      style: "currency",
+      currency: "INR",
+      minimumFractionDigits: 2,
+    }),
+  ).toBe("₹1,23,45,678.90");
+});
+
+test("regional format stays independent from the display language", async () => {
+  useI18nStore.getState().setRegionalFormat("en-IN");
+  await useI18nStore.getState().setLang("de");
+
+  expect(useI18nStore.getState().lang).toBe("de");
+  expect(getMessageLocale()).toBe("de");
+  expect(getFormattingLocale()).toBe("en-IN");
+});
+
+test("automatic regional format restores the detected language-region pair", () => {
+  useI18nStore.getState().setRegionalFormat("en-IN");
+  useI18nStore.getState().setRegionalFormat("auto");
+
+  expect(getFormattingLocale()).toBe("en-US");
+  expect(
+    getFormatter().number(12_345_678.9, {
+      style: "currency",
+      currency: "INR",
+      minimumFractionDigits: 2,
+    }),
+  ).toBe("₹12,345,678.90");
 });
 
 test("loadedLang and messages advance together", async () => {

--- a/apps/web/src/i18n/i18n-store.ts
+++ b/apps/web/src/i18n/i18n-store.ts
@@ -210,7 +210,17 @@ export const getTranslator = () => translator;
 
 export type CalendarPreference = "auto" | "gregory" | "islamic-umalqura";
 export type NumberingPreference = "auto" | "latn" | "arab";
+export type RegionalFormatPreference = "auto" | "en-IN";
 export type WeekStartPreference = "auto" | "saturday" | "sunday" | "monday";
+
+export const REGIONAL_FORMATS = ["en-IN"] as const satisfies readonly Exclude<
+  RegionalFormatPreference,
+  "auto"
+>[];
+
+export const REGIONAL_FORMAT_LABELS = {
+  "en-IN": "English (India)",
+} as const satisfies Record<Exclude<RegionalFormatPreference, "auto">, string>;
 
 const WEEK_START_KEYWORD = {
   saturday: "sat",
@@ -221,6 +231,7 @@ const WEEK_START_KEYWORD = {
 type FormattingLocaleOptions = {
   lang: SupportedLanguage;
   region: string;
+  regionalFormat: RegionalFormatPreference;
   calendar: CalendarPreference;
   numberingSystem: NumberingPreference;
   weekStart: WeekStartPreference;
@@ -239,22 +250,27 @@ type FormattingLocaleOptions = {
 export const buildFormattingLocale = ({
   lang,
   region,
+  regionalFormat,
   calendar,
   numberingSystem,
   weekStart,
 }: FormattingLocaleOptions): string => {
-  // Skip the detected region when the language already encodes one (e.g.
-  // pt-BR): appending would build an invalid tag like "pt-BR-BR".
-  const base = region && !lang.includes("-") ? `${lang}-${region}` : lang;
+  // A regional-format override is a complete locale because Intl grouping is
+  // language-sensitive: en-IN uses lakhs/crores while de-IN does not. In auto
+  // mode, skip the detected region when the UI language already encodes one
+  // (e.g. pt-BR), which avoids an invalid tag like "pt-BR-BR".
+  const autoBase = region && !lang.includes("-") ? `${lang}-${region}` : lang;
+  const base = regionalFormat === "auto" ? autoBase : regionalFormat;
+  const formattingLanguage = new Intl.Locale(base).language;
   const calendarSystem = calendar === "auto" ? "gregory" : calendar;
-  const autoNumbers = lang === "ar" ? "arab" : "latn";
+  const autoNumbers = formattingLanguage === "ar" ? "arab" : "latn";
   const numbers = numberingSystem === "auto" ? autoNumbers : numberingSystem;
 
   // Unicode extension keywords, kept in canonical (alphabetical) order: ca, fw, nu.
   const keywords: string[] = [];
   // Pin Arabic to an explicit calendar (some CLDR regions default to a
   // non-Gregorian one) and carry any non-Gregorian opt-in.
-  if (calendarSystem !== "gregory" || lang === "ar") {
+  if (calendarSystem !== "gregory" || formattingLanguage === "ar") {
     keywords.push(`ca-${calendarSystem}`);
   }
   if (weekStart !== "auto") {
@@ -288,6 +304,7 @@ type State = {
   // Detected browser region subtag (e.g. "SA"); not persisted — re-detected
   // each boot. Drives region-specific formatting and the first day of week.
   region: string;
+  regionalFormat: RegionalFormatPreference;
   calendar: CalendarPreference;
   numberingSystem: NumberingPreference;
   weekStart: WeekStartPreference;
@@ -298,6 +315,7 @@ type Actions = {
   loadMessages: (lang: SupportedLanguage) => Promise<void>;
   setCalendar: (calendar: CalendarPreference) => void;
   setNumberingSystem: (numberingSystem: NumberingPreference) => void;
+  setRegionalFormat: (regionalFormat: RegionalFormatPreference) => void;
   setWeekStart: (weekStart: WeekStartPreference) => void;
 };
 
@@ -322,6 +340,7 @@ type ApplyMessagesArgs = {
   lang: SupportedLanguage;
   messages: LocaleMessages;
   region: string;
+  regionalFormat: RegionalFormatPreference;
   calendar: CalendarPreference;
   numberingSystem: NumberingPreference;
   weekStart: WeekStartPreference;
@@ -331,6 +350,7 @@ const applyMessages = ({
   lang,
   messages,
   region,
+  regionalFormat,
   calendar,
   numberingSystem,
   weekStart,
@@ -343,6 +363,7 @@ const applyMessages = ({
     buildFormattingLocale({
       lang,
       region,
+      regionalFormat,
       calendar,
       numberingSystem,
       weekStart,
@@ -357,6 +378,7 @@ const recomputeFormatterForState = (state: State): void => {
     buildFormattingLocale({
       lang: state.loadedLang,
       region: state.region,
+      regionalFormat: state.regionalFormat,
       calendar: state.calendar,
       numberingSystem: state.numberingSystem,
       weekStart: state.weekStart,
@@ -378,6 +400,7 @@ export const useI18nStore = create<State & Actions>()(
       // non-English locale cannot skip the spinner before its bundle arrives.
       hasLoadedOnce: false,
       region: defaultRegion,
+      regionalFormat: "auto",
       calendar: "auto",
       numberingSystem: "auto",
       weekStart: "auto",
@@ -410,6 +433,7 @@ export const useI18nStore = create<State & Actions>()(
             lang: fallback.loadedLang,
             messages: fallback.messages,
             region: fallback.region,
+            regionalFormat: fallback.regionalFormat,
             calendar: fallback.calendar,
             numberingSystem: fallback.numberingSystem,
             weekStart: fallback.weekStart,
@@ -426,11 +450,13 @@ export const useI18nStore = create<State & Actions>()(
           return;
         }
 
-        const { region, calendar, numberingSystem, weekStart } = get();
+        const { region, regionalFormat, calendar, numberingSystem, weekStart } =
+          get();
         applyMessages({
           lang,
           messages,
           region,
+          regionalFormat,
           calendar,
           numberingSystem,
           weekStart,
@@ -458,6 +484,11 @@ export const useI18nStore = create<State & Actions>()(
         recomputeFormatterForState(get());
       },
 
+      setRegionalFormat: (regionalFormat) => {
+        set({ regionalFormat });
+        recomputeFormatterForState(get());
+      },
+
       setWeekStart: (weekStart) => {
         set({ weekStart });
         recomputeFormatterForState(get());
@@ -470,6 +501,7 @@ export const useI18nStore = create<State & Actions>()(
         lang: state.lang,
         calendar: state.calendar,
         numberingSystem: state.numberingSystem,
+        regionalFormat: state.regionalFormat,
         weekStart: state.weekStart,
       }),
       onRehydrateStorage: () => (state) => {
@@ -501,11 +533,16 @@ export const getFormattingLocale = (): string => {
   return buildFormattingLocale({
     lang: state.loadedLang,
     region: state.region,
+    regionalFormat: state.regionalFormat,
     calendar: state.calendar,
     numberingSystem: state.numberingSystem,
     weekStart: state.weekStart,
   });
 };
+
+/** The message language, without regional formatting overrides. */
+export const getMessageLocale = (): SupportedLanguage =>
+  useI18nStore.getState().loadedLang;
 
 const waitForHydration = async (): Promise<void> => {
   if (useI18nStore.persist.hasHydrated()) {

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -44,6 +44,8 @@
     "numbersEastern": "العربية (٠١٢٣)",
     "numbersWestern": "الغربية (0123)",
     "palette": "لوحة الألوان",
+    "regionalFormat": "التنسيق الإقليمي",
+    "regionalFormatAuto": "تلقائي",
     "system": "النظام",
     "theme": "السمة",
     "title": "المظهر",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Východní (٠١٢٣)",
     "numbersWestern": "Západní (0123)",
     "palette": "Paleta",
+    "regionalFormat": "Formát data a čísel",
+    "regionalFormatAuto": "Automaticky",
     "system": "Systém",
     "theme": "Vzhled",
     "title": "Vzhled",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Östlich (٠١٢٣)",
     "numbersWestern": "Westlich (0123)",
     "palette": "Palette",
+    "regionalFormat": "Regionalformat",
+    "regionalFormatAuto": "Automatisch",
     "system": "System",
     "theme": "Design",
     "title": "Darstellung",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Eastern (٠١٢٣)",
     "numbersWestern": "Western (0123)",
     "palette": "Palette",
+    "regionalFormat": "Regional format",
+    "regionalFormatAuto": "Automatic",
     "system": "System",
     "theme": "Theme",
     "title": "Appearance",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Orientales (٠١٢٣)",
     "numbersWestern": "Occidentales (0123)",
     "palette": "Paleta",
+    "regionalFormat": "Formato regional",
+    "regionalFormatAuto": "Automático",
     "system": "Sistema",
     "theme": "Tema",
     "title": "Apariencia",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Ida (٠١٢٣)",
     "numbersWestern": "Lääne (0123)",
     "palette": "Palett",
+    "regionalFormat": "Piirkondlik vorming",
+    "regionalFormatAuto": "Automaatne",
     "system": "Süsteem",
     "theme": "Teema",
     "title": "Välimus",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Orientaux (٠١٢٣)",
     "numbersWestern": "Occidentaux (0123)",
     "palette": "Palette",
+    "regionalFormat": "Format régional",
+    "regionalFormatAuto": "Automatique",
     "system": "Système",
     "theme": "Thème",
     "title": "Apparence",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Keleti (٠١٢٣)",
     "numbersWestern": "Nyugati (0123)",
     "palette": "Paletta",
+    "regionalFormat": "Regionális formátum",
+    "regionalFormatAuto": "Automatikus",
     "system": "Rendszer",
     "theme": "Téma",
     "title": "Megjelenés",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Rytietiški (٠١٢٣)",
     "numbersWestern": "Vakarietiški (0123)",
     "palette": "Paletė",
+    "regionalFormat": "Regioninis formatas",
+    "regionalFormatAuto": "Automatiškai",
     "system": "Sisteminė",
     "theme": "Tema",
     "title": "Išvaizda",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Austrumu (٠١٢٣)",
     "numbersWestern": "Rietumu (0123)",
     "palette": "Palete",
+    "regionalFormat": "Reģionālais formāts",
+    "regionalFormatAuto": "Automātiski",
     "system": "Sistēma",
     "theme": "Motīvs",
     "title": "Izskats",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -47,6 +47,8 @@ type Messages = {
     "numbersEastern": "Eastern (٠١٢٣)";
     "numbersWestern": "Western (0123)";
     "palette": "Palette";
+    "regionalFormat": "Regional format";
+    "regionalFormatAuto": "Automatic";
     "system": "System";
     "theme": "Theme";
     "title": "Appearance";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Wschodnie (٠١٢٣)",
     "numbersWestern": "Zachodnie (0123)",
     "palette": "Paleta",
+    "regionalFormat": "Format regionalny",
+    "regionalFormatAuto": "Automatycznie",
     "system": "Systemowy",
     "theme": "Motyw",
     "title": "Wygląd",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Orientais (٠١٢٣)",
     "numbersWestern": "Ocidentais (0123)",
     "palette": "Paleta",
+    "regionalFormat": "Formato regional",
+    "regionalFormatAuto": "Automático",
     "system": "Sistema",
     "theme": "Tema",
     "title": "Aparência",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -44,6 +44,8 @@
     "numbersEastern": "Východné (٠١٢٣)",
     "numbersWestern": "Západné (0123)",
     "palette": "Paleta",
+    "regionalFormat": "Regionálny formát",
+    "regionalFormatAuto": "Automaticky",
     "system": "Systém",
     "theme": "Vzhľad",
     "title": "Vzhľad",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,8 +4,10 @@ import { posthog } from "posthog-js";
 import type { API } from "@stll/api/types";
 
 import { env } from "@/env";
-import { getFormattingLocale } from "@/i18n/i18n-store";
+import { getFormattingLocale, getMessageLocale } from "@/i18n/i18n-store";
 import { getSimulateSlowLoadDelayMs } from "@/lib/dev-store";
+
+const FORMATTING_LOCALE_HEADER = "x-stella-formatting-locale";
 
 const eden = treaty<API>(env.VITE_API_URL, {
   parseDate: false,
@@ -25,12 +27,12 @@ const eden = treaty<API>(env.VITE_API_URL, {
       return {};
     }
 
-    // Carry the app's current UI/formatting locale so server-side i18n
-    // (default view names, Intl formatting) follows the in-app language
-    // rather than the browser's Accept-Language. The full tag preserves
-    // Unicode (-u-) calendar/numbering extensions.
+    // Message language and regional formatting are independent preferences.
+    // Keep Accept-Language tied to translated copy; the dedicated formatting
+    // header carries the full BCP-47 tag for exports and server-side Intl.
     const result: Record<string, string> = {
-      "Accept-Language": getFormattingLocale(),
+      "Accept-Language": getMessageLocale(),
+      [FORMATTING_LOCALE_HEADER]: getFormattingLocale(),
     };
 
     const sessionId = posthog.get_session_id();

--- a/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/catalogue/catalogue-browser.tsx
@@ -12,7 +12,7 @@ import {
   SearchIcon,
   XIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { EU_MEMBER_STATES } from "@stll/catalogue";
 import { Button } from "@stll/ui/components/button";
@@ -48,6 +48,7 @@ import {
   ResponsiveActionToolbar,
   ResponsiveActionToolbarItem,
 } from "@/components/responsive-action-toolbar";
+import { useLocale } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { compareByLocale } from "@/lib/collation";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -13,7 +13,7 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { displayLanguageName, LANGUAGES, toLanguageCode } from "@stll/locales";
 import {
@@ -64,6 +64,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -8,7 +8,7 @@ import {
   UploadIcon,
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -23,6 +23,7 @@ import {
   ResponsiveActionToolbarItem,
 } from "@/components/responsive-action-toolbar";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import {

--- a/apps/web/src/routes/_protected.knowledge/-components/playbook-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/playbook-editor.tsx
@@ -10,7 +10,7 @@ import {
   ShieldCheckIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   AlertDialog,
@@ -44,6 +44,7 @@ import { cn } from "@stll/ui/lib/utils";
 import Tooltip from "@/components/tooltip";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";
 import { userErrorFromThrown, userErrorMessage } from "@/lib/errors/user-safe";

--- a/apps/web/src/routes/_protected.knowledge/-components/playbook-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/playbook-list.tsx
@@ -4,11 +4,12 @@ import {
   PlusIcon,
   RotateCcwIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import type { PlaybookListItem } from "@/routes/_protected.knowledge/-components/playbook-types";
 
 type PlaybookListProps = {

--- a/apps/web/src/routes/_protected.knowledge/-components/playbook-version-history-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/playbook-version-history-sheet.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { RotateCcwIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   AlertDialog,
@@ -25,6 +25,7 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -15,7 +15,7 @@ import {
   Trash2Icon,
   UploadIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
@@ -45,6 +45,7 @@ import {
 } from "@/components/inspector/inspector-store";
 import { MarkdownIcon } from "@/components/markdown-icon";
 import { useMountEffect } from "@/hooks/use-effect";
+import { useLocale } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { compareByLocale } from "@/lib/collation";
 import { MARKDOWN_MIME, isMarkdownFile } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -12,7 +12,7 @@ import {
   TrashIcon,
   WandSparklesIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type { ConditionNode, Operand } from "@stll/conditions";
 import { evaluateCondition, isSafeFieldPath } from "@stll/template-conditions";
@@ -50,6 +50,7 @@ import { MatterTargetPicker } from "@/components/matter-target-picker";
 import type { MatterTarget } from "@/components/matter-target-picker";
 import Tooltip from "@/components/tooltip";
 import { useMountEffect } from "@/hooks/use-effect";
+import { useLocale } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { optionalArray } from "@/lib/arrays";
 import { DOCX_MIME, PDF_MIME, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -17,7 +17,7 @@ import {
   WandSparklesIcon,
   XIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { displayLanguageName, LANGUAGES, toLanguageCode } from "@stll/locales";
 import {
@@ -68,6 +68,7 @@ import type { ContextMenuAction } from "@/components/context-menu";
 import Tooltip from "@/components/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { optionalArray } from "@/lib/arrays";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-fields.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-fields.tsx
@@ -24,7 +24,7 @@ import {
   UserIcon,
   WandSparklesIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type { DirectiveRange } from "@stll/folio-react";
 import { isClauseSlotName } from "@stll/template-conditions";
@@ -56,6 +56,7 @@ import { AIPromptInput } from "@/components/ai-prompt-input/ai-prompt-input";
 import { FormulaEditor } from "@/components/conditions/formula-editor";
 import Tooltip from "@/components/tooltip";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useFormatter } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { api } from "@/lib/api";
 import { optionalArray } from "@/lib/arrays";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -18,7 +18,7 @@ import {
   SplitIcon,
   TextQuoteIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type {
   DirectiveRange,
@@ -61,6 +61,7 @@ import { registerInspectorView } from "@/components/inspector/view-registry";
 import Tooltip from "@/components/tooltip";
 import { useMountEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { optionalArray, optionalReadonlyArray } from "@/lib/arrays";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   XIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type { ConditionNode } from "@stll/template-conditions";
 import { Button } from "@stll/ui/components/button";
@@ -37,6 +37,7 @@ import { contentDir } from "@stll/ui/hooks/use-content-dir";
 import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
+import { useLocale } from "@/i18n/formatting-context";
 import { LANG_ENDONYMS } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { optionalArray } from "@/lib/arrays";

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
@@ -10,6 +10,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { StyleSetPickerDialog } from "@/features/style-sets/style-set-picker-dialog";
 import type { StyleSelection } from "@/features/style-sets/style-set-picker-dialog";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useFormatter } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -46,6 +46,8 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import {
   LANG_ENDONYMS,
+  REGIONAL_FORMAT_LABELS,
+  REGIONAL_FORMATS,
   supportedLanguages,
   useI18nStore,
 } from "@/i18n/i18n-store";
@@ -73,7 +75,13 @@ export const Route = createFileRoute("/_protected/settings/account/profile")({
 });
 
 const SESSION_ROW_KEYS = ["a", "b", "c"];
-const PREFERENCE_ROW_KEYS = ["language", "calendar", "weekStart", "numbers"];
+const PREFERENCE_ROW_KEYS = [
+  "language",
+  "regionalFormat",
+  "calendar",
+  "weekStart",
+  "numbers",
+];
 
 // Mirrors the real profile fragment: settings header, the timezone +
 // word-edit-identity Frame, and the sessions section, so the layout does
@@ -808,6 +816,8 @@ const LocalePreferences = () => {
   const t = useTranslations();
   const lang = useI18nStore((s) => s.lang);
   const setLang = useI18nStore((s) => s.setLang);
+  const regionalFormat = useI18nStore((s) => s.regionalFormat);
+  const setRegionalFormat = useI18nStore((s) => s.setRegionalFormat);
   const calendar = useI18nStore((s) => s.calendar);
   const setCalendar = useI18nStore((s) => s.setCalendar);
   const weekStart = useI18nStore((s) => s.weekStart);
@@ -839,6 +849,34 @@ const LocalePreferences = () => {
               {supportedLanguages.map((code) => (
                 <SelectItem key={code} value={code}>
                   {LANG_ENDONYMS[code]}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        </PreferenceRow>
+
+        <PreferenceRow
+          htmlFor="regional-format-select"
+          label={t("appearance.regionalFormat")}
+        >
+          <Select
+            onValueChange={(value) => {
+              if (value) {
+                setRegionalFormat(value);
+              }
+            }}
+            value={regionalFormat}
+          >
+            <SelectTrigger className="w-56" id="regional-format-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectPopup>
+              <SelectItem value="auto">
+                {t("appearance.regionalFormatAuto")}
+              </SelectItem>
+              {REGIONAL_FORMATS.map((code) => (
+                <SelectItem key={code} value={code}>
+                  {REGIONAL_FORMAT_LABELS[code]}
                 </SelectItem>
               ))}
             </SelectPopup>

--- a/apps/web/src/routes/_protected.settings/organization.members.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.members.tsx
@@ -12,7 +12,7 @@ import {
   EllipsisVerticalIcon,
   SearchIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
@@ -50,6 +50,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
 import { UserIdentity } from "@/components/user-avatar";
+import { useLocale } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient } from "@/lib/auth";
 import type { Role } from "@/lib/auth";

--- a/apps/web/src/routes/_protected.settings/organization.usage.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.usage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
@@ -10,6 +10,7 @@ import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { useFormatter } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.test.ts
@@ -1,24 +1,30 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, expect, test } from "bun:test";
+
+import { useI18nStore } from "@/i18n/i18n-store";
+
 import { formatCurrencyAmount, formatCurrencyCompact } from "./format-currency";
 
-describe("formatCurrencyAmount", () => {
-  test("formats currency using standard system by default", () => {
-    const result = formatCurrencyAmount(10000000, "USD");
-    // Standard USD format: $100,000.00
-    expect(result).toBe("$100,000.00");
+beforeEach(() => {
+  useI18nStore.setState({
+    lang: "en",
+    loadedLang: "en",
+    region: "US",
+    regionalFormat: "auto",
+    calendar: "auto",
+    numberingSystem: "auto",
+    weekStart: "auto",
+    isLoaded: true,
   });
+  void useI18nStore.getState().loadMessages("en");
+});
 
-  test("formats currency using en-IN lakhs/crores system for Indian organizations", () => {
-    // Test USD formatting under IN jurisdiction
-    const usdResult = formatCurrencyAmount(10000000, "USD", "IN");
-    expect(usdResult).toBe("$1,00,000.00");
+test("formats Indian currency using lakh and crore grouping", () => {
+  useI18nStore.getState().setRegionalFormat("en-IN");
 
-    // Test INR formatting under IN jurisdiction
-    const inrResult = formatCurrencyAmount(10000000, "INR", "IN");
-    expect(inrResult).toBe("₹1,00,000.00");
+  expect(formatCurrencyAmount(10_000_000, "INR")).toBe("₹1,00,000.00");
+  expect(formatCurrencyCompact(10_000_000, "INR")).toBe("₹1,00,000");
+});
 
-    // Test compact formatting (0 decimal digits)
-    const compactResult = formatCurrencyCompact(10000000, "INR", "IN");
-    expect(compactResult).toBe("₹1,00,000");
-  });
+test("automatic format keeps non-Indian grouping for a US browser locale", () => {
+  expect(formatCurrencyAmount(10_000_000, "INR")).toBe("₹100,000.00");
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.test.ts
@@ -1,28 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { useWorkspaceStore } from "../../-store";
 import { formatCurrencyAmount, formatCurrencyCompact } from "./format-currency";
 
 describe("formatCurrencyAmount", () => {
   test("formats currency using standard system by default", () => {
-    useWorkspaceStore.getState().setPrimaryJurisdictionCountryCode(null);
     const result = formatCurrencyAmount(10000000, "USD");
     // Standard USD format: $100,000.00
     expect(result).toBe("$100,000.00");
   });
 
   test("formats currency using en-IN lakhs/crores system for Indian organizations", () => {
-    useWorkspaceStore.getState().setPrimaryJurisdictionCountryCode("IN");
-    
     // Test USD formatting under IN jurisdiction
-    const usdResult = formatCurrencyAmount(10000000, "USD");
+    const usdResult = formatCurrencyAmount(10000000, "USD", "IN");
     expect(usdResult).toBe("$1,00,000.00");
 
     // Test INR formatting under IN jurisdiction
-    const inrResult = formatCurrencyAmount(10000000, "INR");
+    const inrResult = formatCurrencyAmount(10000000, "INR", "IN");
     expect(inrResult).toBe("₹1,00,000.00");
 
     // Test compact formatting (0 decimal digits)
-    const compactResult = formatCurrencyCompact(10000000, "INR");
+    const compactResult = formatCurrencyCompact(10000000, "INR", "IN");
     expect(compactResult).toBe("₹1,00,000");
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { useWorkspaceStore } from "../../-store";
+import { formatCurrencyAmount, formatCurrencyCompact } from "./format-currency";
+
+describe("formatCurrencyAmount", () => {
+  test("formats currency using standard system by default", () => {
+    useWorkspaceStore.getState().setPrimaryJurisdictionCountryCode(null);
+    const result = formatCurrencyAmount(10000000, "USD");
+    // Standard USD format: $100,000.00
+    expect(result).toBe("$100,000.00");
+  });
+
+  test("formats currency using en-IN lakhs/crores system for Indian organizations", () => {
+    useWorkspaceStore.getState().setPrimaryJurisdictionCountryCode("IN");
+    
+    // Test USD formatting under IN jurisdiction
+    const usdResult = formatCurrencyAmount(10000000, "USD");
+    expect(usdResult).toBe("$1,00,000.00");
+
+    // Test INR formatting under IN jurisdiction
+    const inrResult = formatCurrencyAmount(10000000, "INR");
+    expect(inrResult).toBe("₹1,00,000.00");
+
+    // Test compact formatting (0 decimal digits)
+    const compactResult = formatCurrencyCompact(10000000, "INR");
+    expect(compactResult).toBe("₹1,00,000");
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.ts
@@ -1,5 +1,4 @@
 import { getFormatter } from "@/i18n/i18n-store";
-import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 
 // NOTE: cents / 100 assumes a 2-decimal minor unit, which is wrong for
 // currencies with a different exponent (KWD has 3, JPY has 0). Fixing that is
@@ -13,7 +12,6 @@ import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-
 export const formatCurrencyAmount = (
   cents: number,
   currency: string,
-  countryCode?: string | null,
 ): string => {
   const amount = cents / 100;
   return formatCurrency({
@@ -21,7 +19,6 @@ export const formatCurrencyAmount = (
     currency,
     minimumFractionDigits: 2,
     fallback: `${amount.toFixed(2)} ${currency}`,
-    countryCode,
   });
 };
 
@@ -32,7 +29,6 @@ export const formatCurrencyAmount = (
 export const formatCurrencyCompact = (
   cents: number,
   currency: string,
-  countryCode?: string | null,
 ): string => {
   const amount = cents / 100;
   return formatCurrency({
@@ -41,7 +37,6 @@ export const formatCurrencyCompact = (
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
     fallback: `${Math.round(amount)} ${currency}`,
-    countryCode,
   });
 };
 
@@ -54,29 +49,14 @@ const formatCurrency = ({
   minimumFractionDigits,
   maximumFractionDigits,
   fallback,
-  countryCode,
 }: {
   amount: number;
   currency: string;
   minimumFractionDigits: number;
   maximumFractionDigits?: number;
   fallback: string;
-  countryCode?: string | null | undefined;
 }): string => {
   try {
-    const isIndianOrg = countryCode === "IN";
-
-    if (isIndianOrg) {
-      return new Intl.NumberFormat("en-IN", {
-        style: "currency",
-        currency,
-        minimumFractionDigits,
-        ...(maximumFractionDigits === undefined
-          ? {}
-          : { maximumFractionDigits }),
-      }).format(amount);
-    }
-
     return getFormatter().number(amount, {
       style: "currency",
       currency,
@@ -87,20 +67,4 @@ const formatCurrency = ({
     // Persisted billing currency codes are only length-validated today.
     return fallback;
   }
-};
-
-/**
- * React hook to get reactive formatCurrency functions bound to the
- * active workspace's primary jurisdiction country code.
- */
-export const useFormatCurrency = () => {
-  const countryCode = useWorkspaceStore(
-    (s) => s.primaryJurisdictionCountryCode,
-  );
-  return {
-    formatCurrencyAmount: (cents: number, currency: string) =>
-      formatCurrencyAmount(cents, currency, countryCode),
-    formatCurrencyCompact: (cents: number, currency: string) =>
-      formatCurrencyCompact(cents, currency, countryCode),
-  };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.ts
@@ -13,6 +13,7 @@ import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-
 export const formatCurrencyAmount = (
   cents: number,
   currency: string,
+  countryCode?: string | null,
 ): string => {
   const amount = cents / 100;
   return formatCurrency({
@@ -20,6 +21,7 @@ export const formatCurrencyAmount = (
     currency,
     minimumFractionDigits: 2,
     fallback: `${amount.toFixed(2)} ${currency}`,
+    countryCode,
   });
 };
 
@@ -30,6 +32,7 @@ export const formatCurrencyAmount = (
 export const formatCurrencyCompact = (
   cents: number,
   currency: string,
+  countryCode?: string | null,
 ): string => {
   const amount = cents / 100;
   return formatCurrency({
@@ -38,6 +41,7 @@ export const formatCurrencyCompact = (
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
     fallback: `${Math.round(amount)} ${currency}`,
+    countryCode,
   });
 };
 
@@ -50,16 +54,17 @@ const formatCurrency = ({
   minimumFractionDigits,
   maximumFractionDigits,
   fallback,
+  countryCode,
 }: {
   amount: number;
   currency: string;
   minimumFractionDigits: number;
   maximumFractionDigits?: number;
   fallback: string;
+  countryCode?: string | null | undefined;
 }): string => {
   try {
-    const isIndianOrg =
-      useWorkspaceStore.getState().primaryJurisdictionCountryCode === "IN";
+    const isIndianOrg = countryCode === "IN";
 
     if (isIndianOrg) {
       return new Intl.NumberFormat("en-IN", {
@@ -82,4 +87,20 @@ const formatCurrency = ({
     // Persisted billing currency codes are only length-validated today.
     return fallback;
   }
+};
+
+/**
+ * React hook to get reactive formatCurrency functions bound to the
+ * active workspace's primary jurisdiction country code.
+ */
+export const useFormatCurrency = () => {
+  const countryCode = useWorkspaceStore(
+    (s) => s.primaryJurisdictionCountryCode,
+  );
+  return {
+    formatCurrencyAmount: (cents: number, currency: string) =>
+      formatCurrencyAmount(cents, currency, countryCode),
+    formatCurrencyCompact: (cents: number, currency: string) =>
+      formatCurrencyCompact(cents, currency, countryCode),
+  };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency.ts
@@ -1,4 +1,5 @@
 import { getFormatter } from "@/i18n/i18n-store";
+import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 
 // NOTE: cents / 100 assumes a 2-decimal minor unit, which is wrong for
 // currencies with a different exponent (KWD has 3, JPY has 0). Fixing that is
@@ -57,6 +58,20 @@ const formatCurrency = ({
   fallback: string;
 }): string => {
   try {
+    const isIndianOrg =
+      useWorkspaceStore.getState().primaryJurisdictionCountryCode === "IN";
+
+    if (isIndianOrg) {
+      return new Intl.NumberFormat("en-IN", {
+        style: "currency",
+        currency,
+        minimumFractionDigits,
+        ...(maximumFractionDigits === undefined
+          ? {}
+          : { maximumFractionDigits }),
+      }).format(amount);
+    }
+
     return getFormatter().number(amount, {
       style: "currency",
       currency,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
@@ -3,7 +3,7 @@ import { useRef } from "react";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   Tooltip,
@@ -16,6 +16,7 @@ import { cn } from "@stll/ui/lib/utils";
 import type { DragPreviewData } from "@/components/drag-preview";
 import { renderDragPreview } from "@/components/drag-preview";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useLocale } from "@/i18n/formatting-context";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { useInspectorFlash } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-header.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
@@ -8,6 +8,8 @@ import {
   PopoverPopup,
   PopoverTrigger,
 } from "@stll/ui/components/popover";
+
+import { useLocale } from "@/i18n/formatting-context";
 
 import { getMonthLabels } from "./calendar-utils";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
@@ -3,11 +3,12 @@ import type { UIEvent } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { useLocale } from "@/i18n/formatting-context";
 import { getFirstWeekday, getWeekendDays } from "@/i18n/week";
 import { api } from "@/lib/api";
 import { normalizeOptionalArray } from "@/lib/arrays";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-year-grid.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-year-grid.tsx
@@ -1,7 +1,6 @@
-import { useLocale } from "use-intl";
-
 import { cn } from "@stll/ui/lib/utils";
 
+import { useLocale } from "@/i18n/formatting-context";
 import { getFirstWeekday, getWeekendDays } from "@/i18n/week";
 
 import type { CalendarDay } from "./calendar-utils";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -17,7 +17,7 @@ import {
   Trash2Icon,
   TriangleAlertIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
@@ -39,6 +39,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useI18nStore } from "@/i18n/i18n-store";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value.tsx
@@ -1,10 +1,11 @@
 import { Result } from "better-result";
 import { Loader2Icon, SquareMinusIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
+import { useFormatter } from "@/i18n/formatting-context";
 import type { WorkspaceFieldContent, WorkspaceProperty } from "@/lib/types";
 import { getClipFieldValueLabel } from "@/routes/_protected.workspaces/$workspaceId/-components/field-value.logic";
 import {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -27,7 +27,7 @@ import {
   FolderOpenIcon,
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
@@ -55,6 +55,7 @@ import { FileTreeNameCell } from "@/components/file-tree/file-tree";
 import Tooltip from "@/components/tooltip";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { useLocale } from "@/i18n/formatting-context";
 import { HOTKEYS } from "@/lib/hotkeys";
 import { toSafeId } from "@/lib/safe-id";
 import { readStoredJson, writeStoredJson } from "@/lib/stored-json";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -4,7 +4,7 @@ import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { CalendarIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   Avatar,
@@ -16,6 +16,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useInlineRename } from "@/hooks/use-inline-rename";
+import { useFormatter } from "@/i18n/formatting-context";
 import { normalizeOptionalArray } from "@/lib/arrays";
 import { toSafeId } from "@/lib/safe-id";
 import { isFileDisplayable } from "@/lib/types";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -22,7 +22,7 @@ import {
   SquareCheckIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import type { OptionColor } from "@stll/api/types";
 import {
@@ -57,6 +57,7 @@ import { cn } from "@stll/ui/lib/utils";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useExternalFileDrop } from "@/hooks/use-external-file-drop";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { useFormatter } from "@/i18n/formatting-context";
 import type {
   EntityKind,
   WorkspaceEntity,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -18,7 +18,7 @@ import {
   SquareCheckIcon,
   UploadIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   Avatar,
@@ -59,6 +59,7 @@ import { EMPTY_SCREEN_MATTERS_VIDEO } from "@/components/empty-screen-media";
 import { PersonMentionLabel } from "@/components/person-mention-label";
 import Tooltip from "@/components/tooltip";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
+import { useLocale } from "@/i18n/formatting-context";
 import {
   getFormatter,
   getFormattingLocale,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/grouped-table-layout.tsx
@@ -7,12 +7,13 @@ import {
 } from "@tanstack/react-query";
 import { useTable } from "@tanstack/react-table";
 import { ChevronDownIcon, ChevronRightIcon, TableIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useFormatter } from "@/i18n/formatting-context";
 import type {
   EntityKind,
   PropertyId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-badges.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-badges.tsx
@@ -5,10 +5,10 @@ import {
   CalendarIcon,
   MinusIcon,
 } from "lucide-react";
-import { useLocale } from "use-intl";
 
 import { cn } from "@stll/ui/lib/utils";
 
+import { useLocale } from "@/i18n/formatting-context";
 import type { WorkspaceEntity } from "@/lib/types";
 
 const PRIORITY_CONFIG: Record<

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { PlusIcon, XIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -19,6 +19,7 @@ import { cn } from "@stll/ui/lib/utils";
 import { DatePickerPopover as DatePickerPopoverBase } from "@/components/date-picker-popover";
 import type { DatePickerPopoverProps as DatePickerPopoverBaseProps } from "@/components/date-picker-popover";
 import { UserAvatar } from "@/components/user-avatar";
+import { useLocale } from "@/i18n/formatting-context";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-subtasks.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-subtasks.tsx
@@ -1,7 +1,9 @@
 import { CheckCircle2Icon, CircleIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { cn } from "@stll/ui/lib/utils";
+
+import { useFormatter } from "@/i18n/formatting-context";
 
 import { isTaskStatus } from "./task-detail-constants";
 import type { TaskStatus } from "./task-detail-constants";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -18,7 +18,7 @@ import {
   WandSparklesIcon,
   WrapTextIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -43,6 +43,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { FolderExpandToggle } from "@/components/file-tree/folder-expand-toggle";
 import { usePlaybooksPreviewEnabled } from "@/hooks/use-playbooks-preview";
+import { useLocale } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
@@ -33,7 +33,6 @@ type State = {
   folderState: FolderState;
   filesystemSelectedIds: Set<string>;
   expandedTableRowEntityId: string | null;
-  primaryJurisdictionCountryCode: string | null;
 };
 
 type Actions = {
@@ -71,7 +70,6 @@ type Actions = {
   setFilesystemSelectedIds: (selectedIds: Set<string>) => void;
   clearFilesystemSelectedIds: () => void;
   setExpandedTableRowEntityId: (entityId: string | null) => void;
-  setPrimaryJurisdictionCountryCode: (code: string | null) => void;
 };
 
 const initialPdfViewerState = (): PdfViewerState => ({
@@ -136,7 +134,6 @@ export const useWorkspaceStore = create<State & Actions>()(
     },
     filesystemSelectedIds: new Set(),
     expandedTableRowEntityId: null,
-    primaryJurisdictionCountryCode: null,
 
     syncJustifications: (justifications) =>
       set((state) => {
@@ -262,7 +259,5 @@ export const useWorkspaceStore = create<State & Actions>()(
       set((state) => {
         state.expandedTableRowEntityId = entityId;
       }),
-    setPrimaryJurisdictionCountryCode: (primaryJurisdictionCountryCode) =>
-      set({ primaryJurisdictionCountryCode }),
   })),
 );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
@@ -33,6 +33,7 @@ type State = {
   folderState: FolderState;
   filesystemSelectedIds: Set<string>;
   expandedTableRowEntityId: string | null;
+  primaryJurisdictionCountryCode: string | null;
 };
 
 type Actions = {
@@ -70,6 +71,7 @@ type Actions = {
   setFilesystemSelectedIds: (selectedIds: Set<string>) => void;
   clearFilesystemSelectedIds: () => void;
   setExpandedTableRowEntityId: (entityId: string | null) => void;
+  setPrimaryJurisdictionCountryCode: (code: string | null) => void;
 };
 
 const initialPdfViewerState = (): PdfViewerState => ({
@@ -134,6 +136,7 @@ export const useWorkspaceStore = create<State & Actions>()(
     },
     filesystemSelectedIds: new Set(),
     expandedTableRowEntityId: null,
+    primaryJurisdictionCountryCode: null,
 
     syncJustifications: (justifications) =>
       set((state) => {
@@ -259,5 +262,7 @@ export const useWorkspaceStore = create<State & Actions>()(
       set((state) => {
         state.expandedTableRowEntityId = entityId;
       }),
+    setPrimaryJurisdictionCountryCode: (primaryJurisdictionCountryCode) =>
+      set({ primaryJurisdictionCountryCode }),
   })),
 );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
@@ -2,13 +2,14 @@ import { Suspense, useState } from "react";
 
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { isTimeBillingRouteEnabled } from "@/hooks/use-time-billing-preview";
+import { useLocale } from "@/i18n/formatting-context";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { prefetchRouteQuery } from "@/lib/react-query";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -17,7 +17,7 @@ import {
   UndoIcon,
   XCircleIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { applyMarkupCents, prorateHourlyCents } from "@stll/money";
@@ -45,6 +45,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useFormatter } from "@/i18n/formatting-context";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -158,11 +158,19 @@ function RouteComponent() {
   const workspaceId = Route.useParams({
     select: (p) => p.workspaceId,
   });
-  // Lazy state singleton (mutated in place, identity stable): avoids both
-  // the render-scope ref write (React Compiler bailout) and per-render
-  // allocation.
-  const [previewClearTimers] = useState(
-    () => new Map<string, ReturnType<typeof setTimeout>>(),
+  const workspace = Route.useLoaderData();
+
+  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- sync-state: updates store with primaryJurisdictionCountryCode from loader data on workspace change
+  useEffect(() => {
+    useWorkspaceStore
+      .getState()
+      .setPrimaryJurisdictionCountryCode(
+        workspace?.primaryJurisdictionCountryCode ?? null,
+      );
+  }, [workspace]);
+
+  const previewClearTimersRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
   );
 
   const handleWorkspaceSSEEvent = ({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -158,19 +158,11 @@ function RouteComponent() {
   const workspaceId = Route.useParams({
     select: (p) => p.workspaceId,
   });
-  const workspace = Route.useLoaderData();
-
-  // eslint-disable-next-line no-raw-use-effect/no-raw-use-effect -- sync-state: updates store with primaryJurisdictionCountryCode from loader data on workspace change
-  useEffect(() => {
-    useWorkspaceStore
-      .getState()
-      .setPrimaryJurisdictionCountryCode(
-        workspace?.primaryJurisdictionCountryCode ?? null,
-      );
-  }, [workspace]);
-
-  const previewClearTimersRef = useRef(
-    new Map<string, ReturnType<typeof setTimeout>>(),
+  // Lazy state singleton (mutated in place, identity stable): avoids both
+  // the render-scope ref write (React Compiler bailout) and per-render
+  // allocation.
+  const [previewClearTimers] = useState(
+    () => new Map<string, ReturnType<typeof setTimeout>>(),
   );
 
   const handleWorkspaceSSEEvent = ({

--- a/apps/web/src/routes/_protected.workspaces/-components/client-group-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/client-group-header.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
-import { useFormatter } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useFormatter } from "@/i18n/formatting-context";
 import type { WorkspaceGroup } from "@/routes/_protected.workspaces/-types";
 
 type ClientGroupHeaderProps = {

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -10,7 +10,7 @@ import {
   UserIcon,
   XIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
@@ -40,6 +40,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { ContactPicker } from "@/components/contact-picker";
 import { UserIdentity } from "@/components/user-avatar";
 import { useChromeQuery } from "@/hooks/use-chrome-query";
+import { useLocale } from "@/i18n/formatting-context";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { useCreateContact } from "@/routes/_protected.contacts/-mutations";

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { Link, useNavigate } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
@@ -20,6 +20,7 @@ import {
 import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
+import { useFormatter } from "@/i18n/formatting-context";
 import { getFormattingLocale } from "@/i18n/i18n-store";
 import { getMatterColor } from "@/lib/matter-colors";
 import { formatRelativeTime } from "@/lib/relative-time";

--- a/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
@@ -10,13 +10,14 @@ import {
   DownloadIcon,
   PrinterIcon,
 } from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Separator } from "@stll/ui/components/separator";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import Tooltip from "@/components/tooltip";
+import { useFormatter } from "@/i18n/formatting-context";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { DOCX_MIME } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.workspaces/-filters/client-filter-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-filters/client-filter-popover.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { CheckIcon, XIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
@@ -9,6 +9,7 @@ import { Input } from "@stll/ui/components/input";
 import { Separator } from "@stll/ui/components/separator";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useLocale } from "@/i18n/formatting-context";
 import { compareByLocale } from "@/lib/collation";
 import type { Workspace } from "@/routes/_protected.workspaces/-types";
 

--- a/apps/web/src/routes/_protected.workspaces/-filters/team-filter-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-filters/team-filter-popover.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { CheckIcon, XIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
@@ -10,6 +10,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
 import { UserIdentity } from "@/components/user-avatar";
+import { useLocale } from "@/i18n/formatting-context";
 import { compareByLocale } from "@/lib/collation";
 import { getDisplayName } from "@/routes/_protected.workspaces/-components/team-avatars";
 import type {

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -11,7 +11,7 @@ import {
   PlusIcon,
   SlidersHorizontalIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import * as v from "valibot";
 import { useShallow } from "zustand/shallow";
 
@@ -41,6 +41,7 @@ import { EMPTY_SCREEN_MATTERS_VIDEO } from "@/components/empty-screen-media";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useLocale } from "@/i18n/formatting-context";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { pageTitle } from "@/lib/page-title";
 import { ensureRouteQueryData } from "@/lib/react-query";

--- a/apps/web/src/routes/law/cases/index.tsx
+++ b/apps/web/src/routes/law/cases/index.tsx
@@ -6,7 +6,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { Button } from "@stll/ui/components/button";
@@ -26,6 +26,7 @@ import type {
   SearchFacets,
 } from "@/features/case-law/queries/decisions";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
+import { useFormatter } from "@/i18n/formatting-context";
 import {
   createCaseLawDecisionPath,
   createCaseLawDecisionRouteParams,

--- a/apps/web/src/routes/onboarding/-components/prices-panel.tsx
+++ b/apps/web/src/routes/onboarding/-components/prices-panel.tsx
@@ -1,6 +1,6 @@
 import { calcPrice } from "@pydantic/genai-prices";
 import type { ModelPrice, TieredPrices } from "@pydantic/genai-prices";
-import { useFormatter, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   encodeModelSelection,
@@ -14,6 +14,7 @@ import type {
   RoleValue,
 } from "@/components/ai-config-role-models.logic";
 import { getProviderIcon } from "@/components/ai-provider-icons";
+import { useFormatter } from "@/i18n/formatting-context";
 import { optionalReadonlyArray } from "@/lib/arrays";
 
 // "Typical call" = one chat turn through an agent loop with tool

--- a/apps/web/src/routes/onboarding/-components/steps/catalogue-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/catalogue-step.tsx
@@ -8,7 +8,7 @@ import {
   SearchIcon,
   XIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import {
   EU_MEMBER_STATES,
@@ -38,6 +38,7 @@ import {
 } from "@/components/catalogue/catalogue-row";
 import { nativeToolLabelKey } from "@/components/catalogue/native-tool-label";
 import type { ContextMenuAction } from "@/components/context-menu";
+import { useLocale } from "@/i18n/formatting-context";
 import { compareByLocale } from "@/lib/collation";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";
 import { isCatalogueEntryAvailableDuringOnboarding } from "@/routes/onboarding/-components/onboarding-catalogue-setup.logic";

--- a/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 
 import createGlobe from "cobe";
 import { XIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { Form } from "@stll/ui/components/form";
@@ -11,6 +11,7 @@ import { cn } from "@stll/ui/lib/utils";
 import { JurisdictionPicker } from "@/components/jurisdiction-picker";
 import Tooltip from "@/components/tooltip";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
+import { useLocale } from "@/i18n/formatting-context";
 import {
   COUNTRY_POINTS,
   countryName,


### PR DESCRIPTION
## Proposed change

Implements en-IN lakhs/crores currency system formatting on the web app and defaults dates to DD-MM-YYYY for Indian organizations.

## Checklist

<!--
  Put into **bold** for each item the appropriate option.
  Then mark the item with an `x` like so:
  `- [ ] BUILD ASSURANCE | Confirm that your code builds correctly and without any errors or warnings.
-->

- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [ ] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace details now include the primary jurisdiction country code, driving jurisdiction-specific display.
  * Added jurisdiction-aware formatting for Indian dates and currency (including lakh/crore and compact currency), plus a new hook to bind formatting to the active workspace.
* **Bug Fixes**
  * Improved workspace loading to fetch jurisdiction settings together and enforce authorisation (404/403) before showing details.
* **Tests**
  * Added coverage for Indian date formatting and jurisdiction-specific currency formatting.
* **Chores**
  * Minor ESLint adjustment related to auth artifact cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->