### PR TITLE
fix(ci): harden staging promotion dispatch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,12 +13,6 @@ concurrency:
   group: deploy-staging
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write
-  attestations: write
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/stella-api
@@ -33,6 +27,11 @@ jobs:
     # build + watcher so the job's own timeout never guillotines the
     # watcher before it can read the infra run's real conclusion.
     timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Resolve synthetic ref
@@ -99,7 +98,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: stella-infra
           permission-actions: write
-          permission-contents: read
 
       - name: Dispatch and watch staging promote
         env:
@@ -111,52 +109,84 @@ jobs:
         run: |
           dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           expected_title="Promote ${RELEASE_REF} → staging"
-          dispatch_output="$(
-            gh workflow run promote-release.yml \
-              --repo "$INFRA_REPO" \
-              --field release_ref="$RELEASE_REF" \
-              --field target_environment=staging \
-              --field image_digest="$IMAGE_DIGEST" \
-              --field git_sha="$GIT_SHA" \
-              --field run_migrations=true \
-              --field frontend=true 2>&1
-          )"
-          printf '%s\n' "$dispatch_output"
+          run_id=""
 
-          run_id="$(
-            printf '%s\n' "$dispatch_output" \
-              | sed -nE 's#.*https://github.com/[^/]+/[^/]+/actions/runs/([0-9]+).*#\1#p' \
-              | head -n 1
-          )"
+          find_dispatched_run() {
+            local attempt
+            local max_attempts="$1"
+            local run_list=""
 
-          for _ in {1..30}; do
-            if [[ -n "$run_id" ]]; then
-              break
-            fi
+            for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+              if ! run_list="$(
+                gh api \
+                  "/repos/${INFRA_REPO}/actions/workflows/promote-release.yml/runs?event=workflow_dispatch&per_page=10" \
+                  --jq ".workflow_runs[] | select(.created_at >= \"$dispatched_at\") | select(.display_title == \"$expected_title\") | .id" \
+                  2>&1
+              )"; then
+                printf '%s\n' "$run_list" >&2
+                echo "::warning::Could not list infra promotion runs yet." >&2
+                sleep 2
+                continue
+              fi
 
-            if ! run_list="$(
-              gh run list \
-                --repo "$INFRA_REPO" \
-                --workflow promote-release.yml \
-                --event workflow_dispatch \
-                --json databaseId,createdAt,displayTitle \
-                --jq ".[] | select(.createdAt >= \"$dispatched_at\") | select(.displayTitle == \"$expected_title\") | .databaseId" \
-                --limit 10 2>&1
+              run_id="$(printf '%s\n' "$run_list" | head -n 1)"
+              if [[ -n "$run_id" ]]; then
+                return 0
+              fi
+
+              sleep 2
+            done
+
+            return 1
+          }
+
+          # Call the dispatch endpoint directly: `gh workflow run` first looks
+          # up the workflow by filename and default branch, which adds read
+          # requests unrelated to dispatch and can fail under the narrowly
+          # scoped App token. A dispatch is also a remote state-changing call;
+          # if the client reports an error after GitHub accepted it, retrying
+          # immediately can create a duplicate run. Look for the uniquely
+          # titled run before retrying.
+          for dispatch_attempt in {1..3}; do
+            dispatch_output=""
+            if dispatch_output="$(
+              gh api --method POST \
+                "/repos/${INFRA_REPO}/actions/workflows/promote-release.yml/dispatches" \
+                -f "ref=main" \
+                -f "inputs[release_ref]=${RELEASE_REF}" \
+                -f "inputs[target_environment]=staging" \
+                -f "inputs[image_digest]=${IMAGE_DIGEST}" \
+                -f "inputs[git_sha]=${GIT_SHA}" \
+                -f "inputs[run_migrations]=true" \
+                -f "inputs[frontend]=true" \
+                2>&1
             )"; then
-              echo "::warning::Could not list infra promotion runs yet: ${run_list}" >&2
-              sleep 2
-              continue
-            fi
+              echo "Staging promotion dispatch accepted."
 
-            run_id="$(printf '%s\n' "$run_list" | head -n 1)"
+              if find_dispatched_run 30; then
+                break
+              fi
 
-            if [[ -z "$run_id" ]]; then
-              sleep 2
+              echo "::error::GitHub accepted the staging promotion dispatch, but its workflow run did not become visible." >&2
+              exit 1
+            else
+              dispatch_status=$?
+              printf '%s\n' "$dispatch_output" >&2
+              echo "::warning::Staging promotion dispatch attempt ${dispatch_attempt}/3 failed with exit code ${dispatch_status}." >&2
+
+              if find_dispatched_run 5; then
+                echo "Found the staging promotion run after the dispatch client reported an error."
+                break
+              fi
+
+              if (( dispatch_attempt < 3 )); then
+                sleep $((dispatch_attempt * 5))
+              fi
             fi
           done
 
           if [[ -z "$run_id" ]]; then
-            echo "Could not find the dispatched staging promotion workflow run." >&2
+            echo "::error::Could not dispatch or find the staging promotion workflow run after 3 attempts." >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- call the Actions dispatch endpoint directly with the minimum App permission
- recover from transient and ambiguous dispatch failures without immediately creating duplicate runs
- scope write permissions to the build job