### PR TITLE
docs: prevent policy implementation drift

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,10 @@ bun.lock                                @jan-kubica
 apps/api/src/lib/auth.ts                @jan-kubica
 apps/api/src/db/auth-schema.ts          @jan-kubica
 
+# Database schema, RLS, connection boundaries, and immutable migrations.
+apps/api/src/db/                        @jan-kubica
+apps/api/drizzle/                       @jan-kubica
+
 # Catalogue curation — only maintainers flip recommendations.
 packages/catalogue/entries/recommended.json   @jan-kubica
 packages/catalogue/MAINTAINERS                @jan-kubica

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
         run: bun run lint:ws
 
       - name: Policy evidence
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
         run: bun run policies:check
 
       - name: Railway template shape

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,6 @@ jobs:
         run: bash scripts/sync-ai-skills.sh --check
 
       - name: Setup Bun
-        if: needs.ci-changes.outputs.package_checks_required == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: "package.json"
@@ -173,6 +172,9 @@ jobs:
         # each install.
         if: needs.ci-changes.outputs.package_checks_required == 'true'
         run: bun run lint:ws
+
+      - name: Policy evidence
+        run: bun run policies:check
 
       - name: Railway template shape
         if: needs.ci-changes.outputs.package_checks_required == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,6 @@ jobs:
         run: bun run lint:ws
 
       - name: Policy evidence
-        if: needs.ci-changes.outputs.package_checks_required == 'true'
         run: bun run policies:check
 
       - name: Railway template shape

--- a/apps/api/src/handlers/files/read-by-id.ts
+++ b/apps/api/src/handlers/files/read-by-id.ts
@@ -26,6 +26,8 @@ import { getS3 } from "@/api/lib/s3";
 import { presignDownloadUrl } from "@/api/lib/s3-presign";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
+const FILE_READ_URL_EXPIRY_SECONDS = 15 * 60;
+
 type FilePurpose = "download" | "display" | "native-display";
 
 type ReadFileHandlerProps = {
@@ -101,7 +103,7 @@ export const readFileHandler = async ({
           resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
           resourceId: row.entityId,
           s3Key: fileKey,
-          expiresInSeconds: 900,
+          expiresInSeconds: FILE_READ_URL_EXPIRY_SECONDS,
           fileName: content.fileName,
           organizationId,
           workspaceId,
@@ -147,7 +149,7 @@ export const readFileHandler = async ({
       fileName: content.fileName,
       encrypted: content.encrypted,
       presignedUrl: await presignDownloadUrl(nativeFileKey, {
-        expiresIn: 900,
+        expiresIn: FILE_READ_URL_EXPIRY_SECONDS,
         scope: { organizationId, workspaceId },
       }),
       stampable: false,
@@ -173,7 +175,7 @@ export const readFileHandler = async ({
       fileName: content.fileName,
       encrypted: content.encrypted,
       presignedUrl: await presignDownloadUrl(nativeFileKey, {
-        expiresIn: 900,
+        expiresIn: FILE_READ_URL_EXPIRY_SECONDS,
         scope: { organizationId, workspaceId },
       }),
       stampable: false,
@@ -200,7 +202,7 @@ export const readFileHandler = async ({
     fileName: content.fileName,
     encrypted: content.encrypted,
     presignedUrl: await presignDownloadUrl(displayFileKey, {
-      expiresIn: 900,
+      expiresIn: FILE_READ_URL_EXPIRY_SECONDS,
       scope: { organizationId, workspaceId },
     }),
     stampable: false,
@@ -297,9 +299,12 @@ const inlineContentDisposition = (fileName: string): string =>
 const fetchStoredFileResponse = async (
   key: string,
 ): Promise<Response | null> => {
-  const response = await fetch(getS3().presign(key, { expiresIn: 900 }), {
-    signal: AbortSignal.timeout(30_000),
-  }).catch(() => null);
+  const response = await fetch(
+    getS3().presign(key, { expiresIn: FILE_READ_URL_EXPIRY_SECONDS }),
+    {
+      signal: AbortSignal.timeout(30_000),
+    },
+  ).catch(() => null);
 
   if (!response?.ok) {
     return null;
@@ -453,7 +458,9 @@ export const stampedDownloadHandler = async ({
     mimeType: content.mimeType,
   });
 
-  const presignedUrl = getS3().presign(fileKey, { expiresIn: 900 });
+  const presignedUrl = getS3().presign(fileKey, {
+    expiresIn: FILE_READ_URL_EXPIRY_SECONDS,
+  });
   const response = await fetch(presignedUrl, {
     signal: AbortSignal.timeout(30_000),
   });

--- a/apps/api/src/handlers/templates/delete.test.ts
+++ b/apps/api/src/handlers/templates/delete.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  "apps/api/src/handlers/templates/delete.ts",
+  "utf-8",
+);
+
+describe("template deletion storage ordering", () => {
+  test("awaits object cleanup before deleting the database row", () => {
+    const storageDelete = source.indexOf("await deleteS3Keys");
+    const databaseDelete = source.indexOf(".delete(templates)");
+
+    expect(storageDelete).toBeGreaterThan(-1);
+    expect(databaseDelete).toBeGreaterThan(storageDelete);
+    expect(source).not.toContain(".delete(key).catch");
+  });
+});

--- a/apps/api/src/handlers/templates/delete.test.ts
+++ b/apps/api/src/handlers/templates/delete.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import nodePath from "node:path";
 
 const source = readFileSync(
-  "apps/api/src/handlers/templates/delete.ts",
+  nodePath.join(import.meta.dir, "delete.ts"),
   "utf-8",
 );
 

--- a/apps/api/src/handlers/templates/delete.ts
+++ b/apps/api/src/handlers/templates/delete.ts
@@ -4,7 +4,7 @@ import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db";
 import { templates } from "@/api/db/schema";
-import { captureError } from "@/api/lib/analytics";
+import { deleteS3Keys } from "@/api/handlers/files/utils";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
@@ -12,7 +12,6 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { getS3 } from "@/api/lib/s3";
 
 const deleteTemplateParamsSchema = t.Object({
   templateId: tSafeId("template"),
@@ -60,6 +59,8 @@ const deleteTemplateHandler = async function* ({
     s3Keys.add(v.s3Key);
   }
 
+  Result.unwrap(await deleteS3Keys([...s3Keys]));
+
   yield* Result.await(
     safeDb(async (tx) => {
       await tx
@@ -86,13 +87,6 @@ const deleteTemplateHandler = async function* ({
       });
     }),
   );
-
-  // Delete S3 objects outside the transaction to keep
-  // DB operations short. If any delete fails, files become
-  // orphaned but that is safer than a dangling DB row.
-  for (const key of s3Keys) {
-    getS3().delete(key).catch(captureError);
-  }
 
   return Result.ok({});
 };

--- a/docs/policies/access-control.md
+++ b/docs/policies/access-control.md
@@ -1,7 +1,7 @@
 # Access Control Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-02-22
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual, or after any access-related incident
 
 ## Purpose
@@ -20,6 +20,8 @@ operations runbook (private).
 ## Controls
 
 ### Application layer
+
+<!-- evidence: access-auth-boundary -->
 
 1. **Authentication.** All API requests are authenticated via
    `better-auth` with session tokens. The `authMacro`
@@ -44,19 +46,22 @@ operations runbook (private).
    business logic have been validated by the macro. Ownership
    IDs are never accepted from client-supplied request bodies.
 
-5. **Tenant isolation in storage.** S3 object keys follow the
+5. **Tenant isolation in storage.** Workspace file object keys follow the
    pattern `{organizationId}/{workspaceId}/{fileId}.{ext}`,
    ensuring namespace-level separation. All objects use a
-   `private` ACL; access is granted only through presigned
-   URLs that expire after 15 minutes.
+   `private` ACL. Upload URLs expire after five minutes; normal
+   file-read and download URLs expire after 15 minutes.
 
 ### Repository and CI/CD
+
+<!-- evidence: access-branch-protection -->
 
 6. **Branch protection.** The `main` branch is protected by a
    GitHub ruleset (`.github/branch-protection/ruleset-main.json`)
    that enforces:
    - No direct pushes; all changes via pull request.
-   - At least one approval from a code owner.
+   - At least one approval; matching sensitive paths additionally
+     require their code owner.
    - Stale reviews dismissed on new pushes.
    - Last-push approval required (author cannot self-approve).
    - All review threads resolved before merge.
@@ -64,9 +69,9 @@ operations runbook (private).
    - Signed commits required.
    - No force pushes or branch deletion.
 
-7. **Code ownership.** `CODEOWNERS` assigns default reviewers
-   for all changes and designates specific owners for
-   sensitive paths (database schema, CI workflows).
+7. **Code ownership.** `CODEOWNERS` designates owners for sensitive
+   paths, including CI/release automation, database code and migrations,
+   authentication, dependency manifests, and privileged desktop code.
 
 8. **Fork trust gate.** The CI workflow
    (`.github/workflows/ci.yml`) skips checks on fork PRs
@@ -80,9 +85,10 @@ operations runbook (private).
 
 ## Enforcement
 
-- `workspaceAccessMacro` is applied to all workspace-scoped
-  route groups via `.guard()`. Adding a new workspace endpoint
-  without the macro causes a type error (missing `SafeId`).
+- Workspace-scoped handlers use `createSafeHandler`, whose authorized
+  context requires the `SafeId<"workspace">` minted by
+  `workspaceAccessMacro`; security invariant tests cover route and RLS
+  enforcement.
 - Branch protection rules are enforced by GitHub and audited
   weekly.
 - Lefthook's staged Gitleaks scan helps block commits

--- a/docs/policies/asset-management.md
+++ b/docs/policies/asset-management.md
@@ -1,7 +1,7 @@
 # Asset Management Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-02-22
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual
 
 ## Purpose
@@ -20,40 +20,41 @@ and container base images used in the Stella monorepo.
 
 ### Software Bill of Materials (SBOM)
 
-1. **CycloneDX SBOM.** A machine-readable SBOM
-   (`sbom.cdx.json`) is generated on every push to `main`
-   that modifies `bun.lock` or any `package.json`. The
-   `sbom.yml` workflow uses `@cyclonedx/cdxgen` to produce a
-   CycloneDX 1.6 inventory of all dependencies with package
-   URLs (PURLs) and license metadata.
+<!-- evidence: asset-provenance-inventory -->
 
-2. **Committed to repository.** The SBOM is committed directly
-   to the repo so that any point-in-time checkout includes a
-   complete dependency snapshot. Build artifacts are also
-   uploaded with 365-day retention.
+1. **CycloneDX SBOM.** The shared provenance workflow generates
+   machine-readable CycloneDX inventories for the JavaScript workspace
+   and the desktop Rust application. Project definitions and output
+   locations are declared in `.provenance.yml`; the scheduled
+   `provenance-nightly.yml` workflow proposes refreshed artifacts through
+   a pull request.
 
-3. **Third-party notices.** The `THIRD-PARTY-NOTICES.txt` file
-   is regenerated alongside the SBOM using
-   `generate-license-file`, providing full license texts for
-   all dependencies. This file is committed to the repository.
+2. **Committed to repository.** SBOMs live under
+   `provenance/projects/<project>/sbom.cdx.json`, so a checkout contains
+   the reviewed dependency snapshot for each configured project.
+
+3. **Third-party notices.** Per-project notice files live beside the
+   SBOMs, with the repository-level aggregate at
+   `provenance/THIRD-PARTY-NOTICES.repo.txt`.
 
 ### Dependency tracking
+
+<!-- evidence: asset-dependency-quarantine -->
 
 4. **Lockfile as source of truth.** `bun.lock` records exact
    resolved versions for all packages. It is committed to the
    repository and integrity-checked during `bun ci` in the CI
    pipeline.
 
-5. **Dependabot monitoring.** Dependabot tracks three
+5. **Dependabot monitoring.** Dependabot tracks four
    ecosystems (`.github/dependabot.yml`):
-   - **Bun packages:** daily checks, grouped by library family
-     (TanStack, Vite, React, Prettier, AI, PostHog, TipTap,
-     AWS, Drizzle, Elysia, RivetKit, oxlint, and others).
+   - **Bun packages:** weekly checks, grouped by library family.
    - **GitHub Actions:** weekly checks, grouped.
    - **Docker base images:** weekly checks.
+   - **Cargo crates:** weekly checks, grouped by runtime family.
 
-   All updates use a 3-day cooldown before adoption. Bun
-   updates ignore patch-level changes (minor and major only).
+   All updates use a five-day cooldown before adoption, aligned with
+   Bun's `minimumReleaseAge` quarantine.
 
 6. **Workspace consistency.** `sherif` runs as a `postinstall`
    hook and is available via `bun run lint:ws`. It flags
@@ -85,8 +86,8 @@ and container base images used in the Stella monorepo.
 
 ## Enforcement
 
-- The SBOM is regenerated automatically; manual updates are
-  not required.
+- Provenance refreshes are proposed automatically and remain reviewable
+  as ordinary repository changes.
 - `sherif` runs on every `bun install`, catching version drift
   before it reaches CI.
 - Dependency review is a required status check on `main`;

--- a/docs/policies/change-management.md
+++ b/docs/policies/change-management.md
@@ -1,7 +1,7 @@
 # Change Management Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-02-22
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual
 
 ## Purpose
@@ -26,11 +26,11 @@ and documentation.
    `main`. Direct commits to `main` are blocked by the branch
    protection ruleset.
 
-2. **Required review.** Every PR requires at least one
-   approval from a code owner defined in `CODEOWNERS`. The
-   ruleset dismisses stale approvals when new commits are
-   pushed and requires the last push to be approved by someone
-   other than the author.
+2. **Required review.** Every PR requires at least one approval.
+   Changes matching sensitive paths in `CODEOWNERS` additionally require
+   approval from that owner. The ruleset dismisses stale approvals when
+   new commits are pushed and requires the last push to be approved by
+   someone other than the author.
 
 3. **Thread resolution.** All review conversation threads must
    be resolved before a PR can be merged.
@@ -46,6 +46,8 @@ and documentation.
 
 ### Automated checks (CI gate)
 
+<!-- evidence: change-ci-gate -->
+
 The `ci.yml` workflow runs on every PR and produces a single
 `ci-result` status check that gates merging. The pipeline
 includes:
@@ -56,9 +58,10 @@ includes:
 | i18n sync          | `bun run i18n:check`      | Ensure translation keys are consistent |
 | Lint               | oxlint (ultracite preset) | Code quality and security rules        |
 | Custom lint rules  | oxlint JS plugins         | Semantic tokens, RTL, ownership IDs    |
-| Format             | Prettier                  | Consistent code formatting             |
-| Type check         | TypeScript strict mode    | Type safety                            |
+| Format             | oxfmt                     | Consistent code formatting             |
+| Type check         | TypeScript native preview | Type safety                            |
 | Tests              | Bun test runner           | Functional correctness                 |
+| Policy evidence    | Repository guard          | Policy-to-implementation drift         |
 
 All checks must pass. The `ci-result` aggregation job
 (`if: always()`) ensures the gate is never accidentally
@@ -73,8 +76,8 @@ skipped.
    Elastic, CPAL).
 
 7. **Automated updates.** Dependabot submits PRs for outdated
-   dependencies daily (Bun packages), weekly (GitHub Actions,
-   Docker images). Updates are subject to a 3-day cooldown
+   dependencies weekly (Bun packages, GitHub Actions, and
+   Docker images). Updates are subject to a five-day cooldown
    before adoption.
 
 8. **Workspace consistency.** `sherif` runs as a `postinstall`
@@ -82,14 +85,16 @@ skipped.
 
 ### Database schema changes
 
-9. **Dedicated ownership.** Schema files
-   (`apps/api/src/db/schema.ts`, `schema-validators.ts`)
-   require review from the designated schema owner
-   per `CODEOWNERS`.
+<!-- evidence: change-migration-gate -->
 
-10. **Migration via Drizzle.** Schema changes are applied
-    through `bun run db:push` (Drizzle ORM). Raw SQL is
-    avoided unless strictly necessary.
+9. **Dedicated ownership.** Database code, modular schema files, and
+   migration files require review from their designated owner per
+   `CODEOWNERS`.
+
+10. **Migration via Drizzle.** Production schema changes ship as
+    immutable migrations under `apps/api/drizzle/` and are applied with
+    `bun run db:migrate`. CI checks schema coverage, SQL safety, fresh
+    application, and parity with the declarative Drizzle schema.
 
 ### Sensitive path protection
 

--- a/docs/policies/change-management.md
+++ b/docs/policies/change-management.md
@@ -76,9 +76,9 @@ skipped.
    Elastic, CPAL).
 
 7. **Automated updates.** Dependabot submits PRs for outdated
-   dependencies weekly (Bun packages, GitHub Actions, and
-   Docker images). Updates are subject to a five-day cooldown
-   before adoption.
+   dependencies weekly (Bun packages, GitHub Actions, Docker
+   images, and Cargo crates). Updates are subject to a five-day
+   cooldown before adoption.
 
 8. **Workspace consistency.** `sherif` runs as a `postinstall`
    hook to flag version mismatches across monorepo packages.

--- a/docs/policies/data-classification.md
+++ b/docs/policies/data-classification.md
@@ -1,7 +1,7 @@
 # Data Classification Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-02-22
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual
 
 ## Purpose
@@ -19,27 +19,26 @@ outputs, session tokens, and logs.
 
 ## Classification levels
 
-| Level            | Description                                                                                        | Examples                                                                              |
-| ---------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| **Confidential** | Data protected by legal privilege or regulation. Unauthorized disclosure could cause serious harm. | Document contents, entity metadata, AI review results, attorney-client communications |
-| **Internal**     | Operational data not intended for external disclosure.                                             | User profiles, organization membership, workspace configuration, audit logs           |
-| **Secret**       | Credentials and cryptographic material. Exposure leads to immediate compromise.                    | Session tokens, API keys, S3 credentials, OTP codes, signing keys                     |
+| Level            | Description                                                                                                               | Examples                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Public**       | Material intentionally published or sourced from an official public record.                                               | Public case law, legislation, published catalogue metadata                            |
+| **Confidential** | Data protected by legal privilege, privacy law, or a client obligation. Unauthorized disclosure could cause serious harm. | Document contents, entity metadata, AI review results, attorney-client communications |
+| **Internal**     | Operational data not intended for public disclosure.                                                                      | User profiles, organization membership, workspace configuration, audit logs           |
+| **Secret**       | Credentials and cryptographic material. Exposure leads to immediate compromise.                                           | Session tokens, API keys, S3 credentials, OTP codes, signing keys                     |
 
-Stella does not process or store public-tier data in normal
-operation; all workspace content is treated as Confidential
-by default.
+All workspace content is treated as Confidential by default, regardless
+of whether a source document was previously public.
 
 ## Controls by classification
 
 ### Confidential (document content)
 
-1. **Workspace isolation.** Primary content tables (`entities`,
-   `files`, `properties`, `views`) carry a `workspaceId`
-   foreign key with a cascade-delete constraint. Dependent
-   tables (`entityVersions`, `fields`, `justifications`) are
-   isolated transitively via their parent records. Queries are
-   scoped by `workspaceId`, never filtered in application code
-   after fetching.
+<!-- evidence: classification-object-storage -->
+
+1. **Workspace isolation.** Primary content tables carry a
+   `workspaceId` foreign key or derive their scope through a parent with
+   enforced foreign keys. Queries apply tenant predicates before data is
+   returned; PostgreSQL RLS provides an independent enforcement layer.
 
 2. **Organization boundary.** The `workspaceAccessMacro`
    verifies that the workspace belongs to the caller's active
@@ -49,9 +48,10 @@ by default.
    uses TLS. S3 presigned URLs are generated with HTTPS
    endpoints.
 
-4. **Encryption at rest.** S3 objects use server-side
-   encryption (SSE). The database uses encrypted storage
-   volumes.
+4. **Encryption at rest.** Deployed database and S3-compatible storage
+   must use provider-side encryption. Extracted document text and stored
+   provider credentials additionally use application-layer encryption in
+   deployed environments.
 
 5. **Short-lived access.** Presigned URLs for file downloads
    expire after 15 minutes
@@ -82,8 +82,8 @@ by default.
     credentials, API keys) are stored in environment variables,
     never in source code or configuration files.
 
-11. **Local secret scanning.** Developers who opt into
-    Lefthook pre-commit hooks get a staged Gitleaks scan that
+11. **Local secret scanning.** Developers who install the repository
+    Lefthook hooks get a staged Gitleaks scan that
     blocks commits containing candidate credentials or tokens.
 
 12. **No secrets in logs.** Error handlers and logging

--- a/docs/policies/data-retention.md
+++ b/docs/policies/data-retention.md
@@ -94,6 +94,15 @@ If the database transaction fails after an S3 object has been
 written, the orphaned S3 object is immediately deleted in the
 error handler.
 
+### Template deletion
+
+Handler: `apps/api/src/handlers/templates/delete.ts`
+
+1. Collect the current and historical template object keys.
+2. Delete the deduplicated S3 keys with bounded concurrency.
+3. Delete the template row and record the audit event in one database
+   transaction. Cascade FKs remove its version rows.
+
 ## S3 object lifecycle
 
 - **ACL:** `private` (no public access).
@@ -123,8 +132,8 @@ content. Deletion is immediate and irreversible upon request.
   soft-delete columns in the schema.
 - Cascade and restrict FK constraints are defined in
   `apps/api/src/db/schema/` and enforced by PostgreSQL.
-- S3 cleanup is integrated into every deletion handler;
-  orphan-prevention logic is tested.
+- Deletion flows that own S3 objects await bounded cleanup before removing
+  their database references.
 
 ## Review
 

--- a/docs/policies/data-retention.md
+++ b/docs/policies/data-retention.md
@@ -1,7 +1,7 @@
 # Data Retention and Deletion Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-02-22
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual
 
 ## Purpose
@@ -19,20 +19,23 @@ views, and associated metadata.
 
 ## Principles
 
+<!-- evidence: retention-hard-delete -->
+
 1. **Hard deletes only.** The schema contains no `deletedAt`,
    `isDeleted`, or soft-delete columns. When a user or
    administrator deletes a resource, the corresponding rows
    and objects are permanently removed.
 
-2. **Cascade by design.** Foreign key constraints in the
-   database schema (`apps/api/src/db/schema.ts`) enforce
+2. **Cascade by design.** Foreign key constraints in the modular
+   database schema (`apps/api/src/db/schema/`) enforce
    referential integrity during deletion. Parent resources
    cascade-delete their children automatically.
 
-3. **Storage cleanup.** S3 objects are deleted before the
-   database transaction runs. If S3 deletion fails, the
-   database transaction is not attempted, allowing a safe
-   retry without orphaned records.
+3. **Storage cleanup.** Deletion handlers remove referenced S3 objects
+   and database rows rather than leaving inaccessible objects behind.
+   Cross-store deletion is retriable when object removal fails; it is not
+   a single atomic transaction, so operators must treat a later database
+   failure as a reconciliation event.
 
 ## Deletion flows
 
@@ -41,7 +44,7 @@ views, and associated metadata.
 Handler: `apps/api/src/handlers/entities/delete.ts`
 
 1. Query all files referenced by the entity's versions.
-2. Delete S3 objects in batches of 1,000.
+2. Delete deduplicated S3 keys with bounded concurrency.
 3. Within a database transaction: delete the entity row.
    Cascade FKs remove `entityVersions`, `fields`, and
    `justifications`. Orphaned `files` rows are then deleted
@@ -72,7 +75,7 @@ Handler: `apps/api/src/handlers/workspaces/delete-by-id.ts`
 1. Set workspace status to `"deleting"`, which gates all
    new uploads and actor connections.
 2. Query all files in the workspace.
-3. Delete S3 objects in batches.
+3. Delete S3 objects with bounded concurrency.
 4. Within a transaction:
    - Delete `propertyDependencies` targeting workspace
      properties (required because restrict FKs block cascade).
@@ -85,7 +88,7 @@ Handler: `apps/api/src/handlers/workspaces/delete-by-id.ts`
 
 ### Upload failure cleanup
 
-Handler: `apps/api/src/handlers/entities/upload.ts`
+Handler family: `apps/api/src/handlers/uploads/`
 
 If the database transaction fails after an S3 object has been
 written, the orphaned S3 object is immediately deleted in the
@@ -94,13 +97,14 @@ error handler.
 ## S3 object lifecycle
 
 - **ACL:** `private` (no public access).
-- **Deletion method:** AWS `DeleteObjectsCommand`, batched at
-  1,000 objects per request.
-- **Idempotency:** Deleting an already-removed object is
-  treated as a success (no error on 404).
-- **Ordering:** S3 cleanup runs before the database
-  transaction. This ensures that if S3 fails, the database
-  remains consistent and the operation can be retried.
+- **Deletion method:** Bun `S3Client.delete()`, issued with at most
+  50 object deletions in flight.
+- **Idempotency:** Repeated deletion of an absent object is treated as a
+  successful cleanup by supported S3-compatible providers.
+- **Ordering:** Object cleanup currently precedes the database delete so
+  an object-store failure leaves the database record available for retry.
+  A later database failure requires reconciliation because object storage
+  cannot participate in the PostgreSQL transaction.
 
 ## Retention periods
 
@@ -108,7 +112,6 @@ error handler.
 | ----------------------------------- | ------------------------------------------------------------ |
 | Workspace content (entities, files) | Until explicitly deleted by the user or workspace owner      |
 | User sessions                       | Managed by `better-auth`; sessions expire per configured TTL |
-| CI/CD artifacts (SBOM)              | 365 days (GitHub Actions retention)                          |
 | Application logs                    | Per hosting provider retention policy                        |
 
 Stella does not impose minimum retention periods on user
@@ -119,7 +122,7 @@ content. Deletion is immediate and irreversible upon request.
 - Hard-delete behaviour is enforced by the absence of
   soft-delete columns in the schema.
 - Cascade and restrict FK constraints are defined in
-  `apps/api/src/db/schema.ts` and enforced by PostgreSQL.
+  `apps/api/src/db/schema/` and enforced by PostgreSQL.
 - S3 cleanup is integrated into every deletion handler;
   orphan-prevention logic is tested.
 

--- a/docs/policies/evidence.json
+++ b/docs/policies/evidence.json
@@ -1,0 +1,225 @@
+{
+  "version": 1,
+  "controls": [
+    {
+      "id": "access-auth-boundary",
+      "policy": "docs/policies/access-control.md",
+      "evidence": [
+        {
+          "path": "apps/api/src/lib/auth.ts",
+          "contains": [
+            "export const authMacro",
+            "export const workspaceAccessMacro"
+          ]
+        },
+        {
+          "path": "apps/api/src/lib/branded-types.ts",
+          "contains": ["export type SafeId"]
+        }
+      ]
+    },
+    {
+      "id": "access-branch-protection",
+      "policy": "docs/policies/access-control.md",
+      "evidence": [
+        {
+          "path": ".github/branch-protection/ruleset-main.json",
+          "contains": [
+            "\"required_approving_review_count\": 1",
+            "\"context\": \"ci-result\"",
+            "\"context\": \"dependency-review\""
+          ]
+        },
+        {
+          "path": ".github/workflows/audit-branch-protection.yml",
+          "contains": ["name: Audit Branch Protection"]
+        }
+      ]
+    },
+    {
+      "id": "asset-provenance-inventory",
+      "policy": "docs/policies/asset-management.md",
+      "evidence": [
+        {
+          "path": ".provenance.yml",
+          "contains": [
+            "output_dir: provenance",
+            "id: root",
+            "id: desktop-tauri"
+          ]
+        },
+        {
+          "path": ".github/workflows/provenance-nightly.yml",
+          "contains": ["name: Provenance Nightly", "provenance-update.yml@"]
+        }
+      ]
+    },
+    {
+      "id": "asset-dependency-quarantine",
+      "policy": "docs/policies/asset-management.md",
+      "evidence": [
+        {
+          "path": "bunfig.toml",
+          "contains": ["minimumReleaseAge = 432_000"]
+        },
+        {
+          "path": ".github/dependabot.yml",
+          "contains": [
+            "package-ecosystem: \"bun\"",
+            "interval: \"weekly\"",
+            "default-days: 5"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "change-ci-gate",
+      "policy": "docs/policies/change-management.md",
+      "evidence": [
+        {
+          "path": ".github/workflows/ci.yml",
+          "contains": [
+            "name: CI Checks",
+            "name: Policy evidence",
+            "name: Format",
+            "name: Typecheck",
+            "name: Test"
+          ]
+        },
+        {
+          "path": "scripts/verify.sh",
+          "contains": [
+            "run_step \"Lint\"",
+            "run_step \"Policy evidence\"",
+            "run_step \"Format\"",
+            "run_step \"Typecheck\"",
+            "run_step \"Test\""
+          ]
+        }
+      ]
+    },
+    {
+      "id": "change-migration-gate",
+      "policy": "docs/policies/change-management.md",
+      "evidence": [
+        {
+          "path": ".github/workflows/db-migrations.yml",
+          "contains": [
+            "name: Database Migrations",
+            "Apply all migrations to fresh Postgres",
+            "Verify schema parity with schema.ts"
+          ]
+        },
+        {
+          "path": "scripts/check-migrations.sh",
+          "contains": [
+            "Database schema changed without a migration file",
+            "check-migration-safety.ts"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "classification-object-storage",
+      "policy": "docs/policies/data-classification.md",
+      "evidence": [
+        {
+          "path": "apps/api/src/lib/s3.ts",
+          "contains": ["acl: \"private\""]
+        },
+        {
+          "path": "apps/api/src/handlers/files/utils.ts",
+          "contains": [
+            "`${organizationId}/${workspaceId}/${fileId}",
+            "export const createFileKey"
+          ]
+        },
+        {
+          "path": "apps/api/src/handlers/uploads/lib.ts",
+          "contains": ["PRESIGN_URL_EXPIRY_SECONDS = 5 * 60"]
+        }
+      ]
+    },
+    {
+      "id": "retention-hard-delete",
+      "policy": "docs/policies/data-retention.md",
+      "evidence": [
+        {
+          "path": "apps/api/src/handlers/entities/delete.ts",
+          "contains": ["deleteS3Objects", ".delete(entities)"]
+        },
+        {
+          "path": "apps/api/src/handlers/workspaces/delete-by-id.ts",
+          "contains": ["status: \"deleting\"", ".delete(workspaces)"]
+        }
+      ]
+    },
+    {
+      "id": "vendor-provider-abstraction",
+      "policy": "docs/policies/vendor-management.md",
+      "evidence": [
+        {
+          "path": "apps/api/src/lib/tanstack-ai-models.ts",
+          "contains": [
+            "export const requireTanStackAIAvailableForRole",
+            "switch (config.provider)"
+          ]
+        },
+        {
+          "path": "package.json",
+          "contains": [
+            "\"@tanstack/ai\"",
+            "\"@tanstack/ai-anthropic\"",
+            "\"@tanstack/ai-openai\""
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vendor-supply-chain",
+      "policy": "docs/policies/vendor-management.md",
+      "evidence": [
+        {
+          "path": ".github/workflows/dependency-review.yml",
+          "contains": ["fail-on-severity: high", "allow-licenses: >-"]
+        },
+        {
+          "path": ".github/dependabot.yml",
+          "contains": ["default-days: 5"]
+        }
+      ]
+    },
+    {
+      "id": "vulnerability-static-analysis",
+      "policy": "docs/policies/vulnerability-mgmt.md",
+      "evidence": [
+        {
+          "path": ".github/workflows/codeql.yml",
+          "contains": ["name: CodeQL", "pull_request:", "schedule:"]
+        },
+        {
+          "path": "oxlint.config.ts",
+          "contains": ["security-guards"]
+        }
+      ]
+    },
+    {
+      "id": "vulnerability-disclosure",
+      "policy": "docs/policies/vulnerability-mgmt.md",
+      "evidence": [
+        {
+          "path": "SECURITY.md",
+          "contains": [
+            "security@stll.app",
+            "within 48 hours",
+            "within 7 business days"
+          ]
+        },
+        {
+          "path": "apps/web/public/.well-known/security.txt",
+          "contains": ["Contact: mailto:security@stll.app"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/policies/evidence.json
+++ b/docs/policies/evidence.json
@@ -137,6 +137,10 @@
         {
           "path": "apps/api/src/handlers/uploads/lib.ts",
           "contains": ["PRESIGN_URL_EXPIRY_SECONDS = 5 * 60"]
+        },
+        {
+          "path": "apps/api/src/handlers/files/read-by-id.ts",
+          "contains": ["FILE_READ_URL_EXPIRY_SECONDS = 15 * 60"]
         }
       ]
     },

--- a/docs/policies/vendor-management.md
+++ b/docs/policies/vendor-management.md
@@ -1,7 +1,7 @@
 # Vendor and Third-Party Management Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-05-01
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual
 
 ## Purpose
@@ -42,32 +42,31 @@ service SDKs (AI providers, email, analytics, storage).
 
 ### Supply-chain integrity
 
+<!-- evidence: vendor-supply-chain -->
+
 4. **Pinned versions.** All GitHub Actions are referenced by
    full commit SHA in workflow files. The Docker base image is
    pinned by SHA-256 digest. npm dependencies are locked via
    `bun.lock`.
 
-5. **Cooldown period.** Dependabot is configured with a 3-day
+5. **Cooldown period.** Dependabot is configured with a five-day
    cooldown (`open-pull-requests-limit` and schedule
    settings in `.github/dependabot.yml`) before proposing
    updates, reducing exposure to compromised releases that
    are quickly retracted.
 
-6. **Automated updates.** Dependabot submits PRs for outdated
-   dependencies on a defined cadence: daily for runtime
-   packages, weekly for GitHub Actions and Docker images.
+6. **Automated updates.** Dependabot checks Bun packages, GitHub
+   Actions, Docker images, and Cargo crates weekly.
    Updates pass through the same CI gate as any other PR.
 
 ### Inventory and transparency
 
-7. **SBOM.** A CycloneDX 1.6 SBOM (`sbom.cdx.json`) is
-   generated on every dependency change and committed to the
-   repository, providing a machine-readable inventory of all
-   third-party components with PURLs and license metadata.
+7. **SBOM.** CycloneDX inventories are committed under
+   `provenance/projects/`, providing machine-readable component,
+   package-URL, and license metadata for configured projects.
 
-8. **Third-party notices.** `THIRD-PARTY-NOTICES.txt` contains
-   the full license text of every dependency, regenerated
-   automatically alongside the SBOM.
+8. **Third-party notices.** Project and repository notice files under
+   `provenance/` are regenerated alongside the SBOMs.
 
 9. **Dependency grouping.** Dependabot groups related packages
    (e.g., TanStack, TipTap, Drizzle, Elysia) into single PRs,
@@ -85,8 +84,10 @@ service SDKs (AI providers, email, analytics, storage).
 
 ### Provider abstraction
 
-12. **AI provider independence.** AI features use the Vercel
-    AI SDK, which abstracts the underlying model provider.
+<!-- evidence: vendor-provider-abstraction -->
+
+12. **AI provider independence.** AI features use TanStack AI behind
+    Stella's model-role resolver, which abstracts the underlying provider.
     The provider is selectable via configuration, enabling
     failover or migration without rewriting business logic.
 
@@ -99,8 +100,7 @@ service SDKs (AI providers, email, analytics, storage).
 - `dependency-review` is a required status check on `main`;
   PRs introducing blocked licenses or high-severity CVEs
   cannot merge.
-- SBOM generation is automated; no manual inventory
-  maintenance is required.
+- Provenance refreshes are automated and reviewed as pull requests.
 - Pinned SHAs and digests are reviewed during workflow PR
   review; `CODEOWNERS` assigns `.github/` changes to an admin
   reviewer.

--- a/docs/policies/vendor-management.md
+++ b/docs/policies/vendor-management.md
@@ -50,10 +50,9 @@ service SDKs (AI providers, email, analytics, storage).
    `bun.lock`.
 
 5. **Cooldown period.** Dependabot is configured with a five-day
-   cooldown (`open-pull-requests-limit` and schedule
-   settings in `.github/dependabot.yml`) before proposing
-   updates, reducing exposure to compromised releases that
-   are quickly retracted.
+   cooldown (`cooldown.default-days` in `.github/dependabot.yml`)
+   before proposing updates, reducing exposure to compromised
+   releases that are quickly retracted.
 
 6. **Automated updates.** Dependabot checks Bun packages, GitHub
    Actions, Docker images, and Cargo crates weekly.

--- a/docs/policies/vulnerability-mgmt.md
+++ b/docs/policies/vulnerability-mgmt.md
@@ -1,7 +1,7 @@
 # Vulnerability Management Policy
 
 **Owner:** Engineering
-**Last reviewed:** 2026-05-01
+**Last reviewed:** 2026-07-10
 **Review cadence:** Annual
 
 ## Purpose
@@ -19,6 +19,8 @@ built from the repository.
 ## Controls
 
 ### Static analysis
+
+<!-- evidence: vulnerability-static-analysis -->
 
 1. **CodeQL.** The `codeql.yml` workflow runs GitHub's
    semantic code analysis on every push to `main`, on every
@@ -39,8 +41,8 @@ built from the repository.
 ### Dependency scanning
 
 4. **Dependabot.** Automated dependency update PRs are
-   submitted weekly for Bun packages, GitHub Actions, and
-   Docker base images (`.github/dependabot.yml`). A 5-day
+   submitted weekly for Bun packages, GitHub Actions,
+   Docker base images, and Cargo crates (`.github/dependabot.yml`). A five-day
    cooldown prevents adopting updates that are immediately
    retracted.
 
@@ -63,6 +65,8 @@ built from the repository.
    This prevents supply-chain attacks via tag mutation.
 
 ### Vulnerability disclosure
+
+<!-- evidence: vulnerability-disclosure -->
 
 8. **SECURITY.md.** The repository publishes a security policy
    (`SECURITY.md`) with:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typegen": "turbo run typegen",
     "typecheck": "turbo run typecheck",
     "secrets:check:staged": "bash scripts/check-staged-secrets.sh",
+    "policies:check": "bun test scripts/check-policy-evidence.test.ts && bun scripts/check-policy-evidence.ts",
     "sync-ai": "bash scripts/sync-ai-skills.sh",
     "sync-ai:check": "bash scripts/sync-ai-skills.sh --check",
     "link-codex": "bash scripts/link-codex-skills.sh",

--- a/scripts/check-policy-evidence.test.ts
+++ b/scripts/check-policy-evidence.test.ts
@@ -97,4 +97,20 @@ describe("policy evidence guard", () => {
       "controls[0].evidence[0].path must be a repository-relative path",
     );
   });
+
+  test("reports a missing policies directory instead of throwing", () => {
+    const root = createFixture();
+    writeFileSync(
+      join(root, "evidence.json"),
+      readFileSync(join(root, "docs/policies/evidence.json"), "utf8"),
+    );
+    rmSync(join(root, "docs/policies"), { recursive: true });
+
+    const result = checkPolicyEvidence({
+      manifestPath: "evidence.json",
+      rootDir: root,
+    });
+
+    expect(result.errors).toContain("missing docs/policies directory");
+  });
 });

--- a/scripts/check-policy-evidence.test.ts
+++ b/scripts/check-policy-evidence.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkPolicyEvidence } from "./check-policy-evidence";
+
+const testRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of testRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+const createFixture = ({
+  evidenceSource = "export const authMacro = true;",
+  marker = "auth-boundary",
+}: {
+  evidenceSource?: string;
+  marker?: string;
+} = {}) => {
+  const root = mkdtempSync(join(tmpdir(), "stella-policy-evidence-"));
+  testRoots.push(root);
+  mkdirSync(join(root, "docs/policies"), { recursive: true });
+  mkdirSync(join(root, "apps/api/src/lib"), { recursive: true });
+  writeFileSync(
+    join(root, "docs/policies/access-control.md"),
+    `# Access control\n\n<!-- evidence: ${marker} -->\n`,
+  );
+  writeFileSync(join(root, "apps/api/src/lib/auth.ts"), evidenceSource);
+  writeFileSync(
+    join(root, "docs/policies/evidence.json"),
+    JSON.stringify({
+      version: 1,
+      controls: [
+        {
+          id: "auth-boundary",
+          policy: "docs/policies/access-control.md",
+          evidence: [
+            {
+              path: "apps/api/src/lib/auth.ts",
+              contains: ["export const authMacro"],
+            },
+          ],
+        },
+      ],
+    }),
+  );
+  return root;
+};
+
+describe("policy evidence guard", () => {
+  test("accepts a policy marker backed by matching source evidence", () => {
+    const result = checkPolicyEvidence({ rootDir: createFixture() });
+    expect(result.errors).toEqual([]);
+  });
+
+  test("reports implementation drift at the missing source assertion", () => {
+    const root = createFixture({
+      evidenceSource: "export const other = true;",
+    });
+    const result = checkPolicyEvidence({ rootDir: root });
+    expect(result.errors).toContain(
+      'auth-boundary: apps/api/src/lib/auth.ts no longer contains "export const authMacro"',
+    );
+  });
+
+  test("reports policy markers that are stale or unregistered", () => {
+    const root = createFixture({ marker: "removed-control" });
+    const result = checkPolicyEvidence({ rootDir: root });
+    expect(result.errors).toContain(
+      "auth-boundary: docs/policies/access-control.md is missing <!-- evidence: auth-boundary -->",
+    );
+    expect(result.errors).toContain(
+      "docs/policies/access-control.md references unknown evidence control removed-control",
+    );
+  });
+
+  test("rejects evidence paths outside the repository", () => {
+    const root = createFixture();
+    const manifestPath = join(root, "docs/policies/evidence.json");
+    const manifest = readFileSync(manifestPath, "utf8").replace(
+      "apps/api/src/lib/auth.ts",
+      "../../outside.txt",
+    );
+    writeFileSync(manifestPath, manifest);
+
+    const result = checkPolicyEvidence({ rootDir: root });
+    expect(result.errors).toContain(
+      "controls[0].evidence[0].path must be a repository-relative path",
+    );
+  });
+});

--- a/scripts/check-policy-evidence.test.ts
+++ b/scripts/check-policy-evidence.test.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import nodePath from "node:path";
 
 import { checkPolicyEvidence } from "./check-policy-evidence";
 
@@ -26,17 +26,20 @@ const createFixture = ({
   evidenceSource?: string;
   marker?: string;
 } = {}) => {
-  const root = mkdtempSync(join(tmpdir(), "stella-policy-evidence-"));
+  const root = mkdtempSync(nodePath.join(tmpdir(), "stella-policy-evidence-"));
   testRoots.push(root);
-  mkdirSync(join(root, "docs/policies"), { recursive: true });
-  mkdirSync(join(root, "apps/api/src/lib"), { recursive: true });
+  mkdirSync(nodePath.join(root, "docs/policies"), { recursive: true });
+  mkdirSync(nodePath.join(root, "apps/api/src/lib"), { recursive: true });
   writeFileSync(
-    join(root, "docs/policies/access-control.md"),
+    nodePath.join(root, "docs/policies/access-control.md"),
     `# Access control\n\n<!-- evidence: ${marker} -->\n`,
   );
-  writeFileSync(join(root, "apps/api/src/lib/auth.ts"), evidenceSource);
   writeFileSync(
-    join(root, "docs/policies/evidence.json"),
+    nodePath.join(root, "apps/api/src/lib/auth.ts"),
+    evidenceSource,
+  );
+  writeFileSync(
+    nodePath.join(root, "docs/policies/evidence.json"),
     JSON.stringify({
       version: 1,
       controls: [
@@ -85,8 +88,8 @@ describe("policy evidence guard", () => {
 
   test("rejects evidence paths outside the repository", () => {
     const root = createFixture();
-    const manifestPath = join(root, "docs/policies/evidence.json");
-    const manifest = readFileSync(manifestPath, "utf8").replace(
+    const manifestPath = nodePath.join(root, "docs/policies/evidence.json");
+    const manifest = readFileSync(manifestPath, "utf-8").replace(
       "apps/api/src/lib/auth.ts",
       "../../outside.txt",
     );
@@ -101,10 +104,10 @@ describe("policy evidence guard", () => {
   test("reports a missing policies directory instead of throwing", () => {
     const root = createFixture();
     writeFileSync(
-      join(root, "evidence.json"),
-      readFileSync(join(root, "docs/policies/evidence.json"), "utf8"),
+      nodePath.join(root, "evidence.json"),
+      readFileSync(nodePath.join(root, "docs/policies/evidence.json"), "utf-8"),
     );
-    rmSync(join(root, "docs/policies"), { recursive: true });
+    rmSync(nodePath.join(root, "docs/policies"), { recursive: true });
 
     const result = checkPolicyEvidence({
       manifestPath: "evidence.json",

--- a/scripts/check-policy-evidence.ts
+++ b/scripts/check-policy-evidence.ts
@@ -212,10 +212,18 @@ export const checkPolicyEvidence = ({
   }
 
   const policiesDir = resolve(rootDir, "docs/policies");
-  const policyFiles = readdirSync(policiesDir)
-    .filter((name) => name.endsWith(".md"))
-    .map((name) => `docs/policies/${name}`)
-    .sort();
+  let policyFiles: string[];
+  try {
+    policyFiles = readdirSync(policiesDir)
+      .filter((name) => name.endsWith(".md"))
+      .map((name) => `docs/policies/${name}`)
+      .sort();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { errors: [...errors, "missing docs/policies directory"] };
+    }
+    throw error;
+  }
   for (const policy of policyFiles) {
     const source = readFileSync(resolve(rootDir, policy), "utf8");
     const markers = collectPolicyMarkers(source);

--- a/scripts/check-policy-evidence.ts
+++ b/scripts/check-policy-evidence.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env bun
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
+import nodePath from "node:path";
 
 const DEFAULT_MANIFEST_PATH = "docs/policies/evidence.json";
-const POLICY_MARKER_PATTERN = /<!--\s*evidence:\s*([a-z0-9-]+)\s*-->/gu;
+const POLICY_MARKER_PATTERN =
+  /<!--\s*evidence:\s*(?<controlId>[a-z0-9-]+)\s*-->/gu;
 
 type EvidenceFile = {
   path: string;
@@ -138,7 +139,9 @@ const parseManifest = (
 };
 
 const collectPolicyMarkers = (source: string): string[] =>
-  [...source.matchAll(POLICY_MARKER_PATTERN)].map((match) => match[1] ?? "");
+  [...source.matchAll(POLICY_MARKER_PATTERN)].map(
+    ({ groups }) => groups?.["controlId"] ?? "",
+  );
 
 export const checkPolicyEvidence = ({
   manifestPath = DEFAULT_MANIFEST_PATH,
@@ -148,14 +151,14 @@ export const checkPolicyEvidence = ({
   rootDir: string;
 }): PolicyEvidenceCheckResult => {
   const errors: string[] = [];
-  const absoluteManifestPath = resolve(rootDir, manifestPath);
+  const absoluteManifestPath = nodePath.resolve(rootDir, manifestPath);
   if (!existsSync(absoluteManifestPath)) {
     return { errors: [`missing policy evidence manifest: ${manifestPath}`] };
   }
 
   let rawManifest: unknown;
   try {
-    rawManifest = JSON.parse(readFileSync(absoluteManifestPath, "utf8"));
+    rawManifest = JSON.parse(readFileSync(absoluteManifestPath, "utf-8"));
   } catch (error) {
     return {
       errors: [
@@ -182,12 +185,12 @@ export const checkPolicyEvidence = ({
     policyMarkers.add(control.id);
     manifestMarkersByPolicy.set(control.policy, policyMarkers);
 
-    const policyPath = resolve(rootDir, control.policy);
+    const policyPath = nodePath.resolve(rootDir, control.policy);
     if (!existsSync(policyPath)) {
       errors.push(`${control.id}: missing policy file ${control.policy}`);
       continue;
     }
-    const policySource = readFileSync(policyPath, "utf8");
+    const policySource = readFileSync(policyPath, "utf-8");
     if (!collectPolicyMarkers(policySource).includes(control.id)) {
       errors.push(
         `${control.id}: ${control.policy} is missing <!-- evidence: ${control.id} -->`,
@@ -195,12 +198,12 @@ export const checkPolicyEvidence = ({
     }
 
     for (const evidence of control.evidence) {
-      const evidencePath = resolve(rootDir, evidence.path);
+      const evidencePath = nodePath.resolve(rootDir, evidence.path);
       if (!existsSync(evidencePath)) {
         errors.push(`${control.id}: missing evidence file ${evidence.path}`);
         continue;
       }
-      const source = readFileSync(evidencePath, "utf8");
+      const source = readFileSync(evidencePath, "utf-8");
       for (const expected of evidence.contains) {
         if (!source.includes(expected)) {
           errors.push(
@@ -211,7 +214,7 @@ export const checkPolicyEvidence = ({
     }
   }
 
-  const policiesDir = resolve(rootDir, "docs/policies");
+  const policiesDir = nodePath.resolve(rootDir, "docs/policies");
   let policyFiles: string[];
   try {
     policyFiles = readdirSync(policiesDir)
@@ -225,7 +228,7 @@ export const checkPolicyEvidence = ({
     throw error;
   }
   for (const policy of policyFiles) {
-    const source = readFileSync(resolve(rootDir, policy), "utf8");
+    const source = readFileSync(nodePath.resolve(rootDir, policy), "utf-8");
     const markers = collectPolicyMarkers(source);
     if (markers.length === 0) {
       errors.push(`${policy} has no executable evidence marker`);

--- a/scripts/check-policy-evidence.ts
+++ b/scripts/check-policy-evidence.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const DEFAULT_MANIFEST_PATH = "docs/policies/evidence.json";
+const POLICY_MARKER_PATTERN = /<!--\s*evidence:\s*([a-z0-9-]+)\s*-->/gu;
+
+type EvidenceFile = {
+  path: string;
+  contains: string[];
+};
+
+type PolicyControl = {
+  id: string;
+  policy: string;
+  evidence: EvidenceFile[];
+};
+
+type PolicyEvidenceManifest = {
+  version: 1;
+  controls: PolicyControl[];
+};
+
+export type PolicyEvidenceCheckResult = {
+  errors: string[];
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isRepositoryPath = (value: string): boolean =>
+  !value.startsWith("/") &&
+  !value.includes("\\") &&
+  value
+    .split("/")
+    .every((segment) => segment !== "" && segment !== "." && segment !== "..");
+
+const readStringArray = (
+  value: unknown,
+  field: string,
+  errors: string[],
+): string[] => {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((item) => typeof item !== "string" || item.length === 0)
+  ) {
+    errors.push(`${field} must be a non-empty array of non-empty strings`);
+    return [];
+  }
+  return value;
+};
+
+const parseManifest = (
+  raw: unknown,
+): { errors: string[]; manifest: PolicyEvidenceManifest | null } => {
+  const errors: string[] = [];
+  if (!isRecord(raw) || raw["version"] !== 1) {
+    return {
+      errors: ["policy evidence manifest must be an object with version 1"],
+      manifest: null,
+    };
+  }
+
+  const rawControls = raw["controls"];
+  if (!Array.isArray(rawControls) || rawControls.length === 0) {
+    return {
+      errors: ["policy evidence manifest must contain at least one control"],
+      manifest: null,
+    };
+  }
+
+  const controls: PolicyControl[] = [];
+  for (const [controlIndex, rawControl] of rawControls.entries()) {
+    const prefix = `controls[${controlIndex}]`;
+    if (!isRecord(rawControl)) {
+      errors.push(`${prefix} must be an object`);
+      continue;
+    }
+
+    const id = rawControl["id"];
+    const policy = rawControl["policy"];
+    const rawEvidence = rawControl["evidence"];
+    if (typeof id !== "string" || !/^[a-z0-9-]+$/u.test(id)) {
+      errors.push(`${prefix}.id must use lowercase kebab-case`);
+      continue;
+    }
+    if (
+      typeof policy !== "string" ||
+      !isRepositoryPath(policy) ||
+      !policy.startsWith("docs/policies/") ||
+      !policy.endsWith(".md")
+    ) {
+      errors.push(`${prefix}.policy must point to docs/policies/*.md`);
+      continue;
+    }
+    if (!Array.isArray(rawEvidence) || rawEvidence.length === 0) {
+      errors.push(`${prefix}.evidence must contain at least one file`);
+      continue;
+    }
+
+    const evidence: EvidenceFile[] = [];
+    for (const [evidenceIndex, rawFile] of rawEvidence.entries()) {
+      const evidencePrefix = `${prefix}.evidence[${evidenceIndex}]`;
+      if (!isRecord(rawFile)) {
+        errors.push(`${evidencePrefix} must be an object`);
+        continue;
+      }
+      const path = rawFile["path"];
+      if (
+        typeof path !== "string" ||
+        path.length === 0 ||
+        !isRepositoryPath(path)
+      ) {
+        errors.push(
+          `${evidencePrefix}.path must be a repository-relative path`,
+        );
+        continue;
+      }
+      evidence.push({
+        path,
+        contains: readStringArray(
+          rawFile["contains"],
+          `${evidencePrefix}.contains`,
+          errors,
+        ),
+      });
+    }
+
+    controls.push({ id, policy, evidence });
+  }
+
+  return {
+    errors,
+    manifest: errors.length === 0 ? { version: 1, controls } : null,
+  };
+};
+
+const collectPolicyMarkers = (source: string): string[] =>
+  [...source.matchAll(POLICY_MARKER_PATTERN)].map((match) => match[1] ?? "");
+
+export const checkPolicyEvidence = ({
+  manifestPath = DEFAULT_MANIFEST_PATH,
+  rootDir,
+}: {
+  manifestPath?: string;
+  rootDir: string;
+}): PolicyEvidenceCheckResult => {
+  const errors: string[] = [];
+  const absoluteManifestPath = resolve(rootDir, manifestPath);
+  if (!existsSync(absoluteManifestPath)) {
+    return { errors: [`missing policy evidence manifest: ${manifestPath}`] };
+  }
+
+  let rawManifest: unknown;
+  try {
+    rawManifest = JSON.parse(readFileSync(absoluteManifestPath, "utf8"));
+  } catch (error) {
+    return {
+      errors: [
+        `could not parse ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`,
+      ],
+    };
+  }
+
+  const parsed = parseManifest(rawManifest);
+  if (!parsed.manifest) {
+    return { errors: parsed.errors };
+  }
+
+  const ids = new Set<string>();
+  const manifestMarkersByPolicy = new Map<string, Set<string>>();
+  for (const control of parsed.manifest.controls) {
+    if (ids.has(control.id)) {
+      errors.push(`duplicate control id: ${control.id}`);
+    }
+    ids.add(control.id);
+
+    const policyMarkers =
+      manifestMarkersByPolicy.get(control.policy) ?? new Set();
+    policyMarkers.add(control.id);
+    manifestMarkersByPolicy.set(control.policy, policyMarkers);
+
+    const policyPath = resolve(rootDir, control.policy);
+    if (!existsSync(policyPath)) {
+      errors.push(`${control.id}: missing policy file ${control.policy}`);
+      continue;
+    }
+    const policySource = readFileSync(policyPath, "utf8");
+    if (!collectPolicyMarkers(policySource).includes(control.id)) {
+      errors.push(
+        `${control.id}: ${control.policy} is missing <!-- evidence: ${control.id} -->`,
+      );
+    }
+
+    for (const evidence of control.evidence) {
+      const evidencePath = resolve(rootDir, evidence.path);
+      if (!existsSync(evidencePath)) {
+        errors.push(`${control.id}: missing evidence file ${evidence.path}`);
+        continue;
+      }
+      const source = readFileSync(evidencePath, "utf8");
+      for (const expected of evidence.contains) {
+        if (!source.includes(expected)) {
+          errors.push(
+            `${control.id}: ${evidence.path} no longer contains ${JSON.stringify(expected)}`,
+          );
+        }
+      }
+    }
+  }
+
+  const policiesDir = resolve(rootDir, "docs/policies");
+  const policyFiles = readdirSync(policiesDir)
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => `docs/policies/${name}`)
+    .sort();
+  for (const policy of policyFiles) {
+    const source = readFileSync(resolve(rootDir, policy), "utf8");
+    const markers = collectPolicyMarkers(source);
+    if (markers.length === 0) {
+      errors.push(`${policy} has no executable evidence marker`);
+      continue;
+    }
+    for (const marker of markers) {
+      if (!ids.has(marker)) {
+        errors.push(`${policy} references unknown evidence control ${marker}`);
+      }
+      if (!manifestMarkersByPolicy.get(policy)?.has(marker)) {
+        errors.push(
+          `${marker}: manifest points at a different policy than ${policy}`,
+        );
+      }
+    }
+  }
+
+  return { errors };
+};
+
+if (import.meta.main) {
+  const result = checkPolicyEvidence({ rootDir: process.cwd() });
+  if (result.errors.length > 0) {
+    for (const error of result.errors) {
+      console.error(`policy-evidence: ${error}`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    "policy-evidence: all controls match their implementation evidence",
+  );
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -175,6 +175,7 @@ run_test() {
 
 run_step "AI skill sync" bash scripts/sync-ai-skills.sh --check
 run_step "Workspace hygiene" bun run lint:ws
+run_step "Policy evidence" bun run policies:check
 run_step "Railway template shape" bun run check:railway-template
 run_step "i18n" bun run i18n:check
 run_step "Release changelog guard" bash scripts/check-release-changelog.sh --base "$base_ref"


### PR DESCRIPTION
## Summary

- correct policy statements that no longer matched current provenance, dependency, migration, storage, and AI implementations
- add a repository-relative evidence manifest with focused tests and a CI/local verification guard
- align database CODEOWNERS coverage with the documented review boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated policy evidence validation (`policies:check`) to confirm policy markers match referenced implementation evidence.
  * Introduced an evidence catalogue (`docs/policies/evidence.json`) linking each control to supporting files and required excerpts.
* **Documentation**
  * Refreshed multiple policy documents (access control, asset management, change management, data classification/retention, vendor and vulnerability management) including updated “Last reviewed” dates and clarified security/inventory and deletion semantics.
* **CI Improvements**
  * Added a “Policy evidence” gate to CI/verification to catch policy-to-implementation drift earlier.  
* **Chores**
  * Updated CODEOWNERS to include database-focused ownership guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->