### PR TITLE
fix: cover safe-handler database loops

### DIFF
--- a/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
@@ -117,11 +117,13 @@ export const resultAwaitPromiseAllMapFanOut = async function* () {
   // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- fixture: safe handlers may delegate a Promise.all fan-out through Result.await
   yield* Result.await(
     Promise.all(
-      items.map(async (item) =>
-        safeDb(async (scopedTx: typeof tx) => {
-          const result = await scopedTx.insert(itemsTable).values(item);
-          return result;
-        }),
+      items.map(
+        // oxlint-disable-next-line typescript/promise-function-async -- fixture: the awaitless callback proves Result.await fan-out detection does not depend on an inner AwaitExpression
+        (item) =>
+          safeDb(async (scopedTx: typeof tx) => {
+            const result = await scopedTx.insert(itemsTable).values(item);
+            return result;
+          }),
       ),
     ),
   );

--- a/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
@@ -117,13 +117,12 @@ export const resultAwaitPromiseAllMapFanOut = async function* () {
   // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- fixture: safe handlers may delegate a Promise.all fan-out through Result.await
   yield* Result.await(
     Promise.all(
-      items.map(async (item) => {
-        const inserted = await safeDb(async (scopedTx: typeof tx) => {
+      items.map(async (item) =>
+        safeDb(async (scopedTx: typeof tx) => {
           const result = await scopedTx.insert(itemsTable).values(item);
           return result;
-        });
-        return inserted;
-      }),
+        }),
+      ),
     ),
   );
 };

--- a/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
@@ -1,7 +1,8 @@
 // Passive regression fixture for `no-db-await-in-loop/no-db-await-in-loop`.
 //
 // Each `oxlint-disable-next-line` below intentionally suppresses a case the
-// rule MUST flag (a DB call awaited inside a loop body, or a fan-out via
+// rule MUST flag (a DB call awaited inside a loop body through native `await`
+// or `yield* Result.await(...)`, or a fan-out via
 // `Promise.all(items.map(...))` / `Promise.allSettled(items.map(...))`,
 // inline or via a named callback resolved to its local definition, awaited
 // or not). If the rule regresses, the matching disable goes unused and
@@ -24,6 +25,9 @@ declare const tx: {
   };
 };
 declare const safeDb: <T>(fn: (tx: unknown) => Promise<T>) => Promise<T>;
+declare const Result: {
+  await: <T>(promise: Promise<T>) => AsyncGenerator<never, T, unknown>;
+};
 declare const items: { id: string }[];
 declare const itemsTable: unknown;
 declare const idColumn: unknown;
@@ -54,6 +58,15 @@ export const whileLoopAwaitSafeDb = async () => {
     index += 1;
   }
   return results;
+};
+
+export const forOfLoopResultAwaitSafeDb = async function* () {
+  for (const item of items) {
+    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- fixture: safe handlers await DB results through delegated Result generators
+    yield* Result.await(
+      safeDb((scopedTx: typeof tx) => scopedTx.insert(itemsTable).values(item)),
+    );
+  }
 };
 
 export const promiseAllMapFanOut = async () => {
@@ -97,11 +110,32 @@ export const promiseAllSettledMapFanOut = async () => {
   );
 };
 
+export const resultAwaitPromiseAllMapFanOut = async function* () {
+  // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- fixture: safe handlers may delegate a Promise.all fan-out through Result.await
+  yield* Result.await(
+    Promise.all(
+      items.map((item) =>
+        safeDb((scopedTx: typeof tx) =>
+          scopedTx.insert(itemsTable).values(item),
+        ),
+      ),
+    ),
+  );
+};
+
 // --- Cases the rule MUST NOT flag ---
 
 // A single DB await outside any loop.
 export const singleAwaitOutsideLoop = async () => {
   await db.select().from(itemsTable).where(items[0]?.id);
+};
+
+export const singleResultAwaitOutsideLoop = async function* () {
+  yield* Result.await(
+    safeDb((scopedTx: typeof tx) =>
+      scopedTx.select().from(itemsTable).where(items[0]?.id),
+    ),
+  );
 };
 
 // Batched: one query for the whole loop's ids, built with `inArray` after

--- a/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-db-await-in-loop.fixture.ts
@@ -64,7 +64,10 @@ export const forOfLoopResultAwaitSafeDb = async function* () {
   for (const item of items) {
     // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- fixture: safe handlers await DB results through delegated Result generators
     yield* Result.await(
-      safeDb((scopedTx: typeof tx) => scopedTx.insert(itemsTable).values(item)),
+      safeDb(async (scopedTx: typeof tx) => {
+        const inserted = await scopedTx.insert(itemsTable).values(item);
+        return inserted;
+      }),
     );
   }
 };
@@ -114,11 +117,13 @@ export const resultAwaitPromiseAllMapFanOut = async function* () {
   // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop -- fixture: safe handlers may delegate a Promise.all fan-out through Result.await
   yield* Result.await(
     Promise.all(
-      items.map((item) =>
-        safeDb((scopedTx: typeof tx) =>
-          scopedTx.insert(itemsTable).values(item),
-        ),
-      ),
+      items.map(async (item) => {
+        const inserted = await safeDb(async (scopedTx: typeof tx) => {
+          const result = await scopedTx.insert(itemsTable).values(item);
+          return result;
+        });
+        return inserted;
+      }),
     ),
   );
 };
@@ -132,9 +137,13 @@ export const singleAwaitOutsideLoop = async () => {
 
 export const singleResultAwaitOutsideLoop = async function* () {
   yield* Result.await(
-    safeDb((scopedTx: typeof tx) =>
-      scopedTx.select().from(itemsTable).where(items[0]?.id),
-    ),
+    safeDb(async (scopedTx: typeof tx) => {
+      const selected = await scopedTx
+        .select()
+        .from(itemsTable)
+        .where(items[0]?.id);
+      return selected;
+    }),
   );
 };
 

--- a/.oxlint-plugins/no-db-await-in-loop.ts
+++ b/.oxlint-plugins/no-db-await-in-loop.ts
@@ -14,8 +14,11 @@
 //     call whose callee resolves to `safeDb` — bare (`safeDb(cb)`, common in
 //     `createSafeHandler` generators) or as a property access
 //     (`ctx.safeDb(cb)`, `context.safeDb(cb)`).
+//   - Safe handlers express the same operation as
+//     `yield* Result.await(safeDb(...))`; delegated `YieldExpression` nodes
+//     with that shape are treated as DB awaits too.
 //   - "Inside a loop" is found by walking up `parent` links from the
-//     `AwaitExpression`. The walk stops as soon as it reaches either:
+//     await/yield node. The walk stops as soon as it reaches either:
 //       1. A `for` / `for-of` / `for-in` / `while` / `do-while` node whose
 //          `body` is (an ancestor of) the await -> flag.
 //       2. A function boundary (function declaration/expression/arrow) ->
@@ -183,6 +186,25 @@ const isDbAwaitCall = (node: unknown): boolean => {
   }
   const root = getChainRootName(node);
   return root !== null && DB_ROOT_NAMES.has(root);
+};
+
+const getResultAwaitArgument = (node: unknown): unknown => {
+  if (getType(node) !== "CallExpression") {
+    return null;
+  }
+  const callee = getField(node, "callee");
+  if (
+    getType(callee) !== "MemberExpression" ||
+    isComputed(callee) ||
+    !isIdentifier(getField(callee, "object"), "Result") ||
+    getPropertyName(getField(callee, "property")) !== "await"
+  ) {
+    return null;
+  }
+  const args = getField(node, "arguments");
+  return Array.isArray(args) && args.length === 1
+    ? unwrapExpression(args[0])
+    : null;
 };
 
 // `<expr>.map(...)` / `.forEach(...)` / `.flatMap(...)`.
@@ -473,17 +495,35 @@ export default {
         },
       },
       create(context) {
+        const reportAwaitedExpression = (
+          node: unknown,
+          argument: unknown,
+        ): void => {
+          if (isDbAwaitCall(argument)) {
+            if (findLoopOrMapContext(node) !== null) {
+              context.report({ node, messageId: "noDbAwaitInLoop" });
+            }
+            return;
+          }
+          if (isPromiseAllMapFanOutWithDbCallback(argument)) {
+            context.report({ node, messageId: "noDbAwaitInLoop" });
+          }
+        };
+
         return {
           AwaitExpression(node: unknown) {
             const argument = unwrapExpression(getField(node, "argument"));
-            if (isDbAwaitCall(argument)) {
-              if (findLoopOrMapContext(node) !== null) {
-                context.report({ node, messageId: "noDbAwaitInLoop" });
-              }
+            reportAwaitedExpression(node, argument);
+          },
+          YieldExpression(node: unknown) {
+            if (getField(node, "delegate") !== true) {
               return;
             }
-            if (isPromiseAllMapFanOutWithDbCallback(argument)) {
-              context.report({ node, messageId: "noDbAwaitInLoop" });
+            const resultAwaitArgument = getResultAwaitArgument(
+              unwrapExpression(getField(node, "argument")),
+            );
+            if (resultAwaitArgument !== null) {
+              reportAwaitedExpression(node, resultAwaitArgument);
             }
           },
         };

--- a/apps/api/src/handlers/chat/delete-thread.ts
+++ b/apps/api/src/handlers/chat/delete-thread.ts
@@ -80,6 +80,8 @@ const deleteThread = createSafeRootHandler(
       if (lastFileId !== null) {
         conditions.push(gt(userFiles.id, lastFileId));
       }
+      // SAFETY: sequential keyset pagination keeps each cleanup page bounded; the next page depends on this cursor.
+      // eslint-disable-next-line no-db-await-in-loop
       const files = yield* Result.await(
         safeDb((tx) =>
           tx
@@ -125,6 +127,8 @@ const deleteThread = createSafeRootHandler(
         );
       }
 
+      // SAFETY: storage deletion must succeed before the corresponding bounded page of rows is removed.
+      // eslint-disable-next-line no-db-await-in-loop
       yield* Result.await(
         // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
         safeDb((tx) => {

--- a/apps/api/src/handlers/chat/delete-thread.ts
+++ b/apps/api/src/handlers/chat/delete-thread.ts
@@ -81,7 +81,7 @@ const deleteThread = createSafeRootHandler(
         conditions.push(gt(userFiles.id, lastFileId));
       }
       // SAFETY: sequential keyset pagination keeps each cleanup page bounded; the next page depends on this cursor.
-      // eslint-disable-next-line no-db-await-in-loop
+      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
       const files = yield* Result.await(
         safeDb((tx) =>
           tx
@@ -128,7 +128,7 @@ const deleteThread = createSafeRootHandler(
       }
 
       // SAFETY: storage deletion must succeed before the corresponding bounded page of rows is removed.
-      // eslint-disable-next-line no-db-await-in-loop
+      // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
       yield* Result.await(
         // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
         safeDb((tx) => {

--- a/apps/api/src/handlers/clauses/categories.ts
+++ b/apps/api/src/handlers/clauses/categories.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
@@ -240,34 +240,35 @@ export const updateCategoryHandler = async function* ({
       );
     }
 
-    const categoryParents = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.clauseCategories.findMany({
-          where: { organizationId: { eq: organizationId } },
-          columns: { id: true, parentId: true },
-          limit: LIMITS.clauseCategoriesCount,
+    const createsCycle = yield* Result.await(
+      safeDb(async (tx) => {
+        const result = await tx.execute<{ found: boolean }>(sql`
+          WITH RECURSIVE ancestors(id, parent_id) AS (
+            SELECT category.id, category.parent_id
+            FROM ${clauseCategories} category
+            WHERE category.id = ${parentId}
+              AND category.organization_id = ${organizationId}
+            UNION
+            SELECT category.id, category.parent_id
+            FROM ${clauseCategories} category
+            INNER JOIN ancestors
+              ON category.id = ancestors.parent_id
+            WHERE category.organization_id = ${organizationId}
+          )
+          SELECT EXISTS (
+            SELECT 1 FROM ancestors WHERE id = ${categoryId}
+          ) AS found
+        `);
+        return result.at(0)?.found === true;
+      }),
+    );
+    if (createsCycle) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Cannot create circular category hierarchy",
         }),
-      ),
-    );
-    const parentIdByCategoryId = new Map(
-      categoryParents.map((category) => [category.id, category.parentId]),
-    );
-
-    // Walk the already-bounded organization category set in memory to reject
-    // a reparent that would create a cycle.
-    const visited = new Set<SafeId<"clauseCategory">>([categoryId]);
-    let checkId: SafeId<"clauseCategory"> | null = parentId;
-    while (checkId) {
-      if (visited.has(checkId)) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Cannot create circular category hierarchy",
-          }),
-        );
-      }
-      visited.add(checkId);
-      checkId = parentIdByCategoryId.get(checkId) ?? null;
+      );
     }
   }
 

--- a/apps/api/src/handlers/clauses/categories.ts
+++ b/apps/api/src/handlers/clauses/categories.ts
@@ -240,8 +240,21 @@ export const updateCategoryHandler = async function* ({
       );
     }
 
-    // Walk the ancestor chain to reject a reparent that would create a cycle
-    // (mirrors the template category handler).
+    const categoryParents = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.clauseCategories.findMany({
+          where: { organizationId: { eq: organizationId } },
+          columns: { id: true, parentId: true },
+          limit: LIMITS.clauseCategoriesCount,
+        }),
+      ),
+    );
+    const parentIdByCategoryId = new Map(
+      categoryParents.map((category) => [category.id, category.parentId]),
+    );
+
+    // Walk the already-bounded organization category set in memory to reject
+    // a reparent that would create a cycle.
     const visited = new Set<SafeId<"clauseCategory">>([categoryId]);
     let checkId: SafeId<"clauseCategory"> | null = parentId;
     while (checkId) {
@@ -254,21 +267,7 @@ export const updateCategoryHandler = async function* ({
         );
       }
       visited.add(checkId);
-      const currentId: SafeId<"clauseCategory"> = checkId;
-      const ancestor:
-        | { parentId: SafeId<"clauseCategory"> | null }
-        | undefined = yield* Result.await(
-        safeDb((tx) =>
-          tx.query.clauseCategories.findFirst({
-            where: {
-              id: { eq: currentId },
-              organizationId: { eq: organizationId },
-            },
-            columns: { parentId: true },
-          }),
-        ),
-      );
-      checkId = ancestor?.parentId ?? null;
+      checkId = parentIdByCategoryId.get(checkId) ?? null;
     }
   }
 

--- a/apps/api/src/handlers/time-entries/split.ts
+++ b/apps/api/src/handlers/time-entries/split.ts
@@ -86,28 +86,30 @@ const splitEntry = createSafeHandler(
       );
     }
 
-    // Validate all target matters exist
-    for (const split of body.splits) {
-      const matter = yield* Result.await(
-        safeDb((tx) =>
-          tx.query.entities.findFirst({
-            where: {
-              id: { eq: split.matterId },
-              workspaceId: { eq: workspaceId },
-            },
-            columns: { id: true },
-          }),
-        ),
+    const targetMatterIds = body.splits.map((split) => split.matterId);
+    const targetMatters = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.entities.findMany({
+          where: {
+            id: { in: targetMatterIds },
+            workspaceId: { eq: workspaceId },
+          },
+          columns: { id: true },
+          limit: body.splits.length,
+        }),
+      ),
+    );
+    const foundMatterIds = new Set(targetMatters.map((matter) => matter.id));
+    const missingMatterId = targetMatterIds.find(
+      (matterId) => !foundMatterIds.has(matterId),
+    );
+    if (missingMatterId) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: `Matter ${missingMatterId} not found`,
+        }),
       );
-
-      if (!matter) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: `Matter ${split.matterId} not found`,
-          }),
-        );
-      }
     }
 
     const splitGroupId = createSafeId<"timeEntry">();

--- a/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
+++ b/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
@@ -56,6 +56,9 @@ const generateBoundingBoxes = createSafeHandler(
 
     const generateFn = isMockAI() ? generateBBoxesMock : generateBBoxes;
     const boxes: BoundingBox[] = [];
+    if (preparedData.pageNumbers.length === 0) {
+      return Result.ok({ boxes });
+    }
 
     for (const pageNumber of preparedData.pageNumbers) {
       // oxlint-disable-next-line no-await-in-loop -- pages processed sequentially to bound concurrent AI calls and accumulate boxes in page order
@@ -94,23 +97,23 @@ const generateBoundingBoxes = createSafeHandler(
       }
 
       boxes.push(...pageBoxesResult.value);
-
-      yield* Result.await(
-        safeDb(async (tx) => {
-          // audit: skip — background OCR pipeline persisting computed
-          // bounding boxes; derived AI output, not a user mutation.
-          await tx
-            .update(justifications)
-            .set({
-              boundingBoxes: {
-                version: 1,
-                boxes,
-              },
-            })
-            .where(eq(justifications.id, justificationId));
-        }),
-      );
     }
+
+    yield* Result.await(
+      safeDb(async (tx) => {
+        // audit: skip — background OCR pipeline persisting computed bounding
+        // boxes; derived AI output, not a user mutation.
+        await tx
+          .update(justifications)
+          .set({
+            boundingBoxes: {
+              version: 1,
+              boxes,
+            },
+          })
+          .where(eq(justifications.id, justificationId));
+      }),
+    );
 
     return Result.ok({ boxes });
   },

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1346,7 +1346,8 @@ export default defineConfig({
     },
     {
       // no-db-await-in-loop flags an `await db...` / `await tx...` /
-      // `await safeDb(...)` lexically inside a loop body or a
+      // `await safeDb(...)` or `yield* Result.await(safeDb(...))` lexically
+      // inside a loop body, plus a
       // `Promise.all(items.map(...))` fan-out — the N+1 antipattern. Scoped
       // to backend source, where `db`/`tx`/`safeDb` are Drizzle handles;
       // test files intentionally exercise unbatched loops in fixtures/mocks


### PR DESCRIPTION
Teach the N+1 guard to recognize delegated Result.await database operations used by safe handlers. The fixture covers looped and fan-out forms while preserving single operations outside loops.

Move bounding-box persistence out of the page loop so the derived result is written once after generation completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bounding-box generation when no page numbers are available, returning an empty result without unnecessary processing or persistence.
  - Enhanced detection of database operations awaited inside loops, including generator-based workflows, helping prevent inefficient database access patterns.

- **Documentation**
  - Clarified guidance for avoiding database awaits within loops across both standard and generator-based syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->