### PR TITLE
fix(boe): escape code fields in query_string DSL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -355,8 +355,10 @@
       "name": "@stll/boe",
       "version": "0.1.0",
       "devDependencies": {
+        "@stll/property-testing": "workspace:*",
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
+        "fast-check": "catalog:",
       },
     },
     "packages/business-registries": {

--- a/packages/boe/package.json
+++ b/packages/boe/package.json
@@ -52,7 +52,9 @@
     "prepack": "bun run build"
   },
   "devDependencies": {
+    "@stll/property-testing": "workspace:*",
     "@stll/typescript-config": "workspace:*",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "fast-check": "catalog:"
   }
 }

--- a/packages/boe/src/query.test.ts
+++ b/packages/boe/src/query.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 
-import type { BoeSearchQuery } from "./query.js";
 import { buildSearchQuery } from "./query.js";
 
 describe("BOE search query builder", () => {
@@ -128,8 +127,14 @@ describe("BOE search query builder", () => {
     }
   });
 
+  const CODIGO_FIELD_NAMES = {
+    departmentCode: "departamento@codigo",
+    legalRangeCode: "rango@codigo",
+    matterCode: "materia@codigo",
+  } as const;
+
   test("INVARIANT: code fields cannot inject field clauses, booleans, or unbalanced parens", () => {
-    const attacks: Array<[keyof BoeSearchQuery, string]> = [
+    const attacks: [keyof typeof CODIGO_FIELD_NAMES, string][] = [
       ["departmentCode", "1000) OR titulo:(*"],
       ["legalRangeCode", '1300" OR rango@codigo:"*'],
       ["matterCode", "2765 OR (a"],
@@ -143,12 +148,7 @@ describe("BOE search query builder", () => {
       // proof: the attacker-controlled value must stay inside a single
       // quoted phrase, with any inner quotes/backslashes escaped, and no
       // unescaped injected "OR"/"titulo:"/parens reaching the DSL.
-      const codigoField =
-        field === "departmentCode"
-          ? "departamento@codigo"
-          : field === "legalRangeCode"
-            ? "rango@codigo"
-            : "materia@codigo";
+      const codigoField = CODIGO_FIELD_NAMES[field];
       const escapedValue = value
         .replaceAll("\\", "\\\\")
         .replaceAll('"', '\\"');

--- a/packages/boe/src/query.test.ts
+++ b/packages/boe/src/query.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 
+import { propertyConfig } from "@stll/property-testing";
+
+import type { BoeSearchQuery } from "./query.js";
 import { buildSearchQuery } from "./query.js";
 
 describe("BOE search query builder", () => {
@@ -159,5 +163,155 @@ describe("BOE search query builder", () => {
   test("free text of only symbols produces an empty query (no clause)", () => {
     expect(extractQueryString(buildSearchQuery({ text: "()[]:*?" }))).toBe("");
     expect(extractQueryString(buildSearchQuery({ text: "   " }))).toBe("");
+  });
+
+  // Strips every correctly-escaped quoted phrase from a query_string,
+  // honoring the same backslash-escape grammar `escapeQueryStringPhrase`
+  // writes (`\\` and `\"` are single escaped units inside a phrase). If
+  // attacker content ever manages to close a phrase early with an
+  // unescaped `"`, the remaining text after that point is left in the
+  // output instead of being swallowed, and if a phrase is left dangling
+  // (opened but never closed) this throws instead of silently consuming
+  // the rest of the string — either way the fuzz property below fails
+  // loudly instead of passing on a broken parse.
+  const stripQuotedPhrases = (q: string): string => {
+    let result = "";
+    let i = 0;
+    while (i < q.length) {
+      if (q[i] !== '"') {
+        result += q[i];
+        i += 1;
+        continue;
+      }
+      let j = i + 1;
+      let closed = false;
+      while (j < q.length) {
+        if (q[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (q[j] === '"') {
+          j += 1;
+          closed = true;
+          break;
+        }
+        j += 1;
+      }
+      if (!closed) {
+        throw new Error(`unterminated quoted phrase in query_string: ${q}`);
+      }
+      i = j;
+    }
+    return result;
+  };
+
+  // Paren balance, checked on the quote-stripped remainder rather than the
+  // raw query_string: raw-string quote-parity (as `isStructurallyBalanced`
+  // above checks) breaks once a phrase legitimately contains an escaped
+  // quote (`\"`), which adds one literal `"` to the string without
+  // unbalancing anything. Parens are unaffected by that, so checking them
+  // post-strip stays a meaningful signal without the false positive.
+  const isParenBalanced = (s: string): boolean => {
+    let depth = 0;
+    for (const ch of s) {
+      if (ch === "(") {
+        depth++;
+      } else if (ch === ")") {
+        depth--;
+        if (depth < 0) {
+          return false;
+        }
+      }
+    }
+    return depth === 0;
+  };
+
+  // The exact set of literal syntax fragments `buildSearchQuery` may emit
+  // outside of quoted phrases: parens, the AND/OR joiners, and the field
+  // prefixes for the five clause kinds it can produce. Nothing else is
+  // legitimate: an attacker string that escapes its quoted phrase would
+  // leave behind characters (another field name, a stray `:`, raw
+  // boolean text) that do not match any of these tokens.
+  const GRAMMAR_TOKEN =
+    /^(?:\(|\)| AND | OR |titulo:|texto:|departamento@codigo:|rango@codigo:|materia@codigo:)/u;
+
+  // Repeatedly strips one recognized grammar token from the front of the
+  // (already quote-stripped) remainder. Anything left over once no token
+  // matches is attacker-controlled syntax that escaped its phrase.
+  const stripGrammarTokens = (remainder: string): string => {
+    let s = remainder;
+    for (;;) {
+      const match = GRAMMAR_TOKEN.exec(s);
+      if (!match) {
+        return s;
+      }
+      s = s.slice(match[0].length);
+    }
+  };
+
+  // Attack fragments biased toward the query_string DSL's reserved
+  // syntax (quotes, backslashes, parens, colons, boolean keywords),
+  // mixed with fully arbitrary unicode strings so both targeted and
+  // unstructured input get exercised.
+  const INJECTION_FRAGMENTS = [
+    '"',
+    "\\",
+    '\\"',
+    '") OR (',
+    'x" OR "y',
+    ") OR fecha_publicacion:[* TO *] OR (",
+    " OR ",
+    " AND ",
+    "(",
+    ")",
+    ":",
+    "titulo:",
+    "texto:",
+    "departamento@codigo:",
+    "rango@codigo:",
+    "materia@codigo:",
+    "NOT",
+    "*",
+    "?",
+  ] as const;
+
+  const fieldValueArb: fc.Arbitrary<string> = fc.oneof(
+    fc.string(),
+    fc.constantFrom(...INJECTION_FRAGMENTS),
+    fc
+      .array(fc.constantFrom(...INJECTION_FRAGMENTS), {
+        minLength: 1,
+        maxLength: 5,
+      })
+      .map((fragments) => fragments.join("")),
+  );
+
+  // Every string field of BoeSearchQuery gets independently fuzzed,
+  // including dateFrom/dateTo (which never reach query_string, but are
+  // included so a future regression that routes them through it would
+  // be caught here too).
+  const boeSearchQueryArb: fc.Arbitrary<BoeSearchQuery> = fc.record(
+    {
+      text: fieldValueArb,
+      title: fieldValueArb,
+      departmentCode: fieldValueArb,
+      legalRangeCode: fieldValueArb,
+      matterCode: fieldValueArb,
+      dateFrom: fieldValueArb,
+      dateTo: fieldValueArb,
+    },
+    { requiredKeys: [] },
+  );
+
+  test("INVARIANT (fuzz): no field lets attacker content escape its quoted phrase", () => {
+    fc.assert(
+      fc.property(boeSearchQueryArb, (query) => {
+        const q = extractQueryString(buildSearchQuery(query));
+        const stripped = stripQuotedPhrases(q);
+        expect(isParenBalanced(stripped)).toBe(true);
+        expect(stripGrammarTokens(stripped)).toBe("");
+      }),
+      propertyConfig(),
+    );
   });
 });

--- a/packages/boe/src/query.test.ts
+++ b/packages/boe/src/query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { BoeSearchQuery } from "./query.js";
 import { buildSearchQuery } from "./query.js";
 
 describe("BOE search query builder", () => {
@@ -124,6 +125,34 @@ describe("BOE search query builder", () => {
       // No raw upstream field markers from user input.
       expect(q).not.toContain("fecha_publicacion");
       expect(q).not.toContain("rango@codigo");
+    }
+  });
+
+  test("INVARIANT: code fields cannot inject field clauses, booleans, or unbalanced parens", () => {
+    const attacks: Array<[keyof BoeSearchQuery, string]> = [
+      ["departmentCode", "1000) OR titulo:(*"],
+      ["legalRangeCode", '1300" OR rango@codigo:"*'],
+      ["matterCode", "2765 OR (a"],
+    ];
+    for (const [field, value] of attacks) {
+      const q = extractQueryString(buildSearchQuery({ [field]: value }));
+      // Unlike free text, code fields are wrapped in a single quoted
+      // phrase, so raw paren-counting (isStructurallyBalanced) is not a
+      // meaningful signal here: a "(" inside a quoted phrase does not
+      // unbalance the DSL. The exact-match assertion below is the real
+      // proof: the attacker-controlled value must stay inside a single
+      // quoted phrase, with any inner quotes/backslashes escaped, and no
+      // unescaped injected "OR"/"titulo:"/parens reaching the DSL.
+      const codigoField =
+        field === "departmentCode"
+          ? "departamento@codigo"
+          : field === "legalRangeCode"
+            ? "rango@codigo"
+            : "materia@codigo";
+      const escapedValue = value
+        .replaceAll("\\", "\\\\")
+        .replaceAll('"', '\\"');
+      expect(q).toBe(`${codigoField}:"${escapedValue}"`);
     }
   });
 

--- a/packages/boe/src/query.ts
+++ b/packages/boe/src/query.ts
@@ -45,13 +45,17 @@ export const buildSearchQuery = (input: BoeSearchQuery): string => {
     parts.push(`titulo:"${escapeQueryStringPhrase(input.title)}"`);
   }
   if (input.departmentCode) {
-    parts.push(`departamento@codigo:${input.departmentCode}`);
+    parts.push(
+      `departamento@codigo:"${escapeQueryStringPhrase(input.departmentCode)}"`,
+    );
   }
   if (input.legalRangeCode) {
-    parts.push(`rango@codigo:${input.legalRangeCode}`);
+    parts.push(
+      `rango@codigo:"${escapeQueryStringPhrase(input.legalRangeCode)}"`,
+    );
   }
   if (input.matterCode) {
-    parts.push(`materia@codigo:${input.matterCode}`);
+    parts.push(`materia@codigo:"${escapeQueryStringPhrase(input.matterCode)}"`);
   }
 
   const queryString = parts.join(" AND ");

--- a/packages/boe/src/query.ts
+++ b/packages/boe/src/query.ts
@@ -21,41 +21,102 @@ type RangeClause = {
 };
 type CompoundQuery = QueryStringClause & Partial<RangeClause>;
 
-const escapeQueryStringPhrase = (value: string): string =>
-  value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+/**
+ * Branded marker for fragments of the BOE query_string Lucene DSL that are
+ * known, by construction, to be free of unescaped attacker-controlled
+ * reserved syntax (quotes, colons, parens, boolean keywords). A plain
+ * `string` is not assignable to `QueryStringSafe`, so
+ * `parts.push(\`x:${someRawInput}\`)` is a type error: the only ways to
+ * produce a `QueryStringSafe` are `escapeQueryStringPhrase` (quote-escapes
+ * untrusted input), `freeTextClause` (the tokenizer strips everything but
+ * unicode word characters before quoting), and `fieldClause` (prefixes an
+ * already-safe phrase with a compile-time-literal field name).
+ */
+declare const __queryStringSafeBrand: unique symbol;
+type QueryStringSafe = string & {
+  readonly [__queryStringSafeBrand]: "QueryStringSafe";
+};
+
+/** Wrap a fragment assembled entirely from literal DSL syntax (parens,
+ * AND/OR, field prefixes) plus already-safe pieces. Not exported: every
+ * call site lives in this module and is reviewable alongside the DSL it
+ * emits. */
+const rawClause = (value: string): QueryStringSafe =>
+  // SAFETY: caller asserts `value` is composed only of literal DSL syntax
+  // and already brand-verified-safe fragments; see call site.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  value as QueryStringSafe;
+
+const escapeQueryStringPhrase = (value: string): QueryStringSafe => {
+  const escaped = value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  // SAFETY: quotes and backslashes are escaped above, so this phrase cannot
+  // break out of the surrounding `"..."` it is wrapped in by `fieldClause`.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return escaped as QueryStringSafe;
+};
+
+/**
+ * Build a `field:"phrase"` clause. `field` is always a compile-time string
+ * literal from this module (never derived from `BoeSearchQuery` input);
+ * `phrase` must already carry the `QueryStringSafe` brand, so the escaping
+ * invariant cannot be bypassed by a future caller.
+ */
+const fieldClause = (field: string, phrase: QueryStringSafe): QueryStringSafe =>
+  rawClause(`${field}:"${phrase}"`);
+
+/**
+ * Build the tokenized free-text OR-clause across titulo/texto. Terms are
+ * extracted with a unicode word-character regex, so by construction they
+ * cannot contain quotes, colons, parens, or boolean keywords; quoting and
+ * ANDing them together needs no further escaping. Mirrors the corpus path
+ * (corpusFreeTextClause).
+ */
+const freeTextClause = (text: string): QueryStringSafe | undefined => {
+  const terms = text.match(/[\p{L}\p{N}]+/gu);
+  if (!terms || terms.length === 0) {
+    return undefined;
+  }
+  const quoted = terms.map((term) => `"${term}"`).join(" AND ");
+  return rawClause(`(titulo:(${quoted}) OR texto:(${quoted}))`);
+};
 
 /**
  * Build the JSON-DSL query string the BOE search endpoint expects.
  * Mirrors the shape used by the upstream MCP-BOE client.
  */
 export const buildSearchQuery = (input: BoeSearchQuery): string => {
-  const parts: string[] = [];
+  const parts: QueryStringSafe[] = [];
   if (input.text) {
     // Keep user free text literal: the query_string DSL (field clauses,
     // AND/OR, parentheses, colons) must never be reachable from input.
-    // Mirror the corpus path (corpusFreeTextClause): keep only unicode
-    // word characters, quote each term, AND them.
-    const terms = input.text.match(/[\p{L}\p{N}]+/gu);
-    if (terms && terms.length > 0) {
-      const quoted = terms.map((term) => `"${term}"`).join(" AND ");
-      parts.push(`(titulo:(${quoted}) OR texto:(${quoted}))`);
+    const clause = freeTextClause(input.text);
+    if (clause) {
+      parts.push(clause);
     }
   }
   if (input.title) {
-    parts.push(`titulo:"${escapeQueryStringPhrase(input.title)}"`);
+    parts.push(fieldClause("titulo", escapeQueryStringPhrase(input.title)));
   }
   if (input.departmentCode) {
     parts.push(
-      `departamento@codigo:"${escapeQueryStringPhrase(input.departmentCode)}"`,
+      fieldClause(
+        "departamento@codigo",
+        escapeQueryStringPhrase(input.departmentCode),
+      ),
     );
   }
   if (input.legalRangeCode) {
     parts.push(
-      `rango@codigo:"${escapeQueryStringPhrase(input.legalRangeCode)}"`,
+      fieldClause(
+        "rango@codigo",
+        escapeQueryStringPhrase(input.legalRangeCode),
+      ),
     );
   }
   if (input.matterCode) {
-    parts.push(`materia@codigo:"${escapeQueryStringPhrase(input.matterCode)}"`);
+    parts.push(
+      fieldClause("materia@codigo", escapeQueryStringPhrase(input.matterCode)),
+    );
   }
 
   const queryString = parts.join(" AND ");

--- a/packages/boe/src/query.ts
+++ b/packages/boe/src/query.ts
@@ -61,8 +61,16 @@ const escapeQueryStringPhrase = (value: string): QueryStringSafe => {
  * `phrase` must already carry the `QueryStringSafe` brand, so the escaping
  * invariant cannot be bypassed by a future caller.
  */
-const fieldClause = (field: string, phrase: QueryStringSafe): QueryStringSafe =>
-  rawClause(`${field}:"${phrase}"`);
+type BoeFieldName =
+  | "titulo"
+  | "departamento@codigo"
+  | "rango@codigo"
+  | "materia@codigo";
+
+const fieldClause = (
+  field: BoeFieldName,
+  phrase: QueryStringSafe,
+): QueryStringSafe => rawClause(`${field}:"${phrase}"`);
 
 /**
  * Build the tokenized free-text OR-clause across titulo/texto. Terms are


### PR DESCRIPTION
\`buildSearchQuery\` escaped \`text\` and \`title\` but interpolated \`departmentCode\`, \`legalRangeCode\`, and \`matterCode\` into the Lucene \`query_string\` DSL unescaped, so those fields could alter the query structure instead of being matched literally.

- Emit the three code fields as escaped quoted phrases via the existing \`escapeQueryStringPhrase\` helper, matching the \`title\` handling.
- Make raw interpolation a type error: clause construction is now branded (\`QueryStringSafe\`), with the escaper, the free-text tokenizer, and a module-internal literal-clause constructor as the only producers.
- Generalize the invariant tests: alongside the example-based tests, a fast-check property test feeds adversarial strings into every query field and verifies nothing escapes a quoted phrase (escape-aware phrase stripping, paren balance, strict allow-list grammar for the remainder).
- Separate commit fixes two pre-existing lint findings in the touched test file.