### PR TITLE
fix(api): total timesheet PDF amounts per currency

### DIFF
--- a/apps/api/src/handlers/time-entries/export-pdf.test.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.test.ts
@@ -45,4 +45,40 @@ describe("exportPdfHandler totals", () => {
     expect(text).toContain("Total Hours: 2.00");
     expect(text).not.toContain("Total Hours: 4.00");
   });
+
+  test("totals amounts per currency instead of summing across currencies", async () => {
+    const pdf = await exportPdfHandler({
+      scopedDb: scopedDbReturning([
+        timeEntryRow({
+          currency: "USD",
+          billedMinutes: 60,
+          rateAtEntry: 10_000,
+        }),
+        timeEntryRow({
+          currency: "EUR",
+          billedMinutes: 60,
+          rateAtEntry: 5_000,
+        }),
+        timeEntryRow({
+          currency: "USD",
+          billedMinutes: 60,
+          rateAtEntry: 10_000,
+        }),
+      ]),
+      workspaceId: toSafeId<"workspace">("ws_1"),
+      organizationId: toSafeId<"organization">("org_1"),
+      query: {},
+    });
+
+    const text = new TextDecoder().decode(pdf);
+    expect(text).toContain("Total Amount: EUR 50.00");
+    expect(text).toContain("Total Amount: USD 200.00");
+    // EUR sorts before USD; a cross-currency sum (e.g. "250.00") must
+    // never appear.
+    const eurIndex = text.indexOf("Total Amount: EUR");
+    const usdIndex = text.indexOf("Total Amount: USD");
+    expect(eurIndex).toBeGreaterThan(-1);
+    expect(eurIndex).toBeLessThan(usdIndex);
+    expect(text).not.toContain("250.00");
+  });
 });

--- a/apps/api/src/handlers/time-entries/export-pdf.test.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.test.ts
@@ -57,7 +57,7 @@ describe("exportPdfHandler totals", () => {
         timeEntryRow({
           currency: "EUR",
           billedMinutes: 60,
-          rateAtEntry: 5_000,
+          rateAtEntry: 5000,
         }),
         timeEntryRow({
           currency: "USD",

--- a/apps/api/src/handlers/time-entries/export-pdf.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.ts
@@ -3,7 +3,7 @@ import { and, eq, gte, inArray, lte } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
-import { prorateHourlyCents } from "@stll/money";
+import { MoneyTotals, prorateHourlyCents } from "@stll/money";
 
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";
@@ -121,7 +121,7 @@ export const exportPdfHandler = async ({
   ];
 
   let totalMinutes = 0;
-  const totalAmountByCurrency = new Map<string, number>();
+  const totalAmountByCurrency = new MoneyTotals();
 
   for (const row of rows) {
     const userName = row.userId
@@ -138,10 +138,7 @@ export const exportPdfHandler = async ({
     // amount, which are both derived from billedMinutes; summing raw
     // durationMinutes here produced a total that did not match the lines.
     totalMinutes += row.billedMinutes;
-    totalAmountByCurrency.set(
-      row.currency,
-      (totalAmountByCurrency.get(row.currency) ?? 0) + amount,
-    );
+    totalAmountByCurrency.add(row.currency, amount);
 
     textLines.push(`Date: ${row.dateWorked}  User: ${userName}`);
     textLines.push(
@@ -163,9 +160,10 @@ export const exportPdfHandler = async ({
   textLines.push("-".repeat(80));
   const totalHours = (totalMinutes / 60).toFixed(2);
   textLines.push(`Total Hours: ${totalHours}`);
-  for (const currency of [...totalAmountByCurrency.keys()].sort()) {
-    const amount = totalAmountByCurrency.get(currency) ?? 0;
-    textLines.push(`Total Amount: ${currency} ${(amount / 100).toFixed(2)}`);
+  for (const { currency, amountCents } of totalAmountByCurrency.entries()) {
+    textLines.push(
+      `Total Amount: ${currency} ${(amountCents / 100).toFixed(2)}`,
+    );
   }
 
   return buildMinimalPdf(textLines);

--- a/apps/api/src/handlers/time-entries/export-pdf.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.ts
@@ -121,7 +121,7 @@ export const exportPdfHandler = async ({
   ];
 
   let totalMinutes = 0;
-  let totalAmount = 0;
+  const totalAmountByCurrency = new Map<string, number>();
 
   for (const row of rows) {
     const userName = row.userId
@@ -138,7 +138,10 @@ export const exportPdfHandler = async ({
     // amount, which are both derived from billedMinutes; summing raw
     // durationMinutes here produced a total that did not match the lines.
     totalMinutes += row.billedMinutes;
-    totalAmount += amount;
+    totalAmountByCurrency.set(
+      row.currency,
+      (totalAmountByCurrency.get(row.currency) ?? 0) + amount,
+    );
 
     textLines.push(`Date: ${row.dateWorked}  User: ${userName}`);
     textLines.push(
@@ -160,7 +163,10 @@ export const exportPdfHandler = async ({
   textLines.push("-".repeat(80));
   const totalHours = (totalMinutes / 60).toFixed(2);
   textLines.push(`Total Hours: ${totalHours}`);
-  textLines.push(`Total Amount: ${(totalAmount / 100).toFixed(2)}`);
+  for (const currency of [...totalAmountByCurrency.keys()].sort()) {
+    const amount = totalAmountByCurrency.get(currency) ?? 0;
+    textLines.push(`Total Amount: ${currency} ${(amount / 100).toFixed(2)}`);
+  }
 
   return buildMinimalPdf(textLines);
 };

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -270,6 +270,28 @@ describe("currencyCents() and addCents()", () => {
     addCents(a, b);
   });
 
+  test("COMPILE ERROR: addCents rejects a finite union currency type", () => {
+    // A currency narrowed only to a finite set of allowed codes (e.g. a
+    // validator's `t.UnionEnum(["USD", "EUR"])`) still nominally "shares"
+    // A under a plain `extends` bound, but two `CurrencyCents<"USD" |
+    // "EUR">` values can carry genuinely different runtime currencies —
+    // addCents must reject the union just like it rejects wide `string`.
+    //
+    // The union is routed through a function parameter rather than a
+    // `const ...: "USD" | "EUR" = "USD"` literal initializer: TypeScript's
+    // control-flow analysis narrows a `const` with a union-literal
+    // annotation down to the specific literal of its initializer at each
+    // read site, which would silently collapse the union to `"USD"` and
+    // defeat the point of this test.
+    const checkUnionCurrencyRejected = (currency: "USD" | "EUR") => {
+      const a = currencyCents(currency, 100);
+      const b = currencyCents(currency, 200);
+      // @ts-expect-error - addCents must not accept a union CurrencyCents<"USD" | "EUR">
+      addCents(a, b);
+    };
+    checkUnionCurrencyRejected("USD");
+  });
+
   test("INVARIANT: addCents is commutative and associative", () => {
     const rand = makePrng(4_611_812);
     for (let n = 0; n < 2000; n++) {

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -259,6 +259,17 @@ describe("currencyCents() and addCents()", () => {
     addCents(usd, eur);
   });
 
+  test("COMPILE ERROR: addCents rejects a non-literal (wide) currency type", () => {
+    // A currency read back from a DB row types as plain `string`, not a
+    // literal — `CurrencyCents<string>` must be structurally unusable with
+    // addCents even though both operands nominally "share" currency A.
+    const dynamicCurrency: string = "USD";
+    const a = currencyCents(dynamicCurrency, 100);
+    const b = currencyCents(dynamicCurrency, 200);
+    // @ts-expect-error - addCents must not accept a non-literal CurrencyCents<string>
+    addCents(a, b);
+  });
+
   test("INVARIANT: addCents is commutative and associative", () => {
     const rand = makePrng(4_611_812);
     for (let n = 0; n < 2000; n++) {

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -303,6 +303,10 @@ describe("MoneyTotals", () => {
     expect(new MoneyTotals().entries()).toEqual([]);
   });
 
+  test("rejects an empty currency code", () => {
+    expect(() => new MoneyTotals().add("", cents(100))).toThrow(TypeError);
+  });
+
   test("INVARIANT: entries() total per currency equals the sum of that currency's rows, regardless of insertion order", () => {
     const rand = makePrng(7_310_552);
     const currencies = ["USD", "EUR", "CZK", "GBP"];

--- a/packages/money/src/index.test.ts
+++ b/packages/money/src/index.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
-import { applyMarkupCents, cents, prorateHourlyCents, unsafeCents } from ".";
+import {
+  addCents,
+  applyMarkupCents,
+  cents,
+  currencyCents,
+  MoneyTotals,
+  prorateHourlyCents,
+  unsafeCents,
+} from ".";
+import type { CentsAmount } from ".";
 
 describe("minor-unit billing arithmetic", () => {
   test("rounds prorated hourly rates without floating point cent drift", () => {
@@ -223,3 +232,148 @@ describe("applyMarkupCents invariants", () => {
     ).toThrow(TypeError);
   });
 });
+
+describe("currencyCents() and addCents()", () => {
+  test("currencyCents mints a CentsAmount-compatible value", () => {
+    expect(currencyCents("USD", 1234)).toBe(currencyCents("USD", 1234));
+  });
+
+  test("currencyCents rejects an empty currency code", () => {
+    expect(() => currencyCents("", 100)).toThrow(TypeError);
+  });
+
+  test("addCents sums two amounts of the same currency", () => {
+    const a = currencyCents("USD", 150);
+    const b = currencyCents("USD", 275);
+    expect(addCents(a, b)).toBe(currencyCents("USD", 425));
+  });
+
+  test("addCents rejects a bad minor-unit amount at construction", () => {
+    expect(() => currencyCents("USD", 1.5)).toThrow(TypeError);
+  });
+
+  test("COMPILE ERROR: addCents rejects mismatched currencies", () => {
+    const usd = currencyCents("USD", 100);
+    const eur = currencyCents("EUR", 100);
+    // @ts-expect-error - addCents must not accept two different currencies
+    addCents(usd, eur);
+  });
+
+  test("INVARIANT: addCents is commutative and associative", () => {
+    const rand = makePrng(4_611_812);
+    for (let n = 0; n < 2000; n++) {
+      const x = currencyCents("USD", Math.floor(rand() * 1_000_000));
+      const y = currencyCents("USD", Math.floor(rand() * 1_000_000));
+      const z = currencyCents("USD", Math.floor(rand() * 1_000_000));
+      expect(addCents(x, y)).toBe(addCents(y, x));
+      expect(addCents(addCents(x, y), z)).toBe(addCents(x, addCents(y, z)));
+    }
+  });
+});
+
+describe("MoneyTotals", () => {
+  test("groups amounts by currency", () => {
+    const totals = new MoneyTotals();
+    totals.add("USD", cents(100));
+    totals.add("EUR", cents(200));
+    totals.add("USD", cents(50));
+
+    expect(totals.entries()).toEqual([
+      { currency: "EUR", amountCents: cents(200) },
+      { currency: "USD", amountCents: cents(150) },
+    ]);
+  });
+
+  test("entries() is sorted deterministically by currency code", () => {
+    const totals = new MoneyTotals();
+    totals.add("USD", cents(1));
+    totals.add("CZK", cents(1));
+    totals.add("EUR", cents(1));
+    totals.add("AUD", cents(1));
+
+    expect(totals.entries().map((e) => e.currency)).toEqual([
+      "AUD",
+      "CZK",
+      "EUR",
+      "USD",
+    ]);
+  });
+
+  test("an empty accumulator has no entries", () => {
+    expect(new MoneyTotals().entries()).toEqual([]);
+  });
+
+  test("INVARIANT: entries() total per currency equals the sum of that currency's rows, regardless of insertion order", () => {
+    const rand = makePrng(7_310_552);
+    const currencies = ["USD", "EUR", "CZK", "GBP"];
+
+    for (let trial = 0; trial < 200; trial++) {
+      const rows: { currency: string; amount: number }[] = [];
+      const rowCount = Math.floor(rand() * 40);
+      for (let i = 0; i < rowCount; i++) {
+        rows.push({
+          currency: pickCurrency(currencies, rand),
+          amount: Math.floor(rand() * 10_000),
+        });
+      }
+
+      const expected = new Map<string, CentsAmount>();
+      for (const row of rows) {
+        expected.set(
+          row.currency,
+          cents((expected.get(row.currency) ?? 0) + row.amount),
+        );
+      }
+
+      // Two independent random permutations of the same rows must produce
+      // identical totals: MoneyTotals must be permutation-invariant.
+      const shuffled = shuffle(rows, rand);
+      const totals = new MoneyTotals();
+      for (const row of shuffled) {
+        totals.add(row.currency, cents(row.amount));
+      }
+
+      const actual = new Map(
+        totals.entries().map((e) => [e.currency, e.amountCents]),
+      );
+      expect(actual.size).toBe(expected.size);
+      for (const [currency, sum] of expected) {
+        expect(actual.get(currency)).toBe(sum);
+      }
+
+      // entries() itself is always sorted, independent of insertion order.
+      const currenciesOut = totals.entries().map((e) => e.currency);
+      expect(currenciesOut).toEqual([...currenciesOut].sort());
+    }
+  });
+});
+
+function pickCurrency(
+  currencies: readonly string[],
+  rand: () => number,
+): string {
+  const currency = currencies.at(Math.floor(rand() * currencies.length));
+  if (currency === undefined) {
+    throw new Error("pickCurrency: index out of bounds");
+  }
+  return currency;
+}
+
+function shuffle<T>(items: readonly T[], rand: () => number): T[] {
+  const result = [...items];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    const itemAtI = at(result, i);
+    result[i] = at(result, j);
+    result[j] = itemAtI;
+  }
+  return result;
+}
+
+function at<T>(items: readonly T[], index: number): T {
+  const value = items.at(index);
+  if (value === undefined) {
+    throw new Error(`at: index ${index} out of bounds`);
+  }
+  return value;
+}

--- a/packages/money/src/index.ts
+++ b/packages/money/src/index.ts
@@ -130,6 +130,31 @@ export const currencyCents = <C extends string>(
   return cents(amount) as CurrencyCents<C>;
 };
 
+// Standard "distribute over the union, then intersect" trick: for a union
+// `U = "USD" | "EUR"`, this produces `(x: "USD") => void & (x: "EUR") =>
+// void`, and inferring a single parameter type `I` from that intersection
+// hits TypeScript's contravariant-position inference, which turns the
+// union into an intersection (`"USD" & "EUR"`, i.e. `never` for disjoint
+// string literals) instead of preserving it as a union.
+type UnionToIntersection<U> = (
+  U extends unknown ? (x: U) => void : never
+) extends (x: infer I) => void
+  ? I
+  : never;
+
+// True (evaluates to `C` itself) only when `C` is a single string-literal
+// currency code such as `"USD"` — never the WIDE `string` type, and never a
+// finite union of literals such as `"USD" | "EUR"`. A union only survives
+// `UnionToIntersection` intact when it has exactly one member (intersecting
+// one type with itself is a no-op); intersecting two or more distinct
+// string literals collapses to `never`, so `[C] extends
+// [UnionToIntersection<C>]` fails for any multi-member union.
+type IsSingletonCurrency<C extends string> = string extends C
+  ? never
+  : [C] extends [UnionToIntersection<C>]
+    ? C
+    : never;
+
 /**
  * Add two `CurrencyCents` amounts of the SAME currency. The second
  * parameter's currency `B` is constrained to `extends A`, so passing a
@@ -137,20 +162,23 @@ export const currencyCents = <C extends string>(
  * compile error, not a runtime bug — see `packages/money/src/index.test.ts`
  * for the `@ts-expect-error` proof.
  *
- * Both operands are further constrained to reject the WIDE
- * `CurrencyCents<string>` (as opposed to a literal currency such as
- * `CurrencyCents<"USD">`). A currency read back from a DB row types as
- * plain `string`, so without this, `addCents(currencyCents(row.currency, x),
- * currencyCents(row.currency, y))` would still typecheck even when the two
- * rows carry genuinely different runtime currencies — the compile-time
- * guarantee above only bites for literal currency types. Code that
- * aggregates rows with a dynamic (non-literal) currency must use
- * `MoneyTotals` instead, which buckets by currency at runtime and is the
- * runtime-correct tool for that case.
+ * Both operands are further constrained by `IsSingletonCurrency` to reject
+ * any non-singleton currency type: the WIDE `CurrencyCents<string>`, and
+ * also a finite union such as `CurrencyCents<"USD" | "EUR">` (e.g. from a
+ * validator's `t.UnionEnum`). A currency read back from a DB row or
+ * narrowed only to a finite set of allowed codes types as `string` or a
+ * union, not a single literal, so without this, `addCents(currencyCents(a,
+ * x), currencyCents(b, y))` would still typecheck even when `a`/`b` are
+ * both known only up to a union of currencies that could differ at
+ * runtime — the compile-time guarantee above only bites for a genuine
+ * single-literal currency type on both operands. Code that aggregates rows
+ * with a dynamic or union (non-singleton) currency must use `MoneyTotals`
+ * instead, which buckets by currency at runtime and is the runtime-correct
+ * tool for that case.
  */
 export const addCents = <A extends string, B extends A = A>(
-  a: string extends A ? never : CurrencyCents<A>,
-  b: string extends B ? never : CurrencyCents<B>,
+  a: IsSingletonCurrency<A> extends never ? never : CurrencyCents<A>,
+  b: IsSingletonCurrency<B> extends never ? never : CurrencyCents<B>,
 ): CurrencyCents<A> =>
   // SAFETY: the currency brand is phantom-only (never materialized at
   // runtime, same as CentsAmount itself); the result is just a + b with
@@ -169,11 +197,13 @@ export const addCents = <A extends string, B extends A = A>(
  * API — callers must handle each currency's total explicitly.
  *
  * Division of responsibility with `addCents`: `addCents` gives a
- * compile-time guarantee, but only when both operands carry a literal
- * currency type (`CurrencyCents<"USD">`); it rejects the wide
- * `CurrencyCents<string>` outright. Any flow whose currency is dynamic
- * (read from a DB row, request body, etc.) cannot satisfy that literal
- * constraint and must bucket through `MoneyTotals` instead, which enforces
+ * compile-time guarantee, but only when both operands carry a single
+ * string-literal currency type (`CurrencyCents<"USD">`); it rejects both
+ * the wide `CurrencyCents<string>` and a finite union such as
+ * `CurrencyCents<"USD" | "EUR">` outright. Any flow whose currency is
+ * dynamic or only known up to a union of allowed codes (read from a DB row,
+ * request body, etc.) cannot satisfy that singleton-literal constraint and
+ * must bucket through `MoneyTotals` instead, which enforces
  * the same "never sum across currencies" invariant at runtime via the
  * per-currency `Map`.
  */

--- a/packages/money/src/index.ts
+++ b/packages/money/src/index.ts
@@ -167,6 +167,11 @@ export class MoneyTotals {
 
   /** Add `amountCents` to the running total for `currency`. */
   add(currency: string, amountCents: CentsAmount): void {
+    if (!currency) {
+      throw new TypeError(
+        "MoneyTotals.add(): currency must be a non-empty code",
+      );
+    }
     const running = this.#totals.get(currency) ?? cents(0);
     this.#totals.set(currency, cents(running + amountCents));
   }
@@ -174,10 +179,13 @@ export class MoneyTotals {
   /**
    * Per-currency totals, sorted deterministically by currency code so
    * output (PDF lines, API responses) does not depend on insertion order.
+   * Sorts by UTF-16 code unit (default `Array.sort`) rather than
+   * `localeCompare`, so ordering does not vary with the runtime's locale.
    */
   entries(): MoneyTotalsEntry[] {
-    return [...this.#totals.entries()]
-      .sort(([currencyA], [currencyB]) => currencyA.localeCompare(currencyB))
-      .map(([currency, amountCents]) => ({ currency, amountCents }));
+    return [...this.#totals.keys()].sort().map((currency) => ({
+      currency,
+      amountCents: this.#totals.get(currency) ?? cents(0),
+    }));
   }
 }

--- a/packages/money/src/index.ts
+++ b/packages/money/src/index.ts
@@ -92,3 +92,92 @@ function assertNonNegativeInteger(name: string, value: number) {
     throw new TypeError(`${name} must be a finite non-negative integer`);
   }
 }
+
+declare const __currency: unique symbol;
+
+/**
+ * A `CentsAmount` additionally branded with its ISO 4217-ish currency code
+ * `C`. This makes cross-currency addition a compile error instead of a
+ * runtime bug: `addCents` only accepts two `CurrencyCents` sharing the same
+ * `C`, so `addCents(usdAmount, eurAmount)` fails to typecheck rather than
+ * silently producing a meaningless sum.
+ *
+ * Mint one with `currencyCents()`; there is no unsafe escape hatch because
+ * the underlying `CentsAmount` validation (`cents()`) is cheap and the
+ * currency code is a plain string carried alongside it, so there is no
+ * boundary that needs to skip it.
+ */
+export type CurrencyCents<C extends string = string> = CentsAmount & {
+  readonly [__currency]: C;
+};
+
+/**
+ * Construct a `CurrencyCents<C>` from a currency code and a minor-unit
+ * amount. The only producer of `CurrencyCents`; downstream code narrows `C`
+ * from the literal `currency` argument (e.g. `currencyCents("USD", 100)`
+ * infers `CurrencyCents<"USD">`).
+ */
+export const currencyCents = <C extends string>(
+  currency: C,
+  amount: number,
+): CurrencyCents<C> => {
+  if (!currency) {
+    throw new TypeError("currencyCents(): currency must be a non-empty code");
+  }
+  // SAFETY: cents() validates the minor-unit integer; the currency brand
+  // is nominal and carried only at the type level.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return cents(amount) as CurrencyCents<C>;
+};
+
+/**
+ * Add two `CurrencyCents` amounts of the SAME currency. The second
+ * parameter's currency `B` is constrained to `extends A`, so passing a
+ * different currency literal (e.g. `addCents(usdAmount, eurAmount)`) is a
+ * compile error, not a runtime bug — see `packages/money/src/index.test.ts`
+ * for the `@ts-expect-error` proof.
+ */
+export const addCents = <A extends string, B extends A = A>(
+  a: CurrencyCents<A>,
+  b: CurrencyCents<B>,
+): CurrencyCents<A> =>
+  // SAFETY: the currency brand is phantom-only (never materialized at
+  // runtime, same as CentsAmount itself); the result is just a + b with
+  // A's brand reattached, which is sound because the parameter types
+  // already proved both operands share currency A.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  cents(a + b) as CurrencyCents<A>;
+
+/**
+ * Per-currency accumulator for aggregating money across rows that may carry
+ * different currencies (e.g. time entries across matters, expenses across
+ * clients). There is deliberately no method that returns a single combined
+ * number: the only way to read totals out is `entries()`, which groups by
+ * currency and sorts deterministically by currency code. This keeps
+ * cross-currency summation structurally unreachable through this package's
+ * API — callers must handle each currency's total explicitly.
+ */
+export type MoneyTotalsEntry = {
+  currency: string;
+  amountCents: CentsAmount;
+};
+
+export class MoneyTotals {
+  readonly #totals = new Map<string, CentsAmount>();
+
+  /** Add `amountCents` to the running total for `currency`. */
+  add(currency: string, amountCents: CentsAmount): void {
+    const running = this.#totals.get(currency) ?? cents(0);
+    this.#totals.set(currency, cents(running + amountCents));
+  }
+
+  /**
+   * Per-currency totals, sorted deterministically by currency code so
+   * output (PDF lines, API responses) does not depend on insertion order.
+   */
+  entries(): MoneyTotalsEntry[] {
+    return [...this.#totals.entries()]
+      .sort(([currencyA], [currencyB]) => currencyA.localeCompare(currencyB))
+      .map(([currency, amountCents]) => ({ currency, amountCents }));
+  }
+}

--- a/packages/money/src/index.ts
+++ b/packages/money/src/index.ts
@@ -136,17 +136,28 @@ export const currencyCents = <C extends string>(
  * different currency literal (e.g. `addCents(usdAmount, eurAmount)`) is a
  * compile error, not a runtime bug — see `packages/money/src/index.test.ts`
  * for the `@ts-expect-error` proof.
+ *
+ * Both operands are further constrained to reject the WIDE
+ * `CurrencyCents<string>` (as opposed to a literal currency such as
+ * `CurrencyCents<"USD">`). A currency read back from a DB row types as
+ * plain `string`, so without this, `addCents(currencyCents(row.currency, x),
+ * currencyCents(row.currency, y))` would still typecheck even when the two
+ * rows carry genuinely different runtime currencies — the compile-time
+ * guarantee above only bites for literal currency types. Code that
+ * aggregates rows with a dynamic (non-literal) currency must use
+ * `MoneyTotals` instead, which buckets by currency at runtime and is the
+ * runtime-correct tool for that case.
  */
 export const addCents = <A extends string, B extends A = A>(
-  a: CurrencyCents<A>,
-  b: CurrencyCents<B>,
+  a: string extends A ? never : CurrencyCents<A>,
+  b: string extends B ? never : CurrencyCents<B>,
 ): CurrencyCents<A> =>
   // SAFETY: the currency brand is phantom-only (never materialized at
   // runtime, same as CentsAmount itself); the result is just a + b with
   // A's brand reattached, which is sound because the parameter types
   // already proved both operands share currency A.
   // eslint-disable-next-line typescript/no-unsafe-type-assertion
-  cents(a + b) as CurrencyCents<A>;
+  cents((a as CurrencyCents<A>) + (b as CurrencyCents<B>)) as CurrencyCents<A>;
 
 /**
  * Per-currency accumulator for aggregating money across rows that may carry
@@ -156,6 +167,15 @@ export const addCents = <A extends string, B extends A = A>(
  * currency and sorts deterministically by currency code. This keeps
  * cross-currency summation structurally unreachable through this package's
  * API — callers must handle each currency's total explicitly.
+ *
+ * Division of responsibility with `addCents`: `addCents` gives a
+ * compile-time guarantee, but only when both operands carry a literal
+ * currency type (`CurrencyCents<"USD">`); it rejects the wide
+ * `CurrencyCents<string>` outright. Any flow whose currency is dynamic
+ * (read from a DB row, request body, etc.) cannot satisfy that literal
+ * constraint and must bucket through `MoneyTotals` instead, which enforces
+ * the same "never sum across currencies" invariant at runtime via the
+ * per-currency `Map`.
  */
 export type MoneyTotalsEntry = {
   currency: string;


### PR DESCRIPTION
The timesheet PDF export summed \`prorateHourlyCents\` amounts across all rows regardless of each row's \`currency\` (a per-entry column), printing one unlabeled grand total. A result set spanning two currencies produced a figure that is not a meaningful amount in either.

- The export now prints one labeled \`Total Amount: <currency> <amount>\` line per currency, sorted deterministically; test added asserting mixed-currency entries never collapse into a single sum.
- Make the class structurally impossible in \`@stll/money\`: \`CurrencyCents<C>\` (currency-parametrized brand on \`CentsAmount\`) with \`addCents\` accepting only same-currency operands (cross-currency addition is a compile error, pinned by a \`@ts-expect-error\` test), plus a \`MoneyTotals\` accumulator whose only read path is per-currency \`entries()\` — the package API exposes no single cross-currency number. Property tests cover permutation invariance.
- Invoice line-item sums were reviewed and left as-is: they validate entry currency against the invoice's own \`currency\` column before summing, so they are single-currency by construction.