### PR TITLE
fix(api): emit batch totals and billing period in ledes export

### DIFF
--- a/apps/api/src/handlers/time-entries/export-ledes.test.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.test.ts
@@ -1,8 +1,10 @@
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { BILLING_STATUS } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 import { escapeLedesField, exportLedesHandler } from "./export-ledes";
@@ -37,13 +39,21 @@ const scopedDbReturning = (rows: unknown[]): ScopedDb => {
   });
 };
 
-const runExport = async (rows: unknown[]) =>
+const runExportResult = async (rows: unknown[]) =>
   await exportLedesHandler({
     scopedDb: scopedDbReturning(rows),
     workspaceId: toSafeId<"workspace">("ws_1"),
     organizationId: toSafeId<"organization">("org_1"),
     query: {},
   });
+
+const runExport = async (rows: unknown[]) => {
+  const result = await runExportResult(rows);
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  return result.value;
+};
 
 describe("exportLedesHandler billing integrity", () => {
   test("excludes non-billable, no-charge, and written-off entries from the LEDES file", async () => {
@@ -131,6 +141,26 @@ describe("exportLedesHandler billing integrity", () => {
     expect(secondFields[12]).toBe("300.00");
   });
 
+  test("fails fast on a mixed-currency batch instead of emitting a cross-currency total", async () => {
+    // LEDES 1998B has no currency field: a batch spanning USD and EUR has
+    // no representable INVOICE_TOTAL, so the export must refuse outright.
+    const result = await runExportResult([
+      timeEntryRow({ currency: "USD", narrative: "Dollar work" }),
+      timeEntryRow({ currency: "EUR", narrative: "Euro work" }),
+    ]);
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      throw new TypeError("Expected mixed-currency export to fail");
+    }
+    expect(result.error).toBeInstanceOf(HandlerError);
+    if (!(result.error instanceof HandlerError)) {
+      throw new TypeError("Expected a handler error");
+    }
+    expect(result.error.status).toBe(400);
+    expect(result.error.message).toContain("single currency");
+  });
+
   test("neutralizes delimiter injection in narrative and timekeeper name", async () => {
     let call = 0;
     const scopedDb = asTestRaw<ScopedDb>(async () => {
@@ -145,12 +175,16 @@ describe("exportLedesHandler billing integrity", () => {
         : [{ id: "user_1", name: "Eve|Hacker" }];
     });
 
-    const output = await exportLedesHandler({
+    const result = await exportLedesHandler({
       scopedDb,
       workspaceId: toSafeId<"workspace">("ws_1"),
       organizationId: toSafeId<"organization">("org_1"),
       query: {},
     });
+    if (Result.isError(result)) {
+      throw result.error;
+    }
+    const output = result.value;
 
     // One entry must remain exactly one record line: the narrative newline
     // must not inject a second line.

--- a/apps/api/src/handlers/time-entries/export-ledes.test.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.test.ts
@@ -78,6 +78,59 @@ describe("exportLedesHandler billing integrity", () => {
     expect(dataLines).toHaveLength(2);
   });
 
+  test("emits the batch total and billing period identically on every row, unaffected by a skipped line", async () => {
+    const output = await runExport([
+      timeEntryRow({
+        dateWorked: "2026-06-10",
+        billedMinutes: 60,
+        rateAtEntry: 10_000, // $100.00 line total
+        narrative: "First",
+      }),
+      // Non-billable: must not contribute to the total or widen the period.
+      timeEntryRow({
+        dateWorked: "2026-01-01",
+        billable: false,
+        narrative: "Skipped",
+      }),
+      timeEntryRow({
+        dateWorked: "2026-06-20",
+        billedMinutes: 120,
+        rateAtEntry: 15_000, // $300.00 line total
+        narrative: "Second",
+      }),
+    ]);
+
+    const dataLines = output
+      .split("\n")
+      .filter((line) => line.endsWith("[]") && !line.startsWith("LEDES1998B"))
+      .filter((line) => !line.startsWith("INVOICE_DATE"));
+
+    expect(dataLines).toHaveLength(2);
+
+    // Batch total is the sum of the two included lines ($100 + $300), not
+    // either line's individual total; the skipped non-billable line does
+    // not affect it.
+    const expectedInvoiceTotal = "400.00";
+    // Billing period spans the two included lines' dates only; the skipped
+    // line's earlier date must not widen the period.
+    const expectedStart = "20260610";
+    const expectedEnd = "20260620";
+
+    for (const line of dataLines) {
+      const fields = line.replace(/\[\]$/u, "").split("|");
+      expect(fields[4]).toBe(expectedInvoiceTotal); // INVOICE_TOTAL
+      expect(fields[5]).toBe(expectedStart); // BILLING_START_DATE
+      expect(fields[6]).toBe(expectedEnd); // BILLING_END_DATE
+    }
+
+    // Per-line fields still vary: LINE_ITEM_TOTAL (index 12) differs from
+    // INVOICE_TOTAL and from each other.
+    const firstFields = (dataLines[0] ?? "").replace(/\[\]$/u, "").split("|");
+    const secondFields = (dataLines[1] ?? "").replace(/\[\]$/u, "").split("|");
+    expect(firstFields[12]).toBe("100.00");
+    expect(secondFields[12]).toBe("300.00");
+  });
+
   test("neutralizes delimiter injection in narrative and timekeeper name", async () => {
     let call = 0;
     const scopedDb = asTestRaw<ScopedDb>(async () => {

--- a/apps/api/src/handlers/time-entries/export-ledes.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.ts
@@ -3,7 +3,8 @@ import { and, eq, gte, inArray, lte, ne } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
-import { prorateHourlyCents } from "@stll/money";
+import { MoneyTotals, prorateHourlyCents } from "@stll/money";
+import type { CentsAmount } from "@stll/money";
 
 import { member, user } from "@/api/db/auth-schema";
 import { timeEntryStatusSchema } from "@/api/db/billing-validators";
@@ -13,6 +14,7 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 
 export const exportLedesQuerySchema = t.Object({
@@ -43,7 +45,8 @@ export const escapeLedesField = (value: string): string =>
 type LedesLineItem = {
   matterId: SafeId<"entity">;
   dateWorked: string;
-  totalCents: number;
+  totalCents: CentsAmount;
+  currency: string;
   hours: number;
   taskCode: string;
   activityCode: string;
@@ -179,6 +182,7 @@ export const exportLedesHandler = async ({
       matterId: row.matterId,
       dateWorked: row.dateWorked,
       totalCents,
+      currency: row.currency,
       hours: row.billedMinutes / 60,
       taskCode: escapeLedesField(row.taskCode ?? ""),
       activityCode: escapeLedesField(row.activityCode ?? ""),
@@ -193,9 +197,12 @@ export const exportLedesHandler = async ({
   // invoice/batch (not a single line), and BILLING_START_DATE/
   // BILLING_END_DATE are the min/max dates across the included lines. Per
   // the LEDES 1998B spec, both are repeated identically on every row.
+  // Currency is a per-entry column, so accumulate through MoneyTotals: it
+  // buckets by currency and makes a cross-currency sum structurally
+  // unreachable.
   let billingStart = "";
   let billingEnd = "";
-  let invoiceTotalCents = 0;
+  const invoiceTotals = new MoneyTotals();
   for (const item of lineItems) {
     if (!billingStart || item.dateWorked < billingStart) {
       billingStart = item.dateWorked;
@@ -203,8 +210,22 @@ export const exportLedesHandler = async ({
     if (!billingEnd || item.dateWorked > billingEnd) {
       billingEnd = item.dateWorked;
     }
-    invoiceTotalCents += item.totalCents;
+    invoiceTotals.add(item.currency, item.totalCents);
   }
+
+  // LEDES 1998B has no currency field, so a mixed-currency batch cannot be
+  // represented at all: there is no honest value to put in INVOICE_TOTAL.
+  const totalsEntries = invoiceTotals.entries();
+  if (totalsEntries.length > 1) {
+    const currencies = totalsEntries.map((entry) => entry.currency).join(", ");
+    return Result.err(
+      new HandlerError({
+        status: 400,
+        message: `LEDES 1998B cannot represent a batch spanning multiple currencies (${currencies}); export a single currency at a time by narrowing the date or matter filters`,
+      }),
+    );
+  }
+  const invoiceTotalCents = totalsEntries.at(0)?.amountCents ?? 0;
   const invoiceTotalFormatted = (invoiceTotalCents / 100).toFixed(2);
   const billingStartFormatted = billingStart.replace(/-/gu, "");
   const billingEndFormatted = billingEnd.replace(/-/gu, "");
@@ -252,7 +273,7 @@ export const exportLedesHandler = async ({
     );
   }
 
-  return lines.join("\n");
+  return Result.ok(lines.join("\n"));
 };
 
 const config = {
@@ -276,7 +297,7 @@ const exportLedes = createSafeHandler(
       ),
     );
 
-    return Result.ok(response);
+    return response;
   },
 );
 

--- a/apps/api/src/handlers/time-entries/export-ledes.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.ts
@@ -40,6 +40,19 @@ type ExportLedesHandlerProps = {
 export const escapeLedesField = (value: string): string =>
   value.replace(/[\r\n|]/gu, " ");
 
+type LedesLineItem = {
+  matterId: SafeId<"entity">;
+  dateWorked: string;
+  totalCents: number;
+  hours: number;
+  taskCode: string;
+  activityCode: string;
+  userId: string;
+  narrative: string;
+  rateAtEntry: number;
+  userName: string;
+};
+
 /**
  * Generates a LEDES 1998B formatted export.
  * LEDES 1998B uses pipe-delimited lines with a fixed header row.
@@ -139,6 +152,63 @@ export const exportLedesHandler = async ({
     "|LINE_ITEM_TASK_DESCRIPTION" +
     "|LINE_ITEM_ACTIVITY_DESCRIPTION[]";
 
+  // First pass: apply the same billing-integrity guard as the SQL filter
+  // (defensive: a non-billable, no-charge, or written-off entry must never
+  // produce a charged line), then collect the per-line data needed both to
+  // compute the invoice-level aggregates and to emit each row.
+  const lineItems: LedesLineItem[] = [];
+
+  for (const row of rows) {
+    if (
+      !row.billable ||
+      row.noCharge ||
+      row.status === BILLING_STATUS.WRITTEN_OFF
+    ) {
+      continue;
+    }
+    const totalCents = prorateHourlyCents({
+      billedMinutes: row.billedMinutes,
+      hourlyRateCents: row.rateAtEntry,
+    });
+    const userName = escapeLedesField(
+      row.userId ? (userMap.get(row.userId) ?? "") : "",
+    );
+    const narrative = escapeLedesField(row.invoiceNarrative ?? row.narrative);
+
+    lineItems.push({
+      matterId: row.matterId,
+      dateWorked: row.dateWorked,
+      totalCents,
+      hours: row.billedMinutes / 60,
+      taskCode: escapeLedesField(row.taskCode ?? ""),
+      activityCode: escapeLedesField(row.activityCode ?? ""),
+      userId: row.userId ?? "",
+      narrative,
+      rateAtEntry: row.rateAtEntry,
+      userName,
+    });
+  }
+
+  // Invoice-level aggregates: INVOICE_TOTAL is the total for the whole
+  // invoice/batch (not a single line), and BILLING_START_DATE/
+  // BILLING_END_DATE are the min/max dates across the included lines. Per
+  // the LEDES 1998B spec, both are repeated identically on every row.
+  let billingStart = "";
+  let billingEnd = "";
+  let invoiceTotalCents = 0;
+  for (const item of lineItems) {
+    if (!billingStart || item.dateWorked < billingStart) {
+      billingStart = item.dateWorked;
+    }
+    if (!billingEnd || item.dateWorked > billingEnd) {
+      billingEnd = item.dateWorked;
+    }
+    invoiceTotalCents += item.totalCents;
+  }
+  const invoiceTotalFormatted = (invoiceTotalCents / 100).toFixed(2);
+  const billingStartFormatted = billingStart.replace(/-/gu, "");
+  const billingEndFormatted = billingEnd.replace(/-/gu, "");
+
   const lines = ["LEDES1998B[]", header];
   const now = new Date();
   const invoiceDate = (now.toISOString().split("T")[0] ?? "").replace(
@@ -148,53 +218,34 @@ export const exportLedesHandler = async ({
 
   let lineItemNumber = 0;
 
-  for (const row of rows) {
-    // Defensive billing-integrity guard alongside the SQL filter: a
-    // non-billable, no-charge, or written-off entry must never produce a
-    // charged line.
-    if (
-      !row.billable ||
-      row.noCharge ||
-      row.status === BILLING_STATUS.WRITTEN_OFF
-    ) {
-      continue;
-    }
+  for (const item of lineItems) {
     lineItemNumber++;
-    const hours = row.billedMinutes / 60;
-    const total = prorateHourlyCents({
-      billedMinutes: row.billedMinutes,
-      hourlyRateCents: row.rateAtEntry,
-    });
-    const dateFormatted = row.dateWorked.replace(/-/gu, "");
-    const userName = escapeLedesField(
-      row.userId ? (userMap.get(row.userId) ?? "") : "",
-    );
-    const narrative = escapeLedesField(row.invoiceNarrative ?? row.narrative);
+    const dateFormatted = item.dateWorked.replace(/-/gu, "");
 
     lines.push(
       `${[
         invoiceDate,
         "", // INVOICE_NUMBER
         "", // CLIENT_ID
-        row.matterId,
-        (total / 100).toFixed(2),
-        dateFormatted,
-        dateFormatted,
+        item.matterId,
+        invoiceTotalFormatted,
+        billingStartFormatted,
+        billingEndFormatted,
         "", // INVOICE_DESCRIPTION
         String(lineItemNumber),
         "F", // FEE type
-        hours.toFixed(2),
+        item.hours.toFixed(2),
         "0.00", // ADJUSTMENT
-        (total / 100).toFixed(2),
+        (item.totalCents / 100).toFixed(2),
         dateFormatted,
-        escapeLedesField(row.taskCode ?? ""),
+        item.taskCode,
         "", // EXPENSE_CODE
-        escapeLedesField(row.activityCode ?? ""),
-        row.userId ?? "",
-        narrative,
+        item.activityCode,
+        item.userId,
+        item.narrative,
         "", // LAW_FIRM_ID
-        (row.rateAtEntry / 100).toFixed(2),
-        userName,
+        (item.rateAtEntry / 100).toFixed(2),
+        item.userName,
         "", // TASK_DESCRIPTION
         "", // ACTIVITY_DESCRIPTION
       ].join("|")}[]`,


### PR DESCRIPTION
LEDES 1998B defines INVOICE_TOTAL and BILLING_START_DATE/BILLING_END_DATE as invoice-level fields repeated on every row, but the export populated them with each line's own total and date, so consuming e-billing systems read a different "invoice total" from every row.

- Two-pass restructure: included lines are collected first, the batch total and min/max worked dates are computed once, and every row emits identical invoice-level fields; per-line fields (LINE_ITEM_TOTAL, LINE_ITEM_DATE) are unchanged.
- Mixed-currency batches are now rejected with a 400: currency is per time-entry and the format has no currency field, so a cross-currency sum is unrepresentable; the total is accumulated via \`MoneyTotals\` from \`@stll/money\`, which makes that constraint structural.
- Golden-style test pins identical invoice-level fields across rows, exclusion of skipped lines from total and period, and the mixed-currency rejection.