### PR TITLE
fix(registries): clamp ares search limit like sibling adapters

### DIFF
--- a/packages/business-registries/src/ares/client.test.ts
+++ b/packages/business-registries/src/ares/client.test.ts
@@ -1,9 +1,44 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { lookupByIco, searchByName } from "./client.js";
 import { AresValidationError } from "./errors.js";
 
 const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
+
+type SearchRequestCapture = {
+  pocet: unknown;
+};
+
+const captureSearchRequest = (): {
+  captured: SearchRequestCapture;
+  restore: () => void;
+} => {
+  const captured: SearchRequestCapture = { pocet: undefined };
+  const originalFetch = globalThis.fetch;
+  const stub = async (
+    _input: URL | RequestInfo,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const rawBody = typeof init?.body === "string" ? init.body : "{}";
+    const payload =
+      // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- request body built by client.ts's own JSON.stringify(payload); shape asserted by the expectations below
+      JSON.parse(rawBody) as Record<string, unknown>;
+    captured.pocet = payload["pocet"];
+    return new Response(
+      JSON.stringify({ pocetCelkem: 0, ekonomickeSubjekty: [] }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+  return {
+    captured,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+};
 
 // These tests hit the real ARES API. They serve as integration tests
 // and also document the expected response shape for known subjects.
@@ -88,5 +123,45 @@ describe("searchByName validation", () => {
   test("throws AresValidationError for empty name", async () => {
     expect(searchByName("")).rejects.toBeInstanceOf(AresValidationError);
     expect(searchByName("   ")).rejects.toBeInstanceOf(AresValidationError);
+  });
+});
+
+describe("searchByName limit clamping", () => {
+  let restore: () => void;
+
+  afterEach(() => {
+    restore();
+  });
+
+  test("defaults pocet to 50 when no limit is given", async () => {
+    const ctx = captureSearchRequest();
+    restore = ctx.restore;
+
+    await searchByName("Alza");
+    expect(ctx.captured.pocet).toBe(50);
+  });
+
+  test("forwards an in-range limit unchanged", async () => {
+    const ctx = captureSearchRequest();
+    restore = ctx.restore;
+
+    await searchByName("Alza", { limit: 3 });
+    expect(ctx.captured.pocet).toBe(3);
+  });
+
+  test("clamps a limit above the ceiling to 100", async () => {
+    const ctx = captureSearchRequest();
+    restore = ctx.restore;
+
+    await searchByName("Alza", { limit: 5000 });
+    expect(ctx.captured.pocet).toBe(100);
+  });
+
+  test("clamps a non-positive limit up to 1", async () => {
+    const ctx = captureSearchRequest();
+    restore = ctx.restore;
+
+    await searchByName("Alza", { limit: 0 });
+    expect(ctx.captured.pocet).toBe(1);
   });
 });

--- a/packages/business-registries/src/ares/client.test.ts
+++ b/packages/business-registries/src/ares/client.test.ts
@@ -127,10 +127,11 @@ describe("searchByName validation", () => {
 });
 
 describe("searchByName limit clamping", () => {
-  let restore: () => void;
+  let restore: (() => void) | undefined;
 
   afterEach(() => {
-    restore();
+    restore?.();
+    restore = undefined;
   });
 
   test("defaults pocet to 50 when no limit is given", async () => {

--- a/packages/business-registries/src/ares/client.ts
+++ b/packages/business-registries/src/ares/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import {
   AresAPIError,
   AresRequestError,
@@ -23,6 +24,10 @@ const SEARCH_URL = `${BASE}/ekonomicke-subjekty/vyhledat`;
 
 const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 50;
+// ARES documents `pocet` as a plain non-negative integer with no
+// published upper bound. Mirror the brreg/gcis/prh/orsr ceiling so a
+// runaway caller cannot ask ARES for an unbounded result page.
+const MAX_SEARCH_LIMIT = 100;
 
 // ---------------------------------------------------------------------------
 // Internal fetch helpers
@@ -315,7 +320,8 @@ export const searchByName = async (
     throw new AresValidationError("Search name must not be empty");
   }
 
-  const limit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
+  const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
+  const limit = clampSearchLimit(requestedLimit, MAX_SEARCH_LIMIT);
 
   const payload = {
     obchodniJmeno: trimmed,

--- a/packages/business-registries/src/brreg/client.ts
+++ b/packages/business-registries/src/brreg/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import {
   BrregAPIError,
   BrregRequestError,
@@ -247,7 +248,7 @@ export const searchByName = async (
   }
 
   const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
-  const size = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT);
+  const size = clampSearchLimit(requestedLimit, MAX_SEARCH_LIMIT);
 
   const params = new URLSearchParams({
     navn: trimmed,

--- a/packages/business-registries/src/companies-house/client.ts
+++ b/packages/business-registries/src/companies-house/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import {
   CompaniesHouseAPIError,
   CompaniesHouseAuthError,
@@ -296,7 +297,7 @@ export const searchByName = async (
     throw new CompaniesHouseValidationError("Search query must not be empty");
   }
   const requested = options?.limit ?? DEFAULT_SEARCH_LIMIT;
-  const itemsPerPage = Math.min(Math.max(requested, 1), MAX_SEARCH_LIMIT);
+  const itemsPerPage = clampSearchLimit(requested, MAX_SEARCH_LIMIT);
   const startIndex = Math.max(options?.startIndex ?? 0, 0);
 
   const params = new URLSearchParams({

--- a/packages/business-registries/src/gcis/client.ts
+++ b/packages/business-registries/src/gcis/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import {
   GcisAPIError,
   GcisRequestError,
@@ -214,7 +215,7 @@ export const searchByName = async (
     throw new GcisValidationError("Search name must not be empty");
   }
   const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
-  const top = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT);
+  const top = clampSearchLimit(requestedLimit, MAX_SEARCH_LIMIT);
   const activeOnly = options?.activeOnly ?? true;
   if (!activeOnly) {
     const rows = await gcisGet(buildSearchUrl({ name: trimmed, limit: top }));

--- a/packages/business-registries/src/orsr/client.ts
+++ b/packages/business-registries/src/orsr/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import {
   OrsrAPIError,
   OrsrRequestError,
@@ -248,7 +249,7 @@ export const searchByName = async (
     throw new OrsrValidationError("Search name must not be empty");
   }
   const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
-  const take = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT);
+  const take = clampSearchLimit(requestedLimit, MAX_SEARCH_LIMIT);
   const searchTake = Math.min(
     Math.max(take, DEFAULT_SEARCH_LIMIT),
     MAX_SEARCH_LIMIT,

--- a/packages/business-registries/src/prh/client.ts
+++ b/packages/business-registries/src/prh/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import { PrhAPIError, PrhRequestError, PrhValidationError } from "./errors.js";
 import { parseCompany, parseSearchEntry } from "./parse.js";
 import type {
@@ -168,7 +169,7 @@ export const searchByName = async (
     throw new PrhValidationError("Search name must not be empty");
   }
   const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
-  const limit = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT);
+  const limit = clampSearchLimit(requestedLimit, MAX_SEARCH_LIMIT);
   const params = new URLSearchParams({
     name: trimmed,
     maxResults: limit.toString(),

--- a/packages/business-registries/src/recherche-entreprises/client.ts
+++ b/packages/business-registries/src/recherche-entreprises/client.ts
@@ -1,3 +1,4 @@
+import { clampSearchLimit } from "../shared/search.js";
 import {
   RechercheEntreprisesAPIError,
   RechercheEntreprisesRequestError,
@@ -241,7 +242,7 @@ export const searchByName = async (
     );
   }
   const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
-  const perPage = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT);
+  const perPage = clampSearchLimit(requestedLimit, MAX_SEARCH_LIMIT);
   const params = new URLSearchParams({
     q: trimmed,
     per_page: String(perPage),

--- a/packages/business-registries/src/shared/index.ts
+++ b/packages/business-registries/src/shared/index.ts
@@ -11,5 +11,6 @@ export {
   RegistryUnavailableError,
 } from "./errors.js";
 export type { EntityNotFound } from "./errors.js";
+export { clampSearchLimit } from "./search.js";
 export type { EntityStatus } from "./status.js";
 export { mapEntityStatus } from "./status.js";

--- a/packages/business-registries/src/shared/search.test.ts
+++ b/packages/business-registries/src/shared/search.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { clampSearchLimit } from "./search.js";
+
+describe("clampSearchLimit", () => {
+  test("passes a requested limit within range through unchanged", () => {
+    expect(clampSearchLimit(10, 100)).toBe(10);
+  });
+
+  test("clamps a requested limit above the ceiling down to the ceiling", () => {
+    expect(clampSearchLimit(5000, 100)).toBe(100);
+  });
+
+  test("clamps a requested limit of zero or below up to 1", () => {
+    expect(clampSearchLimit(0, 100)).toBe(1);
+    expect(clampSearchLimit(-5, 100)).toBe(1);
+  });
+
+  test("returns the ceiling itself when requested equals the ceiling", () => {
+    expect(clampSearchLimit(100, 100)).toBe(100);
+  });
+});

--- a/packages/business-registries/src/shared/search.ts
+++ b/packages/business-registries/src/shared/search.ts
@@ -1,0 +1,7 @@
+// Every adapter's `searchByName` exposes a caller-supplied `limit` that
+// gets translated into an upstream page-size parameter (Take, pocet,
+// size, items_per_page, top, per_page, ...). Clamp it once here instead
+// of letting each adapter hand-roll (and potentially forget) the same
+// `Math.min(Math.max(...))` expression.
+export const clampSearchLimit = (requested: number, max: number): number =>
+  Math.min(Math.max(requested, 1), max);


### PR DESCRIPTION
The ARES adapter forwarded \`options.limit\` unclamped to the upstream API while all six sibling registry adapters clamp to \`[1, MAX_SEARCH_LIMIT]\`; a zero/negative limit produced an upstream error instead of a clean validation, and an oversized one requested unbounded rows.

- \`clampSearchLimit\` hoisted into the package's shared module; ARES now clamps to 100 (consistent with brreg/gcis/prh/orsr; upstream OpenAPI documents no ceiling) and the six siblings were migrated to the shared helper so the pattern cannot drift again (orsr's second, different-min overfetch clamp deliberately left inline).
- Unit tests for the helper plus fetch-stub tests pinning the clamped \`pocet\` values.