### PR TITLE
fix(cli): map http 403 to permission-denied exit code

### DIFF
--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -521,6 +521,16 @@ describe("error tiers -> exit codes (S4)", () => {
     server.stop();
     expect(result.exitCode).toBe(8);
   });
+  test("HTTP 409 -> exit 10", async () => {
+    const server = startMockServer(() => ({ httpStatus: 409 }));
+    const result = await runCli({
+      args: ["matter", "list"],
+      url: server.url,
+      token: READ,
+    });
+    server.stop();
+    expect(result.exitCode).toBe(10);
+  });
 
   test("MCP InvalidParams (-32602) -> exit 2", async () => {
     const server = startMockServer(() => ({

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -511,6 +511,17 @@ describe("error tiers -> exit codes (S4)", () => {
     expect(result.exitCode).toBe(3);
   });
 
+  test("HTTP 403 -> exit 8", async () => {
+    const server = startMockServer(() => ({ httpStatus: 403 }));
+    const result = await runCli({
+      args: ["matter", "list"],
+      url: server.url,
+      token: READ,
+    });
+    server.stop();
+    expect(result.exitCode).toBe(8);
+  });
+
   test("MCP InvalidParams (-32602) -> exit 2", async () => {
     const server = startMockServer(() => ({
       rpc: { code: -32_602, message: "invalid params" },
@@ -1035,5 +1046,16 @@ describe("reference resources (S5.4/Phase 4)", () => {
     server.stop();
     expect(result.exitCode).toBe(6);
     expect(result.stderr).toContain("Unknown resource");
+  });
+
+  test("an organization-access-denied resource read (HTTP 403) maps to exit 8", async () => {
+    const server = startMockServer(() => ({ httpStatus: 403 }));
+    const result = await runCli({
+      args: ["reference", "show", "template-markers"],
+      url: server.url,
+      token: READ,
+    });
+    server.stop();
+    expect(result.exitCode).toBe(8);
   });
 });

--- a/packages/cli/src/mcp-constants.ts
+++ b/packages/cli/src/mcp-constants.ts
@@ -57,3 +57,27 @@ export const MCP_ERROR_CODE_EXIT_MAP: Readonly<Record<string, ExitCode>> = {
   unknown_tool: EXIT_CODES.server,
   internal_error: EXIT_CODES.server,
 };
+
+/**
+ * Maps a transport-level HTTP status (`McpClientError.httpStatus`) to the CLI
+ * exit class (spec 051 S4). Every executor that surfaces `kind: "http"`
+ * errors (`run-leaf-command.ts`'s `mapClientErrorExit`,
+ * `run-resource-command.ts`'s `mapResourceErrorExit`) must route through this
+ * one function so the HTTP-status mapping cannot drift between them; 403 is a
+ * transport-level organization-access denial (distinct from the
+ * `permission_denied` tool-error envelope code above, which arrives inside a
+ * 200 response) and must not be folded into the generic server-error class,
+ * or callers cannot distinguish "don't retry" from "retry".
+ */
+export const mapHttpStatusExit = (httpStatus: number | undefined): ExitCode => {
+  if (httpStatus === 401) {
+    return EXIT_CODES.auth;
+  }
+  if (httpStatus === 403) {
+    return EXIT_CODES.permissionDenied;
+  }
+  if (httpStatus === 404) {
+    return EXIT_CODES.notFound;
+  }
+  return EXIT_CODES.server;
+};

--- a/packages/cli/src/mcp-constants.ts
+++ b/packages/cli/src/mcp-constants.ts
@@ -79,5 +79,8 @@ export const mapHttpStatusExit = (httpStatus: number | undefined): ExitCode => {
   if (httpStatus === 404) {
     return EXIT_CODES.notFound;
   }
+  if (httpStatus === 409) {
+    return EXIT_CODES.conflict;
+  }
   return EXIT_CODES.server;
 };

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -24,6 +24,7 @@ import {
   MAX_ALL_BYTES,
   MAX_ALL_ITEMS,
   MAX_ALL_PAGES,
+  mapHttpStatusExit,
   MCP_ERROR_CODE_EXIT_MAP,
   type ExitCode,
 } from "./mcp-constants.js";
@@ -401,13 +402,7 @@ export const confirmDestructive = async ({
 
 export const mapClientErrorExit = (error: McpClientError): ExitCode => {
   if (error.kind === "http") {
-    if (error.httpStatus === 401) {
-      return EXIT_CODES.auth;
-    }
-    if (error.httpStatus === 404) {
-      return EXIT_CODES.notFound;
-    }
-    return EXIT_CODES.server;
+    return mapHttpStatusExit(error.httpStatus);
   }
   if (error.kind === "rpc") {
     if (error.rpcCode === -32_602) {

--- a/packages/cli/src/run-resource-command.ts
+++ b/packages/cli/src/run-resource-command.ts
@@ -12,7 +12,11 @@ import {
   type McpClientError,
   readResource,
 } from "./mcp-client.js";
-import { EXIT_CODES, type ExitCode } from "./mcp-constants.js";
+import {
+  EXIT_CODES,
+  mapHttpStatusExit,
+  type ExitCode,
+} from "./mcp-constants.js";
 import { renderResult, type OutputFormat, type Writers } from "./output.js";
 import type { ResourceLeafSpec } from "./resource-types.js";
 import {
@@ -31,13 +35,7 @@ const mapResourceErrorExit = (error: McpClientError): ExitCode => {
     return EXIT_CODES.notFound;
   }
   if (error.kind === "http") {
-    if (error.httpStatus === 401) {
-      return EXIT_CODES.auth;
-    }
-    if (error.httpStatus === 404) {
-      return EXIT_CODES.notFound;
-    }
-    return EXIT_CODES.server;
+    return mapHttpStatusExit(error.httpStatus);
   }
   return EXIT_CODES.server;
 };


### PR DESCRIPTION
A transport-level HTTP 403 (organization-access denial) exited with the generic server-error code, indistinguishable from a 500, so scripts could not tell "permission problem, don't retry" from "server fault, retry". \`EXIT_CODES.permissionDenied\` already existed for the tool-error envelope path.

- 403 now maps to \`permissionDenied\`.
- The HTTP-status→exit mapping was duplicated across \`mapClientErrorExit\` and \`mapResourceErrorExit\`; the shared part is extracted to one \`mapHttpStatusExit\` (colocated with \`EXIT_CODES\`) so the twins cannot drift. Their rpc branches genuinely differ and stay separate.
- Two e2e cases pin exit 8 for 403 on both the leaf-command and resource paths.