### PR TITLE
fix(scripts): parse nested ICU messages in i18n check

### DIFF
--- a/packages/scripts/src/i18n-check.test.ts
+++ b/packages/scripts/src/i18n-check.test.ts
@@ -239,6 +239,43 @@ describe("findUntranslated", () => {
   });
 });
 
+describe("findUntranslated — nested ICU braces (regression)", () => {
+  // Real en.json value: a select whose "other" branch mixes literal text
+  // ("New ") with a nested placeholder ({layout}). A brace-matcher that
+  // closes on the FIRST "}" (instead of the matching one) swallows "New"
+  // entirely, so a byte-identical locale copy is wrongly treated as
+  // language-neutral and never flagged as untranslated.
+  test("flags a verbatim copy of a nested select as untranslated", () => {
+    const en: NestedMessages = {
+      folio: { newView: "{layoutType, select, other {New {layout}}}" },
+    };
+    const target: NestedMessages = {
+      folio: { newView: "{layoutType, select, other {New {layout}}}" },
+    };
+    expect(findUntranslated(en, target, "cs", emptyBaseline())).toEqual([
+      "folio.newView",
+    ]);
+  });
+
+  test("counts plural branch text but not the plural placeholder itself", () => {
+    const en: NestedMessages = {
+      docs: { count: "{count, plural, one {# document} other {# documents}}" },
+    };
+    const target: NestedMessages = {
+      docs: { count: "{count, plural, one {# document} other {# documents}}" },
+    };
+    expect(findUntranslated(en, target, "cs", emptyBaseline())).toEqual([
+      "docs.count",
+    ]);
+  });
+
+  test("still strips a flat placeholder-only value", () => {
+    const en: NestedMessages = { common: { count: "{n}" } };
+    const target: NestedMessages = { common: { count: "{n}" } };
+    expect(findUntranslated(en, target, "cs", emptyBaseline())).toEqual([]);
+  });
+});
+
 describe("findCommonDuplicates", () => {
   const en: NestedMessages = {
     common: { remove: "Remove", save: "Save" },

--- a/packages/scripts/src/i18n-check.ts
+++ b/packages/scripts/src/i18n-check.ts
@@ -12,6 +12,8 @@
  *                    the current untranslated/duplicate debt so the gate
  *                    stays green while catching new regressions.
  */
+import { parse, TYPE } from "@formatjs/icu-messageformat-parser";
+import type { MessageFormatElement } from "@formatjs/icu-messageformat-parser";
 import path from "node:path";
 
 export type NestedMessages = {
@@ -237,32 +239,69 @@ const ALLOWED_IDENTICAL = new Set<string>([
   "Markdown",
 ]);
 
+// Parsing ICU is on the isTriviallyIdentical hot path, so memoize: every
+// unique string is parsed at most once. A parse failure (invalid ICU; already
+// reported separately by i18n-lint) is cached as null.
+const icuParseCache = new Map<string, MessageFormatElement[] | null>();
+const safeParseIcu = (value: string): MessageFormatElement[] | null => {
+  const cached = icuParseCache.get(value);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let result: MessageFormatElement[] | null;
+  try {
+    result = parse(value);
+  } catch {
+    result = null;
+  }
+  icuParseCache.set(value, result);
+  return result;
+};
+
+/**
+ * Literal, human-translatable text from an ICU MessageFormat AST: plain text
+ * and select/plural BRANCH TEXT count (e.g. "New " in
+ * `{layoutType, select, other {New {layout}}}`), since that text is real
+ * language content a translator must render. Argument placeholders
+ * (`{n}`, `{date, date, short}`), the select/plural variable name and
+ * category keywords (`other`, `one`, ...), and `#` are control syntax, not
+ * translatable text, and are dropped.
+ */
+const extractLiteralText = (elements: MessageFormatElement[]): string => {
+  let text = "";
+
+  for (const element of elements) {
+    switch (element.type) {
+      case TYPE.literal:
+        text += element.value;
+        break;
+      case TYPE.select:
+      case TYPE.plural:
+        for (const option of Object.values(element.options)) {
+          text += extractLiteralText(option.value);
+        }
+        break;
+      case TYPE.tag:
+        text += extractLiteralText(element.children);
+        break;
+      default:
+        // argument, number, date, time, pound: interpolated, not translatable text.
+        break;
+    }
+  }
+
+  return text;
+};
+
+/**
+ * Strip ICU MessageFormat control syntax from a value, keeping literal text
+ * (including select/plural branch text) so it can be checked for real
+ * language content. Falls back to the raw value when it does not parse as
+ * valid ICU (a syntax error there is reported separately by i18n-lint).
+ */
 const stripIcuPlaceholders = (value: string): string => {
-  const literal: string[] = [];
-  let placeholder: string[] | null = null;
-
-  for (const char of value) {
-    if (placeholder) {
-      placeholder.push(char);
-      if (char === "}") {
-        placeholder = null;
-      }
-      continue;
-    }
-
-    if (char === "{") {
-      placeholder = [char];
-      continue;
-    }
-
-    literal.push(char);
-  }
-
-  if (placeholder) {
-    literal.push(...placeholder);
-  }
-
-  return literal.join("");
+  const elements = safeParseIcu(value);
+  return elements === null ? value : extractLiteralText(elements);
 };
 
 /** A value that is expected to read identically in every language. */


### PR DESCRIPTION
\`stripIcuPlaceholders\` closed a placeholder at the first \`}\` rather than the matching one, so for nested ICU (\`{x, select, other {New {y}}}\`) it swallowed real branch text; \`findUntranslated\` then misclassified such strings as language-neutral and skipped genuinely untranslated copies.

- Replaced the hand-rolled scan with the real ICU AST via \`@formatjs/icu-messageformat-parser\` (already a dependency, already used the same way by the sibling \`i18n-lint.ts\`): literal and branch text count as translatable, control syntax does not; graceful fallback on parse failure; memoized on the hot path.
- Regression tests cover the real nested-select key that motivated the fix, plural branch text, and flat placeholders. The current lang corpus was verified unaffected (the class existed; no live instance).