### PR TITLE
chore: drop dead exports from entity constants and web types

### DIFF
--- a/apps/api/src/lib/entity-constants.ts
+++ b/apps/api/src/lib/entity-constants.ts
@@ -69,9 +69,6 @@ export const AGENDA_ATTENDEE_TYPE = {
   RESOURCE: "resource",
 } as const;
 
-export type AgendaAttendeeType =
-  (typeof AGENDA_ATTENDEE_TYPE)[keyof typeof AGENDA_ATTENDEE_TYPE];
-
 export const AGENDA_ATTENDEE_TYPES = Object.values(AGENDA_ATTENDEE_TYPE);
 
 const DOCUMENT_STATUS = {
@@ -82,8 +79,6 @@ const DOCUMENT_STATUS = {
 
 export type DocumentStatus =
   (typeof DOCUMENT_STATUS)[keyof typeof DOCUMENT_STATUS];
-
-export const DOCUMENT_STATUSES = Object.values(DOCUMENT_STATUS);
 
 const ENTITY_PRIORITY = {
   NONE: "none",
@@ -111,8 +106,5 @@ export const TASK_ASSIGNEE_ROLES = Object.values(TASK_ASSIGNEE_ROLE);
 const ENTITY_LINK_TYPE = {
   RELATED: "related",
 } as const;
-
-export type EntityLinkType =
-  (typeof ENTITY_LINK_TYPE)[keyof typeof ENTITY_LINK_TYPE];
 
 export const ENTITY_LINK_TYPES = Object.values(ENTITY_LINK_TYPE);

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -136,8 +136,6 @@ export type WorkspaceProperty = {
   role?: "document-type-classifier" | null;
 };
 
-export type WorkspaceToolType = WorkspaceProperty["tool"]["type"];
-
 export type WorkspacePropertyOption = {
   color: OptionColor;
   value: string;
@@ -290,13 +288,6 @@ export type WorkspaceView<T extends ViewLayoutType = ViewLayoutType> = {
 // ── Inline mention types ─────────────────────────────────
 // Default renders icon/avatar; callers must explicitly
 // opt out via hideIcon / hideAvatar.
-
-export type FileMention = {
-  name: string;
-  mimeType: string;
-  /** Only set when space is extremely constrained. */
-  hideIcon?: boolean;
-};
 
 export type PersonMention = {
   name: string;


### PR DESCRIPTION
Removes five exports with zero importers (re-verified by repo-wide grep at branch time): \`DOCUMENT_STATUSES\`, \`AgendaAttendeeType\`, and \`EntityLinkType\` from \`apps/api/src/lib/entity-constants.ts\`, plus \`WorkspaceToolType\` and \`FileMention\` from \`apps/web/src/lib/types.ts\`. Deletion-only; the backing consts/types that remain in use are untouched.