### PR TITLE
fix(api): serialize entity-cap checks with advisory locks

### DIFF
--- a/apps/api/src/handlers/entities/clip.ts
+++ b/apps/api/src/handlers/entities/clip.ts
@@ -10,6 +10,7 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { tDefaultVarchar } from "@/api/lib/custom-schema";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { acquireWorkspaceEntityCapLock } from "@/api/lib/entity-cap-lock";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { getSearchProvider } from "@/api/lib/search/provider";
@@ -38,18 +39,6 @@ export default createSafeHandler(
       body: { title, url, snippet, citation, jurisdiction, sourceType },
     } = ctx;
 
-    const entityCount = yield* Result.await(
-      safeDb((tx) =>
-        tx.$count(entities, eq(entities.workspaceId, workspaceId)),
-      ),
-    );
-
-    if (entityCount >= LIMITS.entitiesCount) {
-      return Result.err(
-        new HandlerError({ status: 400, message: "Entities limit reached" }),
-      );
-    }
-
     const metadata: LinkMetadata = {
       url,
       ...(snippet !== undefined && { snippet }),
@@ -61,8 +50,22 @@ export default createSafeHandler(
     const entityId = createSafeId<"entity">();
     const entityVersionId = createSafeId<"entityVersion">();
 
-    yield* Result.await(
+    const writeResult = yield* Result.await(
       safeDb(async (tx) => {
+        // A workspace-scoped advisory lock serializes this
+        // count-then-insert sequence against concurrent creations;
+        // same-transaction placement alone does not prevent TOCTOU
+        // races under READ COMMITTED.
+        await acquireWorkspaceEntityCapLock(tx, workspaceId);
+
+        const entityCount = await tx.$count(
+          entities,
+          eq(entities.workspaceId, workspaceId),
+        );
+        if (entityCount >= LIMITS.entitiesCount) {
+          return { ok: false as const };
+        }
+
         const entityStamp = await allocateEntityStamp(tx, workspaceId);
 
         await tx.insert(entities).values({
@@ -126,8 +129,16 @@ export default createSafeHandler(
             },
           },
         ]);
+
+        return { ok: true as const };
       }),
     );
+
+    if (!writeResult.ok) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Entities limit reached" }),
+      );
+    }
 
     getSearchProvider().indexEntity(entityId).catch(captureError);
 

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -16,6 +16,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { acquireWorkspaceEntityCapLock } from "@/api/lib/entity-cap-lock";
 import {
   enqueueImageThumbnailOrMarkFailed,
   enqueuePdfDerivativeOrMarkFailed,
@@ -139,8 +140,14 @@ export const createEntityFromBuffer = async ({
     await getS3().write(s3Key, bytes);
 
     await scopedDb(async (tx) => {
-      // The authoritative limit check must stay in the same
-      // transaction as the insert to avoid TOCTOU races.
+      // A workspace-scoped advisory lock serializes this
+      // count-then-insert sequence against concurrent creations.
+      // Same-transaction placement alone does not prevent TOCTOU
+      // races under READ COMMITTED: without the lock, two
+      // concurrent transactions can each read a count under the
+      // limit before either commits its insert.
+      await acquireWorkspaceEntityCapLock(tx, workspaceId);
+
       const entityCount = await tx.$count(
         entities,
         eq(entities.workspaceId, workspaceId),

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -24,6 +24,7 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { acquireWorkspaceEntityCapLock } from "@/api/lib/entity-cap-lock";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import {
@@ -215,8 +216,24 @@ const uploadEntityHandler = async function* ({
     const entityVersionId = createSafeId<"entityVersion">();
     const fieldId = createSafeId<"field">();
 
-    const fileName = yield* Result.await(
+    const writeResult = yield* Result.await(
       safeDb(async (tx) => {
+        // A workspace-scoped advisory lock serializes this
+        // count-then-insert sequence against concurrent creations;
+        // same-transaction placement alone does not prevent TOCTOU
+        // races under READ COMMITTED. The earlier `entityCount`
+        // check above is a non-authoritative fast-fail to avoid
+        // wasted upload/scan work; this is the authoritative check.
+        await acquireWorkspaceEntityCapLock(tx, workspaceId);
+
+        const authoritativeEntityCount = await tx.$count(
+          entities,
+          eq(entities.workspaceId, workspaceId),
+        );
+        if (authoritativeEntityCount >= LIMITS.entitiesCount) {
+          return { ok: false as const };
+        }
+
         const resolvedName = await resolveFileName({ tx, propertyId, name });
 
         const entityStamp = await allocateEntityStamp(tx, workspaceId);
@@ -294,9 +311,20 @@ const uploadEntityHandler = async function* ({
           },
         });
 
-        return resolvedName;
+        return { ok: true as const, resolvedName };
       }),
     );
+
+    if (!writeResult.ok) {
+      await Promise.allSettled(
+        s3Keys.map(async (key) => await getS3().delete(key)),
+      );
+      return Result.err(
+        new HandlerError({ status: 400, message: "Entities limit reached" }),
+      );
+    }
+
+    const fileName = writeResult.resolvedName;
 
     await processExtraction(entityId).catch((error: unknown) =>
       captureError(error, { entityId, mimeType: file.type }),

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -369,7 +369,9 @@ const uploadEntityHandler = async function* ({
       renamed: fileName.renamed,
     });
   } catch (error) {
-    await Promise.all(s3Keys.map(async (key) => await getS3().delete(key)));
+    await Promise.allSettled(
+      s3Keys.map(async (key) => await getS3().delete(key)),
+    );
     throw error;
   }
 };

--- a/apps/api/src/handlers/tasks/create.ts
+++ b/apps/api/src/handlers/tasks/create.ts
@@ -17,6 +17,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { acquireWorkspaceEntityCapLock } from "@/api/lib/entity-cap-lock";
 import {
   AGENDA_ITEM_KIND,
   AGENDA_ITEM_KINDS,
@@ -131,6 +132,12 @@ export const createTaskEntityHandler = async function* ({
 
   const txResult = yield* Result.await(
     safeDb(async (tx) => {
+      // A workspace-scoped advisory lock serializes this
+      // count-then-insert sequence against concurrent creations;
+      // same-transaction placement alone does not prevent TOCTOU
+      // races under READ COMMITTED.
+      await acquireWorkspaceEntityCapLock(tx, workspaceId);
+
       const totalEntities = await tx.$count(
         entities,
         eq(entities.workspaceId, workspaceId),

--- a/apps/api/src/lib/entity-cap-lock.ts
+++ b/apps/api/src/lib/entity-cap-lock.ts
@@ -1,0 +1,32 @@
+import { sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import type { SafeId } from "@/api/lib/branded-types";
+
+// Entities-per-workspace cap checks are a classic count-then-insert
+// race: two concurrent creations can each read a count under the
+// limit and both insert, pushing the workspace past
+// `LIMITS.entitiesCount`. Placing the count and insert in the same
+// transaction does NOT close this window on its own — at READ
+// COMMITTED, two concurrent transactions each take their own
+// snapshot per statement and neither sees the other's uncommitted
+// insert, so both can read a count below the limit.
+//
+// `pg_advisory_xact_lock` serializes the count-then-insert sequence
+// per workspace: the second concurrent transaction blocks until the
+// first commits (or rolls back), at which point its own count
+// reflects the first transaction's insert. The lock is held for the
+// transaction's lifetime and releases automatically at COMMIT or
+// ROLLBACK.
+//
+// Keyed with an `entity-cap:` prefix so this lock domain never
+// collides with unrelated advisory locks already taken on the same
+// workspace id elsewhere (e.g. property writes, time-entry bumps).
+export const acquireWorkspaceEntityCapLock = async (
+  tx: Transaction,
+  workspaceId: SafeId<"workspace">,
+): Promise<void> => {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('entity-cap:' || ${workspaceId}))`,
+  );
+};


### PR DESCRIPTION
Entities-per-workspace cap checks (upload, clip, create-from-buffer, and task creation) were count-then-insert with no lock; under READ COMMITTED, concurrent creations at the same endpoint each read a passing count and can push a workspace past \`LIMITS.entitiesCount\`.

- New \`acquireWorkspaceEntityCapLock\` (\`pg_advisory_xact_lock\` on an \`entity-cap:\`-prefixed key) serializes the count-then-insert per workspace at those four sites. Advisory locks do not participate in the row-lock ordering that \`copyEntities\` uses, so this introduces no deadlock and leaves the copy/duplicate/cross-workspace paths untouched.
- Also settles all S3 cleanup deletes on upload failure (\`Promise.all\` -> \`Promise.allSettled\`) so one failed delete cannot orphan the rest.

Scope note: unifying every entity-creating path (copy, cross-workspace moves, parented/folder creates, the infosoud batch importer) onto a single workspace-row \`FOR UPDATE\` lock is deferred to a dedicated lock-order design PR — that unification is what surfaced the cross-workspace and parented-move ordering questions, and it deserves a deliberate design rather than incremental patching.