### PR TITLE
fix(api): make workflow completion counting run-scoped and atomic

### DIFF
--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -54,6 +54,10 @@ import {
   readFullWorkflowSnapshotCursor,
 } from "@/api/lib/workflow-target-queries";
 import { resolveWorkflowTargetEntityIds } from "@/api/lib/workflow-targets";
+import {
+  COMPLETE_ENTITY_SCRIPT,
+  parseEntityCompletionReply,
+} from "@/api/lib/workflow/completion-tracking";
 import { getBatchGenerator } from "@/api/lib/workflow/generate-batch-provider";
 import type {
   AIJustification,
@@ -1800,20 +1804,32 @@ const onEntityCompleted = async (
   requestId: string,
   runLockTtlSec: number,
 ) => {
-  const isCurrentRequest = await isCurrentWorkflowRequest({
+  const redis = getRedis();
+
+  // Atomically re-check that this job still belongs to the active
+  // workflow request AND increment the completed counter in the same
+  // Redis command (see `COMPLETE_ENTITY_SCRIPT`). A plain check-then-INCR
+  // (two round trips) leaves a window where a stale job's check can pass
+  // just before the run it belongs to finishes and a new run resets the
+  // counters — the stale job's INCR would then land on the new run's
+  // counter instead of being a no-op. Same idiom as
+  // `RESERVE_RECOVERY_LOCK_SCRIPT` above.
+  const reply: unknown = await redis.send("EVAL", [
+    COMPLETE_ENTITY_SCRIPT,
+    "4",
+    workflowKey(workspaceId, "request-id"),
+    workflowKey(workspaceId, "running"),
+    workflowKey(workspaceId, "completed"),
+    workflowKey(workspaceId, "total"),
     requestId,
-    workspaceId,
-  });
-  if (!isCurrentRequest) {
+    LEGACY_RUNNING_LOCK_VALUE,
+  ]);
+  const result = parseEntityCompletionReply(reply);
+  if (!result.matched) {
     return;
   }
 
-  const redis = getRedis();
-  const completed = await redis.incr(workflowKey(workspaceId, "completed"));
-  const totalStr = await redis.get(workflowKey(workspaceId, "total"));
-  const total = Number(totalStr ?? "0");
-
-  if (completed >= total) {
+  if (result.completed >= result.total) {
     await finishWorkflow(workspaceId, organizationId, userId, requestId);
     return;
   }

--- a/apps/api/src/lib/workflow/completion-tracking.test.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseEntityCompletionReply } from "@/api/lib/workflow/completion-tracking";
+
+describe("parseEntityCompletionReply", () => {
+  test("reads a matched increment", () => {
+    expect(parseEntityCompletionReply([1, 3, 10])).toEqual({
+      matched: true,
+      completed: 3,
+      total: 10,
+    });
+  });
+
+  test("treats an unmatched request as unmatched", () => {
+    // A stale job's requestId no longer equals the workspace's current
+    // request-id (or running lock): the Lua script returns [0, 0, 0]
+    // without touching the counters. This is the case that used to be a
+    // separate, racy `isCurrentWorkflowRequest` check before the INCR.
+    expect(parseEntityCompletionReply([0, 0, 0])).toEqual({ matched: false });
+  });
+
+  test("treats a non-array reply as unmatched", () => {
+    expect(parseEntityCompletionReply(null)).toEqual({ matched: false });
+    expect(parseEntityCompletionReply(undefined)).toEqual({
+      matched: false,
+    });
+    expect(parseEntityCompletionReply("OK")).toEqual({ matched: false });
+  });
+
+  test("treats a short array as unmatched", () => {
+    expect(parseEntityCompletionReply([1, 3])).toEqual({ matched: false });
+  });
+
+  test("treats non-numeric completed/total as unmatched", () => {
+    expect(parseEntityCompletionReply([1, "x", 10])).toEqual({
+      matched: false,
+    });
+    expect(parseEntityCompletionReply([1, 3, "y"])).toEqual({
+      matched: false,
+    });
+  });
+
+  test("treats a matched flag other than 1 as unmatched", () => {
+    expect(parseEntityCompletionReply([2, 3, 10])).toEqual({
+      matched: false,
+    });
+  });
+});

--- a/apps/api/src/lib/workflow/completion-tracking.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.ts
@@ -1,0 +1,70 @@
+// Pure helpers for interpreting the atomic entity-completion Lua script's
+// reply. Kept free of Redis imports so the parsing logic is unit-testable
+// without a live connection, mirroring `orphan-recovery.ts`.
+
+// Atomically re-checks that `requestId` is still the workspace's active
+// workflow request (matching both the `request-id` key and the `running`
+// lock, including the legacy running-lock value) and, only if so,
+// increments the completed counter and reads the total in the same Redis
+// command. A plain check-then-INCR (two separate round trips) leaves a
+// window where a stale job's check can pass just before the run it
+// belongs to finishes and a new run resets the counters: the stale job's
+// INCR would then land on the new run instead of a no-op. Bundling the
+// check and the increment into one script closes that window, since Redis
+// executes Lua scripts atomically with no other command interleaved.
+//
+// KEYS[1] = request-id key, KEYS[2] = running key, KEYS[3] = completed
+// key, KEYS[4] = total key.
+// ARGV[1] = requestId, ARGV[2] = legacy running-lock value.
+//
+// Returns `[matched, completed, total]`, where `matched` is `1` only when
+// the increment happened against the currently active request.
+export const COMPLETE_ENTITY_SCRIPT = `
+local currentRequestId = redis.call("GET", KEYS[1])
+local runningValue = redis.call("GET", KEYS[2])
+local requestId = ARGV[1]
+local legacyRunningLockValue = ARGV[2]
+
+if currentRequestId ~= requestId then
+  return {0, 0, 0}
+end
+if runningValue ~= requestId and runningValue ~= legacyRunningLockValue then
+  return {0, 0, 0}
+end
+
+local completed = redis.call("INCR", KEYS[3])
+local totalRaw = redis.call("GET", KEYS[4])
+local total = tonumber(totalRaw) or 0
+return {1, completed, total}
+`;
+
+export type EntityCompletionReply =
+  | { matched: false }
+  | { matched: true; completed: number; total: number };
+
+const isUnknownArray = (value: unknown): value is readonly unknown[] =>
+  Array.isArray(value);
+
+/**
+ * Parse the raw EVAL reply from `COMPLETE_ENTITY_SCRIPT`. Any shape other
+ * than `[1, completed, total]` (a stale Redis client version, a protocol
+ * hiccup, a mismatched request) is treated as unmatched so a malformed
+ * reply never miscounts a completion.
+ */
+export const parseEntityCompletionReply = (
+  reply: unknown,
+): EntityCompletionReply => {
+  if (!isUnknownArray(reply) || reply.length < 3) {
+    return { matched: false };
+  }
+  const [matchedRaw, completedRaw, totalRaw] = reply;
+  if (Number(matchedRaw) !== 1) {
+    return { matched: false };
+  }
+  const completed = Number(completedRaw);
+  const total = Number(totalRaw);
+  if (!Number.isFinite(completed) || !Number.isFinite(total)) {
+    return { matched: false };
+  }
+  return { matched: true, completed, total };
+};


### PR DESCRIPTION
\`onEntityCompleted\` checked \`isCurrentWorkflowRequest\` (two GETs) and then INCR'd the workspace-scoped completed counter as separate round trips. A stale job from a superseded run could pass the check just as a new run started and land its increment on the new run's counter, which can trigger a premature \`finishWorkflow()\` while the new run's entities are still in flight.

- Check and increment are now one atomic Lua script (same idiom as the file's existing \`RESERVE_RECOVERY_LOCK_SCRIPT\`): the script validates the caller's requestId against the current run and only then increments and reads the total, returning all three facts in one round trip.
- Script and reply parsing live in a new pure \`workflow/completion-tracking.ts\` module, unit-tested at the parser seam per the established \`orphan-recovery\` pattern; the advisory pre-work checks elsewhere are unchanged.