### PR TITLE
fix(api): surface template field suggestion failures

### DIFF
--- a/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Pins the `suggest_template_fields` tool's failure path: a
+ * `suggestTemplateFields` rejection (BYOK misconfiguration, provider outage,
+ * timeout) must still be captured for telemetry, but the tool must surface a
+ * sanitized, stable message to the model instead of the raw provider error —
+ * which can carry internals (key names, quota details) that must not reach
+ * the model verbatim. Split into its own file — `mock.module` must run
+ * before the module under test is first imported anywhere in this file's
+ * module graph, and `template-tools.test.ts` already imports it statically.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SafeDb } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+
+const PROVIDER_ERROR = new Error(
+  "upstream provider rejected request: invalid api key sk-live-abc123",
+);
+
+const suggestTemplateFieldsMock = mock(async () => {
+  throw PROVIDER_ERROR;
+});
+const captureErrorMock = mock();
+
+void mock.module("@/api/handlers/templates/suggest-template-fields", () => ({
+  suggestTemplateFields: suggestTemplateFieldsMock,
+}));
+
+void mock.module("@/api/lib/analytics", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
+}));
+
+const { createTemplateAuthoringTools, SUGGEST_TEMPLATE_FIELDS_TOOL_NAME } =
+  await import("@/api/handlers/chat/tools/template-tools");
+
+const organizationId = toSafeId<"organization">("org-test");
+const userId = toSafeId<"user">("user-test");
+// SAFETY: test double — usage metering only touches `safeDb` on a real
+// model step, which never runs here (`suggestTemplateFields` is mocked to
+// reject before any metering call).
+// eslint-disable-next-line typescript/no-unsafe-type-assertion
+const stubSafeDb = (() => {
+  throw new Error("safeDb stub must not be called");
+}) as unknown as SafeDb;
+
+type SuggestFieldsExecute = (
+  input: { text: string; instructions: string | null },
+  options: unknown,
+) => Promise<unknown>;
+
+describe("suggest_template_fields tool error handling", () => {
+  test("sanitizes the provider error before it reaches the model, while still capturing the original", async () => {
+    const tools = createTemplateAuthoringTools({
+      organizationId,
+      orgAIConfig: null,
+      safeDb: stubSafeDb,
+      userId,
+    });
+
+    // SAFETY: invoke the tool's execute directly with a stub call context.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
+    const execute = tools[SUGGEST_TEMPLATE_FIELDS_TOOL_NAME]
+      .execute as unknown as SuggestFieldsExecute;
+
+    const rejection: unknown = await execute(
+      { instructions: null, text: "Granted by Example Corp." },
+      {},
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    if (!ChatToolError.is(rejection)) {
+      throw new Error("Expected a ChatToolError");
+    }
+    expect(rejection.message).not.toContain("sk-live-abc123");
+    expect(rejection.message).toBe(
+      "Template field suggestion failed; the workspace's AI provider returned an error.",
+    );
+
+    // The original error is still captured for telemetry, not swallowed.
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      PROVIDER_ERROR,
+      expect.anything(),
+    );
+  });
+});

--- a/apps/api/src/handlers/chat/tools/template-tools.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools.ts
@@ -298,14 +298,23 @@ export const createTemplateAuthoringTools = ({
         }),
       ),
     }).server(async ({ text, instructions }) => {
-      const suggestions = await suggestTemplateFields({
-        documentText: text,
-        instructions: instructions ?? undefined,
-        orgAIConfig: orgAIConfig ?? null,
-        organizationId,
-        aiAnalytics,
-      });
-      return { suggestions };
+      // suggestTemplateFields rejects on a call failure (BYOK
+      // misconfiguration, provider outage, timeout); capture it for
+      // telemetry, then rethrow so the tool loop reports it to the model as
+      // a tool error instead of silently returning no suggestions.
+      try {
+        const suggestions = await suggestTemplateFields({
+          documentText: text,
+          instructions: instructions ?? undefined,
+          orgAIConfig: orgAIConfig ?? null,
+          organizationId,
+          aiAnalytics,
+        });
+        return { suggestions };
+      } catch (error) {
+        aiAnalytics.captureError(error);
+        throw error;
+      }
     }),
   };
 };

--- a/apps/api/src/handlers/chat/tools/template-tools.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools.ts
@@ -19,6 +19,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedTemplateId } from "@/api/lib/safe-id-boundaries";
 
@@ -299,9 +300,10 @@ export const createTemplateAuthoringTools = ({
       ),
     }).server(async ({ text, instructions }) => {
       // suggestTemplateFields rejects on a call failure (BYOK
-      // misconfiguration, provider outage, timeout); capture it for
-      // telemetry, then rethrow so the tool loop reports it to the model as
-      // a tool error instead of silently returning no suggestions.
+      // misconfiguration, provider outage, timeout); capture the original
+      // for telemetry, then throw a sanitized, stable message instead of
+      // rethrowing it — the raw provider error can carry internals (key
+      // names, quota details) that must not reach the model verbatim.
       try {
         const suggestions = await suggestTemplateFields({
           documentText: text,
@@ -313,7 +315,11 @@ export const createTemplateAuthoringTools = ({
         return { suggestions };
       } catch (error) {
         aiAnalytics.captureError(error);
-        throw error;
+        throw new ChatToolError({
+          message:
+            "Template field suggestion failed; the workspace's AI provider returned an error.",
+          cause: error,
+        });
       }
     }),
   };

--- a/apps/api/src/handlers/templates/prepare-template.test.ts
+++ b/apps/api/src/handlers/templates/prepare-template.test.ts
@@ -74,4 +74,27 @@ describe("prepareTemplateFromDocument", () => {
     expect(fields).toEqual([]);
     expect(unapplied).toEqual([]);
   });
+
+  test("propagates a suggest() rejection instead of swallowing it", async () => {
+    // prepareTemplateFromDocument stays a thin pass-through: the decision to
+    // degrade a model-call failure to an empty list (or surface it) belongs
+    // to the injected `suggest`, not to this function — see prepare.ts's
+    // `suggestTemplateFieldsOrEmpty`-backed suggest callback.
+    const buffer = await makeDocx(["A plain paragraph."]);
+    const failure = new Error("provider unavailable");
+
+    // .rejects.toThrow trips type-aware lint (bun-types declares it void) and
+    // can report a spurious unhandled-rejection warning; capture explicitly.
+    const rejection: unknown = await prepareTemplateFromDocument({
+      buffer,
+      suggest: async () => {
+        throw failure;
+      },
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBe(failure);
+  });
 });

--- a/apps/api/src/handlers/templates/prepare.ts
+++ b/apps/api/src/handlers/templates/prepare.ts
@@ -2,7 +2,7 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import { prepareTemplateFromDocument } from "@/api/handlers/templates/prepare-template";
-import { suggestTemplateFields } from "@/api/handlers/templates/suggest-template-fields";
+import { suggestTemplateFieldsOrEmpty } from "@/api/handlers/templates/suggest-template-fields";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -67,8 +67,12 @@ const prepareTemplate = createSafeRootHandler(
           const buffer = Buffer.from(await file.arrayBuffer());
           return await prepareTemplateFromDocument({
             buffer,
+            // suggestTemplateFieldsOrEmpty degrades a call failure (BYOK
+            // misconfiguration, provider outage, timeout) to the documented
+            // empty-suggestions fallback — instead of failing the whole
+            // prepare request — capturing it first so it isn't silent.
             suggest: async (documentText) =>
-              await suggestTemplateFields({
+              await suggestTemplateFieldsOrEmpty({
                 documentText,
                 orgAIConfig,
                 organizationId,

--- a/apps/api/src/handlers/templates/suggest-template-fields-error.test.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields-error.test.ts
@@ -17,7 +17,9 @@ import * as realTanStackAIModels from "@/api/lib/tanstack-ai-models";
 
 const FAILURE = new Error("provider unavailable");
 
-const chat = (): Promise<never> => Promise.reject(FAILURE);
+const chat = async (): Promise<never> => {
+  throw FAILURE;
+};
 
 const testModel = {
   adapter: {},

--- a/apps/api/src/handlers/templates/suggest-template-fields-error.test.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields-error.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Pins the failure path of `suggestTemplateFields`: a model-call failure
+ * (BYOK misconfiguration, provider outage, timeout) must reject instead of
+ * being swallowed into an empty list, so callers can distinguish "the model
+ * found nothing" from "the call failed" (see the module doc comment on
+ * suggest-template-fields.ts). Split into its own file — mock.module must run
+ * before the module under test is first imported anywhere in this file's
+ * module graph, and suggest-template-fields.test.ts already imports it
+ * statically for the schema tests.
+ */
+
+import * as realTanStackAI from "@tanstack/ai";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import * as realTanStackAIModels from "@/api/lib/tanstack-ai-models";
+
+const FAILURE = new Error("provider unavailable");
+
+const chat = (): Promise<never> => Promise.reject(FAILURE);
+
+const testModel = {
+  adapter: {},
+  keySource: "instance",
+  modelId: "test-model",
+  modelOptions: {},
+  provider: "openai",
+};
+
+void mock.module("@tanstack/ai", () => ({
+  ...realTanStackAI,
+  chat,
+}));
+
+void mock.module("@/api/lib/tanstack-ai-models", () => ({
+  ...realTanStackAIModels,
+  getTanStackTextModelForRole: () => testModel,
+}));
+
+const { suggestTemplateFields, suggestTemplateFieldsOrEmpty } =
+  await import("./suggest-template-fields");
+const { createTanStackAIAnalyticsCallbacks } =
+  await import("@/api/lib/analytics/tanstack-ai");
+
+afterAll(() => {
+  mock.restore();
+});
+
+const organizationId = toSafeId<"organization">("org_test");
+
+describe("suggestTemplateFields", () => {
+  test("rejects (does not swallow to []) when the model call fails", async () => {
+    // A no-op analytics sink: this test only pins that the helper itself
+    // propagates the failure. Callers (suggest-fields.ts, prepare.ts,
+    // template-tools.ts) are responsible for calling captureError.
+    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
+      analytics: { capture: () => undefined, flush: async () => undefined },
+      feature: "templates.test",
+      traceId: "trace_test",
+    });
+
+    // .rejects.toThrow trips type-aware lint (bun-types declares it void) and
+    // can report a spurious unhandled-rejection warning; capture explicitly.
+    const rejection: unknown = await suggestTemplateFields({
+      documentText: "Granted by ROKA NIERUCHOMOŚCI Sp. z o.o.",
+      orgAIConfig: null,
+      organizationId,
+      aiAnalytics,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBe(FAILURE);
+  });
+});
+
+describe("suggestTemplateFieldsOrEmpty", () => {
+  test("degrades to [] and captures the failure instead of rejecting", async () => {
+    const captured: unknown[] = [];
+    const aiAnalytics = createTanStackAIAnalyticsCallbacks({
+      analytics: {
+        capture: (params) => {
+          captured.push(params);
+        },
+        flush: async () => undefined,
+      },
+      feature: "templates.test",
+      traceId: "trace_test",
+    });
+
+    const suggestions = await suggestTemplateFieldsOrEmpty({
+      documentText: "Granted by ROKA NIERUCHOMOŚCI Sp. z o.o.",
+      orgAIConfig: null,
+      organizationId,
+      aiAnalytics,
+    });
+
+    expect(suggestions).toEqual([]);
+    expect(captured).toHaveLength(1);
+  });
+});

--- a/apps/api/src/handlers/templates/suggest-template-fields.ts
+++ b/apps/api/src/handlers/templates/suggest-template-fields.ts
@@ -5,8 +5,14 @@
  * the document from the returned suggestions.
  *
  * Uses the same structured-output pattern as workflow generation
- * (`generateTanStackObjectForRole`). A failure or unavailable model yields an
- * empty list so the caller can fall back to plain `{{marker}}` discovery.
+ * (`generateTanStackObjectForRole`). An empty list means the model looked and
+ * found nothing to suggest; a call failure (BYOK misconfiguration, provider
+ * outage, timeout) instead rejects. `suggestTemplateFields` is the throwing
+ * primitive for a caller that wants the failure surfaced
+ * (`suggest-fields.ts`); `suggestTemplateFieldsOrEmpty` wraps it for the one
+ * caller that wants the documented degrade-to-empty-and-fall-back-to-plain-
+ * `{{marker}}`-discovery behaviour (`prepare.ts`), capturing the failure
+ * first so it is not silent.
  */
 
 import * as v from "valibot";
@@ -100,43 +106,61 @@ export const suggestTemplateFields = async ({
   organizationId: SafeId<"organization">;
   aiAnalytics: ReturnType<typeof createTanStackAIAnalyticsCallbacks>;
 }): Promise<SuggestedTemplateField[]> => {
-  try {
-    const { suggestions } = await generateTanStackObjectForRole({
+  // No try/catch here: a call failure (BYOK misconfiguration, provider
+  // outage, timeout) propagates to the caller, which decides whether to
+  // surface it (suggest-fields.ts) or degrade to [] after capturing it
+  // (prepare.ts) — see the module doc comment.
+  const { suggestions } = await generateTanStackObjectForRole({
+    role: "fast",
+    orgAIConfig,
+    organizationId,
+    analytics: aiAnalytics,
+    caching: resolveCaching({
+      promptCachingEnabled: false,
       role: "fast",
-      orgAIConfig,
-      organizationId,
-      analytics: aiAnalytics,
-      caching: resolveCaching({
-        promptCachingEnabled: false,
-        role: "fast",
-        scopeKey: organizationId,
-      }),
-      system: SYSTEM_PROMPT,
-      prompt: buildPrompt(documentText, instructions),
-      outputSchema: fieldSuggestionsSchema,
-      abortSignal: AbortSignal.timeout(SUGGEST_TIMEOUT_MS),
-      serviceTier: "standard",
-    });
-    // The schema models "absent" as null (OpenAI strict mode); FieldSuggestion
-    // uses optional members.
-    return suggestions.flatMap((s) => {
-      const fieldPath = sanitizeFieldPath(s.fieldPath);
-      if (fieldPath === null) {
-        return [];
-      }
-      return [
-        {
-          literalText: s.literalText,
-          fieldPath,
-          inputType: s.inputType ?? undefined,
-          label: s.label ?? undefined,
-          hint: s.hint ?? undefined,
-          exampleValue: s.exampleValue ?? undefined,
-          aiPrompt: s.aiPrompt ?? undefined,
-        },
-      ];
-    });
-  } catch {
+      scopeKey: organizationId,
+    }),
+    system: SYSTEM_PROMPT,
+    prompt: buildPrompt(documentText, instructions),
+    outputSchema: fieldSuggestionsSchema,
+    abortSignal: AbortSignal.timeout(SUGGEST_TIMEOUT_MS),
+    serviceTier: "standard",
+  });
+  // The schema models "absent" as null (OpenAI strict mode); FieldSuggestion
+  // uses optional members.
+  return suggestions.flatMap((s) => {
+    const fieldPath = sanitizeFieldPath(s.fieldPath);
+    if (fieldPath === null) {
+      return [];
+    }
+    return [
+      {
+        literalText: s.literalText,
+        fieldPath,
+        inputType: s.inputType ?? undefined,
+        label: s.label ?? undefined,
+        hint: s.hint ?? undefined,
+        exampleValue: s.exampleValue ?? undefined,
+        aiPrompt: s.aiPrompt ?? undefined,
+      },
+    ];
+  });
+};
+
+/**
+ * Degrade-to-empty wrapper around `suggestTemplateFields` for the one caller
+ * that wants that documented fallback (see the module doc comment): a call
+ * failure is captured via `aiAnalytics.captureError` and swallowed into an
+ * empty list instead of rejecting. A genuine "found nothing" response from
+ * the model is already an empty array, so it passes through unchanged.
+ */
+export const suggestTemplateFieldsOrEmpty = async (
+  args: Parameters<typeof suggestTemplateFields>[0],
+): Promise<SuggestedTemplateField[]> => {
+  try {
+    return await suggestTemplateFields(args);
+  } catch (error) {
+    args.aiAnalytics.captureError(error);
     return [];
   }
 };


### PR DESCRIPTION
\`suggestTemplateFields\` swallowed every AI error with \`catch { return []; }\` — no telemetry, and the suggest-fields route's existing 500 + capture path was unreachable: a BYOK misconfiguration or provider outage looked identical to "no fields found".

- The helper now throws; a sibling \`suggestTemplateFieldsOrEmpty\` provides the documented degrade-to-empty behavior (with error capture) for the prepare flow that wants it.
- Per-caller outcomes: the suggest-fields route's pre-existing catch now fires (500 + capture); prepare still degrades to empty but captures; the chat tool captures and rethrows so the model sees a tool error instead of silently empty suggestions.
- Tests pin the rejection, the degrade+capture wrapper, and propagation through prepare-template; 108 template + 191 chat-tool tests green.