### PR TITLE
fix(api): load external mcp tools once per send with bounded discovery

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -315,13 +315,14 @@ const sendMessage = createSafeRootHandler(
     // streaming try/catch, so every other exit path (validation failure,
     // any early return or throw between here and streaming) still closes
     // them exactly once.
-    const externalMcpToolsLoader = createLazyExternalMcpToolsLoader(() =>
-      loadExternalMcpToolsForUser({
-        nullUnionStrategy: externalMcpNullUnionStrategy,
-        organizationId: session.activeOrganizationId,
-        safeDb,
-        userId: user.id,
-      }),
+    const externalMcpToolsLoader = createLazyExternalMcpToolsLoader(
+      async () =>
+        await loadExternalMcpToolsForUser({
+          nullUnionStrategy: externalMcpNullUnionStrategy,
+          organizationId: session.activeOrganizationId,
+          safeDb,
+          userId: user.id,
+        }),
     );
     let externalMcpToolsHandedOffToStreaming = false;
 

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -90,9 +90,13 @@ import {
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import {
   buildExternalMcpSystemHint,
+  createLazyExternalMcpToolsLoader,
   loadExternalMcpToolsForUser,
 } from "@/api/handlers/chat/tools/external-mcp-tools";
-import type { LoadedExternalMcpTools } from "@/api/handlers/chat/tools/external-mcp-tools";
+import type {
+  LazyExternalMcpToolsLoader,
+  LoadedExternalMcpTools,
+} from "@/api/handlers/chat/tools/external-mcp-tools";
 import { SPAWN_SUBAGENTS_TOOL_NAME } from "@/api/handlers/chat/tools/spawn-subagents-tool";
 import {
   type ChatToolScope,
@@ -299,29 +303,35 @@ const sendMessage = createSafeRootHandler(
         userId: user.id,
       }),
     );
-    // Loaded once and reused for both the validation and streaming tool
-    // sets (and for the streaming `externalMcpToolSource`) instead of
-    // running connector discovery twice per send: the streaming pass
-    // always needs this set, so load it up front rather than a second
-    // time right before streaming. `externalMcpToolsHandedOffToStreaming`
-    // below tracks whether ownership of closing these connectors passed
-    // to the streaming try/catch, so every other exit path (validation
-    // failure, any early return or throw between here and streaming) still
-    // closes them exactly once.
-    const externalMcpTools = await loadExternalMcpToolsForUser({
-      nullUnionStrategy: externalMcpNullUnionStrategy,
-      organizationId: session.activeOrganizationId,
-      safeDb,
-      userId: user.id,
-    });
+    // Lazy and memoized: connector discovery only runs once some caller
+    // actually needs the tools (validation only needs them when
+    // `messageNeedsExternalMcpValidation` is true; the streaming pass
+    // always needs them), and at most once per send no matter how many
+    // callers ask — `createLazyExternalMcpToolsLoader` caches the first
+    // call's promise, so a validation-triggered load is reused by the
+    // streaming pass instead of running discovery twice.
+    // `externalMcpToolsHandedOffToStreaming` below tracks whether
+    // ownership of closing these connectors (if ever loaded) passed to the
+    // streaming try/catch, so every other exit path (validation failure,
+    // any early return or throw between here and streaming) still closes
+    // them exactly once.
+    const externalMcpToolsLoader = createLazyExternalMcpToolsLoader(() =>
+      loadExternalMcpToolsForUser({
+        nullUnionStrategy: externalMcpNullUnionStrategy,
+        organizationId: session.activeOrganizationId,
+        safeDb,
+        userId: user.id,
+      }),
+    );
     let externalMcpToolsHandedOffToStreaming = false;
 
-    // The try/finally starts immediately after the load (rather than just
-    // around the streaming pass) so that a throw from any of the awaited
-    // steps below — web-search provider load, tool-set construction,
-    // message validation — still closes `externalMcpTools` instead of
-    // leaking the MCP clients. The streaming pass further below takes over
-    // ownership once it starts consuming the clients (flips
+    // The try/finally starts immediately after the loader is constructed
+    // (rather than just around the streaming pass) so that a throw from
+    // any of the awaited steps below — web-search provider load,
+    // tool-set construction, message validation — still closes
+    // `externalMcpToolsLoader` (a no-op if nothing was ever loaded)
+    // instead of leaking MCP clients. The streaming pass further below
+    // takes over ownership once it starts consuming the clients (flips
     // `externalMcpToolsHandedOffToStreaming`); until then this `finally` is
     // the sole owner. `Result.gen`'s `yield*` short-circuit resumes the
     // generator via `.return()`, which unwinds this `finally` like a normal
@@ -333,6 +343,17 @@ const sendMessage = createSafeRootHandler(
       const webSearchProviders = await loadWebSearchProvidersForOrg(
         session.activeOrganizationId,
       );
+
+      // Only load external MCP tools for validation when the incoming
+      // message actually carries a part that needs them — an ordinary
+      // message never triggers connector discovery here. The streaming
+      // pass below always needs the full set and reuses this same load via
+      // the memoized loader instead of running discovery again.
+      const externalToolsForValidation =
+        await resolveExternalToolsForValidation(
+          body.message,
+          externalMcpToolsLoader,
+        );
 
       // Tool input schemas don't depend on `accessibleWorkspaceIds`
       // (scope is checked at execute time, not in the schema), so we
@@ -370,10 +391,7 @@ const sendMessage = createSafeRootHandler(
         hasActiveDocxFileClient: true,
         webSearchEnabled: validationThreadState.webSearchEnabled,
         webSearchProviders,
-        externalTools: externalToolsForValidation(
-          body.message,
-          externalMcpTools,
-        ),
+        externalTools: externalToolsForValidation,
         disabledNativeToolSlugs,
         activeSkillContext: validationActiveSkillContext,
         recordAuditEvent,
@@ -388,8 +406,9 @@ const sendMessage = createSafeRootHandler(
         userId: user.id,
       });
       if (Result.isError(validatedMessageResult)) {
-        // The wrapping try/finally closes `externalMcpTools` on this exit
-        // path too — no explicit close needed here.
+        // The wrapping try/finally closes `externalMcpToolsLoader` on this
+        // exit path too (a no-op if this message never needed the external
+        // tools) — no explicit close needed here.
         return Result.err(validatedMessageResult.error);
       }
       const validatedMessage = validatedMessageResult.value;
@@ -744,6 +763,18 @@ const sendMessage = createSafeRootHandler(
         }),
       );
 
+      // The streaming pass always needs the external MCP tool set (for the
+      // tool map, the connector system hint, and the `externalMcpToolSource`
+      // handed to `streamChat` below). This is the point where discovery
+      // actually runs for a message that didn't already trigger it during
+      // validation — deferred this far so a request that fails or aborts
+      // earlier (malformed parts, thread scope mismatch, upload/compaction
+      // failure, client disconnect) never contacts a single connector.
+      // `getExternalMcpTools` reuses the validation-triggered load instead
+      // of loading again when one already happened.
+      const externalMcpTools =
+        await externalMcpToolsLoader.getExternalMcpTools();
+
       // Streaming tools mirror the surface the user is on: only the
       // DOCX file-overlay client knows how to satisfy
       // apply-active-docx-edits (it queues into the review store and
@@ -814,7 +845,9 @@ const sendMessage = createSafeRootHandler(
       // From here, the try/catch below owns closing `externalMcpTools` (on a
       // non-streaming response or a thrown error) or hands it to `streamChat`
       // to close once the actual token stream finishes; the outer `finally`
-      // must not close it again.
+      // must not close it again. `externalMcpTools` is guaranteed loaded at
+      // this point (the `await` above), so `externalMcpToolsLoader.closeIfLoaded`
+      // in the outer `finally` would otherwise close the same clients again.
       externalMcpToolsHandedOffToStreaming = true;
       const response = yield* Result.await(
         Result.tryPromise({
@@ -1017,8 +1050,11 @@ const sendMessage = createSafeRootHandler(
 
       return Result.ok(response);
     } finally {
+      // No-op if `getExternalMcpTools` was never called on this exit path
+      // (the message needed neither validation nor streaming to load
+      // external tools before failing/returning early).
       if (!externalMcpToolsHandedOffToStreaming) {
-        await externalMcpTools.close();
+        await externalMcpToolsLoader.closeIfLoaded();
       }
     }
   },
@@ -1312,12 +1348,6 @@ const isChatStreamResponse = (response: Response): boolean => {
   return contentType !== null && contentType.includes("text/event-stream");
 };
 
-const externalToolsForValidation = (
-  message: Static<typeof sendMessageBodySchema>["message"],
-  loaded: LoadedExternalMcpTools,
-): LoadedExternalMcpTools["tools"] | undefined =>
-  messageNeedsExternalMcpValidation(message) ? loaded.tools : undefined;
-
 const messageNeedsExternalMcpValidation = (
   message: Static<typeof sendMessageBodySchema>["message"],
 ): boolean => {
@@ -1327,6 +1357,23 @@ const messageNeedsExternalMcpValidation = (
 
   const parts: unknown[] = Array.isArray(message.parts) ? message.parts : [];
   return parts.some(isExternalMcpToolPart);
+};
+
+/**
+ * Loads external MCP tools (via the memoized `loader`) only when the
+ * incoming message needs them for validation; returns `undefined` without
+ * ever calling the loader otherwise. Kept as a standalone helper so its
+ * branch doesn't add to the handler generator's own cognitive complexity.
+ */
+const resolveExternalToolsForValidation = async (
+  message: Static<typeof sendMessageBodySchema>["message"],
+  loader: LazyExternalMcpToolsLoader,
+): Promise<LoadedExternalMcpTools["tools"] | undefined> => {
+  if (!messageNeedsExternalMcpValidation(message)) {
+    return undefined;
+  }
+  const loaded = await loader.getExternalMcpTools();
+  return loaded.tools;
 };
 
 type ReadThreadValidationStateProps = {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -92,6 +92,7 @@ import {
   buildExternalMcpSystemHint,
   loadExternalMcpToolsForUser,
 } from "@/api/handlers/chat/tools/external-mcp-tools";
+import type { LoadedExternalMcpTools } from "@/api/handlers/chat/tools/external-mcp-tools";
 import { SPAWN_SUBAGENTS_TOOL_NAME } from "@/api/handlers/chat/tools/spawn-subagents-tool";
 import {
   type ChatToolScope,
@@ -298,16 +299,22 @@ const sendMessage = createSafeRootHandler(
         userId: user.id,
       }),
     );
-    const validationExternalMcpTools = messageNeedsExternalMcpValidation(
-      body.message,
-    )
-      ? await loadExternalMcpToolsForUser({
-          nullUnionStrategy: externalMcpNullUnionStrategy,
-          organizationId: session.activeOrganizationId,
-          safeDb,
-          userId: user.id,
-        })
-      : null;
+    // Loaded once and reused for both the validation and streaming tool
+    // sets (and for the streaming `externalMcpToolSource`) instead of
+    // running connector discovery twice per send: the streaming pass
+    // always needs this set, so load it up front rather than a second
+    // time right before streaming. `externalMcpToolsHandedOffToStreaming`
+    // below tracks whether ownership of closing these connectors passed
+    // to the streaming try/catch, so every other exit path (validation
+    // failure, any early return between here and streaming) still closes
+    // them exactly once.
+    const externalMcpTools = await loadExternalMcpToolsForUser({
+      nullUnionStrategy: externalMcpNullUnionStrategy,
+      organizationId: session.activeOrganizationId,
+      safeDb,
+      userId: user.id,
+    });
+    let externalMcpToolsHandedOffToStreaming = false;
 
     // Resolve the org's web-search providers once (BYOK key first,
     // platform env key as fallback) and reuse for both the validation
@@ -352,7 +359,7 @@ const sendMessage = createSafeRootHandler(
       hasActiveDocxFileClient: true,
       webSearchEnabled: validationThreadState.webSearchEnabled,
       webSearchProviders,
-      externalTools: validationExternalMcpTools?.tools,
+      externalTools: externalToolsForValidation(body.message, externalMcpTools),
       disabledNativeToolSlugs,
       activeSkillContext: validationActiveSkillContext,
       recordAuditEvent,
@@ -366,630 +373,649 @@ const sendMessage = createSafeRootHandler(
       tools: validationTools,
       userId: user.id,
     });
-    await validationExternalMcpTools?.close();
     if (Result.isError(validatedMessageResult)) {
+      // Validation is the only exit before the streaming pass takes over
+      // ownership of `externalMcpTools` (see `externalMcpToolsHandedOffToStreaming`
+      // below); every later early return closes it via the wrapping try/finally.
+      await externalMcpTools.close();
       return Result.err(validatedMessageResult.error);
     }
     const validatedMessage = validatedMessageResult.value;
 
-    const thread = yield* Result.await(
-      loadThread({
-        initialContextMatterIds: requestedContextMatterIds,
-        isAnonymized: body.sendMode === CHAT_SEND_MODE.anonymized,
+    // From here on, every early return (validation already handled above)
+    // must still close `externalMcpTools` since the streaming try/catch
+    // below — which owns closing on its own exit paths — may never be
+    // reached. `Result.gen`'s `yield*` short-circuit resumes the generator
+    // via `.return()`, which unwinds this `finally` like a normal early
+    // `return` would.
+    try {
+      const thread = yield* Result.await(
+        loadThread({
+          initialContextMatterIds: requestedContextMatterIds,
+          isAnonymized: body.sendMode === CHAT_SEND_MODE.anonymized,
+          organizationId: session.activeOrganizationId,
+          recordAuditEvent,
+          safeDb,
+          threadId: body.threadId,
+          title: extractTitle(validatedMessage.message.parts),
+          userId: user.id,
+          workspaceId,
+        }),
+      );
+
+      // The thread's persisted chat-model override wins over the org/instance
+      // default, but the dev-only body override still wins over everything
+      // (matches `assertDevModelOverride` above). Re-validated here (not just
+      // at write time in update-thread-model.ts) so a provider key removal or
+      // a catalog bump that drops the model falls back to the org default
+      // silently instead of failing the send.
+      const chatModelOverride = resolveEffectiveChatModelId({
+        devModelId: body.devModelId,
+        threadChatModel: thread.data.chatModel,
+        orgAIConfig,
+      });
+
+      // For an existing thread, accept a non-empty body update as
+      // "user changed scope, persist it"; an omitted/empty body keeps
+      // the stored value so re-sends from cached transports don't
+      // silently widen access. Persisted pins are always intersected
+      // with the currently accessible set so a revoked workspace
+      // cannot be re-authorized through a stale stored pin.
+      const storedPinsThisRequest =
+        thread.type === "existing" && body.contextMatterIds !== undefined
+          ? requestedContextMatterIds
+          : thread.data.contextMatterIds;
+      const effectiveContextMatterIds = intersectAccessibleWorkspaceIds({
+        pinnedIds: storedPinsThisRequest,
+        accessibleWorkspaceIds,
+      });
+      if (
+        thread.type === "existing" &&
+        !workspaceIdsEqual(
+          thread.data.contextMatterIds,
+          effectiveContextMatterIds,
+        )
+      ) {
+        yield* Result.await(
+          safeDb(async (tx) => {
+            await tx
+              .update(chatThreads)
+              .set({ contextMatterIds: effectiveContextMatterIds })
+              .where(eq(chatThreads.id, body.threadId));
+
+            await recordAuditEvent(tx, {
+              action: AUDIT_ACTION.UPDATE,
+              resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+              resourceId: body.threadId,
+              workspaceId,
+              changes: {
+                contextMatterIds: {
+                  old: [...thread.data.contextMatterIds],
+                  new: [...effectiveContextMatterIds],
+                },
+              },
+            });
+          }),
+        );
+      }
+
+      const thirdPartyBoundary = createChatThirdPartyBoundary({
+        anonymizationScopeId: workspaceId ?? body.threadId,
         organizationId: session.activeOrganizationId,
-        recordAuditEvent,
+        scopedDb,
+        sendMode: body.sendMode,
+        workspaceId: workspaceId ?? undefined,
+      });
+
+      const isClientConnectionAborted = () => request.signal.aborted;
+
+      if (isClientConnectionAborted()) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
+
+      const uploadResult = yield* Result.await(
+        uploadMessageFilesWithRollback({
+          message: validatedMessage.message,
+          recordAuditEvent,
+          safeDb,
+          threadId: thread.data.id,
+          threadState: thread,
+          userId: user.id,
+        }),
+      );
+
+      const parsedMessage = parseMessage({
+        accessibleWorkspaceIds,
+        message: uploadResult.message,
+      });
+
+      let messagesForPersistence: ThreadRecord["messages"] =
+        thread.data.messages;
+      let deleteMessageIdsBeforeLatest: SafeId<"chatMessage">[] = [];
+      // The incoming message normally is new. Outside the truncation path the
+      // stored list is a bounded window that may exclude an old re-sent/edited
+      // id, so a targeted existence check guards against a duplicate insert.
+      let incomingMessageExists = false;
+      if (body.truncateAfterMessageId !== undefined) {
+        if (parsedMessage.message.id !== body.truncateAfterMessageId) {
+          return Result.err(
+            new HandlerError({
+              status: 400,
+              message: "Truncation target must match the incoming message",
+            }),
+          );
+        }
+
+        // Resolve the target against the full thread history, not the windowed
+        // in-memory list: a replay target can be older than the window. The
+        // retained prefix is needed to recompute the thread data scope.
+        const truncationTarget = yield* Result.await(
+          resolveTruncationTarget({
+            safeDb,
+            threadId: body.threadId,
+            targetMessageId: body.truncateAfterMessageId,
+          }),
+        );
+        if (truncationTarget === null) {
+          return Result.err(
+            new HandlerError({
+              status: 400,
+              message: "Truncation target was not found in the chat thread",
+            }),
+          );
+        }
+
+        messagesForPersistence = truncationTarget.messagesForPersistence;
+        deleteMessageIdsBeforeLatest =
+          truncationTarget.deleteMessageIdsBeforeLatest;
+      } else {
+        incomingMessageExists = yield* Result.await(
+          chatMessageExistsForThread({
+            messageId: brandPersistedChatMessageId(parsedMessage.message.id),
+            safeDb,
+            threadId: body.threadId,
+          }),
+        );
+      }
+
+      const latestMessagePlan = planMessagePersistence({
+        message: parsedMessage.message,
+        storedMessages: messagesForPersistence,
+        incomingMessageExists,
+      });
+      if (
+        body.truncateAfterMessageId !== undefined &&
+        latestMessagePlan.persistencePlan.type !== "update"
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Truncation requires updating an existing message",
+          }),
+        );
+      }
+
+      const recomputedDataWorkspaceIds =
+        body.truncateAfterMessageId !== undefined
+          ? recomputeThreadDataScope({
+              accessibleSet,
+              baseWorkspaceId: workspaceId,
+              messages: latestMessagePlan.messages,
+            })
+          : null;
+
+      const messagesForContextInput = await selectMessagesForContextInput({
+        messages: latestMessagePlan.messages,
+        safeDb,
+        skipCheckpoint: body.truncateAfterMessageId !== undefined,
+        threadId: body.threadId,
+      });
+
+      // Metered provider calls must not be directly cancelled by the client
+      // connection. A disconnect can arrive after preflight succeeds but before
+      // the AI SDK emits token usage; allowing that abort to reach the provider
+      // would skip the usage ledger callback while still spending provider work.
+      const createMeteredAIAbortSignal = () =>
+        AbortSignal.timeout(CHAT_METERED_AI_TIMEOUT_MS);
+
+      if (isClientConnectionAborted()) {
+        yield* Result.await(
+          rollbackUnpersistedChatSideEffects({
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadState: thread,
+            uploadedFiles: uploadResult.uploadedFiles,
+            userId: user.id,
+          }),
+        );
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
+
+      const messagesForContextResult = await compactMessagesForContext({
+        abortSignal: createMeteredAIAbortSignal(),
+        boundary: thirdPartyBoundary,
+        chatModelOverride,
+        messages: messagesForContextInput,
+        organizationId: session.activeOrganizationId,
+        orgAIConfig,
         safeDb,
         threadId: body.threadId,
-        title: extractTitle(validatedMessage.message.parts),
         userId: user.id,
         workspaceId,
-      }),
-    );
-
-    // The thread's persisted chat-model override wins over the org/instance
-    // default, but the dev-only body override still wins over everything
-    // (matches `assertDevModelOverride` above). Re-validated here (not just
-    // at write time in update-thread-model.ts) so a provider key removal or
-    // a catalog bump that drops the model falls back to the org default
-    // silently instead of failing the send.
-    const chatModelOverride = resolveEffectiveChatModelId({
-      devModelId: body.devModelId,
-      threadChatModel: thread.data.chatModel,
-      orgAIConfig,
-    });
-
-    // For an existing thread, accept a non-empty body update as
-    // "user changed scope, persist it"; an omitted/empty body keeps
-    // the stored value so re-sends from cached transports don't
-    // silently widen access. Persisted pins are always intersected
-    // with the currently accessible set so a revoked workspace
-    // cannot be re-authorized through a stale stored pin.
-    const storedPinsThisRequest =
-      thread.type === "existing" && body.contextMatterIds !== undefined
-        ? requestedContextMatterIds
-        : thread.data.contextMatterIds;
-    const effectiveContextMatterIds = intersectAccessibleWorkspaceIds({
-      pinnedIds: storedPinsThisRequest,
-      accessibleWorkspaceIds,
-    });
-    if (
-      thread.type === "existing" &&
-      !workspaceIdsEqual(
-        thread.data.contextMatterIds,
-        effectiveContextMatterIds,
-      )
-    ) {
-      yield* Result.await(
-        safeDb(async (tx) => {
-          await tx
-            .update(chatThreads)
-            .set({ contextMatterIds: effectiveContextMatterIds })
-            .where(eq(chatThreads.id, body.threadId));
-
-          await recordAuditEvent(tx, {
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
-            resourceId: body.threadId,
-            workspaceId,
-            changes: {
-              contextMatterIds: {
-                old: [...thread.data.contextMatterIds],
-                new: [...effectiveContextMatterIds],
-              },
-            },
-          });
-        }),
-      );
-    }
-
-    const thirdPartyBoundary = createChatThirdPartyBoundary({
-      anonymizationScopeId: workspaceId ?? body.threadId,
-      organizationId: session.activeOrganizationId,
-      scopedDb,
-      sendMode: body.sendMode,
-      workspaceId: workspaceId ?? undefined,
-    });
-
-    const isClientConnectionAborted = () => request.signal.aborted;
-
-    if (isClientConnectionAborted()) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Client disconnected before AI work started",
-        }),
-      );
-    }
-
-    const uploadResult = yield* Result.await(
-      uploadMessageFilesWithRollback({
-        message: validatedMessage.message,
-        recordAuditEvent,
-        safeDb,
-        threadId: thread.data.id,
-        threadState: thread,
-        userId: user.id,
-      }),
-    );
-
-    const parsedMessage = parseMessage({
-      accessibleWorkspaceIds,
-      message: uploadResult.message,
-    });
-
-    let messagesForPersistence: ThreadRecord["messages"] = thread.data.messages;
-    let deleteMessageIdsBeforeLatest: SafeId<"chatMessage">[] = [];
-    // The incoming message normally is new. Outside the truncation path the
-    // stored list is a bounded window that may exclude an old re-sent/edited
-    // id, so a targeted existence check guards against a duplicate insert.
-    let incomingMessageExists = false;
-    if (body.truncateAfterMessageId !== undefined) {
-      if (parsedMessage.message.id !== body.truncateAfterMessageId) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Truncation target must match the incoming message",
-          }),
-        );
-      }
-
-      // Resolve the target against the full thread history, not the windowed
-      // in-memory list: a replay target can be older than the window. The
-      // retained prefix is needed to recompute the thread data scope.
-      const truncationTarget = yield* Result.await(
-        resolveTruncationTarget({
-          safeDb,
-          threadId: body.threadId,
-          targetMessageId: body.truncateAfterMessageId,
-        }),
-      );
-      if (truncationTarget === null) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Truncation target was not found in the chat thread",
-          }),
-        );
-      }
-
-      messagesForPersistence = truncationTarget.messagesForPersistence;
-      deleteMessageIdsBeforeLatest =
-        truncationTarget.deleteMessageIdsBeforeLatest;
-    } else {
-      incomingMessageExists = yield* Result.await(
-        chatMessageExistsForThread({
-          messageId: brandPersistedChatMessageId(parsedMessage.message.id),
-          safeDb,
-          threadId: body.threadId,
-        }),
-      );
-    }
-
-    const latestMessagePlan = planMessagePersistence({
-      message: parsedMessage.message,
-      storedMessages: messagesForPersistence,
-      incomingMessageExists,
-    });
-    if (
-      body.truncateAfterMessageId !== undefined &&
-      latestMessagePlan.persistencePlan.type !== "update"
-    ) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Truncation requires updating an existing message",
-        }),
-      );
-    }
-
-    const recomputedDataWorkspaceIds =
-      body.truncateAfterMessageId !== undefined
-        ? recomputeThreadDataScope({
-            accessibleSet,
-            baseWorkspaceId: workspaceId,
-            messages: latestMessagePlan.messages,
-          })
-        : null;
-
-    const messagesForContextInput = await selectMessagesForContextInput({
-      messages: latestMessagePlan.messages,
-      safeDb,
-      skipCheckpoint: body.truncateAfterMessageId !== undefined,
-      threadId: body.threadId,
-    });
-
-    // Metered provider calls must not be directly cancelled by the client
-    // connection. A disconnect can arrive after preflight succeeds but before
-    // the AI SDK emits token usage; allowing that abort to reach the provider
-    // would skip the usage ledger callback while still spending provider work.
-    const createMeteredAIAbortSignal = () =>
-      AbortSignal.timeout(CHAT_METERED_AI_TIMEOUT_MS);
-
-    if (isClientConnectionAborted()) {
-      yield* Result.await(
-        rollbackUnpersistedChatSideEffects({
+      });
+      if (Result.isError(messagesForContextResult)) {
+        const rollbackResult = await rollbackUnpersistedChatSideEffects({
           recordAuditEvent,
           safeDb,
           threadId: body.threadId,
           threadState: thread,
           uploadedFiles: uploadResult.uploadedFiles,
           userId: user.id,
-        }),
-      );
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Client disconnected before AI work started",
-        }),
-      );
-    }
-
-    const messagesForContextResult = await compactMessagesForContext({
-      abortSignal: createMeteredAIAbortSignal(),
-      boundary: thirdPartyBoundary,
-      chatModelOverride,
-      messages: messagesForContextInput,
-      organizationId: session.activeOrganizationId,
-      orgAIConfig,
-      safeDb,
-      threadId: body.threadId,
-      userId: user.id,
-      workspaceId,
-    });
-    if (Result.isError(messagesForContextResult)) {
-      const rollbackResult = await rollbackUnpersistedChatSideEffects({
-        recordAuditEvent,
-        safeDb,
-        threadId: body.threadId,
-        threadState: thread,
-        uploadedFiles: uploadResult.uploadedFiles,
-        userId: user.id,
-      });
-      if (Result.isError(rollbackResult)) {
-        captureError(messagesForContextResult.error, {
-          threadId: body.threadId,
         });
-        return yield* Result.err(rollbackResult.error);
+        if (Result.isError(rollbackResult)) {
+          captureError(messagesForContextResult.error, {
+            threadId: body.threadId,
+          });
+          return yield* Result.err(rollbackResult.error);
+        }
+
+        return yield* Result.err(messagesForContextResult.error);
       }
 
-      return yield* Result.err(messagesForContextResult.error);
-    }
-
-    const chatContextResult = await prepareChatContext({
-      activeDecision: body.activeDecision,
-      activeExternal: body.activeExternal,
-      activeFile: body.activeFile,
-      activeSkill: body.activeSkill,
-      activeTemplate: body.activeTemplate,
-      contextMatterIds: effectiveContextMatterIds,
-      memberRole,
-      messageWindow: messagesForContextResult.value,
-      organizationId: session.activeOrganizationId,
-      safeDb,
-      sendMode: body.sendMode,
-      // Derived from the same predicates/inputs `getChatTools` uses to
-      // register `web_search`/`fetch_url` and `suggest_template_fields`
-      // below, so the prompt only steers the model to tools that are
-      // actually handed to it.
-      toolAvailability: {
-        templateAuthoring: areTemplateAuthoringToolsRegistered(memberRole.role),
-        webResearch: areWebResearchToolsRegistered({
-          webSearchEnabled: thread.data.webSearchEnabled,
-          webSearchProviders,
-          disabledNativeToolSlugs,
-        }),
-        folioAgentDocTools: hasActiveDocxFileClient,
-        // Only at the top level of a turn, and only when the turn's scope (if
-        // any) allows spawn_subagents — a restricted scope (e.g.
-        // suggest-template-fields) drops the tool from the streaming set, so
-        // the prompt must not steer the model toward a tool it was never handed.
-        subagents: areSubagentToolsAvailableForTurn(body.toolScope),
-      },
-      userContext: body.userContext,
-      userId: user.id,
-      workspaceId,
-      refRegistry,
-    });
-    if (Result.isError(chatContextResult)) {
-      const rollbackResult = await rollbackUnpersistedChatSideEffects({
-        recordAuditEvent,
+      const chatContextResult = await prepareChatContext({
+        activeDecision: body.activeDecision,
+        activeExternal: body.activeExternal,
+        activeFile: body.activeFile,
+        activeSkill: body.activeSkill,
+        activeTemplate: body.activeTemplate,
+        contextMatterIds: effectiveContextMatterIds,
+        memberRole,
+        messageWindow: messagesForContextResult.value,
+        organizationId: session.activeOrganizationId,
         safeDb,
-        threadId: body.threadId,
-        threadState: thread,
-        uploadedFiles: uploadResult.uploadedFiles,
+        sendMode: body.sendMode,
+        // Derived from the same predicates/inputs `getChatTools` uses to
+        // register `web_search`/`fetch_url` and `suggest_template_fields`
+        // below, so the prompt only steers the model to tools that are
+        // actually handed to it.
+        toolAvailability: {
+          templateAuthoring: areTemplateAuthoringToolsRegistered(
+            memberRole.role,
+          ),
+          webResearch: areWebResearchToolsRegistered({
+            webSearchEnabled: thread.data.webSearchEnabled,
+            webSearchProviders,
+            disabledNativeToolSlugs,
+          }),
+          folioAgentDocTools: hasActiveDocxFileClient,
+          // Only at the top level of a turn, and only when the turn's scope (if
+          // any) allows spawn_subagents — a restricted scope (e.g.
+          // suggest-template-fields) drops the tool from the streaming set, so
+          // the prompt must not steer the model toward a tool it was never handed.
+          subagents: areSubagentToolsAvailableForTurn(body.toolScope),
+        },
+        userContext: body.userContext,
         userId: user.id,
+        workspaceId,
+        refRegistry,
       });
-      if (Result.isError(rollbackResult)) {
-        captureError(chatContextResult.error, { threadId: body.threadId });
-        return yield* Result.err(rollbackResult.error);
-      }
-
-      return yield* Result.err(chatContextResult.error);
-    }
-    const chatContext = chatContextResult.value;
-
-    // Keep the thread's data scope aligned with the messages being
-    // stored. Normal sends append newly observed workspace IDs
-    // before persisting. Replay truncation recomputes the exact
-    // retained scope and writes it in the same transaction as the
-    // replay update below.
-    //
-    // Intersect with `accessibleWorkspaceIds` first: an unknown ID
-    // (model hallucination, copy-pasted UUID from elsewhere) added
-    // to `data_workspace_ids` would fail the RLS subset check on
-    // every subsequent message persist, silently breaking the
-    // thread.
-    const incomingMessageWorkspaceIds = extractIncomingMessageWorkspaceIds({
-      mentions: parsedMessage.mentions,
-      message: parsedMessage.message,
-    }).filter((id) => accessibleSet.has(id));
-    let dataScopeAfterIncomingMessage: SafeId<"workspace">[];
-    if (recomputedDataWorkspaceIds !== null) {
-      dataScopeAfterIncomingMessage = recomputedDataWorkspaceIds;
-    } else {
-      dataScopeAfterIncomingMessage = yield* Result.await(
-        expandThreadDataScope({
-          currentDataWorkspaceIds: thread.data.dataWorkspaceIds,
-          newWorkspaceIds: incomingMessageWorkspaceIds,
+      if (Result.isError(chatContextResult)) {
+        const rollbackResult = await rollbackUnpersistedChatSideEffects({
           recordAuditEvent,
           safeDb,
           threadId: body.threadId,
-          threadWorkspaceId: workspaceId,
+          threadState: thread,
+          uploadedFiles: uploadResult.uploadedFiles,
+          userId: user.id,
+        });
+        if (Result.isError(rollbackResult)) {
+          captureError(chatContextResult.error, { threadId: body.threadId });
+          return yield* Result.err(rollbackResult.error);
+        }
+
+        return yield* Result.err(chatContextResult.error);
+      }
+      const chatContext = chatContextResult.value;
+
+      // Keep the thread's data scope aligned with the messages being
+      // stored. Normal sends append newly observed workspace IDs
+      // before persisting. Replay truncation recomputes the exact
+      // retained scope and writes it in the same transaction as the
+      // replay update below.
+      //
+      // Intersect with `accessibleWorkspaceIds` first: an unknown ID
+      // (model hallucination, copy-pasted UUID from elsewhere) added
+      // to `data_workspace_ids` would fail the RLS subset check on
+      // every subsequent message persist, silently breaking the
+      // thread.
+      const incomingMessageWorkspaceIds = extractIncomingMessageWorkspaceIds({
+        mentions: parsedMessage.mentions,
+        message: parsedMessage.message,
+      }).filter((id) => accessibleSet.has(id));
+      let dataScopeAfterIncomingMessage: SafeId<"workspace">[];
+      if (recomputedDataWorkspaceIds !== null) {
+        dataScopeAfterIncomingMessage = recomputedDataWorkspaceIds;
+      } else {
+        dataScopeAfterIncomingMessage = yield* Result.await(
+          expandThreadDataScope({
+            currentDataWorkspaceIds: thread.data.dataWorkspaceIds,
+            newWorkspaceIds: incomingMessageWorkspaceIds,
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadWorkspaceId: workspaceId,
+          }),
+        );
+      }
+
+      yield* Result.await(
+        persistMessage({
+          acceptedSendMode: body.sendMode,
+          recordAuditEvent,
+          safeDb,
+          threadId: body.threadId,
+          userId: user.id,
+          workspaceId,
+          persistencePlan: latestMessagePlan.persistencePlan,
+          deleteMessageIds: deleteMessageIdsBeforeLatest,
+          dataWorkspaceIdsChange:
+            recomputedDataWorkspaceIds === null
+              ? undefined
+              : {
+                  oldDataWorkspaceIds: thread.data.dataWorkspaceIds,
+                  newDataWorkspaceIds: recomputedDataWorkspaceIds,
+                },
         }),
       );
-    }
 
-    yield* Result.await(
-      persistMessage({
-        acceptedSendMode: body.sendMode,
-        recordAuditEvent,
+      // Streaming tools mirror the surface the user is on: only the
+      // DOCX file-overlay client knows how to satisfy
+      // apply-active-docx-edits (it queues into the review store and
+      // sends the output back via TanStack ChatClient.addToolResult).
+      // PDF/file overlays
+      // still send active-file context, but they must not expose the
+      // DOCX edit tool or the model can chase an impossible path. The
+      // folio-agents `read_document`/`find_text` tools are narrower
+      // still — `hasActiveDocxFileClient` only, since Template Studio
+      // mounts no watcher to resolve them.
+      const chatTools = getChatTools({
+        organizationId: session.activeOrganizationId,
+        memberRole: memberRole.role,
+        orgAIConfig,
+        pinServerValidatedWorkspaceId,
+        requestWorkspaceId: workspaceId,
+        refRegistry,
         safeDb,
+        scopedDb,
         threadId: body.threadId,
+        thirdPartyBoundary,
+        excludedChatHistoryMessageIds: deleteMessageIdsBeforeLatest,
         userId: user.id,
-        workspaceId,
-        persistencePlan: latestMessagePlan.persistencePlan,
-        deleteMessageIds: deleteMessageIdsBeforeLatest,
-        dataWorkspaceIdsChange:
-          recomputedDataWorkspaceIds === null
-            ? undefined
-            : {
-                oldDataWorkspaceIds: thread.data.dataWorkspaceIds,
-                newDataWorkspaceIds: recomputedDataWorkspaceIds,
-              },
-      }),
-    );
+        toolWorkspaceIds: resolveToolWorkspaceIds({
+          pinnedIds: effectiveContextMatterIds,
+          accessibleWorkspaceIds,
+        }),
+        activeFile: body.activeFile,
+        hasActiveDocxEditClient:
+          hasActiveDocxFileClient || body.activeTemplate !== undefined,
+        hasActiveDocxFileClient,
+        webSearchEnabled: thread.data.webSearchEnabled,
+        webSearchProviders,
+        externalTools: externalMcpTools.tools,
+        disabledNativeToolSlugs,
+        skillMetadata: chatContext.skillMetadata,
+        activeSkillContext: chatContext.activeSkillContext,
+        recordAuditEvent,
+        workspaceStatusById,
+      });
+      // A named scope narrows the streaming turn to its server-defined
+      // allowlist (validation above stays broad so persisted tool parts
+      // keep validating). The scope name is schema-validated; unknown
+      // names never reach this point.
+      const streamingTools =
+        body.toolScope === undefined
+          ? chatTools
+          : restrictChatToolsToScope(chatTools, body.toolScope);
 
-    const externalMcpTools = await loadExternalMcpToolsForUser({
-      nullUnionStrategy: externalMcpNullUnionStrategy,
-      organizationId: session.activeOrganizationId,
-      safeDb,
-      userId: user.id,
-    });
-    // Streaming tools mirror the surface the user is on: only the
-    // DOCX file-overlay client knows how to satisfy
-    // apply-active-docx-edits (it queues into the review store and
-    // sends the output back via TanStack ChatClient.addToolResult).
-    // PDF/file overlays
-    // still send active-file context, but they must not expose the
-    // DOCX edit tool or the model can chase an impossible path. The
-    // folio-agents `read_document`/`find_text` tools are narrower
-    // still — `hasActiveDocxFileClient` only, since Template Studio
-    // mounts no watcher to resolve them.
-    const chatTools = getChatTools({
-      organizationId: session.activeOrganizationId,
-      memberRole: memberRole.role,
-      orgAIConfig,
-      pinServerValidatedWorkspaceId,
-      requestWorkspaceId: workspaceId,
-      refRegistry,
-      safeDb,
-      scopedDb,
-      threadId: body.threadId,
-      thirdPartyBoundary,
-      excludedChatHistoryMessageIds: deleteMessageIdsBeforeLatest,
-      userId: user.id,
-      toolWorkspaceIds: resolveToolWorkspaceIds({
-        pinnedIds: effectiveContextMatterIds,
-        accessibleWorkspaceIds,
-      }),
-      activeFile: body.activeFile,
-      hasActiveDocxEditClient:
-        hasActiveDocxFileClient || body.activeTemplate !== undefined,
-      hasActiveDocxFileClient,
-      webSearchEnabled: thread.data.webSearchEnabled,
-      webSearchProviders,
-      externalTools: externalMcpTools.tools,
-      disabledNativeToolSlugs,
-      skillMetadata: chatContext.skillMetadata,
-      activeSkillContext: chatContext.activeSkillContext,
-      recordAuditEvent,
-      workspaceStatusById,
-    });
-    // A named scope narrows the streaming turn to its server-defined
-    // allowlist (validation above stays broad so persisted tool parts
-    // keep validating). The scope name is schema-validated; unknown
-    // names never reach this point.
-    const streamingTools =
-      body.toolScope === undefined
-        ? chatTools
-        : restrictChatToolsToScope(chatTools, body.toolScope);
+      const externalMcpSystemHint = buildExternalMcpSystemHint(
+        externalMcpTools.connectors,
+      );
+      // The "safe" half is whatever the prompt builder declared
+      // safe. The anonymized-mode hint is a fixed assembler-owned
+      // addition, so callers cannot brand arbitrary strings as safe.
+      // The external MCP catalog is organization/user-configured text,
+      // so it rides with the dynamic suffix and crosses the boundary in
+      // anonymized mode.
+      const systemSafe =
+        body.sendMode === CHAT_SEND_MODE.anonymized
+          ? appendAnonymizedModeHintToChatSafePrompt(chatContext.systemSafe)
+          : chatContext.systemSafe;
+      const systemUntrusted = extendChatUntrustedPromptSuffix(
+        chatContext.systemUntrusted,
+        [externalMcpSystemHint],
+      );
 
-    const externalMcpSystemHint = buildExternalMcpSystemHint(
-      externalMcpTools.connectors,
-    );
-    // The "safe" half is whatever the prompt builder declared
-    // safe. The anonymized-mode hint is a fixed assembler-owned
-    // addition, so callers cannot brand arbitrary strings as safe.
-    // The external MCP catalog is organization/user-configured text,
-    // so it rides with the dynamic suffix and crosses the boundary in
-    // anonymized mode.
-    const systemSafe =
-      body.sendMode === CHAT_SEND_MODE.anonymized
-        ? appendAnonymizedModeHintToChatSafePrompt(chatContext.systemSafe)
-        : chatContext.systemSafe;
-    const systemUntrusted = extendChatUntrustedPromptSuffix(
-      chatContext.systemUntrusted,
-      [externalMcpSystemHint],
-    );
+      // From here, the try/catch below owns closing `externalMcpTools` (on a
+      // non-streaming response or a thrown error) or hands it to `streamChat`
+      // to close once the actual token stream finishes; the outer `finally`
+      // must not close it again.
+      externalMcpToolsHandedOffToStreaming = true;
+      const response = yield* Result.await(
+        Result.tryPromise({
+          try: async () => {
+            try {
+              if (isClientConnectionAborted()) {
+                throw new HandlerError({
+                  status: 400,
+                  message: "Client disconnected before stream started",
+                });
+              }
 
-    const response = yield* Result.await(
-      Result.tryPromise({
-        try: async () => {
-          try {
-            if (isClientConnectionAborted()) {
-              throw new HandlerError({
-                status: 400,
-                message: "Client disconnected before stream started",
+              // Snapshot the refs the registry already holds before streaming.
+              // Prompt-time pins (`contextMatterIds` → `toMatterRef`) are
+              // resolved during prompt construction; folding the WHOLE registry
+              // into thread scope at onFinish would over-broaden it to pinned-
+              // but-never-read matters, which could make the thread unreadable
+              // after that matter's access is revoked even though its content was
+              // never persisted. Only the delta minted DURING the stream (a
+              // matter/entity a tool or subagent actually read) should widen
+              // `data_workspace_ids`.
+              const workspaceIdsBeforeStream = new Set(
+                refRegistry.getRegisteredWorkspaceIds(),
+              );
+
+              const chatResponse = await streamChat({
+                abortSignal: createMeteredAIAbortSignal(),
+                messages: chatContext.hydratedMessages,
+                latestMessageId: parsedMessage.message.id,
+                onFinish: async ({ isAborted, responseMessage }) => {
+                  const resolvedMessages = resolveAssistantMessageRefs({
+                    messages: [responseMessage],
+                    refRegistry,
+                  });
+                  const resolvedResponseMessage = resolvedMessages.at(0);
+                  if (!resolvedResponseMessage) {
+                    panic("Missing chat response message");
+                  }
+
+                  const persistencePlan = planAssistantFinishPersistence({
+                    existingIds: latestMessagePlan.existingIds,
+                    isAborted: isAborted || isClientConnectionAborted(),
+                    message: resolvedResponseMessage,
+                  });
+
+                  // Skip scope expansion when the assistant message
+                  // will not be persisted (aborted stream, planner
+                  // returned `none`). Widening `data_workspace_ids`
+                  // for transient parts that never land in
+                  // `chat_messages` could make the thread unreadable
+                  // after future access changes even though no
+                  // corresponding content was saved.
+                  if (persistencePlan.type === "none") {
+                    return;
+                  }
+
+                  // Widen the thread's data scope to cover any
+                  // workspace-scoped content the assistant just
+                  // emitted (source-document parts from search and
+                  // workspace tools). Run before persistMessage so
+                  // the recorded scope already includes the
+                  // workspaces when the message lands in
+                  // `chat_messages`.
+                  //
+                  // If expansion fails (transient DB error, etc.),
+                  // SKIP the message persist. Storing workspace-
+                  // scoped content in `chat_messages` while the
+                  // owning thread's `data_workspace_ids` stays stale
+                  // would leave the new content readable after the
+                  // user loses access to those workspaces — the same
+                  // class of leak this whole change exists to close.
+                  //
+                  // Intersect with `accessibleWorkspaceIds` so a
+                  // hallucinated or stale UUID from the model never
+                  // lands in `data_workspace_ids`. An out-of-set ID
+                  // would fail the RLS subset check on every later
+                  // persist, silently breaking the thread. Also union in the
+                  // workspaces the ref registry resolved DURING this stream —
+                  // see `computeAssistantTurnWorkspaceIds`'s docstring for why
+                  // that delta matters for subagent reads.
+                  const assistantWorkspaceIds =
+                    computeAssistantTurnWorkspaceIds({
+                      responseParts: resolvedResponseMessage.parts,
+                      workspaceIdsBeforeStream,
+                      registeredWorkspaceIdsAfterStream:
+                        refRegistry.getRegisteredWorkspaceIds(),
+                      accessibleWorkspaceIds: accessibleSet,
+                    });
+                  const expandResult = await expandThreadDataScope({
+                    currentDataWorkspaceIds: dataScopeAfterIncomingMessage,
+                    newWorkspaceIds: assistantWorkspaceIds,
+                    recordAuditEvent,
+                    safeDb,
+                    threadId: body.threadId,
+                    threadWorkspaceId: workspaceId,
+                  });
+                  if (Result.isError(expandResult)) {
+                    captureError(expandResult.error, {
+                      threadId: body.threadId,
+                    });
+                    return;
+                  }
+                  const persistResult = await persistMessage({
+                    persistencePlan,
+                    recordAuditEvent,
+                    safeDb,
+                    threadId: body.threadId,
+                    userId: user.id,
+                    workspaceId,
+                  });
+
+                  if (Result.isError(persistResult)) {
+                    captureError(persistResult.error, {
+                      threadId: body.threadId,
+                    });
+                  } else {
+                    const messagesAfterAssistantPersist =
+                      applyAssistantPersistencePlan({
+                        messages: latestMessagePlan.messages,
+                        persistencePlan,
+                      });
+                    if (
+                      messagesAfterAssistantPersist !== null &&
+                      body.sendMode !== CHAT_SEND_MODE.anonymized
+                    ) {
+                      scheduleChatCompactionCheckpoint({
+                        abortSignal: AbortSignal.timeout(
+                          CHAT_COMPACTION_CHECKPOINT_TIMEOUT_MS,
+                        ),
+                        boundary: thirdPartyBoundary,
+                        chatModelOverride,
+                        messages: messagesAfterAssistantPersist,
+                        organizationId: session.activeOrganizationId,
+                        orgAIConfig,
+                        safeDb,
+                        threadId: body.threadId,
+                      });
+                    }
+
+                    if (
+                      thread.type === "created" &&
+                      body.sendMode !== CHAT_SEND_MODE.anonymized
+                    ) {
+                      void generateThreadTitle({
+                        messages: [
+                          parsedMessage.message,
+                          resolvedResponseMessage,
+                        ],
+                        organizationId: session.activeOrganizationId,
+                        orgAIConfig,
+                        promptCachingEnabled,
+                        recordAuditEvent,
+                        safeDb,
+                        threadId: body.threadId,
+                        threadWorkspaceId: workspaceId,
+                        userId: user.id,
+                      });
+                    }
+                  }
+                },
+                orgAIConfig,
+                organizationId: session.activeOrganizationId,
+                devModelId: chatModelOverride,
+                promptCacheKey: chatContext.promptCacheKey,
+                promptCachingEnabled,
+                resolveAssistantTextRefs: refRegistry.resolveAssistantTextRefs,
+                resolveAssistantValueRefs:
+                  refRegistry.resolveAssistantValueRefs,
+                safeDb,
+                thirdPartyBoundary,
+                threadId: body.threadId,
+                tools: streamingTools,
+                externalMcpToolSource: externalMcpTools.source,
+                systemSafe,
+                systemUntrusted,
+                userId: user.id,
+                workspaceId,
               });
-            }
 
-            // Snapshot the refs the registry already holds before streaming.
-            // Prompt-time pins (`contextMatterIds` → `toMatterRef`) are
-            // resolved during prompt construction; folding the WHOLE registry
-            // into thread scope at onFinish would over-broaden it to pinned-
-            // but-never-read matters, which could make the thread unreadable
-            // after that matter's access is revoked even though its content was
-            // never persisted. Only the delta minted DURING the stream (a
-            // matter/entity a tool or subagent actually read) should widen
-            // `data_workspace_ids`.
-            const workspaceIdsBeforeStream = new Set(
-              refRegistry.getRegisteredWorkspaceIds(),
-            );
+              if (!isChatStreamResponse(chatResponse)) {
+                await externalMcpTools.close();
+              }
 
-            const chatResponse = await streamChat({
-              abortSignal: createMeteredAIAbortSignal(),
-              messages: chatContext.hydratedMessages,
-              latestMessageId: parsedMessage.message.id,
-              onFinish: async ({ isAborted, responseMessage }) => {
-                const resolvedMessages = resolveAssistantMessageRefs({
-                  messages: [responseMessage],
-                  refRegistry,
-                });
-                const resolvedResponseMessage = resolvedMessages.at(0);
-                if (!resolvedResponseMessage) {
-                  panic("Missing chat response message");
-                }
-
-                const persistencePlan = planAssistantFinishPersistence({
-                  existingIds: latestMessagePlan.existingIds,
-                  isAborted: isAborted || isClientConnectionAborted(),
-                  message: resolvedResponseMessage,
-                });
-
-                // Skip scope expansion when the assistant message
-                // will not be persisted (aborted stream, planner
-                // returned `none`). Widening `data_workspace_ids`
-                // for transient parts that never land in
-                // `chat_messages` could make the thread unreadable
-                // after future access changes even though no
-                // corresponding content was saved.
-                if (persistencePlan.type === "none") {
-                  return;
-                }
-
-                // Widen the thread's data scope to cover any
-                // workspace-scoped content the assistant just
-                // emitted (source-document parts from search and
-                // workspace tools). Run before persistMessage so
-                // the recorded scope already includes the
-                // workspaces when the message lands in
-                // `chat_messages`.
-                //
-                // If expansion fails (transient DB error, etc.),
-                // SKIP the message persist. Storing workspace-
-                // scoped content in `chat_messages` while the
-                // owning thread's `data_workspace_ids` stays stale
-                // would leave the new content readable after the
-                // user loses access to those workspaces — the same
-                // class of leak this whole change exists to close.
-                //
-                // Intersect with `accessibleWorkspaceIds` so a
-                // hallucinated or stale UUID from the model never
-                // lands in `data_workspace_ids`. An out-of-set ID
-                // would fail the RLS subset check on every later
-                // persist, silently breaking the thread. Also union in the
-                // workspaces the ref registry resolved DURING this stream —
-                // see `computeAssistantTurnWorkspaceIds`'s docstring for why
-                // that delta matters for subagent reads.
-                const assistantWorkspaceIds = computeAssistantTurnWorkspaceIds({
-                  responseParts: resolvedResponseMessage.parts,
-                  workspaceIdsBeforeStream,
-                  registeredWorkspaceIdsAfterStream:
-                    refRegistry.getRegisteredWorkspaceIds(),
-                  accessibleWorkspaceIds: accessibleSet,
-                });
-                const expandResult = await expandThreadDataScope({
-                  currentDataWorkspaceIds: dataScopeAfterIncomingMessage,
-                  newWorkspaceIds: assistantWorkspaceIds,
-                  recordAuditEvent,
-                  safeDb,
-                  threadId: body.threadId,
-                  threadWorkspaceId: workspaceId,
-                });
-                if (Result.isError(expandResult)) {
-                  captureError(expandResult.error, {
-                    threadId: body.threadId,
-                  });
-                  return;
-                }
-                const persistResult = await persistMessage({
-                  persistencePlan,
-                  recordAuditEvent,
-                  safeDb,
-                  threadId: body.threadId,
-                  userId: user.id,
-                  workspaceId,
-                });
-
-                if (Result.isError(persistResult)) {
-                  captureError(persistResult.error, {
-                    threadId: body.threadId,
-                  });
-                } else {
-                  const messagesAfterAssistantPersist =
-                    applyAssistantPersistencePlan({
-                      messages: latestMessagePlan.messages,
-                      persistencePlan,
-                    });
-                  if (
-                    messagesAfterAssistantPersist !== null &&
-                    body.sendMode !== CHAT_SEND_MODE.anonymized
-                  ) {
-                    scheduleChatCompactionCheckpoint({
-                      abortSignal: AbortSignal.timeout(
-                        CHAT_COMPACTION_CHECKPOINT_TIMEOUT_MS,
-                      ),
-                      boundary: thirdPartyBoundary,
-                      chatModelOverride,
-                      messages: messagesAfterAssistantPersist,
-                      organizationId: session.activeOrganizationId,
-                      orgAIConfig,
-                      safeDb,
-                      threadId: body.threadId,
-                    });
-                  }
-
-                  if (
-                    thread.type === "created" &&
-                    body.sendMode !== CHAT_SEND_MODE.anonymized
-                  ) {
-                    void generateThreadTitle({
-                      messages: [
-                        parsedMessage.message,
-                        resolvedResponseMessage,
-                      ],
-                      organizationId: session.activeOrganizationId,
-                      orgAIConfig,
-                      promptCachingEnabled,
-                      recordAuditEvent,
-                      safeDb,
-                      threadId: body.threadId,
-                      threadWorkspaceId: workspaceId,
-                      userId: user.id,
-                    });
-                  }
-                }
-              },
-              orgAIConfig,
-              organizationId: session.activeOrganizationId,
-              devModelId: chatModelOverride,
-              promptCacheKey: chatContext.promptCacheKey,
-              promptCachingEnabled,
-              resolveAssistantTextRefs: refRegistry.resolveAssistantTextRefs,
-              resolveAssistantValueRefs: refRegistry.resolveAssistantValueRefs,
-              safeDb,
-              thirdPartyBoundary,
-              threadId: body.threadId,
-              tools: streamingTools,
-              externalMcpToolSource: externalMcpTools.source,
-              systemSafe,
-              systemUntrusted,
-              userId: user.id,
-              workspaceId,
-            });
-
-            if (!isChatStreamResponse(chatResponse)) {
+              return chatResponse;
+            } catch (error) {
               await externalMcpTools.close();
+              throw error;
             }
+          },
+          catch: (cause) =>
+            cause instanceof HandlerError
+              ? cause
+              : new HandlerError({
+                  status: 500,
+                  message: "Failed to start chat response",
+                  cause,
+                }),
+        }),
+      );
 
-            return chatResponse;
-          } catch (error) {
-            await externalMcpTools.close();
-            throw error;
-          }
-        },
-        catch: (cause) =>
-          cause instanceof HandlerError
-            ? cause
-            : new HandlerError({
-                status: 500,
-                message: "Failed to start chat response",
-                cause,
-              }),
-      }),
-    );
-
-    return Result.ok(response);
+      return Result.ok(response);
+    } finally {
+      if (!externalMcpToolsHandedOffToStreaming) {
+        await externalMcpTools.close();
+      }
+    }
   },
 );
 
@@ -1280,6 +1306,12 @@ const isChatStreamResponse = (response: Response): boolean => {
   const contentType = response.headers.get("content-type");
   return contentType !== null && contentType.includes("text/event-stream");
 };
+
+const externalToolsForValidation = (
+  message: Static<typeof sendMessageBodySchema>["message"],
+  loaded: LoadedExternalMcpTools,
+): LoadedExternalMcpTools["tools"] | undefined =>
+  messageNeedsExternalMcpValidation(message) ? loaded.tools : undefined;
 
 const messageNeedsExternalMcpValidation = (
   message: Static<typeof sendMessageBodySchema>["message"],

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -306,8 +306,8 @@ const sendMessage = createSafeRootHandler(
     // time right before streaming. `externalMcpToolsHandedOffToStreaming`
     // below tracks whether ownership of closing these connectors passed
     // to the streaming try/catch, so every other exit path (validation
-    // failure, any early return between here and streaming) still closes
-    // them exactly once.
+    // failure, any early return or throw between here and streaming) still
+    // closes them exactly once.
     const externalMcpTools = await loadExternalMcpToolsForUser({
       nullUnionStrategy: externalMcpNullUnionStrategy,
       organizationId: session.activeOrganizationId,
@@ -316,79 +316,84 @@ const sendMessage = createSafeRootHandler(
     });
     let externalMcpToolsHandedOffToStreaming = false;
 
-    // Resolve the org's web-search providers once (BYOK key first,
-    // platform env key as fallback) and reuse for both the validation
-    // and streaming tool sets.
-    const webSearchProviders = await loadWebSearchProvidersForOrg(
-      session.activeOrganizationId,
-    );
-
-    // Tool input schemas don't depend on `accessibleWorkspaceIds`
-    // (scope is checked at execute time, not in the schema), so we
-    // can validate the incoming message against the broad set and
-    // then rebuild the tools with the narrowed `effective` set
-    // before streaming. This lets the picker's scope actually
-    // govern tool authorization rather than just being persisted.
-    // Validation tools include the broadest workspace surface, but
-    // still honor thread/org gates for tools whose presence is an
-    // explicit user or administrator opt-in.
-    const validationTools = getChatTools({
-      organizationId: session.activeOrganizationId,
-      memberRole: memberRole.role,
-      orgAIConfig,
-      pinServerValidatedWorkspaceId,
-      requestWorkspaceId: workspaceId,
-      refRegistry,
-      safeDb,
-      scopedDb,
-      threadId: body.threadId,
-      userId: user.id,
-      // Schema validation only; this tool set's `spawn_subagents` never
-      // executes, so a raw (non-anonymizing) boundary is correct here —
-      // the real per-request boundary is created below and threaded
-      // into the streaming tool set instead.
-      thirdPartyBoundary: { type: "raw" },
-      // Schema validation runs against the user's full accessible
-      // set; per-tool scope checks happen at execute time below.
-      toolWorkspaceIds: resolveToolWorkspaceIds({
-        pinnedIds: [],
-        accessibleWorkspaceIds,
-      }),
-      activeFile: body.activeFile,
-      hasActiveDocxEditClient: true,
-      hasActiveDocxFileClient: true,
-      webSearchEnabled: validationThreadState.webSearchEnabled,
-      webSearchProviders,
-      externalTools: externalToolsForValidation(body.message, externalMcpTools),
-      disabledNativeToolSlugs,
-      activeSkillContext: validationActiveSkillContext,
-      recordAuditEvent,
-      workspaceStatusById,
-    });
-
-    const validatedMessageResult = await validateMessage({
-      message: body.message,
-      safeDb,
-      threadId: body.threadId,
-      tools: validationTools,
-      userId: user.id,
-    });
-    if (Result.isError(validatedMessageResult)) {
-      // Validation is the only exit before the streaming pass takes over
-      // ownership of `externalMcpTools` (see `externalMcpToolsHandedOffToStreaming`
-      // below); every later early return closes it via the wrapping try/finally.
-      await externalMcpTools.close();
-      return Result.err(validatedMessageResult.error);
-    }
-    const validatedMessage = validatedMessageResult.value;
-
-    // From here on, every early return (validation already handled above)
-    // must still close `externalMcpTools` since the streaming try/catch
-    // below — which owns closing on its own exit paths — may never be
-    // reached. `Result.gen`'s `yield*` short-circuit resumes the generator
-    // via `.return()`, which unwinds this `finally` like a normal early
-    // `return` would.
+    // The try/finally starts immediately after the load (rather than just
+    // around the streaming pass) so that a throw from any of the awaited
+    // steps below — web-search provider load, tool-set construction,
+    // message validation — still closes `externalMcpTools` instead of
+    // leaking the MCP clients. The streaming pass further below takes over
+    // ownership once it starts consuming the clients (flips
+    // `externalMcpToolsHandedOffToStreaming`); until then this `finally` is
+    // the sole owner. `Result.gen`'s `yield*` short-circuit resumes the
+    // generator via `.return()`, which unwinds this `finally` like a normal
+    // early `return` would.
     try {
+      // Resolve the org's web-search providers once (BYOK key first,
+      // platform env key as fallback) and reuse for both the validation
+      // and streaming tool sets.
+      const webSearchProviders = await loadWebSearchProvidersForOrg(
+        session.activeOrganizationId,
+      );
+
+      // Tool input schemas don't depend on `accessibleWorkspaceIds`
+      // (scope is checked at execute time, not in the schema), so we
+      // can validate the incoming message against the broad set and
+      // then rebuild the tools with the narrowed `effective` set
+      // before streaming. This lets the picker's scope actually
+      // govern tool authorization rather than just being persisted.
+      // Validation tools include the broadest workspace surface, but
+      // still honor thread/org gates for tools whose presence is an
+      // explicit user or administrator opt-in.
+      const validationTools = getChatTools({
+        organizationId: session.activeOrganizationId,
+        memberRole: memberRole.role,
+        orgAIConfig,
+        pinServerValidatedWorkspaceId,
+        requestWorkspaceId: workspaceId,
+        refRegistry,
+        safeDb,
+        scopedDb,
+        threadId: body.threadId,
+        userId: user.id,
+        // Schema validation only; this tool set's `spawn_subagents` never
+        // executes, so a raw (non-anonymizing) boundary is correct here —
+        // the real per-request boundary is created below and threaded
+        // into the streaming tool set instead.
+        thirdPartyBoundary: { type: "raw" },
+        // Schema validation runs against the user's full accessible
+        // set; per-tool scope checks happen at execute time below.
+        toolWorkspaceIds: resolveToolWorkspaceIds({
+          pinnedIds: [],
+          accessibleWorkspaceIds,
+        }),
+        activeFile: body.activeFile,
+        hasActiveDocxEditClient: true,
+        hasActiveDocxFileClient: true,
+        webSearchEnabled: validationThreadState.webSearchEnabled,
+        webSearchProviders,
+        externalTools: externalToolsForValidation(
+          body.message,
+          externalMcpTools,
+        ),
+        disabledNativeToolSlugs,
+        activeSkillContext: validationActiveSkillContext,
+        recordAuditEvent,
+        workspaceStatusById,
+      });
+
+      const validatedMessageResult = await validateMessage({
+        message: body.message,
+        safeDb,
+        threadId: body.threadId,
+        tools: validationTools,
+        userId: user.id,
+      });
+      if (Result.isError(validatedMessageResult)) {
+        // The wrapping try/finally closes `externalMcpTools` on this exit
+        // path too — no explicit close needed here.
+        return Result.err(validatedMessageResult.error);
+      }
+      const validatedMessage = validatedMessageResult.value;
+
       const thread = yield* Result.await(
         loadThread({
           initialContextMatterIds: requestedContextMatterIds,

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
@@ -1,0 +1,180 @@
+import type { MCPClient } from "@tanstack/ai-mcp";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SafeDb } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
+
+const loadActiveMcpConnectionsForUserMock = mock();
+const createMcpClientForConnectionMock = mock();
+const captureErrorMock = mock();
+const withTimeoutMock =
+  mock<
+    (
+      operation: () => Promise<unknown>,
+      opts: { label: string; timeoutMs: number },
+    ) => Promise<unknown>
+  >();
+
+void mock.module("@/api/lib/mcp-upstream/connections", () => ({
+  createMcpClientForConnection: createMcpClientForConnectionMock,
+  loadActiveMcpConnectionsForUser: loadActiveMcpConnectionsForUserMock,
+}));
+
+void mock.module("@/api/lib/analytics", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
+}));
+
+void mock.module("@/api/lib/with-timeout", () => ({
+  withTimeout: withTimeoutMock,
+}));
+
+const { loadExternalMcpToolsForUser } =
+  await import("@/api/handlers/chat/tools/external-mcp-tools");
+
+const orgId = toSafeId<"organization">("org-test");
+const userId = toSafeId<"user">("user-test");
+// SAFETY: test double — every call this suite exercises is mocked at the
+// `mcp-upstream/connections` module boundary, so `safeDb` is never touched.
+// eslint-disable-next-line typescript/no-unsafe-type-assertion
+const stubSafeDb = (() => {
+  throw new Error("safeDb stub must not be called");
+}) as unknown as SafeDb;
+
+type FakeMcpClient = {
+  close: ReturnType<typeof mock<() => Promise<void>>>;
+  tools: ReturnType<typeof mock<() => Promise<never[]>>>;
+};
+
+const buildRow = (): LoadedMcpConnection => ({
+  allowedTools: null,
+  connectorId: toSafeId<"mcpConnector">("connector-test"),
+  description: "Test connector",
+  displayName: "Test Connector",
+  slug: "test-connector",
+  type: "none",
+  url: "https://mcp.example.test",
+  userConnectionId: toSafeId<"mcpUserConnection">("connection-test"),
+});
+
+const buildFakeClient = (
+  overrides: Partial<FakeMcpClient> = {},
+): FakeMcpClient => ({
+  close: mock(async () => undefined),
+  tools: mock(async () => []),
+  ...overrides,
+});
+
+const createDeferred = <T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} => {
+  let resolveDeferred!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve;
+  });
+  return { promise, resolve: resolveDeferred };
+};
+
+// SAFETY: test double — the fake client's `close`/`tools` cover the only
+// members `loadConnectorTools` exercises; the rest of the `MCPClient`
+// surface (resources, prompts, callTool, ...) is intentionally
+// unimplemented.
+const asMcpClient = (client: FakeMcpClient): MCPClient =>
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test double; MCPClient's full surface isn't exercised by loadConnectorTools
+  client as unknown as MCPClient;
+
+const passThroughTimeout = async (
+  operation: () => Promise<unknown>,
+): Promise<unknown> => await operation();
+
+beforeEach(() => {
+  loadActiveMcpConnectionsForUserMock.mockReset();
+  createMcpClientForConnectionMock.mockReset();
+  captureErrorMock.mockReset();
+  withTimeoutMock.mockReset();
+  withTimeoutMock.mockImplementation(passThroughTimeout);
+});
+
+describe("loadExternalMcpToolsForUser client lifecycle", () => {
+  test("closes the MCP client when discovery fails after the client is created", async () => {
+    const row = buildRow();
+    loadActiveMcpConnectionsForUserMock.mockResolvedValue([row]);
+
+    const fakeClient = buildFakeClient({
+      tools: mock(async () => {
+        throw new Error("upstream tools() call failed");
+      }),
+    });
+    createMcpClientForConnectionMock.mockResolvedValue(asMcpClient(fakeClient));
+
+    const loaded = await loadExternalMcpToolsForUser({
+      nullUnionStrategy: "json-schema",
+      organizationId: orgId,
+      safeDb: stubSafeDb,
+      userId,
+    });
+
+    expect(loaded.connectors).toEqual([]);
+    expect(fakeClient.close).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        source: "external-mcp-tools",
+        connectorSlug: "test-connector",
+      }),
+    );
+
+    // The whole-load `close()` never learned about this client (discovery
+    // discarded it before returning), so it must not double-close.
+    await loaded.close();
+    expect(fakeClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes the MCP client when it settles late after a discovery timeout", async () => {
+    const row = buildRow();
+    loadActiveMcpConnectionsForUserMock.mockResolvedValue([row]);
+
+    const clientCreation = createDeferred<MCPClient>();
+    const closeCalled = createDeferred<undefined>();
+    const fakeClient = buildFakeClient({
+      close: mock(async () => {
+        closeCalled.resolve(undefined);
+      }),
+    });
+    createMcpClientForConnectionMock.mockReturnValue(clientCreation.promise);
+
+    withTimeoutMock.mockImplementation(async (operation, opts) => {
+      // Mirrors the real `withTimeout`: the timer wins the race and the
+      // caller moves on, but the still-running `operation()` (the
+      // `discovery` promise) is left to settle on its own.
+      void operation();
+      throw new TimeoutError({
+        message: `${opts.label} exceeded ${opts.timeoutMs}ms`,
+        label: opts.label,
+        timeoutMs: opts.timeoutMs,
+      });
+    });
+
+    const loaded = await loadExternalMcpToolsForUser({
+      nullUnionStrategy: "json-schema",
+      organizationId: orgId,
+      safeDb: stubSafeDb,
+      userId,
+    });
+
+    // The connector is discarded immediately: the caller never sees this
+    // client, so it can only be closed by the abandoned-discovery path.
+    expect(loaded.connectors).toEqual([]);
+    expect(fakeClient.close).not.toHaveBeenCalled();
+
+    // Discovery settles well after the timeout already gave up on it.
+    clientCreation.resolve(asMcpClient(fakeClient));
+    await closeCalled.promise;
+
+    expect(fakeClient.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
@@ -177,4 +177,48 @@ describe("loadExternalMcpToolsForUser client lifecycle", () => {
 
     expect(fakeClient.close).toHaveBeenCalledTimes(1);
   });
+
+  test("closes the MCP client immediately on timeout when the client was already created and tools() is the hung step", async () => {
+    const row = buildRow();
+    loadActiveMcpConnectionsForUserMock.mockResolvedValue([row]);
+
+    // Never resolves — simulates `client.tools()` (not client creation)
+    // being the step that hangs past the aggregate discovery timeout.
+    const hangingTools = createDeferred<never[]>();
+    const fakeClient = buildFakeClient({
+      tools: mock(async () => await hangingTools.promise),
+    });
+    createMcpClientForConnectionMock.mockResolvedValue(asMcpClient(fakeClient));
+
+    withTimeoutMock.mockImplementation(async (operation, opts) => {
+      // Mirrors the real `withTimeout`, but flushes microtasks first so the
+      // still-running `discovery` promise has a chance to resolve
+      // `createMcpClientForConnection` (already-resolved) and assign its
+      // closure's `client` variable before hanging on `client.tools()` —
+      // otherwise this test could not distinguish "client known" from
+      // "client not yet created" at the moment the timeout fires.
+      void operation();
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      throw new TimeoutError({
+        message: `${opts.label} exceeded ${opts.timeoutMs}ms`,
+        label: opts.label,
+        timeoutMs: opts.timeoutMs,
+      });
+    });
+
+    const loaded = await loadExternalMcpToolsForUser({
+      nullUnionStrategy: "json-schema",
+      organizationId: orgId,
+      safeDb: stubSafeDb,
+      userId,
+    });
+
+    expect(loaded.connectors).toEqual([]);
+    // The client was already known when the timeout fired, so it is closed
+    // right away — the fix does not wait for the permanently-hung
+    // `tools()` call to settle before closing the leaked client/sockets.
+    expect(fakeClient.close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.test.ts
@@ -234,13 +234,19 @@ describe("createLazyExternalMcpToolsLoader", () => {
     });
     const loader = createLazyExternalMcpToolsLoader(load);
 
-    await expect(loader.getExternalMcpTools()).rejects.toThrow(
+    const rejection = await loader.getExternalMcpTools().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection instanceof Error ? rejection.message : "").toContain(
       "discovery failed",
     );
 
     // The finally block's cleanup call must not throw a second time on top
-    // of the original failure already surfaced to the caller above.
-    await expect(loader.closeIfLoaded()).resolves.toBeUndefined();
+    // of the original failure already surfaced to the caller above: a bare
+    // await that completes is the assertion (the test fails if it throws).
+    await loader.closeIfLoaded();
   });
 });
 

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.test.ts
@@ -1,10 +1,14 @@
 import { toolDefinition } from "@tanstack/ai";
 import type { ServerTool } from "@tanstack/ai";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import type { ChatTool } from "@/api/handlers/chat/tools/chat-tool-types";
 import { selectAllowedExternalMcpToolDefinitions } from "@/api/handlers/chat/tools/external-mcp-tool-definitions";
-import { createStellaMcpToolSource } from "@/api/handlers/chat/tools/external-mcp-tools";
+import {
+  createLazyExternalMcpToolsLoader,
+  createStellaMcpToolSource,
+} from "@/api/handlers/chat/tools/external-mcp-tools";
+import type { LoadedExternalMcpTools } from "@/api/handlers/chat/tools/external-mcp-tools";
 import { normalizeExternalMcpToolsForChat } from "@/api/handlers/chat/tools/external-mcp-tools-normalization";
 
 const tool = (name: string): ChatTool => ({
@@ -169,6 +173,74 @@ describe("external MCP typed definitions", () => {
         definitions: [lookup, deleteRecord],
       }),
     ).toEqual([lookup]);
+  });
+});
+
+describe("createLazyExternalMcpToolsLoader", () => {
+  const buildLoaded = (
+    overrides: Partial<LoadedExternalMcpTools> = {},
+  ): LoadedExternalMcpTools => ({
+    close: mock(async () => undefined),
+    connectors: [],
+    source: createStellaMcpToolSource({
+      closeClients: async () => undefined,
+      sourceTools: {},
+    }),
+    tools: {},
+    ...overrides,
+  });
+
+  test("never calls the loader when getExternalMcpTools is never invoked", async () => {
+    const load = mock(async () => buildLoaded());
+    const loader = createLazyExternalMcpToolsLoader(load);
+
+    // A message that needs neither validation nor streaming to load
+    // external tools must not trigger connector discovery at all.
+    await loader.closeIfLoaded();
+
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  test("loads at most once across concurrent and sequential callers", async () => {
+    const load = mock(async () => buildLoaded());
+    const loader = createLazyExternalMcpToolsLoader(load);
+
+    const [first, second] = await Promise.all([
+      loader.getExternalMcpTools(),
+      loader.getExternalMcpTools(),
+    ]);
+    const third = await loader.getExternalMcpTools();
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(first).toBe(third);
+  });
+
+  test("closeIfLoaded closes the cached load exactly once", async () => {
+    const closeMock = mock(async () => undefined);
+    const load = mock(async () => buildLoaded({ close: closeMock }));
+    const loader = createLazyExternalMcpToolsLoader(load);
+
+    await loader.getExternalMcpTools();
+    await loader.closeIfLoaded();
+    await loader.closeIfLoaded();
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("closeIfLoaded is a no-op and does not rethrow when the load failed", async () => {
+    const load = mock(async () => {
+      throw new Error("discovery failed");
+    });
+    const loader = createLazyExternalMcpToolsLoader(load);
+
+    await expect(loader.getExternalMcpTools()).rejects.toThrow(
+      "discovery failed",
+    );
+
+    // The finally block's cleanup call must not throw a second time on top
+    // of the original failure already surfaced to the caller above.
+    await expect(loader.closeIfLoaded()).resolves.toBeUndefined();
   });
 });
 

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -121,6 +121,59 @@ export const loadExternalMcpToolsForUser = async ({
   return { close: closeClients, connectors, source, tools: loadedTools };
 };
 
+export type LazyExternalMcpToolsLoader = {
+  /**
+   * Loads on first call and caches the in-flight/settled promise for every
+   * later call, so concurrent callers within one send (validation, then
+   * streaming) share a single connector-discovery round trip instead of
+   * running it twice.
+   */
+  getExternalMcpTools: () => Promise<LoadedExternalMcpTools>;
+  /**
+   * No-op when `getExternalMcpTools` was never called (nothing was loaded,
+   * so no connector clients exist to close). Otherwise awaits the cached
+   * load and closes it exactly once, no matter how many times
+   * `closeIfLoaded` itself is called — the close, like the load, is
+   * memoized. Swallows a load failure instead of rethrowing: a failed load
+   * already has no clients to leak, and the failure itself already
+   * surfaced to its own caller via `getExternalMcpTools`.
+   */
+  closeIfLoaded: () => Promise<void>;
+};
+
+/**
+ * Wraps a `LoadedExternalMcpTools` loader (normally a
+ * `loadExternalMcpToolsForUser` call bound to the current request) in a
+ * lazy, memoized accessor: connector discovery only runs if some caller
+ * actually needs the tools, and runs at most once no matter how many
+ * callers ask. Closing is memoized the same way, so a caller cannot
+ * accidentally double-close by calling `closeIfLoaded` more than once.
+ */
+export const createLazyExternalMcpToolsLoader = (
+  load: () => Promise<LoadedExternalMcpTools>,
+): LazyExternalMcpToolsLoader => {
+  let loadPromise: Promise<LoadedExternalMcpTools> | null = null;
+  let closePromise: Promise<void> | null = null;
+
+  const getExternalMcpTools = (): Promise<LoadedExternalMcpTools> => {
+    loadPromise ??= load();
+    return loadPromise;
+  };
+
+  const closeIfLoaded = async (): Promise<void> => {
+    if (loadPromise === null) {
+      return;
+    }
+    closePromise ??= loadPromise.then(
+      async (loaded) => await loaded.close(),
+      () => undefined,
+    );
+    await closePromise;
+  };
+
+  return { closeIfLoaded, getExternalMcpTools };
+};
+
 export const createStellaMcpToolSource = ({
   closeClients,
   sourceTools,

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -13,6 +13,7 @@ import {
 import { normalizeExternalMcpToolsForChat } from "@/api/handlers/chat/tools/external-mcp-tools-normalization";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import {
   createMcpClientForConnection,
   loadActiveMcpConnectionsForUser,
@@ -75,14 +76,15 @@ export const loadExternalMcpToolsForUser = async ({
   // timeout — degrades to "no tools from that connector" rather than
   // failing the whole load; see `loadConnectorTools`.
   const results = await Promise.all(
-    rows.map((row) =>
-      loadConnectorTools({
-        nullUnionStrategy,
-        organizationId,
-        row,
-        safeDb,
-        userId,
-      }),
+    rows.map(
+      async (row) =>
+        await loadConnectorTools({
+          nullUnionStrategy,
+          organizationId,
+          row,
+          safeDb,
+          userId,
+        }),
     ),
   );
 
@@ -181,49 +183,101 @@ const loadConnectorTools = async ({
   safeDb: SafeDb;
   userId: SafeId<"user">;
 }): Promise<LoadedExternalMcpConnectorResult | null> => {
+  // Tracks the client for the whole life of this discovery attempt, from
+  // the moment `createMcpClientForConnection` resolves, so every failure
+  // path below — a synchronous throw or a discovery timeout — has a
+  // handle to close it. Nothing else owns this client: on success it is
+  // handed to the caller via the returned result (which takes over
+  // closing it), and on any failure path it must be closed here or it
+  // leaks.
+  let client: MCPClient | undefined;
+
+  // Constructed once, outside `withTimeout`, so the same promise can be
+  // raced against the timeout AND, on the timeout path, awaited again
+  // afterwards to close whatever client discovery eventually produces.
+  // `withTimeout` itself only swallows the loser's late rejection to
+  // avoid an unhandled-rejection warning; it does not close resources
+  // the loser created.
+  const discovery =
+    (async (): Promise<LoadedExternalMcpConnectorResult | null> => {
+      const createdClient = await createMcpClientForConnection({
+        organizationId,
+        row,
+        safeDb,
+        userId,
+      });
+      if (!createdClient) {
+        return null;
+      }
+      client = createdClient;
+
+      const tools = await loadMcpConnectorTools({ client, row });
+      const normalized = normalizeExternalMcpToolsForChat({
+        allowedTools: row.allowedTools,
+        connectorSlug: row.slug,
+        nullUnionStrategy,
+        tools,
+      });
+
+      return {
+        client,
+        connector: {
+          description: row.description,
+          displayName: row.displayName,
+          slug: row.slug,
+          toolNames: normalized.toolNames,
+        },
+        tools: normalized.tools,
+      };
+    })();
+
   try {
-    return await withTimeout(
-      async () => {
-        const client = await createMcpClientForConnection({
-          organizationId,
-          row,
-          safeDb,
-          userId,
-        });
-        if (!client) {
-          return null;
-        }
-
-        const tools = await loadMcpConnectorTools({ client, row });
-        const normalized = normalizeExternalMcpToolsForChat({
-          allowedTools: row.allowedTools,
-          connectorSlug: row.slug,
-          nullUnionStrategy,
-          tools,
-        });
-
-        return {
-          client,
-          connector: {
-            description: row.description,
-            displayName: row.displayName,
-            slug: row.slug,
-            toolNames: normalized.toolNames,
-          },
-          tools: normalized.tools,
-        };
-      },
-      {
-        label: `external-mcp-tools:${row.slug}`,
-        timeoutMs: EXTERNAL_MCP_DISCOVERY_TIMEOUT_MS,
-      },
-    );
+    return await withTimeout(async () => await discovery, {
+      label: `external-mcp-tools:${row.slug}`,
+      timeoutMs: EXTERNAL_MCP_DISCOVERY_TIMEOUT_MS,
+    });
   } catch (error) {
+    if (error instanceof TimeoutError) {
+      // `discovery` is still running; wait for it to settle (success or
+      // failure) and close whatever client it created, since the timeout
+      // already discarded its result and no caller will ever see it.
+      void discovery
+        .catch(() => undefined)
+        .then(
+          async () =>
+            await closeAbandonedClient({ client, connectorSlug: row.slug }),
+        );
+    } else {
+      // `discovery` has already settled (that rejection is `error`), so
+      // any client it created is safe to close immediately.
+      await closeAbandonedClient({ client, connectorSlug: row.slug });
+    }
+
     captureError(error, {
       source: "external-mcp-tools",
       connectorSlug: row.slug,
     });
     return null;
+  }
+};
+
+const closeAbandonedClient = async ({
+  client,
+  connectorSlug,
+}: {
+  client: MCPClient | undefined;
+  connectorSlug: string;
+}): Promise<void> => {
+  if (!client) {
+    return;
+  }
+  try {
+    await client.close();
+  } catch (closeError) {
+    captureError(closeError, {
+      source: "external-mcp-tools-close",
+      connectorSlug,
+    });
   }
 };
 

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -238,9 +238,22 @@ const loadConnectorTools = async ({
     });
   } catch (error) {
     if (error instanceof TimeoutError) {
-      // `discovery` is still running; wait for it to settle (success or
-      // failure) and close whatever client it created, since the timeout
-      // already discarded its result and no caller will ever see it.
+      // Close whatever client discovery has already produced right away,
+      // instead of waiting for `discovery` to settle first: `MCPClient.close()`
+      // closes the underlying transport, which aborts the fetch backing an
+      // in-flight `client.tools()` call and locally rejects that pending
+      // call with a `ConnectionClosed` error (see `Protocol.close()` /
+      // `_onclose()` in the MCP SDK). So closing here cannot hang the way
+      // the timed-out discovery itself did — if `client.tools()` is the
+      // stuck step, this unblocks it. If discovery hasn't created a client
+      // yet (still inside `createMcpClientForConnection`, e.g. a hung
+      // DB/KMS call), `client` is still `undefined` here and there is
+      // nothing to close yet.
+      await closeAbandonedClient({ client, connectorSlug: row.slug });
+      // Still attach a best-effort close to `discovery`'s eventual
+      // settlement: it covers the case above where no client existed yet
+      // at timeout, and is a no-op otherwise since `MCPClient.close()` is
+      // idempotent (safe even if it ends up closing the same client twice).
       void discovery
         .catch(() => undefined)
         .then(

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -19,6 +19,18 @@ import {
 } from "@/api/lib/mcp-upstream/connections";
 import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
 import type { NullUnionStrategy } from "@/api/lib/provider-safe-json-schema";
+import { withTimeout } from "@/api/lib/with-timeout";
+
+// A single connector call can legitimately chain several sequential
+// upstream HTTP round trips (OAuth authorization-server discovery, token
+// refresh, then the MCP `tools()` call itself), each already bounded by
+// its own ~10s per-call timeout inside `mcp-upstream/connections.ts`. This
+// is the aggregate ceiling for one connector's whole discovery — client
+// creation through tool listing — so a connector stuck in an unbounded
+// step (e.g. a hung DB/KMS call with no timeout of its own) cannot stall
+// discovery past a bounded budget, regardless of how many connectors the
+// user has configured.
+const EXTERNAL_MCP_DISCOVERY_TIMEOUT_MS = 20_000;
 
 export type LoadedExternalMcpTools = {
   close: () => Promise<void> | void;
@@ -47,30 +59,51 @@ export const loadExternalMcpToolsForUser = async ({
   safeDb: SafeDb;
   userId: SafeId<"user">;
 }): Promise<LoadedExternalMcpTools> => {
-  const clients: MCPClient[] = [];
-  const connectors: LoadedExternalMcpConnector[] = [];
-  const sourceTools: Record<string, ServerTool | undefined> = {};
-  const loadedTools: ChatToolMap = {};
-
   const rows = await loadActiveMcpConnectionsForUser({
     organizationId,
     safeDb,
     userId,
   });
 
-  for (const row of rows) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential per-connector load; mutates shared clients/connectors/loadedTools and avoids fanning out concurrent external MCP connections
-    await loadConnectorTools({
-      clients,
-      connectors,
-      loadedTools,
-      nullUnionStrategy,
-      organizationId,
-      row,
-      safeDb,
-      sourceTools,
-      userId,
-    });
+  // Connectors are independent per-user integrations — separate client,
+  // separate auth, separate tool set — so loading them concurrently is
+  // safe; there is no ordering dependency between them (each row carries
+  // its own resolved credentials). Each call is individually bounded by
+  // `EXTERNAL_MCP_DISCOVERY_TIMEOUT_MS`, so one slow or unresponsive
+  // upstream server no longer multiplies latency by connector count the
+  // way a sequential loop would. A per-connector failure — including a
+  // timeout — degrades to "no tools from that connector" rather than
+  // failing the whole load; see `loadConnectorTools`.
+  const results = await Promise.all(
+    rows.map((row) =>
+      loadConnectorTools({
+        nullUnionStrategy,
+        organizationId,
+        row,
+        safeDb,
+        userId,
+      }),
+    ),
+  );
+
+  const clients: MCPClient[] = [];
+  const connectors: LoadedExternalMcpConnector[] = [];
+  const sourceTools: Record<string, ServerTool | undefined> = {};
+  const loadedTools: ChatToolMap = {};
+
+  // Merge sequentially, after every connector has settled, instead of
+  // mutating these shared collections from inside the concurrent loop
+  // above — keeps connector order and any tool-name collision resolution
+  // deterministic (row order) regardless of which connector's promise
+  // resolves first.
+  for (const result of results) {
+    if (result === null) {
+      continue;
+    }
+    clients.push(result.client);
+    connectors.push(result.connector);
+    Object.assign(loadedTools, result.tools);
+    copyServerTools({ sourceTools, tools: result.tools });
   }
 
   const closeClients = async (): Promise<void> => {
@@ -129,60 +162,68 @@ const copyServerTools = ({
 const isServerTool = (tool: ChatTool | undefined): tool is ServerTool =>
   tool !== undefined && "__toolSide" in tool && tool.__toolSide === "server";
 
+type LoadedExternalMcpConnectorResult = {
+  client: MCPClient;
+  connector: LoadedExternalMcpConnector;
+  tools: ChatToolMap;
+};
+
 const loadConnectorTools = async ({
-  clients,
-  connectors,
-  loadedTools,
   nullUnionStrategy,
   organizationId,
   row,
   safeDb,
-  sourceTools,
   userId,
 }: {
-  clients: MCPClient[];
-  connectors: LoadedExternalMcpConnector[];
-  loadedTools: ChatToolMap;
   nullUnionStrategy: NullUnionStrategy;
   organizationId: SafeId<"organization">;
   row: LoadedMcpConnection;
   safeDb: SafeDb;
-  sourceTools: Record<string, ServerTool | undefined>;
   userId: SafeId<"user">;
-}) => {
+}): Promise<LoadedExternalMcpConnectorResult | null> => {
   try {
-    const client = await createMcpClientForConnection({
-      organizationId,
-      row,
-      safeDb,
-      userId,
-    });
-    if (!client) {
-      return;
-    }
-    clients.push(client);
+    return await withTimeout(
+      async () => {
+        const client = await createMcpClientForConnection({
+          organizationId,
+          row,
+          safeDb,
+          userId,
+        });
+        if (!client) {
+          return null;
+        }
 
-    const tools = await loadMcpConnectorTools({ client, row });
-    const normalized = normalizeExternalMcpToolsForChat({
-      allowedTools: row.allowedTools,
-      connectorSlug: row.slug,
-      nullUnionStrategy,
-      tools,
-    });
-    Object.assign(loadedTools, normalized.tools);
-    copyServerTools({ sourceTools, tools: normalized.tools });
+        const tools = await loadMcpConnectorTools({ client, row });
+        const normalized = normalizeExternalMcpToolsForChat({
+          allowedTools: row.allowedTools,
+          connectorSlug: row.slug,
+          nullUnionStrategy,
+          tools,
+        });
 
-    connectors.push({
-      description: row.description,
-      displayName: row.displayName,
-      slug: row.slug,
-      toolNames: normalized.toolNames,
-    });
+        return {
+          client,
+          connector: {
+            description: row.description,
+            displayName: row.displayName,
+            slug: row.slug,
+            toolNames: normalized.toolNames,
+          },
+          tools: normalized.tools,
+        };
+      },
+      {
+        label: `external-mcp-tools:${row.slug}`,
+        timeoutMs: EXTERNAL_MCP_DISCOVERY_TIMEOUT_MS,
+      },
+    );
   } catch (error) {
     captureError(error, {
       source: "external-mcp-tools",
       connectorSlug: row.slug,
     });
+    return null;
   }
 };
 

--- a/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools.ts
@@ -155,9 +155,9 @@ export const createLazyExternalMcpToolsLoader = (
   let loadPromise: Promise<LoadedExternalMcpTools> | null = null;
   let closePromise: Promise<void> | null = null;
 
-  const getExternalMcpTools = (): Promise<LoadedExternalMcpTools> => {
+  const getExternalMcpTools = async (): Promise<LoadedExternalMcpTools> => {
     loadPromise ??= load();
-    return loadPromise;
+    return await loadPromise;
   };
 
   const closeIfLoaded = async (): Promise<void> => {
@@ -165,7 +165,7 @@ export const createLazyExternalMcpToolsLoader = (
       return;
     }
     closePromise ??= loadPromise.then(
-      async (loaded) => await loaded.close(),
+      (loaded): void | Promise<void> => loaded.close(),
       () => undefined,
     );
     await closePromise;


### PR DESCRIPTION
External MCP connector tools were discovered twice per chat send (validation pass and streaming pass, independent and uncached), with connectors loaded sequentially and only a per-HTTP-call 10s bound — one unresponsive third-party server multiplied into tens of seconds on every send for that user.

- Tools are now loaded once per request and reused by both passes, with explicit close-ownership on every exit path (validation failure, early returns, streaming handoff).
- Connectors load concurrently (they are independent per-user integrations; per-connector failure still degrades to "no tools from that connector") under a 20s per-connector aggregate discovery ceiling that also covers auth chaining, not just individual HTTP calls; merge order stays deterministic by row order.
- A validation-tools helper keeps the handler under the cognitive-complexity budget. Chat tools suite green (191 tests); api typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to external tools, with safer handling of slow, failing, or timed-out tool discovery.
  * Prevented chat sessions from stalling during external tool validation or streaming.
  * Ensured external tool connections are closed correctly across both normal and error scenarios, avoiding double-close issues.
* **Performance**
  * External tool discovery now runs concurrently where possible, reducing setup time.
* **Tests**
  * Added coverage for timeout and lifecycle edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->