### PR TITLE
fix(api): rank citations with seeded court weights

### DIFF
--- a/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   citationScore,
   courtWeight,
+  courtWeightSql,
   recencyFactor,
   weightedCitationSum,
 } from "@/api/handlers/case-law/citation-score";
@@ -200,5 +201,66 @@ describe("citationScore", () => {
       now,
     );
     expect(score).toBeGreaterThan(0);
+  });
+});
+
+// Non-ASCII (Czech/Polish/German) regex source characters serialize as
+// `\uXXXX` escapes via `RegExp.prototype.source` under the `u` flag —
+// Postgres's ARE regex engine natively understands `\uwxyz`, so this is
+// an equivalent (not broken) representation. Assertions below stick to
+// ASCII-safe fragments (weights, structure) rather than matching the
+// escaped accented text verbatim.
+describe("courtWeightSql", () => {
+  test("with no entries, falls back to the legacy hardcoded tiers (3 CZ/SK patterns)", () => {
+    const generated = courtWeightSql("citing_d.court");
+    expect(generated.match(/WHEN citing_d\.court ~\*/gu)).toHaveLength(3);
+    expect(generated).toContain("THEN 4");
+    expect(generated).toContain("THEN 3");
+    expect(generated).toContain("THEN 2");
+    expect(generated).toContain("ELSE 1 END");
+  });
+
+  test("with explicit undefined entries, falls back to the legacy tiers", () => {
+    // Mirrors what callers pass when the DB-seeded table is empty
+    // (loadCourtWeightEntriesForSql() resolves to undefined, not []).
+    const withUndefined = courtWeightSql("citing_d.court", undefined);
+    const withOmitted = courtWeightSql("citing_d.court");
+    expect(withUndefined).toBe(withOmitted);
+  });
+
+  test("with DB-seeded entries, generates from those instead of the legacy tiers", () => {
+    const generated = courtWeightSql("citing_d.court", [
+      {
+        pattern: /verfassungsgerichtshof/iu,
+        tier: 4,
+        tierLabel: "constitutional",
+        weight: 10,
+      },
+      {
+        pattern: /oberster gerichtshof/iu,
+        tier: 3,
+        tierLabel: "supreme",
+        weight: 8,
+      },
+    ]);
+
+    expect(generated).toContain("verfassungsgerichtshof");
+    expect(generated).toContain("THEN 10");
+    expect(generated).toContain("oberster gerichtshof");
+    expect(generated).toContain("THEN 8");
+    expect(generated.match(/WHEN citing_d\.court ~\*/gu)).toHaveLength(2);
+    // The legacy CZ/SK-only tiers must not leak in alongside the seeded
+    // entries (legacy tier 2's ASCII-safe fragment is distinctive).
+    expect(generated).not.toContain("krajsk");
+    expect(generated).toContain("ELSE 1 END");
+  });
+
+  test("an empty entries array does NOT fall back (documents the footgun that callers must avoid)", () => {
+    // courtWeightSql only falls back on `undefined`/omitted entries; an
+    // empty array is passed through verbatim. Callers that load from the
+    // DB must convert an empty result to `undefined`
+    // (see court-weights.test.ts: flattenCourtWeightEntries).
+    const generated = courtWeightSql("citing_d.court", []);
+    expect(generated).toBe("CASE \n      ELSE 1 END");
   });
 });

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -37,80 +37,89 @@ const supremeCitingId = createSafeId<"caseLawDecision">();
 const regionalCitingId = createSafeId<"caseLawDecision">();
 const orphanId = createSafeId<"caseLawDecision">();
 
-beforeAll(async () => {
-  client = await createSchemaPglite();
-  db = drizzle({ client });
-  await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
-  await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
-  await installPgliteSchemaPrerequisites(db);
-  const { sqlStatements } = await pushSchema(allSchema, db);
-  for (const statement of sqlStatements) {
-    // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)
-    await db.execute(sql.raw(statement));
-  }
+// The full pushSchema() DDL push against pglite is close enough to
+// bun:test's 5s default hook timeout that running this file alongside
+// others in the same worker occasionally tips it over; match the
+// { timeout: 30_000 } convention used by the other pglite-schema
+// fixtures (entity-filters.differential.test.ts, legislation/
+// ingestion.test.ts).
+beforeAll(
+  async () => {
+    client = await createSchemaPglite();
+    db = drizzle({ client });
+    await db.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
+    await db.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
+    await installPgliteSchemaPrerequisites(db);
+    const { sqlStatements } = await pushSchema(allSchema, db);
+    for (const statement of sqlStatements) {
+      // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)
+      await db.execute(sql.raw(statement));
+    }
 
-  await db.insert(caseLawSources).values({
-    id: sourceId,
-    adapterKey: "test",
-    name: "Test source",
-  });
+    await db.insert(caseLawSources).values({
+      id: sourceId,
+      adapterKey: "test",
+      name: "Test source",
+    });
 
-  await db.insert(caseLawDecisions).values([
-    {
-      id: citedId,
-      sourceId,
-      caseNumber: "1 Cdo 1/2020",
-      court: "Okresní soud",
-      country: "CZE",
-      language: "cs",
-      decisionDate: "2020-01-01",
-    },
-    {
-      id: supremeCitingId,
-      sourceId,
-      caseNumber: "2 Cdo 2/2025",
-      court: "Nejvyšší soud",
-      country: "CZE",
-      language: "cs",
-      decisionDate: "2025-01-01",
-    },
-    {
-      id: regionalCitingId,
-      sourceId,
-      caseNumber: "3 Co 3/2018",
-      court: "Krajský soud",
-      country: "CZE",
-      language: "cs",
-      decisionDate: "2018-01-01",
-    },
-    {
-      id: orphanId,
-      sourceId,
-      caseNumber: "4 Cdo 4/2021",
-      court: "Okresní soud",
-      country: "CZE",
-      language: "cs",
-      decisionDate: "2021-01-01",
-    },
-  ]);
+    await db.insert(caseLawDecisions).values([
+      {
+        id: citedId,
+        sourceId,
+        caseNumber: "1 Cdo 1/2020",
+        court: "Okresní soud",
+        country: "CZE",
+        language: "cs",
+        decisionDate: "2020-01-01",
+      },
+      {
+        id: supremeCitingId,
+        sourceId,
+        caseNumber: "2 Cdo 2/2025",
+        court: "Nejvyšší soud",
+        country: "CZE",
+        language: "cs",
+        decisionDate: "2025-01-01",
+      },
+      {
+        id: regionalCitingId,
+        sourceId,
+        caseNumber: "3 Co 3/2018",
+        court: "Krajský soud",
+        country: "CZE",
+        language: "cs",
+        decisionDate: "2018-01-01",
+      },
+      {
+        id: orphanId,
+        sourceId,
+        caseNumber: "4 Cdo 4/2021",
+        court: "Okresní soud",
+        country: "CZE",
+        language: "cs",
+        decisionDate: "2021-01-01",
+      },
+    ]);
 
-  await db.insert(caseLawCitations).values([
-    {
-      citingDecisionId: supremeCitingId,
-      citedDecisionId: citedId,
-      citationText: "1 Cdo 1/2020",
-    },
-    {
-      citingDecisionId: regionalCitingId,
-      citedDecisionId: citedId,
-      citationText: "1 Cdo 1/2020",
-    },
-  ]);
+    await db.insert(caseLawCitations).values([
+      {
+        citingDecisionId: supremeCitingId,
+        citedDecisionId: citedId,
+        citationText: "1 Cdo 1/2020",
+      },
+      {
+        citingDecisionId: regionalCitingId,
+        citedDecisionId: citedId,
+        citationText: "1 Cdo 1/2020",
+      },
+    ]);
 
-  await db.transaction(async (tx) =>
-    recomputeCitationAuthorityForAll(tx, { now: NOW }),
-  );
-});
+    await db.transaction(async (tx) =>
+      recomputeCitationAuthorityForAll(tx, { now: NOW }),
+    );
+  },
+  { timeout: 30_000 },
+);
 
 afterAll(async () => {
   await client.close();
@@ -168,4 +177,84 @@ test("a more authoritative citing court yields higher authority", async () => {
     NOW,
   );
   expect(supreme).toBeGreaterThan(regional);
+});
+
+// Bug fix: DB-seeded court weights (case_law_court_weights, loaded via
+// loadCourtWeightEntriesForSql()) were never threaded into
+// recomputeCitationAuthorityForAll's SQL, so it silently always used
+// LEGACY_COURT_TIERS regardless of what was seeded. This test pins the
+// `courtWeightEntries` option actually reaching the generated SQL. It
+// reuses the file's shared pglite fixture (adding one more decision/
+// citation) rather than standing up a second pglite instance, which is
+// expensive enough to trip the default hook timeout when run alongside
+// the file's existing fixture.
+test("courtWeightEntries option drives the SQL instead of the legacy tiers", async () => {
+  // A court name that matches none of LEGACY_COURT_TIERS' CZ/SK patterns
+  // (so the legacy fallback would score it at DEFAULT_WEIGHT=1), but
+  // matches CUSTOM_ENTRIES below at weight 7 — proving the entries
+  // actually drove the SQL rather than being silently ignored.
+  const customCitedId = createSafeId<"caseLawDecision">();
+  const customCitingId = createSafeId<"caseLawDecision">();
+  const CUSTOM_ENTRIES = [
+    {
+      pattern: /^Custom Seeded Court$/u,
+      tier: 5,
+      tierLabel: "seeded-only",
+      weight: 7,
+    },
+  ];
+
+  await db.insert(caseLawDecisions).values([
+    {
+      id: customCitedId,
+      sourceId,
+      caseNumber: "5 Cdo 5/2020",
+      court: "Okresní soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate: "2020-01-01",
+    },
+    {
+      id: customCitingId,
+      sourceId,
+      caseNumber: "6 Cdo 6/2025",
+      court: "Custom Seeded Court",
+      country: "CZE",
+      language: "cs",
+      decisionDate: "2025-01-01",
+    },
+  ]);
+  await db.insert(caseLawCitations).values({
+    citingDecisionId: customCitingId,
+    citedDecisionId: customCitedId,
+    citationText: "5 Cdo 5/2020",
+  });
+
+  await db.transaction(async (tx) =>
+    recomputeCitationAuthorityForAll(tx, {
+      now: NOW,
+      courtWeightEntries: CUSTOM_ENTRIES,
+    }),
+  );
+
+  expect(await authorityOf(customCitedId)).toBeCloseTo(
+    citationScore(
+      [{ citingCourt: "Custom Seeded Court", citingDate: "2025-01-01" }],
+      "2020-01-01",
+      NOW,
+      new Map([["CZE", CUSTOM_ENTRIES]]),
+    ),
+    9,
+  );
+  // Sanity check: under the legacy fallback this citing court matches no
+  // pattern (DEFAULT_WEIGHT=1), which differs from the custom weight (7)
+  // enough that the assertion above cannot pass by coincidence.
+  expect(await authorityOf(customCitedId)).not.toBeCloseTo(
+    citationScore(
+      [{ citingCourt: "Custom Seeded Court", citingDate: "2025-01-01" }],
+      "2020-01-01",
+      NOW,
+    ),
+    2,
+  );
 });

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -2,6 +2,7 @@ import type { SQL } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
 import { courtWeightSql } from "@/api/handlers/case-law/citation-score";
+import type { CourtWeightEntry } from "@/api/handlers/case-law/court-weights";
 import { redistributableCaseLawSourceSqlFor } from "@/api/handlers/case-law/redistribution";
 import { setCorpusBackfillStatementTimeout } from "@/api/lib/legal-search/backfill-statement-timeout";
 import { isRecord } from "@/api/lib/type-guards";
@@ -31,6 +32,13 @@ import { isRecord } from "@/api/lib/type-guards";
  * (jurisdiction) scale this is cheap; at hundreds-of-millions scale it
  * should become incremental, keyed off `citation_authority_computed_at`
  * (the column exists for that future bound).
+ *
+ * Court weights are passed in via `courtWeightEntries` rather than
+ * loaded internally: this keeps the function a pure `tx`-in/count-out
+ * unit that is safe to exercise against a pglite fixture in tests.
+ * Production callers load the current DB-seeded weights themselves
+ * (`loadCourtWeightEntriesForSql()`) before calling in; omitting the
+ * option falls back to `courtWeightSql`'s legacy hardcoded tiers.
  */
 
 type CitationAuthorityTx = {
@@ -41,14 +49,19 @@ const SECONDS_PER_YEAR = 365.25 * 86_400;
 
 export const recomputeCitationAuthorityForAll = async (
   tx: CitationAuthorityTx,
-  options: { now?: Date } = {},
+  options: {
+    now?: Date;
+    courtWeightEntries?: CourtWeightEntry[] | undefined;
+  } = {},
 ): Promise<number> => {
   const nowExpr = options.now
     ? sql`${options.now.toISOString()}::timestamptz`
     : sql`now()`;
   // Court-authority weighting as a CASE expression over the citing
   // court name; mirrors the search SQL's `courtWeightSql`.
-  const courtWeightExpr = sql.raw(courtWeightSql("citing_d.court"));
+  const courtWeightExpr = sql.raw(
+    courtWeightSql("citing_d.court", options.courtWeightEntries),
+  );
 
   // The aggregate over (citation ⨝ citing decision) is LEFT JOINed onto
   // every decision so decisions with zero citations are reset to 0 too.

--- a/apps/api/src/handlers/case-law/court-weights.test.ts
+++ b/apps/api/src/handlers/case-law/court-weights.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  courtWeightFromMap,
+  flattenCourtWeightEntries,
+} from "@/api/handlers/case-law/court-weights";
+import type { CourtWeightMap } from "@/api/handlers/case-law/court-weights";
+
+const buildMap = (): CourtWeightMap =>
+  new Map([
+    [
+      "CZE",
+      [
+        {
+          pattern: /ústavní soud/iu,
+          tier: 4,
+          tierLabel: "constitutional",
+          weight: 10,
+        },
+        { pattern: /nejvyšší/iu, tier: 3, tierLabel: "supreme", weight: 8 },
+      ],
+    ],
+    [
+      "POL",
+      [
+        {
+          pattern: /sąd najwyższy/iu,
+          tier: 3,
+          tierLabel: "supreme",
+          weight: 8,
+        },
+      ],
+    ],
+  ]);
+
+describe("courtWeightFromMap", () => {
+  test("matches within the given country first", () => {
+    const map = buildMap();
+    expect(courtWeightFromMap(map, "Nejvyšší soud", "CZE")).toEqual({
+      weight: 8,
+      tier: 3,
+    });
+  });
+
+  test("falls back across countries when no country given", () => {
+    const map = buildMap();
+    expect(courtWeightFromMap(map, "Sąd Najwyższy")).toEqual({
+      weight: 8,
+      tier: 3,
+    });
+  });
+
+  test("falls back across countries when the named country has no match", () => {
+    const map = buildMap();
+    // A Polish court name, but caller passed the wrong country.
+    expect(courtWeightFromMap(map, "Sąd Najwyższy", "CZE")).toEqual({
+      weight: 8,
+      tier: 3,
+    });
+  });
+
+  test("unmatched court → default weight/tier 1", () => {
+    const map = buildMap();
+    expect(courtWeightFromMap(map, "Okresní soud")).toEqual({
+      weight: 1,
+      tier: 1,
+    });
+  });
+});
+
+describe("flattenCourtWeightEntries", () => {
+  test("empty map → undefined (preserves courtWeightSql's legacy fallback)", () => {
+    expect(flattenCourtWeightEntries(new Map())).toBeUndefined();
+  });
+
+  test("flattens entries across every country, sorted by tier descending", () => {
+    const flattened = flattenCourtWeightEntries(buildMap());
+    expect(flattened).toBeDefined();
+    expect(flattened).toHaveLength(3);
+    expect(flattened?.map((e) => e.tier)).toEqual([4, 3, 3]);
+    // Both country's entries are present, not just the first country's.
+    expect(flattened?.map((e) => e.tierLabel)).toContain("constitutional");
+    expect(flattened?.filter((e) => e.tierLabel === "supreme")).toHaveLength(2);
+  });
+});

--- a/apps/api/src/handlers/case-law/court-weights.ts
+++ b/apps/api/src/handlers/case-law/court-weights.ts
@@ -127,6 +127,19 @@ export const loadCourtWeightsForCountry = async (
 // -- SQL entries -----------------------------------------------------------
 
 /**
+ * Per-map-instance cache of the flattened, sorted entries. `loadCourtWeights`
+ * only ever mutates `cached.map` by swapping in a brand-new `Map` on refresh
+ * (never mutating an existing instance in place), so keying on the map
+ * instance gives free invalidation: once the 60 s TTL rotates in a new map,
+ * this WeakMap simply misses and recomputes, and the old entry is GC'd along
+ * with its map.
+ */
+const flattenedEntriesCache = new WeakMap<
+  CourtWeightMap,
+  CourtWeightEntry[] | undefined
+>();
+
+/**
  * Flatten every country's entries into one list, sorted by tier
  * descending so the highest-authority pattern is checked first.
  *
@@ -143,8 +156,14 @@ export const loadCourtWeightsForCountry = async (
 export const flattenCourtWeightEntries = (
   map: CourtWeightMap,
 ): CourtWeightEntry[] | undefined => {
+  if (flattenedEntriesCache.has(map)) {
+    return flattenedEntriesCache.get(map);
+  }
+
   const entries = [...map.values()].flat().sort((a, b) => b.tier - a.tier);
-  return entries.length > 0 ? entries : undefined;
+  const result = entries.length > 0 ? entries : undefined;
+  flattenedEntriesCache.set(map, result);
+  return result;
 };
 
 /**

--- a/apps/api/src/handlers/case-law/court-weights.ts
+++ b/apps/api/src/handlers/case-law/court-weights.ts
@@ -7,6 +7,7 @@
 
 import { arrayOrEmpty } from "@/api/lib/array";
 import { readCourtWeightRows } from "@/api/lib/case-law/case-law-config-store";
+import { logger } from "@/api/lib/observability/logger";
 
 // -- Types ---------------------------------------------------------------
 
@@ -33,6 +34,17 @@ export const loadCourtWeights = async (): Promise<CourtWeightMap> => {
   }
 
   const rows = await readCourtWeightRows();
+
+  if (rows.length === 0) {
+    // Self-host before seeding, or a fresh environment that has not run
+    // seed-court-weights.ts yet: callers fall back to the hardcoded
+    // LEGACY_COURT_TIERS in citation-score.ts. Surface this so an
+    // unseeded production table is visible rather than silently ranking
+    // every non-CZ/SK court the same.
+    logger.warn("case_law.court_weights.table_empty", {
+      fallback: "legacy_hardcoded_tiers",
+    });
+  }
 
   const map: CourtWeightMap = new Map();
   for (const row of rows) {
@@ -111,3 +123,34 @@ export const loadCourtWeightsForCountry = async (
   const entries = map.get(country);
   return arrayOrEmpty(entries);
 };
+
+// -- SQL entries -----------------------------------------------------------
+
+/**
+ * Flatten every country's entries into one list, sorted by tier
+ * descending so the highest-authority pattern is checked first.
+ *
+ * For building a single SQL `CASE` expression (`courtWeightSql`) that is
+ * not scoped to one jurisdiction — citation graphs cross borders, so the
+ * citing court in `citation-authority.ts` and `decisions/search.ts` can
+ * belong to any seeded country.
+ *
+ * Returns `undefined` when the map is empty so callers can pass that
+ * straight to `courtWeightSql`'s `entries` parameter: an empty array
+ * would short-circuit its `entries ?? LEGACY_COURT_TIERS` fallback,
+ * silently disabling the legacy tiers instead of falling back to them.
+ */
+export const flattenCourtWeightEntries = (
+  map: CourtWeightMap,
+): CourtWeightEntry[] | undefined => {
+  const entries = [...map.values()].flat().sort((a, b) => b.tier - a.tier);
+  return entries.length > 0 ? entries : undefined;
+};
+
+/**
+ * Load and flatten court weights for a cross-jurisdiction SQL `CASE`
+ * expression. See `flattenCourtWeightEntries`.
+ */
+export const loadCourtWeightEntriesForSql = async (): Promise<
+  CourtWeightEntry[] | undefined
+> => flattenCourtWeightEntries(await loadCourtWeights());

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -6,6 +6,7 @@ import type { Static } from "elysia";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { envBase } from "@/api/env-base";
 import { courtWeightSql } from "@/api/handlers/case-law/citation-score";
+import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { validCaseLawLanguageAlternateCountSql } from "@/api/handlers/case-law/decisions/language";
 import type { searchDecisionsBodySchema } from "@/api/handlers/case-law/decisions/search-schema";
 import {
@@ -149,7 +150,11 @@ const searchPostgresDecisions = async (
     ${languageFilter}
   `;
 
-  const courtWeightExpr = courtWeightSql("citing_d.court");
+  // DB-seeded weights (case_law_court_weights, 60s cache) cover every
+  // jurisdiction; courtWeightSql falls back to the legacy CZ/SK-only
+  // tiers only when the table has not been seeded yet.
+  const courtWeightEntries = await loadCourtWeightEntriesForSql();
+  const courtWeightExpr = courtWeightSql("citing_d.court", courtWeightEntries);
 
   const citationBoost = sql.raw(`
     LATERAL (

--- a/apps/api/src/scripts/backfill-citation-authority.ts
+++ b/apps/api/src/scripts/backfill-citation-authority.ts
@@ -10,11 +10,14 @@
  */
 import { rootDb } from "@/api/db/root";
 import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
+import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 
 console.log("=== BACKFILL CITATION AUTHORITY ===");
 
+const courtWeightEntries = await loadCourtWeightEntriesForSql();
 const updated = await rootDb.transaction(
-  async (tx) => await recomputeCitationAuthorityForAll(tx),
+  async (tx) =>
+    await recomputeCitationAuthorityForAll(tx, { courtWeightEntries }),
 );
 
 console.log(`Citation authority materialized for ${updated} cited decisions.`);

--- a/apps/api/src/scripts/resolve-citations.ts
+++ b/apps/api/src/scripts/resolve-citations.ts
@@ -25,6 +25,7 @@ import {
   caseLawPolarityRules,
 } from "@/api/db/schema";
 import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
+import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { extractContext } from "@/api/handlers/case-law/polarity/context";
 import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -697,8 +698,10 @@ if (!REPORT_ONLY) {
   // recomputing the citation-graph aggregate per query.
   if (!DRY_RUN) {
     console.log("\n=== RECOMPUTING CITATION AUTHORITY ===");
+    const courtWeightEntries = await loadCourtWeightEntriesForSql();
     const updated = await rootDb.transaction(
-      async (tx) => await recomputeCitationAuthorityForAll(tx),
+      async (tx) =>
+        await recomputeCitationAuthorityForAll(tx, { courtWeightEntries }),
     );
     console.log(`Citation authority refreshed for ${updated} cited decisions.`);
   }

--- a/apps/legal-atlas-runner/src/db.ts
+++ b/apps/legal-atlas-runner/src/db.ts
@@ -18,6 +18,10 @@ import { rootDb, rlsDb } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawSources } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
+import {
+  type CourtWeightEntry,
+  loadCourtWeightEntriesForSql,
+} from "@/api/handlers/case-law/court-weights";
 import { withTimeout } from "@/api/lib/with-timeout";
 
 import { LEGAL_ATLAS_RUNNER_ENV } from "./env";
@@ -118,3 +122,19 @@ export const createCaseLawSource = async (
     },
     { label: "case-law-source-create", timeoutMs: rootQueryTimeoutMs },
   );
+
+/**
+ * Load the flattened court-weight entries used to rank citations. The
+ * underlying loader (`loadCourtWeightEntriesForSql`) reads through the
+ * API's root pool with its own 60 s in-memory cache and has no bounded-db
+ * seam to inject, so this wraps the call itself in the runner's
+ * `withTimeout` budget: a reaped root-pool connection rejects instead of
+ * hanging the citation-authority recompute loop forever.
+ */
+export const loadCourtWeightEntries = async (): Promise<
+  CourtWeightEntry[] | undefined
+> =>
+  await withTimeout(loadCourtWeightEntriesForSql, {
+    label: "court-weight-entries-lookup",
+    timeoutMs: rootQueryTimeoutMs,
+  });

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -24,6 +24,7 @@ import { envBase } from "@/api/env-base";
 import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
 import { ADAPTER_KEYS, MAX_CYCLE_MS } from "@/api/handlers/case-law/consts";
 import { backfillCorpusIndex } from "@/api/handlers/case-law/corpus-index";
+import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
 import { backfillSearchIndex } from "@/api/handlers/case-law/search-index";
@@ -823,8 +824,12 @@ export const runCaseLawIngest = async (
       await Bun.sleep(CITATION_AUTHORITY_INTERVAL_MS);
       try {
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
+        const courtWeightEntries = await loadCourtWeightEntriesForSql();
+        // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const updated = await ingestionDb(async (tx) => {
-          const count = await recomputeCitationAuthorityForAll(tx);
+          const count = await recomputeCitationAuthorityForAll(tx, {
+            courtWeightEntries,
+          });
           return count;
         });
         logInfo(`[citation-authority] Recomputed (${updated} cited decisions)`);

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -24,7 +24,6 @@ import { envBase } from "@/api/env-base";
 import { recomputeCitationAuthorityForAll } from "@/api/handlers/case-law/citation-authority";
 import { ADAPTER_KEYS, MAX_CYCLE_MS } from "@/api/handlers/case-law/consts";
 import { backfillCorpusIndex } from "@/api/handlers/case-law/corpus-index";
-import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
 import { backfillSearchIndex } from "@/api/handlers/case-law/search-index";
@@ -47,6 +46,7 @@ import {
   createCaseLawSource,
   findCaseLawSource,
   ingestionDb,
+  loadCourtWeightEntries,
 } from "../db";
 import { LEGAL_ATLAS_RUNNER_ENV } from "../env";
 
@@ -824,7 +824,7 @@ export const runCaseLawIngest = async (
       await Bun.sleep(CITATION_AUTHORITY_INTERVAL_MS);
       try {
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
-        const courtWeightEntries = await loadCourtWeightEntriesForSql();
+        const courtWeightEntries = await loadCourtWeightEntries();
         // oxlint-disable-next-line no-await-in-loop -- one full recompute per interval; the next poll only runs after this recompute completes
         const updated = await ingestionDb(async (tx) => {
           const count = await recomputeCitationAuthorityForAll(tx, {


### PR DESCRIPTION
The DB-seeded court weights (\`case_law_court_weights\`: CZE, SVK, POL, AUT, EU; tiers up to 10) were never consumed — the loaders had zero production callers, so citation-authority recomputes and search ranking always fell back to the legacy hardcoded CZ/SK-only tiers, scoring PL/AT/EU top courts the same as any regional court.

- \`courtWeightSql\` call sites (citation-authority recompute, decision search, ingest runner, both backfill scripts) now pass DB-loaded entries via a new cross-jurisdiction \`loadCourtWeightEntriesForSql()\` (flattened, tier-descending, 60s cache).
- The recompute stays a pure tx-in/count-out unit — entries are injected by callers, keeping the pglite test fixtures viable; empty/unseeded tables still fall back to the legacy tiers, now with a structured warning so an unseeded production table is visible.
- Tests extended to pin DB-entry usage and the fallback; 354 case-law tests green, api and legal-atlas-runner typechecks clean.