### PR TITLE
fix(api): ship lib/type-guards.ts in the migrate image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -90,9 +90,14 @@ COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
 # Loose files for the one-off migrate task (the API itself is the compiled
 # /app/server binary). migrate.ts runs the drizzle migrator over Bun's SQL
-# client; it imports db-url.ts and reads the drizzle/ migration folder.
+# client; it imports db-url.ts (which imports lib/type-guards.ts) and reads
+# the drizzle/ migration folder. This COPY set is the migrate entrypoint's
+# full transitive @/api dependency — keep it in sync when db-url.ts/migrate.ts
+# gain an import, or the loose-file task fails at runtime with "Cannot find
+# module" (the compiled API binary bundles these, so it won't catch it).
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle.config.ts /app/apps/api/drizzle.config.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/src/db-url.ts /app/apps/api/src/db-url.ts
+COPY --chown=stella:stella --from=builder /app/apps/api/src/lib/type-guards.ts /app/apps/api/src/lib/type-guards.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/src/db/migrate.ts /app/apps/api/src/db/migrate.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle /app/apps/api/drizzle
 RUN mkdir -p '/$bunfs/root'


### PR DESCRIPTION
## Incident
The staging promotion's DB-migration task has been failing (exit 1, all retries) with:
```
error: Cannot find module '@/api/lib/type-guards' from '/app/apps/api/src/db-url.ts'
```
This blocks the staging deploy pipeline (the compiled API binary is unaffected — it bundles all imports; only the loose-file migrate task breaks).

## Cause
The migrate task runs as loose source files (`bun run src/db/migrate.ts`), and the Dockerfile hand-copies only `db-url.ts`, `migrate.ts`, `drizzle.config.ts`, and `drizzle/`. A recent convention refactor made `db-url.ts` import `{ includes }` from `@/api/lib/type-guards`, but that new file was never added to the migrate COPY set, so it is absent from the image at runtime.

## Fix
Add `apps/api/src/lib/type-guards.ts` to the migrate COPY set (it is the entrypoint's only missing transitive `@/api` dependency: migrate.ts has no `@/api` imports, db-url.ts imports only type-guards, and type-guards is a leaf module). Also tightened the comment to name this COPY set as the migrate entrypoint's full transitive dependency, so future imports are kept in sync.

## Follow-up (not in this hotfix)
The hand-maintained loose-file COPY list is fragile — any new import in `db-url.ts`/`migrate.ts` silently breaks the migrate task at runtime, invisible to typecheck/lint/unit CI (only a real deploy catches it). A durable fix is to bundle `migrate.ts` (like the workers/backfill: `bun build --target bun`) so all transitive imports resolve at build time; that also needs the migrate task-def command updated in infra, so it is deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by ensuring a required runtime file is included in the migration environment.
  * Added safeguards to help prevent migration failures caused by missing application files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->