### PR TITLE
fix(api): repair dead @/api/db facade imports on main

### DIFF
--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
@@ -1,7 +1,7 @@
 import type { MCPClient } from "@tanstack/ai-mcp";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { SafeDb } from "@/api/db";
+import type { SafeDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";

--- a/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
-import type { SafeDb } from "@/api/db";
+import type { SafeDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 


### PR DESCRIPTION
## Incident — main is red
`#1109` (no-facade-imports convention) removed the `@/api/db` facade and added a lint rule forbidding it. Two test files added by `#1132`/`#1133` import `SafeDb` from `@/api/db`; each PR was green on its own base, but they collided on main after #1109 landed, so main's typecheck (`Cannot find module '@/api/db'`) and lint (`import an approved owning leaf`) are now failing.

## Fix
Point both imports at the approved leaf `@/api/db/safe-db` (the same path every other chat handler uses post-#1109). Test-only, type-only change.