### PR TITLE
fix(api): bundle the migrate entrypoint instead of a loose-file COPY list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1034,7 +1034,7 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         # Overlay pruned source the same way apps/api/Dockerfile copies
         # /app/out/full/ onto the dependency layer, then compile the API
-        # binary and runtime workers.
+        # binary, migration bundle, and runtime workers.
         run: |
           set -euo pipefail
           cd api-install
@@ -1047,6 +1047,11 @@ jobs:
             --target bun \
             --outfile /tmp/server \
             apps/api/src/server.ts
+          bun build \
+            --target bun \
+            --outfile apps/api/src/db/migrate.js \
+            apps/api/src/db/migrate.ts
+          test -s apps/api/src/db/migrate.js
           mkdir -p /tmp/runtime-workers
           bun build \
             --target bun \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           docker run --rm --network host \
             --env DATABASE_URL \
             stella-api:smoke \
-            bun run src/db/migrate.ts
+            bun /app/apps/api/src/db/migrate.js
 
       - name: Run smoke container
         env:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -55,6 +55,21 @@ RUN bun build \
     --target bun \
     --outfile /app/backfill.js \
     apps/api/src/scripts/backfill-case-law-slugs.ts
+# Durable fix for the migrate task's "Cannot find module" class of failure
+# (#1141 band-aided one instance by hand-adding a missing loose file).
+# Bundling resolves migrate.ts's full transitive @/api import graph at
+# build time, so a new import can never again silently break the migrate
+# task the way the loose-file COPY list below can — that failure mode is
+# invisible to typecheck/lint/unit CI and only a real deploy catches it.
+# Output next to the loose migrate.ts source (same directory depth) so
+# migrate.ts's cwd-independent migrationsFolder lookup
+# (`import.meta.dir` + `../../drizzle`, see migrate.ts) resolves to the
+# same drizzle/ copy the loose file already uses below, without a second
+# copy of the migrations folder.
+RUN bun build \
+    --target bun \
+    --outfile /app/apps/api/src/db/migrate.js \
+    apps/api/src/db/migrate.ts
 RUN mkdir -p /app/runtime-workers && \
     bun build \
       --target bun \
@@ -90,17 +105,32 @@ RUN groupadd --system --gid 1001 stella && \
 COPY --chown=stella:stella --from=builder /app/server /app/server
 COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
+# Migrate task entrypoint, bundled. This is the target for deployment
+# migration commands once they switch over:
+#   ["bun", "/app/apps/api/src/db/migrate.js"]
+# Placed at the same directory depth as the loose migrate.ts below so its
+# import.meta.dir-relative migrationsFolder lookup resolves to the same
+# drizzle/ copy the loose file uses, with no second copy needed.
+COPY --chown=stella:stella --from=builder /app/apps/api/src/db/migrate.js /app/apps/api/src/db/migrate.js
 # Loose files for the one-off migrate task (the API itself is the compiled
-# /app/server binary). migrate.ts runs the drizzle migrator over Bun's SQL
-# client; it imports db-url.ts (which imports lib/type-guards.ts) and reads
-# the drizzle/ migration folder. This COPY set is the migrate entrypoint's
-# full transitive @/api dependency — keep it in sync when db-url.ts/migrate.ts
-# gain an import, or the loose-file task fails at runtime with "Cannot find
-# module" (the compiled API binary bundles these, so it won't catch it).
+# /app/server binary), kept so the current deployment migration command
+# (`bun run src/db/migrate.ts`, cwd /app/apps/api) keeps working during the
+# transition to the bundle above. migrate.ts runs the drizzle migrator over
+# Bun's SQL client; it imports db-url.ts (which imports lib/type-guards.ts)
+# and reads the drizzle/ migration folder. This COPY set is the loose
+# entrypoint's full transitive @/api dependency — keep it in sync when
+# db-url.ts/migrate.ts gain an import, or the loose-file task fails at
+# runtime with "Cannot find module" (the compiled API binary and the
+# migrate.js bundle above both resolve imports at build time, so neither
+# would catch a missing entry here). Delete these loose-source COPYs once
+# every deployment target uses the bundle and the loose path is confirmed
+# dead in production.
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle.config.ts /app/apps/api/drizzle.config.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/src/db-url.ts /app/apps/api/src/db-url.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/src/lib/type-guards.ts /app/apps/api/src/lib/type-guards.ts
 COPY --chown=stella:stella --from=builder /app/apps/api/src/db/migrate.ts /app/apps/api/src/db/migrate.ts
+# The bundled entrypoint still reads migration SQL from this external folder;
+# retain it after removing the loose TypeScript source files above.
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle /app/apps/api/drizzle
 RUN mkdir -p '/$bunfs/root'
 COPY --chown=stella:stella --from=builder /app/runtime-workers /\$bunfs/root/workers

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -56,13 +56,22 @@ END
 $$;
 `;
 
+// Resolve migrationsFolder relative to *this module's own location*, not
+// `process.cwd()`. The entrypoint ships in two shapes that run with
+// different working directories: the loose source file
+// (apps/api/src/db/migrate.ts, cwd = /app/apps/api) and the bundled
+// single-file build (apps/api/src/db/migrate.js, invoked directly with
+// `bun <path>` and no fixed cwd). `import.meta.dir` tracks the file's own
+// directory in both shapes — including inside a `bun build --target bun`
+// bundle, which preserves the entrypoint's original build-time path — so
+// walking up two levels (src/db -> src -> apps/api) and into `drizzle`
+// lands on the same migrations folder either way. Keep the bundle's COPY
+// destination two directories above its drizzle/ copy to preserve this.
+const migrationsFolder = nodePath.resolve(import.meta.dir, "../../drizzle");
+
 try {
   await client.unsafe(bootstrapRoleSql);
-  await migrate(drizzle({ client }), {
-    // cwd is the migrate task's workingDirectory (/app/apps/api); mirrors
-    // the path that assert-migrations-applied.ts checks at startup.
-    migrationsFolder: nodePath.resolve(process.cwd(), "drizzle"),
-  });
+  await migrate(drizzle({ client }), { migrationsFolder });
   // eslint-disable-next-line no-console -- migrate CLI entrypoint; stdout is its interface (no app logger in this minimal-env task)
   console.info("[migrate] migrations applied");
 } catch (error) {

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -329,12 +329,11 @@ notes before applying an upstream template update.
 
 ## Migrations
 
-`railway/api.railway.json` runs `bun src/db/migrate.ts` as the API pre-deploy
-command. The
-migration entrypoint is included in the API runtime image and uses the same
-`DATABASE_URL` as the server. It bootstraps the `stella` RLS role idempotently
-before applying migrations, so a fresh managed Postgres needs no manual role
-setup.
+`railway/api.railway.json` runs the bundled
+`bun /app/apps/api/src/db/migrate.js` entrypoint as the API pre-deploy command.
+The bundle is included in the API runtime image and uses the same `DATABASE_URL`
+as the server. It bootstraps the `stella` RLS role idempotently before applying
+migrations, so a fresh managed Postgres needs no manual role setup.
 
 If a migration fails, Railway should not promote the API deployment. Fix the
 database/config problem, then redeploy the API service.

--- a/railway/api.railway.json
+++ b/railway/api.railway.json
@@ -18,7 +18,7 @@
     "drainingSeconds": 15,
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
-    "preDeployCommand": ["bun src/db/migrate.ts"],
+    "preDeployCommand": ["bun /app/apps/api/src/db/migrate.js"],
     "restartPolicyMaxRetries": 10,
     "restartPolicyType": "ON_FAILURE"
   }

--- a/scripts/check-railway-template-shape.ts
+++ b/scripts/check-railway-template-shape.ts
@@ -185,8 +185,8 @@ validateServiceConfig({
 const apiDeploy = getRecord(readJson(API_CONFIG_PATH), "deploy");
 expect(
   JSON.stringify(apiDeploy["preDeployCommand"]) ===
-    JSON.stringify(["bun src/db/migrate.ts"]),
-  "API config must run migrations as a pre-deploy command",
+    JSON.stringify(["bun /app/apps/api/src/db/migrate.js"]),
+  "API config must run the bundled migrations as a pre-deploy command",
 );
 
 const railwayDoc = readText(RAILWAY_DOC_PATH);


### PR DESCRIPTION
## Summary

The API image previously shipped the database migration entrypoint as a hand-maintained set of loose TypeScript files. A new transitive import could therefore pass typecheck, lint, and unit tests but fail at deployment time with `Cannot find module`.

- Bundle `apps/api/src/db/migrate.ts` into `apps/api/src/db/migrate.js` during the Docker build, resolving the complete transitive import graph at build time.
- Resolve the migrations folder relative to `import.meta.dir`, so both the loose compatibility entrypoint and bundled entrypoint find the same external `apps/api/drizzle/` directory regardless of the process working directory.
- Compile the migration bundle in the API image dependency guard and execute the shipped bundle in the release image smoke.
- Switch Railway's pre-deploy command, structural check, and documentation to the bundled entrypoint.
- Retain the loose source files temporarily for deployment commands that have not switched yet. A later cleanup can remove those source files, but must retain the external `drizzle/` directory used by the bundle.

## Rollout

1. Merge and ship an API image containing both the bundled and compatibility entrypoints.
2. Switch remaining deployment migration commands to `bun /app/apps/api/src/db/migrate.js` after the compatible image is live.
3. Confirm the bundled command succeeds in each environment, then remove the loose TypeScript compatibility files while retaining `apps/api/drizzle/`.

## Validation

- [x] `bun run check:railway-template`
- [x] Migration bundle compiled with the repository-pinned Bun 1.3.14 (204 modules, approximately 0.46 MB)
- [x] `docker build -f apps/api/Dockerfile -t stella-api:pr1143-smoke .`
- [x] The built image ran `bun /app/apps/api/src/db/migrate.js` against a fresh disposable PostgreSQL 18 database and applied all migrations successfully
- [x] Formatting check for all changed supported files
- [x] `git diff --check`

Related: #1141
