### PR TITLE
fix(api): keep db-url.ts @/api-import-free for the loose migrate task

### DIFF
--- a/apps/api/src/db-url.ts
+++ b/apps/api/src/db-url.ts
@@ -1,7 +1,5 @@
 import { panic } from "better-result";
 
-import { includes } from "@/api/lib/type-guards";
-
 /**
  * Resolve the Postgres connection URL.
  *
@@ -61,7 +59,7 @@ export const resolveDatabaseUrl = (
   }
 
   const sslmode = DB_SSLMODE ?? "require";
-  if (!includes(ALLOWED_SSLMODES, sslmode)) {
+  if (!ALLOWED_SSLMODES.some((mode) => mode === sslmode)) {
     panic(`DB_SSLMODE must be one of ${ALLOWED_SSLMODES.join(", ")}`);
   }
   // DB_HOST is left unencoded so IPv6 literals like `[::1]` survive,


### PR DESCRIPTION
## Incident — staging still blocked
The staging migrate task keeps failing with `Cannot find module '@/api/lib/type-guards' from db-url.ts`, even after #1141 shipped that file. Root cause: the migrate task runs `db-url.ts` as a **loose source file** with no `tsconfig.json` shipped, so Bun has no `@/api/*` path mapping and cannot resolve the alias at runtime — putting the file on disk doesn't help. Before #1109, `db-url.ts` had no `@/api` imports, so this never mattered.

## Fix
Inline `db-url.ts`'s single `includes(ALLOWED_SSLMODES, sslmode)` call as `ALLOWED_SSLMODES.some((mode) => mode === sslmode)` (identical semantics — the helper is literally `arr.some(x => x === v)`), and drop the `@/api/lib/type-guards` import. The loose migrate entrypoint (`migrate.ts` + `db-url.ts`) is now `@/api`-import-free again, so it runs without alias resolution. The compiled API bundles imports and is unaffected.

Complements the durable fix in #1143 (bundle the migrate entrypoint so aliases resolve at build time regardless); this restores the "bootstrap depends only on better-result" invariant as the immediate unblock.