### PR TITLE
fix(api): unify entity-cap locking onto one canonical workspace-row order

### DIFF
--- a/apps/api/src/handlers/entities/clip.ts
+++ b/apps/api/src/handlers/entities/clip.ts
@@ -10,6 +10,7 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { tDefaultVarchar } from "@/api/lib/custom-schema";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { getSearchProvider } from "@/api/lib/search/provider";
@@ -38,6 +39,10 @@ export default createSafeHandler(
       body: { title, url, snippet, citation, jurisdiction, sourceType },
     } = ctx;
 
+    // Non-authoritative fast-fail: cheap, unlocked, avoids doing
+    // metadata work for a request that's obviously over the limit.
+    // The authoritative check is inside the write transaction below,
+    // behind the workspace-row lock.
     const entityCount = yield* Result.await(
       safeDb((tx) =>
         tx.$count(entities, eq(entities.workspaceId, workspaceId)),
@@ -61,8 +66,20 @@ export default createSafeHandler(
     const entityId = createSafeId<"entity">();
     const entityVersionId = createSafeId<"entityVersion">();
 
-    yield* Result.await(
+    const writeResult = yield* Result.await(
       safeDb(async (tx) => {
+        // See `lockWorkspacesForEntityCap` for the canonical lock
+        // order every entity-creating path follows (issue #1139).
+        await lockWorkspacesForEntityCap(tx, [workspaceId]);
+
+        const authoritativeEntityCount = await tx.$count(
+          entities,
+          eq(entities.workspaceId, workspaceId),
+        );
+        if (authoritativeEntityCount >= LIMITS.entitiesCount) {
+          return { ok: false as const };
+        }
+
         const entityStamp = await allocateEntityStamp(tx, workspaceId);
 
         await tx.insert(entities).values({
@@ -126,8 +143,16 @@ export default createSafeHandler(
             },
           },
         ]);
+
+        return { ok: true as const };
       }),
     );
+
+    if (!writeResult.ok) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Entities limit reached" }),
+      );
+    }
 
     getSearchProvider().indexEntity(entityId).catch(captureError);
 

--- a/apps/api/src/handlers/entities/copy-to-workspace.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.ts
@@ -472,6 +472,7 @@ const copyToWorkspaceHandler = async function* ({
       sourceEntityId,
       sourceEntities: remappedEntities,
       sourceWorkspaceId,
+      deleteSource,
     });
 
     if (!copyResult.ok) {

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -484,6 +484,13 @@ type CopyEntitiesProps = {
   sourceEntities: WritableEntitySnapshot[];
   /** Source workspace ID for audit log (cross-workspace only). */
   sourceWorkspaceId?: SafeId<"workspace">;
+  /**
+   * Whether the caller will delete the source rows in the same
+   * transaction (a move) as opposed to leaving them untouched (a
+   * copy). Only a move mutates the source workspace, so only a move
+   * needs the source row locked — see the lock-set comment below.
+   */
+  deleteSource: boolean;
 };
 
 /**
@@ -499,16 +506,22 @@ export const copyEntities = async ({
   sourceEntityId,
   sourceEntities,
   sourceWorkspaceId,
+  deleteSource,
 }: CopyEntitiesProps): Promise<CopyEntitiesResult> => {
-  // Same-workspace duplicate locks the target only; cross-workspace
-  // copy/move also locks the source (needed when the caller deletes
-  // source rows afterward). Both ids go through
+  // Same-workspace duplicate and cross-workspace copy both lock the
+  // target only: a pure copy never mutates the source workspace's
+  // rows or its cap, so locking the source would only add unrelated
+  // contention (blocking uploads/tasks/clips there) for no
+  // correctness benefit. Only a cross-workspace MOVE
+  // (`deleteSource`) also locks the source, since the caller deletes
+  // source rows in the same transaction and that must serialize with
+  // concurrent source-side inserts. Both ids go through
   // `lockWorkspacesForEntityCap`, which sorts them ascending before
   // locking — see that function for why this closes the
   // cross-workspace ABBA between an A->B and a concurrent B->A move.
   await lockWorkspacesForEntityCap(
     tx,
-    sourceWorkspaceId
+    sourceWorkspaceId && deleteSource
       ? [sourceWorkspaceId, targetWorkspaceId]
       : [targetWorkspaceId],
   );

--- a/apps/api/src/handlers/entities/copy-utils.ts
+++ b/apps/api/src/handlers/entities/copy-utils.ts
@@ -18,6 +18,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import { escapeLike } from "@/api/lib/escape-like";
 import { LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
@@ -499,6 +500,19 @@ export const copyEntities = async ({
   sourceEntities,
   sourceWorkspaceId,
 }: CopyEntitiesProps): Promise<CopyEntitiesResult> => {
+  // Same-workspace duplicate locks the target only; cross-workspace
+  // copy/move also locks the source (needed when the caller deletes
+  // source rows afterward). Both ids go through
+  // `lockWorkspacesForEntityCap`, which sorts them ascending before
+  // locking — see that function for why this closes the
+  // cross-workspace ABBA between an A->B and a concurrent B->A move.
+  await lockWorkspacesForEntityCap(
+    tx,
+    sourceWorkspaceId
+      ? [sourceWorkspaceId, targetWorkspaceId]
+      : [targetWorkspaceId],
+  );
+
   const entityCount = await tx.$count(
     entities,
     eq(entities.workspaceId, targetWorkspaceId),

--- a/apps/api/src/handlers/entities/create-from-buffer.ts
+++ b/apps/api/src/handlers/entities/create-from-buffer.ts
@@ -16,6 +16,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import {
   enqueueImageThumbnailOrMarkFailed,
   enqueuePdfDerivativeOrMarkFailed,
@@ -139,8 +140,13 @@ export const createEntityFromBuffer = async ({
     await getS3().write(s3Key, bytes);
 
     await scopedDb(async (tx) => {
+      // See `lockWorkspacesForEntityCap` for the canonical lock
+      // order every entity-creating path follows (issue #1139).
+      await lockWorkspacesForEntityCap(tx, [workspaceId]);
+
       // The authoritative limit check must stay in the same
-      // transaction as the insert to avoid TOCTOU races.
+      // transaction as the insert, behind the lock above, to avoid
+      // TOCTOU races.
       const entityCount = await tx.$count(
         entities,
         eq(entities.workspaceId, workspaceId),

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -157,6 +157,9 @@ const duplicateEntityHandler = async function* ({
         recordAuditEvent,
         sourceEntityId,
         sourceEntities: remappedEntities,
+        // Same-workspace duplicate never deletes the source; the
+        // lock set is target-only regardless (see `copyEntities`).
+        deleteSource: false,
       }),
   );
 

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -64,6 +64,40 @@ type ResolveFileNameProps = {
 
 const MAX_FILENAME_LENGTH = 255;
 
+type CleanupUploadedS3KeysOptions = {
+  keys: string[];
+  fileId: string;
+  workspaceId: SafeId<"workspace">;
+};
+
+/**
+ * Best-effort delete of S3 objects written before an authoritative
+ * cap check (or an unexpected error) aborts the upload. Every key's
+ * delete is attempted independently (`allSettled`, not `all`) so one
+ * rejection doesn't stop cleanup of the rest; any rejection is
+ * captured instead of silently dropped, since a swallowed failure
+ * here leaves an orphaned S3 object with no telemetry trail.
+ */
+const cleanupUploadedS3Keys = async ({
+  keys,
+  fileId,
+  workspaceId,
+}: CleanupUploadedS3KeysOptions): Promise<void> => {
+  const results = await Promise.allSettled(
+    keys.map(async (key) => await getS3().delete(key)),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      captureError(result.reason, {
+        operation: "upload-s3-cleanup",
+        fileId,
+        workspaceId,
+      });
+    }
+  }
+};
+
 const resolveFileName = async ({
   tx,
   propertyId,
@@ -319,9 +353,7 @@ const uploadEntityHandler = async function* ({
     );
 
     if (!writeResult.ok) {
-      await Promise.allSettled(
-        s3Keys.map(async (key) => await getS3().delete(key)),
-      );
+      await cleanupUploadedS3Keys({ keys: s3Keys, fileId, workspaceId });
       return Result.err(
         new HandlerError({ status: 400, message: "Entities limit reached" }),
       );
@@ -372,11 +404,7 @@ const uploadEntityHandler = async function* ({
       renamed: fileName.renamed,
     });
   } catch (error) {
-    // Settled, not `Promise.all`: one failed delete must not stop
-    // cleanup of the remaining keys and orphan them in S3.
-    await Promise.allSettled(
-      s3Keys.map(async (key) => await getS3().delete(key)),
-    );
+    await cleanupUploadedS3Keys({ keys: s3Keys, fileId, workspaceId });
     throw error;
   }
 };

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -24,6 +24,7 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import {
@@ -107,6 +108,10 @@ const uploadEntityHandler = async function* ({
   body: { file, name: rawName, propertyId },
 }: UploadEntityHandlerProps) {
   const name = sanitizeFilename(rawName);
+  // Non-authoritative fast-fail: cheap, unlocked, avoids scanning
+  // and uploading a file for a request that's obviously over the
+  // limit. The authoritative check is inside the write transaction
+  // below, behind the workspace-row lock.
   const [entityCountResult, propertyResult] = await Promise.all([
     safeDb((tx) => tx.$count(entities, eq(entities.workspaceId, workspaceId))),
     safeDb((tx) =>
@@ -215,8 +220,23 @@ const uploadEntityHandler = async function* ({
     const entityVersionId = createSafeId<"entityVersion">();
     const fieldId = createSafeId<"field">();
 
-    const fileName = yield* Result.await(
+    const writeResult = yield* Result.await(
       safeDb(async (tx) => {
+        // See `lockWorkspacesForEntityCap` for the canonical lock
+        // order every entity-creating path follows (issue #1139).
+        await lockWorkspacesForEntityCap(tx, [workspaceId]);
+
+        // The earlier `entityCount` check above is a
+        // non-authoritative fast-fail to avoid wasted scan/upload
+        // work; this is the authoritative check.
+        const authoritativeEntityCount = await tx.$count(
+          entities,
+          eq(entities.workspaceId, workspaceId),
+        );
+        if (authoritativeEntityCount >= LIMITS.entitiesCount) {
+          return { ok: false as const };
+        }
+
         const resolvedName = await resolveFileName({ tx, propertyId, name });
 
         const entityStamp = await allocateEntityStamp(tx, workspaceId);
@@ -294,9 +314,20 @@ const uploadEntityHandler = async function* ({
           },
         });
 
-        return resolvedName;
+        return { ok: true as const, resolvedName };
       }),
     );
+
+    if (!writeResult.ok) {
+      await Promise.allSettled(
+        s3Keys.map(async (key) => await getS3().delete(key)),
+      );
+      return Result.err(
+        new HandlerError({ status: 400, message: "Entities limit reached" }),
+      );
+    }
+
+    const fileName = writeResult.resolvedName;
 
     await processExtraction(entityId).catch((error: unknown) =>
       captureError(error, { entityId, mimeType: file.type }),
@@ -341,7 +372,11 @@ const uploadEntityHandler = async function* ({
       renamed: fileName.renamed,
     });
   } catch (error) {
-    await Promise.all(s3Keys.map(async (key) => await getS3().delete(key)));
+    // Settled, not `Promise.all`: one failed delete must not stop
+    // cleanup of the remaining keys and orphan them in S3.
+    await Promise.allSettled(
+      s3Keys.map(async (key) => await getS3().delete(key)),
+    );
     throw error;
   }
 };

--- a/apps/api/src/handlers/properties/property-lock.ts
+++ b/apps/api/src/handlers/properties/property-lock.ts
@@ -3,6 +3,14 @@ import { sql } from "drizzle-orm";
 import type { Transaction } from "@/api/db/root";
 import type { SafeId } from "@/api/lib/branded-types";
 
+// This advisory-lock domain (bare `hashtext(workspaceId)`, shared
+// with the time-entries locks) is deliberately NOT unified with
+// `lockWorkspacesForEntityCap`'s workspace-row `FOR UPDATE` lock
+// (issue #1139). Property writes never insert rows counted against
+// `LIMITS.entitiesCount`, and no entity-creating path takes this
+// advisory lock, so the two domains never contend for the same
+// resource in one transaction — there is no shared state to order
+// against, and therefore no deadlock to reconcile.
 export const lockWorkspacePropertyWrites = async (
   tx: Transaction,
   workspaceId: SafeId<"workspace">,

--- a/apps/api/src/handlers/tasks/create.ts
+++ b/apps/api/src/handlers/tasks/create.ts
@@ -17,6 +17,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import {
   AGENDA_ITEM_KIND,
   AGENDA_ITEM_KINDS,
@@ -131,6 +132,10 @@ export const createTaskEntityHandler = async function* ({
 
   const txResult = yield* Result.await(
     safeDb(async (tx) => {
+      // See `lockWorkspacesForEntityCap` for the canonical lock
+      // order every entity-creating path follows (issue #1139).
+      await lockWorkspacesForEntityCap(tx, [workspaceId]);
+
       const totalEntities = await tx.$count(
         entities,
         eq(entities.workspaceId, workspaceId),

--- a/apps/api/src/handlers/uploads/entity-create.test.ts
+++ b/apps/api/src/handlers/uploads/entity-create.test.ts
@@ -116,19 +116,19 @@ const createCapacityInsertTx = (
   existingEntityCount: number,
   reservedUploadCount = 0,
 ) => {
-  const forUpdate = mock(async () => [{ id: workspaceId }]);
-  const limit = mock(() => ({ for: forUpdate }));
-  const where = mock(() => ({ limit }));
-  const from = mock(() => ({ where }));
-  const select = mock(() => ({ from }));
+  // `checkEntityCreateCapacityForInsert` acquires its workspace-row
+  // lock via the shared `lockWorkspacesForEntityCap` helper, which
+  // issues a raw `tx.execute(sql\`... FOR UPDATE\`)` per workspace id
+  // (see apps/api/src/lib/entity-cap-lock.ts).
+  const execute = mock(async () => [{ id: workspaceId }]);
   const countEntities = mock(async (table) =>
     table === pendingUploads ? reservedUploadCount : existingEntityCount,
   );
 
   return {
-    forUpdate,
+    execute,
     tx: {
-      select,
+      execute,
       $count: countEntities,
     },
   };
@@ -139,7 +139,7 @@ const runCapacityInsertCheck = async (
   reservedUploadCount = 0,
   excludeUploadId?: SafeId<"pendingUpload">,
 ) => {
-  const { forUpdate, tx } = createCapacityInsertTx(
+  const { execute, tx } = createCapacityInsertTx(
     existingEntityCount,
     reservedUploadCount,
   );
@@ -150,7 +150,7 @@ const runCapacityInsertCheck = async (
     excludeUploadId,
   });
 
-  return { forUpdate, result };
+  return { execute, result };
 };
 
 type RolledBackTxCallback<T> = (tx: TestDatabaseTransaction) => Promise<T>;
@@ -428,12 +428,12 @@ describe("entity-create presigned upload validation", () => {
   });
 
   test("rejects finalization writes that no longer fit entity capacity", async () => {
-    const { forUpdate, result } = await runCapacityInsertCheck(
+    const { execute, result } = await runCapacityInsertCheck(
       LIMITS.entitiesCount,
     );
 
     expect(Result.isError(result)).toBe(true);
-    expect(forUpdate).toHaveBeenCalledWith("update");
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   test("accepts finalization writes that exactly fit remaining capacity", async () => {

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -50,6 +50,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import {
@@ -448,15 +449,9 @@ export const checkEntityCreateCapacityForInsert = async ({
     panic("Entity create insert count must be a positive integer");
   }
 
-  const workspaceRows = await tx
-    .select({ id: workspaces.id })
-    .from(workspaces)
-    .where(eq(workspaces.id, workspaceId))
-    .limit(1)
-    .for("update");
-  if (!workspaceRows.at(0)) {
-    panic("Workspace lock for entity create returned no rows");
-  }
+  // See `lockWorkspacesForEntityCap` for the canonical lock order
+  // every entity-creating path follows (issue #1139).
+  await lockWorkspacesForEntityCap(tx, [workspaceId]);
 
   const existingEntityCount = await tx.$count(
     entities,

--- a/apps/api/src/lib/entity-cap-lock.test.ts
+++ b/apps/api/src/lib/entity-cap-lock.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { TransactionRollbackError } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 
 import { organization } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
@@ -28,17 +29,29 @@ import { lockWorkspacesForEntityCap } from "./entity-cap-lock";
  * form an ABBA cycle — which is the actual property #1139 asks for.
  */
 
-// A raw string interpolated into a drizzle `sql` template shows up
-// verbatim in `SQL.queryChunks`; every other chunk in this query
-// (the literal text, the `workspaces` table reference) is a class
-// instance, not a plain string, so this reliably extracts the one
-// interpolated workspace id per call regardless of exact SQL text.
+// Reading `SQL.queryChunks` directly is fragile: whether a literal
+// or interpolated part shows up as a raw string vs. a wrapper object
+// (`StringChunk`, `Param`, ...) is a Drizzle internal that has
+// already changed across versions. `PgDialect#sqlToQuery` is the
+// same public compilation step Drizzle itself uses to build the
+// query sent to Postgres, so it stays correct however chunks are
+// represented internally — it returns the driver-bound `params`
+// array, and this lock query interpolates exactly one value (the
+// workspace id) per call.
+const pgDialect = new PgDialect();
+
 const lockedWorkspaceId = (query: SQL): string => {
-  const chunk = query.queryChunks.find((c) => typeof c === "string");
-  if (typeof chunk !== "string") {
+  const { params } = pgDialect.sqlToQuery(query);
+  if (params.length !== 1) {
+    throw new TypeError(
+      `Expected the lock query to bind exactly one param, got ${params.length}`,
+    );
+  }
+  const [id] = params;
+  if (typeof id !== "string") {
     throw new TypeError("Lock query did not interpolate a workspace id");
   }
-  return chunk;
+  return id;
 };
 
 const createOrderTrackingTx = () => {

--- a/apps/api/src/lib/entity-cap-lock.test.ts
+++ b/apps/api/src/lib/entity-cap-lock.test.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { TransactionRollbackError } from "drizzle-orm";
+
+import { organization } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import { workspaces } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import { lockWorkspacesForEntityCap } from "./entity-cap-lock";
+
+/**
+ * Every entity-creating path shares `lockWorkspacesForEntityCap` so
+ * cap checks serialize with each other (issue #1139). True
+ * concurrent-deadlock behavior isn't observable with the shared
+ * PGlite test instance (a single-threaded WASM connection, so two
+ * transactions can't actually block on each other's locks — see
+ * `apps/api/src/tests/security/test-utils.ts`). What IS testable
+ * without real concurrency is the invariant the whole design leans
+ * on: that this function always locks a shared set of workspace ids
+ * in the SAME deterministic order, no matter what order the caller
+ * passes them in. If that holds, an A->B move and a concurrent B->A
+ * move provably request their locks in the same order and cannot
+ * form an ABBA cycle — which is the actual property #1139 asks for.
+ */
+
+// A raw string interpolated into a drizzle `sql` template shows up
+// verbatim in `SQL.queryChunks`; every other chunk in this query
+// (the literal text, the `workspaces` table reference) is a class
+// instance, not a plain string, so this reliably extracts the one
+// interpolated workspace id per call regardless of exact SQL text.
+const lockedWorkspaceId = (query: SQL): string => {
+  const chunk = query.queryChunks.find((c) => typeof c === "string");
+  if (typeof chunk !== "string") {
+    throw new TypeError("Lock query did not interpolate a workspace id");
+  }
+  return chunk;
+};
+
+const createOrderTrackingTx = () => {
+  const lockedOrder: string[] = [];
+  const execute = mock(async (query: SQL) => {
+    lockedOrder.push(lockedWorkspaceId(query));
+    return [];
+  });
+  return { execute, lockedOrder, tx: { execute } };
+};
+
+describe("lockWorkspacesForEntityCap ordering", () => {
+  const wsLow = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000a");
+  const wsHigh = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000b");
+
+  test("locks a single workspace exactly once", async () => {
+    const { execute, lockedOrder, tx } = createOrderTrackingTx();
+
+    await lockWorkspacesForEntityCap(asTestRaw<Transaction>(tx), [wsLow]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(lockedOrder).toEqual([wsLow]);
+  });
+
+  test("dedupes a workspace id repeated in the input", async () => {
+    const { execute, tx } = createOrderTrackingTx();
+
+    await lockWorkspacesForEntityCap(asTestRaw<Transaction>(tx), [
+      wsLow,
+      wsLow,
+    ]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  test("locks two workspaces ascending when passed low-then-high", async () => {
+    const { lockedOrder, tx } = createOrderTrackingTx();
+
+    await lockWorkspacesForEntityCap(asTestRaw<Transaction>(tx), [
+      wsLow,
+      wsHigh,
+    ]);
+
+    expect(lockedOrder).toEqual([wsLow, wsHigh]);
+  });
+
+  test("locks two workspaces ascending when passed high-then-low — the cross-workspace move-direction case", async () => {
+    const { lockedOrder, tx } = createOrderTrackingTx();
+
+    // This is `copy-to-workspace` with `deleteSource` called for a
+    // B->A move: the handler's own {source, target} pair is
+    // {wsHigh, wsLow} (opposite argument order from the A->B test
+    // above), but the lock order must come out identical so a
+    // concurrent A->B move can't hold {wsLow} and wait on {wsHigh}
+    // while this one holds {wsHigh} and waits on {wsLow}.
+    await lockWorkspacesForEntityCap(asTestRaw<Transaction>(tx), [
+      wsHigh,
+      wsLow,
+    ]);
+
+    expect(lockedOrder).toEqual([wsLow, wsHigh]);
+  });
+});
+
+let testDb: TestDatabase;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+type RolledBackTxCallback<T> = (tx: Transaction) => Promise<T>;
+
+const runRolledBack = async <T>(
+  callback: RolledBackTxCallback<T>,
+): Promise<T> => {
+  let value: T | undefined;
+  try {
+    await testDb.transaction(async (tx) => {
+      // oxlint-disable-next-line node/callback-return -- must call tx.rollback() after capturing the value
+      value = await callback(asTestRaw<Transaction>(tx));
+      tx.rollback();
+    });
+  } catch (error) {
+    if (error instanceof TransactionRollbackError && value !== undefined) {
+      return value;
+    }
+    throw error;
+  }
+
+  if (value === undefined) {
+    throw new Error("Rolled-back test transaction did not return a value");
+  }
+  return value;
+};
+
+const seedTestWorkspace = async (
+  tx: Transaction,
+): Promise<SafeId<"workspace">> => {
+  const organizationId = toSafeId<"organization">(`org_${Bun.randomUUIDv7()}`);
+  const workspaceId = toSafeId<"workspace">(Bun.randomUUIDv7());
+
+  await tx.insert(organization).values({
+    id: organizationId,
+    name: "Entity Cap Lock Test",
+    slug: `entity-cap-lock-${Bun.randomUUIDv7()}`,
+    createdAt: new Date(),
+  });
+  await tx.insert(workspaces).values({
+    id: workspaceId,
+    organizationId,
+    name: "Entity cap lock matter",
+    reference: Bun.randomUUIDv7().slice(0, 8),
+  });
+
+  return workspaceId;
+};
+
+describe("lockWorkspacesForEntityCap against a real workspace row", () => {
+  test("locks a single seeded workspace without error", async () => {
+    const result = await runRolledBack(async (tx) => {
+      const workspaceId = await seedTestWorkspace(tx);
+      await lockWorkspacesForEntityCap(tx, [workspaceId]);
+      return "ok" as const;
+    });
+
+    expect(result).toBe("ok");
+  });
+
+  test("locks two seeded workspaces without error, regardless of input order", async () => {
+    const result = await runRolledBack(async (tx) => {
+      const first = await seedTestWorkspace(tx);
+      const second = await seedTestWorkspace(tx);
+      const [wsLow, wsHigh] = [first, second].sort();
+      if (!wsLow || !wsHigh) {
+        throw new Error("Expected two seeded workspace ids");
+      }
+
+      // Passed high-then-low; the function must not error or
+      // reorder incorrectly against a real `workspaces` row.
+      await lockWorkspacesForEntityCap(tx, [wsHigh, wsLow]);
+      return "ok" as const;
+    });
+
+    expect(result).toBe("ok");
+  });
+});

--- a/apps/api/src/lib/entity-cap-lock.ts
+++ b/apps/api/src/lib/entity-cap-lock.ts
@@ -1,0 +1,86 @@
+import { sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { workspaces } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+
+/**
+ * Canonical lock order for every entity-creating path (issue #1139,
+ * follow-up to #1126).
+ *
+ * All paths that insert rows counted against `LIMITS.entitiesCount`
+ * — or that must serialize with such an insert — take locks in this
+ * order, inside the same transaction:
+ *
+ *   1. `lockWorkspacesForEntityCap` (this function): a row-level
+ *      `SELECT ... FOR UPDATE` on every `workspaces` row the
+ *      operation touches, acquired ONE AT A TIME in ascending
+ *      workspace-id order (never via a single multi-row query — see
+ *      below).
+ *   2. Parent-entity `FOR UPDATE`, only when the insert is scoped to
+ *      a folder parent (`checkEntityCreateParentForInsert`).
+ *   3. The `document_counters` row for the target workspace, via
+ *      `allocateEntityStamp`'s `INSERT ... ON CONFLICT DO UPDATE`.
+ *
+ * Same-workspace callers lock a single row (step 1 is a list of
+ * one). Cross-workspace callers (`copy-to-workspace` with
+ * `deleteSource`, moving in either direction between the same two
+ * workspaces) pass both workspace ids; sorting them ascending before
+ * locking means an A->B move and a concurrent B->A move both lock
+ * {A, B} in the SAME order, so neither can hold one row and block on
+ * the other (no ABBA).
+ *
+ * Locks are taken with sequential single-row queries, not one
+ * `WHERE id IN (...) ORDER BY id FOR UPDATE`: Postgres places the
+ * row-locking step (`LockRows`) below `ORDER BY` in the plan, so an
+ * `ORDER BY` does NOT guarantee lock-acquisition order for `FOR
+ * UPDATE` — only issuing the queries in order does.
+ *
+ * Participants as of this writing (see #1139 for the full audit):
+ *   - `checkEntityCreateCapacityForInsert` (`entity-create.ts`) —
+ *     used by `entities/create.ts`, presigned `entity-create.ts`
+ *     finalize, `entity-create-tree.ts`, `presign.ts`.
+ *   - `copyEntities` (`copy-utils.ts`) — used by `duplicate.ts`
+ *     (same-workspace: locks target only) and `copy-to-workspace.ts`
+ *     (cross-workspace: locks {source, target} ascending whenever
+ *     `deleteSource` also needs the source row).
+ *   - `entities/clip.ts`, `entities/create-from-buffer.ts`,
+ *     `entities/upload.ts`, `tasks/create.ts` — single-workspace
+ *     inserts, previously unlocked (or advisory-locked under a
+ *     separate `entity-cap:` domain in #1126) count-then-insert
+ *     sequences.
+ *   - `infosoud/agenda-import.ts` — moved here from its own bare
+ *     `pg_advisory_xact_lock(hashtext(workspaceId))` domain (shared,
+ *     confusingly, with unrelated property-write and time-entry
+ *     locks); see that file's comment for why the move is safe.
+ *
+ * Explicitly NOT a participant: `workspaces/duplicate.ts` (whole
+ * -workspace clone). It always inserts into a brand-new
+ * `targetWorkspaceId` created inside the same transaction, so there
+ * is no pre-existing row for a concurrent transaction to contend
+ * for — the INSERT itself is the only synchronization the target
+ * side needs, and the source side is a read-only snapshot, not an
+ * insert counted against the source's cap.
+ */
+export const lockWorkspacesForEntityCap = async (
+  tx: Transaction,
+  workspaceIds: readonly SafeId<"workspace">[],
+): Promise<void> => {
+  const orderedIds = [...new Set(workspaceIds)].sort();
+
+  for (const id of orderedIds) {
+    // Raw `FOR UPDATE`, not the query-builder form: it locks the
+    // exact same `workspaces` row either way (Postgres doesn't care
+    // how the SQL was generated), but matches the `tx.execute(sql...)`
+    // shape every other advisory/row lock in this codebase already
+    // uses. A missing row is not distinguished here — access control
+    // upstream already guarantees `workspaceId` exists for every
+    // caller, and the insert that follows has an FK to `workspaces`
+    // that would fail regardless.
+    //
+    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential, ascending-id acquisition is the invariant this function exists to provide; see the module doc comment
+    await tx.execute(
+      sql`SELECT id FROM ${workspaces} WHERE id = ${id} FOR UPDATE`,
+    );
+  }
+};

--- a/apps/api/src/lib/infosoud/agenda-import.ts
+++ b/apps/api/src/lib/infosoud/agenda-import.ts
@@ -11,8 +11,9 @@ import type { Transaction } from "@/api/db/root";
 import { entities, entityVersions, workspaces } from "@/api/db/schema";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { AgendaItemKind } from "@/api/lib/entity-constants";
+import { lockWorkspacesForEntityCap } from "@/api/lib/entity-cap-lock";
 import { AGENDA_ITEM_KIND, TASK_STATUS } from "@/api/lib/entity-constants";
+import type { AgendaItemKind } from "@/api/lib/entity-constants";
 import { LIMITS } from "@/api/lib/limits";
 
 type InfoSoudAgendaItem = {
@@ -78,7 +79,21 @@ export const importInfoSoudAgendaItems = async ({
   tx,
   workspaceId,
 }: ImportInfoSoudAgendaItemsOptions): Promise<ImportInfoSoudAgendaItemsResult> => {
-  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${workspaceId}))`);
+  // Previously a bare `pg_advisory_xact_lock(hashtext(workspaceId))` —
+  // a domain accidentally shared with unrelated property-write
+  // (`lockWorkspacePropertyWrites`) and time-entry advisory locks,
+  // and NOT shared with the entity-count check every other
+  // entity-creating path serializes on. That meant a concurrent
+  // infosoud import and, say, an upload could each read a passing
+  // count and both insert, overshooting `LIMITS.entitiesCount`.
+  // Locking the workspace row instead puts this on the same lock
+  // manager and canonical order as every other entity-creating path
+  // (see `lockWorkspacesForEntityCap`), which closes that race. This
+  // insert never touches `document_counters` (agenda items are
+  // `task`-kind entities, which don't get a doc stamp) or a parent
+  // entity, so the workspace-row lock is the only one this path
+  // needs.
+  await lockWorkspacesForEntityCap(tx, [workspaceId]);
 
   const externalIds = agendaItems.map((item) => item.externalId);
   const existingRows =


### PR DESCRIPTION
Ref #1139 (follow-up to #1126, which was narrowed to an advisory-lock
core for four endpoints). #1126 was not merged when this branch was
cut, so this implements the unified version directly on `main`
instead of building on top of it.

## Design

### Step 1 — audit: every path that locks or should serialize on `LIMITS.entitiesCount`

| Path | Lock before this PR | Order |
|---|---|---|
| `checkEntityCreateCapacityForInsert` (`entity-create.ts`) — used by `entities/create.ts`, presigned `entity-create.ts` finalize, `entity-create-tree.ts`, `presign.ts` | `workspaces` row `FOR UPDATE` (query-builder `.for("update")`) | workspace-row lock → parent-entity `FOR UPDATE` (`checkEntityCreateParentForInsert`) → `document_counters` upsert (`allocateEntityStamp`) |
| `copyEntities` (`copy-utils.ts`, via `duplicate.ts` / `copy-to-workspace.ts`) | none — unlocked `$count`, then a stamp-allocation loop, then a final unlocked `UPDATE workspaces SET last_activity_at` | unlocked count → stamp loop → target workspace UPDATE → (move only) source entity deletes → source workspace UPDATE |
| `entities/clip.ts` | none | unlocked count (separate `safeDb` call) → separate tx: stamp → insert (no recheck) |
| `entities/create-from-buffer.ts` | none | single tx: unlocked count → stamp → insert (recheck present, but unlocked) |
| `entities/upload.ts` | none | unlocked count (separate `safeDb` call) → separate tx: stamp → insert (**no recheck at all** in the write tx) |
| `tasks/create.ts` | none | single tx: unlocked count → insert (recheck present, but unlocked) |
| `infosoud/agenda-import.ts` | `pg_advisory_xact_lock(hashtext(workspaceId))` — a **bare, unprefixed** key, coincidentally the same domain `lockWorkspacePropertyWrites` (property writes) and the time-entry locks (`timer-start.ts`, `split.ts`, `create.ts`) already use for unrelated purposes | advisory lock → unlocked count → insert |

The `clip`/`create-from-buffer`/`upload`/`tasks` unlocked count-then-insert is the same-endpoint race #1126 targeted with advisory locks; `copyEntities`'s unlocked count plus stamp-then-workspace-UPDATE ordering is the cross-path ABBA candidate against `checkEntityCreateCapacityForInsert`'s workspace-then-stamp order that #1126 explicitly deferred.

### Step 2 — canonical order chosen

One shared helper, `lockWorkspacesForEntityCap` (`apps/api/src/lib/entity-cap-lock.ts`), used by every path above:

1. **Workspace-row `FOR UPDATE`**, one row at a time, in **ascending workspace-id order**, sequential (not a single `WHERE id IN (...) ORDER BY id FOR UPDATE` — Postgres places the `LockRows` step below `ORDER BY` in the plan, so `ORDER BY` does not guarantee lock-acquisition order for `FOR UPDATE`; only issuing the queries in order does).
2. Parent-entity `FOR UPDATE`, only when the insert is scoped to a folder parent.
3. The `document_counters` row, via `allocateEntityStamp`'s `INSERT ... ON CONFLICT DO UPDATE`.

This is the order `checkEntityCreateCapacityForInsert` already used before this PR (workspace → parent → stamp); everything else now follows it.

**(a) Same-workspace.** Every single-workspace caller (`create`, presigned create/tree, `clip`, `create-from-buffer`, `upload`, `tasks/create`, `duplicate` via `copyEntities`, `infosoud`) locks one row. This removes the clip-vs-copy ABBA the issue named: previously `copyEntities` allocated stamps (locking `document_counters`) before ever touching the workspace row, while `checkEntityCreateCapacityForInsert` always locked the workspace row first — two paths on the same workspace could take those two resources in opposite order. Now both always take the workspace row first.

**(b) Cross-workspace bidirectional moves.** `copyEntities` locks `{sourceWorkspaceId, targetWorkspaceId}` whenever the caller passes both (i.e., `copy-to-workspace.ts` with `deleteSource`), sorted ascending by `lockWorkspacesForEntityCap` before locking. An A→B move and a concurrent B→A move between the same two workspaces both lock `{A, B}` in the same order, so neither can hold one row and block on the other — no two-row ABBA regardless of which direction each request names source/target.

**(c) Parented/folder creates.** The parent-entity `FOR UPDATE` (`checkEntityCreateParentForInsert`) already ran strictly after the workspace-row lock in every path that takes it; this PR didn't change that relationship, just documented it as part of the canonical order. (`entities/create.ts`'s own parent check, `validateParentId`, is a plain unlocked `SELECT` — it can't participate in an ABBA since it never blocks or is blocked; left as-is.)

**(d) infosoud.** Moved off its own advisory-lock domain onto the same workspace-row lock. Two reasons this is safe and correct, not just non-deadlocking:
- It never touches `document_counters` (agenda items are `task`-kind entities, which don't get a doc stamp) or a parent entity, so the workspace-row lock is the only lock this path needs — no ordering question against steps 2/3.
- The old advisory domain was doing double duty: it happened to share a bare, unprefixed `hashtext(workspaceId)` key with `lockWorkspacePropertyWrites` (property writes) and three time-entry call sites, none of which insert entities. That meant infosoud imports were *not* serialized against the entity-count check every other entity-creating path uses — a concurrent infosoud import and, say, an upload could each read a passing count and both insert, overshooting `LIMITS.entitiesCount`. Moving it onto the shared row lock closes that gap.

`lockWorkspacePropertyWrites` itself stays on its separate advisory domain — documented in place with the rationale: property writes never insert entities, and no entity-creating path takes that advisory lock, so there is no shared resource between the two domains to order against, and therefore no deadlock to reconcile.

**Explicitly out of scope: `workspaces/duplicate.ts`** (whole-workspace clone). It always inserts entities into a brand-new `targetWorkspaceId` created inside the same transaction — there is no pre-existing row for a concurrent transaction to contend for, so the INSERT itself is the only synchronization the target side needs, and the source side is a read-only snapshot, not an insert counted against the source's cap. Documented in the helper's doc comment rather than touched.

### Step 3 — implementation

- New `apps/api/src/lib/entity-cap-lock.ts`: `lockWorkspacesForEntityCap(tx, workspaceIds)`. Raw `tx.execute(sql\`SELECT id FROM workspaces WHERE id = ${id} FOR UPDATE\`)` per id (dedup'd, sorted ascending) rather than the query-builder form — same row lock either way, but it matches the `tx.execute(sql...)` shape every other lock helper in this codebase already uses, and composes cleanly with `infosoud`'s prior advisory-lock call site.
- `checkEntityCreateCapacityForInsert` now calls the shared helper instead of its own inline `.for("update")`.
- `copyEntities` calls the shared helper before its count check, locking `{source, target}` (cross-workspace) or `{target}` (same-workspace).
- `clip.ts`, `create-from-buffer.ts`, `upload.ts`, `tasks/create.ts`: added the shared lock plus an authoritative (locked) recheck inside the write transaction, following the same "cheap unlocked fast-fail, then locked authoritative check" shape `checkEntityCreateCapacityForInsert` already used. `upload.ts` had *no* recheck at all in its write transaction before this change — that's the gap #1126 targeted for this endpoint; `clip.ts`/`create-from-buffer.ts`/`tasks/create.ts` had an unlocked recheck, now locked. Every cap-exceeded error keeps its existing shape (`400`, `"Entities limit reached"`).
- `infosoud/agenda-import.ts`: swapped its advisory lock for the shared helper, with a comment explaining the correctness gap it closes.
- `upload.ts`: also switched its S3 cleanup from `Promise.all` to `Promise.allSettled` (in both the new cap-exceeded branch and the existing catch block) so one failed delete can't orphan the rest — same fix #1126 made for this file.
- No `entity-cap-lock.ts` advisory-lock file existed on `main` to delete (`#1126` wasn't merged), so there was nothing to supersede in-tree.

### Step 4 — tests

- `apps/api/src/lib/entity-cap-lock.test.ts` (new): unit tests against a mocked `tx.execute` asserting `lockWorkspacesForEntityCap` (1) locks a single workspace once, (2) dedupes a repeated id, (3)/(4) locks two workspaces in ascending order regardless of whether the caller passes them low-then-high or high-then-low — the deterministic-order invariant an A→B vs. B→A move relies on to avoid a two-row ABBA. Plus two integration tests against the real (PGlite) test DB seeding actual `workspaces` rows, proving the SQL is valid and works against a real table/row.
- Updated `entity-create.test.ts`'s `checkEntityCreateCapacityForInsert` mock to match the new `tx.execute`-based lock call (previously mocked the query-builder `.select().for("update")` chain).
- True concurrent-deadlock behavior isn't observable in this harness: the shared test DB is a single-threaded PGlite WASM instance (see `apps/api/src/tests/security/test-utils.ts`), so two transactions can't actually block on each other's locks to prove a deadlock is avoided by execution. The testable seam is the ordering invariant itself — if `lockWorkspacesForEntityCap` provably always locks a given set of workspace ids in the same order no matter what order the caller passes them, then two concurrent callers locking the same set can never form an ABBA cycle, which is the property #1139 asks for. That's what the mock-based ordering tests assert directly.

Ran: full `apps/api` type-aware lint, `apps/api` typecheck, and the affected test files (entity-creation, copy, duplicate, tasks, infosoud, and the new lock helper tests) with `--concurrency=1 --timeout 60000` — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened enforcement of per-workspace entity capacity during creation, copying/moving, uploads, task creation, and agenda imports.
  * Added deterministic workspace locking to prevent concurrent operations from exceeding limits.
  * Improved “entity limit reached” handling by fast-failing early and re-checking authoritatively within the transaction.
  * Enhanced upload cleanup to continue deleting remaining temporary files even if one deletion fails.
* **Tests**
  * Added and updated tests covering workspace locking, capacity checks, and the new failure/locking interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->