### PR TITLE
fix(api): isolate mock.module across the chat-tools test files

### DIFF
--- a/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
+++ b/apps/api/src/handlers/chat/tools/external-mcp-tools-discovery.test.ts
@@ -1,5 +1,5 @@
 import type { MCPClient } from "@tanstack/ai-mcp";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SafeDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
@@ -22,7 +22,7 @@ void mock.module("@/api/lib/mcp-upstream/connections", () => ({
   loadActiveMcpConnectionsForUser: loadActiveMcpConnectionsForUserMock,
 }));
 
-void mock.module("@/api/lib/analytics", () => ({
+void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
   getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
@@ -97,6 +97,14 @@ beforeEach(() => {
   captureErrorMock.mockReset();
   withTimeoutMock.mockReset();
   withTimeoutMock.mockImplementation(passThroughTimeout);
+});
+
+// Bun runs every test file in one process, and `mock.module` mutates a
+// shared registry: without restoring here, these `mock.module` calls (for
+// `mcp-upstream/connections`, `analytics/capture`, and `with-timeout`) would
+// leak into whichever other test file runs next in the same process.
+afterAll(() => {
+  mock.restore();
 });
 
 describe("loadExternalMcpToolsForUser client lifecycle", () => {

--- a/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
+++ b/apps/api/src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts
@@ -9,7 +9,7 @@
  * module graph, and `template-tools.test.ts` already imports it statically.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 
 import type { SafeDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
@@ -28,11 +28,19 @@ void mock.module("@/api/handlers/templates/suggest-template-fields", () => ({
   suggestTemplateFields: suggestTemplateFieldsMock,
 }));
 
-void mock.module("@/api/lib/analytics", () => ({
+void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
   getAnalytics: mock(() => ({ capture: mock(), flush: mock() })),
 }));
+
+// Bun runs every test file in one process, and `mock.module` mutates a
+// shared registry: without restoring here, these `mock.module` calls (for
+// `suggest-template-fields` and `analytics/capture`) would leak into
+// whichever other test file runs next in the same process.
+afterAll(() => {
+  mock.restore();
+});
 
 const { createTemplateAuthoringTools, SUGGEST_TEMPLATE_FIELDS_TOOL_NAME } =
   await import("@/api/handlers/chat/tools/template-tools");


### PR DESCRIPTION
## Summary

- `external-mcp-tools-discovery.test.ts` and `template-tools-suggest-fields-error.test.ts` both mocked `@/api/lib/analytics` — a specifier that doesn't resolve to a real module (the analytics package only exports `@/api/lib/analytics/capture`, `client`, etc.; there is no `index.ts`). The code under test imports `@/api/lib/analytics/capture` directly, so `mock.module("@/api/lib/analytics", ...)` never intercepted the real `captureError` call, and the `captureErrorMock` assertions failed with "was not called."
- Fixed the specifier to `@/api/lib/analytics/capture` in both files, matching the pattern already used by every other test file in the repo that mocks this module (`src/mcp/template-tools.test.ts`, `src/mcp/tools.test.ts`, etc.).
- Added `afterAll(() => mock.restore())` to both files (again matching the established convention), since Bun runs every test file in one process and `mock.module` mutates a shared registry — without restoring, these files' `mock.module` calls could leak into whichever test file runs next in the same process.

This repairs the two failing tests that have kept main's `ci-checks` red since #1132 and #1133 (both merged via admin bypass of the gate).

## Test plan

- [x] `bun test src/handlers/chat/tools/external-mcp-tools-discovery.test.ts src/handlers/chat/tools/template-tools-suggest-fields-error.test.ts` → 4 pass, 0 fail
- [x] Same two files in reverse argument order → 4 pass, 0 fail
- [x] Each file run alone → passes
- [x] Full `bun run test` (apps/api): pre-fix baseline was 4301 pass / 5 fail; post-fix is 4303 pass / 3 fail — the 2 target tests now pass, and the remaining 3 failures (`entity-create presigned upload validation`, `citation-authority` precision, `courtWeightEntries`) are pre-existing and unrelated to this change
- [x] `bun run --filter @stll/api lint` and `bun run --filter @stll/api typecheck` clean