### PR TITLE
fix: update branch protection audit workflow

### DIFF
--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -22,7 +22,7 @@ jobs:
   audit-branch:
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@44c8092f11c2f454916c320aa7d2144c173329d8
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@031769ee1803778378b9438a674f2ab4b386e817
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json
     secrets:
@@ -32,7 +32,7 @@ jobs:
   audit-tag:
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@44c8092f11c2f454916c320aa7d2144c173329d8
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@031769ee1803778378b9438a674f2ab4b386e817
     with:
       expected-config-path: .github/branch-protection/tags-v.json
     secrets:

--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -22,7 +22,7 @@ jobs:
   audit-branch:
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@031769ee1803778378b9438a674f2ab4b386e817
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@fb20338adb73b3295279519a5c4bc8fdbe32ca37
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json
     secrets:
@@ -32,7 +32,7 @@ jobs:
   audit-tag:
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@031769ee1803778378b9438a674f2ab4b386e817
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@fb20338adb73b3295279519a5c4bc8fdbe32ca37
     with:
       expected-config-path: .github/branch-protection/tags-v.json
     secrets:


### PR DESCRIPTION
## Summary

- update branch and tag protection audits to the normalized shared workflow
- retain an immutable commit SHA and existing least-privilege job permissions

Depends on https://github.com/stella/.github/pull/49