### PR TITLE
fix: enforce AI provider request contracts

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -1,0 +1,125 @@
+name: AI provider canary
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Provider to probe
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - google
+          - openrouter
+          - openai
+          - anthropic
+          - bedrock
+          - mistral
+
+permissions: {}
+
+jobs:
+  provider-canary:
+    name: ${{ matrix.provider }} capability contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.provider != 'all' && format('["{0}"]', inputs.provider) || '["google","openrouter","openai","anthropic","bedrock","mistral"]') }}
+    concurrency:
+      group: ai-provider-canary-${{ matrix.provider }}
+      cancel-in-progress: true
+    steps:
+      - name: Check canary credential
+        id: credential
+        env:
+          AI_CANARY_API_KEY: ${{ matrix.provider == 'google' && secrets.GOOGLE_GENERATIVE_AI_API_KEY || matrix.provider == 'openrouter' && secrets.OPENROUTER_API_KEY || matrix.provider == 'openai' && secrets.OPENAI_API_KEY || matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || matrix.provider == 'bedrock' && secrets.BEDROCK_API_KEY || matrix.provider == 'mistral' && secrets.MISTRAL_API_KEY || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          PROVIDER: ${{ matrix.provider }}
+        run: |
+          if [[ -n "$AI_CANARY_API_KEY" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "::error title=Missing canary credential::No repository secret is configured for $PROVIDER."
+            exit 1
+          fi
+
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Canary not configured::$PROVIDER was skipped because its repository secret is absent."
+
+      - name: Checkout default branch
+        if: steps.credential.outputs.configured == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        if: steps.credential.outputs.configured == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        if: steps.credential.outputs.configured == 'true'
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Record configured provider
+        if: steps.credential.outputs.configured == 'true'
+        env:
+          PROVIDER: ${{ matrix.provider }}
+        run: |
+          mkdir -p .canary-ran
+          touch ".canary-ran/$PROVIDER"
+
+      - name: Upload configured-provider marker
+        if: steps.credential.outputs.configured == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ai-provider-canary-${{ matrix.provider }}
+          path: .canary-ran/
+          retention-days: 1
+
+      - name: Probe provider capability contract
+        if: steps.credential.outputs.configured == 'true'
+        env:
+          AI_CANARY_API_KEY: ${{ matrix.provider == 'google' && secrets.GOOGLE_GENERATIVE_AI_API_KEY || matrix.provider == 'openrouter' && secrets.OPENROUTER_API_KEY || matrix.provider == 'openai' && secrets.OPENAI_API_KEY || matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || matrix.provider == 'bedrock' && secrets.BEDROCK_API_KEY || matrix.provider == 'mistral' && secrets.MISTRAL_API_KEY || '' }}
+          USE_MOCK_AI: "false"
+        run: bun run canary:ai-provider -- --provider "${{ matrix.provider }}"
+
+  require-provider-coverage:
+    name: Require configured provider coverage
+    if: always()
+    needs: provider-canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: Download configured-provider markers
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ai-provider-canary-*
+          path: .canary-ran
+          merge-multiple: true
+
+      - name: Require at least one configured provider
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+        run: |
+          if [[ "$DOWNLOAD_OUTCOME" != "success" ]] || [[ -z "$(find .canary-ran -type f -print -quit 2>/dev/null)" ]]; then
+            echo "::error title=No AI provider canary coverage::Configure at least one supported provider repository secret."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,7 +571,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/web/*|packages/*|scripts/bundle-baseline.ts|scripts/bundle-baseline.json|VERSION|bun.lock|bunfig.toml|package.json|.npmrc|.github/workflows/ci.yml)
+              apps/web/*|packages/*|patches/*|scripts/bundle-baseline.ts|scripts/bundle-baseline.json|VERSION|bun.lock|bunfig.toml|package.json|.npmrc|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;
@@ -688,7 +688,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/landing/*|docs/changelog/*|VERSION|packages/*|bun.lock|package.json|.github/workflows/ci.yml)
+              apps/landing/*|docs/changelog/*|VERSION|packages/*|patches/*|bun.lock|package.json|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;
@@ -754,7 +754,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/web/*|apps/api/*|packages/*|docker-compose.yml|bun.lock|package.json|.github/workflows/ci.yml)
+              apps/web/*|apps/api/*|packages/*|patches/*|docker-compose.yml|bun.lock|package.json|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;
@@ -979,7 +979,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/api/*|apps/legal-atlas-runner/*|packages/*|bun.lock|bunfig.toml|package.json|.npmrc|turbo.json|.github/workflows/ci.yml)
+              apps/api/*|apps/legal-atlas-runner/*|packages/*|patches/*|bun.lock|bunfig.toml|package.json|.npmrc|turbo.json|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;
@@ -1008,7 +1008,9 @@ jobs:
           rm -rf install-json
           mkdir -p install-json
           cp bun.lock package.json install-json/
-          for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" install-json/; done
+          for input in bunfig.toml .npmrc patches; do
+            [ ! -e "$input" ] || cp -a "$input" install-json/
+          done
           find apps packages -mindepth 2 -maxdepth 2 -name package.json \
             -not -path '*/node_modules/*' \
             -exec cp --parents -t install-json/ {} +

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,7 +9,9 @@ FROM base AS install-inputs
 COPY . .
 RUN mkdir -p /json && \
     cp bun.lock package.json /json/ && \
-    for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" /json/; done && \
+    for input in bunfig.toml .npmrc patches; do \
+      [ ! -e "$input" ] || cp -a "$input" /json/; \
+    done && \
     find apps packages -mindepth 2 -maxdepth 2 -name package.json \
       -not -path '*/node_modules/*' \
       -exec cp --parents -t /json/ {} +

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware apps/api",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/api",
     "format": "oxfmt .",
+    "canary:ai-provider": "bun --env-file=.env.example scripts/ai-provider-canary.ts",
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",
     "db:migrate": "bun run --env-file=.env src/db/migrate.ts",
     "db:push": "bun run --env-file=.env drizzle-kit push",

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,0 +1,309 @@
+import { chat, toolDefinition } from "@tanstack/ai";
+import type { Tool } from "@tanstack/ai";
+import * as v from "valibot";
+
+import { DEFAULT_MODELS } from "@stll/ai-catalog";
+import type { ModelRole } from "@stll/ai-catalog";
+
+import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+import type { CachingDecision, OrgAIConfig } from "@/api/lib/ai-config";
+import { nullUnionStrategyForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import {
+  abortControllerFromSignal,
+  generateTanStackObjectForRole,
+  generateTanStackTextForRole,
+  mergeGenerationOptions,
+  resolveTanStackTextModel,
+} from "@/api/lib/tanstack-ai-generate";
+import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
+import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
+
+const CANARY_PROVIDERS = [
+  "google",
+  "openrouter",
+  "openai",
+  "anthropic",
+  "bedrock",
+  "mistral",
+] as const satisfies readonly TanStackTextProvider[];
+
+type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
+
+const CANARY_ROLE = "fast" satisfies ModelRole;
+const MAX_OUTPUT_TOKENS = 64;
+const PROBE_TIMEOUT_MS = 20_000;
+const SYNTHETIC_PROMPT = "Reply with exactly OK.";
+const TOOL_PROMPT = "Do not call any tool. Reply with exactly OK.";
+
+const NO_CACHING = {
+  enabled: false,
+  reason: "org-disabled",
+} as const satisfies CachingDecision;
+
+const CANARY_CACHING = {
+  enabled: true,
+  ttl: "5m",
+  scopeKey: "stella-synthetic-provider-canary",
+} as const satisfies CachingDecision;
+
+const structuredOutputSchema = v.strictObject({ ok: v.literal(true) });
+
+const strictTool = toolDefinition({
+  name: "canary_closed_tool",
+  description: "Synthetic no-op tool with a closed input schema.",
+  inputSchema: toTanStackToolSchema(
+    v.strictObject({ value: v.literal("canary") }),
+  ),
+}).client();
+
+const openMapTool = toolDefinition({
+  name: "canary_open_map_tool",
+  description: "Synthetic no-op tool with a free-form map input.",
+  inputSchema: toTanStackToolSchema(
+    v.strictObject({ values: v.record(v.string(), v.unknown()) }),
+  ),
+}).client();
+
+type Probe = {
+  name: string;
+  run: (context: CanaryContext, signal: AbortSignal) => Promise<void>;
+};
+
+type CanaryContext = {
+  config: OrgAIConfig;
+  provider: CanaryProvider;
+};
+
+const probes = [
+  {
+    name: "text",
+    run: async ({ config }, signal) => {
+      const output = await generateTanStackTextForRole({
+        abortSignal: signal,
+        caching: NO_CACHING,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        organizationId: null,
+        orgAIConfig: config,
+        prompt: SYNTHETIC_PROMPT,
+        role: CANARY_ROLE,
+        serviceTier: "standard",
+      });
+      requireNonEmptyText(output);
+    },
+  },
+  {
+    name: "structured-output",
+    run: async ({ config }, signal) => {
+      await generateTanStackObjectForRole({
+        abortSignal: signal,
+        caching: NO_CACHING,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        organizationId: null,
+        orgAIConfig: config,
+        outputSchema: structuredOutputSchema,
+        prompt: "Return an object whose ok field is true.",
+        role: CANARY_ROLE,
+        serviceTier: "standard",
+      });
+    },
+  },
+  {
+    name: "strict-tool-schema",
+    run: async (context, signal) => {
+      await runToolSchemaProbe(context, strictTool, signal);
+    },
+  },
+  {
+    name: "open-map-tool-schema",
+    run: async (context, signal) => {
+      await runToolSchemaProbe(context, openMapTool, signal);
+    },
+  },
+  {
+    name: "prompt-caching",
+    run: async ({ config }, signal) => {
+      const output = await generateTanStackTextForRole({
+        abortSignal: signal,
+        caching: CANARY_CACHING,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        organizationId: null,
+        orgAIConfig: config,
+        prompt: SYNTHETIC_PROMPT,
+        role: CANARY_ROLE,
+        serviceTier: "standard",
+        system: "This is a synthetic provider-contract canary.",
+      });
+      requireNonEmptyText(output);
+    },
+  },
+] as const satisfies readonly Probe[];
+
+const runToolSchemaProbe = async (
+  { config, provider }: CanaryContext,
+  tool: Tool,
+  signal: AbortSignal,
+): Promise<void> => {
+  const model = resolveTanStackTextModel({
+    organizationId: null,
+    orgAIConfig: config,
+    role: CANARY_ROLE,
+  });
+  const inputSchema = projectSchemaInputJsonSchema(tool.inputSchema, {
+    nullUnionStrategy: nullUnionStrategyForTanStackProvider(provider),
+  });
+  const projectedTool = {
+    ...tool,
+    ...(inputSchema === undefined ? {} : { inputSchema }),
+  };
+
+  const output = await chat({
+    adapter: model.adapter,
+    abortController: abortControllerFromSignal(signal),
+    messages: [{ role: "user", content: TOOL_PROMPT }],
+    modelOptions: mergeGenerationOptions({
+      caching: NO_CACHING,
+      model,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      serviceTier: "standard",
+      temperature: 0,
+    }),
+    stream: false,
+    tools: [projectedTool],
+  });
+  requireNonEmptyText(output);
+};
+
+const requireNonEmptyText = (output: string): void => {
+  if (output.trim().length === 0) {
+    throw new TypeError("Provider returned no text.");
+  }
+};
+
+const modelSelections = (provider: CanaryProvider) => ({
+  fast: { provider, modelId: DEFAULT_MODELS[provider].fast },
+  chat: { provider, modelId: DEFAULT_MODELS[provider].chat },
+  reasoning: { provider, modelId: DEFAULT_MODELS[provider].reasoning },
+  pdf: { provider, modelId: DEFAULT_MODELS[provider].pdf },
+});
+
+const createCanaryConfig = (
+  provider: CanaryProvider,
+  apiKey: string,
+): OrgAIConfig => {
+  switch (provider) {
+    case "google":
+    case "openrouter":
+    case "openai":
+    case "anthropic":
+    case "bedrock":
+    case "mistral":
+      return {
+        providers: [{ provider, apiKey }],
+        overrideModels: modelSelections(provider),
+      };
+    default: {
+      const _exhaustive: never = provider;
+      return _exhaustive;
+    }
+  }
+};
+
+const parseProvider = (args: string[]): CanaryProvider => {
+  const providerFlagIndex = args.indexOf("--provider");
+  const value = args.at(providerFlagIndex + 1);
+  if (providerFlagIndex !== -1) {
+    switch (value) {
+      case "google":
+      case "openrouter":
+      case "openai":
+      case "anthropic":
+      case "bedrock":
+      case "mistral":
+        return value;
+      case undefined:
+        break;
+    }
+  }
+
+  throw new TypeError(
+    `Pass --provider followed by one of: ${CANARY_PROVIDERS.join(", ")}.`,
+  );
+};
+
+const errorSummary = (error: unknown, signal: AbortSignal): string => {
+  if (signal.aborted) {
+    return "timeout";
+  }
+
+  const status = providerStatus(error);
+  return status === null ? "provider error" : `provider HTTP ${status}`;
+};
+
+const providerStatus = (error: unknown): number | null => {
+  if (!isRecord(error)) {
+    return null;
+  }
+  for (const key of ["status", "statusCode"] as const) {
+    const value = error[key];
+    if (typeof value === "number" && Number.isInteger(value)) {
+      return value;
+    }
+  }
+  return null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const run = async (): Promise<void> => {
+  const provider = parseProvider(Bun.argv.slice(2));
+  const apiKey = process.env["AI_CANARY_API_KEY"];
+  if (!apiKey) {
+    throw new TypeError(`No canary credential is configured for ${provider}.`);
+  }
+
+  const context = {
+    config: createCanaryConfig(provider, apiKey),
+    provider,
+  } satisfies CanaryContext;
+  const failures = await runProbes(context, 0, 0);
+
+  if (failures > 0) {
+    throw new TypeError(
+      `${failures} provider capability probe${failures === 1 ? "" : "s"} failed.`,
+    );
+  }
+};
+
+const runProbes = async (
+  context: CanaryContext,
+  index: number,
+  failures: number,
+): Promise<number> => {
+  const probe = probes.at(index);
+  if (!probe) {
+    return failures;
+  }
+
+  const signal = AbortSignal.timeout(PROBE_TIMEOUT_MS);
+  try {
+    await probe.run(context, signal);
+    console.log(`[ai-canary] ${context.provider}/${probe.name}: passed`);
+    return await runProbes(context, index + 1, failures);
+  } catch (error) {
+    console.error(
+      `[ai-canary] ${context.provider}/${probe.name}: failed (${errorSummary(error, signal)})`,
+    );
+    return await runProbes(context, index + 1, failures + 1);
+  }
+};
+
+if (import.meta.main) {
+  await run().catch((error: unknown) => {
+    // Never print provider errors: bodies can echo request content or headers.
+    const message =
+      error instanceof TypeError ? error.message : "Canary failed.";
+    console.error(`[ai-canary] ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -3,6 +3,7 @@ import {
   parseWithStandardSchema,
   toolDefinition,
 } from "@tanstack/ai";
+import { convertFunctionToolToAdapterFormat } from "@tanstack/ai-openai/tools";
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
@@ -88,6 +89,59 @@ const editableActiveSkillContext: ActiveChatSkillContext = {
   source: "installed",
   toolName: "closing-review",
   version: null,
+};
+
+const isSchemaObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Construct args so every conditional tool group registers: owner role
+// (template use + create), active docx edit client, web search enabled with
+// a resolved provider, and an editable active skill context. BOE, infosoud,
+// and business-registry tools register by default (no disabled slugs).
+const buildFullCoverageChatTools = () => {
+  const webSearchProvider: WebSearchProvider = {
+    name: "tavily",
+    search: async () => ({ results: [] }),
+  };
+  const urlFetcher: UrlFetcher = {
+    name: "jina",
+    fetch: async () => ({
+      url: "",
+      content: "",
+      truncated: false,
+      provider: "jina",
+    }),
+  };
+
+  return getChatTools({
+    orgAIConfig: null,
+    memberRole: "owner",
+    organizationId,
+    requestWorkspaceId: workspaceId,
+    thirdPartyBoundary: { type: "raw" },
+    refRegistry: createChatRefRegistry(),
+    safeDb: unusedSafeDb,
+    scopedDb: unusedScopedDb,
+    threadId,
+    userId,
+    toolWorkspaceIds: resolveToolWorkspaceIds({
+      pinnedIds: [],
+      accessibleWorkspaceIds: [workspaceId],
+    }),
+    hasActiveDocxEditClient: true,
+    hasActiveDocxFileClient: true,
+    webSearchEnabled: true,
+    webSearchProviders: { webSearchProvider, urlFetcher },
+    activeSkillContext: editableActiveSkillContext,
+    recordAuditEvent: noopAuditRecorder,
+    skillMetadata: [
+      {
+        description: editableActiveSkillContext.description,
+        name: editableActiveSkillContext.toolName,
+        version: editableActiveSkillContext.version,
+      },
+    ],
+  });
 };
 
 describe("chat tool schemas", () => {
@@ -606,53 +660,7 @@ describe("chat tool schemas", () => {
   });
 
   test("every registered chat tool serializes to a provider-safe JSON schema", () => {
-    // Construct args so every conditional tool group registers: owner role
-    // (template use + create), active docx edit client, web search enabled with
-    // a resolved provider, and an editable active skill context. BOE, infosoud,
-    // and business-registry tools register by default (no disabled slugs).
-    const webSearchProvider: WebSearchProvider = {
-      name: "tavily",
-      search: async () => ({ results: [] }),
-    };
-    const urlFetcher: UrlFetcher = {
-      name: "jina",
-      fetch: async () => ({
-        url: "",
-        content: "",
-        truncated: false,
-        provider: "jina",
-      }),
-    };
-
-    const tools = getChatTools({
-      orgAIConfig: null,
-      memberRole: "owner",
-      organizationId,
-      requestWorkspaceId: workspaceId,
-      thirdPartyBoundary: { type: "raw" },
-      refRegistry: createChatRefRegistry(),
-      safeDb: unusedSafeDb,
-      scopedDb: unusedScopedDb,
-      threadId,
-      userId,
-      toolWorkspaceIds: resolveToolWorkspaceIds({
-        pinnedIds: [],
-        accessibleWorkspaceIds: [workspaceId],
-      }),
-      hasActiveDocxEditClient: true,
-      hasActiveDocxFileClient: true,
-      webSearchEnabled: true,
-      webSearchProviders: { webSearchProvider, urlFetcher },
-      activeSkillContext: editableActiveSkillContext,
-      recordAuditEvent: noopAuditRecorder,
-      skillMetadata: [
-        {
-          description: editableActiveSkillContext.description,
-          name: editableActiveSkillContext.toolName,
-          version: editableActiveSkillContext.version,
-        },
-      ],
-    });
+    const tools = buildFullCoverageChatTools();
 
     // Sanity: the groups we depend on for coverage are actually present.
     for (const requiredTool of [
@@ -668,9 +676,6 @@ describe("chat tool schemas", () => {
     }
 
     const allowedKeywords = new Set<string>(PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS);
-    const isSchemaObject = (value: unknown): value is Record<string, unknown> =>
-      typeof value === "object" && value !== null && !Array.isArray(value);
-
     const violations: string[] = [];
     const assertProviderSafe = (
       node: unknown,
@@ -731,6 +736,115 @@ describe("chat tool schemas", () => {
     }
 
     expect(violations).toEqual([]);
+  });
+
+  // OpenAI rejects the entire request (400) when any tool is sent with
+  // `strict: true` but a schema outside the strict Structured Outputs subset.
+  // This test runs the real adapter conversion over every registered chat tool
+  // offline, so a schema that would 400 in production fails here first, even
+  // under USE_MOCK_AI. It also fails if the @tanstack/openai-base patch
+  // (patches/) stops applying, e.g. after a version bump.
+  test("every registered chat tool converts to strict-legal OpenAI parameters or the deliberate non-strict fallback", () => {
+    const tools = buildFullCoverageChatTools();
+
+    // Free-form map inputs (`v.record(...)`, `additionalProperties: true`)
+    // cannot be expressed under strict mode, which requires every object node
+    // closed with its keys enumerated; the adapter must send those tools with
+    // `strict: false`. fill_template, save_clause and save_template degrade
+    // for open maps; set_field_value for its deliberately typeless
+    // `content.value` node. Growing this list is a deliberate trade: prefer
+    // closed schemas so a tool keeps strict-mode adherence.
+    const expectedNonStrictTools = [
+      "fill_template",
+      "save_clause",
+      "save_template",
+      "set_field_value",
+    ];
+
+    // A strict:true tool must satisfy OpenAI's strict subset: every object
+    // node closed via `additionalProperties: false` with enumerated
+    // `properties`, and no typeless schema nodes anywhere.
+    const strictTypeIndicators = ["type", "enum", "const", "anyOf"];
+    const violations: string[] = [];
+    const collectStrictViolations = (
+      node: unknown,
+      path: string,
+      toolName: string,
+    ): void => {
+      if (!isSchemaObject(node)) {
+        return;
+      }
+
+      const { type, additionalProperties, properties, items, anyOf } = node;
+      const isObjectNode =
+        type === "object" || (Array.isArray(type) && type.includes("object"));
+      if (isObjectNode) {
+        if (additionalProperties !== false) {
+          violations.push(
+            `tool "${toolName}" at "${path}" sends strict: true with an object node not closed by additionalProperties: false`,
+          );
+        }
+        if (!isSchemaObject(properties)) {
+          violations.push(
+            `tool "${toolName}" at "${path}" sends strict: true with an object node without enumerated properties`,
+          );
+        }
+      }
+      if (!strictTypeIndicators.some((key) => key in node)) {
+        violations.push(
+          `tool "${toolName}" at "${path}" sends strict: true with a typeless schema node`,
+        );
+      }
+      if (isSchemaObject(properties)) {
+        for (const [name, child] of Object.entries(properties)) {
+          collectStrictViolations(
+            child,
+            `${path}.properties.${name}`,
+            toolName,
+          );
+        }
+      }
+      if (Array.isArray(items)) {
+        for (const [index, child] of items.entries()) {
+          collectStrictViolations(child, `${path}.items[${index}]`, toolName);
+        }
+      } else if (isSchemaObject(items)) {
+        collectStrictViolations(items, `${path}.items`, toolName);
+      }
+      if (Array.isArray(anyOf)) {
+        for (const [index, child] of anyOf.entries()) {
+          collectStrictViolations(child, `${path}.anyOf[${index}]`, toolName);
+        }
+      }
+    };
+
+    const nonStrictTools: string[] = [];
+    for (const [name, tool] of Object.entries(tools)) {
+      const inputSchema = tool?.inputSchema;
+      if (!inputSchema) {
+        continue;
+      }
+      // The exact pipeline the runtime runs: the ai layer serializes the
+      // Standard Schema to JSON Schema, then the OpenAI adapter converts it
+      // to a function tool and decides strict mode.
+      const serialized = convertSchemaToJsonSchema(inputSchema);
+      if (!serialized) {
+        continue;
+      }
+      const converted = convertFunctionToolToAdapterFormat({
+        name,
+        description: tool.description,
+        inputSchema: serialized,
+      });
+      if (converted.strict !== true) {
+        nonStrictTools.push(name);
+        continue;
+      }
+      collectStrictViolations(converted.parameters, "root", name);
+    }
+
+    expect(violations).toEqual([]);
+    expect(nonStrictTools.toSorted()).toEqual(expectedNonStrictTools);
   });
 
   test("created document output includes the canonical entity mention", () => {

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -2,8 +2,20 @@ import {
   convertSchemaToJsonSchema,
   parseWithStandardSchema,
   toolDefinition,
+  type Tool,
 } from "@tanstack/ai";
+import {
+  convertToolsToProviderFormat as convertAnthropicTools,
+  createAnthropicChat,
+} from "@tanstack/ai-anthropic";
+import { webSearchTool as anthropicWebSearchTool } from "@tanstack/ai-anthropic/tools";
+import { bedrockText } from "@tanstack/ai-bedrock";
+import { createGeminiChat } from "@tanstack/ai-gemini";
+import { createMistralText } from "@tanstack/ai-mistral";
+import { createOpenaiChat } from "@tanstack/ai-openai";
 import { convertFunctionToolToAdapterFormat } from "@tanstack/ai-openai/tools";
+import { createOpenRouterResponsesText } from "@tanstack/ai-openrouter";
+import { resolveDebugOption } from "@tanstack/ai/adapter-internals";
 import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
@@ -94,6 +106,35 @@ const editableActiveSkillContext: ActiveChatSkillContext = {
 const isSchemaObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const emptyProviderStream = async function* () {
+  // The contract probes only need the adapter to issue its SDK request.
+};
+
+const consumeProviderStream = async (
+  stream: AsyncIterable<unknown>,
+): Promise<void> => {
+  for await (const _chunk of stream) {
+    // Consume the fake provider stream so request mapping runs to completion.
+  }
+};
+
+const requireRecord = (
+  value: unknown,
+  description: string,
+): Record<string, unknown> => {
+  if (!isSchemaObject(value)) {
+    throw new TypeError(`Expected ${description} to be an object.`);
+  }
+  return value;
+};
+
+const requireArray = (value: unknown, description: string): unknown[] => {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`Expected ${description} to be an array.`);
+  }
+  return value;
+};
+
 // Construct args so every conditional tool group registers: owner role
 // (template use + create), active docx edit client, web search enabled with
 // a resolved provider, and an editable active skill context. BOE, infosoud,
@@ -143,6 +184,208 @@ const buildFullCoverageChatTools = () => {
     ],
   });
 };
+
+const serializeFullCoverageChatTools = (): Tool[] =>
+  Object.entries(buildFullCoverageChatTools()).map(([name, tool]) => {
+    if (!tool?.inputSchema) {
+      throw new TypeError(`Registered tool "${name}" has no input schema.`);
+    }
+    const inputSchema = convertSchemaToJsonSchema(tool.inputSchema);
+    if (!inputSchema) {
+      throw new TypeError(`Registered tool "${name}" did not serialize.`);
+    }
+    return { name, description: tool.description, inputSchema };
+  });
+
+const commonProviderOptions = (tools: Tool[]) => ({
+  logger: resolveDebugOption(false),
+  messages: [{ role: "user" as const, content: "Contract probe." }],
+  tools,
+});
+
+type ProviderRequestProbe = {
+  provider:
+    | "anthropic"
+    | "bedrock"
+    | "google"
+    | "mistral"
+    | "openai"
+    | "openrouter";
+  capture: (tools: Tool[]) => Promise<Record<string, unknown>>;
+  toolsFromRequest: (request: Record<string, unknown>) => unknown[];
+};
+
+const providerRequestProbes: ProviderRequestProbe[] = [
+  {
+    provider: "openai",
+    capture: async (tools) => {
+      const adapter = createOpenaiChat("gpt-5.2", "test-key");
+      let request: unknown;
+      Reflect.set(adapter, "client", {
+        responses: {
+          create: (payload: unknown) => {
+            request = payload;
+            return emptyProviderStream();
+          },
+        },
+      });
+      await consumeProviderStream(
+        adapter.chatStream({
+          ...commonProviderOptions(tools),
+          model: adapter.model,
+        }),
+      );
+      return requireRecord(request, "OpenAI request");
+    },
+    toolsFromRequest: (request) =>
+      requireArray(request["tools"], "OpenAI request tools"),
+  },
+  {
+    provider: "google",
+    capture: async (tools) => {
+      const adapter = createGeminiChat("gemini-3.5-flash", "test-key");
+      let request: unknown;
+      Reflect.set(adapter, "client", {
+        models: {
+          generateContentStream: (payload: unknown) => {
+            request = payload;
+            return emptyProviderStream();
+          },
+        },
+      });
+      await consumeProviderStream(
+        adapter.chatStream({
+          ...commonProviderOptions(tools),
+          model: adapter.model,
+        }),
+      );
+      return requireRecord(request, "Gemini request");
+    },
+    toolsFromRequest: (request) => {
+      const config = requireRecord(request["config"], "Gemini request config");
+      const groups = requireArray(config["tools"], "Gemini request tools");
+      return groups.flatMap((group) => {
+        const record = requireRecord(group, "Gemini tool group");
+        return Array.isArray(record["functionDeclarations"])
+          ? record["functionDeclarations"]
+          : [record];
+      });
+    },
+  },
+  {
+    provider: "anthropic",
+    capture: async (tools) => {
+      const adapter = createAnthropicChat("claude-opus-4-6", "test-key");
+      let request: unknown;
+      Reflect.set(adapter, "client", {
+        beta: {
+          messages: {
+            create: (payload: unknown) => {
+              request = payload;
+              return emptyProviderStream();
+            },
+          },
+        },
+      });
+      await consumeProviderStream(
+        adapter.chatStream({
+          ...commonProviderOptions(tools),
+          model: adapter.model,
+        }),
+      );
+      if (request === undefined) {
+        throw new TypeError("Anthropic adapter did not issue its SDK request.");
+      }
+      return requireRecord(request, "Anthropic request");
+    },
+    toolsFromRequest: (request) =>
+      requireArray(request["tools"], "Anthropic request tools"),
+  },
+  {
+    provider: "bedrock",
+    capture: async (tools) => {
+      const adapter = bedrockText("us.amazon.nova-micro-v1:0", {
+        apiKey: "test-key",
+      });
+      let request: unknown;
+      Reflect.set(adapter, "sendStream", async (payload: unknown) => {
+        request = payload;
+        return emptyProviderStream();
+      });
+      await consumeProviderStream(
+        adapter.chatStream({
+          ...commonProviderOptions(tools),
+          model: adapter.model,
+        }),
+      );
+      return requireRecord(request, "Bedrock Converse request");
+    },
+    toolsFromRequest: (request) => {
+      const toolConfig = requireRecord(
+        request["toolConfig"],
+        "Bedrock tool config",
+      );
+      return requireArray(toolConfig["tools"], "Bedrock request tools");
+    },
+  },
+  {
+    provider: "openrouter",
+    capture: async (tools) => {
+      const adapter = createOpenRouterResponsesText(
+        "openai/gpt-5.2",
+        "test-key",
+      );
+      let request: unknown;
+      Reflect.set(adapter, "orClient", {
+        beta: {
+          responses: {
+            send: (payload: unknown) => {
+              request = payload;
+              return emptyProviderStream();
+            },
+          },
+        },
+      });
+      await consumeProviderStream(
+        adapter.chatStream({
+          ...commonProviderOptions(tools),
+          model: adapter.model,
+        }),
+      );
+      return requireRecord(request, "OpenRouter SDK request");
+    },
+    toolsFromRequest: (request) => {
+      const responsesRequest = requireRecord(
+        request["responsesRequest"],
+        "OpenRouter responses request",
+      );
+      return requireArray(
+        responsesRequest["tools"],
+        "OpenRouter request tools",
+      );
+    },
+  },
+  {
+    provider: "mistral",
+    capture: async (tools) => {
+      const adapter = createMistralText("mistral-large-latest", "test-key");
+      let request: unknown;
+      Reflect.set(adapter, "fetchRawMistralStream", (payload: unknown) => {
+        request = payload;
+        return emptyProviderStream();
+      });
+      await consumeProviderStream(
+        adapter.chatStream({
+          ...commonProviderOptions(tools),
+          model: adapter.model,
+        }),
+      );
+      return requireRecord(request, "Mistral request");
+    },
+    toolsFromRequest: (request) =>
+      requireArray(request["tools"], "Mistral request tools"),
+  },
+];
 
 describe("chat tool schemas", () => {
   test("construct org-level tools as JSON-schema-compatible AI tools", () => {
@@ -736,6 +979,61 @@ describe("chat tool schemas", () => {
     }
 
     expect(violations).toEqual([]);
+  });
+
+  for (const probe of providerRequestProbes) {
+    test(`every registered chat tool reaches the final ${probe.provider} request`, async () => {
+      const tools = serializeFullCoverageChatTools();
+      const request = await probe.capture(tools);
+      const providerTools = probe.toolsFromRequest(request);
+
+      // This is deliberately an adapter/SDK-boundary invariant, matching the
+      // provider suites in TanStack AI itself. Schema-only tests stop before
+      // provider-specific conversion, which is where request-breaking fields
+      // such as OpenAI strict mode and provider wire-name changes are added.
+      expect(providerTools).toHaveLength(tools.length);
+      for (const providerTool of providerTools) {
+        expect(isSchemaObject(providerTool)).toBe(true);
+      }
+    });
+  }
+
+  test("Anthropic keeps an ordinary web_search function distinct from its native web-search tool", () => {
+    const ordinaryWebSearch: Tool = {
+      name: "web_search",
+      description: "Search through stella's configured provider.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    };
+    const nativeWebSearch = anthropicWebSearchTool({
+      name: "web_search",
+      type: "web_search_20250305",
+    });
+
+    expect(convertAnthropicTools([ordinaryWebSearch, nativeWebSearch])).toEqual(
+      [
+        {
+          name: "web_search",
+          type: "custom",
+          description: ordinaryWebSearch.description,
+          input_schema: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+          },
+          cache_control: null,
+        },
+        {
+          name: "web_search",
+          type: "web_search_20250305",
+          cache_control: null,
+        },
+      ],
+    );
   });
 
   // OpenAI rejects the entire request (400) when any tool is sent with

--- a/apps/api/src/lib/ai-caching-invariants.test.ts
+++ b/apps/api/src/lib/ai-caching-invariants.test.ts
@@ -33,10 +33,15 @@ describe("TanStack AI is the only live app provider SDK boundary", () => {
     expect(offenders).toEqual([]);
   });
 
-  test("TanStack provider adapter factories stay in tanstack-ai-models.ts", async () => {
+  test("TanStack provider adapter factories stay at explicit boundaries", async () => {
     const apiSrc = path.resolve(import.meta.dir, "..");
     const glob = new Glob("**/*.ts");
-    const allowed = new Set(["lib/tanstack-ai-models.ts"]);
+    const allowed = new Set([
+      "lib/tanstack-ai-models.ts",
+      // This is the final-request contract matrix. It deliberately constructs the
+      // real adapters with intercepted clients; it is not imported by app code.
+      "handlers/chat/tools/tool-schema.test.ts",
+    ]);
     const forbiddenPackages = [
       "@tanstack/ai-anthropic",
       "@tanstack/ai-gemini",

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -214,6 +214,40 @@ describe("TanStack AI structured output generation", () => {
     expect(options).toEqual({ max_tokens: 1000 });
   });
 
+  test("enables OpenAI prompt caching without sending a model-specific retention value", () => {
+    // SAFETY: mergeGenerationOptions only reads provider/modelOptions/modelId.
+    // The adapter is irrelevant for this pure option-merge regression test.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- focused pure helper test
+    const model = {
+      adapter: {},
+      keySource: "instance",
+      modelId: "gpt-5.4-mini",
+      modelOptions: {},
+      provider: "openai",
+    } as ResolvedTanStackTextModel;
+
+    const options = mergeGenerationOptions({
+      caching: {
+        enabled: true,
+        scopeKey: "organization:contract-probe",
+        ttl: "5m",
+      },
+      maxOutputTokens: 1000,
+      model,
+      serviceTier: "standard",
+      temperature: 0,
+    });
+
+    expect(options).toEqual({
+      max_output_tokens: 1000,
+      prompt_cache_key:
+        "106a444562569784437b331c30f0edcfa70367d5e744cdba050d7234d6ee197c",
+      service_tier: "default",
+      temperature: 0,
+    });
+    expect(options).not.toHaveProperty("prompt_cache_retention");
+  });
+
   test("forwards deferred service tiers to Gemini requests", () => {
     // SAFETY: mergeGenerationOptions only reads provider/modelOptions/modelId.
     // The adapter is irrelevant for this pure option-merge test.

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -678,11 +678,14 @@ export const mergeGenerationOptions = ({
 const isDeferredServiceTier = (serviceTier: AIRequestServiceTier): boolean =>
   serviceTier === "flex" || serviceTier === "batch";
 
-// `prompt_cache_retention` is omitted because no single value is valid across
-// this catalogue: the API accepts "in_memory" | "24h", but gpt-5.5 supports only
-// "24h". Omission is the one portable choice, and it takes the provider default:
-// "24h" for a non-ZDR org, "in_memory" for a ZDR one. Retention is a per-model
-// capability, so setting it belongs in the model catalogue, not here.
+// `prompt_cache_retention` is omitted because no explicit value is valid across
+// this catalogue: gpt-5.5 accepts only "24h", while OpenAI's extended-retention
+// model list does not include gpt-5.4-mini or gpt-5.4-nano, so "24h" is not
+// portable either. Omission takes the provider default, which also adapts to
+// the org's data-retention posture: "24h" without ZDR, "in_memory" with it.
+// Retention is a per-model capability (gpt-5.6+ replaces this field with
+// `prompt_cache_options.ttl`), so a retention policy belongs in the model
+// catalogue, not here.
 const openAICacheOptions = (
   caching: CachingDecision,
 ): Partial<Pick<OpenAITextProviderOptions, "prompt_cache_key">> => {

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -678,17 +678,19 @@ export const mergeGenerationOptions = ({
 const isDeferredServiceTier = (serviceTier: AIRequestServiceTier): boolean =>
   serviceTier === "flex" || serviceTier === "batch";
 
+// `prompt_cache_retention` is omitted because no single value is valid across
+// this catalogue: the API accepts "in_memory" | "24h", but gpt-5.5 supports only
+// "24h". Omission is the one portable choice, and it takes the provider default:
+// "24h" for a non-ZDR org, "in_memory" for a ZDR one. Retention is a per-model
+// capability, so setting it belongs in the model catalogue, not here.
 const openAICacheOptions = (
   caching: CachingDecision,
-): Partial<
-  Pick<OpenAITextProviderOptions, "prompt_cache_key" | "prompt_cache_retention">
-> => {
+): Partial<Pick<OpenAITextProviderOptions, "prompt_cache_key">> => {
   if (!caching.enabled || caching.scopeKey === null) {
     return {};
   }
   return {
     prompt_cache_key: hashCacheScopeKey(caching.scopeKey),
-    prompt_cache_retention: "in-memory",
   };
 };
 

--- a/apps/legal-atlas-runner/Dockerfile
+++ b/apps/legal-atlas-runner/Dockerfile
@@ -9,7 +9,9 @@ FROM base AS install-inputs
 COPY . .
 RUN mkdir -p /json && \
     cp bun.lock package.json /json/ && \
-    for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" /json/; done && \
+    for input in bunfig.toml .npmrc patches; do \
+      [ ! -e "$input" ] || cp -a "$input" /json/; \
+    done && \
     find apps packages -mindepth 2 -maxdepth 2 -name package.json \
       -not -path '*/node_modules/*' \
       -exec cp --parents -t /json/ {} +

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -9,7 +9,9 @@ FROM base AS install-inputs
 COPY . .
 RUN mkdir -p /json && \
     cp bun.lock package.json /json/ && \
-    for f in bunfig.toml .npmrc; do [ ! -e "$f" ] || cp "$f" /json/; done && \
+    for input in bunfig.toml .npmrc patches; do \
+      [ ! -e "$input" ] || cp -a "$input" /json/; \
+    done && \
     find apps packages -mindepth 2 -maxdepth 2 -name package.json \
       -not -path '*/node_modules/*' \
       -exec cp --parents -t /json/ {} +

--- a/bun.lock
+++ b/bun.lock
@@ -618,6 +618,7 @@
   },
   "patchedDependencies": {
     "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch",
+    "@tanstack/ai-anthropic@0.16.1": "patches/@tanstack%2Fai-anthropic@0.16.1.patch",
   },
   "overrides": {
     "@emnapi/core": "1.9.1",

--- a/bun.lock
+++ b/bun.lock
@@ -616,6 +616,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch",
+  },
   "overrides": {
     "@emnapi/core": "1.9.1",
     "@emnapi/runtime": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "i18n:check": "turbo run i18n:check --",
     "i18n:sync": "turbo run i18n:sync --",
     "check:model-catalog": "bun packages/scripts/src/model-catalog-upstream.ts",
+    "canary:ai-provider": "bun --cwd apps/api canary:ai-provider",
     "check:railway-template-draft": "bun scripts/check-railway-template-draft.ts",
     "check:railway-template": "bun scripts/check-railway-template-shape.ts",
     "check:railway-template-source-runtime": "bun scripts/sync-railway-template-source.ts --check-rendered-credentials",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     }
   },
   "patchedDependencies": {
-    "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch"
+    "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch",
+    "@tanstack/ai-anthropic@0.16.1": "patches/@tanstack%2Fai-anthropic@0.16.1.patch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -140,5 +140,8 @@
       "react": "^19.2.7",
       "react-dom": "^19.2.7"
     }
+  },
+  "patchedDependencies": {
+    "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch"
   }
 }

--- a/patches/@tanstack%2Fai-anthropic@0.16.1.patch
+++ b/patches/@tanstack%2Fai-anthropic@0.16.1.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/esm/tools/tool-converter.js b/dist/esm/tools/tool-converter.js
+index c595d3f078f0ac3fe43299718b260e7de3208c08..6ea7f7e1e7ab8b9167cae5b1db2fbab711852ce6 100644
+--- a/dist/esm/tools/tool-converter.js
++++ b/dist/esm/tools/tool-converter.js
+@@ -6,6 +6,10 @@ import { convertMemoryToolToAdapterFormat } from "./memory-tool.js";
+ import { convertTextEditorToolToAdapterFormat } from "./text-editor-tool.js";
+ import { convertWebFetchToolToAdapterFormat } from "./web-fetch-tool.js";
+ import { convertWebSearchToolToAdapterFormat } from "./web-search-tool.js";
++function isAnthropicWebSearchTool(tool) {
++  const metadata = tool.metadata;
++  return typeof metadata === "object" && metadata !== null && "type" in metadata && metadata.type === "web_search_20250305" && "name" in metadata && metadata.name === "web_search";
++}
+ function convertToolsToProviderFormat(tools) {
+   return tools.map((tool) => {
+     const name = tool.name;
+@@ -23,7 +27,7 @@ function convertToolsToProviderFormat(tools) {
+       case "web_fetch":
+         return convertWebFetchToolToAdapterFormat(tool);
+       case "web_search":
+-        return convertWebSearchToolToAdapterFormat(tool);
++        return isAnthropicWebSearchTool(tool) ? convertWebSearchToolToAdapterFormat(tool) : convertCustomToolToAdapterFormat(tool);
+       default:
+         return convertCustomToolToAdapterFormat(tool);
+     }

--- a/patches/@tanstack%2Fopenai-base@0.9.7.patch
+++ b/patches/@tanstack%2Fopenai-base@0.9.7.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/esm/utils/schema-converter.js b/dist/esm/utils/schema-converter.js
+index 6977689012fb8caccc28e1bcde4154b69b60cc46..18bd07c23e75adb3a367b376ae9846d330554e6a 100644
+--- a/dist/esm/utils/schema-converter.js
++++ b/dist/esm/utils/schema-converter.js
+@@ -42,7 +42,32 @@ const TYPE_INDICATOR_KEYWORDS = [
+   "$ref"
+ ];
+ function isStrictModeCompatible(schema) {
+-  return !containsStrictUnsupportedKeyword(schema) && !containsTypelessSchema(schema);
++  return !containsStrictUnsupportedKeyword(schema) && !containsTypelessSchema(schema) && !containsOpenObject(schema);
++}
++// PATCH (stella): strict mode compiles the schema into a constrained-decoding
++// grammar, so every object must be closed: `additionalProperties: false`, with
++// every key enumerated. A free-form map has no grammar and 400s the request.
++// `containsTypelessSchema` never walks `additionalProperties`, and
++// `coerceStrictSchema` only closes objects that have a `properties` key, so a
++// map input reaches the API with `strict: true` and poisons the whole call.
++// Two distinct 400s result: `additionalProperties: {}` (from a record schema)
++// fails with "schema must have a 'type' key", `additionalProperties: true` with
++// "'additionalProperties' is required to be supplied and to be false". Flag both,
++// so such tools take the existing `strict: false` fallback instead.
++function containsOpenObject(node) {
++  if (Array.isArray(node)) {
++    return node.some(containsOpenObject);
++  }
++  if (node === null || typeof node !== "object") return false;
++  const isObjectSchema = node.type === "object" || Array.isArray(node.type) && node.type.includes("object");
++  if (isObjectSchema) {
++    // An omitted `additionalProperties` is fine only when `properties` is
++    // present: `coerceStrictSchema` closes that node. Without it there is
++    // nothing to close and no keys to enumerate.
++    if ("additionalProperties" in node && node.additionalProperties !== false) return true;
++    if (!node.properties) return true;
++  }
++  return Object.values(node).some(containsOpenObject);
+ }
+ function containsStrictUnsupportedKeyword(node) {
+   if (Array.isArray(node)) {


### PR DESCRIPTION
## Summary

Fixes three provider-boundary failures and adds coverage at the layer that was missing:

- OpenAI no longer receives the invalid `prompt_cache_retention: "in-memory"` option. `prompt_cache_key` remains enabled; retention is omitted because no explicit value is portable across the offered model catalogue.
- OpenAI free-form map tools use TanStack's existing `strict: false` fallback instead of being mislabeled `strict: true` and rejecting the entire request.
- Anthropic distinguishes Stella's ordinary `web_search` function from Anthropic's provider-native web-search tool by metadata, not by a colliding public function name.

The two TanStack runtime fixes are carried as pinned Bun patches and protected by adapter-boundary regression tests, so they can be removed independently once upstream releases the fixes.

## Why existing tests missed this

The test suite validated provider-neutral JSON Schema and exercised chat E2E through `USE_MOCK_AI=true`. Neither path observed the final request produced by a concrete provider adapter. The invalid cache option was also only reachable with prompt caching enabled, while generation tests used the disabled-caching fixture.

## Provider contract architecture

The mandatory offline suite now serializes every registered Stella chat tool through the real final request path for all six supported TanStack providers:

- OpenAI Responses
- Google Gemini
- Anthropic Messages
- Amazon Bedrock Converse
- OpenRouter Responses
- Mistral

It fails if any tool disappears before the SDK boundary. OpenAI additionally gets a strict-schema invariant with an exact non-strict allowlist, and cache-enabled generation asserts the complete model options plus the absence of `prompt_cache_retention`.

The new scheduled/manual live canary complements the offline gate. On the trusted default branch it probes text generation, structured output, closed strict tools, free-form map tools, and cache-enabled generation using synthetic inputs, the catalogue's `fast` model, a 64-token cap, and 20-second per-probe timeouts. It never logs prompts, responses, headers, keys, provider bodies, or stacks. Each matrix job receives only its selected provider credential; the workflow has least-privilege permissions, pinned actions, lifecycle scripts disabled during install, and fails if no provider canary is configured.

This follows TanStack AI's useful final-SDK-payload and provider-feature-matrix patterns, while closing two upstream gaps: its real-provider tool scripts are manual rather than CI canaries, and its `aimock` matrix cannot exercise native Bedrock Converse.

## Verification

- `bun install --frozen-lockfile --force --ignore-scripts`: both pinned patches apply cleanly.
- Focused provider/cache suite: 37 passed, 0 failed, 485 assertions.
- API typecheck: passed.
- Type-aware API lint: 0 warnings, 0 errors.
- Formatting: passed.
- `actionlint .github/workflows/ai-provider-canary.yml`: passed.
- Staged secret scans: no leaks.
- Security review: no critical/high open dependency alerts; no untrusted-trigger or secret-exposure path in the workflow.

The full local verifier completed skill sync, workspace hygiene, policy evidence, i18n, affected-package lint, and formatting successfully. Its unchanged web typecheck was stopped due local runtime; required GitHub CI remains the merge gate.

## Follow-ups

- Upstream the OpenAI open-object strictness fix and Anthropic native-tool discriminator as separate TanStack AI PRs.
- Replace the carried patches when fixed TanStack releases are adopted.
- If Stella needs a retention guarantee rather than the provider default, model that as a per-model catalogue capability; current OpenAI model generations do not share one portable retention field/value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated daily and on-demand checks for configured AI provider capabilities.
  * Added a command to run provider capability checks locally or in CI.
  * Added coverage reporting to confirm configured providers were tested.

* **Bug Fixes**
  * Improved compatibility of tool schemas with strict OpenAI requests.
  * Corrected handling of Anthropic web-search tools.
  * Improved prompt caching configuration portability.

* **Tests**
  * Expanded coverage across supported AI providers, tool conversion, schemas, and prompt caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->