### PR TITLE
feat: enforce API and CLI release compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,21 @@ jobs:
       - name: Test release-channel script
         run: bash scripts/release-channel.test.sh
 
+      # Release ordering and freshness are safety properties. These tests have
+      # no workspace dependencies, so they remain runnable when a PR changes
+      # only workflows and the dependency install above is intentionally skipped.
+      - name: Test release policy scripts
+        run: >-
+          bun test
+          scripts/check-api-deployment.test.ts
+          scripts/check-production-freshness.test.ts
+
+      - name: Test API and CLI contract invariants
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        run: >-
+          bun test --preload ./apps/api/src/tests/setup-env.ts
+          scripts/check-api-cli-contract.test.ts
+
       # Self-test the desktop-release skip decision. This script
       # decides whether prod desktop users get an update at all; a
       # regression either ships stale desktop builds or reintroduces

--- a/.github/workflows/production-freshness.yml
+++ b/.github/workflows/production-freshness.yml
@@ -1,0 +1,48 @@
+name: Production freshness
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      max_lag_commits:
+        description: Maximum number of commits production may trail main
+        default: "100"
+        required: true
+        type: string
+      max_lag_hours:
+        description: Maximum age of the oldest unreleased commit in hours
+        default: "168"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-freshness
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check production age and commit lag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Check production freshness
+        env:
+          MAX_PRODUCTION_LAG_COMMITS: ${{ inputs.max_lag_commits || '100' }}
+          MAX_PRODUCTION_LAG_HOURS: ${{ inputs.max_lag_hours || '168' }}
+          PRODUCTION_API_URL: https://api.stll.app
+        run: bun scripts/check-production-freshness.ts

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -64,17 +64,69 @@ on:
         type: string
 
 concurrency:
-  group: publish-npm-${{ github.event.workflow_run.head_sha || github.ref }}
+  group: publish-npm-${{ github.event.workflow_run.id || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  release-trigger:
+    name: Resolve release trigger
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      eligible: ${{ steps.source.outputs.eligible }}
+      release_ref: ${{ steps.source.outputs.release_ref }}
+      release_sha: ${{ steps.source.outputs.release_sha }}
+    steps:
+      - name: Resolve upstream release receipt
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != "workflow_run" ]]; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$UPSTREAM_CONCLUSION" != "success" ]]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          receipt_dir="${RUNNER_TEMP}/release-source-receipt"
+          gh run download "$UPSTREAM_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name release-source-receipt \
+            --dir "$receipt_dir"
+          receipt="${receipt_dir}/release-source-receipt.json"
+          release_ref="$(jq -er '.release_ref | strings' "$receipt")"
+          release_sha="$(jq -er '.release_sha | strings' "$receipt")"
+          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
+            echo "::error::Upstream release receipt has an invalid release_ref: ${release_ref}" >&2
+            exit 1
+          fi
+          if [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Upstream release receipt has an invalid release_sha." >&2
+            exit 1
+          fi
+
+          eligible=false
+          if [[ "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            eligible=true
+          fi
+          {
+            echo "eligible=${eligible}"
+            echo "release_ref=${release_ref}"
+            echo "release_sha=${release_sha}"
+          } >> "$GITHUB_OUTPUT"
+
   pack:
     name: Build and pack
-    if: >-
-      github.event_name != 'workflow_run'
-      || (github.event.workflow_run.conclusion == 'success'
-      && startsWith(github.event.workflow_run.head_branch, 'v')
-      && !contains(github.event.workflow_run.head_branch, '-'))
+    needs: release-trigger
+    if: ${{ needs.release-trigger.outputs.eligible == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # deliberately NO id-token: untrusted build scripts run here
@@ -89,7 +141,7 @@ jobs:
           MANUAL_PUBLISH: ${{ inputs.publish || false }}
           MANUAL_RELEASE_REF: ${{ inputs.release_ref || '' }}
           RUN_SHA: ${{ github.sha }}
-          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+          UPSTREAM_SHA: ${{ needs.release-trigger.outputs.release_sha }}
         run: |
           set -euo pipefail
           source_ref="$RUN_SHA"
@@ -179,7 +231,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           MANUAL_RELEASE_REF: ${{ inputs.release_ref || '' }}
-          UPSTREAM_RELEASE_REF: ${{ github.event.workflow_run.head_branch || '' }}
+          UPSTREAM_RELEASE_REF: ${{ needs.release-trigger.outputs.release_ref }}
         run: |
           set -euo pipefail
           release_ref="$MANUAL_RELEASE_REF"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -270,7 +270,7 @@ jobs:
           cd "${canary}"
           npm init -y >/dev/null
           npm install --ignore-scripts "${tgz}"
-          node_modules/@stll/cli/dist/cli.js compatibility check \
+          node node_modules/@stll/cli/dist/cli.js compatibility check \
             --server https://api.stll.app
 
       - name: Upload tarballs

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,9 +10,9 @@ name: Publish npm packages
 # Least privilege: packing and publishing are separate jobs. The `pack` job runs
 # the untrusted build (bun install, prepack, bun pm pack) with NO id-token, so a
 # compromised build/postinstall script cannot mint an OIDC credential. Only the
-# `publish` job — which just downloads the prebuilt tarballs and runs the
-# hardened action — is granted id-token: write, and it runs only from main when
-# auto-release or an explicit manual publish requests it.
+# `publish` job — which only verifies and publishes the prebuilt tarballs — is
+# granted id-token: write. CLI publication additionally requires the successful
+# stable-release proof; shared packages retain their main/manual flow.
 #
 # Prerequisite (one-time, per package, by a maintainer on npmjs.com): configure
 # an npm "trusted publisher" for each @stll/* package pointing at this repository
@@ -27,17 +27,21 @@ env:
   NODE_VERSION: "22"
   NPM_VERSION: "11.11.1"
 
+permissions: {}
+
 on:
-  # Auto-release: a version bump merged to main publishes that package. The
-  # hardened action is idempotent, so the packages you did not bump are
-  # packed but skipped (their version already exists on the registry).
+  # Shared libraries publish from their package-version bump. The CLI is
+  # deliberately excluded: it publishes only after a successful stable
+  # Release Artifacts run has promoted the corresponding API to production.
   push:
     branches: [main]
     paths:
       - packages/conditions/package.json
       - packages/template-conditions/package.json
       - packages/docx-utils/package.json
-      - packages/cli/package.json
+  workflow_run: # zizmor: ignore[dangerous-triggers] the release tag and SHA are revalidated before the publish job receives id-token
+    workflows: ["Release Artifacts"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       package:
@@ -54,21 +58,57 @@ on:
         description: Publish to npm (leave unchecked for a build + pack dry run)
         type: boolean
         default: false
+      release_ref:
+        description: Stable release tag already in production; required when manually publishing cli
+        required: false
+        type: string
 
 concurrency:
-  group: publish-npm-${{ github.ref }}
+  group: publish-npm-${{ github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: false
 
 jobs:
   pack:
     name: Build and pack
+    if: >-
+      github.event_name != 'workflow_run'
+      || (github.event.workflow_run.conclusion == 'success'
+      && startsWith(github.event.workflow_run.head_branch, 'v')
+      && !contains(github.event.workflow_run.head_branch, '-'))
     runs-on: ubuntu-latest
     permissions:
       contents: read # deliberately NO id-token: untrusted build scripts run here
     outputs:
       packages: ${{ steps.pack.outputs.packages }}
     steps:
+      - name: Resolve trusted source
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PACKAGE: ${{ inputs.package || '' }}
+          MANUAL_PUBLISH: ${{ inputs.publish || false }}
+          MANUAL_RELEASE_REF: ${{ inputs.release_ref || '' }}
+          RUN_SHA: ${{ github.sha }}
+          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+          source_ref="$RUN_SHA"
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            source_ref="$UPSTREAM_SHA"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$MANUAL_PUBLISH" == "true" && ( "$MANUAL_PACKAGE" == "cli" || "$MANUAL_PACKAGE" == "all" ) ]]; then
+            if [[ -z "$MANUAL_RELEASE_REF" ]]; then
+              echo "::error::release_ref is required to manually publish the CLI." >&2
+              exit 1
+            fi
+            source_ref="$MANUAL_RELEASE_REF"
+          fi
+          echo "ref=${source_ref}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ steps.source.outputs.ref }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
@@ -77,18 +117,25 @@ jobs:
       - name: Build and pack selected packages (dependency order)
         id: pack
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PACKAGE: ${{ inputs.package || 'all' }}
         run: |
           set -euo pipefail
-          # On push (auto-release) there is no input, so pack all and let the
-          # idempotent publish skip unchanged versions. conditions before
-          # template-conditions (which depends on it); docx-utils and cli are
-          # independent (cli has no workspace dependency on any other published
-          # package).
-          selected="${{ github.event_name == 'workflow_dispatch' && inputs.package || 'all' }}"
-          case "${selected}" in
-            all) pkgs=(conditions template-conditions docx-utils cli) ;;
-            *) pkgs=("${selected}") ;;
-          esac
+          # A completed stable release publishes only the CLI built from that
+          # release SHA. Ordinary main pushes publish shared libraries only, so
+          # an unpublished CLI bump cannot leak out through an unrelated package
+          # release. Manual dry-runs retain the explicit package selector.
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            pkgs=(cli)
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            pkgs=(conditions template-conditions docx-utils)
+          else
+            case "$MANUAL_PACKAGE" in
+              all) pkgs=(conditions template-conditions docx-utils cli) ;;
+              *) pkgs=("$MANUAL_PACKAGE") ;;
+            esac
+          fi
 
           # Build, then transform each package.json from its in-repo source
           # shape (exports -> ./src/*.ts) to the published dist shape
@@ -124,6 +171,53 @@ jobs:
           for p in "${pkgs[@]}"; do [ "${p}" = "cli" ] && cli_selected=true; done
           echo "cli=${cli_selected}" >> "${GITHUB_OUTPUT}"
 
+      - name: Validate CLI release source
+        id: release-source
+        if: >-
+          steps.pack.outputs.cli == 'true'
+          && (github.event_name == 'workflow_run' || inputs.publish)
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_RELEASE_REF: ${{ inputs.release_ref || '' }}
+          UPSTREAM_RELEASE_REF: ${{ github.event.workflow_run.head_branch || '' }}
+        run: |
+          set -euo pipefail
+          release_ref="$MANUAL_RELEASE_REF"
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            release_ref="$UPSTREAM_RELEASE_REF"
+          fi
+          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::CLI publication requires a stable vX.Y.Z release; got '${release_ref}'." >&2
+            exit 1
+          fi
+
+          # Resolve the tag namespace explicitly. A same-named branch must
+          # never influence source selection in a workflow that can mint npm
+          # provenance for a release artifact.
+          if git ls-remote --exit-code --heads origin "refs/heads/${release_ref}" >/dev/null 2>&1; then
+            echo "::error::A branch named ${release_ref} exists alongside the release tag; refusing ambiguous publication." >&2
+            exit 1
+          fi
+          git fetch --no-tags origin \
+            "refs/tags/${release_ref}:refs/tags/${release_ref}" \
+            main:refs/remotes/origin/main
+
+          source_sha="$(git rev-parse HEAD)"
+          release_sha="$(git rev-parse "refs/tags/${release_ref}^{commit}")"
+          if [[ "$source_sha" != "$release_sha" ]]; then
+            echo "::error::Checked-out source ${source_sha} does not match ${release_ref} (${release_sha})." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::${release_ref} is not reachable from protected main." >&2
+            exit 1
+          fi
+          if [[ "$(tr -d '[:space:]' < VERSION)" != "${release_ref#v}" ]]; then
+            echo "::error::VERSION does not match ${release_ref}." >&2
+            exit 1
+          fi
+          echo "expected_production_commit=${release_sha}" >> "$GITHUB_OUTPUT"
+
       # The CLI is the one published package with an executable entrypoint, and
       # it must run under plain Node (not Bun). Set up Node, install the packed
       # tarball into a throwaway project exactly as an external consumer would
@@ -137,7 +231,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Smoke-test the packed CLI under plain Node
+      - name: Smoke-test the packed CLI under plain Node # zizmor: ignore[adhoc-packages] intentionally installs the locally packed artifact as a consumer
         if: ${{ steps.pack.outputs.cli == 'true' }}
         shell: bash
         run: |
@@ -155,6 +249,30 @@ jobs:
           echo "Running: node ${cli} --help"
           node "${cli}" --help
 
+      - name: Wait for the corresponding API release in production
+        if: >-
+          steps.pack.outputs.cli == 'true'
+          && (github.event_name == 'workflow_run' || inputs.publish)
+        env:
+          API_DEPLOYMENT_EXPECTED_COMMIT: ${{ steps.release-source.outputs.expected_production_commit }}
+          API_DEPLOYMENT_URL: https://api.stll.app
+        run: bun scripts/check-api-deployment.ts
+
+      - name: Canary the exact packed CLI against production # zizmor: ignore[adhoc-packages] the exact local tarball is the canary subject
+        if: >-
+          steps.pack.outputs.cli == 'true'
+          && (github.event_name == 'workflow_run' || inputs.publish)
+        shell: bash
+        run: |
+          set -euo pipefail
+          tgz="$(ls "${GITHUB_WORKSPACE}/release-artifacts/cli"/*.tgz)"
+          canary="$(mktemp -d)"
+          cd "${canary}"
+          npm init -y >/dev/null
+          npm install --ignore-scripts "${tgz}"
+          node_modules/@stll/cli/dist/cli.js compatibility check \
+            --server https://api.stll.app
+
       - name: Upload tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -166,9 +284,14 @@ jobs:
   publish:
     name: Publish @stll/${{ matrix.package }}
     needs: pack
-    # Auto-publish only from main: a version-bump push to main, or a manual
-    # dispatch from main with the publish checkbox ticked.
-    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish) }}
+    # Shared packages publish only from main. CLI packages publish only after a
+    # successful stable release, or a recovery dispatch from main that passes
+    # the identical stable-tag, deployed-commit, and canary checks.
+    if: >-
+      needs.pack.result == 'success'
+      && (github.event_name == 'workflow_run'
+      || (github.ref == 'refs/heads/main'
+      && (github.event_name == 'push' || inputs.publish)))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -190,11 +313,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
 
-      - name: Install npm for trusted publishing
+      - name: Install npm for trusted publishing # zizmor: ignore[adhoc-packages] exact npm version is pinned below
         # --ignore-scripts: this job holds id-token: write, so do not run any
         # lifecycle hooks from the fetched npm package before the hardened
         # publish step (npm itself needs none to run).
-        run: npm install --global --ignore-scripts "npm@${{ env.NPM_VERSION }}"
+        env:
+          NPM_VERSION_TO_INSTALL: ${{ env.NPM_VERSION }}
+        run: npm install --global --ignore-scripts "npm@${NPM_VERSION_TO_INSTALL}"
 
       - name: Download tarballs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -202,12 +327,17 @@ jobs:
           name: npm-tarballs
           path: release-artifacts/
 
+      - name: Verify canaried tarball integrity
+        run: sha256sum --check release-artifacts/SHA256SUMS
+
       - name: Resolve tarball path
         id: tarball
         shell: bash
+        env:
+          PACKAGE_NAME: ${{ matrix.package }}
         run: |
           set -euo pipefail
-          tgz="$(ls "release-artifacts/${{ matrix.package }}"/*.tgz)"
+          tgz="$(ls "release-artifacts/${PACKAGE_NAME}"/*.tgz)"
           echo "path=${tgz}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,25 @@ jobs:
             exit 1
           fi
 
+      - name: Write trusted release receipt
+        env:
+          RELEASE_REF: ${{ steps.release.outputs.ref }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          jq -n \
+            --arg release_ref "$RELEASE_REF" \
+            --arg release_sha "$RELEASE_SHA" \
+            '{release_ref: $release_ref, release_sha: $release_sha}' \
+            > release-source-receipt.json
+
+      - name: Upload trusted release receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-source-receipt
+          path: release-source-receipt.json
+          retention-days: 1
+          if-no-files-found: error
+
   smoke:
     name: Build and smoke test API image
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,7 +505,9 @@ jobs:
     # carrying a prerelease label (vX.Y.Z-anything) publishes the
     # artifact and is handled by `promote-staging` below.
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Infra promotion can consume most of the old 30-minute budget; retain
+    # headroom for the exact-commit verification that gates CLI publication.
+    timeout-minutes: 40
     needs: [resolve, manifest, smoke]
     if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
     permissions:
@@ -582,6 +584,24 @@ jobs:
             --repo "$INFRA_REPO" \
             --compact \
             --exit-status
+
+      - name: Checkout release verification script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+          no-cache: true
+
+      - name: Verify production serves the release commit
+        env:
+          API_DEPLOYMENT_EXPECTED_COMMIT: ${{ needs.resolve.outputs.release_sha }}
+          API_DEPLOYMENT_URL: https://api.stll.app
+        run: bun scripts/check-api-deployment.ts
 
   promote-staging:
     # Auto-promote release-candidate tags (vX.Y.Z-rc.N) to staging.

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -55,6 +55,10 @@ beforeAll(
       // oxlint-disable-next-line no-await-in-loop -- DDL statements must apply in emitted order (deterministic test schema setup)
       await db.execute(sql.raw(statement));
     }
+    // Calendar-only decision dates are UTC midnights in the TypeScript
+    // reference implementation. A non-UTC database session must produce the
+    // same score instead of applying its local offset during the implicit cast.
+    await db.execute(sql.raw("SET TIME ZONE 'Europe/Prague'"));
 
     await db.insert(caseLawSources).values({
       id: sourceId,

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -74,7 +74,12 @@ export const recomputeCitationAuthorityForAll = async (
       citation_authority = ln(1 + (
         agg.raw_sum / GREATEST(
           COALESCE(
-            extract(epoch FROM (${nowExpr} - d.decision_date)) / ${SECONDS_PER_YEAR},
+            extract(
+              epoch FROM (
+                ${nowExpr}
+                - (d.decision_date::timestamp AT TIME ZONE 'UTC')
+              )
+            ) / ${SECONDS_PER_YEAR},
             1.0
           ),
           1.0
@@ -89,7 +94,12 @@ export const recomputeCitationAuthorityForAll = async (
           CASE WHEN c.id IS NULL THEN 0 ELSE
             (${courtWeightExpr})
             * (1.0 / (1 + COALESCE(
-                extract(epoch FROM (${nowExpr} - citing_d.decision_date))
+                extract(
+                  epoch FROM (
+                    ${nowExpr}
+                    - (citing_d.decision_date::timestamp AT TIME ZONE 'UTC')
+                  )
+                )
                   / ${SECONDS_PER_YEAR},
                 1.0
               )))

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -404,7 +404,7 @@ describe("runSandbox", () => {
       registry: baseRegistry,
       limits: {
         maxStackBytes: 32 * 1024,
-        maxDurationMs: 1000,
+        maxDurationMs: 5000,
       },
     });
 

--- a/apps/api/src/handlers/mcp/routes.test.ts
+++ b/apps/api/src/handlers/mcp/routes.test.ts
@@ -7,6 +7,9 @@ import {
   MCP_DISCOVERY_PATH,
   MCP_HTTP_PATH,
   ROOT_MCP_DISCOVERY_PATH,
+  STELLA_CLI_MAXIMUM_VERSION,
+  STELLA_CLI_MINIMUM_VERSION,
+  STELLA_MCP_API_CONTRACT_VERSION,
 } from "@/api/mcp/constants";
 import { getMcpProtectedResourceMetadata } from "@/api/mcp/metadata";
 
@@ -29,7 +32,22 @@ describe("MCP protected resource discovery routes", () => {
   };
 
   test("serves protected resource metadata from the canonical path", async () => {
-    await assertMetadataResponse(MCP_DISCOVERY_PATH);
+    const response = await mcpRoute.handle(
+      new Request(`http://localhost${MCP_DISCOVERY_PATH}`),
+    );
+    const metadata = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(metadata).toMatchObject({
+      scopes_supported: expect.arrayContaining(["stella:read"]),
+      stella_compatibility: {
+        api_contract_version: STELLA_MCP_API_CONTRACT_VERSION,
+        cli_version: {
+          maximum: STELLA_CLI_MAXIMUM_VERSION,
+          minimum: STELLA_CLI_MINIMUM_VERSION,
+        },
+      },
+    });
   });
 
   test("serves protected resource metadata from the root compatibility path", async () => {

--- a/apps/api/src/handlers/uploads/entity-create.test.ts
+++ b/apps/api/src/handlers/uploads/entity-create.test.ts
@@ -1,6 +1,6 @@
 import { Result } from "better-result";
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
-import { eq, TransactionRollbackError } from "drizzle-orm";
+import { eq, sql, TransactionRollbackError } from "drizzle-orm";
 
 import { organization, user } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
@@ -42,9 +42,12 @@ const SHA_256_HEX = "a".repeat(64);
 
 let testDb: TestDatabase;
 
-beforeAll(async () => {
-  testDb = await getTestDb();
-});
+beforeAll(
+  async () => {
+    testDb = await getTestDb();
+  },
+  { timeout: 30_000 },
+);
 
 afterAll(async () => {
   await releaseTestDb();
@@ -161,6 +164,7 @@ const runRolledBack = async <T>(
   let value: T | undefined;
   try {
     await testDb.transaction(async (tx) => {
+      await tx.execute(sql.raw("RESET ROLE"));
       // oxlint-disable-next-line node/callback-return -- must call tx.rollback() after capturing the value
       value = await callback(tx);
       tx.rollback();
@@ -455,13 +459,13 @@ describe("entity-create presigned upload validation", () => {
     const result = await runRolledBack(async (tx) => {
       const seeded = await seedWorkspace(tx);
       const currentUploadId = toSafeId<"pendingUpload">(Bun.randomUUIDv7());
-      const now = new Date();
-      const future = new Date(now.getTime() + 60_000);
-      const past = new Date(now.getTime() - 60_000);
-      const recentClaim = new Date(now.getTime() - 1000);
-      const staleClaim = new Date(
-        now.getTime() - FINALIZE_CLAIM_TIMEOUT_MS - 1000,
-      );
+      const future = sql<Date>`NOW() + interval '1 minute'`;
+      const past = sql<Date>`NOW() - interval '1 minute'`;
+      const recentClaim = sql<Date>`NOW() - interval '1 second'`;
+      const staleClaimSeconds =
+        Math.floor(FINALIZE_CLAIM_TIMEOUT_MS / 1000) + 1;
+      const staleClaim = sql<Date>`NOW() - ${staleClaimSeconds} * interval '1 second'`;
+      const createdAt = sql<Date>`NOW()`;
 
       await tx.insert(pendingUploads).values([
         {
@@ -480,7 +484,7 @@ describe("entity-create presigned upload validation", () => {
           declaredSha256: SHA_256_HEX,
           status: "pending",
           expiresAt: future,
-          createdAt: now,
+          createdAt,
         },
         {
           id: toSafeId<"pendingUpload">(Bun.randomUUIDv7()),
@@ -499,7 +503,7 @@ describe("entity-create presigned upload validation", () => {
           status: "failed",
           expiresAt: future,
           claimedAt: recentClaim,
-          createdAt: now,
+          createdAt,
         },
         {
           id: toSafeId<"pendingUpload">(Bun.randomUUIDv7()),
@@ -518,7 +522,7 @@ describe("entity-create presigned upload validation", () => {
           status: "scanning",
           expiresAt: past,
           claimedAt: recentClaim,
-          createdAt: now,
+          createdAt,
         },
         {
           id: currentUploadId,
@@ -536,7 +540,7 @@ describe("entity-create presigned upload validation", () => {
           declaredSha256: SHA_256_HEX,
           status: "pending",
           expiresAt: future,
-          createdAt: now,
+          createdAt,
         },
         {
           id: toSafeId<"pendingUpload">(Bun.randomUUIDv7()),
@@ -554,7 +558,7 @@ describe("entity-create presigned upload validation", () => {
           declaredSha256: SHA_256_HEX,
           status: "pending",
           expiresAt: past,
-          createdAt: now,
+          createdAt,
         },
         {
           id: toSafeId<"pendingUpload">(Bun.randomUUIDv7()),
@@ -573,7 +577,7 @@ describe("entity-create presigned upload validation", () => {
           status: "scanning",
           expiresAt: past,
           claimedAt: staleClaim,
-          createdAt: now,
+          createdAt,
         },
         {
           id: toSafeId<"pendingUpload">(Bun.randomUUIDv7()),
@@ -591,7 +595,7 @@ describe("entity-create presigned upload validation", () => {
           declaredSha256: SHA_256_HEX,
           status: "pending",
           expiresAt: future,
-          createdAt: now,
+          createdAt,
         },
       ]);
 

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, mock, test, vi } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { createAuthRateLimitStorage } from "@/api/lib/rate-limit/auth-storage";
 
 // A controllable fake of Bun's RedisClient: `redisDown` toggles whether
 // get/set reject, simulating an unreachable Redis without real I/O.
@@ -30,7 +32,12 @@ class FakeRedisClient {
     return this.maybeDelay(redisStore.get(key) ?? null);
   }
 
-  async set(key: string, value: string): Promise<"OK"> {
+  async set(
+    key: string,
+    value: string,
+    _expiryMode: "PX",
+    _ttlMs: number,
+  ): Promise<"OK"> {
     if (redisDown) {
       throw new Error("redis unreachable");
     }
@@ -39,12 +46,8 @@ class FakeRedisClient {
   }
 }
 
-void mock.module("@/api/lib/redis-client", () => ({
-  createRedisClient: () => new FakeRedisClient(),
-}));
-
-const { createAuthRateLimitStorage } =
-  await import("@/api/lib/rate-limit/auth-storage");
+const createStorage = () =>
+  createAuthRateLimitStorage(60_000, { redis: new FakeRedisClient() });
 
 const value = (count: number, lastRequest = 1000) => ({
   key: "ip:1.2.3.4",
@@ -60,7 +63,7 @@ describe("auth rate-limit storage", () => {
   });
 
   test("round-trips through Redis when it is reachable", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
 
     await storage.set("ip:1.2.3.4", value(3));
 
@@ -68,13 +71,13 @@ describe("auth rate-limit storage", () => {
   });
 
   test("returns null for an unknown key", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
 
     expect(await storage.get("ip:9.9.9.9")).toBeNull();
   });
 
   test("fails open: a get after Redis goes down reads the fallback", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
 
     // A successful set warms both Redis and the in-memory fallback.
     await storage.set("ip:1.2.3.4", value(5));
@@ -86,7 +89,7 @@ describe("auth rate-limit storage", () => {
   });
 
   test("fails open: set never throws when Redis is down", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
     redisDown = true;
 
     // set must resolve (not reject) even though the Redis write fails.
@@ -97,7 +100,7 @@ describe("auth rate-limit storage", () => {
   });
 
   test("falls back when Redis is reachable but missing a warmed key", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
     redisDown = true;
 
     await storage.set("ip:1.2.3.4", value(4));
@@ -107,7 +110,7 @@ describe("auth rate-limit storage", () => {
   });
 
   test("stores fallback values as snapshots", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
     const counter = value(7);
 
     await storage.set("ip:1.2.3.4", counter);
@@ -118,7 +121,7 @@ describe("auth rate-limit storage", () => {
   });
 
   test("keeps the stricter fallback counter when Redis has stale data", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
 
     await storage.set("ip:1.2.3.4", value(5, 1000));
     redisDown = true;
@@ -132,7 +135,7 @@ describe("auth rate-limit storage", () => {
   });
 
   test("fails open when a Redis command hangs past the timeout", async () => {
-    const storage = createAuthRateLimitStorage(60_000);
+    const storage = createStorage();
 
     // Warm the fallback.
     await storage.set("ip:1.2.3.4", value(8));
@@ -152,17 +155,23 @@ describe("auth rate-limit storage", () => {
   });
 
   test("clears command timeout timers after Redis resolves", async () => {
-    vi.useFakeTimers();
-    try {
-      const storage = createAuthRateLimitStorage(60_000);
-      const baselineTimers = vi.getTimerCount();
+    let activeTimerCount = 0;
+    const storage = createAuthRateLimitStorage(60_000, {
+      redis: new FakeRedisClient(),
+      commandTimer: {
+        set: (callback, delayMs) => {
+          activeTimerCount += 1;
+          return setTimeout(callback, delayMs);
+        },
+        clear: (timeoutId) => {
+          clearTimeout(timeoutId);
+          activeTimerCount -= 1;
+        },
+      },
+    });
 
-      await storage.set("ip:1.2.3.4", value(9));
+    await storage.set("ip:1.2.3.4", value(9));
 
-      expect(vi.getTimerCount()).toBe(baselineTimers);
-    } finally {
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
+    expect(activeTimerCount).toBe(0);
   });
 });

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -25,6 +25,26 @@ type AuthRateLimitStorage = {
   set: (key: string, value: RateLimitValue) => Promise<void>;
 };
 
+type AuthRateLimitRedisClient = {
+  get: (key: string) => Promise<string | null>;
+  set: (
+    key: string,
+    value: string,
+    expiryMode: "PX",
+    ttlMs: number,
+  ) => Promise<unknown>;
+};
+
+type CommandTimer = {
+  set: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clear: (timeoutId: ReturnType<typeof setTimeout>) => void;
+};
+
+type AuthRateLimitStorageOptions = {
+  redis?: AuthRateLimitRedisClient;
+  commandTimer?: CommandTimer;
+};
+
 const REDIS_KEY_PREFIX = "auth:ratelimit:";
 const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
 /**
@@ -34,6 +54,10 @@ const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
  * if it does not resolve in time.
  */
 const COMMAND_TIMEOUT_MS = 500;
+const DEFAULT_COMMAND_TIMER: CommandTimer = {
+  set: (callback, delayMs) => setTimeout(callback, delayMs),
+  clear: (timeoutId) => clearTimeout(timeoutId),
+};
 
 const isRateLimitValue = (value: unknown): value is RateLimitValue =>
   typeof value === "object" &&
@@ -53,17 +77,20 @@ const isStricterRateLimitValue = (
   (candidate.count === current.count &&
     candidate.lastRequest > current.lastRequest);
 
-const withCommandTimeout = async <T>(promise: Promise<T>): Promise<T> => {
+const withCommandTimeout = async <T>(
+  promise: Promise<T>,
+  commandTimer: CommandTimer,
+): Promise<T> => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(
+    timeoutId = commandTimer.set(
       () => reject(new Error("redis command timeout")),
       COMMAND_TIMEOUT_MS,
     );
   });
   return await Promise.race([promise, timeout]).finally(() => {
     if (timeoutId) {
-      clearTimeout(timeoutId);
+      commandTimer.clear(timeoutId);
     }
   });
 };
@@ -74,11 +101,15 @@ const withCommandTimeout = async <T>(promise: Promise<T>): Promise<T> => {
  */
 export const createAuthRateLimitStorage = (
   ttlMs: number,
+  options: AuthRateLimitStorageOptions = {},
 ): AuthRateLimitStorage => {
-  const redis = createRedisClient({
-    connectionTimeout: COMMAND_TIMEOUT_MS,
-    enableOfflineQueue: false,
-  });
+  const redis =
+    options.redis ??
+    createRedisClient({
+      connectionTimeout: COMMAND_TIMEOUT_MS,
+      enableOfflineQueue: false,
+    });
+  const commandTimer = options.commandTimer ?? DEFAULT_COMMAND_TIMER;
   // Bun's RedisClient surfaces connection loss via the onclose callback
   // and exposes errors through rejected commands. Leaving onclose unset
   // is safe; per-command rejections drive the fail-open path below.
@@ -111,6 +142,7 @@ export const createAuthRateLimitStorage = (
         "PX",
         ttlMs,
       ),
+      commandTimer,
     );
   };
 
@@ -120,6 +152,7 @@ export const createAuthRateLimitStorage = (
         const fallbackValue = readFallback(key);
         const raw = await withCommandTimeout(
           redis.get(`${REDIS_KEY_PREFIX}${key}`),
+          commandTimer,
         );
         if (raw === null) {
           return fallbackValue;

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -1,3 +1,4 @@
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 /**
  * Redis-backed storage for better-auth's rate limiter.
  *
@@ -84,7 +85,14 @@ const withCommandTimeout = async <T>(
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
     timeoutId = commandTimer.set(
-      () => reject(new Error("redis command timeout")),
+      () =>
+        reject(
+          new TimeoutError({
+            label: "auth-rate-limit-redis-command",
+            message: "Redis command timed out",
+            timeoutMs: COMMAND_TIMEOUT_MS,
+          }),
+        ),
       COMMAND_TIMEOUT_MS,
     );
   });

--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -68,16 +68,28 @@ export const MCP_ALLOWED_HEADERS = [
   "MCP-Protocol-Version",
 ] as const;
 
+// Public compatibility contract advertised by protected-resource discovery.
+// Deploy support for a CLI version before publishing it: the production
+// canary checks these inclusive bounds against the exact packed CLI version.
+export const STELLA_MCP_API_CONTRACT_VERSION = 1;
+export const STELLA_CLI_MINIMUM_VERSION = "0.2.0";
+export const STELLA_CLI_MAXIMUM_VERSION = "0.2.0";
+export const STELLA_MCP_API_CONTRACT_HEADER = "x-stella-api-contract-version";
+export const STELLA_CLI_MINIMUM_HEADER = "x-stella-cli-minimum";
+
 // Feeds the @stll/cli update nudge: the CLI reads `x-stella-cli-latest` off its
 // runtime `tools/list` fetch and, if this is newer than the running CLI, prints
-// one stderr hint. Bump this line when publishing a new @stll/cli. The header
-// name is mirrored (by design, no shared module) in
-// `packages/cli/src/cli-version-nudge.ts`.
+// one stderr hint. Keep this at the latest version already published to npm;
+// the maximum may move ahead in the API release that deliberately precedes a
+// CLI publication. The header name is mirrored (by design, no shared module)
+// in `packages/cli/src/cli-version-nudge.ts`.
 export const STELLA_CLI_LATEST_VERSION = "0.2.0";
 export const STELLA_CLI_LATEST_HEADER = "x-stella-cli-latest";
 
 export const MCP_EXPOSE_HEADERS = [
   "WWW-Authenticate",
+  STELLA_MCP_API_CONTRACT_HEADER,
+  STELLA_CLI_MINIMUM_HEADER,
   STELLA_CLI_LATEST_HEADER,
   // The per-request receipt (also on the global CORS exposeHeaders list):
   // browser-based MCP clients correlate a failed/successful call with server

--- a/apps/api/src/mcp/metadata.test.ts
+++ b/apps/api/src/mcp/metadata.test.ts
@@ -6,6 +6,10 @@ import {
   MCP_DEFAULT_RESOURCE_SCOPES,
   getMcpProtectedResourceMetadataUrl,
   getMcpResourceUrl,
+  STELLA_CLI_LATEST_VERSION,
+  STELLA_CLI_MAXIMUM_VERSION,
+  STELLA_CLI_MINIMUM_VERSION,
+  STELLA_MCP_API_CONTRACT_VERSION,
 } from "@/api/mcp/constants";
 import {
   createMcpCorsHeaders,
@@ -21,6 +25,13 @@ describe("MCP protected resource metadata", () => {
       bearer_methods_supported: ["header"],
       resource: getMcpResourceUrl(),
       scopes_supported: [...MCP_DEFAULT_RESOURCE_SCOPES],
+      stella_compatibility: {
+        api_contract_version: STELLA_MCP_API_CONTRACT_VERSION,
+        cli_version: {
+          maximum: STELLA_CLI_MAXIMUM_VERSION,
+          minimum: STELLA_CLI_MINIMUM_VERSION,
+        },
+      },
     });
   });
 
@@ -30,6 +41,13 @@ describe("MCP protected resource metadata", () => {
       bearer_methods_supported: ["header"],
       resource: getMcpResourceUrl("anonymized"),
       scopes_supported: [...MCP_ANONYMIZED_RESOURCE_SCOPES],
+      stella_compatibility: {
+        api_contract_version: STELLA_MCP_API_CONTRACT_VERSION,
+        cli_version: {
+          maximum: STELLA_CLI_MAXIMUM_VERSION,
+          minimum: STELLA_CLI_MINIMUM_VERSION,
+        },
+      },
     });
   });
 
@@ -42,8 +60,13 @@ describe("MCP protected resource metadata", () => {
       "Authorization, Content-Type, MCP-Protocol-Version",
     );
     expect(headers.get("Access-Control-Expose-Headers")).toBe(
-      "WWW-Authenticate, x-stella-cli-latest, x-request-id",
+      "WWW-Authenticate, x-stella-api-contract-version, x-stella-cli-minimum, x-stella-cli-latest, x-request-id",
     );
+    expect(headers.get("x-stella-api-contract-version")).toBe("1");
+    expect(headers.get("x-stella-cli-minimum")).toBe(
+      STELLA_CLI_MINIMUM_VERSION,
+    );
+    expect(headers.get("x-stella-cli-latest")).toBe(STELLA_CLI_LATEST_VERSION);
   });
 
   test("returns browser-friendly MCP transport headers", () => {
@@ -53,6 +76,11 @@ describe("MCP protected resource metadata", () => {
     expect(headers.get("Access-Control-Allow-Methods")).toBe(
       "GET, POST, DELETE, OPTIONS",
     );
+    expect(headers.get("x-stella-api-contract-version")).toBe("1");
+    expect(headers.get("x-stella-cli-minimum")).toBe(
+      STELLA_CLI_MINIMUM_VERSION,
+    );
+    expect(headers.get("x-stella-cli-latest")).toBe(STELLA_CLI_LATEST_VERSION);
   });
 
   test("points WWW-Authenticate at the path-specific protected resource metadata URL", () => {

--- a/apps/api/src/mcp/metadata.ts
+++ b/apps/api/src/mcp/metadata.ts
@@ -6,6 +6,13 @@ import {
   getMcpResourceUrl,
   MCP_ALLOWED_HEADERS,
   MCP_EXPOSE_HEADERS,
+  STELLA_CLI_LATEST_HEADER,
+  STELLA_CLI_LATEST_VERSION,
+  STELLA_CLI_MAXIMUM_VERSION,
+  STELLA_CLI_MINIMUM_HEADER,
+  STELLA_CLI_MINIMUM_VERSION,
+  STELLA_MCP_API_CONTRACT_HEADER,
+  STELLA_MCP_API_CONTRACT_VERSION,
 } from "@/api/mcp/constants";
 
 export const createMcpMetadataHeaders = () =>
@@ -15,6 +22,9 @@ export const createMcpMetadataHeaders = () =>
     "Access-Control-Allow-Headers": MCP_ALLOWED_HEADERS.join(", "),
     "Access-Control-Expose-Headers": MCP_EXPOSE_HEADERS.join(", "),
     "Cache-Control": "public, max-age=300",
+    [STELLA_MCP_API_CONTRACT_HEADER]: String(STELLA_MCP_API_CONTRACT_VERSION),
+    [STELLA_CLI_MINIMUM_HEADER]: STELLA_CLI_MINIMUM_VERSION,
+    [STELLA_CLI_LATEST_HEADER]: STELLA_CLI_LATEST_VERSION,
   });
 
 export const createMcpCorsHeaders = () =>
@@ -24,6 +34,9 @@ export const createMcpCorsHeaders = () =>
     "Access-Control-Allow-Headers": MCP_ALLOWED_HEADERS.join(", "),
     "Access-Control-Expose-Headers": MCP_EXPOSE_HEADERS.join(", "),
     "Access-Control-Max-Age": "86400",
+    [STELLA_MCP_API_CONTRACT_HEADER]: String(STELLA_MCP_API_CONTRACT_VERSION),
+    [STELLA_CLI_MINIMUM_HEADER]: STELLA_CLI_MINIMUM_VERSION,
+    [STELLA_CLI_LATEST_HEADER]: STELLA_CLI_LATEST_VERSION,
   });
 
 export const getMcpProtectedResourceMetadata = (mode: McpMode = "default") => ({
@@ -31,6 +44,16 @@ export const getMcpProtectedResourceMetadata = (mode: McpMode = "default") => ({
   authorization_servers: [getAuthIssuerUrl()],
   scopes_supported: [...getMcpResourceScopes(mode)],
   bearer_methods_supported: ["header"],
+  // RFC 9728 permits additional protected-resource metadata parameters and
+  // requires clients to ignore ones they do not understand. Keeping Stella's
+  // release contract in one extension preserves the standard OAuth fields.
+  stella_compatibility: {
+    api_contract_version: STELLA_MCP_API_CONTRACT_VERSION,
+    cli_version: {
+      minimum: STELLA_CLI_MINIMUM_VERSION,
+      maximum: STELLA_CLI_MAXIMUM_VERSION,
+    },
+  },
 });
 
 export const getMcpWwwAuthenticateHeader = (mode: McpMode = "default") =>

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -14,11 +14,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import type { McpSession } from "@/api/mcp/auth";
-import {
-  STELLA_CLI_LATEST_HEADER,
-  STELLA_CLI_LATEST_VERSION,
-  type McpMode,
-} from "@/api/mcp/constants";
+import type { McpMode } from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   McpAuthenticationError,
@@ -104,10 +100,6 @@ const withMcpCors = (response: Response) => {
       headers.set(key, value);
     }
   }
-  // Rides on every MCP response (incl. the CLI's tools/list fetch) to feed the
-  // @stll/cli update nudge; never touches the JSON-RPC payload.
-  headers.set(STELLA_CLI_LATEST_HEADER, STELLA_CLI_LATEST_VERSION);
-
   return new Response(response.body, {
     headers,
     status: response.status,

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -6,7 +6,11 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { STELLA_CLI_LATEST_VERSION } from "@/api/mcp/constants";
+import {
+  STELLA_CLI_LATEST_VERSION,
+  STELLA_CLI_MINIMUM_VERSION,
+  STELLA_MCP_API_CONTRACT_VERSION,
+} from "@/api/mcp/constants";
 import {
   McpAuthenticationError,
   McpOrganizationAccessError,
@@ -220,7 +224,14 @@ describe("handleMcpHttpRequest", () => {
     expect(body.result.tools.map((tool) => tool.name)).toEqual([
       "list_matters",
     ]);
-    // The response carries the CLI update-nudge header (spec 051 addendum).
+    // Every transport response carries the same release contract as public
+    // discovery, so an authenticated CLI can warn about incompatibility too.
+    expect(response.headers.get("x-stella-api-contract-version")).toBe(
+      String(STELLA_MCP_API_CONTRACT_VERSION),
+    );
+    expect(response.headers.get("x-stella-cli-minimum")).toBe(
+      STELLA_CLI_MINIMUM_VERSION,
+    );
     expect(response.headers.get("x-stella-cli-latest")).toBe(
       STELLA_CLI_LATEST_VERSION,
     );

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -41,10 +41,13 @@ const privilegesForTable = (
     .map((p) => p.privilege)
     .sort();
 
-beforeAll(async () => {
-  const fixture = await getRlsFixture();
-  testDb = fixture.testDb;
-});
+beforeAll(
+  async () => {
+    const fixture = await getRlsFixture();
+    testDb = fixture.testDb;
+  },
+  { timeout: 30_000 },
+);
 
 afterAll(async () => {
   await releaseRlsFixture();

--- a/apps/api/src/tests/security/rls-fixture.ts
+++ b/apps/api/src/tests/security/rls-fixture.ts
@@ -25,7 +25,8 @@ type RlsFixture = {
 };
 
 let fixturePromise: Promise<RlsFixture> | null = null;
-let refCount = 0;
+let fixtureReleasePromise = Promise.resolve();
+let fixtureRefCount = 0;
 
 const initFixture = async (): Promise<RlsFixture> => {
   const testDb = await getTestDb();
@@ -42,22 +43,29 @@ const initFixture = async (): Promise<RlsFixture> => {
  * promise.
  */
 export const getRlsFixture = async (): Promise<RlsFixture> => {
-  refCount++;
-
-  fixturePromise ??= initFixture();
+  fixtureRefCount += 1;
+  fixturePromise ??= fixtureReleasePromise.then(initFixture);
 
   return await fixturePromise;
 };
 
 /**
- * Release the shared RLS fixture. When the last consumer
- * releases, the underlying PGlite instance ref is released.
+ * Release the shared RLS fixture. Serialize teardown with later acquisition
+ * so the next fixture cannot reuse a database client that is still closing.
  */
 export const releaseRlsFixture = async (): Promise<void> => {
-  refCount--;
-  if (refCount <= 0 && fixturePromise) {
-    fixturePromise = null;
-    refCount = 0;
-    await releaseTestDb();
+  fixtureRefCount -= 1;
+  if (fixtureRefCount > 0 || !fixturePromise) {
+    return;
   }
+
+  const releasedFixturePromise = fixturePromise;
+  fixturePromise = null;
+  fixtureRefCount = 0;
+  fixtureReleasePromise = fixtureReleasePromise.then(async () => {
+    await releasedFixturePromise;
+    await releaseTestDb();
+    return undefined;
+  });
+  await fixtureReleasePromise;
 };

--- a/apps/api/src/tests/security/rls-fixture.ts
+++ b/apps/api/src/tests/security/rls-fixture.ts
@@ -62,10 +62,19 @@ export const releaseRlsFixture = async (): Promise<void> => {
   const releasedFixturePromise = fixturePromise;
   fixturePromise = null;
   fixtureRefCount = 0;
-  fixtureReleasePromise = fixtureReleasePromise.then(async () => {
-    await releasedFixturePromise;
-    await releaseTestDb();
-    return undefined;
-  });
-  await fixtureReleasePromise;
+  const previousReleasePromise = fixtureReleasePromise;
+  const releasePromise = (async () => {
+    await previousReleasePromise;
+    try {
+      await releasedFixturePromise;
+    } finally {
+      // initFixture acquires the shared DB before it seeds RLS data. Release
+      // that reference even when seeding fails.
+      await releaseTestDb();
+    }
+  })();
+  // Keep the current failure visible while allowing future test files to
+  // create a fresh fixture rather than inheriting a rejected teardown chain.
+  fixtureReleasePromise = releasePromise.catch(() => undefined);
+  await releasePromise;
 };

--- a/apps/api/src/tests/security/rls-scoped-db.test.ts
+++ b/apps/api/src/tests/security/rls-scoped-db.test.ts
@@ -30,7 +30,7 @@ const otherPersonalWorkspaceId = createSafeId<"workspace">();
 const scopedAuthorizationLifetimeWorkspaceId = createSafeId<"workspace">();
 const safeAuthorizationLifetimeWorkspaceId = createSafeId<"workspace">();
 
-beforeAll(async () => {
+const setupRlsScopedDb = async () => {
   const fixture = await getRlsFixture();
   testDb = fixture.testDb;
   ids = fixture.ids;
@@ -93,7 +93,9 @@ beforeAll(async () => {
       userId: ids.userA2,
     },
   ]);
-});
+};
+
+beforeAll(setupRlsScopedDb, { timeout: 30_000 });
 
 afterAll(async () => {
   await releaseRlsFixture();

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -257,12 +257,15 @@ export const releaseTestDb = async (): Promise<void> => {
   const closingDbPromise = dbPromise;
   dbPromise = null;
   dbRefCount = 0;
-  dbClosePromise = dbClosePromise.then(async () => {
+  const closePromise = dbClosePromise.then(async () => {
     const testDb = await closingDbPromise;
     await testDb.$client.close();
     return undefined;
   });
-  await dbClosePromise;
+  // Preserve the failure for this release call, but recover the shared chain
+  // so one failed initialization or close cannot poison every later test.
+  dbClosePromise = closePromise.catch(() => undefined);
+  await closePromise;
 };
 
 export const createScopedQuery = (testDb: TestDatabase) => {

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -228,6 +228,7 @@ const DEFAULT_TEST_USER_ID = toSafeId<"user">("user_test");
 // across all test files that need one.
 
 let dbPromise: Promise<TestDatabase> | null = null;
+let dbClosePromise = Promise.resolve();
 let dbRefCount = 0;
 
 /**
@@ -236,25 +237,32 @@ let dbRefCount = 0;
  * same promise.
  */
 export const getTestDb = async (): Promise<TestDatabase> => {
-  dbRefCount++;
-
-  dbPromise ??= createTestDb();
+  dbRefCount += 1;
+  dbPromise ??= dbClosePromise.then(createTestDb);
 
   return await dbPromise;
 };
 
 /**
- * Release the shared test database. When the last consumer
- * releases, the PGlite instance is closed.
+ * Release the shared test database. Detach the closing instance before the
+ * asynchronous close starts; a later acquisition then waits for that close
+ * before creating a replacement instead of receiving a closing client.
  */
 export const releaseTestDb = async (): Promise<void> => {
-  dbRefCount--;
-  if (dbRefCount <= 0 && dbPromise) {
-    const testDb = await dbPromise;
-    await testDb.$client.close();
-    dbPromise = null;
-    dbRefCount = 0;
+  dbRefCount -= 1;
+  if (dbRefCount > 0 || !dbPromise) {
+    return;
   }
+
+  const closingDbPromise = dbPromise;
+  dbPromise = null;
+  dbRefCount = 0;
+  dbClosePromise = dbClosePromise.then(async () => {
+    const testDb = await closingDbPromise;
+    await testDb.$client.close();
+    return undefined;
+  });
+  await dbClosePromise;
 };
 
 export const createScopedQuery = (testDb: TestDatabase) => {

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -53,10 +53,55 @@ should lag the release that stopped using the old data.
 
    For RCs, use matching values such as `VERSION=1.2.3-rc.1` and
    `docs/changelog/v1.2.3-rc.1.md`.
+
 4. Merge the commit to `main`. The `tag-on-version-bump.yml` workflow pushes
    the matching `vX.Y.Z` tag automatically. The tag then triggers
    `release.yml`.
 5. Wait for the release workflow to publish the image, manifest, and GitHub
-   release notes.
-6. Promote the release from a private deploy repository or your own deployment
-   system by consuming the manifest's immutable image digest.
+   release notes. Stable releases are promoted automatically; the workflow does
+   not succeed until `https://api.stll.app/health` reports the exact release
+   commit. RCs continue to target staging.
+6. After a stable release succeeds, `publish-npm.yml` checks out the same
+   release commit, packs the CLI, installs that exact tarball under plain Node,
+   and runs its unauthenticated compatibility canary against production. Only
+   then can the hardened npm publishing job publish `@stll/cli`.
+
+Changing `packages/cli/package.json` on `main` does not publish the CLI by
+itself. This ordering is deliberate: the API must advertise support for the
+packed CLI version and all of its resource scopes before the client becomes
+public. A manual CLI publish is recovery-only and requires `release_ref` to
+name the stable release currently served by production.
+
+## API and CLI Compatibility
+
+MCP protected-resource discovery publishes the versioned
+`stella_compatibility` contract. It contains the API contract version and the
+inclusive CLI version range supported by that server; `scopes_supported`
+remains the authoritative OAuth resource-scope list.
+
+Before expanding the CLI contract:
+
+1. Add the API behavior and scopes, then raise the server's maximum supported
+   CLI version.
+2. Ship that API in a stable release.
+3. Let the post-release exact-tarball canary publish the CLI.
+
+The CLI intersects ordinary login requests with the authorization server's
+advertised scopes, so an older server remains usable for capabilities it
+actually supports. Explicitly requested scopes remain requirements and fail
+before browser authorization when unavailable.
+
+CI enforces the cross-boundary invariants as one contract: the API contract
+number must match the CLI implementation, the API's maximum CLI version must
+equal the package version, the published-version hint must remain within the
+advertised range, and every packaged CLI scope must exist in the API's OAuth
+and MCP scope sets. The canaried tarball's SHA-256 checksum is verified again
+in the isolated OIDC publishing job, so npm receives those exact bytes.
+
+## Production Freshness
+
+`production-freshness.yml` checks production daily. It fails when production
+trails `main` by more than 100 commits or when the oldest unreleased commit has
+waited more than 168 hours. The check also rejects a production commit that is
+not an ancestor of `main`. Threshold overrides are available only on a manual
+workflow run, keeping the scheduled policy reviewable in source.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,19 @@ Authenticate against a Stella server with:
 stella auth login
 ```
 
+The login flow negotiates the server's advertised OAuth scopes. Optional
+scopes unsupported by an older server are omitted; scopes passed explicitly
+with `--scopes` must all be available.
+
+To verify the public API contract without signing in:
+
+```sh
+stella compatibility check --server https://api.stll.app
+```
+
+Release automation runs this command from the exact packed tarball against
+production before publishing a new CLI version.
+
 ## Links
 
 - Repository: https://github.com/stella/stella/tree/main/packages/cli

--- a/packages/cli/src/auth/cli-config.test.ts
+++ b/packages/cli/src/auth/cli-config.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  configFilePath,
+  getRegisteredClient,
+  readCliConfig,
+  registeredClientSupportsScopes,
+  setRegisteredClient,
+} from "./cli-config.js";
+
+const withConfigDir = async (
+  run: (configDir: string) => Promise<void>,
+): Promise<void> => {
+  const configDir = await mkdtemp(path.join(tmpdir(), "stella-cli-config-"));
+  try {
+    await run(configDir);
+  } finally {
+    await rm(configDir, { force: true, recursive: true });
+  }
+};
+
+describe("OAuth client registration cache", () => {
+  test("treats a legacy scope-less entry as requiring one-time registration", async () => {
+    await withConfigDir(async (configDir) => {
+      await writeFile(
+        configFilePath(configDir),
+        JSON.stringify({
+          oauthClients: {
+            "https://api.example.com": {
+              clientId: "legacy-client",
+              registeredAt: 1,
+            },
+          },
+          version: 1,
+        }),
+      );
+
+      const client = await getRegisteredClient(
+        configDir,
+        "https://api.example.com",
+      );
+      expect(client).toBeDefined();
+      if (client !== undefined) {
+        expect(registeredClientSupportsScopes(client, ["stella:read"])).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  test("persists negotiated scopes and detects a later scope expansion", async () => {
+    await withConfigDir(async (configDir) => {
+      await setRegisteredClient(
+        configDir,
+        "https://api.example.com",
+        "current-client",
+        ["openid", "stella:read"],
+      );
+
+      const client = await getRegisteredClient(
+        configDir,
+        "https://api.example.com",
+      );
+      expect(client).toBeDefined();
+      if (client !== undefined) {
+        expect(
+          registeredClientSupportsScopes(client, ["openid", "stella:read"]),
+        ).toBe(true);
+        expect(
+          registeredClientSupportsScopes(client, [
+            "openid",
+            "stella:read",
+            "stella:admin_write",
+          ]),
+        ).toBe(false);
+      }
+
+      const config = await readCliConfig(configDir);
+      expect(
+        config.oauthClients["https://api.example.com"]?.registeredScopes,
+      ).toEqual(["openid", "stella:read"]);
+    });
+  });
+});

--- a/packages/cli/src/auth/cli-config.ts
+++ b/packages/cli/src/auth/cli-config.ts
@@ -24,14 +24,20 @@ export type { ConfigPathOverrides };
 export type CliConfig = {
   readonly version: 1;
   readonly defaultServerUrl?: string | undefined;
-  readonly oauthClients: Readonly<
-    Record<string, { readonly clientId: string; readonly registeredAt: number }>
-  >;
+  readonly oauthClients: Readonly<Record<string, RegisteredOAuthClient>>;
+};
+
+export type RegisteredOAuthClient = {
+  readonly clientId: string;
+  readonly registeredAt: number;
+  /** Missing only on config entries written before scope-aware registration. */
+  readonly registeredScopes?: readonly string[] | undefined;
 };
 
 const oauthClientEntrySchema = v.strictObject({
   clientId: v.string(),
   registeredAt: v.number(),
+  registeredScopes: v.optional(v.array(v.string())),
 });
 
 const cliConfigSchema = v.strictObject({
@@ -84,25 +90,37 @@ export const setDefaultServerUrl = async (
   await writeCliConfig(configDir, { ...config, defaultServerUrl: serverUrl });
 };
 
-export const getRegisteredClientId = async (
+export const getRegisteredClient = async (
   configDir: string,
   serverUrl: string,
-): Promise<string | undefined> => {
+): Promise<RegisteredOAuthClient | undefined> => {
   const config = await readCliConfig(configDir);
-  return config.oauthClients[serverUrl]?.clientId;
+  return config.oauthClients[serverUrl];
 };
 
-export const setRegisteredClientId = async (
+export const registeredClientSupportsScopes = (
+  client: RegisteredOAuthClient,
+  scopes: readonly string[],
+): boolean => {
+  const registeredScopes = client.registeredScopes;
+  if (registeredScopes === undefined) {
+    return false;
+  }
+  return scopes.every((scope) => registeredScopes.includes(scope));
+};
+
+export const setRegisteredClient = async (
   configDir: string,
   serverUrl: string,
   clientId: string,
+  registeredScopes: readonly string[],
 ): Promise<void> => {
   const config = await readCliConfig(configDir);
   await writeCliConfig(configDir, {
     ...config,
     oauthClients: {
       ...config.oauthClients,
-      [serverUrl]: { clientId, registeredAt: Date.now() },
+      [serverUrl]: { clientId, registeredAt: Date.now(), registeredScopes },
     },
   });
 };

--- a/packages/cli/src/auth/constants.ts
+++ b/packages/cli/src/auth/constants.ts
@@ -66,6 +66,9 @@ export const CLI_DEFAULT_SCOPES = [
   "stella:search",
 ] as const;
 
+/** Minimum scopes needed for the default CLI login to be useful. */
+export const CLI_REQUIRED_SCOPES = ["openid", "stella:read"] as const;
+
 /** Every OAuth scope `stella auth login --scopes` is documented to accept. */
 export const CLI_KNOWN_SCOPES = [
   "openid",
@@ -87,6 +90,10 @@ export const CLI_KNOWN_SCOPES = [
   "stella:external_mcps",
   "stella:feedback",
 ] as const;
+
+/** Full resource scope surface the packaged CLI release expects its API to expose. */
+export const CLI_REQUIRED_RESOURCE_SCOPES: readonly string[] =
+  CLI_KNOWN_SCOPES.filter((scope) => scope.startsWith("stella:"));
 
 export const CLIENT_NAME = "stella-cli";
 

--- a/packages/cli/src/auth/errors.ts
+++ b/packages/cli/src/auth/errors.ts
@@ -143,6 +143,16 @@ export class MissingOrgClaimError extends CliBaseError<"MissingOrgClaimError"> {
   }
 }
 
+export class UnsupportedOAuthScopesError extends CliBaseError<"UnsupportedOAuthScopesError"> {
+  override readonly name = "UnsupportedOAuthScopesError";
+  readonly missingScopes: readonly string[];
+
+  constructor(props: { message: string; missingScopes: readonly string[] }) {
+    super("UnsupportedOAuthScopesError", props.message);
+    this.missingScopes = props.missingScopes;
+  }
+}
+
 export class NoRefreshTokenError extends CliBaseError<"NoRefreshTokenError"> {
   override readonly name = "NoRefreshTokenError";
 
@@ -162,4 +172,5 @@ export type CliAuthError =
   | ServerUrlNotConfiguredError
   | CredentialNotFoundError
   | MissingOrgClaimError
+  | UnsupportedOAuthScopesError
   | NoRefreshTokenError;

--- a/packages/cli/src/auth/login.ts
+++ b/packages/cli/src/auth/login.ts
@@ -8,7 +8,11 @@ import { Result } from "better-result";
 import { createInterface } from "node:readline/promises";
 
 import { openInBrowser } from "./browser-open.js";
-import { getRegisteredClientId, setRegisteredClientId } from "./cli-config.js";
+import {
+  getRegisteredClient,
+  registeredClientSupportsScopes,
+  setRegisteredClient,
+} from "./cli-config.js";
 import {
   getMcpResourceUrl,
   LOGIN_TIMEOUT_MS,
@@ -34,6 +38,7 @@ import { registerLoopbackClient } from "./oauth-client-registration.js";
 import { discoverAuthorizationServerMetadata } from "./oauth-metadata.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
 import { createOAuthState, createPkcePair } from "./pkce.js";
+import { negotiateOAuthScopes } from "./scope-negotiation.js";
 import { resolveServerUrl } from "./server-resolution.js";
 import { exchangeAuthorizationCode } from "./token-exchange.js";
 
@@ -42,6 +47,7 @@ export type LoginOptions = {
   readonly orgHint: string | undefined;
   readonly registrationScopes: readonly string[];
   readonly requestedScopes: readonly string[];
+  readonly requiredScopes: readonly string[];
   readonly serverFlag: string | undefined;
 };
 
@@ -104,9 +110,9 @@ const getOrRegisterClient = async (
   metadata: AuthorizationServerMetadata,
   registrationScopes: readonly string[],
 ): Promise<Result<string, CliAuthError>> => {
-  const cached = await getRegisteredClientId(configDir, serverUrl);
-  if (cached) {
-    return Result.ok(cached);
+  const cached = await getRegisteredClient(configDir, serverUrl);
+  if (cached && registeredClientSupportsScopes(cached, registrationScopes)) {
+    return Result.ok(cached.clientId);
   }
 
   const registered = await registerLoopbackClient(metadata, registrationScopes);
@@ -114,7 +120,12 @@ const getOrRegisterClient = async (
     return registered;
   }
 
-  await setRegisteredClientId(configDir, serverUrl, registered.value);
+  await setRegisteredClient(
+    configDir,
+    serverUrl,
+    registered.value,
+    registrationScopes,
+  );
   return Result.ok(registered.value);
 };
 
@@ -213,12 +224,18 @@ export const login = async (
     const metadata = yield* Result.await(
       discoverAuthorizationServerMetadata(serverUrl),
     );
+    const scopes = yield* negotiateOAuthScopes({
+      advertisedScopes: metadata.scopes_supported,
+      registrationScopes: options.registrationScopes,
+      requestedScopes: options.requestedScopes,
+      requiredScopes: options.requiredScopes,
+    });
     const clientId = yield* Result.await(
       getOrRegisterClient(
         options.configDir,
         serverUrl,
         metadata,
-        options.registrationScopes,
+        scopes.registrationScopes,
       ),
     );
 
@@ -244,7 +261,7 @@ export const login = async (
       clientId,
       codeChallenge,
       redirectUri,
-      scopes: options.requestedScopes,
+      scopes: scopes.requestedScopes,
       state,
     });
 
@@ -283,7 +300,7 @@ export const login = async (
       orgId: claims.org_id,
       ...(options.orgHint ? { orgLabel: options.orgHint } : {}),
       refreshToken: token.refresh_token,
-      scope: token.scope ?? options.requestedScopes.join(" "),
+      scope: token.scope ?? scopes.requestedScopes.join(" "),
       serverUrl,
       tokenType: token.token_type,
       updatedAt: now,

--- a/packages/cli/src/auth/scope-negotiation.test.ts
+++ b/packages/cli/src/auth/scope-negotiation.test.ts
@@ -1,0 +1,112 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { negotiateOAuthScopes } from "./scope-negotiation.js";
+
+describe("OAuth scope negotiation", () => {
+  test("uses only server-advertised authorization and registration scopes", () => {
+    const result = negotiateOAuthScopes({
+      advertisedScopes: ["openid", "stella:read"],
+      registrationScopes: [
+        "openid",
+        "offline_access",
+        "stella:read",
+        "stella:admin_write",
+      ],
+      requestedScopes: [
+        "openid",
+        "offline_access",
+        "stella:read",
+        "stella:search",
+      ],
+      requiredScopes: ["openid", "stella:read"],
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value).toEqual({
+        registrationScopes: ["openid", "stella:read"],
+        requestedScopes: ["openid", "stella:read"],
+      });
+    }
+  });
+
+  test("keeps old servers without offline_access usable", () => {
+    const result = negotiateOAuthScopes({
+      advertisedScopes: ["openid", "stella:read", "stella:search"],
+      registrationScopes: [
+        "openid",
+        "offline_access",
+        "stella:read",
+        "stella:search",
+      ],
+      requestedScopes: [
+        "openid",
+        "offline_access",
+        "stella:read",
+        "stella:search",
+      ],
+      requiredScopes: ["openid", "stella:read"],
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.requestedScopes).not.toContain("offline_access");
+      expect(result.value.registrationScopes).not.toContain("offline_access");
+    }
+  });
+
+  test("fails before authorization when a required scope is unavailable", () => {
+    const result = negotiateOAuthScopes({
+      advertisedScopes: ["openid", "stella:read"],
+      registrationScopes: ["openid", "stella:read", "stella:admin_write"],
+      requestedScopes: ["openid", "stella:admin_write"],
+      requiredScopes: ["openid", "stella:admin_write"],
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.missingScopes).toEqual(["stella:admin_write"]);
+      expect(result.error.message).toContain("stella:admin_write");
+    }
+  });
+
+  test("defers to servers whose RFC metadata omits scopes_supported", () => {
+    const requestedScopes = ["openid", "offline_access", "stella:read"];
+    const registrationScopes = [
+      "openid",
+      "offline_access",
+      "stella:read",
+      "stella:admin_write",
+    ];
+    const result = negotiateOAuthScopes({
+      advertisedScopes: undefined,
+      registrationScopes,
+      requestedScopes,
+      requiredScopes: ["openid", "stella:read"],
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value).toEqual({ registrationScopes, requestedScopes });
+    }
+  });
+
+  test("registers an explicitly requested server extension scope", () => {
+    const result = negotiateOAuthScopes({
+      advertisedScopes: ["openid", "stella:read", "stella:server_extension"],
+      registrationScopes: ["openid", "stella:read"],
+      requestedScopes: ["openid", "stella:server_extension"],
+      requiredScopes: ["openid", "stella:server_extension"],
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.registrationScopes).toEqual([
+        "openid",
+        "stella:read",
+        "stella:server_extension",
+      ]);
+    }
+  });
+});

--- a/packages/cli/src/auth/scope-negotiation.ts
+++ b/packages/cli/src/auth/scope-negotiation.ts
@@ -1,0 +1,65 @@
+import { Result } from "better-result";
+
+import { UnsupportedOAuthScopesError } from "./errors.js";
+
+export type NegotiatedOAuthScopes = {
+  readonly registrationScopes: readonly string[];
+  readonly requestedScopes: readonly string[];
+};
+
+type NegotiateOAuthScopesOptions = {
+  readonly advertisedScopes: readonly string[] | undefined;
+  readonly registrationScopes: readonly string[];
+  readonly requestedScopes: readonly string[];
+  readonly requiredScopes: readonly string[];
+};
+
+/**
+ * Restricts the CLI's OAuth requests to scopes the authorization server says
+ * it supports. Metadata predating `scopes_supported` remains usable because
+ * RFC 8414 makes that field optional; in that case the server still makes the
+ * final decision at its registration and authorization endpoints.
+ */
+export const negotiateOAuthScopes = ({
+  advertisedScopes,
+  registrationScopes,
+  requestedScopes,
+  requiredScopes,
+}: NegotiateOAuthScopesOptions): Result<
+  NegotiatedOAuthScopes,
+  UnsupportedOAuthScopesError
+> => {
+  if (advertisedScopes === undefined) {
+    return Result.ok({
+      registrationScopes: [
+        ...registrationScopes,
+        ...requestedScopes.filter(
+          (scope) => !registrationScopes.includes(scope),
+        ),
+      ],
+      requestedScopes,
+    });
+  }
+
+  const supported = new Set(advertisedScopes);
+  const missingScopes = requiredScopes.filter((scope) => !supported.has(scope));
+  if (missingScopes.length > 0) {
+    return Result.err(
+      new UnsupportedOAuthScopesError({
+        message: `The server cannot satisfy this login because it does not advertise the required OAuth ${missingScopes.length === 1 ? "scope" : "scopes"}: ${missingScopes.join(", ")}. Request scopes supported by this server or upgrade the server.`,
+        missingScopes,
+      }),
+    );
+  }
+
+  const registrationCandidates = [
+    ...registrationScopes,
+    ...requestedScopes.filter((scope) => !registrationScopes.includes(scope)),
+  ];
+  return Result.ok({
+    registrationScopes: registrationCandidates.filter((scope) =>
+      supported.has(scope),
+    ),
+    requestedScopes: requestedScopes.filter((scope) => supported.has(scope)),
+  });
+};

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import {
 import { resolveServerUrl } from "./auth/server-resolution.js";
 import { buildGeneratedRoutes, buildResourceRoutes } from "./build-cli-tree.js";
 import { authRoute } from "./commands/auth.js";
+import { compatibilityRoute } from "./commands/compatibility.js";
 import type { Context } from "./context.js";
 import { HOME, XDG_CACHE_HOME } from "./env.js";
 import { generatedResourceTree } from "./generated/resource-tree.js";
@@ -78,6 +79,7 @@ const buildApp = (tree: RouteNode) => {
     docs: { brief: "Stella command-line client" },
     routes: {
       auth: authRoute,
+      compatibility: compatibilityRoute,
       tools: toolsRoute,
       reference: buildResourceRoutes(generatedResourceTree),
       ...buildGeneratedRoutes(tree),

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -4,7 +4,11 @@ import { buildCommand, buildRouteMap } from "@stricli/core";
 import type { RouteMap } from "@stricli/core";
 import { Result } from "better-result";
 
-import { CLI_DEFAULT_SCOPES, CLI_KNOWN_SCOPES } from "../auth/constants.js";
+import {
+  CLI_DEFAULT_SCOPES,
+  CLI_KNOWN_SCOPES,
+  CLI_REQUIRED_SCOPES,
+} from "../auth/constants.js";
 import { login } from "../auth/login.js";
 import { logout, switchOrg, whoami } from "../auth/manage.js";
 import { parseScopesFlag } from "../auth/scopes.js";
@@ -46,12 +50,14 @@ const loginCommand = buildCommand<LoginFlags, [], Context>({
   },
   func: async function func(this: Context, flags) {
     let requestedScopes: readonly string[] = CLI_DEFAULT_SCOPES;
+    let requiredScopes: readonly string[] = CLI_REQUIRED_SCOPES;
     if (flags.scopes) {
       const parsedScopes = parseScopesFlag(flags.scopes);
       if (Result.isError(parsedScopes)) {
         return new Error(parsedScopes.error.message);
       }
       requestedScopes = parsedScopes.value;
+      requiredScopes = parsedScopes.value;
     }
 
     if (!flags.keychain) {
@@ -65,6 +71,7 @@ const loginCommand = buildCommand<LoginFlags, [], Context>({
       orgHint: flags.org,
       registrationScopes: CLI_KNOWN_SCOPES,
       requestedScopes,
+      requiredScopes,
       serverFlag: flags.server,
     });
 

--- a/packages/cli/src/commands/compatibility.ts
+++ b/packages/cli/src/commands/compatibility.ts
@@ -1,0 +1,43 @@
+import { buildCommand, buildRouteMap } from "@stricli/core";
+import type { RouteMap } from "@stricli/core";
+import { Result } from "better-result";
+
+import { checkServerCompatibility } from "../compatibility.js";
+import type { Context } from "../context.js";
+
+type CheckFlags = {
+  readonly server: string;
+};
+
+const checkCommand = buildCommand<CheckFlags, [], Context>({
+  docs: {
+    brief: "Verify that a deployed stella API supports this CLI",
+    fullDescription:
+      "Checks the public MCP protected-resource contract, inclusive CLI version range, and the packaged CLI's full resource-scope surface. This command does not require authentication.",
+  },
+  func: async function func(this: Context, flags) {
+    const result = await checkServerCompatibility(flags.server);
+    if (Result.isError(result)) {
+      return new Error(result.error.message);
+    }
+
+    this.process.stdout.write(
+      `Compatible: CLI ${result.value.cliVersion}, API contract ${result.value.apiContractVersion} at ${result.value.serverUrl}.\n`,
+    );
+    return undefined;
+  },
+  parameters: {
+    flags: {
+      server: {
+        brief: "Stella API origin to verify",
+        kind: "parsed",
+        parse: (input: string) => input,
+      },
+    },
+  },
+});
+
+export const compatibilityRoute: RouteMap<Context> = buildRouteMap({
+  docs: { brief: "Check CLI and deployed API compatibility" },
+  routes: { check: checkCommand },
+});

--- a/packages/cli/src/compatibility.test.ts
+++ b/packages/cli/src/compatibility.test.ts
@@ -1,0 +1,175 @@
+import { Result } from "better-result";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import packageJson from "../package.json" with { type: "json" };
+import { CLI_REQUIRED_RESOURCE_SCOPES } from "./auth/constants.js";
+import { checkServerCompatibility } from "./compatibility.js";
+
+const CLI_ENTRYPOINT = path.join(import.meta.dirname, "cli.ts");
+const tempDirs: string[] = [];
+
+type CompatibilityOverrides = {
+  readonly apiContractVersion?: number;
+  readonly maximum?: string;
+  readonly minimum?: string;
+  readonly scopes?: readonly string[];
+};
+
+const startCompatibilityServer = (overrides: CompatibilityOverrides = {}) =>
+  Bun.serve({
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname !== "/.well-known/oauth-protected-resource/mcp") {
+        return new Response("Not found", { status: 404 });
+      }
+      return Response.json({
+        authorization_servers: [`${url.origin}/api/auth`],
+        bearer_methods_supported: ["header"],
+        resource: `${url.origin}/mcp`,
+        scopes_supported: overrides.scopes ?? CLI_REQUIRED_RESOURCE_SCOPES,
+        stella_compatibility: {
+          api_contract_version: overrides.apiContractVersion ?? 1,
+          cli_version: {
+            maximum: overrides.maximum ?? packageJson.version,
+            minimum: overrides.minimum ?? packageJson.version,
+          },
+        },
+      });
+    },
+    port: 0,
+  });
+
+const runCompatibilityCli = async (serverUrl: string) => {
+  const configHome = await mkdtemp(path.join(tmpdir(), "stella-compat-"));
+  tempDirs.push(configHome);
+  const process = Bun.spawn({
+    cmd: [
+      "bun",
+      CLI_ENTRYPOINT,
+      "compatibility",
+      "check",
+      "--server",
+      serverUrl,
+    ],
+    env: { ...globalThis.process.env, XDG_CONFIG_HOME: configHome },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  return { exitCode, stderr, stdout };
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await rm(dir, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe("deployed API compatibility", () => {
+  test("accepts the inclusive current CLI range and required resource scopes", async () => {
+    const server = startCompatibilityServer();
+    try {
+      const result = await checkServerCompatibility(server.url.origin);
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        expect(result.value.apiContractVersion).toBe(1);
+        expect(result.value.cliVersion).toBe(packageJson.version);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("rejects a server without the public compatibility contract", async () => {
+    const server = Bun.serve({
+      fetch(request) {
+        const url = new URL(request.url);
+        return Response.json({
+          resource: `${url.origin}/mcp`,
+          scopes_supported: ["stella:read"],
+        });
+      },
+      port: 0,
+    });
+    try {
+      const result = await checkServerCompatibility(server.url.origin);
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.message).toContain("absent or malformed");
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("rejects a CLI version outside the server's inclusive range", async () => {
+    const server = startCompatibilityServer({
+      maximum: "0.3.0",
+      minimum: "0.2.1",
+    });
+    try {
+      const result = await checkServerCompatibility(server.url.origin);
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.message).toContain(
+          `CLI ${packageJson.version} is incompatible`,
+        );
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("rejects a server missing the packaged CLI resource scope surface", async () => {
+    const server = startCompatibilityServer({ scopes: ["stella:search"] });
+    try {
+      const result = await checkServerCompatibility(server.url.origin);
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.message).toContain("stella:read");
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("exposes an unauthenticated root command suitable for release canaries", async () => {
+    const server = startCompatibilityServer();
+    try {
+      const { exitCode, stderr, stdout } = await runCompatibilityCli(
+        server.url.origin,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`Compatible: CLI ${packageJson.version}`);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("the release-canary command exits nonzero for an incompatible API", async () => {
+    const server = startCompatibilityServer({ scopes: ["stella:search"] });
+    try {
+      const { exitCode, stderr } = await runCompatibilityCli(server.url.origin);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("stella:read");
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/packages/cli/src/compatibility.ts
+++ b/packages/cli/src/compatibility.ts
@@ -1,0 +1,282 @@
+import { Result } from "better-result";
+import * as v from "valibot";
+
+import packageJson from "../package.json" with { type: "json" };
+import {
+  AUTH_FETCH_TIMEOUT_MS,
+  CLI_REQUIRED_RESOURCE_SCOPES,
+} from "./auth/constants.js";
+import { CliBaseError } from "./auth/errors.js";
+
+const MCP_DISCOVERY_PATH = "/.well-known/oauth-protected-resource/mcp";
+export const CLI_SUPPORTED_API_CONTRACT_VERSION = 1;
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
+const SEMVER_BUILD_PATTERN = /^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/u;
+
+const compatibilityMetadataSchema = v.looseObject({
+  resource: v.pipe(v.string(), v.url()),
+  scopes_supported: v.array(v.string()),
+  stella_compatibility: v.strictObject({
+    api_contract_version: v.pipe(v.number(), v.integer()),
+    cli_version: v.strictObject({
+      minimum: v.string(),
+      maximum: v.string(),
+    }),
+  }),
+});
+
+type CompatibilityMetadata = {
+  readonly resource: string;
+  readonly scopes_supported: readonly string[];
+  readonly stella_compatibility: {
+    readonly api_contract_version: number;
+    readonly cli_version: {
+      readonly minimum: string;
+      readonly maximum: string;
+    };
+  };
+};
+
+type SemverIdentifier =
+  | { readonly type: "numeric"; readonly value: number }
+  | { readonly type: "text"; readonly value: string };
+
+type ParsedSemver = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly prerelease: readonly SemverIdentifier[];
+};
+
+export type CompatibilityReport = {
+  readonly apiContractVersion: number;
+  readonly cliMaximumVersion: string;
+  readonly cliMinimumVersion: string;
+  readonly cliVersion: string;
+  readonly resource: string;
+  readonly serverUrl: string;
+};
+
+export class CompatibilityCheckError extends CliBaseError<"CompatibilityCheckError"> {
+  override readonly name = "CompatibilityCheckError";
+  override readonly cause?: unknown;
+
+  constructor(props: { message: string; cause?: unknown }) {
+    super("CompatibilityCheckError", props.message);
+    this.cause = props.cause;
+  }
+}
+
+const parseSemver = (input: string): ParsedSemver | undefined => {
+  const buildParts = input.split("+");
+  const version = buildParts.at(0);
+  const build = buildParts.at(1);
+  if (
+    version === undefined ||
+    buildParts.length > 2 ||
+    (build !== undefined && !SEMVER_BUILD_PATTERN.test(build))
+  ) {
+    return undefined;
+  }
+
+  const match = SEMVER_PATTERN.exec(version);
+  if (match === null) {
+    return undefined;
+  }
+
+  const prerelease = match
+    .at(4)
+    ?.split(".")
+    .map((identifier) => {
+      if (/^(0|[1-9]\d*)$/u.test(identifier)) {
+        return { type: "numeric", value: Number(identifier) } as const;
+      }
+      return { type: "text", value: identifier } as const;
+    });
+
+  return {
+    major: Number(match.at(1)),
+    minor: Number(match.at(2)),
+    patch: Number(match.at(3)),
+    prerelease: prerelease ?? [],
+  };
+};
+
+const compareIdentifiers = (
+  left: SemverIdentifier,
+  right: SemverIdentifier,
+): number => {
+  if (left.type === "numeric" && right.type === "numeric") {
+    return left.value - right.value;
+  }
+  if (left.type === "numeric") {
+    return -1;
+  }
+  if (right.type === "numeric") {
+    return 1;
+  }
+  if (left.value === right.value) {
+    return 0;
+  }
+  return left.value < right.value ? -1 : 1;
+};
+
+const compareSemver = (left: ParsedSemver, right: ParsedSemver): number => {
+  const coreComparison =
+    left.major - right.major ||
+    left.minor - right.minor ||
+    left.patch - right.patch;
+  if (coreComparison !== 0) {
+    return coreComparison;
+  }
+  if (left.prerelease.length === 0) {
+    return right.prerelease.length === 0 ? 0 : 1;
+  }
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const identifierCount = Math.max(
+    left.prerelease.length,
+    right.prerelease.length,
+  );
+  for (let index = 0; index < identifierCount; index += 1) {
+    const leftIdentifier = left.prerelease.at(index);
+    const rightIdentifier = right.prerelease.at(index);
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+    const comparison = compareIdentifiers(leftIdentifier, rightIdentifier);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+  return 0;
+};
+
+const validateCompatibility = (
+  metadata: CompatibilityMetadata,
+  serverUrl: string,
+): Result<CompatibilityReport, CompatibilityCheckError> => {
+  const compatibility = metadata.stella_compatibility;
+  if (
+    compatibility.api_contract_version !== CLI_SUPPORTED_API_CONTRACT_VERSION
+  ) {
+    return Result.err(
+      new CompatibilityCheckError({
+        message: `Server API contract ${compatibility.api_contract_version} is incompatible; this CLI requires contract ${CLI_SUPPORTED_API_CONTRACT_VERSION}.`,
+      }),
+    );
+  }
+
+  const cliVersion = parseSemver(packageJson.version);
+  const minimum = parseSemver(compatibility.cli_version.minimum);
+  const maximum = parseSemver(compatibility.cli_version.maximum);
+  if (
+    cliVersion === undefined ||
+    minimum === undefined ||
+    maximum === undefined
+  ) {
+    return Result.err(
+      new CompatibilityCheckError({
+        message: `Server compatibility metadata contains an invalid semantic version range: ${compatibility.cli_version.minimum} - ${compatibility.cli_version.maximum}.`,
+      }),
+    );
+  }
+  if (compareSemver(minimum, maximum) > 0) {
+    return Result.err(
+      new CompatibilityCheckError({
+        message: `Server compatibility metadata has an inverted CLI version range: ${compatibility.cli_version.minimum} - ${compatibility.cli_version.maximum}.`,
+      }),
+    );
+  }
+  if (
+    compareSemver(cliVersion, minimum) < 0 ||
+    compareSemver(cliVersion, maximum) > 0
+  ) {
+    return Result.err(
+      new CompatibilityCheckError({
+        message: `CLI ${packageJson.version} is incompatible with this server; supported CLI versions are ${compatibility.cli_version.minimum} through ${compatibility.cli_version.maximum}, inclusive.`,
+      }),
+    );
+  }
+
+  const supportedScopes = new Set(metadata.scopes_supported);
+  const missingScopes = CLI_REQUIRED_RESOURCE_SCOPES.filter(
+    (scope) => !supportedScopes.has(scope),
+  );
+  if (missingScopes.length > 0) {
+    return Result.err(
+      new CompatibilityCheckError({
+        message: `Server protected-resource metadata is missing required ${missingScopes.length === 1 ? "scope" : "scopes"}: ${missingScopes.join(", ")}.`,
+      }),
+    );
+  }
+
+  const expectedResource = new URL(
+    "/mcp",
+    `${serverUrl.replace(/\/$/u, "")}/`,
+  ).toString();
+  if (metadata.resource !== expectedResource) {
+    return Result.err(
+      new CompatibilityCheckError({
+        message: `Server metadata advertises resource ${metadata.resource}, but this CLI would connect to ${expectedResource}.`,
+      }),
+    );
+  }
+
+  return Result.ok({
+    apiContractVersion: compatibility.api_contract_version,
+    cliMaximumVersion: compatibility.cli_version.maximum,
+    cliMinimumVersion: compatibility.cli_version.minimum,
+    cliVersion: packageJson.version,
+    resource: metadata.resource,
+    serverUrl,
+  });
+};
+
+export const checkServerCompatibility = async (
+  serverUrl: string,
+): Promise<Result<CompatibilityReport, CompatibilityCheckError>> =>
+  await Result.tryPromise({
+    catch: (cause) =>
+      cause instanceof CompatibilityCheckError
+        ? cause
+        : new CompatibilityCheckError({
+            cause,
+            message: `Could not check stella compatibility at ${serverUrl}: ${cause instanceof Error ? cause.message : "unknown error"}.`,
+          }),
+    try: async () => {
+      const discoveryUrl = new URL(
+        MCP_DISCOVERY_PATH,
+        `${serverUrl.replace(/\/$/u, "")}/`,
+      );
+      const response = await fetch(discoveryUrl, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new CompatibilityCheckError({
+          message: `Stella compatibility discovery responded ${response.status} at ${discoveryUrl.toString()}. Deploy an API that exposes the public compatibility contract before publishing this CLI.`,
+        });
+      }
+
+      const body: unknown = await response.json();
+      const parsed = v.safeParse(compatibilityMetadataSchema, body);
+      if (!parsed.success) {
+        throw new CompatibilityCheckError({
+          message: `Stella compatibility discovery at ${discoveryUrl.toString()} is absent or malformed. Deploy an API that advertises stella_compatibility before publishing this CLI.`,
+        });
+      }
+
+      const result = validateCompatibility(parsed.output, serverUrl);
+      if (Result.isError(result)) {
+        throw result.error;
+      }
+      return result.value;
+    },
+  });

--- a/scripts/api-health.ts
+++ b/scripts/api-health.ts
@@ -1,0 +1,15 @@
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+
+export const getApiHealthUrl = (apiUrl: string) =>
+  new URL("health", `${apiUrl.replace(/\/+$/u, "")}/`);
+
+export const parseHealthCommit = (value: unknown) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const commit = Reflect.get(value, "commit");
+  if (typeof commit !== "string" || !COMMIT_SHA_PATTERN.test(commit)) {
+    return undefined;
+  }
+  return commit;
+};

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -54,4 +54,24 @@ describe("API and CLI release contract", () => {
     expectSubset(CLI_DEFAULT_SCOPES, CLI_KNOWN_SCOPES);
     expectSubset(CLI_REQUIRED_SCOPES, CLI_DEFAULT_SCOPES);
   });
+
+  test("manual releases preserve their resolved tag for CLI publication", async () => {
+    const [releaseWorkflow, publishWorkflow] = await Promise.all([
+      Bun.file(
+        new URL("../.github/workflows/release.yml", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL("../.github/workflows/publish-npm.yml", import.meta.url),
+      ).text(),
+    ]);
+
+    expect(releaseWorkflow).toContain("name: release-source-receipt");
+    expect(publishWorkflow).toContain('gh run download "$UPSTREAM_RUN_ID"');
+    expect(publishWorkflow).toContain(
+      "UPSTREAM_RELEASE_REF: ${{ needs.release-trigger.outputs.release_ref }}",
+    );
+    expect(publishWorkflow).not.toContain(
+      "github.event.workflow_run.head_branch",
+    );
+  });
 });

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  MCP_DEFAULT_RESOURCE_SCOPES,
+  MCP_OAUTH_SCOPES,
+  STELLA_CLI_LATEST_VERSION,
+  STELLA_CLI_MAXIMUM_VERSION,
+  STELLA_CLI_MINIMUM_VERSION,
+  STELLA_MCP_API_CONTRACT_VERSION,
+} from "../apps/api/src/mcp/constants";
+import cliPackage from "../packages/cli/package.json" with { type: "json" };
+import {
+  CLI_DEFAULT_SCOPES,
+  CLI_KNOWN_SCOPES,
+  CLI_REQUIRED_RESOURCE_SCOPES,
+  CLI_REQUIRED_SCOPES,
+} from "../packages/cli/src/auth/constants";
+import { CLI_SUPPORTED_API_CONTRACT_VERSION } from "../packages/cli/src/compatibility";
+
+const expectSubset = (
+  subset: readonly string[],
+  superset: readonly string[],
+) => {
+  const available = new Set(superset);
+  expect(subset.filter((value) => !available.has(value))).toEqual([]);
+};
+
+describe("API and CLI release contract", () => {
+  test("the server advertises the contract version implemented by the CLI", () => {
+    expect(STELLA_MCP_API_CONTRACT_VERSION).toBe(
+      CLI_SUPPORTED_API_CONTRACT_VERSION,
+    );
+  });
+
+  test("a CLI version bump cannot merge without server support", () => {
+    expect(STELLA_CLI_MAXIMUM_VERSION).toBe(cliPackage.version);
+    expect(
+      Bun.semver.satisfies(
+        cliPackage.version,
+        `>=${STELLA_CLI_MINIMUM_VERSION} <=${STELLA_CLI_MAXIMUM_VERSION}`,
+      ),
+    ).toBe(true);
+    expect(
+      Bun.semver.satisfies(
+        STELLA_CLI_LATEST_VERSION,
+        `>=${STELLA_CLI_MINIMUM_VERSION} <=${STELLA_CLI_MAXIMUM_VERSION}`,
+      ),
+    ).toBe(true);
+  });
+
+  test("every packaged CLI scope is supported by the same API source", () => {
+    expectSubset(CLI_KNOWN_SCOPES, MCP_OAUTH_SCOPES);
+    expectSubset(CLI_REQUIRED_RESOURCE_SCOPES, MCP_DEFAULT_RESOURCE_SCOPES);
+    expectSubset(CLI_DEFAULT_SCOPES, CLI_KNOWN_SCOPES);
+    expectSubset(CLI_REQUIRED_SCOPES, CLI_DEFAULT_SCOPES);
+  });
+});

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { getApiHealthUrl, parseHealthCommit } from "./api-health";
+import { advanceDeploymentStability } from "./check-api-deployment";
 
 describe("API deployment health receipt", () => {
   test("preserves a configured API path prefix", () => {
@@ -31,5 +32,37 @@ describe("API deployment health receipt", () => {
     expect(parseHealthCommit(undefined)).toBeUndefined();
     expect(parseHealthCommit([])).toBeUndefined();
     expect(parseHealthCommit({ status: "ok" })).toBeUndefined();
+  });
+
+  test("requires a stable target streak across mixed rollout traffic", () => {
+    const expectedCommit = "7a1b25220298e7b93d38c1d949ef77b93f86bf84";
+    const staleCommit = "6b0a14110298e7b93d38c1d949ef77b93f86bf73";
+    let consecutiveMatches = 0;
+
+    for (const observedCommit of [
+      expectedCommit,
+      expectedCommit,
+      staleCommit,
+      expectedCommit,
+      expectedCommit,
+    ]) {
+      const result = advanceDeploymentStability({
+        consecutiveMatches,
+        expectedCommit,
+        observedCommit,
+        requiredMatches: 3,
+      });
+      consecutiveMatches = result.consecutiveMatches;
+      expect(result.status).toBe("waiting");
+    }
+
+    const result = advanceDeploymentStability({
+      consecutiveMatches,
+      expectedCommit,
+      observedCommit: expectedCommit,
+      requiredMatches: 3,
+    });
+
+    expect(result).toEqual({ status: "stable", consecutiveMatches: 3 });
   });
 });

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseHealthCommit } from "./check-api-deployment";
+import { getApiHealthUrl, parseHealthCommit } from "./api-health";
 
 describe("API deployment health receipt", () => {
+  test("preserves a configured API path prefix", () => {
+    expect(getApiHealthUrl("https://example.com/api").toString()).toBe(
+      "https://example.com/api/health",
+    );
+    expect(getApiHealthUrl("https://example.com").toString()).toBe(
+      "https://example.com/health",
+    );
+  });
+
   test("accepts only a full lowercase commit SHA", () => {
     expect(
       parseHealthCommit({

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseHealthCommit } from "./check-api-deployment";
+
+describe("API deployment health receipt", () => {
+  test("accepts only a full lowercase commit SHA", () => {
+    expect(
+      parseHealthCommit({
+        commit: "7a1b25220298e7b93d38c1d949ef77b93f86bf84",
+        status: "ok",
+      }),
+    ).toBe("7a1b25220298e7b93d38c1d949ef77b93f86bf84");
+    expect(parseHealthCommit({ commit: "7a1b252" })).toBeUndefined();
+    expect(
+      parseHealthCommit({
+        commit: "7A1B25220298E7B93D38C1D949EF77B93F86BF84",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("rejects malformed health payloads", () => {
+    expect(parseHealthCommit(undefined)).toBeUndefined();
+    expect(parseHealthCommit([])).toBeUndefined();
+    expect(parseHealthCommit({ status: "ok" })).toBeUndefined();
+  });
+});

--- a/scripts/check-api-deployment.ts
+++ b/scripts/check-api-deployment.ts
@@ -1,0 +1,120 @@
+const DEFAULT_ATTEMPTS = 30;
+const DEFAULT_DELAY_MS = 10_000;
+const FETCH_TIMEOUT_MS = 10_000;
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+
+class ApiDeploymentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApiDeploymentError";
+  }
+}
+
+export const parseHealthCommit = (value: unknown) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const commit = Reflect.get(value, "commit");
+  if (typeof commit !== "string" || !COMMIT_SHA_PATTERN.test(commit)) {
+    return undefined;
+  }
+  return commit;
+};
+
+const readRequiredEnv = (name: string) => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new ApiDeploymentError(`${name} is required`);
+  }
+  return value;
+};
+
+const readPositiveInteger = (name: string, fallback: number) => {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new ApiDeploymentError(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const readDeployedCommit = async (apiUrl: string) => {
+  const healthUrl = new URL("/health", `${apiUrl.replace(/\/+$/u, "")}/`);
+  const response = await fetch(healthUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new ApiDeploymentError(
+      `${healthUrl.toString()} returned HTTP ${response.status}`,
+    );
+  }
+  const commit = parseHealthCommit(await response.json());
+  if (!commit) {
+    throw new ApiDeploymentError(
+      `${healthUrl.toString()} did not return a full commit SHA`,
+    );
+  }
+  return commit;
+};
+
+const main = async () => {
+  const apiUrl = readRequiredEnv("API_DEPLOYMENT_URL");
+  const expectedCommit = readRequiredEnv("API_DEPLOYMENT_EXPECTED_COMMIT");
+  if (!COMMIT_SHA_PATTERN.test(expectedCommit)) {
+    throw new ApiDeploymentError(
+      "API_DEPLOYMENT_EXPECTED_COMMIT must be a full lowercase commit SHA",
+    );
+  }
+  const attempts = readPositiveInteger(
+    "API_DEPLOYMENT_ATTEMPTS",
+    DEFAULT_ATTEMPTS,
+  );
+  const delayMs = readPositiveInteger(
+    "API_DEPLOYMENT_DELAY_MS",
+    DEFAULT_DELAY_MS,
+  );
+
+  let lastObservedCommit: string | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- each probe must observe the deployed commit before deciding whether to retry.
+      lastObservedCommit = await readDeployedCommit(apiUrl);
+      if (lastObservedCommit === expectedCommit) {
+        console.log(`api-deployment: ok (${expectedCommit})`);
+        return;
+      }
+      console.log(
+        `api-deployment: waiting for ${expectedCommit}; observed ${lastObservedCommit} (${attempt}/${attempts})`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(
+        `api-deployment: probe failed (${attempt}/${attempts}): ${message}`,
+      );
+    }
+    if (attempt < attempts) {
+      // eslint-disable-next-line no-await-in-loop -- deployment probes are intentionally sequential and bounded.
+      await sleep(delayMs);
+    }
+  }
+
+  throw new ApiDeploymentError(
+    `production did not reach ${expectedCommit}; last observed ${lastObservedCommit ?? "unavailable"}`,
+  );
+};
+
+if (import.meta.main) {
+  await main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`api-deployment: ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-api-deployment.ts
+++ b/scripts/check-api-deployment.ts
@@ -2,6 +2,7 @@ import { getApiHealthUrl, parseHealthCommit } from "./api-health";
 
 const DEFAULT_ATTEMPTS = 30;
 const DEFAULT_DELAY_MS = 10_000;
+const DEFAULT_STABLE_PROBES = 5;
 const FETCH_TIMEOUT_MS = 10_000;
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
 
@@ -30,6 +31,33 @@ const readPositiveInteger = (name: string, fallback: number) => {
     throw new ApiDeploymentError(`${name} must be a positive integer`);
   }
   return value;
+};
+
+type AdvanceDeploymentStabilityOptions = {
+  consecutiveMatches: number;
+  expectedCommit: string;
+  observedCommit: string;
+  requiredMatches: number;
+};
+
+export const advanceDeploymentStability = ({
+  consecutiveMatches,
+  expectedCommit,
+  observedCommit,
+  requiredMatches,
+}: AdvanceDeploymentStabilityOptions) => {
+  const nextConsecutiveMatches =
+    observedCommit === expectedCommit ? consecutiveMatches + 1 : 0;
+  if (nextConsecutiveMatches >= requiredMatches) {
+    return {
+      status: "stable",
+      consecutiveMatches: nextConsecutiveMatches,
+    } as const;
+  }
+  return {
+    status: "waiting",
+    consecutiveMatches: nextConsecutiveMatches,
+  } as const;
 };
 
 const sleep = async (ms: number) => {
@@ -73,20 +101,46 @@ const main = async () => {
     "API_DEPLOYMENT_DELAY_MS",
     DEFAULT_DELAY_MS,
   );
+  const requiredStableProbes = readPositiveInteger(
+    "API_DEPLOYMENT_STABLE_PROBES",
+    DEFAULT_STABLE_PROBES,
+  );
+  if (requiredStableProbes > attempts) {
+    throw new ApiDeploymentError(
+      "API_DEPLOYMENT_STABLE_PROBES cannot exceed API_DEPLOYMENT_ATTEMPTS",
+    );
+  }
 
   let lastObservedCommit: string | undefined;
+  let consecutiveMatches = 0;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
       // eslint-disable-next-line no-await-in-loop -- each probe must observe the deployed commit before deciding whether to retry.
       lastObservedCommit = await readDeployedCommit(apiUrl);
-      if (lastObservedCommit === expectedCommit) {
-        console.log(`api-deployment: ok (${expectedCommit})`);
+      const stability = advanceDeploymentStability({
+        consecutiveMatches,
+        expectedCommit,
+        observedCommit: lastObservedCommit,
+        requiredMatches: requiredStableProbes,
+      });
+      consecutiveMatches = stability.consecutiveMatches;
+      if (stability.status === "stable") {
+        console.log(
+          `api-deployment: ok (${expectedCommit}; ${requiredStableProbes} consecutive probes)`,
+        );
         return;
       }
-      console.log(
-        `api-deployment: waiting for ${expectedCommit}; observed ${lastObservedCommit} (${attempt}/${attempts})`,
-      );
+      if (lastObservedCommit === expectedCommit) {
+        console.log(
+          `api-deployment: confirming ${expectedCommit} (${consecutiveMatches}/${requiredStableProbes} stable probes; ${attempt}/${attempts} attempts)`,
+        );
+      } else {
+        console.log(
+          `api-deployment: waiting for ${expectedCommit}; observed ${lastObservedCommit} (${attempt}/${attempts})`,
+        );
+      }
     } catch (error) {
+      consecutiveMatches = 0;
       const message = error instanceof Error ? error.message : String(error);
       console.log(
         `api-deployment: probe failed (${attempt}/${attempts}): ${message}`,
@@ -99,7 +153,7 @@ const main = async () => {
   }
 
   throw new ApiDeploymentError(
-    `production did not reach ${expectedCommit}; last observed ${lastObservedCommit ?? "unavailable"}`,
+    `production did not remain at ${expectedCommit} for ${requiredStableProbes} consecutive probes; last observed ${lastObservedCommit ?? "unavailable"}; final streak ${consecutiveMatches}`,
   );
 };
 

--- a/scripts/check-api-deployment.ts
+++ b/scripts/check-api-deployment.ts
@@ -1,3 +1,5 @@
+import { getApiHealthUrl, parseHealthCommit } from "./api-health";
+
 const DEFAULT_ATTEMPTS = 30;
 const DEFAULT_DELAY_MS = 10_000;
 const FETCH_TIMEOUT_MS = 10_000;
@@ -9,17 +11,6 @@ class ApiDeploymentError extends Error {
     this.name = "ApiDeploymentError";
   }
 }
-
-export const parseHealthCommit = (value: unknown) => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return undefined;
-  }
-  const commit = Reflect.get(value, "commit");
-  if (typeof commit !== "string" || !COMMIT_SHA_PATTERN.test(commit)) {
-    return undefined;
-  }
-  return commit;
-};
 
 const readRequiredEnv = (name: string) => {
   const value = process.env[name]?.trim();
@@ -41,13 +32,14 @@ const readPositiveInteger = (name: string, fallback: number) => {
   return value;
 };
 
-const sleep = (ms: number) =>
-  new Promise((resolve) => {
+const sleep = async (ms: number) => {
+  await new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
+};
 
 const readDeployedCommit = async (apiUrl: string) => {
-  const healthUrl = new URL("/health", `${apiUrl.replace(/\/+$/u, "")}/`);
+  const healthUrl = getApiHealthUrl(apiUrl);
   const response = await fetch(healthUrl, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });

--- a/scripts/check-production-freshness.test.ts
+++ b/scripts/check-production-freshness.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { evaluateProductionFreshness } from "./check-production-freshness";
+
+describe("production freshness policy", () => {
+  test("accepts production at both policy boundaries", () => {
+    expect(
+      evaluateProductionFreshness({
+        lagCommits: 100,
+        lagHours: 168,
+        maxLagCommits: 100,
+        maxLagHours: 168,
+      }),
+    ).toEqual({ status: "current" });
+  });
+
+  test("reports every exceeded boundary", () => {
+    expect(
+      evaluateProductionFreshness({
+        lagCommits: 101,
+        lagHours: 169,
+        maxLagCommits: 100,
+        maxLagHours: 168,
+      }),
+    ).toEqual({
+      reasons: [
+        "production is 101 commits behind main (maximum 100)",
+        "the oldest unreleased main commit has waited 169 hours (maximum 168)",
+      ],
+      status: "stale",
+    });
+  });
+
+  test("does not fail a fresh release merely because main moved", () => {
+    expect(
+      evaluateProductionFreshness({
+        lagCommits: 3,
+        lagHours: 12,
+        maxLagCommits: 100,
+        maxLagHours: 168,
+      }),
+    ).toEqual({ status: "current" });
+  });
+});

--- a/scripts/check-production-freshness.ts
+++ b/scripts/check-production-freshness.ts
@@ -1,10 +1,11 @@
 import { appendFile } from "node:fs/promises";
 
+import { getApiHealthUrl, parseHealthCommit } from "./api-health";
+
 const DEFAULT_PRODUCTION_API_URL = "https://api.stll.app";
 const DEFAULT_MAX_LAG_COMMITS = 100;
 const DEFAULT_MAX_LAG_HOURS = 7 * 24;
 const FETCH_TIMEOUT_MS = 10_000;
-const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
 
 class ProductionFreshnessError extends Error {
   constructor(message: string) {
@@ -64,10 +65,8 @@ const readPositiveInteger = (name: string, fallback: number) => {
   return value;
 };
 
-const stripTrailingSlash = (value: string) => value.replace(/\/+$/u, "");
-
 const readProductionCommit = async (apiUrl: string) => {
-  const healthUrl = new URL("/health", `${stripTrailingSlash(apiUrl)}/`);
+  const healthUrl = getApiHealthUrl(apiUrl);
   const response = await fetch(healthUrl, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
@@ -77,15 +76,8 @@ const readProductionCommit = async (apiUrl: string) => {
     );
   }
 
-  const value: unknown = await response.json();
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new ProductionFreshnessError(
-      "production /health did not return an object",
-    );
-  }
-
-  const commit = Reflect.get(value, "commit");
-  if (typeof commit !== "string" || !COMMIT_SHA_PATTERN.test(commit)) {
+  const commit = parseHealthCommit(await response.json());
+  if (!commit) {
     throw new ProductionFreshnessError(
       "production /health did not return a full lowercase commit SHA",
     );

--- a/scripts/check-production-freshness.ts
+++ b/scripts/check-production-freshness.ts
@@ -1,3 +1,5 @@
+import { appendFile } from "node:fs/promises";
+
 const DEFAULT_PRODUCTION_API_URL = "https://api.stll.app";
 const DEFAULT_MAX_LAG_COMMITS = 100;
 const DEFAULT_MAX_LAG_HOURS = 7 * 24;
@@ -149,7 +151,7 @@ const appendSummary = async (lines: string[]) => {
   if (!summaryPath) {
     return;
   }
-  await Bun.write(summaryPath, `${lines.join("\n")}\n`);
+  await appendFile(summaryPath, `${lines.join("\n")}\n`);
 };
 
 const main = async () => {

--- a/scripts/check-production-freshness.ts
+++ b/scripts/check-production-freshness.ts
@@ -1,0 +1,198 @@
+const DEFAULT_PRODUCTION_API_URL = "https://api.stll.app";
+const DEFAULT_MAX_LAG_COMMITS = 100;
+const DEFAULT_MAX_LAG_HOURS = 7 * 24;
+const FETCH_TIMEOUT_MS = 10_000;
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+
+class ProductionFreshnessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProductionFreshnessError";
+  }
+}
+
+type ProductionFreshnessInput = {
+  lagCommits: number;
+  lagHours: number;
+  maxLagCommits: number;
+  maxLagHours: number;
+};
+
+type ProductionFreshnessResult =
+  | { status: "current" }
+  | { reasons: string[]; status: "stale" };
+
+export const evaluateProductionFreshness = ({
+  lagCommits,
+  lagHours,
+  maxLagCommits,
+  maxLagHours,
+}: ProductionFreshnessInput): ProductionFreshnessResult => {
+  const reasons: string[] = [];
+
+  if (lagCommits > maxLagCommits) {
+    reasons.push(
+      `production is ${lagCommits} commits behind main (maximum ${maxLagCommits})`,
+    );
+  }
+  if (lagHours > maxLagHours) {
+    reasons.push(
+      `the oldest unreleased main commit has waited ${Math.floor(lagHours)} hours (maximum ${maxLagHours})`,
+    );
+  }
+
+  if (reasons.length > 0) {
+    return { reasons, status: "stale" };
+  }
+  return { status: "current" };
+};
+
+const readPositiveInteger = (name: string, fallback: number) => {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return fallback;
+  }
+
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new ProductionFreshnessError(
+      `${name} must be a positive integer; received ${raw}`,
+    );
+  }
+  return value;
+};
+
+const stripTrailingSlash = (value: string) => value.replace(/\/+$/u, "");
+
+const readProductionCommit = async (apiUrl: string) => {
+  const healthUrl = new URL("/health", `${stripTrailingSlash(apiUrl)}/`);
+  const response = await fetch(healthUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new ProductionFreshnessError(
+      `${healthUrl.toString()} returned HTTP ${response.status}`,
+    );
+  }
+
+  const value: unknown = await response.json();
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ProductionFreshnessError(
+      "production /health did not return an object",
+    );
+  }
+
+  const commit = Reflect.get(value, "commit");
+  if (typeof commit !== "string" || !COMMIT_SHA_PATTERN.test(commit)) {
+    throw new ProductionFreshnessError(
+      "production /health did not return a full lowercase commit SHA",
+    );
+  }
+  return commit;
+};
+
+const runGit = async (args: string[]) => {
+  const process = Bun.spawn(["git", ...args], {
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    throw new ProductionFreshnessError(
+      `git ${args.join(" ")} failed: ${stderr.trim()}`,
+    );
+  }
+  return stdout.trim();
+};
+
+const readLag = async (productionCommit: string) => {
+  await runGit(["merge-base", "--is-ancestor", productionCommit, "HEAD"]);
+
+  const [lagCommitsRaw, unreleasedCommitEpochs] = await Promise.all([
+    runGit(["rev-list", "--count", `${productionCommit}..HEAD`]),
+    runGit(["log", "--reverse", "--format=%ct", `${productionCommit}..HEAD`]),
+  ]);
+  const lagCommits = Number(lagCommitsRaw);
+  const oldestUnreleasedCommitEpochRaw = unreleasedCommitEpochs
+    .split("\n")
+    .find(Boolean);
+  const oldestUnreleasedCommitEpoch = oldestUnreleasedCommitEpochRaw
+    ? Number(oldestUnreleasedCommitEpochRaw)
+    : undefined;
+  if (!Number.isSafeInteger(lagCommits)) {
+    throw new ProductionFreshnessError(
+      "git returned invalid production freshness metadata",
+    );
+  }
+  if (
+    lagCommits > 0 &&
+    (oldestUnreleasedCommitEpoch === undefined ||
+      !Number.isSafeInteger(oldestUnreleasedCommitEpoch))
+  ) {
+    throw new ProductionFreshnessError(
+      "git returned no timestamp for the oldest unreleased commit",
+    );
+  }
+
+  const lagHours = oldestUnreleasedCommitEpoch
+    ? Math.max(0, Date.now() / 3_600_000 - oldestUnreleasedCommitEpoch / 3600)
+    : 0;
+  return { lagCommits, lagHours };
+};
+
+const appendSummary = async (lines: string[]) => {
+  const summaryPath = process.env["GITHUB_STEP_SUMMARY"];
+  if (!summaryPath) {
+    return;
+  }
+  await Bun.write(summaryPath, `${lines.join("\n")}\n`);
+};
+
+const main = async () => {
+  const apiUrl =
+    process.env["PRODUCTION_API_URL"]?.trim() || DEFAULT_PRODUCTION_API_URL;
+  const maxLagCommits = readPositiveInteger(
+    "MAX_PRODUCTION_LAG_COMMITS",
+    DEFAULT_MAX_LAG_COMMITS,
+  );
+  const maxLagHours = readPositiveInteger(
+    "MAX_PRODUCTION_LAG_HOURS",
+    DEFAULT_MAX_LAG_HOURS,
+  );
+  const productionCommit = await readProductionCommit(apiUrl);
+  const { lagCommits, lagHours } = await readLag(productionCommit);
+  const result = evaluateProductionFreshness({
+    lagCommits,
+    lagHours,
+    maxLagCommits,
+    maxLagHours,
+  });
+  const facts = [
+    "## Production freshness",
+    "",
+    `- Production commit: \`${productionCommit}\``,
+    `- Main HEAD: \`${await runGit(["rev-parse", "HEAD"])}\``,
+    `- Commit lag: ${lagCommits} (maximum ${maxLagCommits})`,
+    `- Oldest unreleased change: ${Math.floor(lagHours)} hours (maximum ${maxLagHours})`,
+  ];
+  await appendSummary(facts);
+
+  if (result.status === "stale") {
+    throw new ProductionFreshnessError(result.reasons.join("; "));
+  }
+  console.log(
+    `production-freshness: ok (${lagCommits} commits, ${Math.floor(lagHours)} hours)`,
+  );
+};
+
+if (import.meta.main) {
+  await main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`production-freshness: ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -198,6 +198,11 @@ run_step "Knip production deps" run_knip
 run_step "Test" run_test
 run_step "Bridge-version guard self-test" bash scripts/check-bridge-version.test.sh
 run_step "Release-channel self-test" bash scripts/release-channel.test.sh
+run_step "API release contract self-test" bun test \
+  --preload ./apps/api/src/tests/setup-env.ts \
+  scripts/check-api-cli-contract.test.ts \
+  scripts/check-api-deployment.test.ts \
+  scripts/check-production-freshness.test.ts
 run_step "Desktop-release-changes self-test" bash scripts/detect-desktop-release-changes.test.sh
 run_step "Bridge-version guard" bash scripts/check-bridge-version.sh
 


### PR DESCRIPTION
## Summary

- publish a versioned API/CLI compatibility contract and negotiate OAuth scopes in the CLI
- gate CLI publication on an immutable stable-release identity and an exact packed-artifact production canary
- enforce contract coherence and production freshness through CI and scheduled release checks
- eliminate API test state and timezone drift exposed by full repository verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stella compatibility check` to verify API and CLI compatibility before sign-in.
  * OAuth login now negotiates supported scopes and reports unavailable required scopes clearly.
  * MCP discovery metadata now advertises API contract and supported CLI versions.

* **Bug Fixes**
  * Improved date handling for citation authority calculations across time zones.
  * Rate limiting now fails over more reliably when Redis is unavailable or slow.

* **Documentation**
  * Expanded release, compatibility, authentication, and production freshness guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->