### PR TITLE
fix: upload AI canary coverage markers

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -80,15 +80,15 @@ jobs:
         env:
           PROVIDER: ${{ matrix.provider }}
         run: |
-          mkdir -p .canary-ran
-          touch ".canary-ran/$PROVIDER"
+          mkdir -p canary-ran
+          touch "canary-ran/$PROVIDER"
 
       - name: Upload configured-provider marker
         if: steps.credential.outputs.configured == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ai-provider-canary-${{ matrix.provider }}
-          path: .canary-ran/
+          path: canary-ran/
           retention-days: 1
 
       - name: Probe provider capability contract
@@ -112,14 +112,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ai-provider-canary-*
-          path: .canary-ran
+          path: canary-ran
           merge-multiple: true
 
       - name: Require at least one configured provider
         env:
           DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
         run: |
-          if [[ "$DOWNLOAD_OUTCOME" != "success" ]] || [[ -z "$(find .canary-ran -type f -print -quit 2>/dev/null)" ]]; then
+          if [[ "$DOWNLOAD_OUTCOME" != "success" ]] || [[ -z "$(find canary-ran -type f -print -quit 2>/dev/null)" ]]; then
             echo "::error title=No AI provider canary coverage::Configure at least one supported provider repository secret."
             exit 1
           fi


### PR DESCRIPTION
The configured-provider artifact was empty because the marker lived under a hidden directory that upload-artifact excludes by default. Use a normal marker directory so the coverage job can download and verify configured providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI provider canary workflow to consistently store, transfer and validate provider coverage markers.
  * Improved reliability of automated provider coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->