### PR TITLE
fix: preserve boolean types in provider schemas

### DIFF
--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -168,9 +168,8 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(droppedKeywords).toEqual([]);
   });
 
-  test("drops const constraints that cannot be lowered to provider-safe enums", () => {
+  test("preserves the inferred boolean type when dropping a const constraint", () => {
     const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
-      type: "boolean",
       const: true,
     });
 

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -169,6 +169,10 @@ const normalizeConstKeyword = ({
 
   const constValue = next["const"];
   delete next["const"];
+  if (typeof constValue === "boolean" && !("type" in next)) {
+    next["type"] = "boolean";
+  }
+
   if (constValue === null && !("enum" in next) && !("type" in next)) {
     if (context.nullUnionStrategy === "json-schema") {
       next["type"] = "null";


### PR DESCRIPTION
## Summary

- retain the inferred boolean type when provider projection drops an unsupported boolean const constraint
- cover the type-less boolean literal shape emitted by the Valibot tool-schema path

## Why

Boolean literals can be serialized as a const without an explicit type. Dropping the exact constraint previously projected that schema to an unconstrained object, allowing providers to return a string where Stella expects a boolean.

## Testing

- bun test apps/api/src/lib/provider-safe-json-schema.test.ts
- oxfmt check on changed files
- type-aware oxlint on changed files
- git diff --check