### PR TITLE
fix: harden AI tool round trips

### DIFF
--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -10,6 +10,7 @@ import {
   projectToProviderSafeJsonSchema,
   PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
 } from "@/api/lib/provider-safe-json-schema";
+import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
 
 const PROVIDER_SAFE_KEYWORDS = new Set<string>(
   PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
@@ -177,6 +178,22 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(droppedKeywords).toEqual(["const"]);
   });
 
+  test("preserves a numeric literal type through the provider tool funnel", () => {
+    const inputSchema = projectSchemaInputJsonSchema(
+      toTanStackToolSchema(v.strictObject({ count: v.literal(7) })),
+      { nullUnionStrategy: "openapi" },
+    );
+
+    expect(convertSchemaToJsonSchema(inputSchema)).toEqual({
+      type: "object",
+      properties: {
+        count: { type: "number", enum: [7] },
+      },
+      required: ["count"],
+      additionalProperties: false,
+    });
+  });
+
   test("records const when enum already carries the allowed values", () => {
     const { schema, droppedKeywords } = projectToProviderSafeJsonSchema({
       type: "string",
@@ -336,7 +353,7 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(schema).toEqual({
       type: "object",
       properties: {
-        kind: { enum: ["lookup"] },
+        kind: { type: "string", enum: ["lookup"] },
         mode: { enum: ["auto"], nullable: true },
       },
       required: ["kind"],

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -169,8 +169,14 @@ const normalizeConstKeyword = ({
 
   const constValue = next["const"];
   delete next["const"];
-  if (typeof constValue === "boolean" && !("type" in next)) {
-    next["type"] = "boolean";
+  const constType = typeof constValue;
+  if (
+    !("type" in next) &&
+    (constType === "boolean" ||
+      constType === "number" ||
+      constType === "string")
+  ) {
+    next["type"] = constType;
   }
 
   if (constValue === null && !("enum" in next) && !("type" in next)) {

--- a/bun.lock
+++ b/bun.lock
@@ -618,6 +618,7 @@
   },
   "patchedDependencies": {
     "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch",
+    "@tanstack/ai-openrouter@0.15.8": "patches/@tanstack%2Fai-openrouter@0.15.8.patch",
     "@tanstack/ai-anthropic@0.16.1": "patches/@tanstack%2Fai-anthropic@0.16.1.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   },
   "patchedDependencies": {
     "@tanstack/openai-base@0.9.7": "patches/@tanstack%2Fopenai-base@0.9.7.patch",
-    "@tanstack/ai-anthropic@0.16.1": "patches/@tanstack%2Fai-anthropic@0.16.1.patch"
+    "@tanstack/ai-anthropic@0.16.1": "patches/@tanstack%2Fai-anthropic@0.16.1.patch",
+    "@tanstack/ai-openrouter@0.15.8": "patches/@tanstack%2Fai-openrouter@0.15.8.patch"
   }
 }

--- a/patches/@tanstack%2Fai-openrouter@0.15.8.patch
+++ b/patches/@tanstack%2Fai-openrouter@0.15.8.patch
@@ -1,0 +1,154 @@
+diff --git a/dist/esm/adapters/responses-text.js b/dist/esm/adapters/responses-text.js
+index 0eb06fdef60286749e5e607b940613f754af090b..c463387ae602ebab998ddd9b71229bb0da69bf80 100644
+--- a/dist/esm/adapters/responses-text.js
++++ b/dist/esm/adapters/responses-text.js
+@@ -831,24 +831,28 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+             let metadata = toolCallMetadata.get(item.id);
+             if (!metadata) {
+               metadata = {
++                callId: item.callId || item.id,
+                 index: chunk.outputIndex ?? 0,
++                itemId: item.id,
+                 name: item.name,
+                 started: false
+               };
+               toolCallMetadata.set(item.id, metadata);
+-            } else if (!metadata.name) {
+-              metadata.name = item.name;
++            } else {
++              if (item.callId) metadata.callId = item.callId;
++              if (!metadata.name) metadata.name = item.name;
+             }
+             if (!metadata.started && metadata.name) {
+               yield {
+                 type: EventType.TOOL_CALL_START,
+-                toolCallId: item.id,
++                toolCallId: metadata.callId,
+                 toolCallName: metadata.name,
+                 toolName: metadata.name,
+                 parentMessageId: aguiState.messageId,
+                 model: model || options.model,
+                 timestamp: Date.now(),
+-                index: chunk.outputIndex ?? 0
++                index: chunk.outputIndex ?? 0,
++                metadata: { itemId: metadata.itemId }
+               };
+               metadata.started = true;
+             }
+@@ -870,7 +874,7 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+           }
+           yield {
+             type: EventType.TOOL_CALL_ARGS,
+-            toolCallId: itemId,
++            toolCallId: metadata.callId,
+             model: model || options.model,
+             timestamp: Date.now(),
+             delta: typeof chunk.delta === "string" ? chunk.delta : ""
+@@ -920,7 +924,7 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+           }
+           yield {
+             type: EventType.TOOL_CALL_END,
+-            toolCallId: itemId,
++            toolCallId: metadata.callId,
+             toolCallName: name,
+             toolName: name,
+             model: model || options.model,
+@@ -932,25 +936,29 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+           const item = chunk.item;
+           if (item?.type === "function_call" && item.id) {
+             const metadata = toolCallMetadata.get(item.id) ?? {
++              callId: item.callId || item.id,
+               index: chunk.outputIndex ?? 0,
++              itemId: item.id,
+               name: item.name,
+               started: false
+             };
+             if (!toolCallMetadata.has(item.id)) {
+               toolCallMetadata.set(item.id, metadata);
+-            } else if (!metadata.name) {
+-              metadata.name = item.name;
++            } else {
++              if (item.callId) metadata.callId = item.callId;
++              if (!metadata.name) metadata.name = item.name;
+             }
+             if (!metadata.started && metadata.name) {
+               yield {
+                 type: EventType.TOOL_CALL_START,
+-                toolCallId: item.id,
++                toolCallId: metadata.callId,
+                 toolCallName: metadata.name,
+                 toolName: metadata.name,
+                 parentMessageId: aguiState.messageId,
+                 model: model || options.model,
+                 timestamp: Date.now(),
+-                index: metadata.index
++                index: metadata.index,
++                metadata: { itemId: metadata.itemId }
+               };
+               metadata.started = true;
+             }
+@@ -981,7 +989,7 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+               }
+               yield {
+                 type: EventType.TOOL_CALL_END,
+-                toolCallId: item.id,
++                toolCallId: metadata.callId,
+                 toolCallName: name,
+                 toolName: name,
+                 model: model || options.model,
+@@ -999,25 +1007,29 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+           for (const item of outputItems) {
+             if (item.type !== "function_call" || !item.id) continue;
+             const metadata = toolCallMetadata.get(item.id) ?? {
++              callId: item.callId || item.id,
+               index: 0,
++              itemId: item.id,
+               name: item.name || "",
+               started: false
+             };
+             if (!toolCallMetadata.has(item.id)) {
+               toolCallMetadata.set(item.id, metadata);
+-            } else if (!metadata.name && item.name) {
+-              metadata.name = item.name;
++            } else {
++              if (item.callId) metadata.callId = item.callId;
++              if (!metadata.name && item.name) metadata.name = item.name;
+             }
+             if (!metadata.started && metadata.name) {
+               yield {
+                 type: EventType.TOOL_CALL_START,
+-                toolCallId: item.id,
++                toolCallId: metadata.callId,
+                 toolCallName: metadata.name,
+                 toolName: metadata.name,
+                 parentMessageId: aguiState.messageId,
+                 model: model || options.model,
+                 timestamp: Date.now(),
+-                index: metadata.index
++                index: metadata.index,
++                metadata: { itemId: metadata.itemId }
+               };
+               metadata.started = true;
+             }
+@@ -1048,7 +1060,7 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+               }
+               yield {
+                 type: EventType.TOOL_CALL_END,
+-                toolCallId: item.id,
++                toolCallId: metadata.callId,
+                 toolCallName: name,
+                 toolName: name,
+                 model: model || options.model,
+@@ -1215,10 +1227,11 @@ class OpenRouterResponsesTextAdapter extends BaseTextAdapter {
+         if (message.toolCalls && message.toolCalls.length > 0) {
+           for (const toolCall of message.toolCalls) {
+             const argumentsString = typeof toolCall.function.arguments === "string" ? toolCall.function.arguments : JSON.stringify(toolCall.function.arguments);
++            const itemId = toolCall.metadata?.itemId;
+             result.push({
+               type: "function_call",
+               callId: toolCall.id,
+-              id: toolCall.id,
++              id: itemId || toolCall.id,
+               name: toolCall.function.name,
+               arguments: argumentsString
+             });


### PR DESCRIPTION
## What changed

- preserve primitive `const` types when projecting provider-safe tool schemas
- carry distinct OpenRouter Responses output-item and function-call IDs through server tool execution
- pin the temporary OpenRouter adapter fix as a Bun dependency patch

## Root cause

Numeric literals were lowered to `enum` without retaining their JSON Schema type, which Gemini interpreted as a string enum. Separately, the OpenRouter Responses adapter used the output-item ID as the tool-call correlation ID, so the follow-up `function_call_output` referenced the wrong call.

## Impact

Gemini receives correctly typed numeric literals, and OpenRouter server tools can complete a real two-turn call/result round trip. The dependency patch is version-pinned and can be removed after the upstream fix is released.

## Validation

- `bun test apps/api/src/lib/provider-safe-json-schema.test.ts` (36 passed)
- focused schema lint passed before the request to defer local lint/typecheck to CI
- `bun install --frozen-lockfile --ignore-scripts`
- expanded provider canary will validate both fixes against live APIs after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tool-call events by maintaining consistent call identifiers across streamed and completed responses.
  * Tool-call metadata now remains available throughout the response lifecycle.
  * Improved handling of numeric literal values in generated JSON Schemas.
  * Boolean, number and string constants now retain their appropriate schema types.
  * Updated schema projections to include explicit type information where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->