### PR TITLE
fix: model AI provider schema capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
       && (needs.trust-check.outputs.trusted == 'true'
           || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
 
@@ -415,7 +415,9 @@ jobs:
         run: |
           args=()
           [[ -z "$AFFECTED_FLAG" ]] || args+=("$AFFECTED_FLAG")
-          bun run lint -- "${args[@]}"
+          # Type-aware API and web linting together can exhaust the hosted
+          # runner. Serialize packages so lint failures remain deterministic.
+          bun run lint -- "${args[@]}" --concurrency=1
 
   typecheck:
     needs: [trust-check, ci-changes]

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,4 +1,4 @@
-import { chat, maxIterations, toolDefinition } from "@tanstack/ai";
+import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
 import type { Tool } from "@tanstack/ai";
 import * as v from "valibot";
 
@@ -381,10 +381,10 @@ const runToolProbe = async ({
   });
   let output = "";
   for await (const chunk of stream) {
-    if (chunk.type === "TEXT_MESSAGE_CONTENT" && chunk.delta) {
+    if (chunk.type === EventType.TEXT_MESSAGE_CONTENT && chunk.delta) {
       output += chunk.delta;
     }
-    if (chunk.type === "RUN_ERROR") {
+    if (chunk.type === EventType.RUN_ERROR) {
       throw new CanaryProviderRunError(chunk);
     }
   }

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -11,7 +11,7 @@ import type { ModelRole } from "@stll/ai-catalog";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 import type { CachingDecision, OrgAIConfig } from "@/api/lib/ai-config";
-import { nullUnionStrategyForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import {
   abortControllerFromSignal,
   generateTanStackObjectForRole,
@@ -49,6 +49,55 @@ const TOOL_ROUND_TRIP_PROMPT =
   `Call ${TOOL_ROUND_TRIP_NAME} exactly once with value "${TOOL_ROUND_TRIP_VALUE}" ` +
   `and count ${TOOL_ROUND_TRIP_COUNT}. Then reply with only the confirmation ` +
   "value returned by the tool.";
+
+const SAFE_CANARY_ERROR_MESSAGES = new Set([
+  "Canary resolved an unexpected provider model.",
+  "Provider did not execute the canary tool exactly once.",
+  "Provider returned unexpected canary tool arguments.",
+  "Provider did not return the canary tool result.",
+  "Provider returned no text.",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const providerStatus = (error: unknown, depth = 0): number | null => {
+  if (!isRecord(error)) {
+    return null;
+  }
+  for (const key of ["status", "statusCode", "code"] as const) {
+    const value = error[key];
+    if (
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= 100 &&
+      value <= 599
+    ) {
+      return value;
+    }
+  }
+
+  if (depth >= 3) {
+    return null;
+  }
+  for (const key of ["rawEvent", "error", "cause"] as const) {
+    const nestedStatus = providerStatus(error[key], depth + 1);
+    if (nestedStatus !== null) {
+      return nestedStatus;
+    }
+  }
+  return null;
+};
+
+class CanaryProviderRunError extends TypeError {
+  readonly status: number | null;
+
+  constructor(event: unknown) {
+    super("Provider stream failed.");
+    this.name = "CanaryProviderRunError";
+    this.status = providerStatus(event);
+  }
+}
 
 const NO_CACHING = {
   enabled: false,
@@ -306,15 +355,16 @@ const runToolProbe = async ({
     orgAIConfig: config,
     role,
   });
-  const inputSchema = projectSchemaInputJsonSchema(tool.inputSchema, {
-    nullUnionStrategy: nullUnionStrategyForTanStackProvider(provider),
-  });
+  const inputSchema = projectSchemaInputJsonSchema(
+    tool.inputSchema,
+    providerSafeJsonSchemaOptionsForTanStackProvider(provider),
+  );
   const projectedTool = {
     ...tool,
     ...(inputSchema === undefined ? {} : { inputSchema }),
   };
 
-  const output = await chat({
+  const stream = chat({
     adapter: model.adapter,
     abortController: abortControllerFromSignal(signal),
     agentLoopStrategy: maxIterations(2),
@@ -326,9 +376,18 @@ const runToolProbe = async ({
       serviceTier: "standard",
       temperature: 0,
     }),
-    stream: false,
+    stream: true,
     tools: [projectedTool],
   });
+  let output = "";
+  for await (const chunk of stream) {
+    if (chunk.type === "TEXT_MESSAGE_CONTENT" && chunk.delta) {
+      output += chunk.delta;
+    }
+    if (chunk.type === "RUN_ERROR") {
+      throw new CanaryProviderRunError(chunk);
+    }
+  }
   requireNonEmptyText(output);
   return output;
 };
@@ -395,25 +454,22 @@ const errorSummary = (error: unknown, signal: AbortSignal): string => {
     return "timeout";
   }
 
+  if (error instanceof CanaryProviderRunError) {
+    return error.status === null
+      ? "provider stream error"
+      : `provider HTTP ${error.status}`;
+  }
+
+  if (
+    error instanceof TypeError &&
+    SAFE_CANARY_ERROR_MESSAGES.has(error.message)
+  ) {
+    return error.message;
+  }
+
   const status = providerStatus(error);
   return status === null ? "provider error" : `provider HTTP ${status}`;
 };
-
-const providerStatus = (error: unknown): number | null => {
-  if (!isRecord(error)) {
-    return null;
-  }
-  for (const key of ["status", "statusCode"] as const) {
-    const value = error[key];
-    if (typeof value === "number" && Number.isInteger(value)) {
-      return value;
-    }
-  }
-  return null;
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
 
 const probeLabel = (context: CanaryContext, probe: Probe): string => {
   if (probe.type === "capability") {

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -80,7 +80,7 @@ import {
   ChatLoopDetectedError,
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
-import { nullUnionStrategyForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import {
   abortControllerFromSignal,
   mergeGenerationOptions,
@@ -368,9 +368,8 @@ export const projectChatToolSchemasForProvider = ({
   modelTools: ReturnType<typeof chatToolMapToArray>;
   provider: string;
 }): ReturnType<typeof chatToolMapToArray> => {
-  const projectionOptions = {
-    nullUnionStrategy: nullUnionStrategyForTanStackProvider(provider),
-  };
+  const projectionOptions =
+    providerSafeJsonSchemaOptionsForTanStackProvider(provider);
   const projectedTools: ReturnType<typeof chatToolMapToArray> = [];
   for (const tool of modelTools) {
     const projectedTool = { ...tool };
@@ -404,9 +403,8 @@ const projectServerToolsForProvider = ({
   provider: string;
   serverTools: readonly ServerTool[];
 }): ServerTool[] => {
-  const projectionOptions = {
-    nullUnionStrategy: nullUnionStrategyForTanStackProvider(provider),
-  };
+  const projectionOptions =
+    providerSafeJsonSchemaOptionsForTanStackProvider(provider);
   const projectedTools: ServerTool[] = [];
   for (const tool of serverTools) {
     const projectedTool = { ...tool };

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -7,6 +7,7 @@ import { propertyConfig } from "@stll/property-testing";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 import {
+  providerSafeJsonSchemaOptionsForTanStackProvider,
   projectToProviderSafeJsonSchema,
   PROVIDER_SAFE_JSON_SCHEMA_KEYWORDS,
 } from "@/api/lib/provider-safe-json-schema";
@@ -118,6 +119,23 @@ const schemaWithComposition = fc.oneof(
 );
 
 describe("projectToProviderSafeJsonSchema", () => {
+  test("selects explicit schema dialects for provider adapters", () => {
+    expect(providerSafeJsonSchemaOptionsForTanStackProvider("google")).toEqual({
+      enumValueStrategy: "string-only",
+      nullUnionStrategy: "openapi",
+    });
+    expect(
+      providerSafeJsonSchemaOptionsForTanStackProvider("openrouter"),
+    ).toEqual({
+      enumValueStrategy: "string-only",
+      nullUnionStrategy: "json-schema",
+    });
+    expect(providerSafeJsonSchemaOptionsForTanStackProvider("openai")).toEqual({
+      enumValueStrategy: "json-schema",
+      nullUnionStrategy: "json-schema",
+    });
+  });
+
   test("drops propertyNames from the fill_template repro while keeping additionalProperties", () => {
     const input = {
       type: "object",
@@ -187,7 +205,7 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(convertSchemaToJsonSchema(inputSchema)).toEqual({
       type: "object",
       properties: {
-        count: { type: "number", enum: [7] },
+        count: { type: "number" },
       },
       required: ["count"],
       additionalProperties: false,
@@ -225,8 +243,24 @@ describe("projectToProviderSafeJsonSchema", () => {
       { nullUnionStrategy: "openapi" },
     );
 
-    expect(schema).toEqual({ enum: ["ready", 1], nullable: true });
-    expect(droppedKeywords).toEqual(["enum[1]"]);
+    expect(schema).toEqual({ enum: ["ready"], nullable: true });
+    expect(droppedKeywords).toEqual(["enum[1]", "enum[3]"]);
+  });
+
+  test("applies string-only enums independently of the null dialect", () => {
+    const { schema, droppedKeywords } = projectToProviderSafeJsonSchema(
+      {
+        type: "number",
+        enum: [7],
+      },
+      {
+        enumValueStrategy: "string-only",
+        nullUnionStrategy: "json-schema",
+      },
+    );
+
+    expect(schema).toEqual({ type: "number" });
+    expect(droppedKeywords).toEqual(["enum[0]"]);
   });
 
   test("lowers oneOf to anyOf and recurses into branches", () => {
@@ -744,7 +778,12 @@ describe("projectToProviderSafeJsonSchema", () => {
           );
 
           expect(schema["nullable"]).toBe(true);
-          expect(schema["enum"]).toEqual(values);
+          const stringValues = values.filter(
+            (value): value is string => typeof value === "string",
+          );
+          expect(schema["enum"]).toEqual(
+            stringValues.length === 0 ? undefined : stringValues,
+          );
         },
       ),
       propertyConfig({ numRuns: 200 }),

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -196,12 +196,22 @@ describe("projectToProviderSafeJsonSchema", () => {
     expect(droppedKeywords).toEqual(["const"]);
   });
 
-  test("preserves a numeric literal type through the provider tool funnel", () => {
-    const inputSchema = projectSchemaInputJsonSchema(
-      toTanStackToolSchema(v.strictObject({ count: v.literal(7) })),
-      { nullUnionStrategy: "openapi" },
+  test("projects numeric literals without weakening local tool validation", async () => {
+    const sourceInputSchema = toTanStackToolSchema(
+      v.strictObject({ count: v.literal(7) }),
     );
+    const inputSchema = projectSchemaInputJsonSchema(sourceInputSchema, {
+      nullUnionStrategy: "openapi",
+    });
 
+    expect(inputSchema).toHaveProperty(
+      "~standard.validate",
+      sourceInputSchema["~standard"].validate,
+    );
+    const invalidResult = await sourceInputSchema["~standard"].validate({
+      count: 8,
+    });
+    expect(invalidResult.issues).toBeDefined();
     expect(convertSchemaToJsonSchema(inputSchema)).toEqual({
       type: "object",
       properties: {

--- a/apps/api/src/lib/provider-safe-json-schema.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.ts
@@ -68,14 +68,22 @@ export type ProviderSafeJsonSchemaProjection = {
 };
 
 export type NullUnionStrategy = "json-schema" | "openapi";
+export type EnumValueStrategy = "json-schema" | "string-only";
 
 export type ProviderSafeJsonSchemaProjectionOptions = {
+  enumValueStrategy?: EnumValueStrategy;
   nullUnionStrategy?: NullUnionStrategy;
 };
 
-export const nullUnionStrategyForTanStackProvider = (
+export const providerSafeJsonSchemaOptionsForTanStackProvider = (
   provider: string,
-): NullUnionStrategy => (provider === "google" ? "openapi" : "json-schema");
+): ProviderSafeJsonSchemaProjectionOptions => ({
+  enumValueStrategy:
+    provider === "google" || provider === "openrouter"
+      ? "string-only"
+      : "json-schema",
+  nullUnionStrategy: provider === "google" ? "openapi" : "json-schema",
+});
 
 const isJsonObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -110,6 +118,7 @@ const resolveLocalJsonPointer = (root: JsonObject, ref: string): unknown => {
 type ProjectionContext = {
   root: JsonObject;
   dropped: string[];
+  enumValueStrategy: EnumValueStrategy;
   nullUnionStrategy: NullUnionStrategy;
 };
 
@@ -200,7 +209,7 @@ const normalizeConstKeyword = ({
   context.dropped.push(joinPath(path, "const"));
 };
 
-const filterOpenApiEnumValues = ({
+const filterEnumValues = ({
   context,
   next,
   path,
@@ -213,17 +222,17 @@ const filterOpenApiEnumValues = ({
     return;
   }
 
-  if (context.nullUnionStrategy === "json-schema") {
+  if (context.enumValueStrategy === "json-schema") {
     return;
   }
 
   const providerSafeValues: unknown[] = [];
   for (const [index, value] of next["enum"].entries()) {
-    if (typeof value === "string" || typeof value === "number") {
+    if (typeof value === "string") {
       providerSafeValues.push(value);
       continue;
     }
-    if (value === null) {
+    if (value === null && context.nullUnionStrategy === "openapi") {
       next["nullable"] = true;
       continue;
     }
@@ -248,7 +257,7 @@ const normalizeLiteralKeywords = ({
   path: string;
 }): void => {
   normalizeConstKeyword({ context, next, path });
-  filterOpenApiEnumValues({ context, next, path });
+  filterEnumValues({ context, next, path });
 };
 
 const stringArrayFrom = (value: unknown): string[] | null => {
@@ -902,10 +911,14 @@ export const projectToProviderSafeJsonSchema = (
   schema: Record<string, unknown>,
   options: ProviderSafeJsonSchemaProjectionOptions = {},
 ): ProviderSafeJsonSchemaProjection => {
+  const nullUnionStrategy = options.nullUnionStrategy ?? "json-schema";
   const context: ProjectionContext = {
     root: schema,
     dropped: [],
-    nullUnionStrategy: options.nullUnionStrategy ?? "json-schema",
+    enumValueStrategy:
+      options.enumValueStrategy ??
+      (nullUnionStrategy === "openapi" ? "string-only" : "json-schema"),
+    nullUnionStrategy,
   };
   const projected = projectNode({
     node: schema,

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -18,7 +18,7 @@ import type {
 import type { TanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { nullUnionStrategyForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import { tanStackCacheControl } from "@/api/lib/tanstack-ai-caching";
 import {
   getTanStackTextModelById,
@@ -333,9 +333,10 @@ export const generateTanStackObjectForRole = async <
   const abortController = options.abortSignal
     ? abortControllerFromSignal(options.abortSignal)
     : undefined;
-  const tanStackOutputSchema = toTanStackValibotSchema(outputSchema, {
-    nullUnionStrategy: nullUnionStrategyForTanStackProvider(model.provider),
-  });
+  const tanStackOutputSchema = toTanStackValibotSchema(
+    outputSchema,
+    providerSafeJsonSchemaOptionsForTanStackProvider(model.provider),
+  );
 
   const output = await withStandardServiceTierFallback({
     model,
@@ -420,9 +421,10 @@ const streamTanStackStructuredOutput = async function* <
 }): AsyncIterable<TanStackStructuredOutputEvent<v.InferOutput<TSchema>>> {
   let completed = false;
   let rawJson = "";
-  const tanStackOutputSchema = toTanStackValibotSchema(outputSchema, {
-    nullUnionStrategy: nullUnionStrategyForTanStackProvider(model.provider),
-  });
+  const tanStackOutputSchema = toTanStackValibotSchema(
+    outputSchema,
+    providerSafeJsonSchemaOptionsForTanStackProvider(model.provider),
+  );
 
   const stream = iterateWithStandardServiceTierFallback({
     model,


### PR DESCRIPTION
## What changed

- model enum-value and null-union support as separate provider schema capabilities
- use string-only enum values for Google and OpenRouter while retaining numeric field types
- apply the same provider projection options to chat tools, server tools, and structured outputs
- preserve the original Standard Schema validator while projecting only the provider-facing JSON Schema
- consume tool canary streams directly so `RUN_ERROR` events cannot collapse into an empty-text symptom
- serialize affected-package lint execution on hosted runners without changing lint rules or affected scope

## Root cause

Gemini function declarations only accept string enum values. OpenRouter can route Responses requests to Gemini, so preserving a numeric enum for OpenRouter also failed after routing, despite using the JSON Schema null dialect. The previous projection coupled enum behavior to null-union behavior and therefore could not represent this combination.

## Impact

Provider dialect selection is explicit at the adapter boundary, without inspecting model names. Unsupported numeric enum constraints are dropped from the provider-facing schema while the numeric type and original server-side Valibot validation remain intact.

## Validation

- provider schema test suite, including an invariant that rejects an invalid literal after projection
- live OpenRouter canary: all nine probes passed, including tool-call round trip
- live Google schema probes passed; remaining Google responses were upstream 503 capacity and the existing zero-quota reasoning role
- GitHub CI: all checks passed, including lint, typecheck, type-cost baseline, builds, and e2e
- local lint/typecheck intentionally deferred to GitHub CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved compatibility of AI tool schemas and structured outputs across supported providers using provider-safe JSON schema settings.
  * More consistent handling of enum and nullable behaviour, including refined treatment of unsupported enum values.
  * Better reliability for both streamed and non-streamed structured output generation.

* **Bug Fixes**
  * Improved canary execution accuracy by classifying streamed provider errors more precisely and reporting HTTP-level failures clearly.
  * Enhanced error reporting when provider stream failures occur during tool probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->