### PR TITLE
fix(ci): clear workflow permission warnings

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,6 +32,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
 
     steps:
       - name: Resolve synthetic ref

--- a/.github/workflows/sync-branch-protection.yml
+++ b/.github/workflows/sync-branch-protection.yml
@@ -48,7 +48,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
+          client-id: ${{ vars.BRANCH_PROTECTION_APP_CLIENT_ID }}
           private-key: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
 
       - name: Apply ruleset


### PR DESCRIPTION
## Summary

- grant the staging provenance job permission to persist artifact metadata
- replace the deprecated GitHub App `app-id` input with the recommended client ID input
- keep the App private key secret and leave the minted token scope unchanged

The repository variable used by the updated workflow is configured. These changes remove warnings emitted by provenance attestation and branch-protection synchronization without broadening unrelated workflow permissions.

Validated with diff integrity checks, staged secret scanning, action-input assertions, repository-variable verification, and a scoped workflow-permissions review. CI provides the repository workflow and policy checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment permissions to support artifact metadata.
  * Updated branch protection synchronisation to use the configured application client ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->