### PR TITLE
fix: budget canary reasoning output

### DIFF
--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { MODEL_ROLES } from "@stll/ai-catalog";
+
+import { modelRoleMaxOutputTokens } from "./ai-provider-canary-config";
+
+describe("AI provider canary role budgets", () => {
+  test("reserves reasoning capacity without inflating other role probes", () => {
+    for (const role of MODEL_ROLES) {
+      expect(modelRoleMaxOutputTokens(role)).toBe(
+        role === "reasoning" ? 25_000 : 512,
+      );
+    }
+  });
+});

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -1,0 +1,11 @@
+import type { ModelRole } from "@stll/ai-catalog";
+
+const MODEL_ROLE_MAX_OUTPUT_TOKENS = {
+  fast: 512,
+  chat: 512,
+  reasoning: 25_000,
+  pdf: 512,
+} as const satisfies Record<ModelRole, number>;
+
+export const modelRoleMaxOutputTokens = (role: ModelRole) =>
+  MODEL_ROLE_MAX_OUTPUT_TOKENS[role];

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -22,6 +22,8 @@ import {
 import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
 import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
 
+import { modelRoleMaxOutputTokens } from "./ai-provider-canary-config";
+
 const CANARY_PROVIDERS = [
   "google",
   "openrouter",
@@ -36,7 +38,6 @@ type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
 const CAPABILITY_ROLE = "fast" satisfies ModelRole;
 const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
 const MAX_OUTPUT_TOKENS = 64;
-const MODEL_ROLE_MAX_OUTPUT_TOKENS = 512;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
@@ -278,7 +279,7 @@ const runModelRoleProbe = async ({
   const output = await generateTanStackTextForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    maxOutputTokens: MODEL_ROLE_MAX_OUTPUT_TOKENS,
+    maxOutputTokens: modelRoleMaxOutputTokens(role),
     organizationId: null,
     orgAIConfig: config,
     prompt: SYNTHETIC_PROMPT,


### PR DESCRIPTION
## Summary

- reserve sufficient output capacity for reasoning-role provider canaries
- keep non-reasoning role probes on the existing bounded budget
- make role budgets exhaustive and cover the selection with a regression test