### PR TITLE
fix: omit sampling for OpenAI reasoning

### DIFF
--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -51,8 +51,10 @@ void mock.module("@/api/lib/tanstack-ai-models", () => ({
 }));
 
 const {
+  generateTanStackTextForRole,
   generateTanStackObjectForRole,
   mergeGenerationOptions,
+  streamTanStackTextForRole,
   streamTanStackObjectForRole,
 } = await import("@/api/lib/tanstack-ai-generate");
 
@@ -381,6 +383,82 @@ describe("TanStack AI structured output generation", () => {
   });
 });
 
+describe("TanStack AI text generation", () => {
+  test("collects text through the error-aware streaming boundary", async () => {
+    capturedChatOptions.length = 0;
+    nextChatResult = createTextStream(["hello", " world"]);
+
+    const output = await generateTanStackTextForRole({
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Say hello.",
+      role: "chat",
+      serviceTier: "standard",
+    });
+
+    expect(output).toBe("hello world");
+    expect(getOnlyCapturedChatOptions().stream).toBeUndefined();
+  });
+
+  test("propagates provider run errors from collected text", async () => {
+    capturedChatOptions.length = 0;
+    nextChatResult = createRunErrorStream({
+      code: "invalid_request_error",
+      message: "OpenAI rejected the request.",
+    });
+
+    const caught = await generateTanStackTextForRole({
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Say hello.",
+      role: "chat",
+      serviceTier: "standard",
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({
+      code: "invalid_request_error",
+      message: "OpenAI rejected the request.",
+      status: 502,
+    });
+  });
+
+  test("propagates provider run errors from streaming text", async () => {
+    capturedChatOptions.length = 0;
+    nextChatResult = createRunErrorStream({
+      code: "rate_limit_exceeded",
+      message: "OpenAI rate limit exceeded.",
+    });
+
+    const consume = async (): Promise<void> => {
+      for await (const _delta of streamTanStackTextForRole({
+        caching: noCaching,
+        organizationId: null,
+        orgAIConfig: null,
+        prompt: "Say hello.",
+        role: "chat",
+        serviceTier: "standard",
+      })) {
+        // Consume the full stream so terminal provider events are observed.
+      }
+    };
+    const caught = await consume().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({
+      code: "rate_limit_exceeded",
+      message: "OpenAI rate limit exceeded.",
+      status: 502,
+    });
+  });
+});
+
 const captureChatOptions = (options: unknown): CapturedChatOptions => {
   if (!isRecord(options)) {
     throw new TypeError("Expected TanStack chat options object.");
@@ -432,6 +510,29 @@ const createStructuredOutputStream = async function* ({
     name: "structured-output.complete",
     type: realTanStackAI.EventType.CUSTOM,
     value: { object, raw },
+  };
+};
+
+const createTextStream = async function* (deltas: string[]) {
+  for (const delta of deltas) {
+    yield {
+      delta,
+      type: realTanStackAI.EventType.TEXT_MESSAGE_CONTENT,
+    };
+  }
+};
+
+const createRunErrorStream = async function* ({
+  code,
+  message,
+}: {
+  code: string;
+  message: string;
+}) {
+  yield {
+    code,
+    message,
+    type: realTanStackAI.EventType.RUN_ERROR,
   };
 };
 

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -1,6 +1,8 @@
 import { EventType, chat, parsePartialJSON } from "@tanstack/ai";
 import type {
   ModelMessage,
+  RunErrorEvent,
+  StreamChunk,
   StructuredOutputPart,
   SystemPrompt,
 } from "@tanstack/ai";
@@ -97,33 +99,23 @@ export const generateTanStackTextForRole = async (
   const abortController = options.abortSignal
     ? abortControllerFromSignal(options.abortSignal)
     : undefined;
+  let output = "";
 
-  return await withStandardServiceTierFallback({
+  for await (const delta of streamTanStackTextDeltas({
+    abortController,
+    analytics: options.analytics,
+    caching: options.caching,
+    maxOutputTokens: options.maxOutputTokens,
+    messages: requestMessages,
     model,
     serviceTier: options.serviceTier,
-    run: async (serviceTier) =>
-      await chat({
-        adapter: model.adapter,
-        messages: requestMessages,
-        stream: false,
-        ...systemPromptsPatch({
-          caching: options.caching,
-          model,
-          system: options.system,
-        }),
-        modelOptions: mergeGenerationOptions({
-          caching: options.caching,
-          model,
-          maxOutputTokens: options.maxOutputTokens,
-          serviceTier,
-          temperature: options.temperature,
-        }),
-        ...(options.analytics
-          ? { middleware: [options.analytics.middleware] }
-          : {}),
-        ...(abortController ? { abortController } : {}),
-      }),
-  });
+    system: options.system,
+    temperature: options.temperature,
+  })) {
+    output += delta;
+  }
+
+  return output;
 };
 
 export const streamTanStackTextForRole = (
@@ -221,29 +213,24 @@ const withStandardServiceTierFallback = async <TResult>({
   }
 };
 
-type StandardServiceTierStreamFallbackOptions<TChunk, TResult> = {
+type StandardServiceTierStreamFallbackOptions<TResult> = {
   model: ResolvedTanStackTextModel;
   serviceTier: AIRequestServiceTier;
-  stream: (serviceTier: AIRequestServiceTier) => AsyncIterable<TChunk>;
-  onChunk: (chunk: TChunk) => TResult | undefined;
+  stream: (serviceTier: AIRequestServiceTier) => AsyncIterable<StreamChunk>;
+  onChunk: (chunk: StreamChunk) => TResult | undefined;
 };
 
-const iterateWithStandardServiceTierFallback = async function* <
-  TChunk,
-  TResult,
->({
+const iterateWithStandardServiceTierFallback = async function* <TResult>({
   model,
   serviceTier,
   stream,
   onChunk,
-}: StandardServiceTierStreamFallbackOptions<
-  TChunk,
-  TResult
->): AsyncIterable<TResult> {
+}: StandardServiceTierStreamFallbackOptions<TResult>): AsyncIterable<TResult> {
   let yielded = false;
 
   try {
     for await (const chunk of stream(serviceTier)) {
+      throwIfTanStackRunError(chunk);
       const result = onChunk(chunk);
       if (result === undefined) {
         continue;
@@ -262,12 +249,29 @@ const iterateWithStandardServiceTierFallback = async function* <
   }
 
   for await (const chunk of stream("standard")) {
+    throwIfTanStackRunError(chunk);
     const result = onChunk(chunk);
     if (result !== undefined) {
       yield result;
     }
   }
 };
+
+const throwIfTanStackRunError = (chunk: StreamChunk): void => {
+  if (chunk.type !== EventType.RUN_ERROR) {
+    return;
+  }
+
+  throw tanStackRunError(chunk);
+};
+
+const tanStackRunError = (chunk: RunErrorEvent): HandlerError =>
+  new HandlerError({
+    status: 502,
+    message: chunk.message,
+    ...(chunk.code ? { code: chunk.code } : {}),
+    ...(chunk.rawEvent === undefined ? {} : { cause: chunk.rawEvent }),
+  });
 
 const shouldRetryWithStandardServiceTier = ({
   error,

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -213,19 +213,28 @@ const withStandardServiceTierFallback = async <TResult>({
   }
 };
 
-type StandardServiceTierStreamFallbackOptions<TResult> = {
+type StandardServiceTierStreamFallbackOptions<
+  TChunk extends StreamChunk,
+  TResult,
+> = {
   model: ResolvedTanStackTextModel;
   serviceTier: AIRequestServiceTier;
-  stream: (serviceTier: AIRequestServiceTier) => AsyncIterable<StreamChunk>;
-  onChunk: (chunk: StreamChunk) => TResult | undefined;
+  stream: (serviceTier: AIRequestServiceTier) => AsyncIterable<TChunk>;
+  onChunk: (chunk: TChunk) => TResult | undefined;
 };
 
-const iterateWithStandardServiceTierFallback = async function* <TResult>({
+const iterateWithStandardServiceTierFallback = async function* <
+  TChunk extends StreamChunk,
+  TResult,
+>({
   model,
   serviceTier,
   stream,
   onChunk,
-}: StandardServiceTierStreamFallbackOptions<TResult>): AsyncIterable<TResult> {
+}: StandardServiceTierStreamFallbackOptions<
+  TChunk,
+  TResult
+>): AsyncIterable<TResult> {
   let yielded = false;
 
   try {

--- a/apps/api/src/lib/tanstack-ai-models.test.ts
+++ b/apps/api/src/lib/tanstack-ai-models.test.ts
@@ -305,8 +305,7 @@ describe("TanStack text model resolution", () => {
     });
     expect(model.adapter.name).toBe("openai");
     expect(model.adapter.model).toBe("gpt-5.4");
-    expect(model.modelOptions).toMatchObject({
-      temperature: 0,
+    expect(model.modelOptions).toEqual({
       reasoning: { effort: "medium" },
     });
   });

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -1015,7 +1015,6 @@ const tanStackOpenAIModelOptionsForRole = ({
     return { temperature: 0 };
   }
   return {
-    temperature: 0,
     reasoning: { effort: "medium" },
   };
 };

--- a/patches/@tanstack%2Fopenai-base@0.9.7.patch
+++ b/patches/@tanstack%2Fopenai-base@0.9.7.patch
@@ -36,3 +36,51 @@ index 6977689012fb8caccc28e1bcde4154b69b60cc46..18bd07c23e75adb3a367b376ae9846d3
  }
  function containsStrictUnsupportedKeyword(node) {
    if (Array.isArray(node)) {
+diff --git a/dist/esm/adapters/responses-text.js b/dist/esm/adapters/responses-text.js
+index 64b80b74b3d56b7486f7978b1c1585c12a4d5b39..2c994e76c6d0107319677f63eed9675a83e36184 100644
+--- a/dist/esm/adapters/responses-text.js
++++ b/dist/esm/adapters/responses-text.js
+@@ -761,8 +761,8 @@ class OpenAIResponsesTextAdapter extends BaseTextAdapter {
+             };
+           }
+-          if (contentPart.type === "output_text") {
++          if (contentPart.type === "output_text" && contentPart.text) {
+             hasStreamedContentDeltas = true;
+-          } else if (contentPart.type === "reasoning_text") {
++          } else if (contentPart.type === "reasoning_text" && contentPart.text) {
+             hasStreamedReasoningDeltas = true;
+           }
+           const partChunk = handleContentPart(contentPart);
+@@ -976,6 +976,32 @@ class OpenAIResponsesTextAdapter extends BaseTextAdapter {
+           }
+         }
+         if (chunk.type === "response.completed") {
++          // PATCH (stella): reasoning responses may only carry their final text
++          // on the completed response. Backfill it when no text was streamed so
++          // a successful provider response cannot become an empty AI result.
++          const completedText = chunk.response.output.flatMap((item) => item.type === "message" ? item.content : []).filter((part) => part.type === "output_text").map((part) => part.text).join("");
++          if (!accumulatedContent && completedText) {
++            if (!hasEmittedTextMessageStart) {
++              hasEmittedTextMessageStart = true;
++              yield {
++                type: EventType.TEXT_MESSAGE_START,
++                messageId: aguiState.messageId,
++                model: model || options.model,
++                timestamp: Date.now(),
++                role: "assistant"
++              };
++            }
++            accumulatedContent = completedText;
++            hasStreamedContentDeltas = true;
++            yield {
++              type: EventType.TEXT_MESSAGE_CONTENT,
++              messageId: aguiState.messageId,
++              model: model || options.model,
++              timestamp: Date.now(),
++              delta: completedText,
++              content: accumulatedContent
++            };
++          }
+           for (const item of chunk.response.output) {
+             if (item.type !== "function_call" || !item.id) continue;
+             const metadata = toolCallMetadata.get(item.id) ?? {


### PR DESCRIPTION
## Summary

- omit unsupported sampling parameters from OpenAI reasoning requests
- require the exact reasoning-role option shape in the model resolution regression test

## Verification

- `bun --filter @stll/api test src/lib/tanstack-ai-models.test.ts`
- live OpenAI provider canary will run against this branch before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for OpenAI reasoning models by avoiding an unsupported temperature setting when configuring reasoning effort.
  * Tightened validation so OpenAI model option expectations must match exactly.
  * Fixed text generation streaming to correctly surface provider errors as failures and return aggregated text deltas.  
* **New Features**
  * Added coverage for text-generation and error propagation across both non-streaming and streaming paths, improving confidence in generated output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->