### PR TITLE
fix: budget canary tool round trips

### DIFF
--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -198,6 +198,7 @@ const capabilityProbes = [
     run: async (context, signal) => {
       await runToolProbe({
         context,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: TOOL_SCHEMA_PROMPT,
         role: CAPABILITY_ROLE,
         signal,
@@ -212,6 +213,7 @@ const capabilityProbes = [
     run: async (context, signal) => {
       await runToolProbe({
         context,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: TOOL_SCHEMA_PROMPT,
         role: CAPABILITY_ROLE,
         signal,
@@ -312,6 +314,7 @@ const runToolCallRoundTripProbe = async ({
 
   const output = await runToolProbe({
     context,
+    maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
     prompt: TOOL_ROUND_TRIP_PROMPT,
     role: TOOL_CALL_ROLE,
     signal,
@@ -338,6 +341,7 @@ const runToolCallRoundTripProbe = async ({
 
 type RunToolProbeOptions = {
   context: CanaryContext;
+  maxOutputTokens: number;
   prompt: string;
   role: ModelRole;
   signal: AbortSignal;
@@ -346,6 +350,7 @@ type RunToolProbeOptions = {
 
 const runToolProbe = async ({
   context: { config, provider },
+  maxOutputTokens,
   prompt,
   role,
   signal,
@@ -373,7 +378,7 @@ const runToolProbe = async ({
     modelOptions: mergeGenerationOptions({
       caching: NO_CACHING,
       model,
-      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      maxOutputTokens,
       serviceTier: "standard",
       temperature: 0,
     }),


### PR DESCRIPTION
Use the chat role output budget for the two-turn tool-call canary while keeping the one-turn schema probes on their smaller capability budget. This prevents a valid post-tool response from being classified as a provider-contract failure when it reaches the 64-token ceiling.\n\nThe live Anthropic canary passed all four model roles and all five capability probes with this change.