### PR TITLE
fix: stream Bedrock responses through fetch transport

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -45,6 +45,7 @@
     "@opentelemetry/api-logs": "^0.220.0",
     "@react-email/render": "^2.0.10",
     "@sinclair/typebox": "^0.34.50",
+    "@smithy/fetch-http-handler": "^5.4.6",
     "@stll/ai-catalog": "workspace:*",
     "@stll/anonymize-chat": "workspace:*",
     "@stll/anonymize-data": "catalog:",

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -5,10 +5,7 @@ import type { AnyTextAdapter } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import type { AnthropicTextProviderOptions } from "@tanstack/ai-anthropic";
 import { BedrockConverseTextAdapter } from "@tanstack/ai-bedrock";
-import type {
-  BedrockConverseProviderOptions,
-  ResolvedBedrockAuth,
-} from "@tanstack/ai-bedrock";
+import type { BedrockConverseProviderOptions } from "@tanstack/ai-bedrock";
 import { createGeminiChat } from "@tanstack/ai-gemini";
 import type { GeminiTextProviderOptions } from "@tanstack/ai-gemini";
 import { createMistralText } from "@tanstack/ai-mistral";
@@ -400,18 +397,14 @@ const createExtendedMistralAdapter = (
   return mistral(modelId, apiKey);
 };
 
-// The AWS SDK's default Node transport closes Converse event streams early in Bun.
+// The AWS SDK's default Node HTTP/2 transport closes Converse streams early in Bun.
 class BunBedrockTextAdapter extends BedrockConverseTextAdapter<never> {
-  protected override buildClientConfig(
-    resolved: ResolvedBedrockAuth,
-    region: string,
-    endpoint: string | undefined,
-  ) {
-    return {
-      // eslint-disable-next-line typescript/no-unsafe-argument -- Oxc loses this re-exported upstream type; the override uses the base method's exact parameter type.
-      ...super.buildClientConfig(resolved, region, endpoint),
-      requestHandler: new FetchHttpHandler(),
-    };
+  private readonly requestHandler = new FetchHttpHandler();
+
+  protected override async getClient() {
+    const client = await super.getClient();
+    client.config.requestHandler = this.requestHandler;
+    return client;
   }
 }
 

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -1,10 +1,14 @@
 import { HarmBlockThreshold, HarmCategory } from "@google/genai";
+import { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import { createModel, extendAdapter } from "@tanstack/ai";
 import type { AnyTextAdapter } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import type { AnthropicTextProviderOptions } from "@tanstack/ai-anthropic";
-import { bedrockText } from "@tanstack/ai-bedrock";
-import type { BedrockConverseProviderOptions } from "@tanstack/ai-bedrock";
+import { BedrockConverseTextAdapter } from "@tanstack/ai-bedrock";
+import type {
+  BedrockConverseProviderOptions,
+  ResolvedBedrockAuth,
+} from "@tanstack/ai-bedrock";
 import { createGeminiChat } from "@tanstack/ai-gemini";
 import type { GeminiTextProviderOptions } from "@tanstack/ai-gemini";
 import { createMistralText } from "@tanstack/ai-mistral";
@@ -396,11 +400,25 @@ const createExtendedMistralAdapter = (
   return mistral(modelId, apiKey);
 };
 
+// The AWS SDK's default Node transport closes Converse event streams early in Bun.
+class BunBedrockTextAdapter extends BedrockConverseTextAdapter<never> {
+  protected override buildClientConfig(
+    resolved: ResolvedBedrockAuth,
+    region: string,
+    endpoint: string | undefined,
+  ) {
+    return {
+      ...super.buildClientConfig(resolved, region, endpoint),
+      requestHandler: new FetchHttpHandler(),
+    };
+  }
+}
+
 const createBedrockTextAdapter = (
   model: never,
   config?: BedrockTextAdapterConfig,
 ): AnyTextAdapter => {
-  const adapter = bedrockText(model, config);
+  const adapter = new BunBedrockTextAdapter(config ?? {}, model);
   return {
     kind: "text",
     name: adapter.name,

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -4,11 +4,11 @@ import { createModel, extendAdapter } from "@tanstack/ai";
 import type { AnyTextAdapter } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import type { AnthropicTextProviderOptions } from "@tanstack/ai-anthropic";
-import {
-  BedrockConverseTextAdapter,
-  resolveBedrockAuth,
+import { BedrockConverseTextAdapter } from "@tanstack/ai-bedrock";
+import type {
+  BedrockConverseProviderOptions,
+  ResolvedBedrockAuth,
 } from "@tanstack/ai-bedrock";
-import type { BedrockConverseProviderOptions } from "@tanstack/ai-bedrock";
 import { createGeminiChat } from "@tanstack/ai-gemini";
 import type { GeminiTextProviderOptions } from "@tanstack/ai-gemini";
 import { createMistralText } from "@tanstack/ai-mistral";
@@ -401,8 +401,6 @@ const createExtendedMistralAdapter = (
 };
 
 // The AWS SDK's default Node transport closes Converse event streams early in Bun.
-type ResolvedBedrockAuth = ReturnType<typeof resolveBedrockAuth>;
-
 class BunBedrockTextAdapter extends BedrockConverseTextAdapter<never> {
   protected override buildClientConfig(
     resolved: ResolvedBedrockAuth,
@@ -410,6 +408,7 @@ class BunBedrockTextAdapter extends BedrockConverseTextAdapter<never> {
     endpoint: string | undefined,
   ) {
     return {
+      // eslint-disable-next-line typescript/no-unsafe-argument -- Oxc loses this re-exported upstream type; the override uses the base method's exact parameter type.
       ...super.buildClientConfig(resolved, region, endpoint),
       requestHandler: new FetchHttpHandler(),
     };

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -4,11 +4,11 @@ import { createModel, extendAdapter } from "@tanstack/ai";
 import type { AnyTextAdapter } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import type { AnthropicTextProviderOptions } from "@tanstack/ai-anthropic";
-import { BedrockConverseTextAdapter } from "@tanstack/ai-bedrock";
-import type {
-  BedrockConverseProviderOptions,
-  ResolvedBedrockAuth,
+import {
+  BedrockConverseTextAdapter,
+  resolveBedrockAuth,
 } from "@tanstack/ai-bedrock";
+import type { BedrockConverseProviderOptions } from "@tanstack/ai-bedrock";
 import { createGeminiChat } from "@tanstack/ai-gemini";
 import type { GeminiTextProviderOptions } from "@tanstack/ai-gemini";
 import { createMistralText } from "@tanstack/ai-mistral";
@@ -401,6 +401,8 @@ const createExtendedMistralAdapter = (
 };
 
 // The AWS SDK's default Node transport closes Converse event streams early in Bun.
+type ResolvedBedrockAuth = ReturnType<typeof resolveBedrockAuth>;
+
 class BunBedrockTextAdapter extends BedrockConverseTextAdapter<never> {
   protected override buildClientConfig(
     resolved: ResolvedBedrockAuth,

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@opentelemetry/api-logs": "^0.220.0",
         "@react-email/render": "^2.0.10",
         "@sinclair/typebox": "^0.34.50",
+        "@smithy/fetch-http-handler": "^5.4.6",
         "@stll/ai-catalog": "workspace:*",
         "@stll/anonymize-chat": "workspace:*",
         "@stll/anonymize-data": "catalog:",


### PR DESCRIPTION
## Summary

- route Bedrock Converse streams through the AWS SDK fetch transport under Bun
- centralize the transport selection in Stella's Bedrock adapter boundary
- declare the transport as a direct API dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Amazon Bedrock text generation in Bun environments.
  * Prevented potential request transport issues when using Bedrock-powered features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->