### PR TITLE
fix: gate fork PR lint on maintainer trust

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -6,8 +6,6 @@ on:
     # trusts a fork with "run-ci" or requests a rerun with "run-pr-lint".
     # This metadata-only workflow must never check out or execute PR code.
     types: [opened, labeled]
-    branches-ignore:
-      - "dependabot/**"
 
 concurrency:
   # Keep manual reruns cancellable, but do not let unrelated label
@@ -26,8 +24,9 @@ permissions:
 jobs:
   pr-lint:
     if: >-
-      (github.event.pull_request.head.repo.full_name == github.repository
-       || contains(github.event.pull_request.labels.*.name, 'run-ci'))
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      && (github.event.pull_request.head.repo.full_name == github.repository
+          || contains(github.event.pull_request.labels.*.name, 'run-ci'))
       && (github.event.action != 'labeled'
           || github.event.label.name == 'run-ci'
           || github.event.label.name == 'run-pr-lint')

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,9 +1,10 @@
 name: PR Lint
 
 on:
-  pull_request:
+  pull_request_target:
     # Run once when the PR opens, then only when a maintainer explicitly
-    # adds the "run-pr-lint" label.
+    # trusts a fork with "run-ci" or requests a rerun with "run-pr-lint".
+    # This metadata-only workflow must never check out or execute PR code.
     types: [opened, labeled]
     branches-ignore:
       - "dependabot/**"
@@ -12,7 +13,7 @@ concurrency:
   # Keep manual reruns cancellable, but do not let unrelated label
   # events cancel an in-flight `run-pr-lint` execution.
   group: >-
-    ${{ github.workflow }}-${{ github.ref }}-${{
+    ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{
       github.event.action == 'labeled' && github.event.label.name || 'opened'
     }}
   cancel-in-progress: true
@@ -25,8 +26,11 @@ permissions:
 jobs:
   pr-lint:
     if: >-
-      github.event.action != 'labeled'
-      || github.event.label.name == 'run-pr-lint'
+      (github.event.pull_request.head.repo.full_name == github.repository
+       || contains(github.event.pull_request.labels.*.name, 'run-ci'))
+      && (github.event.action != 'labeled'
+          || github.event.label.name == 'run-ci'
+          || github.event.label.name == 'run-pr-lint')
     # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
     # Do not switch to `secrets: inherit` — that widens the blast radius
     # if the reusable ever starts touching named secrets.


### PR DESCRIPTION
Fork pull requests now leave PR lint skipped until a maintainer adds the `run-ci` label. The metadata-only lint workflow then runs with the permissions required for its label operations, without checking out contributor code.\n\nConcurrency is scoped per pull request, and Dependabot exclusion now checks the PR author instead of the target branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation workflow triggers and conditions.
  * Improved handling of labelled pull requests, including explicit support for `run-ci` and `run-pr-lint` labels.
  * Refined execution controls for automated dependency-update pull requests and concurrent validation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->