### PR TITLE
fix: require complete scheduled AI canary coverage

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -100,13 +100,25 @@ jobs:
         run: bun run canary:ai-provider -- --provider "${{ matrix.provider }}"
 
   require-provider-coverage:
-    name: Require configured provider coverage
+    name: Require selected provider coverage
     if: always()
     needs: provider-canary
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Checkout default branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
       - name: Download configured-provider markers
         id: download
         continue-on-error: true
@@ -116,11 +128,11 @@ jobs:
           path: canary-ran
           merge-multiple: true
 
-      - name: Require at least one configured provider
+      - name: Require selected provider coverage
         env:
           DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
-        run: |
-          if [[ "$DOWNLOAD_OUTCOME" != "success" ]] || [[ -z "$(find canary-ran -type f -print -quit 2>/dev/null)" ]]; then
-            echo "::error title=No AI provider canary coverage::Configure at least one supported provider repository secret."
-            exit 1
-          fi
+          PROVIDER_SELECTION: ${{ github.event_name == 'workflow_dispatch' && inputs.provider || 'all' }}
+        run: >-
+          bun apps/api/scripts/ai-provider-canary-coverage.ts
+          --provider "$PROVIDER_SELECTION"
+          --download-outcome "$DOWNLOAD_OUTCOME"

--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import { MODEL_ROLES } from "@stll/ai-catalog";
 
-import { modelRoleMaxOutputTokens } from "./ai-provider-canary-config";
+import {
+  CANARY_PROVIDERS,
+  missingCanaryProviders,
+  modelRoleMaxOutputTokens,
+} from "./ai-provider-canary-config";
 
 describe("AI provider canary role budgets", () => {
   test("reserves reasoning capacity without inflating other role probes", () => {
@@ -11,5 +15,32 @@ describe("AI provider canary role budgets", () => {
         role === "reasoning" ? 25_000 : 512,
       );
     }
+  });
+});
+
+describe("AI provider canary coverage", () => {
+  test("requires every supported provider for an all-provider run", () => {
+    const configuredProviders = CANARY_PROVIDERS.filter(
+      (provider) => provider !== "bedrock",
+    );
+
+    expect(
+      missingCanaryProviders({ configuredProviders, selection: "all" }),
+    ).toEqual(["bedrock"]);
+  });
+
+  test("requires only the selected provider for a focused manual run", () => {
+    expect(
+      missingCanaryProviders({
+        configuredProviders: ["openai"],
+        selection: "openai",
+      }),
+    ).toEqual([]);
+    expect(
+      missingCanaryProviders({
+        configuredProviders: ["openai"],
+        selection: "bedrock",
+      }),
+    ).toEqual(["bedrock"]);
   });
 });

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -1,4 +1,5 @@
 import type { ModelRole } from "@stll/ai-catalog";
+
 import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
 
 export const CANARY_PROVIDERS = [

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -1,15 +1,7 @@
+import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
 import type { ModelRole } from "@stll/ai-catalog";
 
-import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
-
-export const CANARY_PROVIDERS = [
-  "google",
-  "openrouter",
-  "openai",
-  "anthropic",
-  "bedrock",
-  "mistral",
-] as const satisfies readonly TanStackTextProvider[];
+export const CANARY_PROVIDERS = TANSTACK_AI_PROVIDERS;
 
 export type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
 export type CanaryProviderSelection = "all" | CanaryProvider;

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -1,7 +1,22 @@
-import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
 import type { ModelRole } from "@stll/ai-catalog";
 
-export const CANARY_PROVIDERS = TANSTACK_AI_PROVIDERS;
+import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
+
+const defineCanaryProviders = <
+  const TProviders extends readonly TanStackTextProvider[],
+>(
+  providers: TProviders &
+    ([TanStackTextProvider] extends [TProviders[number]] ? unknown : never),
+): TProviders => providers;
+
+export const CANARY_PROVIDERS = defineCanaryProviders([
+  "google",
+  "openrouter",
+  "openai",
+  "anthropic",
+  "bedrock",
+  "mistral",
+]);
 
 export type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
 export type CanaryProviderSelection = "all" | CanaryProvider;

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -1,4 +1,17 @@
 import type { ModelRole } from "@stll/ai-catalog";
+import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
+
+export const CANARY_PROVIDERS = [
+  "google",
+  "openrouter",
+  "openai",
+  "anthropic",
+  "bedrock",
+  "mistral",
+] as const satisfies readonly TanStackTextProvider[];
+
+export type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
+export type CanaryProviderSelection = "all" | CanaryProvider;
 
 const MODEL_ROLE_MAX_OUTPUT_TOKENS = {
   fast: 512,
@@ -9,3 +22,20 @@ const MODEL_ROLE_MAX_OUTPUT_TOKENS = {
 
 export const modelRoleMaxOutputTokens = (role: ModelRole) =>
   MODEL_ROLE_MAX_OUTPUT_TOKENS[role];
+
+export const isCanaryProvider = (value: string): value is CanaryProvider =>
+  CANARY_PROVIDERS.some((provider) => provider === value);
+
+type MissingCanaryProvidersOptions = {
+  configuredProviders: readonly string[];
+  selection: CanaryProviderSelection;
+};
+
+export const missingCanaryProviders = ({
+  configuredProviders,
+  selection,
+}: MissingCanaryProvidersOptions): CanaryProvider[] => {
+  const configured = new Set(configuredProviders);
+  const required = selection === "all" ? CANARY_PROVIDERS : [selection];
+  return required.filter((provider) => !configured.has(provider));
+};

--- a/apps/api/scripts/ai-provider-canary-coverage.test.ts
+++ b/apps/api/scripts/ai-provider-canary-coverage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCanaryCoverageArgs } from "./ai-provider-canary-coverage";
+
+describe("AI provider canary coverage arguments", () => {
+  test("parses explicit workflow flags", () => {
+    expect(
+      parseCanaryCoverageArgs([
+        "--provider",
+        "all",
+        "--download-outcome",
+        "success",
+      ]),
+    ).toEqual({ downloadOutcome: "success", selection: "all" });
+  });
+
+  test("does not treat a positional provider as a flag value", () => {
+    expect(() => parseCanaryCoverageArgs(["all"])).toThrow(
+      "Pass --provider followed by all or a canary provider.",
+    );
+  });
+
+  test("leaves an omitted download outcome undefined", () => {
+    expect(
+      parseCanaryCoverageArgs(["--provider", "bedrock"]).downloadOutcome,
+    ).toBeUndefined();
+  });
+});

--- a/apps/api/scripts/ai-provider-canary-coverage.ts
+++ b/apps/api/scripts/ai-provider-canary-coverage.ts
@@ -1,0 +1,42 @@
+import {
+  isCanaryProvider,
+  missingCanaryProviders,
+} from "./ai-provider-canary-config";
+import type { CanaryProviderSelection } from "./ai-provider-canary-config";
+
+const parseProviderSelection = (args: string[]): CanaryProviderSelection => {
+  const providerFlagIndex = args.indexOf("--provider");
+  const value = args.at(providerFlagIndex + 1);
+  if (value === "all" || (value !== undefined && isCanaryProvider(value))) {
+    return value;
+  }
+
+  throw new TypeError("Pass --provider followed by all or a canary provider.");
+};
+
+const run = (): void => {
+  const args = Bun.argv.slice(2);
+  const selection = parseProviderSelection(args);
+  const downloadOutcome = args.at(args.indexOf("--download-outcome") + 1);
+  const configuredProviders =
+    downloadOutcome === "success"
+      ? [...new Bun.Glob("*").scanSync({ cwd: "canary-ran", onlyFiles: true })]
+      : [];
+  const missingProviders = missingCanaryProviders({
+    configuredProviders,
+    selection,
+  });
+
+  if (missingProviders.length === 0) {
+    return;
+  }
+
+  console.error(
+    `::error title=Missing AI provider canary coverage::Configure canary credentials for: ${missingProviders.join(", ")}.`,
+  );
+  process.exitCode = 1;
+};
+
+if (import.meta.main) {
+  run();
+}

--- a/apps/api/scripts/ai-provider-canary-coverage.ts
+++ b/apps/api/scripts/ai-provider-canary-coverage.ts
@@ -4,9 +4,18 @@ import {
 } from "./ai-provider-canary-config";
 import type { CanaryProviderSelection } from "./ai-provider-canary-config";
 
+type CanaryCoverageArgs = {
+  downloadOutcome: string | undefined;
+  selection: CanaryProviderSelection;
+};
+
+const flagValue = (args: string[], flag: string): string | undefined => {
+  const flagIndex = args.indexOf(flag);
+  return flagIndex === -1 ? undefined : args.at(flagIndex + 1);
+};
+
 const parseProviderSelection = (args: string[]): CanaryProviderSelection => {
-  const providerFlagIndex = args.indexOf("--provider");
-  const value = args.at(providerFlagIndex + 1);
+  const value = flagValue(args, "--provider");
   if (value === "all" || (value !== undefined && isCanaryProvider(value))) {
     return value;
   }
@@ -14,10 +23,17 @@ const parseProviderSelection = (args: string[]): CanaryProviderSelection => {
   throw new TypeError("Pass --provider followed by all or a canary provider.");
 };
 
+export const parseCanaryCoverageArgs = (
+  args: string[],
+): CanaryCoverageArgs => ({
+  downloadOutcome: flagValue(args, "--download-outcome"),
+  selection: parseProviderSelection(args),
+});
+
 const run = (): void => {
-  const args = Bun.argv.slice(2);
-  const selection = parseProviderSelection(args);
-  const downloadOutcome = args.at(args.indexOf("--download-outcome") + 1);
+  const { downloadOutcome, selection } = parseCanaryCoverageArgs(
+    Bun.argv.slice(2),
+  );
   const configuredProviders =
     downloadOutcome === "success"
       ? [...new Bun.Glob("*").scanSync({ cwd: "canary-ran", onlyFiles: true })]

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -19,21 +19,13 @@ import {
   mergeGenerationOptions,
   resolveTanStackTextModel,
 } from "@/api/lib/tanstack-ai-generate";
-import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
 import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
 
-import { modelRoleMaxOutputTokens } from "./ai-provider-canary-config";
-
-const CANARY_PROVIDERS = [
-  "google",
-  "openrouter",
-  "openai",
-  "anthropic",
-  "bedrock",
-  "mistral",
-] as const satisfies readonly TanStackTextProvider[];
-
-type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
+import {
+  CANARY_PROVIDERS,
+  modelRoleMaxOutputTokens,
+} from "./ai-provider-canary-config";
+import type { CanaryProvider } from "./ai-provider-canary-config";
 
 const CAPABILITY_ROLE = "fast" satisfies ModelRole;
 const TOOL_CALL_ROLE = "chat" satisfies ModelRole;

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -26,7 +26,12 @@ import {
   isBYOKModelRoleSupported,
   isBYOKProviderRoleSupported,
 } from "@stll/ai-catalog";
-import type { AIProvider, BYOKProvider, ModelRole } from "@stll/ai-catalog";
+import type {
+  AIProvider,
+  BYOKProvider,
+  ModelRole,
+  TanStackAIProvider,
+} from "@stll/ai-catalog";
 
 import { env } from "@/api/env";
 import {
@@ -54,10 +59,7 @@ export type { AIProvider, BYOKProvider, ModelRole };
 
 type TanStackTextAdapterFactory = (modelId: string) => AnyTextAdapter;
 
-export type TanStackTextProvider = Exclude<
-  AIProvider,
-  "azure_foundry" | "huggingface" | "openai_compatible"
->;
+export type TanStackTextProvider = TanStackAIProvider;
 
 const INSTANCE_PROVIDER_PREFERENCE = [
   "openrouter",


### PR DESCRIPTION
Scheduled AI canaries now fail when any supported provider lacks a configured marker. Focused manual runs still require only their selected provider.\n\nThe provider list is shared with the canary executable, so adding a supported provider without scheduling and configuring it becomes a visible coverage failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider canary verification to enforce coverage based on the selected provider (or all providers when chosen).
  * Added clearer, provider-aware error messaging when required coverage is missing.

* **Reliability**
  * Standardised provider coverage enforcement via a dedicated validation step.
  * Added runtime provider selection validation and “missing provider” detection to keep canary runs consistent.

* **Tests**
  * Added unit tests for provider coverage argument parsing and missing-provider scenarios (all, focused, and excluded cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->