### PR TITLE
fix: allow two-turn AI canary latency

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -25,7 +25,7 @@ jobs:
   provider-canary:
     name: ${{ matrix.provider }} capability contract
     runs-on: ubuntu-latest
-    # Serial probe timeouts total 220 seconds; leave room for runner setup and install.
+    # Serial probe timeouts total 245 seconds; leave room for runner setup and install.
     timeout-minutes: 10
     permissions:
       contents: read

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -32,6 +32,7 @@ const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
 const MAX_OUTPUT_TOKENS = 64;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
+const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
 const TOOL_SCHEMA_PROMPT = "Do not call any tool. Reply with exactly OK.";
 const TOOL_ROUND_TRIP_NAME = "canary_round_trip";
@@ -216,7 +217,7 @@ const capabilityProbes = [
   {
     type: "capability",
     name: "tool-call-round-trip",
-    timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
+    timeoutMs: TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS,
     run: async (context, signal) => {
       await runToolCallRoundTripProbe({ context, signal });
     },


### PR DESCRIPTION
## Summary

- give the live tool-call round trip its own 45-second timeout
- keep single-turn capability probes at 20 seconds
- update the documented serial timeout budget

## Validation

Hosted CI is the validation path for this workflow-only canary adjustment.