### PR TITLE
feat: add weekly AI canary rotation

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -2,7 +2,10 @@ name: AI provider canary
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    # The weekly tier is a superset of the daily tier, so it replaces Monday's
+    # daily run instead of duplicating the same provider calls.
+    - cron: "17 3 * * 2-7"
+    - cron: "17 3 * * 1"
   workflow_dispatch:
     inputs:
       provider:
@@ -18,6 +21,14 @@ on:
           - anthropic
           - bedrock
           - mistral
+      tier:
+        description: Canary coverage tier
+        required: true
+        default: daily
+        type: choice
+        options:
+          - daily
+          - weekly
 
 permissions: {}
 
@@ -25,8 +36,9 @@ jobs:
   provider-canary:
     name: ${{ matrix.provider }} capability contract
     runs-on: ubuntu-latest
-    # Serial probe timeouts total 245 seconds; leave room for runner setup and install.
-    timeout-minutes: 10
+    # Weekly serial probe timeouts total at most 410 seconds; leave room for
+    # runner setup and install. Daily runs remain below the previous 10-minute budget.
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
@@ -96,8 +108,12 @@ jobs:
         if: steps.credential.outputs.configured == 'true'
         env:
           AI_CANARY_API_KEY: ${{ matrix.provider == 'google' && secrets.GOOGLE_GENERATIVE_AI_API_KEY || matrix.provider == 'openrouter' && secrets.OPENROUTER_API_KEY || matrix.provider == 'openai' && secrets.OPENAI_API_KEY || matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || matrix.provider == 'bedrock' && secrets.BEDROCK_API_KEY || matrix.provider == 'mistral' && secrets.MISTRAL_API_KEY || '' }}
+          CANARY_TIER: ${{ github.event_name == 'workflow_dispatch' && inputs.tier || github.event.schedule == '17 3 * * 1' && 'weekly' || 'daily' }}
           USE_MOCK_AI: "false"
-        run: bun run canary:ai-provider -- --provider "${{ matrix.provider }}"
+        run: >-
+          bun run canary:ai-provider --
+          --provider "${{ matrix.provider }}"
+          --tier "$CANARY_TIER"
 
   require-provider-coverage:
     name: Require selected provider coverage

--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -3,8 +3,9 @@ name: AI provider canary
 on:
   schedule:
     # The weekly tier is a superset of the daily tier, so it replaces Monday's
-    # daily run instead of duplicating the same provider calls.
-    - cron: "17 3 * * 2-7"
+    # daily run instead of duplicating the same provider calls. GitHub Actions
+    # day-of-week accepts 0-6 (0 = Sunday); Tuesday-Sunday is "0,2-6".
+    - cron: "17 3 * * 0,2-6"
     - cron: "17 3 * * 1"
   workflow_dispatch:
     inputs:

--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -72,9 +72,9 @@ describe("AI provider weekly rotation", () => {
         expect(modelRoles.length).toBeGreaterThan(0);
         for (const role of modelRoles) {
           expect(modelId).not.toBe(DEFAULT_MODELS[provider][role]);
-          expect(
-            isBYOKModelRoleSupported({ modelId, provider, role }),
-          ).toBe(true);
+          expect(isBYOKModelRoleSupported({ modelId, provider, role })).toBe(
+            true,
+          );
         }
       }
     }

--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { MODEL_ROLES } from "@stll/ai-catalog";
+import {
+  BYOK_MODEL_OPTIONS,
+  DEFAULT_MODELS,
+  isBYOKModelRoleSupported,
+  MODEL_ROLES,
+} from "@stll/ai-catalog";
 
 import {
   CANARY_PROVIDERS,
   missingCanaryProviders,
   modelRoleMaxOutputTokens,
+  WEEKLY_TOOL_SHAPES,
+  weeklyCanaryRotation,
 } from "./ai-provider-canary-config";
 
 describe("AI provider canary role budgets", () => {
@@ -42,5 +49,54 @@ describe("AI provider canary coverage", () => {
         selection: "bedrock",
       }),
     ).toEqual(["bedrock"]);
+  });
+});
+
+describe("AI provider weekly rotation", () => {
+  test("cycles through every curated model with non-default supported roles", () => {
+    for (const provider of CANARY_PROVIDERS) {
+      const models = BYOK_MODEL_OPTIONS[provider];
+      const rotations = models.map((_, rotationIndex) =>
+        weeklyCanaryRotation({ provider, rotationIndex }),
+      );
+
+      expect(rotations.map(({ modelId }) => modelId)).toEqual(models);
+      expect(
+        weeklyCanaryRotation({
+          provider,
+          rotationIndex: models.length,
+        }).modelId,
+      ).toBe(models.at(0));
+
+      for (const { modelId, modelRoles } of rotations) {
+        expect(modelRoles.length).toBeGreaterThan(0);
+        for (const role of modelRoles) {
+          expect(modelId).not.toBe(DEFAULT_MODELS[provider][role]);
+          expect(
+            isBYOKModelRoleSupported({ modelId, provider, role }),
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  test("rotates executable tool shapes independently of model catalog size", () => {
+    for (const [rotationIndex, toolShape] of WEEKLY_TOOL_SHAPES.entries()) {
+      expect(
+        weeklyCanaryRotation({ provider: "openai", rotationIndex }).toolShape,
+      ).toBe(toolShape);
+    }
+    expect(
+      weeklyCanaryRotation({
+        provider: "openai",
+        rotationIndex: WEEKLY_TOOL_SHAPES.length,
+      }).toolShape,
+    ).toBe(WEEKLY_TOOL_SHAPES.at(0));
+  });
+
+  test("rejects invalid rotation indexes", () => {
+    expect(() =>
+      weeklyCanaryRotation({ provider: "google", rotationIndex: -1 }),
+    ).toThrow("Weekly canary rotation index must be non-negative.");
   });
 });

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -1,3 +1,9 @@
+import {
+  BYOK_MODEL_OPTIONS,
+  DEFAULT_MODELS,
+  isBYOKModelRoleSupported,
+  MODEL_ROLES,
+} from "@stll/ai-catalog";
 import type { ModelRole } from "@stll/ai-catalog";
 
 import type { TanStackTextProvider } from "@/api/lib/tanstack-ai-models";
@@ -20,6 +26,60 @@ export const CANARY_PROVIDERS = defineCanaryProviders([
 
 export type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
 export type CanaryProviderSelection = "all" | CanaryProvider;
+
+export const CANARY_TIERS = ["daily", "weekly"] as const;
+export type CanaryTier = (typeof CANARY_TIERS)[number];
+
+export const WEEKLY_TOOL_SHAPES = [
+  "nested-optional",
+  "array-item-optional",
+  "open-map",
+  "discriminated-union",
+] as const;
+export type WeeklyToolShape = (typeof WEEKLY_TOOL_SHAPES)[number];
+
+export type WeeklyCanaryRotation = {
+  modelId: string;
+  modelRoles: ModelRole[];
+  rotationIndex: number;
+  toolShape: WeeklyToolShape;
+};
+
+type WeeklyCanaryRotationOptions = {
+  provider: CanaryProvider;
+  rotationIndex: number;
+};
+
+export const weeklyCanaryRotation = ({
+  provider,
+  rotationIndex,
+}: WeeklyCanaryRotationOptions): WeeklyCanaryRotation => {
+  if (!Number.isSafeInteger(rotationIndex) || rotationIndex < 0) {
+    throw new TypeError("Weekly canary rotation index must be non-negative.");
+  }
+
+  const models = BYOK_MODEL_OPTIONS[provider];
+  const modelId = models.at(rotationIndex % models.length);
+  const toolShape = WEEKLY_TOOL_SHAPES.at(
+    rotationIndex % WEEKLY_TOOL_SHAPES.length,
+  );
+  if (modelId === undefined || toolShape === undefined) {
+    throw new TypeError("Weekly canary rotation catalog must not be empty.");
+  }
+
+  const modelRoles = MODEL_ROLES.filter(
+    (role) =>
+      DEFAULT_MODELS[provider][role] !== modelId &&
+      isBYOKModelRoleSupported({ modelId, provider, role }),
+  );
+  if (modelRoles.length === 0) {
+    throw new TypeError(
+      `Weekly canary model ${modelId} has no non-default supported role.`,
+    );
+  }
+
+  return { modelId, modelRoles, rotationIndex, toolShape };
+};
 
 const MODEL_ROLE_MAX_OUTPUT_TOKENS = {
   fast: 512,

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -27,6 +27,24 @@ export const CANARY_PROVIDERS = defineCanaryProviders([
 export type CanaryProvider = (typeof CANARY_PROVIDERS)[number];
 export type CanaryProviderSelection = "all" | CanaryProvider;
 
+// Providers whose strict/structured tool-calling mode forces every optional
+// property to be present, widening it to accept a synthetic `null` in place
+// of true omission. Both the flat round-trip probe and the weekly tool-shape
+// probes ask these providers for that null explicitly (deterministically)
+// instead of leaving them to guess omission vs. hallucination (#1194/#1196).
+export const NULL_WIDENING_CANARY_PROVIDERS = new Set<CanaryProvider>([
+  "mistral",
+  "openai",
+]);
+
+// JSON Schema patterns have no regex flag channel. OpenAI strict Structured
+// Outputs supports `pattern`; `a^` cannot match any string. Used to make the
+// "omit or send this impossible value" duality deterministic: no real string
+// can validly satisfy the optional field, only omission (or, for
+// null-widening providers, the synthetic null their strict mode forces).
+// eslint-disable-next-line require-unicode-regexp
+export const NEVER_MATCH_PATTERN = /a^/;
+
 export const CANARY_TIERS = ["daily", "weekly"] as const;
 export type CanaryTier = (typeof CANARY_TIERS)[number];
 

--- a/apps/api/scripts/ai-provider-canary-weekly.test.ts
+++ b/apps/api/scripts/ai-provider-canary-weekly.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
-
 import { convertSchemaToJsonSchema } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+import { isDeepStrictEqual } from "node:util";
 
 import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
@@ -11,15 +11,23 @@ import {
 } from "./ai-provider-canary-config";
 import { createWeeklyToolShapeDefinition } from "./ai-provider-canary-weekly";
 
+const isAcceptedWeeklyInput = (
+  expectedInputs: unknown[],
+  observedInput: unknown,
+): boolean =>
+  expectedInputs.some((expectedInput) =>
+    isDeepStrictEqual(expectedInput, observedInput),
+  );
+
 describe("AI provider weekly tool shapes", () => {
   test("projects every rotating shape for every canary provider", () => {
     const toolNames = new Set<string>();
 
     for (const shape of WEEKLY_TOOL_SHAPES) {
-      const { tool } = createWeeklyToolShapeDefinition(shape, []);
-      toolNames.add(tool.name);
-
       for (const provider of CANARY_PROVIDERS) {
+        const { tool } = createWeeklyToolShapeDefinition(shape, provider, []);
+        toolNames.add(tool.name);
+
         const projected = projectSchemaInputJsonSchema(
           tool.inputSchema,
           providerSafeJsonSchemaOptionsForTanStackProvider(provider),
@@ -29,11 +37,107 @@ describe("AI provider weekly tool shapes", () => {
         expect(jsonSchema?.type).toBe("object");
         expect(jsonSchema?.additionalProperties).toBe(false);
         expect(JSON.stringify(jsonSchema)).not.toMatch(
-          /"(?:const|oneOf|propertyNames|\$defs)":/,
+          /"(?:const|oneOf|propertyNames|\$defs)":/u,
         );
       }
     }
 
     expect(toolNames.size).toBe(WEEKLY_TOOL_SHAPES.length);
+  });
+});
+
+describe("AI provider weekly null-widening duality", () => {
+  test("non-null-widening providers still require omission on both affected shapes", () => {
+    const nested = createWeeklyToolShapeDefinition(
+      "nested-optional",
+      "openrouter",
+      [],
+    );
+    expect(nested.prompt).toContain("Omit details.optionalNote.");
+    expect(
+      isAcceptedWeeklyInput(nested.expectedInputs, {
+        details: { value: "stella-weekly" },
+        type: "nested",
+      }),
+    ).toBe(true);
+    expect(
+      isAcceptedWeeklyInput(nested.expectedInputs, {
+        details: { optionalNote: null, value: "stella-weekly" },
+        type: "nested",
+      }),
+    ).toBe(false);
+
+    const arrayItem = createWeeklyToolShapeDefinition(
+      "array-item-optional",
+      "openrouter",
+      [],
+    );
+    expect(arrayItem.prompt).toContain("Omit items[0].optionalLabel.");
+    expect(
+      isAcceptedWeeklyInput(arrayItem.expectedInputs, {
+        items: [{ id: "item-1" }],
+        type: "array",
+      }),
+    ).toBe(true);
+    expect(
+      isAcceptedWeeklyInput(arrayItem.expectedInputs, {
+        items: [{ id: "item-1", optionalLabel: null }],
+        type: "array",
+      }),
+    ).toBe(false);
+  });
+
+  test("null-widening providers accept omission or a synthetic null, but not a hallucinated literal", () => {
+    for (const provider of ["openai", "mistral"] as const) {
+      const nested = createWeeklyToolShapeDefinition(
+        "nested-optional",
+        provider,
+        [],
+      );
+      expect(nested.prompt).toContain("Set details.optionalNote to null.");
+      expect(
+        isAcceptedWeeklyInput(nested.expectedInputs, {
+          details: { value: "stella-weekly" },
+          type: "nested",
+        }),
+      ).toBe(true);
+      expect(
+        isAcceptedWeeklyInput(nested.expectedInputs, {
+          details: { optionalNote: null, value: "stella-weekly" },
+          type: "nested",
+        }),
+      ).toBe(true);
+      expect(
+        isAcceptedWeeklyInput(nested.expectedInputs, {
+          details: { optionalNote: "unexpected", value: "stella-weekly" },
+          type: "nested",
+        }),
+      ).toBe(false);
+
+      const arrayItem = createWeeklyToolShapeDefinition(
+        "array-item-optional",
+        provider,
+        [],
+      );
+      expect(arrayItem.prompt).toContain("Set items[0].optionalLabel to null.");
+      expect(
+        isAcceptedWeeklyInput(arrayItem.expectedInputs, {
+          items: [{ id: "item-1" }],
+          type: "array",
+        }),
+      ).toBe(true);
+      expect(
+        isAcceptedWeeklyInput(arrayItem.expectedInputs, {
+          items: [{ id: "item-1", optionalLabel: null }],
+          type: "array",
+        }),
+      ).toBe(true);
+      expect(
+        isAcceptedWeeklyInput(arrayItem.expectedInputs, {
+          items: [{ id: "item-1", optionalLabel: "unexpected" }],
+          type: "array",
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/apps/api/scripts/ai-provider-canary-weekly.test.ts
+++ b/apps/api/scripts/ai-provider-canary-weekly.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { convertSchemaToJsonSchema } from "@tanstack/ai";
+
+import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
+
+import {
+  CANARY_PROVIDERS,
+  WEEKLY_TOOL_SHAPES,
+} from "./ai-provider-canary-config";
+import { createWeeklyToolShapeDefinition } from "./ai-provider-canary-weekly";
+
+describe("AI provider weekly tool shapes", () => {
+  test("projects every rotating shape for every canary provider", () => {
+    const toolNames = new Set<string>();
+
+    for (const shape of WEEKLY_TOOL_SHAPES) {
+      const { tool } = createWeeklyToolShapeDefinition(shape, []);
+      toolNames.add(tool.name);
+
+      for (const provider of CANARY_PROVIDERS) {
+        const projected = projectSchemaInputJsonSchema(
+          tool.inputSchema,
+          providerSafeJsonSchemaOptionsForTanStackProvider(provider),
+        );
+        const jsonSchema = convertSchemaToJsonSchema(projected);
+
+        expect(jsonSchema?.type).toBe("object");
+        expect(jsonSchema?.additionalProperties).toBe(false);
+        expect(JSON.stringify(jsonSchema)).not.toMatch(
+          /"(?:const|oneOf|propertyNames|\$defs)":/,
+        );
+      }
+    }
+
+    expect(toolNames.size).toBe(WEEKLY_TOOL_SHAPES.length);
+  });
+});

--- a/apps/api/scripts/ai-provider-canary-weekly.ts
+++ b/apps/api/scripts/ai-provider-canary-weekly.ts
@@ -4,27 +4,73 @@ import * as v from "valibot";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 
-import type { WeeklyToolShape } from "./ai-provider-canary-config";
+// Reused rather than duplicated: same allow-list and impossible-match
+// pattern the daily round-trip probe uses to make the omission-vs-null
+// duality deterministic (see ai-provider-canary.ts, #1194/#1196).
+import {
+  NEVER_MATCH_PATTERN,
+  NULL_WIDENING_CANARY_PROVIDERS,
+} from "./ai-provider-canary-config";
+import type {
+  CanaryProvider,
+  WeeklyToolShape,
+} from "./ai-provider-canary-config";
 
 export const WEEKLY_TOOL_RESULT = "stella-weekly-tool-round-trip-ok";
 
-const nestedOptionalInputSchema = v.strictObject({
-  details: v.strictObject({
-    optionalNote: v.optional(v.literal("must-not-be-sent")),
-    value: v.literal("stella-weekly"),
-  }),
-  type: v.literal("nested"),
-});
+// Mistral rejects `pattern` in strict tool schemas (see the flat round-trip
+// probe's MISTRAL_TOOL_ROUND_TRIP_JSON_SCHEMA). Mirror the same workaround
+// here: an empty string enum is the deterministic omission marker instead of
+// an impossible regex.
+const NESTED_OPTIONAL_MISTRAL_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    details: {
+      type: "object",
+      properties: {
+        optionalNote: { type: "string", enum: [] },
+        value: { type: "string", enum: ["stella-weekly"] },
+      },
+      required: ["value"],
+      additionalProperties: false,
+    },
+    type: { type: "string", enum: ["nested"] },
+  },
+  required: ["details", "type"],
+  additionalProperties: false,
+} as const;
 
-const arrayItemOptionalInputSchema = v.strictObject({
-  items: v.array(
-    v.strictObject({
-      id: v.literal("item-1"),
-      optionalLabel: v.optional(v.literal("must-not-be-sent")),
-    }),
-  ),
-  type: v.literal("array"),
-});
+const ARRAY_ITEM_OPTIONAL_MISTRAL_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: { type: "string", enum: ["item-1"] },
+          optionalLabel: { type: "string", enum: [] },
+        },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    },
+    type: { type: "string", enum: ["array"] },
+  },
+  required: ["items", "type"],
+  additionalProperties: false,
+} as const;
+
+// Same duality the flat round-trip probe uses: null-widening providers are
+// asked to set the field to the synthetic null their strict mode forces,
+// everyone else is asked to omit it outright.
+const fieldOmissionInstruction = (
+  provider: CanaryProvider,
+  fieldPath: string,
+): string =>
+  NULL_WIDENING_CANARY_PROVIDERS.has(provider)
+    ? `Set ${fieldPath} to null.`
+    : `Omit ${fieldPath}.`;
 
 const openMapInputSchema = v.strictObject({
   type: v.literal("map"),
@@ -52,31 +98,65 @@ const outputSchema = v.strictObject({
 });
 
 export type WeeklyToolShapeDefinition = {
-  expectedInput: unknown;
+  expectedInputs: unknown[];
   prompt: string;
   tool: Tool;
 };
 
 export const createWeeklyToolShapeDefinition = (
   shape: WeeklyToolShape,
+  provider: CanaryProvider,
   observedInputs: unknown[],
 ): WeeklyToolShapeDefinition => {
   switch (shape) {
     case "nested-optional": {
       const name = "canary_weekly_nested_optional";
-      return {
-        expectedInput: {
-          details: { value: "stella-weekly" },
+      const isNullWidening = NULL_WIDENING_CANARY_PROVIDERS.has(provider);
+      const nestedOptionalInputSchema = v.strictObject({
+        details: v.strictObject({
+          optionalNote: v.optional(
+            v.pipe(v.string(), v.regex(NEVER_MATCH_PATTERN)),
+          ),
+          value: v.literal("stella-weekly"),
+        }),
+        type: v.literal("nested"),
+      });
+      const nestedOptionalStandardSchema = toTanStackToolSchema(
+        nestedOptionalInputSchema,
+      );
+      const inputSchema =
+        provider === "mistral"
+          ? {
+              ...nestedOptionalStandardSchema,
+              "~standard": {
+                ...nestedOptionalStandardSchema["~standard"],
+                jsonSchema: {
+                  ...nestedOptionalStandardSchema["~standard"].jsonSchema,
+                  input: () => NESTED_OPTIONAL_MISTRAL_JSON_SCHEMA,
+                },
+              },
+            }
+          : nestedOptionalStandardSchema;
+      const expectedInputs: unknown[] = [
+        { details: { value: "stella-weekly" }, type: "nested" },
+      ];
+      if (isNullWidening) {
+        expectedInputs.push({
+          details: { optionalNote: null, value: "stella-weekly" },
           type: "nested",
-        },
+        });
+      }
+
+      return {
+        expectedInputs,
         prompt:
           `Call ${name} exactly once with type "nested" and details.value ` +
-          '"stella-weekly". Omit details.optionalNote. Then reply with only ' +
-          "the confirmation returned by the tool.",
+          `"stella-weekly". ${fieldOmissionInstruction(provider, "details.optionalNote")} ` +
+          "Then reply with only the confirmation returned by the tool.",
         tool: toolDefinition({
           name,
           description: "Exercise a nested optional tool input.",
-          inputSchema: toTanStackToolSchema(nestedOptionalInputSchema),
+          inputSchema,
           outputSchema: toTanStackToolSchema(outputSchema),
         }).server((input) => {
           observedInputs.push(input);
@@ -86,16 +166,54 @@ export const createWeeklyToolShapeDefinition = (
     }
     case "array-item-optional": {
       const name = "canary_weekly_array_item_optional";
+      const isNullWidening = NULL_WIDENING_CANARY_PROVIDERS.has(provider);
+      const arrayItemOptionalInputSchema = v.strictObject({
+        items: v.array(
+          v.strictObject({
+            id: v.literal("item-1"),
+            optionalLabel: v.optional(
+              v.pipe(v.string(), v.regex(NEVER_MATCH_PATTERN)),
+            ),
+          }),
+        ),
+        type: v.literal("array"),
+      });
+      const arrayItemOptionalStandardSchema = toTanStackToolSchema(
+        arrayItemOptionalInputSchema,
+      );
+      const inputSchema =
+        provider === "mistral"
+          ? {
+              ...arrayItemOptionalStandardSchema,
+              "~standard": {
+                ...arrayItemOptionalStandardSchema["~standard"],
+                jsonSchema: {
+                  ...arrayItemOptionalStandardSchema["~standard"].jsonSchema,
+                  input: () => ARRAY_ITEM_OPTIONAL_MISTRAL_JSON_SCHEMA,
+                },
+              },
+            }
+          : arrayItemOptionalStandardSchema;
+      const expectedInputs: unknown[] = [
+        { items: [{ id: "item-1" }], type: "array" },
+      ];
+      if (isNullWidening) {
+        expectedInputs.push({
+          items: [{ id: "item-1", optionalLabel: null }],
+          type: "array",
+        });
+      }
+
       return {
-        expectedInput: { items: [{ id: "item-1" }], type: "array" },
+        expectedInputs,
         prompt:
           `Call ${name} exactly once with type "array" and one item whose id ` +
-          'is "item-1". Omit items[0].optionalLabel. Then reply with only ' +
-          "the confirmation returned by the tool.",
+          `is "item-1". ${fieldOmissionInstruction(provider, "items[0].optionalLabel")} ` +
+          "Then reply with only the confirmation returned by the tool.",
         tool: toolDefinition({
           name,
           description: "Exercise an optional field inside an array item.",
-          inputSchema: toTanStackToolSchema(arrayItemOptionalInputSchema),
+          inputSchema,
           outputSchema: toTanStackToolSchema(outputSchema),
         }).server((input) => {
           observedInputs.push(input);
@@ -106,7 +224,7 @@ export const createWeeklyToolShapeDefinition = (
     case "open-map": {
       const name = "canary_weekly_open_map";
       return {
-        expectedInput: { type: "map", values: { source: "canary" } },
+        expectedInputs: [{ type: "map", values: { source: "canary" } }],
         prompt:
           `Call ${name} exactly once with type "map" and values containing ` +
           'only source="canary". Then reply with only the confirmation ' +
@@ -125,14 +243,16 @@ export const createWeeklyToolShapeDefinition = (
     case "discriminated-union": {
       const name = "canary_weekly_discriminated_union";
       return {
-        expectedInput: {
-          payload: {
-            kind: "nullable",
-            note: null,
-            value: "stella-weekly",
+        expectedInputs: [
+          {
+            payload: {
+              kind: "nullable",
+              note: null,
+              value: "stella-weekly",
+            },
+            type: "union",
           },
-          type: "union",
-        },
+        ],
         prompt:
           `Call ${name} exactly once with type "union" and payload kind ` +
           '"nullable", value "stella-weekly", and note null. Then reply with ' +

--- a/apps/api/scripts/ai-provider-canary-weekly.ts
+++ b/apps/api/scripts/ai-provider-canary-weekly.ts
@@ -1,0 +1,156 @@
+import { toolDefinition } from "@tanstack/ai";
+import type { Tool } from "@tanstack/ai";
+import * as v from "valibot";
+
+import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+
+import type { WeeklyToolShape } from "./ai-provider-canary-config";
+
+export const WEEKLY_TOOL_RESULT = "stella-weekly-tool-round-trip-ok";
+
+const nestedOptionalInputSchema = v.strictObject({
+  details: v.strictObject({
+    optionalNote: v.optional(v.literal("must-not-be-sent")),
+    value: v.literal("stella-weekly"),
+  }),
+  type: v.literal("nested"),
+});
+
+const arrayItemOptionalInputSchema = v.strictObject({
+  items: v.array(
+    v.strictObject({
+      id: v.literal("item-1"),
+      optionalLabel: v.optional(v.literal("must-not-be-sent")),
+    }),
+  ),
+  type: v.literal("array"),
+});
+
+const openMapInputSchema = v.strictObject({
+  type: v.literal("map"),
+  values: v.record(v.string(), v.literal("canary")),
+});
+
+const discriminatedUnionInputSchema = v.strictObject({
+  payload: v.variant("kind", [
+    v.strictObject({
+      kind: v.literal("optional"),
+      note: v.optional(v.literal("must-not-be-sent")),
+      value: v.literal("stella-weekly"),
+    }),
+    v.strictObject({
+      kind: v.literal("nullable"),
+      note: v.nullable(v.literal("must-not-be-sent")),
+      value: v.literal("stella-weekly"),
+    }),
+  ]),
+  type: v.literal("union"),
+});
+
+const outputSchema = v.strictObject({
+  confirmation: v.literal(WEEKLY_TOOL_RESULT),
+});
+
+export type WeeklyToolShapeDefinition = {
+  expectedInput: unknown;
+  prompt: string;
+  tool: Tool;
+};
+
+export const createWeeklyToolShapeDefinition = (
+  shape: WeeklyToolShape,
+  observedInputs: unknown[],
+): WeeklyToolShapeDefinition => {
+  switch (shape) {
+    case "nested-optional": {
+      const name = "canary_weekly_nested_optional";
+      return {
+        expectedInput: {
+          details: { value: "stella-weekly" },
+          type: "nested",
+        },
+        prompt:
+          `Call ${name} exactly once with type "nested" and details.value ` +
+          '"stella-weekly". Omit details.optionalNote. Then reply with only ' +
+          "the confirmation returned by the tool.",
+        tool: toolDefinition({
+          name,
+          description: "Exercise a nested optional tool input.",
+          inputSchema: toTanStackToolSchema(nestedOptionalInputSchema),
+          outputSchema: toTanStackToolSchema(outputSchema),
+        }).server((input) => {
+          observedInputs.push(input);
+          return { confirmation: WEEKLY_TOOL_RESULT };
+        }),
+      };
+    }
+    case "array-item-optional": {
+      const name = "canary_weekly_array_item_optional";
+      return {
+        expectedInput: { items: [{ id: "item-1" }], type: "array" },
+        prompt:
+          `Call ${name} exactly once with type "array" and one item whose id ` +
+          'is "item-1". Omit items[0].optionalLabel. Then reply with only ' +
+          "the confirmation returned by the tool.",
+        tool: toolDefinition({
+          name,
+          description: "Exercise an optional field inside an array item.",
+          inputSchema: toTanStackToolSchema(arrayItemOptionalInputSchema),
+          outputSchema: toTanStackToolSchema(outputSchema),
+        }).server((input) => {
+          observedInputs.push(input);
+          return { confirmation: WEEKLY_TOOL_RESULT };
+        }),
+      };
+    }
+    case "open-map": {
+      const name = "canary_weekly_open_map";
+      return {
+        expectedInput: { type: "map", values: { source: "canary" } },
+        prompt:
+          `Call ${name} exactly once with type "map" and values containing ` +
+          'only source="canary". Then reply with only the confirmation ' +
+          "returned by the tool.",
+        tool: toolDefinition({
+          name,
+          description: "Exercise a free-form map tool input.",
+          inputSchema: toTanStackToolSchema(openMapInputSchema),
+          outputSchema: toTanStackToolSchema(outputSchema),
+        }).server((input) => {
+          observedInputs.push(input);
+          return { confirmation: WEEKLY_TOOL_RESULT };
+        }),
+      };
+    }
+    case "discriminated-union": {
+      const name = "canary_weekly_discriminated_union";
+      return {
+        expectedInput: {
+          payload: {
+            kind: "nullable",
+            note: null,
+            value: "stella-weekly",
+          },
+          type: "union",
+        },
+        prompt:
+          `Call ${name} exactly once with type "union" and payload kind ` +
+          '"nullable", value "stella-weekly", and note null. Then reply with ' +
+          "only the confirmation returned by the tool.",
+        tool: toolDefinition({
+          name,
+          description: "Exercise genuine nullability in a union branch.",
+          inputSchema: toTanStackToolSchema(discriminatedUnionInputSchema),
+          outputSchema: toTanStackToolSchema(outputSchema),
+        }).server((input) => {
+          observedInputs.push(input);
+          return { confirmation: WEEKLY_TOOL_RESULT };
+        }),
+      };
+    }
+    default: {
+      const _exhaustive: never = shape;
+      return _exhaustive;
+    }
+  }
+};

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -27,6 +27,8 @@ import {
   CANARY_TIERS,
   CANARY_PROVIDERS,
   modelRoleMaxOutputTokens,
+  NEVER_MATCH_PATTERN,
+  NULL_WIDENING_CANARY_PROVIDERS,
   weeklyCanaryRotation,
 } from "./ai-provider-canary-config";
 import type {
@@ -51,19 +53,11 @@ const TOOL_ROUND_TRIP_NAME = "canary_round_trip";
 const TOOL_ROUND_TRIP_VALUE = "stella-canary";
 const TOOL_ROUND_TRIP_COUNT = 7;
 const TOOL_ROUND_TRIP_RESULT = "stella-tool-round-trip-ok";
-// JSON Schema patterns have no regex flag channel. OpenAI strict Structured
-// Outputs supports `pattern`; `a^` cannot match any string.
-// eslint-disable-next-line require-unicode-regexp
-const NEVER_MATCH_PATTERN = /a^/;
 const TOOL_ROUND_TRIP_PROMPT_PREFIX =
   `Call ${TOOL_ROUND_TRIP_NAME} exactly once with value "${TOOL_ROUND_TRIP_VALUE}" ` +
   `and count ${TOOL_ROUND_TRIP_COUNT}.`;
 const TOOL_ROUND_TRIP_PROMPT_SUFFIX =
   "Then reply with only the confirmation value returned by the tool.";
-const NULL_WIDENING_CANARY_PROVIDERS = new Set<CanaryProvider>([
-  "mistral",
-  "openai",
-]);
 
 export const toolRoundTripPromptForProvider = (
   provider: CanaryProvider,
@@ -523,8 +517,9 @@ const runWeeklyToolShapeProbe = async ({
   signal,
 }: RunWeeklyToolShapeProbeOptions): Promise<void> => {
   const observedInputs: unknown[] = [];
-  const { expectedInput, prompt, tool } = createWeeklyToolShapeDefinition(
+  const { expectedInputs, prompt, tool } = createWeeklyToolShapeDefinition(
     context.rotation.toolShape,
+    context.provider,
     observedInputs,
   );
   const output = await runToolProbe({
@@ -541,7 +536,12 @@ const runWeeklyToolShapeProbe = async ({
       "Provider did not execute the weekly canary tool exactly once.",
     );
   }
-  if (!isDeepStrictEqual(observedInputs.at(0), expectedInput)) {
+  const observedInput = observedInputs.at(0);
+  if (
+    !expectedInputs.some((expectedInput) =>
+      isDeepStrictEqual(observedInput, expectedInput),
+    )
+  ) {
     throw new TypeError(
       "Provider returned unexpected weekly canary tool arguments.",
     );

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,9 +1,12 @@
+import { isDeepStrictEqual } from "node:util";
+
 import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
 import type { Tool } from "@tanstack/ai";
 import * as v from "valibot";
 
 import {
   DEFAULT_MODELS,
+  isBYOKModelRoleSupported,
   isBYOKProviderRoleSupported,
   MODEL_ROLES,
 } from "@stll/ai-catalog";
@@ -22,10 +25,19 @@ import {
 import { projectSchemaInputJsonSchema } from "@/api/lib/tanstack-ai-schema";
 
 import {
+  CANARY_TIERS,
   CANARY_PROVIDERS,
   modelRoleMaxOutputTokens,
+  weeklyCanaryRotation,
 } from "./ai-provider-canary-config";
-import type { CanaryProvider } from "./ai-provider-canary-config";
+import type {
+  CanaryProvider,
+  WeeklyCanaryRotation,
+} from "./ai-provider-canary-config";
+import {
+  createWeeklyToolShapeDefinition,
+  WEEKLY_TOOL_RESULT,
+} from "./ai-provider-canary-weekly";
 
 const CAPABILITY_ROLE = "fast" satisfies ModelRole;
 const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
@@ -33,6 +45,7 @@ const MAX_OUTPUT_TOKENS = 64;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
+const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
 const TOOL_SCHEMA_PROMPT = "Do not call any tool. Reply with exactly OK.";
 const TOOL_ROUND_TRIP_NAME = "canary_round_trip";
@@ -70,6 +83,9 @@ const SAFE_CANARY_ERROR_MESSAGES = new Set([
   "Provider generated an unexpected optional tool argument.",
   "Provider returned unexpected canary tool arguments.",
   "Provider did not return the canary tool result.",
+  "Provider did not execute the weekly canary tool exactly once.",
+  "Provider returned unexpected weekly canary tool arguments.",
+  "Provider did not return the weekly canary tool result.",
   "Provider returned no text.",
 ]);
 
@@ -271,6 +287,11 @@ type CanaryContext = {
   provider: CanaryProvider;
 };
 
+type WeeklyCanaryContext = CanaryContext & {
+  rotatedConfig: OrgAIConfig;
+  rotation: WeeklyCanaryRotation;
+};
+
 const modelRoleProbes = MODEL_ROLES.map(
   (role) =>
     ({
@@ -402,6 +423,39 @@ const runModelRoleProbe = async ({
   requireNonEmptyText(output);
 };
 
+type RunWeeklyModelRoleProbeOptions = {
+  context: WeeklyCanaryContext;
+  role: ModelRole;
+  signal: AbortSignal;
+};
+
+const runWeeklyModelRoleProbe = async ({
+  context: { provider, rotatedConfig, rotation },
+  role,
+  signal,
+}: RunWeeklyModelRoleProbeOptions): Promise<void> => {
+  const model = resolveTanStackTextModel({
+    organizationId: null,
+    orgAIConfig: rotatedConfig,
+    role,
+  });
+  if (model.provider !== provider || model.modelId !== rotation.modelId) {
+    throw new TypeError("Canary resolved an unexpected provider model.");
+  }
+
+  const output = await generateTanStackTextForRole({
+    abortSignal: signal,
+    caching: NO_CACHING,
+    maxOutputTokens: modelRoleMaxOutputTokens(role),
+    organizationId: null,
+    orgAIConfig: rotatedConfig,
+    prompt: SYNTHETIC_PROMPT,
+    role,
+    serviceTier: "standard",
+  });
+  requireNonEmptyText(output);
+};
+
 type RunToolCallRoundTripProbeOptions = {
   context: CanaryContext;
   signal: AbortSignal;
@@ -457,6 +511,44 @@ const runToolCallRoundTripProbe = async ({
   }
   if (output.trim() !== TOOL_ROUND_TRIP_RESULT) {
     throw new TypeError("Provider did not return the canary tool result.");
+  }
+};
+
+type RunWeeklyToolShapeProbeOptions = {
+  context: WeeklyCanaryContext;
+  signal: AbortSignal;
+};
+
+const runWeeklyToolShapeProbe = async ({
+  context,
+  signal,
+}: RunWeeklyToolShapeProbeOptions): Promise<void> => {
+  const observedInputs: unknown[] = [];
+  const { expectedInput, prompt, tool } = createWeeklyToolShapeDefinition(
+    context.rotation.toolShape,
+    observedInputs,
+  );
+  const output = await runToolProbe({
+    context: { config: context.rotatedConfig, provider: context.provider },
+    maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
+    prompt,
+    role: TOOL_CALL_ROLE,
+    signal,
+    tool,
+  });
+
+  if (observedInputs.length !== 1) {
+    throw new TypeError(
+      "Provider did not execute the weekly canary tool exactly once.",
+    );
+  }
+  if (!isDeepStrictEqual(observedInputs.at(0), expectedInput)) {
+    throw new TypeError(
+      "Provider returned unexpected weekly canary tool arguments.",
+    );
+  }
+  if (output.trim() !== WEEKLY_TOOL_RESULT) {
+    throw new TypeError("Provider did not return the weekly canary tool result.");
   }
 };
 
@@ -532,17 +624,35 @@ const requireNonEmptyText = (output: string): void => {
   }
 };
 
-const modelSelections = (provider: CanaryProvider) => ({
-  fast: { provider, modelId: DEFAULT_MODELS[provider].fast },
-  chat: { provider, modelId: DEFAULT_MODELS[provider].chat },
-  reasoning: { provider, modelId: DEFAULT_MODELS[provider].reasoning },
-  pdf: { provider, modelId: DEFAULT_MODELS[provider].pdf },
-});
-
-const createCanaryConfig = (
+const modelSelections = (
   provider: CanaryProvider,
-  apiKey: string,
-): OrgAIConfig => {
+  rotatedModelId?: string,
+) => {
+  const modelIdForRole = (role: ModelRole) =>
+    rotatedModelId !== undefined &&
+    isBYOKModelRoleSupported({ modelId: rotatedModelId, provider, role })
+      ? rotatedModelId
+      : DEFAULT_MODELS[provider][role];
+
+  return {
+    fast: { provider, modelId: modelIdForRole("fast") },
+    chat: { provider, modelId: modelIdForRole("chat") },
+    reasoning: { provider, modelId: modelIdForRole("reasoning") },
+    pdf: { provider, modelId: modelIdForRole("pdf") },
+  };
+};
+
+type CreateCanaryConfigOptions = {
+  apiKey: string;
+  provider: CanaryProvider;
+  rotatedModelId?: string;
+};
+
+const createCanaryConfig = ({
+  apiKey,
+  provider,
+  rotatedModelId,
+}: CreateCanaryConfigOptions): OrgAIConfig => {
   switch (provider) {
     case "google":
     case "openrouter":
@@ -552,7 +662,7 @@ const createCanaryConfig = (
     case "mistral":
       return {
         providers: [{ provider, apiKey }],
-        overrideModels: modelSelections(provider),
+        overrideModels: modelSelections(provider, rotatedModelId),
       };
     default: {
       const _exhaustive: never = provider;
@@ -561,26 +671,58 @@ const createCanaryConfig = (
   }
 };
 
+const flagValue = (args: string[], flag: string): string | undefined => {
+  const flagIndex = args.indexOf(flag);
+  return flagIndex === -1 ? undefined : args.at(flagIndex + 1);
+};
+
 const parseProvider = (args: string[]): CanaryProvider => {
-  const providerFlagIndex = args.indexOf("--provider");
-  const value = args.at(providerFlagIndex + 1);
-  if (providerFlagIndex !== -1) {
-    switch (value) {
-      case "google":
-      case "openrouter":
-      case "openai":
-      case "anthropic":
-      case "bedrock":
-      case "mistral":
-        return value;
-      case undefined:
-        break;
-    }
+  const value = flagValue(args, "--provider");
+  switch (value) {
+    case "google":
+    case "openrouter":
+    case "openai":
+    case "anthropic":
+    case "bedrock":
+    case "mistral":
+      return value;
+    case undefined:
+      break;
   }
 
   throw new TypeError(
     `Pass --provider followed by one of: ${CANARY_PROVIDERS.join(", ")}.`,
   );
+};
+
+type CanaryRunArgs =
+  | { provider: CanaryProvider; tier: "daily" }
+  | { provider: CanaryProvider; rotationIndex: number; tier: "weekly" };
+
+const parseCanaryRunArgs = (args: string[]): CanaryRunArgs => {
+  const provider = parseProvider(args);
+  const tierValue = flagValue(args, "--tier") ?? "daily";
+  if (tierValue === "daily") {
+    return { provider, tier: "daily" };
+  }
+  if (tierValue !== "weekly") {
+    throw new TypeError(
+      `Pass --tier followed by one of: ${CANARY_TIERS.join(", ")}.`,
+    );
+  }
+
+  const rotationValue = flagValue(args, "--rotation-index");
+  const rotationIndex =
+    rotationValue === undefined
+      ? Math.floor(Date.now() / MILLISECONDS_PER_WEEK)
+      : Number(rotationValue);
+  if (!Number.isSafeInteger(rotationIndex) || rotationIndex < 0) {
+    throw new TypeError(
+      "Pass --rotation-index followed by a non-negative integer.",
+    );
+  }
+
+  return { provider, rotationIndex, tier: "weekly" };
 };
 
 export const errorSummary = (error: unknown, signal: AbortSignal): string => {
@@ -618,17 +760,40 @@ const probeLabel = (context: CanaryContext, probe: Probe): string => {
 };
 
 const run = async (): Promise<void> => {
-  const provider = parseProvider(Bun.argv.slice(2));
+  const args = parseCanaryRunArgs(Bun.argv.slice(2));
+  const { provider } = args;
   const apiKey = process.env["AI_CANARY_API_KEY"];
   if (!apiKey) {
     throw new TypeError(`No canary credential is configured for ${provider}.`);
   }
 
   const context = {
-    config: createCanaryConfig(provider, apiKey),
+    config: createCanaryConfig({ apiKey, provider }),
     provider,
   } satisfies CanaryContext;
-  const failures = await runProbes(context, 0, 0);
+  let failures = await runProbes(context, 0, 0);
+
+  if (args.tier === "weekly") {
+    const rotation = weeklyCanaryRotation({
+      provider,
+      rotationIndex: args.rotationIndex,
+    });
+    const weeklyContext = {
+      ...context,
+      rotatedConfig: createCanaryConfig({
+        apiKey,
+        provider,
+        rotatedModelId: rotation.modelId,
+      }),
+      rotation,
+    } satisfies WeeklyCanaryContext;
+    console.log(
+      `[ai-canary] ${provider}/weekly-rotation-${rotation.rotationIndex}: ` +
+        `${rotation.modelId}, roles=${rotation.modelRoles.join(",")}, ` +
+        `tool-shape=${rotation.toolShape}`,
+    );
+    failures = await runWeeklyCanaryProbes(weeklyContext, 0, failures);
+  }
 
   if (failures > 0) {
     throw new TypeError(
@@ -671,6 +836,46 @@ const runProbes = async (
       `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
     );
     return await runProbes(context, index + 1, failures + 1);
+  }
+};
+
+const runWeeklyCanaryProbes = async (
+  context: WeeklyCanaryContext,
+  index: number,
+  failures: number,
+): Promise<number> => {
+  const role = context.rotation.modelRoles.at(index);
+  if (role !== undefined) {
+    const label = `weekly-role-${role}:${context.rotation.modelId}`;
+    const signal = AbortSignal.timeout(MODEL_ROLE_PROBE_TIMEOUT_MS);
+    try {
+      await runWeeklyModelRoleProbe({ context, role, signal });
+      console.log(`[ai-canary] ${context.provider}/${label}: passed`);
+      return await runWeeklyCanaryProbes(context, index + 1, failures);
+    } catch (error) {
+      console.error(
+        `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
+      );
+      return await runWeeklyCanaryProbes(context, index + 1, failures + 1);
+    }
+  }
+
+  if (index !== context.rotation.modelRoles.length) {
+    return failures;
+  }
+
+  const label =
+    `weekly-tool-${context.rotation.toolShape}:` + context.rotation.modelId;
+  const signal = AbortSignal.timeout(TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS);
+  try {
+    await runWeeklyToolShapeProbe({ context, signal });
+    console.log(`[ai-canary] ${context.provider}/${label}: passed`);
+    return failures;
+  } catch (error) {
+    console.error(
+      `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
+    );
+    return failures + 1;
   }
 };
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,7 +1,6 @@
-import { isDeepStrictEqual } from "node:util";
-
 import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
 import type { Tool } from "@tanstack/ai";
+import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
 import {
@@ -548,7 +547,9 @@ const runWeeklyToolShapeProbe = async ({
     );
   }
   if (output.trim() !== WEEKLY_TOOL_RESULT) {
-    throw new TypeError("Provider did not return the weekly canary tool result.");
+    throw new TypeError(
+      "Provider did not return the weekly canary tool result.",
+    );
   }
 };
 
@@ -624,10 +625,7 @@ const requireNonEmptyText = (output: string): void => {
   }
 };
 
-const modelSelections = (
-  provider: CanaryProvider,
-  rotatedModelId?: string,
-) => {
+const modelSelections = (provider: CanaryProvider, rotatedModelId?: string) => {
   const modelIdForRole = (role: ModelRole) =>
     rotatedModelId !== undefined &&
     isBYOKModelRoleSupported({ modelId: rotatedModelId, provider, role })
@@ -673,7 +671,16 @@ const createCanaryConfig = ({
 
 const flagValue = (args: string[], flag: string): string | undefined => {
   const flagIndex = args.indexOf(flag);
-  return flagIndex === -1 ? undefined : args.at(flagIndex + 1);
+  if (flagIndex === -1) {
+    return undefined;
+  }
+
+  const value = args.at(flagIndex + 1);
+  if (value === undefined || value.startsWith("--")) {
+    throw new TypeError(`Pass ${flag} followed by a value.`);
+  }
+
+  return value;
 };
 
 const parseProvider = (args: string[]): CanaryProvider => {
@@ -792,7 +799,7 @@ const run = async (): Promise<void> => {
         `${rotation.modelId}, roles=${rotation.modelRoles.join(",")}, ` +
         `tool-shape=${rotation.toolShape}`,
     );
-    failures = await runWeeklyCanaryProbes(weeklyContext, 0, failures);
+    failures = await runWeeklyCanaryProbes(weeklyContext, failures);
   }
 
   if (failures > 0) {
@@ -841,41 +848,36 @@ const runProbes = async (
 
 const runWeeklyCanaryProbes = async (
   context: WeeklyCanaryContext,
-  index: number,
   failures: number,
 ): Promise<number> => {
-  const role = context.rotation.modelRoles.at(index);
-  if (role !== undefined) {
+  let totalFailures = failures;
+
+  for (const role of context.rotation.modelRoles) {
     const label = `weekly-role-${role}:${context.rotation.modelId}`;
     const signal = AbortSignal.timeout(MODEL_ROLE_PROBE_TIMEOUT_MS);
     try {
+      // oxlint-disable-next-line no-await-in-loop -- role probes must stay sequential so the failure count and console output stay ordered.
       await runWeeklyModelRoleProbe({ context, role, signal });
       console.log(`[ai-canary] ${context.provider}/${label}: passed`);
-      return await runWeeklyCanaryProbes(context, index + 1, failures);
     } catch (error) {
       console.error(
         `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
       );
-      return await runWeeklyCanaryProbes(context, index + 1, failures + 1);
+      totalFailures += 1;
     }
   }
 
-  if (index !== context.rotation.modelRoles.length) {
-    return failures;
-  }
-
-  const label =
-    `weekly-tool-${context.rotation.toolShape}:` + context.rotation.modelId;
+  const label = `weekly-tool-${context.rotation.toolShape}:${context.rotation.modelId}`;
   const signal = AbortSignal.timeout(TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS);
   try {
     await runWeeklyToolShapeProbe({ context, signal });
     console.log(`[ai-canary] ${context.provider}/${label}: passed`);
-    return failures;
+    return totalFailures;
   } catch (error) {
     console.error(
       `[ai-canary] ${context.provider}/${label}: failed (${errorSummary(error, signal)})`,
     );
-    return failures + 1;
+    return totalFailures + 1;
   }
 };
 


### PR DESCRIPTION
Adds a weekly provider-canary tier that replaces Monday's daily run.

The weekly tier deterministically rotates through curated non-default models and deeper tool-schema shapes while retaining the complete daily capability contract. It also adds offline invariants for catalog coverage and provider-safe schema projection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added weekly AI provider checks alongside existing daily checks.
  - Weekly checks now rotate across supported models, roles and tool interaction scenarios.
  - Manual runs can select either daily or weekly testing.
  - Weekly checks automatically select the current rotation period when no index is provided.

- **Bug Fixes**
  - Improved validation and error handling for invalid rotation selections and unsupported provider capabilities.

- **Tests**
  - Added coverage for weekly model rotation, tool schemas and round-trip tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->