### PR TITLE
chore: characterize chat persistence boundaries

### DIFF
--- a/.agents/plans/050-maintainability-cleanup-wave.md
+++ b/.agents/plans/050-maintainability-cleanup-wave.md
@@ -1,0 +1,107 @@
+# Plan: Maintainability Cleanup Wave
+
+Date: 2026-07-17
+
+## Goal
+
+Reduce change risk in the chat, Template Studio, and template-filling hotspots
+without changing product behaviour. Land the work as six independently
+reviewable pull requests, preserving vertical-slice ownership and adding a
+safety net before each structural extraction.
+
+## Design Decisions
+
+- **Safety nets precede extraction:** Characterization and browser tests land
+  before moving high-churn orchestration so failures distinguish behavioural
+  regressions from mechanical movement.
+- **Keep ownership inside the existing slice:** Chat helpers stay in the chat
+  slice, Template Studio interactions stay in the knowledge route slice, and
+  reusable template-filling logic becomes a templates-domain service. This is
+  not a package or shared-folder reorganization.
+- **Extract by side-effect boundary:** File operations, persistence,
+  compaction, and external-model preparation get explicit seams. Endpoint files
+  retain contracts, permissions, and orchestration.
+- **Reduce ratchets through hotspot fixes:** Cross-handler and route-private
+  import counts should fall as a consequence of clearer ownership; repository-
+  wide mechanical rewrites are out of scope.
+- **Observability remains opt-in and data-minimizing:** Remote export is disabled
+  unless configured and only accepts explicitly allowlisted structured
+  attributes. Legal content, prompts, filenames, tokens, and personal data are
+  never exported.
+
+## Scope
+
+**In scope:**
+
+- PR 1: characterize chat send-message failure, rollback, tenant-scope,
+  persistence, and usage invariants.
+- PR 2: decompose send-message orchestration within the chat slice.
+- PR 3: add browser coverage for Template Studio edit, directive insertion,
+  save, and reload.
+- PR 4: extract Template Studio slash-menu and selection-gesture subsystems
+  within the knowledge slice.
+- PR 5: move the highest-leverage template-filling helpers out of endpoint
+  modules and into templates-domain services.
+- PR 6: add an optional privacy-safe production log exporter with correlation
+  identifiers and fail-closed attribute filtering.
+
+**Out of scope:**
+
+- Behaviour or UI redesign.
+- Billing, plan, or entitlement changes.
+- Broad package reorganization or new barrel modules.
+- Repository-wide lint-suppression, detached-promise, or large-file cleanup.
+- Database schema changes unless a later PR demonstrates an unavoidable
+  observability requirement; such a change requires a plan amendment first.
+
+## Implementation
+
+- `apps/api/src/handlers/chat/send-message.ts` — retain the endpoint contract
+  and readable turn orchestration; move independently testable preparation,
+  file-side-effect, persistence, and compaction responsibilities into adjacent
+  chat modules.
+- `apps/api/src/handlers/chat/*.test.ts` — add invariants around authorization,
+  workspace scope, rollback, idempotent persistence, aborted streams, and
+  exactly-once usage accounting at the highest practical layer.
+- `apps/web/e2e/specs/` — add a focused Template Studio editor journey using the
+  existing Playwright stack.
+- `apps/web/src/routes/_protected.knowledge/-components/` — give slash-menu and
+  selection-gesture interactions their own state, behaviour, and presentation
+  modules without exporting route-private implementation across slices.
+- `apps/api/src/handlers/templates/` — place reusable fill behaviour in domain
+  service modules so endpoints stop importing helpers from other endpoints.
+- `apps/api/src/lib/observability/` — add an optional exporter interface,
+  allowlisted record projection, trace/request correlation, configuration, and
+  privacy regression tests.
+- `scripts/ratchet-baseline.json` — lower affected metrics only after the
+  implementation reduces them; never reseed upward.
+
+**DB schema changes:** none planned.
+
+## Test Cases
+
+- An aborted or failed chat turn cannot leave persisted partial messages or
+  uploaded objects behind.
+- Chat workspace scope is never widened by extraction; deleting workspaces are
+  excluded from model and search allowlists.
+- Persistence retry and finish callbacks cannot double-write a turn or charge
+  usage twice.
+- Compaction failure preserves the conversation tail and leaves the turn usable.
+- Template Studio supports keyboard and pointer insertion, save, reload, and
+  focus restoration after subsystem extraction.
+- Template fill endpoints produce byte-for-byte equivalent successful outputs
+  and equivalent structured errors after service extraction.
+- Remote logs contain correlation and allowlisted operational attributes but
+  reject content, prompt, filename, secret, token, and identity fields.
+- Each PR passes its focused tests plus `bun run verify`; build and E2E jobs run
+  where the changed surface requires them.
+
+## Open Questions
+
+- Which send-message invariants require a handler integration fixture versus a
+  smaller extracted state-machine test? Resolve during PR 1 without weakening
+  tenant or side-effect coverage.
+- Which Template Studio directive best exercises both keyboard interaction and
+  persistence without coupling the browser test to incidental presentation?
+- Which OTLP-compatible backend will receive production logs? PR 6 keeps the
+  exporter provider-neutral unless deployment requirements select one.

--- a/apps/api/src/handlers/chat/persist-message.test.ts
+++ b/apps/api/src/handlers/chat/persist-message.test.ts
@@ -235,3 +235,34 @@ describe("chat approval persistence", () => {
     expect(finishPlan).toEqual({ type: "none" });
   });
 });
+
+describe("chat user-message persistence", () => {
+  const userMessage = {
+    id: chatMessageId("019aef0c-4df0-7d25-b5ad-cfa5a548fb2f"),
+    role: "user",
+    parts: [{ type: "text", content: "Summarize this matter" }],
+  } satisfies PersistableChatMessage;
+
+  test("does not append a re-sent message already present in the loaded window", () => {
+    const result = planMessagePersistence({
+      message: userMessage,
+      storedMessages: [stored(userMessage)],
+    });
+
+    expect(result.persistencePlan).toEqual({ type: "none" });
+    expect(result.messages).toEqual([userMessage]);
+    expect(result.existingIds).toEqual(new Set([userMessage.id]));
+  });
+
+  test("does not insert an existing message that falls outside the loaded window", () => {
+    const result = planMessagePersistence({
+      message: userMessage,
+      storedMessages: [],
+      incomingMessageExists: true,
+    });
+
+    expect(result.persistencePlan).toEqual({ type: "none" });
+    expect(result.messages).toEqual([]);
+    expect(result.existingIds).toEqual(new Set());
+  });
+});

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+
+import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
+
+import type { OrgAIConfig } from "@/api/lib/ai-config";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import sendMessage from "./send-message";
+
+type SendMessageCtx = Parameters<typeof sendMessage.handler>[0];
+
+const organizationId = toSafeId<"organization">(
+  "00000000-0000-0000-0000-000000000001",
+);
+const userId = toSafeId<"user">("00000000-0000-0000-0000-000000000002");
+const threadId = toSafeId<"chatThread">("00000000-0000-0000-0000-000000000003");
+const messageId = toSafeId<"chatMessage">(
+  "00000000-0000-0000-0000-000000000004",
+);
+const activeWorkspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000005",
+);
+const deletingWorkspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000006",
+);
+const inaccessibleWorkspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000007",
+);
+
+const orgAIConfig = {
+  providers: [{ provider: "openai", apiKey: "test-api-key" }],
+  overrideModels: {
+    chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+    fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+    pdf: { provider: "openai", modelId: "gpt-5.4" },
+    reasoning: { provider: "openai", modelId: "gpt-5.4" },
+  },
+} satisfies OrgAIConfig;
+
+const createContext = ({
+  contextMatterIds,
+}: {
+  contextMatterIds: SendMessageCtx["body"]["contextMatterIds"];
+}): SendMessageCtx => {
+  const { safeDb, scopedDb } = createScopedDbMock({
+    query: {
+      organizationSettings: {
+        findFirst: async () => null,
+      },
+    },
+  });
+
+  return asTestRaw<SendMessageCtx>({
+    body: {
+      threadId,
+      sendMode: CHAT_SEND_MODE.rawOverride,
+      contextMatterIds,
+      message: {
+        id: messageId,
+        role: "user",
+        parts: [{ type: "text", content: "Summarize the selected matters" }],
+      },
+    },
+    createAuditRecorder: () => async () => {},
+    getAccessibleWorkspaces: async () => [
+      { id: activeWorkspaceId, status: "active" },
+      { id: deletingWorkspaceId, status: "deleting" },
+    ],
+    getActiveWorkspaceIds: async () => [activeWorkspaceId],
+    getWorkspaceAccess: async () => null,
+    memberRole: { role: "owner" },
+    orgAIConfig,
+    pinServerValidatedWorkspaceId: () => false,
+    promptCachingEnabled: false,
+    recordAuditEvent: async () => {},
+    request: new Request("http://localhost/v1/chat/send"),
+    route: "/v1/chat/send",
+    safeDb,
+    scopedDb,
+    session: { activeOrganizationId: organizationId },
+    user: { id: userId },
+  });
+};
+
+describe("send message context-matter authorization", () => {
+  test("rejects a requested matter outside the caller's accessible set", async () => {
+    const result = await sendMessage.handler(
+      createContext({ contextMatterIds: [inaccessibleWorkspaceId] }),
+    );
+
+    expect(result).toEqual({
+      code: 403,
+      response: { message: "contextMatterIds includes inaccessible matter" },
+    });
+  });
+
+  test("treats a deleting matter as inaccessible even when membership still resolves", async () => {
+    const result = await sendMessage.handler(
+      createContext({ contextMatterIds: [deletingWorkspaceId] }),
+    );
+
+    expect(result).toEqual({
+      code: 403,
+      response: { message: "contextMatterIds includes inaccessible matter" },
+    });
+  });
+});

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -1,10 +1,10 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 
 import type { Transaction } from "@/api/db/root";
-import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
+import type { SafeDb } from "@/api/db/safe-db";
 import {
   TEXT_CSV_MIME_TYPE,
   TEXT_MARKDOWN_MIME_TYPE,
@@ -220,8 +220,7 @@ describe("chat attachment hydration", () => {
     const databaseError = new DatabaseError({
       message: "user file insert failed",
     });
-    const safeDb: SafeDb = async <T>() =>
-      Result.err<T, SafeDbError>(databaseError);
+    const safeDb: SafeDb = async <T>() => Result.err(databaseError);
     const recordAuditEvent = mock(async () => undefined);
 
     const result = await uploadUserFile({
@@ -239,7 +238,7 @@ describe("chat attachment hydration", () => {
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isOk(result)) {
-      throw new Error("Expected the database save to fail");
+      panic("Expected the database save to fail");
     }
     expect(result.error).toBe(databaseError);
     expect(writeMock).toHaveBeenCalledTimes(1);

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -220,7 +220,8 @@ describe("chat attachment hydration", () => {
     const databaseError = new DatabaseError({
       message: "user file insert failed",
     });
-    const safeDb: SafeDb = async <T>() => Result.err(databaseError);
+    const safeDb: SafeDb = async <T>(_fn: (tx: Transaction) => Promise<T>) =>
+      Result.err(databaseError);
     const recordAuditEvent = mock(async () => undefined);
 
     const result = await uploadUserFile({

--- a/apps/api/src/handlers/chat/upload-files.test.ts
+++ b/apps/api/src/handlers/chat/upload-files.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 
 import type { Transaction } from "@/api/db/root";
-import type { SafeDb } from "@/api/db/safe-db";
+import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
 import {
   TEXT_CSV_MIME_TYPE,
   TEXT_MARKDOWN_MIME_TYPE,
@@ -17,6 +17,7 @@ import {
 import type { PersistableChatMessage } from "@/api/handlers/chat/types";
 import { toSafeId } from "@/api/lib/branded-types";
 import { parseDataUrl, toDataUrl } from "@/api/lib/data-url";
+import { DatabaseError } from "@/api/lib/errors/tagged-errors";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
@@ -36,8 +37,12 @@ void mock.module("@/api/lib/s3", () => ({
   getS3: () => ({ delete: s3DeleteMock, file: fileMock, write: writeMock }),
 }));
 
-const { canHydrateFilePartAsPlainText, hydrateFilePart, uploadMessageFiles } =
-  await import("./upload-files");
+const {
+  canHydrateFilePartAsPlainText,
+  hydrateFilePart,
+  uploadMessageFiles,
+  uploadUserFile,
+} = await import("./upload-files");
 
 describe("chat attachment hydration", () => {
   beforeEach(() => {
@@ -209,5 +214,36 @@ describe("chat attachment hydration", () => {
       testTx,
       expect.arrayContaining([expect.objectContaining({ workspaceId })]),
     );
+  });
+
+  test("deletes the stored object when the database save fails", async () => {
+    const databaseError = new DatabaseError({
+      message: "user file insert failed",
+    });
+    const safeDb: SafeDb = async <T>() =>
+      Result.err<T, SafeDbError>(databaseError);
+    const recordAuditEvent = mock(async () => undefined);
+
+    const result = await uploadUserFile({
+      file: {
+        bytes: new TextEncoder().encode("confidential text"),
+        fileName: "notes.txt",
+        mimeType: TEXT_PLAIN_MIME_TYPE,
+      },
+      recordAuditEvent,
+      safeDb,
+      threadId: toSafeId<"chatThread">("11111111-1111-4111-8111-111111111112"),
+      userId: toSafeId<"user">("11111111-1111-4111-8111-111111111113"),
+      workspaceId,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) {
+      throw new Error("Expected the database save to fail");
+    }
+    expect(result.error).toBe(databaseError);
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(s3DeleteMock).toHaveBeenCalledTimes(1);
+    expect(recordAuditEvent).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Proposed change

Add characterization coverage around chat send-message boundaries before decomposing the endpoint:

- reject inaccessible and deleting context matters
- preserve idempotent user-message persistence across bounded history windows
- clean up stored attachments when database persistence fails
- document the ordered maintainability cleanup wave

## Checklist

- [x] BUILD ASSURANCE | Required CI checks pass; PR-title check rerun pending after metadata correction.
- [x] TESTING | Focused API tests pass: 16 tests, 0 failures.
- [x] DARK MODE SUPPORT | Not applicable; no UI changes.
- [x] ISSUE LINKED | Not applicable.
- [x] SCREENSHOT INCLUDED | Not applicable; test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened protection against unauthorised or deleting-context references in chat requests.
  * Fixed file-upload failure handling to clean up storage correctly and avoid misleading audit events.
  * Prevented duplicate chat messages during user-message persistence.
* **Tests**
  * Added Bun test coverage for chat context-matter authorisation, message persistence invariants, and upload failure regression cases.
* **Documentation**
  * Added a maintainability cleanup wave plan outlining future reliability-focused refactors and testing improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->