### PR TITLE
fix: stop aborted chat work before AI

### DIFF
--- a/apps/api/drizzle/20260717100000_chat_thread_rollback_token/migration.sql
+++ b/apps/api/drizzle/20260717100000_chat_thread_rollback_token/migration.sql
@@ -1,0 +1,3 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+ALTER TABLE "chat_threads" ADD COLUMN IF NOT EXISTS "rollback_token" text;

--- a/apps/api/src/db/schema/chat.ts
+++ b/apps/api/src/db/schema/chat.ts
@@ -49,6 +49,7 @@ export const chatThreads = p.pgTable(
       .$type<"ai" | "user">()
       .notNull()
       .default("user"),
+    rollbackToken: p.text("rollback_token"),
     /**
      * Matters the chat draws context from. Empty array (the
      * default) means "no specific matters pinned" — the AI

--- a/apps/api/src/db/schema/chat.ts
+++ b/apps/api/src/db/schema/chat.ts
@@ -49,7 +49,12 @@ export const chatThreads = p.pgTable(
       .$type<"ai" | "user">()
       .notNull()
       .default("user"),
-    rollbackToken: p.text("rollback_token"),
+    /**
+     * A successful mutation adopts a newly created thread, preventing the
+     * creating request's disconnect compensation from deleting changed state.
+     * Explicit token writes (creation and compare-and-set claim) take priority.
+     */
+    rollbackToken: p.text("rollback_token").$onUpdate(() => sql`null`),
     /**
      * Matters the chat draws context from. Empty array (the
      * default) means "no specific matters pinned" — the AI

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 
@@ -207,5 +209,66 @@ describe("send message disconnect handling", () => {
       response: { message: "Client disconnected before AI work started" },
     });
     expect(deleteReturning).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves thread recency when adopting rollback ownership", async () => {
+    const abortController = new AbortController();
+    const claimUpdates: { rollbackToken: null; updatedAt: SQL }[] = [];
+    const setClaimValues = mock(
+      (values: { rollbackToken: null; updatedAt: SQL }) => {
+        claimUpdates.push(values);
+        abortController.abort();
+        return {
+          where: () => ({ returning: async () => [{ id: threadId }] }),
+        };
+      },
+    );
+    const selectMessages = () => ({
+      from: () => ({
+        where: () => ({ orderBy: async () => [] }),
+      }),
+    });
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          query: {
+            chatThreadCompactions: { findFirst: async () => null },
+            chatThreads: {
+              findFirst: async () => ({
+                chatModel: null,
+                contextMatterIds: [],
+                dataWorkspaceIds: [],
+                id: threadId,
+                rollbackToken: "pending-rollback",
+                title: "Existing thread",
+                webSearchEnabled: false,
+                workspaceId: null,
+              }),
+            },
+            organizationSettings: { findFirst: async () => null },
+          },
+          select: selectMessages,
+          update: () => ({ set: setClaimValues }),
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    const claimUpdate = claimUpdates.at(0);
+    if (!claimUpdate) {
+      throw new Error("Expected the rollback ownership claim to update");
+    }
+    expect(claimUpdate.rollbackToken).toBeNull();
+    expect(new PgDialect().sqlToQuery(claimUpdate.updatedAt).sql).toContain(
+      '"chat_threads"."updated_at"',
+    );
   });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 
@@ -7,7 +7,14 @@ import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-import sendMessage from "./send-message";
+void mock.module("@/api/lib/web-search/load-org-keys", () => ({
+  loadWebSearchProvidersForOrg: async () => ({
+    urlFetcher: null,
+    webSearchProvider: null,
+  }),
+}));
+
+const sendMessage = (await import("./send-message")).default;
 
 type SendMessageCtx = Parameters<typeof sendMessage.handler>[0];
 
@@ -41,16 +48,20 @@ const orgAIConfig = {
 
 const createContext = ({
   contextMatterIds,
-}: {
-  contextMatterIds: SendMessageCtx["body"]["contextMatterIds"];
-}): SendMessageCtx => {
-  const { safeDb, scopedDb } = createScopedDbMock({
+  request = new Request("http://localhost/v1/chat/send"),
+  transaction = {
     query: {
       organizationSettings: {
         findFirst: async () => null,
       },
     },
-  });
+  },
+}: {
+  contextMatterIds: SendMessageCtx["body"]["contextMatterIds"];
+  request?: Request;
+  transaction?: unknown;
+}): SendMessageCtx => {
+  const { safeDb, scopedDb } = createScopedDbMock(transaction);
 
   return asTestRaw<SendMessageCtx>({
     body: {
@@ -75,7 +86,7 @@ const createContext = ({
     pinServerValidatedWorkspaceId: () => false,
     promptCachingEnabled: false,
     recordAuditEvent: async () => {},
-    request: new Request("http://localhost/v1/chat/send"),
+    request,
     route: "/v1/chat/send",
     safeDb,
     scopedDb,
@@ -105,5 +116,61 @@ describe("send message context-matter authorization", () => {
       code: 403,
       response: { message: "contextMatterIds includes inaccessible matter" },
     });
+  });
+});
+
+describe("send message disconnect rollback", () => {
+  test("does not create a thread when the request is already aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const insert = mock(() => ({ values: async () => undefined }));
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: { insert },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  test("deletes a newly created thread when the request aborts during creation", async () => {
+    const abortController = new AbortController();
+    const insertValues = mock(async () => {
+      abortController.abort();
+    });
+    const deleteWhere = mock(async () => undefined);
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          delete: () => ({ where: deleteWhere }),
+          insert: () => ({ values: insertValues }),
+          query: {
+            chatThreads: { findFirst: async () => null },
+            organizationSettings: { findFirst: async () => null },
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -61,7 +61,7 @@ const orgAIConfig = {
 } satisfies OrgAIConfig;
 
 const emptyOrderedRows = () =>
-  Object.assign(Promise.resolve([]), { limit: async () => [] });
+  Object.assign([], { limit: async () => [] });
 
 const selectChatMessages = () => ({
   from: () => ({

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -60,9 +60,12 @@ const orgAIConfig = {
   },
 } satisfies OrgAIConfig;
 
+const emptyOrderedRows = () =>
+  Object.assign(Promise.resolve([]), { limit: async () => [] });
+
 const selectChatMessages = () => ({
   from: () => ({
-    where: () => ({ orderBy: async () => [] }),
+    where: () => ({ orderBy: emptyOrderedRows }),
   }),
 });
 

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -17,6 +17,21 @@ void mock.module("@/api/lib/web-search/load-org-keys", () => ({
   }),
 }));
 
+const upsertChatThreadSearchDocumentMock = mock(async () => undefined);
+void mock.module("@/api/lib/search/index-chat", () => ({
+  upsertChatThreadSearchDocument: upsertChatThreadSearchDocumentMock,
+}));
+
+const externalMcpToolsModule =
+  await import("@/api/handlers/chat/tools/external-mcp-tools");
+const loadExternalMcpToolsForUserMock = mock(async () => {
+  throw new Error("Connector discovery must not run after a disconnect");
+});
+void mock.module("@/api/handlers/chat/tools/external-mcp-tools", () => ({
+  ...externalMcpToolsModule,
+  loadExternalMcpToolsForUser: loadExternalMcpToolsForUserMock,
+}));
+
 let analyticsCreationHook: (() => void) | undefined;
 void mock.module("@/api/lib/analytics/tanstack-ai", () => ({
   createTanStackAIAnalyticsCallbacks: () => {
@@ -382,5 +397,57 @@ describe("send message disconnect handling", () => {
     expect(findOrganizationSettings).toHaveBeenCalledTimes(2);
     expect(insertValues).toHaveBeenCalledTimes(1);
     expect(deleteReturning).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops before connector discovery when the client disconnects during persistence", async () => {
+    const abortController = new AbortController();
+    const insertValues = mock(async () => undefined);
+    const updateWhere = mock(async () => {
+      abortController.abort();
+    });
+    loadExternalMcpToolsForUserMock.mockClear();
+    upsertChatThreadSearchDocumentMock.mockClear();
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          insert: () => ({ values: insertValues }),
+          query: {
+            chatMessages: { findFirst: async () => null },
+            chatThreadCompactions: { findFirst: async () => null },
+            chatThreads: {
+              findFirst: async () => ({
+                chatModel: null,
+                contextMatterIds: [],
+                dataWorkspaceIds: [],
+                id: threadId,
+                rollbackToken: null,
+                title: "Existing thread",
+                webSearchEnabled: false,
+                workspaceId: null,
+              }),
+            },
+            organizationSettings: { findFirst: async () => null },
+          },
+          select: selectChatMessages,
+          update: () => ({
+            set: () => ({ where: updateWhere }),
+          }),
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before stream started" },
+    });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(updateWhere).toHaveBeenCalledTimes(1);
+    expect(upsertChatThreadSearchDocumentMock).toHaveBeenCalledWith(threadId);
+    expect(loadExternalMcpToolsForUserMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -334,4 +334,48 @@ describe("send message disconnect handling", () => {
     expect(insertValues).toHaveBeenCalledTimes(1);
     expect(deleteReturning).toHaveBeenCalledTimes(1);
   });
+
+  test("rolls back when the client disconnects during context preparation", async () => {
+    const abortController = new AbortController();
+    let organizationSettingsReads = 0;
+    const findOrganizationSettings = mock(async () => {
+      organizationSettingsReads += 1;
+      if (organizationSettingsReads === 2) {
+        abortController.abort();
+      }
+      return null;
+    });
+    const insertValues = mock(async () => undefined);
+    const deleteReturning = mock(async () => [{ id: threadId }]);
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          delete: () => ({
+            where: () => ({ returning: deleteReturning }),
+          }),
+          insert: () => ({ values: insertValues }),
+          query: {
+            chatMessages: { findFirst: async () => null },
+            chatThreadCompactions: { findFirst: async () => null },
+            chatThreads: { findFirst: async () => null },
+            organizationSettings: { findFirst: findOrganizationSettings },
+          },
+          select: selectChatMessages,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(findOrganizationSettings).toHaveBeenCalledTimes(2);
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -147,7 +147,7 @@ describe("send message disconnect rollback", () => {
     const insertValues = mock(async () => {
       abortController.abort();
     });
-    const deleteWhere = mock(async () => undefined);
+    const deleteReturning = mock(async () => [{ id: threadId }]);
 
     const result = await sendMessage.handler(
       createContext({
@@ -156,12 +156,17 @@ describe("send message disconnect rollback", () => {
           signal: abortController.signal,
         }),
         transaction: {
-          delete: () => ({ where: deleteWhere }),
+          delete: () => ({
+            where: () => ({ returning: deleteReturning }),
+          }),
           insert: () => ({ values: insertValues }),
           query: {
             chatThreads: { findFirst: async () => null },
             organizationSettings: { findFirst: async () => null },
           },
+          select: () => ({
+            from: () => ({ where: () => undefined }),
+          }),
         },
       }),
     );
@@ -171,6 +176,42 @@ describe("send message disconnect rollback", () => {
       response: { message: "Client disconnected before AI work started" },
     });
     expect(insertValues).toHaveBeenCalledTimes(1);
-    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves a newly created thread when another request has added a message", async () => {
+    const abortController = new AbortController();
+    const insertValues = mock(async () => {
+      abortController.abort();
+    });
+    const deleteReturning = mock(async () => []);
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          delete: () => ({
+            where: () => ({ returning: deleteReturning }),
+          }),
+          insert: () => ({ values: insertValues }),
+          query: {
+            chatThreads: { findFirst: async () => null },
+            organizationSettings: { findFirst: async () => null },
+          },
+          select: () => ({
+            from: () => ({ where: () => undefined }),
+          }),
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { SQL } from "drizzle-orm";
+import { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 
+import { chatThreads } from "@/api/db/schema";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
 import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
@@ -122,6 +123,15 @@ describe("send message context-matter authorization", () => {
 });
 
 describe("send message disconnect handling", () => {
+  test("treats every thread mutation as rollback ownership adoption", () => {
+    const adoptionUpdate = chatThreads.rollbackToken.onUpdateFn?.();
+    if (!(adoptionUpdate instanceof SQL)) {
+      throw new Error("Expected rollback ownership to have a SQL update hook");
+    }
+
+    expect(new PgDialect().sqlToQuery(adoptionUpdate).sql).toBe("null");
+  });
+
   test("does not create a thread when the request is already aborted", async () => {
     const abortController = new AbortController();
     abortController.abort();

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -29,8 +29,24 @@ void mock.module("@/api/lib/search/index-chat", () => ({
 
 const externalMcpToolsModule =
   await import("@/api/handlers/chat/tools/external-mcp-tools");
+let externalMcpToolsLoadHook: (() => void) | undefined;
 const loadExternalMcpToolsForUserMock = mock(async () => {
-  throw new Error("Connector discovery must not run after a disconnect");
+  const hook = externalMcpToolsLoadHook;
+  if (hook === undefined) {
+    throw new Error("Connector discovery must not run after a disconnect");
+  }
+  externalMcpToolsLoadHook = undefined;
+  hook();
+  const close = async () => undefined;
+  return {
+    close,
+    connectors: [],
+    source: externalMcpToolsModule.createStellaMcpToolSource({
+      closeClients: close,
+      sourceTools: {},
+    }),
+    tools: {},
+  };
 });
 void mock.module("@/api/handlers/chat/tools/external-mcp-tools", () => ({
   ...externalMcpToolsModule,
@@ -271,6 +287,43 @@ describe("send message disconnect handling", () => {
     });
     expect(loadWebSearchProvidersForOrgMock).toHaveBeenCalledTimes(1);
     expect(loadExternalMcpToolsForUserMock).not.toHaveBeenCalled();
+  });
+
+  test("stops preflight after disconnecting during connector discovery", async () => {
+    const abortController = new AbortController();
+    externalMcpToolsLoadHook = () => {
+      abortController.abort();
+    };
+    const findChatThread = mock(async () => null);
+    loadExternalMcpToolsForUserMock.mockClear();
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        message: {
+          id: messageId,
+          role: "assistant",
+          parts: [{ type: "tool-call", name: "mcp__test__lookup" }],
+        },
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          query: {
+            chatThreads: { findFirst: findChatThread },
+            organizationSettings: { findFirst: async () => null },
+          },
+        },
+      }),
+    );
+    externalMcpToolsLoadHook = undefined;
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(loadExternalMcpToolsForUserMock).toHaveBeenCalledTimes(1);
+    expect(findChatThread).toHaveBeenCalledTimes(1);
   });
 
   test("deletes an exclusively owned thread when the request aborts during creation", async () => {

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -10,11 +10,16 @@ import { toSafeId } from "@/api/lib/branded-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-void mock.module("@/api/lib/web-search/load-org-keys", () => ({
-  loadWebSearchProvidersForOrg: async () => ({
+let webSearchProviderLoadHook: (() => void) | undefined;
+const loadWebSearchProvidersForOrgMock = mock(async () => {
+  webSearchProviderLoadHook?.();
+  return {
     urlFetcher: null,
     webSearchProvider: null,
-  }),
+  };
+});
+void mock.module("@/api/lib/web-search/load-org-keys", () => ({
+  loadWebSearchProvidersForOrg: loadWebSearchProvidersForOrgMock,
 }));
 
 const upsertChatThreadSearchDocumentMock = mock(async () => undefined);
@@ -88,6 +93,11 @@ const selectChatMessages = () => ({
 
 const createContext = ({
   contextMatterIds,
+  message = {
+    id: messageId,
+    role: "user",
+    parts: [{ type: "text", content: "Summarize the selected matters" }],
+  },
   request = new Request("http://localhost/v1/chat/send"),
   transaction = {
     query: {
@@ -98,6 +108,7 @@ const createContext = ({
   },
 }: {
   contextMatterIds: SendMessageCtx["body"]["contextMatterIds"];
+  message?: SendMessageCtx["body"]["message"];
   request?: Request;
   transaction?: unknown;
 }): SendMessageCtx => {
@@ -108,11 +119,7 @@ const createContext = ({
       threadId,
       sendMode: CHAT_SEND_MODE.rawOverride,
       contextMatterIds,
-      message: {
-        id: messageId,
-        role: "user",
-        parts: [{ type: "text", content: "Summarize the selected matters" }],
-      },
+      message,
     },
     createAuditRecorder: () => async () => {},
     getAccessibleWorkspaces: async () => [
@@ -189,6 +196,81 @@ describe("send message disconnect handling", () => {
       response: { message: "Client disconnected before AI work started" },
     });
     expect(insert).not.toHaveBeenCalled();
+  });
+
+  test("does not start validation providers after a preflight disconnect", async () => {
+    const abortController = new AbortController();
+    const findChatThread = mock(async () => {
+      abortController.abort();
+      return null;
+    });
+    loadExternalMcpToolsForUserMock.mockClear();
+    loadWebSearchProvidersForOrgMock.mockClear();
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        message: {
+          id: messageId,
+          role: "assistant",
+          parts: [{ type: "tool-call", name: "mcp__test__lookup" }],
+        },
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          query: {
+            chatThreads: { findFirst: findChatThread },
+            organizationSettings: { findFirst: async () => null },
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(loadWebSearchProvidersForOrgMock).not.toHaveBeenCalled();
+    expect(loadExternalMcpToolsForUserMock).not.toHaveBeenCalled();
+  });
+
+  test("does not discover connectors after disconnecting during web provider load", async () => {
+    const abortController = new AbortController();
+    webSearchProviderLoadHook = () => {
+      webSearchProviderLoadHook = undefined;
+      abortController.abort();
+    };
+    loadExternalMcpToolsForUserMock.mockClear();
+    loadWebSearchProvidersForOrgMock.mockClear();
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        message: {
+          id: messageId,
+          role: "assistant",
+          parts: [{ type: "tool-call", name: "mcp__test__lookup" }],
+        },
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          query: {
+            chatThreads: { findFirst: async () => null },
+            organizationSettings: { findFirst: async () => null },
+          },
+        },
+      }),
+    );
+    webSearchProviderLoadHook = undefined;
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(loadWebSearchProvidersForOrgMock).toHaveBeenCalledTimes(1);
+    expect(loadExternalMcpToolsForUserMock).not.toHaveBeenCalled();
   });
 
   test("deletes an exclusively owned thread when the request aborts during creation", async () => {
@@ -313,6 +395,60 @@ describe("send message disconnect handling", () => {
     expect(new PgDialect().sqlToQuery(claimUpdate.updatedAt).sql).toContain(
       '"chat_threads"."updated_at"',
     );
+  });
+
+  test("does not update existing thread pins after disconnecting during its history read", async () => {
+    const abortController = new AbortController();
+    const update = mock(() => ({
+      set: () => ({ where: async () => undefined }),
+    }));
+    const selectWithAbort = () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [],
+          orderBy: () => {
+            abortController.abort();
+            return emptyOrderedRows();
+          },
+        }),
+      }),
+    });
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [activeWorkspaceId],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          query: {
+            chatMessages: { findFirst: async () => null },
+            chatThreadCompactions: { findFirst: async () => null },
+            chatThreads: {
+              findFirst: async () => ({
+                chatModel: null,
+                contextMatterIds: [],
+                dataWorkspaceIds: [],
+                id: threadId,
+                rollbackToken: null,
+                title: "Existing thread",
+                webSearchEnabled: false,
+                workspaceId: null,
+              }),
+            },
+            organizationSettings: { findFirst: async () => null },
+          },
+          select: selectWithAbort,
+          update,
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(update).not.toHaveBeenCalled();
   });
 
   test("rolls back when the client disconnects during context compaction", async () => {

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -17,6 +17,17 @@ void mock.module("@/api/lib/web-search/load-org-keys", () => ({
   }),
 }));
 
+let analyticsCreationHook: (() => void) | undefined;
+void mock.module("@/api/lib/analytics/tanstack-ai", () => ({
+  createTanStackAIAnalyticsCallbacks: () => {
+    analyticsCreationHook?.();
+    return {
+      captureError: () => undefined,
+      middleware: [],
+    };
+  },
+}));
+
 const sendMessage = (await import("./send-message")).default;
 
 type SendMessageCtx = Parameters<typeof sendMessage.handler>[0];
@@ -280,5 +291,44 @@ describe("send message disconnect handling", () => {
     expect(new PgDialect().sqlToQuery(claimUpdate.updatedAt).sql).toContain(
       '"chat_threads"."updated_at"',
     );
+  });
+
+  test("rolls back when the client disconnects during context compaction", async () => {
+    const abortController = new AbortController();
+    analyticsCreationHook = () => {
+      analyticsCreationHook = undefined;
+      abortController.abort();
+    };
+    const insertValues = mock(async () => undefined);
+    const deleteReturning = mock(async () => [{ id: threadId }]);
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          delete: () => ({
+            where: () => ({ returning: deleteReturning }),
+          }),
+          insert: () => ({ values: insertValues }),
+          query: {
+            chatMessages: { findFirst: async () => null },
+            chatThreadCompactions: { findFirst: async () => null },
+            chatThreads: { findFirst: async () => null },
+            organizationSettings: { findFirst: async () => null },
+          },
+        },
+      }),
+    );
+    analyticsCreationHook = undefined;
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -60,6 +60,12 @@ const orgAIConfig = {
   },
 } satisfies OrgAIConfig;
 
+const selectChatMessages = () => ({
+  from: () => ({
+    where: () => ({ orderBy: async () => [] }),
+  }),
+});
+
 const createContext = ({
   contextMatterIds,
   request = new Request("http://localhost/v1/chat/send"),
@@ -187,6 +193,7 @@ describe("send message disconnect handling", () => {
             chatThreads: { findFirst: async () => null },
             organizationSettings: { findFirst: async () => null },
           },
+          select: selectChatMessages,
         },
       }),
     );
@@ -221,6 +228,7 @@ describe("send message disconnect handling", () => {
             chatThreads: { findFirst: async () => null },
             organizationSettings: { findFirst: async () => null },
           },
+          select: selectChatMessages,
         },
       }),
     );
@@ -244,12 +252,6 @@ describe("send message disconnect handling", () => {
         };
       },
     );
-    const selectMessages = () => ({
-      from: () => ({
-        where: () => ({ orderBy: async () => [] }),
-      }),
-    });
-
     const result = await sendMessage.handler(
       createContext({
         contextMatterIds: [],
@@ -273,7 +275,7 @@ describe("send message disconnect handling", () => {
             },
             organizationSettings: { findFirst: async () => null },
           },
-          select: selectMessages,
+          select: selectChatMessages,
           update: () => ({ set: setClaimValues }),
         },
       }),
@@ -319,6 +321,7 @@ describe("send message disconnect handling", () => {
             chatThreads: { findFirst: async () => null },
             organizationSettings: { findFirst: async () => null },
           },
+          select: selectChatMessages,
         },
       }),
     );

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -64,7 +64,10 @@ const emptyOrderedRows = () => Object.assign([], { limit: async () => [] });
 
 const selectChatMessages = () => ({
   from: () => ({
-    where: () => ({ orderBy: emptyOrderedRows }),
+    where: () => ({
+      limit: async () => [],
+      orderBy: emptyOrderedRows,
+    }),
   }),
 });
 

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -119,7 +119,7 @@ describe("send message context-matter authorization", () => {
   });
 });
 
-describe("send message disconnect rollback", () => {
+describe("send message disconnect handling", () => {
   test("does not create a thread when the request is already aborted", async () => {
     const abortController = new AbortController();
     abortController.abort();
@@ -142,12 +142,12 @@ describe("send message disconnect rollback", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
-  test("deletes a newly created thread when the request aborts during creation", async () => {
+  test("preserves a committed thread when the request aborts during creation", async () => {
     const abortController = new AbortController();
     const insertValues = mock(async () => {
       abortController.abort();
     });
-    const deleteReturning = mock(async () => [{ id: threadId }]);
+    const deleteThread = mock(() => ({ where: async () => undefined }));
 
     const result = await sendMessage.handler(
       createContext({
@@ -156,17 +156,12 @@ describe("send message disconnect rollback", () => {
           signal: abortController.signal,
         }),
         transaction: {
-          delete: () => ({
-            where: () => ({ returning: deleteReturning }),
-          }),
+          delete: deleteThread,
           insert: () => ({ values: insertValues }),
           query: {
             chatThreads: { findFirst: async () => null },
             organizationSettings: { findFirst: async () => null },
           },
-          select: () => ({
-            from: () => ({ where: () => undefined }),
-          }),
         },
       }),
     );
@@ -176,42 +171,6 @@ describe("send message disconnect rollback", () => {
       response: { message: "Client disconnected before AI work started" },
     });
     expect(insertValues).toHaveBeenCalledTimes(1);
-    expect(deleteReturning).toHaveBeenCalledTimes(1);
-  });
-
-  test("preserves a newly created thread when another request has added a message", async () => {
-    const abortController = new AbortController();
-    const insertValues = mock(async () => {
-      abortController.abort();
-    });
-    const deleteReturning = mock(async () => []);
-
-    const result = await sendMessage.handler(
-      createContext({
-        contextMatterIds: [],
-        request: new Request("http://localhost/v1/chat/send", {
-          signal: abortController.signal,
-        }),
-        transaction: {
-          delete: () => ({
-            where: () => ({ returning: deleteReturning }),
-          }),
-          insert: () => ({ values: insertValues }),
-          query: {
-            chatThreads: { findFirst: async () => null },
-            organizationSettings: { findFirst: async () => null },
-          },
-          select: () => ({
-            from: () => ({ where: () => undefined }),
-          }),
-        },
-      }),
-    );
-
-    expect(result).toEqual({
-      code: 400,
-      response: { message: "Client disconnected before AI work started" },
-    });
-    expect(deleteReturning).toHaveBeenCalledTimes(1);
+    expect(deleteThread).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -60,8 +60,7 @@ const orgAIConfig = {
   },
 } satisfies OrgAIConfig;
 
-const emptyOrderedRows = () =>
-  Object.assign([], { limit: async () => [] });
+const emptyOrderedRows = () => Object.assign([], { limit: async () => [] });
 
 const selectChatMessages = () => ({
   from: () => ({

--- a/apps/api/src/handlers/chat/send-message.test.ts
+++ b/apps/api/src/handlers/chat/send-message.test.ts
@@ -142,12 +142,12 @@ describe("send message disconnect handling", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
-  test("preserves a committed thread when the request aborts during creation", async () => {
+  test("deletes an exclusively owned thread when the request aborts during creation", async () => {
     const abortController = new AbortController();
     const insertValues = mock(async () => {
       abortController.abort();
     });
-    const deleteThread = mock(() => ({ where: async () => undefined }));
+    const deleteReturning = mock(async () => [{ id: threadId }]);
 
     const result = await sendMessage.handler(
       createContext({
@@ -156,7 +156,9 @@ describe("send message disconnect handling", () => {
           signal: abortController.signal,
         }),
         transaction: {
-          delete: deleteThread,
+          delete: () => ({
+            where: () => ({ returning: deleteReturning }),
+          }),
           insert: () => ({ values: insertValues }),
           query: {
             chatThreads: { findFirst: async () => null },
@@ -171,6 +173,39 @@ describe("send message disconnect handling", () => {
       response: { message: "Client disconnected before AI work started" },
     });
     expect(insertValues).toHaveBeenCalledTimes(1);
-    expect(deleteThread).not.toHaveBeenCalled();
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves a thread whose ownership marker changed before rollback", async () => {
+    const abortController = new AbortController();
+    const insertValues = mock(async () => {
+      abortController.abort();
+    });
+    const deleteReturning = mock(async () => []);
+
+    const result = await sendMessage.handler(
+      createContext({
+        contextMatterIds: [],
+        request: new Request("http://localhost/v1/chat/send", {
+          signal: abortController.signal,
+        }),
+        transaction: {
+          delete: () => ({
+            where: () => ({ returning: deleteReturning }),
+          }),
+          insert: () => ({ values: insertValues }),
+          query: {
+            chatThreads: { findFirst: async () => null },
+            organizationSettings: { findFirst: async () => null },
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Client disconnected before AI work started" },
+    });
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1496,13 +1496,14 @@ type LoadThreadResult =
       rollbackToken: string;
     };
 
+type LoadThreadError = HandlerError<400 | 404 | 409> | SafeDbError;
+
 const MAX_THREAD_CLAIM_ATTEMPTS = 3;
 
-const loadThread = async (
+const loadThread = (
   props: LoadThreadProps,
-): Promise<
-  Result<LoadThreadResult, HandlerError<400 | 404 | 409> | SafeDbError>
-> => await loadThreadAttempt({ ...props, claimAttempt: 0 });
+): Promise<Result<LoadThreadResult, LoadThreadError>> =>
+  loadThreadAttempt({ ...props, claimAttempt: 0 });
 
 type LoadThreadAttemptProps = LoadThreadProps & {
   claimAttempt: number;
@@ -1520,7 +1521,7 @@ const loadThreadAttempt = async ({
   userId,
   workspaceId,
 }: LoadThreadAttemptProps): Promise<
-  Result<LoadThreadResult, HandlerError<400 | 404 | 409> | SafeDbError>
+  Result<LoadThreadResult, LoadThreadError>
 > =>
   await Result.gen(async function* () {
     // Look the thread up by id+user only. Filtering by workspaceId
@@ -1539,8 +1540,8 @@ const loadThreadAttempt = async ({
       rollbackToken: string | null;
     };
 
-    const lookup = async () =>
-      await safeDb((tx) =>
+    const lookup = () =>
+      safeDb((tx) =>
         tx.query.chatThreads.findFirst({
           where: {
             id: { eq: threadId },
@@ -1595,29 +1596,37 @@ const loadThreadAttempt = async ({
     // Every adopter CAS-clears that token before using the row.
     // If rollback deletes first, the failed CAS retries and creates/claims the
     // replacement; if adoption wins, the creator's guarded delete is a no-op.
-    const claimExisting = async (existing: ExistingThreadRow) => {
-      if (existing.rollbackToken === null) {
+    const claimExisting = async (
+      existing: ExistingThreadRow,
+    ): Promise<Result<boolean, SafeDbError>> => {
+      const rollbackToken = existing.rollbackToken;
+      if (rollbackToken === null) {
         return Result.ok(true);
       }
-      const claimResult = await safeDb(async (tx) =>
-        await tx
+
+      const claimResult = await safeDb(async (tx) => {
+        // audit: skip — clears an ephemeral rollback-ownership token; the
+        // thread's user-facing state is unchanged
+        return await tx
           .update(chatThreads)
           .set({ rollbackToken: null })
           .where(
             and(
               eq(chatThreads.id, threadId),
-              eq(chatThreads.rollbackToken, existing.rollbackToken),
+              eq(chatThreads.rollbackToken, rollbackToken),
             ),
           )
-          .returning({ id: chatThreads.id }),
-      );
+          .returning({ id: chatThreads.id });
+      });
       if (Result.isError(claimResult)) {
-        return claimResult;
+        return Result.err(claimResult.error);
       }
       return Result.ok(claimResult.value.length > 0);
     };
 
-    const retryAfterClaimRace = async () => {
+    const retryAfterClaimRace = async (): Promise<
+      Result<LoadThreadResult, LoadThreadError>
+    > => {
       if (claimAttempt >= MAX_THREAD_CLAIM_ATTEMPTS) {
         return Result.err(
           new HandlerError({
@@ -1648,7 +1657,8 @@ const loadThreadAttempt = async ({
       }
       const claimed = yield* Result.await(claimExisting(thread));
       if (!claimed) {
-        return yield* Result.await(retryAfterClaimRace());
+        const retried = yield* Result.await(retryAfterClaimRace());
+        return Result.ok(retried);
       }
       const windowedMessages = yield* Result.await(
         loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
@@ -1744,7 +1754,8 @@ const loadThreadAttempt = async ({
         }
         const claimed = yield* Result.await(claimExisting(recovered));
         if (!claimed) {
-          return yield* Result.await(retryAfterClaimRace());
+          const retried = yield* Result.await(retryAfterClaimRace());
+          return Result.ok(retried);
         }
         const recoveredMessages = yield* Result.await(
           loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -221,6 +221,17 @@ const sendMessage = createSafeRootHandler(
     session,
     user,
   }) {
+    const isClientConnectionAborted = () => request.signal.aborted;
+
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
     yield* requireTanStackAIAvailableForRole({
       orgConfig: orgAIConfig,
       role: "chat",
@@ -503,9 +514,17 @@ const sendMessage = createSafeRootHandler(
         workspaceId: workspaceId ?? undefined,
       });
 
-      const isClientConnectionAborted = () => request.signal.aborted;
-
       if (isClientConnectionAborted()) {
+        yield* Result.await(
+          rollbackUnpersistedChatSideEffects({
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadState: thread,
+            uploadedFiles: [],
+            userId: user.id,
+          }),
+        );
         return Result.err(
           new HandlerError({
             status: 400,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -396,6 +396,15 @@ const sendMessage = createSafeRootHandler(
           externalMcpToolsLoader,
         );
 
+      if (isClientConnectionAborted()) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
+
       // Tool input schemas don't depend on `accessibleWorkspaceIds`
       // (scope is checked at execute time, not in the schema), so we
       // can validate the incoming message against the broad set and

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -360,12 +360,30 @@ const sendMessage = createSafeRootHandler(
     // generator via `.return()`, which unwinds this `finally` like a normal
     // early `return` would.
     try {
+      if (isClientConnectionAborted()) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
+
       // Resolve the org's web-search providers once (BYOK key first,
       // platform env key as fallback) and reuse for both the validation
       // and streaming tool sets.
       const webSearchProviders = await loadWebSearchProvidersForOrg(
         session.activeOrganizationId,
       );
+
+      if (isClientConnectionAborted()) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
 
       // Only load external MCP tools for validation when the incoming
       // message actually carries a part that needs them — an ordinary
@@ -449,6 +467,29 @@ const sendMessage = createSafeRootHandler(
           workspaceId,
         }),
       );
+
+      // Existing-thread pin changes are durable side effects, so stop before
+      // applying them when any earlier validation or thread read observed a
+      // client disconnect. Created threads still need their rollback token
+      // cleaned up on this exit path.
+      if (isClientConnectionAborted()) {
+        yield* Result.await(
+          rollbackUnpersistedChatSideEffects({
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadState: thread,
+            uploadedFiles: [],
+            userId: user.id,
+          }),
+        );
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
 
       // The thread's persisted chat-model override wins over the org/instance
       // default, but the dev-only body override still wins over everything

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, eq, inArray, notExists } from "drizzle-orm";
+import { and, eq, inArray, notExists, sql } from "drizzle-orm";
 import type { Static } from "elysia";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -1609,7 +1609,10 @@ const loadThreadAttempt = async ({
         // thread's user-facing state is unchanged
         const claimQuery = tx
           .update(chatThreads)
-          .set({ rollbackToken: null })
+          .set({
+            rollbackToken: null,
+            updatedAt: sql`${chatThreads.updatedAt}`,
+          })
           .where(
             and(
               eq(chatThreads.id, threadId),

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -832,6 +832,19 @@ const sendMessage = createSafeRootHandler(
         }),
       );
 
+      // The incoming message is durable now, so a disconnect must not run the
+      // pre-persistence rollback (which would delete files referenced by that
+      // message). It should still stop before connector discovery and any
+      // metered provider work.
+      if (isClientConnectionAborted()) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before stream started",
+          }),
+        );
+      }
+
       // The streaming pass always needs the external MCP tool set (for the
       // tool map, the connector system hint, and the `externalMcpToolSource`
       // handed to `streamChat` below). This is the point where discovery

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -762,6 +762,25 @@ const sendMessage = createSafeRootHandler(
       }
       const chatContext = chatContextResult.value;
 
+      if (isClientConnectionAborted()) {
+        yield* Result.await(
+          rollbackUnpersistedChatSideEffects({
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadState: thread,
+            uploadedFiles: uploadResult.uploadedFiles,
+            userId: user.id,
+          }),
+        );
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
+
       // Keep the thread's data scope aligned with the messages being
       // stored. Normal sends append newly observed workspace IDs
       // before persisting. Replay truncation recomputes the exact

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1500,10 +1500,10 @@ type LoadThreadError = HandlerError<400 | 404 | 409> | SafeDbError;
 
 const MAX_THREAD_CLAIM_ATTEMPTS = 3;
 
-const loadThread = (
+const loadThread = async (
   props: LoadThreadProps,
 ): Promise<Result<LoadThreadResult, LoadThreadError>> =>
-  loadThreadAttempt({ ...props, claimAttempt: 0 });
+  await loadThreadAttempt({ ...props, claimAttempt: 0 });
 
 type LoadThreadAttemptProps = LoadThreadProps & {
   claimAttempt: number;
@@ -1540,8 +1540,8 @@ const loadThreadAttempt = async ({
       rollbackToken: string | null;
     };
 
-    const lookup = () =>
-      safeDb((tx) =>
+    const lookup = async () =>
+      await safeDb((tx) =>
         tx.query.chatThreads.findFirst({
           where: {
             id: { eq: threadId },
@@ -1607,7 +1607,7 @@ const loadThreadAttempt = async ({
       const claimResult = await safeDb(async (tx) => {
         // audit: skip — clears an ephemeral rollback-ownership token; the
         // thread's user-facing state is unchanged
-        return await tx
+        const claimQuery = tx
           .update(chatThreads)
           .set({ rollbackToken: null })
           .where(
@@ -1617,6 +1617,7 @@ const loadThreadAttempt = async ({
             ),
           )
           .returning({ id: chatThreads.id });
+        return await claimQuery;
       });
       if (Result.isError(claimResult)) {
         return Result.err(claimResult.error);

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, eq, inArray, notExists } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { Static } from "elysia";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -515,16 +515,6 @@ const sendMessage = createSafeRootHandler(
       });
 
       if (isClientConnectionAborted()) {
-        yield* Result.await(
-          rollbackUnpersistedChatSideEffects({
-            recordAuditEvent,
-            safeDb,
-            threadId: body.threadId,
-            threadState: thread,
-            uploadedFiles: [],
-            userId: user.id,
-          }),
-        );
         return Result.err(
           new HandlerError({
             status: 400,
@@ -1785,40 +1775,7 @@ const rollbackUnpersistedChatSideEffects = async ({
     return fileRollbackResult;
   }
 
-  if (threadState.type !== "created") {
-    return Result.ok();
-  }
-
-  const threadRollbackResult = await safeDb(async (tx) => {
-    const deletedThreads = await tx
-      .delete(chatThreads)
-      .where(
-        and(
-          eq(chatThreads.id, threadId),
-          notExists(
-            tx
-              .select({ id: chatMessages.id })
-              .from(chatMessages)
-              .where(eq(chatMessages.threadId, chatThreads.id)),
-          ),
-        ),
-      )
-      .returning({ id: chatThreads.id });
-
-    if (deletedThreads.length === 0) {
-      return;
-    }
-
-    await recordAuditEvent(tx, {
-      action: AUDIT_ACTION.DELETE,
-      resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
-      resourceId: threadId,
-      workspaceId: threadState.data.workspaceId,
-      metadata: { reason: "rollback_unpersisted_chat_side_effects" },
-    });
-  });
-
-  return threadRollbackResult.andThen(() => Result.ok());
+  return Result.ok();
 };
 
 type PrepareChatContextProps = {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -515,6 +515,16 @@ const sendMessage = createSafeRootHandler(
       });
 
       if (isClientConnectionAborted()) {
+        yield* Result.await(
+          rollbackUnpersistedChatSideEffects({
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadState: thread,
+            uploadedFiles: [],
+            userId: user.id,
+          }),
+        );
         return Result.err(
           new HandlerError({
             status: 400,
@@ -1483,9 +1493,23 @@ type LoadThreadResult =
   | {
       type: "created";
       data: ThreadRecord;
+      rollbackMarker: Date;
     };
 
-const loadThread = async ({
+const MAX_THREAD_CLAIM_ATTEMPTS = 3;
+
+const loadThread = async (
+  props: LoadThreadProps,
+): Promise<
+  Result<LoadThreadResult, HandlerError<400 | 404 | 409> | SafeDbError>
+> => await loadThreadAttempt({ ...props, claimAttempt: 0 });
+
+type LoadThreadAttemptProps = LoadThreadProps & {
+  claimAttempt: number;
+};
+
+const loadThreadAttempt = async ({
+  claimAttempt,
   initialContextMatterIds,
   isAnonymized,
   organizationId,
@@ -1495,8 +1519,8 @@ const loadThread = async ({
   title,
   userId,
   workspaceId,
-}: LoadThreadProps): Promise<
-  Result<LoadThreadResult, HandlerError<400 | 404> | SafeDbError>
+}: LoadThreadAttemptProps): Promise<
+  Result<LoadThreadResult, HandlerError<400 | 404 | 409> | SafeDbError>
 > =>
   await Result.gen(async function* () {
     // Look the thread up by id+user only. Filtering by workspaceId
@@ -1512,6 +1536,7 @@ const loadThread = async ({
       dataWorkspaceIds: SafeId<"workspace">[];
       webSearchEnabled: boolean;
       chatModel: string | null;
+      updatedAt: Date;
     };
 
     const lookup = async () =>
@@ -1529,6 +1554,7 @@ const loadThread = async ({
             dataWorkspaceIds: true,
             webSearchEnabled: true,
             chatModel: true,
+            updatedAt: true,
           },
         }),
       );
@@ -1565,11 +1591,60 @@ const loadThread = async ({
       });
     };
 
+    // A created row remains rollback-owned only while its updatedAt marker is
+    // unchanged. Every adopter CAS-advances that marker before using the row.
+    // If rollback deletes first, the failed CAS retries and creates/claims the
+    // replacement; if adoption wins, the creator's guarded delete is a no-op.
+    const claimExisting = async (existing: ExistingThreadRow) => {
+      const claimedAt = new Date(
+        Math.max(Date.now(), existing.updatedAt.getTime() + 1),
+      );
+      return await safeDb(async (tx) =>
+        await tx
+          .update(chatThreads)
+          .set({ updatedAt: claimedAt })
+          .where(
+            and(
+              eq(chatThreads.id, threadId),
+              eq(chatThreads.updatedAt, existing.updatedAt),
+            ),
+          )
+          .returning({ id: chatThreads.id }),
+      );
+    };
+
+    const retryAfterClaimRace = async () => {
+      if (claimAttempt >= MAX_THREAD_CLAIM_ATTEMPTS) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "Chat thread changed concurrently; retry request",
+          }),
+        );
+      }
+      return await loadThreadAttempt({
+        claimAttempt: claimAttempt + 1,
+        initialContextMatterIds,
+        isAnonymized,
+        organizationId,
+        recordAuditEvent,
+        safeDb,
+        threadId,
+        title,
+        userId,
+        workspaceId,
+      });
+    };
+
     const thread = yield* Result.await(lookup());
     if (thread) {
       const existingResult = buildExisting(thread);
       if (Result.isError(existingResult)) {
         return Result.err(existingResult.error);
+      }
+      const claimed = yield* Result.await(claimExisting(thread));
+      if (claimed.length === 0) {
+        return yield* Result.await(retryAfterClaimRace());
       }
       const windowedMessages = yield* Result.await(
         loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
@@ -1609,6 +1684,7 @@ const loadThread = async ({
     const initialDataWorkspaceIds: SafeId<"workspace">[] = workspaceId
       ? [workspaceId]
       : [];
+    const rollbackMarker = new Date();
 
     const insertResult = await safeDb(async (tx) => {
       await tx.insert(chatThreads).values({
@@ -1618,6 +1694,7 @@ const loadThread = async ({
         userId,
         workspaceId,
         contextMatterIds: initialContextMatterIds,
+        updatedAt: rollbackMarker,
         // Workspace-scoped chats embed at minimum their own
         // workspace's content. Global chats start with no
         // embedded workspace data; subsequent messages widen
@@ -1661,6 +1738,10 @@ const loadThread = async ({
         if (Result.isError(recoveredResult)) {
           return Result.err(recoveredResult.error);
         }
+        const claimed = yield* Result.await(claimExisting(recovered));
+        if (claimed.length === 0) {
+          return yield* Result.await(retryAfterClaimRace());
+        }
         const recoveredMessages = yield* Result.await(
           loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
         );
@@ -1677,6 +1758,7 @@ const loadThread = async ({
 
     return Result.ok<LoadThreadResult>({
       type: "created",
+      rollbackMarker,
       data: {
         id: threadId,
         workspaceId,
@@ -1775,7 +1857,35 @@ const rollbackUnpersistedChatSideEffects = async ({
     return fileRollbackResult;
   }
 
-  return Result.ok();
+  if (threadState.type !== "created") {
+    return Result.ok();
+  }
+
+  const threadRollbackResult = await safeDb(async (tx) => {
+    const deletedThreads = await tx
+      .delete(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, threadId),
+          eq(chatThreads.updatedAt, threadState.rollbackMarker),
+        ),
+      )
+      .returning({ id: chatThreads.id });
+
+    if (deletedThreads.length === 0) {
+      return;
+    }
+
+    await recordAuditEvent(tx, {
+      action: AUDIT_ACTION.DELETE,
+      resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+      resourceId: threadId,
+      workspaceId: threadState.data.workspaceId,
+      metadata: { reason: "rollback_unpersisted_chat_side_effects" },
+    });
+  });
+
+  return threadRollbackResult.andThen(() => Result.ok());
 };
 
 type PrepareChatContextProps = {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, notExists } from "drizzle-orm";
 import type { Static } from "elysia";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -1790,7 +1790,24 @@ const rollbackUnpersistedChatSideEffects = async ({
   }
 
   const threadRollbackResult = await safeDb(async (tx) => {
-    await tx.delete(chatThreads).where(eq(chatThreads.id, threadId));
+    const deletedThreads = await tx
+      .delete(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, threadId),
+          notExists(
+            tx
+              .select({ id: chatMessages.id })
+              .from(chatMessages)
+              .where(eq(chatMessages.threadId, chatThreads.id)),
+          ),
+        ),
+      )
+      .returning({ id: chatThreads.id });
+
+    if (deletedThreads.length === 0) {
+      return;
+    }
 
     await recordAuditEvent(tx, {
       action: AUDIT_ACTION.DELETE,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, notExists } from "drizzle-orm";
 import type { Static } from "elysia";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -1493,7 +1493,7 @@ type LoadThreadResult =
   | {
       type: "created";
       data: ThreadRecord;
-      rollbackMarker: Date;
+      rollbackToken: string;
     };
 
 const MAX_THREAD_CLAIM_ATTEMPTS = 3;
@@ -1536,7 +1536,7 @@ const loadThreadAttempt = async ({
       dataWorkspaceIds: SafeId<"workspace">[];
       webSearchEnabled: boolean;
       chatModel: string | null;
-      updatedAt: Date;
+      rollbackToken: string | null;
     };
 
     const lookup = async () =>
@@ -1554,7 +1554,7 @@ const loadThreadAttempt = async ({
             dataWorkspaceIds: true,
             webSearchEnabled: true,
             chatModel: true,
-            updatedAt: true,
+            rollbackToken: true,
           },
         }),
       );
@@ -1591,26 +1591,30 @@ const loadThreadAttempt = async ({
       });
     };
 
-    // A created row remains rollback-owned only while its updatedAt marker is
-    // unchanged. Every adopter CAS-advances that marker before using the row.
+    // A created row remains rollback-owned only while its token is unchanged.
+    // Every adopter CAS-clears that token before using the row.
     // If rollback deletes first, the failed CAS retries and creates/claims the
     // replacement; if adoption wins, the creator's guarded delete is a no-op.
     const claimExisting = async (existing: ExistingThreadRow) => {
-      const claimedAt = new Date(
-        Math.max(Date.now(), existing.updatedAt.getTime() + 1),
-      );
-      return await safeDb(async (tx) =>
+      if (existing.rollbackToken === null) {
+        return Result.ok(true);
+      }
+      const claimResult = await safeDb(async (tx) =>
         await tx
           .update(chatThreads)
-          .set({ updatedAt: claimedAt })
+          .set({ rollbackToken: null })
           .where(
             and(
               eq(chatThreads.id, threadId),
-              eq(chatThreads.updatedAt, existing.updatedAt),
+              eq(chatThreads.rollbackToken, existing.rollbackToken),
             ),
           )
           .returning({ id: chatThreads.id }),
       );
+      if (Result.isError(claimResult)) {
+        return claimResult;
+      }
+      return Result.ok(claimResult.value.length > 0);
     };
 
     const retryAfterClaimRace = async () => {
@@ -1643,7 +1647,7 @@ const loadThreadAttempt = async ({
         return Result.err(existingResult.error);
       }
       const claimed = yield* Result.await(claimExisting(thread));
-      if (claimed.length === 0) {
+      if (!claimed) {
         return yield* Result.await(retryAfterClaimRace());
       }
       const windowedMessages = yield* Result.await(
@@ -1684,7 +1688,7 @@ const loadThreadAttempt = async ({
     const initialDataWorkspaceIds: SafeId<"workspace">[] = workspaceId
       ? [workspaceId]
       : [];
-    const rollbackMarker = new Date();
+    const rollbackToken = Bun.randomUUIDv7();
 
     const insertResult = await safeDb(async (tx) => {
       await tx.insert(chatThreads).values({
@@ -1694,7 +1698,7 @@ const loadThreadAttempt = async ({
         userId,
         workspaceId,
         contextMatterIds: initialContextMatterIds,
-        updatedAt: rollbackMarker,
+        rollbackToken,
         // Workspace-scoped chats embed at minimum their own
         // workspace's content. Global chats start with no
         // embedded workspace data; subsequent messages widen
@@ -1739,7 +1743,7 @@ const loadThreadAttempt = async ({
           return Result.err(recoveredResult.error);
         }
         const claimed = yield* Result.await(claimExisting(recovered));
-        if (claimed.length === 0) {
+        if (!claimed) {
           return yield* Result.await(retryAfterClaimRace());
         }
         const recoveredMessages = yield* Result.await(
@@ -1758,7 +1762,7 @@ const loadThreadAttempt = async ({
 
     return Result.ok<LoadThreadResult>({
       type: "created",
-      rollbackMarker,
+      rollbackToken,
       data: {
         id: threadId,
         workspaceId,
@@ -1867,7 +1871,13 @@ const rollbackUnpersistedChatSideEffects = async ({
       .where(
         and(
           eq(chatThreads.id, threadId),
-          eq(chatThreads.updatedAt, threadState.rollbackMarker),
+          eq(chatThreads.rollbackToken, threadState.rollbackToken),
+          notExists(
+            tx
+              .select({ id: chatMessages.id })
+              .from(chatMessages)
+              .where(eq(chatMessages.threadId, chatThreads.id)),
+          ),
         ),
       )
       .returning({ id: chatThreads.id });

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -688,6 +688,25 @@ const sendMessage = createSafeRootHandler(
         return yield* Result.err(messagesForContextResult.error);
       }
 
+      if (isClientConnectionAborted()) {
+        yield* Result.await(
+          rollbackUnpersistedChatSideEffects({
+            recordAuditEvent,
+            safeDb,
+            threadId: body.threadId,
+            threadState: thread,
+            uploadedFiles: uploadResult.uploadedFiles,
+            userId: user.id,
+          }),
+        );
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Client disconnected before AI work started",
+          }),
+        );
+      }
+
       const chatContextResult = await prepareChatContext({
         activeDecision: body.activeDecision,
         activeExternal: body.activeExternal,


### PR DESCRIPTION
## Proposed change

Stop disconnected chat sends before AI work and clean up only threads still owned by that request:

- reject requests already aborted before handler work starts
- stop after thread loading when the connection aborts
- add a nullable internal rollback token to newly created threads
- require every concurrent adopter to CAS-clear that token before proceeding
- delete on rollback only while the creator's token still matches and no message exists
- retain uploaded-file rollback for failed sends
- cover pre-creation, exclusive rollback, changed-ownership, and adoption-race paths

This is stacked on #1190 so the regression fixture remains separate from the fix.

## Checklist

- [ ] BUILD ASSURANCE | Fresh CI and migration checks pending.
- [x] TESTING | Handler coverage exercises both disconnect boundaries and rollback ownership; CI is the verifier.
- [x] DARK MODE SUPPORT | Not applicable; no UI changes.
- [x] ISSUE LINKED | Not applicable.
- [x] SCREENSHOT INCLUDED | Not applicable; backend-only change.