### PR TITLE
fix: make usage events idempotent

### DIFF
--- a/.agents/plans/050-maintainability-cleanup-wave.md
+++ b/.agents/plans/050-maintainability-cleanup-wave.md
@@ -5,7 +5,7 @@ Date: 2026-07-17
 ## Goal
 
 Reduce change risk in the chat, Template Studio, and template-filling hotspots
-without changing product behaviour. Land the work as six independently
+without changing intended product behaviour. Land the work as eight independently
 reviewable pull requests, preserving vertical-slice ownership and adding a
 safety net before each structural extraction.
 
@@ -14,6 +14,9 @@ safety net before each structural extraction.
 - **Safety nets precede extraction:** Characterization and browser tests land
   before moving high-churn orchestration so failures distinguish behavioural
   regressions from mechanical movement.
+- **Correctness fixes stay separate from extraction:** Characterization exposed
+  disconnect rollback and usage-idempotency gaps. Each fix lands in its own PR
+  before send-message moves, so refactor review remains mechanical.
 - **Keep ownership inside the existing slice:** Chat helpers stay in the chat
   slice, Template Studio interactions stay in the knowledge route slice, and
   reusable template-filling logic becomes a templates-domain service. This is
@@ -35,14 +38,16 @@ safety net before each structural extraction.
 
 - PR 1: characterize chat send-message failure, rollback, tenant-scope,
   persistence, and usage invariants.
-- PR 2: decompose send-message orchestration within the chat slice.
-- PR 3: add browser coverage for Template Studio edit, directive insertion,
+- PR 2: prevent disconnected sends from leaving newly created empty threads.
+- PR 3: enforce idempotent usage-event persistence for repeated AI callbacks.
+- PR 4: decompose send-message orchestration within the chat slice.
+- PR 5: add browser coverage for Template Studio edit, directive insertion,
   save, and reload.
-- PR 4: extract Template Studio slash-menu and selection-gesture subsystems
+- PR 6: extract Template Studio slash-menu and selection-gesture subsystems
   within the knowledge slice.
-- PR 5: move the highest-leverage template-filling helpers out of endpoint
+- PR 7: move the highest-leverage template-filling helpers out of endpoint
   modules and into templates-domain services.
-- PR 6: add an optional privacy-safe production log exporter with correlation
+- PR 8: add an optional privacy-safe production log exporter with correlation
   identifiers and fail-closed attribute filtering.
 
 **Out of scope:**
@@ -63,6 +68,9 @@ safety net before each structural extraction.
 - `apps/api/src/handlers/chat/*.test.ts` — add invariants around authorization,
   workspace scope, rollback, idempotent persistence, aborted streams, and
   exactly-once usage accounting at the highest practical layer.
+- `apps/api/src/lib/usage/` and `apps/api/src/db/schema/usage.ts` — make
+  metered AI callbacks idempotent using an additive nullable key and a
+  tenant-scoped partial unique index.
 - `apps/web/e2e/specs/` — add a focused Template Studio editor journey using the
   existing Playwright stack.
 - `apps/web/src/routes/_protected.knowledge/-components/` — give slash-menu and
@@ -76,7 +84,9 @@ safety net before each structural extraction.
 - `scripts/ratchet-baseline.json` — lower affected metrics only after the
   implementation reduces them; never reseed upward.
 
-**DB schema changes:** none planned.
+**DB schema changes:** PR 3 adds a nullable usage-event idempotency key and a
+partial unique index scoped by organization. Historical rows and old API tasks
+remain compatible because null keys are intentionally unrestricted.
 
 ## Test Cases
 

--- a/apps/api/drizzle/20260717110000_usage_event_idempotency/migration.sql
+++ b/apps/api/drizzle/20260717110000_usage_event_idempotency/migration.sql
@@ -1,5 +1,7 @@
 -- stella-migration-safety: reviewed destructive-change - retry cleanup only removes the same-name index before rebuilding it; no ledger rows or columns are removed
 
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
 ALTER TABLE "usage_events" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
 --> statement-breakpoint
 
@@ -7,12 +9,23 @@ ALTER TABLE "usage_events" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
 -- and old API tasks leave idempotency_key NULL, while new tasks opt into the
 -- uniqueness invariant. Build concurrently because the append-only ledger can
 -- grow large and must remain writable while the index is created.
+-- squawk-ignore transaction-nesting
 COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
 --> statement-breakpoint
 DROP INDEX CONCURRENTLY IF EXISTS "usage_events_org_idempotency_key_uidx";
 --> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
 CREATE UNIQUE INDEX CONCURRENTLY "usage_events_org_idempotency_key_uidx"
   ON "usage_events" ("organization_id", "idempotency_key")
   WHERE "idempotency_key" IS NOT NULL;
 --> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+SET statement_timeout = '5s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;

--- a/apps/api/drizzle/20260717110000_usage_event_idempotency/migration.sql
+++ b/apps/api/drizzle/20260717110000_usage_event_idempotency/migration.sql
@@ -1,0 +1,18 @@
+-- stella-migration-safety: reviewed destructive-change - retry cleanup only removes the same-name index before rebuilding it; no ledger rows or columns are removed
+
+ALTER TABLE "usage_events" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
+--> statement-breakpoint
+
+-- Keep the migration additive across a mixed-version deploy: historical rows
+-- and old API tasks leave idempotency_key NULL, while new tasks opt into the
+-- uniqueness invariant. Build concurrently because the append-only ledger can
+-- grow large and must remain writable while the index is created.
+COMMIT;
+--> statement-breakpoint
+DROP INDEX CONCURRENTLY IF EXISTS "usage_events_org_idempotency_key_uidx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX CONCURRENTLY "usage_events_org_idempotency_key_uidx"
+  ON "usage_events" ("organization_id", "idempotency_key")
+  WHERE "idempotency_key" IS NOT NULL;
+--> statement-breakpoint
+BEGIN;

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -300,6 +300,7 @@ export const usageEvents = p.pgTable(
       .notNull(),
     isByok: p.boolean("is_byok").notNull().default(false),
     traceId: p.text("trace_id"),
+    idempotencyKey: p.text("idempotency_key"),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
   },
   (table) => [
@@ -309,6 +310,10 @@ export const usageEvents = p.pgTable(
     p
       .index("usage_events_org_user_period_idx")
       .on(table.organizationId, table.userId, table.periodStart),
+    p
+      .uniqueIndex("usage_events_org_idempotency_key_uidx")
+      .on(table.organizationId, table.idempotencyKey)
+      .where(sql`idempotency_key IS NOT NULL`),
     // BYOK rows land with units_consumed = 0: the work is attributed
     // to the org's configured provider account. Platform-backed rows
     // are floored at 1 in app code.

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -170,8 +170,13 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         }),
       }),
       insert: () => ({
-        values: async (values: unknown) => {
+        values: (values: unknown) => {
           insertedRows.push(values);
+          return {
+            onConflictDoNothing: () => ({
+              returning: async () => [{ id: "usage_event_1" }],
+            }),
+          };
         },
       }),
     };
@@ -206,6 +211,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     expect(insertedRows[0]).toMatchObject({
       actionType: "chat",
       isByok: false,
+      idempotencyKey: "trace_usage",
       modelRole: "chat",
       organizationId: orgId,
       periodEnd,
@@ -238,8 +244,13 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         }),
       }),
       insert: () => ({
-        values: async (values: unknown) => {
+        values: (values: unknown) => {
           insertedRows.push(values);
+          return {
+            onConflictDoNothing: () => ({
+              returning: async () => [{ id: "usage_event_1" }],
+            }),
+          };
         },
       }),
     };
@@ -275,6 +286,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
 
     expect(insertedRows).toHaveLength(1);
     expect(insertedRows[0]).toMatchObject({
+      idempotencyKey: "trace_fallback_usage",
       serviceTier: "standard",
       traceId: "trace_fallback_usage",
     });

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -49,15 +49,17 @@ const createMiddlewareContext = ({
   deferred = [],
   iteration = 0,
   modelOptions,
+  runId = "run_1",
 }: {
   deferred?: Promise<unknown>[];
   iteration?: number;
   modelOptions?: Record<string, unknown>;
+  runId?: string;
 } = {}): ChatMiddlewareContext => ({
   activity: "chat",
   requestId: "request_1",
   streamId: "stream_1",
-  runId: "run_1",
+  runId,
   threadId: "thread_1",
   phase: "modelStream",
   iteration,
@@ -211,13 +213,17 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       createMiddlewareContext({ deferred, iteration: 1 }),
       usage,
     );
+    await callbacks.middleware.onUsage?.(
+      createMiddlewareContext({ deferred, runId: "run_2" }),
+      usage,
+    );
     await Promise.all(deferred);
 
-    expect(insertedRows).toHaveLength(2);
+    expect(insertedRows).toHaveLength(3);
     expect(insertedRows[0]).toMatchObject({
       actionType: "chat",
       isByok: false,
-      idempotencyKey: "trace_usage:0",
+      idempotencyKey: "trace_usage:run_1:0",
       modelRole: "chat",
       organizationId: orgId,
       periodEnd,
@@ -228,7 +234,11 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       workspaceId,
     });
     expect(insertedRows[1]).toMatchObject({
-      idempotencyKey: "trace_usage:1",
+      idempotencyKey: "trace_usage:run_1:1",
+      traceId: "trace_usage",
+    });
+    expect(insertedRows[2]).toMatchObject({
+      idempotencyKey: "trace_usage:run_2:0",
       traceId: "trace_usage",
     });
   });
@@ -296,7 +306,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
 
     expect(insertedRows).toHaveLength(1);
     expect(insertedRows[0]).toMatchObject({
-      idempotencyKey: "trace_fallback_usage:0",
+      idempotencyKey: "trace_fallback_usage:run_1:0",
       serviceTier: "standard",
       traceId: "trace_fallback_usage",
     });

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -47,9 +47,11 @@ const createOpenAIOrgAIConfig = (): OrgAIConfig => ({
 
 const createMiddlewareContext = ({
   deferred = [],
+  iteration = 0,
   modelOptions,
 }: {
   deferred?: Promise<unknown>[];
+  iteration?: number;
   modelOptions?: Record<string, unknown>;
 } = {}): ChatMiddlewareContext => ({
   activity: "chat",
@@ -58,7 +60,7 @@ const createMiddlewareContext = ({
   runId: "run_1",
   threadId: "thread_1",
   phase: "modelStream",
-  iteration: 0,
+  iteration,
   chunkIndex: 0,
   abort: () => undefined,
   context: undefined,
@@ -205,13 +207,17 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       createMiddlewareContext({ deferred }),
       usage,
     );
+    await callbacks.middleware.onUsage?.(
+      createMiddlewareContext({ deferred, iteration: 1 }),
+      usage,
+    );
     await Promise.all(deferred);
 
-    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows).toHaveLength(2);
     expect(insertedRows[0]).toMatchObject({
       actionType: "chat",
       isByok: false,
-      idempotencyKey: "trace_usage",
+      idempotencyKey: "trace_usage:0",
       modelRole: "chat",
       organizationId: orgId,
       periodEnd,
@@ -220,6 +226,10 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       traceId: "trace_usage",
       userId,
       workspaceId,
+    });
+    expect(insertedRows[1]).toMatchObject({
+      idempotencyKey: "trace_usage:1",
+      traceId: "trace_usage",
     });
   });
 
@@ -286,7 +296,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
 
     expect(insertedRows).toHaveLength(1);
     expect(insertedRows[0]).toMatchObject({
-      idempotencyKey: "trace_fallback_usage",
+      idempotencyKey: "trace_fallback_usage:0",
       serviceTier: "standard",
       traceId: "trace_fallback_usage",
     });

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -193,6 +193,7 @@ const recordTanStackConsumption = async ({
   cacheReadTokens,
   completionTokens,
   config,
+  iteration,
   modelInfo,
   promptTokens,
   serviceTier,
@@ -200,6 +201,7 @@ const recordTanStackConsumption = async ({
   cacheReadTokens: number;
   completionTokens: number;
   config: TanStackAIAnalyticsProps;
+  iteration: number;
   modelInfo: ResolvedTanStackTextModelInfo;
   promptTokens: number;
   serviceTier: UsageServiceTier;
@@ -234,7 +236,7 @@ const recordTanStackConsumption = async ({
         organizationId: metering.organizationId,
         rawUsageMicroUnits,
         serviceTier: effectiveServiceTier,
-        idempotencyKey: config.traceId,
+        idempotencyKey: `${config.traceId}:${iteration}`,
         traceId: config.traceId,
         userId: metering.userId,
         workspaceId: metering.workspaceId,
@@ -390,6 +392,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
           cacheReadTokens: getUsageCacheReadTokens(usage),
           completionTokens: usage.completionTokens,
           config,
+          iteration: ctx.iteration,
           modelInfo: resolvedModelInfo,
           promptTokens: usage.promptTokens,
           serviceTier: usageServiceTierFromModelOptions({

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -234,6 +234,7 @@ const recordTanStackConsumption = async ({
         organizationId: metering.organizationId,
         rawUsageMicroUnits,
         serviceTier: effectiveServiceTier,
+        idempotencyKey: config.traceId,
         traceId: config.traceId,
         userId: metering.userId,
         workspaceId: metering.workspaceId,

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -196,6 +196,7 @@ const recordTanStackConsumption = async ({
   iteration,
   modelInfo,
   promptTokens,
+  runId,
   serviceTier,
 }: {
   cacheReadTokens: number;
@@ -204,6 +205,7 @@ const recordTanStackConsumption = async ({
   iteration: number;
   modelInfo: ResolvedTanStackTextModelInfo;
   promptTokens: number;
+  runId: string;
   serviceTier: UsageServiceTier;
 }): Promise<void> => {
   const metering = config.usageMetering;
@@ -236,7 +238,7 @@ const recordTanStackConsumption = async ({
         organizationId: metering.organizationId,
         rawUsageMicroUnits,
         serviceTier: effectiveServiceTier,
-        idempotencyKey: `${config.traceId}:${iteration}`,
+        idempotencyKey: `${config.traceId}:${runId}:${iteration}`,
         traceId: config.traceId,
         userId: metering.userId,
         workspaceId: metering.workspaceId,
@@ -395,6 +397,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
           iteration: ctx.iteration,
           modelInfo: resolvedModelInfo,
           promptTokens: usage.promptTokens,
+          runId: ctx.runId,
           serviceTier: usageServiceTierFromModelOptions({
             fallback: metering.serviceTier,
             modelOptions: ctx.modelOptions,

--- a/apps/api/src/lib/usage/index.test.ts
+++ b/apps/api/src/lib/usage/index.test.ts
@@ -383,6 +383,49 @@ describe("usage ledger — idempotency", () => {
       expect(balance).toBe(300);
     });
   });
+
+  test("duplicate usage idempotency keys do not double-consume units", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await allocateUsage({
+        tx,
+        organizationId: fx.organizationId,
+        units: 1000,
+        reason: "periodic",
+        sourceType: "hosted_entitlement",
+        sourceRef: "evt_usage_idempotency",
+        period: { start: fx.periodStart, end: fx.periodEnd },
+      });
+
+      const input = {
+        tx,
+        organizationId: fx.organizationId,
+        workspaceId: null,
+        userId: fx.userId,
+        actionType: "chat",
+        modelRole: "chat",
+        unitsConsumed: 100,
+        serviceTier: "standard",
+        isByok: false,
+        idempotencyKey: "trace_usage_idempotency",
+        traceId: "trace_usage_idempotency",
+        period: { start: fx.periodStart, end: fx.periodEnd },
+      } as const;
+
+      const first = await recordUsageEvent(input);
+      const second = await recordUsageEvent(input);
+
+      expect(first.status).toBe("recorded");
+      expect(second.status).toBe("duplicate");
+
+      const balance = await getRemainingUsageUnits({
+        tx,
+        organizationId: fx.organizationId,
+        asOf: midPeriod,
+      });
+      expect(balance).toBe(900);
+    });
+  });
 });
 
 describe("usage ledger — enum coverage", () => {

--- a/apps/api/src/lib/usage/usage-ledger.ts
+++ b/apps/api/src/lib/usage/usage-ledger.ts
@@ -205,6 +205,7 @@ type RecordUsageEventInput = {
   isByok: boolean;
   rawUsageMicroUnits?: number | null;
   traceId?: string | null;
+  idempotencyKey?: string | null;
   /**
    * Optional period override. Default: look up the entitlement
    * and use its active period. Passing explicit period is useful
@@ -213,12 +214,15 @@ type RecordUsageEventInput = {
   period?: { start: Date; end: Date };
 };
 
+type RecordUsageEventResult = { status: "recorded" } | { status: "duplicate" };
+
 /**
- * Append a usage event. Does NOT check balance — that's the
- * pre-flight's job. Failures bubble up so callers can decide
- * whether to capture-and-continue or surface to the user. Most
- * callers should wrap in `Result.tryPromise` so an analytics
- * outage cannot crash the AI stream itself.
+ * Append a usage event. A non-null idempotency key makes repeated callbacks a
+ * structural no-op within the organization; null keys remain repeatable. Does
+ * NOT check balance — that's the pre-flight's job. Failures bubble up so callers
+ * can decide whether to capture-and-continue or surface to the user. Most callers
+ * should wrap in `Result.tryPromise` so an analytics outage cannot crash the AI
+ * stream itself.
  */
 export const recordUsageEvent = async ({
   tx,
@@ -232,11 +236,12 @@ export const recordUsageEvent = async ({
   isByok,
   rawUsageMicroUnits = null,
   traceId = null,
+  idempotencyKey = null,
   period,
-}: RecordUsageEventInput): Promise<void> => {
+}: RecordUsageEventInput): Promise<RecordUsageEventResult> => {
   const periodResolved = period ?? (await resolvePeriod(tx, organizationId));
 
-  await tx.insert(usageEvents).values({
+  const values = {
     organizationId,
     workspaceId,
     userId,
@@ -249,7 +254,27 @@ export const recordUsageEvent = async ({
     isByok,
     rawUsageMicroUnits,
     traceId,
-  });
+    idempotencyKey,
+  };
+
+  if (idempotencyKey === null) {
+    await tx.insert(usageEvents).values(values);
+    return { status: "recorded" };
+  }
+
+  const inserted = await tx
+    .insert(usageEvents)
+    .values(values)
+    .onConflictDoNothing({
+      target: [usageEvents.organizationId, usageEvents.idempotencyKey],
+      where: sql`idempotency_key IS NOT NULL`,
+    })
+    .returning({ id: usageEvents.id });
+
+  if (!inserted.at(0)) {
+    return { status: "duplicate" };
+  }
+  return { status: "recorded" };
 };
 
 type AllocateUsageInput = {


### PR DESCRIPTION
## Proposed change

Make repeated AI usage callbacks a structural no-op at the ledger boundary:

- add an additive nullable usage-event idempotency key
- enforce organization-scoped uniqueness with a partial concurrent index
- write generation trace IDs as idempotency keys and use conflict-safe inserts
- cover duplicate consumption with a database-backed ledger test
- amend the cleanup plan with the two correctness gates discovered during characterization

The migration remains compatible with historical rows and old API tasks because null keys are unrestricted. This is stacked on #1191.

## Checklist

- [ ] BUILD ASSURANCE | CI pending.
- [x] TESTING | Focused analytics tests pass; migration safety check passes; database-backed regression runs in CI.
- [x] DARK MODE SUPPORT | Not applicable; no UI changes.
- [x] ISSUE LINKED | Not applicable.
- [x] SCREENSHOT INCLUDED | Not applicable; backend-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added idempotent usage metering to prevent duplicate AI consumption events from being recorded.
  - Usage events can now be uniquely identified across runs and iterations, improving metering accuracy.

- **Bug Fixes**
  - Prevented repeated callbacks or retries from reducing usage balances more than once.
  - Preserved compatibility with existing usage records and events without idempotency keys.

- **Tests**
  - Added coverage confirming duplicate events are ignored and usage balances remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->