### PR TITLE
refactor: extract chat thread lifecycle

### DIFF
--- a/apps/api/src/handlers/chat/send-message-side-effects.test.ts
+++ b/apps/api/src/handlers/chat/send-message-side-effects.test.ts
@@ -1,0 +1,92 @@
+import { Result } from "better-result";
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ChatThreadState } from "@/api/handlers/chat/send-message-thread";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import { rollbackUnpersistedChatSideEffects } from "./send-message-side-effects";
+
+const threadId = toSafeId<"chatThread">("00000000-0000-0000-0000-000000000001");
+const userId = toSafeId<"user">("00000000-0000-0000-0000-000000000002");
+const workspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000003",
+);
+const rollbackToken = "rollback-token";
+
+const threadData: ChatThreadState["data"] = {
+  chatModel: null,
+  contextMatterIds: [],
+  dataWorkspaceIds: [workspaceId],
+  id: threadId,
+  messages: [],
+  webSearchEnabled: false,
+  workspaceId,
+};
+
+describe("send-message side-effect rollback", () => {
+  test("deletes a created thread while its ownership marker matches", async () => {
+    const deleteReturning = mock(async () => [{ id: threadId }]);
+    const recordAuditEvent = mock(async () => undefined);
+    const { safeDb } = createScopedDbMock({
+      delete: () => ({
+        where: () => ({ returning: deleteReturning }),
+      }),
+    });
+
+    const result = await rollbackUnpersistedChatSideEffects({
+      recordAuditEvent,
+      safeDb,
+      threadId,
+      threadState: { type: "created", data: threadData, rollbackToken },
+      uploadedFiles: [],
+      userId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
+    expect(recordAuditEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves a created thread after an adopter changes its marker", async () => {
+    const deleteReturning = mock(async () => []);
+    const recordAuditEvent = mock(async () => undefined);
+    const { safeDb } = createScopedDbMock({
+      delete: () => ({
+        where: () => ({ returning: deleteReturning }),
+      }),
+    });
+
+    const result = await rollbackUnpersistedChatSideEffects({
+      recordAuditEvent,
+      safeDb,
+      threadId,
+      threadState: { type: "created", data: threadData, rollbackToken },
+      uploadedFiles: [],
+      userId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(deleteReturning).toHaveBeenCalledTimes(1);
+    expect(recordAuditEvent).not.toHaveBeenCalled();
+  });
+
+  test("never deletes an existing thread", async () => {
+    const deleteThread = mock(() => ({ where: async () => undefined }));
+    const recordAuditEvent = mock(async () => undefined);
+    const { safeDb } = createScopedDbMock({ delete: deleteThread });
+
+    const result = await rollbackUnpersistedChatSideEffects({
+      recordAuditEvent,
+      safeDb,
+      threadId,
+      threadState: { type: "existing", data: threadData },
+      uploadedFiles: [],
+      userId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(deleteThread).not.toHaveBeenCalled();
+    expect(recordAuditEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/handlers/chat/send-message-side-effects.test.ts
+++ b/apps/api/src/handlers/chat/send-message-side-effects.test.ts
@@ -1,6 +1,6 @@
 import { Result } from "better-result";
 import { describe, expect, mock, test } from "bun:test";
-import type { SQL } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import type { ChatThreadState } from "@/api/handlers/chat/send-message-thread";
@@ -25,6 +25,12 @@ const workspaceId = toSafeId<"workspace">(
 );
 const rollbackToken = "rollback-token";
 const pgDialect = new PgDialect();
+
+const selectNoChatMessages = () => ({
+  from: () => ({
+    where: () => sql`select 1 where false`,
+  }),
+});
 
 const threadData: ChatThreadState["data"] = {
   chatModel: null,
@@ -51,6 +57,7 @@ describe("send-message side-effect rollback", () => {
       delete: () => ({
         where,
       }),
+      select: selectNoChatMessages,
     });
 
     const result = await rollbackUnpersistedChatSideEffects({
@@ -82,6 +89,7 @@ describe("send-message side-effect rollback", () => {
       delete: () => ({
         where,
       }),
+      select: selectNoChatMessages,
     });
 
     const result = await rollbackUnpersistedChatSideEffects({

--- a/apps/api/src/handlers/chat/send-message-side-effects.test.ts
+++ b/apps/api/src/handlers/chat/send-message-side-effects.test.ts
@@ -1,11 +1,22 @@
 import { Result } from "better-result";
 import { describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 
 import type { ChatThreadState } from "@/api/handlers/chat/send-message-thread";
+import type { UploadedChatFile } from "@/api/handlers/chat/upload-files";
+import { AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-import { rollbackUnpersistedChatSideEffects } from "./send-message-side-effects";
+const s3Delete = mock(async () => undefined);
+
+void mock.module("@/api/lib/s3", () => ({
+  getS3: () => ({ delete: s3Delete }),
+}));
+
+const { rollbackUnpersistedChatSideEffects } =
+  await import("./send-message-side-effects");
 
 const threadId = toSafeId<"chatThread">("00000000-0000-0000-0000-000000000001");
 const userId = toSafeId<"user">("00000000-0000-0000-0000-000000000002");
@@ -13,6 +24,7 @@ const workspaceId = toSafeId<"workspace">(
   "00000000-0000-0000-0000-000000000003",
 );
 const rollbackToken = "rollback-token";
+const pgDialect = new PgDialect();
 
 const threadData: ChatThreadState["data"] = {
   chatModel: null,
@@ -26,11 +38,18 @@ const threadData: ChatThreadState["data"] = {
 
 describe("send-message side-effect rollback", () => {
   test("deletes a created thread while its ownership marker matches", async () => {
-    const deleteReturning = mock(async () => [{ id: threadId }]);
+    const where = mock((condition: SQL) => ({
+      returning: async () => {
+        const { params } = pgDialect.sqlToQuery(condition);
+        return params.includes(rollbackToken) && params.includes(userId)
+          ? [{ id: threadId }]
+          : [];
+      },
+    }));
     const recordAuditEvent = mock(async () => undefined);
     const { safeDb } = createScopedDbMock({
       delete: () => ({
-        where: () => ({ returning: deleteReturning }),
+        where,
       }),
     });
 
@@ -44,16 +63,24 @@ describe("send-message side-effect rollback", () => {
     });
 
     expect(Result.isOk(result)).toBe(true);
-    expect(deleteReturning).toHaveBeenCalledTimes(1);
+    expect(where).toHaveBeenCalledTimes(1);
     expect(recordAuditEvent).toHaveBeenCalledTimes(1);
   });
 
   test("preserves a created thread after an adopter changes its marker", async () => {
-    const deleteReturning = mock(async () => []);
+    const adoptedRollbackToken = "adopted-rollback-token";
+    const where = mock((condition: SQL) => ({
+      returning: async () => {
+        const { params } = pgDialect.sqlToQuery(condition);
+        return params.includes(adoptedRollbackToken) && params.includes(userId)
+          ? [{ id: threadId }]
+          : [];
+      },
+    }));
     const recordAuditEvent = mock(async () => undefined);
     const { safeDb } = createScopedDbMock({
       delete: () => ({
-        where: () => ({ returning: deleteReturning }),
+        where,
       }),
     });
 
@@ -67,7 +94,7 @@ describe("send-message side-effect rollback", () => {
     });
 
     expect(Result.isOk(result)).toBe(true);
-    expect(deleteReturning).toHaveBeenCalledTimes(1);
+    expect(where).toHaveBeenCalledTimes(1);
     expect(recordAuditEvent).not.toHaveBeenCalled();
   });
 
@@ -88,5 +115,38 @@ describe("send-message side-effect rollback", () => {
     expect(Result.isOk(result)).toBe(true);
     expect(deleteThread).not.toHaveBeenCalled();
     expect(recordAuditEvent).not.toHaveBeenCalled();
+  });
+
+  test("removes uploaded attachments without deleting an existing thread", async () => {
+    s3Delete.mockClear();
+    const deleteRowsWhere = mock(async () => undefined);
+    const deleteRows = mock(() => ({ where: deleteRowsWhere }));
+    const recordAuditEvent = mock(async () => undefined);
+    const { safeDb } = createScopedDbMock({ delete: deleteRows });
+    const uploadedFile: UploadedChatFile = {
+      id: toSafeId<"userFile">("00000000-0000-0000-0000-000000000004"),
+      s3Key: "chat/thread/attachment.txt",
+      thumbnailS3Key: null,
+    };
+
+    const result = await rollbackUnpersistedChatSideEffects({
+      recordAuditEvent,
+      safeDb,
+      threadId,
+      threadState: { type: "existing", data: threadData },
+      uploadedFiles: [uploadedFile],
+      userId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(s3Delete).toHaveBeenCalledWith(uploadedFile.s3Key);
+    expect(deleteRows).toHaveBeenCalledTimes(1);
+    expect(deleteRowsWhere).toHaveBeenCalledTimes(1);
+    expect(recordAuditEvent).toHaveBeenCalledWith(expect.anything(), [
+      expect.objectContaining({
+        resourceId: uploadedFile.id,
+        resourceType: AUDIT_RESOURCE_TYPE.CHAT_FILE,
+      }),
+    ]);
   });
 });

--- a/apps/api/src/handlers/chat/send-message-side-effects.ts
+++ b/apps/api/src/handlers/chat/send-message-side-effects.ts
@@ -1,0 +1,140 @@
+import { Result } from "better-result";
+import { and, eq, notExists } from "drizzle-orm";
+
+import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
+import { chatMessages, chatThreads } from "@/api/db/schema";
+import type { ChatThreadState } from "@/api/handlers/chat/send-message-thread";
+import type { PersistableChatMessage } from "@/api/handlers/chat/types";
+import {
+  deleteUploadedChatFiles,
+  uploadMessageFiles,
+} from "@/api/handlers/chat/upload-files";
+import type { UploadedChatFile } from "@/api/handlers/chat/upload-files";
+import { captureError } from "@/api/lib/analytics/capture";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+type UploadMessageFilesWithRollbackProps = {
+  message: PersistableChatMessage;
+  recordAuditEvent: AuditRecorder;
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  threadState: ChatThreadState;
+  userId: SafeId<"user">;
+};
+
+type UploadMessageFilesWithRollbackResult = Result<
+  {
+    message: PersistableChatMessage;
+    uploadedFiles: UploadedChatFile[];
+  },
+  HandlerError<400 | 422 | 500> | SafeDbError
+>;
+
+export const uploadMessageFilesWithRollback = async ({
+  message,
+  recordAuditEvent,
+  safeDb,
+  threadId,
+  threadState,
+  userId,
+}: UploadMessageFilesWithRollbackProps): Promise<UploadMessageFilesWithRollbackResult> => {
+  const uploadResult = await uploadMessageFiles({
+    message,
+    recordAuditEvent,
+    safeDb,
+    threadId,
+    userId,
+    workspaceId: threadState.data.workspaceId,
+  });
+
+  if (Result.isOk(uploadResult)) {
+    return uploadResult;
+  }
+
+  if (threadState.type !== "created") {
+    return uploadResult;
+  }
+
+  const rollbackResult = await rollbackUnpersistedChatSideEffects({
+    recordAuditEvent,
+    safeDb,
+    threadId,
+    threadState,
+    uploadedFiles: [],
+    userId,
+  });
+
+  if (Result.isOk(rollbackResult)) {
+    return Result.err(uploadResult.error);
+  }
+
+  captureError(uploadResult.error, { threadId });
+  return Result.err(rollbackResult.error);
+};
+
+export const rollbackUnpersistedChatSideEffects = async ({
+  recordAuditEvent,
+  safeDb,
+  threadId,
+  threadState,
+  uploadedFiles,
+  userId,
+}: {
+  recordAuditEvent: AuditRecorder;
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  threadState: ChatThreadState;
+  uploadedFiles: UploadedChatFile[];
+  userId: SafeId<"user">;
+}): Promise<Result<void, HandlerError<500> | SafeDbError>> => {
+  const fileRollbackResult = await deleteUploadedChatFiles({
+    files: uploadedFiles,
+    recordAuditEvent,
+    safeDb,
+    threadId,
+    userId,
+    workspaceId: threadState.data.workspaceId,
+  });
+  if (Result.isError(fileRollbackResult)) {
+    return fileRollbackResult;
+  }
+
+  if (threadState.type !== "created") {
+    return Result.ok();
+  }
+
+  const threadRollbackResult = await safeDb(async (tx) => {
+    const deletedThreads = await tx
+      .delete(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, threadId),
+          eq(chatThreads.rollbackToken, threadState.rollbackToken),
+          notExists(
+            tx
+              .select({ id: chatMessages.id })
+              .from(chatMessages)
+              .where(eq(chatMessages.threadId, chatThreads.id)),
+          ),
+        ),
+      )
+      .returning({ id: chatThreads.id });
+
+    if (deletedThreads.length === 0) {
+      return;
+    }
+
+    await recordAuditEvent(tx, {
+      action: AUDIT_ACTION.DELETE,
+      resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+      resourceId: threadId,
+      workspaceId: threadState.data.workspaceId,
+      metadata: { reason: "rollback_unpersisted_chat_side_effects" },
+    });
+  });
+
+  return threadRollbackResult;
+};

--- a/apps/api/src/handlers/chat/send-message-side-effects.ts
+++ b/apps/api/src/handlers/chat/send-message-side-effects.ts
@@ -112,6 +112,7 @@ export const rollbackUnpersistedChatSideEffects = async ({
       .where(
         and(
           eq(chatThreads.id, threadId),
+          eq(chatThreads.userId, userId),
           eq(chatThreads.rollbackToken, threadState.rollbackToken),
           notExists(
             tx

--- a/apps/api/src/handlers/chat/send-message-thread.test.ts
+++ b/apps/api/src/handlers/chat/send-message-thread.test.ts
@@ -1,0 +1,179 @@
+import { Result } from "better-result";
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SafeId } from "@/api/lib/branded-types";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import { loadThread } from "./send-message-thread";
+
+const organizationId = toSafeId<"organization">(
+  "00000000-0000-0000-0000-000000000001",
+);
+const userId = toSafeId<"user">("00000000-0000-0000-0000-000000000002");
+const threadId = toSafeId<"chatThread">("00000000-0000-0000-0000-000000000003");
+const workspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000004",
+);
+const otherWorkspaceId = toSafeId<"workspace">(
+  "00000000-0000-0000-0000-000000000005",
+);
+
+describe("send-message thread loading", () => {
+  test("rejects an existing thread whose scope differs from the request", async () => {
+    const insert = mock(() => ({ values: async () => undefined }));
+    const { safeDb } = createScopedDbMock({
+      insert,
+      query: {
+        chatThreads: {
+          findFirst: async () => ({
+            chatModel: null,
+            contextMatterIds: [],
+            dataWorkspaceIds: [otherWorkspaceId],
+            id: threadId,
+            title: "Existing thread",
+            rollbackToken: null,
+            webSearchEnabled: false,
+            workspaceId: otherWorkspaceId,
+          }),
+        },
+      },
+    });
+
+    const result = await loadThread({
+      initialContextMatterIds: [],
+      isAnonymized: false,
+      organizationId,
+      recordAuditEvent: async () => undefined,
+      safeDb,
+      threadId,
+      title: "Incoming title",
+      userId,
+      workspaceId,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) {
+      throw new Error("Expected the scope mismatch to fail");
+    }
+    expect(result.error).toMatchObject({
+      message: "Chat thread scope does not match request",
+      status: 400,
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  test("initializes a workspace thread with its workspace in the data scope", async () => {
+    await expectCreatedThreadDataScope(workspaceId, [workspaceId]);
+  });
+
+  test("initializes an organization thread with an empty data scope", async () => {
+    await expectCreatedThreadDataScope(null, []);
+  });
+
+  test("retries creation when rollback deletes before the adoption claim", async () => {
+    const rollbackToken = "rollback-token";
+    let lookupCount = 0;
+    const insertValues = mock(async () => undefined);
+    const claimReturning = mock(async () => []);
+    const { safeDb } = createScopedDbMock({
+      insert: () => ({ values: insertValues }),
+      query: {
+        chatThreads: {
+          findFirst: async () => {
+            lookupCount += 1;
+            if (lookupCount > 1) {
+              return null;
+            }
+            return {
+              chatModel: null,
+              contextMatterIds: [],
+              dataWorkspaceIds: [workspaceId],
+              id: threadId,
+              title: "Concurrent thread",
+              rollbackToken,
+              webSearchEnabled: false,
+              workspaceId,
+            };
+          },
+        },
+      },
+      update: () => ({
+        set: () => ({
+          where: () => ({ returning: claimReturning }),
+        }),
+      }),
+    });
+
+    const result = await loadThread({
+      initialContextMatterIds: [],
+      isAnonymized: false,
+      organizationId,
+      recordAuditEvent: async () => undefined,
+      safeDb,
+      threadId,
+      title: "New thread",
+      userId,
+      workspaceId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw result.error;
+    }
+    expect(result.value.type).toBe("created");
+    expect(claimReturning).toHaveBeenCalledTimes(1);
+    expect(insertValues).toHaveBeenCalledTimes(1);
+  });
+});
+
+const expectCreatedThreadDataScope = async (
+  requestedWorkspaceId: SafeId<"workspace"> | null,
+  expectedDataWorkspaceIds: SafeId<"workspace">[],
+) => {
+  const insertedRows: unknown[] = [];
+  const insertValues = mock(async (values: unknown) => {
+    insertedRows.push(values);
+  });
+  const recordAuditEvent = mock(async () => undefined);
+  const { safeDb } = createScopedDbMock({
+    insert: () => ({ values: insertValues }),
+    query: { chatThreads: { findFirst: async () => null } },
+  });
+
+  const result = await loadThread({
+    initialContextMatterIds: [],
+    isAnonymized: false,
+    organizationId,
+    recordAuditEvent,
+    safeDb,
+    threadId,
+    title: "New thread",
+    userId,
+    workspaceId: requestedWorkspaceId,
+  });
+
+  expect(Result.isOk(result)).toBe(true);
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  if (result.value.type !== "created") {
+    throw new Error("Expected a newly created thread");
+  }
+  expect(result.value).toMatchObject({
+    type: "created",
+    data: {
+      dataWorkspaceIds: expectedDataWorkspaceIds,
+      workspaceId: requestedWorkspaceId,
+    },
+    rollbackToken: expect.any(String),
+  });
+  expect(insertedRows).toEqual([
+    expect.objectContaining({
+      dataWorkspaceIds: expectedDataWorkspaceIds,
+      rollbackToken: result.value.rollbackToken,
+      workspaceId: requestedWorkspaceId,
+    }),
+  ]);
+  expect(recordAuditEvent).toHaveBeenCalledTimes(1);
+};

--- a/apps/api/src/handlers/chat/send-message-thread.test.ts
+++ b/apps/api/src/handlers/chat/send-message-thread.test.ts
@@ -1,8 +1,13 @@
 import { Result } from "better-result";
 import { describe, expect, mock, test } from "bun:test";
 
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
 import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
+import { DatabaseError } from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
 import { loadThread } from "./send-message-thread";
@@ -22,20 +27,21 @@ const otherWorkspaceId = toSafeId<"workspace">(
 describe("send-message thread loading", () => {
   test("rejects an existing thread whose scope differs from the request", async () => {
     const insert = mock(() => ({ values: async () => undefined }));
+    const findFirst = mock(async () => ({
+      chatModel: null,
+      contextMatterIds: [],
+      dataWorkspaceIds: [otherWorkspaceId],
+      id: threadId,
+      title: "Existing thread",
+      rollbackToken: null,
+      webSearchEnabled: false,
+      workspaceId: otherWorkspaceId,
+    }));
     const { safeDb } = createScopedDbMock({
       insert,
       query: {
         chatThreads: {
-          findFirst: async () => ({
-            chatModel: null,
-            contextMatterIds: [],
-            dataWorkspaceIds: [otherWorkspaceId],
-            id: threadId,
-            title: "Existing thread",
-            rollbackToken: null,
-            webSearchEnabled: false,
-            workspaceId: otherWorkspaceId,
-          }),
+          findFirst,
         },
       },
     });
@@ -61,6 +67,15 @@ describe("send-message thread loading", () => {
       status: 400,
     });
     expect(insert).not.toHaveBeenCalled();
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: { eq: threadId },
+          organizationId: { eq: organizationId },
+          userId: { eq: userId },
+        },
+      }),
+    );
   });
 
   test("initializes a workspace thread with its workspace in the data scope", async () => {
@@ -124,6 +139,48 @@ describe("send-message thread loading", () => {
     expect(result.value.type).toBe("created");
     expect(claimReturning).toHaveBeenCalledTimes(1);
     expect(insertValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates an audit unique violation instead of treating it as a thread race", async () => {
+    const auditUniqueError = new DatabaseError({
+      code: PG_ERROR.UNIQUE_VIOLATION,
+      message: "Audit event already exists",
+      cause: Object.assign(new Error("duplicate audit event"), {
+        code: PG_ERROR.UNIQUE_VIOLATION,
+        constraint: "audit_log_event_id_key",
+      }),
+    });
+    const tx = asTestRaw<Transaction>({
+      insert: () => ({ values: async () => undefined }),
+      query: { chatThreads: { findFirst: async () => null } },
+    });
+    const safeDb: SafeDb = async (callback) =>
+      await Result.tryPromise({
+        try: async () => await callback(tx),
+        catch: () => auditUniqueError,
+      });
+    const recordAuditEvent = mock(async () => {
+      throw auditUniqueError;
+    });
+
+    const result = await loadThread({
+      initialContextMatterIds: [],
+      isAnonymized: false,
+      organizationId,
+      recordAuditEvent,
+      safeDb,
+      threadId,
+      title: "New thread",
+      userId,
+      workspaceId,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) {
+      throw new Error("Expected the audit write to fail");
+    }
+    expect(result.error).toBe(auditUniqueError);
+    expect(recordAuditEvent).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/handlers/chat/send-message-thread.test.ts
+++ b/apps/api/src/handlers/chat/send-message-thread.test.ts
@@ -154,9 +154,9 @@ describe("send-message thread loading", () => {
       insert: () => ({ values: async () => undefined }),
       query: { chatThreads: { findFirst: async () => null } },
     });
-    const safeDb: SafeDb = async (callback) =>
+    const safeDb: SafeDb = async (operation) =>
       await Result.tryPromise({
-        try: async () => await callback(tx),
+        try: async () => await operation(tx),
         catch: () => auditUniqueError,
       });
     const recordAuditEvent = mock(async () => {

--- a/apps/api/src/handlers/chat/send-message-thread.ts
+++ b/apps/api/src/handlers/chat/send-message-thread.ts
@@ -13,9 +13,10 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
-import { PG_ERROR } from "@/api/lib/pg-error";
+import { PG_ERROR, pgErrorFields } from "@/api/lib/pg-error";
 
 type ReadThreadValidationStateProps = {
+  organizationId: SafeId<"organization">;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
   userId: SafeId<"user">;
@@ -27,6 +28,7 @@ type ThreadValidationState = {
 };
 
 export const readThreadValidationState = async ({
+  organizationId,
   safeDb,
   threadId,
   userId,
@@ -40,6 +42,7 @@ export const readThreadValidationState = async ({
         tx.query.chatThreads.findFirst({
           where: {
             id: { eq: threadId },
+            organizationId: { eq: organizationId },
             userId: { eq: userId },
           },
           columns: {
@@ -107,6 +110,7 @@ export type ChatThreadState =
 type LoadThreadError = HandlerError<400 | 404 | 409> | SafeDbError;
 
 const MAX_THREAD_CLAIM_ATTEMPTS = 3;
+const CHAT_THREADS_PRIMARY_KEY_CONSTRAINT = "chat_threads_pkey";
 
 export const loadThread = async (
   props: LoadThreadProps,
@@ -130,7 +134,7 @@ const loadThreadAttempt = async ({
   workspaceId,
 }: LoadThreadAttemptProps): Promise<Result<ChatThreadState, LoadThreadError>> =>
   await Result.gen(async function* () {
-    // Look the thread up by id+user only. Filtering by workspaceId
+    // Look the thread up by id+organization+user only. Filtering by workspaceId
     // here would mask a scope mismatch — a thread persisted with
     // workspaceId=X but requested as global would look "missing"
     // and the insert below would then collide on the PK. We want a
@@ -151,6 +155,7 @@ const loadThreadAttempt = async ({
         tx.query.chatThreads.findFirst({
           where: {
             id: { eq: threadId },
+            organizationId: { eq: organizationId },
             userId: { eq: userId },
           },
           columns: {
@@ -222,6 +227,8 @@ const loadThreadAttempt = async ({
           .where(
             and(
               eq(chatThreads.id, threadId),
+              eq(chatThreads.organizationId, organizationId),
+              eq(chatThreads.userId, userId),
               eq(chatThreads.rollbackToken, rollbackToken),
             ),
           )
@@ -288,7 +295,13 @@ const loadThreadAttempt = async ({
             await tx
               .update(chatThreads)
               .set({ title })
-              .where(eq(chatThreads.id, threadId));
+              .where(
+                and(
+                  eq(chatThreads.id, threadId),
+                  eq(chatThreads.organizationId, organizationId),
+                  eq(chatThreads.userId, userId),
+                ),
+              );
 
             await recordAuditEvent(tx, {
               action: AUDIT_ACTION.UPDATE,
@@ -338,7 +351,9 @@ const loadThreadAttempt = async ({
     if (Result.isError(insertResult)) {
       if (
         !DatabaseError.is(insertResult.error) ||
-        insertResult.error.code !== PG_ERROR.UNIQUE_VIOLATION
+        insertResult.error.code !== PG_ERROR.UNIQUE_VIOLATION ||
+        pgErrorFields(insertResult.error)["error.cause.pg_constraint"] !==
+          CHAT_THREADS_PRIMARY_KEY_CONSTRAINT
       ) {
         return Result.err(insertResult.error);
       }

--- a/apps/api/src/handlers/chat/send-message-thread.ts
+++ b/apps/api/src/handlers/chat/send-message-thread.ts
@@ -1,0 +1,397 @@
+import { Result } from "better-result";
+import { and, eq, sql } from "drizzle-orm";
+
+import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
+import { chatThreads } from "@/api/db/schema";
+import { loadWindowedThreadMessages } from "@/api/handlers/chat/history-window";
+import { shouldRefreshEmptyThreadTitle } from "@/api/handlers/chat/thread-title";
+import type {
+  ChatMessage,
+  PersistedChatMessageContent,
+} from "@/api/handlers/chat/types";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
+
+type ReadThreadValidationStateProps = {
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace"> | null;
+};
+
+type ThreadValidationState = {
+  webSearchEnabled: boolean;
+};
+
+export const readThreadValidationState = async ({
+  safeDb,
+  threadId,
+  userId,
+  workspaceId,
+}: ReadThreadValidationStateProps): Promise<
+  Result<ThreadValidationState, HandlerError<400> | SafeDbError>
+> =>
+  await Result.gen(async function* () {
+    const thread = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.chatThreads.findFirst({
+          where: {
+            id: { eq: threadId },
+            userId: { eq: userId },
+          },
+          columns: {
+            workspaceId: true,
+            webSearchEnabled: true,
+          },
+        }),
+      ),
+    );
+
+    if (!thread) {
+      return Result.ok({ webSearchEnabled: false });
+    }
+
+    const persistedWorkspaceId = thread.workspaceId ?? null;
+    if (persistedWorkspaceId !== workspaceId) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Chat thread scope does not match request",
+        }),
+      );
+    }
+
+    return Result.ok({ webSearchEnabled: thread.webSearchEnabled });
+  });
+
+type ChatThreadRecord = {
+  id: SafeId<"chatThread">;
+  workspaceId: SafeId<"workspace"> | null;
+  contextMatterIds: SafeId<"workspace">[];
+  dataWorkspaceIds: SafeId<"workspace">[];
+  webSearchEnabled: boolean;
+  chatModel: string | null;
+  messages: {
+    id: SafeId<"chatMessage">;
+    role: ChatMessage["role"];
+    content: PersistedChatMessageContent;
+  }[];
+};
+
+type LoadThreadProps = {
+  initialContextMatterIds: SafeId<"workspace">[];
+  isAnonymized: boolean;
+  organizationId: SafeId<"organization">;
+  recordAuditEvent: AuditRecorder;
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  title: string;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace"> | null;
+};
+
+export type ChatThreadState =
+  | {
+      type: "existing";
+      data: ChatThreadRecord;
+    }
+  | {
+      type: "created";
+      data: ChatThreadRecord;
+      rollbackToken: string;
+    };
+
+type LoadThreadError = HandlerError<400 | 404 | 409> | SafeDbError;
+
+const MAX_THREAD_CLAIM_ATTEMPTS = 3;
+
+export const loadThread = async (
+  props: LoadThreadProps,
+): Promise<Result<ChatThreadState, LoadThreadError>> =>
+  await loadThreadAttempt({ ...props, claimAttempt: 0 });
+
+type LoadThreadAttemptProps = LoadThreadProps & {
+  claimAttempt: number;
+};
+
+const loadThreadAttempt = async ({
+  claimAttempt,
+  initialContextMatterIds,
+  isAnonymized,
+  organizationId,
+  recordAuditEvent,
+  safeDb,
+  threadId,
+  title,
+  userId,
+  workspaceId,
+}: LoadThreadAttemptProps): Promise<Result<ChatThreadState, LoadThreadError>> =>
+  await Result.gen(async function* () {
+    // Look the thread up by id+user only. Filtering by workspaceId
+    // here would mask a scope mismatch — a thread persisted with
+    // workspaceId=X but requested as global would look "missing"
+    // and the insert below would then collide on the PK. We want a
+    // clear 400 instead of a constraint violation 500.
+    type ExistingThreadRow = {
+      id: SafeId<"chatThread">;
+      title: string;
+      workspaceId: SafeId<"workspace"> | null;
+      contextMatterIds: SafeId<"workspace">[];
+      dataWorkspaceIds: SafeId<"workspace">[];
+      webSearchEnabled: boolean;
+      chatModel: string | null;
+      rollbackToken: string | null;
+    };
+
+    const lookup = async () =>
+      await safeDb((tx) =>
+        tx.query.chatThreads.findFirst({
+          where: {
+            id: { eq: threadId },
+            userId: { eq: userId },
+          },
+          columns: {
+            id: true,
+            title: true,
+            workspaceId: true,
+            contextMatterIds: true,
+            dataWorkspaceIds: true,
+            webSearchEnabled: true,
+            chatModel: true,
+            rollbackToken: true,
+          },
+        }),
+      );
+
+    // Load only the per-send window: when an active compaction checkpoint
+    // exists, the already-summarized [0..firstKept) prefix is dropped, so a
+    // normal send no longer re-reads the whole thread into memory. The
+    // truncation/edit path resolves an older target directly against the DB
+    // (resolveTruncationTarget), so a window miss never makes a target
+    // unfindable.
+    const buildExisting = (
+      existing: ExistingThreadRow,
+    ): Result<ChatThreadState, HandlerError<400>> => {
+      const persistedWorkspaceId = existing.workspaceId ?? null;
+      if (persistedWorkspaceId !== workspaceId) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Chat thread scope does not match request",
+          }),
+        );
+      }
+      return Result.ok<ChatThreadState>({
+        type: "existing",
+        data: {
+          id: existing.id,
+          workspaceId: existing.workspaceId,
+          contextMatterIds: existing.contextMatterIds,
+          dataWorkspaceIds: existing.dataWorkspaceIds,
+          webSearchEnabled: existing.webSearchEnabled,
+          chatModel: existing.chatModel,
+          messages: [],
+        },
+      });
+    };
+
+    // A created row remains rollback-owned only while its token is unchanged.
+    // Every adopter CAS-clears that token before using the row.
+    // If rollback deletes first, the failed CAS retries and creates/claims the
+    // replacement; if adoption wins, the creator's guarded delete is a no-op.
+    const claimExisting = async (
+      existing: ExistingThreadRow,
+    ): Promise<Result<boolean, SafeDbError>> => {
+      const rollbackToken = existing.rollbackToken;
+      if (rollbackToken === null) {
+        return Result.ok(true);
+      }
+
+      const claimResult = await safeDb(async (tx) => {
+        // audit: skip — clears an ephemeral rollback-ownership token; the
+        // thread's user-facing state is unchanged
+        const claimQuery = tx
+          .update(chatThreads)
+          .set({
+            rollbackToken: null,
+            updatedAt: sql`${chatThreads.updatedAt}`,
+          })
+          .where(
+            and(
+              eq(chatThreads.id, threadId),
+              eq(chatThreads.rollbackToken, rollbackToken),
+            ),
+          )
+          .returning({ id: chatThreads.id });
+        return await claimQuery;
+      });
+      if (Result.isError(claimResult)) {
+        return Result.err(claimResult.error);
+      }
+      return Result.ok(claimResult.value.length > 0);
+    };
+
+    const retryAfterClaimRace = async (): Promise<
+      Result<ChatThreadState, LoadThreadError>
+    > => {
+      if (claimAttempt >= MAX_THREAD_CLAIM_ATTEMPTS) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "Chat thread changed concurrently; retry request",
+          }),
+        );
+      }
+      return await loadThreadAttempt({
+        claimAttempt: claimAttempt + 1,
+        initialContextMatterIds,
+        isAnonymized,
+        organizationId,
+        recordAuditEvent,
+        safeDb,
+        threadId,
+        title,
+        userId,
+        workspaceId,
+      });
+    };
+
+    const thread = yield* Result.await(lookup());
+    if (thread) {
+      const existingResult = buildExisting(thread);
+      if (Result.isError(existingResult)) {
+        return Result.err(existingResult.error);
+      }
+      const claimed = yield* Result.await(claimExisting(thread));
+      if (!claimed) {
+        const retried = yield* Result.await(retryAfterClaimRace());
+        return Result.ok(retried);
+      }
+      const windowedMessages = yield* Result.await(
+        loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
+      );
+      existingResult.value.data.messages = windowedMessages;
+      if (
+        shouldRefreshEmptyThreadTitle({
+          // A non-empty thread always includes at least its first-kept
+          // message in the window, so window length === 0 iff the thread is
+          // empty — the only thing this check needs to know.
+          messageCount: windowedMessages.length,
+          title: thread.title,
+        })
+      ) {
+        yield* Result.await(
+          safeDb(async (tx) => {
+            await tx
+              .update(chatThreads)
+              .set({ title })
+              .where(eq(chatThreads.id, threadId));
+
+            await recordAuditEvent(tx, {
+              action: AUDIT_ACTION.UPDATE,
+              resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+              resourceId: threadId,
+              workspaceId,
+              changes: {
+                title: { old: thread.title, new: title },
+              },
+            });
+          }),
+        );
+      }
+      return Result.ok(existingResult.value);
+    }
+
+    const initialDataWorkspaceIds: SafeId<"workspace">[] = workspaceId
+      ? [workspaceId]
+      : [];
+    const rollbackToken = Bun.randomUUIDv7();
+
+    const insertResult = await safeDb(async (tx) => {
+      await tx.insert(chatThreads).values({
+        id: threadId,
+        organizationId,
+        title,
+        userId,
+        workspaceId,
+        contextMatterIds: initialContextMatterIds,
+        rollbackToken,
+        // Workspace-scoped chats embed at minimum their own
+        // workspace's content. Global chats start with no
+        // embedded workspace data; subsequent messages widen
+        // this set via expandThreadDataScope when they reference
+        // workspace assets (mentions, source-document parts).
+        dataWorkspaceIds: initialDataWorkspaceIds,
+      });
+
+      await recordAuditEvent(tx, {
+        action: AUDIT_ACTION.CREATE,
+        resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+        resourceId: threadId,
+        workspaceId,
+        metadata: { title },
+      });
+    });
+    if (Result.isError(insertResult)) {
+      if (
+        !DatabaseError.is(insertResult.error) ||
+        insertResult.error.code !== PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return Result.err(insertResult.error);
+      }
+      // Two interleaved cases collide on the primary key here:
+      //
+      //   (a) Race: two concurrent send-message calls with the
+      //       same new threadId — one insert wins, the other
+      //       sees the winner's row and should treat it as
+      //       existing.
+      //   (b) Hidden thread: the row exists but is invisible
+      //       under the new RLS predicate (data_workspace_ids ⊄
+      //       session), so the initial findFirst returned null.
+      //       Returning 404 matches what get-messages already
+      //       returns for the same shape and avoids leaking
+      //       thread existence to a revoked user.
+      //
+      // Re-run the lookup under current RLS to disambiguate.
+      const recovered = yield* Result.await(lookup());
+      if (recovered) {
+        const recoveredResult = buildExisting(recovered);
+        if (Result.isError(recoveredResult)) {
+          return Result.err(recoveredResult.error);
+        }
+        const claimed = yield* Result.await(claimExisting(recovered));
+        if (!claimed) {
+          const retried = yield* Result.await(retryAfterClaimRace());
+          return Result.ok(retried);
+        }
+        const recoveredMessages = yield* Result.await(
+          loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
+        );
+        recoveredResult.value.data.messages = recoveredMessages;
+        return Result.ok(recoveredResult.value);
+      }
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Chat thread not found",
+        }),
+      );
+    }
+
+    return Result.ok<ChatThreadState>({
+      type: "created",
+      rollbackToken,
+      data: {
+        id: threadId,
+        workspaceId,
+        contextMatterIds: initialContextMatterIds,
+        dataWorkspaceIds: initialDataWorkspaceIds,
+        webSearchEnabled: false,
+        chatModel: null,
+        messages: [],
+      },
+    });
+  });

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -310,6 +310,7 @@ const sendMessage = createSafeRootHandler(
     const hasActiveDocxFileClient = body.activeFile?.supportsDocxEdits === true;
     const validationThreadState = yield* Result.await(
       readThreadValidationState({
+        organizationId: session.activeOrganizationId,
         safeDb,
         threadId: body.threadId,
         userId: user.id,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, eq, inArray, notExists, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { Static } from "elysia";
 
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
@@ -53,7 +53,6 @@ import { generateThreadTitle } from "@/api/handlers/chat/generate-thread-title";
 import {
   chatMessageExistsForThread,
   loadFullThreadHistory,
-  loadWindowedThreadMessages,
   resolveTruncationTarget,
 } from "@/api/handlers/chat/history-window";
 import { isExternalMcpToolPart } from "@/api/handlers/chat/mcp-tool-parts";
@@ -70,13 +69,21 @@ import {
   shouldInvalidateChatCompactionCheckpoint,
 } from "@/api/handlers/chat/persistent-compaction";
 import {
+  rollbackUnpersistedChatSideEffects,
+  uploadMessageFilesWithRollback,
+} from "@/api/handlers/chat/send-message-side-effects";
+import {
+  loadThread,
+  readThreadValidationState,
+} from "@/api/handlers/chat/send-message-thread";
+import type { ChatThreadState } from "@/api/handlers/chat/send-message-thread";
+import {
   resolveActiveChatSkillContext,
   type ActiveChatSkillContext,
 } from "@/api/handlers/chat/skills";
 import { hydrateMessages, streamChat } from "@/api/handlers/chat/stream-chat";
 import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import { shouldMarkThreadUsedAnonymization } from "@/api/handlers/chat/thread-anonymization";
-import { shouldRefreshEmptyThreadTitle } from "@/api/handlers/chat/thread-title";
 import {
   intersectAccessibleWorkspaceIds,
   resolveToolWorkspaceIds,
@@ -106,14 +113,8 @@ import {
 import type {
   ChatMessage,
   PersistableChatMessage,
-  PersistedChatMessageContent,
 } from "@/api/handlers/chat/types";
-import {
-  createRawChatFilePart,
-  deleteUploadedChatFiles,
-  uploadMessageFiles,
-} from "@/api/handlers/chat/upload-files";
-import type { UploadedChatFile } from "@/api/handlers/chat/upload-files";
+import { createRawChatFilePart } from "@/api/handlers/chat/upload-files";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { getDisabledNativeToolSlugs } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
@@ -126,9 +127,8 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
 import { resolveEffectiveChatModelId } from "@/api/lib/chat-model-selection";
-import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FILE_SIZE_LIMIT_BYTES, FILE_SIZE_LIMITS } from "@/api/lib/limits";
-import { PG_ERROR } from "@/api/lib/pg-error";
 import { getS3 } from "@/api/lib/s3";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
 import { upsertChatThreadSearchDocument } from "@/api/lib/search/index-chat";
@@ -599,7 +599,7 @@ const sendMessage = createSafeRootHandler(
         message: uploadResult.message,
       });
 
-      let messagesForPersistence: ThreadRecord["messages"] =
+      let messagesForPersistence: ChatThreadState["data"]["messages"] =
         thread.data.messages;
       let deleteMessageIdsBeforeLatest: SafeId<"chatMessage">[] = [];
       // The incoming message normally is new. Outside the truncation path the
@@ -1506,512 +1506,6 @@ const resolveExternalToolsForValidation = async (
   }
   const loaded = await loader.getExternalMcpTools();
   return loaded.tools;
-};
-
-type ReadThreadValidationStateProps = {
-  safeDb: SafeDb;
-  threadId: SafeId<"chatThread">;
-  userId: SafeId<"user">;
-  workspaceId: SafeId<"workspace"> | null;
-};
-
-type ThreadValidationState = {
-  webSearchEnabled: boolean;
-};
-
-const readThreadValidationState = async ({
-  safeDb,
-  threadId,
-  userId,
-  workspaceId,
-}: ReadThreadValidationStateProps): Promise<
-  Result<ThreadValidationState, HandlerError<400> | SafeDbError>
-> =>
-  await Result.gen(async function* () {
-    const thread = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.chatThreads.findFirst({
-          where: {
-            id: { eq: threadId },
-            userId: { eq: userId },
-          },
-          columns: {
-            workspaceId: true,
-            webSearchEnabled: true,
-          },
-        }),
-      ),
-    );
-
-    if (!thread) {
-      return Result.ok({ webSearchEnabled: false });
-    }
-
-    const persistedWorkspaceId = thread.workspaceId ?? null;
-    if (persistedWorkspaceId !== workspaceId) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Chat thread scope does not match request",
-        }),
-      );
-    }
-
-    return Result.ok({ webSearchEnabled: thread.webSearchEnabled });
-  });
-
-type ThreadRecord = {
-  id: SafeId<"chatThread">;
-  workspaceId: SafeId<"workspace"> | null;
-  contextMatterIds: SafeId<"workspace">[];
-  dataWorkspaceIds: SafeId<"workspace">[];
-  webSearchEnabled: boolean;
-  chatModel: string | null;
-  messages: {
-    id: SafeId<"chatMessage">;
-    role: ChatMessage["role"];
-    content: PersistedChatMessageContent;
-  }[];
-};
-
-type LoadThreadProps = {
-  initialContextMatterIds: SafeId<"workspace">[];
-  isAnonymized: boolean;
-  organizationId: SafeId<"organization">;
-  recordAuditEvent: AuditRecorder;
-  safeDb: SafeDb;
-  threadId: SafeId<"chatThread">;
-  title: string;
-  userId: SafeId<"user">;
-  workspaceId: SafeId<"workspace"> | null;
-};
-
-type LoadThreadResult =
-  | {
-      type: "existing";
-      data: ThreadRecord;
-    }
-  | {
-      type: "created";
-      data: ThreadRecord;
-      rollbackToken: string;
-    };
-
-type LoadThreadError = HandlerError<400 | 404 | 409> | SafeDbError;
-
-const MAX_THREAD_CLAIM_ATTEMPTS = 3;
-
-const loadThread = async (
-  props: LoadThreadProps,
-): Promise<Result<LoadThreadResult, LoadThreadError>> =>
-  await loadThreadAttempt({ ...props, claimAttempt: 0 });
-
-type LoadThreadAttemptProps = LoadThreadProps & {
-  claimAttempt: number;
-};
-
-const loadThreadAttempt = async ({
-  claimAttempt,
-  initialContextMatterIds,
-  isAnonymized,
-  organizationId,
-  recordAuditEvent,
-  safeDb,
-  threadId,
-  title,
-  userId,
-  workspaceId,
-}: LoadThreadAttemptProps): Promise<
-  Result<LoadThreadResult, LoadThreadError>
-> =>
-  await Result.gen(async function* () {
-    // Look the thread up by id+user only. Filtering by workspaceId
-    // here would mask a scope mismatch — a thread persisted with
-    // workspaceId=X but requested as global would look "missing"
-    // and the insert below would then collide on the PK. We want a
-    // clear 400 instead of a constraint violation 500.
-    type ExistingThreadRow = {
-      id: SafeId<"chatThread">;
-      title: string;
-      workspaceId: SafeId<"workspace"> | null;
-      contextMatterIds: SafeId<"workspace">[];
-      dataWorkspaceIds: SafeId<"workspace">[];
-      webSearchEnabled: boolean;
-      chatModel: string | null;
-      rollbackToken: string | null;
-    };
-
-    const lookup = async () =>
-      await safeDb((tx) =>
-        tx.query.chatThreads.findFirst({
-          where: {
-            id: { eq: threadId },
-            userId: { eq: userId },
-          },
-          columns: {
-            id: true,
-            title: true,
-            workspaceId: true,
-            contextMatterIds: true,
-            dataWorkspaceIds: true,
-            webSearchEnabled: true,
-            chatModel: true,
-            rollbackToken: true,
-          },
-        }),
-      );
-
-    // Load only the per-send window: when an active compaction checkpoint
-    // exists, the already-summarized [0..firstKept) prefix is dropped, so a
-    // normal send no longer re-reads the whole thread into memory. The
-    // truncation/edit path resolves an older target directly against the DB
-    // (resolveTruncationTarget), so a window miss never makes a target
-    // unfindable.
-    const buildExisting = (
-      existing: ExistingThreadRow,
-    ): Result<LoadThreadResult, HandlerError<400>> => {
-      const persistedWorkspaceId = existing.workspaceId ?? null;
-      if (persistedWorkspaceId !== workspaceId) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Chat thread scope does not match request",
-          }),
-        );
-      }
-      return Result.ok<LoadThreadResult>({
-        type: "existing",
-        data: {
-          id: existing.id,
-          workspaceId: existing.workspaceId,
-          contextMatterIds: existing.contextMatterIds,
-          dataWorkspaceIds: existing.dataWorkspaceIds,
-          webSearchEnabled: existing.webSearchEnabled,
-          chatModel: existing.chatModel,
-          messages: [],
-        },
-      });
-    };
-
-    // A created row remains rollback-owned only while its token is unchanged.
-    // Every adopter CAS-clears that token before using the row.
-    // If rollback deletes first, the failed CAS retries and creates/claims the
-    // replacement; if adoption wins, the creator's guarded delete is a no-op.
-    const claimExisting = async (
-      existing: ExistingThreadRow,
-    ): Promise<Result<boolean, SafeDbError>> => {
-      const rollbackToken = existing.rollbackToken;
-      if (rollbackToken === null) {
-        return Result.ok(true);
-      }
-
-      const claimResult = await safeDb(async (tx) => {
-        // audit: skip — clears an ephemeral rollback-ownership token; the
-        // thread's user-facing state is unchanged
-        const claimQuery = tx
-          .update(chatThreads)
-          .set({
-            rollbackToken: null,
-            updatedAt: sql`${chatThreads.updatedAt}`,
-          })
-          .where(
-            and(
-              eq(chatThreads.id, threadId),
-              eq(chatThreads.rollbackToken, rollbackToken),
-            ),
-          )
-          .returning({ id: chatThreads.id });
-        return await claimQuery;
-      });
-      if (Result.isError(claimResult)) {
-        return Result.err(claimResult.error);
-      }
-      return Result.ok(claimResult.value.length > 0);
-    };
-
-    const retryAfterClaimRace = async (): Promise<
-      Result<LoadThreadResult, LoadThreadError>
-    > => {
-      if (claimAttempt >= MAX_THREAD_CLAIM_ATTEMPTS) {
-        return Result.err(
-          new HandlerError({
-            status: 409,
-            message: "Chat thread changed concurrently; retry request",
-          }),
-        );
-      }
-      return await loadThreadAttempt({
-        claimAttempt: claimAttempt + 1,
-        initialContextMatterIds,
-        isAnonymized,
-        organizationId,
-        recordAuditEvent,
-        safeDb,
-        threadId,
-        title,
-        userId,
-        workspaceId,
-      });
-    };
-
-    const thread = yield* Result.await(lookup());
-    if (thread) {
-      const existingResult = buildExisting(thread);
-      if (Result.isError(existingResult)) {
-        return Result.err(existingResult.error);
-      }
-      const claimed = yield* Result.await(claimExisting(thread));
-      if (!claimed) {
-        const retried = yield* Result.await(retryAfterClaimRace());
-        return Result.ok(retried);
-      }
-      const windowedMessages = yield* Result.await(
-        loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
-      );
-      existingResult.value.data.messages = windowedMessages;
-      if (
-        shouldRefreshEmptyThreadTitle({
-          // A non-empty thread always includes at least its first-kept
-          // message in the window, so window length === 0 iff the thread is
-          // empty — the only thing this check needs to know.
-          messageCount: windowedMessages.length,
-          title: thread.title,
-        })
-      ) {
-        yield* Result.await(
-          safeDb(async (tx) => {
-            await tx
-              .update(chatThreads)
-              .set({ title })
-              .where(eq(chatThreads.id, threadId));
-
-            await recordAuditEvent(tx, {
-              action: AUDIT_ACTION.UPDATE,
-              resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
-              resourceId: threadId,
-              workspaceId,
-              changes: {
-                title: { old: thread.title, new: title },
-              },
-            });
-          }),
-        );
-      }
-      return Result.ok(existingResult.value);
-    }
-
-    const initialDataWorkspaceIds: SafeId<"workspace">[] = workspaceId
-      ? [workspaceId]
-      : [];
-    const rollbackToken = Bun.randomUUIDv7();
-
-    const insertResult = await safeDb(async (tx) => {
-      await tx.insert(chatThreads).values({
-        id: threadId,
-        organizationId,
-        title,
-        userId,
-        workspaceId,
-        contextMatterIds: initialContextMatterIds,
-        rollbackToken,
-        // Workspace-scoped chats embed at minimum their own
-        // workspace's content. Global chats start with no
-        // embedded workspace data; subsequent messages widen
-        // this set via expandThreadDataScope when they reference
-        // workspace assets (mentions, source-document parts).
-        dataWorkspaceIds: initialDataWorkspaceIds,
-      });
-
-      await recordAuditEvent(tx, {
-        action: AUDIT_ACTION.CREATE,
-        resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
-        resourceId: threadId,
-        workspaceId,
-        metadata: { title },
-      });
-    });
-    if (Result.isError(insertResult)) {
-      if (
-        !DatabaseError.is(insertResult.error) ||
-        insertResult.error.code !== PG_ERROR.UNIQUE_VIOLATION
-      ) {
-        return Result.err(insertResult.error);
-      }
-      // Two interleaved cases collide on the primary key here:
-      //
-      //   (a) Race: two concurrent send-message calls with the
-      //       same new threadId — one insert wins, the other
-      //       sees the winner's row and should treat it as
-      //       existing.
-      //   (b) Hidden thread: the row exists but is invisible
-      //       under the new RLS predicate (data_workspace_ids ⊄
-      //       session), so the initial findFirst returned null.
-      //       Returning 404 matches what get-messages already
-      //       returns for the same shape and avoids leaking
-      //       thread existence to a revoked user.
-      //
-      // Re-run the lookup under current RLS to disambiguate.
-      const recovered = yield* Result.await(lookup());
-      if (recovered) {
-        const recoveredResult = buildExisting(recovered);
-        if (Result.isError(recoveredResult)) {
-          return Result.err(recoveredResult.error);
-        }
-        const claimed = yield* Result.await(claimExisting(recovered));
-        if (!claimed) {
-          const retried = yield* Result.await(retryAfterClaimRace());
-          return Result.ok(retried);
-        }
-        const recoveredMessages = yield* Result.await(
-          loadWindowedThreadMessages({ safeDb, threadId, isAnonymized }),
-        );
-        recoveredResult.value.data.messages = recoveredMessages;
-        return Result.ok(recoveredResult.value);
-      }
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Chat thread not found",
-        }),
-      );
-    }
-
-    return Result.ok<LoadThreadResult>({
-      type: "created",
-      rollbackToken,
-      data: {
-        id: threadId,
-        workspaceId,
-        contextMatterIds: initialContextMatterIds,
-        dataWorkspaceIds: initialDataWorkspaceIds,
-        webSearchEnabled: false,
-        chatModel: null,
-        messages: [],
-      },
-    });
-  });
-
-type UploadMessageFilesWithRollbackProps = {
-  message: PersistableChatMessage;
-  recordAuditEvent: AuditRecorder;
-  safeDb: SafeDb;
-  threadId: SafeId<"chatThread">;
-  threadState: LoadThreadResult;
-  userId: SafeId<"user">;
-};
-
-type UploadMessageFilesWithRollbackResult = Result<
-  {
-    message: PersistableChatMessage;
-    uploadedFiles: UploadedChatFile[];
-  },
-  HandlerError<400 | 422 | 500> | SafeDbError
->;
-
-const uploadMessageFilesWithRollback = async ({
-  message,
-  recordAuditEvent,
-  safeDb,
-  threadId,
-  threadState,
-  userId,
-}: UploadMessageFilesWithRollbackProps): Promise<UploadMessageFilesWithRollbackResult> => {
-  const uploadResult = await uploadMessageFiles({
-    message,
-    recordAuditEvent,
-    safeDb,
-    threadId,
-    userId,
-    workspaceId: threadState.data.workspaceId,
-  });
-
-  if (Result.isOk(uploadResult)) {
-    return uploadResult;
-  }
-
-  if (threadState.type !== "created") {
-    return uploadResult;
-  }
-
-  const rollbackResult = await rollbackUnpersistedChatSideEffects({
-    recordAuditEvent,
-    safeDb,
-    threadId,
-    threadState,
-    uploadedFiles: [],
-    userId,
-  });
-
-  if (Result.isOk(rollbackResult)) {
-    return Result.err(uploadResult.error);
-  }
-
-  captureError(uploadResult.error, { threadId });
-  return Result.err(rollbackResult.error);
-};
-
-const rollbackUnpersistedChatSideEffects = async ({
-  recordAuditEvent,
-  safeDb,
-  threadId,
-  threadState,
-  uploadedFiles,
-  userId,
-}: {
-  recordAuditEvent: AuditRecorder;
-  safeDb: SafeDb;
-  threadId: SafeId<"chatThread">;
-  threadState: LoadThreadResult;
-  uploadedFiles: UploadedChatFile[];
-  userId: SafeId<"user">;
-}): Promise<Result<void, HandlerError<500> | SafeDbError>> => {
-  const fileRollbackResult = await deleteUploadedChatFiles({
-    files: uploadedFiles,
-    recordAuditEvent,
-    safeDb,
-    threadId,
-    userId,
-    workspaceId: threadState.data.workspaceId,
-  });
-  if (Result.isError(fileRollbackResult)) {
-    return fileRollbackResult;
-  }
-
-  if (threadState.type !== "created") {
-    return Result.ok();
-  }
-
-  const threadRollbackResult = await safeDb(async (tx) => {
-    const deletedThreads = await tx
-      .delete(chatThreads)
-      .where(
-        and(
-          eq(chatThreads.id, threadId),
-          eq(chatThreads.rollbackToken, threadState.rollbackToken),
-          notExists(
-            tx
-              .select({ id: chatMessages.id })
-              .from(chatMessages)
-              .where(eq(chatMessages.threadId, chatThreads.id)),
-          ),
-        ),
-      )
-      .returning({ id: chatThreads.id });
-
-    if (deletedThreads.length === 0) {
-      return;
-    }
-
-    await recordAuditEvent(tx, {
-      action: AUDIT_ACTION.DELETE,
-      resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
-      resourceId: threadId,
-      workspaceId: threadState.data.workspaceId,
-      metadata: { reason: "rollback_unpersisted_chat_side_effects" },
-    });
-  });
-
-  return threadRollbackResult.andThen(() => Result.ok());
 };
 
 type PrepareChatContextProps = {


### PR DESCRIPTION
## Proposed change

Extract the send-message thread lifecycle into two chat-owned modules:

- thread validation, creation, title refresh and unique-race recovery
- attachment compensation and created-thread rollback
- focused tests for scope mismatches, initial data scope and rollback ownership

The endpoint remains the sole owner of its contract, permissions, validation order, metering, abort signals, streaming and external-client cleanup. Production logic is moved mechanically; normalized source comparison shows no behavioral changes. This is stacked on #1192.

## Checklist

- [ ] BUILD ASSURANCE | CI pending.
- [x] TESTING | Focused handler and extracted-module tests pass: 9 tests, 0 failures.
- [x] DARK MODE SUPPORT | Not applicable; no UI changes.
- [x] ISSUE LINKED | Not applicable.
- [x] SCREENSHOT INCLUDED | Not applicable; backend-only refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace-aware chat thread loading with scope validation.
  - Added reliable thread creation, adoption, and recovery during concurrent requests.
  - Added rollback for failed message uploads, including cleanup of uploaded files.
  - Added safeguards to prevent deleting threads that contain messages.

- **Bug Fixes**
  - Improved handling of thread ownership changes and hidden or missing threads.
  - Preserved original upload errors while reporting rollback failures appropriately.

- **Tests**
  - Added coverage for thread scoping, concurrency, creation, rollback, attachments, and audit events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Note on scope:** review iterations folded two behavior changes into this extraction beyond the mechanical move: thread lookups and updates now filter by `organizationId` in addition to `id`/`userId`, and the unique-violation recovery path in thread creation now recovers only on the `chat_threads_pkey` constraint (other unique violations propagate). Both are covered by the new unit tests.
