### PR TITLE
fix: make optional canary deterministic

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -1,6 +1,62 @@
 import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
 
-import { CanaryProviderRunError, errorSummary } from "./ai-provider-canary";
+import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+
+import {
+  CanaryProviderRunError,
+  errorSummary,
+  toolRoundTripInputSchema,
+  toolRoundTripPromptForProvider,
+} from "./ai-provider-canary";
+
+describe("AI provider canary tool contract", () => {
+  test("keeps the omission marker outside the application schema", () => {
+    const requiredInput = {
+      count: 7,
+      value: "stella-canary",
+    };
+
+    expect(v.safeParse(toolRoundTripInputSchema, requiredInput).success).toBe(
+      true,
+    );
+    expect(
+      v.safeParse(toolRoundTripInputSchema, {
+        ...requiredInput,
+        optionalNote: "any string",
+      }).success,
+    ).toBe(false);
+    expect(
+      v.safeParse(toolRoundTripInputSchema, {
+        ...requiredInput,
+        optionalNote: null,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      toTanStackToolSchema(toolRoundTripInputSchema)[
+        "~standard"
+      ].jsonSchema.input({ target: "draft-07" }),
+    ).toMatchObject({
+      properties: {
+        optionalNote: { pattern: "a^", type: "string" },
+      },
+      required: ["count", "value"],
+    });
+  });
+
+  test("requests the provider representation used by each adapter", () => {
+    expect(toolRoundTripPromptForProvider("openai")).toContain(
+      "Set optionalNote to null.",
+    );
+    expect(toolRoundTripPromptForProvider("mistral")).toContain(
+      "Set optionalNote to null.",
+    );
+    expect(toolRoundTripPromptForProvider("openrouter")).toContain(
+      "Do not include optionalNote.",
+    );
+  });
+});
 
 describe("AI provider canary error summaries", () => {
   test("reports only bounded provider codes and the failed tool stage", () => {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -39,16 +39,36 @@ const TOOL_ROUND_TRIP_NAME = "canary_round_trip";
 const TOOL_ROUND_TRIP_VALUE = "stella-canary";
 const TOOL_ROUND_TRIP_COUNT = 7;
 const TOOL_ROUND_TRIP_RESULT = "stella-tool-round-trip-ok";
-const TOOL_ROUND_TRIP_PROMPT =
+// JSON Schema patterns have no regex flag channel. OpenAI strict Structured
+// Outputs supports `pattern`; `a^` cannot match any string.
+// eslint-disable-next-line require-unicode-regexp
+const NEVER_MATCH_PATTERN = /a^/;
+const TOOL_ROUND_TRIP_PROMPT_PREFIX =
   `Call ${TOOL_ROUND_TRIP_NAME} exactly once with value "${TOOL_ROUND_TRIP_VALUE}" ` +
-  `and count ${TOOL_ROUND_TRIP_COUNT}. Do not include optionalNote. Then reply ` +
-  "with only the confirmation value returned by the tool.";
+  `and count ${TOOL_ROUND_TRIP_COUNT}.`;
+const TOOL_ROUND_TRIP_PROMPT_SUFFIX =
+  "Then reply with only the confirmation value returned by the tool.";
+const NULL_WIDENING_CANARY_PROVIDERS = new Set<CanaryProvider>([
+  "mistral",
+  "openai",
+]);
+
+export const toolRoundTripPromptForProvider = (
+  provider: CanaryProvider,
+): string => {
+  if (NULL_WIDENING_CANARY_PROVIDERS.has(provider)) {
+    return `${TOOL_ROUND_TRIP_PROMPT_PREFIX} Set optionalNote to null. ${TOOL_ROUND_TRIP_PROMPT_SUFFIX}`;
+  }
+
+  return `${TOOL_ROUND_TRIP_PROMPT_PREFIX} Do not include optionalNote. ${TOOL_ROUND_TRIP_PROMPT_SUFFIX}`;
+};
 
 const SAFE_CANARY_ERROR_MESSAGES = new Set([
   "Canary resolved an unexpected provider model.",
   "Provider did not execute the canary tool exactly once.",
+  "Provider adapter preserved a synthetic null tool argument.",
+  "Provider generated an unexpected optional tool argument.",
   "Provider returned unexpected canary tool arguments.",
-  "Provider did not preserve an omitted optional tool argument.",
   "Provider did not return the canary tool result.",
   "Provider returned no text.",
 ]);
@@ -176,9 +196,13 @@ const openMapTool = toolDefinition({
   ),
 }).client();
 
-const toolRoundTripInputSchema = v.strictObject({
+export const toolRoundTripInputSchema = v.strictObject({
   count: v.literal(TOOL_ROUND_TRIP_COUNT),
-  optionalNote: v.optional(v.literal("must-not-be-sent")),
+  // Strict adapters require every provider-facing property and widen this
+  // optional string with null. The provider is asked for that synthetic null;
+  // the adapter must remove it before the server validates and executes the
+  // tool because null is deliberately invalid in this application schema.
+  optionalNote: v.optional(v.pipe(v.string(), v.regex(NEVER_MATCH_PATTERN))),
   value: v.literal(TOOL_ROUND_TRIP_VALUE),
 });
 
@@ -363,7 +387,7 @@ const runToolCallRoundTripProbe = async ({
   const output = await runToolProbe({
     context,
     maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
-    prompt: TOOL_ROUND_TRIP_PROMPT,
+    prompt: toolRoundTripPromptForProvider(context.provider),
     role: TOOL_CALL_ROLE,
     signal,
     tool,
@@ -383,8 +407,13 @@ const runToolCallRoundTripProbe = async ({
     throw new TypeError("Provider returned unexpected canary tool arguments.");
   }
   if ("optionalNote" in observedInput) {
+    if (observedInput["optionalNote"] === null) {
+      throw new TypeError(
+        "Provider adapter preserved a synthetic null tool argument.",
+      );
+    }
     throw new TypeError(
-      "Provider did not preserve an omitted optional tool argument.",
+      "Provider generated an unexpected optional tool argument.",
     );
   }
   if (output.trim() !== TOOL_ROUND_TRIP_RESULT) {


### PR DESCRIPTION
## Summary

- make the optional tool argument impossible to satisfy with a non-null value, so strict providers have exactly one valid wire representation: their synthetic `null`
- ask OpenAI and Mistral for that strict representation while preserving true omission instructions for providers that do not widen optional fields
- distinguish a leaked synthetic `null` from an unexpected generated value in safe canary diagnostics
- cover the application validation boundary, provider-visible JSON Schema, and provider-specific prompt contract

## Testing

- `REDIS_URL=redis://localhost:6379 GOTENBERG_URL=http://localhost:3003 GOTENBERG_USERNAME=test GOTENBERG_PASSWORD=test bun test apps/api/scripts/ai-provider-canary.test.ts` (5 passed)
- full GitHub CI and provider canaries will run from merged `main`; the workflow intentionally refuses to execute PR-branch code with provider secrets

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of optional tool arguments across supported AI providers.
  * Detects providers that incorrectly include unsupported values or preserve invalid `null` arguments.

* **Tests**
  * Added coverage for provider-specific tool instructions and schema enforcement.
  * Expanded canary checks to verify consistent handling of omitted optional arguments and clearer error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->