### PR TITLE
chore: cover Template Studio persistence

### DIFF
--- a/apps/web/e2e/helpers/api.ts
+++ b/apps/web/e2e/helpers/api.ts
@@ -124,6 +124,37 @@ export const apiUploadDocx = async (
   };
 };
 
+type UploadTemplateOptions = {
+  file: { name: string; mimeType: string; buffer: Buffer };
+  name: string;
+};
+
+export const apiUploadTemplate = async (
+  request: APIRequestContext,
+  { file, name }: UploadTemplateOptions,
+) => {
+  const response = await request.put(url("/templates"), {
+    timeout: API_REQUEST_TIMEOUT_MS,
+    multipart: {
+      file,
+      name,
+    },
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `PUT /templates -> ${String(response.status())}: ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as {
+    id: string;
+    name: string;
+    fileName: string;
+    fieldCount: number;
+    sizeBytes: number;
+    createdAt: string;
+  };
+};
+
 export const apiDownloadFileField = async (
   request: APIRequestContext,
   workspaceId: string,

--- a/apps/web/e2e/specs/template-studio.spec.ts
+++ b/apps/web/e2e/specs/template-studio.spec.ts
@@ -1,0 +1,100 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { apiDelete, apiUploadTemplate } from "../helpers/api";
+import { expect, test } from "../helpers/test";
+
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
+const TEMPLATE_STUDIO_TEST_TIMEOUT_MS = 120_000;
+
+test.describe("Template Studio", () => {
+  let templateId: string | null = null;
+
+  test.afterEach(async ({ request }) => {
+    if (templateId === null) {
+      return;
+    }
+
+    await apiDelete(request, `/templates/${templateId}`);
+    templateId = null;
+  });
+
+  test("persists document edits and conditions across reload", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(TEMPLATE_STUDIO_TEST_TIMEOUT_MS);
+
+    const testToken = String(Date.now());
+    const templateName = `Template Studio E2E ${testToken}`;
+    const editToken = ` E2EEDIT${testToken}`;
+    const conditionName = `e2e_condition_${testToken}`;
+    const docxBuffer = await readFile(DOCX_PATH);
+    const template = await apiUploadTemplate(request, {
+      file: {
+        name: "template-studio-e2e.docx",
+        mimeType: DOCX_MIME,
+        buffer: docxBuffer,
+      },
+      name: templateName,
+    });
+    templateId = template.id;
+
+    await page.goto("/knowledge/templates", { waitUntil: "domcontentloaded" });
+
+    const templateButton = page.getByRole("button", {
+      exact: true,
+      name: templateName,
+    });
+    await expect(templateButton).toBeVisible({ timeout: 30_000 });
+    await templateButton.click();
+
+    const fixtureText = page.locator(".layout-run-text", {
+      hasText: "Stella E2E test document.",
+    });
+    await expect(fixtureText).toBeVisible({ timeout: 45_000 });
+    await fixtureText.click();
+    await page.keyboard.type(editToken);
+    await expect(
+      page.locator(".layout-run-text", { hasText: editToken.trim() }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    const documentEditor = page.getByRole("textbox", {
+      name: "Document content",
+    });
+    await page.getByRole("button", { exact: true, name: "Insert" }).click();
+    await page
+      .getByRole("menuitem", { exact: true, name: "Condition" })
+      .click();
+    await expect(documentEditor).toBeFocused();
+    await page.keyboard.type(conditionName);
+    await expect(documentEditor).toContainText(conditionName);
+
+    const saveButton = page.getByRole("button", {
+      exact: true,
+      name: "Save",
+    });
+    const saveResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname.endsWith(
+          `/v1/templates/${template.id}/document`,
+        ),
+      { timeout: 45_000 },
+    );
+    await saveButton.click();
+    expect((await saveResponse).ok()).toBe(true);
+    await expect(saveButton).toHaveCount(0);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(templateButton).toBeVisible({ timeout: 30_000 });
+    await templateButton.click();
+
+    await expect(
+      page.locator(".layout-run-text", { hasText: editToken.trim() }),
+    ).toBeVisible({ timeout: 45_000 });
+    await expect(documentEditor).toContainText(conditionName);
+  });
+});

--- a/apps/web/e2e/specs/template-studio.spec.ts
+++ b/apps/web/e2e/specs/template-studio.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -10,91 +11,89 @@ const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
 const TEMPLATE_STUDIO_TEST_TIMEOUT_MS = 120_000;
 
 test.describe("Template Studio", () => {
-  let templateId: string | null = null;
-
-  test.afterEach(async ({ request }) => {
-    if (templateId === null) {
-      return;
-    }
-
-    await apiDelete(request, `/templates/${templateId}`);
-    templateId = null;
-  });
-
   test("persists document edits and conditions across reload", async ({
     page,
     request,
   }) => {
     test.setTimeout(TEMPLATE_STUDIO_TEST_TIMEOUT_MS);
 
-    const testToken = String(Date.now());
-    const templateName = `Template Studio E2E ${testToken}`;
-    const editToken = ` E2EEDIT${testToken}`;
-    const conditionName = `e2e_condition_${testToken}`;
-    const docxBuffer = await readFile(DOCX_PATH);
-    const template = await apiUploadTemplate(request, {
-      file: {
-        name: "template-studio-e2e.docx",
-        mimeType: DOCX_MIME,
-        buffer: docxBuffer,
-      },
-      name: templateName,
-    });
-    templateId = template.id;
+    let templateId: string | null = null;
+    try {
+      const testToken = randomUUID().replaceAll("-", "");
+      const templateName = `Template Studio E2E ${testToken}`;
+      const editToken = ` E2EEDIT${testToken}`;
+      const conditionName = `e2e_condition_${testToken}`;
+      const docxBuffer = await readFile(DOCX_PATH);
+      const template = await apiUploadTemplate(request, {
+        file: {
+          name: "template-studio-e2e.docx",
+          mimeType: DOCX_MIME,
+          buffer: docxBuffer,
+        },
+        name: templateName,
+      });
+      templateId = template.id;
 
-    await page.goto("/knowledge/templates", { waitUntil: "domcontentloaded" });
+      await page.goto("/knowledge/templates", {
+        waitUntil: "domcontentloaded",
+      });
 
-    const templateButton = page.getByRole("button", {
-      exact: true,
-      name: templateName,
-    });
-    await expect(templateButton).toBeVisible({ timeout: 30_000 });
-    await templateButton.click();
+      const templateButton = page.getByRole("button", {
+        exact: true,
+        name: templateName,
+      });
+      await expect(templateButton).toBeVisible({ timeout: 30_000 });
+      await templateButton.click();
 
-    const fixtureText = page.locator(".layout-run-text", {
-      hasText: "Stella E2E test document.",
-    });
-    await expect(fixtureText).toBeVisible({ timeout: 45_000 });
-    await fixtureText.click();
-    await page.keyboard.type(editToken);
-    await expect(
-      page.locator(".layout-run-text", { hasText: editToken.trim() }),
-    ).toBeVisible({ timeout: 20_000 });
+      const fixtureText = page.locator(".layout-run-text", {
+        hasText: "Stella E2E test document.",
+      });
+      await expect(fixtureText).toBeVisible({ timeout: 45_000 });
+      await fixtureText.click();
+      await page.keyboard.insertText(editToken);
+      await expect(
+        page.locator(".layout-run-text", { hasText: editToken.trim() }),
+      ).toBeVisible({ timeout: 20_000 });
 
-    const documentEditor = page.getByRole("textbox", {
-      name: "Document content",
-    });
-    await page.getByRole("button", { exact: true, name: "Insert" }).click();
-    await page
-      .getByRole("menuitem", { exact: true, name: "Condition" })
-      .click();
-    await expect(documentEditor).toBeFocused();
-    await page.keyboard.type(conditionName);
-    await expect(documentEditor).toContainText(conditionName);
+      const documentEditor = page.getByRole("textbox", {
+        name: "Document content",
+      });
+      await page.getByRole("button", { exact: true, name: "Insert" }).click();
+      await page
+        .getByRole("menuitem", { exact: true, name: "Condition" })
+        .click();
+      await expect(documentEditor).toBeFocused();
+      await page.keyboard.insertText(conditionName);
+      await expect(documentEditor).toContainText(conditionName);
 
-    const saveButton = page.getByRole("button", {
-      exact: true,
-      name: "Save",
-    });
-    const saveResponse = page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" &&
-        new URL(response.url()).pathname.endsWith(
-          `/v1/templates/${template.id}/document`,
-        ),
-      { timeout: 45_000 },
-    );
-    await saveButton.click();
-    expect((await saveResponse).ok()).toBe(true);
-    await expect(saveButton).toHaveCount(0);
+      const saveButton = page.getByRole("button", {
+        exact: true,
+        name: "Save",
+      });
+      const saveResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname.endsWith(
+            `/v1/templates/${template.id}/document`,
+          ),
+        { timeout: 45_000 },
+      );
+      await saveButton.click();
+      expect((await saveResponse).ok()).toBe(true);
+      await expect(saveButton).toHaveCount(0);
 
-    await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(templateButton).toBeVisible({ timeout: 30_000 });
-    await templateButton.click();
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await expect(templateButton).toBeVisible({ timeout: 30_000 });
+      await templateButton.click();
 
-    await expect(
-      page.locator(".layout-run-text", { hasText: editToken.trim() }),
-    ).toBeVisible({ timeout: 45_000 });
-    await expect(documentEditor).toContainText(conditionName);
+      await expect(
+        page.locator(".layout-run-text", { hasText: editToken.trim() }),
+      ).toBeVisible({ timeout: 45_000 });
+      await expect(documentEditor).toContainText(conditionName);
+    } finally {
+      if (templateId !== null) {
+        await apiDelete(request, `/templates/${templateId}`);
+      }
+    }
   });
 });

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -1022,12 +1022,6 @@ export const StudioInsertRow = () => {
             setCaretInLoop(actions.isCaretInLoop());
           }
         }}
-        onOpenChangeComplete={(open) => {
-          if (!open && preserveEditorFocusRef.current) {
-            preserveEditorFocusRef.current = false;
-            actions.focusEditor();
-          }
-        }}
       >
         <MenuTrigger
           aria-label={t("templates.studio.insert")}
@@ -1037,7 +1031,13 @@ export const StudioInsertRow = () => {
         </MenuTrigger>
         <MenuPopup
           align="end"
-          finalFocus={() => !preserveEditorFocusRef.current}
+          finalFocus={() => {
+            if (!preserveEditorFocusRef.current) {
+              return true;
+            }
+            preserveEditorFocusRef.current = false;
+            return actions.focusEditor();
+          }}
         >
           {fields.length > 0 && (
             <MenuSub>

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -1022,6 +1022,12 @@ export const StudioInsertRow = () => {
             setCaretInLoop(actions.isCaretInLoop());
           }
         }}
+        onOpenChangeComplete={(open) => {
+          if (!open && preserveEditorFocusRef.current) {
+            preserveEditorFocusRef.current = false;
+            actions.focusEditor();
+          }
+        }}
       >
         <MenuTrigger
           aria-label={t("templates.studio.insert")}

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -976,6 +976,7 @@ export const StudioInsertRow = () => {
   // recompute it each time the menu opens rather than reactively.
   const [caretInLoop, setCaretInLoop] = useState(false);
   const preserveEditorFocusRef = useRef(false);
+  const linkClauseDialogLaunchRef = useRef(false);
   // Clause linking lives inline here (the standalone clauses tab was removed):
   // link a clause, then drop its slot at the caret from the same menu.
   const [linkClauseOpen, setLinkClauseOpen] = useState(false);
@@ -1032,6 +1033,11 @@ export const StudioInsertRow = () => {
         <MenuPopup
           align="end"
           finalFocus={() => {
+            if (linkClauseDialogLaunchRef.current) {
+              linkClauseDialogLaunchRef.current = false;
+              preserveEditorFocusRef.current = false;
+              return false;
+            }
             if (!preserveEditorFocusRef.current) {
               return true;
             }
@@ -1134,7 +1140,12 @@ export const StudioInsertRow = () => {
               {sessionTemplateId !== null && (
                 <>
                   <MenuSeparator />
-                  <MenuItem onClick={() => setLinkClauseOpen(true)}>
+                  <MenuItem
+                    onClick={() => {
+                      linkClauseDialogLaunchRef.current = true;
+                      setLinkClauseOpen(true);
+                    }}
+                  >
                     <PlusIcon />
                     {t("clauses.linkClause")}
                   </MenuItem>

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { panic, TaggedError } from "better-result";
@@ -937,6 +937,8 @@ const effectiveSlotByLink = (
 
 /** Document actions row — rendered in the inspector tab's top area; the page
  *  registers the handlers + UI state in the session store. */
+const MENU_ITEM_PRESS_REASON = "item-press";
+
 export const StudioInsertRow = () => {
   const t = useTranslations();
   const actions = useTemplateStudioStore((s) => s.actions);
@@ -973,6 +975,7 @@ export const StudioInsertRow = () => {
   // an `{{#each}}` body. `isCaretInLoop` reads the live caret imperatively, so
   // recompute it each time the menu opens rather than reactively.
   const [caretInLoop, setCaretInLoop] = useState(false);
+  const preserveEditorFocusRef = useRef(false);
   // Clause linking lives inline here (the standalone clauses tab was removed):
   // link a clause, then drop its slot at the caret from the same menu.
   const [linkClauseOpen, setLinkClauseOpen] = useState(false);
@@ -1012,7 +1015,9 @@ export const StudioInsertRow = () => {
     >
       <StudioPrimaryInsertButton actions={actions} selected={selected} />
       <Menu
-        onOpenChange={(open) => {
+        onOpenChange={(open, eventDetails) => {
+          preserveEditorFocusRef.current =
+            !open && eventDetails.reason === MENU_ITEM_PRESS_REASON;
           if (open) {
             setCaretInLoop(actions.isCaretInLoop());
           }
@@ -1024,7 +1029,10 @@ export const StudioInsertRow = () => {
         >
           <ChevronDownIcon />
         </MenuTrigger>
-        <MenuPopup align="end">
+        <MenuPopup
+          align="end"
+          finalFocus={() => !preserveEditorFocusRef.current}
+        >
           {fields.length > 0 && (
             <MenuSub>
               <MenuSubTrigger>

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-store.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-store.ts
@@ -97,6 +97,8 @@ export type StudioActions = {
   focusField: (path: string) => void;
   /** Move the document caret to an exact document position. */
   focusPosition: (pos: number) => void;
+  /** Restore keyboard focus to the document without moving its selection. */
+  focusEditor: () => void;
   /** Live fill preview in the document: path → value (plain text, or
    *  formatted spans for lookup renderings), or null to clear. */
   setFillPreview: (values: Record<string, TemplatePreviewValue> | null) => void;

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-store.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-store.ts
@@ -97,8 +97,9 @@ export type StudioActions = {
   focusField: (path: string) => void;
   /** Move the document caret to an exact document position. */
   focusPosition: (pos: number) => void;
-  /** Restore keyboard focus to the document without moving its selection. */
-  focusEditor: () => void;
+  /** Restore keyboard focus without moving the selection, and return the
+   * editor element for overlay focus-management contracts. */
+  focusEditor: () => HTMLElement | null;
   /** Live fill preview in the document: path → value (plain text, or
    *  formatted spans for lookup renderings), or null to clear. */
   setFillPreview: (values: Record<string, TemplatePreviewValue> | null) => void;

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -622,6 +622,7 @@ export const TemplateStudioPage = ({
         actionsRef.current?.focusAdjacentField(direction),
       focusField: (path) => actionsRef.current?.focusField(path),
       focusPosition: (pos) => actionsRef.current?.focusPosition(pos),
+      focusEditor: () => actionsRef.current?.focusEditor(),
       setFillPreview: (values) => actionsRef.current?.setFillPreview(values),
       insertExistingField: (path, formatKey) =>
         actionsRef.current?.insertExistingField(path, formatKey),
@@ -2513,6 +2514,7 @@ export const TemplateStudioPage = ({
       editorRef.current?.getEditorRef()?.scrollToPosition(pos);
       flashDirectiveAt(view, pos);
     },
+    focusEditor: () => editorViewRef.current?.focus(),
     renameFieldPath: (oldPath, newPath) => {
       const view = editorViewRef.current;
       const trimmed = newPath.trim();

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -622,7 +622,7 @@ export const TemplateStudioPage = ({
         actionsRef.current?.focusAdjacentField(direction),
       focusField: (path) => actionsRef.current?.focusField(path),
       focusPosition: (pos) => actionsRef.current?.focusPosition(pos),
-      focusEditor: () => actionsRef.current?.focusEditor(),
+      focusEditor: () => actionsRef.current?.focusEditor() ?? null,
       setFillPreview: (values) => actionsRef.current?.setFillPreview(values),
       insertExistingField: (path, formatKey) =>
         actionsRef.current?.insertExistingField(path, formatKey),
@@ -2514,7 +2514,11 @@ export const TemplateStudioPage = ({
       editorRef.current?.getEditorRef()?.scrollToPosition(pos);
       flashDirectiveAt(view, pos);
     },
-    focusEditor: () => editorViewRef.current?.focus(),
+    focusEditor: () => {
+      const view = editorViewRef.current;
+      view?.focus();
+      return view?.dom ?? null;
+    },
     renameFieldPath: (oldPath, newPath) => {
       const view = editorViewRef.current;
       const trimmed = newPath.trim();


### PR DESCRIPTION
## Summary

- seed a real DOCX template through the authenticated API helper
- exercise document editing, condition insertion, save, reload, and persistence in one browser journey
- delete the seeded template during test cleanup

## Testing

CI only; local lint and typecheck were not run.


**Note:** beyond the new browser coverage, this PR also ships the focus-management fixes the test surfaced (Insert menu focus restoration, Link Clause dialog focus, and a new `focusEditor()` studio action). It is not test-only.
