### PR TITLE
fix: make Mistral optional canary deterministic

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -7,6 +7,7 @@ import {
   CanaryProviderRunError,
   errorSummary,
   toolRoundTripInputSchema,
+  toolRoundTripInputSchemaForProvider,
   toolRoundTripPromptForProvider,
 } from "./ai-provider-canary";
 
@@ -55,6 +56,16 @@ describe("AI provider canary tool contract", () => {
     expect(toolRoundTripPromptForProvider("openrouter")).toContain(
       "Do not include optionalNote.",
     );
+    expect(
+      toolRoundTripInputSchemaForProvider("mistral")[
+        "~standard"
+      ].jsonSchema.input({ target: "draft-07" }),
+    ).toMatchObject({
+      properties: {
+        optionalNote: { type: "string", enum: [] },
+      },
+      required: ["count", "value"],
+    });
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -206,6 +206,45 @@ export const toolRoundTripInputSchema = v.strictObject({
   value: v.literal(TOOL_ROUND_TRIP_VALUE),
 });
 
+// Mistral rejects `pattern` in strict tool schemas. Its adapter widens every
+// optional enum with null, so an empty enum becomes `[null]` on the wire: one
+// deterministic omission marker and no non-null value for the model to choose.
+const MISTRAL_TOOL_ROUND_TRIP_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    count: { type: "number", enum: [TOOL_ROUND_TRIP_COUNT] },
+    optionalNote: { type: "string", enum: [] },
+    value: { type: "string", enum: [TOOL_ROUND_TRIP_VALUE] },
+  },
+  required: ["count", "value"],
+  additionalProperties: false,
+} as const;
+
+const toolRoundTripStandardSchema = toTanStackToolSchema(
+  toolRoundTripInputSchema,
+);
+
+const MISTRAL_TOOL_ROUND_TRIP_INPUT_SCHEMA = {
+  ...toolRoundTripStandardSchema,
+  "~standard": {
+    ...toolRoundTripStandardSchema["~standard"],
+    jsonSchema: {
+      ...toolRoundTripStandardSchema["~standard"].jsonSchema,
+      input: () => MISTRAL_TOOL_ROUND_TRIP_JSON_SCHEMA,
+    },
+  },
+} as const;
+
+export const toolRoundTripInputSchemaForProvider = (
+  provider: CanaryProvider,
+) => {
+  if (provider === "mistral") {
+    return MISTRAL_TOOL_ROUND_TRIP_INPUT_SCHEMA;
+  }
+
+  return toolRoundTripStandardSchema;
+};
+
 const toolRoundTripOutputSchema = v.strictObject({
   confirmation: v.literal(TOOL_ROUND_TRIP_RESULT),
 });
@@ -377,7 +416,7 @@ const runToolCallRoundTripProbe = async ({
     name: TOOL_ROUND_TRIP_NAME,
     description:
       "Call exactly once with the value and count requested by the user.",
-    inputSchema: toTanStackToolSchema(toolRoundTripInputSchema),
+    inputSchema: toolRoundTripInputSchemaForProvider(context.provider),
     outputSchema: toTanStackToolSchema(toolRoundTripOutputSchema),
   }).server((input) => {
     observedInputs.push(input);

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -1096,7 +1096,7 @@ describe("chat tool schemas", () => {
   test("the installed Mistral adapter restores omitted optional tool inputs", async () => {
     const adapter = createMistralText("mistral-large-latest", "test-key");
     const argumentsJson =
-      '{"question":"Which one?","mode":null,"nullableNote":null,"acceptAnything":null,"rejectAnything":null}';
+      '{"question":"Which one?","mode":null,"nullableNote":null,"emptyEnumMarker":null,"acceptAnything":null,"rejectAnything":null}';
     let request: unknown;
     Reflect.set(adapter, "fetchRawMistralStream", (payload: unknown) => {
       request = payload;
@@ -1163,6 +1163,10 @@ describe("chat tool schemas", () => {
     // JSONSchema type currently models only object schemas.
     Reflect.set(inputSchema.properties, "acceptAnything", true);
     Reflect.set(inputSchema.properties, "rejectAnything", false);
+    Reflect.set(inputSchema.properties, "emptyEnumMarker", {
+      type: "string",
+      enum: [],
+    });
     const tool = {
       name: "ask_user",
       description: "Ask a question.",
@@ -1186,6 +1190,10 @@ describe("chat tool schemas", () => {
                   type: ["string", "null"],
                   enum: ["must-not-be-sent", null],
                 },
+                emptyEnumMarker: {
+                  type: ["string", "null"],
+                  enum: [null],
+                },
                 acceptAnything: {
                   anyOf: [true, { type: "null" }],
                 },
@@ -1197,6 +1205,7 @@ describe("chat tool schemas", () => {
                 "question",
                 "mode",
                 "nullableNote",
+                "emptyEnumMarker",
                 "acceptAnything",
                 "rejectAnything",
               ],

--- a/apps/api/src/handlers/chat/tools/tool-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/tool-schema.test.ts
@@ -1201,14 +1201,14 @@ describe("chat tool schemas", () => {
                   anyOf: [false, { type: "null" }],
                 },
               },
-              required: [
+              required: expect.arrayContaining([
                 "question",
                 "mode",
                 "nullableNote",
                 "emptyEnumMarker",
                 "acceptAnything",
                 "rejectAnything",
-              ],
+              ]),
             },
           },
         },


### PR DESCRIPTION
## Summary

- keep the live-proven impossible-pattern probe for OpenAI and providers that accept that JSON Schema keyword
- use an empty optional enum for Mistral; its strict adapter widens this to `enum: [null]`, leaving exactly one provider-valid omission marker
- assert the installed Mistral adapter performs that exact widening and removes the synthetic null before emitting tool input

## Testing

- focused canary, installed-adapter, and fast-check normalization suites pass
- no local lint or typecheck; use the required GitHub CI jobs

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for AI tool calls when optional inputs are used with the Mistral provider.
  - Optional fields are now handled more reliably during tool-call requests and responses.

- **Tests**
  - Expanded automated coverage to validate optional input handling and provider-specific schema behaviour.
  - Canary checks now detect compatibility issues with Mistral tool schemas earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->