### PR TITLE
refactor: isolate template clause link operations

### DIFF
--- a/apps/api/src/handlers/clauses/template-links.test.ts
+++ b/apps/api/src/handlers/clauses/template-links.test.ts
@@ -4,11 +4,11 @@ import {
   clauseBodyToPlainText,
   clauseBodyToRichPatch,
 } from "@/api/handlers/clauses/clause-to-patch";
+import { toSafeId } from "@/api/lib/branded-types";
 import {
   isOutdatedLink,
   isVariantDeleted,
 } from "@/api/lib/template-clause-links";
-import { toSafeId } from "@/api/lib/branded-types";
 
 describe("isOutdatedLink", () => {
   test("true when the pinned version trails the clause's current one", () => {

--- a/apps/api/src/handlers/clauses/template-links.test.ts
+++ b/apps/api/src/handlers/clauses/template-links.test.ts
@@ -7,7 +7,7 @@ import {
 import {
   isOutdatedLink,
   isVariantDeleted,
-} from "@/api/handlers/clauses/template-links";
+} from "@/api/lib/template-clause-links";
 import { toSafeId } from "@/api/lib/branded-types";
 
 describe("isOutdatedLink", () => {

--- a/apps/api/src/handlers/docx/resolve-clause-slots.ts
+++ b/apps/api/src/handlers/docx/resolve-clause-slots.ts
@@ -10,7 +10,7 @@ import {
   clauseBodyToPlainText,
   clauseBodyToRichPatch,
 } from "@/api/handlers/clauses/clause-to-patch";
-import { isVariantDeleted } from "@/api/handlers/clauses/template-links";
+import { isVariantDeleted } from "@/api/lib/template-clause-links";
 import type { ClauseBody } from "@/api/handlers/clauses/types";
 import type { SafeId } from "@/api/lib/branded-types";
 

--- a/apps/api/src/handlers/docx/resolve-clause-slots.ts
+++ b/apps/api/src/handlers/docx/resolve-clause-slots.ts
@@ -10,9 +10,9 @@ import {
   clauseBodyToPlainText,
   clauseBodyToRichPatch,
 } from "@/api/handlers/clauses/clause-to-patch";
-import { isVariantDeleted } from "@/api/lib/template-clause-links";
 import type { ClauseBody } from "@/api/handlers/clauses/types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { isVariantDeleted } from "@/api/lib/template-clause-links";
 
 import type { ClauseSlot } from "./discover-clause-slots";
 import type { RichPatchValue } from "./types";

--- a/apps/api/src/handlers/templates/check.ts
+++ b/apps/api/src/handlers/templates/check.ts
@@ -2,7 +2,7 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
-import { listTemplateClausesHandler } from "@/api/handlers/clauses/template-links";
+import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 import { discoverClauseSlots } from "@/api/handlers/docx/discover-clause-slots";
 import { discoverTemplate } from "@/api/handlers/docx/discover-template";
 import { extractText } from "@/api/handlers/docx/extract-text";

--- a/apps/api/src/handlers/templates/check.ts
+++ b/apps/api/src/handlers/templates/check.ts
@@ -2,7 +2,6 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
-import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 import { discoverClauseSlots } from "@/api/handlers/docx/discover-clause-slots";
 import { discoverTemplate } from "@/api/handlers/docx/discover-template";
 import { extractText } from "@/api/handlers/docx/extract-text";
@@ -14,6 +13,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getS3 } from "@/api/lib/s3";
+import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 
 const checkTemplateParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/handlers/templates/clauses-link.ts
+++ b/apps/api/src/handlers/templates/clauses-link.ts
@@ -4,7 +4,7 @@ import { t } from "elysia";
 import {
   linkClauseBodySchema,
   linkClauseHandler,
-} from "@/api/handlers/clauses/template-links";
+} from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";

--- a/apps/api/src/handlers/templates/clauses-link.ts
+++ b/apps/api/src/handlers/templates/clauses-link.ts
@@ -1,14 +1,14 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import {
-  linkClauseBodySchema,
-  linkClauseHandler,
-} from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  linkClauseBodySchema,
+  linkClauseHandler,
+} from "@/api/lib/template-clause-links";
 
 const linkTemplateClauseParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/handlers/templates/clauses-list.ts
+++ b/apps/api/src/handlers/templates/clauses-list.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { listTemplateClausesHandler } from "@/api/handlers/clauses/template-links";
+import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";

--- a/apps/api/src/handlers/templates/clauses-list.ts
+++ b/apps/api/src/handlers/templates/clauses-list.ts
@@ -1,11 +1,11 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { listTemplateClausesHandler } from "@/api/lib/template-clause-links";
 
 const listTemplateClausesParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/handlers/templates/clauses-slot-update.ts
+++ b/apps/api/src/handlers/templates/clauses-slot-update.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { updateClauseSlotHandler } from "@/api/handlers/clauses/template-links";
+import { updateClauseSlotHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";

--- a/apps/api/src/handlers/templates/clauses-slot-update.ts
+++ b/apps/api/src/handlers/templates/clauses-slot-update.ts
@@ -1,11 +1,11 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { updateClauseSlotHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { updateClauseSlotHandler } from "@/api/lib/template-clause-links";
 
 const updateClauseSlotParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/handlers/templates/clauses-sync-all.ts
+++ b/apps/api/src/handlers/templates/clauses-sync-all.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { syncAllClausesHandler } from "@/api/handlers/clauses/template-links";
+import { syncAllClausesHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";

--- a/apps/api/src/handlers/templates/clauses-sync-all.ts
+++ b/apps/api/src/handlers/templates/clauses-sync-all.ts
@@ -1,11 +1,11 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { syncAllClausesHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { syncAllClausesHandler } from "@/api/lib/template-clause-links";
 
 const syncAllTemplateClausesParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/handlers/templates/clauses-sync.ts
+++ b/apps/api/src/handlers/templates/clauses-sync.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { syncClauseHandler } from "@/api/handlers/clauses/template-links";
+import { syncClauseHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";

--- a/apps/api/src/handlers/templates/clauses-sync.ts
+++ b/apps/api/src/handlers/templates/clauses-sync.ts
@@ -1,11 +1,11 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { syncClauseHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { syncClauseHandler } from "@/api/lib/template-clause-links";
 
 const syncTemplateClauseParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/handlers/templates/clauses-unlink.ts
+++ b/apps/api/src/handlers/templates/clauses-unlink.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { unlinkClauseHandler } from "@/api/handlers/clauses/template-links";
+import { unlinkClauseHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";

--- a/apps/api/src/handlers/templates/clauses-unlink.ts
+++ b/apps/api/src/handlers/templates/clauses-unlink.ts
@@ -1,11 +1,11 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { unlinkClauseHandler } from "@/api/lib/template-clause-links";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { unlinkClauseHandler } from "@/api/lib/template-clause-links";
 
 const unlinkTemplateClauseParamsSchema = t.Object({
   templateId: tSafeId("template"),

--- a/apps/api/src/lib/template-clause-links.ts
+++ b/apps/api/src/lib/template-clause-links.ts
@@ -1,3 +1,4 @@
+/** Shared template-clause link operations used by the clause and template slices. */
 import { panic } from "better-result";
 import { and, eq, sql } from "drizzle-orm";
 import { status, t } from "elysia";

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -533,7 +533,7 @@
     }
   },
   "cross-handler-imports": {
-    "count": 265,
+    "count": 257,
     "files": {
       "apps/api/src/handlers/catalogue/bundled-skill-resources.ts": 1,
       "apps/api/src/handlers/catalogue/install-skill.ts": 1,
@@ -562,7 +562,7 @@
       "apps/api/src/handlers/docx/ai-field-generator.ts": 1,
       "apps/api/src/handlers/docx/ai-skill-tools.ts": 3,
       "apps/api/src/handlers/docx/registry-org-gate.ts": 1,
-      "apps/api/src/handlers/docx/resolve-clause-slots.ts": 3,
+      "apps/api/src/handlers/docx/resolve-clause-slots.ts": 2,
       "apps/api/src/handlers/entities/checkpoint-desktop-edit-session.ts": 1,
       "apps/api/src/handlers/entities/compare-versions.ts": 1,
       "apps/api/src/handlers/entities/compute-version-diff.ts": 3,
@@ -599,14 +599,8 @@
       "apps/api/src/handlers/reports/report-export-queue.ts": 4,
       "apps/api/src/handlers/template-recipes/definition.ts": 1,
       "apps/api/src/handlers/templates/check-template.ts": 3,
-      "apps/api/src/handlers/templates/check.ts": 5,
+      "apps/api/src/handlers/templates/check.ts": 4,
       "apps/api/src/handlers/templates/clause-slots.ts": 2,
-      "apps/api/src/handlers/templates/clauses-link.ts": 1,
-      "apps/api/src/handlers/templates/clauses-list.ts": 1,
-      "apps/api/src/handlers/templates/clauses-slot-update.ts": 1,
-      "apps/api/src/handlers/templates/clauses-sync-all.ts": 1,
-      "apps/api/src/handlers/templates/clauses-sync.ts": 1,
-      "apps/api/src/handlers/templates/clauses-unlink.ts": 1,
       "apps/api/src/handlers/templates/configure-template-fields-service.ts": 3,
       "apps/api/src/handlers/templates/create-template-service.ts": 3,
       "apps/api/src/handlers/templates/create.ts": 1,


### PR DESCRIPTION
## Summary
- move template-clause link operations out of the clauses handler slice into a shared API library module
- update the clause, document, and template consumers to use the shared boundary
- lower the cross-handler import ratchet by eight

## Validation
- `git diff --check`
- lint, typecheck, and test validation delegated to CI

CC on behalf of @jan-kubica