### PR TITLE
fix: redact desktop diagnostics

### DIFF
--- a/apps/desktop/src-tauri/src/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::types::{DesktopNotificationPreferences, SessionStatus};
+use crate::types::SessionStatus;
 
 pub(crate) struct DiagnosticsInput<'a> {
   pub generated_at: String,
@@ -8,7 +8,7 @@ pub(crate) struct DiagnosticsInput<'a> {
   pub running_since: &'a str,
   pub linked_account_present: bool,
   pub store_load_issue: Option<DiagnosticStoreLoadIssue>,
-  pub notification_preferences: &'a DesktopNotificationPreferences,
+  pub notification_preferences: DiagnosticNotificationPreferences,
   pub update: DiagnosticUpdate<'a>,
   pub sessions: Vec<DiagnosticSession>,
   pub cleanup_paths_queued: usize,
@@ -33,6 +33,14 @@ pub(crate) struct DiagnosticUpdate<'a> {
   pub update_ready: bool,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DiagnosticNotificationPreferences {
+  pub document_ready: bool,
+  pub revision_created: bool,
+  pub sync_issues: bool,
+}
+
 pub(crate) struct DiagnosticSession {
   pub status: SessionStatus,
   pub has_last_checkpoint: bool,
@@ -49,7 +57,7 @@ struct DiagnosticsExport<'a> {
   app: DiagnosticApp<'a>,
   linked_account_present: bool,
   store_load_issue: Option<DiagnosticStoreLoadIssue>,
-  notification_preferences: &'a DesktopNotificationPreferences,
+  notification_preferences: DiagnosticNotificationPreferences,
   update: DiagnosticUpdate<'a>,
   sessions: DiagnosticSessionSummary,
   cleanup_paths_queued: usize,

--- a/apps/desktop/src-tauri/src/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/diagnostics.rs
@@ -1,0 +1,136 @@
+use serde::Serialize;
+
+use crate::types::{DesktopNotificationPreferences, SessionStatus};
+
+pub(crate) struct DiagnosticsInput<'a> {
+  pub generated_at: String,
+  pub bridge_port: u16,
+  pub running_since: &'a str,
+  pub linked_account_present: bool,
+  pub store_load_issue: Option<DiagnosticStoreLoadIssue>,
+  pub notification_preferences: &'a DesktopNotificationPreferences,
+  pub update: DiagnosticUpdate<'a>,
+  pub sessions: Vec<DiagnosticSession>,
+  pub cleanup_paths_queued: usize,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DiagnosticStoreLoadIssue {
+  InvalidStore,
+  UnreadableStore,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DiagnosticUpdate<'a> {
+  pub configured: bool,
+  pub channel_configured: bool,
+  pub current_version: Option<&'a str>,
+  pub last_checked_at: Option<&'a str>,
+  pub latest_version: Option<&'a str>,
+  pub update_available: bool,
+  pub update_ready: bool,
+}
+
+pub(crate) struct DiagnosticSession {
+  pub status: SessionStatus,
+  pub has_last_checkpoint: bool,
+  pub has_last_error: bool,
+  pub pending_finalize: bool,
+  pub takeover_detected: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticsExport<'a> {
+  generated_at: String,
+  platform: DiagnosticPlatform,
+  app: DiagnosticApp<'a>,
+  linked_account_present: bool,
+  store_load_issue: Option<DiagnosticStoreLoadIssue>,
+  notification_preferences: &'a DesktopNotificationPreferences,
+  update: DiagnosticUpdate<'a>,
+  sessions: DiagnosticSessionSummary,
+  cleanup_paths_queued: usize,
+}
+
+#[derive(Serialize)]
+struct DiagnosticPlatform {
+  arch: &'static str,
+  os: &'static str,
+  framework: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticApp<'a> {
+  bridge_port: u16,
+  running_since: &'a str,
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticSessionSummary {
+  total: usize,
+  by_status: DiagnosticSessionStatusCounts,
+  with_last_checkpoint: usize,
+  with_last_error: usize,
+  pending_finalize: usize,
+  takeover_detected: usize,
+}
+
+#[derive(Default, Serialize)]
+struct DiagnosticSessionStatusCounts {
+  opening: usize,
+  ready: usize,
+  syncing: usize,
+  finalizing: usize,
+  error: usize,
+}
+
+pub(crate) fn render_diagnostics(input: DiagnosticsInput<'_>) -> String {
+  let diagnostics = DiagnosticsExport {
+    generated_at: input.generated_at,
+    platform: DiagnosticPlatform {
+      arch: std::env::consts::ARCH,
+      os: std::env::consts::OS,
+      framework: "tauri",
+    },
+    app: DiagnosticApp {
+      bridge_port: input.bridge_port,
+      running_since: input.running_since,
+    },
+    linked_account_present: input.linked_account_present,
+    store_load_issue: input.store_load_issue,
+    notification_preferences: input.notification_preferences,
+    update: input.update,
+    sessions: summarize_sessions(input.sessions),
+    cleanup_paths_queued: input.cleanup_paths_queued,
+  };
+
+  serde_json::to_string_pretty(&diagnostics).unwrap_or_default()
+}
+
+fn summarize_sessions(
+  sessions: impl IntoIterator<Item = DiagnosticSession>,
+) -> DiagnosticSessionSummary {
+  let mut summary = DiagnosticSessionSummary::default();
+
+  for session in sessions {
+    summary.total += 1;
+    match session.status {
+      SessionStatus::Opening => summary.by_status.opening += 1,
+      SessionStatus::Ready => summary.by_status.ready += 1,
+      SessionStatus::Syncing => summary.by_status.syncing += 1,
+      SessionStatus::Finalizing => summary.by_status.finalizing += 1,
+      SessionStatus::Error => summary.by_status.error += 1,
+    }
+    summary.with_last_checkpoint += usize::from(session.has_last_checkpoint);
+    summary.with_last_error += usize::from(session.has_last_error);
+    summary.pending_finalize += usize::from(session.pending_finalize);
+    summary.takeover_detected += usize::from(session.takeover_detected);
+  }
+
+  summary
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod bridge;
 mod commands;
 mod config;
 mod deep_link;
+mod diagnostics;
 #[cfg(test)]
 mod e2e;
 mod i18n;

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -18,8 +18,8 @@ use tokio::task::JoinHandle;
 use crate::config;
 pub use crate::config::normalize_api_base_url;
 use crate::diagnostics::{
-  DiagnosticSession, DiagnosticStoreLoadIssue, DiagnosticUpdate, DiagnosticsInput,
-  render_diagnostics,
+  DiagnosticNotificationPreferences, DiagnosticSession, DiagnosticStoreLoadIssue,
+  DiagnosticUpdate, DiagnosticsInput, render_diagnostics,
 };
 use crate::session_store::{self, PersistedDesktopSession, StoreLoadIssue};
 use crate::types::*;
@@ -2084,7 +2084,11 @@ impl SessionManager {
         StoreLoadIssue::InvalidStore => DiagnosticStoreLoadIssue::InvalidStore,
         StoreLoadIssue::UnreadableStore => DiagnosticStoreLoadIssue::UnreadableStore,
       }),
-      notification_preferences: &self.notification_preferences,
+      notification_preferences: DiagnosticNotificationPreferences {
+        document_ready: self.notification_preferences.document_ready,
+        revision_created: self.notification_preferences.revision_created,
+        sync_issues: self.notification_preferences.sync_issues,
+      },
       update: DiagnosticUpdate {
         configured: self.update.base_url.is_some(),
         channel_configured: self.update.channel.is_some(),
@@ -2757,6 +2761,14 @@ mod tests {
     assert!(parsed["update"].get("statusMessage").is_none());
     assert_eq!(parsed["linkedAccountPresent"], true);
     assert_eq!(parsed["storeLoadIssue"], "invalidStore");
+    assert_eq!(
+      parsed["notificationPreferences"],
+      serde_json::json!({
+        "documentReady": true,
+        "revisionCreated": true,
+        "syncIssues": true,
+      })
+    );
     assert_eq!(parsed["update"]["configured"], true);
     assert_eq!(parsed["update"]["channelConfigured"], true);
     assert_eq!(parsed["update"]["latestVersion"], "9.9.9");

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -17,6 +17,10 @@ use tokio::task::JoinHandle;
 
 use crate::config;
 pub use crate::config::normalize_api_base_url;
+use crate::diagnostics::{
+  DiagnosticSession, DiagnosticStoreLoadIssue, DiagnosticUpdate, DiagnosticsInput,
+  render_diagnostics,
+};
 use crate::session_store::{self, PersistedDesktopSession, StoreLoadIssue};
 use crate::types::*;
 use zip::ZipArchive;
@@ -2071,38 +2075,38 @@ impl SessionManager {
   }
 
   fn get_diagnostics_text(&self) -> String {
-    let diagnostics = serde_json::json!({
-        "generatedAt": chrono_now(),
-        "platform": {
-            "arch": std::env::consts::ARCH,
-            "os": std::env::consts::OS,
-            "framework": "tauri",
-        },
-        "app": {
-            "bridgePort": self.bridge_port,
-            "runningSince": self.running_since,
-            "supportRoot": self.support_root.to_string_lossy(),
-            "temporaryWorkingCopiesRoot": self.edit_root.to_string_lossy(),
-        },
-        "linkedAccount": self.linked_account,
-        "storeLoadIssue": self.store_load_issue.as_ref().map(|i| format!("{i:?}")),
-        "notificationPreferences": self.notification_preferences,
-        "update": self.update,
-        "sessions": self.sessions.values().map(|s| {
-            serde_json::json!({
-                "hasLocalCopy": true,
-                "id": s.id,
-                "lastCheckpointAt": s.last_checkpoint_at,
-                "lastError": s.last_error,
-                "pendingFinalize": s.pending_finalize,
-                "status": s.status,
-                "takeoverDetected": s.takeover_detected,
-            })
-        }).collect::<Vec<_>>(),
-        "cleanupPathsQueued": self.cleanup_paths.len(),
-    });
-
-    serde_json::to_string_pretty(&diagnostics).unwrap_or_default()
+    render_diagnostics(DiagnosticsInput {
+      generated_at: chrono_now(),
+      bridge_port: self.bridge_port,
+      running_since: &self.running_since,
+      linked_account_present: self.linked_account.is_some(),
+      store_load_issue: self.store_load_issue.as_ref().map(|issue| match issue {
+        StoreLoadIssue::InvalidStore => DiagnosticStoreLoadIssue::InvalidStore,
+        StoreLoadIssue::UnreadableStore => DiagnosticStoreLoadIssue::UnreadableStore,
+      }),
+      notification_preferences: &self.notification_preferences,
+      update: DiagnosticUpdate {
+        configured: self.update.base_url.is_some(),
+        channel_configured: self.update.channel.is_some(),
+        current_version: self.update.current_version.as_deref(),
+        last_checked_at: self.update.last_checked_at.as_deref(),
+        latest_version: self.update.latest_version.as_deref(),
+        update_available: self.update.update_available,
+        update_ready: self.update.update_ready,
+      },
+      sessions: self
+        .sessions
+        .values()
+        .map(|session| DiagnosticSession {
+          status: session.status,
+          has_last_checkpoint: session.last_checkpoint_at.is_some(),
+          has_last_error: session.last_error.is_some(),
+          pending_finalize: session.pending_finalize,
+          takeover_detected: session.takeover_detected,
+        })
+        .collect(),
+      cleanup_paths_queued: self.cleanup_paths.len(),
+    })
   }
 }
 
@@ -2683,6 +2687,86 @@ mod tests {
     assert_eq!(sanitize_path_segment(""), "session");
     assert_eq!(sanitize_path_segment("."), "session");
     assert_eq!(sanitize_path_segment("   "), "session");
+  }
+
+  #[test]
+  fn diagnostics_export_redacts_private_session_and_account_data() {
+    let mut manager = SessionManager::new();
+    manager.support_root = PathBuf::from("/Users/alice/Client Matter/support");
+    manager.edit_root = PathBuf::from("/Users/alice/Client Matter/editing");
+    manager.linked_account = Some(LinkedAccountSnapshot {
+      email: "attorney@example.com".to_string(),
+      name: Some("Private Attorney".to_string()),
+      verified_at: "private-verification-time".to_string(),
+    });
+    manager.store_load_issue = Some(StoreLoadIssue::InvalidStore);
+    manager.update.base_url = Some("https://private-api.example.com".to_string());
+    manager.update.channel = Some("secret-channel".to_string());
+    manager.update.current_hash = Some("private-current-hash".to_string());
+    manager.update.latest_hash = Some("private-latest-hash".to_string());
+    manager.update.latest_version = Some("9.9.9".to_string());
+    manager.update.status_message = "private status details".to_string();
+    manager.update.update_available = true;
+
+    let mut persisted = persisted_session_for_test("private-session-id");
+    persisted.file_name = "Client Matter.docx".to_string();
+    persisted.file_path = "/Users/alice/Client Matter.docx".to_string();
+    persisted.last_checkpoint_at = Some("private-checkpoint-time".to_string());
+    persisted.last_error =
+      Some("upload failed for /Users/alice/Client Matter.docx".to_string());
+    persisted.pending_finalize = true;
+    persisted.status = SessionStatus::Error;
+    persisted.takeover_detected = true;
+    manager.sessions.insert(
+      persisted.id.clone(),
+      desktop_session_for_test(persisted, "private-session-token"),
+    );
+    manager
+      .cleanup_paths
+      .insert("/Users/alice/Client Matter/orphan.docx".to_string());
+
+    let diagnostics = manager.get_diagnostics_text();
+    let parsed: serde_json::Value = serde_json::from_str(&diagnostics).unwrap();
+
+    for private_value in [
+      "/Users/alice",
+      "Client Matter",
+      "attorney@example.com",
+      "Private Attorney",
+      "private-verification-time",
+      "private-api.example.com",
+      "secret-channel",
+      "private-current-hash",
+      "private-latest-hash",
+      "private status details",
+      "private-session-id",
+      "private-session-token",
+      "private-checkpoint-time",
+      "upload failed",
+    ] {
+      assert!(!diagnostics.contains(private_value));
+    }
+
+    assert!(parsed.get("linkedAccount").is_none());
+    assert!(parsed["app"].get("supportRoot").is_none());
+    assert!(parsed["app"].get("temporaryWorkingCopiesRoot").is_none());
+    assert!(parsed["update"].get("baseUrl").is_none());
+    assert!(parsed["update"].get("channel").is_none());
+    assert!(parsed["update"].get("currentHash").is_none());
+    assert!(parsed["update"].get("latestHash").is_none());
+    assert!(parsed["update"].get("statusMessage").is_none());
+    assert_eq!(parsed["linkedAccountPresent"], true);
+    assert_eq!(parsed["storeLoadIssue"], "invalidStore");
+    assert_eq!(parsed["update"]["configured"], true);
+    assert_eq!(parsed["update"]["channelConfigured"], true);
+    assert_eq!(parsed["update"]["latestVersion"], "9.9.9");
+    assert_eq!(parsed["sessions"]["total"], 1);
+    assert_eq!(parsed["sessions"]["byStatus"]["error"], 1);
+    assert_eq!(parsed["sessions"]["withLastCheckpoint"], 1);
+    assert_eq!(parsed["sessions"]["withLastError"], 1);
+    assert_eq!(parsed["sessions"]["pendingFinalize"], 1);
+    assert_eq!(parsed["sessions"]["takeoverDetected"], 1);
+    assert_eq!(parsed["cleanupPathsQueued"], 1);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- replace the raw desktop diagnostic snapshot with an explicit privacy-safe export DTO
- expose only operational aggregates and presence flags for account, update, session, and cleanup state
- cover the export boundary with sensitive sentinel values so paths, identity, IDs, URLs, hashes, and raw errors cannot regress into clipboard output

## Validation

- formatting, linting, Rust checks, and tests delegated to CI