### PR TITLE
refactor: prepare workflow queue topology

### DIFF
--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -7,6 +7,15 @@ export const LIMITS = {
   entitiesWindowSizeDefault: 200,
   entitiesWindowSizeMax: 500,
   workflowEntityBatchSize: 500,
+  /** Per-replica concurrency for the legacy workflow worker. The topology
+   *  expansion preserves today's budget while every tier still routes here. */
+  workflowStandardWorkerConcurrency: 10,
+  /** Per-replica budget for the rollout-prepared flex queue. No producer uses
+   *  this queue until the separate routing PR lands. */
+  workflowFlexWorkerConcurrency: 2,
+  /** Per-queue cap for orphan-reconciliation live-job snapshots. Reaching the
+   *  cap in either queue skips recovery rather than risking a false orphan. */
+  workflowLiveJobScanLimit: 10_000,
   /** Generous cap on versions read for one entity's history panel (newest
    *  first). Versions accumulate one-per-finalize/upload/restore with no
    *  write-side cap; 1000 is far above realistic editing histories. Cursor

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1,5 +1,6 @@
 import { panic, Result } from "better-result";
 import { Queue, Worker } from "bullmq";
+import type { Job } from "bullmq";
 import type { RedisClient } from "bun";
 import { sleep } from "bun";
 import { and, eq, inArray, sql } from "drizzle-orm";
@@ -82,6 +83,15 @@ import {
   selectRunningLockReservation,
 } from "@/api/lib/workflow/orphan-recovery";
 import {
+  combineLiveWorkflowJobSnapshots,
+  workflowQueueClassForServiceTier,
+  WORKFLOW_QUEUE_CLASSES,
+  WORKFLOW_QUEUE_NAMES,
+  WORKFLOW_WORKER_SPECS,
+  type WorkflowQueueClass,
+  type WorkflowWorkerSpec,
+} from "@/api/lib/workflow/queue-topology";
+import {
   computeWorkflowJobTimeoutMs,
   computeWorkflowRunLockTtlSec,
   getWorkflowBatchAITimeoutMs,
@@ -121,12 +131,7 @@ type ExtractionPreviewPayload = {
   status: "streaming" | "clear";
 };
 
-// ── Queue name ─────────────────────────────────────────
-const QUEUE_NAME = "workflow";
-
 // ── Entity processing ──────────────────────────────────
-
-const MAX_CONCURRENT_ENTITIES = 10;
 
 type EntityJobData = {
   workspaceId: string;
@@ -146,9 +151,15 @@ type EntityJobData = {
   forcePropertyIds?: string[];
 };
 
+const WORKFLOW_ENTITY_JOB_NAME = "process-entity" as const;
+type WorkflowEntityJobName = typeof WORKFLOW_ENTITY_JOB_NAME;
+type WorkflowEntityQueue = Queue<EntityJobData, void, WorkflowEntityJobName>;
+type WorkflowEntityWorker = Worker<EntityJobData, void, WorkflowEntityJobName>;
+type WorkflowEntityJob = Job<EntityJobData, void, WorkflowEntityJobName>;
+
 // ── Public API ─────────────────────────────────────────
 
-let queue: Queue<EntityJobData> | null = null;
+const queues = new Map<WorkflowQueueClass, WorkflowEntityQueue>();
 let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
 let redisClient: RedisClient | null = null;
 
@@ -162,24 +173,38 @@ const getRedis = (): RedisClient => {
   return redisClient;
 };
 
-const getQueue = (): Queue<EntityJobData> => {
-  queue ??= new Queue<EntityJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      removeOnComplete: 100,
-      removeOnFail: 500,
-      // Retry once with backoff so a single transient failure (network
-      // blip, AI provider 5xx) doesn't leave the cell empty. Stays low
-      // enough that genuine logic errors surface quickly.
-      attempts: WORKFLOW_ENTITY_JOB_ATTEMPTS,
-      backoff: {
-        type: "exponential",
-        delay: WORKFLOW_ENTITY_JOB_BACKOFF_DELAY_MS,
+const getQueueForClass = (
+  queueClass: WorkflowQueueClass,
+): WorkflowEntityQueue => {
+  const existing = queues.get(queueClass);
+  if (existing) {
+    return existing;
+  }
+
+  const queue = new Queue<EntityJobData, void, WorkflowEntityJobName>(
+    WORKFLOW_QUEUE_NAMES[queueClass],
+    {
+      connection: getQueueConnection(),
+      defaultJobOptions: {
+        removeOnComplete: 100,
+        removeOnFail: 500,
+        // Retry once with backoff so a single transient failure (network
+        // blip, AI provider 5xx) doesn't leave the cell empty. Stays low
+        // enough that genuine logic errors surface quickly.
+        attempts: WORKFLOW_ENTITY_JOB_ATTEMPTS,
+        backoff: {
+          type: "exponential",
+          delay: WORKFLOW_ENTITY_JOB_BACKOFF_DELAY_MS,
+        },
       },
     },
-  });
+  );
+  queues.set(queueClass, queue);
   return queue;
 };
+
+const getAllWorkflowQueues = (): WorkflowEntityQueue[] =>
+  WORKFLOW_QUEUE_CLASSES.map(getQueueForClass);
 
 const clearWorkflowRunState = async (
   redis: RedisClient,
@@ -287,7 +312,7 @@ type EnqueueEntityJobsArgs = {
   executionPlan: ExecutionLevel[];
   jobIds: readonly string[];
   organizationId: SafeId<"organization">;
-  q: Queue;
+  q: WorkflowEntityQueue;
   requestId: string;
   runLockTtlSec: number;
   userId: SafeId<"user">;
@@ -336,7 +361,7 @@ const enqueueEntityJobs = async ({
     entityIds.map((entityId, index) => {
       const jobId = jobIds.at(index) ?? panic("Missing workflow job ID");
       return {
-        name: "process-entity",
+        name: WORKFLOW_ENTITY_JOB_NAME,
         data: {
           workspaceId,
           organizationId,
@@ -358,7 +383,7 @@ const enqueueEntityJobs = async ({
 };
 
 const removeQueuedWorkflowJobs = async (
-  q: Queue,
+  q: WorkflowEntityQueue,
   jobIds: readonly string[],
 ): Promise<void> => {
   for (const chunk of chunkItems(jobIds, LIMITS.workflowEntityBatchSize)) {
@@ -567,7 +592,10 @@ export const startWorkflow = async ({
     // Broadcast running status
     broadcastWorkflowStatus(workspaceId, true);
 
-    const q = getQueue();
+    // Select once for the whole workflow. The same queue instance owns every
+    // chunk and any partial-enqueue cleanup, so one request cannot straddle
+    // queue classes even during a rolling routing change.
+    const q = getQueueForClass(workflowQueueClassForServiceTier(serviceTier));
     const queuedJobIds: string[] = [];
     try {
       for (const chunk of chunkItems(
@@ -645,14 +673,8 @@ const LIVE_JOB_STATES = [
 // jobs than this, skip the cycle rather than risk treating a busy
 // workspace as orphaned from a truncated scan — a false positive must
 // never clobber a healthy run. A later, quieter cycle reconciles it.
-const LIVE_JOB_SCAN_LIMIT = 10_000;
 const RUNNING_LOCK_SCAN_PATTERN = `${WORKFLOW_KEY_PREFIX}:*:running`;
 const RUNNING_LOCK_SCAN_COUNT = "200";
-
-type LiveWorkspaceSnapshot = {
-  workspaceIds: Set<string>;
-  truncated: boolean;
-};
 
 // `Array.isArray` widens `unknown` to `any[]`; this guard narrows to
 // `unknown[]` instead so the SCAN reply stays type-checked.
@@ -732,23 +754,21 @@ const selectWorkspacesWithPendingCells = async (
   return pendingWorkspaceIds;
 };
 
-const snapshotLiveWorkspaceIds = async (
-  q: Queue<EntityJobData>,
-): Promise<LiveWorkspaceSnapshot> => {
-  const jobs = await q.getJobs(
-    [...LIVE_JOB_STATES],
-    0,
-    LIVE_JOB_SCAN_LIMIT - 1,
+const snapshotLiveWorkspaceIds = async () => {
+  const jobSnapshots = await Promise.all(
+    getAllWorkflowQueues().map(
+      async (queue) =>
+        await queue.getJobs(
+          [...LIVE_JOB_STATES],
+          0,
+          LIMITS.workflowLiveJobScanLimit - 1,
+        ),
+    ),
   );
-  const workspaceIds = new Set<string>();
-  for (const job of jobs) {
-    const workspaceId = job.data.workspaceId;
-    if (workspaceId.length === 0) {
-      continue;
-    }
-    workspaceIds.add(workspaceId);
-  }
-  return { workspaceIds, truncated: jobs.length >= LIVE_JOB_SCAN_LIMIT };
+  return combineLiveWorkflowJobSnapshots({
+    jobSnapshots,
+    scanLimit: LIMITS.workflowLiveJobScanLimit,
+  });
 };
 
 const readWorkflowRequestIds = async (
@@ -948,7 +968,7 @@ type ReconcileOrphanedWorkflowsOptions = {
 /**
  * Reconcile workflows orphaned by a killed worker. Safe to call
  * repeatedly; a no-op when nothing is orphaned. Exported for the boot +
- * interval wiring in `initWorkflowWorker` and for operational scripts.
+ * interval wiring in `initWorkflowWorkers` and for operational scripts.
  */
 export const reconcileOrphanedWorkflows = async ({
   scanPendingCells,
@@ -964,8 +984,7 @@ export const reconcileOrphanedWorkflows = async ({
     return;
   }
 
-  const q = getQueue();
-  const live = await snapshotLiveWorkspaceIds(q);
+  const live = await snapshotLiveWorkspaceIds();
   if (live.truncated) {
     logger.warn("workflow.reconcile_skipped_backlog", {
       candidates: String(candidateWorkspaceIds.length),
@@ -991,7 +1010,7 @@ export const reconcileOrphanedWorkflows = async ({
   // (lock taken, first batch not yet enqueued) is not mistaken for an
   // orphan.
   await sleep(RECONCILE_SETTLE_MS);
-  const confirmed = await snapshotLiveWorkspaceIds(q);
+  const confirmed = await snapshotLiveWorkspaceIds();
   if (confirmed.truncated) {
     return;
   }
@@ -1028,131 +1047,127 @@ export const reconcileOrphanedWorkflows = async ({
 
 // ── Worker ─────────────────────────────────────────────
 
-/**
- * Initialize the BullMQ worker. Call once at API startup.
- */
-export const initWorkflowWorker = () => {
-  // BullMQ Worker uses blocking commands (BRPOPLPUSH) so it
-  // needs a dedicated Redis connection, not the shared one.
-  const workerConnection = createBullMqConnection();
+const processWorkflowJob = async (job: WorkflowEntityJob): Promise<void> => {
+  // Hard process-level timeout. A hung AI provider, a runaway batch, or a
+  // broken external call would otherwise keep the job "active" indefinitely.
+  // The signal reaches the provider, so a retry cannot race abandoned work.
+  const controller = new AbortController();
+  const jobTimeoutMs = computeWorkflowJobTimeoutMs(
+    job.data.executionPlan,
+    job.data.serviceTier ?? "standard",
+  );
+  const timeoutHandle = setTimeout(() => {
+    controller.abort(
+      new Error(
+        `workflow.job_timeout: entity ${job.data.entityId} exceeded ${jobTimeoutMs}ms`,
+      ),
+    );
+  }, jobTimeoutMs);
+  try {
+    await processEntityJob(job.data, controller.signal);
+    controller.signal.throwIfAborted();
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+};
 
-  const worker = new Worker<EntityJobData>(
-    QUEUE_NAME,
-    async (job) => {
-      // Hard process-level timeout. A hung AI provider, a runaway
-      // batch, or a broken external call would otherwise keep the
-      // job "active" indefinitely and block follow-up workflow runs.
-      //
-      // We pipe an AbortSignal through `processEntityJob` so the
-      // timeout actually CANCELS the in-flight work (the TanStack AI
-      // request honours the signal). Without that, a `Promise.race`-style
-      // wrapper would only reject the wrapper while the original
-      // attempt kept running — racing the BullMQ retry and double-
-      // incrementing the workflow completion counter.
-      const controller = new AbortController();
-      // Per-job timeout scales with the execution plan: each
-      // dependency level runs sequentially and inherits the per-batch
-      // AI timeout. A fixed 6-min ceiling would deterministically
-      // abort entities with several slow levels even when each
-      // individual batch stays within budget.
-      const jobTimeoutMs = computeWorkflowJobTimeoutMs(
-        job.data.executionPlan,
-        job.data.serviceTier ?? "standard",
-      );
-      const timeoutHandle = setTimeout(() => {
-        controller.abort(
-          new Error(
-            `workflow.job_timeout: entity ${job.data.entityId} exceeded ${jobTimeoutMs}ms`,
-          ),
-        );
-      }, jobTimeoutMs);
-      try {
-        await processEntityJob(job.data, controller.signal);
-        // If the signal aborted between the last awaited call and
-        // here, surface it so BullMQ marks the attempt failed
-        // rather than counting it as completed.
-        controller.signal.throwIfAborted();
-      } finally {
-        clearTimeout(timeoutHandle);
-      }
-    },
+const handleWorkflowJobFailed = (
+  job: WorkflowEntityJob | undefined,
+  error: Error,
+): void => {
+  if (!job) {
+    return;
+  }
+  const data = job.data;
+  logger.error("workflow.entity_failed", {
+    workspaceId: data.workspaceId,
+    entityId: data.entityId,
+    attemptsMade: String(job.attemptsMade),
+    "error.type": errorTag(error),
+  });
+
+  // With `attempts: 2` enabled on the queue, the failed event fires for
+  // transient first-attempt failures too. Only count the entity once BullMQ
+  // has exhausted retries, or the workflow could finalize mid-retry.
+  const totalAttempts = job.opts.attempts ?? 1;
+  if (job.attemptsMade < totalAttempts) {
+    return;
+  }
+
+  const branded = brandValidatedWorkflowActorKey({
+    organizationId: data.organizationId,
+    workspaceId: data.workspaceId,
+  });
+  void (async () => {
+    const isCurrentRequest = await isCurrentWorkflowRequest({
+      requestId: data.requestId,
+      workspaceId: branded.workspaceId,
+    });
+    if (!isCurrentRequest) {
+      return;
+    }
+
+    await markPendingPlannedFieldsErrored(data).catch(
+      (pendingFieldsError: unknown) => {
+        captureError(pendingFieldsError, {
+          workspaceId: data.workspaceId,
+          entityId: data.entityId,
+        });
+      },
+    );
+    await onEntityCompleted(
+      branded.workspaceId,
+      branded.organizationId,
+      brandPersistedUserId(data.userId),
+      data.requestId,
+      data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
+    );
+  })().catch((completionError: unknown) => {
+    captureError(completionError, {
+      workspaceId: data.workspaceId,
+      entityId: data.entityId,
+    });
+  });
+};
+
+const createWorkflowWorker = ({
+  concurrency,
+  queueClass,
+}: WorkflowWorkerSpec): WorkflowEntityWorker => {
+  const queueName = WORKFLOW_QUEUE_NAMES[queueClass];
+  // Every BullMQ Worker uses blocking commands, so each queue needs its own
+  // dedicated connection rather than the producer's shared connection.
+  const worker = new Worker<EntityJobData, void, WorkflowEntityJobName>(
+    queueName,
+    processWorkflowJob,
     {
-      connection: workerConnection,
-      concurrency: MAX_CONCURRENT_ENTITIES,
-      // Lock-extension lets BullMQ's stalled-job detector evict a
-      // crashed worker's jobs back onto the queue.
+      connection: createBullMqConnection(),
+      concurrency,
       lockDuration: LOCK_DURATION_MS,
       stalledInterval: STALLED_INTERVAL_MS,
       maxStalledCount: MAX_STALLED_COUNT,
     },
   );
 
-  worker.on("failed", (job, error) => {
-    if (!job) {
-      return;
-    }
-    const data = job.data;
-    logger.error("workflow.entity_failed", {
-      workspaceId: data.workspaceId,
-      entityId: data.entityId,
-      attemptsMade: String(job.attemptsMade),
-      "error.type": errorTag(error),
-    });
-
-    // With `attempts: 2` enabled on the queue, the failed event fires
-    // for transient first-attempt failures too. Only count the entity
-    // as completed once BullMQ has exhausted its retries — otherwise
-    // `completed >= total` can flip to true mid-run and finalize the
-    // workflow while jobs are still queued for retry.
-    const totalAttempts = job.opts.attempts ?? 1;
-    const isFinalAttempt = job.attemptsMade >= totalAttempts;
-    if (!isFinalAttempt) {
-      return;
-    }
-
-    const branded = brandValidatedWorkflowActorKey({
-      organizationId: data.organizationId,
-      workspaceId: data.workspaceId,
-    });
-    void (async () => {
-      const isCurrentRequest = await isCurrentWorkflowRequest({
-        requestId: data.requestId,
-        workspaceId: branded.workspaceId,
-      });
-      if (!isCurrentRequest) {
-        return;
-      }
-
-      await markPendingPlannedFieldsErrored(data).catch(
-        (pendingFieldsError: unknown) => {
-          captureError(pendingFieldsError, {
-            workspaceId: data.workspaceId,
-            entityId: data.entityId,
-          });
-        },
-      );
-      await onEntityCompleted(
-        branded.workspaceId,
-        branded.organizationId,
-        brandPersistedUserId(data.userId),
-        data.requestId,
-        data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
-      );
-    })().catch((completionError: unknown) => {
-      captureError(completionError, {
-        workspaceId: data.workspaceId,
-        entityId: data.entityId,
-      });
-    });
-  });
-
+  worker.on("failed", handleWorkflowJobFailed);
   worker.on("error", (error) => {
-    logger.error("workflow.worker_error", connectionErrorFields(error));
+    logger.error("workflow.worker_error", {
+      ...connectionErrorFields(error),
+      queueClass,
+      queueName,
+    });
   });
-
   logger.info("workflow.worker_started", {
-    concurrency: String(MAX_CONCURRENT_ENTITIES),
+    concurrency: String(concurrency),
+    queueClass,
+    queueName,
   });
+  return worker;
+};
+
+/** Initialize every workflow worker. Call once at API startup. */
+export const initWorkflowWorkers = () => {
+  const workers = WORKFLOW_WORKER_SPECS.map(createWorkflowWorker);
 
   // Heal whatever a previously-killed worker left orphaned. Boot runs a
   // thorough pass (also sweeping the DB for pending cells whose lock has
@@ -1175,7 +1190,12 @@ export const initWorkflowWorker = () => {
   // The reconcile cadence must not keep the process alive at shutdown.
   reconcileTimer.unref();
 
-  return worker;
+  return {
+    close: async (): Promise<void> => {
+      clearInterval(reconcileTimer);
+      await Promise.all(workers.map(async (worker) => await worker.close()));
+    },
+  };
 };
 
 // ── Entity processing ──────────────────────────────────

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -29,6 +29,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { acquireCellLocks } from "@/api/lib/cell-lock";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import {
   connectionErrorFields,
   errorSystemFields,
@@ -1058,9 +1059,11 @@ const processWorkflowJob = async (job: WorkflowEntityJob): Promise<void> => {
   );
   const timeoutHandle = setTimeout(() => {
     controller.abort(
-      new Error(
-        `workflow.job_timeout: entity ${job.data.entityId} exceeded ${jobTimeoutMs}ms`,
-      ),
+      new TimeoutError({
+        label: "workflow.job",
+        message: `workflow.job_timeout: entity ${job.data.entityId} exceeded ${jobTimeoutMs}ms`,
+        timeoutMs: jobTimeoutMs,
+      }),
     );
   }, jobTimeoutMs);
   try {
@@ -1069,6 +1072,15 @@ const processWorkflowJob = async (job: WorkflowEntityJob): Promise<void> => {
   } finally {
     clearTimeout(timeoutHandle);
   }
+};
+
+const pendingFailedJobFinalizations = new Set<Promise<void>>();
+
+const trackFailedJobFinalization = (work: Promise<void>): void => {
+  const tracked = work.finally(() => {
+    pendingFailedJobFinalizations.delete(tracked);
+  });
+  pendingFailedJobFinalizations.add(tracked);
 };
 
 const handleWorkflowJobFailed = (
@@ -1098,36 +1110,38 @@ const handleWorkflowJobFailed = (
     organizationId: data.organizationId,
     workspaceId: data.workspaceId,
   });
-  void (async () => {
-    const isCurrentRequest = await isCurrentWorkflowRequest({
-      requestId: data.requestId,
-      workspaceId: branded.workspaceId,
-    });
-    if (!isCurrentRequest) {
-      return;
-    }
+  trackFailedJobFinalization(
+    (async () => {
+      const isCurrentRequest = await isCurrentWorkflowRequest({
+        requestId: data.requestId,
+        workspaceId: branded.workspaceId,
+      });
+      if (!isCurrentRequest) {
+        return;
+      }
 
-    await markPendingPlannedFieldsErrored(data).catch(
-      (pendingFieldsError: unknown) => {
-        captureError(pendingFieldsError, {
-          workspaceId: data.workspaceId,
-          entityId: data.entityId,
-        });
-      },
-    );
-    await onEntityCompleted(
-      branded.workspaceId,
-      branded.organizationId,
-      brandPersistedUserId(data.userId),
-      data.requestId,
-      data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
-    );
-  })().catch((completionError: unknown) => {
-    captureError(completionError, {
-      workspaceId: data.workspaceId,
-      entityId: data.entityId,
-    });
-  });
+      await markPendingPlannedFieldsErrored(data).catch(
+        (pendingFieldsError: unknown) => {
+          captureError(pendingFieldsError, {
+            workspaceId: data.workspaceId,
+            entityId: data.entityId,
+          });
+        },
+      );
+      await onEntityCompleted(
+        branded.workspaceId,
+        branded.organizationId,
+        brandPersistedUserId(data.userId),
+        data.requestId,
+        data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
+      );
+    })().catch((completionError: unknown) => {
+      captureError(completionError, {
+        workspaceId: data.workspaceId,
+        entityId: data.entityId,
+      });
+    }),
+  );
 };
 
 const createWorkflowWorker = ({
@@ -1193,7 +1207,15 @@ export const initWorkflowWorkers = () => {
   return {
     close: async (): Promise<void> => {
       clearInterval(reconcileTimer);
-      await Promise.all(workers.map(async (worker) => await worker.close()));
+      const closeResults = await Promise.allSettled(
+        workers.map(async (worker) => await worker.close()),
+      );
+      for (const result of closeResults) {
+        if (result.status === "rejected") {
+          captureError(result.reason);
+        }
+      }
+      await Promise.allSettled([...pendingFailedJobFinalizations]);
     },
   };
 };

--- a/apps/api/src/lib/workflow/queue-topology.test.ts
+++ b/apps/api/src/lib/workflow/queue-topology.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  combineLiveWorkflowJobSnapshots,
+  workflowQueueClassForServiceTier,
+  WORKFLOW_QUEUE_CLASS,
+  WORKFLOW_QUEUE_NAMES,
+  WORKFLOW_WORKER_SPECS,
+} from "@/api/lib/workflow/queue-topology";
+
+describe("workflow queue topology", () => {
+  test("keeps the legacy queue name distinct from the future flex queue", () => {
+    expect(WORKFLOW_QUEUE_NAMES.standard).toBe("workflow");
+    expect(WORKFLOW_QUEUE_NAMES.flex).not.toBe(WORKFLOW_QUEUE_NAMES.standard);
+  });
+
+  test("preserves legacy routing for every service tier", () => {
+    expect(workflowQueueClassForServiceTier("standard")).toBe(
+      WORKFLOW_QUEUE_CLASS.standard,
+    );
+    expect(workflowQueueClassForServiceTier("flex")).toBe(
+      WORKFLOW_QUEUE_CLASS.standard,
+    );
+    expect(workflowQueueClassForServiceTier("batch")).toBe(
+      WORKFLOW_QUEUE_CLASS.standard,
+    );
+  });
+
+  test("gives each worker an explicit positive concurrency budget", () => {
+    expect(WORKFLOW_WORKER_SPECS).toHaveLength(2);
+    expect(WORKFLOW_WORKER_SPECS.map(({ queueClass }) => queueClass)).toEqual([
+      WORKFLOW_QUEUE_CLASS.standard,
+      WORKFLOW_QUEUE_CLASS.flex,
+    ]);
+    expect(
+      new Set(WORKFLOW_WORKER_SPECS.map(({ queueClass }) => queueClass)).size,
+    ).toBe(WORKFLOW_WORKER_SPECS.length);
+    for (const spec of WORKFLOW_WORKER_SPECS) {
+      expect(spec.concurrency).toBeGreaterThan(0);
+    }
+  });
+
+  test("unions live workspaces across every queue and ignores empty IDs", () => {
+    const snapshot = combineLiveWorkflowJobSnapshots({
+      jobSnapshots: [
+        [
+          { data: { workspaceId: "workspace-standard" } },
+          { data: { workspaceId: "" } },
+        ],
+        [
+          { data: { workspaceId: "workspace-flex" } },
+          { data: { workspaceId: "workspace-standard" } },
+        ],
+      ],
+      scanLimit: 3,
+    });
+
+    expect(snapshot.workspaceIds).toEqual(
+      new Set(["workspace-standard", "workspace-flex"]),
+    );
+    expect(snapshot.truncated).toBe(false);
+  });
+
+  test("marks the combined snapshot truncated when either queue reaches its limit", () => {
+    const standardTruncated = combineLiveWorkflowJobSnapshots({
+      jobSnapshots: [
+        [
+          { data: { workspaceId: "standard-a" } },
+          { data: { workspaceId: "standard-b" } },
+        ],
+        [{ data: { workspaceId: "flex-a" } }],
+      ],
+      scanLimit: 2,
+    });
+    const flexTruncated = combineLiveWorkflowJobSnapshots({
+      jobSnapshots: [
+        [{ data: { workspaceId: "standard-a" } }],
+        [
+          { data: { workspaceId: "flex-a" } },
+          { data: { workspaceId: "flex-b" } },
+        ],
+      ],
+      scanLimit: 2,
+    });
+
+    expect(standardTruncated.truncated).toBe(true);
+    expect(flexTruncated.truncated).toBe(true);
+  });
+});

--- a/apps/api/src/lib/workflow/queue-topology.ts
+++ b/apps/api/src/lib/workflow/queue-topology.ts
@@ -1,0 +1,84 @@
+import type { AIRequestServiceTier } from "@/api/lib/ai-config";
+import { LIMITS } from "@/api/lib/limits";
+
+export const WORKFLOW_QUEUE_CLASS = {
+  standard: "standard",
+  flex: "flex",
+} as const;
+
+export type WorkflowQueueClass =
+  (typeof WORKFLOW_QUEUE_CLASS)[keyof typeof WORKFLOW_QUEUE_CLASS];
+
+export const WORKFLOW_QUEUE_NAMES = {
+  [WORKFLOW_QUEUE_CLASS.standard]: "workflow",
+  [WORKFLOW_QUEUE_CLASS.flex]: "workflow-flex",
+} as const satisfies Record<WorkflowQueueClass, string>;
+
+export const WORKFLOW_QUEUE_CLASSES = [
+  WORKFLOW_QUEUE_CLASS.standard,
+  WORKFLOW_QUEUE_CLASS.flex,
+] as const satisfies readonly WorkflowQueueClass[];
+
+// Rollout phase one only expands topology awareness. Keeping every producer on
+// the legacy queue means an older replica can still drain all admitted jobs;
+// deferred-tier routing changes only after this topology is deployed.
+const WORKFLOW_QUEUE_CLASS_BY_SERVICE_TIER = {
+  standard: WORKFLOW_QUEUE_CLASS.standard,
+  flex: WORKFLOW_QUEUE_CLASS.standard,
+  batch: WORKFLOW_QUEUE_CLASS.standard,
+} as const satisfies Record<AIRequestServiceTier, WorkflowQueueClass>;
+
+export const workflowQueueClassForServiceTier = (
+  serviceTier: AIRequestServiceTier,
+): WorkflowQueueClass => WORKFLOW_QUEUE_CLASS_BY_SERVICE_TIER[serviceTier];
+
+export type WorkflowWorkerSpec = {
+  queueClass: WorkflowQueueClass;
+  concurrency: number;
+};
+
+export const WORKFLOW_WORKER_SPECS = [
+  {
+    queueClass: WORKFLOW_QUEUE_CLASS.standard,
+    concurrency: LIMITS.workflowStandardWorkerConcurrency,
+  },
+  {
+    queueClass: WORKFLOW_QUEUE_CLASS.flex,
+    concurrency: LIMITS.workflowFlexWorkerConcurrency,
+  },
+] as const satisfies readonly WorkflowWorkerSpec[];
+
+type WorkflowLiveJob = {
+  data: {
+    workspaceId: string;
+  };
+};
+
+type LiveWorkflowWorkspaceSnapshot = {
+  workspaceIds: Set<string>;
+  truncated: boolean;
+};
+
+export const combineLiveWorkflowJobSnapshots = ({
+  jobSnapshots,
+  scanLimit,
+}: {
+  jobSnapshots: readonly (readonly WorkflowLiveJob[])[];
+  scanLimit: number;
+}): LiveWorkflowWorkspaceSnapshot => {
+  const workspaceIds = new Set<string>();
+  let truncated = false;
+
+  for (const jobs of jobSnapshots) {
+    if (jobs.length >= scanLimit) {
+      truncated = true;
+    }
+    for (const job of jobs) {
+      if (job.data.workspaceId.length > 0) {
+        workspaceIds.add(job.data.workspaceId);
+      }
+    }
+  }
+
+  return { workspaceIds, truncated };
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -108,7 +108,7 @@ import {
 } from "@/api/lib/s3";
 import { setSecurityHeaders } from "@/api/lib/security-headers";
 import { initStyleSetPackageCleanupWorker } from "@/api/lib/style-set-package-cleanup-queue";
-import { initWorkflowWorker } from "@/api/lib/workflow-queue";
+import { initWorkflowWorkers } from "@/api/lib/workflow-queue";
 
 const HEALTH_PATH = "/health";
 const DEFAULT_API_PORT = 3001;
@@ -531,7 +531,7 @@ const startServer = async (): Promise<void> => {
   const fileDerivativeWorker = initFileDerivativeWorker();
 
   // BullMQ workflow worker for AI extraction.
-  const workflowWorker = initWorkflowWorker();
+  const workflowWorkers = initWorkflowWorkers();
 
   // BullMQ worker for durable account-deletion storage cleanup.
   const accountDeletionCleanupWorker = initAccountDeletionCleanupWorker();
@@ -566,7 +566,7 @@ const startServer = async (): Promise<void> => {
     });
     await Promise.race([
       Promise.allSettled([
-        workflowWorker.close(),
+        workflowWorkers.close(),
         fileDerivativeWorker.close(),
         accountDeletionCleanupWorker.close(),
         styleSetPackageCleanupWorker.close(),


### PR DESCRIPTION
## Summary

- add legacy and flex workflow queue topology while keeping every service tier on the legacy queue
- start one worker per queue with independent blocking Redis connections and explicit per-replica budgets
- reconcile live workflow jobs across both queues and close the composite worker lifecycle cleanly

## Rollout safety

This is the expand-only deployment step: producer routing does not change. Deferred-tier routing will follow separately after this topology is deployed. Existing job IDs and the legacy `workflow` queue name remain unchanged.

## Validation

- scoped formatting completed
- `git diff --check` passed
- lint, typecheck, and tests delegated to CI as requested

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new workflow concurrency and job scan limits for better throughput control.
  - Introduced multi-queue workflow processing with routing based on service tier, including standard and flex worker pools.
- **Bug Fixes**
  - Improved orphan reconciliation by aggregating live workspace activity across all workflow queues.
  - Added hard timeouts for workflow entity handling and more reliable retry/failure completion behaviour, including safer shutdown.
- **Tests**
  - Added queue topology and live-workspace snapshot aggregation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->