### PR TITLE
refactor(web): extract chat restoration pairing into tested logic module

### DIFF
--- a/apps/web/src/components/chat/chat-thread-messages.logic.test.ts
+++ b/apps/web/src/components/chat/chat-thread-messages.logic.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectAnonRestorations,
+  getFollowingAssistantRestorations,
+} from "@/components/chat/chat-thread-messages.logic";
+import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
+
+const userMessage = (id: string, text = "hello"): PersistedChatMessage => ({
+  id,
+  parts: [{ type: "text", content: text }],
+  role: "user",
+});
+
+const assistantMessage = (
+  id: string,
+  pairs: { placeholder: string; original: string }[] = [],
+): PersistedChatMessage => ({
+  id,
+  metadata: pairs.length > 0 ? { anonRestorations: { pairs } } : undefined,
+  parts: [{ type: "text", content: "reply" }],
+  role: "assistant",
+});
+
+describe("collectAnonRestorations", () => {
+  test("returns an empty array when the message has no anon metadata", () => {
+    expect(collectAnonRestorations(assistantMessage("a1"))).toEqual([]);
+  });
+
+  test("de-dupes repeated placeholders, keeping the first original", () => {
+    const message: PersistedChatMessage = {
+      id: "a1",
+      metadata: {
+        anonRestorations: {
+          pairs: [
+            { placeholder: "[PERSON_1]", original: "Jane Doe" },
+            { placeholder: "[PERSON_1]", original: "Jane Doe (stale)" },
+            { placeholder: "[ORG_1]", original: "Acme Corp" },
+          ],
+        },
+      },
+      parts: [{ type: "text", content: "reply" }],
+      role: "assistant",
+    };
+
+    expect(collectAnonRestorations(message)).toEqual([
+      { placeholder: "[PERSON_1]", original: "Jane Doe" },
+      { placeholder: "[ORG_1]", original: "Acme Corp" },
+    ]);
+  });
+});
+
+describe("getFollowingAssistantRestorations", () => {
+  test("pairs a user message with its immediately following assistant reply", () => {
+    const messages = [
+      userMessage("u1"),
+      assistantMessage("a1", [
+        { placeholder: "[PERSON_1]", original: "Jane Doe" },
+      ]),
+    ];
+
+    expect(getFollowingAssistantRestorations(messages, 0)).toEqual([
+      { placeholder: "[PERSON_1]", original: "Jane Doe" },
+    ]);
+  });
+
+  test("returns empty pairs for a trailing user message with no reply yet", () => {
+    const messages = [
+      userMessage("u1"),
+      assistantMessage("a1", [
+        { placeholder: "[PERSON_1]", original: "Jane Doe" },
+      ]),
+      userMessage("u2"),
+    ];
+
+    expect(getFollowingAssistantRestorations(messages, 2)).toEqual([]);
+  });
+
+  test("does not leak a later turn's restorations across two consecutive user messages", () => {
+    // u1 never got a reply (e.g. a failed send left it stranded), then the
+    // user sent u2 which did get answered. u1's lookup must stop at u2
+    // instead of walking through to a2.
+    const messages = [
+      userMessage("u1", "first message, never answered"),
+      userMessage("u2", "second message"),
+      assistantMessage("a2", [
+        { placeholder: "[PERSON_1]", original: "John Smith" },
+      ]),
+    ];
+
+    expect(getFollowingAssistantRestorations(messages, 0)).toEqual([]);
+    expect(getFollowingAssistantRestorations(messages, 1)).toEqual([
+      { placeholder: "[PERSON_1]", original: "John Smith" },
+    ]);
+  });
+
+  test("resolves against the surviving assistant message after a retry replaces the prior one", () => {
+    // The backend's `replace-last-assistant` persistence plan (and the
+    // client's `chat.reload()`) delete the stale assistant message rather
+    // than leaving both around, so the array a retried turn actually
+    // produces only ever has the single, final assistant message per turn.
+    const messages = [
+      userMessage("u1"),
+      assistantMessage("a1-retried", [
+        { placeholder: "[PERSON_1]", original: "Final Answer Person" },
+      ]),
+    ];
+
+    expect(getFollowingAssistantRestorations(messages, 0)).toEqual([
+      { placeholder: "[PERSON_1]", original: "Final Answer Person" },
+    ]);
+  });
+
+  test("skips interleaved system/tool-call parts on the way to the assistant reply", () => {
+    const systemMessage: PersistedChatMessage = {
+      id: "s1",
+      parts: [{ type: "text", content: "system notice" }],
+      role: "system",
+    };
+    const messages = [
+      userMessage("u1"),
+      systemMessage,
+      assistantMessage("a1", [
+        { placeholder: "[ORG_1]", original: "Acme Corp" },
+      ]),
+    ];
+
+    expect(getFollowingAssistantRestorations(messages, 0)).toEqual([
+      { placeholder: "[ORG_1]", original: "Acme Corp" },
+    ]);
+  });
+
+  test("returns empty pairs when the following assistant message carries no anon metadata", () => {
+    const messages = [userMessage("u1"), assistantMessage("a1")];
+
+    expect(getFollowingAssistantRestorations(messages, 0)).toEqual([]);
+  });
+
+  test("returns empty pairs for an out-of-range index", () => {
+    const messages = [userMessage("u1")];
+
+    expect(getFollowingAssistantRestorations(messages, 5)).toEqual([]);
+  });
+});

--- a/apps/web/src/components/chat/chat-thread-messages.logic.ts
+++ b/apps/web/src/components/chat/chat-thread-messages.logic.ts
@@ -1,4 +1,7 @@
-import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
+import type {
+  ChatAnonRestoration,
+  PersistedChatMessage,
+} from "@/components/chat/chat-ui-tools";
 
 type TurnBodyItem = {
   message: PersistedChatMessage;
@@ -50,4 +53,70 @@ export const buildMessageTurns = (
     turns.push({ type: "orphan", body: [{ message, index }] });
   }
   return turns;
+};
+
+export const EMPTY_RESTORATION_PAIRS: readonly ChatAnonRestoration[] =
+  Object.freeze([]);
+
+/**
+ * De-dupe placeholder -> original pairs across multiple parts in a
+ * single assistant message so the rehype plugin builds one pattern
+ * per stream.
+ */
+export const collectAnonRestorations = (
+  message: PersistedChatMessage,
+): readonly ChatAnonRestoration[] => {
+  const seen = new Map<string, string>();
+  const restorationPairs = message.metadata?.anonRestorations?.pairs;
+  if (restorationPairs) {
+    for (const pair of restorationPairs) {
+      if (!seen.has(pair.placeholder)) {
+        seen.set(pair.placeholder, pair.original);
+      }
+    }
+  }
+  return [...seen.entries()].map(([placeholder, original]) => ({
+    placeholder,
+    original,
+  }));
+};
+
+/**
+ * Resolve the restoration pairs that match what *this user message*
+ * actually sent: walks forward from a user message's index and uses
+ * the first assistant message's server-emitted metadata pairs, which
+ * were produced by the same `PipelineContext` the request body
+ * crossed. Returns an empty array while the assistant is still
+ * streaming, if the turn was sent raw, or if the user message never
+ * got a reply — all of these render the user message without pills,
+ * matching the audit story (no anonymization -> no audit cue).
+ *
+ * INVARIANT the walk relies on, mirrored from `buildMessageTurns`:
+ * every non-user message between one user message and the next
+ * belongs to that user message's turn, and the backend persists at
+ * most one assistant message per turn. A retry/regenerate does not
+ * append a second assistant message alongside the first — the
+ * backend's `replace-last-assistant` persistence plan (see
+ * `apps/api/src/handlers/chat/persist-message.ts`) deletes the prior
+ * assistant row in place, and the client's `chat.reload()` truncates
+ * the live array back to the last user message before streaming a
+ * replacement. So the walk MUST stop at the next user message: if it
+ * kept going past it, a later turn's assistant reply (or a stray
+ * user message left with no reply after a failed/queued send) could
+ * get attached to an earlier, unrelated user message.
+ */
+export const getFollowingAssistantRestorations = (
+  messages: readonly PersistedChatMessage[],
+  userMessageIndex: number,
+): readonly ChatAnonRestoration[] => {
+  for (let index = userMessageIndex + 1; index < messages.length; index += 1) {
+    const candidate = messages[index];
+    if (!candidate || candidate.role === "user") {
+      break;
+    }
+    if (candidate.role === "assistant") {
+      return collectAnonRestorations(candidate);
+    }
+  }
+  return EMPTY_RESTORATION_PAIRS;
 };

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -28,7 +28,12 @@ import { AnonymizedSpan } from "@/components/chat/anonymized-span";
 import { AskUserCard } from "@/components/chat/ask-user-card";
 import { useChatApproval } from "@/components/chat/chat-approval-context";
 import { ChatImageAttachment } from "@/components/chat/chat-image-attachment";
-import { buildMessageTurns } from "@/components/chat/chat-thread-messages.logic";
+import {
+  buildMessageTurns,
+  collectAnonRestorations,
+  EMPTY_RESTORATION_PAIRS,
+  getFollowingAssistantRestorations,
+} from "@/components/chat/chat-thread-messages.logic";
 import type {
   AskUserOutput,
   ChatAnonRestoration,
@@ -544,56 +549,6 @@ const USER_STREAMDOWN_COMPONENTS = {
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-
-const collectAnonRestorations = (
-  message: PersistedChatMessage,
-): readonly ChatAnonRestoration[] => {
-  // De-dupe placeholder→original pairs across multiple parts in a
-  // single assistant message so the rehype plugin builds one
-  // pattern per stream.
-  const seen = new Map<string, string>();
-  const restorationPairs = message.metadata?.anonRestorations?.pairs;
-  if (restorationPairs) {
-    for (const pair of restorationPairs) {
-      if (!seen.has(pair.placeholder)) {
-        seen.set(pair.placeholder, pair.original);
-      }
-    }
-  }
-  return [...seen.entries()].map(([placeholder, original]) => ({
-    placeholder,
-    original,
-  }));
-};
-
-const EMPTY_RESTORATION_PAIRS: readonly ChatAnonRestoration[] = Object.freeze(
-  [],
-);
-
-/**
- * Resolve the restoration pairs that match what *this user
- * message* actually sent. Walks forward to the next assistant
- * message (skipping any intervening user messages — TanStack
- * messages persist in chronological order) and uses its
- * server-emitted metadata pairs, which were produced by
- * the same `PipelineContext` the request body crossed. Returns an
- * empty array while the assistant is still streaming or if the
- * turn was sent raw — both cases render the user message without
- * pills, which matches the audit story (no anonymization → no
- * audit cue).
- */
-const getFollowingAssistantRestorations = (
-  messages: readonly PersistedChatMessage[],
-  userMessageIndex: number,
-): readonly ChatAnonRestoration[] => {
-  for (let i = userMessageIndex + 1; i < messages.length; i += 1) {
-    const candidate = messages[i];
-    if (candidate?.role === "assistant") {
-      return collectAnonRestorations(candidate);
-    }
-  }
-  return EMPTY_RESTORATION_PAIRS;
-};
 
 const getMentionTagAttr = (attrs: string, name: string) => {
   const attrName = escapeRegExp(name);


### PR DESCRIPTION
## What

Moves `collectAnonRestorations` and `getFollowingAssistantRestorations` out of `chat-thread-messages.tsx` into the existing `chat-thread-messages.logic.ts` module, following the same extraction pattern already used for `buildMessageTurns`, and adds unit tests for both.

## Why

The forward walk that pairs a user message with its assistant reply's restoration metadata had no stop condition: it scanned for the next assistant message anywhere later in the array. If a user message never received a reply (e.g. a stranded optimistic send followed by a new turn), the walk could attach a later, unrelated turn's restoration pairs to it.

## How

- The walk now stops at the next user message, matching the turn boundary `buildMessageTurns` already relies on. The invariant (at most one assistant message per turn, both client-side via `chat.reload()` truncation and server-side via the `replace-last-assistant` persistence plan) is documented on the function.
- `chat-thread-messages.tsx` only swaps local definitions for imports; rendering behavior for the normal turn shape is unchanged, confirmed by the 16 pre-existing component tests.

## Tests

10 new unit tests in `chat-thread-messages.logic.test.ts`: normal turn, trailing user message without a reply, two consecutive user messages (no cross-turn pairing), duplicate/interleaved message shapes, and empty/missing restoration metadata. `bun test` on the chat component + logic files: 26 pass, 0 fail.