### PR TITLE
refactor(api): make SSE keepalive and Redis lifecycle explicit and disposable

### DIFF
--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+type FakeRedisClient = {
+  subscribe: ReturnType<typeof mock>;
+  publish: ReturnType<typeof mock>;
+  close: ReturnType<typeof mock>;
+};
+
+const createdClients: FakeRedisClient[] = [];
+let subscribeBehavior: "reject" | "resolve" = "resolve";
+
+const makeFakeRedisClient = (): FakeRedisClient => {
+  const client: FakeRedisClient = {
+    subscribe: mock(async () => {
+      if (subscribeBehavior === "reject") {
+        throw new Error("redis unavailable");
+      }
+    }),
+    publish: mock(async () => undefined),
+    close: mock(() => undefined),
+  };
+  createdClients.push(client);
+  return client;
+};
+
+const createRedisClientMock = mock(() => makeFakeRedisClient());
+
+void mock.module("@/api/lib/redis-client", () => ({
+  createRedisClient: createRedisClientMock,
+}));
+
+// setInterval/clearInterval are spied (not replaced) so startSse/stopSse
+// still schedule and clear a real timer; the spies only let the tests
+// observe whether the module called them, matching how sse.ts calls the
+// global functions directly.
+const setIntervalSpy = spyOn(globalThis, "setInterval");
+const clearIntervalSpy = spyOn(globalThis, "clearInterval");
+
+const { broadcast, startSse, stopSse, subscribe } =
+  await import("@/api/lib/sse");
+
+// Let the fire-and-forget subscribe promise inside startSse settle.
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const workspaceId = toSafeId<"workspace">("ws_1");
+const organizationId = toSafeId<"organization">("org_1");
+
+describe("sse module import", () => {
+  test("importing the module opens no Redis connection and starts no timer", () => {
+    expect(createdClients).toHaveLength(0);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(createRedisClientMock).not.toHaveBeenCalled();
+  });
+
+  test("registering a local connection before startSse does not throw", () => {
+    const controller = new AbortController();
+
+    expect(() =>
+      subscribe(workspaceId, organizationId, controller.signal),
+    ).not.toThrow();
+
+    controller.abort();
+  });
+
+  test("broadcasting before startSse does not throw", async () => {
+    expect(() =>
+      broadcast(workspaceId, { type: "test-event", data: null }),
+    ).not.toThrow();
+
+    await flushMicrotasks();
+  });
+});
+
+describe("startSse / stopSse lifecycle", () => {
+  test("startSse starts the keep-alive timer and connects the Redis subscriber", async () => {
+    setIntervalSpy.mockClear();
+    createdClients.length = 0;
+
+    startSse();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+
+    expect(createdClients).toHaveLength(1);
+    expect(createdClients[0]?.subscribe).toHaveBeenCalledTimes(1);
+
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("startSse is idempotent: repeated calls create only one timer and one subscriber", async () => {
+    setIntervalSpy.mockClear();
+    createdClients.length = 0;
+
+    startSse();
+    startSse();
+    startSse();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+
+    expect(createdClients).toHaveLength(1);
+
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("stopSse clears the interval and closes the subscriber", async () => {
+    clearIntervalSpy.mockClear();
+    createdClients.length = 0;
+
+    startSse();
+    await flushMicrotasks();
+
+    const client = createdClients[0];
+    expect(client).toBeDefined();
+
+    stopSse();
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(client?.close).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+  });
+
+  test("stopSse is safe when startSse was never called", () => {
+    expect(() => stopSse()).not.toThrow();
+  });
+
+  test("stopSse is safe when called more than once", async () => {
+    createdClients.length = 0;
+
+    startSse();
+    await flushMicrotasks();
+
+    stopSse();
+    expect(() => stopSse()).not.toThrow();
+
+    await flushMicrotasks();
+  });
+
+  test("a Redis connection failure during startSse is logged and does not throw", async () => {
+    subscribeBehavior = "reject";
+    createdClients.length = 0;
+
+    expect(() => startSse()).not.toThrow();
+
+    await flushMicrotasks();
+
+    // The client created for the failed connection attempt is still
+    // closed, so a repeated failure does not leak a raw client handle.
+    expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
+
+    stopSse();
+    await flushMicrotasks();
+    subscribeBehavior = "resolve";
+  });
+
+  test("stopping before the in-flight Redis connection resolves closes it instead of leaking it", async () => {
+    createdClients.length = 0;
+
+    startSse();
+    // stopSse runs before the mocked subscribe() promise has settled.
+    stopSse();
+
+    await flushMicrotasks();
+
+    expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -175,4 +175,31 @@ describe("startSse / stopSse lifecycle", () => {
 
     expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
   });
+
+  test("a stop+restart during connect does not attach the old subscriber to the new lifecycle", async () => {
+    createdClients.length = 0;
+
+    startSse();
+    stopSse();
+    // The first connection attempt is still in flight (its subscribe()
+    // promise has not settled) when a new lifecycle starts.
+    startSse();
+
+    await flushMicrotasks();
+
+    expect(createdClients).toHaveLength(2);
+    const [oldClient, newClient] = createdClients;
+
+    // The stale connection recognizes it no longer belongs to the active
+    // lifecycle and closes itself instead of attaching to the new one.
+    expect(oldClient?.close).toHaveBeenCalledTimes(1);
+    expect(newClient?.close).not.toHaveBeenCalled();
+
+    // The new lifecycle's subscriber is the one actually attached:
+    // stopping it now closes newClient exactly once.
+    stopSse();
+    expect(newClient?.close).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+  });
 });

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -162,20 +162,6 @@ const handleMessage = (message: string) => {
   }
 };
 
-const initRedis = async () => {
-  try {
-    const subscriber = createRedisClient();
-    await subscriber.subscribe(REDIS_CHANNEL, (message) => {
-      handleMessage(message);
-    });
-    logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
-  } catch (error: unknown) {
-    logger.error("sse.redis_connection_failed", connectionErrorFields(error));
-  }
-};
-
-void initRedis();
-
 /**
  * Broadcast an SSE event to all API instances via Redis pub/sub.
  * Every instance (including this one) receives the message on the
@@ -270,9 +256,95 @@ const sendKeepAlive = () => {
   }
 };
 
-const keepAliveTimer = setInterval(sendKeepAlive, KEEP_ALIVE_INTERVAL_MS);
-keepAliveTimer.unref();
+// ── Lifecycle ────────────────────────────────────────────
+//
+// Importing this module must have no side effects: it is pulled in
+// transitively by ~24 modules (via invalidate-query-macro.ts, which most
+// routes.ts files use), so an eager Redis connection or timer here would
+// fire for every process that imports the route tree, including the
+// exact-mirror schema guard and the test runner. `startSse`/`stopSse` make
+// the keep-alive timer and the cross-instance Redis subscriber an explicit
+// lifecycle that only the server's boot/shutdown path drives, mirroring the
+// BullMQ `init*Worker` / `.close()` pairs in server.ts.
 
-logger.info("sse.initialized", {
-  keepAliveIntervalMs: KEEP_ALIVE_INTERVAL_MS,
-});
+let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+let redisSubscriber: ReturnType<typeof createRedisClient> | null = null;
+let started = false;
+
+/**
+ * Start the SSE keep-alive heartbeat and the cross-instance Redis
+ * subscriber. Idempotent: a second call while already started is a no-op.
+ *
+ * Redis connection failure is fail-soft (logged, not thrown) so a
+ * single-instance deployment without Redis still serves local SSE events
+ * via `broadcastLocal`/`broadcastLocalToOrganization`.
+ *
+ * Ordering hazard: `broadcast`/`broadcastToOrganization`/
+ * `broadcastSessionEvent` can be called before `startSse` runs (they only
+ * touch the independent lazy publisher in sse-broadcast.ts and the local
+ * `connections` registry, neither of which this function owns). A publish
+ * that happens in that window still reaches every already-subscribed
+ * instance; the only thing this instance can miss is its own event, since
+ * its subscriber has not attached yet. Callers must call `startSse` before
+ * accepting traffic (server.ts does so before `api.listen()`) to keep that
+ * window closed in practice, matching the timing the previous
+ * import-time `void initRedis()` had.
+ */
+export const startSse = (): void => {
+  if (started) {
+    return;
+  }
+  started = true;
+
+  keepAliveTimer = setInterval(sendKeepAlive, KEEP_ALIVE_INTERVAL_MS);
+  keepAliveTimer.unref();
+
+  void (async () => {
+    const subscriber = createRedisClient();
+    try {
+      await subscriber.subscribe(REDIS_CHANNEL, (message) => {
+        handleMessage(message);
+      });
+      if (!started) {
+        // stopSse ran while the connection was still being established;
+        // do not hand a live client to a lifecycle that already stopped.
+        subscriber.close();
+        return;
+      }
+      redisSubscriber = subscriber;
+      logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
+    } catch (error: unknown) {
+      logger.error("sse.redis_connection_failed", connectionErrorFields(error));
+      subscriber.close();
+    }
+  })();
+
+  logger.info("sse.initialized", {
+    keepAliveIntervalMs: KEEP_ALIVE_INTERVAL_MS,
+  });
+};
+
+/**
+ * Stop the keep-alive heartbeat and close the Redis subscriber. Safe to
+ * call when `startSse` was never called, and safe to call more than once.
+ */
+export const stopSse = (): void => {
+  if (!started) {
+    return;
+  }
+  started = false;
+
+  if (keepAliveTimer) {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = null;
+  }
+
+  if (redisSubscriber) {
+    try {
+      redisSubscriber.close();
+    } catch (error: unknown) {
+      logger.warn("sse.redis_close_failed", { "error.type": errorTag(error) });
+    }
+    redisSubscriber = null;
+  }
+};

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -267,9 +267,20 @@ const sendKeepAlive = () => {
 // lifecycle that only the server's boot/shutdown path drives, mirroring the
 // BullMQ `init*Worker` / `.close()` pairs in server.ts.
 
-let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
-let redisSubscriber: ReturnType<typeof createRedisClient> | null = null;
-let started = false;
+/**
+ * One running instance of the SSE lifecycle: the keep-alive timer, plus the
+ * Redis subscriber once its (async) connection attempt has attached. Object
+ * identity — not a boolean flag — is what `stopSse` and the in-flight
+ * connect callback use to tell "this lifecycle" apart from "whatever
+ * lifecycle is active now," including a stop+restart that happens between
+ * the connect's await points.
+ */
+type SseLifecycle = {
+  keepAliveTimer: ReturnType<typeof setInterval>;
+  subscriber: ReturnType<typeof createRedisClient> | null;
+};
+
+let activeLifecycle: SseLifecycle | null = null;
 
 /**
  * Start the SSE keep-alive heartbeat and the cross-instance Redis
@@ -291,31 +302,39 @@ let started = false;
  * import-time `void initRedis()` had.
  */
 export const startSse = (): void => {
-  if (started) {
+  if (activeLifecycle) {
     return;
   }
-  started = true;
 
-  keepAliveTimer = setInterval(sendKeepAlive, KEEP_ALIVE_INTERVAL_MS);
-  keepAliveTimer.unref();
+  const lifecycle: SseLifecycle = {
+    keepAliveTimer: setInterval(sendKeepAlive, KEEP_ALIVE_INTERVAL_MS),
+    subscriber: null,
+  };
+  lifecycle.keepAliveTimer.unref();
+  activeLifecycle = lifecycle;
 
   void (async () => {
-    const subscriber = createRedisClient();
+    // The client is constructed inside the try so a throwing constructor
+    // hits the fail-soft catch below instead of escaping this detached
+    // IIFE as an unhandled rejection.
+    let subscriber: ReturnType<typeof createRedisClient> | undefined;
     try {
+      subscriber = createRedisClient();
       await subscriber.subscribe(REDIS_CHANNEL, (message) => {
         handleMessage(message);
       });
-      if (!started) {
-        // stopSse ran while the connection was still being established;
-        // do not hand a live client to a lifecycle that already stopped.
+      if (activeLifecycle !== lifecycle) {
+        // stopSse (and possibly a subsequent startSse) ran while the
+        // connection was still being established; do not attach a stale
+        // subscriber to a lifecycle that is no longer the active one.
         subscriber.close();
         return;
       }
-      redisSubscriber = subscriber;
+      lifecycle.subscriber = subscriber;
       logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
     } catch (error: unknown) {
       logger.error("sse.redis_connection_failed", connectionErrorFields(error));
-      subscriber.close();
+      subscriber?.close();
     }
   })();
 
@@ -329,22 +348,19 @@ export const startSse = (): void => {
  * call when `startSse` was never called, and safe to call more than once.
  */
 export const stopSse = (): void => {
-  if (!started) {
+  if (!activeLifecycle) {
     return;
   }
-  started = false;
+  const lifecycle = activeLifecycle;
+  activeLifecycle = null;
 
-  if (keepAliveTimer) {
-    clearInterval(keepAliveTimer);
-    keepAliveTimer = null;
-  }
+  clearInterval(lifecycle.keepAliveTimer);
 
-  if (redisSubscriber) {
+  if (lifecycle.subscriber) {
     try {
-      redisSubscriber.close();
+      lifecycle.subscriber.close();
     } catch (error: unknown) {
       logger.warn("sse.redis_close_failed", { "error.type": errorTag(error) });
     }
-    redisSubscriber = null;
   }
 };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -107,6 +107,7 @@ import {
   refreshS3,
 } from "@/api/lib/s3";
 import { setSecurityHeaders } from "@/api/lib/security-headers";
+import { startSse, stopSse } from "@/api/lib/sse";
 import { initStyleSetPackageCleanupWorker } from "@/api/lib/style-set-package-cleanup-queue";
 import { initWorkflowWorker } from "@/api/lib/workflow-queue";
 
@@ -519,6 +520,12 @@ const startS3RefreshLoop = () => {
 // schema mirror — must yield the fully constructed `api` without any of
 // these side effects (no DB, no Redis, no listen).
 const startServer = async (): Promise<void> => {
+  // Start the SSE keep-alive heartbeat and cross-instance Redis subscriber
+  // first, before any awaited setup below, so its connection timing
+  // matches the previous import-time behavior and completes well before
+  // `api.listen()` starts accepting requests.
+  startSse();
+
   // Schema-drift fail-fast. If the runtime expects migrations
   // the database has not received, exit before serving any
   // request against a stale schema.
@@ -564,6 +571,7 @@ const startServer = async (): Promise<void> => {
         "error.type": errorTag(error),
       });
     });
+    stopSse();
     await Promise.race([
       Promise.allSettled([
         workflowWorker.close(),


### PR DESCRIPTION
## What

Removes the module-level side effects from `apps/api/src/lib/sse.ts` (an eager `void initRedis()` pub/sub connection and a `setInterval` keepalive started at import time) and replaces them with explicit `startSse()` / `stopSse()` lifecycle functions, mirroring the existing `init*Worker` / `.close()` pairs in `server.ts`.

## Why

`lib/sse.ts` is imported transitively by most of the route tree via `invalidate-query-macro.ts`, so any process importing routes (including the test runner and the exact-mirror schema guard) opened a live Redis connection and started a timer as an import side effect. The subscriber was a local variable with no reference kept, so the graceful-shutdown path had no way to close it. This also violates the repo convention of no module-level side effects in shared modules.

## How

- `startSse()` starts the keepalive interval and the Redis subscriber (fail-soft on connection errors, same as before) and is idempotent; `stopSse()` clears the interval and closes the subscriber, and is safe when never started or called twice.
- `server.ts` calls `startSse()` at the top of `startServer()` (before any awaited setup, so connection timing matches the previous import-time behavior and completes before `api.listen()`) and `stopSse()` in the existing shutdown path next to the worker `.close()` calls.
- If `stopSse()` runs while the async subscribe is still in flight, the connect callback now closes the client instead of leaking it; the old code had no way to close it at all.
- Public exports used by the ~24 importers are unchanged.

## Tests

New `sse.test.ts` (10 tests): importing the module creates no timer/connection; start is idempotent; stop clears the interval and closes the subscriber; stop-before-connect-completes closes the in-flight client; stop when never started is a no-op. Scoped run via `bun test --preload ./src/tests/setup-env.ts src/lib/sse.test.ts`: 10 pass, 0 fail.