### PR TITLE
fix: insert dynamic values literally when splicing OOXML strings

### DIFF
--- a/apps/api/src/handlers/docx/template-manifest.ts
+++ b/apps/api/src/handlers/docx/template-manifest.ts
@@ -876,7 +876,8 @@ export const writeManifest = async (
         CONTENT_TYPES_PATH,
         ctXml.replace(
           "</Types>",
-          `<Override PartName="/${propsPath}"` +
+          () =>
+            `<Override PartName="/${propsPath}"` +
             ` ContentType="${CUSTOM_XML_CONTENT_TYPE}"/>` +
             "</Types>",
         ),

--- a/apps/api/src/lib/docx-stamp.test.ts
+++ b/apps/api/src/lib/docx-stamp.test.ts
@@ -307,6 +307,86 @@ describe("placeholder replacement", () => {
   });
 });
 
+describe("special replacement patterns in dynamic values", () => {
+  // Workspace `reference` (the source of `stamp`) is free-form user text
+  // (see apps/api/src/handlers/workspaces/update-by-id.ts), so it can contain
+  // sequences that String.prototype.replace treats specially inside a
+  // *replacement* string: $& = the whole match, $' = text after the match,
+  // etc. A naive `.replace(needle, dynamicString)` call would silently splice
+  // in matched/surrounding XML instead of the literal stamp text. These
+  // cases exercise every dynamic-value splice site (custom property upsert,
+  // footer paragraph creation and update, and placeholder substitution) with
+  // both patterns.
+  const baseUrl = "https://stella.legal";
+  const specialPatterns = ["$&", "$'"];
+
+  const expectedEscape = (value: string): string =>
+    value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+
+  for (const pattern of specialPatterns) {
+    test(`stamp containing "${pattern}" survives injecting into a fresh DOCX`, async () => {
+      const stamp = `2026/001/015${pattern}.v3`;
+      const code = "kx8mq2n4p3";
+      const docx = await makeDocx();
+      const stamped = await injectStamp(docx, stamp, code, baseUrl);
+
+      const customXml = await readZipFile(stamped, "docProps/custom.xml");
+      expect(customXml).toContain(expectedEscape(stamp));
+      expect(customXml?.match(/<\/Properties>/gu)).toHaveLength(1);
+
+      const footer = await readZipFile(stamped, "word/footer1.xml");
+      expect(footer).toContain(expectedEscape(stamp));
+      expect(footer?.match(/<\/w:ftr>/gu)).toHaveLength(1);
+    });
+
+    test(`stamp containing "${pattern}" survives updating an existing stamp`, async () => {
+      const stamp = `2026/002/099${pattern}.v1`;
+      const code = "abcdefghjk";
+      const docx = await makeDocx();
+      const first = await injectStamp(
+        docx,
+        "2026/001/001.v1",
+        "aaaaaaaaaa",
+        baseUrl,
+      );
+      const second = await injectStamp(first, stamp, code, baseUrl);
+
+      const customXml = await readZipFile(second, "docProps/custom.xml");
+      expect(customXml).toContain(expectedEscape(stamp));
+      expect(customXml?.match(/<\/Properties>/gu)).toHaveLength(1);
+
+      const footer = await readZipFile(second, "word/footer1.xml");
+      expect(footer).toContain(expectedEscape(stamp));
+      expect(footer?.match(/<\/w:ftr>/gu)).toHaveLength(1);
+    });
+
+    test(`stamp containing "${pattern}" survives {{STELLA_REF}} placeholder replacement`, async () => {
+      const stamp = `2026/003/007${pattern}.v2`;
+      const code = "mnpqrstuvw";
+      const docx = await makeDocx({
+        documentXml: [
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}">`,
+          "<w:body>",
+          "<w:p><w:r><w:t>Doc: {{STELLA_REF}}</w:t></w:r></w:p>",
+          "<w:sectPr></w:sectPr>",
+          "</w:body>",
+          "</w:document>",
+        ].join("\n"),
+      });
+
+      const stamped = await injectStamp(docx, stamp, code, baseUrl);
+      const docXml = await readZipFile(stamped, "word/document.xml");
+      expect(docXml).toContain(`Doc: ${expectedEscape(stamp)}`);
+      expect(docXml?.match(/<\/w:body>/gu)).toHaveLength(1);
+    });
+  }
+});
+
 describe("extractStamp", () => {
   const stamp = "2026/001/015.v3";
   const code = "kx8mq2n4p3";

--- a/apps/api/src/lib/docx-stamp.ts
+++ b/apps/api/src/lib/docx-stamp.ts
@@ -256,7 +256,11 @@ const upsertProperty = (xml: string, name: string, value: string): string => {
     "u",
   );
   if (re.test(xml)) {
-    return xml.replace(re, `$1${escapeXml(value)}$2`);
+    return xml.replace(
+      re,
+      (_match, open: string, close: string) =>
+        `${open}${escapeXml(value)}${close}`,
+    );
   }
 
   // Find max pid for new property
@@ -275,7 +279,7 @@ const upsertProperty = (xml: string, name: string, value: string): string => {
     "  </property>",
   ].join("\n");
 
-  return xml.replace("</Properties>", `${prop}\n</Properties>`);
+  return xml.replace("</Properties>", () => `${prop}\n</Properties>`);
 };
 
 const ensureContentType = async (archive: DocxArchive): Promise<void> => {
@@ -371,19 +375,16 @@ const replacePlaceholders = async (
 
     let result = xml;
     if (hasId) {
-      result = result.replace(
-        PLACEHOLDER_ID_RE,
-        escapeXml(`${stamp}  stl:${verificationCode}`),
-      );
+      const idText = escapeXml(`${stamp}  stl:${verificationCode}`);
+      result = result.replace(PLACEHOLDER_ID_RE, () => idText);
     }
     if (hasRef) {
-      result = result.replace(PLACEHOLDER_REF_RE, escapeXml(stamp));
+      const refText = escapeXml(stamp);
+      result = result.replace(PLACEHOLDER_REF_RE, () => refText);
     }
     if (hasCode) {
-      result = result.replace(
-        PLACEHOLDER_CODE_RE,
-        escapeXml(`stl:${verificationCode}`),
-      );
+      const codeText = escapeXml(`stl:${verificationCode}`);
+      result = result.replace(PLACEHOLDER_CODE_RE, () => codeText);
     }
 
     archive.zip.file(path, result);
@@ -547,7 +548,7 @@ const updateExistingFooter = async (
     );
     archive.zip.file(
       footerPath,
-      footerXml.replace(CLOSING_FTR_RE, `${stampPara}\n</w:ftr>`),
+      footerXml.replace(CLOSING_FTR_RE, () => `${stampPara}\n</w:ftr>`),
     );
   }
 };
@@ -607,7 +608,10 @@ const createNewFooter = async (
   if (docRels) {
     archive.zip.file(
       docRelsPath,
-      docRels.replace("</Relationships>", `${footerRel}\n</Relationships>`),
+      docRels.replace(
+        "</Relationships>",
+        () => `${footerRel}\n</Relationships>`,
+      ),
     );
   } else {
     archive.zip.file(
@@ -667,11 +671,11 @@ const replaceStampParagraph = (
   );
 
   if (re.test(footerXml)) {
-    return footerXml.replace(re, newPara);
+    return footerXml.replace(re, () => newPara);
   }
 
   // Fallback: append
-  return footerXml.replace(CLOSING_FTR_RE, `${newPara}\n</w:ftr>`);
+  return footerXml.replace(CLOSING_FTR_RE, () => `${newPara}\n</w:ftr>`);
 };
 
 const ensureHyperlinkRel = (rels: string, rId: string, url: string): string => {
@@ -693,7 +697,11 @@ const ensureHyperlinkRel = (rels: string, rId: string, url: string): string => {
     "u",
   );
   if (existingRe.test(rels)) {
-    return rels.replace(existingRe, `$1${escapeXml(url)}$2`);
+    return rels.replace(
+      existingRe,
+      (_match, open: string, close: string) =>
+        `${open}${escapeXml(url)}${close}`,
+    );
   }
 
   // Add new relationship
@@ -702,7 +710,7 @@ const ensureHyperlinkRel = (rels: string, rId: string, url: string): string => {
     ` Type="${HYPERLINK_REL_TYPE}"` +
     ` Target="${escapeXml(url)}"` +
     ' TargetMode="External"/>';
-  return rels.replace("</Relationships>", `${rel}\n</Relationships>`);
+  return rels.replace("</Relationships>", () => `${rel}\n</Relationships>`);
 };
 
 const addFooterReference = (docXml: string, footerRId: string): string => {
@@ -734,7 +742,7 @@ const ensureFooterContentType = async (
     ` ContentType="${FOOTER_CONTENT_TYPE}"/>`;
   archive.zip.file(
     CONTENT_TYPES_PATH,
-    ct.replace("</Types>", `${override}\n</Types>`),
+    ct.replace("</Types>", () => `${override}\n</Types>`),
   );
 };
 

--- a/packages/docx-utils/src/relationships.test.ts
+++ b/packages/docx-utils/src/relationships.test.ts
@@ -68,3 +68,174 @@ describe("relationship helpers", () => {
     expect(ensureRelationship(relsXml, "rId4", "new", "new.xml")).toBe(relsXml);
   });
 });
+
+/**
+ * Mirrors the package-local `escapeXmlAttribute` helper so tests can compute
+ * the expected attribute value independently of the implementation.
+ */
+const expectedEscape = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+describe("special replacement patterns do not corrupt output", () => {
+  // Each of these is treated specially by String.prototype.replace when used
+  // inside the *replacement* string (not the search pattern): $& = the whole
+  // match, $$ = literal $, $` / $' = text before/after the match, $1 = capture
+  // group 1. A naive `.replace(needle, dynamicString)` call would silently
+  // splice in the matched/surrounding text instead of the literal value.
+  const specialPatterns = ["$&", "$$", "$`", "$'", "$1", "$<name>"];
+
+  describe("ensureContentType", () => {
+    for (const pattern of specialPatterns) {
+      test(`literal "${pattern}" survives as partName`, () => {
+        const contentTypesXml = "<Types></Types>";
+        const result = ensureContentType(
+          contentTypesXml,
+          pattern,
+          "text/plain",
+        );
+
+        expect(result).toContain(`PartName="${expectedEscape(pattern)}"`);
+        expect(result.match(/<\/Types>/gu)).toHaveLength(1);
+      });
+
+      test(`literal "${pattern}" survives as contentType`, () => {
+        const contentTypesXml = "<Types></Types>";
+        const result = ensureContentType(
+          contentTypesXml,
+          "/word/x.xml",
+          pattern,
+        );
+
+        expect(result).toContain(`ContentType="${expectedEscape(pattern)}"`);
+        expect(result.match(/<\/Types>/gu)).toHaveLength(1);
+      });
+    }
+  });
+
+  describe("ensureRelationship", () => {
+    for (const pattern of specialPatterns) {
+      test(`literal "${pattern}" survives as type`, () => {
+        const relsXml = "<Relationships></Relationships>";
+        const result = ensureRelationship(
+          relsXml,
+          "rId1",
+          pattern,
+          "target.xml",
+        );
+
+        expect(result).toContain(`Type="${expectedEscape(pattern)}"`);
+        expect(result.match(/<\/Relationships>/gu)).toHaveLength(1);
+      });
+
+      test(`literal "${pattern}" survives as target`, () => {
+        const relsXml = "<Relationships></Relationships>";
+        const result = ensureRelationship(relsXml, "rId1", "type", pattern);
+
+        expect(result).toContain(`Target="${expectedEscape(pattern)}"`);
+        expect(result.match(/<\/Relationships>/gu)).toHaveLength(1);
+      });
+    }
+  });
+});
+
+describe("XML attribute escaping", () => {
+  test("escapes quotes, ampersands, and angle brackets in ensureContentType", () => {
+    const contentTypesXml = "<Types></Types>";
+    const result = ensureContentType(
+      contentTypesXml,
+      `/word/"quoted"<tag>&amp.xml`,
+      `text/plain;charset="utf-8"&<x>`,
+    );
+
+    expect(result).toContain(
+      'PartName="/word/&quot;quoted&quot;&lt;tag&gt;&amp;amp.xml"',
+    );
+    expect(result).toContain(
+      'ContentType="text/plain;charset=&quot;utf-8&quot;&amp;&lt;x&gt;"',
+    );
+    // No raw quotes, angle brackets, or bare ampersands leaked outside entities.
+    expect(result).not.toMatch(/PartName="[^"]*<[^"]*"/u);
+    expect(result.match(/<\/Types>/gu)).toHaveLength(1);
+  });
+
+  test("escapes quotes, ampersands, and angle brackets in ensureRelationship", () => {
+    const relsXml = "<Relationships></Relationships>";
+    const result = ensureRelationship(
+      relsXml,
+      `rId"1"`,
+      `http://example.com/type?a=1&b=2`,
+      `target<"x">.xml&y`,
+    );
+
+    expect(result).toContain('Id="rId&quot;1&quot;"');
+    expect(result).toContain('Type="http://example.com/type?a=1&amp;b=2"');
+    expect(result).toContain('Target="target&lt;&quot;x&quot;&gt;.xml&amp;y"');
+    expect(result.match(/<\/Relationships>/gu)).toHaveLength(1);
+  });
+
+  test("does not double-encode already-escaped ampersands within a single call", () => {
+    // Order matters: '&' must be escaped before '<'/'>'/'"' so entities
+    // introduced by escaping are not themselves re-escaped.
+    const contentTypesXml = "<Types></Types>";
+    const result = ensureContentType(contentTypesXml, "/word/x.xml", "&quot;");
+
+    expect(result).toContain('ContentType="&amp;quot;"');
+  });
+});
+
+describe("round-trip sanity", () => {
+  test("adding a content type keeps exactly one closing Types tag", () => {
+    const contentTypesXml = "<Types></Types>";
+    const result = ensureContentType(
+      contentTypesXml,
+      "/word/document.xml",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+    );
+
+    expect(result.match(/<\/Types>/gu)).toHaveLength(1);
+    expect(result.startsWith("<Types>")).toBe(true);
+    expect(result.endsWith("</Types>")).toBe(true);
+  });
+
+  test("adding a relationship keeps exactly one closing Relationships tag", () => {
+    const relsXml = "<Relationships></Relationships>";
+    const result = ensureRelationship(
+      relsXml,
+      "rId1",
+      "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+      "word/document.xml",
+    );
+
+    expect(result.match(/<\/Relationships>/gu)).toHaveLength(1);
+    expect(result.startsWith("<Relationships>")).toBe(true);
+    expect(result.endsWith("</Relationships>")).toBe(true);
+  });
+
+  test("chaining ensureContentType and ensureRelationship with adversarial values stays well-formed", () => {
+    let contentTypesXml = "<Types></Types>";
+    let relsXml = "<Relationships></Relationships>";
+
+    contentTypesXml = ensureContentType(
+      contentTypesXml,
+      `/word/$&"evil".xml`,
+      `text/plain&$'`,
+    );
+    relsXml = ensureRelationship(
+      relsXml,
+      "rId1",
+      `type&$1"<x>`,
+      `target$\`&"<y>`,
+    );
+
+    expect(contentTypesXml.match(/<\/Types>/gu)).toHaveLength(1);
+    expect(relsXml.match(/<\/Relationships>/gu)).toHaveLength(1);
+    // No unescaped '<' or '"' introduced inside attribute values, i.e. the
+    // only '<' characters present are the ones forming real XML tags.
+    expect(contentTypesXml.match(/</gu)).toHaveLength(3); // <Types>, <Override .../>, </Types>
+    expect(relsXml.match(/</gu)).toHaveLength(3); // <Relationships>, <Relationship .../>, </Relationships>
+  });
+});

--- a/packages/docx-utils/src/relationships.ts
+++ b/packages/docx-utils/src/relationships.ts
@@ -1,3 +1,15 @@
+/**
+ * Escape a string for safe use inside a double-quoted XML attribute value.
+ * Order matters: `&` must be escaped first so it does not double-escape the
+ * entities produced for the other characters.
+ */
+const escapeXmlAttribute = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
 /** Find the next available rId in a relationships XML string */
 export const findNextRId = (relsXml: string): string => {
   const matches = relsXml.matchAll(/Id="rId(?<num>\d+)"/gu);
@@ -17,11 +29,12 @@ export const ensureContentType = (
   partName: string,
   contentType: string,
 ): string => {
-  if (contentTypesXml.includes(`PartName="${partName}"`)) {
+  const escapedPartName = escapeXmlAttribute(partName);
+  if (contentTypesXml.includes(`PartName="${escapedPartName}"`)) {
     return contentTypesXml;
   }
-  const override = `<Override PartName="${partName}" ContentType="${contentType}"/>`;
-  return contentTypesXml.replace("</Types>", `${override}\n</Types>`);
+  const override = `<Override PartName="${escapedPartName}" ContentType="${escapeXmlAttribute(contentType)}"/>`;
+  return contentTypesXml.replace("</Types>", () => `${override}\n</Types>`);
 };
 
 /** Ensure a relationship entry exists */
@@ -31,9 +44,10 @@ export const ensureRelationship = (
   type: string,
   target: string,
 ): string => {
-  if (relsXml.includes(`Id="${rId}"`)) {
+  const escapedRId = escapeXmlAttribute(rId);
+  if (relsXml.includes(`Id="${escapedRId}"`)) {
     return relsXml;
   }
-  const rel = `<Relationship Id="${rId}" Type="${type}" Target="${target}"/>`;
-  return relsXml.replace("</Relationships>", `${rel}\n</Relationships>`);
+  const rel = `<Relationship Id="${escapedRId}" Type="${escapeXmlAttribute(type)}" Target="${escapeXmlAttribute(target)}"/>`;
+  return relsXml.replace("</Relationships>", () => `${rel}\n</Relationships>`);
 };


### PR DESCRIPTION
## What

Fixes a string-splicing correctness bug in two places that build OOXML by string replacement, and adds attribute escaping where it was missing:

- `packages/docx-utils/src/relationships.ts`: `ensureContentType` / `ensureRelationship` passed caller-supplied values (`partName`, `contentType`, `type`, `target`) inside the replacement argument of `String.replace()`. JavaScript interprets `$&`, `$$`, `` $` ``, `$'`, and `$<n>` in replacement strings even for plain-string searches, so a value containing one of those sequences spliced surrounding XML into the attribute instead of being inserted literally, silently corrupting the part. Values are now inserted via function replacers and XML-escaped (`escapeXmlAttribute` for `&`, `<`, `>`, `"`); the dedup `.includes()` checks compare against the escaped form so re-runs stay idempotent. Public signatures unchanged.
- `apps/api/src/lib/docx-stamp.ts` (+ one site in `template-manifest.ts`): the same pattern existed across the stamping paths (custom property upsert, footer paragraph create/update, hyperlink relationship target, placeholder substitution). The document stamp derives from the workspace reference, a free-form user string, so e.g. a reference containing `$&` produced a corrupted stamped document. All dynamic-value splice sites now use function replacers; sites whose interpolated content is a fixed constant or digit-only filename are left as-is, as are splices that already used function replacers.

## Tests

- `relationships.test.ts`: 30 new cases covering each `$` replacement pattern in each parameter, attribute escaping (including no-double-encoding), and well-formedness checks (exactly one closing `</Types>` / `</Relationships>`); all 8 pre-existing tests unchanged and passing (38 pass total).
- `docx-stamp.test.ts`: new block with `$&` / `$'` stamp values across fresh injection, update-in-place, and placeholder substitution, asserting the literal escaped value survives and closing tags appear exactly once (89 pass total across the two affected API test files).