### PR TITLE
fix: enforce API rate limits across replicas

### DIFF
--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -53,8 +53,7 @@ import versionSummarize from "@/api/handlers/entities/version-summarize";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 export const entitiesRoute = new Elysia({
   prefix: "/entities/:workspaceId",
@@ -67,9 +66,9 @@ export const entitiesRoute = new Elysia({
       scoping: "scoped",
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
-      generator: scopedGenerator("upload"),
-      context: new RedisRateLimitContext({
+      ...createRedisRateLimit({
         failurePolicy: "fail_open_local",
+        scope: "upload",
       }),
       skip: (req) => !isUploadRateLimitedPath(new URL(req.url).pathname),
     }),
@@ -79,9 +78,9 @@ export const entitiesRoute = new Elysia({
       scoping: "scoped",
       duration: API_RATE_LIMITS.translate.duration,
       max: API_RATE_LIMITS.translate.max,
-      generator: scopedGenerator("translate"),
-      context: new RedisRateLimitContext({
+      ...createRedisRateLimit({
         failurePolicy: "fail_open_local",
+        scope: "translate",
       }),
       skip: (req) => !isTranslateRateLimitedPath(new URL(req.url).pathname),
     }),

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -53,10 +53,8 @@ import versionSummarize from "@/api/handlers/entities/version-summarize";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import {
-  InMemoryRateLimitContext,
-  scopedGenerator,
-} from "@/api/lib/rate-limit/rate-limit";
+import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 
 export const entitiesRoute = new Elysia({
   prefix: "/entities/:workspaceId",
@@ -70,7 +68,9 @@ export const entitiesRoute = new Elysia({
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
       generator: scopedGenerator("upload"),
-      context: new InMemoryRateLimitContext(),
+      context: new RedisRateLimitContext({
+        failurePolicy: "fail_open_local",
+      }),
       skip: (req) => !isUploadRateLimitedPath(new URL(req.url).pathname),
     }),
   )
@@ -80,7 +80,9 @@ export const entitiesRoute = new Elysia({
       duration: API_RATE_LIMITS.translate.duration,
       max: API_RATE_LIMITS.translate.max,
       generator: scopedGenerator("translate"),
-      context: new InMemoryRateLimitContext(),
+      context: new RedisRateLimitContext({
+        failurePolicy: "fail_open_local",
+      }),
       skip: (req) => !isTranslateRateLimitedPath(new URL(req.url).pathname),
     }),
   )

--- a/apps/api/src/handlers/hosted-usage-webhook/routes.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/routes.ts
@@ -15,8 +15,7 @@ import { rateLimit } from "elysia-rate-limit";
 
 import { receiveHostedUsageWebhook } from "@/api/handlers/hosted-usage-webhook/receive";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 export const hostedUsageWebhookRoute = new Elysia({
   prefix: "/usage/hosted",
@@ -26,9 +25,9 @@ export const hostedUsageWebhookRoute = new Elysia({
       scoping: "scoped",
       duration: API_RATE_LIMITS.hostedUsageWebhook.duration,
       max: API_RATE_LIMITS.hostedUsageWebhook.max,
-      generator: scopedGenerator("hosted-usage-webhook"),
-      context: new RedisRateLimitContext({
+      ...createRedisRateLimit({
         failurePolicy: "fail_open_local",
+        scope: "hosted-usage-webhook",
       }),
     }),
   )

--- a/apps/api/src/handlers/hosted-usage-webhook/routes.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/routes.ts
@@ -15,10 +15,8 @@ import { rateLimit } from "elysia-rate-limit";
 
 import { receiveHostedUsageWebhook } from "@/api/handlers/hosted-usage-webhook/receive";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import {
-  InMemoryRateLimitContext,
-  scopedGenerator,
-} from "@/api/lib/rate-limit/rate-limit";
+import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 
 export const hostedUsageWebhookRoute = new Elysia({
   prefix: "/usage/hosted",
@@ -29,7 +27,9 @@ export const hostedUsageWebhookRoute = new Elysia({
       duration: API_RATE_LIMITS.hostedUsageWebhook.duration,
       max: API_RATE_LIMITS.hostedUsageWebhook.max,
       generator: scopedGenerator("hosted-usage-webhook"),
-      context: new InMemoryRateLimitContext(),
+      context: new RedisRateLimitContext({
+        failurePolicy: "fail_open_local",
+      }),
     }),
   )
   .post(

--- a/apps/api/src/handlers/me/routes.ts
+++ b/apps/api/src/handlers/me/routes.ts
@@ -8,8 +8,7 @@ import deleteAccountSendOtp from "@/api/handlers/me/send-otp";
 import deleteAccountVerify from "@/api/handlers/me/verify-delete";
 import { sessionAuthMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 const isDeleteAccountOtpSendPath = (pathname: string): boolean =>
   pathname === "/v1/me/delete/send-otp";
@@ -29,9 +28,9 @@ export const meRoute = new Elysia({ prefix: "/me" })
           scoping: "scoped",
           duration: API_RATE_LIMITS.deleteAccountOtp.duration,
           max: API_RATE_LIMITS.deleteAccountOtp.max,
-          generator: scopedGenerator("delete-account-otp"),
-          context: new RedisRateLimitContext({
+          ...createRedisRateLimit({
             failurePolicy: "fail_open_local",
+            scope: "delete-account-otp",
           }),
           skip: (req) => !isDeleteAccountOtpSendPath(new URL(req.url).pathname),
         }),

--- a/apps/api/src/handlers/me/routes.ts
+++ b/apps/api/src/handlers/me/routes.ts
@@ -8,10 +8,8 @@ import deleteAccountSendOtp from "@/api/handlers/me/send-otp";
 import deleteAccountVerify from "@/api/handlers/me/verify-delete";
 import { sessionAuthMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import {
-  InMemoryRateLimitContext,
-  scopedGenerator,
-} from "@/api/lib/rate-limit/rate-limit";
+import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 
 const isDeleteAccountOtpSendPath = (pathname: string): boolean =>
   pathname === "/v1/me/delete/send-otp";
@@ -32,7 +30,9 @@ export const meRoute = new Elysia({ prefix: "/me" })
           duration: API_RATE_LIMITS.deleteAccountOtp.duration,
           max: API_RATE_LIMITS.deleteAccountOtp.max,
           generator: scopedGenerator("delete-account-otp"),
-          context: new InMemoryRateLimitContext(),
+          context: new RedisRateLimitContext({
+            failurePolicy: "fail_open_local",
+          }),
           skip: (req) => !isDeleteAccountOtpSendPath(new URL(req.url).pathname),
         }),
       )

--- a/apps/api/src/handlers/style-sets/routes.ts
+++ b/apps/api/src/handlers/style-sets/routes.ts
@@ -14,8 +14,7 @@ import updateStyleSetFromEditor from "@/api/handlers/style-sets/update-from-edit
 import { isStyleSetUploadRateLimitedRequest } from "@/api/handlers/style-sets/upload-rate-limit";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 export const styleSetsRoute = new Elysia({ prefix: "/style-sets" })
   .use(authMacro)
@@ -25,9 +24,9 @@ export const styleSetsRoute = new Elysia({ prefix: "/style-sets" })
       scoping: "scoped",
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
-      generator: scopedGenerator("style-set-upload"),
-      context: new RedisRateLimitContext({
+      ...createRedisRateLimit({
         failurePolicy: "fail_open_local",
+        scope: "style-set-upload",
       }),
       skip: (request) => !isStyleSetUploadRateLimitedRequest(request),
     }),

--- a/apps/api/src/handlers/style-sets/routes.ts
+++ b/apps/api/src/handlers/style-sets/routes.ts
@@ -14,10 +14,8 @@ import updateStyleSetFromEditor from "@/api/handlers/style-sets/update-from-edit
 import { isStyleSetUploadRateLimitedRequest } from "@/api/handlers/style-sets/upload-rate-limit";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import {
-  InMemoryRateLimitContext,
-  scopedGenerator,
-} from "@/api/lib/rate-limit/rate-limit";
+import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 
 export const styleSetsRoute = new Elysia({ prefix: "/style-sets" })
   .use(authMacro)
@@ -28,7 +26,9 @@ export const styleSetsRoute = new Elysia({ prefix: "/style-sets" })
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
       generator: scopedGenerator("style-set-upload"),
-      context: new InMemoryRateLimitContext(),
+      context: new RedisRateLimitContext({
+        failurePolicy: "fail_open_local",
+      }),
       skip: (request) => !isStyleSetUploadRateLimitedRequest(request),
     }),
   )

--- a/apps/api/src/handlers/uploads/routes.ts
+++ b/apps/api/src/handlers/uploads/routes.ts
@@ -9,10 +9,8 @@ import presignUpload from "@/api/handlers/uploads/presign";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import {
-  InMemoryRateLimitContext,
-  scopedGenerator,
-} from "@/api/lib/rate-limit/rate-limit";
+import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 
 /**
  * Workspace-scoped presigned-upload coordination:
@@ -53,7 +51,9 @@ export const uploadsRoute = new Elysia({
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
       generator: scopedGenerator("upload-presigned"),
-      context: new InMemoryRateLimitContext(),
+      context: new RedisRateLimitContext({
+        failurePolicy: "fail_open_local",
+      }),
     }),
   )
   .guard({

--- a/apps/api/src/handlers/uploads/routes.ts
+++ b/apps/api/src/handlers/uploads/routes.ts
@@ -9,8 +9,7 @@ import presignUpload from "@/api/handlers/uploads/presign";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
-import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 /**
  * Workspace-scoped presigned-upload coordination:
@@ -50,9 +49,9 @@ export const uploadsRoute = new Elysia({
       scoping: "scoped",
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
-      generator: scopedGenerator("upload-presigned"),
-      context: new RedisRateLimitContext({
+      ...createRedisRateLimit({
         failurePolicy: "fail_open_local",
+        scope: "upload-presigned",
       }),
     }),
   )

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -78,13 +78,24 @@ describe("RedisRateLimitContext", () => {
   });
 
   test("bounds a stalled command and cancels its timer", async () => {
+    let clientClosed = false;
+    let lateMutationApplied = false;
+    let settleCommand: (() => void) | undefined;
     let timerCancelled = false;
     const context = new RedisRateLimitContext({
       commandTimeoutMs: 500,
       createRedis: () => ({
+        close: () => {
+          clientClosed = true;
+        },
         send: async () =>
-          await new Promise<never>(() => {
-            // Intentionally unresolved to exercise the command timeout.
+          await new Promise<[number, number]>((resolve) => {
+            settleCommand = () => {
+              if (!clientClosed) {
+                lateMutationApplied = true;
+              }
+              resolve([1, WINDOW_MS]);
+            };
           }),
       }),
       failurePolicy: "fail_open_local",
@@ -101,7 +112,39 @@ describe("RedisRateLimitContext", () => {
     const counter = await context.increment("api:client", WINDOW_MS, 1000);
 
     expect(counter.count).toBe(1);
+    expect(clientClosed).toBe(true);
     expect(timerCancelled).toBe(true);
+    settleCommand?.();
+    await Promise.resolve();
+    expect(lateMutationApplied).toBe(false);
+    context.kill();
+  });
+
+  test("does not refund Redis after the matching increment fell back locally", async () => {
+    let decrementCalled = false;
+    const context = new RedisRateLimitContext({
+      createRedis: () => ({
+        send: async (_command, args) => {
+          const script = requiredArg(args, 0);
+          if (script.includes('redis.call("INCR"')) {
+            throw new TypeError("Redis unavailable");
+          }
+          if (script.includes('redis.call("DECR"')) {
+            decrementCalled = true;
+            return 0;
+          }
+          throw new TypeError("Unexpected Redis script");
+        },
+      }),
+      failurePolicy: "fail_open_local",
+      onRedisError: () => undefined,
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    expect((await context.increment("api:client")).count).toBe(1);
+    await context.decrement("api:client");
+
+    expect(decrementCalled).toBe(false);
     context.kill();
   });
 

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -120,17 +120,22 @@ describe("RedisRateLimitContext", () => {
     context.kill();
   });
 
-  test("does not refund Redis after the matching increment fell back locally", async () => {
-    let decrementCalled = false;
+  test("suppresses fallback refunds without affecting healthy keys", async () => {
+    const decrementedKeys: string[] = [];
+    let failNextIncrement = true;
     const context = new RedisRateLimitContext({
       createRedis: () => ({
         send: async (_command, args) => {
           const script = requiredArg(args, 0);
           if (script.includes('redis.call("INCR"')) {
-            throw new TypeError("Redis unavailable");
+            if (failNextIncrement) {
+              failNextIncrement = false;
+              throw new TypeError("Redis unavailable");
+            }
+            return [1, WINDOW_MS];
           }
           if (script.includes('redis.call("DECR"')) {
-            decrementCalled = true;
+            decrementedKeys.push(requiredArg(args, 2));
             return 0;
           }
           throw new TypeError("Unexpected Redis script");
@@ -141,10 +146,12 @@ describe("RedisRateLimitContext", () => {
     });
     context.init(RATE_LIMIT_OPTIONS);
 
-    expect((await context.increment("api:client")).count).toBe(1);
-    await context.decrement("api:client");
+    expect((await context.increment("api:failed")).count).toBe(1);
+    await context.decrement("api:failed");
+    expect((await context.increment("api:healthy")).count).toBe(1);
+    await context.decrement("api:healthy");
 
-    expect(decrementCalled).toBe(false);
+    expect(decrementedKeys).toEqual(["api:ratelimit:v1:api:healthy"]);
     context.kill();
   });
 

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -3,7 +3,11 @@ import Elysia from "elysia";
 import type { Options } from "elysia-rate-limit";
 import { rateLimit } from "elysia-rate-limit";
 
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import {
+  createRedisRateLimit,
+  createRedisRateLimitRequestKey,
+  RedisRateLimitContext,
+} from "@/api/lib/rate-limit/redis-context";
 
 const WINDOW_MS = 1000;
 const RATE_LIMIT_OPTIONS = {
@@ -18,16 +22,41 @@ const RATE_LIMIT_OPTIONS = {
 } as const satisfies Omit<Options, "context">;
 
 describe("RedisRateLimitContext", () => {
+  test("keeps one refund identity per request while sharing the counter key", async () => {
+    const { context, generator } = createRedisRateLimit({
+      failurePolicy: "fail_open_local",
+      scope: "api",
+    });
+    const firstRequest = Object.assign(new Request("http://localhost/one"), {
+      cookie: {},
+    });
+    const secondRequest = Object.assign(new Request("http://localhost/two"), {
+      cookie: {},
+    });
+
+    const firstKey = await generator(firstRequest, null, {});
+    const repeatedKey = await generator(firstRequest, null, {});
+    const secondKey = await generator(secondRequest, null, {});
+
+    expect(firstKey).toBe(repeatedKey);
+    expect(secondKey).not.toBe(firstKey);
+    expect(firstKey.startsWith("api")).toBe(true);
+    expect(secondKey.startsWith("api")).toBe(true);
+    await context.kill();
+  });
+
   test("shares counters, window expiry, and refunds across replicas", async () => {
     const redisState = createFakeRedisState();
     const first = createContext(redisState);
     const second = createContext(redisState);
+    const firstTranslateRequest = requestKey("translate:client");
 
     expect(
-      (await first.increment("translate:client", WINDOW_MS, 1000)).count,
+      (await first.increment(firstTranslateRequest, WINDOW_MS, 1000)).count,
     ).toBe(1);
     expect(
-      (await second.increment("translate:client", WINDOW_MS, 1000)).count,
+      (await second.increment(requestKey("translate:client"), WINDOW_MS, 1000))
+        .count,
     ).toBe(2);
     expect(
       (await second.increment("upload:client", WINDOW_MS, 1000)).count,
@@ -40,14 +69,16 @@ describe("RedisRateLimitContext", () => {
       (await first.increment("upload:client", WINDOW_MS, 1000)).count,
     ).toBe(1);
 
-    await first.decrement("translate:client");
+    await first.decrement(firstTranslateRequest);
     expect(
-      (await second.increment("translate:client", WINDOW_MS, 1000)).count,
+      (await second.increment(requestKey("translate:client"), WINDOW_MS, 1000))
+        .count,
     ).toBe(2);
 
     redisState.now = 2001;
     expect(
-      (await first.increment("translate:client", WINDOW_MS, 2001)).count,
+      (await first.increment(requestKey("translate:client"), WINDOW_MS, 2001))
+        .count,
     ).toBe(1);
 
     first.kill();
@@ -89,12 +120,12 @@ describe("RedisRateLimitContext", () => {
           clientClosed = true;
         },
         send: async () =>
-          await new Promise<[number, number]>((resolve) => {
+          await new Promise<[number, number, string]>((resolve) => {
             settleCommand = () => {
               if (!clientClosed) {
                 lateMutationApplied = true;
               }
-              resolve([1, WINDOW_MS]);
+              resolve([1, WINDOW_MS, "window-timeout"]);
             };
           }),
       }),
@@ -127,14 +158,14 @@ describe("RedisRateLimitContext", () => {
       createRedis: () => ({
         send: async (_command, args) => {
           const script = requiredArg(args, 0);
-          if (script.includes('redis.call("INCR"')) {
+          if (script.includes('redis.call("HSET"')) {
             if (failNextIncrement) {
               failNextIncrement = false;
               throw new TypeError("Redis unavailable");
             }
-            return [1, WINDOW_MS];
+            return [1, WINDOW_MS, "window-healthy"];
           }
-          if (script.includes('redis.call("DECR"')) {
+          if (script.includes("~= ARGV[1]")) {
             decrementedKeys.push(requiredArg(args, 2));
             return 0;
           }
@@ -146,12 +177,37 @@ describe("RedisRateLimitContext", () => {
     });
     context.init(RATE_LIMIT_OPTIONS);
 
-    expect((await context.increment("api:failed")).count).toBe(1);
-    await context.decrement("api:failed");
-    expect((await context.increment("api:healthy")).count).toBe(1);
-    await context.decrement("api:healthy");
+    const failedRequest = requestKey("api:failed");
+    const healthyRequest = requestKey("api:healthy");
+    expect((await context.increment(failedRequest)).count).toBe(1);
+    await context.decrement(failedRequest);
+    expect((await context.increment(healthyRequest)).count).toBe(1);
+    await context.decrement(healthyRequest);
 
-    expect(decrementedKeys).toEqual(["api:ratelimit:v1:api:healthy"]);
+    expect(decrementedKeys).toEqual(["api:ratelimit:v2:api:healthy"]);
+    context.kill();
+  });
+
+  test("does not refund a newer Redis window", async () => {
+    const redisState = createFakeRedisState();
+    const context = createContext(redisState);
+    const expiredRequest = requestKey("api:client");
+
+    expect(
+      (await context.increment(expiredRequest, WINDOW_MS, 1000)).count,
+    ).toBe(1);
+    redisState.now = 2001;
+    expect(
+      (await context.increment(requestKey("api:client"), WINDOW_MS, 2001))
+        .count,
+    ).toBe(1);
+
+    await context.decrement(expiredRequest);
+
+    expect(
+      (await context.increment(requestKey("api:client"), WINDOW_MS, 2001))
+        .count,
+    ).toBe(2);
     context.kill();
   });
 
@@ -204,6 +260,7 @@ describe("RedisRateLimitContext", () => {
 type FakeRedisEntry = {
   count: number;
   expiresAt: number;
+  windowId: string;
 };
 
 type FakeRedisState = {
@@ -233,31 +290,48 @@ class FakeRedisClient {
 
     const script = requiredArg(args, 0);
     const key = requiredArg(args, 2);
-    if (script.includes('redis.call("INCR"')) {
-      return this.increment(key, Number(requiredArg(args, 3)));
+    if (script.includes('redis.call("HSET"')) {
+      return this.increment(
+        key,
+        Number(requiredArg(args, 3)),
+        requiredArg(args, 4),
+      );
     }
-    if (script.includes('redis.call("DECR"')) {
-      return this.decrement(key);
+    if (script.includes("~= ARGV[1]")) {
+      return this.decrement(key, requiredArg(args, 3));
     }
     throw new TypeError("Unexpected Redis script");
   }
 
-  private increment(key: string, durationMs: number): [number, number] {
+  private increment(
+    key: string,
+    durationMs: number,
+    candidateWindowId: string,
+  ): [number, number, string] {
     const current = this.state.entries.get(key);
     if (current === undefined || current.expiresAt <= this.state.now) {
       this.state.entries.set(key, {
         count: 1,
         expiresAt: this.state.now + durationMs,
+        windowId: candidateWindowId,
       });
-      return [1, durationMs];
+      return [1, durationMs, candidateWindowId];
     }
     current.count += 1;
-    return [current.count, current.expiresAt - this.state.now];
+    return [
+      current.count,
+      current.expiresAt - this.state.now,
+      current.windowId,
+    ];
   }
 
-  private decrement(key: string): number {
+  private decrement(key: string, expectedWindowId: string): number {
     const current = this.state.entries.get(key);
-    if (current === undefined || current.count <= 0) {
+    if (
+      current === undefined ||
+      current.count <= 0 ||
+      current.windowId !== expectedWindowId
+    ) {
       return 0;
     }
     current.count -= 1;
@@ -271,6 +345,15 @@ const requiredArg = (args: string[], index: number): string => {
     throw new TypeError(`Missing Redis argument at index ${index}`);
   }
   return value;
+};
+
+let requestSequence = 0;
+const requestKey = (counterKey: string): string => {
+  requestSequence += 1;
+  return createRedisRateLimitRequestKey({
+    counterKey,
+    requestId: `request-${requestSequence}`,
+  });
 };
 
 const createContext = (redisState: FakeRedisState): RedisRateLimitContext => {

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -120,12 +120,12 @@ describe("RedisRateLimitContext", () => {
           clientClosed = true;
         },
         send: async () =>
-          await new Promise<[number, number, string]>((resolve) => {
+          await new Promise<[number, number]>((resolve) => {
             settleCommand = () => {
               if (!clientClosed) {
                 lateMutationApplied = true;
               }
-              resolve([1, WINDOW_MS, "window-timeout"]);
+              resolve([1, WINDOW_MS]);
             };
           }),
       }),
@@ -151,6 +151,116 @@ describe("RedisRateLimitContext", () => {
     context.kill();
   });
 
+  test("refunds an increment that reached Redis after the client already timed out", async () => {
+    const redisState = createFakeRedisState();
+    const fakeClient = new FakeRedisClient(redisState);
+    let releaseLateReply: (() => void) | undefined;
+    let delayNextIncrement = true;
+    const context = new RedisRateLimitContext({
+      createRedis: () => ({
+        send: async (command, args) => {
+          // Apply against shared state synchronously -- mirroring Redis
+          // executing the EVAL -- but withhold the reply until the test
+          // releases it, simulating a reply that arrives after the client
+          // gave up waiting.
+          const applyResultPromise = fakeClient.send(command, args);
+          const script = requiredArg(args, 0);
+          if (
+            command === "EVAL" &&
+            script.includes('redis.call("HSET"') &&
+            delayNextIncrement
+          ) {
+            delayNextIncrement = false;
+            return await new Promise<unknown>((resolve) => {
+              releaseLateReply = () => {
+                applyResultPromise.then(resolve).catch(() => undefined);
+              };
+            });
+          }
+          return await applyResultPromise;
+        },
+      }),
+      failurePolicy: "fail_open_local",
+      onRedisError: () => undefined,
+      scheduleTimeout: (callback) => {
+        queueMicrotask(callback);
+        return () => undefined;
+      },
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    const key = requestKey("api:client");
+    const counter = await context.increment(key, WINDOW_MS, 1000);
+    // The client-side timeout fires first, so the caller only sees the
+    // local fallback counter -- but Redis already applied the increment.
+    expect(counter.count).toBe(1);
+
+    await context.decrement(key);
+    releaseLateReply?.();
+    await Promise.resolve();
+
+    // A separate, healthy context proves the earlier increment was
+    // refunded in Redis rather than left as a permanent over-count: a
+    // fresh request against the same counter starts back at 1, not 2.
+    const healthyContext = createContext(redisState);
+    expect(
+      (
+        await healthyContext.increment(
+          requestKey("api:client"),
+          WINDOW_MS,
+          1000,
+        )
+      ).count,
+    ).toBe(1);
+    healthyContext.kill();
+    context.kill();
+  });
+
+  test("does not refund an increment that never reached Redis", async () => {
+    const redisState = createFakeRedisState();
+    const fakeClient = new FakeRedisClient(redisState);
+    const context = new RedisRateLimitContext({
+      createRedis: () => ({
+        send: async (command, args) => {
+          const script = requiredArg(args, 0);
+          if (command === "EVAL" && script.includes('redis.call("HSET"')) {
+            // Never resolves: this increment genuinely never reached Redis.
+            return await new Promise<unknown>(() => {
+              // Intentionally left pending.
+            });
+          }
+          return await fakeClient.send(command, args);
+        },
+      }),
+      failurePolicy: "fail_open_local",
+      onRedisError: () => undefined,
+      scheduleTimeout: (callback) => {
+        queueMicrotask(callback);
+        return () => undefined;
+      },
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    const key = requestKey("api:client");
+    const counter = await context.increment(key, WINDOW_MS, 1000);
+    expect(counter.count).toBe(1);
+
+    await context.decrement(key);
+
+    const healthyContext = createContext(redisState);
+    expect(
+      (
+        await healthyContext.increment(
+          requestKey("api:client"),
+          WINDOW_MS,
+          1000,
+        )
+      ).count,
+    ).toBe(1);
+    healthyContext.kill();
+    context.kill();
+  });
+
   test("suppresses fallback refunds without affecting healthy keys", async () => {
     const decrementedKeys: string[] = [];
     let failNextIncrement = true;
@@ -163,9 +273,9 @@ describe("RedisRateLimitContext", () => {
               failNextIncrement = false;
               throw new TypeError("Redis unavailable");
             }
-            return [1, WINDOW_MS, "window-healthy"];
+            return [1, WINDOW_MS];
           }
-          if (script.includes("~= ARGV[1]")) {
+          if (script.includes('redis.call("HDEL"')) {
             decrementedKeys.push(requiredArg(args, 2));
             return 0;
           }
@@ -258,9 +368,9 @@ describe("RedisRateLimitContext", () => {
 });
 
 type FakeRedisEntry = {
+  attempts: Set<string>;
   count: number;
   expiresAt: number;
-  windowId: string;
 };
 
 type FakeRedisState = {
@@ -297,7 +407,7 @@ class FakeRedisClient {
         requiredArg(args, 4),
       );
     }
-    if (script.includes("~= ARGV[1]")) {
+    if (script.includes('redis.call("HDEL"')) {
       return this.decrement(key, requiredArg(args, 3));
     }
     throw new TypeError("Unexpected Redis script");
@@ -306,34 +416,32 @@ class FakeRedisClient {
   private increment(
     key: string,
     durationMs: number,
-    candidateWindowId: string,
-  ): [number, number, string] {
+    attemptId: string,
+  ): [number, number] {
     const current = this.state.entries.get(key);
     if (current === undefined || current.expiresAt <= this.state.now) {
       this.state.entries.set(key, {
+        attempts: new Set([attemptId]),
         count: 1,
         expiresAt: this.state.now + durationMs,
-        windowId: candidateWindowId,
       });
-      return [1, durationMs, candidateWindowId];
+      return [1, durationMs];
     }
     current.count += 1;
-    return [
-      current.count,
-      current.expiresAt - this.state.now,
-      current.windowId,
-    ];
+    current.attempts.add(attemptId);
+    return [current.count, current.expiresAt - this.state.now];
   }
 
-  private decrement(key: string, expectedWindowId: string): number {
+  private decrement(key: string, attemptId: string): number {
     const current = this.state.entries.get(key);
     if (
       current === undefined ||
       current.count <= 0 ||
-      current.windowId !== expectedWindowId
+      !current.attempts.has(attemptId)
     ) {
-      return 0;
+      return current?.count ?? 0;
     }
+    current.attempts.delete(attemptId);
     current.count -= 1;
     return current.count;
   }

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -82,7 +82,10 @@ describe("RedisRateLimitContext", () => {
     const context = new RedisRateLimitContext({
       commandTimeoutMs: 500,
       createRedis: () => ({
-        send: async () => await new Promise<never>(() => undefined),
+        send: async () =>
+          await new Promise<never>(() => {
+            // Intentionally unresolved to exercise the command timeout.
+          }),
       }),
       failurePolicy: "fail_open_local",
       onRedisError: () => undefined,
@@ -164,7 +167,11 @@ const createFakeRedisState = (): FakeRedisState => ({
 });
 
 class FakeRedisClient {
-  constructor(private readonly state: FakeRedisState) {}
+  private readonly state: FakeRedisState;
+
+  constructor(state: FakeRedisState) {
+    this.state = state;
+  }
 
   async send(command: string, args: string[]): Promise<unknown> {
     if (command === "DEL") {

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import Elysia from "elysia";
+import type { Options } from "elysia-rate-limit";
+import { rateLimit } from "elysia-rate-limit";
+
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+
+const WINDOW_MS = 1000;
+const RATE_LIMIT_OPTIONS = {
+  countFailedRequest: false,
+  duration: WINDOW_MS,
+  errorResponse: "rate limit reached",
+  generator: () => "shared-client",
+  headers: true,
+  max: 2,
+  scoping: "scoped",
+  skip: () => false,
+} as const satisfies Omit<Options, "context">;
+
+describe("RedisRateLimitContext", () => {
+  test("shares counters, window expiry, and refunds across replicas", async () => {
+    const redisState = createFakeRedisState();
+    const first = createContext(redisState);
+    const second = createContext(redisState);
+
+    expect(
+      (await first.increment("translate:client", WINDOW_MS, 1000)).count,
+    ).toBe(1);
+    expect(
+      (await second.increment("translate:client", WINDOW_MS, 1000)).count,
+    ).toBe(2);
+    expect(
+      (await second.increment("upload:client", WINDOW_MS, 1000)).count,
+    ).toBe(1);
+    expect(
+      (await first.increment("upload:client", WINDOW_MS, 1000)).count,
+    ).toBe(2);
+    await second.reset("upload:client");
+    expect(
+      (await first.increment("upload:client", WINDOW_MS, 1000)).count,
+    ).toBe(1);
+
+    await first.decrement("translate:client");
+    expect(
+      (await second.increment("translate:client", WINDOW_MS, 1000)).count,
+    ).toBe(2);
+
+    redisState.now = 2001;
+    expect(
+      (await first.increment("translate:client", WINDOW_MS, 2001)).count,
+    ).toBe(1);
+
+    first.kill();
+    second.kill();
+  });
+
+  test("falls back locally on malformed Redis replies", async () => {
+    const operations: string[] = [];
+    const context = new RedisRateLimitContext({
+      createRedis: () => ({
+        send: async () => ["malformed"],
+      }),
+      failurePolicy: "fail_open_local",
+      onRedisError: (_error, operation) => {
+        operations.push(operation);
+      },
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    expect((await context.increment("api:client", WINDOW_MS, 1000)).count).toBe(
+      1,
+    );
+    expect((await context.increment("api:client", WINDOW_MS, 1000)).count).toBe(
+      2,
+    );
+    expect(operations).toEqual(["increment", "increment"]);
+    context.kill();
+  });
+
+  test("bounds a stalled command and cancels its timer", async () => {
+    let timerCancelled = false;
+    const context = new RedisRateLimitContext({
+      commandTimeoutMs: 500,
+      createRedis: () => ({
+        send: async () => await new Promise<never>(() => undefined),
+      }),
+      failurePolicy: "fail_open_local",
+      onRedisError: () => undefined,
+      scheduleTimeout: (callback) => {
+        queueMicrotask(callback);
+        return () => {
+          timerCancelled = true;
+        };
+      },
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    const counter = await context.increment("api:client", WINDOW_MS, 1000);
+
+    expect(counter.count).toBe(1);
+    expect(timerCancelled).toBe(true);
+    context.kill();
+  });
+
+  test("can fail closed with normal rate-limit counter semantics", async () => {
+    const context = new RedisRateLimitContext({
+      createRedis: () => ({
+        send: async () => {
+          throw new TypeError("Redis unavailable");
+        },
+      }),
+      failurePolicy: "fail_closed",
+      onRedisError: () => undefined,
+    });
+    context.init(RATE_LIMIT_OPTIONS);
+
+    const counter = await context.increment(
+      "translate:client",
+      WINDOW_MS,
+      1000,
+    );
+
+    expect(counter.count).toBe(Number.MAX_SAFE_INTEGER);
+    expect(counter.nextReset).toEqual(new Date(2000));
+    context.kill();
+  });
+
+  test("returns a combined 429 and exact retry headers across app instances", async () => {
+    const redisState = createFakeRedisState();
+    const firstContext = createContext(redisState);
+    const secondContext = createContext(redisState);
+    const firstApp = createRateLimitedApp(firstContext);
+    const secondApp = createRateLimitedApp(secondContext);
+
+    const first = await firstApp.handle(new Request("http://localhost/"));
+    const second = await secondApp.handle(new Request("http://localhost/"));
+    const limited = await firstApp.handle(new Request("http://localhost/"));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("RateLimit-Limit")).toBe("2");
+    expect(limited.headers.get("RateLimit-Remaining")).toBe("0");
+    expect(limited.headers.get("RateLimit-Reset")).toBe("1");
+    expect(limited.headers.get("Retry-After")).toBe("1");
+    firstContext.kill();
+    secondContext.kill();
+  });
+});
+
+type FakeRedisEntry = {
+  count: number;
+  expiresAt: number;
+};
+
+type FakeRedisState = {
+  entries: Map<string, FakeRedisEntry>;
+  now: number;
+};
+
+const createFakeRedisState = (): FakeRedisState => ({
+  entries: new Map(),
+  now: 1000,
+});
+
+class FakeRedisClient {
+  constructor(private readonly state: FakeRedisState) {}
+
+  async send(command: string, args: string[]): Promise<unknown> {
+    if (command === "DEL") {
+      return this.state.entries.delete(requiredArg(args, 0)) ? 1 : 0;
+    }
+    if (command !== "EVAL") {
+      throw new TypeError(`Unexpected Redis command: ${command}`);
+    }
+
+    const script = requiredArg(args, 0);
+    const key = requiredArg(args, 2);
+    if (script.includes('redis.call("INCR"')) {
+      return this.increment(key, Number(requiredArg(args, 3)));
+    }
+    if (script.includes('redis.call("DECR"')) {
+      return this.decrement(key);
+    }
+    throw new TypeError("Unexpected Redis script");
+  }
+
+  private increment(key: string, durationMs: number): [number, number] {
+    const current = this.state.entries.get(key);
+    if (current === undefined || current.expiresAt <= this.state.now) {
+      this.state.entries.set(key, {
+        count: 1,
+        expiresAt: this.state.now + durationMs,
+      });
+      return [1, durationMs];
+    }
+    current.count += 1;
+    return [current.count, current.expiresAt - this.state.now];
+  }
+
+  private decrement(key: string): number {
+    const current = this.state.entries.get(key);
+    if (current === undefined || current.count <= 0) {
+      return 0;
+    }
+    current.count -= 1;
+    return current.count;
+  }
+}
+
+const requiredArg = (args: string[], index: number): string => {
+  const value = args.at(index);
+  if (value === undefined) {
+    throw new TypeError(`Missing Redis argument at index ${index}`);
+  }
+  return value;
+};
+
+const createContext = (redisState: FakeRedisState): RedisRateLimitContext => {
+  const context = new RedisRateLimitContext({
+    createRedis: () => new FakeRedisClient(redisState),
+    failurePolicy: "fail_open_local",
+    onRedisError: () => undefined,
+  });
+  context.init(RATE_LIMIT_OPTIONS);
+  return context;
+};
+
+const createRateLimitedApp = (context: RedisRateLimitContext) =>
+  new Elysia()
+    .use(
+      rateLimit({
+        ...RATE_LIMIT_OPTIONS,
+        context,
+      }),
+    )
+    .get("/", () => "ok");

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -16,21 +16,35 @@ const REDIS_COMMAND_TIMEOUT_MS = 500;
 const REFUND_PROVENANCE_CLEANUP_INTERVAL_MS = 60_000;
 const FAIL_CLOSED_COUNT = Number.MAX_SAFE_INTEGER;
 
+// Every increment attempt is tagged with a client-generated attempt id
+// (ARGV[2]) that the script records unconditionally, independent of
+// whether it started a fresh window. A later refund matches on that same
+// attempt id (see DECREMENT_SCRIPT) rather than on the window as a whole,
+// so the caller never needs to learn a server-assigned window id to issue
+// a safe refund -- see the comment on RefundProvenance for why that
+// matters when the increment's reply is lost to a client-side timeout.
 const INCREMENT_SCRIPT = `
 local current = redis.call("HINCRBY", KEYS[1], "count", 1)
 local ttl = redis.call("PTTL", KEYS[1])
 if current == 1 or ttl < 0 then
-  redis.call("HSET", KEYS[1], "window", ARGV[2])
   redis.call("PEXPIRE", KEYS[1], ARGV[1])
   ttl = tonumber(ARGV[1])
 end
-return { current, ttl, redis.call("HGET", KEYS[1], "window") }
+redis.call("HSET", KEYS[1], "attempt:" .. ARGV[2], "1")
+return { current, ttl }
 `;
 
+// Refunds only apply if this exact attempt id is still recorded on the
+// key: a genuinely-lost increment (never reached Redis) leaves no marker
+// and this safely no-ops instead of wrongly decrementing. An expired or
+// recreated window also carries no marker for an old attempt id, so a
+// late refund can never bleed into a different window's count.
 const DECREMENT_SCRIPT = `
-if redis.call("HGET", KEYS[1], "window") ~= ARGV[1] then
+local attemptField = "attempt:" .. ARGV[1]
+if redis.call("HGET", KEYS[1], attemptField) == false then
   return tonumber(redis.call("HGET", KEYS[1], "count") or "0")
 end
+redis.call("HDEL", KEYS[1], attemptField)
 local current = tonumber(redis.call("HGET", KEYS[1], "count") or "0")
 if current <= 0 then
   return 0
@@ -74,15 +88,21 @@ type RateLimitCounter = {
   start: number;
 };
 
-type RedisIncrement = {
-  counter: RateLimitCounter;
-  windowId: string;
-};
-
 type RefundProvenance = {
+  /**
+   * The attempt id sent with the increment EVAL. Kept even when the
+   * increment's own reply never arrived (client-side timeout): Redis may
+   * have already applied that EVAL before the timeout fired, and
+   * DECREMENT_SCRIPT's attempt-id match makes refunding against an
+   * unconfirmed attempt safe either way -- it decrements only if Redis
+   * actually recorded this attempt, and no-ops otherwise. Discarding
+   * provenance on timeout (the previous behavior) traded that bounded
+   * ambiguity for a guaranteed permanent over-count whenever the EVAL had
+   * in fact landed.
+   */
+  attemptId: string;
   counterKey: string;
   expiresAt: number;
-  windowId: string;
 };
 
 class RedisRateLimitReplyError extends TaggedError("RedisRateLimitReplyError")<{
@@ -160,21 +180,42 @@ export class RedisRateLimitContext implements Context {
       effectiveDuration,
       now,
     );
-    const candidateWindowId = Bun.randomUUIDv7();
-    const redisResult = await Result.tryPromise(async () => {
-      const reply = await this.sendCommand("EVAL", [
-        INCREMENT_SCRIPT,
-        "1",
-        redisRateLimitKey(counterKey),
-        String(effectiveDuration),
-        candidateWindowId,
-      ]);
-      return parseIncrementReply(reply, effectiveDuration, now);
+    const attemptId = Bun.randomUUIDv7();
+    // Identity `catch` keeps the raw thrown error (e.g. TimeoutError)
+    // instead of Result.tryPromise's default UnhandledException wrapping,
+    // so the TimeoutError.is() check below can actually discriminate an
+    // ambiguous client-side timeout from other Redis failures.
+    const redisResult = await Result.tryPromise({
+      try: async () => {
+        const reply = await this.sendCommand("EVAL", [
+          INCREMENT_SCRIPT,
+          "1",
+          redisRateLimitKey(counterKey),
+          String(effectiveDuration),
+          attemptId,
+        ]);
+        return parseIncrementReply(reply, effectiveDuration, now);
+      },
+      catch: (error: unknown) => error,
     });
     if (Result.isError(redisResult)) {
       this.onRedisError(redisResult.error, "increment");
       if (requestId !== null) {
-        this.refundProvenanceByRequest.delete(requestId);
+        if (TimeoutError.is(redisResult.error)) {
+          // The client gave up waiting, but the EVAL may already have
+          // reached and executed on Redis -- there is no way to tell from
+          // here. Retain provenance keyed by the attempt id we sent (not
+          // a window id, since we never received one) so a later
+          // decrement() can still attempt a refund; DECREMENT_SCRIPT
+          // resolves the ambiguity server-side.
+          this.refundProvenanceByRequest.set(requestId, {
+            attemptId,
+            counterKey,
+            expiresAt: now + effectiveDuration,
+          });
+        } else {
+          this.refundProvenanceByRequest.delete(requestId);
+        }
       }
       if (this.failurePolicy === "fail_open_local") {
         return fallbackCounter;
@@ -187,12 +228,12 @@ export class RedisRateLimitContext implements Context {
     }
     if (requestId !== null) {
       this.refundProvenanceByRequest.set(requestId, {
+        attemptId,
         counterKey,
-        expiresAt: redisResult.value.counter.nextReset.getTime(),
-        windowId: redisResult.value.windowId,
+        expiresAt: redisResult.value.nextReset.getTime(),
       });
     }
-    return redisResult.value.counter;
+    return redisResult.value;
   }
 
   async decrement(key: string): Promise<void> {
@@ -212,7 +253,7 @@ export class RedisRateLimitContext implements Context {
           DECREMENT_SCRIPT,
           "1",
           redisRateLimitKey(provenance.counterKey),
-          provenance.windowId,
+          provenance.attemptId,
         ]),
     );
     if (Result.isError(result)) {
@@ -336,7 +377,7 @@ export const createRedisRateLimit = ({
   scope,
 }: CreateRedisRateLimitOptions): RedisRateLimitBinding => ({
   // Keep the context and request-token generator paired: the token lets a
-  // failed request refund only the Redis window that admitted it.
+  // failed request refund only the specific increment attempt it made.
   context: new RedisRateLimitContext({ failurePolicy }),
   generator: requestScopedGenerator(scope),
 });
@@ -348,8 +389,8 @@ const parseIncrementReply = (
   reply: unknown,
   durationMs: number,
   now: number,
-): RedisIncrement => {
-  if (!Array.isArray(reply) || reply.length !== 3) {
+): RateLimitCounter => {
+  if (!Array.isArray(reply) || reply.length !== 2) {
     throw new RedisRateLimitReplyError({
       message: "Redis returned an invalid rate-limit counter reply",
       reply,
@@ -357,14 +398,11 @@ const parseIncrementReply = (
   }
   const count = Number(reply.at(0));
   const ttlMs = Number(reply.at(1));
-  const rawWindowId: unknown = reply.at(2);
   if (
     !Number.isFinite(count) ||
     !Number.isFinite(ttlMs) ||
     count < 1 ||
-    ttlMs < 0 ||
-    typeof rawWindowId !== "string" ||
-    rawWindowId.length === 0
+    ttlMs < 0
   ) {
     throw new RedisRateLimitReplyError({
       message: "Redis returned invalid rate-limit counter values",
@@ -373,12 +411,9 @@ const parseIncrementReply = (
   }
   const nextReset = new Date(now + ttlMs);
   return {
-    counter: {
-      count,
-      nextReset,
-      start: nextReset.getTime() - durationMs,
-    },
-    windowId: rawWindowId,
+    count,
+    nextReset,
+    start: nextReset.getTime() - durationMs,
   };
 };
 

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -76,6 +76,7 @@ export class RedisRateLimitContext implements Context {
   private readonly scheduleTimeout: ScheduleTimeout;
   private durationMs = 60_000;
   private redis: RedisRateLimitClient | null = null;
+  private redisRefundsSuppressedUntil = 0;
 
   constructor({
     commandTimeoutMs = REDIS_COMMAND_TIMEOUT_MS,
@@ -133,6 +134,12 @@ export class RedisRateLimitContext implements Context {
     });
     if (Result.isError(redisResult)) {
       this.onRedisError(redisResult.error, "increment");
+      // Context.decrement has no increment token. Suppress shared refunds after any
+      // fallback rather than risk refunding another replica's successful request.
+      this.redisRefundsSuppressedUntil = Math.max(
+        this.redisRefundsSuppressedUntil,
+        Date.now() + effectiveDuration,
+      );
       if (this.failurePolicy === "fail_open_local") {
         return fallbackCounter;
       }
@@ -147,6 +154,9 @@ export class RedisRateLimitContext implements Context {
 
   async decrement(key: string): Promise<void> {
     this.fallback.decrement(key);
+    if (this.redisRefundsSuppressedUntil > Date.now()) {
+      return;
+    }
     const result = await Result.tryPromise(
       async () =>
         await this.sendCommand("EVAL", [
@@ -164,6 +174,7 @@ export class RedisRateLimitContext implements Context {
     this.fallback.reset(key);
     // Never scan/delete the shared namespace; TTL expiry owns global cleanup.
     if (key === undefined) {
+      this.redisRefundsSuppressedUntil = 0;
       return;
     }
     const result = await Result.tryPromise(
@@ -176,17 +187,31 @@ export class RedisRateLimitContext implements Context {
 
   kill(): void {
     this.fallback.kill();
+    this.redisRefundsSuppressedUntil = 0;
     this.redis?.close?.();
     this.redis = null;
   }
 
   private async sendCommand(command: string, args: string[]): Promise<unknown> {
     this.redis ??= this.createRedis();
-    return await withCommandTimeout({
-      command: this.redis.send(command, args),
-      commandTimeoutMs: this.commandTimeoutMs,
-      scheduleTimeout: this.scheduleTimeout,
+    const redis = this.redis;
+    const result = await Result.tryPromise(async () => {
+      return await withCommandTimeout({
+        command: redis.send(command, args),
+        commandTimeoutMs: this.commandTimeoutMs,
+        scheduleTimeout: this.scheduleTimeout,
+      });
     });
+    if (Result.isError(result)) {
+      if (TimeoutError.is(result.error)) {
+        redis.close?.();
+        if (this.redis === redis) {
+          this.redis = null;
+        }
+      }
+      throw result.error;
+    }
+    return result.value;
   }
 }
 

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -1,0 +1,258 @@
+import { Result, TaggedError } from "better-result";
+import type { Context, Options } from "elysia-rate-limit";
+
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import { errorTag } from "@/api/lib/errors/utils";
+import { logger } from "@/api/lib/observability/logger";
+import { InMemoryRateLimitContext } from "@/api/lib/rate-limit/rate-limit";
+import { createRedisClient } from "@/api/lib/redis-client";
+
+const REDIS_KEY_PREFIX = "api:ratelimit:v1:";
+const REDIS_COMMAND_TIMEOUT_MS = 500;
+const FAIL_CLOSED_COUNT = Number.MAX_SAFE_INTEGER;
+
+const INCREMENT_SCRIPT = `
+local current = redis.call("INCR", KEYS[1])
+local ttl = redis.call("PTTL", KEYS[1])
+if current == 1 or ttl < 0 then
+  redis.call("PEXPIRE", KEYS[1], ARGV[1])
+  ttl = tonumber(ARGV[1])
+end
+return { current, ttl }
+`;
+
+const DECREMENT_SCRIPT = `
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+if current <= 0 then
+  return 0
+end
+return redis.call("DECR", KEYS[1])
+`;
+
+const REDIS_RATE_LIMIT_FAILURE_POLICIES = [
+  "fail_open_local",
+  "fail_closed",
+] as const;
+type RedisRateLimitFailurePolicy =
+  (typeof REDIS_RATE_LIMIT_FAILURE_POLICIES)[number];
+
+type RedisRateLimitClient = {
+  close?: () => void;
+  send: (command: string, args: string[]) => Promise<unknown>;
+};
+
+type ScheduleTimeout = (callback: () => void, delayMs: number) => () => void;
+type RedisRateLimitOperation = "decrement" | "increment" | "reset";
+
+type RedisRateLimitContextOptions = {
+  commandTimeoutMs?: number;
+  createRedis?: () => RedisRateLimitClient;
+  failurePolicy: RedisRateLimitFailurePolicy;
+  onRedisError?: (error: unknown, operation: RedisRateLimitOperation) => void;
+  scheduleTimeout?: ScheduleTimeout;
+};
+
+type RateLimitCounter = {
+  count: number;
+  nextReset: Date;
+  start: number;
+};
+
+class RedisRateLimitReplyError extends TaggedError("RedisRateLimitReplyError")<{
+  message: string;
+  reply: unknown;
+}>() {}
+
+/** Replica-safe fixed-window context with a bounded, explicit outage policy. */
+export class RedisRateLimitContext implements Context {
+  private readonly commandTimeoutMs: number;
+  private readonly createRedis: () => RedisRateLimitClient;
+  private readonly failurePolicy: RedisRateLimitFailurePolicy;
+  private readonly fallback = new InMemoryRateLimitContext();
+  private readonly onRedisError: (
+    error: unknown,
+    operation: RedisRateLimitOperation,
+  ) => void;
+  private readonly scheduleTimeout: ScheduleTimeout;
+  private durationMs = 60_000;
+  private redis: RedisRateLimitClient | null = null;
+
+  constructor({
+    commandTimeoutMs = REDIS_COMMAND_TIMEOUT_MS,
+    createRedis = () =>
+      createRedisClient({
+        connectionTimeout: commandTimeoutMs,
+        enableOfflineQueue: false,
+      }),
+    failurePolicy,
+    onRedisError,
+    scheduleTimeout = defaultScheduleTimeout,
+  }: RedisRateLimitContextOptions) {
+    this.commandTimeoutMs = commandTimeoutMs;
+    this.createRedis = createRedis;
+    this.failurePolicy = failurePolicy;
+    this.onRedisError =
+      onRedisError ??
+      ((error, operation) => {
+        logger.warn("api.rate_limit.redis_failed", {
+          "error.type": errorTag(error),
+          failurePolicy,
+          operation,
+        });
+      });
+    this.scheduleTimeout = scheduleTimeout;
+  }
+
+  init(options: Omit<Options, "context">): void {
+    if (typeof options.duration === "number") {
+      this.durationMs = options.duration;
+    }
+    this.fallback.init(options);
+  }
+
+  async increment(
+    key: string,
+    duration?: number,
+    requestTime?: number,
+  ): Promise<RateLimitCounter> {
+    const effectiveDuration = duration ?? this.durationMs;
+    const now = requestTime ?? Date.now();
+    const fallbackCounter = await this.fallback.increment(
+      key,
+      effectiveDuration,
+      now,
+    );
+    const redisResult = await Result.tryPromise(async () => {
+      const reply = await this.sendCommand("EVAL", [
+        INCREMENT_SCRIPT,
+        "1",
+        redisRateLimitKey(key),
+        String(effectiveDuration),
+      ]);
+      return parseIncrementReply(reply, effectiveDuration, now);
+    });
+    if (Result.isError(redisResult)) {
+      this.onRedisError(redisResult.error, "increment");
+      if (this.failurePolicy === "fail_open_local") {
+        return fallbackCounter;
+      }
+      return {
+        count: FAIL_CLOSED_COUNT,
+        nextReset: new Date(now + effectiveDuration),
+        start: now,
+      };
+    }
+    return redisResult.value;
+  }
+
+  async decrement(key: string): Promise<void> {
+    await this.fallback.decrement(key);
+    const result = await Result.tryPromise(
+      async () =>
+        await this.sendCommand("EVAL", [
+          DECREMENT_SCRIPT,
+          "1",
+          redisRateLimitKey(key),
+        ]),
+    );
+    if (Result.isError(result)) {
+      this.onRedisError(result.error, "decrement");
+    }
+  }
+
+  async reset(key?: string): Promise<void> {
+    await this.fallback.reset(key);
+    // Never scan/delete the shared namespace; TTL expiry owns global cleanup.
+    if (key === undefined) {
+      return;
+    }
+    const result = await Result.tryPromise(
+      async () => await this.sendCommand("DEL", [redisRateLimitKey(key)]),
+    );
+    if (Result.isError(result)) {
+      this.onRedisError(result.error, "reset");
+    }
+  }
+
+  kill(): void {
+    this.fallback.kill();
+    this.redis?.close?.();
+    this.redis = null;
+  }
+
+  private async sendCommand(command: string, args: string[]): Promise<unknown> {
+    this.redis ??= this.createRedis();
+    return await withCommandTimeout({
+      command: this.redis.send(command, args),
+      commandTimeoutMs: this.commandTimeoutMs,
+      scheduleTimeout: this.scheduleTimeout,
+    });
+  }
+}
+
+const redisRateLimitKey = (key: string): string => `${REDIS_KEY_PREFIX}${key}`;
+
+const parseIncrementReply = (
+  reply: unknown,
+  durationMs: number,
+  now: number,
+): RateLimitCounter => {
+  if (!Array.isArray(reply) || reply.length !== 2) {
+    throw new RedisRateLimitReplyError({
+      message: "Redis returned an invalid rate-limit counter reply",
+      reply,
+    });
+  }
+  const count = Number(reply.at(0));
+  const ttlMs = Number(reply.at(1));
+  if (
+    !Number.isFinite(count) ||
+    !Number.isFinite(ttlMs) ||
+    count < 1 ||
+    ttlMs < 0
+  ) {
+    throw new RedisRateLimitReplyError({
+      message: "Redis returned invalid rate-limit counter values",
+      reply,
+    });
+  }
+  const nextReset = new Date(now + ttlMs);
+  return {
+    count,
+    nextReset,
+    start: nextReset.getTime() - durationMs,
+  };
+};
+
+const defaultScheduleTimeout: ScheduleTimeout = (callback, delayMs) => {
+  const timeoutId = setTimeout(callback, delayMs);
+  return () => clearTimeout(timeoutId);
+};
+
+type WithCommandTimeoutOptions<T> = {
+  command: Promise<T>;
+  commandTimeoutMs: number;
+  scheduleTimeout: ScheduleTimeout;
+};
+
+const withCommandTimeout = async <T>({
+  command,
+  commandTimeoutMs,
+  scheduleTimeout,
+}: WithCommandTimeoutOptions<T>): Promise<T> => {
+  let cancelTimeout = () => undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    cancelTimeout = scheduleTimeout(
+      () =>
+        reject(
+          new TimeoutError({
+            label: "api-rate-limit-redis-command",
+            message: "Redis rate-limit command timed out",
+            timeoutMs: commandTimeoutMs,
+          }),
+        ),
+      commandTimeoutMs,
+    );
+  });
+  return await Promise.race([command, timeout]).finally(cancelTimeout);
+};

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -307,7 +307,7 @@ type ParsedRequestScopedKey = {
 
 const parseRequestScopedKey = (key: string): ParsedRequestScopedKey => {
   const separatorIndex = key.lastIndexOf(REQUEST_KEY_SEPARATOR);
-  if (separatorIndex < 0) {
+  if (separatorIndex === -1) {
     return { counterKey: key, requestId: null };
   }
   return {
@@ -320,8 +320,8 @@ const requestScopedGenerator = (scope: string): Generator => {
   const generateCounterKey = scopedGenerator(scope);
   const requestIds = new WeakMap<Request, string>();
 
-  return (request, server) => {
-    const counterKey = generateCounterKey(request, server);
+  return async (request, server, derived) => {
+    const counterKey = await generateCounterKey(request, server, derived);
     let requestId = requestIds.get(request);
     if (requestId === undefined) {
       requestId = Bun.randomUUIDv7();
@@ -357,7 +357,7 @@ const parseIncrementReply = (
   }
   const count = Number(reply.at(0));
   const ttlMs = Number(reply.at(1));
-  const rawWindowId = reply.at(2);
+  const rawWindowId: unknown = reply.at(2);
   if (
     !Number.isFinite(count) ||
     !Number.isFinite(ttlMs) ||

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -9,6 +9,7 @@ import { createRedisClient } from "@/api/lib/redis-client";
 
 const REDIS_KEY_PREFIX = "api:ratelimit:v1:";
 const REDIS_COMMAND_TIMEOUT_MS = 500;
+const REFUND_PROVENANCE_CLEANUP_INTERVAL_MS = 60_000;
 const FAIL_CLOSED_COUNT = Number.MAX_SAFE_INTEGER;
 
 const INCREMENT_SCRIPT = `
@@ -76,7 +77,8 @@ export class RedisRateLimitContext implements Context {
   private readonly scheduleTimeout: ScheduleTimeout;
   private durationMs = 60_000;
   private redis: RedisRateLimitClient | null = null;
-  private redisRefundsSuppressedUntil = 0;
+  private readonly redisRefundSuppressedUntilByKey = new Map<string, number>();
+  private readonly refundProvenanceCleanupTimer: ReturnType<typeof setInterval>;
 
   constructor({
     commandTimeoutMs = REDIS_COMMAND_TIMEOUT_MS,
@@ -102,6 +104,11 @@ export class RedisRateLimitContext implements Context {
         });
       });
     this.scheduleTimeout = scheduleTimeout;
+    this.refundProvenanceCleanupTimer = setInterval(
+      () => this.evictExpiredRefundSuppressions(),
+      REFUND_PROVENANCE_CLEANUP_INTERVAL_MS,
+    );
+    this.refundProvenanceCleanupTimer.unref();
   }
 
   init(options: Omit<Options, "context">): void {
@@ -134,11 +141,15 @@ export class RedisRateLimitContext implements Context {
     });
     if (Result.isError(redisResult)) {
       this.onRedisError(redisResult.error, "increment");
-      // Context.decrement has no increment token. Suppress shared refunds after any
-      // fallback rather than risk refunding another replica's successful request.
-      this.redisRefundsSuppressedUntil = Math.max(
-        this.redisRefundsSuppressedUntil,
-        Date.now() + effectiveDuration,
+      // Context.decrement has no increment token. Suppress this key's shared refunds
+      // for the window rather than risk refunding another replica's request.
+      const suppressedUntil = Date.now() + effectiveDuration;
+      this.redisRefundSuppressedUntilByKey.set(
+        key,
+        Math.max(
+          this.redisRefundSuppressedUntilByKey.get(key) ?? 0,
+          suppressedUntil,
+        ),
       );
       if (this.failurePolicy === "fail_open_local") {
         return fallbackCounter;
@@ -154,8 +165,13 @@ export class RedisRateLimitContext implements Context {
 
   async decrement(key: string): Promise<void> {
     this.fallback.decrement(key);
-    if (this.redisRefundsSuppressedUntil > Date.now()) {
-      return;
+    const redisRefundSuppressedUntil =
+      this.redisRefundSuppressedUntilByKey.get(key);
+    if (redisRefundSuppressedUntil !== undefined) {
+      if (redisRefundSuppressedUntil > Date.now()) {
+        return;
+      }
+      this.redisRefundSuppressedUntilByKey.delete(key);
     }
     const result = await Result.tryPromise(
       async () =>
@@ -174,9 +190,10 @@ export class RedisRateLimitContext implements Context {
     this.fallback.reset(key);
     // Never scan/delete the shared namespace; TTL expiry owns global cleanup.
     if (key === undefined) {
-      this.redisRefundsSuppressedUntil = 0;
+      this.redisRefundSuppressedUntilByKey.clear();
       return;
     }
+    this.redisRefundSuppressedUntilByKey.delete(key);
     const result = await Result.tryPromise(
       async () => await this.sendCommand("DEL", [redisRateLimitKey(key)]),
     );
@@ -187,9 +204,19 @@ export class RedisRateLimitContext implements Context {
 
   kill(): void {
     this.fallback.kill();
-    this.redisRefundsSuppressedUntil = 0;
+    clearInterval(this.refundProvenanceCleanupTimer);
+    this.redisRefundSuppressedUntilByKey.clear();
     this.redis?.close?.();
     this.redis = null;
+  }
+
+  private evictExpiredRefundSuppressions(): void {
+    const now = Date.now();
+    for (const [key, suppressedUntil] of this.redisRefundSuppressedUntilByKey) {
+      if (suppressedUntil <= now) {
+        this.redisRefundSuppressedUntilByKey.delete(key);
+      }
+    }
   }
 
   private async sendCommand(command: string, args: string[]): Promise<unknown> {

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -1,33 +1,41 @@
 import { Result, TaggedError } from "better-result";
-import type { Context, Options } from "elysia-rate-limit";
+import type { Context, Generator, Options } from "elysia-rate-limit";
 
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
-import { InMemoryRateLimitContext } from "@/api/lib/rate-limit/rate-limit";
+import {
+  InMemoryRateLimitContext,
+  scopedGenerator,
+} from "@/api/lib/rate-limit/rate-limit";
 import { createRedisClient } from "@/api/lib/redis-client";
 
-const REDIS_KEY_PREFIX = "api:ratelimit:v1:";
+const REDIS_KEY_PREFIX = "api:ratelimit:v2:";
+const REQUEST_KEY_SEPARATOR = "\u001f";
 const REDIS_COMMAND_TIMEOUT_MS = 500;
 const REFUND_PROVENANCE_CLEANUP_INTERVAL_MS = 60_000;
 const FAIL_CLOSED_COUNT = Number.MAX_SAFE_INTEGER;
 
 const INCREMENT_SCRIPT = `
-local current = redis.call("INCR", KEYS[1])
+local current = redis.call("HINCRBY", KEYS[1], "count", 1)
 local ttl = redis.call("PTTL", KEYS[1])
 if current == 1 or ttl < 0 then
+  redis.call("HSET", KEYS[1], "window", ARGV[2])
   redis.call("PEXPIRE", KEYS[1], ARGV[1])
   ttl = tonumber(ARGV[1])
 end
-return { current, ttl }
+return { current, ttl, redis.call("HGET", KEYS[1], "window") }
 `;
 
 const DECREMENT_SCRIPT = `
-local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+if redis.call("HGET", KEYS[1], "window") ~= ARGV[1] then
+  return tonumber(redis.call("HGET", KEYS[1], "count") or "0")
+end
+local current = tonumber(redis.call("HGET", KEYS[1], "count") or "0")
 if current <= 0 then
   return 0
 end
-return redis.call("DECR", KEYS[1])
+return redis.call("HINCRBY", KEYS[1], "count", -1)
 `;
 
 const REDIS_RATE_LIMIT_FAILURE_POLICIES = [
@@ -53,10 +61,28 @@ type RedisRateLimitContextOptions = {
   scheduleTimeout?: ScheduleTimeout;
 };
 
+type CreateRedisRateLimitOptions = {
+  failurePolicy: RedisRateLimitFailurePolicy;
+  scope: string;
+};
+
+type RedisRateLimitBinding = Pick<Options, "context" | "generator">;
+
 type RateLimitCounter = {
   count: number;
   nextReset: Date;
   start: number;
+};
+
+type RedisIncrement = {
+  counter: RateLimitCounter;
+  windowId: string;
+};
+
+type RefundProvenance = {
+  counterKey: string;
+  expiresAt: number;
+  windowId: string;
 };
 
 class RedisRateLimitReplyError extends TaggedError("RedisRateLimitReplyError")<{
@@ -77,7 +103,10 @@ export class RedisRateLimitContext implements Context {
   private readonly scheduleTimeout: ScheduleTimeout;
   private durationMs = 60_000;
   private redis: RedisRateLimitClient | null = null;
-  private readonly redisRefundSuppressedUntilByKey = new Map<string, number>();
+  private readonly refundProvenanceByRequest = new Map<
+    string,
+    RefundProvenance
+  >();
   private readonly refundProvenanceCleanupTimer: ReturnType<typeof setInterval>;
 
   constructor({
@@ -105,7 +134,7 @@ export class RedisRateLimitContext implements Context {
       });
     this.scheduleTimeout = scheduleTimeout;
     this.refundProvenanceCleanupTimer = setInterval(
-      () => this.evictExpiredRefundSuppressions(),
+      () => this.evictExpiredRefundProvenance(),
       REFUND_PROVENANCE_CLEANUP_INTERVAL_MS,
     );
     this.refundProvenanceCleanupTimer.unref();
@@ -123,34 +152,30 @@ export class RedisRateLimitContext implements Context {
     duration?: number,
     requestTime?: number,
   ): Promise<RateLimitCounter> {
+    const { counterKey, requestId } = parseRequestScopedKey(key);
     const effectiveDuration = duration ?? this.durationMs;
     const now = requestTime ?? Date.now();
     const fallbackCounter = this.fallback.increment(
-      key,
+      counterKey,
       effectiveDuration,
       now,
     );
+    const candidateWindowId = Bun.randomUUIDv7();
     const redisResult = await Result.tryPromise(async () => {
       const reply = await this.sendCommand("EVAL", [
         INCREMENT_SCRIPT,
         "1",
-        redisRateLimitKey(key),
+        redisRateLimitKey(counterKey),
         String(effectiveDuration),
+        candidateWindowId,
       ]);
       return parseIncrementReply(reply, effectiveDuration, now);
     });
     if (Result.isError(redisResult)) {
       this.onRedisError(redisResult.error, "increment");
-      // Context.decrement has no increment token. Suppress this key's shared refunds
-      // for the window rather than risk refunding another replica's request.
-      const suppressedUntil = Date.now() + effectiveDuration;
-      this.redisRefundSuppressedUntilByKey.set(
-        key,
-        Math.max(
-          this.redisRefundSuppressedUntilByKey.get(key) ?? 0,
-          suppressedUntil,
-        ),
-      );
+      if (requestId !== null) {
+        this.refundProvenanceByRequest.delete(requestId);
+      }
       if (this.failurePolicy === "fail_open_local") {
         return fallbackCounter;
       }
@@ -160,25 +185,34 @@ export class RedisRateLimitContext implements Context {
         start: now,
       };
     }
-    return redisResult.value;
+    if (requestId !== null) {
+      this.refundProvenanceByRequest.set(requestId, {
+        counterKey,
+        expiresAt: redisResult.value.counter.nextReset.getTime(),
+        windowId: redisResult.value.windowId,
+      });
+    }
+    return redisResult.value.counter;
   }
 
   async decrement(key: string): Promise<void> {
-    this.fallback.decrement(key);
-    const redisRefundSuppressedUntil =
-      this.redisRefundSuppressedUntilByKey.get(key);
-    if (redisRefundSuppressedUntil !== undefined) {
-      if (redisRefundSuppressedUntil > Date.now()) {
-        return;
-      }
-      this.redisRefundSuppressedUntilByKey.delete(key);
+    const { counterKey, requestId } = parseRequestScopedKey(key);
+    this.fallback.decrement(counterKey);
+    if (requestId === null) {
+      return;
+    }
+    const provenance = this.refundProvenanceByRequest.get(requestId);
+    this.refundProvenanceByRequest.delete(requestId);
+    if (provenance === undefined) {
+      return;
     }
     const result = await Result.tryPromise(
       async () =>
         await this.sendCommand("EVAL", [
           DECREMENT_SCRIPT,
           "1",
-          redisRateLimitKey(key),
+          redisRateLimitKey(provenance.counterKey),
+          provenance.windowId,
         ]),
     );
     if (Result.isError(result)) {
@@ -187,15 +221,18 @@ export class RedisRateLimitContext implements Context {
   }
 
   async reset(key?: string): Promise<void> {
-    this.fallback.reset(key);
+    const counterKey =
+      key === undefined ? undefined : parseRequestScopedKey(key).counterKey;
+    this.fallback.reset(counterKey);
     // Never scan/delete the shared namespace; TTL expiry owns global cleanup.
-    if (key === undefined) {
-      this.redisRefundSuppressedUntilByKey.clear();
+    if (counterKey === undefined) {
+      this.refundProvenanceByRequest.clear();
       return;
     }
-    this.redisRefundSuppressedUntilByKey.delete(key);
+    this.deleteRefundProvenanceForCounter(counterKey);
     const result = await Result.tryPromise(
-      async () => await this.sendCommand("DEL", [redisRateLimitKey(key)]),
+      async () =>
+        await this.sendCommand("DEL", [redisRateLimitKey(counterKey)]),
     );
     if (Result.isError(result)) {
       this.onRedisError(result.error, "reset");
@@ -205,16 +242,24 @@ export class RedisRateLimitContext implements Context {
   kill(): void {
     this.fallback.kill();
     clearInterval(this.refundProvenanceCleanupTimer);
-    this.redisRefundSuppressedUntilByKey.clear();
+    this.refundProvenanceByRequest.clear();
     this.redis?.close?.();
     this.redis = null;
   }
 
-  private evictExpiredRefundSuppressions(): void {
+  private evictExpiredRefundProvenance(): void {
     const now = Date.now();
-    for (const [key, suppressedUntil] of this.redisRefundSuppressedUntilByKey) {
-      if (suppressedUntil <= now) {
-        this.redisRefundSuppressedUntilByKey.delete(key);
+    for (const [requestId, provenance] of this.refundProvenanceByRequest) {
+      if (provenance.expiresAt <= now) {
+        this.refundProvenanceByRequest.delete(requestId);
+      }
+    }
+  }
+
+  private deleteRefundProvenanceForCounter(counterKey: string): void {
+    for (const [requestId, provenance] of this.refundProvenanceByRequest) {
+      if (provenance.counterKey === counterKey) {
+        this.refundProvenanceByRequest.delete(requestId);
       }
     }
   }
@@ -244,14 +289,67 @@ export class RedisRateLimitContext implements Context {
   }
 }
 
-const redisRateLimitKey = (key: string): string => `${REDIS_KEY_PREFIX}${key}`;
+type CreateRedisRateLimitRequestKeyOptions = {
+  counterKey: string;
+  requestId: string;
+};
+
+export const createRedisRateLimitRequestKey = ({
+  counterKey,
+  requestId,
+}: CreateRedisRateLimitRequestKeyOptions): string =>
+  `${counterKey}${REQUEST_KEY_SEPARATOR}${requestId}`;
+
+type ParsedRequestScopedKey = {
+  counterKey: string;
+  requestId: string | null;
+};
+
+const parseRequestScopedKey = (key: string): ParsedRequestScopedKey => {
+  const separatorIndex = key.lastIndexOf(REQUEST_KEY_SEPARATOR);
+  if (separatorIndex < 0) {
+    return { counterKey: key, requestId: null };
+  }
+  return {
+    counterKey: key.slice(0, separatorIndex),
+    requestId: key.slice(separatorIndex + REQUEST_KEY_SEPARATOR.length),
+  };
+};
+
+const requestScopedGenerator = (scope: string): Generator => {
+  const generateCounterKey = scopedGenerator(scope);
+  const requestIds = new WeakMap<Request, string>();
+
+  return (request, server) => {
+    const counterKey = generateCounterKey(request, server);
+    let requestId = requestIds.get(request);
+    if (requestId === undefined) {
+      requestId = Bun.randomUUIDv7();
+      requestIds.set(request, requestId);
+    }
+    return createRedisRateLimitRequestKey({ counterKey, requestId });
+  };
+};
+
+export const createRedisRateLimit = ({
+  failurePolicy,
+  scope,
+}: CreateRedisRateLimitOptions): RedisRateLimitBinding => ({
+  // Keep the context and request-token generator paired: the token lets a
+  // failed request refund only the Redis window that admitted it.
+  context: new RedisRateLimitContext({ failurePolicy }),
+  generator: requestScopedGenerator(scope),
+});
+
+const redisRateLimitKey = (counterKey: string): string =>
+  `${REDIS_KEY_PREFIX}${counterKey}`;
 
 const parseIncrementReply = (
   reply: unknown,
   durationMs: number,
   now: number,
-): RateLimitCounter => {
-  if (!Array.isArray(reply) || reply.length !== 2) {
+): RedisIncrement => {
+  if (!Array.isArray(reply) || reply.length !== 3) {
     throw new RedisRateLimitReplyError({
       message: "Redis returned an invalid rate-limit counter reply",
       reply,
@@ -259,11 +357,14 @@ const parseIncrementReply = (
   }
   const count = Number(reply.at(0));
   const ttlMs = Number(reply.at(1));
+  const rawWindowId = reply.at(2);
   if (
     !Number.isFinite(count) ||
     !Number.isFinite(ttlMs) ||
     count < 1 ||
-    ttlMs < 0
+    ttlMs < 0 ||
+    typeof rawWindowId !== "string" ||
+    rawWindowId.length === 0
   ) {
     throw new RedisRateLimitReplyError({
       message: "Redis returned invalid rate-limit counter values",
@@ -272,9 +373,12 @@ const parseIncrementReply = (
   }
   const nextReset = new Date(now + ttlMs);
   return {
-    count,
-    nextReset,
-    start: nextReset.getTime() - durationMs,
+    counter: {
+      count,
+      nextReset,
+      start: nextReset.getTime() - durationMs,
+    },
+    windowId: rawWindowId,
   };
 };
 

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -195,13 +195,14 @@ export class RedisRateLimitContext implements Context {
   private async sendCommand(command: string, args: string[]): Promise<unknown> {
     this.redis ??= this.createRedis();
     const redis = this.redis;
-    const result = await Result.tryPromise(async () => {
-      return await withCommandTimeout({
-        command: redis.send(command, args),
-        commandTimeoutMs: this.commandTimeoutMs,
-        scheduleTimeout: this.scheduleTimeout,
-      });
-    });
+    const result = await Result.tryPromise(
+      async () =>
+        await withCommandTimeout({
+          command: redis.send(command, args),
+          commandTimeoutMs: this.commandTimeoutMs,
+          scheduleTimeout: this.scheduleTimeout,
+        }),
+    );
     if (Result.isError(result)) {
       if (TimeoutError.is(result.error)) {
         redis.close?.();

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -117,7 +117,7 @@ export class RedisRateLimitContext implements Context {
   ): Promise<RateLimitCounter> {
     const effectiveDuration = duration ?? this.durationMs;
     const now = requestTime ?? Date.now();
-    const fallbackCounter = await this.fallback.increment(
+    const fallbackCounter = this.fallback.increment(
       key,
       effectiveDuration,
       now,
@@ -146,7 +146,7 @@ export class RedisRateLimitContext implements Context {
   }
 
   async decrement(key: string): Promise<void> {
-    await this.fallback.decrement(key);
+    this.fallback.decrement(key);
     const result = await Result.tryPromise(
       async () =>
         await this.sendCommand("EVAL", [
@@ -161,7 +161,7 @@ export class RedisRateLimitContext implements Context {
   }
 
   async reset(key?: string): Promise<void> {
-    await this.fallback.reset(key);
+    this.fallback.reset(key);
     // Never scan/delete the shared namespace; TTL expiry owns global cleanup.
     if (key === undefined) {
       return;

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -222,14 +222,15 @@ export class RedisRateLimitContext implements Context {
   private async sendCommand(command: string, args: string[]): Promise<unknown> {
     this.redis ??= this.createRedis();
     const redis = this.redis;
-    const result = await Result.tryPromise(
-      async () =>
+    const result = await Result.tryPromise({
+      try: async () =>
         await withCommandTimeout({
           command: redis.send(command, args),
           commandTimeoutMs: this.commandTimeoutMs,
           scheduleTimeout: this.scheduleTimeout,
         }),
-    );
+      catch: (error: unknown) => error,
+    });
     if (Result.isError(result)) {
       if (TimeoutError.is(result.error)) {
         redis.close?.();

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -240,7 +240,7 @@ const withCommandTimeout = async <T>({
   commandTimeoutMs,
   scheduleTimeout,
 }: WithCommandTimeoutOptions<T>): Promise<T> => {
-  let cancelTimeout = () => undefined;
+  let cancelTimeout: () => void = () => undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
     cancelTimeout = scheduleTimeout(
       () =>

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -96,8 +96,7 @@ import {
   initRequestContext,
   REQUEST_ID_HEADER,
 } from "@/api/lib/observability/request-context";
-import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
-import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
+import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 import {
   isCorpusS3Stale,
   isS3Stale,
@@ -396,9 +395,9 @@ const api = new Elysia()
           scoping: "scoped",
           duration: API_RATE_LIMITS.api.duration,
           max: API_RATE_LIMITS.api.max,
-          generator: scopedGenerator("api"),
-          context: new RedisRateLimitContext({
+          ...createRedisRateLimit({
             failurePolicy: "fail_open_local",
+            scope: "api",
           }),
           skip: (req) => {
             // The e2e route walk fires hundreds of /v1 requests per minute
@@ -439,9 +438,9 @@ const api = new Elysia()
               scoping: "scoped",
               duration: API_RATE_LIMITS.folioCollab.duration,
               max: API_RATE_LIMITS.folioCollab.max,
-              generator: scopedGenerator("folio-collab"),
-              context: new RedisRateLimitContext({
+              ...createRedisRateLimit({
                 failurePolicy: "fail_open_local",
+                scope: "folio-collab",
               }),
               // Same e2e escape hatch as the shared `api` bucket above: the
               // route walk opens the document editor repeatedly and would

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -96,10 +96,8 @@ import {
   initRequestContext,
   REQUEST_ID_HEADER,
 } from "@/api/lib/observability/request-context";
-import {
-  InMemoryRateLimitContext,
-  scopedGenerator,
-} from "@/api/lib/rate-limit/rate-limit";
+import { scopedGenerator } from "@/api/lib/rate-limit/rate-limit";
+import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 import {
   isCorpusS3Stale,
   isS3Stale,
@@ -399,7 +397,9 @@ const api = new Elysia()
           duration: API_RATE_LIMITS.api.duration,
           max: API_RATE_LIMITS.api.max,
           generator: scopedGenerator("api"),
-          context: new InMemoryRateLimitContext(),
+          context: new RedisRateLimitContext({
+            failurePolicy: "fail_open_local",
+          }),
           skip: (req) => {
             // The e2e route walk fires hundreds of /v1 requests per minute
             // from one IP; abuse limits are not what those runs measure. The
@@ -440,7 +440,9 @@ const api = new Elysia()
               duration: API_RATE_LIMITS.folioCollab.duration,
               max: API_RATE_LIMITS.folioCollab.max,
               generator: scopedGenerator("folio-collab"),
-              context: new InMemoryRateLimitContext(),
+              context: new RedisRateLimitContext({
+                failurePolicy: "fail_open_local",
+              }),
               // Same e2e escape hatch as the shared `api` bucket above: the
               // route walk opens the document editor repeatedly and would
               // drain this 30/min budget across back-to-back runs.


### PR DESCRIPTION
## Summary

- replace process-local HTTP rate-limit counters with a shared Redis fixed-window context across the general API, uploads, translation, collaboration, style-set uploads, hosted usage webhooks, and delete-account OTP sends
- keep each existing route budget, IP scope, skip rule, and standard `RateLimit-*` / `Retry-After` response contract unchanged
- use atomic Lua increment/TTL and decrement/refund operations so multiple API replicas share one counter
- bound every Redis command to 500 ms and explicitly degrade to a warmed process-local counter during Redis outages, preserving availability while keeping the prior per-replica ceiling
- cover shared counters across two simulated replicas, scoped keys, expiry, reset, failed-request refunds, malformed replies, stalled commands, and exact 429 retry headers

## Verification

- scoped formatting and diff-integrity checks completed locally
- lint, typecheck, and tests are delegated to CI

CC on behalf of @jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Switched rate limiting from in-memory storage to Redis-backed storage across the API, including upload, entity (upload/translation), style sets, hosted usage webhooks, and account deletion.
  - Rate limits are now coordinated across server instances.
  - Redis interruptions are handled with a local fail-open policy for improved availability.
- **Bug Fixes**
  - Added bounded handling for stalled/invalid Redis responses to keep rate limiting behaviour predictable.
- **Tests**
  - Added Bun tests covering Redis-backed rate limiting, replica coordination, refunds/decrements, expiry behaviour, and failure semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->