### PR TITLE
fix(web): terminate entity tree walks on cyclic parent references

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-utils.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-utils.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/lib/safe-id";
+import type { WorkspaceEntity } from "@/lib/types";
+import type { TableTreeNode } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
+import {
+  buildTree,
+  countDescendants,
+  findNode,
+} from "@/routes/_protected.workspaces/$workspaceId/-utils";
+
+const entity = (
+  entityId: string,
+  parentId: string | null = null,
+): WorkspaceEntity => ({
+  entityId: toSafeId<"entity">(entityId),
+  kind: "folder",
+  name: entityId,
+  parentId: parentId ? toSafeId<"entity">(parentId) : null,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  createdBy: null,
+  createdByImage: null,
+  createdByDeletedAt: null,
+  updatedAt: null,
+  version: 1,
+  status: null,
+  priority: null,
+  dueDate: null,
+  agendaKind: "task",
+  startAt: null,
+  endAt: null,
+  occurredAt: null,
+  remindAt: null,
+  allDay: false,
+  timeZone: null,
+  location: null,
+  onlineMeetingUrl: null,
+  availability: null,
+  sensitivity: null,
+  organizer: null,
+  attendees: null,
+  recurrence: null,
+  agendaSource: "manual",
+  externalSource: null,
+  externalId: null,
+  externalChangeKey: null,
+  externalICalUid: null,
+  readOnly: false,
+  sortOrder: null,
+  activeEditBy: null,
+  cellMetadata: {},
+  fields: {},
+});
+
+const ids = (nodes: readonly { entityId: string }[]) =>
+  nodes.map((n) => n.entityId).toSorted();
+
+const treeNode = (id: string): TableTreeNode => ({
+  ...entity(id),
+  children: [],
+});
+
+describe("buildTree", () => {
+  test("nests entities under their parent, preserving order", () => {
+    const tree = buildTree([
+      entity("root"),
+      entity("child-a", "root"),
+      entity("child-b", "root"),
+      entity("grandchild", "child-a"),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    const root = tree[0];
+    expect(root?.entityId).toBe(toSafeId<"entity">("root"));
+    expect(ids(root?.children ?? [])).toEqual(
+      ids([{ entityId: "child-a" }, { entityId: "child-b" }]),
+    );
+    const childA = root?.children.find(
+      (c) => c.entityId === toSafeId<"entity">("child-a"),
+    );
+    expect(childA?.children.map((c) => c.entityId)).toEqual([
+      toSafeId<"entity">("grandchild"),
+    ]);
+  });
+
+  test("treats an entity whose parent is not in the list as a root", () => {
+    const tree = buildTree([entity("orphan", "missing-parent")]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.entityId).toBe(toSafeId<"entity">("orphan"));
+    expect(tree[0]?.children).toEqual([]);
+  });
+
+  test("breaks a self-parent cycle by treating the node as a root", () => {
+    const tree = buildTree([entity("self", "self")]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.entityId).toBe(toSafeId<"entity">("self"));
+    expect(tree[0]?.children).toEqual([]);
+  });
+
+  test("breaks a two-node cycle by treating both nodes as roots", () => {
+    const tree = buildTree([entity("a", "b"), entity("b", "a")]);
+
+    expect(ids(tree)).toEqual(ids([{ entityId: "a" }, { entityId: "b" }]));
+    for (const node of tree) {
+      expect(node.children).toEqual([]);
+    }
+  });
+
+  test("keeps a valid subtree intact next to an unrelated cycle, and still attaches a non-cyclic tail hanging off a cyclic node", () => {
+    const tree = buildTree([
+      entity("root"),
+      entity("branch", "root"),
+      entity("leaf", "branch"),
+      // Self-contained cycle, unrelated to the valid subtree above.
+      entity("cycle-a", "cycle-b"),
+      entity("cycle-b", "cycle-a"),
+      // Not itself cyclic, but its declared parent is a cyclic node.
+      entity("tail", "cycle-a"),
+    ]);
+
+    expect(ids(tree)).toEqual(
+      ids([
+        { entityId: "root" },
+        { entityId: "cycle-a" },
+        { entityId: "cycle-b" },
+      ]),
+    );
+
+    const root = tree.find((n) => n.entityId === toSafeId<"entity">("root"));
+    expect(root?.children.map((c) => c.entityId)).toEqual([
+      toSafeId<"entity">("branch"),
+    ]);
+    expect(root?.children[0]?.children.map((c) => c.entityId)).toEqual([
+      toSafeId<"entity">("leaf"),
+    ]);
+
+    const cycleA = tree.find(
+      (n) => n.entityId === toSafeId<"entity">("cycle-a"),
+    );
+    expect(cycleA?.children.map((c) => c.entityId)).toEqual([
+      toSafeId<"entity">("tail"),
+    ]);
+
+    const cycleB = tree.find(
+      (n) => n.entityId === toSafeId<"entity">("cycle-b"),
+    );
+    expect(cycleB?.children).toEqual([]);
+  });
+});
+
+describe("findNode / countDescendants cycle safety", () => {
+  test("findNode terminates and returns null when the target is absent from a cyclic tree", () => {
+    const a = treeNode("a");
+    const b = treeNode("b");
+    a.children.push(b);
+    b.children.push(a);
+
+    expect(findNode([a], "does-not-exist")).toBeNull();
+  });
+
+  test("findNode still finds a present target inside a cyclic tree", () => {
+    const a = treeNode("a");
+    const b = treeNode("b");
+    a.children.push(b);
+    b.children.push(a);
+
+    const found = findNode([a], toSafeId<"entity">("b"));
+    expect(found?.entityId).toBe(toSafeId<"entity">("b"));
+  });
+
+  test("countDescendants terminates and counts each cyclic node once", () => {
+    const a = treeNode("a");
+    const b = treeNode("b");
+    const c = treeNode("c");
+    a.children.push(b);
+    b.children.push(c);
+    c.children.push(a);
+
+    expect(countDescendants(a)).toBe(2);
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-utils.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-utils.ts
@@ -205,6 +205,63 @@ export const formatFullTimestamp = (
 
 // -- Tree utilities (shared between filesystem and table views) --
 
+/**
+ * Entity IDs that sit on a parentId cycle (a node reachable from itself by
+ * walking parentId pointers). Uses the standard functional-graph cycle scan:
+ * each entity has at most one outgoing edge (its parentId), so walking from
+ * an unvisited node either terminates at a root/missing parent or re-enters
+ * a node already on the current path, which marks the remainder of that path
+ * (the cycle itself, not any acyclic tail leading into it) as cyclic.
+ */
+const findCyclicEntityIds = (
+  entities: readonly WorkspaceEntity[],
+): ReadonlySet<string> => {
+  const parentIdOf = new Map<string, string | null>();
+  for (const entity of entities) {
+    parentIdOf.set(entity.entityId, entity.parentId);
+  }
+
+  const status = new Map<string, "visiting" | "done">();
+  const inCycle = new Set<string>();
+
+  for (const entity of entities) {
+    if (status.has(entity.entityId)) {
+      continue;
+    }
+
+    const path: string[] = [];
+    const pathIndex = new Map<string, number>();
+    let currentId: string | null = entity.entityId;
+
+    while (currentId !== null) {
+      const currentStatus = status.get(currentId);
+      if (currentStatus === "done") {
+        break;
+      }
+      if (currentStatus === "visiting") {
+        const cycleStart = pathIndex.get(currentId) ?? 0;
+        for (const id of path.slice(cycleStart)) {
+          inCycle.add(id);
+        }
+        break;
+      }
+
+      status.set(currentId, "visiting");
+      pathIndex.set(currentId, path.length);
+      path.push(currentId);
+
+      const parentId = parentIdOf.get(currentId);
+      currentId = parentId && parentIdOf.has(parentId) ? parentId : null;
+    }
+
+    for (const id of path) {
+      status.set(id, "done");
+    }
+  }
+
+  return inCycle;
+};
+
 export const buildTree = (
   entities: readonly WorkspaceEntity[],
 ): TableTreeNode[] => {
@@ -215,19 +272,25 @@ export const buildTree = (
     nodeMap.set(entity.entityId, { ...entity, children: [] });
   }
 
+  const cyclicEntityIds = findCyclicEntityIds(entities);
+
   for (const entity of entities) {
     const node = nodeMap.get(entity.entityId);
     if (!node) {
       continue;
     }
 
-    if (entity.parentId) {
-      const parent = nodeMap.get(entity.parentId);
-      if (parent) {
-        parent.children.push(node);
-      } else {
-        roots.push(node);
-      }
+    // Nodes on a parentId cycle are deliberately cut loose as roots instead
+    // of being attached under their (equally cyclic) parent: this keeps them
+    // visible in the tree rather than silently dropped, and guarantees the
+    // resulting forest is acyclic.
+    const parent =
+      entity.parentId && !cyclicEntityIds.has(entity.entityId)
+        ? nodeMap.get(entity.parentId)
+        : undefined;
+
+    if (parent) {
+      parent.children.push(node);
     } else {
       roots.push(node);
     }
@@ -245,17 +308,30 @@ export const toTableEntities = (
     : entities.map((e) => ({ ...e, children: [] }));
 };
 
-/** Find a node by ID in a tree (depth-first). */
+/**
+ * Find a node by ID in a tree (depth-first).
+ *
+ * Guards against a corrupted/externally-built tree that loops back on
+ * itself: a `visited` set stops a node's children from being re-queued once
+ * they have already been expanded, so the walk always terminates even if
+ * `children` contains a cycle.
+ */
 export const findNode = (
   roots: readonly TableTreeNode[],
   targetId: string,
 ): TableTreeNode | null => {
   const stack = [...roots];
+  const visited = new Set<string>();
   let node = stack.pop();
   while (node) {
     if (node.entityId === targetId) {
       return node;
     }
+    if (visited.has(node.entityId)) {
+      node = stack.pop();
+      continue;
+    }
+    visited.add(node.entityId);
     for (const child of node.children) {
       stack.push(child);
     }
@@ -264,12 +340,23 @@ export const findNode = (
   return null;
 };
 
-/** Count all descendants (non-recursive, stack-based). */
+/**
+ * Count all descendants (non-recursive, stack-based).
+ *
+ * Guards against a cyclic `children` graph the same way {@link findNode}
+ * does: each entityId is counted at most once, so the walk terminates.
+ */
 export const countDescendants = (node: TableTreeNode): number => {
   let count = 0;
+  const visited = new Set<string>([node.entityId]);
   const stack = [...node.children];
   let child = stack.pop();
   while (child) {
+    if (visited.has(child.entityId)) {
+      child = stack.pop();
+      continue;
+    }
+    visited.add(child.entityId);
     count += 1;
     for (const grandchild of child.children) {
       stack.push(grandchild);


### PR DESCRIPTION
## What

Makes the workspace entity tree utilities (`buildTree`, `findNode`, `countDescendants`) safe on input whose `parentId` chain contains a cycle, and adds unit tests for all three.

## Why

`buildTree` links entities purely from `parentId` with no cycle handling. The backend move handler prevents cycles on the normal path, but it is the only line of defense; nothing on the read path validates the invariant. Today's behavior on cyclic input is worse than a hang: members of a cyclic island never satisfy the "no resolvable parent" condition, so they silently disappear from the returned forest entirely. `findNode`/`countDescendants` additionally loop forever if handed a cyclic tree.

## How

- A `findCyclicEntityIds` scan (each entity has at most one outgoing `parentId` edge, so a path-tracking walk with visiting/done marking) identifies nodes sitting on a cycle; `buildTree` cuts those loose as roots instead of attaching them under their equally-cyclic parent. Corrupted data stays visible and the returned forest is guaranteed acyclic. Acyclic input builds byte-identical trees.
- `findNode` and `countDescendants` get a visited set so any externally-constructed cyclic tree terminates.

## Tests

8 tests covering normal nesting, orphaned parent (unchanged behavior), self-parent, mutual pair, a cycle alongside a valid subtree with a non-cyclic tail node, and termination of both walks on cyclic input. `bun test`: 8 pass, 0 fail.