### PR TITLE
refactor(web): route chat send-queue transitions through a pure reducer

### DIFF
--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic.test.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic.test.ts
@@ -1,20 +1,27 @@
 import type { ChatClientState } from "@tanstack/ai-client";
 import { describe, expect, test } from "bun:test";
 
+import { toSafeId } from "@/lib/safe-id";
 import {
   createInitialSendQueueState,
   reduceSendQueue,
   type QueuedChatEntry,
   type SendQueueState,
 } from "@/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic";
+import type { ChatUserMessageInput } from "@/routes/_protected.chat/-queries";
 
 const CONVERSATION_ID = "conversation-1";
+
+const makeMessage = (id: string): ChatUserMessageInput => ({
+  id: toSafeId<"chatMessage">(id),
+  content: `message ${id}`,
+});
 
 const makeEntry = (id: string): QueuedChatEntry => ({
   id,
   text: `message ${id}`,
   fileCount: 0,
-  message: { content: `message ${id}` },
+  message: makeMessage(id),
 });
 
 /**

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic.test.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic.test.ts
@@ -1,0 +1,249 @@
+import type { ChatClientState } from "@tanstack/ai-client";
+import { describe, expect, test } from "bun:test";
+
+import {
+  createInitialSendQueueState,
+  reduceSendQueue,
+  type QueuedChatEntry,
+  type SendQueueState,
+} from "@/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic";
+
+const CONVERSATION_ID = "conversation-1";
+
+const makeEntry = (id: string): QueuedChatEntry => ({
+  id,
+  text: `message ${id}`,
+  fileCount: 0,
+  message: { content: `message ${id}` },
+});
+
+/**
+ * `useChatSession` fires two separate effects off the same render's
+ * `isGenerating` value: one mirrors it straight into the state
+ * (`generation-status-synced`) and one runs the finished-turn/error-gate
+ * check (`turn-boundary-checked`), in that order. Tests that need to
+ * simulate "a render happened with the runtime reporting X" replay both,
+ * exactly like the hook does, instead of calling either event alone.
+ */
+const applyRenderTick = (
+  state: SendQueueState,
+  isGenerating: boolean,
+  status: ChatClientState,
+) => {
+  const synced = reduceSendQueue(state, {
+    type: "generation-status-synced",
+    isGenerating,
+  });
+  return reduceSendQueue(synced.state, {
+    type: "turn-boundary-checked",
+    isGenerating,
+    status,
+  });
+};
+
+describe("reduceSendQueue", () => {
+  test("idle state: dispatching the oldest message on an empty queue is a no-op", () => {
+    // "Normal send while idle" never touches the queue at all in
+    // `useChatSession` (it calls `sendChatMessage` directly). The queue's
+    // own idle behavior is that popping from an empty queue changes
+    // nothing and hands back no entry to dispatch.
+    const state = createInitialSendQueueState(CONVERSATION_ID);
+
+    const result = reduceSendQueue(state, { type: "oldest-dispatch-started" });
+
+    expect(result.dispatchedEntry).toBeNull();
+    expect(result.state).toBe(state);
+  });
+
+  test("enqueue while generating, then dispatch once the turn finishes", () => {
+    let state = createInitialSendQueueState(CONVERSATION_ID);
+
+    // A turn starts.
+    state = applyRenderTick(state, true, "streaming").state;
+    expect(state.isGenerating).toBe(true);
+
+    // A message typed mid-stream is queued, not sent.
+    const entry = makeEntry("a");
+    const enqueueResult = reduceSendQueue(state, {
+      type: "message-enqueued",
+      entry,
+    });
+    state = enqueueResult.state;
+    expect(enqueueResult.dispatchedEntry).toBeNull();
+    expect(state.queue).toEqual([entry]);
+
+    // The turn finishes: the falling edge dispatches the oldest queued
+    // message and flips `isGenerating` back on for it.
+    const finishResult = applyRenderTick(state, false, "ready");
+    state = finishResult.state;
+
+    expect(finishResult.dispatchedEntry).toEqual(entry);
+    expect(state.queue).toEqual([]);
+    expect(state.isGenerating).toBe(true);
+  });
+
+  test("a turn ending in error holds the queue instead of draining it", () => {
+    let state = createInitialSendQueueState(CONVERSATION_ID);
+    state = applyRenderTick(state, true, "streaming").state;
+    const entry = makeEntry("a");
+    state = reduceSendQueue(state, { type: "message-enqueued", entry }).state;
+
+    const result = applyRenderTick(state, false, "error");
+
+    expect(result.dispatchedEntry).toBeNull();
+    expect(result.state.queue).toEqual([entry]);
+    expect(result.state.isGenerating).toBe(false);
+  });
+
+  test("dispatch failure from a message-start error requeues the entry at the front", () => {
+    const waiting = makeEntry("waiting");
+    const state: SendQueueState = {
+      ...createInitialSendQueueState(CONVERSATION_ID),
+      isGenerating: true,
+      queue: [waiting],
+    };
+    const failedEntry = makeEntry("failed");
+
+    const result = reduceSendQueue(state, {
+      type: "dispatch-failed",
+      entry: failedEntry,
+      requeue: true,
+    });
+
+    // The failed send never got underway, so it goes back to the front —
+    // ahead of anything queued while it was in flight.
+    expect(result.state.queue).toEqual([failedEntry, waiting]);
+    expect(result.state.isGenerating).toBe(false);
+  });
+
+  test("dispatch failure without a message-start error drops the entry (matches `dispatchQueuedMessage`'s catch block, which only requeues on `isChatMessageStartError`)", () => {
+    const waiting = makeEntry("waiting");
+    const state: SendQueueState = {
+      ...createInitialSendQueueState(CONVERSATION_ID),
+      isGenerating: true,
+      queue: [waiting],
+    };
+    const failedEntry = makeEntry("failed");
+
+    const result = reduceSendQueue(state, {
+      type: "dispatch-failed",
+      entry: failedEntry,
+      requeue: false,
+    });
+
+    // The failed message is not put back: a non-start error means the
+    // turn may already have begun server-side, so retrying it here would
+    // risk sending it twice.
+    expect(result.state.queue).toEqual([waiting]);
+    expect(result.state.isGenerating).toBe(false);
+  });
+
+  test("conversation switch clears the queue and the generating flags", () => {
+    const state: SendQueueState = {
+      conversationId: CONVERSATION_ID,
+      isGenerating: true,
+      queue: [makeEntry("a"), makeEntry("b")],
+      wasGenerating: true,
+    };
+
+    const result = reduceSendQueue(state, {
+      type: "conversation-switched",
+      conversationId: "conversation-2",
+    });
+
+    expect(result.state).toEqual({
+      conversationId: "conversation-2",
+      isGenerating: false,
+      queue: [],
+      wasGenerating: false,
+    });
+    expect(result.dispatchedEntry).toBeNull();
+  });
+
+  test("two generation-finished events in a row dispatch only once", () => {
+    let state = createInitialSendQueueState(CONVERSATION_ID);
+    state = applyRenderTick(state, true, "streaming").state;
+    const entry = makeEntry("a");
+    state = reduceSendQueue(state, { type: "message-enqueued", entry }).state;
+
+    const first = applyRenderTick(state, false, "ready");
+    // Simulate the effect re-running (e.g. a re-render with unrelated
+    // state changes) with the same "not generating" reading, before
+    // anything else has changed `isGenerating` again. `wasGenerating` was
+    // already dropped to `false` by the first run, so this can't re-fire
+    // a second dispatch of the same (already-popped) turn.
+    const second = reduceSendQueue(first.state, {
+      type: "turn-boundary-checked",
+      isGenerating: false,
+      status: "ready",
+    });
+
+    expect(first.dispatchedEntry).toEqual(entry);
+    expect(second.dispatchedEntry).toBeNull();
+    expect(second.state.queue).toEqual([]);
+    expect(second.state.isGenerating).toBe(true);
+  });
+
+  test("generation-status-synced mirrors the runtime's flag without touching the queue", () => {
+    const entry = makeEntry("a");
+    const state: SendQueueState = {
+      ...createInitialSendQueueState(CONVERSATION_ID),
+      queue: [entry],
+    };
+
+    const result = reduceSendQueue(state, {
+      type: "generation-status-synced",
+      isGenerating: true,
+    });
+
+    expect(result.state.isGenerating).toBe(true);
+    expect(result.state.queue).toBe(state.queue);
+    expect(result.dispatchedEntry).toBeNull();
+  });
+
+  test("removing a queued message by id drops only that entry", () => {
+    const first = makeEntry("a");
+    const second = makeEntry("b");
+    const state: SendQueueState = {
+      ...createInitialSendQueueState(CONVERSATION_ID),
+      queue: [first, second],
+    };
+
+    const result = reduceSendQueue(state, {
+      type: "queued-message-removed",
+      id: first.id,
+    });
+
+    expect(result.state.queue).toEqual([second]);
+  });
+
+  test("removing a non-existent id is a safe no-op", () => {
+    const entry = makeEntry("a");
+    const state: SendQueueState = {
+      ...createInitialSendQueueState(CONVERSATION_ID),
+      queue: [entry],
+    };
+
+    const result = reduceSendQueue(state, {
+      type: "queued-message-removed",
+      id: "does-not-exist",
+    });
+
+    expect(result.state.queue).toEqual([entry]);
+  });
+
+  test("dispatching the oldest of several queued messages preserves FIFO order", () => {
+    const first = makeEntry("a");
+    const second = makeEntry("b");
+    const state: SendQueueState = {
+      ...createInitialSendQueueState(CONVERSATION_ID),
+      queue: [first, second],
+    };
+
+    const result = reduceSendQueue(state, { type: "oldest-dispatch-started" });
+
+    expect(result.dispatchedEntry).toEqual(first);
+    expect(result.state.queue).toEqual([second]);
+    expect(result.state.isGenerating).toBe(true);
+  });
+});

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic.ts
@@ -1,0 +1,227 @@
+import type { ChatClientState } from "@tanstack/ai-client";
+import { panic } from "better-result";
+
+import type {
+  ChatSendMessageOptions,
+  ChatUserMessageInput,
+} from "@/routes/_protected.chat/-queries";
+
+/**
+ * A user message composed while a response was still streaming.
+ * `useChatSession` holds these in a queue and dispatches them —
+ * oldest first — once the turn finishes. `text` is the raw editor
+ * HTML (rendered like any sent user message); `fileCount` lets the
+ * pending bubble show an attachment hint without the view ever
+ * touching the file payloads.
+ */
+export type QueuedChatMessage = {
+  id: string;
+  text: string;
+  fileCount: number;
+};
+
+export type QueuedChatEntry = QueuedChatMessage & {
+  /** Fully-built payload handed to TanStack ChatClient on dispatch. */
+  message: ChatUserMessageInput;
+  options?: ChatSendMessageOptions;
+};
+
+/**
+ * Pull a display preview out of an outgoing chat payload. The SDK
+ * accepts either raw text or multimodal content; queued bubbles only
+ * need a text preview and attachment count.
+ */
+export const describeQueuedMessage = (
+  message: ChatUserMessageInput,
+): Pick<QueuedChatMessage, "fileCount" | "text"> => {
+  if (typeof message.content === "string") {
+    return { text: message.content, fileCount: 0 };
+  }
+
+  const textParts: string[] = [];
+  for (const part of message.content) {
+    if (part.type === "text") {
+      textParts.push(part.content);
+    }
+  }
+
+  return {
+    text: textParts.join("\n\n"),
+    fileCount: message.content.filter((part) => part.type !== "text").length,
+  };
+};
+
+/**
+ * State backing `useChatSession`'s send queue. Owns exactly the fields
+ * that used to be split across `isGeneratingRef`, `queueRef`,
+ * `wasGeneratingRef`, and `conversationIdRef` — mirrored here so a
+ * single `reduceSendQueue` call is the only way any of them changes.
+ */
+export type SendQueueState = {
+  /** Id of the conversation the queue currently belongs to. */
+  readonly conversationId: string;
+  /**
+   * Mirrors the runtime's live "a turn is in flight" signal, plus the
+   * brief window right after a queued dispatch starts (set eagerly, ahead
+   * of the runtime's own status catching up) and right after it fails
+   * (cleared immediately so a retried send isn't blocked by a stale flag).
+   */
+  readonly isGenerating: boolean;
+  /** Messages typed while `isGenerating` was true, oldest first. */
+  readonly queue: readonly QueuedChatEntry[];
+  /** `isGenerating` as of the previous turn-boundary check; used to detect the falling edge that ends a turn. */
+  readonly wasGenerating: boolean;
+};
+
+export const createInitialSendQueueState = (
+  conversationId: string,
+): SendQueueState => ({
+  conversationId,
+  isGenerating: false,
+  queue: [],
+  wasGenerating: false,
+});
+
+/**
+ * Every site in `useChatSession` that used to write one of the four
+ * queue-related refs by hand. Each variant name traces back to the
+ * call site it replaces (see `use-chat-session.ts`):
+ *
+ * - `message-enqueued` — `enqueueMessage`
+ * - `queued-message-removed` — `removeQueuedMessage`
+ * - `oldest-dispatch-started` — `takeOldestQueuedMessage` immediately
+ *   followed by `dispatchQueuedMessage`'s eager `isGeneratingRef = true`.
+ *   The two are merged into one atomic transition: in the original code
+ *   every pop of the queue was always immediately followed by flipping
+ *   `isGenerating`, with no await in between — so this event makes that
+ *   pairing structural instead of a convention two call sites had to
+ *   remember to uphold.
+ * - `dispatch-failed` — `dispatchQueuedMessage`'s catch block
+ * - `generation-status-synced` — the `isGeneratingRef.current = isGenerating` effect
+ * - `turn-boundary-checked` — the queue-drain effect
+ * - `conversation-switched` — both the inline guard at the top of
+ *   `sendMessage` and the conversation-switch effect
+ */
+export type SendQueueEvent =
+  | { type: "message-enqueued"; entry: QueuedChatEntry }
+  | { type: "queued-message-removed"; id: string }
+  | { type: "oldest-dispatch-started" }
+  | { type: "dispatch-failed"; entry: QueuedChatEntry; requeue: boolean }
+  | { type: "generation-status-synced"; isGenerating: boolean }
+  | {
+      type: "turn-boundary-checked";
+      isGenerating: boolean;
+      status: ChatClientState;
+    }
+  | { type: "conversation-switched"; conversationId: string };
+
+export type SendQueueTransition = {
+  state: SendQueueState;
+  /**
+   * The entry that just started dispatching, if this transition popped
+   * one off the queue. Only `oldest-dispatch-started` and a
+   * queue-draining `turn-boundary-checked` ever populate this; every
+   * other event returns `null`. The caller is responsible for actually
+   * sending it (the reducer only decides the state transition).
+   */
+  dispatchedEntry: QueuedChatEntry | null;
+};
+
+const startOldestDispatch = (state: SendQueueState): SendQueueTransition => {
+  const [oldest, ...rest] = state.queue;
+  if (!oldest) {
+    return { state, dispatchedEntry: null };
+  }
+  return {
+    state: { ...state, isGenerating: true, queue: rest },
+    dispatchedEntry: oldest,
+  };
+};
+
+/**
+ * Pure transition for `useChatSession`'s send queue. Total over every
+ * `SendQueueEvent` in every `SendQueueState` — there is no reachable
+ * combination that falls through unhandled, so an exit path can no
+ * longer update the generating flag without also updating the queue
+ * (or vice versa).
+ */
+export const reduceSendQueue = (
+  state: SendQueueState,
+  event: SendQueueEvent,
+): SendQueueTransition => {
+  switch (event.type) {
+    case "message-enqueued": {
+      return {
+        state: { ...state, queue: [...state.queue, event.entry] },
+        dispatchedEntry: null,
+      };
+    }
+
+    case "queued-message-removed": {
+      return {
+        state: {
+          ...state,
+          queue: state.queue.filter((entry) => entry.id !== event.id),
+        },
+        dispatchedEntry: null,
+      };
+    }
+
+    case "oldest-dispatch-started": {
+      return startOldestDispatch(state);
+    }
+
+    case "dispatch-failed": {
+      return {
+        state: {
+          ...state,
+          isGenerating: false,
+          // A message-start failure means the send never got underway,
+          // so it's safe (and necessary) to retry: put it back at the
+          // front of the queue. Any other failure means the turn may
+          // already have started server-side; re-queueing it would risk
+          // a duplicate turn, so it's dropped instead — matching the
+          // original `dispatchQueuedMessage` catch block, which only
+          // requeued on `isChatMessageStartError`.
+          queue: event.requeue ? [event.entry, ...state.queue] : state.queue,
+        },
+        dispatchedEntry: null,
+      };
+    }
+
+    case "generation-status-synced": {
+      return {
+        state: { ...state, isGenerating: event.isGenerating },
+        dispatchedEntry: null,
+      };
+    }
+
+    case "turn-boundary-checked": {
+      const finishedTurn = state.wasGenerating && !event.isGenerating;
+      const next: SendQueueState = {
+        ...state,
+        wasGenerating: event.isGenerating,
+      };
+      // Hold the queue if the turn ended in error: firing every queued
+      // message into a failing provider just burns quota and spams the
+      // user with repeats of the same error. The next manual send (or a
+      // successful regenerate) lifts the gate.
+      if (!finishedTurn || event.status === "error") {
+        return { state: next, dispatchedEntry: null };
+      }
+      return startOldestDispatch(next);
+    }
+
+    case "conversation-switched": {
+      return {
+        state: createInitialSendQueueState(event.conversationId),
+        dispatchedEntry: null,
+      };
+    }
+
+    default: {
+      event satisfies never;
+      return panic("Unhandled send-queue event");
+    }
+  }
+};

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -50,6 +50,14 @@ import { internalToolErrorMessage, toAPIError } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
 import { readStoredJson, writeStoredJson } from "@/lib/stored-json";
 import {
+  createInitialSendQueueState,
+  describeQueuedMessage,
+  reduceSendQueue,
+  type QueuedChatEntry,
+  type SendQueueEvent,
+  type SendQueueState,
+} from "@/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic";
+import {
   fetchOlderMessages,
   isChatMessageStartError,
   sendThreadChatMessage,
@@ -99,50 +107,11 @@ export type ResendLatestMessageOptions = {
 const EMPTY_MCP_CONNECTOR_IDENTITIES: readonly McpConnectorApprovalIdentity[] =
   [];
 
-/**
- * A user message composed while a response was still streaming.
- * `useChatSession` holds these in a queue and dispatches them —
- * oldest first — once the turn finishes. `text` is the raw editor
- * HTML (rendered like any sent user message); `fileCount` lets the
- * pending bubble show an attachment hint without the view ever
- * touching the file payloads.
- */
-export type QueuedChatMessage = {
-  id: string;
-  text: string;
-  fileCount: number;
-};
-
-type QueuedChatEntry = QueuedChatMessage & {
-  /** Fully-built payload handed to TanStack ChatClient on dispatch. */
-  message: ChatUserMessageInput;
-  options?: ChatSendMessageOptions;
-};
-
-/**
- * Pull a display preview out of an outgoing chat payload. The SDK
- * accepts either raw text or multimodal content; queued bubbles only
- * need a text preview and attachment count.
- */
-const describeQueuedMessage = (
-  message: ChatUserMessageInput,
-): Pick<QueuedChatMessage, "fileCount" | "text"> => {
-  if (typeof message.content === "string") {
-    return { text: message.content, fileCount: 0 };
-  }
-
-  const textParts: string[] = [];
-  for (const part of message.content) {
-    if (part.type === "text") {
-      textParts.push(part.content);
-    }
-  }
-
-  return {
-    text: textParts.join("\n\n"),
-    fileCount: message.content.filter((part) => part.type !== "text").length,
-  };
-};
+// `QueuedChatMessage` is the view-facing shape of a queued entry; the
+// canonical definition (plus `QueuedChatEntry` and the send-queue
+// reducer) lives in the sibling `.logic.ts` file. Re-exported here so
+// existing consumers keep importing it from this hook.
+export type { QueuedChatMessage } from "@/routes/_protected.chat/-hooks/use-chat-session-send-queue.logic";
 
 type AskUserToolCallPart = Extract<
   ChatPart,
@@ -308,18 +277,35 @@ export const useChatSession = ({
 
   // Mirror `isGenerating` (computed below) and the live queue into
   // refs so the stable `sendMessage` callback can branch on the
-  // latest committed values. The refs are updated in effects or
+  // latest committed values. The ref is updated in effects or
   // queue-event helpers (not during render) so a concurrent re-render
-  // that bails out can't strand them ahead of committed state.
-  const isGeneratingRef = useRef(false);
-  const queueRef = useRef<QueuedChatEntry[]>([]);
-  const wasGeneratingRef = useRef(false);
-  const conversationIdRef = useRef(conversationId);
-  const [queuedMessages, setQueuedMessages] = useState<QueuedChatEntry[]>([]);
+  // that bails out can't strand it ahead of committed state.
+  //
+  // The four pieces of queue bookkeeping (generating flag, queue
+  // contents, "was generating last check" edge marker, and the
+  // conversation the queue belongs to) all live in one
+  // `SendQueueState`, and every write goes through `reduceSendQueue` via
+  // `applySendQueueEvent` below — see use-chat-session-send-queue.logic.ts.
+  // No call site writes a single field by hand anymore, so an exit path
+  // can no longer update one without the others.
+  const sendQueueRef = useRef<SendQueueState>(
+    createInitialSendQueueState(conversationId),
+  );
+  const [queuedMessages, setQueuedMessages] = useState<
+    readonly QueuedChatEntry[]
+  >([]);
 
-  const replaceQueuedMessages = useCallback((next: QueuedChatEntry[]) => {
-    queueRef.current = next;
-    setQueuedMessages(next);
+  const applySendQueueEvent = useCallback((event: SendQueueEvent) => {
+    const { state: nextState, dispatchedEntry } = reduceSendQueue(
+      sendQueueRef.current,
+      event,
+    );
+    const queueChanged = nextState.queue !== sendQueueRef.current.queue;
+    sendQueueRef.current = nextState;
+    if (queueChanged) {
+      setQueuedMessages(nextState.queue);
+    }
+    return dispatchedEntry;
   }, []);
 
   const withSendModeSnapshot = useCallback(
@@ -341,53 +327,41 @@ export const useChatSession = ({
 
   const enqueueMessage = useCallback(
     (message: ChatUserMessageInput, options?: ChatSendMessageOptions) => {
-      const queuedMessage = {
+      const entry: QueuedChatEntry = {
         id: uuidv7(),
         message,
         ...describeQueuedMessage(message),
         ...(options === undefined ? {} : { options }),
       };
-      replaceQueuedMessages([...queueRef.current, queuedMessage]);
+      applySendQueueEvent({ type: "message-enqueued", entry });
     },
-    [replaceQueuedMessages],
+    [applySendQueueEvent],
   );
-
-  const takeOldestQueuedMessage = useCallback(() => {
-    const next = queueRef.current.at(0);
-    if (!next) {
-      return null;
-    }
-    replaceQueuedMessages(queueRef.current.slice(1));
-    return next;
-  }, [replaceQueuedMessages]);
 
   const dispatchQueuedMessage = useCallback(
     async (entry: QueuedChatEntry) => {
-      isGeneratingRef.current = true;
       try {
         await sendChatMessage(entry.message, entry.options);
       } catch (sendError) {
-        isGeneratingRef.current = false;
-        if (isChatMessageStartError(sendError)) {
-          replaceQueuedMessages([entry, ...queueRef.current]);
-        }
+        applySendQueueEvent({
+          type: "dispatch-failed",
+          entry,
+          requeue: isChatMessageStartError(sendError),
+        });
         throw sendError;
       }
     },
-    [replaceQueuedMessages, sendChatMessage],
+    [applySendQueueEvent, sendChatMessage],
   );
 
   const sendMessage = useCallback(
     async (message: ChatUserMessageInput, options?: ChatSendMessageOptions) => {
-      if (conversationIdRef.current !== conversationId) {
-        conversationIdRef.current = conversationId;
-        isGeneratingRef.current = false;
-        wasGeneratingRef.current = false;
-        replaceQueuedMessages([]);
+      if (sendQueueRef.current.conversationId !== conversationId) {
+        applySendQueueEvent({ type: "conversation-switched", conversationId });
       }
 
       const requestOptions = withSendModeSnapshot(options);
-      if (isGeneratingRef.current) {
+      if (sendQueueRef.current.isGenerating) {
         enqueueMessage(message, requestOptions);
         return;
       }
@@ -395,11 +369,13 @@ export const useChatSession = ({
       // When the queue is gated after an errored turn, a manual send
       // should resume the queue without reordering the transcript:
       // append the new prompt, then dispatch the oldest waiting one.
-      if (queueRef.current.length > 0) {
+      if (sendQueueRef.current.queue.length > 0) {
         enqueueMessage(message, requestOptions);
-        const next = takeOldestQueuedMessage();
-        if (next) {
-          await dispatchQueuedMessage(next);
+        const dispatched = applySendQueueEvent({
+          type: "oldest-dispatch-started",
+        });
+        if (dispatched) {
+          await dispatchQueuedMessage(dispatched);
         }
         return;
       }
@@ -407,23 +383,20 @@ export const useChatSession = ({
       await sendChatMessage(message, requestOptions);
     },
     [
+      applySendQueueEvent,
       conversationId,
       dispatchQueuedMessage,
       enqueueMessage,
-      replaceQueuedMessages,
       sendChatMessage,
-      takeOldestQueuedMessage,
       withSendModeSnapshot,
     ],
   );
 
   const removeQueuedMessage = useCallback(
     (id: string) => {
-      replaceQueuedMessages(
-        queueRef.current.filter((entry) => entry.id !== id),
-      );
+      applySendQueueEvent({ type: "queued-message-removed", id });
     },
-    [replaceQueuedMessages],
+    [applySendQueueEvent],
   );
 
   const resendLatestMessage = useCallback(
@@ -760,11 +733,8 @@ export const useChatSession = ({
       sessionGenerating ||
       hasRunningToolCall);
   useExternalSyncEffect(() => {
-    isGeneratingRef.current = isGenerating;
-  }, [isGenerating]);
-  useExternalSyncEffect(() => {
-    queueRef.current = queuedMessages;
-  }, [queuedMessages]);
+    applySendQueueEvent({ type: "generation-status-synced", isGenerating });
+  }, [applySendQueueEvent, isGenerating]);
 
   // Notify `onError` exactly once per new error instance. TanStack keeps
   // the same Error reference alive across renders until the turn is
@@ -786,11 +756,8 @@ export const useChatSession = ({
   }, [error, notifyError]);
 
   useExternalSyncEffect(() => {
-    conversationIdRef.current = conversationId;
-    isGeneratingRef.current = false;
-    replaceQueuedMessages([]);
-    wasGeneratingRef.current = false;
-  }, [conversationId, replaceQueuedMessages]);
+    applySendQueueEvent({ type: "conversation-switched", conversationId });
+  }, [applySendQueueEvent, conversationId]);
 
   // Drain the queue one message per turn. When the response
   // finishes (`isGenerating` falls back to false) the oldest queued
@@ -800,31 +767,35 @@ export const useChatSession = ({
   // queue if the turn ended in error: firing every queued message
   // into a failing provider just burns quota and spams the user
   // with repeats of the same error. The next manual send (or a
-  // successful `regenerate`) lifts the gate.
+  // successful `regenerate`) lifts the gate. `reduceSendQueue` owns the
+  // finished-turn edge detection and the error gate (see
+  // `turn-boundary-checked` in use-chat-session-send-queue.logic.ts);
+  // this effect only forwards the runtime's latest status and, if a
+  // dispatch was returned, sends it.
   useExternalSyncEffect(() => {
-    const finishedTurn = wasGeneratingRef.current && !isGenerating;
-    wasGeneratingRef.current = isGenerating;
-    if (!finishedTurn || status === "error") {
+    const dispatched = applySendQueueEvent({
+      type: "turn-boundary-checked",
+      isGenerating,
+      status,
+    });
+    if (!dispatched) {
       return;
     }
-    const next = queuedMessages.at(0);
-    if (!next) {
-      return;
-    }
-    replaceQueuedMessages(queuedMessages.slice(1));
-    isGeneratingRef.current = true;
     // Preserve the request options the message was queued with —
     // notably `body.sendMode` (anonymized / raw) snapshotted by
     // withSendModeSnapshot at queue time. The manual drain path
     // already passes them; the automatic drain must too, otherwise
     // toggling the mode between queueing and draining sends the
     // queued turn with the wrong mode.
-    void dispatchQueuedMessage(next).catch(ignoreQueuedDispatchError);
+    void dispatchQueuedMessage(dispatched).catch(ignoreQueuedDispatchError);
   }, [
+    applySendQueueEvent,
     dispatchQueuedMessage,
     isGenerating,
+    // Not read in the body — `sendQueueRef` is always current — but kept
+    // as a dependency so this effect still re-runs on every queue change,
+    // matching the original effect's re-run cadence 1:1.
     queuedMessages,
-    replaceQueuedMessages,
     status,
   ]);
 

--- a/scripts/react-compiler-bailouts.json
+++ b/scripts/react-compiler-bailouts.json
@@ -72,7 +72,7 @@
   "apps/web/src/routes/_protected.chat/-components/chat-anonymized-toggle.tsx::ChatAnonymizedToggle": 0,
   "apps/web/src/routes/_protected.chat/-components/chat-web-search-toggle.tsx::ChatWebSearchToggle": 0,
   "apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx::ThreadsSheet": 0,
-  "apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts::useChatSession": 23,
+  "apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts::useChatSession": 22,
   "apps/web/src/routes/_protected.chat/-hooks/use-workspace-chat-mention-registration.ts::useWorkspaceChatMentionRegistration": 4,
   "apps/web/src/routes/_protected.chat/index.tsx::ChatIndex": 4,
   "apps/web/src/routes/_protected.chat/index.tsx::LandingItemText": 0,


### PR DESCRIPTION
## What

Extracts the chat send-queue state machine from `use-chat-session.ts` into a pure, total reducer (`use-chat-session-send-queue.logic.ts`) with a discriminated-union event type, and routes every mutation site through it. Behavior-preserving.

## Why

The queue was managed through four separate refs (`isGeneratingRef`, `queueRef`, `wasGeneratingRef`, `conversationIdRef`) mirrored into state and written by hand from ten different sites, including error catch paths and two duplicated conversation-switch resets. Nothing enforced that paired writes (pop queue + set generating) stayed paired, so a missed field write on one exit path could silently strand or drop queued messages.

## How

- `SendQueueState` unifies the four fields; `SendQueueEvent` has one variant per real mutation site; `reduceSendQueue` is exhaustive (`satisfies never` default).
- Queue-pop and generating-flag-set are merged into one atomic `oldest-dispatch-started` transition, making the previously conventional pairing structural.
- One provably dead defensive mirror effect was removed; a redundant effect dependency was deliberately kept to preserve the original re-run cadence.
- Non-start dispatch errors still drop (not requeue) the entry, matching existing behavior; the reasoning is now documented in the reducer and encoded in a test.

## Tests

11 new transition tests (enqueue/drain, error-gated hold, requeue-on-start-error vs drop, conversation switch, double-finish idempotency, FIFO order). All 45 existing chat-route and 136 chat-component tests pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable chat message queuing while a response is generating.
  * Queued messages are sent in order when the current turn finishes.
  * Added support for viewing queued message previews, including attachment counts.
  * Queues are cleared when switching conversations.

* **Bug Fixes**
  * Prevented duplicate sends after completed turns.
  * Preserved queued messages when a send fails before starting.
  * Suppressed automatic dispatch after an errored turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->