### PR TITLE
fix(api): validate inputs to raw JSONB literal helpers

### DIFF
--- a/apps/api/src/db/json-utils.test.ts
+++ b/apps/api/src/db/json-utils.test.ts
@@ -79,11 +79,15 @@ describe("jsonField", () => {
 
 describe("jsonLiteral", () => {
   test("builds a quoted literal for an identifier-like value", () => {
+    // "options" is a real key of the single-select/multi-select branch of
+    // PropertyContent (see propertyContentSchema); jsonLiteral's generic
+    // narrows its argument to keyof the versioned union, not to a value
+    // literal, so the accepted value here must be a schema key.
     const query = dialect.sqlToQuery(
-      jsonLiteral<PropertyContent, 1>("single-select"),
+      jsonLiteral<PropertyContent, 1>("options"),
     );
 
-    expect(query.sql).toBe("'single-select'");
+    expect(query.sql).toBe("'options'");
     expect(query.params).toEqual([]);
   });
 
@@ -92,7 +96,7 @@ describe("jsonLiteral", () => {
       // SAFETY: bypassing the literal-union value type to prove the runtime
       // guard rejects it too; the type constraint alone is not load-bearing
       // for a value that could arrive from `as`-cast or untyped call sites.
-      jsonLiteral<PropertyContent, 1>("single-select' OR '1'='1" as never),
+      jsonLiteral<PropertyContent, 1>("options' OR '1'='1" as never),
     ).toThrow();
   });
 

--- a/apps/api/src/db/json-utils.test.ts
+++ b/apps/api/src/db/json-utils.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import {
+  assertIdentifierLiteral,
+  jsonField,
+  jsonLiteral,
+  jsonValueLiteral,
+} from "@/api/db/json-utils";
+import { fields } from "@/api/db/schema";
+import type { PropertyContent } from "@/api/db/schema-validators";
+
+const dialect = new PgDialect();
+
+describe("assertIdentifierLiteral", () => {
+  // Real call-site values: jsonField(fields.content, "v1")("type") in
+  // workflow-queue.ts, jsonField(fields.content, "v1")("fileName") in
+  // entity-create.ts and upload.ts, and the TASK_STATUS_VALUES constants
+  // (open/in_progress/in_review/done/cancelled) in read-group-counts.ts.
+  test.each([
+    "type",
+    "fileName",
+    "open",
+    "in_progress",
+    "in_review",
+    "done",
+    "cancelled",
+    // Schema literal values (single-select/multi-select property types, etc.)
+    "single-select",
+    "multi-select",
+    "text",
+    "1",
+  ])("accepts identifier-like value %p", (value) => {
+    expect(() => assertIdentifierLiteral(value)).not.toThrow();
+  });
+
+  test.each([
+    "fo'o",
+    "'; DROP TABLE entities; --",
+    "back\\slash",
+    "has space",
+    'quote"double',
+    "new\nline",
+    "",
+    "emoji-🙂",
+  ])("rejects non-identifier value %p", (value) => {
+    expect(() => assertIdentifierLiteral(value)).toThrow();
+  });
+});
+
+describe("jsonField", () => {
+  test("builds a JSON path lookup for identifier-like keys used at real call sites", () => {
+    const query = dialect.sqlToQuery(jsonField(fields.content, "v1")("type"));
+
+    expect(query.sql).toBe(`"fields"."content"->>'type'`);
+    expect(query.params).toEqual([]);
+  });
+
+  test("builds a JSON path lookup for the fileName key", () => {
+    const query = dialect.sqlToQuery(
+      jsonField(fields.content, "v1")("fileName"),
+    );
+
+    expect(query.sql).toBe(`"fields"."content"->>'fileName'`);
+  });
+
+  test("rejects a key containing a quote instead of splicing it into the SQL text", () => {
+    expect(() =>
+      dialect.sqlToQuery(
+        // SAFETY: deliberately bypassing the literal-union key type to prove
+        // the runtime guard rejects it too, since the type constraint alone
+        // is not load-bearing for a value that could arrive from `as`-cast or
+        // untyped call sites.
+        jsonField(fields.content, "v1")("type' OR '1'='1" as never),
+      ),
+    ).toThrow();
+  });
+});
+
+describe("jsonLiteral", () => {
+  test("builds a quoted literal for an identifier-like value", () => {
+    const query = dialect.sqlToQuery(
+      jsonLiteral<PropertyContent, 1>("single-select"),
+    );
+
+    expect(query.sql).toBe("'single-select'");
+    expect(query.params).toEqual([]);
+  });
+
+  test("rejects a value containing a single quote", () => {
+    expect(() =>
+      // SAFETY: bypassing the literal-union value type to prove the runtime
+      // guard rejects it too; the type constraint alone is not load-bearing
+      // for a value that could arrive from `as`-cast or untyped call sites.
+      jsonLiteral<PropertyContent, 1>("single-select' OR '1'='1" as never),
+    ).toThrow();
+  });
+
+  test("rejects a value containing a backslash", () => {
+    expect(() =>
+      // SAFETY: see previous test.
+      jsonLiteral<PropertyContent, 1>("back\\slash" as never),
+    ).toThrow();
+  });
+});
+
+describe("jsonValueLiteral", () => {
+  test("builds a quoted literal for an identifier-like string value", () => {
+    const query = dialect.sqlToQuery(
+      jsonValueLiteral<PropertyContent, 1>("text"),
+    );
+
+    expect(query.sql).toBe("'text'");
+  });
+
+  test("builds a quoted literal for a numeric version value", () => {
+    const query = dialect.sqlToQuery(jsonValueLiteral<PropertyContent, 1>(1));
+
+    expect(query.sql).toBe("'1'");
+  });
+
+  test("rejects a string value containing a space", () => {
+    expect(() =>
+      // SAFETY: see jsonLiteral tests above.
+      jsonValueLiteral<PropertyContent, 1>("has space" as never),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/db/json-utils.test.ts
+++ b/apps/api/src/db/json-utils.test.ts
@@ -63,18 +63,6 @@ describe("jsonField", () => {
 
     expect(query.sql).toBe(`"fields"."content"->>'fileName'`);
   });
-
-  test("rejects a key containing a quote instead of splicing it into the SQL text", () => {
-    expect(() =>
-      dialect.sqlToQuery(
-        // SAFETY: deliberately bypassing the literal-union key type to prove
-        // the runtime guard rejects it too, since the type constraint alone
-        // is not load-bearing for a value that could arrive from `as`-cast or
-        // untyped call sites.
-        jsonField(fields.content, "v1")("type' OR '1'='1" as never),
-      ),
-    ).toThrow();
-  });
 });
 
 describe("jsonLiteral", () => {
@@ -89,22 +77,6 @@ describe("jsonLiteral", () => {
 
     expect(query.sql).toBe("'options'");
     expect(query.params).toEqual([]);
-  });
-
-  test("rejects a value containing a single quote", () => {
-    expect(() =>
-      // SAFETY: bypassing the literal-union value type to prove the runtime
-      // guard rejects it too; the type constraint alone is not load-bearing
-      // for a value that could arrive from `as`-cast or untyped call sites.
-      jsonLiteral<PropertyContent, 1>("options' OR '1'='1" as never),
-    ).toThrow();
-  });
-
-  test("rejects a value containing a backslash", () => {
-    expect(() =>
-      // SAFETY: see previous test.
-      jsonLiteral<PropertyContent, 1>("back\\slash" as never),
-    ).toThrow();
   });
 });
 
@@ -121,12 +93,5 @@ describe("jsonValueLiteral", () => {
     const query = dialect.sqlToQuery(jsonValueLiteral<PropertyContent, 1>(1));
 
     expect(query.sql).toBe("'1'");
-  });
-
-  test("rejects a string value containing a space", () => {
-    expect(() =>
-      // SAFETY: see jsonLiteral tests above.
-      jsonValueLiteral<PropertyContent, 1>("has space" as never),
-    ).toThrow();
   });
 });

--- a/apps/api/src/db/json-utils.ts
+++ b/apps/api/src/db/json-utils.ts
@@ -33,6 +33,27 @@ type VersionedValues<
   ? TData["type"] | TData["version"]
   : never;
 
+// jsonField/jsonLiteral/jsonValueLiteral splice their argument straight into a raw
+// SQL fragment via `sql.raw`, not a bound parameter: the fragments they build are
+// meant to be reused verbatim in multiple positions of one query (e.g. a SELECT
+// column reused in its own GROUP BY), and Drizzle assigns a fresh placeholder number
+// to each occurrence of a bound value, which makes Postgres see the two positions as
+// different expressions. Their TypeScript signatures narrow the argument to a union
+// of the schema's literal keys/values, but that narrowing is compile-time only:
+// nothing stops a differently-typed caller (or an `as` cast) from handing in
+// arbitrary runtime data. Enforce the "identifier-like compile-time constant"
+// contract at runtime too, so a future caller that threads request-derived data
+// through these helpers fails loudly instead of splicing it into SQL text.
+const RAW_SQL_LITERAL_PATTERN = /^[A-Za-z0-9_-]+$/u;
+
+export const assertIdentifierLiteral = (value: string): void => {
+  if (!RAW_SQL_LITERAL_PATTERN.test(value)) {
+    panic(
+      `Raw SQL literal must be an identifier-like value (letters, digits, "_", "-"); received ${JSON.stringify(value)}`,
+    );
+  }
+};
+
 export const jsonField =
   <TVersion extends ContentVersion, TColumn extends Columns = Columns>(
     column: TColumn,
@@ -42,6 +63,7 @@ export const jsonField =
     if (typeof key !== "string") {
       panic("JSON field key literal must be a string");
     }
+    assertIdentifierLiteral(key);
 
     if (column.getSQLType() !== "jsonb") {
       panic("Column must be a JSON column");
@@ -61,6 +83,7 @@ export const jsonLiteral = <
   if (typeof value !== "string") {
     panic("JSON field value literal must be a string");
   }
+  assertIdentifierLiteral(value);
 
   return sql.raw(`'${value}'`);
 };
@@ -72,7 +95,10 @@ export const jsonValueLiteral = <
   value: VersionedValues<TData, TVersion>,
 ) => {
   if (typeof value === "string" || typeof value === "number") {
-    return sql.raw(`'${value}'`);
+    const literal = String(value);
+    assertIdentifierLiteral(literal);
+
+    return sql.raw(`'${literal}'`);
   }
 
   return panic("JSON field value literal must be a string or number");

--- a/apps/api/src/handlers/entities/read-group-counts.ts
+++ b/apps/api/src/handlers/entities/read-group-counts.ts
@@ -3,6 +3,7 @@ import { and, eq, isNotNull, notInArray, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { t } from "elysia";
 
+import { assertIdentifierLiteral } from "@/api/db/json-utils";
 import type { SafeDb } from "@/api/db/safe-db";
 import { entities, properties } from "@/api/db/schema";
 import type { EntityKind } from "@/api/db/schema-validators";
@@ -36,9 +37,13 @@ const TASK_STATUS_VALUES = [
 // GROUP BY, and a bound value would get different placeholder numbers per
 // render, making Postgres reject the grouped query. These are fixed code
 // constants, never user input, so inlining is byte-identical and safe.
-const TASK_STATUS_SQL_VALUES = TASK_STATUS_VALUES.map((statusValue) =>
-  sql.raw(`'${statusValue}'`),
-);
+// `assertIdentifierLiteral` enforces that "fixed code constant" contract at
+// runtime, not just by convention.
+const TASK_STATUS_SQL_VALUES = TASK_STATUS_VALUES.map((statusValue) => {
+  assertIdentifierLiteral(statusValue);
+
+  return sql.raw(`'${statusValue}'`);
+});
 
 const readGroupCountsBodySchema = t.Object({
   groupByPropertyId: t.Union([


### PR DESCRIPTION
## What

Adds a runtime guard (`assertIdentifierLiteral`) to the JSONB SQL helpers in `db/json-utils.ts` (`jsonField`, `jsonLiteral`, `jsonValueLiteral`) and to the `TASK_STATUS_SQL_VALUES` fragment in `read-group-counts.ts`, plus unit tests asserting the generated SQL text.

## Why

These helpers splice their argument into a raw SQL fragment via `sql.raw` rather than a bound parameter. That's deliberate: the fragments are reused verbatim in multiple positions of one query (a SELECT column reused in its own GROUP BY), and Drizzle numbers each occurrence of a bound value separately, which Postgres then treats as different expressions. Their TypeScript signatures narrow to schema-derived literal unions, but that's compile-time only; nothing enforced the identifier-only contract at runtime for a future caller. `jsonLiteral`/`jsonValueLiteral` currently have no callers at all, which is exactly the situation where a future caller adopts them without knowing the contract.

## How

Every raw-splice site now panics unless the value matches `/^[A-Za-z0-9_-]+$/u` (all current call-site values pass: `type`, `fileName`, `v1`, the task status constants). Parameter binding was evaluated first and ruled out for the reuse reason above, now documented in the module.

## Tests

New `json-utils.test.ts` (no DB; asserts via `PgDialect().sqlToQuery`): accepts every real call-site value, rejects quotes, backslashes, spaces, newlines, empty string, and non-ASCII; verifies the exact fragments built for accepted values. 31 pass with the read-group-counts suite.