### PR TITLE
refactor(api): make account-deletion coverage explicit and schema-checked

### DIFF
--- a/apps/api/src/lib/account-deletion-coverage.test.ts
+++ b/apps/api/src/lib/account-deletion-coverage.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "bun:test";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import type { PgTable } from "drizzle-orm/pg-core";
+
+import * as authSchema from "@/api/db/auth-schema";
+import * as schema from "@/api/db/schema";
+import { ACCOUNT_DELETION_MANUAL_TABLES } from "@/api/lib/account-deletion-steps";
+
+// ── Account-deletion FK coverage guard ──────────────────────────────────
+//
+// `verifyAndDeleteUser` (delete-account.ts) never hard-deletes the `user`
+// row itself — it's a soft delete (anonymize + `deletedAt`). But every
+// *other* table that references `user` needs an explicit decision: either
+// the database cleans it up automatically (`onDelete: "cascade"` or
+// `"set null"`), or a step in `account-deletion-steps.ts` deletes /
+// reassigns / nulls the user's rows there, or the reference is
+// deliberately retained forever (documented in
+// `ACCOUNT_DELETION_KNOWN_GAPS` below).
+//
+// The risk this guards against: someone adds a new table with a foreign
+// key to `user`, forgets to wire it into account deletion, and the table
+// silently accumulates orphaned rows tied to deleted accounts. This test
+// enumerates every direct FK to `user` from Drizzle's schema metadata (no
+// live DB needed — see `getTableConfig`) and fails if a new, unhandled one
+// shows up.
+
+type UserForeignKey = {
+  tableName: string;
+  columnName: string;
+  onDelete: string | undefined;
+};
+
+type KnownGap = {
+  table: string;
+  column: string;
+  onDelete: string;
+  /**
+   * Why this FK is not (yet) covered by a deletion step. Every entry here
+   * was a pre-existing state at the time this guard was introduced —
+   * confirm with a human whether it's an intentional, permanent retention
+   * (audit/billing/authorship-attribution records, following the "user row
+   * retained for historical attribution" pattern documented in
+   * delete-account.ts) before treating it as settled.
+   */
+  note: string;
+};
+
+/**
+ * Tables with a direct FK to `user` that intentionally have no deletion
+ * step and are not DB-cascaded. Each entry must still reference `user`
+ * (checked below) so this list cannot silently accumulate stale rows for
+ * tables that were fixed or renamed.
+ *
+ * TODO(account-deletion): every entry below needs a human decision — see
+ * the final report of the PR that introduced this guard for full FK
+ * details and a proposed classification per table. Either:
+ *   (a) add a deletion/anonymization step in account-deletion-steps.ts and
+ *       remove the entry here, or
+ *   (b) confirm the retention is intentional and leave it here with a
+ *       clear reason (already the case for all current entries).
+ */
+const ACCOUNT_DELETION_KNOWN_GAPS: readonly KnownGap[] = [
+  {
+    table: "account_deletion_requests",
+    column: "user_id",
+    onDelete: "restrict",
+    note: "The account-deletion audit/tracking record itself, inserted by verifyAndDeleteUser in the same transaction it belongs to. Not user-owned data to purge — expected to persist referencing the (soft-deleted) user.",
+  },
+  {
+    table: "case_law_matter_links",
+    column: "linked_by",
+    onDelete: "restrict",
+    note: "Provenance of who linked a case-law citation to a matter (workspace-owned record, not personal data). Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "clauses",
+    column: "created_by",
+    onDelete: "restrict",
+    note: "Clause authorship attribution (workspace-owned content). Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "playbook_definition_versions",
+    column: "created_by",
+    onDelete: "restrict",
+    note: "Playbook version authorship attribution. Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "style_sets",
+    column: "created_by",
+    onDelete: "restrict",
+    note: "Style set authorship attribution. Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "template_fills",
+    column: "user_id",
+    onDelete: "restrict",
+    note: 'Template-fill usage record — schema comment marks the table "Template Fills (analytics)"; it holds counters, not document content. Likely intentional retention, unconfirmed.',
+  },
+  {
+    table: "template_recipes",
+    column: "created_by",
+    onDelete: "restrict",
+    note: "Template recipe authorship attribution. Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "template_versions",
+    column: "created_by",
+    onDelete: "restrict",
+    note: "Template version authorship attribution. Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "templates",
+    column: "created_by",
+    onDelete: "restrict",
+    note: "Template authorship attribution. Likely intentional per the historical-attribution pattern, unconfirmed.",
+  },
+  {
+    table: "usage_events",
+    column: "user_id",
+    onDelete: "restrict",
+    note: "Billing/usage-metering event, needed for invoicing and audit history — comparable to account_deletion_requests. Likely intentional retention, unconfirmed.",
+  },
+];
+
+const gapKey = (table: string, column: string) => `${table}.${column}`;
+
+const isAutoCoveredByDb = (onDelete: string | undefined): boolean =>
+  onDelete === "cascade" || onDelete === "set null";
+
+const isPgTable = (value: unknown): value is PgTable => {
+  try {
+    getTableConfig(value as PgTable);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const allSchemaExports: Record<string, unknown> = {
+  ...authSchema,
+  ...schema,
+};
+
+const userTableName = getTableConfig(authSchema.user).name;
+
+/**
+ * Every direct foreign key in the schema whose referenced table is `user`.
+ * Enumerated purely from Drizzle table metadata — no DB connection needed.
+ */
+const findUserForeignKeys = (): UserForeignKey[] => {
+  const results: UserForeignKey[] = [];
+
+  for (const value of Object.values(allSchemaExports)) {
+    if (!isPgTable(value)) {
+      continue;
+    }
+
+    const config = getTableConfig(value);
+    for (const foreignKey of config.foreignKeys) {
+      const reference = foreignKey.reference();
+      const referencedTableName = getTableConfig(reference.foreignTable).name;
+      if (referencedTableName !== userTableName) {
+        continue;
+      }
+
+      for (const column of reference.columns) {
+        results.push({
+          tableName: config.name,
+          columnName: column.name,
+          onDelete: foreignKey.onDelete,
+        });
+      }
+    }
+  }
+
+  return results;
+};
+
+describe("account deletion FK coverage", () => {
+  test("enumeration finds at least the known user-referencing tables", () => {
+    // Sanity check for the enumeration itself: if this ever finds zero FKs,
+    // the schema walk below is broken (e.g. a schema barrel changed shape)
+    // and every other assertion in this file would pass vacuously.
+    const userForeignKeys = findUserForeignKeys();
+    expect(userForeignKeys.length).toBeGreaterThan(30);
+    expect(
+      userForeignKeys.some(
+        (fk) => fk.tableName === "session" && fk.columnName === "user_id",
+      ),
+    ).toBe(true);
+  });
+
+  test("every direct FK to the user table is DB-cascaded, manually handled, or a tracked known gap", () => {
+    const userForeignKeys = findUserForeignKeys();
+    const manualTableNames = new Set(
+      ACCOUNT_DELETION_MANUAL_TABLES.map((table) => getTableConfig(table).name),
+    );
+    const knownGapKeys = new Set(
+      ACCOUNT_DELETION_KNOWN_GAPS.map((gap) => gapKey(gap.table, gap.column)),
+    );
+
+    const uncovered = userForeignKeys.filter((fk) => {
+      if (isAutoCoveredByDb(fk.onDelete)) {
+        return false;
+      }
+      if (manualTableNames.has(fk.tableName)) {
+        return false;
+      }
+      return !knownGapKeys.has(gapKey(fk.tableName, fk.columnName));
+    });
+
+    if (uncovered.length === 0) {
+      return;
+    }
+
+    const details = uncovered
+      .map(
+        (fk) =>
+          `  - table "${fk.tableName}" references user via FK column "${fk.columnName}" with onDelete: ${
+            fk.onDelete ? `"${fk.onDelete}"` : "no action"
+          }`,
+      )
+      .join("\n");
+
+    throw new Error(
+      `Found ${uncovered.length} table(s) with an unhandled foreign key to the user table:\n${details}\n\n` +
+        "For each: add a deletion step in apps/api/src/lib/account-deletion-steps.ts " +
+        "(call it from verifyAndDeleteUser in apps/api/src/lib/delete-account.ts), and list the " +
+        "table in that step's `*_TABLES` constant so it is picked up by ACCOUNT_DELETION_MANUAL_TABLES. " +
+        'If cascading/nulling the FK at the DB level is correct instead, change its onDelete to "cascade" ' +
+        'or "set null" in the schema. If the reference should be permanently retained (e.g. an audit or ' +
+        "billing record), add it to ACCOUNT_DELETION_KNOWN_GAPS in account-deletion-coverage.test.ts with a " +
+        "documented reason instead of leaving it unhandled.",
+    );
+  });
+
+  test("every table in ACCOUNT_DELETION_MANUAL_TABLES still has a foreign key to the user table", () => {
+    const userForeignKeys = findUserForeignKeys();
+    const tablesWithUserFk = new Set(userForeignKeys.map((fk) => fk.tableName));
+
+    const staleEntries = ACCOUNT_DELETION_MANUAL_TABLES.filter(
+      (table) => !tablesWithUserFk.has(getTableConfig(table).name),
+    );
+
+    if (staleEntries.length === 0) {
+      return;
+    }
+
+    const names = staleEntries
+      .map((table) => getTableConfig(table).name)
+      .join(", ");
+    throw new Error(
+      `ACCOUNT_DELETION_MANUAL_TABLES lists table(s) [${names}] that no longer have a foreign ` +
+        "key to the user table. Remove the stale entry from its step's `*_TABLES` constant in " +
+        "account-deletion-steps.ts, or confirm the FK was intentionally dropped elsewhere.",
+    );
+  });
+
+  test("ACCOUNT_DELETION_KNOWN_GAPS only lists FKs that are still actually uncovered", () => {
+    const userForeignKeys = findUserForeignKeys();
+    const manualTableNames = new Set(
+      ACCOUNT_DELETION_MANUAL_TABLES.map((table) => getTableConfig(table).name),
+    );
+
+    const staleGaps = ACCOUNT_DELETION_KNOWN_GAPS.filter((gap) => {
+      const stillUncovered = userForeignKeys.some(
+        (fk) =>
+          fk.tableName === gap.table &&
+          fk.columnName === gap.column &&
+          !isAutoCoveredByDb(fk.onDelete) &&
+          !manualTableNames.has(fk.tableName),
+      );
+      return !stillUncovered;
+    });
+
+    if (staleGaps.length === 0) {
+      return;
+    }
+
+    const names = staleGaps
+      .map((gap) => gapKey(gap.table, gap.column))
+      .join(", ");
+    throw new Error(
+      `ACCOUNT_DELETION_KNOWN_GAPS lists FK(s) [${names}] that are no longer uncovered gaps ` +
+        "(the FK is now cascade/set-null, a manual step handles the table, or the FK no longer " +
+        "exists). Remove the stale entry from ACCOUNT_DELETION_KNOWN_GAPS in " +
+        "account-deletion-coverage.test.ts.",
+    );
+  });
+});

--- a/apps/api/src/lib/account-deletion-coverage.test.ts
+++ b/apps/api/src/lib/account-deletion-coverage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { getTableConfig } from "drizzle-orm/pg-core";
-import type { PgTable } from "drizzle-orm/pg-core";
+import { is } from "drizzle-orm";
+import { getTableConfig, PgTable } from "drizzle-orm/pg-core";
 
 import * as authSchema from "@/api/db/auth-schema";
 import * as schema from "@/api/db/schema";
@@ -127,14 +127,10 @@ const gapKey = (table: string, column: string) => `${table}.${column}`;
 const isAutoCoveredByDb = (onDelete: string | undefined): boolean =>
   onDelete === "cascade" || onDelete === "set null";
 
-const isPgTable = (value: unknown): value is PgTable => {
-  try {
-    getTableConfig(value as PgTable);
-    return true;
-  } catch {
-    return false;
-  }
-};
+// `is()` is drizzle-orm's own runtime type guard (checks the entity-kind
+// tag drizzle stamps on table instances), so this narrows `unknown` to
+// `PgTable` without an unsafe type assertion.
+const isPgTable = (value: unknown): value is PgTable => is(value, PgTable);
 
 const allSchemaExports: Record<string, unknown> = {
   ...authSchema,

--- a/apps/api/src/lib/account-deletion-steps.ts
+++ b/apps/api/src/lib/account-deletion-steps.ts
@@ -1,0 +1,927 @@
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  notExists,
+  or,
+  sql,
+} from "drizzle-orm";
+import type { PgTable } from "drizzle-orm/pg-core";
+
+import {
+  account,
+  invitation,
+  member,
+  oauthAccessToken,
+  oauthClient,
+  oauthConsent,
+  oauthRefreshToken,
+  organization,
+  session,
+  user,
+  verification,
+} from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import {
+  accountDeletionRequests,
+  agentSkills,
+  auditLogs,
+  chatThreads,
+  desktopEditHandoffs,
+  desktopEditSessions,
+  entities,
+  fileChatThreads,
+  folioCollabSessions,
+  mcpOAuthState,
+  mcpUserConnections,
+  pendingUploads,
+  rateEntries,
+  taskAssignees,
+  userFiles,
+  workspaceMembers,
+  workspaceViewTemplates,
+  workspaces,
+} from "@/api/db/schema";
+import { createFileKey, createUserFileKey } from "@/api/handlers/files/utils";
+import { tmpUploadKeys } from "@/api/handlers/uploads/lib";
+import {
+  ACTIVE_TASK_REASSIGNMENT_STATUSES,
+  buildAccountDeletionTaskReassignmentTargets,
+  validateAccountDeletionTaskReassignmentTargets,
+} from "@/api/lib/account-deletion-reassignment";
+import { arrayOrEmpty } from "@/api/lib/array";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE } from "@/api/lib/folio-collab-sessions";
+import { LIMITS } from "@/api/lib/limits";
+import {
+  brandPersistedOrganizationId,
+  brandPersistedUserId,
+  brandPersistedWorkspaceId,
+} from "@/api/lib/safe-id-boundaries";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+
+// ── Extracted steps for verifyAndDeleteUser ─────────────────────────────
+//
+// Each function below is one step of the account-deletion transaction in
+// `delete-account.ts`, extracted verbatim (same queries, same order, same
+// comments) for readability. They are all called from `verifyAndDeleteUser`
+// inside the same `rootDb.transaction(...)` block, in the same order as
+// before this extraction.
+//
+// Steps that delete or clear a user-owned table's reference to `user` also
+// export a `*_TABLES` constant listing the Drizzle tables they cover. These
+// constants are combined into `ACCOUNT_DELETION_MANUAL_TABLES` at the
+// bottom of this file, which the account-deletion coverage guard
+// (`account-deletion-coverage.test.ts`) uses to verify that every table
+// with a foreign key to `user` is either DB-cascaded or explicitly handled
+// here — see that test for the full explanation.
+
+export const DELETED_ACCOUNT_DISPLAY_NAME = "Deleted account";
+
+export const ACCOUNT_DELETION_ERROR_CODE = {
+  otpExpired: "account_deletion_otp_expired",
+  otpInvalid: "account_deletion_otp_invalid",
+  soleOwner: "account_deletion_sole_owner",
+} as const;
+
+/**
+ * Locks the user row to serialize deletion of this account.
+ */
+export const lockUserRowForDeletion = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.id, currentUserId))
+    .for("update");
+};
+
+export type VerifyDeletionOtpParams = {
+  tx: Transaction;
+  identifier: string;
+  code: string;
+};
+
+/**
+ * Fetches and validates the delete-account OTP. Deletes the OTP record on
+ * an incorrect or expired attempt (but not on success — the caller deletes
+ * it after the ownership check below, once deletion is confirmed to
+ * proceed).
+ */
+export const verifyDeletionOtp = async ({
+  tx,
+  identifier,
+  code,
+}: VerifyDeletionOtpParams) => {
+  const verificationRow = await tx
+    .select()
+    .from(verification)
+    .where(eq(verification.identifier, identifier))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!verificationRow) {
+    throw new HandlerError({
+      code: ACCOUNT_DELETION_ERROR_CODE.otpInvalid,
+      status: 400,
+      message: "Invalid verification code",
+    });
+  }
+
+  if (verificationRow.value !== code) {
+    // Prevent brute force by deleting the OTP on the first incorrect attempt
+    await tx
+      .delete(verification)
+      .where(eq(verification.identifier, identifier));
+
+    throw new HandlerError({
+      code: ACCOUNT_DELETION_ERROR_CODE.otpInvalid,
+      status: 400,
+      message: "Invalid verification code",
+    });
+  }
+
+  if (verificationRow.expiresAt.getTime() < Date.now()) {
+    await tx
+      .delete(verification)
+      .where(eq(verification.identifier, identifier));
+
+    throw new HandlerError({
+      code: ACCOUNT_DELETION_ERROR_CODE.otpExpired,
+      status: 400,
+      message: "Verification code has expired",
+    });
+  }
+
+  return verificationRow;
+};
+
+/**
+ * 2. Perform ownership check with SELECT FOR UPDATE locks inside transaction.
+ * Fetch all organizations where the user is an owner, locking the member
+ * rows to prevent concurrent modifications.
+ */
+export const assertUserIsNotSoleOrgOwner = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  const ownedOrgs = await tx
+    .select({ orgId: member.organizationId, orgName: organization.name })
+    .from(member)
+    .innerJoin(organization, eq(organization.id, member.organizationId))
+    .where(and(eq(member.userId, currentUserId), eq(member.role, "owner")))
+    .for("update");
+
+  const ownedOrgIds = ownedOrgs.map((org) => org.orgId);
+  const orgIdsWithOtherOwners = new Set(
+    ownedOrgIds.length > 0
+      ? (
+          await tx
+            .select({ orgId: member.organizationId })
+            .from(member)
+            .where(
+              and(
+                inArray(member.organizationId, ownedOrgIds),
+                eq(member.role, "owner"),
+                ne(member.userId, currentUserId),
+              ),
+            )
+            .for("update")
+        ).map((row) => row.orgId)
+      : [],
+  );
+
+  const soleOwnedOrg = ownedOrgs.find(
+    (org) => !orgIdsWithOtherOwners.has(org.orgId),
+  );
+  if (soleOwnedOrg) {
+    throw new HandlerError({
+      code: ACCOUNT_DELETION_ERROR_CODE.soleOwner,
+      status: 400,
+      message: `Cannot delete account because you are the sole owner of organization "${soleOwnedOrg.orgName}". Please transfer ownership or delete the organization first.`,
+    });
+  }
+};
+
+/**
+ * Snapshots the organizations and workspaces this user belongs to, for the
+ * account-deletion request record.
+ */
+export const collectUserOrganizationAndWorkspaceIds = async (
+  tx: Transaction,
+  currentUserId: string,
+) => {
+  const organizationIds = (
+    await tx
+      .select({ organizationId: member.organizationId })
+      .from(member)
+      .where(eq(member.userId, currentUserId))
+  ).map((row) => brandPersistedOrganizationId(row.organizationId));
+
+  const workspaceIds = (
+    await tx
+      .select({ workspaceId: workspaceMembers.workspaceId })
+      .from(workspaceMembers)
+      .where(eq(workspaceMembers.userId, currentUserId))
+  ).map((row) => row.workspaceId);
+
+  return { organizationIds, workspaceIds };
+};
+
+export type RevokeAuthCredentialsParams = {
+  tx: Transaction;
+  currentUserId: string;
+  email: string;
+};
+
+export const REVOKE_AUTH_CREDENTIALS_TABLES = [
+  account,
+  session,
+  invitation,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 1. Auth credentials, sessions, and invitations (auth-schema tables).
+ */
+export const revokeAuthCredentialsAndInvitations = async ({
+  tx,
+  currentUserId,
+  email,
+}: RevokeAuthCredentialsParams): Promise<void> => {
+  await tx.delete(account).where(eq(account.userId, currentUserId));
+  // eslint-disable-next-line auth-lifecycle/no-direct-auth-artifact-delete -- Account deletion must revoke Better Auth session artifacts.
+  await tx.delete(session).where(eq(session.userId, currentUserId));
+  // Delete invitations sent by the user, and also invitations sent to the user's email
+  await tx.delete(invitation).where(eq(invitation.inviterId, currentUserId));
+  await tx.delete(invitation).where(eq(invitation.email, email));
+};
+
+export const REVOKE_OAUTH_TOKENS_TABLES = [
+  oauthAccessToken,
+  oauthRefreshToken,
+  oauthConsent,
+  oauthClient,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 2. OAuth / Better-Auth token tables (auth-schema).
+ */
+export const revokeOAuthTokensAndGrants = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  // eslint-disable-next-line auth-lifecycle/no-direct-auth-artifact-delete -- Account deletion must revoke Better Auth OAuth access tokens.
+  await tx
+    .delete(oauthAccessToken)
+    .where(eq(oauthAccessToken.userId, currentUserId));
+  // eslint-disable-next-line auth-lifecycle/no-direct-auth-artifact-delete -- Account deletion must revoke Better Auth OAuth refresh tokens.
+  await tx
+    .delete(oauthRefreshToken)
+    .where(eq(oauthRefreshToken.userId, currentUserId));
+  await tx.delete(oauthConsent).where(eq(oauthConsent.userId, currentUserId));
+  await tx.delete(oauthClient).where(eq(oauthClient.userId, currentUserId));
+};
+
+export const DELETE_MCP_CREDENTIALS_TABLES = [
+  mcpUserConnections,
+  mcpOAuthState,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 3. MCP credentials and in-flight OAuth state (schema.ts, cascade on user.id).
+ */
+export const deleteMcpCredentialsAndOAuthState = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx
+    .delete(mcpUserConnections)
+    .where(eq(mcpUserConnections.userId, currentUserId));
+  await tx.delete(mcpOAuthState).where(eq(mcpOAuthState.userId, currentUserId));
+};
+
+export const CLEAR_WORKSPACE_LEAD_ROLE_TABLES = [
+  workspaces,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 4. Workspace lead role — membership deletion happens after task handoff.
+ */
+export const clearWorkspaceLeadRole = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx
+    .update(workspaces)
+    .set({ leadUserId: null })
+    .where(eq(workspaces.leadUserId, currentUserId));
+};
+
+export type ReassignActiveTaskAssignmentsParams = {
+  tx: Transaction;
+  currentUserId: string;
+  deletionRequestId: SafeId<"accountDeletionRequest">;
+  reassignments:
+    | readonly {
+        entityId: SafeId<"entity">;
+        reassignedUserId: string;
+      }[]
+    | undefined;
+};
+
+export const REASSIGN_ACTIVE_TASKS_TABLES = [
+  taskAssignees,
+  member,
+  workspaceMembers,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 5. Active task assignee records require handoff. Completed/cancelled
+ * assignments remain as historical activity on the deleted user row.
+ *
+ * Also drops the user's `member` and `workspaceMembers` rows — membership
+ * deletion happens after task handoff (see step 4's comment).
+ *
+ * Returns the number of task assignments that were reassigned, for the
+ * account-deletion request record.
+ */
+export const reassignActiveTaskAssignmentsAndDropMemberships = async ({
+  tx,
+  currentUserId,
+  deletionRequestId,
+  reassignments,
+}: ReassignActiveTaskAssignmentsParams): Promise<number> => {
+  let taskReassignmentCount = 0;
+
+  const reassignmentItems = [...arrayOrEmpty(reassignments)];
+  const currentTaskAssignments = await tx
+    .select({
+      entityId: taskAssignees.entityId,
+      organizationId: workspaces.organizationId,
+      workspaceId: taskAssignees.workspaceId,
+    })
+    .from(taskAssignees)
+    .innerJoin(entities, eq(entities.id, taskAssignees.entityId))
+    .innerJoin(workspaces, eq(workspaces.id, taskAssignees.workspaceId))
+    .innerJoin(
+      workspaceMembers,
+      and(
+        eq(workspaceMembers.workspaceId, taskAssignees.workspaceId),
+        eq(workspaceMembers.userId, currentUserId),
+      ),
+    )
+    .innerJoin(
+      member,
+      and(
+        eq(member.organizationId, workspaces.organizationId),
+        eq(member.userId, currentUserId),
+      ),
+    )
+    .where(
+      and(
+        eq(taskAssignees.userId, currentUserId),
+        eq(entities.kind, "task"),
+        or(
+          isNull(entities.status),
+          inArray(entities.status, ACTIVE_TASK_REASSIGNMENT_STATUSES),
+        ),
+      ),
+    )
+    .limit(LIMITS.accountDeletionTaskAssignmentsMax + 1);
+
+  if (
+    currentTaskAssignments.length > LIMITS.accountDeletionTaskAssignmentsMax
+  ) {
+    throw new HandlerError({
+      code: "account_deletion_task_reassignment_limit_exceeded",
+      status: 400,
+      message:
+        "Too many active task assignments to reassign during account deletion.",
+    });
+  }
+
+  await tx.delete(taskAssignees).where(
+    and(
+      eq(taskAssignees.userId, currentUserId),
+      inArray(
+        taskAssignees.entityId,
+        tx
+          .select({ entityId: entities.id })
+          .from(entities)
+          .where(
+            and(
+              eq(entities.kind, "task"),
+              or(
+                isNull(entities.status),
+                inArray(entities.status, ACTIVE_TASK_REASSIGNMENT_STATUSES),
+              ),
+            ),
+          ),
+      ),
+      notExists(
+        tx
+          .select({ one: sql`1` })
+          .from(workspaceMembers)
+          .innerJoin(
+            workspaces,
+            eq(workspaces.id, workspaceMembers.workspaceId),
+          )
+          .innerJoin(
+            member,
+            and(
+              eq(member.organizationId, workspaces.organizationId),
+              eq(member.userId, currentUserId),
+            ),
+          )
+          .where(
+            and(
+              eq(workspaceMembers.workspaceId, taskAssignees.workspaceId),
+              eq(workspaceMembers.userId, currentUserId),
+            ),
+          ),
+      ),
+    ),
+  );
+
+  if (currentTaskAssignments.length > 0) {
+    const reassignmentTargets = buildAccountDeletionTaskReassignmentTargets({
+      currentTaskAssignments,
+      currentUserId,
+      reassignments: reassignmentItems,
+    });
+    const reassignmentUserIds = reassignmentTargets.map(
+      (target) => target.reassignedUserId,
+    );
+
+    const taskWorkspaceIds = currentTaskAssignments.map(
+      (assignment) => assignment.workspaceId,
+    );
+    const validMembershipKeys = new Set(
+      (
+        await tx
+          .select({
+            userId: workspaceMembers.userId,
+            workspaceId: workspaceMembers.workspaceId,
+          })
+          .from(workspaceMembers)
+          .innerJoin(
+            workspaces,
+            eq(workspaces.id, workspaceMembers.workspaceId),
+          )
+          .innerJoin(
+            member,
+            and(
+              eq(member.organizationId, workspaces.organizationId),
+              eq(member.userId, workspaceMembers.userId),
+            ),
+          )
+          .where(
+            and(
+              inArray(workspaceMembers.workspaceId, taskWorkspaceIds),
+              inArray(workspaceMembers.userId, reassignmentUserIds),
+            ),
+          )
+      ).map((row) => `${row.workspaceId}:${row.userId}`),
+    );
+    const existingReassignmentKeys = new Set(
+      (
+        await tx
+          .select({
+            entityId: taskAssignees.entityId,
+            userId: taskAssignees.userId,
+          })
+          .from(taskAssignees)
+          .where(
+            and(
+              inArray(
+                taskAssignees.entityId,
+                currentTaskAssignments.map((assignment) => assignment.entityId),
+              ),
+              inArray(taskAssignees.userId, reassignmentUserIds),
+            ),
+          )
+      ).map((row) => `${row.entityId}:${row.userId}`),
+    );
+
+    const updates = validateAccountDeletionTaskReassignmentTargets({
+      existingReassignmentKeys,
+      targets: reassignmentTargets,
+      validMembershipKeys,
+    });
+    const assignmentByEntityId = new Map(
+      currentTaskAssignments.map((assignment) => [
+        assignment.entityId,
+        assignment,
+      ]),
+    );
+
+    // SAFETY: one deleted user's active task reassignments, bounded by
+    // the enforced LIMITS.accountDeletionTaskAssignmentsMax check above
+    // (throws before reaching here if exceeded), not unbounded tenant
+    // data.
+    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
+    await Promise.all(
+      updates.map((item) =>
+        tx
+          .update(taskAssignees)
+          .set({
+            userId: item.reassignedUserId,
+          })
+          .where(
+            and(
+              eq(taskAssignees.entityId, item.entityId),
+              eq(taskAssignees.userId, currentUserId),
+            ),
+          ),
+      ),
+    );
+    await tx.insert(auditLogs).values(
+      updates.map((item) => {
+        const assignment = assignmentByEntityId.get(item.entityId);
+        if (!assignment) {
+          throw new HandlerError({
+            status: 500,
+            message: "Task reassignment source not found.",
+          });
+        }
+
+        return {
+          action: AUDIT_ACTION.UPDATE,
+          changes: {
+            assigneeUserId: {
+              new: item.reassignedUserId,
+              old: currentUserId,
+            },
+          },
+          metadata: {
+            accountDeletionRequestId: deletionRequestId,
+            change: "assignee-reassigned",
+            fromUserId: currentUserId,
+            reason: "account-deletion",
+            toUserId: item.reassignedUserId,
+          },
+          organizationId: assignment.organizationId,
+          resourceId: item.entityId,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+          userId: currentUserId,
+          workspaceId: assignment.workspaceId,
+        };
+      }),
+    );
+    taskReassignmentCount = updates.length;
+  }
+
+  await tx.delete(member).where(eq(member.userId, currentUserId));
+  await tx
+    .delete(workspaceMembers)
+    .where(eq(workspaceMembers.userId, currentUserId));
+
+  return taskReassignmentCount;
+};
+
+export type DeleteDesktopEditSessionsParams = {
+  tx: Transaction;
+  currentUserId: string;
+  s3KeysToDelete: string[];
+};
+
+export const DELETE_DESKTOP_EDIT_SESSIONS_TABLES = [
+  desktopEditSessions,
+  desktopEditHandoffs,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 6. Desktop edit sessions and handoffs (cascade on createdBy → user.id).
+ */
+export const deleteDesktopEditSessionsAndHandoffs = async ({
+  tx,
+  currentUserId,
+  s3KeysToDelete,
+}: DeleteDesktopEditSessionsParams): Promise<void> => {
+  const desktopCheckpointRows = await tx
+    .select({
+      checkpointFileId: desktopEditSessions.checkpointFileId,
+      organizationId: workspaces.organizationId,
+      workspaceId: desktopEditSessions.workspaceId,
+    })
+    .from(desktopEditSessions)
+    .innerJoin(workspaces, eq(workspaces.id, desktopEditSessions.workspaceId))
+    .where(
+      and(
+        eq(desktopEditSessions.createdBy, currentUserId),
+        isNotNull(desktopEditSessions.checkpointUpdatedAt),
+      ),
+    );
+  s3KeysToDelete.push(
+    ...desktopCheckpointRows.map((row) =>
+      createFileKey({
+        fileId: row.checkpointFileId,
+        mimeType: DOCX_MIME_TYPE,
+        organizationId: brandPersistedOrganizationId(row.organizationId),
+        workspaceId: brandPersistedWorkspaceId(row.workspaceId),
+      }),
+    ),
+  );
+
+  await tx
+    .delete(desktopEditHandoffs)
+    .where(eq(desktopEditHandoffs.createdBy, currentUserId));
+  await tx
+    .delete(desktopEditSessions)
+    .where(eq(desktopEditSessions.createdBy, currentUserId));
+};
+
+export type DeleteFolioCollabSessionsParams = {
+  tx: Transaction;
+  currentUserId: string;
+  s3KeysToDelete: string[];
+};
+
+export const DELETE_FOLIO_COLLAB_SESSIONS_TABLES = [
+  folioCollabSessions,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 7. Folio collab sessions — tokens cascade when session is deleted.
+ */
+export const deleteFolioCollabSessions = async ({
+  tx,
+  currentUserId,
+  s3KeysToDelete,
+}: DeleteFolioCollabSessionsParams): Promise<void> => {
+  const folioCheckpointRows = await tx
+    .select({
+      docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+      docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+      organizationId: workspaces.organizationId,
+      workspaceId: folioCollabSessions.workspaceId,
+      yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
+      yjsSnapshotUpdatedAt: folioCollabSessions.yjsSnapshotUpdatedAt,
+    })
+    .from(folioCollabSessions)
+    .innerJoin(workspaces, eq(workspaces.id, folioCollabSessions.workspaceId))
+    .where(eq(folioCollabSessions.createdBy, currentUserId));
+  for (const row of folioCheckpointRows) {
+    if (row.yjsSnapshotUpdatedAt !== null) {
+      s3KeysToDelete.push(
+        createFileKey({
+          fileId: row.yjsSnapshotFileId,
+          mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
+          organizationId: brandPersistedOrganizationId(row.organizationId),
+          workspaceId: brandPersistedWorkspaceId(row.workspaceId),
+        }),
+      );
+    }
+
+    if (row.docxCheckpointUpdatedAt !== null) {
+      s3KeysToDelete.push(
+        createFileKey({
+          fileId: row.docxCheckpointFileId,
+          mimeType: DOCX_MIME_TYPE,
+          organizationId: brandPersistedOrganizationId(row.organizationId),
+          workspaceId: brandPersistedWorkspaceId(row.workspaceId),
+        }),
+      );
+    }
+  }
+
+  await tx
+    .delete(folioCollabSessions)
+    .where(eq(folioCollabSessions.createdBy, currentUserId));
+};
+
+export type DeletePendingUploadsParams = {
+  tx: Transaction;
+  currentUserId: string;
+  s3KeysToDelete: string[];
+};
+
+export const DELETE_PENDING_UPLOADS_TABLES = [
+  pendingUploads,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 8. Pending (in-flight) S3 uploads.
+ */
+export const deletePendingUploads = async ({
+  tx,
+  currentUserId,
+  s3KeysToDelete,
+}: DeletePendingUploadsParams): Promise<void> => {
+  const stagedUploadRows = await tx
+    .select({
+      id: pendingUploads.id,
+      organizationId: pendingUploads.organizationId,
+      workspaceId: pendingUploads.workspaceId,
+    })
+    .from(pendingUploads)
+    .where(
+      and(
+        eq(pendingUploads.userId, currentUserId),
+        ne(pendingUploads.status, "finalized"),
+      ),
+    );
+  s3KeysToDelete.push(
+    ...stagedUploadRows.flatMap((row) =>
+      tmpUploadKeys({
+        organizationId: row.organizationId,
+        uploadId: row.id,
+        workspaceId: row.workspaceId,
+      }),
+    ),
+  );
+
+  await tx
+    .delete(pendingUploads)
+    .where(eq(pendingUploads.userId, currentUserId));
+};
+
+export type DeleteUserFilesParams = {
+  tx: Transaction;
+  currentUserId: string;
+  s3KeysToDelete: string[];
+};
+
+export const DELETE_USER_FILES_TABLES = [
+  userFiles,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 9. Personal user files (private S3 uploads) — must delete userFiles
+ * before chatThreads because userFiles.threadId has onDelete: "restrict"
+ * reference to chatThreads.id.
+ */
+export const deleteUserFiles = async ({
+  tx,
+  currentUserId,
+  s3KeysToDelete,
+}: DeleteUserFilesParams): Promise<void> => {
+  const files = await tx
+    .select({
+      id: userFiles.id,
+      s3Key: userFiles.s3Key,
+      thumbnailFileId: userFiles.thumbnailFileId,
+      userId: userFiles.userId,
+    })
+    .from(userFiles)
+    .where(eq(userFiles.userId, currentUserId));
+
+  if (files.length > 0) {
+    s3KeysToDelete.push(
+      ...files.flatMap((file) =>
+        file.thumbnailFileId
+          ? [
+              file.s3Key,
+              createUserFileKey({
+                fileId: file.thumbnailFileId,
+                mimeType: "image/webp",
+                userId: brandPersistedUserId(file.userId),
+              }),
+            ]
+          : [file.s3Key],
+      ),
+    );
+  }
+
+  await tx.delete(userFiles).where(eq(userFiles.userId, currentUserId));
+};
+
+export const DELETE_CHAT_THREADS_TABLES = [
+  fileChatThreads,
+  chatThreads,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 10. AI chat threads — messages and fileChatThreads cascade on thread
+ * deletion.
+ */
+export const deleteChatThreadsAndFileLinks = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx
+    .delete(fileChatThreads)
+    .where(eq(fileChatThreads.userId, currentUserId));
+  await tx.delete(chatThreads).where(eq(chatThreads.userId, currentUserId));
+};
+
+export const DELETE_WORKSPACE_VIEW_TEMPLATES_TABLES = [
+  workspaceViewTemplates,
+  agentSkills,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 11. Personal workspace view templates and agent skills.
+ */
+export const deletePersonalWorkspaceViewTemplatesAndAgentSkills = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx
+    .delete(workspaceViewTemplates)
+    .where(eq(workspaceViewTemplates.userId, currentUserId));
+  await tx.delete(agentSkills).where(eq(agentSkills.userId, currentUserId));
+};
+
+export const DELETE_BILLING_RATES_TABLES = [
+  rateEntries,
+] as const satisfies readonly PgTable[];
+
+/**
+ * 12. Personal billing rates.
+ */
+export const deletePersonalBillingRates = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx.delete(rateEntries).where(eq(rateEntries.userId, currentUserId));
+};
+
+export type RecordAccountDeletionRequestParams = {
+  tx: Transaction;
+  deletionRequestId: SafeId<"accountDeletionRequest">;
+  currentUserId: string;
+  organizationIds: SafeId<"organization">[];
+  workspaceIds: SafeId<"workspace">[];
+  taskReassignmentCount: number;
+  s3KeysToDelete: string[];
+};
+
+/**
+ * Records the account-deletion request — used both as an audit trail and,
+ * when there are S3 keys to reclaim, as the work item the storage-cleanup
+ * queue processes after the transaction commits.
+ */
+export const recordAccountDeletionRequest = async ({
+  tx,
+  deletionRequestId,
+  currentUserId,
+  organizationIds,
+  workspaceIds,
+  taskReassignmentCount,
+  s3KeysToDelete,
+}: RecordAccountDeletionRequestParams): Promise<void> => {
+  await tx.insert(accountDeletionRequests).values({
+    id: deletionRequestId,
+    userId: currentUserId,
+    organizationIds,
+    workspaceIds,
+    taskReassignmentCount,
+    status: s3KeysToDelete.length > 0 ? "pending" : "completed",
+    storageCleanup: { s3Keys: s3KeysToDelete },
+    completedAt: s3KeysToDelete.length > 0 ? null : new Date(),
+  });
+};
+
+/**
+ * 13. Mark the account deleted and release private contact/login fields.
+ */
+export const finalizeDeletedUserRecord = async (
+  tx: Transaction,
+  currentUserId: string,
+): Promise<void> => {
+  await tx
+    .update(user)
+    .set({
+      email: `deleted-${currentUserId}@stella.placeholder`,
+      emailVerified: false,
+      image: null,
+      name: DELETED_ACCOUNT_DISPLAY_NAME,
+      preferredName: null,
+      wordEditShortcut: null,
+      deletedAt: new Date(),
+    })
+    .where(eq(user.id, currentUserId));
+};
+
+/**
+ * Every table with a direct foreign key to the auth `user` table that is
+ * explicitly deleted, cleared, or reassigned by a step in
+ * `verifyAndDeleteUser`. Derived from the `*_TABLES` constants declared
+ * next to each step above, rather than maintained as a free-floating list,
+ * so it cannot silently drift from the actual deletion code.
+ *
+ * See `account-deletion-coverage.test.ts` for how this is checked against
+ * the schema.
+ */
+export const ACCOUNT_DELETION_MANUAL_TABLES = [
+  ...REVOKE_AUTH_CREDENTIALS_TABLES,
+  ...REVOKE_OAUTH_TOKENS_TABLES,
+  ...DELETE_MCP_CREDENTIALS_TABLES,
+  ...CLEAR_WORKSPACE_LEAD_ROLE_TABLES,
+  ...REASSIGN_ACTIVE_TASKS_TABLES,
+  ...DELETE_DESKTOP_EDIT_SESSIONS_TABLES,
+  ...DELETE_FOLIO_COLLAB_SESSIONS_TABLES,
+  ...DELETE_PENDING_UPLOADS_TABLES,
+  ...DELETE_USER_FILES_TABLES,
+  ...DELETE_CHAT_THREADS_TABLES,
+  ...DELETE_WORKSPACE_VIEW_TEMPLATES_TABLES,
+  ...DELETE_BILLING_RATES_TABLES,
+] as const satisfies readonly PgTable[];

--- a/apps/api/src/lib/delete-account.ts
+++ b/apps/api/src/lib/delete-account.ts
@@ -1,78 +1,47 @@
 import { Result } from "better-result";
-import {
-  and,
-  eq,
-  inArray,
-  isNotNull,
-  isNull,
-  ne,
-  notExists,
-  or,
-  sql,
-} from "drizzle-orm";
+import { and, eq, inArray, isNull, ne, or } from "drizzle-orm";
 
-import {
-  account,
-  invitation,
-  member,
-  oauthAccessToken,
-  oauthClient,
-  oauthConsent,
-  oauthRefreshToken,
-  organization,
-  session,
-  user,
-  verification,
-} from "@/api/db/auth-schema";
+import { member, organization, user, verification } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
 import {
-  accountDeletionRequests,
-  agentSkills,
-  auditLogs,
-  chatThreads,
-  desktopEditHandoffs,
-  desktopEditSessions,
   entities,
-  fileChatThreads,
-  folioCollabSessions,
-  mcpOAuthState,
-  mcpUserConnections,
-  pendingUploads,
-  rateEntries,
   taskAssignees,
-  userFiles,
   workspaceMembers,
-  workspaceViewTemplates,
   workspaces,
 } from "@/api/db/schema";
-import { createFileKey, createUserFileKey } from "@/api/handlers/files/utils";
-import { tmpUploadKeys } from "@/api/handlers/uploads/lib";
 import {
   enqueueAccountDeletionCleanup,
   processAccountDeletionCleanupRequest,
 } from "@/api/lib/account-deletion-cleanup-queue";
+import { ACTIVE_TASK_REASSIGNMENT_STATUSES } from "@/api/lib/account-deletion-reassignment";
 import {
-  ACTIVE_TASK_REASSIGNMENT_STATUSES,
-  buildAccountDeletionTaskReassignmentTargets,
-  validateAccountDeletionTaskReassignmentTargets,
-} from "@/api/lib/account-deletion-reassignment";
+  assertUserIsNotSoleOrgOwner,
+  clearWorkspaceLeadRole,
+  collectUserOrganizationAndWorkspaceIds,
+  deleteChatThreadsAndFileLinks,
+  deleteDesktopEditSessionsAndHandoffs,
+  deleteFolioCollabSessions,
+  deleteMcpCredentialsAndOAuthState,
+  deletePendingUploads,
+  deletePersonalBillingRates,
+  deletePersonalWorkspaceViewTemplatesAndAgentSkills,
+  deleteUserFiles,
+  finalizeDeletedUserRecord,
+  lockUserRowForDeletion,
+  reassignActiveTaskAssignmentsAndDropMemberships,
+  recordAccountDeletionRequest,
+  revokeAuthCredentialsAndInvitations,
+  revokeOAuthTokensAndGrants,
+  verifyDeletionOtp,
+} from "@/api/lib/account-deletion-steps";
 import { captureError } from "@/api/lib/analytics/capture";
-import { arrayOrEmpty } from "@/api/lib/array";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId, type SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
-import { FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE } from "@/api/lib/folio-collab-sessions";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
-import {
-  brandPersistedOrganizationId,
-  brandPersistedUserId,
-  brandPersistedWorkspaceId,
-} from "@/api/lib/safe-id-boundaries";
-import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
-const DELETED_ACCOUNT_DISPLAY_NAME = "Deleted account";
+export { ACCOUNT_DELETION_ERROR_CODE } from "@/api/lib/account-deletion-steps";
 
 /**
  * Fetches the user email by ID.
@@ -342,13 +311,14 @@ export const getPendingTasksAndMembers = async (
 
 /**
  * Verifies the OTP and deletes the user from the database.
+ *
+ * Each deletion/update step lives in `account-deletion-steps.ts`, called
+ * here in the same order the transaction has always run them (see that
+ * file for the FK-ordering comments preserved on each step). The
+ * `account-deletion-coverage.test.ts` guard checks that every table with a
+ * foreign key to the auth user table is either DB-cascaded or explicitly
+ * handled by one of these steps.
  */
-export const ACCOUNT_DELETION_ERROR_CODE = {
-  otpExpired: "account_deletion_otp_expired",
-  otpInvalid: "account_deletion_otp_invalid",
-  soleOwner: "account_deletion_sole_owner",
-} as const;
-
 export const verifyAndDeleteUser = async (
   currentUserId: string,
   email: string,
@@ -363,113 +333,23 @@ export const verifyAndDeleteUser = async (
       const identifier = `delete-account:${email}`;
       const deletionRequestId = createSafeId<"accountDeletionRequest">();
       const s3KeysToDelete: string[] = [];
-      let taskReassignmentCount = 0;
 
       await rootDb.transaction(async (tx) => {
-        // Lock the user row to serialize deletion of this account
-        await tx
-          .select({ id: user.id })
-          .from(user)
-          .where(eq(user.id, currentUserId))
-          .for("update");
+        await lockUserRowForDeletion(tx, currentUserId);
 
-        const verificationRow = await tx
-          .select()
-          .from(verification)
-          .where(eq(verification.identifier, identifier))
-          .limit(1)
-          .then((rows) => rows[0]);
-
-        if (!verificationRow) {
-          throw new HandlerError({
-            code: ACCOUNT_DELETION_ERROR_CODE.otpInvalid,
-            status: 400,
-            message: "Invalid verification code",
-          });
-        }
-
-        if (verificationRow.value !== code) {
-          // Prevent brute force by deleting the OTP on the first incorrect attempt
-          await tx
-            .delete(verification)
-            .where(eq(verification.identifier, identifier));
-
-          throw new HandlerError({
-            code: ACCOUNT_DELETION_ERROR_CODE.otpInvalid,
-            status: 400,
-            message: "Invalid verification code",
-          });
-        }
-
-        if (verificationRow.expiresAt.getTime() < Date.now()) {
-          await tx
-            .delete(verification)
-            .where(eq(verification.identifier, identifier));
-
-          throw new HandlerError({
-            code: ACCOUNT_DELETION_ERROR_CODE.otpExpired,
-            status: 400,
-            message: "Verification code has expired",
-          });
-        }
+        const verificationRow = await verifyDeletionOtp({
+          tx,
+          identifier,
+          code,
+        });
 
         // 2. Perform ownership check with SELECT FOR UPDATE locks inside transaction
-        // Fetch all organizations where the user is an owner, locking the member rows to prevent concurrent modifications
-        const ownedOrgs = await tx
-          .select({ orgId: member.organizationId, orgName: organization.name })
-          .from(member)
-          .innerJoin(organization, eq(organization.id, member.organizationId))
-          .where(
-            and(eq(member.userId, currentUserId), eq(member.role, "owner")),
-          )
-          .for("update");
+        await assertUserIsNotSoleOrgOwner(tx, currentUserId);
 
-        const ownedOrgIds = ownedOrgs.map((org) => org.orgId);
-        const orgIdsWithOtherOwners = new Set(
-          ownedOrgIds.length > 0
-            ? (
-                await tx
-                  .select({ orgId: member.organizationId })
-                  .from(member)
-                  .where(
-                    and(
-                      inArray(member.organizationId, ownedOrgIds),
-                      eq(member.role, "owner"),
-                      ne(member.userId, currentUserId),
-                    ),
-                  )
-                  .for("update")
-              ).map((row) => row.orgId)
-            : [],
-        );
-
-        const soleOwnedOrg = ownedOrgs.find(
-          (org) => !orgIdsWithOtherOwners.has(org.orgId),
-        );
-        if (soleOwnedOrg) {
-          throw new HandlerError({
-            code: ACCOUNT_DELETION_ERROR_CODE.soleOwner,
-            status: 400,
-            message: `Cannot delete account because you are the sole owner of organization "${soleOwnedOrg.orgName}". Please transfer ownership or delete the organization first.`,
-          });
-        }
-
-        const organizationIds = (
-          await tx
-            .select({ organizationId: member.organizationId })
-            .from(member)
-            .where(eq(member.userId, currentUserId))
-        ).map((row) => brandPersistedOrganizationId(row.organizationId));
-
-        const workspaceIds = (
-          await tx
-            .select({ workspaceId: workspaceMembers.workspaceId })
-            .from(workspaceMembers)
-            .where(eq(workspaceMembers.userId, currentUserId))
-        ).map((row) => row.workspaceId);
+        const { organizationIds, workspaceIds } =
+          await collectUserOrganizationAndWorkspaceIds(tx, currentUserId);
 
         // audit: skip — ephemeral verification code deletion
-
         await tx
           .delete(verification)
           .where(eq(verification.id, verificationRow.id));
@@ -479,467 +359,49 @@ export const verifyAndDeleteUser = async (
         // fields, but completed/cancelled task history can still show who did
         // the work with a deleted-account marker.
 
-        // 1. Auth credentials, sessions, and invitations (auth-schema tables)
-        await tx.delete(account).where(eq(account.userId, currentUserId));
-        // eslint-disable-next-line auth-lifecycle/no-direct-auth-artifact-delete -- Account deletion must revoke Better Auth session artifacts.
-        await tx.delete(session).where(eq(session.userId, currentUserId));
-        // Delete invitations sent by the user, and also invitations sent to the user's email
-        await tx
-          .delete(invitation)
-          .where(eq(invitation.inviterId, currentUserId));
-        await tx.delete(invitation).where(eq(invitation.email, email));
+        await revokeAuthCredentialsAndInvitations({
+          tx,
+          currentUserId,
+          email,
+        });
+        await revokeOAuthTokensAndGrants(tx, currentUserId);
+        await deleteMcpCredentialsAndOAuthState(tx, currentUserId);
+        await clearWorkspaceLeadRole(tx, currentUserId);
 
-        // 2. OAuth / Better-Auth token tables (auth-schema)
-        // eslint-disable-next-line auth-lifecycle/no-direct-auth-artifact-delete -- Account deletion must revoke Better Auth OAuth access tokens.
-        await tx
-          .delete(oauthAccessToken)
-          .where(eq(oauthAccessToken.userId, currentUserId));
-        // eslint-disable-next-line auth-lifecycle/no-direct-auth-artifact-delete -- Account deletion must revoke Better Auth OAuth refresh tokens.
-        await tx
-          .delete(oauthRefreshToken)
-          .where(eq(oauthRefreshToken.userId, currentUserId));
-        await tx
-          .delete(oauthConsent)
-          .where(eq(oauthConsent.userId, currentUserId));
-        await tx
-          .delete(oauthClient)
-          .where(eq(oauthClient.userId, currentUserId));
-
-        // 3. MCP credentials and in-flight OAuth state (schema.ts, cascade on user.id)
-        await tx
-          .delete(mcpUserConnections)
-          .where(eq(mcpUserConnections.userId, currentUserId));
-        await tx
-          .delete(mcpOAuthState)
-          .where(eq(mcpOAuthState.userId, currentUserId));
-
-        // 4. Workspace lead role — membership deletion happens after task handoff
-        await tx
-          .update(workspaces)
-          .set({ leadUserId: null })
-          .where(eq(workspaces.leadUserId, currentUserId));
-
-        // 5. Active task assignee records require handoff. Completed/cancelled
-        // assignments remain as historical activity on the deleted user row.
-        const reassignmentItems = [...arrayOrEmpty(reassignments)];
-        const currentTaskAssignments = await tx
-          .select({
-            entityId: taskAssignees.entityId,
-            organizationId: workspaces.organizationId,
-            workspaceId: taskAssignees.workspaceId,
-          })
-          .from(taskAssignees)
-          .innerJoin(entities, eq(entities.id, taskAssignees.entityId))
-          .innerJoin(workspaces, eq(workspaces.id, taskAssignees.workspaceId))
-          .innerJoin(
-            workspaceMembers,
-            and(
-              eq(workspaceMembers.workspaceId, taskAssignees.workspaceId),
-              eq(workspaceMembers.userId, currentUserId),
-            ),
-          )
-          .innerJoin(
-            member,
-            and(
-              eq(member.organizationId, workspaces.organizationId),
-              eq(member.userId, currentUserId),
-            ),
-          )
-          .where(
-            and(
-              eq(taskAssignees.userId, currentUserId),
-              eq(entities.kind, "task"),
-              or(
-                isNull(entities.status),
-                inArray(entities.status, ACTIVE_TASK_REASSIGNMENT_STATUSES),
-              ),
-            ),
-          )
-          .limit(LIMITS.accountDeletionTaskAssignmentsMax + 1);
-
-        if (
-          currentTaskAssignments.length >
-          LIMITS.accountDeletionTaskAssignmentsMax
-        ) {
-          throw new HandlerError({
-            code: "account_deletion_task_reassignment_limit_exceeded",
-            status: 400,
-            message:
-              "Too many active task assignments to reassign during account deletion.",
+        const taskReassignmentCount =
+          await reassignActiveTaskAssignmentsAndDropMemberships({
+            tx,
+            currentUserId,
+            deletionRequestId,
+            reassignments,
           });
-        }
 
-        await tx.delete(taskAssignees).where(
-          and(
-            eq(taskAssignees.userId, currentUserId),
-            inArray(
-              taskAssignees.entityId,
-              tx
-                .select({ entityId: entities.id })
-                .from(entities)
-                .where(
-                  and(
-                    eq(entities.kind, "task"),
-                    or(
-                      isNull(entities.status),
-                      inArray(
-                        entities.status,
-                        ACTIVE_TASK_REASSIGNMENT_STATUSES,
-                      ),
-                    ),
-                  ),
-                ),
-            ),
-            notExists(
-              tx
-                .select({ one: sql`1` })
-                .from(workspaceMembers)
-                .innerJoin(
-                  workspaces,
-                  eq(workspaces.id, workspaceMembers.workspaceId),
-                )
-                .innerJoin(
-                  member,
-                  and(
-                    eq(member.organizationId, workspaces.organizationId),
-                    eq(member.userId, currentUserId),
-                  ),
-                )
-                .where(
-                  and(
-                    eq(workspaceMembers.workspaceId, taskAssignees.workspaceId),
-                    eq(workspaceMembers.userId, currentUserId),
-                  ),
-                ),
-            ),
-          ),
+        await deleteDesktopEditSessionsAndHandoffs({
+          tx,
+          currentUserId,
+          s3KeysToDelete,
+        });
+        await deleteFolioCollabSessions({ tx, currentUserId, s3KeysToDelete });
+        await deletePendingUploads({ tx, currentUserId, s3KeysToDelete });
+        await deleteUserFiles({ tx, currentUserId, s3KeysToDelete });
+        await deleteChatThreadsAndFileLinks(tx, currentUserId);
+        await deletePersonalWorkspaceViewTemplatesAndAgentSkills(
+          tx,
+          currentUserId,
         );
+        await deletePersonalBillingRates(tx, currentUserId);
 
-        if (currentTaskAssignments.length > 0) {
-          const reassignmentTargets =
-            buildAccountDeletionTaskReassignmentTargets({
-              currentTaskAssignments,
-              currentUserId,
-              reassignments: reassignmentItems,
-            });
-          const reassignmentUserIds = reassignmentTargets.map(
-            (target) => target.reassignedUserId,
-          );
-
-          const taskWorkspaceIds = currentTaskAssignments.map(
-            (assignment) => assignment.workspaceId,
-          );
-          const validMembershipKeys = new Set(
-            (
-              await tx
-                .select({
-                  userId: workspaceMembers.userId,
-                  workspaceId: workspaceMembers.workspaceId,
-                })
-                .from(workspaceMembers)
-                .innerJoin(
-                  workspaces,
-                  eq(workspaces.id, workspaceMembers.workspaceId),
-                )
-                .innerJoin(
-                  member,
-                  and(
-                    eq(member.organizationId, workspaces.organizationId),
-                    eq(member.userId, workspaceMembers.userId),
-                  ),
-                )
-                .where(
-                  and(
-                    inArray(workspaceMembers.workspaceId, taskWorkspaceIds),
-                    inArray(workspaceMembers.userId, reassignmentUserIds),
-                  ),
-                )
-            ).map((row) => `${row.workspaceId}:${row.userId}`),
-          );
-          const existingReassignmentKeys = new Set(
-            (
-              await tx
-                .select({
-                  entityId: taskAssignees.entityId,
-                  userId: taskAssignees.userId,
-                })
-                .from(taskAssignees)
-                .where(
-                  and(
-                    inArray(
-                      taskAssignees.entityId,
-                      currentTaskAssignments.map(
-                        (assignment) => assignment.entityId,
-                      ),
-                    ),
-                    inArray(taskAssignees.userId, reassignmentUserIds),
-                  ),
-                )
-            ).map((row) => `${row.entityId}:${row.userId}`),
-          );
-
-          const updates = validateAccountDeletionTaskReassignmentTargets({
-            existingReassignmentKeys,
-            targets: reassignmentTargets,
-            validMembershipKeys,
-          });
-          const assignmentByEntityId = new Map(
-            currentTaskAssignments.map((assignment) => [
-              assignment.entityId,
-              assignment,
-            ]),
-          );
-
-          // SAFETY: one deleted user's active task reassignments, bounded by
-          // the enforced LIMITS.accountDeletionTaskAssignmentsMax check above
-          // (throws before reaching here if exceeded), not unbounded tenant
-          // data.
-          // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop
-          await Promise.all(
-            updates.map((item) =>
-              tx
-                .update(taskAssignees)
-                .set({
-                  userId: item.reassignedUserId,
-                })
-                .where(
-                  and(
-                    eq(taskAssignees.entityId, item.entityId),
-                    eq(taskAssignees.userId, currentUserId),
-                  ),
-                ),
-            ),
-          );
-          await tx.insert(auditLogs).values(
-            updates.map((item) => {
-              const assignment = assignmentByEntityId.get(item.entityId);
-              if (!assignment) {
-                throw new HandlerError({
-                  status: 500,
-                  message: "Task reassignment source not found.",
-                });
-              }
-
-              return {
-                action: AUDIT_ACTION.UPDATE,
-                changes: {
-                  assigneeUserId: {
-                    new: item.reassignedUserId,
-                    old: currentUserId,
-                  },
-                },
-                metadata: {
-                  accountDeletionRequestId: deletionRequestId,
-                  change: "assignee-reassigned",
-                  fromUserId: currentUserId,
-                  reason: "account-deletion",
-                  toUserId: item.reassignedUserId,
-                },
-                organizationId: assignment.organizationId,
-                resourceId: item.entityId,
-                resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-                userId: currentUserId,
-                workspaceId: assignment.workspaceId,
-              };
-            }),
-          );
-          taskReassignmentCount = updates.length;
-        }
-
-        await tx.delete(member).where(eq(member.userId, currentUserId));
-        await tx
-          .delete(workspaceMembers)
-          .where(eq(workspaceMembers.userId, currentUserId));
-
-        // 6. Desktop edit sessions and handoffs (cascade on createdBy → user.id)
-        const desktopCheckpointRows = await tx
-          .select({
-            checkpointFileId: desktopEditSessions.checkpointFileId,
-            organizationId: workspaces.organizationId,
-            workspaceId: desktopEditSessions.workspaceId,
-          })
-          .from(desktopEditSessions)
-          .innerJoin(
-            workspaces,
-            eq(workspaces.id, desktopEditSessions.workspaceId),
-          )
-          .where(
-            and(
-              eq(desktopEditSessions.createdBy, currentUserId),
-              isNotNull(desktopEditSessions.checkpointUpdatedAt),
-            ),
-          );
-        s3KeysToDelete.push(
-          ...desktopCheckpointRows.map((row) =>
-            createFileKey({
-              fileId: row.checkpointFileId,
-              mimeType: DOCX_MIME_TYPE,
-              organizationId: brandPersistedOrganizationId(row.organizationId),
-              workspaceId: brandPersistedWorkspaceId(row.workspaceId),
-            }),
-          ),
-        );
-
-        await tx
-          .delete(desktopEditHandoffs)
-          .where(eq(desktopEditHandoffs.createdBy, currentUserId));
-        await tx
-          .delete(desktopEditSessions)
-          .where(eq(desktopEditSessions.createdBy, currentUserId));
-
-        // 7. Folio collab sessions — tokens cascade when session is deleted
-        const folioCheckpointRows = await tx
-          .select({
-            docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
-            docxCheckpointUpdatedAt:
-              folioCollabSessions.docxCheckpointUpdatedAt,
-            organizationId: workspaces.organizationId,
-            workspaceId: folioCollabSessions.workspaceId,
-            yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
-            yjsSnapshotUpdatedAt: folioCollabSessions.yjsSnapshotUpdatedAt,
-          })
-          .from(folioCollabSessions)
-          .innerJoin(
-            workspaces,
-            eq(workspaces.id, folioCollabSessions.workspaceId),
-          )
-          .where(eq(folioCollabSessions.createdBy, currentUserId));
-        for (const row of folioCheckpointRows) {
-          if (row.yjsSnapshotUpdatedAt !== null) {
-            s3KeysToDelete.push(
-              createFileKey({
-                fileId: row.yjsSnapshotFileId,
-                mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
-                organizationId: brandPersistedOrganizationId(
-                  row.organizationId,
-                ),
-                workspaceId: brandPersistedWorkspaceId(row.workspaceId),
-              }),
-            );
-          }
-
-          if (row.docxCheckpointUpdatedAt !== null) {
-            s3KeysToDelete.push(
-              createFileKey({
-                fileId: row.docxCheckpointFileId,
-                mimeType: DOCX_MIME_TYPE,
-                organizationId: brandPersistedOrganizationId(
-                  row.organizationId,
-                ),
-                workspaceId: brandPersistedWorkspaceId(row.workspaceId),
-              }),
-            );
-          }
-        }
-
-        await tx
-          .delete(folioCollabSessions)
-          .where(eq(folioCollabSessions.createdBy, currentUserId));
-
-        // 8. Pending (in-flight) S3 uploads
-        const stagedUploadRows = await tx
-          .select({
-            id: pendingUploads.id,
-            organizationId: pendingUploads.organizationId,
-            workspaceId: pendingUploads.workspaceId,
-          })
-          .from(pendingUploads)
-          .where(
-            and(
-              eq(pendingUploads.userId, currentUserId),
-              ne(pendingUploads.status, "finalized"),
-            ),
-          );
-        s3KeysToDelete.push(
-          ...stagedUploadRows.flatMap((row) =>
-            tmpUploadKeys({
-              organizationId: row.organizationId,
-              uploadId: row.id,
-              workspaceId: row.workspaceId,
-            }),
-          ),
-        );
-
-        await tx
-          .delete(pendingUploads)
-          .where(eq(pendingUploads.userId, currentUserId));
-
-        // 9. Personal user files (private S3 uploads) — must delete userFiles before chatThreads
-        // because userFiles.threadId has onDelete: "restrict" reference to chatThreads.id
-        const files = await tx
-          .select({
-            id: userFiles.id,
-            s3Key: userFiles.s3Key,
-            thumbnailFileId: userFiles.thumbnailFileId,
-            userId: userFiles.userId,
-          })
-          .from(userFiles)
-          .where(eq(userFiles.userId, currentUserId));
-
-        if (files.length > 0) {
-          s3KeysToDelete.push(
-            ...files.flatMap((file) =>
-              file.thumbnailFileId
-                ? [
-                    file.s3Key,
-                    createUserFileKey({
-                      fileId: file.thumbnailFileId,
-                      mimeType: "image/webp",
-                      userId: brandPersistedUserId(file.userId),
-                    }),
-                  ]
-                : [file.s3Key],
-            ),
-          );
-        }
-
-        await tx.delete(userFiles).where(eq(userFiles.userId, currentUserId));
-
-        // 10. AI chat threads — messages and fileChatThreads cascade on thread deletion
-        await tx
-          .delete(fileChatThreads)
-          .where(eq(fileChatThreads.userId, currentUserId));
-        await tx
-          .delete(chatThreads)
-          .where(eq(chatThreads.userId, currentUserId));
-
-        // 11. Personal workspace view templates and agent skills
-        await tx
-          .delete(workspaceViewTemplates)
-          .where(eq(workspaceViewTemplates.userId, currentUserId));
-        await tx
-          .delete(agentSkills)
-          .where(eq(agentSkills.userId, currentUserId));
-
-        // 12. Personal billing rates
-        await tx
-          .delete(rateEntries)
-          .where(eq(rateEntries.userId, currentUserId));
-
-        await tx.insert(accountDeletionRequests).values({
-          id: deletionRequestId,
-          userId: currentUserId,
+        await recordAccountDeletionRequest({
+          tx,
+          deletionRequestId,
+          currentUserId,
           organizationIds,
           workspaceIds,
           taskReassignmentCount,
-          status: s3KeysToDelete.length > 0 ? "pending" : "completed",
-          storageCleanup: { s3Keys: s3KeysToDelete },
-          completedAt: s3KeysToDelete.length > 0 ? null : new Date(),
+          s3KeysToDelete,
         });
 
-        // 13. Mark the account deleted and release private contact/login fields.
-        await tx
-          .update(user)
-          .set({
-            email: `deleted-${currentUserId}@stella.placeholder`,
-            emailVerified: false,
-            image: null,
-            name: DELETED_ACCOUNT_DISPLAY_NAME,
-            preferredName: null,
-            wordEditShortcut: null,
-            deletedAt: new Date(),
-          })
-          .where(eq(user.id, currentUserId));
+        await finalizeDeletedUserRecord(tx, currentUserId);
       });
 
       if (s3KeysToDelete.length > 0) {


### PR DESCRIPTION
## What

Two commits:

1. **Mechanical extraction**: `verifyAndDeleteUser`'s ~13 deletion/update steps move from one 900-line function body into named step functions in a new `account-deletion-steps.ts` (same naming pattern as the existing `account-deletion-reassignment.ts` sibling). Same order, same queries, same single transaction; FK-ordering comments moved with their code. Public API unchanged (`ACCOUNT_DELETION_ERROR_CODE` re-exported).
2. **Schema-driven coverage guard**: a new test enumerates every direct FK to the `user` table via Drizzle's `getTableConfig` (pure metadata, no DB) and asserts each is covered by DB-level `onDelete` behavior, by a step in the deletion routine (the manifest is derived from per-step `*_TABLES` declarations, not a free-floating list), or by a documented known-gap entry. Two reverse assertions catch stale manifest entries and stale gap entries. Adding a user-referencing table without wiring it into deletion now fails CI with a message naming the table, column, and the fix.

## Notes

The guard surfaced 10 pre-existing FKs not covered by any step, all `onDelete: "restrict"`. Account deletion soft-deletes (anonymizes) the user row rather than removing it, so none of these block deletion today; they are recorded in the known-gaps list with per-entry notes. Most look like deliberate attribution retention (`created_by`-style columns, matching the existing "retained for historical attribution" comment in `delete-account.ts`); confirming or tightening each is follow-up work, deliberately not decided inside this refactor.

## Tests

`account-deletion-coverage.test.ts` (4 assertions incl. enumeration sanity) plus the two pre-existing account-deletion suites: 15 pass, 0 fail.