### PR TITLE
feat(lint): require function replacers for dynamic replace arguments

### DIFF
--- a/.claude/mcp/server.ts
+++ b/.claude/mcp/server.ts
@@ -169,7 +169,7 @@ const parseMarkdownLinks = (line: string) => {
 const stripMarkdownFormatting = (value: string) => {
   let text = value;
   for (const { title, matchedText } of parseMarkdownLinks(value)) {
-    text = text.replaceAll(matchedText, title);
+    text = text.replaceAll(matchedText, () => title);
   }
 
   return text

--- a/.oxlint-plugins/__fixtures__/require-function-replacer.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/require-function-replacer.fixture.ts
@@ -1,0 +1,129 @@
+// Passive regression fixture for
+// `require-function-replacer/require-function-replacer`.
+//
+// Each `oxlint-disable-next-line` below intentionally suppresses a case the
+// rule MUST flag. If the rule regresses, the matching disable becomes unused
+// and `--report-unused-disable-directives-severity=error` fails CI. The
+// allowed cases carry no disable, so a false positive would fail the
+// fixture too.
+
+declare const text: string;
+declare const dynamicValue: string;
+declare const pattern: string;
+declare const getReplacement: () => string;
+declare const flag: boolean;
+declare function importedReplacer(match: string): string;
+
+// MUST flag: bare identifier bound to a dynamic (non-function) value.
+export const identifierValue = () =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replace(pattern, dynamicValue);
+
+// MUST flag: template literal WITH interpolation — `$` sequences inside
+// `dynamicValue` would still be pattern-substituted.
+export const templateWithInterpolation = () =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replace(pattern, `prefix-${dynamicValue}`);
+
+// MUST flag: call expression result used directly.
+export const callExpressionValue = () =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replace(pattern, getReplacement());
+
+// MUST flag: member expression used directly.
+export const memberExpressionValue = () => {
+  const holder = { field: dynamicValue };
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  return text.replace(pattern, holder.field);
+};
+
+// MUST flag: conditional expression.
+export const conditionalValue = () =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replace(pattern, flag ? dynamicValue : "fallback");
+
+// MUST flag: same analysis applies to replaceAll.
+export const replaceAllIdentifierValue = () =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replaceAll(pattern, dynamicValue);
+
+// MUST flag: identifier resolves to a function PARAMETER, not a
+// declaration/arrow-assignment — the rule only trusts the two syntactic
+// forms it documents, so a parameter (even if callers only ever pass
+// functions) is reported.
+export const parameterBoundReplacer = (replacer: (match: string) => string) =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replace(pattern, replacer);
+
+// MUST flag: identifier resolves to an IMPORTED function — the rule does
+// not trust import bindings, only local declarations/arrow assignments.
+export const importedFunctionReplacer = () =>
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  text.replace(pattern, importedReplacer);
+
+// MUST flag: `let` re-assigned away from its function initializer is still
+// allowed by this purely syntactic rule (documented limitation) is NOT what
+// this case tests — this one is a `let` whose initializer is itself
+// non-function, which must always be flagged.
+export const letBoundToDynamicValue = () => {
+  let label = dynamicValue;
+  label = `${label}!`;
+  // oxlint-disable-next-line require-function-replacer/require-function-replacer
+  return text.replace(pattern, label);
+};
+
+// Allowed — inline arrow function replacer.
+export const arrowReplacer = () => text.replace(pattern, () => dynamicValue);
+
+// Allowed — inline function-expression replacer.
+export const functionExpressionReplacer = () =>
+  text.replace(pattern, (match) => match.toUpperCase());
+
+// Allowed — string literal replacement (author-visible `$` usage, if any,
+// is intentional).
+export const stringLiteralReplacer = () => text.replace(pattern, "literal");
+
+// Allowed — no-substitution template literal, same reasoning as a string
+// literal.
+export const templateLiteralReplacer = () => text.replace(pattern, `literal`);
+
+// Allowed — identifier resolving to a local function declaration.
+export const functionDeclarationReplacer = () => {
+  function toReplacement(match: string) {
+    return match;
+  }
+  return text.replace(pattern, toReplacement);
+};
+
+// Allowed — identifier resolving to a local `const` arrow-function
+// assignment.
+export const constArrowReplacer = () => {
+  const toReplacement = (match: string) => match;
+  return text.replace(pattern, toReplacement);
+};
+
+// Allowed — identifier resolving to a local `const` function-expression
+// assignment.
+export const constFunctionExpressionReplacer = () => {
+  const toReplacement = (match: string) => match;
+  return text.replaceAll(pattern, toReplacement);
+};
+
+// Allowed — single-argument call is not checked at all (not a
+// pattern+replacement pair).
+export const singleArgumentCall = () => text.replace(pattern);
+
+// Allowed — spread call is not checked (not a syntactically-visible
+// two-argument pair).
+export const spreadArgumentsCall = (args: [string, string]) =>
+  text.replace(...args);
+
+// Allowed — an object-expression second argument means this is not
+// `String.prototype.replace` at all (e.g. Bun's `HTMLRewriter`
+// `Element.replace(content, { html })`), so it is skipped rather than
+// required to be a function.
+declare const htmlRewriterElement: {
+  replace: (content: string, options?: { html?: boolean }) => unknown;
+};
+export const nonStringReplaceWithOptionsObject = () =>
+  htmlRewriterElement.replace(dynamicValue, { html: true });

--- a/.oxlint-plugins/require-function-replacer.ts
+++ b/.oxlint-plugins/require-function-replacer.ts
@@ -1,0 +1,253 @@
+// Bans a dynamic string as the replacement (second) argument of
+// `String.prototype.replace()`/`replaceAll()`.
+//
+// JS interprets special replacement patterns (`$&`, `$$`, `` $` ``, `$'`,
+// `$<n>`/`$<name>`) inside the replacement string even when the search
+// argument is a plain string, not a regex. A caller who builds the
+// replacement dynamically (user input, a DB value, a concatenated/templated
+// string) has no reason to expect that syntax to be interpreted, so a `$`
+// landing in the dynamic value silently corrupts the output instead of
+// being inserted literally. A function replacer is immune: its return
+// value is inserted verbatim, with no pattern substitution.
+//
+// Flags any `.replace(...)`/`.replaceAll(...)` call with exactly two
+// arguments whose second argument is not one of:
+//   (a) an inline arrow/function expression — return value is used as-is;
+//   (b) a string literal or no-substitution template literal — `$`
+//       sequences are then author-visible in the source and presumed
+//       intentional;
+//   (c) an identifier that resolves, through the scope API, to a function
+//       declaration or a `const`/`let` arrow/function-expression
+//       assignment. Any other resolution (parameter, import, class name,
+//       catch binding, unresolved) is reported, since a purely syntactic
+//       check cannot prove the binding is a function.
+//
+// Flags:
+//   text.replace(pattern, dynamicValue)
+//   text.replace(pattern, `prefix-${dynamicValue}`)
+//   text.replace(pattern, getReplacement())
+//   text.replace(pattern, cond ? a : b)
+//   text.replaceAll(pattern, someObject.field)
+//   const label = computeLabel(); text.replace(pattern, label);
+//
+// Allows:
+//   text.replace(pattern, () => dynamicValue)
+//   text.replace(pattern, "literal")
+//   text.replace(pattern, `literal`)
+//   text.replace(pattern, (match) => match.toUpperCase())
+//   function toReplacement(match) { return match; }
+//   text.replace(pattern, toReplacement);
+//   const toReplacement = (match) => match;
+//   text.replace(pattern, toReplacement);
+//
+// Scope: only `context.sourceCode.getScope` + `Scope.set`, walking `.upper`
+// (mirrors require-eden-error-check.ts) is used to resolve identifiers —
+// no type information. This is why an identifier bound via `import`,
+// destructuring, or aliasing to another function-valued binding is not
+// resolved as "provably a function" and gets reported; wrap it in an arrow
+// (`.replace(pattern, () => importedFn(match))`) or a local
+// `const`/function declaration to satisfy the rule.
+//
+// Known limits:
+// - Purely syntactic: reassignment after a function-valued `let`
+//   declaration is not tracked, so `let f = () => x; f = "$&";
+//   text.replace(p, f);` is allowed even though `f` is no longer a
+//   function at the call site. Repo-wide grep at authoring time found no
+//   such reassignment pattern.
+// - Only calls with exactly two non-spread arguments are checked, so a
+//   spread call (`text.replace(...args)`) or a single-argument call is
+//   skipped. `.replace`/`.replaceAll` are matched by property name alone
+//   (computed or not).
+// - One confirmed non-string two-argument `replace` exists in the repo's
+//   dependencies: Bun's `HTMLRewriter` `Element`/`Comment`/`Text.replace
+//   (content, options?: { html?: boolean })` (see
+//   apps/api/src/lib/markdown/ai-tool.ts). `String.prototype.replace`/
+//   `replaceAll` never take a plain object as their second argument, so a
+//   second argument that is an object expression (`{ ... }`) is skipped
+//   outright — not reported, not required to be a function — rather than
+//   trying to allowlist every such API by callee name. If a future non-
+//   string `replace(pattern, value)` method takes a non-object second
+//   argument, add a callee-name/type exclusion here.
+
+import { isIdentifier, isStringLiteral, unwrapExpression } from "./utils.ts";
+
+type AstNode = { type: string } & Record<string, unknown>;
+
+const isAstNode = (node: unknown): node is AstNode =>
+  typeof node === "object" &&
+  node !== null &&
+  "type" in node &&
+  typeof (node as { type: unknown }).type === "string";
+
+const REPLACE_METHODS = new Set(["replace", "replaceAll"]);
+
+// Resolve the static name of a (possibly computed) MemberExpression
+// property, the same way the reference rule's callee checks do: an
+// Identifier's name, or a string Literal's value.
+const getStaticPropertyName = (node: unknown): string | null => {
+  if (isIdentifier(node)) {
+    return node.name;
+  }
+  if (isStringLiteral(node)) {
+    return node.value;
+  }
+  return null;
+};
+
+const isFunctionExpressionLike = (node: unknown): boolean =>
+  isAstNode(node) &&
+  (node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionExpression");
+
+// A no-substitution template literal (`` `plain text` ``, no `${...}`
+// interpolation): its contents are as author-visible and static as a
+// string literal, so `$&`-style sequences in it are presumed intentional.
+const isNoSubstitutionTemplateLiteral = (node: unknown): boolean =>
+  isAstNode(node) &&
+  node.type === "TemplateLiteral" &&
+  Array.isArray(node.expressions) &&
+  node.expressions.length === 0;
+
+export default {
+  meta: { name: "require-function-replacer" },
+  rules: {
+    "require-function-replacer": {
+      meta: {
+        type: "problem",
+        messages: {
+          requireFunctionReplacer:
+            "Dynamic value passed as the replacement argument of " +
+            "'.{{method}}()'. JS interprets '$&', '$$', \"$`\", \"$'\", " +
+            "and '$<name>' in replacement strings even for a plain-string " +
+            "search, so dynamic content can silently corrupt the output. " +
+            "Wrap the replacement in a function: " +
+            ".{{method}}(pattern, () => value).",
+        },
+      },
+      create(context) {
+        // Resolve the `Variable` an Identifier reference binds to by
+        // walking the scope chain outward from its use site (mirrors
+        // require-eden-error-check.ts's resolveVariable — this plugin API
+        // has no ready-made `findVariable` helper of its own).
+        const resolveVariable = (
+          identifierNode: AstNode & { name: string },
+        ) => {
+          let scope = context.sourceCode.getScope(identifierNode);
+          while (scope) {
+            const variable = scope.set.get(identifierNode.name);
+            if (variable) {
+              return variable;
+            }
+            scope = scope.upper;
+          }
+          return null;
+        };
+
+        // True when `identifierNode` resolves, through scope, to a
+        // function declaration (`function foo() {}`) or a `const`/`let`
+        // variable whose own initializer is an arrow/function expression.
+        // Any other resolution (`var`, parameter, import binding, class
+        // name, catch binding, or unresolved) is not provably a function
+        // from syntax alone and returns false.
+        const isFunctionBinding = (
+          identifierNode: AstNode & { name: string },
+        ): boolean => {
+          const variable = resolveVariable(identifierNode);
+          if (variable === null) {
+            return false;
+          }
+          return variable.defs.some((def) => {
+            if (def.type === "FunctionName") {
+              return (
+                isAstNode(def.node) && def.node.type === "FunctionDeclaration"
+              );
+            }
+            if (def.type !== "Variable" || !isAstNode(def.node)) {
+              return false;
+            }
+            if (def.node.type !== "VariableDeclarator") {
+              return false;
+            }
+            if (
+              !isAstNode(def.parent) ||
+              def.parent.type !== "VariableDeclaration" ||
+              def.parent.kind === "var"
+            ) {
+              return false;
+            }
+            return isFunctionExpressionLike(unwrapExpression(def.node.init));
+          });
+        };
+
+        // True when `argument` (already unwrapped of TS wrapping) is an
+        // allowed replacement value under the rule's three branches.
+        const isAllowedReplacement = (argument: unknown): boolean => {
+          if (isFunctionExpressionLike(argument)) {
+            return true;
+          }
+          if (isStringLiteral(argument)) {
+            return true;
+          }
+          if (isNoSubstitutionTemplateLiteral(argument)) {
+            return true;
+          }
+          if (isIdentifier(argument)) {
+            return isFunctionBinding(argument);
+          }
+          return false;
+        };
+
+        return {
+          CallExpression(node) {
+            const callee = unwrapExpression(node.callee);
+            if (!isAstNode(callee) || callee.type !== "MemberExpression") {
+              return;
+            }
+
+            const method = getStaticPropertyName(callee.property);
+            if (method === null || !REPLACE_METHODS.has(method)) {
+              return;
+            }
+
+            if (node.arguments.length !== 2) {
+              return;
+            }
+            const [pattern, replacement] = node.arguments;
+            if (
+              !isAstNode(pattern) ||
+              pattern.type === "SpreadElement" ||
+              !isAstNode(replacement) ||
+              replacement.type === "SpreadElement"
+            ) {
+              return;
+            }
+
+            const unwrappedReplacement = unwrapExpression(replacement);
+
+            // `String.prototype.replace`/`replaceAll` never take a plain
+            // object as their second argument, so an object-expression
+            // second argument means this is not a String.replace call at
+            // all (e.g. Bun's `HTMLRewriter` `Element.replace(content,
+            // { html })`) — skip rather than report or require a function.
+            if (
+              isAstNode(unwrappedReplacement) &&
+              unwrappedReplacement.type === "ObjectExpression"
+            ) {
+              return;
+            }
+
+            if (isAllowedReplacement(unwrappedReplacement)) {
+              return;
+            }
+
+            context.report({
+              node: replacement,
+              messageId: "requireFunctionReplacer",
+              data: { method },
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/apps/api/scripts/lib/capability-catalog.ts
+++ b/apps/api/scripts/lib/capability-catalog.ts
@@ -783,7 +783,7 @@ const importToCapabilityId = ({
   }
   const file = `${importPath.replace(
     HANDLER_IMPORT_ALIAS_PREFIX,
-    HANDLER_ALIAS_TO_SRC_PREFIX,
+    () => HANDLER_ALIAS_TO_SRC_PREFIX,
   )}.ts`;
   return deriveCapabilityId({ file, exportName });
 };

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -37,7 +37,7 @@ const anonymizeTextFieldsMock = mock(
       let next = field;
       for (const [placeholder, original] of swaps) {
         if (next.includes(original)) {
-          next = next.replaceAll(original, placeholder);
+          next = next.replaceAll(original, () => placeholder);
           if (!seen.has(placeholder)) {
             redactionMap.set(placeholder, original);
             seen.add(placeholder);
@@ -596,7 +596,7 @@ describe("chat third-party anonymization boundary", () => {
         for (const original of ["Alice", "Bob"]) {
           if (next.includes(original)) {
             const placeholder = `[PERSON_${nextIndex}]`;
-            next = next.replaceAll(original, placeholder);
+            next = next.replaceAll(original, () => placeholder);
             redactionMap.set(placeholder, original);
             nextIndex += 1;
           }
@@ -656,7 +656,7 @@ describe("chat third-party anonymization boundary", () => {
         for (const original of ["Bob", "Alice"]) {
           if (next.includes(original)) {
             const placeholder = `[PERSON_${nextIndex}]`;
-            next = next.replaceAll(original, placeholder);
+            next = next.replaceAll(original, () => placeholder);
             redactionMap.set(placeholder, original);
             nextIndex += 1;
           }

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -1281,8 +1281,8 @@ export const rewriteIterationTokensInText = (
   count: number,
 ): string =>
   text
-    .replace(indexPattern(), String(index + 1))
-    .replace(countPattern(), String(count));
+    .replace(indexPattern(), () => String(index + 1))
+    .replace(countPattern(), () => String(count));
 
 // ── Loop-scoped clause numbering ─────────────────────────
 

--- a/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
+++ b/apps/api/src/handlers/docx/template-manifest-foreign-customxml.test.ts
@@ -87,14 +87,14 @@ const createDocxWithUnsafeManifestSlot = async (): Promise<Buffer> => {
     `customXml/_rels/item${UNSAFE_MANIFEST_INDEX}.xml.rels`,
     relsXml.replaceAll(
       "itemProps1.xml",
-      `itemProps${UNSAFE_MANIFEST_INDEX}.xml`,
+      () => `itemProps${UNSAFE_MANIFEST_INDEX}.xml`,
     ),
   );
   zip.file(
     "[Content_Types].xml",
     contentTypesXml.replaceAll(
       "itemProps1.xml",
-      `itemProps${UNSAFE_MANIFEST_INDEX}.xml`,
+      () => `itemProps${UNSAFE_MANIFEST_INDEX}.xml`,
     ),
   );
 

--- a/apps/api/src/lib/docx-stamp.ts
+++ b/apps/api/src/lib/docx-stamp.ts
@@ -293,7 +293,7 @@ const ensureContentType = async (archive: DocxArchive): Promise<void> => {
     ` ContentType="${CUSTOM_PROPS_CONTENT_TYPE}"/>`;
   archive.zip.file(
     CONTENT_TYPES_PATH,
-    ct.replace("</Types>", `${override}\n</Types>`),
+    ct.replace("</Types>", () => `${override}\n</Types>`),
   );
 };
 
@@ -330,7 +330,7 @@ const ensureCustomPropsRelationship = async (
     relsPath,
     rels.replace(
       "</Relationships>",
-      `<Relationship Id=${rel}\n</Relationships>`,
+      () => `<Relationship Id=${rel}\n</Relationships>`,
     ),
   );
 };
@@ -718,13 +718,13 @@ const addFooterReference = (docXml: string, footerRId: string): string => {
 
   // If there's already a sectPr, add footer reference inside
   if (docXml.includes("<w:sectPr")) {
-    return docXml.replace(SECT_PR_RE, `$<sect>\n    ${footerRef}`);
+    return docXml.replace(SECT_PR_RE, (match) => `${match}\n    ${footerRef}`);
   }
 
   // No sectPr: create one before </w:body>
   return docXml.replace(
     CLOSING_BODY_RE,
-    `<w:sectPr>${footerRef}</w:sectPr>\n</w:body>`,
+    () => `<w:sectPr>${footerRef}</w:sectPr>\n</w:body>`,
   );
 };
 

--- a/apps/api/src/lib/markdown/html-to-markdown.ts
+++ b/apps/api/src/lib/markdown/html-to-markdown.ts
@@ -165,7 +165,7 @@ const renderList = (el: Element, ordered: boolean): string => {
       const marker = ordered ? `${index + 1}. ` : "- ";
       const indent = " ".repeat(marker.length);
       const content = renderListItem(li);
-      return marker + content.replace(/\n/g, `\n${indent}`);
+      return marker + content.replace(/\n/g, () => `\n${indent}`);
     })
     .join("\n");
 };

--- a/apps/api/src/lib/matter-reference.ts
+++ b/apps/api/src/lib/matter-reference.ts
@@ -110,9 +110,9 @@ export const toScopeKey = (pattern: string, now: Date): string => {
   const mm = String(now.getMonth() + 1).padStart(2, "0");
 
   return pattern
-    .replaceAll("{YYYY}", yyyy)
-    .replaceAll("{YY}", yy)
-    .replaceAll("{MM}", mm)
+    .replaceAll("{YYYY}", () => yyyy)
+    .replaceAll("{YY}", () => yy)
+    .replaceAll("{MM}", () => mm)
     .replaceAll("{SEQ}", "");
 };
 
@@ -143,8 +143,8 @@ export const toReference = ({
   const paddedSeq = String(seq).padStart(padding, "0");
 
   return pattern
-    .replaceAll("{YYYY}", yyyy)
-    .replaceAll("{YY}", yy)
-    .replaceAll("{MM}", mm)
-    .replaceAll("{SEQ}", paddedSeq);
+    .replaceAll("{YYYY}", () => yyyy)
+    .replaceAll("{YY}", () => yy)
+    .replaceAll("{MM}", () => mm)
+    .replaceAll("{SEQ}", () => paddedSeq);
 };

--- a/apps/api/src/scripts/prepare-spa-template.ts
+++ b/apps/api/src/scripts/prepare-spa-template.ts
@@ -63,7 +63,7 @@ const run = async () => {
   // a proper XML-aware replacement.
   // Simple full-text replacements
   for (const [search, replacement] of SIMPLE_REPLACEMENTS) {
-    xml = xml.replaceAll(search, replacement);
+    xml = xml.replaceAll(search, () => replacement);
   }
 
   // Sequential: replace each occurrence with a different tag

--- a/apps/web/src/lib/matter-reference.ts
+++ b/apps/web/src/lib/matter-reference.ts
@@ -60,8 +60,8 @@ export const previewReference = ({
   const paddedSeq = "1".padStart(padding, "0");
 
   return pattern
-    .replaceAll("{YYYY}", yyyy)
-    .replaceAll("{YY}", yy)
-    .replaceAll("{MM}", mm)
-    .replaceAll("{SEQ}", paddedSeq);
+    .replaceAll("{YYYY}", () => yyyy)
+    .replaceAll("{YY}", () => yy)
+    .replaceAll("{MM}", () => mm)
+    .replaceAll("{SEQ}", () => paddedSeq);
 };

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -581,7 +581,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
     // Drop new uploads into knowledge/ by default. The user can rename
     // afterward if they want a different folder.
     const extMatch = /(?<ext>\.[^.]+)?$/u.exec(sanitizedName);
-    const ext = extMatch?.groups?.ext ?? "";
+    const ext = extMatch?.groups?.["ext"] ?? "";
     const stem = ext ? sanitizedName.slice(0, -ext.length) : sanitizedName;
     let path = `knowledge/${sanitizedName}`;
     let suffix = 1;

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -580,11 +580,14 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
     }
     // Drop new uploads into knowledge/ by default. The user can rename
     // afterward if they want a different folder.
+    const extMatch = /(?<ext>\.[^.]+)?$/u.exec(sanitizedName);
+    const ext = extMatch?.groups?.ext ?? "";
+    const stem = ext ? sanitizedName.slice(0, -ext.length) : sanitizedName;
     let path = `knowledge/${sanitizedName}`;
     let suffix = 1;
     while (existingPaths.has(path)) {
       suffix += 1;
-      path = `knowledge/${sanitizedName.replace(/(?<ext>\.[^.]+)?$/u, `-${suffix}$<ext>`)}`;
+      path = `knowledge/${stem}-${suffix}${ext}`;
     }
     if (binary) {
       uploadResource.mutate({ path, file });

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -144,6 +144,7 @@ export default defineConfig({
     "no-raw-public-law-seo/no-raw-public-law-seo": "off",
     "public-case-law-db-boundary/public-case-law-db-boundary": "off",
     "require-contained-handler/require-contained-handler": "error",
+    "require-function-replacer/require-function-replacer": "error",
     "no-void": ["error", { allowAsStatement: true }],
 
     // --- Disabled ultracite defaults ---
@@ -349,6 +350,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-secret-in-log-sink.ts",
     "./.oxlint-plugins/no-raw-api-url.ts",
     "./.oxlint-plugins/require-eden-error-check.ts",
+    "./.oxlint-plugins/require-function-replacer.ts",
     "./.oxlint-plugins/require-fetch-timeout.ts",
     "./.oxlint-plugins/require-escape-like.ts",
     "./.oxlint-plugins/no-bare-error.ts",

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -113,7 +113,10 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
           let redactedText = fullText;
           for (const [idx, entity] of entities.entries()) {
             const placeholder = `[${entity.label.toUpperCase()}_${idx + 1}]`;
-            redactedText = redactedText.replaceAll(entity.text, placeholder);
+            redactedText = redactedText.replaceAll(
+              entity.text,
+              () => placeholder,
+            );
             redactionMap.set(placeholder, entity.text);
             operatorMap.set(placeholder, "replace");
           }
@@ -139,7 +142,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     deanonymise: (redactedText, redactionMap) => {
       let result = redactedText;
       for (const [placeholder, original] of redactionMap) {
-        result = result.replaceAll(placeholder, original);
+        result = result.replaceAll(placeholder, () => original);
       }
       return result;
     },

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -215,7 +215,7 @@ const restoreLiteralPlaceholders = (
 ): string => {
   let result = text;
   for (const [sentinel, placeholder] of restoreMap) {
-    result = result.replaceAll(sentinel, placeholder);
+    result = result.replaceAll(sentinel, () => placeholder);
   }
   return result;
 };

--- a/packages/business-registries/src/orsr/parse.ts
+++ b/packages/business-registries/src/orsr/parse.ts
@@ -231,9 +231,11 @@ const parseCourtFile = (
 };
 
 const buildRegistryUrl = (file: OrsrCourtFile): string =>
-  SLOVAK_REGISTRY_URL.replaceAll("{section}", encodeURIComponent(file.section))
-    .replaceAll("{insertNumber}", encodeURIComponent(file.insertNumber))
-    .replaceAll("{court}", encodeURIComponent(file.court));
+  SLOVAK_REGISTRY_URL.replaceAll("{section}", () =>
+    encodeURIComponent(file.section),
+  )
+    .replaceAll("{insertNumber}", () => encodeURIComponent(file.insertNumber))
+    .replaceAll("{court}", () => encodeURIComponent(file.court));
 
 const normalizeName = (raw: string | null | undefined): string | null => {
   if (!raw) {

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -240,10 +240,11 @@ const countAsCasts = (content: string): number => {
       continue;
     }
     const scanned = code
-      .replace(AS_UNKNOWN_AS, AS_UNKNOWN_PLACEHOLDER)
+      .replace(AS_UNKNOWN_AS, () => AS_UNKNOWN_PLACEHOLDER)
       .replace(
         MAPPED_TYPE_KEY_REMAP,
-        `$<mappedPrefix>${MAPPED_TYPE_REMAP_PLACEHOLDER}`,
+        (_match, mappedPrefix: string) =>
+          `${mappedPrefix}${MAPPED_TYPE_REMAP_PLACEHOLDER}`,
       );
     total += (scanned.match(AS_CAST) ?? []).length;
   }


### PR DESCRIPTION
## What

New custom oxlint rule `require-function-replacer` plus a repo-wide cleanup bringing violations to zero (34 → 0 across 18 files).

## Why

JavaScript interprets `$&`, `$$`, `` $` ``, `$'`, `$<name>` inside the replacement argument of `String.prototype.replace()`/`replaceAll()` even for plain-string searches, so passing a dynamic string silently corrupts output when the value contains such a sequence (the bug class fixed case-by-case in #1207). This rule makes the class structurally impossible: dynamic replacement values must go through a function replacer, which is immune.

## Rule design

Mirrors the existing `require-eden-error-check` plugin structure (scope-API identifier resolution, fixture-based tests, wired in `oxlint.config.ts` repo-wide). Second argument must be an inline function, a literal/no-substitution template (intentional `$` stays author-visible), or an identifier provably bound to a local function. Object-expression second args are skipped — that shape is Bun's `HTMLRewriter.replace(content, options)`, found live in `markdown/ai-tool.ts`, not a string replace. Limits (purely syntactic, no reassignment tracking) are documented in the rule.

## Notable finds in the cleanup

Four `docx-stamp.ts` splice sites that #1207's manual pass missed (including two mixing an intentional `$<sect>` backreference with a dynamic value in one replacement string — rewritten as match callbacks), the same mixed pattern in `scripts/ratchet.ts`, and mechanical `() =>` wraps across matter-reference token substitution, registry URL building, anonymization placeholder restoration, and template token rewriting.

## Tests

Fixture suite for every allow/deny branch (`scripts/lint-oxlint-fixtures.sh` clean); full-repo run of the rule confirms 0 remaining violations; scoped package tests across all touched code: 352 pass, 0 fail.