### PR TITLE
fix(business-registries): consistent ORSR temporal fallbacks; ignore malformed KRS bankruptcy entries

### DIFF
--- a/packages/business-registries/src/krs/parse.test.ts
+++ b/packages/business-registries/src/krs/parse.test.ts
@@ -284,6 +284,44 @@ describe("parseStatus", () => {
     ).toEqual({ type: "bankruptcy" });
   });
 
+  test("ignores malformed bankruptcy entries rather than flagging bankruptcy", () => {
+    // Null / non-record elements in `postepowanieUpadlosciowe` are
+    // structural garbage and must NOT be read as open proceedings.
+    expect(
+      parseStatus(
+        { postepowanieUpadlosciowe: [null, "not-a-record", 42] },
+        "ACME SP. Z O.O.",
+      ),
+    ).toEqual({ type: "active" });
+  });
+
+  test("a well-formed open proceeding still flags despite malformed siblings", () => {
+    // Malformed neighbours are skipped, but a genuine open bankruptcy
+    // entry alongside them still surfaces as `bankruptcy`.
+    expect(
+      parseStatus(
+        { postepowanieUpadlosciowe: [null, { data: "01.01.2026" }] },
+        "ACME SP. Z O.O.",
+      ),
+    ).toEqual({ type: "bankruptcy" });
+  });
+
+  test("a malformed entry beside a closed proceeding stays `active`", () => {
+    // The only well-formed entry is a closed proceeding; the malformed
+    // sibling must not tip the result to bankruptcy.
+    expect(
+      parseStatus(
+        {
+          postepowanieUpadlosciowe: [
+            null,
+            { opisZakonczeniaProcesuUpadlosci: { data: "01.02.2024" } },
+          ],
+        },
+        "ACME SP. Z O.O.",
+      ),
+    ).toEqual({ type: "active" });
+  });
+
   test("maps `wykreslenia` to `dissolved` even when other arrays are present", () => {
     expect(
       parseStatus(

--- a/packages/business-registries/src/krs/parse.ts
+++ b/packages/business-registries/src/krs/parse.ts
@@ -47,8 +47,13 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const hasRecordFields = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) && Object.keys(value).length > 0;
 
-const isOpenBankruptcyProceeding = (entry: unknown): boolean =>
-  !isRecord(entry) ||
+// A bankruptcy entry is OPEN when it carries no populated
+// `opisZakonczeniaProcesuUpadlosci` (bankruptcy-close description).
+// Callers must pre-filter to well-formed records via `isRecord`: a
+// non-record element is structural garbage, and treating it as an open
+// proceeding would flip a solvent company to `bankruptcy` on a single
+// malformed array element.
+const isOpenBankruptcyProceeding = (entry: Record<string, unknown>): boolean =>
   !hasRecordFields(entry["opisZakonczeniaProcesuUpadlosci"]);
 
 const isOpenCombinedProceeding = (
@@ -85,7 +90,13 @@ export const parseStatus = (
   if (hasEntries(dzial6?.wykreslenia)) {
     return { type: "dissolved" };
   }
-  if (dzial6?.postepowanieUpadlosciowe?.some(isOpenBankruptcyProceeding)) {
+  // Skip structurally malformed entries (null / non-record elements)
+  // before deciding whether any bankruptcy proceeding is still open, so
+  // a single garbage element cannot report a solvent company as bankrupt.
+  const bankruptcyProceedings = (dzial6?.postepowanieUpadlosciowe ?? []).filter(
+    isRecord,
+  );
+  if (bankruptcyProceedings.some(isOpenBankruptcyProceeding)) {
     return { type: "bankruptcy" };
   }
   const proceedings = (

--- a/packages/business-registries/src/orsr/parse.test.ts
+++ b/packages/business-registries/src/orsr/parse.test.ts
@@ -169,6 +169,63 @@ describe("parseExtract (ESET)", () => {
   });
 });
 
+describe("parseExtract live-entity temporal fallback", () => {
+  // A live entity whose temporal rows carry no `current: true` flag must
+  // resolve name, legal form / address / equity, and acting clause from
+  // the SAME array end. The upstream orders each array newest-first, so
+  // every picker must fall back to index 0. Appending an older (stale)
+  // row at the end and clearing every `current` flag proves all pickers
+  // read the newest (index-0) record rather than the trailing one.
+  test("all pickers fall back to the newest (index 0) record", async () => {
+    const raw = await readFixture<OrsrRawExtractResponse>("extract-eset.json");
+    const body = raw.legalPerson?.corporateBody;
+    if (!body) {
+      throw new Error("Expected corporate body in ORSR fixture");
+    }
+
+    const currentName = body.corporateBodyFullName?.at(0)?.value;
+    const currentClause = body.authorizationToExecute?.at(0)?.value;
+    const currentLegalFormName =
+      body.legalForm?.at(0)?.item?.codelistItem?.itemName;
+    expect(currentName).toBeTruthy();
+    expect(currentClause).toBeTruthy();
+    expect(currentLegalFormName).toBeTruthy();
+
+    // Keep the newest record at index 0, drop every `current` flag in
+    // place, then append an older row at the end so only the array-end
+    // convention decides which row each picker returns.
+    for (const row of body.corporateBodyFullName ?? []) {
+      row.current = false;
+    }
+    for (const row of body.authorizationToExecute ?? []) {
+      row.current = false;
+    }
+    for (const row of body.legalForm ?? []) {
+      row.current = false;
+    }
+    body.corporateBodyFullName?.push({
+      value: "STALE NAME s.r.o.",
+      current: false,
+    });
+    body.authorizationToExecute?.push({
+      value: "Stale acting clause",
+      current: false,
+    });
+    body.legalForm?.push({
+      item: { codelistItem: { itemName: "Stale legal form" } },
+      current: false,
+    });
+
+    const company = parseExtract(raw);
+    expect(company).not.toBeNull();
+    // Name (pickPrimaryName), legal form (pickActiveRecord), and acting
+    // clause (pickActingClause) all read index 0, not the trailing row.
+    expect(company?.name).toBe(currentName);
+    expect(company?.legalForm).toBe(currentLegalFormName);
+    expect(company?.actingClause).toBe(currentClause);
+  });
+});
+
 describe("parseExtract status branches", () => {
   test("surfaces termination as terminated status", async () => {
     const raw = await readFixture<OrsrRawExtractResponse>("extract-eset.json");

--- a/packages/business-registries/src/orsr/parse.ts
+++ b/packages/business-registries/src/orsr/parse.ts
@@ -92,6 +92,17 @@ const pickCurrent = <T extends OrsrRawTemporal>(
   return records.find((record) => record.current === true) ?? null;
 };
 
+// Single source of truth for "which array end is the latest record".
+// Every temporal array the upstream returns is ordered newest-first, so
+// index 0 is the most recent entry (the same convention the search client
+// uses when it sorts hits descending and takes `.at(0)`). Every temporal
+// picker funnels its fallback through here so name / legal form / address /
+// equity / acting clause can never resolve to opposite ends of the same
+// array.
+const pickLatestRaw = <T extends OrsrRawTemporal>(
+  raws: T[] | undefined,
+): T | null => raws?.at(0) ?? null;
+
 const unwrapCodelist = (
   wrapped: OrsrRawWrappedCodelist | undefined,
 ): OrsrRawCodelistItem | null => {
@@ -247,48 +258,28 @@ const normalizeName = (raw: string | null | undefined): string | null => {
   return collapsed.replaceAll(/^"|"$/gu, "");
 };
 
-const pickPrimaryName = (
-  raws: OrsrRawValueTemporal[] | undefined,
-  terminated: boolean,
-): string | null => {
-  if (!raws || raws.length === 0) {
-    return null;
-  }
-  // Terminated entities have no `current` record; use the latest
-  // historical name (the entry the registry kept on file).
-  const picked = terminated ? raws.at(0) : (pickCurrent(raws) ?? raws.at(0));
-  return normalizeName(picked?.value ?? null);
-};
-
-// Pick the in-force record for an entity. Terminated entities have
-// every history entry flipped to `current: false`, so the canonical
-// "current" pick falls through to the latest historical version
-// instead.
+// Pick the in-force record for an entity. Live entities use the row
+// flagged `current: true`; when none is flagged — terminated entities
+// have every `current` flag wiped, and some live entities never carry
+// one — fall back to the latest historical record. Both branches resolve
+// the latest end via the shared `pickLatestRaw` helper so every temporal
+// picker agrees on which end is newest.
 const pickActiveRecord = <T extends OrsrRawTemporal>(
   raws: T[] | undefined,
   terminated: boolean,
-): T | null => {
-  if (!raws || raws.length === 0) {
-    return null;
-  }
-  if (terminated) {
-    return raws.at(0) ?? null;
-  }
-  return pickCurrent(raws) ?? raws.at(-1) ?? null;
-};
+): T | null =>
+  terminated ? pickLatestRaw(raws) : (pickCurrent(raws) ?? pickLatestRaw(raws));
+
+const pickPrimaryName = (
+  raws: OrsrRawValueTemporal[] | undefined,
+  terminated: boolean,
+): string | null =>
+  normalizeName(pickActiveRecord(raws, terminated)?.value ?? null);
 
 const pickActingClause = (
   raws: OrsrRawValueTemporal[] | undefined,
   terminated: boolean,
-): string | null => {
-  if (!raws || raws.length === 0) {
-    return null;
-  }
-  if (terminated) {
-    return raws.at(0)?.value ?? null;
-  }
-  return pickCurrent(raws)?.value ?? null;
-};
+): string | null => pickActiveRecord(raws, terminated)?.value ?? null;
 
 const pickPersonName = (
   member: OrsrRawStatutoryBodyMember | OrsrRawStakeholderMember,


### PR DESCRIPTION
## Summary

Fixes three parsing bugs in `packages/business-registries` that could surface incorrect legal-registry data:

- **ORSR temporal pickers disagreed on which array end is latest.** For a live entity with no `current: true` row, `pickPrimaryName` fell back to `raws.at(0)` while `pickActiveRecord` used `raws.at(-1)`, so name vs legal-form/address/equity could be read from opposite ends of the same temporal array, presenting the oldest record as current. All pickers now route through a single `pickLatestRaw` helper (index 0 = newest, matching the search client's `pickLatestHit` convention), making the divergence class structurally impossible.
- **ORSR `pickActingClause` had no historical fallback**, unlike its sibling pickers; a live company whose rows are all `current: false` silently lost its acting clause. Now delegates to the same shared fallback.
- **KRS treated malformed bankruptcy entries as open proceedings.** A single `null`/garbage element in `postepowanieUpadlosciowe` flagged the company as bankrupt. `parseStatus` now filters to well-formed records before checking for open proceedings, so structural garbage is skipped instead of inverting the safe default.

## Tests

New cases covering the live-entity-no-current fallback for all three pickers and malformed-vs-well-formed bankruptcy entries. Package suite: 416 pass, 33 skip (SMOKE_TEST-gated), 0 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved business registry status detection so malformed bankruptcy records no longer cause incorrect bankruptcy statuses.
  * Preserved accurate bankruptcy status when valid records appear alongside invalid data.
  * Improved parsing of company names, legal forms and acting clauses when current temporal records are unavailable, using the latest available information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->