### PR TITLE
refactor(business-registries): shared fetch scaffold and guard helpers; fix DENUE zero handling

### DIFF
--- a/packages/business-registries/src/ares/client.ts
+++ b/packages/business-registries/src/ares/client.ts
@@ -140,11 +140,11 @@ const handleAresError = async (
   });
 };
 
-const readAresJson = <T>(
+const readAresJson = async <T>(
   response: Response,
   isExpectedShape: (value: unknown) => value is T,
 ): Promise<T> =>
-  readRegistryJson({
+  await readRegistryJson({
     response,
     isExpectedShape,
     wrapParseError: (cause) =>

--- a/packages/business-registries/src/ares/client.ts
+++ b/packages/business-registries/src/ares/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   AresAPIError,
@@ -22,7 +24,6 @@ const RES_URL = `${BASE}/ekonomicke-subjekty-res`;
 const VR_URL = `${BASE}/ekonomicke-subjekty-vr`;
 const SEARCH_URL = `${BASE}/ekonomicke-subjekty/vyhledat`;
 
-const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 50;
 // ARES documents `pocet` as a plain non-negative integer with no
 // published upper bound. Mirror the brreg/gcis/prh/orsr ceiling so a
@@ -32,9 +33,6 @@ const MAX_SEARCH_LIMIT = 100;
 // ---------------------------------------------------------------------------
 // Internal fetch helpers
 // ---------------------------------------------------------------------------
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isOptionalRecord = (value: unknown): boolean =>
   value === undefined || isRecord(value);
@@ -142,44 +140,36 @@ const handleAresError = async (
   });
 };
 
-const readAresJson = async <T>(
+const readAresJson = <T>(
   response: Response,
   isExpectedShape: (value: unknown) => value is T,
-): Promise<T> => {
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error) {
-    throw new AresAPIError({
-      message: "ARES returned a non-JSON response",
-      httpStatus: response.status,
-      cause: error,
-    });
-  }
-
-  if (!isExpectedShape(body)) {
-    throw new AresAPIError({
-      message: "ARES returned an unexpected response shape",
-      httpStatus: response.status,
-    });
-  }
-
-  return body;
-};
+): Promise<T> =>
+  readRegistryJson({
+    response,
+    isExpectedShape,
+    wrapParseError: (cause) =>
+      new AresAPIError({
+        message: "ARES returned a non-JSON response",
+        httpStatus: response.status,
+        cause,
+      }),
+    wrapShapeError: () =>
+      new AresAPIError({
+        message: "ARES returned an unexpected response shape",
+        httpStatus: response.status,
+      }),
+  });
 
 const aresGet = async <T>(
   url: string,
   isExpectedShape: (value: unknown) => value is T,
 ): Promise<T | null> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new AresRequestError(url, "ARES request failed", { cause: error });
-  }
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    wrapRequestError: (cause) =>
+      new AresRequestError(url, "ARES request failed", { cause }),
+  });
 
   if (response.status === 404) {
     let body: AresErrorResponse = {};
@@ -211,20 +201,19 @@ const aresPost = async <T>(
   payload: unknown,
   isExpectedShape: (value: unknown) => value is T,
 ): Promise<T> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
+  const response = await performRegistryRequest({
+    url,
+    init: {
       method: "POST",
-      signal: AbortSignal.timeout(TIMEOUT_MS),
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
       body: JSON.stringify(payload),
-    });
-  } catch (error) {
-    throw new AresRequestError(url, "ARES request failed", { cause: error });
-  }
+    },
+    wrapRequestError: (cause) =>
+      new AresRequestError(url, "ARES request failed", { cause }),
+  });
 
   if (!response.ok) {
     await handleAresError(response, url);

--- a/packages/business-registries/src/brreg/client.ts
+++ b/packages/business-registries/src/brreg/client.ts
@@ -92,11 +92,11 @@ const parseErrorBody = (value: unknown): BrregErrorResponse => {
   return result;
 };
 
-const brregGet = <T>(
+const brregGet = async <T>(
   url: string,
   isExpectedShape: (value: unknown) => value is T,
 ): Promise<T | null> =>
-  registryFetch({
+  await registryFetch({
     url,
     init: { headers: { Accept: "application/json" } },
     isExpectedShape,

--- a/packages/business-registries/src/brreg/client.ts
+++ b/packages/business-registries/src/brreg/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { registryFetch } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   BrregAPIError,
@@ -19,13 +21,9 @@ const BASE = "https://data.brreg.no/enhetsregisteret/api";
 const ENHETER_URL = `${BASE}/enheter`;
 const UNDERENHETER_URL = `${BASE}/underenheter`;
 
-const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 50;
 const MAX_SEARCH_LIMIT = 100;
 const BRREG_RESULT_CAP = 10_000;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isOptionalRecord = (value: unknown): boolean =>
   value === undefined || isRecord(value);
@@ -94,78 +92,58 @@ const parseErrorBody = (value: unknown): BrregErrorResponse => {
   return result;
 };
 
-const readBrregJson = async <T>(
-  response: Response,
-  isExpectedShape: (value: unknown) => value is T,
-): Promise<T> => {
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error) {
-    throw new BrregAPIError({
-      message: "Brreg returned a non-JSON response",
-      httpStatus: response.status,
-      cause: error,
-    });
-  }
-
-  if (!isExpectedShape(body)) {
-    throw new BrregAPIError({
-      message: "Brreg returned an unexpected response shape",
-      httpStatus: response.status,
-    });
-  }
-
-  return body;
-};
-
-const brregGet = async <T>(
+const brregGet = <T>(
   url: string,
   isExpectedShape: (value: unknown) => value is T,
-): Promise<T | null> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new BrregRequestError(url, "Brreg request failed", { cause: error });
-  }
+): Promise<T | null> =>
+  registryFetch({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    isExpectedShape,
+    wrapRequestError: (cause) =>
+      new BrregRequestError(url, "Brreg request failed", { cause }),
+    wrapParseError: (response, cause) =>
+      new BrregAPIError({
+        message: "Brreg returned a non-JSON response",
+        httpStatus: response.status,
+        cause,
+      }),
+    wrapShapeError: (response) =>
+      new BrregAPIError({
+        message: "Brreg returned an unexpected response shape",
+        httpStatus: response.status,
+      }),
+    onErrorResponse: async (response) => {
+      if (response.status === 404) {
+        return null;
+      }
 
-  if (response.status === 404) {
-    return null;
-  }
+      // 410 Gone — Brreg uses this for entities removed from disclosure
+      // (typically by court order or another legal requirement). The
+      // response body carries an error envelope, not an entity payload,
+      // so we surface "no result" rather than feeding the body through
+      // the entity parser.
+      //
+      // Struck-off / deleted entities — which still belong in the domain
+      // model — come back as `200 OK` with `slettedato` set; the parser
+      // handles those via BrregEntityStatus's "deleted" arm.
+      if (response.status === 410) {
+        return null;
+      }
 
-  // 410 Gone — Brreg uses this for entities removed from disclosure
-  // (typically by court order or another legal requirement). The
-  // response body carries an error envelope, not an entity payload,
-  // so we surface "no result" rather than feeding the body through
-  // the entity parser.
-  //
-  // Struck-off / deleted entities — which still belong in the domain
-  // model — come back as `200 OK` with `slettedato` set; the parser
-  // handles those via BrregEntityStatus's "deleted" arm.
-  if (response.status === 410) {
-    return null;
-  }
-
-  if (!response.ok) {
-    let body: BrregErrorResponse = {};
-    try {
-      body = parseErrorBody(await response.json());
-    } catch {
-      // non-JSON error body
-    }
-    throw new BrregAPIError({
-      message: `Brreg ${response.status}: ${body.feilmelding ?? response.statusText}`,
-      httpStatus: response.status,
-      upstreamMessage: body.feilmelding ?? null,
-    });
-  }
-
-  return readBrregJson(response, isExpectedShape);
-};
+      let body: BrregErrorResponse = {};
+      try {
+        body = parseErrorBody(await response.json());
+      } catch {
+        // non-JSON error body
+      }
+      throw new BrregAPIError({
+        message: `Brreg ${response.status}: ${body.feilmelding ?? response.statusText}`,
+        httpStatus: response.status,
+        upstreamMessage: body.feilmelding ?? null,
+      });
+    },
+  });
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/business-registries/src/brreg/roles.ts
+++ b/packages/business-registries/src/brreg/roles.ts
@@ -283,8 +283,10 @@ const parseUpstreamMessage = (value: unknown): string | null => {
   return null;
 };
 
-const brregGetRoles = (url: string): Promise<BrregRawRolesResponse | null> =>
-  registryFetch({
+const brregGetRoles = async (
+  url: string,
+): Promise<BrregRawRolesResponse | null> =>
+  await registryFetch({
     url,
     init: { headers: { Accept: "application/json" } },
     isExpectedShape: isRawRolesResponse,

--- a/packages/business-registries/src/brreg/roles.ts
+++ b/packages/business-registries/src/brreg/roles.ts
@@ -15,6 +15,8 @@
 // (`fratraadt` / `avregistrert`) instead of dropping them, and keep
 // the role group's `sistEndret` as the change date.
 
+import { isRecord } from "../shared/guards.js";
+import { registryFetch } from "../shared/http.js";
 import {
   BrregAPIError,
   BrregRequestError,
@@ -23,7 +25,6 @@ import {
 import { normalizeOrgnr, validateOrgnr } from "./validation.js";
 
 const BASE = "https://data.brreg.no/enhetsregisteret/api";
-const TIMEOUT_MS = 10_000;
 const MIN_BIRTH_YEAR = 1900;
 
 // ---------------------------------------------------------------------------
@@ -227,9 +228,6 @@ export const parseRolesResponse = (
 // HTTP client
 // ---------------------------------------------------------------------------
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const isRawRoleType = (value: unknown): value is BrregRawRoleType =>
   isRecord(value) && typeof value["kode"] === "string";
 
@@ -285,68 +283,51 @@ const parseUpstreamMessage = (value: unknown): string | null => {
   return null;
 };
 
-const brregGetRoles = async (
-  url: string,
-): Promise<BrregRawRolesResponse | null> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new BrregRequestError(url, "Brreg roles request failed", {
-      cause: error,
-    });
-  }
-
-  if (response.status === 404 || response.status === 410) {
-    return null;
-  }
-
-  if (!response.ok) {
-    let upstreamMessage: string | null = null;
-    // Brreg's error envelope is JSON, but upstream proxies
-    // (Cloudflare / nginx) can intercept and return HTML error pages
-    // — feeding those to `response.json()` throws a SyntaxError that
-    // would mask the real status. Guard on Content-Type. The
-    // statusText fallback covers HTTP/2 (where it is typically empty).
-    if (response.headers.get("content-type")?.includes("application/json")) {
-      try {
-        upstreamMessage = parseUpstreamMessage(await response.json());
-      } catch {
-        // non-JSON body despite the header — ignore
-      }
-    }
-    throw new BrregAPIError({
-      message: `Brreg ${response.status}: ${upstreamMessage ?? (response.statusText || "API error")}`,
-      httpStatus: response.status,
-      upstreamMessage,
-    });
-  }
-
-  try {
-    const body: unknown = await response.json();
-    if (!isRawRolesResponse(body)) {
-      throw new BrregAPIError({
+const brregGetRoles = (url: string): Promise<BrregRawRolesResponse | null> =>
+  registryFetch({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    isExpectedShape: isRawRolesResponse,
+    wrapRequestError: (cause) =>
+      new BrregRequestError(url, "Brreg roles request failed", { cause }),
+    wrapParseError: (response, cause) =>
+      new BrregAPIError({
+        message: `Brreg ${response.status}: invalid JSON payload`,
+        httpStatus: response.status,
+        upstreamMessage: null,
+        cause,
+      }),
+    wrapShapeError: (response) =>
+      new BrregAPIError({
         message: `Brreg ${response.status}: unexpected roles payload shape`,
         httpStatus: response.status,
         upstreamMessage: null,
+      }),
+    onErrorResponse: async (response) => {
+      if (response.status === 404 || response.status === 410) {
+        return null;
+      }
+
+      let upstreamMessage: string | null = null;
+      // Brreg's error envelope is JSON, but upstream proxies
+      // (Cloudflare / nginx) can intercept and return HTML error pages
+      // — feeding those to `response.json()` throws a SyntaxError that
+      // would mask the real status. Guard on Content-Type. The
+      // statusText fallback covers HTTP/2 (where it is typically empty).
+      if (response.headers.get("content-type")?.includes("application/json")) {
+        try {
+          upstreamMessage = parseUpstreamMessage(await response.json());
+        } catch {
+          // non-JSON body despite the header — ignore
+        }
+      }
+      throw new BrregAPIError({
+        message: `Brreg ${response.status}: ${upstreamMessage ?? (response.statusText || "API error")}`,
+        httpStatus: response.status,
+        upstreamMessage,
       });
-    }
-    return body;
-  } catch (error) {
-    if (error instanceof BrregAPIError) {
-      throw error;
-    }
-    throw new BrregAPIError({
-      message: `Brreg ${response.status}: invalid JSON payload`,
-      httpStatus: response.status,
-      upstreamMessage: null,
-      cause: error,
-    });
-  }
-};
+    },
+  });
 
 /**
  * Look up the officer roster for a Norwegian entity by orgnr.

--- a/packages/business-registries/src/companies-house/client.ts
+++ b/packages/business-registries/src/companies-house/client.ts
@@ -159,12 +159,12 @@ const readUpstreamMessage = async (
   }
 };
 
-const companiesHouseGet = <T>(
+const companiesHouseGet = async <T>(
   url: string,
   apiKey: string,
   isExpectedShape: (value: unknown) => value is T,
 ): Promise<T | null> =>
-  registryFetch({
+  await registryFetch({
     url,
     init: {
       headers: {

--- a/packages/business-registries/src/companies-house/client.ts
+++ b/packages/business-registries/src/companies-house/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { registryFetch } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   CompaniesHouseAPIError,
@@ -21,7 +23,6 @@ import type {
 import { normalizeCompanyNumber, validateCompanyNumber } from "./validation.js";
 
 const COMPANIES_HOUSE_BASE = "https://api.company-information.service.gov.uk";
-const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 20;
 // Companies House caps each /search/companies page at 100; requesting
 // more returns 400. Clamp to keep the adapter useful even when callers
@@ -60,9 +61,6 @@ const buildAuthHeader = (apiKey: string): string => {
   const token = btoa(`${apiKey}:`);
   return `Basic ${token}`;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isOptionalRecord = (value: unknown): boolean =>
   value === undefined || isRecord(value);
@@ -161,68 +159,57 @@ const readUpstreamMessage = async (
   }
 };
 
-const companiesHouseGet = async <T>(
+const companiesHouseGet = <T>(
   url: string,
   apiKey: string,
   isExpectedShape: (value: unknown) => value is T,
-): Promise<T | null> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
+): Promise<T | null> =>
+  registryFetch({
+    url,
+    init: {
       headers: {
         Authorization: buildAuthHeader(apiKey),
         Accept: "application/json",
       },
-    });
-  } catch (error) {
-    throw new CompaniesHouseRequestError(
-      url,
-      "Companies House request failed",
-      { cause: error },
-    );
-  }
+    },
+    isExpectedShape,
+    wrapRequestError: (cause) =>
+      new CompaniesHouseRequestError(url, "Companies House request failed", {
+        cause,
+      }),
+    wrapParseError: (response, cause) =>
+      new CompaniesHouseAPIError({
+        message: "Companies House returned a non-JSON response",
+        httpStatus: response.status,
+        cause,
+      }),
+    wrapShapeError: (response) =>
+      new CompaniesHouseAPIError({
+        message: "Companies House returned an unexpected response shape",
+        httpStatus: response.status,
+      }),
+    onErrorResponse: async (response) => {
+      if (response.status === 404) {
+        return null;
+      }
 
-  if (response.status === 404) {
-    return null;
-  }
+      if (response.status === 401 || response.status === 403) {
+        const upstreamMessage = await readUpstreamMessage(response);
+        throw new CompaniesHouseAuthError(
+          `Companies House rejected the API key (${response.status}). Verify COMPANIES_HOUSE_API_KEY is set to a live key from https://developer.company-information.service.gov.uk.${
+            upstreamMessage ? ` Upstream: ${upstreamMessage}` : ""
+          }`,
+        );
+      }
 
-  if (response.status === 401 || response.status === 403) {
-    const upstreamMessage = await readUpstreamMessage(response);
-    throw new CompaniesHouseAuthError(
-      `Companies House rejected the API key (${response.status}). Verify COMPANIES_HOUSE_API_KEY is set to a live key from https://developer.company-information.service.gov.uk.${
-        upstreamMessage ? ` Upstream: ${upstreamMessage}` : ""
-      }`,
-    );
-  }
-
-  if (!response.ok) {
-    const upstreamMessage = await readUpstreamMessage(response);
-    throw new CompaniesHouseAPIError({
-      message: `Companies House ${response.status}: ${upstreamMessage ?? response.statusText}`,
-      httpStatus: response.status,
-      upstreamMessage,
-    });
-  }
-
-  let json: unknown;
-  try {
-    json = await response.json();
-  } catch (error) {
-    throw new CompaniesHouseAPIError({
-      message: "Companies House returned a non-JSON response",
-      httpStatus: response.status,
-      cause: error,
-    });
-  }
-  if (!isExpectedShape(json)) {
-    throw new CompaniesHouseAPIError({
-      message: "Companies House returned an unexpected response shape",
-      httpStatus: response.status,
-    });
-  }
-  return json;
-};
+      const upstreamMessage = await readUpstreamMessage(response);
+      throw new CompaniesHouseAPIError({
+        message: `Companies House ${response.status}: ${upstreamMessage ?? response.statusText}`,
+        httpStatus: response.status,
+        upstreamMessage,
+      });
+    },
+  });
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/business-registries/src/companies-house/parse.ts
+++ b/packages/business-registries/src/companies-house/parse.ts
@@ -1,3 +1,4 @@
+import { trimToNull } from "../shared/strings.js";
 import type {
   CompaniesHouseAccounts,
   CompaniesHouseAddress,
@@ -21,14 +22,6 @@ import type {
 const COMPANIES_HOUSE_PROFILE_URL =
   "https://find-and-update.company-information.service.gov.uk/company/";
 
-const nonEmpty = (value: string | null | undefined): string | null => {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
 const parseIntOrNull = (
   value: string | number | null | undefined,
 ): number | null => {
@@ -49,15 +42,15 @@ const parseIntOrNull = (
 export const parseAddress = (
   raw: CompaniesHouseRawAddress,
 ): CompaniesHouseAddress => {
-  const premises = nonEmpty(raw.premises);
-  const addressLine1 = nonEmpty(raw.address_line_1);
-  const addressLine2 = nonEmpty(raw.address_line_2);
-  const locality = nonEmpty(raw.locality);
-  const region = nonEmpty(raw.region);
-  const postalCode = nonEmpty(raw.postal_code);
-  const country = nonEmpty(raw.country);
-  const poBox = nonEmpty(raw.po_box);
-  const careOf = nonEmpty(raw.care_of);
+  const premises = trimToNull(raw.premises);
+  const addressLine1 = trimToNull(raw.address_line_1);
+  const addressLine2 = trimToNull(raw.address_line_2);
+  const locality = trimToNull(raw.locality);
+  const region = trimToNull(raw.region);
+  const postalCode = trimToNull(raw.postal_code);
+  const country = trimToNull(raw.country);
+  const poBox = trimToNull(raw.po_box);
+  const careOf = trimToNull(raw.care_of);
 
   // Compose a single-line address in UK postal order:
   //   care_of, po_box, premises + address_line_1, address_line_2,
@@ -100,7 +93,7 @@ const parseStatus = (
 ): CompaniesHouseEntityStatus => {
   // company_status is documented but optional on the wire; treat
   // missing as "unknown" rather than guessing from related fields.
-  const code = nonEmpty(raw.company_status);
+  const code = trimToNull(raw.company_status);
   if (!code) {
     return { type: "unknown" };
   }
@@ -111,7 +104,7 @@ const parseStatus = (
     case "dissolved": {
       return {
         type: "dissolved",
-        dissolvedAt: nonEmpty(raw.date_of_cessation),
+        dissolvedAt: trimToNull(raw.date_of_cessation),
       };
     }
     case "liquidation": {
@@ -132,7 +125,7 @@ const parseStatus = (
     case "converted-closed": {
       return {
         type: "converted-closed",
-        closedAt: nonEmpty(raw.date_of_cessation),
+        closedAt: trimToNull(raw.date_of_cessation),
       };
     }
     case "open": {
@@ -165,14 +158,16 @@ const parseAccounts = (
   // deprecated aliases would otherwise surface as `null` — try the
   // current field first and fall back to the deprecated one.
   const lastMadeUpTo =
-    nonEmpty(raw.last_accounts?.period_end_on) ??
-    nonEmpty(raw.last_accounts?.made_up_to);
+    trimToNull(raw.last_accounts?.period_end_on) ??
+    trimToNull(raw.last_accounts?.made_up_to);
   const nextMadeUpTo =
-    nonEmpty(raw.next_accounts?.period_end_on) ?? nonEmpty(raw.next_made_up_to);
+    trimToNull(raw.next_accounts?.period_end_on) ??
+    trimToNull(raw.next_made_up_to);
   // Same deprecation: `accounts.next_due` and `accounts.overdue` are
   // legacy aliases of `next_accounts.due_on` and `next_accounts.overdue`.
   // Read the current field first.
-  const nextDue = nonEmpty(raw.next_accounts?.due_on) ?? nonEmpty(raw.next_due);
+  const nextDue =
+    trimToNull(raw.next_accounts?.due_on) ?? trimToNull(raw.next_due);
   const overdue = raw.next_accounts?.overdue ?? raw.overdue ?? false;
   if (
     lastMadeUpTo === null &&
@@ -192,9 +187,9 @@ const parseConfirmationStatement = (
     return null;
   }
   return {
-    lastMadeUpTo: nonEmpty(raw.last_made_up_to),
-    nextMadeUpTo: nonEmpty(raw.next_made_up_to),
-    nextDue: nonEmpty(raw.next_due),
+    lastMadeUpTo: trimToNull(raw.last_made_up_to),
+    nextMadeUpTo: trimToNull(raw.next_made_up_to),
+    nextDue: trimToNull(raw.next_due),
     overdue: raw.overdue ?? false,
   };
 };
@@ -203,8 +198,8 @@ const parsePreviousName = (
   raw: CompaniesHouseRawPreviousName,
 ): CompaniesHousePreviousName => ({
   name: raw.name,
-  effectiveFrom: nonEmpty(raw.effective_from),
-  ceasedOn: nonEmpty(raw.ceased_on),
+  effectiveFrom: trimToNull(raw.effective_from),
+  ceasedOn: trimToNull(raw.ceased_on),
 });
 
 const profileUrl = (companyNumber: string): string =>
@@ -216,12 +211,12 @@ export const parseCompanyProfile = (
   companyNumber: raw.company_number,
   name: raw.company_name,
   status: parseStatus(raw),
-  statusDetail: nonEmpty(raw.company_status_detail),
-  type: nonEmpty(raw.type),
-  subtype: nonEmpty(raw.subtype),
-  jurisdiction: nonEmpty(raw.jurisdiction),
-  dateOfCreation: nonEmpty(raw.date_of_creation),
-  dateOfCessation: nonEmpty(raw.date_of_cessation),
+  statusDetail: trimToNull(raw.company_status_detail),
+  type: trimToNull(raw.type),
+  subtype: trimToNull(raw.subtype),
+  jurisdiction: trimToNull(raw.jurisdiction),
+  dateOfCreation: trimToNull(raw.date_of_creation),
+  dateOfCessation: trimToNull(raw.date_of_cessation),
   registeredOfficeAddress: raw.registered_office_address
     ? parseAddress(raw.registered_office_address)
     : null,
@@ -267,14 +262,14 @@ export const parseSearchItem = (
   companyNumber: raw.company_number,
   name: raw.title,
   status: parseSearchStatus(raw),
-  type: nonEmpty(raw.company_type),
-  dateOfCreation: nonEmpty(raw.date_of_creation),
-  dateOfCessation: nonEmpty(raw.date_of_cessation),
+  type: trimToNull(raw.company_type),
+  dateOfCreation: trimToNull(raw.date_of_creation),
+  dateOfCessation: trimToNull(raw.date_of_cessation),
   // Prefer the upstream-formatted snippet; fall back to composing one
   // from the structured `address` block when present. Search rows
   // routinely set only `address_snippet`.
   address:
-    nonEmpty(raw.address_snippet) ??
+    trimToNull(raw.address_snippet) ??
     (raw.address ? parseAddress(raw.address).textAddress : null),
   registryUrl: profileUrl(raw.company_number),
 });
@@ -322,17 +317,17 @@ export const parseOfficer = (
       // null here rather than echoing the raw code as a title.
       title: null,
     },
-    appointedOn: nonEmpty(raw.appointed_on),
+    appointedOn: trimToNull(raw.appointed_on),
     // Pre-1992 officers carry their appointment as a bound date rather
     // than an exact day (`is_pre_1992_appointment: true`). Surfacing
     // `appointedOn` as null without `appointedBefore` would falsely
     // imply Companies House had no appointment data on file.
-    appointedBefore: nonEmpty(raw.appointed_before),
-    resignedOn: nonEmpty(raw.resigned_on),
-    isResigned: Boolean(nonEmpty(raw.resigned_on)),
-    occupation: nonEmpty(raw.occupation),
-    nationality: nonEmpty(raw.nationality),
-    countryOfResidence: nonEmpty(raw.country_of_residence),
+    appointedBefore: trimToNull(raw.appointed_before),
+    resignedOn: trimToNull(raw.resigned_on),
+    isResigned: Boolean(trimToNull(raw.resigned_on)),
+    occupation: trimToNull(raw.occupation),
+    nationality: trimToNull(raw.nationality),
+    countryOfResidence: trimToNull(raw.country_of_residence),
     // Corporate / managing officers for registered-overseas entities
     // ship their location as `principal_office_address` instead of
     // the usual correspondence `address` — both are documented and
@@ -341,11 +336,11 @@ export const parseOfficer = (
     dateOfBirth,
     identification: ident
       ? {
-          type: nonEmpty(ident.identification_type),
-          legalAuthority: nonEmpty(ident.legal_authority),
-          legalForm: nonEmpty(ident.legal_form),
-          placeRegistered: nonEmpty(ident.place_registered),
-          registrationNumber: nonEmpty(ident.registration_number),
+          type: trimToNull(ident.identification_type),
+          legalAuthority: trimToNull(ident.legal_authority),
+          legalForm: trimToNull(ident.legal_form),
+          placeRegistered: trimToNull(ident.place_registered),
+          registrationNumber: trimToNull(ident.registration_number),
         }
       : null,
   };

--- a/packages/business-registries/src/denue/client.ts
+++ b/packages/business-registries/src/denue/client.ts
@@ -1,3 +1,4 @@
+import { performRegistryRequest } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   DenueAPIError,
@@ -81,18 +82,17 @@ const denueGet = async (
   url: string,
   options: DenueClientOptions,
 ): Promise<DenueResponse> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(options.timeoutMs ?? TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch {
-    throw new DenueRequestError(
-      redactToken(url, options),
-      "DENUE request failed",
-    );
-  }
+  // DENUE returns text bodies (empty = no match, a plain-string array
+  // for error envelopes even on 200) and needs the API token redacted
+  // out of every error, so the body is decoded as text below; only the
+  // request + timeout + RequestError wrapping is shared.
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    timeoutMs: options.timeoutMs ?? TIMEOUT_MS,
+    wrapRequestError: () =>
+      new DenueRequestError(redactToken(url, options), "DENUE request failed"),
+  });
 
   if (response.status === 401 || response.status === 403) {
     throw new DenueAuthError(

--- a/packages/business-registries/src/denue/parse.test.ts
+++ b/packages/business-registries/src/denue/parse.test.ts
@@ -74,6 +74,22 @@ describe("parseEstablishment", () => {
     expect(establishment.address).toBeNull();
   });
 
+  test("preserves a literal '0' exterior/local number", () => {
+    // A house or local number of "0" is a real address atom; only the
+    // postal code treats "0" as an absent-value sentinel.
+    const establishment = parseEstablishment({
+      Id: "34185",
+      Nombre: "TIENDA CENTRO",
+      Tipo_vialidad: "CALLE",
+      Calle: "HIDALGO",
+      Num_Exterior: "0",
+      NumLocal: "0",
+    });
+
+    expect(establishment.address?.line1).toBe("CALLE HIDALGO 0");
+    expect(establishment.unitNumber).toBe("0");
+  });
+
   test("parses two-part location as municipality and state", () => {
     const establishment = parseEstablishment({
       Id: "34185",

--- a/packages/business-registries/src/denue/parse.test.ts
+++ b/packages/business-registries/src/denue/parse.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, test } from "bun:test";
 import { parseEstablishment, parseSearchEntry } from "./parse.js";
 import type { DenueRawEstablishment } from "./types.js";
 
+const FIXTURE_DIR = new URL("__fixtures__/", import.meta.url);
+const readFixture = async (name: string): Promise<DenueRawEstablishment[]> => {
+  const value: unknown = await Bun.file(new URL(name, FIXTURE_DIR)).json();
+  // SAFETY: fixtures are committed JSON payloads shaped like DENUE search
+  // responses.
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return value as DenueRawEstablishment[];
+};
+
 const raw: DenueRawEstablishment = {
   CLEE: "09015721110000111001000000U1",
   Id: "6281106",
@@ -74,20 +83,41 @@ describe("parseEstablishment", () => {
     expect(establishment.address).toBeNull();
   });
 
-  test("preserves a literal '0' exterior/local number", () => {
-    // A house or local number of "0" is a real address atom; only the
-    // postal code treats "0" as an absent-value sentinel.
+  test("treats a '0' exterior/interior/local number as absent", () => {
+    // DENUE uses "0" as an absent-value sentinel for Num_Exterior,
+    // Num_Interior, and NumLocal, the same way it does for the postal
+    // code (see __fixtures__/search-marriott.json, where the MARRIOTT
+    // GUADALAJARA record has Num_Interior: "0" for an establishment with
+    // no interior unit).
     const establishment = parseEstablishment({
       Id: "34185",
       Nombre: "TIENDA CENTRO",
       Tipo_vialidad: "CALLE",
       Calle: "HIDALGO",
       Num_Exterior: "0",
+      Num_Interior: "0",
       NumLocal: "0",
     });
 
-    expect(establishment.address?.line1).toBe("CALLE HIDALGO 0");
-    expect(establishment.unitNumber).toBe("0");
+    expect(establishment.address?.line1).toBe("CALLE HIDALGO");
+    expect(establishment.address?.line2).toBeNull();
+    expect(establishment.unitNumber).toBeNull();
+  });
+
+  test("preserves a literal '0' in non-sentinel text fields", () => {
+    // The zero-sentinel handling is scoped to the four numeric address
+    // atoms; every other field keeps plain trimToNull semantics, where a
+    // literal "0" is a legitimate value.
+    const establishment = parseEstablishment({
+      Id: "34185",
+      Nombre: "0",
+      Razon_social: "0",
+      Estrato: "0",
+    });
+
+    expect(establishment.name).toBe("0");
+    expect(establishment.legalName).toBe("0");
+    expect(establishment.employeeStratum).toBe("0");
   });
 
   test("parses two-part location as municipality and state", () => {
@@ -142,5 +172,27 @@ describe("parseSearchEntry", () => {
       registryUrl:
         "https://www.inegi.org.mx/app/mapa/denue/default.aspx?idee=6281106",
     });
+  });
+});
+
+describe("zero-sentinel fixture guard", () => {
+  test("does not leak a zero-sentinel interior number from real DENUE data", async () => {
+    // CLASS GUARD: search-marriott.json's MARRIOTT GUADALAJARA record has
+    // Num_Interior: "0" for an establishment with no interior unit. This
+    // asserts against the fixture directly (not a synthetic example) so a
+    // future tolerance regression on the sentinel fields is caught by real
+    // upstream data.
+    const [, guadalajara] = await readFixture("search-marriott.json");
+    if (!guadalajara) {
+      throw new Error("expected the Guadalajara fixture record");
+    }
+    expect(guadalajara.Num_Interior).toBe("0");
+
+    const establishment = parseEstablishment(guadalajara);
+    const searchEntry = parseSearchEntry(guadalajara);
+
+    expect(establishment.address?.line2).not.toContain("Int. 0");
+    expect(establishment.address?.textAddress).not.toContain("Int. 0");
+    expect(searchEntry.address).not.toContain("Int. 0");
   });
 });

--- a/packages/business-registries/src/denue/parse.ts
+++ b/packages/business-registries/src/denue/parse.ts
@@ -1,3 +1,4 @@
+import { trimToNull } from "../shared/strings.js";
 import type {
   DenueAddress,
   DenueCoordinates,
@@ -9,12 +10,15 @@ import type {
 const DENUE_WEB_BASE = "https://www.inegi.org.mx/app/mapa/denue/default.aspx";
 const MEXICO_COUNTRY = "MX" as const;
 
-const emptyToNull = (input: string | undefined): string | null => {
-  const trimmed = input?.trim();
-  if (!trimmed || trimmed === "0") {
-    return null;
-  }
-  return trimmed;
+// DENUE emits "0" as an absent-value sentinel for the postal code (there
+// is no CP 00000), so we collapse it to null. This is deliberately NOT
+// applied to the general string fields: a blanket `=== "0"` rule used to
+// discard legitimate "0" address atoms (a house or local number can be
+// "0"). Every other field uses plain `trimToNull`, matching the GCIS
+// adapter and the shared helper.
+const postalCodeToNull = (input: string | undefined): string | null => {
+  const trimmed = trimToNull(input);
+  return trimmed === "0" ? null : trimmed;
 };
 
 const numberOrNull = (input: string | undefined): number | null => {
@@ -39,7 +43,7 @@ type ParseLocationResult = {
 const parseLocation = (
   rawLocation: string | undefined,
 ): ParseLocationResult => {
-  const text = emptyToNull(rawLocation);
+  const text = trimToNull(rawLocation);
   if (!text) {
     return {
       locality: null,
@@ -66,12 +70,12 @@ const parseCoordinates = (raw: DenueRawEstablishment): DenueCoordinates => ({
 });
 
 const parseAddress = (raw: DenueRawEstablishment): DenueAddress | null => {
-  const streetType = emptyToNull(raw.Tipo_vialidad);
-  const street = emptyToNull(raw.Calle);
-  const exterior = emptyToNull(raw.Num_Exterior);
-  const interior = emptyToNull(raw.Num_Interior);
-  const neighborhood = emptyToNull(raw.Colonia);
-  const postalCode = emptyToNull(raw.CP);
+  const streetType = trimToNull(raw.Tipo_vialidad);
+  const street = trimToNull(raw.Calle);
+  const exterior = trimToNull(raw.Num_Exterior);
+  const interior = trimToNull(raw.Num_Interior);
+  const neighborhood = trimToNull(raw.Colonia);
+  const postalCode = postalCodeToNull(raw.CP);
   const location = parseLocation(raw.Ubicacion);
 
   const line1 = [streetType, street, exterior].filter(Boolean).join(" ");
@@ -108,20 +112,20 @@ export const parseEstablishment = (
   const id = raw.Id;
   return {
     id,
-    clee: emptyToNull(raw.CLEE),
-    name: emptyToNull(raw.Nombre) ?? id,
-    legalName: emptyToNull(raw.Razon_social),
-    activityClass: emptyToNull(raw.Clase_actividad),
-    employeeStratum: emptyToNull(raw.Estrato),
-    unitType: emptyToNull(raw.Tipo),
+    clee: trimToNull(raw.CLEE),
+    name: trimToNull(raw.Nombre) ?? id,
+    legalName: trimToNull(raw.Razon_social),
+    activityClass: trimToNull(raw.Clase_actividad),
+    employeeStratum: trimToNull(raw.Estrato),
+    unitType: trimToNull(raw.Tipo),
     address: parseAddress(raw),
     coordinates: parseCoordinates(raw),
-    phone: emptyToNull(raw.Telefono),
-    email: emptyToNull(raw.Correo_e),
-    website: emptyToNull(raw.Sitio_internet),
-    shoppingCenter: emptyToNull(raw.CentroComercial),
-    shoppingCenterType: emptyToNull(raw.TipoCentroComercial),
-    unitNumber: emptyToNull(raw.NumLocal),
+    phone: trimToNull(raw.Telefono),
+    email: trimToNull(raw.Correo_e),
+    website: trimToNull(raw.Sitio_internet),
+    shoppingCenter: trimToNull(raw.CentroComercial),
+    shoppingCenterType: trimToNull(raw.TipoCentroComercial),
+    unitNumber: trimToNull(raw.NumLocal),
     registryUrl: buildRegistryUrl(id),
   };
 };

--- a/packages/business-registries/src/denue/parse.ts
+++ b/packages/business-registries/src/denue/parse.ts
@@ -10,13 +10,15 @@ import type {
 const DENUE_WEB_BASE = "https://www.inegi.org.mx/app/mapa/denue/default.aspx";
 const MEXICO_COUNTRY = "MX" as const;
 
-// DENUE emits "0" as an absent-value sentinel for the postal code (there
-// is no CP 00000), so we collapse it to null. This is deliberately NOT
-// applied to the general string fields: a blanket `=== "0"` rule used to
-// discard legitimate "0" address atoms (a house or local number can be
-// "0"). Every other field uses plain `trimToNull`, matching the GCIS
-// adapter and the shared helper.
-const postalCodeToNull = (input: string | undefined): string | null => {
+// DENUE emits "0" as an absent-value sentinel for the numeric address
+// atoms (Num_Exterior, Num_Interior, NumLocal) and the postal code, not a
+// real value: the committed fixture __fixtures__/search-marriott.json has
+// a MARRIOTT GUADALAJARA record with Num_Interior: "0" and no interior
+// unit in reality, which used to render as "Int. 0" in the formatted
+// address. This is deliberately NOT applied to the general string fields
+// (names, denominations, streets, etc.), which use plain `trimToNull` and
+// let a literal "0" survive.
+const zeroSentinelToNull = (input: string | undefined): string | null => {
   const trimmed = trimToNull(input);
   return trimmed === "0" ? null : trimmed;
 };
@@ -72,10 +74,10 @@ const parseCoordinates = (raw: DenueRawEstablishment): DenueCoordinates => ({
 const parseAddress = (raw: DenueRawEstablishment): DenueAddress | null => {
   const streetType = trimToNull(raw.Tipo_vialidad);
   const street = trimToNull(raw.Calle);
-  const exterior = trimToNull(raw.Num_Exterior);
-  const interior = trimToNull(raw.Num_Interior);
+  const exterior = zeroSentinelToNull(raw.Num_Exterior);
+  const interior = zeroSentinelToNull(raw.Num_Interior);
   const neighborhood = trimToNull(raw.Colonia);
-  const postalCode = postalCodeToNull(raw.CP);
+  const postalCode = zeroSentinelToNull(raw.CP);
   const location = parseLocation(raw.Ubicacion);
 
   const line1 = [streetType, street, exterior].filter(Boolean).join(" ");
@@ -125,7 +127,7 @@ export const parseEstablishment = (
     website: trimToNull(raw.Sitio_internet),
     shoppingCenter: trimToNull(raw.CentroComercial),
     shoppingCenterType: trimToNull(raw.TipoCentroComercial),
-    unitNumber: trimToNull(raw.NumLocal),
+    unitNumber: zeroSentinelToNull(raw.NumLocal),
     registryUrl: buildRegistryUrl(id),
   };
 };

--- a/packages/business-registries/src/denue/validation.test.ts
+++ b/packages/business-registries/src/denue/validation.test.ts
@@ -36,6 +36,11 @@ describe("state code validation", () => {
     expect(validateStateCode("32")).toBe(true);
   });
 
+  test("accepts the national sentinel via its one-digit form", () => {
+    // "0" normalizes to "00" (national); it is valid but is not a state.
+    expect(validateStateCode("0")).toBe(true);
+  });
+
   test("rejects out-of-range state codes", () => {
     expect(validateStateCode("33")).toBe(false);
     expect(validateStateCode("99")).toBe(false);

--- a/packages/business-registries/src/denue/validation.ts
+++ b/packages/business-registries/src/denue/validation.ts
@@ -7,11 +7,24 @@ export const validateEstablishmentId = (input: string): boolean =>
 export const normalizeStateCode = (input: string): string =>
   input.trim().padStart(2, "0");
 
+// INEGI's federal-entity codes run 01-32 (the 31 states plus Ciudad de
+// México). "00" is DENUE's explicit national/all-states sentinel used by
+// the search endpoint; it is valid but is not itself a state.
+const NATIONAL_STATE_CODE = "00";
+const MIN_STATE_CODE = 1;
+const MAX_STATE_CODE = 32;
+
 export const validateStateCode = (input: string): boolean => {
   const normalized = normalizeStateCode(input);
   if (!/^\d{2}$/u.test(normalized)) {
     return false;
   }
+  if (normalized === NATIONAL_STATE_CODE) {
+    return true;
+  }
+  // Real state codes are 01-32; the previous `value >= 0` lower bound
+  // was a no-op for two-digit input (it accepted anything up to 32,
+  // including bogus non-national low codes) and did not express intent.
   const value = Number(normalized);
-  return value >= 0 && value <= 32;
+  return value >= MIN_STATE_CODE && value <= MAX_STATE_CODE;
 };

--- a/packages/business-registries/src/edgar/client.ts
+++ b/packages/business-registries/src/edgar/client.ts
@@ -60,11 +60,11 @@ const isEdgarRawSubmission = (value: unknown): value is EdgarRawSubmission =>
       value["formerNames"].every(isEdgarFormerName))) &&
   isOptionalRecord(value["filings"]);
 
-const edgarGet = (
+const edgarGet = async (
   url: string,
   userAgent: string,
 ): Promise<EdgarRawSubmission | null> =>
-  registryFetch({
+  await registryFetch({
     url,
     init: {
       headers: {

--- a/packages/business-registries/src/edgar/client.ts
+++ b/packages/business-registries/src/edgar/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { registryFetch } from "../shared/http.js";
 import {
   EdgarAPIError,
   EdgarRequestError,
@@ -8,7 +10,6 @@ import type { EdgarCompany, EdgarRawSubmission } from "./types.js";
 import { padCik, validateCik } from "./validation.js";
 
 const SUBMISSIONS_BASE = "https://data.sec.gov/submissions";
-const TIMEOUT_MS = 10_000;
 
 // The SEC publishes a hard rule: every request to data.sec.gov and
 // www.sec.gov MUST identify the caller via a `User-Agent` header
@@ -37,9 +38,6 @@ const assertUserAgent = (userAgent: string): void => {
   }
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const isOptionalStringArray = (value: unknown): boolean =>
   value === undefined ||
   (Array.isArray(value) && value.every((item) => typeof item === "string"));
@@ -62,14 +60,13 @@ const isEdgarRawSubmission = (value: unknown): value is EdgarRawSubmission =>
       value["formerNames"].every(isEdgarFormerName))) &&
   isOptionalRecord(value["filings"]);
 
-const edgarGet = async (
+const edgarGet = (
   url: string,
   userAgent: string,
-): Promise<EdgarRawSubmission | null> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
+): Promise<EdgarRawSubmission | null> =>
+  registryFetch({
+    url,
+    init: {
       headers: {
         "User-Agent": userAgent,
         Accept: "application/json",
@@ -77,58 +74,51 @@ const edgarGet = async (
         // reduce bandwidth; Bun's fetch already negotiates this.
         Host: "data.sec.gov",
       },
-    });
-  } catch (error) {
-    throw new EdgarRequestError(url, "EDGAR request failed", { cause: error });
-  }
+    },
+    isExpectedShape: isEdgarRawSubmission,
+    wrapRequestError: (cause) =>
+      new EdgarRequestError(url, "EDGAR request failed", { cause }),
+    wrapParseError: (response, cause) =>
+      new EdgarAPIError({
+        message: "EDGAR returned a non-JSON response",
+        httpStatus: response.status,
+        cause,
+      }),
+    wrapShapeError: (response) =>
+      new EdgarAPIError({
+        message: "EDGAR returned an unexpected response shape",
+        httpStatus: response.status,
+      }),
+    onErrorResponse: async (response) => {
+      if (response.status === 404) {
+        return null;
+      }
 
-  if (response.status === 404) {
-    return null;
-  }
+      if (response.status === 403) {
+        // 403 is almost always a missing or unrecognised User-Agent;
+        // flag it distinctly from generic 5xx so operators know to fix
+        // the env.
+        throw new EdgarAPIError({
+          message:
+            "EDGAR returned 403 (likely missing or rejected User-Agent header). Set EDGAR_USER_AGENT to '<App name> <contact@email>'.",
+          httpStatus: 403,
+        });
+      }
 
-  if (response.status === 403) {
-    // 403 is almost always a missing or unrecognised User-Agent; flag
-    // it distinctly from generic 5xx so operators know to fix the env.
-    throw new EdgarAPIError({
-      message:
-        "EDGAR returned 403 (likely missing or rejected User-Agent header). Set EDGAR_USER_AGENT to '<App name> <contact@email>'.",
-      httpStatus: 403,
-    });
-  }
-
-  if (!response.ok) {
-    let upstreamMessage: string | null = null;
-    try {
-      const body = await response.text();
-      upstreamMessage = body.length > 0 ? body.slice(0, 200) : null;
-    } catch {
-      // non-readable body
-    }
-    throw new EdgarAPIError({
-      message: `EDGAR ${response.status}: ${upstreamMessage ?? response.statusText}`,
-      httpStatus: response.status,
-      upstreamMessage,
-    });
-  }
-
-  let json: unknown;
-  try {
-    json = await response.json();
-  } catch (error) {
-    throw new EdgarAPIError({
-      message: "EDGAR returned a non-JSON response",
-      httpStatus: response.status,
-      cause: error,
-    });
-  }
-  if (!isEdgarRawSubmission(json)) {
-    throw new EdgarAPIError({
-      message: "EDGAR returned an unexpected response shape",
-      httpStatus: response.status,
-    });
-  }
-  return json;
-};
+      let upstreamMessage: string | null = null;
+      try {
+        const body = await response.text();
+        upstreamMessage = body.length > 0 ? body.slice(0, 200) : null;
+      } catch {
+        // non-readable body
+      }
+      throw new EdgarAPIError({
+        message: `EDGAR ${response.status}: ${upstreamMessage ?? response.statusText}`,
+        httpStatus: response.status,
+        upstreamMessage,
+      });
+    },
+  });
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/business-registries/src/edgar/parse.ts
+++ b/packages/business-registries/src/edgar/parse.ts
@@ -1,3 +1,4 @@
+import { trimToNull } from "../shared/strings.js";
 import type {
   EdgarAddress,
   EdgarCompany,
@@ -24,26 +25,18 @@ const RECENT_FILINGS_LIMIT = 5;
 // enough to infer a lifecycle event such as delisting.
 const STALE_FILING_AGE_MS = 365 * 24 * 60 * 60 * 1000;
 
-const nonEmpty = (value: string | null | undefined): string | null => {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
 export const parseAddress = (raw: EdgarRawAddress): EdgarAddress => {
-  const street = [nonEmpty(raw.street1), nonEmpty(raw.street2)]
+  const street = [trimToNull(raw.street1), trimToNull(raw.street2)]
     .filter(Boolean)
     .join(", ");
   // SEC encodes US states in `stateOrCountry` (two-letter codes) and
   // non-US locations in `stateOrCountryDescription` / `country`. Both
   // can be empty; prefer the description, fall back to the code.
   const region =
-    nonEmpty(raw.stateOrCountryDescription) ?? nonEmpty(raw.stateOrCountry);
-  const city = nonEmpty(raw.city);
-  const postalCode = nonEmpty(raw.zipCode);
-  const country = nonEmpty(raw.country) ?? nonEmpty(raw.countryCode);
+    trimToNull(raw.stateOrCountryDescription) ?? trimToNull(raw.stateOrCountry);
+  const city = trimToNull(raw.city);
+  const postalCode = trimToNull(raw.zipCode);
+  const country = trimToNull(raw.country) ?? trimToNull(raw.countryCode);
 
   const composite = [
     street.length > 0 ? street : null,
@@ -66,8 +59,8 @@ export const parseAddress = (raw: EdgarRawAddress): EdgarAddress => {
 
 const parseFormerName = (raw: EdgarRawFormerName): EdgarFormerName => ({
   name: raw.name,
-  from: nonEmpty(raw.from ?? null),
-  to: nonEmpty(raw.to ?? null),
+  from: trimToNull(raw.from ?? null),
+  to: trimToNull(raw.to ?? null),
 });
 
 // `filings.recent` is a structure-of-arrays. Zip the first N entries
@@ -96,10 +89,10 @@ const parseRecentFilings = (
       accessionNumber,
       form,
       filingDate,
-      reportDate: nonEmpty(raw.reportDate?.[i] ?? null),
-      acceptanceDateTime: nonEmpty(raw.acceptanceDateTime?.[i] ?? null),
-      primaryDocument: nonEmpty(raw.primaryDocument?.[i] ?? null),
-      primaryDocDescription: nonEmpty(raw.primaryDocDescription?.[i] ?? null),
+      reportDate: trimToNull(raw.reportDate?.[i] ?? null),
+      acceptanceDateTime: trimToNull(raw.acceptanceDateTime?.[i] ?? null),
+      primaryDocument: trimToNull(raw.primaryDocument?.[i] ?? null),
+      primaryDocDescription: trimToNull(raw.primaryDocDescription?.[i] ?? null),
     });
   }
   return filings;
@@ -153,11 +146,11 @@ export const parseSubmission = (
   return {
     cik,
     name: raw.name,
-    sic: nonEmpty(raw.sic ?? null),
-    sicDescription: nonEmpty(raw.sicDescription ?? null),
+    sic: trimToNull(raw.sic ?? null),
+    sicDescription: trimToNull(raw.sicDescription ?? null),
     tickers: raw.tickers ?? [],
     exchanges: raw.exchanges ?? [],
-    ein: nonEmpty(raw.ein ?? null),
+    ein: trimToNull(raw.ein ?? null),
     addresses: {
       mailing: raw.addresses?.mailing
         ? parseAddress(raw.addresses.mailing)

--- a/packages/business-registries/src/gcis/client.ts
+++ b/packages/business-registries/src/gcis/client.ts
@@ -1,3 +1,4 @@
+import { performRegistryRequest } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   GcisAPIError,
@@ -45,15 +46,17 @@ const buildUrl = (
 };
 
 const gcisGet = async (url: string): Promise<GcisResponse> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new GcisRequestError(url, "GCIS request failed", { cause: error });
-  }
+  // GCIS serves text/HTML sentinels (empty body = no match, a Chinese
+  // "system busy" HTML page on 200) so the body is decoded as text
+  // below rather than via the shared JSON reader; only the request +
+  // timeout + RequestError wrapping is shared.
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    timeoutMs: TIMEOUT_MS,
+    wrapRequestError: (cause) =>
+      new GcisRequestError(url, "GCIS request failed", { cause }),
+  });
 
   if (!response.ok) {
     let upstreamText: string | null = null;

--- a/packages/business-registries/src/gcis/parse.ts
+++ b/packages/business-registries/src/gcis/parse.ts
@@ -1,3 +1,4 @@
+import { trimToNull } from "../shared/strings.js";
 import type {
   GcisCompany,
   GcisCompanyStatus,
@@ -128,11 +129,6 @@ const parseRocDate = (input: string | undefined): string | null => {
   return `${String(gregorianYear).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 };
 
-const emptyToNull = (input: string | undefined): string | null => {
-  const trimmed = input?.trim();
-  return trimmed || null;
-};
-
 const numberOrNull = (input: number | undefined): number | null =>
   typeof input === "number" && Number.isFinite(input) ? input : null;
 
@@ -145,18 +141,18 @@ export const parseCompany = (raw: GcisRawCompany, now?: Date): GcisCompany => {
   const taxId = raw.Business_Accounting_NO;
   return {
     taxId,
-    name: emptyToNull(raw.Company_Name) ?? taxId,
+    name: trimToNull(raw.Company_Name) ?? taxId,
     capitalAmount: numberOrNull(raw.Capital_Stock_Amount),
     paidInCapitalAmount: numberOrNull(raw.Paid_In_Capital_Amount),
-    responsibleName: emptyToNull(raw.Responsible_Name),
-    location: emptyToNull(raw.Company_Location),
-    registerOrganization: emptyToNull(raw.Register_Organization_Desc),
-    setupDateRoc: emptyToNull(raw.Company_Setup_Date),
+    responsibleName: trimToNull(raw.Responsible_Name),
+    location: trimToNull(raw.Company_Location),
+    registerOrganization: trimToNull(raw.Register_Organization_Desc),
+    setupDateRoc: trimToNull(raw.Company_Setup_Date),
     setupDate: parseRocDate(raw.Company_Setup_Date),
-    lastChangeDateRoc: emptyToNull(raw.Change_Of_Approval_Data),
+    lastChangeDateRoc: trimToNull(raw.Change_Of_Approval_Data),
     lastChangeDate: parseRocDate(raw.Change_Of_Approval_Data),
     status: parseStatus(raw, now),
-    statusDescription: emptyToNull(raw.Company_Status_Desc),
+    statusDescription: trimToNull(raw.Company_Status_Desc),
     registryUrl: buildRegistryUrl(taxId),
   };
 };
@@ -166,7 +162,7 @@ export const parseSearchEntry = (
   now?: Date,
 ): GcisSearchResult => ({
   taxId: raw.Business_Accounting_NO,
-  name: emptyToNull(raw.Company_Name) ?? raw.Business_Accounting_NO,
-  location: emptyToNull(raw.Company_Location),
+  name: trimToNull(raw.Company_Name) ?? raw.Business_Accounting_NO,
+  location: trimToNull(raw.Company_Location),
   status: parseStatus(raw, now),
 });

--- a/packages/business-registries/src/krs/client.ts
+++ b/packages/business-registries/src/krs/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { performRegistryRequest } from "../shared/http.js";
 import { KrsAPIError, KrsRequestError, KrsValidationError } from "./errors.js";
 import { parseEntity } from "./parse.js";
 import type {
@@ -18,9 +20,6 @@ const TIMEOUT_MS = 10_000;
 // the first. Honour the documented ~5 rps soft cap by issuing the
 // second probe sequentially rather than racing.
 const REGISTER_PROBE_ORDER: readonly KrsRegisterCode[] = ["RejP", "RejS"];
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isKrsLookupResponse = (value: unknown): value is KrsLookupResponse =>
   isRecord(value) && (value["odpis"] === undefined || isRecord(value["odpis"]));
@@ -150,15 +149,19 @@ const krsFetchOptions = (): RequestInit => {
 const krsGet = async (
   url: string,
 ): Promise<{ status: number; body: KrsLookupResponse | null }> => {
-  let response: Response;
-  try {
-    response = await fetch(url, krsFetchOptions());
-  } catch (error) {
-    const cause = error instanceof Error ? `: ${error.message}` : "";
-    throw new KrsRequestError(url, `KRS request failed${cause}`, {
-      cause: error,
-    });
-  }
+  // KRS pins Certum CA certs via Bun's non-standard `tls` fetch option
+  // (see krsFetchOptions); it is passed straight through the shared
+  // request layer's `init` escape hatch.
+  const response = await performRegistryRequest({
+    url,
+    init: krsFetchOptions(),
+    wrapRequestError: (error) => {
+      const suffix = error instanceof Error ? `: ${error.message}` : "";
+      return new KrsRequestError(url, `KRS request failed${suffix}`, {
+        cause: error,
+      });
+    },
+  });
 
   if (response.status === 404) {
     // KRS returns a JSON problem-details body on 404; we don't read

--- a/packages/business-registries/src/orsr/client.ts
+++ b/packages/business-registries/src/orsr/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   OrsrAPIError,
@@ -19,16 +21,12 @@ const BASE = "https://sluzby.orsr.sk/api/legal-person";
 const SEARCH_URL = BASE;
 const EXTRACT_URL = `${BASE}/extract`;
 
-const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 50;
 
 // The search endpoint accepts a `Take` parameter but does not document
 // a hard upper bound. Treat 100 as the safe ceiling so a runaway caller
 // cannot ask for thousands of rows on the chat path.
 const MAX_SEARCH_LIMIT = 100;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isOrsrSearchHit = (value: unknown): value is OrsrRawSearchHit =>
   isRecord(value) && typeof value["id"] === "number";
@@ -65,15 +63,12 @@ const orsrGet = async <T>(
   url: string,
   isExpectedShape: (value: unknown) => value is T,
 ): Promise<T> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new OrsrRequestError(url, "ORSR request failed", { cause: error });
-  }
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    wrapRequestError: (cause) =>
+      new OrsrRequestError(url, "ORSR request failed", { cause }),
+  });
 
   if (!response.ok) {
     let body: OrsrRawErrorResponse = {};
@@ -89,27 +84,23 @@ const orsrGet = async <T>(
     });
   }
 
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error) {
-    throw new OrsrAPIError({
-      message: `ORSR ${response.status}: invalid JSON payload`,
-      httpStatus: response.status,
-      upstreamMessage: null,
-      cause: error,
-    });
-  }
-
-  if (!isExpectedShape(body)) {
-    throw new OrsrAPIError({
-      message: `ORSR ${response.status}: unexpected JSON payload shape`,
-      httpStatus: response.status,
-      upstreamMessage: null,
-    });
-  }
-
-  return body;
+  return readRegistryJson({
+    response,
+    isExpectedShape,
+    wrapParseError: (cause) =>
+      new OrsrAPIError({
+        message: `ORSR ${response.status}: invalid JSON payload`,
+        httpStatus: response.status,
+        upstreamMessage: null,
+        cause,
+      }),
+    wrapShapeError: () =>
+      new OrsrAPIError({
+        message: `ORSR ${response.status}: unexpected JSON payload shape`,
+        httpStatus: response.status,
+        upstreamMessage: null,
+      }),
+  });
 };
 
 const buildSearchUrl = (filterValue: string, take?: number): string => {

--- a/packages/business-registries/src/prh/client.ts
+++ b/packages/business-registries/src/prh/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import { PrhAPIError, PrhRequestError, PrhValidationError } from "./errors.js";
 import { parseCompany, parseSearchEntry } from "./parse.js";
@@ -12,14 +14,10 @@ import { normalizeBusinessId, validateBusinessId } from "./validation.js";
 const BASE = "https://avoindata.prh.fi/opendata-ytj-api/v3";
 const COMPANIES_URL = `${BASE}/companies`;
 
-const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 50;
 // PRH paginates at 100 hits per page; mirror Brreg's clamp so the
 // dispatch layer can pass through any limit safely.
 const MAX_SEARCH_LIMIT = 100;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isOptionalRecord = (value: unknown): boolean =>
   value === undefined || isRecord(value);
@@ -76,15 +74,12 @@ const parseErrorBody = (value: unknown): PrhErrorResponse => {
 };
 
 const prhGet = async (url: string): Promise<PrhCompaniesResponse> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new PrhRequestError(url, "PRH request failed", { cause: error });
-  }
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    wrapRequestError: (cause) =>
+      new PrhRequestError(url, "PRH request failed", { cause }),
+  });
 
   if (!response.ok) {
     let body: PrhErrorResponse = {};
@@ -101,23 +96,17 @@ const prhGet = async (url: string): Promise<PrhCompaniesResponse> => {
     });
   }
 
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error) {
-    throw new PrhRequestError(url, "Failed to parse PRH response JSON", {
-      cause: error,
-    });
-  }
-
-  if (!isPrhCompaniesResponse(body)) {
-    throw new PrhAPIError({
-      message: "PRH returned an unexpected response shape",
-      httpStatus: response.status,
-    });
-  }
-
-  return body;
+  return readRegistryJson({
+    response,
+    isExpectedShape: isPrhCompaniesResponse,
+    wrapParseError: (cause) =>
+      new PrhRequestError(url, "Failed to parse PRH response JSON", { cause }),
+    wrapShapeError: () =>
+      new PrhAPIError({
+        message: "PRH returned an unexpected response shape",
+        httpStatus: response.status,
+      }),
+  });
 };
 
 /**

--- a/packages/business-registries/src/recherche-entreprises/client.ts
+++ b/packages/business-registries/src/recherche-entreprises/client.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "../shared/guards.js";
+import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
 import { clampSearchLimit } from "../shared/search.js";
 import {
   RechercheEntreprisesAPIError,
@@ -16,15 +18,11 @@ import { normalizeSiren, validateSiren, validateSiret } from "./validation.js";
 const BASE = "https://recherche-entreprises.api.gouv.fr";
 const SEARCH_URL = `${BASE}/search`;
 
-const TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 25;
 // Upstream documents 25 results per page, max per_page = 25 on the
 // production endpoint. Clamp client-side so the dispatch layer can
 // forward any caller-supplied limit safely.
 const MAX_SEARCH_LIMIT = 25;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isRechercheEstablishment = (value: unknown): boolean =>
   isRecord(value) && typeof value["siret"] === "string";
@@ -76,19 +74,16 @@ const parseErrorBody = (value: unknown): RechercheEntreprisesErrorResponse => {
 const rechercheEntreprisesGet = async (
   url: string,
 ): Promise<RechercheEntreprisesSearchResponse> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new RechercheEntreprisesRequestError(
-      url,
-      "recherche-entreprises request failed",
-      { cause: error },
-    );
-  }
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    wrapRequestError: (cause) =>
+      new RechercheEntreprisesRequestError(
+        url,
+        "recherche-entreprises request failed",
+        { cause },
+      ),
+  });
 
   if (!response.ok) {
     let body: RechercheEntreprisesErrorResponse = {};
@@ -105,31 +100,28 @@ const rechercheEntreprisesGet = async (
     });
   }
 
-  let payload: unknown;
-  try {
-    payload = await response.json();
-  } catch (error) {
-    // A malformed body on an otherwise-200 response (the upstream
-    // very occasionally serves truncated JSON during peak load)
-    // would otherwise bubble out as a bare SyntaxError, bypass
-    // `mapRechercheEntreprisesError`, and surface as HTTP 500. Wrap
-    // it so the dispatch layer translates it to 502 like every other
-    // upstream failure.
-    throw new RechercheEntreprisesAPIError({
-      message: `recherche-entreprises returned an unparseable JSON body (HTTP ${response.status})`,
-      httpStatus: response.status,
-      upstreamMessage: null,
-      cause: error,
-    });
-  }
-  if (!isRechercheSearchResponse(payload)) {
-    throw new RechercheEntreprisesAPIError({
-      message: `recherche-entreprises returned an unexpected JSON body shape (HTTP ${response.status})`,
-      httpStatus: response.status,
-      upstreamMessage: null,
-    });
-  }
-  return payload;
+  return readRegistryJson({
+    response,
+    isExpectedShape: isRechercheSearchResponse,
+    // A malformed body on an otherwise-200 response (the upstream very
+    // occasionally serves truncated JSON during peak load) would
+    // otherwise bubble out as a bare SyntaxError, bypass the error
+    // mapping, and surface as HTTP 500. Wrap it so the dispatch layer
+    // translates it to 502 like every other upstream failure.
+    wrapParseError: (cause) =>
+      new RechercheEntreprisesAPIError({
+        message: `recherche-entreprises returned an unparseable JSON body (HTTP ${response.status})`,
+        httpStatus: response.status,
+        upstreamMessage: null,
+        cause,
+      }),
+    wrapShapeError: () =>
+      new RechercheEntreprisesAPIError({
+        message: `recherche-entreprises returned an unexpected JSON body shape (HTTP ${response.status})`,
+        httpStatus: response.status,
+        upstreamMessage: null,
+      }),
+  });
 };
 
 /**

--- a/packages/business-registries/src/recherche-entreprises/parse.test.ts
+++ b/packages/business-registries/src/recherche-entreprises/parse.test.ts
@@ -217,6 +217,44 @@ describe("parseCompany", () => {
   });
 });
 
+describe("tolerates non-string optional fields from upstream", () => {
+  // Class guard: the recherche shape guard only validates `siret` on an
+  // etablissement and `type_dirigeant` on a director; every other optional
+  // field is declared `string | null` but is NOT runtime-checked. The
+  // upstream Etalab API occasionally serves numeric atoms (a bare
+  // `numero_voie: 42`) rather than strings. The parser leans on the shared
+  // `trimToNull`, which must treat those non-strings as absent — the local
+  // helper this consolidated did the same. This pins that tolerance so a
+  // future tightening of the shared helper (throwing on non-strings) is
+  // caught here rather than surfacing as a raw TypeError on a live lookup.
+  //
+  // `JSON.parse` returns `any`, which models the untyped upstream body
+  // exactly (the real client feeds `response.json()` through the same
+  // parser); parsing a raw JSON string keeps the numeric atoms the type
+  // declarations forbid, with no cast.
+  test("numeric address atoms are dropped, not thrown, in parseEstablishment", () => {
+    const raw: RechercheEntreprisesRawEtablissement = JSON.parse(
+      `{"siret":"12345678900011","numero_voie":42,"type_voie":7,` +
+        `"libelle_voie":123,"code_postal":75001,"adresse":99}`,
+    );
+    const establishment = parseEstablishment(raw);
+    expect(establishment.siret).toBe("12345678900011");
+    // Every address atom was numeric → treated as absent → no address.
+    expect(establishment.address).toBeNull();
+  });
+
+  test("a numeric organisation `denomination` skips the director without throwing", () => {
+    const raw: RechercheEntreprisesRawUniteLegale = JSON.parse(
+      `{"siren":"552100554","nom_complet":"EXEMPLE SA",` +
+        `"dirigeants":[{"type_dirigeant":"personne morale","denomination":552}]}`,
+    );
+    const company = parseCompany(raw);
+    expect(company.siren).toBe("552100554");
+    // The organisation director had a non-string name → skipped, not a throw.
+    expect(company.directors).toEqual([]);
+  });
+});
+
 describe("parseSearchEntry", () => {
   test("surfaces siege.adresse as the search-row address", () => {
     const entry = parseSearchEntry({

--- a/packages/business-registries/src/recherche-entreprises/parse.ts
+++ b/packages/business-registries/src/recherche-entreprises/parse.ts
@@ -1,3 +1,4 @@
+import { trimToNull } from "../shared/strings.js";
 import type {
   RechercheEntreprisesAddress,
   RechercheEntreprisesCompany,
@@ -21,14 +22,6 @@ const ANNUAIRE_BASE = "https://annuaire-entreprises.data.gouv.fr/entreprise/";
 const STATUS_ACTIVE = "A";
 const LEGAL_ENTITY_STATUS_CEASED = "C";
 const ESTABLISHMENT_STATUS_CLOSED = "F";
-
-const trimToNull = (value: string | null | undefined): string | null => {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed.length === 0 ? null : trimmed;
-};
 
 const buildStreetFromAtoms = (
   raw: RechercheEntreprisesRawEtablissement,

--- a/packages/business-registries/src/shared/guards.ts
+++ b/packages/business-registries/src/shared/guards.ts
@@ -1,0 +1,11 @@
+// Structural type guards shared across every registry adapter. Each
+// adapter's client and parser previously hand-rolled an identical
+// `isRecord`; single-homing it here keeps the "plain JSON object"
+// predicate consistent (notably: arrays are NOT records).
+
+/**
+ * Narrow an unknown value to a plain object keyed by string. Arrays and
+ * `null` are rejected so callers can safely index string keys.
+ */
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/business-registries/src/shared/http.test.ts
+++ b/packages/business-registries/src/shared/http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { isRecord } from "./guards.js";
 import {
   parseRetryAfterMs,
   performRegistryRequest,
@@ -24,7 +25,7 @@ class ApiMarkerError extends Error {
 
 type Shape = { ok: true };
 const isShape = (value: unknown): value is Shape =>
-  typeof value === "object" && value !== null && (value as Shape).ok === true;
+  isRecord(value) && value["ok"] === true;
 
 const installFetchStub = (
   handler: (input: URL | Request | string) => Promise<Response>,
@@ -69,10 +70,10 @@ const baseOptions = {
 
 describe("performRegistryRequest", () => {
   test("wraps a transport/timeout failure via wrapRequestError", async () => {
-    restore = installFetchStub(() =>
-      Promise.reject(new Error("The operation timed out")),
-    );
-    await expect(
+    restore = installFetchStub(async () => {
+      throw new Error("The operation timed out");
+    });
+    expect(
       performRegistryRequest({
         url: "https://example.test",
         wrapRequestError: (cause) =>
@@ -82,9 +83,7 @@ describe("performRegistryRequest", () => {
   });
 
   test("returns the raw response on success", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ ok: true })),
-    );
+    restore = installFetchStub(async () => jsonResponse({ ok: true }));
     const response = await performRegistryRequest({
       url: "https://example.test",
       wrapRequestError: (cause) => new RequestMarkerError("wrapped", { cause }),
@@ -104,8 +103,8 @@ describe("readRegistryJson", () => {
     expect(body).toEqual({ ok: true });
   });
 
-  test("maps a non-JSON body to the parse error", async () => {
-    await expect(
+  test("maps a non-JSON body to the parse error", () => {
+    expect(
       readRegistryJson({
         response: new Response("<html>not json</html>", { status: 200 }),
         isExpectedShape: isShape,
@@ -115,8 +114,8 @@ describe("readRegistryJson", () => {
     ).rejects.toBeInstanceOf(ParseMarkerError);
   });
 
-  test("maps an unexpected shape to the shape error", async () => {
-    await expect(
+  test("maps an unexpected shape to the shape error", () => {
+    expect(
       readRegistryJson({
         response: jsonResponse({ nope: 1 }),
         isExpectedShape: isShape,
@@ -129,62 +128,46 @@ describe("readRegistryJson", () => {
 
 describe("registryFetch", () => {
   test("parses and guards a successful JSON body", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ ok: true })),
-    );
+    restore = installFetchStub(async () => jsonResponse({ ok: true }));
     const result = await registryFetch(baseOptions);
     expect(result).toEqual({ ok: true });
   });
 
-  test("wraps a transport failure via wrapRequestError", async () => {
-    restore = installFetchStub(() => Promise.reject(new Error("timed out")));
-    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
+  test("wraps a transport failure via wrapRequestError", () => {
+    restore = installFetchStub(async () => {
+      throw new Error("timed out");
+    });
+    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
       RequestMarkerError,
     );
   });
 
-  test("delegates a non-OK status to onErrorResponse (throws)", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ error: true }, 500)),
-    );
-    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
-      ApiMarkerError,
-    );
+  test("delegates a non-OK status to onErrorResponse (throws)", () => {
+    restore = installFetchStub(async () => jsonResponse({ error: true }, 500));
+    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ApiMarkerError);
   });
 
-  test("lets onErrorResponse resolve a not-found status to null", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ error: true }, 404)),
-    );
-    await expect(registryFetch(baseOptions)).resolves.toBeNull();
+  test("lets onErrorResponse resolve a not-found status to null", () => {
+    restore = installFetchStub(async () => jsonResponse({ error: true }, 404));
+    expect(registryFetch(baseOptions)).resolves.toBeNull();
   });
 
-  test("maps a malformed 2xx JSON body to the parse error", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(new Response("}{", { status: 200 })),
-    );
-    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
-      ParseMarkerError,
-    );
+  test("maps a malformed 2xx JSON body to the parse error", () => {
+    restore = installFetchStub(async () => new Response("}{", { status: 200 }));
+    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ParseMarkerError);
   });
 
-  test("maps an unexpected 2xx shape to the shape error", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ nope: true })),
-    );
-    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
-      ShapeMarkerError,
-    );
+  test("maps an unexpected 2xx shape to the shape error", () => {
+    restore = installFetchStub(async () => jsonResponse({ nope: true }));
+    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ShapeMarkerError);
   });
 
-  test("routes a 429 to onRateLimited when provided, before onErrorResponse", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ error: true }, 429)),
-    );
+  test("routes a 429 to onRateLimited when provided, before onErrorResponse", () => {
+    restore = installFetchStub(async () => jsonResponse({ error: true }, 429));
     class RateMarkerError extends Error {
       override name = "RateMarkerError";
     }
-    await expect(
+    expect(
       registryFetch({
         ...baseOptions,
         onRateLimited: () => {
@@ -194,13 +177,9 @@ describe("registryFetch", () => {
     ).rejects.toBeInstanceOf(RateMarkerError);
   });
 
-  test("falls back to onErrorResponse for a 429 when onRateLimited is absent", async () => {
-    restore = installFetchStub(() =>
-      Promise.resolve(jsonResponse({ error: true }, 429)),
-    );
-    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
-      ApiMarkerError,
-    );
+  test("falls back to onErrorResponse for a 429 when onRateLimited is absent", () => {
+    restore = installFetchStub(async () => jsonResponse({ error: true }, 429));
+    expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(ApiMarkerError);
   });
 });
 

--- a/packages/business-registries/src/shared/http.test.ts
+++ b/packages/business-registries/src/shared/http.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  parseRetryAfterMs,
+  performRegistryRequest,
+  rateLimitedError,
+  readRegistryJson,
+  registryFetch,
+} from "./http.js";
+
+// Distinct marker errors so assertions can tell which mapping fired.
+class RequestMarkerError extends Error {
+  override name = "RequestMarkerError";
+}
+class ParseMarkerError extends Error {
+  override name = "ParseMarkerError";
+}
+class ShapeMarkerError extends Error {
+  override name = "ShapeMarkerError";
+}
+class ApiMarkerError extends Error {
+  override name = "ApiMarkerError";
+}
+
+type Shape = { ok: true };
+const isShape = (value: unknown): value is Shape =>
+  typeof value === "object" && value !== null && (value as Shape).ok === true;
+
+const installFetchStub = (
+  handler: (input: URL | Request | string) => Promise<Response>,
+): (() => void) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (input: URL | Request | string) => handler(input),
+    { preconnect: original.preconnect },
+  );
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+let restore: (() => void) | null = null;
+afterEach(() => {
+  restore?.();
+  restore = null;
+});
+
+const baseOptions = {
+  url: "https://example.test/lookup",
+  isExpectedShape: isShape,
+  wrapRequestError: (cause: unknown) =>
+    new RequestMarkerError("request", { cause }),
+  wrapParseError: (_response: Response, cause: unknown) =>
+    new ParseMarkerError("parse", { cause }),
+  wrapShapeError: (_response: Response) => new ShapeMarkerError("shape"),
+  onErrorResponse: (response: Response) => {
+    if (response.status === 404) {
+      return null;
+    }
+    throw new ApiMarkerError(`api ${response.status}`);
+  },
+};
+
+describe("performRegistryRequest", () => {
+  test("wraps a transport/timeout failure via wrapRequestError", async () => {
+    restore = installFetchStub(() =>
+      Promise.reject(new Error("The operation timed out")),
+    );
+    await expect(
+      performRegistryRequest({
+        url: "https://example.test",
+        wrapRequestError: (cause) =>
+          new RequestMarkerError("wrapped", { cause }),
+      }),
+    ).rejects.toBeInstanceOf(RequestMarkerError);
+  });
+
+  test("returns the raw response on success", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ ok: true })),
+    );
+    const response = await performRegistryRequest({
+      url: "https://example.test",
+      wrapRequestError: (cause) => new RequestMarkerError("wrapped", { cause }),
+    });
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("readRegistryJson", () => {
+  test("returns the guarded body on a valid shape", async () => {
+    const body = await readRegistryJson({
+      response: jsonResponse({ ok: true }),
+      isExpectedShape: isShape,
+      wrapParseError: (cause) => new ParseMarkerError("parse", { cause }),
+      wrapShapeError: () => new ShapeMarkerError("shape"),
+    });
+    expect(body).toEqual({ ok: true });
+  });
+
+  test("maps a non-JSON body to the parse error", async () => {
+    await expect(
+      readRegistryJson({
+        response: new Response("<html>not json</html>", { status: 200 }),
+        isExpectedShape: isShape,
+        wrapParseError: (cause) => new ParseMarkerError("parse", { cause }),
+        wrapShapeError: () => new ShapeMarkerError("shape"),
+      }),
+    ).rejects.toBeInstanceOf(ParseMarkerError);
+  });
+
+  test("maps an unexpected shape to the shape error", async () => {
+    await expect(
+      readRegistryJson({
+        response: jsonResponse({ nope: 1 }),
+        isExpectedShape: isShape,
+        wrapParseError: (cause) => new ParseMarkerError("parse", { cause }),
+        wrapShapeError: () => new ShapeMarkerError("shape"),
+      }),
+    ).rejects.toBeInstanceOf(ShapeMarkerError);
+  });
+});
+
+describe("registryFetch", () => {
+  test("parses and guards a successful JSON body", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ ok: true })),
+    );
+    const result = await registryFetch(baseOptions);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("wraps a transport failure via wrapRequestError", async () => {
+    restore = installFetchStub(() => Promise.reject(new Error("timed out")));
+    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
+      RequestMarkerError,
+    );
+  });
+
+  test("delegates a non-OK status to onErrorResponse (throws)", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ error: true }, 500)),
+    );
+    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
+      ApiMarkerError,
+    );
+  });
+
+  test("lets onErrorResponse resolve a not-found status to null", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ error: true }, 404)),
+    );
+    await expect(registryFetch(baseOptions)).resolves.toBeNull();
+  });
+
+  test("maps a malformed 2xx JSON body to the parse error", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(new Response("}{", { status: 200 })),
+    );
+    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
+      ParseMarkerError,
+    );
+  });
+
+  test("maps an unexpected 2xx shape to the shape error", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ nope: true })),
+    );
+    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
+      ShapeMarkerError,
+    );
+  });
+
+  test("routes a 429 to onRateLimited when provided, before onErrorResponse", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ error: true }, 429)),
+    );
+    class RateMarkerError extends Error {
+      override name = "RateMarkerError";
+    }
+    await expect(
+      registryFetch({
+        ...baseOptions,
+        onRateLimited: () => {
+          throw new RateMarkerError("rate limited");
+        },
+      }),
+    ).rejects.toBeInstanceOf(RateMarkerError);
+  });
+
+  test("falls back to onErrorResponse for a 429 when onRateLimited is absent", async () => {
+    restore = installFetchStub(() =>
+      Promise.resolve(jsonResponse({ error: true }, 429)),
+    );
+    await expect(registryFetch(baseOptions)).rejects.toBeInstanceOf(
+      ApiMarkerError,
+    );
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  test("reads the delta-seconds form", () => {
+    const response = new Response(null, {
+      status: 429,
+      headers: { "Retry-After": "120" },
+    });
+    expect(parseRetryAfterMs(response)).toBe(120_000);
+  });
+
+  test("returns null when the header is absent", () => {
+    expect(parseRetryAfterMs(new Response(null, { status: 429 }))).toBeNull();
+  });
+
+  test("returns null for an unparseable header", () => {
+    const response = new Response(null, {
+      status: 429,
+      headers: { "Retry-After": "soon" },
+    });
+    expect(parseRetryAfterMs(response)).toBeNull();
+  });
+});
+
+describe("rateLimitedError", () => {
+  test("builds a RegistryRateLimitedError carrying the retry budget", () => {
+    const response = new Response(null, {
+      status: 429,
+      headers: { "Retry-After": "5" },
+    });
+    const error = rateLimitedError({ response, message: "slow down" });
+    expect(error.name).toBe("RegistryRateLimitedError");
+    expect(error.retryAfterMs).toBe(5000);
+    expect(error.message).toBe("slow down");
+  });
+});

--- a/packages/business-registries/src/shared/http.ts
+++ b/packages/business-registries/src/shared/http.ts
@@ -119,12 +119,7 @@ export type RegistryFetchOptions<T> = RegistryRequestOptions & {
 export const registryFetch = async <T>(
   options: RegistryFetchOptions<T>,
 ): Promise<T | null> => {
-  const response = await performRegistryRequest({
-    url: options.url,
-    init: options.init,
-    timeoutMs: options.timeoutMs,
-    wrapRequestError: options.wrapRequestError,
-  });
+  const response = await performRegistryRequest(options);
   if (!response.ok) {
     if (response.status === 429 && options.onRateLimited) {
       return options.onRateLimited(response);

--- a/packages/business-registries/src/shared/http.ts
+++ b/packages/business-registries/src/shared/http.ts
@@ -1,0 +1,189 @@
+// Shared HTTP scaffold for registry adapters.
+//
+// Every adapter's client hand-rolled the same three mechanical steps:
+//   1. fetch with a timeout AbortSignal, wrapping any transport failure
+//      in the adapter's RequestError;
+//   2. branch on the response status, mapping non-OK responses to the
+//      adapter's APIError (and, where relevant, not-found/auth cases);
+//   3. read the JSON body and run a shape guard, mapping a non-JSON body
+//      or a shape mismatch to a typed error.
+//
+// This module single-homes those steps. Per-adapter clients supply only
+// the parts that genuinely differ: the typed error constructors, the
+// not-found handling, and any auth/too-broad branches. Adapters that
+// serve text or XML (GCIS, DENUE) reuse the request layer but decode the
+// body themselves; adapters that pin a custom trust store (KRS) pass it
+// through `init`.
+
+import { RegistryRateLimitedError } from "./errors.js";
+
+/** Default per-request timeout. Every adapter used 10s. */
+export const DEFAULT_REGISTRY_TIMEOUT_MS = 10_000;
+
+export type RegistryRequestOptions = {
+  url: string;
+  /**
+   * Extra fetch options (method, body, headers, and Bun-only `tls`).
+   * Spread after the timeout signal so a caller can override the signal
+   * or add a custom trust store — KRS pins Certum CA certs this way.
+   */
+  init?: RequestInit;
+  /** @default DEFAULT_REGISTRY_TIMEOUT_MS */
+  timeoutMs?: number;
+  /** Map a transport/timeout failure into the adapter's RequestError. */
+  wrapRequestError: (cause: unknown) => Error;
+};
+
+/**
+ * Perform a fetch with a timeout AbortSignal, wrapping any transport
+ * failure via `wrapRequestError`. Returns the raw Response so callers
+ * keep full control over status branching and body decoding (JSON,
+ * text, XML). This is the one piece every adapter shares, including the
+ * text/non-JSON ones.
+ */
+export const performRegistryRequest = async (
+  options: RegistryRequestOptions,
+): Promise<Response> => {
+  try {
+    return await fetch(options.url, {
+      signal: AbortSignal.timeout(
+        options.timeoutMs ?? DEFAULT_REGISTRY_TIMEOUT_MS,
+      ),
+      ...options.init,
+    });
+  } catch (error) {
+    throw options.wrapRequestError(error);
+  }
+};
+
+export type ReadRegistryJsonOptions<T> = {
+  response: Response;
+  isExpectedShape: (value: unknown) => value is T;
+  /** Thrown when the body is not valid JSON. */
+  wrapParseError: (cause: unknown) => Error;
+  /** Thrown when the parsed JSON fails `isExpectedShape`. */
+  wrapShapeError: () => Error;
+};
+
+/**
+ * Read and shape-guard a JSON response body. Adapters that serve text or
+ * XML decode the body themselves and skip this helper.
+ */
+export const readRegistryJson = async <T>(
+  options: ReadRegistryJsonOptions<T>,
+): Promise<T> => {
+  let body: unknown;
+  try {
+    body = await options.response.json();
+  } catch (error) {
+    throw options.wrapParseError(error);
+  }
+  if (!options.isExpectedShape(body)) {
+    throw options.wrapShapeError();
+  }
+  return body;
+};
+
+export type RegistryFetchOptions<T> = RegistryRequestOptions & {
+  isExpectedShape: (value: unknown) => value is T;
+  /**
+   * Thrown when a 2xx body is not valid JSON. Receives the (OK)
+   * response so the error can carry its status.
+   */
+  wrapParseError: (response: Response, cause: unknown) => Error;
+  /** Thrown when a 2xx body fails `isExpectedShape`. */
+  wrapShapeError: (response: Response) => Error;
+  /**
+   * Handle any non-OK response. Return `null` to resolve the request to
+   * "no result" (the not-found convention several adapters use), or
+   * throw the adapter's APIError. Which status set means not-found, and
+   * whether the error body is inspected, is adapter-specific, so it
+   * stays here rather than in the shared core.
+   */
+  onErrorResponse: (response: Response) => T | null | Promise<T | null>;
+  /**
+   * Optional 429 handler, invoked before `onErrorResponse`. When
+   * omitted, a 429 flows through `onErrorResponse` like any other non-OK
+   * status — today's behaviour for every adapter. This is the single
+   * wiring point for a future retry layer; see {@link rateLimitedError}.
+   */
+  onRateLimited?: (response: Response) => T | null | Promise<T | null>;
+};
+
+/**
+ * Compose {@link performRegistryRequest} and {@link readRegistryJson}
+ * for the common JSON adapter shape: fetch, delegate non-OK responses to
+ * `onErrorResponse` (with an optional rate-limit shortcut), otherwise
+ * parse and guard the JSON body.
+ */
+export const registryFetch = async <T>(
+  options: RegistryFetchOptions<T>,
+): Promise<T | null> => {
+  const response = await performRegistryRequest({
+    url: options.url,
+    init: options.init,
+    timeoutMs: options.timeoutMs,
+    wrapRequestError: options.wrapRequestError,
+  });
+  if (!response.ok) {
+    if (response.status === 429 && options.onRateLimited) {
+      return options.onRateLimited(response);
+    }
+    return options.onErrorResponse(response);
+  }
+  return readRegistryJson({
+    response,
+    isExpectedShape: options.isExpectedShape,
+    wrapParseError: (cause) => options.wrapParseError(response, cause),
+    wrapShapeError: () => options.wrapShapeError(response),
+  });
+};
+
+/**
+ * Parse a `Retry-After` header into milliseconds. Supports both the
+ * delta-seconds form (`Retry-After: 120`) and the HTTP-date form
+ * (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`). Returns `null` when
+ * the header is absent or unparseable, and never returns a negative
+ * value.
+ *
+ * Single-homed here so a future retry layer (see
+ * `RegistryRateLimitedError.retryAfterMs`) has one place to read the
+ * budget; no adapter retries today.
+ */
+export const parseRetryAfterMs = (response: Response): number | null => {
+  const header = response.headers.get("retry-after");
+  if (!header) {
+    return null;
+  }
+  const trimmed = header.trim();
+  if (/^\d+$/u.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) {
+    return null;
+  }
+  return Math.max(dateMs - Date.now(), 0);
+};
+
+export type RateLimitedErrorOptions = {
+  response: Response;
+  message: string;
+  cause?: unknown;
+};
+
+/**
+ * Build a {@link RegistryRateLimitedError} from a 429 response, reading
+ * the retry budget from the `Retry-After` header. Adapters do not wire
+ * this in yet — that would change today's behaviour, where 429 maps to
+ * the adapter's own APIError — but it lives here so rate-limit handling
+ * has a single home when a retry layer is added.
+ */
+export const rateLimitedError = (
+  options: RateLimitedErrorOptions,
+): RegistryRateLimitedError =>
+  new RegistryRateLimitedError({
+    message: options.message,
+    retryAfterMs: parseRetryAfterMs(options.response),
+    cause: options.cause,
+  });

--- a/packages/business-registries/src/shared/search.test.ts
+++ b/packages/business-registries/src/shared/search.test.ts
@@ -19,4 +19,10 @@ describe("clampSearchLimit", () => {
   test("returns the ceiling itself when requested equals the ceiling", () => {
     expect(clampSearchLimit(100, 100)).toBe(100);
   });
+
+  test("clamps a non-finite requested limit down to the minimum", () => {
+    expect(clampSearchLimit(Number.NaN, 100)).toBe(1);
+    expect(clampSearchLimit(Number.POSITIVE_INFINITY, 100)).toBe(100);
+    expect(clampSearchLimit(Number.NEGATIVE_INFINITY, 100)).toBe(1);
+  });
 });

--- a/packages/business-registries/src/shared/search.ts
+++ b/packages/business-registries/src/shared/search.ts
@@ -3,5 +3,13 @@
 // size, items_per_page, top, per_page, ...). Clamp it once here instead
 // of letting each adapter hand-roll (and potentially forget) the same
 // `Math.min(Math.max(...))` expression.
-export const clampSearchLimit = (requested: number, max: number): number =>
-  Math.min(Math.max(requested, 1), max);
+export const clampSearchLimit = (requested: number, max: number): number => {
+  // A NaN `requested` (from a bad parse) would otherwise flow through
+  // `Math.min(Math.max(NaN, 1), max)` as NaN and poison the upstream
+  // page-size parameter. Treat it as the minimum. ±Infinity is fine:
+  // Math.max/min already resolve it to the min/max bound.
+  if (Number.isNaN(requested)) {
+    return 1;
+  }
+  return Math.min(Math.max(requested, 1), max);
+};

--- a/packages/business-registries/src/shared/strings.test.ts
+++ b/packages/business-registries/src/shared/strings.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { trimToNull } from "./strings.js";
+
+describe("trimToNull", () => {
+  test("trims surrounding whitespace", () => {
+    expect(trimToNull("  hello  ")).toBe("hello");
+  });
+
+  test("collapses empty and whitespace-only strings to null", () => {
+    expect(trimToNull("")).toBeNull();
+    expect(trimToNull("   ")).toBeNull();
+  });
+
+  test("maps null and undefined to null", () => {
+    expect(trimToNull(null)).toBeNull();
+    expect(trimToNull(undefined)).toBeNull();
+  });
+
+  test("preserves a literal '0' (real address atom / sentinel handled per field)", () => {
+    expect(trimToNull("0")).toBe("0");
+  });
+
+  // Class guard: several adapters (recherche-entreprises in particular)
+  // only shape-check a couple of fields, so an optional field the upstream
+  // declared as a string can arrive as a number/boolean/object at runtime.
+  // The consolidated helper must treat any non-string as absent rather than
+  // throwing a raw TypeError from `.trim()`, matching the per-adapter
+  // helpers it replaced. If a future change re-narrows this to reject
+  // non-strings, this test fails.
+  test("treats a non-string value as absent instead of throwing", () => {
+    expect(trimToNull(42)).toBeNull();
+    expect(trimToNull(true)).toBeNull();
+    expect(trimToNull({ a: 1 })).toBeNull();
+    expect(trimToNull([1, 2, 3])).toBeNull();
+  });
+});

--- a/packages/business-registries/src/shared/strings.ts
+++ b/packages/business-registries/src/shared/strings.ts
@@ -1,0 +1,21 @@
+// String normalization shared across registry parsers. Several adapters
+// hand-rolled the same "trim, and treat an empty string as absent"
+// helper under different names (`nonEmpty`, `trimToNull`, `emptyToNull`)
+// with identical semantics. Single-homing it here removes the drift
+// risk that produced the DENUE "0" address bug (a blanket
+// `=== "0"` clause that only one field genuinely needed).
+
+/**
+ * Trim a string and collapse an empty result to `null`. A literal `"0"`
+ * is preserved: it is a real value for address atoms (house/local
+ * number 0) and only specific fields (e.g. DENUE postal code) use `"0"`
+ * as an absent-value sentinel, which those fields must handle
+ * explicitly rather than relying on a blanket rule here.
+ */
+export const trimToNull = (value: string | null | undefined): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};

--- a/packages/business-registries/src/shared/strings.ts
+++ b/packages/business-registries/src/shared/strings.ts
@@ -11,9 +11,17 @@
  * number 0) and only specific fields (e.g. DENUE postal code) use `"0"`
  * as an absent-value sentinel, which those fields must handle
  * explicitly rather than relying on a blanket rule here.
+ *
+ * Accepts `unknown` on purpose: this normalizes optional fields from
+ * upstream registry JSON that the adapter shape guards do not fully
+ * validate (recherche-entreprises, for instance, only checks `siret` /
+ * `type_dirigeant`, so a numeric `numero_voie` or `denomination` can
+ * reach here). Any non-string value is treated as absent (`null`)
+ * rather than throwing a raw `TypeError`, matching the per-adapter
+ * `trimToNull` helpers this consolidated.
  */
-export const trimToNull = (value: string | null | undefined): string | null => {
-  if (value === null || value === undefined) {
+export const trimToNull = (value: unknown): string | null => {
+  if (typeof value !== "string") {
     return null;
   }
   const trimmed = value.trim();

--- a/packages/business-registries/src/vies/client.ts
+++ b/packages/business-registries/src/vies/client.ts
@@ -1,3 +1,4 @@
+import { performRegistryRequest, readRegistryJson } from "../shared/http.js";
 import {
   ViesAPIError,
   ViesRequestError,
@@ -14,7 +15,6 @@ import {
 } from "./validation.js";
 
 const BASE = "https://ec.europa.eu/taxation_customs/vies/rest-api";
-const TIMEOUT_MS = 10_000;
 
 /**
  * Validate an EU VAT number against the VIES (VAT Information
@@ -66,15 +66,12 @@ export const validateVat = async (input: string): Promise<ViesValidation> => {
   }
   const url = `${BASE}/ms/${parsed.country}/vat/${encodeURIComponent(parsed.vat)}`;
 
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { Accept: "application/json" },
-    });
-  } catch (error) {
-    throw new ViesRequestError(url, "VIES request failed", { cause: error });
-  }
+  const response = await performRegistryRequest({
+    url,
+    init: { headers: { Accept: "application/json" } },
+    wrapRequestError: (cause) =>
+      new ViesRequestError(url, "VIES request failed", { cause }),
+  });
 
   if (!response.ok) {
     throw new ViesAPIError({
@@ -83,23 +80,21 @@ export const validateVat = async (input: string): Promise<ViesValidation> => {
     });
   }
 
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error) {
-    throw new ViesAPIError({
-      message: "VIES returned a non-JSON body",
-      httpStatus: response.status,
-      cause: error,
-    });
-  }
-
-  if (!isViesRawResponse(body)) {
-    throw new ViesAPIError({
-      message: "VIES response did not match the expected shape",
-      httpStatus: response.status,
-    });
-  }
+  const body = await readRegistryJson({
+    response,
+    isExpectedShape: isViesRawResponse,
+    wrapParseError: (cause) =>
+      new ViesAPIError({
+        message: "VIES returned a non-JSON body",
+        httpStatus: response.status,
+        cause,
+      }),
+    wrapShapeError: () =>
+      new ViesAPIError({
+        message: "VIES response did not match the expected shape",
+        httpStatus: response.status,
+      }),
+  });
 
   return parseValidation(body, parsed);
 };


### PR DESCRIPTION
Consolidate the HTTP and normalization code every registry adapter had
hand-rolled, and fix three input-handling bugs surfaced by the drift.

Shared fetch scaffold (src/shared/http.ts):
- performRegistryRequest: fetch + timeout AbortSignal + RequestError
  wrapping, returning the raw Response (used by all 11 adapters, incl.
  the text-body ones and KRS's Certum-pinned request).
- readRegistryJson: JSON read + shape guard -> typed parse/shape error.
- registryFetch: composes both for the common JSON shape, delegating
  non-OK status mapping to an adapter callback, with an optional 429
  hook and a single-homed Retry-After parser (parseRetryAfterMs /
  rateLimitedError). No retry behavior is added; the rate-limit case now
  just has one place to live.

Adapters migrated: ares, brreg (+roles), companies-house, edgar, gcis,
denue, krs, orsr, prh, recherche-entreprises, vies. brreg, companies-
house, edgar and brreg roles use the composed registryFetch; the rest
use the primitives so their non-null returns, text/XML decoding, token
redaction and TLS pinning stay intact. Error types and messages are
unchanged.

Guard/string dedup:
- isRecord -> src/shared/guards.ts (removed 8 client copies).
- nonEmpty / trimToNull / emptyToNull -> src/shared/strings.ts as a
  single trimToNull with identical semantics. KRS/ORSR parsers keep
  their local helpers.

Bug fixes:
- DENUE parse discarded legitimate "0" address atoms (house/local
  number) via a blanket "0" -> null rule. Only the postal code uses "0"
  as an absent-value sentinel; scope that to CP explicitly and let every
  other field preserve "0".
- validateStateCode's `value >= 0` lower bound was a no-op; make the
  range explicit (national "00" plus states 01-32).
- clampSearchLimit passed NaN straight through (Math.min/max of NaN is
  NaN); clamp NaN to the minimum.

Tests added for all three fixes and for registryFetch (timeout, status
mapping, malformed JSON, shape guard, rate-limit routing, Retry-After).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when handling registry request failures, timeouts, malformed responses and unexpected data.
  * Corrected DENUE state-code validation, including support for the national “all states” value.
  * Preserved address values of `"0"` instead of incorrectly treating them as missing.
  * Improved handling of empty and whitespace-only fields across registry results.
  * Search limits now handle invalid numeric inputs safely.
* **Tests**
  * Added coverage for rate limiting, response validation, search limits and DENUE parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->