### PR TITLE
fix(infosoud): serialize politeness throttle and share one client across handlers

### DIFF
--- a/apps/api/src/handlers/chat/tools/infosoud-tools.ts
+++ b/apps/api/src/handlers/chat/tools/infosoud-tools.ts
@@ -2,7 +2,7 @@ import { toolDefinition } from "@tanstack/ai";
 import * as v from "valibot";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
-import { createInfoSoudClient } from "@/api/handlers/workspaces/infosoud-common";
+import { getInfoSoudClient } from "@/api/handlers/workspaces/infosoud-common";
 import { mapInfoSoudResult } from "@/api/handlers/workspaces/infosoud-result";
 
 export const createInfosoudTools = () => ({
@@ -27,7 +27,7 @@ export const createInfosoudTools = () => ({
       }),
     ),
   }).server(async ({ courtCode, spisZn }) => {
-    const client = createInfoSoudClient();
+    const client = getInfoSoudClient();
     const lookupResult = await client.searchCaseWithHearings({
       courtCode,
       spisZn,

--- a/apps/api/src/handlers/workspaces/infosoud-common.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-common.ts
@@ -4,6 +4,7 @@ import {
   InfoSoudAPIError,
   InfoSoudClient,
   InfoSoudParseError,
+  InfoSoudPragueCourtResolutionError,
   InfoSoudRequestError,
 } from "@stll/infosoud";
 
@@ -14,7 +15,28 @@ export const infosoudLookupBodySchema = t.Object({
   spisZn: t.String({ minLength: 1, maxLength: 64 }),
 });
 
-export const createInfoSoudClient = () => new InfoSoudClient({ cache: false });
+let sharedClient: InfoSoudClient | undefined;
+
+/**
+ * One process-wide InfoSoud client, created lazily on first use.
+ *
+ * A single instance is required for the client's politeness throttle to pace
+ * concurrent callers, since the throttle is per-instance; a per-request client
+ * would defeat it. Caching is enabled only for the courts list (its default
+ * 24h TTL), which is identical for every workspace and rarely changes.
+ * Per-case reads keep a 0ms TTL so lookups and the tracked-case sync always
+ * see live registry data.
+ */
+export const getInfoSoudClient = (): InfoSoudClient => {
+  sharedClient ??= new InfoSoudClient({
+    cache: {
+      caseTtlMs: 0,
+      eventDetailTtlMs: 0,
+      hearingsTtlMs: 0,
+    },
+  });
+  return sharedClient;
+};
 
 export const toInfoSoudLookupError = (error: unknown): HandlerError => {
   if (error instanceof InfoSoudParseError) {
@@ -36,15 +58,15 @@ export const toInfoSoudLookupError = (error: unknown): HandlerError => {
     });
   }
 
-  if (error instanceof InfoSoudRequestError) {
-    if (error.message.startsWith("Cannot resolve Prague district court")) {
-      return new HandlerError({
-        status: 404,
-        message: "InfoSoud case not found",
-        cause: error,
-      });
-    }
+  if (error instanceof InfoSoudPragueCourtResolutionError) {
+    return new HandlerError({
+      status: 404,
+      message: "InfoSoud case not found",
+      cause: error,
+    });
+  }
 
+  if (error instanceof InfoSoudRequestError) {
     return new HandlerError({
       status: 502,
       message: "InfoSoud request failed",

--- a/apps/api/src/handlers/workspaces/infosoud-courts.test.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-courts.test.ts
@@ -32,10 +32,59 @@ const createFailingFirstCallClient = (): {
   return { client, fetchCallCount: () => fetchCount };
 };
 
-let tracked = createFailingFirstCallClient();
+/**
+ * Two concurrent /infosoud-courts requests hitting a cold courts cache must
+ * share one in-flight load: the handler calls client.getCourts() and
+ * client.getDistrictCourts() without threading request.signal, so the
+ * shared client's #getCachedOrLoad dedup keeps both endpoints' fetches
+ * shared instead of each caller starting its own redundant throttled
+ * fetch. Holding the fetch open until both handler calls have started
+ * proves the second caller actually joins the first's in-flight load
+ * rather than merely benefiting from a fast synchronous resolution.
+ */
+const createGatedCourtsClient = (): {
+  client: InfoSoudClient;
+  fetchCallCountByPath: () => Record<string, number>;
+  release: () => void;
+} => {
+  const fetchCallCountByPath: Record<string, number> = {};
+  let releaseFetch: (() => void) | undefined;
+  const fetchGate = new Promise<void>((resolve) => {
+    releaseFetch = resolve;
+  });
+
+  const client = new InfoSoudClient({
+    delayMs: 0,
+    fetch: async (input) => {
+      const path = new URL(input instanceof Request ? input.url : input)
+        .pathname;
+      fetchCallCountByPath[path] = (fetchCallCountByPath[path] ?? 0) + 1;
+      await fetchGate;
+      return path.endsWith("/organizace/lov")
+        ? new Response(
+            JSON.stringify([
+              { kod: "KSUL", nazev: "Krajský soud Ústí nad Labem" },
+            ]),
+            { headers: { "content-type": "application/json" } },
+          )
+        : new Response(
+            JSON.stringify([{ kod: "OSSCEDC", nazev: "Okresní soud Děčín" }]),
+            { headers: { "content-type": "application/json" } },
+          );
+    },
+  });
+
+  return {
+    client,
+    fetchCallCountByPath: () => fetchCallCountByPath,
+    release: () => releaseFetch?.(),
+  };
+};
+
+let activeClient: InfoSoudClient = createFailingFirstCallClient().client;
 
 void mock.module("@/api/handlers/workspaces/infosoud-common", () => ({
-  getInfoSoudClient: () => tracked.client,
+  getInfoSoudClient: () => activeClient,
 }));
 
 const { default: infosoudCourts } = await import("./infosoud-courts");
@@ -59,7 +108,8 @@ const createContext = (): InfosoudCourtsContext =>
 
 describe("infosoudCourts", () => {
   test("does not queue the district-court load after the courts load fails", async () => {
-    tracked = createFailingFirstCallClient();
+    const tracked = createFailingFirstCallClient();
+    activeClient = tracked.client;
 
     const result = await infosoudCourts.handler(createContext());
 
@@ -72,5 +122,32 @@ describe("infosoudCourts", () => {
     // Reintroducing Promise.all here would enqueue it regardless of the
     // first call's outcome, bumping this to 2.
     expect(tracked.fetchCallCount()).toBe(1);
+  });
+
+  test("two concurrent requests on a cold courts cache share one in-flight load", async () => {
+    const gated = createGatedCourtsClient();
+    activeClient = gated.client;
+
+    // Fire both handler calls without awaiting either first, so the second
+    // reaches the shared client's in-flight check while the first call's
+    // load is still pending behind the gate.
+    const firstRequest = infosoudCourts.handler(createContext());
+    const secondRequest = infosoudCourts.handler(createContext());
+
+    gated.release();
+
+    const [first, second] = await Promise.all([firstRequest, secondRequest]);
+
+    if ("code" in first || "code" in second) {
+      throw new Error("Expected both concurrent requests to succeed");
+    }
+    expect(first).toEqual(second);
+    // One fetch per endpoint total, not one per endpoint per caller: a
+    // caller passing its own AbortSignal into client.getCourts()/
+    // getDistrictCourts() here would disable #getCachedOrLoad's in-flight
+    // sharing and double this to 2 fetches per path.
+    const fetchCounts = Object.values(gated.fetchCallCountByPath());
+    expect(fetchCounts).toHaveLength(2);
+    expect(fetchCounts.every((count) => count === 1)).toBe(true);
   });
 });

--- a/apps/api/src/handlers/workspaces/infosoud-courts.test.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-courts.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { InfoSoudClient } from "@stll/infosoud";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+/**
+ * The handler's district-court load must never run once the courts load has
+ * already failed. The shared InfoSoud client serializes both calls through
+ * one politeness throttle, so `Promise.all`-ing them provides zero
+ * concurrency here; it only enqueues the district load behind the courts
+ * load, which then still fires against InfoSoud after the handler has
+ * already returned its error response. Building a real client (with a fake
+ * `fetch` counting calls) instead of a hand-rolled stub pins the fix against
+ * the actual shared-throttle mechanics, not just the handler's own control
+ * flow.
+ */
+const createFailingFirstCallClient = (): {
+  client: InfoSoudClient;
+  fetchCallCount: () => number;
+} => {
+  let fetchCount = 0;
+  const client = new InfoSoudClient({
+    delayMs: 0,
+    fetch: async () => {
+      fetchCount += 1;
+      throw new TypeError("network unreachable");
+    },
+  });
+
+  return { client, fetchCallCount: () => fetchCount };
+};
+
+let tracked = createFailingFirstCallClient();
+
+void mock.module("@/api/handlers/workspaces/infosoud-common", () => ({
+  getInfoSoudClient: () => tracked.client,
+}));
+
+const { default: infosoudCourts } = await import("./infosoud-courts");
+
+type InfosoudCourtsContext = Parameters<typeof infosoudCourts.handler>[0];
+
+const createContext = (): InfosoudCourtsContext =>
+  asTestRaw<InfosoudCourtsContext>({
+    memberRole: { role: "owner" },
+    query: {},
+    request: new Request("https://example.test/infosoud-courts"),
+    route: "/infosoud-courts",
+    session: {
+      activeOrganizationId: toSafeId<"organization">(
+        "019e7000-0000-7000-8000-000000000002",
+      ),
+    },
+    set: { headers: {} },
+    user: { id: toSafeId<"user">("019e7000-0000-7000-8000-000000000001") },
+  });
+
+describe("infosoudCourts", () => {
+  test("does not queue the district-court load after the courts load fails", async () => {
+    tracked = createFailingFirstCallClient();
+
+    const result = await infosoudCourts.handler(createContext());
+
+    if (!("code" in result)) {
+      throw new Error("Expected the courts load failure to return a status");
+    }
+    expect(result.code).toBe(502);
+    // Sequential awaits short-circuit on the first rejection: the
+    // district-court call is never issued, so only one fetch ever fires.
+    // Reintroducing Promise.all here would enqueue it regardless of the
+    // first call's outcome, bumping this to 2.
+    expect(tracked.fetchCallCount()).toBe(1);
+  });
+});

--- a/apps/api/src/handlers/workspaces/infosoud-courts.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-courts.ts
@@ -3,7 +3,6 @@ import { Result } from "better-result";
 import {
   buildCourtMapFromEntries,
   InfoSoudAPIError,
-  InfoSoudClient,
   InfoSoudParseError,
   InfoSoudRequestError,
 } from "@stll/infosoud";
@@ -13,7 +12,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { compareByLocale } from "@/api/lib/collation";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
-const createInfoSoudClient = () => new InfoSoudClient({ cache: false });
+import { getInfoSoudClient } from "./infosoud-common";
 
 const toInfoSoudCourtsError = (error: unknown): HandlerError => {
   if (error instanceof InfoSoudAPIError) {
@@ -57,7 +56,7 @@ const infosoudCourts = createSafeHandler(config, async function* ({ request }) {
   const result = yield* Result.await(
     Result.tryPromise({
       try: async () => {
-        const client = createInfoSoudClient();
+        const client = getInfoSoudClient();
         const [courts, districtCourts] = await Promise.all([
           client.getCourts({ signal }),
           client.getDistrictCourts({ signal }),

--- a/apps/api/src/handlers/workspaces/infosoud-courts.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-courts.ts
@@ -57,10 +57,14 @@ const infosoudCourts = createSafeHandler(config, async function* ({ request }) {
     Result.tryPromise({
       try: async () => {
         const client = getInfoSoudClient();
-        const [courts, districtCourts] = await Promise.all([
-          client.getCourts({ signal }),
-          client.getDistrictCourts({ signal }),
-        ]);
+        // Sequential, not Promise.all: the shared client serializes every
+        // call through one politeness throttle, so both loads never run
+        // concurrently anyway. Promise.all would still enqueue the district
+        // load immediately, so a failure on the first load left the second
+        // queued and running against InfoSoud after this handler had already
+        // returned its error response.
+        const courts = await client.getCourts({ signal });
+        const districtCourts = await client.getDistrictCourts({ signal });
         const courtMap = buildCourtMapFromEntries([
           ...courts,
           ...districtCourts,

--- a/apps/api/src/handlers/workspaces/infosoud-courts.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-courts.ts
@@ -51,20 +51,27 @@ const config = {
   mcp: { type: "internal", reason: "native_tool_ui" },
 } satisfies HandlerConfig;
 
-const infosoudCourts = createSafeHandler(config, async function* ({ request }) {
-  const signal = request.signal;
+const infosoudCourts = createSafeHandler(config, async function* () {
   const result = yield* Result.await(
     Result.tryPromise({
       try: async () => {
         const client = getInfoSoudClient();
+        // Shared cacheable load; deliberately detached from caller signals
+        // so in-flight dedup works: #getCachedOrLoad only shares an
+        // in-flight load when no signal is passed, so threading each
+        // request's own AbortSignal here would make every concurrent caller
+        // on a cold courts cache start its own redundant throttled fetch. A
+        // disconnected caller just abandons its await; the load keeps
+        // running and populates the 24h cache for every other caller.
+        //
         // Sequential, not Promise.all: the shared client serializes every
         // call through one politeness throttle, so both loads never run
         // concurrently anyway. Promise.all would still enqueue the district
         // load immediately, so a failure on the first load left the second
         // queued and running against InfoSoud after this handler had already
         // returned its error response.
-        const courts = await client.getCourts({ signal });
-        const districtCourts = await client.getDistrictCourts({ signal });
+        const courts = await client.getCourts();
+        const districtCourts = await client.getDistrictCourts();
         const courtMap = buildCourtMapFromEntries([
           ...courts,
           ...districtCourts,

--- a/apps/api/src/handlers/workspaces/infosoud-import-agenda.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-import-agenda.ts
@@ -12,7 +12,7 @@ import {
 import { LIMITS } from "@/api/lib/limits";
 
 import {
-  createInfoSoudClient,
+  getInfoSoudClient,
   infosoudLookupBodySchema,
   toInfoSoudLookupError,
 } from "./infosoud-common";
@@ -38,7 +38,7 @@ const infosoudImportAgenda = createSafeHandler(
     const lookupResult = yield* Result.await(
       Result.tryPromise({
         try: async () => {
-          const client = createInfoSoudClient();
+          const client = getInfoSoudClient();
           return await client.searchCaseWithHearings({
             courtCode,
             signal: request.signal,

--- a/apps/api/src/handlers/workspaces/infosoud-lookup.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-lookup.ts
@@ -4,7 +4,7 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 
 import {
-  createInfoSoudClient,
+  getInfoSoudClient,
   infosoudLookupBodySchema,
   toInfoSoudLookupError,
 } from "./infosoud-common";
@@ -22,7 +22,7 @@ const infosoudLookup = createSafeHandler(
     const result = yield* Result.await(
       Result.tryPromise({
         try: async () => {
-          const client = createInfoSoudClient();
+          const client = getInfoSoudClient();
           const lookupResult = await client.searchCaseWithHearings({
             courtCode: body.courtCode,
             signal: request.signal,

--- a/apps/api/src/lib/scheduler/tasks/infosoud.ts
+++ b/apps/api/src/lib/scheduler/tasks/infosoud.ts
@@ -4,7 +4,7 @@ import { and, asc, eq, isNull, lt, or, sql } from "drizzle-orm";
 import { rootDb } from "@/api/db/root";
 import type { Transaction } from "@/api/db/root";
 import { infoSoudTrackedCases } from "@/api/db/schema";
-import { createInfoSoudClient } from "@/api/handlers/workspaces/infosoud-common";
+import { getInfoSoudClient } from "@/api/handlers/workspaces/infosoud-common";
 import { errorTag } from "@/api/lib/errors/utils";
 import {
   buildInfoSoudAgendaItems,
@@ -20,7 +20,7 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
   logger,
   signal,
 }) => {
-  const client = createInfoSoudClient();
+  const client = getInfoSoudClient();
   const syncStartedAt = new Date();
   let synced = 0;
   let failed = 0;

--- a/packages/infosoud/src/client.test.ts
+++ b/packages/infosoud/src/client.test.ts
@@ -5,6 +5,7 @@ import {
   InfoSoudAPIError,
   InfoSoudParseError,
   InfoSoudPragueCourtResolutionError,
+  InfoSoudRequestError,
 } from "./errors.js";
 
 const jsonResponse = (body: unknown, status = 200): Response =>
@@ -565,9 +566,135 @@ describe("InfoSoudClient", () => {
 
     expect(fetchStartedAt).toHaveLength(2);
     const [firstStart, secondStart] = fetchStartedAt;
+    if (firstStart === undefined || secondStart === undefined) {
+      throw new Error("Expected two fetch timestamps");
+    }
     // setTimeout never fires early, so the gap is a firm lower bound; allow a
     // small slack for timer-resolution rounding.
     expect(secondStart - firstStart).toBeGreaterThanOrEqual(delayMs - 5);
+  });
+
+  test("a queued caller aborted mid-wait does not spend a politeness slot", async () => {
+    const delayMs = 40;
+    const fetchStartedAt: number[] = [];
+
+    const client = new InfoSoudClient({
+      cache: false,
+      delayMs,
+      fetch: async () => {
+        fetchStartedAt.push(Date.now());
+        return jsonResponse(createCaseSearchResponse());
+      },
+    });
+
+    const abortController = new AbortController();
+
+    // First call runs immediately; the second and third queue behind it. The
+    // second is aborted while queued, so it must reject without fetching and
+    // without advancing the politeness clock, leaving the third paced from the
+    // first request's completion (one gap) rather than two.
+    const first = client.searchCase({
+      courtCode: "OSSCEDC",
+      spisZn: "1 T 64/2024",
+    });
+    const aborted = client.searchCase({
+      courtCode: "OSSCEDC",
+      signal: abortController.signal,
+      spisZn: "2 T 65/2024",
+    });
+    const third = client.searchCase({
+      courtCode: "OSSCEDC",
+      spisZn: "3 T 66/2024",
+    });
+    abortController.abort();
+
+    let abortError: unknown;
+    try {
+      await aborted;
+    } catch (error) {
+      abortError = error;
+    }
+    expect(abortError).toBeInstanceOf(InfoSoudRequestError);
+
+    await Promise.all([first, third]);
+
+    // The aborted caller never reached the network.
+    expect(fetchStartedAt).toHaveLength(2);
+    const [firstStart, thirdStart] = fetchStartedAt;
+    if (firstStart === undefined || thirdStart === undefined) {
+      throw new Error("Expected two fetch timestamps");
+    }
+    // One politeness gap from the first request, not two: the aborted caller
+    // did not push the third caller back by an extra delay.
+    expect(thirdStart - firstStart).toBeGreaterThanOrEqual(delayMs - 5);
+    expect(thirdStart - firstStart).toBeLessThan(delayMs * 2);
+  });
+
+  test("a pre-aborted signal performs no request at all", async () => {
+    let fetchCount = 0;
+
+    const client = new InfoSoudClient({
+      cache: false,
+      delayMs: 0,
+      fetch: async () => {
+        fetchCount += 1;
+        return jsonResponse(createCaseSearchResponse());
+      },
+    });
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    let abortError: unknown;
+    try {
+      await client.searchCase({
+        courtCode: "OSSCEDC",
+        signal: abortController.signal,
+        spisZn: "1 T 64/2024",
+      });
+    } catch (error) {
+      abortError = error;
+    }
+    expect(abortError).toBeInstanceOf(InfoSoudRequestError);
+
+    expect(fetchCount).toBe(0);
+  });
+
+  test("an aborted queued caller does not poison the shared throttle chain", async () => {
+    let fetchCount = 0;
+
+    const client = new InfoSoudClient({
+      cache: false,
+      delayMs: 0,
+      fetch: async () => {
+        fetchCount += 1;
+        return jsonResponse(createCaseSearchResponse());
+      },
+    });
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    let abortError: unknown;
+    try {
+      await client.searchCase({
+        courtCode: "OSSCEDC",
+        signal: abortController.signal,
+        spisZn: "1 T 64/2024",
+      });
+    } catch (error) {
+      abortError = error;
+    }
+    expect(abortError).toBeInstanceOf(InfoSoudRequestError);
+
+    // A subsequent caller behind the aborted one still runs to completion.
+    const result = await client.searchCase({
+      courtCode: "OSSCEDC",
+      spisZn: "2 T 65/2024",
+    });
+
+    expect(result.bcVec).toBe(64);
+    expect(fetchCount).toBe(1);
   });
 
   test("raises a typed Prague resolution error when no district matches", async () => {

--- a/packages/infosoud/src/client.test.ts
+++ b/packages/infosoud/src/client.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { InfoSoudClient } from "./client.js";
-import { InfoSoudAPIError, InfoSoudParseError } from "./errors.js";
+import {
+  InfoSoudAPIError,
+  InfoSoudParseError,
+  InfoSoudPragueCourtResolutionError,
+} from "./errors.js";
 
 const jsonResponse = (body: unknown, status = 200): Response =>
   new Response(JSON.stringify(body), {
@@ -534,6 +538,69 @@ describe("InfoSoudClient", () => {
     await client.searchCase({ courtCode: "OSSCEDC", spisZn: "1 T 64/2024" });
 
     expect(requestCount).toBe(2);
+  });
+
+  test("serializes concurrent requests on one instance with the politeness gap", async () => {
+    const delayMs = 40;
+    const fetchStartedAt: number[] = [];
+
+    const client = new InfoSoudClient({
+      // Disable caching so both lookups reach the network and are paced by the
+      // throttle rather than deduplicated.
+      cache: false,
+      delayMs,
+      fetch: async () => {
+        fetchStartedAt.push(Date.now());
+        return jsonResponse(createCaseSearchResponse());
+      },
+    });
+
+    // Fire two lookups concurrently on the same instance. Without a serializing
+    // throttle both would pass the pacing check together and hit the upstream
+    // registry simultaneously.
+    await Promise.all([
+      client.searchCase({ courtCode: "OSSCEDC", spisZn: "1 T 64/2024" }),
+      client.searchCase({ courtCode: "OSSCEDC", spisZn: "2 T 65/2024" }),
+    ]);
+
+    expect(fetchStartedAt).toHaveLength(2);
+    const [firstStart, secondStart] = fetchStartedAt;
+    // setTimeout never fires early, so the gap is a firm lower bound; allow a
+    // small slack for timer-resolution rounding.
+    expect(secondStart - firstStart).toBeGreaterThanOrEqual(delayMs - 5);
+  });
+
+  test("raises a typed Prague resolution error when no district matches", async () => {
+    const client = new InfoSoudClient({
+      delayMs: 0,
+      fetch: async () =>
+        jsonResponse(
+          {
+            error: "Bad Request",
+            message: "not found",
+            path: "/infosoud/api/v1/rizeni/vyhledej",
+            status: 400,
+            timestamp: "2026-04-05T00:00:00.000+00:00",
+          },
+          400,
+        ),
+    });
+
+    expect.assertions(2);
+
+    try {
+      await client.searchCase({ courtCode: "OSPHA", spisZn: "1 T 64/2024" });
+    } catch (error) {
+      expect(error).toBeInstanceOf(InfoSoudPragueCourtResolutionError);
+      if (error instanceof InfoSoudPragueCourtResolutionError) {
+        expect(error.spisZn).toMatchObject({
+          bcVec: 64,
+          cisloSenatu: 1,
+          druhVeci: "T",
+          rocnik: 2024,
+        });
+      }
+    }
   });
 
   test("hydrates matching case events with parsed event detail helpers", async () => {

--- a/packages/infosoud/src/client.test.ts
+++ b/packages/infosoud/src/client.test.ts
@@ -584,6 +584,34 @@ describe("InfoSoudClient", () => {
     expect(requestCount).toBe(2);
   });
 
+  test("buildCourtMap does not queue the district-court load after the courts load fails", async () => {
+    let fetchCount = 0;
+
+    const client = new InfoSoudClient({
+      delayMs: 0,
+      fetch: async () => {
+        fetchCount += 1;
+        throw new TypeError("network unreachable");
+      },
+    });
+
+    // resolveCourtCode delegates straight to buildCourtMap, so exercising
+    // buildCourtMap here also pins resolveCourtCode's callers.
+    let buildError: unknown;
+    try {
+      await client.buildCourtMap();
+    } catch (error) {
+      buildError = error;
+    }
+
+    expect(buildError).toBeInstanceOf(InfoSoudRequestError);
+    // Sequential awaits short-circuit on the first rejection: the
+    // district-court call is never issued, so only one fetch ever fires.
+    // Reintroducing Promise.all here would enqueue it regardless of the
+    // first call's outcome, bumping this to 2.
+    expect(fetchCount).toBe(1);
+  });
+
   test("serializes concurrent requests on one instance with the politeness gap", async () => {
     const delayMs = 40;
     const fetchStartedAt: number[] = [];

--- a/packages/infosoud/src/client.test.ts
+++ b/packages/infosoud/src/client.test.ts
@@ -46,6 +46,40 @@ const getRequestPath = (input: URL | Request | string): string => {
   return new URL(input.url).pathname;
 };
 
+/**
+ * Wraps a real AbortSignal's addEventListener/removeEventListener with
+ * counters, so tests can assert the throttle's abortable delay balances every
+ * listener it registers with a matching removal instead of leaking one per
+ * successful wait on a long-lived, reused signal.
+ */
+const patchSignalListenerCounts = (
+  signal: AbortSignal,
+): { addCount: () => number; removeCount: () => number } => {
+  let adds = 0;
+  let removes = 0;
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+
+  signal.addEventListener = (
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void => {
+    adds += 1;
+    originalAdd(type, listener, options);
+  };
+  signal.removeEventListener = (
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean,
+  ): void => {
+    removes += 1;
+    originalRemove(type, listener, options);
+  };
+
+  return { addCount: () => adds, removeCount: () => removes };
+};
+
 const createCaseSearchResponse = (overrides: Record<string, unknown> = {}) => ({
   bcVec: 64,
   cislo: 1,
@@ -695,6 +729,41 @@ describe("InfoSoudClient", () => {
 
     expect(result.bcVec).toBe(64);
     expect(fetchCount).toBe(1);
+  });
+
+  test("successful throttled waits do not accumulate abort listeners on a shared signal", async () => {
+    // Mirrors syncInfoSoudTrackedCases, which threads one long-lived scheduler
+    // AbortSignal through a whole tracked-case sweep: every throttled call
+    // that actually waits must remove its abort listener once the wait
+    // settles, or the listener count on the shared signal grows without bound.
+    const delayMs = 5;
+    const callCount = 5;
+
+    const client = new InfoSoudClient({
+      cache: false,
+      delayMs,
+      fetch: async () => jsonResponse(createCaseSearchResponse()),
+    });
+
+    const abortController = new AbortController();
+    const { addCount, removeCount } = patchSignalListenerCounts(
+      abortController.signal,
+    );
+
+    for (let index = 0; index < callCount; index += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential calls are required to actually exercise the politeness wait (and its listener) on each pass
+      await client.searchCase({
+        courtCode: "OSSCEDC",
+        signal: abortController.signal,
+        spisZn: `${index + 1} T 64/2024`,
+      });
+    }
+
+    // At least the calls after the first register a listener for their
+    // politeness wait (the first call has no prior request to be paced
+    // against, so it never waits and never registers one).
+    expect(addCount()).toBeGreaterThan(0);
+    expect(removeCount()).toBe(addCount());
   });
 
   test("raises a typed Prague resolution error when no district matches", async () => {

--- a/packages/infosoud/src/client.test.ts
+++ b/packages/infosoud/src/client.test.ts
@@ -89,6 +89,32 @@ const patchSignalListenerCounts = (
   return { addCount: () => adds, removeCount: () => removes };
 };
 
+type WaitForConditionProps = {
+  condition: () => boolean;
+  timeoutMs?: number;
+};
+
+// Poll a condition that is GUARANTEED to become true under correct behaviour
+// (e.g. "the queued caller has registered its abort listener"). The timeout
+// is a bug guard, not an observation window: it only fires when the property
+// under test is actually broken, so it is set generously rather than tuned to
+// expected wall-clock progress.
+const waitForCondition = async ({
+  condition,
+  timeoutMs = 5000,
+}: WaitForConditionProps): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error("Condition was not met before timeout.");
+    }
+    // oxlint-disable-next-line no-await-in-loop -- polling loop: each tick must wait before re-checking the condition
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 1);
+    });
+  }
+};
+
 const createCaseSearchResponse = (overrides: Record<string, unknown> = {}) => ({
   bcVec: 64,
   cislo: 1,
@@ -612,6 +638,55 @@ describe("InfoSoudClient", () => {
     expect(fetchCount).toBe(1);
   });
 
+  test("concurrent cold-cache buildCourtMap callers share one in-flight courts load, and an aborted caller's signal does not deprive anyone of the result", async () => {
+    const fetchCountByPath: Record<string, number> = {};
+    let releaseFetch: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+
+    const client = new InfoSoudClient({
+      delayMs: 0,
+      fetch: async (input) => {
+        const path = getRequestPath(input);
+        fetchCountByPath[path] = (fetchCountByPath[path] ?? 0) + 1;
+        // Hold every response open until the test releases it, so both
+        // concurrent callers are guaranteed to observe the fetch as still
+        // in flight when the signal below is aborted.
+        await fetchGate;
+        return path.endsWith("/organizace/lov")
+          ? jsonResponse([
+              { kod: "KSUL", nazev: "Krajský soud Ústí nad Labem" },
+            ])
+          : jsonResponse([{ kod: "OSSCEDC", nazev: "Okresní soud Děčín" }]);
+      },
+    });
+
+    const abortController = new AbortController();
+
+    // Fire both calls without awaiting either first, so the second reaches
+    // #getCachedOrLoad's in-flight check while the first call's load is
+    // still pending (and thus already registered in #inFlightRequests).
+    const firstPromise = client.buildCourtMap();
+    const secondPromise = client.buildCourtMap({
+      signal: abortController.signal,
+    });
+
+    // Abort mid-load: buildCourtMap's load() never forwards a signal into
+    // getCourts()/getDistrictCourts(), so this must not cancel the shared
+    // fetch or reject either caller — it only ever gated the outer
+    // court-map cache's own in-flight bookkeeping, never the network call.
+    abortController.abort();
+    releaseFetch?.();
+
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    const fetchCounts = Object.values(fetchCountByPath);
+    expect(fetchCounts).toHaveLength(2);
+    expect(fetchCounts.every((count) => count === 1)).toBe(true);
+    expect(first).toEqual(second);
+  });
+
   test("serializes concurrent requests on one instance with the politeness gap", async () => {
     const delayMs = 40;
     const fetchStartedAt: number[] = [];
@@ -659,6 +734,7 @@ describe("InfoSoudClient", () => {
     });
 
     const abortController = new AbortController();
+    const { addCount } = patchSignalListenerCounts(abortController.signal);
 
     // First call runs immediately; the second and third queue behind it. The
     // second is aborted while queued, so it must reject without fetching and
@@ -677,6 +753,14 @@ describe("InfoSoudClient", () => {
       courtCode: "OSSCEDC",
       spisZn: "3 T 66/2024",
     });
+
+    // Wait until the queued caller has actually registered its abort
+    // listener (i.e. entered the politeness delay) before aborting. Without
+    // this, abort() can fire before the throttle chain even reaches the
+    // second call's task, which short-circuits on the pre-task
+    // signal.throwIfAborted() check and never exercises a genuine mid-wait
+    // cancellation.
+    await waitForCondition({ condition: () => addCount() > 0 });
     abortController.abort();
 
     let abortError: unknown;

--- a/packages/infosoud/src/client.test.ts
+++ b/packages/infosoud/src/client.test.ts
@@ -57,8 +57,17 @@ const patchSignalListenerCounts = (
 ): { addCount: () => number; removeCount: () => number } => {
   let adds = 0;
   let removes = 0;
-  const originalAdd = signal.addEventListener.bind(signal);
-  const originalRemove = signal.removeEventListener.bind(signal);
+  // Bind off EventTarget.prototype (what AbortSignal's listener methods
+  // actually resolve to at runtime), not off `signal.addEventListener`
+  // directly: AbortSignal narrows addEventListener/removeEventListener to an
+  // overload set keyed by event name, and Function.prototype.bind() on an
+  // overloaded method collapses to only its last overload, which drops the
+  // `| null` that EventTarget's single signature (and this wrapper's own
+  // parameter type below) allows.
+  const originalAdd: EventTarget["addEventListener"] =
+    EventTarget.prototype.addEventListener.bind(signal);
+  const originalRemove: EventTarget["removeEventListener"] =
+    EventTarget.prototype.removeEventListener.bind(signal);
 
   signal.addEventListener = (
     type: string,
@@ -658,10 +667,23 @@ describe("InfoSoudClient", () => {
     if (firstStart === undefined || thirdStart === undefined) {
       throw new Error("Expected two fetch timestamps");
     }
-    // One politeness gap from the first request, not two: the aborted caller
-    // did not push the third caller back by an extra delay.
+    // setTimeout never fires early, so this lower bound is a firm proof that
+    // at least one politeness gap elapsed before the third fetch (the
+    // aborted caller did not let the third one through instantly).
     expect(thirdStart - firstStart).toBeGreaterThanOrEqual(delayMs - 5);
-    expect(thirdStart - firstStart).toBeLessThan(delayMs * 2);
+    // This is a loose sanity ceiling, not a precise "one gap, not two" proof:
+    // a real timer plus the event loop has no firm upper bound on how late
+    // it can fire if the CI worker stalls, so asserting close to
+    // `delayMs * 2` (the value that would indicate the aborted caller
+    // wrongly consumed a politeness slot) is flaky under scheduler pauses
+    // even though the implementation is correct. Kept wide enough that
+    // ordinary CI jitter cannot trip it, so it only catches a total
+    // stall/deadlock in the throttle chain; it intentionally no longer
+    // pins the exact single-vs-double-gap distinction that the original
+    // tight bound asserted, per PR review guidance trading that precision
+    // for CI robustness (the fetch-count check above still proves the
+    // aborted caller never reaches the network, independent of timing).
+    expect(thirdStart - firstStart).toBeLessThan(delayMs * 10);
   });
 
   test("a pre-aborted signal performs no request at all", async () => {

--- a/packages/infosoud/src/client.ts
+++ b/packages/infosoud/src/client.ts
@@ -378,19 +378,22 @@ const delay = async (ms: number, signal?: AbortSignal): Promise<void> => {
     // chain for the full politeness gap; the throttle re-checks the signal
     // once this resolves and rejects the caller. The timer and the abort
     // listener are mutually exclusive (abort clears the timer), so the wait
-    // settles exactly once.
+    // settles exactly once. Both settlement paths remove the abort listener:
+    // `{ once: true }` drops it as part of dispatching the abort event, and
+    // the timer path removes it explicitly. Without the explicit removal, a
+    // long-lived signal reused across many *successful* waits (e.g. a
+    // scheduler sweep threading one AbortSignal through hundreds of throttled
+    // calls) would accumulate one stale listener per call.
     const finish = (): void => {
+      signal?.removeEventListener("abort", onAbort);
       resolve();
     };
     const timer = setTimeout(finish, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        finish();
-      },
-      { once: true },
-    );
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      finish();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 };
 

--- a/packages/infosoud/src/client.ts
+++ b/packages/infosoud/src/client.ts
@@ -368,13 +368,29 @@ const parseErrorMessage = (
   return `InfoSoud request failed with ${status} for ${path}`;
 };
 
-const delay = async (ms: number): Promise<void> => {
-  if (ms <= 0) {
+const delay = async (ms: number, signal?: AbortSignal): Promise<void> => {
+  if (ms <= 0 || signal?.aborted) {
     return;
   }
 
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
+  await new Promise<void>((resolve) => {
+    // Wake early on abort so a cancelled caller does not hold the throttle
+    // chain for the full politeness gap; the throttle re-checks the signal
+    // once this resolves and rejects the caller. The timer and the abort
+    // listener are mutually exclusive (abort clears the timer), so the wait
+    // settles exactly once.
+    const finish = (): void => {
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        finish();
+      },
+      { once: true },
+    );
   });
 };
 
@@ -839,16 +855,19 @@ export class InfoSoudClient {
       cacheKey,
       cacheTtlMs,
       deserialize: parse,
-      load: () =>
-        this.#throttle(async () => {
-          const url = new URL(`${this.#baseUrl}${path}`);
-          if (query) {
-            url.search = query.toString();
-          }
+      load: async () => {
+        // Normalize both transport failures and a throttle-level abort (the
+        // throttle can reject before the task runs when the caller's signal is
+        // already aborted) into a single InfoSoudRequestError shape.
+        try {
+          return await this.#throttle(async () => {
+            const url = new URL(`${this.#baseUrl}${path}`);
+            if (query) {
+              url.search = query.toString();
+            }
 
-          const timeoutSignal = withTimeoutSignal(signal, this.#timeoutMs);
+            const timeoutSignal = withTimeoutSignal(signal, this.#timeoutMs);
 
-          try {
             const response = await this.#fetchImpl(url, {
               ...(body ? { body: JSON.stringify(body) } : {}),
               headers: {
@@ -872,20 +891,21 @@ export class InfoSoudClient {
             }
 
             return parse(responseBody);
-          } catch (error) {
-            if (
-              error instanceof InfoSoudAPIError ||
-              error instanceof InfoSoudParseError ||
-              error instanceof InfoSoudRequestError
-            ) {
-              throw error;
-            }
-
-            throw new InfoSoudRequestError(path, `Request failed for ${path}`, {
-              cause: error,
-            });
+          }, signal);
+        } catch (error) {
+          if (
+            error instanceof InfoSoudAPIError ||
+            error instanceof InfoSoudParseError ||
+            error instanceof InfoSoudRequestError
+          ) {
+            throw error;
           }
-        }),
+
+          throw new InfoSoudRequestError(path, `Request failed for ${path}`, {
+            cause: error,
+          });
+        }
+      },
       signal,
     });
     return result;
@@ -907,11 +927,24 @@ export class InfoSoudClient {
    * for the previous request to finish, then honours the politeness interval
    * measured from that request's completion, then runs. Two concurrent calls
    * on one instance are therefore paced apart instead of firing together.
+   *
+   * The caller's AbortSignal is honoured while queued. If it aborts before the
+   * task starts (either before or during the politeness wait), the caller
+   * rejects with the signal's abort reason without running the task and
+   * without advancing #lastRequestFinishedAt, so a cancelled caller never
+   * spends a politeness slot or an upstream request, and the next waiter is
+   * still paced from the previous *completed* request rather than the skipped
+   * one. An abort during the task is left to the task's own signal handling.
    */
-  #throttle<T>(task: () => Promise<T>): Promise<T> {
+  async #throttle<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
     const run = this.#throttleChain.then(async () => {
+      signal?.throwIfAborted();
+
       const elapsed = Date.now() - this.#lastRequestFinishedAt;
-      await delay(this.#delayMs - elapsed);
+      await delay(this.#delayMs - elapsed, signal);
+
+      signal?.throwIfAborted();
+
       try {
         return await task();
       } finally {
@@ -919,13 +952,13 @@ export class InfoSoudClient {
       }
     });
 
-    // Keep the chain alive even if a request rejects, so one failure cannot
-    // wedge every queued caller behind it.
+    // Keep the chain alive even if a request rejects or a queued caller is
+    // aborted, so one failure cannot wedge every queued caller behind it.
     this.#throttleChain = run.then(
       () => undefined,
       () => undefined,
     );
-    return run;
+    return await run;
   }
 
   #buildRequestCacheKey({

--- a/packages/infosoud/src/client.ts
+++ b/packages/infosoud/src/client.ts
@@ -752,14 +752,23 @@ export class InfoSoudClient {
       cacheTtlMs: this.#cacheConfig.derivedCourtMapTtlMs,
       deserialize: parseCourtMap,
       load: async () => {
+        // Shared cacheable load; deliberately detached from caller signals
+        // so in-flight dedup works: #getCachedOrLoad only shares an
+        // in-flight load when no signal is passed, so threading this call's
+        // signal into the two loads below would make every concurrent
+        // caller on a cold courts cache start its own redundant throttled
+        // fetch instead of sharing one. A caller that aborts simply
+        // abandons its await; the load keeps running and populates the
+        // cache for everyone else.
+        //
         // Sequential, not Promise.all: this instance serializes every call
         // through one politeness throttle, so both loads never run
         // concurrently anyway. Promise.all would still enqueue the district
         // load immediately, so a failure on the courts load left the
         // district load queued and running against InfoSoud after this
         // call had already rejected.
-        const courts = await this.getCourts({ signal });
-        const districtCourts = await this.getDistrictCourts({ signal });
+        const courts = await this.getCourts();
+        const districtCourts = await this.getDistrictCourts();
 
         return buildCourtMapFromEntries([...courts, ...districtCourts]);
       },

--- a/packages/infosoud/src/client.ts
+++ b/packages/infosoud/src/client.ts
@@ -752,10 +752,14 @@ export class InfoSoudClient {
       cacheTtlMs: this.#cacheConfig.derivedCourtMapTtlMs,
       deserialize: parseCourtMap,
       load: async () => {
-        const [courts, districtCourts] = await Promise.all([
-          this.getCourts({ signal }),
-          this.getDistrictCourts({ signal }),
-        ]);
+        // Sequential, not Promise.all: this instance serializes every call
+        // through one politeness throttle, so both loads never run
+        // concurrently anyway. Promise.all would still enqueue the district
+        // load immediately, so a failure on the courts load left the
+        // district load queued and running against InfoSoud after this
+        // call had already rejected.
+        const courts = await this.getCourts({ signal });
+        const districtCourts = await this.getDistrictCourts({ signal });
 
         return buildCourtMapFromEntries([...courts, ...districtCourts]);
       },

--- a/packages/infosoud/src/client.ts
+++ b/packages/infosoud/src/client.ts
@@ -20,6 +20,7 @@ import {
 import {
   InfoSoudAPIError,
   InfoSoudParseError,
+  InfoSoudPragueCourtResolutionError,
   InfoSoudRequestError,
 } from "./errors.js";
 import { enrichCaseEventWithDetail } from "./event-details.js";
@@ -483,6 +484,10 @@ export class InfoSoudClient {
   readonly #fetchImpl: FetchLike;
   readonly #inFlightRequests = new Map<string, Promise<unknown>>();
   #lastRequestFinishedAt = 0;
+  // Serializes the network critical section so concurrent calls on one
+  // instance queue up and honour the politeness interval instead of firing
+  // in parallel against the upstream registry.
+  #throttleChain: Promise<void> = Promise.resolve();
   readonly #timeoutMs: number;
   readonly #userAgent: string;
 
@@ -817,10 +822,7 @@ export class InfoSoudClient {
       }
     }
 
-    throw new InfoSoudRequestError(
-      path,
-      `Cannot resolve Prague district court for ${spisZn.cisloSenatu} ${spisZn.druhVeci} ${spisZn.bcVec}/${spisZn.rocnik}`,
-    );
+    throw new InfoSoudPragueCourtResolutionError(path, spisZn);
   }
 
   async #request<T>({
@@ -837,55 +839,53 @@ export class InfoSoudClient {
       cacheKey,
       cacheTtlMs,
       deserialize: parse,
-      load: async () => {
-        await this.#throttle();
+      load: () =>
+        this.#throttle(async () => {
+          const url = new URL(`${this.#baseUrl}${path}`);
+          if (query) {
+            url.search = query.toString();
+          }
 
-        const url = new URL(`${this.#baseUrl}${path}`);
-        if (query) {
-          url.search = query.toString();
-        }
+          const timeoutSignal = withTimeoutSignal(signal, this.#timeoutMs);
 
-        const timeoutSignal = withTimeoutSignal(signal, this.#timeoutMs);
+          try {
+            const response = await this.#fetchImpl(url, {
+              ...(body ? { body: JSON.stringify(body) } : {}),
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+                "User-Agent": this.#userAgent,
+              },
+              method,
+              signal: timeoutSignal,
+            });
 
-        try {
-          const response = await this.#fetchImpl(url, {
-            ...(body ? { body: JSON.stringify(body) } : {}),
-            headers: {
-              Accept: "application/json",
-              "Content-Type": "application/json",
-              "User-Agent": this.#userAgent,
-            },
-            method,
-            signal: timeoutSignal,
-          });
+            const responseBody = await this.#readResponseBody(response);
 
-          const responseBody = await this.#readResponseBody(response);
-          this.#lastRequestFinishedAt = Date.now();
+            if (!response.ok) {
+              throw new InfoSoudAPIError({
+                message: parseErrorMessage(responseBody, response.status, path),
+                path,
+                responseBody,
+                status: response.status,
+              });
+            }
 
-          if (!response.ok) {
-            throw new InfoSoudAPIError({
-              message: parseErrorMessage(responseBody, response.status, path),
-              path,
-              responseBody,
-              status: response.status,
+            return parse(responseBody);
+          } catch (error) {
+            if (
+              error instanceof InfoSoudAPIError ||
+              error instanceof InfoSoudParseError ||
+              error instanceof InfoSoudRequestError
+            ) {
+              throw error;
+            }
+
+            throw new InfoSoudRequestError(path, `Request failed for ${path}`, {
+              cause: error,
             });
           }
-
-          return parse(responseBody);
-        } catch (error) {
-          if (
-            error instanceof InfoSoudAPIError ||
-            error instanceof InfoSoudParseError ||
-            error instanceof InfoSoudRequestError
-          ) {
-            throw error;
-          }
-
-          throw new InfoSoudRequestError(path, `Request failed for ${path}`, {
-            cause: error,
-          });
-        }
-      },
+        }),
       signal,
     });
     return result;
@@ -902,10 +902,30 @@ export class InfoSoudClient {
     return result;
   }
 
-  async #throttle(): Promise<void> {
-    const elapsed = Date.now() - this.#lastRequestFinishedAt;
-    const remainingDelay = this.#delayMs - elapsed;
-    await delay(remainingDelay);
+  /**
+   * Serializes network work through a single promise chain: each call waits
+   * for the previous request to finish, then honours the politeness interval
+   * measured from that request's completion, then runs. Two concurrent calls
+   * on one instance are therefore paced apart instead of firing together.
+   */
+  #throttle<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.#throttleChain.then(async () => {
+      const elapsed = Date.now() - this.#lastRequestFinishedAt;
+      await delay(this.#delayMs - elapsed);
+      try {
+        return await task();
+      } finally {
+        this.#lastRequestFinishedAt = Date.now();
+      }
+    });
+
+    // Keep the chain alive even if a request rejects, so one failure cannot
+    // wedge every queued caller behind it.
+    this.#throttleChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   #buildRequestCacheKey({

--- a/packages/infosoud/src/errors.test.ts
+++ b/packages/infosoud/src/errors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { InfoSoudAPIError } from "./errors.js";
+import {
+  InfoSoudAPIError,
+  InfoSoudPragueCourtResolutionError,
+  InfoSoudRequestError,
+} from "./errors.js";
+import type { SpisZn } from "./types.js";
 
 describe("InfoSoudAPIError", () => {
   test("preserves ErrorOptions cause like the other exported error types", () => {
@@ -16,5 +21,49 @@ describe("InfoSoudAPIError", () => {
     expect(error.cause).toBe(cause);
     expect(error.status).toBe(400);
     expect(error.path).toBe("/rizeni/vyhledej");
+  });
+});
+
+describe("InfoSoudPragueCourtResolutionError", () => {
+  const spisZn: SpisZn = {
+    bcVec: 64,
+    cisloSenatu: 1,
+    druhVeci: "T",
+    rocnik: 2024,
+  };
+
+  test("is discriminable by class without sniffing the message", () => {
+    const error = new InfoSoudPragueCourtResolutionError(
+      "/rizeni/vyhledej",
+      spisZn,
+    );
+
+    // Discriminates against its own class...
+    expect(error).toBeInstanceOf(InfoSoudPragueCourtResolutionError);
+    // ...and still satisfies the generic request-error fallback.
+    expect(error).toBeInstanceOf(InfoSoudRequestError);
+    expect(error.name).toBe("InfoSoudPragueCourtResolutionError");
+    expect(error.path).toBe("/rizeni/vyhledej");
+    expect(error.spisZn).toEqual(spisZn);
+  });
+
+  test("carries the queried case mark in a stable message", () => {
+    const error = new InfoSoudPragueCourtResolutionError(
+      "/jednani/vyhledej",
+      spisZn,
+    );
+
+    expect(error.message).toBe(
+      "Cannot resolve Prague district court for 1 T 64/2024",
+    );
+  });
+
+  test("a plain InfoSoudRequestError is not misclassified as the Prague variant", () => {
+    const error = new InfoSoudRequestError(
+      "/rizeni/vyhledej",
+      "Request failed for /rizeni/vyhledej",
+    );
+
+    expect(error).not.toBeInstanceOf(InfoSoudPragueCourtResolutionError);
   });
 });

--- a/packages/infosoud/src/errors.ts
+++ b/packages/infosoud/src/errors.ts
@@ -1,3 +1,5 @@
+import type { SpisZn } from "./types.js";
+
 export class InfoSoudError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
@@ -45,5 +47,28 @@ export class InfoSoudRequestError extends InfoSoudError {
     super(message, options);
     this.name = "InfoSoudRequestError";
     this.path = path;
+  }
+}
+
+/**
+ * Raised when a Prague spisová značka cannot be attributed to a single
+ * obvodní soud because every candidate district rejected the lookup.
+ *
+ * A distinct class so callers can map this "case not found" outcome to
+ * their own status codes without sniffing the error message; extends
+ * {@link InfoSoudRequestError} so existing request-error handling still
+ * applies as a fallback.
+ */
+export class InfoSoudPragueCourtResolutionError extends InfoSoudRequestError {
+  readonly spisZn: SpisZn;
+
+  constructor(path: string, spisZn: SpisZn, options?: ErrorOptions) {
+    super(
+      path,
+      `Cannot resolve Prague district court for ${spisZn.cisloSenatu} ${spisZn.druhVeci} ${spisZn.bcVec}/${spisZn.rocnik}`,
+      options,
+    );
+    this.name = "InfoSoudPragueCourtResolutionError";
+    this.spisZn = spisZn;
   }
 }

--- a/packages/infosoud/src/index.ts
+++ b/packages/infosoud/src/index.ts
@@ -38,6 +38,7 @@ export {
   InfoSoudAPIError,
   InfoSoudError,
   InfoSoudParseError,
+  InfoSoudPragueCourtResolutionError,
   InfoSoudRequestError,
 } from "./errors.js";
 export {


### PR DESCRIPTION
The client throttle compared each call against an instance-level
last-finished timestamp with no queue, so concurrent calls on one
instance all passed the pacing check and hit the upstream court
registry simultaneously. Every API handler also built its own
`new InfoSoudClient({ cache: false })` per request, so the throttle
never applied across users and the highly cacheable courts list was
refetched every time.

- Make `#throttle` a serializing promise-chain: each request waits for
  the previous one to finish, then honours the politeness interval,
  then runs. Concurrent calls are now paced apart.
- Add one lazily-created shared client via `getInfoSoudClient()` and
  route every handler, chat tool, and the scheduler sync task through
  it. Enable caching only for the courts list (default 24h TTL); keep
  per-case, hearings, and event-detail TTLs at 0 so lookups and the
  tracked-case sync always read live data.
- Replace the `createInfoSoudClient` duplicate in the courts handler
  with the shared getter.
- Expose Prague district resolution failure as a dedicated
  `InfoSoudPragueCourtResolutionError` (extends `InfoSoudRequestError`)
  and discriminate on the class instead of the error message prefix, so
  rewording the message can no longer change API status mapping.

Extends the package tests with throttle serialization and Prague
resolution error coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - InfoSoud requests are now paced more consistently to reduce throttling issues during concurrent activity.
  - Requests can be cancelled cleanly while waiting or in progress, improving responsiveness.
  - Court and case lookups now stop promptly when an earlier data request fails.
  - Shared request handling improves reliability across chat, workspace, import, lookup and synchronisation workflows.

- **Bug Fixes**
  - Prague court resolution failures are now reported as clear “case not found” errors.
  - Failed or cancelled requests no longer interfere with subsequent InfoSoud requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->