### PR TITLE
feat: enforce per-app crawl posture with a self-testing CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,28 @@ jobs:
           bun scripts/ratchet.ts --self-test
           bun scripts/ratchet.ts --check
 
+      - name: Crawl posture guard
+        if: needs.ci-changes.outputs.package_checks_required == 'true'
+        # Every app under apps/ declares a `crawlPosture` in package.json:
+        # "public" (indexable SEO/LLM surface), "private" (authenticated app that
+        # must stay invisible to crawlers), "mixed" (an SSR app with both public
+        # and private routes), or "unserved" (not an internet-facing HTML
+        # surface). This guard verifies the crawl artifacts match the declared
+        # posture — a public surface must ship a crawler-inviting robots.txt
+        # (Sitemap, no deny-all) plus an llms.txt and carry no `noindex`; a
+        # private surface must ship a deny-all robots.txt (no Sitemap), a
+        # `noindex` robots meta on every served page, and no llms.txt; a mixed
+        # surface must serve a dynamic default-deny robots.txt with an explicit
+        # public allowlist (a robots server route, no shadowing static
+        # robots.txt, and a crawl-prefix allowlist that maps to real routes,
+        # checked in source) instead of static files — so the SEO/LLM surface and
+        # the private routes cannot silently drift. The --self-test run first
+        # proves each detector still fires, so a broken guard cannot pass
+        # silently.
+        run: |
+          bun scripts/crawl-posture.ts --self-test
+          bun scripts/crawl-posture.ts --check
+
       - name: CLI registry snapshot guard
         if: needs.ci-changes.outputs.package_checks_required == 'true'
         # The stella CLI's committed registry snapshot, generated route map, and

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -112,5 +112,6 @@
     "drizzle-kit": "catalog:",
     "expect-type": "^1.4.0",
     "fast-check": "catalog:"
-  }
+  },
+  "crawlPosture": "unserved"
 }

--- a/apps/collab/package.json
+++ b/apps/collab/package.json
@@ -27,5 +27,6 @@
     "@hocuspocus/provider": "^4.3.0",
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:"
-  }
+  },
+  "crawlPosture": "unserved"
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,5 +32,6 @@
     "@types/react-dom": "catalog:react19",
     "@vitejs/plugin-react": "catalog:",
     "vite": "catalog:"
-  }
+  },
+  "crawlPosture": "unserved"
 }

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -29,5 +29,6 @@
     "@resvg/resvg-js": "^2.6.2",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19"
-  }
+  },
+  "crawlPosture": "public"
 }

--- a/apps/legal-atlas-runner/package.json
+++ b/apps/legal-atlas-runner/package.json
@@ -41,5 +41,6 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@types/bun": "catalog:"
-  }
+  },
+  "crawlPosture": "unserved"
 }

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -27,5 +27,6 @@
     "@vitejs/plugin-react": "catalog:",
     "tailwindcss": "catalog:",
     "vite": "catalog:"
-  }
+  },
+  "crawlPosture": "unserved"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -139,5 +139,6 @@
     "react-grab": "^0.1.48",
     "rollup-plugin-visualizer": "^7.0.1",
     "unified": "^11.0.5"
-  }
+  },
+  "crawlPosture": "mixed"
 }

--- a/apps/web/src/lib/public-law-sitemap.test.ts
+++ b/apps/web/src/lib/public-law-sitemap.test.ts
@@ -428,14 +428,15 @@ describe("public law sitemap", () => {
       publicLawCrawlAllowed: false,
       seoIndexable: true,
     });
+    const lines = robots.split("\n");
 
     // No allow-list yet, so default-deny keeps every path (including /law) out.
-    expect(robots).toContain("User-agent: *");
-    expect(robots).toContain("Disallow: /");
-    expect(robots).not.toContain("Allow: /law");
-    expect(robots).not.toContain("Disallow: /law/");
-    expect(robots).not.toContain("Disallow: /workspaces");
-    expect(robots).toContain("Sitemap: http://localhost:3000/sitemap.xml");
+    expect(lines).toContain("User-agent: *");
+    expect(lines).toContain("Disallow: /");
+    expect(lines.some((line) => line.startsWith("Allow:"))).toBe(false);
+    expect(lines).not.toContain("Disallow: /law/");
+    expect(lines).not.toContain("Disallow: /workspaces");
+    expect(lines).toContain("Sitemap: http://localhost:3000/sitemap.xml");
   });
 
   test("robots allow-lists the public crawl prefixes when indexable and crawling is permitted", () => {
@@ -443,21 +444,33 @@ describe("public law sitemap", () => {
       publicLawCrawlAllowed: true,
       seoIndexable: true,
     });
+    const lines = robots.split("\n");
+    const allowLines = lines.filter((line) => line.startsWith("Allow:"));
 
-    // Allow the public prefixes, then default-deny everything else.
-    expect(robots).toContain("Allow: /law");
-    expect(robots).toContain("Allow: /sitemap.xml");
-    expect(robots).toContain("Allow: /sitemaps");
-    expect(robots).toContain("Disallow: /");
-    expect(robots).not.toContain("Disallow: /law/");
-    expect(robots).toContain("Sitemap: http://localhost:3000/sitemap.xml");
+    // Boundary-anchored rules: dir prefixes emit a subtree + exact-path pair,
+    // the sitemap.xml file prefix emits just the exact-path rule.
+    expect(allowLines).toEqual([
+      "Allow: /law/",
+      "Allow: /law$",
+      "Allow: /sitemap.xml$",
+      "Allow: /sitemaps/",
+      "Allow: /sitemaps$",
+    ]);
+    // Sibling-path regression: never emit a bare un-anchored prefix (which
+    // would also match /lawyer, /law-admin, …). Every Allow rule ends in / or $.
+    for (const line of allowLines) {
+      expect(line.endsWith("/") || line.endsWith("$")).toBe(true);
+    }
+    expect(lines).toContain("Disallow: /");
+    expect(lines).not.toContain("Disallow: /law/");
+    expect(lines).toContain("Sitemap: http://localhost:3000/sitemap.xml");
   });
 
   test("robots always default-denies for every flag combination", () => {
     for (const publicLawCrawlAllowed of [false, true]) {
       for (const seoIndexable of [false, true]) {
         const robots = createRobotsTxt({ publicLawCrawlAllowed, seoIndexable });
-        expect(robots).toContain("Disallow: /");
+        expect(robots.split("\n")).toContain("Disallow: /");
       }
     }
   });

--- a/apps/web/src/lib/public-law-sitemap.test.ts
+++ b/apps/web/src/lib/public-law-sitemap.test.ts
@@ -423,29 +423,43 @@ describe("public law sitemap", () => {
     expect(createRobotsTxt()).toBe("User-agent: *\nDisallow: /\n");
   });
 
-  test("robots disallows public law but keeps path rules when indexable without crawl permission", () => {
+  test("robots default-denies the whole host when indexable without crawl permission", () => {
     const robots = createRobotsTxt({
       publicLawCrawlAllowed: false,
       seoIndexable: true,
     });
 
-    expect(robots).toContain("Disallow: /law/");
-    expect(robots).toContain("Disallow: /workspaces");
-    expect(robots).toContain("Disallow: /knowledge");
-    expect(robots).toContain("Disallow: /chat");
+    // No allow-list yet, so default-deny keeps every path (including /law) out.
+    expect(robots).toContain("User-agent: *");
+    expect(robots).toContain("Disallow: /");
+    expect(robots).not.toContain("Allow: /law");
+    expect(robots).not.toContain("Disallow: /law/");
+    expect(robots).not.toContain("Disallow: /workspaces");
     expect(robots).toContain("Sitemap: http://localhost:3000/sitemap.xml");
-    expect(robots).not.toContain("Allow: /law/");
   });
 
-  test("robots allows public law only when indexable and crawling is permitted", () => {
+  test("robots allow-lists the public crawl prefixes when indexable and crawling is permitted", () => {
     const robots = createRobotsTxt({
       publicLawCrawlAllowed: true,
       seoIndexable: true,
     });
 
-    expect(robots).toContain("Allow: /law/");
+    // Allow the public prefixes, then default-deny everything else.
+    expect(robots).toContain("Allow: /law");
+    expect(robots).toContain("Allow: /sitemap.xml");
+    expect(robots).toContain("Allow: /sitemaps");
+    expect(robots).toContain("Disallow: /");
     expect(robots).not.toContain("Disallow: /law/");
     expect(robots).toContain("Sitemap: http://localhost:3000/sitemap.xml");
+  });
+
+  test("robots always default-denies for every flag combination", () => {
+    for (const publicLawCrawlAllowed of [false, true]) {
+      for (const seoIndexable of [false, true]) {
+        const robots = createRobotsTxt({ publicLawCrawlAllowed, seoIndexable });
+        expect(robots).toContain("Disallow: /");
+      }
+    }
   });
 
   test("sitemaps are still served while a non-indexable deployment blocks crawlers", () => {

--- a/apps/web/src/lib/public-law-sitemap.ts
+++ b/apps/web/src/lib/public-law-sitemap.ts
@@ -346,6 +346,18 @@ type RobotsTxtOptions = {
   seoIndexable?: boolean;
 };
 
+// The ONLY crawlable path prefixes on the app host. The indexable robots.txt
+// allow-lists exactly these and then default-denies everything else with a
+// trailing `Disallow: /`, so every route that is not one of these is private
+// by default — a newly added route cannot leak into crawler reach without being
+// added here on purpose. Longest-match precedence means the `Allow:` lines win
+// for their own prefixes while `Disallow: /` covers the rest.
+export const PUBLIC_CRAWL_PATH_PREFIXES = [
+  "/law",
+  "/sitemap.xml",
+  "/sitemaps",
+] as const;
+
 export const createRobotsTxt = ({
   publicLawCrawlAllowed = isPublicLawCrawlAllowed(),
   seoIndexable = env.VITE_SEO_INDEXABLE,
@@ -363,20 +375,15 @@ Disallow: /
     "/sitemap.xml",
     env.VITE_PUBLIC_APP_URL,
   ).toString();
-  const lawRule = publicLawCrawlAllowed ? "Allow: /law/" : "Disallow: /law/";
 
-  return `User-agent: *
-${lawRule}
-Disallow: /auth
-Disallow: /onboarding
-Disallow: /consent
-Disallow: /chat
-Disallow: /workspaces
-Disallow: /knowledge
-Disallow: /settings
-Disallow: /organization
-Disallow: /todos
-Disallow: /contacts
-Sitemap: ${sitemapUrl}
+  // Fail closed: allow-list the public crawl prefixes (only once crawling is
+  // permitted), then default-deny everything else. When crawling is not
+  // permitted the allow-list is empty, so `Disallow: /` alone keeps the whole
+  // host — including /law — out of crawler reach.
+  const allowLines = publicLawCrawlAllowed
+    ? PUBLIC_CRAWL_PATH_PREFIXES.map((prefix) => `Allow: ${prefix}`)
+    : [];
+
+  return `${["User-agent: *", ...allowLines, "Disallow: /", `Sitemap: ${sitemapUrl}`].join("\n")}
 `;
 };

--- a/apps/web/src/lib/public-law-sitemap.ts
+++ b/apps/web/src/lib/public-law-sitemap.ts
@@ -347,11 +347,12 @@ type RobotsTxtOptions = {
 };
 
 // The ONLY crawlable path prefixes on the app host. The indexable robots.txt
-// allow-lists exactly these and then default-denies everything else with a
-// trailing `Disallow: /`, so every route that is not one of these is private
-// by default — a newly added route cannot leak into crawler reach without being
-// added here on purpose. Longest-match precedence means the `Allow:` lines win
-// for their own prefixes while `Disallow: /` covers the rest.
+// allow-lists exactly these (boundary-anchored, see below) and then
+// default-denies everything else with a trailing `Disallow: /`, so every route
+// that is not one of these is private by default — a newly added route cannot
+// leak into crawler reach without being added here on purpose. Longest-match
+// precedence means the `Allow:` rules win for their own prefixes while
+// `Disallow: /` covers the rest.
 export const PUBLIC_CRAWL_PATH_PREFIXES = [
   "/law",
   "/sitemap.xml",
@@ -380,8 +381,21 @@ Disallow: /
   // permitted), then default-deny everything else. When crawling is not
   // permitted the allow-list is empty, so `Disallow: /` alone keeps the whole
   // host — including /law — out of crawler reach.
+  //
+  // Boundary-anchored rules: raw robots.txt prefix matching means `Allow: /law`
+  // would also open `/lawyer` or `/law-admin`, silently un-failing-closed for a
+  // future sibling route. So a directory prefix emits two rules — `<prefix>/`
+  // (the subtree) and `<prefix>$` (the exact path) — and a file prefix (one
+  // containing a ".") emits just `<prefix>$`. `$` is the end-of-path anchor
+  // supported by Googlebot and Bing; crawlers that don't support `$` treat it
+  // literally and simply fail to match, erring toward not crawling — the
+  // failure direction we want.
   const allowLines = publicLawCrawlAllowed
-    ? PUBLIC_CRAWL_PATH_PREFIXES.map((prefix) => `Allow: ${prefix}`)
+    ? PUBLIC_CRAWL_PATH_PREFIXES.flatMap((prefix) =>
+        prefix.includes(".")
+          ? [`Allow: ${prefix}$`]
+          : [`Allow: ${prefix}/`, `Allow: ${prefix}$`],
+      )
     : [];
 
   return `${["User-agent: *", ...allowLines, "Disallow: /", `Sitemap: ${sitemapUrl}`].join("\n")}

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -10,8 +10,8 @@
 //
 // Postures:
 //   public   — an indexable SEO/LLM surface. robots.txt must invite crawlers
-//              (a Sitemap, no deny-all), an llms.txt must exist, and no source
-//              page may carry a `noindex` robots meta.
+//              (a Sitemap, no wildcard or bot-specific deny-all), an llms.txt
+//              must exist, and no source page may carry a `noindex` robots meta.
 //   private  — an authenticated app that must stay invisible to crawlers.
 //              robots.txt must deny all (`User-agent: *` + `Disallow: /`) with
 //              no Sitemap and no `Allow:` rule (a more specific Allow can beat
@@ -92,6 +92,7 @@ type ViolationCode =
   | "private-has-llms"
   | "public-robots-missing"
   | "public-robots-deny-all"
+  | "public-robots-bot-specific-deny-all"
   | "public-robots-missing-sitemap"
   | "public-llms-missing"
   | "public-src-noindex"
@@ -194,6 +195,25 @@ const hasPermissiveBotGroup = (robotsText: string): boolean =>
     (group) =>
       !group.agents.includes("*") &&
       !group.rules.some(
+        (rule) => rule.field === "disallow" && rule.value === "/",
+      ),
+  );
+
+// A non-wildcard group (e.g. `User-agent: Googlebot`) that denies all itself.
+// Per the robots.txt spec, a crawler follows the MOST SPECIFIC group that names
+// it and ignores the wildcard fallback entirely — so a `User-agent: Googlebot`
+// group with `Disallow: /` blocks that bot even though the wildcard
+// `User-agent: *` group invites everyone else. `hasDenyAll` only inspects the
+// wildcard group, so it does not catch this. A group whose stacked agents
+// include `*` shares the wildcard's rules and is exempt. This mirrors
+// `hasPermissiveBotGroup` on the private side: there a bot-specific group can
+// carve an unwanted opening in a deny-all; here one can carve an unwanted
+// closure in an invite-all.
+const hasBotSpecificDenyAll = (robotsText: string): boolean =>
+  parseRobotsGroups(robotsText).some(
+    (group) =>
+      !group.agents.includes("*") &&
+      group.rules.some(
         (rule) => rule.field === "disallow" && rule.value === "/",
       ),
   );
@@ -442,6 +462,15 @@ const checkPublic = (appDir: string, app: string): Violation[] => {
         message:
           "public app public/robots.txt contains a deny-all `Disallow: /`.",
         fix: "remove the deny-all; a public surface must invite crawlers.",
+      });
+    }
+    if (hasBotSpecificDenyAll(robots)) {
+      violations.push({
+        app,
+        code: "public-robots-bot-specific-deny-all",
+        message:
+          "public app public/robots.txt contains a bot-specific `User-agent` group that denies all.",
+        fix: "remove the bot-specific group, or its `Disallow: /`: a named bot follows only its own most-specific group and ignores the wildcard invite.",
       });
     }
     if (!hasSitemapLine(robots)) {
@@ -755,6 +784,8 @@ const DENY_ALL_ROBOTS_WITH_BOT_CARVEOUT =
 const PUBLIC_ROBOTS =
   "User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n";
 const PUBLIC_ROBOTS_NO_SITEMAP = "User-agent: *\nAllow: /\n";
+const PUBLIC_ROBOTS_WITH_BOT_DENY_ALL =
+  "User-agent: *\nAllow: /\n\nUser-agent: Googlebot\nDisallow: /\n\nSitemap: https://example.com/sitemap.xml\n";
 const LLMS_TXT = "# Example\nA public surface for LLM readers.\n";
 
 const pkg = (posture: string): string =>
@@ -1021,6 +1052,24 @@ const runSelfTest = (): number => {
       writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
     }),
     "public-robots-deny-all",
+  );
+
+  // 8a. public with a bot-specific group that denies all, even though the
+  //     wildcard group invites everyone. That bot follows only its own
+  //     most-specific group and ignores the wildcard invite, so it is silently
+  //     blocked from a supposedly public surface.
+  expectCode(
+    "public with bot-specific deny-all",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("public"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        PUBLIC_ROBOTS_WITH_BOT_DENY_ALL,
+      );
+      writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
+    }),
+    "public-robots-bot-specific-deny-all",
   );
 
   // 8b. public with no robots.txt at all.

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -71,15 +71,8 @@ const MIXED_ROUTES_DIR = "src/routes";
 const MIXED_INDEX_HTML = "index.html";
 const MIXED_CRAWL_PREFIX_CONST = "PUBLIC_CRAWL_PATH_PREFIXES";
 
-// Source file extensions scanned for a stray `noindex` on a public surface.
-const PUBLIC_SRC_EXTENSIONS = [
-  ".astro",
-  ".html",
-  ".tsx",
-  ".ts",
-  ".mdx",
-  ".md",
-] as const;
+// Source files scanned for a stray `noindex` robots meta on a public surface.
+const PUBLIC_SRC_GLOB = "**/*.{astro,html,tsx,ts,mdx,md}";
 
 // --- Violations -------------------------------------------------------------
 // A stable `code` discriminator identifies which detector fired (drives the
@@ -104,6 +97,7 @@ type ViolationCode =
   | "mixed-index-html-robots-meta"
   | "mixed-lib-missing"
   | "mixed-lib-no-default-deny"
+  | "mixed-lib-constant-unused"
   | "mixed-allow-not-in-constant"
   | "mixed-prefix-no-route";
 
@@ -181,12 +175,25 @@ const hasDenyAll = (robotsText: string): boolean =>
 
 const META_TAG = /<meta\b[^>]*>/giu;
 const ROBOTS_NAME_ATTR = /\bname\s*=\s*["']robots["']/iu;
-const NOINDEX = /noindex/iu;
+const CONTENT_ATTR = /\bcontent\s*=\s*["']([^"']*)["']/iu;
+
+// `noindex` as a comma/whitespace-delimited directive token inside the robots
+// meta `content` value — not a raw substring of the whole tag, which would both
+// false-positive on unrelated attribute values and be order-sensitive.
+const robotsContentHasNoindex = (tag: string): boolean => {
+  const content = CONTENT_ATTR.exec(tag)?.[1];
+  if (content === undefined) {
+    return false;
+  }
+  return content
+    .split(/[\s,]+/u)
+    .some((token) => token.toLowerCase() === "noindex");
+};
 
 const hasNoindexRobotsMeta = (html: string): boolean => {
   for (const match of html.matchAll(META_TAG)) {
     const tag = match[0];
-    if (ROBOTS_NAME_ATTR.test(tag) && NOINDEX.test(tag)) {
+    if (ROBOTS_NAME_ATTR.test(tag) && robotsContentHasNoindex(tag)) {
       return true;
     }
   }
@@ -207,15 +214,47 @@ const hasRobotsMetaTag = (html: string): boolean => {
 
 // --- Mixed (dynamic SSR) robots-source helpers ------------------------------
 
+// Strip comments before lexical checks so a commented-out `Allow:` example or a
+// prose mention of the constant cannot satisfy (or trip) a detector. Removes
+// `/* ... */` blocks, then drops line comments ONLY when the trimmed line
+// starts with `//`. A naive `//.*$` would eat the tail of any line containing a
+// URL (`https://…`) and is deliberately avoided; a trailing `// ...` comment on
+// a code line is left in place (harmless for these presence/allowlist checks).
+const stripSourceComments = (source: string): string =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//gu, "")
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("//"))
+    .join("\n");
+
 // The indexable branch emits its default-deny as a quoted `"Disallow: /"`
 // array element (distinct from the non-indexable branch's template line and
 // from any backtick-quoted mention in a comment), so match the quoted literal.
 const INDEXABLE_DEFAULT_DENY = /["']Disallow:\s*\/["']/u;
-// An `Allow:` directive whose value is a literal path (`Allow: /law`); the
-// leading `/` requirement skips the generated `Allow: ${prefix}` template form,
-// which is what the constant expands to at runtime.
+// An `Allow:` directive whose value is a literal path (`Allow: /law`, and with
+// the boundary emission `Allow: /law/` or `Allow: /law$`); the leading `/`
+// requirement skips the generated `Allow: ${prefix}...` template form.
 const ALLOW_PATH_LITERAL = /Allow:\s*(\/[^\s"'`]+)/gu;
 const QUOTED_STRING = /["'`]([^"'`]+)["'`]/gu;
+
+// Normalize an emitted allow path back to its crawl-prefix by dropping a
+// trailing boundary marker (`/` subtree rule or `$` exact-path anchor).
+const allowPathToPrefix = (allowPath: string): string =>
+  allowPath.replace(/[/$]$/u, "");
+
+// The body of `createRobotsTxt` (from its declaration to the next top-level
+// `export`, or end of file). Used to confirm the function actually consults the
+// crawl-prefix constant rather than hand-building Allow lines around it.
+const createRobotsTxtBody = (source: string): string | null => {
+  const marker = "createRobotsTxt";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    return null;
+  }
+  const rest = source.slice(start + marker.length);
+  const nextExport = rest.search(/\nexport\s/u);
+  return nextExport === -1 ? rest : rest.slice(0, nextExport);
+};
 
 // String entries of `export const <NAME> = [ ... ] as const`.
 const crawlPrefixConstantEntries = (
@@ -379,10 +418,7 @@ const checkPublic = (appDir: string, app: string): Violation[] => {
 
   const srcDir = path.join(appDir, "src");
   if (existsSync(srcDir)) {
-    for (const rel of new Bun.Glob("**/*").scanSync({ cwd: srcDir })) {
-      if (!PUBLIC_SRC_EXTENSIONS.some((ext) => rel.endsWith(ext))) {
-        continue;
-      }
+    for (const rel of new Bun.Glob(PUBLIC_SRC_GLOB).scanSync({ cwd: srcDir })) {
       const text = readFileSync(path.join(srcDir, rel), "utf-8");
       if (hasNoindexRobotsMeta(text)) {
         violations.push({
@@ -446,8 +482,8 @@ const checkMixed = (appDir: string, app: string): Violation[] => {
 
   // e. the robots lib default-denies, and its allowlist and the crawl-prefix
   //    constant stay in sync with real routes.
-  const libSource = readTextIfExists(path.join(appDir, MIXED_ROBOTS_LIB));
-  if (libSource === null) {
+  const rawLibSource = readTextIfExists(path.join(appDir, MIXED_ROBOTS_LIB));
+  if (rawLibSource === null) {
     violations.push({
       app,
       code: "mixed-lib-missing",
@@ -456,6 +492,10 @@ const checkMixed = (appDir: string, app: string): Violation[] => {
     });
     return violations;
   }
+
+  // Strip comments before lexical checks: a commented-out `Allow:` example or a
+  // prose mention of the constant must not satisfy or trip a detector.
+  const libSource = stripSourceComments(rawLibSource);
 
   // The indexable branch must carry a default-deny after its allowlist, so any
   // route not in the allowlist stays private by default.
@@ -468,22 +508,36 @@ const checkMixed = (appDir: string, app: string): Violation[] => {
     });
   }
 
+  // createRobotsTxt must build its Allow lines from the crawl-prefix constant;
+  // if its body never references the identifier, the allowlist has been
+  // bypassed with hand-built rules and the whole guard is moot.
+  const body = createRobotsTxtBody(libSource);
+  if (body === null || !body.includes(MIXED_CRAWL_PREFIX_CONST)) {
+    violations.push({
+      app,
+      code: "mixed-lib-constant-unused",
+      message: `${MIXED_ROBOTS_LIB} createRobotsTxt does not reference ${MIXED_CRAWL_PREFIX_CONST}.`,
+      fix: `build the Allow lines from ${MIXED_CRAWL_PREFIX_CONST} so the allowlist cannot be bypassed by hand-built rules.`,
+    });
+  }
+
   const prefixes = crawlPrefixConstantEntries(
     libSource,
     MIXED_CRAWL_PREFIX_CONST,
   );
 
-  // Every literal `Allow: /path` in the source must be an allow-listed prefix,
-  // so a hand-added allow cannot bypass the single crawl-prefix allowlist.
+  // Every literal `Allow: /path` in the source, once its boundary marker (`/`
+  // or `$`) is dropped, must be an allow-listed prefix, so a hand-added allow
+  // cannot bypass the single crawl-prefix allowlist.
   const constantSet = new Set(prefixes);
   for (const match of libSource.matchAll(ALLOW_PATH_LITERAL)) {
-    const allowed = match[1];
-    if (!constantSet.has(allowed)) {
+    const prefix = allowPathToPrefix(match[1]);
+    if (!constantSet.has(prefix)) {
       violations.push({
         app,
         code: "mixed-allow-not-in-constant",
-        message: `${MIXED_ROBOTS_LIB} allows \`${allowed}\`, which is not in ${MIXED_CRAWL_PREFIX_CONST}.`,
-        fix: `add ${allowed} to ${MIXED_CRAWL_PREFIX_CONST} or remove the Allow line.`,
+        message: `${MIXED_ROBOTS_LIB} allows \`${match[1]}\`, whose prefix \`${prefix}\` is not in ${MIXED_CRAWL_PREFIX_CONST}.`,
+        fix: `add ${prefix} to ${MIXED_CRAWL_PREFIX_CONST} or remove the Allow line.`,
       });
     }
   }
@@ -657,30 +711,74 @@ const pkg = (posture: string): string =>
 
 // --- Mixed fixtures ---------------------------------------------------------
 // The guard only reads these lexically, so the fixtures are minimal stand-ins,
-// not runnable modules. A valid robots lib: a crawl-prefix constant, literal
-// `Allow:` lines all drawn from it, and a quoted `"Disallow: /"` default-deny.
+// not runnable modules. Allow lines use the boundary-anchored emission
+// (`<prefix>/` and `<prefix>$` for dirs, `<prefix>$` for files).
 const ROUTE_STUB = "export const Route = {};\n";
-const MIXED_LIB_VALID_LINES = [
+const libFixture = (lines: readonly string[]): string =>
+  `${lines.join("\n")}\n`;
+
+// A valid robots lib: the crawl-prefix constant, a createRobotsTxt whose body
+// references it, boundary-anchored `Allow:` literals all drawn from it, and a
+// quoted `"Disallow: /"` default-deny. It also proves comment-stripping: the
+// block-comment `Allow: /secret$`, the `//`-line `Allow: /admin$`, and the
+// `https://` URL sitting before the real `"Disallow: /"` would each break a
+// detector if stripping were naive, so this fixture passing exercises all three.
+const MIXED_LIB_VALID = libFixture([
+  "/* ignored example: Allow: /secret$ (block comment) */",
   'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/sitemap.xml"] as const;',
-  'const lines = ["User-agent: *", "Allow: /law", "Allow: /sitemap.xml", "Disallow: /"];',
-] as const;
-const MIXED_LIB_VALID = `${MIXED_LIB_VALID_LINES.join("\n")}\n`;
+  "export const createRobotsTxt = () => {",
+  "  // commented-out example: Allow: /admin$",
+  "  const allowed = PUBLIC_CRAWL_PATH_PREFIXES;",
+  '  const url = "https://example.com/sitemap.xml"; const deny = "Disallow: /";',
+  '  const lines = ["User-agent: *", "Allow: /law/", "Allow: /law$", "Allow: /sitemap.xml$", deny, ...allowed];',
+  "  return { lines, url };",
+  "};",
+]);
 // No quoted "Disallow: /" anywhere.
-const MIXED_LIB_NO_DENY =
-  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/sitemap.xml"] as const;\n' +
-  'const lines = ["User-agent: *", "Allow: /law", "Allow: /sitemap.xml"];\n';
-// An `Allow: /secret` literal that is not in the constant.
-const MIXED_LIB_BAD_ALLOW =
-  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;\n' +
-  'const lines = ["User-agent: *", "Allow: /law", "Allow: /secret", "Disallow: /"];\n';
+const MIXED_LIB_NO_DENY = libFixture([
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/sitemap.xml"] as const;',
+  "export const createRobotsTxt = () => {",
+  "  const allowed = PUBLIC_CRAWL_PATH_PREFIXES;",
+  '  const lines = ["User-agent: *", "Allow: /law/", "Allow: /sitemap.xml$", ...allowed];',
+  "  return lines;",
+  "};",
+]);
+// A boundary-anchored `Allow: /secret$` literal whose prefix is not in the
+// constant.
+const MIXED_LIB_BAD_ALLOW = libFixture([
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;',
+  "export const createRobotsTxt = () => {",
+  "  const allowed = PUBLIC_CRAWL_PATH_PREFIXES;",
+  '  const lines = ["User-agent: *", "Allow: /law/", "Allow: /secret$", "Disallow: /", ...allowed];',
+  "  return lines;",
+  "};",
+]);
 // A constant prefix (`/ghost`) that maps to no route.
-const MIXED_LIB_GHOST_PREFIX =
-  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/ghost"] as const;\n' +
-  'const lines = ["User-agent: *", "Allow: /law", "Disallow: /"];\n';
+const MIXED_LIB_GHOST_PREFIX = libFixture([
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/ghost"] as const;',
+  "export const createRobotsTxt = () => {",
+  "  const allowed = PUBLIC_CRAWL_PATH_PREFIXES;",
+  '  const lines = ["User-agent: *", "Allow: /law/", "Disallow: /", ...allowed];',
+  "  return lines;",
+  "};",
+]);
 // A law-only constant, used where /sitemap.xml must not be required as a route.
-const MIXED_LIB_LAW_ONLY =
-  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;\n' +
-  'const lines = ["User-agent: *", "Allow: /law", "Disallow: /"];\n';
+const MIXED_LIB_LAW_ONLY = libFixture([
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;',
+  "export const createRobotsTxt = () => {",
+  "  const allowed = PUBLIC_CRAWL_PATH_PREFIXES;",
+  '  const lines = ["User-agent: *", "Allow: /law/", "Disallow: /", ...allowed];',
+  "  return lines;",
+  "};",
+]);
+// createRobotsTxt hand-builds its Allow lines and never consults the constant.
+const MIXED_LIB_CONSTANT_UNUSED = libFixture([
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;',
+  "export const createRobotsTxt = () => {",
+  '  const lines = ["User-agent: *", "Allow: /law/", "Allow: /law$", "Disallow: /"];',
+  "  return lines;",
+  "};",
+]);
 
 // Lay out a fully valid mixed app; broken fixtures start here and mutate one
 // thing. `/law` resolves to a directory route, `/sitemap.xml` to the escaped
@@ -842,6 +940,16 @@ const runSelfTest = (): number => {
     "public-robots-deny-all",
   );
 
+  // 8b. public with no robots.txt at all.
+  expectCode(
+    "public missing robots.txt",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("public"));
+      writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
+    }),
+    "public-robots-missing",
+  );
+
   // 9. public missing Sitemap line
   expectCode(
     "public missing Sitemap",
@@ -983,6 +1091,30 @@ const runSelfTest = (): number => {
     "mixed-prefix-no-route",
   );
 
+  // 19. mixed robots lib missing entirely.
+  expectCode(
+    "mixed missing robots lib",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      rmSync(path.join(root, app, MIXED_ROBOTS_LIB));
+    }),
+    "mixed-lib-missing",
+  );
+
+  // 20. mixed robots lib whose createRobotsTxt never consults the constant.
+  expectCode(
+    "mixed lib bypasses the crawl-prefix constant",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      writeFixtureFile(
+        root,
+        path.join(app, MIXED_ROBOTS_LIB),
+        MIXED_LIB_CONSTANT_UNUSED,
+      );
+    }),
+    "mixed-lib-constant-unused",
+  );
+
   // A valid mixed app must pass clean.
   const validMixed = reportForSingleApp(layoutValidMixed);
   if (validMixed.violations.length !== 0) {
@@ -1040,5 +1172,6 @@ const main = (): number => {
 };
 
 if (import.meta.main) {
-  process.exit(main());
+  // Set exitCode rather than process.exit() so stdout/stderr flush before exit.
+  process.exitCode = main();
 }

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -14,8 +14,10 @@
 //              page may carry a `noindex` robots meta.
 //   private  — an authenticated app that must stay invisible to crawlers.
 //              robots.txt must deny all (`User-agent: *` + `Disallow: /`) with
-//              no Sitemap, every served *.html must carry a `noindex` robots
-//              meta, and no llms.txt may exist (it would advertise the surface).
+//              no Sitemap and no `Allow:` rule (a more specific Allow can beat
+//              the deny-all for the paths it names), every served *.html must
+//              carry a `noindex` robots meta, and no llms.txt may exist (it
+//              would advertise the surface).
 //   unserved — not an internet-facing HTML surface (API, desktop shell, CLI
 //              runtime, collab server). No requirements.
 //
@@ -84,6 +86,7 @@ type ViolationCode =
   | "private-robots-missing"
   | "private-robots-not-deny-all"
   | "private-robots-has-sitemap"
+  | "private-robots-has-allow"
   | "private-html-no-noindex"
   | "private-has-llms"
   | "public-robots-missing"
@@ -167,6 +170,14 @@ const hasDenyAll = (robotsText: string): boolean =>
       group.rules.some(
         (rule) => rule.field === "disallow" && rule.value === "/",
       ),
+  );
+
+// Any `Allow:` rule at all, in any group. Crawlers resolve Allow/Disallow by
+// most-specific-path-wins, so a single `Allow: /public` rule can carve a hole
+// in an otherwise deny-all robots.txt; a private app must never emit one.
+const hasAnyAllowRule = (robotsText: string): boolean =>
+  parseRobotsGroups(robotsText).some((group) =>
+    group.rules.some((rule) => rule.field === "allow"),
   );
 
 // --- robots meta detection --------------------------------------------------
@@ -348,6 +359,15 @@ const checkPrivate = (appDir: string, app: string): Violation[] => {
         code: "private-robots-has-sitemap",
         message: "private app public/robots.txt advertises a Sitemap.",
         fix: "remove the `Sitemap:` line; a private surface must not point crawlers at a sitemap.",
+      });
+    }
+    if (hasAnyAllowRule(robots)) {
+      violations.push({
+        app,
+        code: "private-robots-has-allow",
+        message:
+          "private app public/robots.txt contains an `Allow:` rule alongside the deny-all.",
+        fix: "remove the `Allow:` rule; a more specific Allow can override the deny-all for the paths it names.",
       });
     }
   }
@@ -701,6 +721,8 @@ const DENY_ALL_ROBOTS = "User-agent: *\nDisallow: /\n";
 const DENY_ALL_ROBOTS_WITH_SITEMAP =
   "User-agent: *\nDisallow: /\n\nSitemap: https://example.com/sitemap.xml\n";
 const NOT_DENY_ALL_ROBOTS = "User-agent: *\nDisallow: /admin\n";
+const DENY_ALL_ROBOTS_WITH_ALLOW =
+  "User-agent: *\nDisallow: /\nAllow: /public\n";
 const PUBLIC_ROBOTS =
   "User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n";
 const PUBLIC_ROBOTS_NO_SITEMAP = "User-agent: *\nAllow: /\n";
@@ -892,6 +914,21 @@ const runSelfTest = (): number => {
       writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
     }),
     "private-robots-has-sitemap",
+  );
+
+  // 5b. private robots.txt with a deny-all plus an Allow rule
+  expectCode(
+    "private robots.txt with Allow rule",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS_WITH_ALLOW,
+      );
+      writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
+    }),
+    "private-robots-has-allow",
   );
 
   // 6. private index.html without noindex meta

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -621,7 +621,7 @@ const checkApp = (appsRoot: string, app: string): AppReport => {
   );
   const posture =
     typeof pkg === "object" && pkg !== null && "crawlPosture" in pkg
-      ? (pkg as { crawlPosture: unknown }).crawlPosture
+      ? pkg.crawlPosture
       : undefined;
 
   if (posture === undefined) {

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -87,6 +87,7 @@ type ViolationCode =
   | "private-robots-not-deny-all"
   | "private-robots-has-sitemap"
   | "private-robots-has-allow"
+  | "private-robots-permissive-bot-group"
   | "private-html-no-noindex"
   | "private-has-llms"
   | "public-robots-missing"
@@ -178,6 +179,23 @@ const hasDenyAll = (robotsText: string): boolean =>
 const hasAnyAllowRule = (robotsText: string): boolean =>
   parseRobotsGroups(robotsText).some((group) =>
     group.rules.some((rule) => rule.field === "allow"),
+  );
+
+// A non-wildcard group (e.g. `User-agent: Googlebot`) that does not itself
+// deny all. Per the robots.txt spec, a crawler follows the MOST SPECIFIC
+// group that names it and ignores the wildcard fallback entirely — so a
+// `User-agent: Googlebot` group with `Allow: /` (or no rules at all) lets
+// that bot in even though the `User-agent: *` group denies everyone else.
+// `hasDenyAll`/`hasAnyAllowRule` only inspect the wildcard group and a
+// deny-all's own `Allow:` lines, so neither catches this. A group whose
+// stacked agents include `*` shares the wildcard's rules and is exempt.
+const hasPermissiveBotGroup = (robotsText: string): boolean =>
+  parseRobotsGroups(robotsText).some(
+    (group) =>
+      !group.agents.includes("*") &&
+      !group.rules.some(
+        (rule) => rule.field === "disallow" && rule.value === "/",
+      ),
   );
 
 // --- robots meta detection --------------------------------------------------
@@ -368,6 +386,15 @@ const checkPrivate = (appDir: string, app: string): Violation[] => {
         message:
           "private app public/robots.txt contains an `Allow:` rule alongside the deny-all.",
         fix: "remove the `Allow:` rule; a more specific Allow can override the deny-all for the paths it names.",
+      });
+    }
+    if (hasPermissiveBotGroup(robots)) {
+      violations.push({
+        app,
+        code: "private-robots-permissive-bot-group",
+        message:
+          "private app public/robots.txt contains a bot-specific `User-agent` group that does not itself deny all.",
+        fix: "remove the bot-specific group, or add `Disallow: /` to it: a named bot follows only its own most-specific group and ignores the wildcard deny-all.",
       });
     }
   }
@@ -723,6 +750,8 @@ const DENY_ALL_ROBOTS_WITH_SITEMAP =
 const NOT_DENY_ALL_ROBOTS = "User-agent: *\nDisallow: /admin\n";
 const DENY_ALL_ROBOTS_WITH_ALLOW =
   "User-agent: *\nDisallow: /\nAllow: /public\n";
+const DENY_ALL_ROBOTS_WITH_BOT_CARVEOUT =
+  "User-agent: *\nDisallow: /\n\nUser-agent: Googlebot\nAllow: /\n";
 const PUBLIC_ROBOTS =
   "User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n";
 const PUBLIC_ROBOTS_NO_SITEMAP = "User-agent: *\nAllow: /\n";
@@ -929,6 +958,23 @@ const runSelfTest = (): number => {
       writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
     }),
     "private-robots-has-allow",
+  );
+
+  // 5c. private robots.txt with a wildcard deny-all plus a bot-specific group
+  //     that carves its own access back out (e.g. `User-agent: Googlebot` +
+  //     `Allow: /`), which that bot follows instead of the wildcard.
+  expectCode(
+    "private robots.txt with bot-specific carve-out",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS_WITH_BOT_CARVEOUT,
+      );
+      writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
+    }),
+    "private-robots-permissive-bot-group",
   );
 
   // 6. private index.html without noindex meta

--- a/scripts/crawl-posture.ts
+++ b/scripts/crawl-posture.ts
@@ -1,0 +1,1044 @@
+// Crawl-posture convention guard.
+//
+// Stella splits its web surfaces in two: public SSR pages (the landing site)
+// must be fully crawlable — indexed by search engines AND readable by LLM bots
+// — while the private authenticated app must be invisible to crawlers. This
+// guard makes that split structural: every app under apps/ declares a
+// `crawlPosture` in its package.json, and CI verifies the on-disk artifacts
+// (robots.txt, per-page robots meta tags, llms.txt) actually match the declared
+// posture. A posture and its artifacts can no longer silently drift apart.
+//
+// Postures:
+//   public   — an indexable SEO/LLM surface. robots.txt must invite crawlers
+//              (a Sitemap, no deny-all), an llms.txt must exist, and no source
+//              page may carry a `noindex` robots meta.
+//   private  — an authenticated app that must stay invisible to crawlers.
+//              robots.txt must deny all (`User-agent: *` + `Disallow: /`) with
+//              no Sitemap, every served *.html must carry a `noindex` robots
+//              meta, and no llms.txt may exist (it would advertise the surface).
+//   unserved — not an internet-facing HTML surface (API, desktop shell, CLI
+//              runtime, collab server). No requirements.
+//
+// Modes:
+//   bun scripts/crawl-posture.ts             CI gate over apps/ (same as --check)
+//   bun scripts/crawl-posture.ts --check     CI gate over apps/ (explicit)
+//   bun scripts/crawl-posture.ts --self-test prove each detector fires
+//
+// CI-only wiring lives in .github/workflows/ci.yml and scripts/verify.sh
+// alongside the other convention guards.
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPTS_DIR = import.meta.dir;
+const REPO_ROOT = path.resolve(SCRIPTS_DIR, "..");
+const APPS_ROOT = path.join(REPO_ROOT, "apps");
+
+// --- Posture domain ---------------------------------------------------------
+
+const CRAWL_POSTURES = ["public", "private", "mixed", "unserved"] as const;
+type CrawlPosture = (typeof CRAWL_POSTURES)[number];
+
+const isCrawlPosture = (value: unknown): value is CrawlPosture =>
+  typeof value === "string" &&
+  (CRAWL_POSTURES as readonly string[]).includes(value);
+
+const POSTURE_HELP =
+  'add a top-level "crawlPosture" to package.json: ' +
+  '"public" (indexable SEO/LLM surface), ' +
+  '"private" (authenticated app, must be invisible to crawlers), ' +
+  '"mixed" (an SSR app with both public and private routes, served by a ' +
+  "dynamic default-deny robots route with an explicit public allowlist), or " +
+  '"unserved" (not an internet-facing HTML surface).';
+
+// Mixed apps serve crawl policy dynamically from server routes rather than from
+// static files, so the guard checks the source of those routes instead. These
+// paths are relative to the app directory.
+const MIXED_ROBOTS_ROUTE = "src/routes/robots[.]txt.ts";
+const MIXED_SITEMAP_ROUTE = "src/routes/sitemap[.]xml.ts";
+const MIXED_ROBOTS_LIB = "src/lib/public-law-sitemap.ts";
+const MIXED_ROUTES_DIR = "src/routes";
+const MIXED_INDEX_HTML = "index.html";
+const MIXED_CRAWL_PREFIX_CONST = "PUBLIC_CRAWL_PATH_PREFIXES";
+
+// Source file extensions scanned for a stray `noindex` on a public surface.
+const PUBLIC_SRC_EXTENSIONS = [
+  ".astro",
+  ".html",
+  ".tsx",
+  ".ts",
+  ".mdx",
+  ".md",
+] as const;
+
+// --- Violations -------------------------------------------------------------
+// A stable `code` discriminator identifies which detector fired (drives the
+// self-test); `message` and `fix` are the human-facing output.
+
+type ViolationCode =
+  | "missing-posture"
+  | "invalid-posture"
+  | "private-robots-missing"
+  | "private-robots-not-deny-all"
+  | "private-robots-has-sitemap"
+  | "private-html-no-noindex"
+  | "private-has-llms"
+  | "public-robots-missing"
+  | "public-robots-deny-all"
+  | "public-robots-missing-sitemap"
+  | "public-llms-missing"
+  | "public-src-noindex"
+  | "mixed-robots-route-missing"
+  | "mixed-static-robots-present"
+  | "mixed-sitemap-route-missing"
+  | "mixed-index-html-robots-meta"
+  | "mixed-lib-missing"
+  | "mixed-lib-no-default-deny"
+  | "mixed-allow-not-in-constant"
+  | "mixed-prefix-no-route";
+
+type Violation = {
+  readonly app: string;
+  readonly code: ViolationCode;
+  readonly message: string;
+  readonly fix: string;
+};
+
+// --- robots.txt parsing -----------------------------------------------------
+// A record group is one or more stacked `User-agent` lines followed by their
+// rules, per the robots.txt grouping convention. `Sitemap` is a non-group
+// directive, so it is detected against the raw text instead.
+
+type RobotsRule = { readonly field: string; readonly value: string };
+type RobotsGroup = { readonly agents: string[]; readonly rules: RobotsRule[] };
+
+const parseRobotsGroups = (text: string): RobotsGroup[] => {
+  const groups: RobotsGroup[] = [];
+  let current: RobotsGroup | null = null;
+  // True while consecutive `User-agent` lines are still stacking onto the
+  // current group; the first rule line closes the agent list, and the next
+  // `User-agent` after a rule starts a fresh group.
+  let stackingAgents = false;
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.replace(/#.*$/u, "").trim();
+    if (line === "") {
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (colon === -1) {
+      continue;
+    }
+    const field = line.slice(0, colon).trim().toLowerCase();
+    const value = line.slice(colon + 1).trim();
+
+    if (field === "user-agent") {
+      if (current === null || !stackingAgents) {
+        current = { agents: [], rules: [] };
+        groups.push(current);
+      }
+      current.agents.push(value);
+      stackingAgents = true;
+      continue;
+    }
+    if (current === null) {
+      continue;
+    }
+    current.rules.push({ field, value });
+    stackingAgents = false;
+  }
+  return groups;
+};
+
+const SITEMAP_LINE = /^\s*sitemap\s*:/imu;
+
+const hasSitemapLine = (robotsText: string): boolean =>
+  SITEMAP_LINE.test(robotsText);
+
+// A deny-all for every crawler: a `User-agent: *` group carrying `Disallow: /`.
+const hasDenyAll = (robotsText: string): boolean =>
+  parseRobotsGroups(robotsText).some(
+    (group) =>
+      group.agents.includes("*") &&
+      group.rules.some(
+        (rule) => rule.field === "disallow" && rule.value === "/",
+      ),
+  );
+
+// --- robots meta detection --------------------------------------------------
+// Matches a `<meta name="robots" ...>` tag whose directives include `noindex`,
+// regardless of attribute order.
+
+const META_TAG = /<meta\b[^>]*>/giu;
+const ROBOTS_NAME_ATTR = /\bname\s*=\s*["']robots["']/iu;
+const NOINDEX = /noindex/iu;
+
+const hasNoindexRobotsMeta = (html: string): boolean => {
+  for (const match of html.matchAll(META_TAG)) {
+    const tag = match[0];
+    if (ROBOTS_NAME_ATTR.test(tag) && NOINDEX.test(tag)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// Any `<meta name="robots" ...>` tag at all (a mixed SSR app owns robots meta
+// per-route in the router; a static one in the app-root HTML would apply to
+// public and private pages alike).
+const hasRobotsMetaTag = (html: string): boolean => {
+  for (const match of html.matchAll(META_TAG)) {
+    if (ROBOTS_NAME_ATTR.test(match[0])) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// --- Mixed (dynamic SSR) robots-source helpers ------------------------------
+
+// The indexable branch emits its default-deny as a quoted `"Disallow: /"`
+// array element (distinct from the non-indexable branch's template line and
+// from any backtick-quoted mention in a comment), so match the quoted literal.
+const INDEXABLE_DEFAULT_DENY = /["']Disallow:\s*\/["']/u;
+// An `Allow:` directive whose value is a literal path (`Allow: /law`); the
+// leading `/` requirement skips the generated `Allow: ${prefix}` template form,
+// which is what the constant expands to at runtime.
+const ALLOW_PATH_LITERAL = /Allow:\s*(\/[^\s"'`]+)/gu;
+const QUOTED_STRING = /["'`]([^"'`]+)["'`]/gu;
+
+// String entries of `export const <NAME> = [ ... ] as const`.
+const crawlPrefixConstantEntries = (
+  source: string,
+  constName: string,
+): string[] => {
+  const declaration = new RegExp(
+    `${constName}\\s*=\\s*\\[([^\\]]*)\\]`,
+    "u",
+  ).exec(source);
+  if (declaration === null) {
+    return [];
+  }
+  return [...declaration[1].matchAll(QUOTED_STRING)].map((match) => match[1]);
+};
+
+const isDirectory = (candidate: string): boolean =>
+  existsSync(candidate) && statSync(candidate).isDirectory();
+
+// A public crawl prefix (e.g. `/law`, `/sitemap.xml`) resolves to a real route
+// under routesDir. Directory route: `<routesDir>/<rel>/`. File route: the
+// TanStack filename escapes each dot as `[.]`, so `/sitemap.xml` maps to a file
+// `sitemap[.]xml.<ext>`. Implemented generically, not as a per-prefix table.
+const routeExistsForPrefix = (routesDir: string, prefix: string): boolean => {
+  const rel = prefix.replace(/^\//u, "");
+  if (rel === "") {
+    return false;
+  }
+  if (isDirectory(path.join(routesDir, rel))) {
+    return true;
+  }
+  const segments = rel.split("/");
+  const last = segments.pop();
+  if (last === undefined || last === "") {
+    return false;
+  }
+  const parent = path.join(routesDir, ...segments);
+  if (!existsSync(parent)) {
+    return false;
+  }
+  const escaped = last.replaceAll(".", "[.]");
+  return readdirSync(parent).some((entry) => entry.startsWith(`${escaped}.`));
+};
+
+// --- Filesystem helpers -----------------------------------------------------
+
+const readTextIfExists = (file: string): string | null =>
+  existsSync(file) ? readFileSync(file, "utf-8") : null;
+
+// Served *.html files for a private app: the app root (non-recursive) plus
+// everything under public/ (recursive).
+const servedHtmlFiles = (appDir: string): string[] => {
+  const files: string[] = [];
+  for (const rel of new Bun.Glob("*.html").scanSync({ cwd: appDir })) {
+    files.push(rel);
+  }
+  const publicDir = path.join(appDir, "public");
+  if (existsSync(publicDir)) {
+    for (const rel of new Bun.Glob("**/*.html").scanSync({ cwd: publicDir })) {
+      files.push(path.join("public", rel));
+    }
+  }
+  return files.sort();
+};
+
+// --- Per-posture checks -----------------------------------------------------
+
+const checkPrivate = (appDir: string, app: string): Violation[] => {
+  const violations: Violation[] = [];
+  const robots = readTextIfExists(path.join(appDir, "public", "robots.txt"));
+
+  if (robots === null) {
+    violations.push({
+      app,
+      code: "private-robots-missing",
+      message: "private app is missing public/robots.txt.",
+      fix: "add public/robots.txt with a `User-agent: *` / `Disallow: /` deny-all block.",
+    });
+  } else {
+    if (!hasDenyAll(robots)) {
+      violations.push({
+        app,
+        code: "private-robots-not-deny-all",
+        message: "private app public/robots.txt does not deny all crawlers.",
+        fix: "the `User-agent: *` group must contain `Disallow: /` (deny-all).",
+      });
+    }
+    if (hasSitemapLine(robots)) {
+      violations.push({
+        app,
+        code: "private-robots-has-sitemap",
+        message: "private app public/robots.txt advertises a Sitemap.",
+        fix: "remove the `Sitemap:` line; a private surface must not point crawlers at a sitemap.",
+      });
+    }
+  }
+
+  for (const rel of servedHtmlFiles(appDir)) {
+    const html = readFileSync(path.join(appDir, rel), "utf-8");
+    if (!hasNoindexRobotsMeta(html)) {
+      violations.push({
+        app,
+        code: "private-html-no-noindex",
+        message: `private app served page ${rel} has no \`noindex\` robots meta.`,
+        fix: `add <meta name="robots" content="noindex, nofollow" /> to the <head> of ${rel}.`,
+      });
+    }
+  }
+
+  if (existsSync(path.join(appDir, "public", "llms.txt"))) {
+    violations.push({
+      app,
+      code: "private-has-llms",
+      message: "private app ships a public/llms.txt.",
+      fix: "remove public/llms.txt; it advertises the surface to LLM crawlers.",
+    });
+  }
+
+  return violations;
+};
+
+const checkPublic = (appDir: string, app: string): Violation[] => {
+  const violations: Violation[] = [];
+  const robots = readTextIfExists(path.join(appDir, "public", "robots.txt"));
+
+  if (robots === null) {
+    violations.push({
+      app,
+      code: "public-robots-missing",
+      message: "public app is missing public/robots.txt.",
+      fix: "add public/robots.txt with a `Sitemap:` line and no deny-all.",
+    });
+  } else {
+    if (hasDenyAll(robots)) {
+      violations.push({
+        app,
+        code: "public-robots-deny-all",
+        message:
+          "public app public/robots.txt contains a deny-all `Disallow: /`.",
+        fix: "remove the deny-all; a public surface must invite crawlers.",
+      });
+    }
+    if (!hasSitemapLine(robots)) {
+      violations.push({
+        app,
+        code: "public-robots-missing-sitemap",
+        message: "public app public/robots.txt has no `Sitemap:` line.",
+        fix: "add a `Sitemap:` line pointing at the site's sitemap.",
+      });
+    }
+  }
+
+  if (!existsSync(path.join(appDir, "public", "llms.txt"))) {
+    violations.push({
+      app,
+      code: "public-llms-missing",
+      message: "public app is missing public/llms.txt.",
+      fix: "add public/llms.txt so LLM crawlers can read the surface.",
+    });
+  }
+
+  const srcDir = path.join(appDir, "src");
+  if (existsSync(srcDir)) {
+    for (const rel of new Bun.Glob("**/*").scanSync({ cwd: srcDir })) {
+      if (!PUBLIC_SRC_EXTENSIONS.some((ext) => rel.endsWith(ext))) {
+        continue;
+      }
+      const text = readFileSync(path.join(srcDir, rel), "utf-8");
+      if (hasNoindexRobotsMeta(text)) {
+        violations.push({
+          app,
+          code: "public-src-noindex",
+          message: `public app source ${path.join("src", rel)} sets a \`noindex\` robots meta.`,
+          fix: "remove the noindex robots meta; a public surface must stay indexable.",
+        });
+      }
+    }
+  }
+
+  return violations;
+};
+
+const checkMixed = (appDir: string, app: string): Violation[] => {
+  const violations: Violation[] = [];
+
+  // a. dynamic robots route present (it is the source of truth for policy).
+  if (!existsSync(path.join(appDir, MIXED_ROBOTS_ROUTE))) {
+    violations.push({
+      app,
+      code: "mixed-robots-route-missing",
+      message: `mixed app is missing the dynamic robots route ${MIXED_ROBOTS_ROUTE}.`,
+      fix: `add ${MIXED_ROBOTS_ROUTE} serving createRobotsTxt(); it is the source of truth for crawl policy.`,
+    });
+  }
+
+  // b. no static robots.txt (it would shadow the dynamic route).
+  if (existsSync(path.join(appDir, "public", "robots.txt"))) {
+    violations.push({
+      app,
+      code: "mixed-static-robots-present",
+      message:
+        "mixed app ships a static public/robots.txt that shadows the dynamic robots route.",
+      fix: "delete public/robots.txt; the dynamic server route must serve robots.txt.",
+    });
+  }
+
+  // c. dynamic sitemap route present.
+  if (!existsSync(path.join(appDir, MIXED_SITEMAP_ROUTE))) {
+    violations.push({
+      app,
+      code: "mixed-sitemap-route-missing",
+      message: `mixed app is missing the dynamic sitemap route ${MIXED_SITEMAP_ROUTE}.`,
+      fix: `add ${MIXED_SITEMAP_ROUTE}; the sitemap is served dynamically.`,
+    });
+  }
+
+  // d. the app-root HTML carries no static robots meta (router owns per-page
+  //    meta; a static one would apply to public and private pages alike).
+  const indexHtml = readTextIfExists(path.join(appDir, MIXED_INDEX_HTML));
+  if (indexHtml !== null && hasRobotsMetaTag(indexHtml)) {
+    violations.push({
+      app,
+      code: "mixed-index-html-robots-meta",
+      message: `mixed app ${MIXED_INDEX_HTML} contains a static robots <meta> tag.`,
+      fix: `remove the robots <meta> from ${MIXED_INDEX_HTML}; per-page robots meta is router-owned.`,
+    });
+  }
+
+  // e. the robots lib default-denies, and its allowlist and the crawl-prefix
+  //    constant stay in sync with real routes.
+  const libSource = readTextIfExists(path.join(appDir, MIXED_ROBOTS_LIB));
+  if (libSource === null) {
+    violations.push({
+      app,
+      code: "mixed-lib-missing",
+      message: `mixed app is missing the robots source ${MIXED_ROBOTS_LIB}.`,
+      fix: `add ${MIXED_ROBOTS_LIB} exporting createRobotsTxt and ${MIXED_CRAWL_PREFIX_CONST}.`,
+    });
+    return violations;
+  }
+
+  // The indexable branch must carry a default-deny after its allowlist, so any
+  // route not in the allowlist stays private by default.
+  if (!INDEXABLE_DEFAULT_DENY.test(libSource)) {
+    violations.push({
+      app,
+      code: "mixed-lib-no-default-deny",
+      message: `${MIXED_ROBOTS_LIB} indexable robots branch has no default-deny \`Disallow: /\` line.`,
+      fix: "end the indexable robots.txt with `Disallow: /` so unlisted routes are private by default.",
+    });
+  }
+
+  const prefixes = crawlPrefixConstantEntries(
+    libSource,
+    MIXED_CRAWL_PREFIX_CONST,
+  );
+
+  // Every literal `Allow: /path` in the source must be an allow-listed prefix,
+  // so a hand-added allow cannot bypass the single crawl-prefix allowlist.
+  const constantSet = new Set(prefixes);
+  for (const match of libSource.matchAll(ALLOW_PATH_LITERAL)) {
+    const allowed = match[1];
+    if (!constantSet.has(allowed)) {
+      violations.push({
+        app,
+        code: "mixed-allow-not-in-constant",
+        message: `${MIXED_ROBOTS_LIB} allows \`${allowed}\`, which is not in ${MIXED_CRAWL_PREFIX_CONST}.`,
+        fix: `add ${allowed} to ${MIXED_CRAWL_PREFIX_CONST} or remove the Allow line.`,
+      });
+    }
+  }
+
+  // Every allow-listed prefix must map to a real route, so the allowlist cannot
+  // advertise a path the app does not serve.
+  const routesDir = path.join(appDir, MIXED_ROUTES_DIR);
+  for (const prefix of prefixes) {
+    if (!routeExistsForPrefix(routesDir, prefix)) {
+      violations.push({
+        app,
+        code: "mixed-prefix-no-route",
+        message: `${MIXED_CRAWL_PREFIX_CONST} lists \`${prefix}\`, but no route resolves under ${MIXED_ROUTES_DIR}.`,
+        fix: `add a route for ${prefix} (a ${MIXED_ROUTES_DIR}/<path>/ dir or a <path>[.]<ext> route file) or drop it from ${MIXED_CRAWL_PREFIX_CONST}.`,
+      });
+    }
+  }
+
+  return violations;
+};
+
+// --- App enumeration + aggregation ------------------------------------------
+
+type AppReport = {
+  readonly app: string;
+  readonly posture: CrawlPosture | null;
+  readonly violations: readonly Violation[];
+};
+
+const checkApp = (appsRoot: string, app: string): AppReport => {
+  const appDir = path.join(appsRoot, app);
+  const pkg: unknown = JSON.parse(
+    readFileSync(path.join(appDir, "package.json"), "utf-8"),
+  );
+  const posture =
+    typeof pkg === "object" && pkg !== null && "crawlPosture" in pkg
+      ? (pkg as { crawlPosture: unknown }).crawlPosture
+      : undefined;
+
+  if (posture === undefined) {
+    return {
+      app,
+      posture: null,
+      violations: [
+        {
+          app,
+          code: "missing-posture",
+          message: 'package.json has no top-level "crawlPosture".',
+          fix: POSTURE_HELP,
+        },
+      ],
+    };
+  }
+  if (!isCrawlPosture(posture)) {
+    return {
+      app,
+      posture: null,
+      violations: [
+        {
+          app,
+          code: "invalid-posture",
+          message: `package.json "crawlPosture" is ${JSON.stringify(posture)}, not one of ${CRAWL_POSTURES.join(", ")}.`,
+          fix: POSTURE_HELP,
+        },
+      ],
+    };
+  }
+
+  if (posture === "private") {
+    return { app, posture, violations: checkPrivate(appDir, app) };
+  }
+  if (posture === "public") {
+    return { app, posture, violations: checkPublic(appDir, app) };
+  }
+  if (posture === "mixed") {
+    return { app, posture, violations: checkMixed(appDir, app) };
+  }
+  return { app, posture, violations: [] };
+};
+
+// Direct children of apps/ that contain a package.json.
+const listApps = (appsRoot: string): string[] =>
+  readdirSync(appsRoot, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        existsSync(path.join(appsRoot, entry.name, "package.json")),
+    )
+    .map((entry) => entry.name)
+    .sort();
+
+type CheckResult = {
+  readonly reports: readonly AppReport[];
+  readonly violations: readonly Violation[];
+};
+
+const checkAll = (appsRoot: string): CheckResult => {
+  const reports = listApps(appsRoot).map((app) => checkApp(appsRoot, app));
+  const violations = reports.flatMap((report) => report.violations);
+  return { reports, violations };
+};
+
+// --- Modes ------------------------------------------------------------------
+
+const summarize = (reports: readonly AppReport[]): string => {
+  const counts: Record<string, number> = {
+    public: 0,
+    private: 0,
+    mixed: 0,
+    unserved: 0,
+    invalid: 0,
+  };
+  for (const report of reports) {
+    counts[report.posture ?? "invalid"] += 1;
+  }
+  return `${reports.length} app(s): ${counts.public} public, ${counts.private} private, ${counts.mixed} mixed, ${counts.unserved} unserved`;
+};
+
+const runCheck = (appsRoot: string): number => {
+  const { reports, violations } = checkAll(appsRoot);
+
+  if (violations.length === 0) {
+    console.log(`crawl-posture --check: OK. ${summarize(reports)}.`);
+    return 0;
+  }
+
+  console.error("\ncrawl-posture --check: posture violation(s):\n");
+  for (const report of reports) {
+    if (report.violations.length === 0) {
+      continue;
+    }
+    const postureLabel = report.posture ?? "unknown posture";
+    console.error(`  ${report.app} (${postureLabel}):`);
+    for (const violation of report.violations) {
+      console.error(`      - ${violation.message}`);
+      console.error(`        fix: ${violation.fix}`);
+    }
+  }
+  console.error(
+    "\nEach app's on-disk crawl artifacts must match its declared crawlPosture.\n" +
+      "Fix the artifact(s) above, or correct the posture in the app's package.json.",
+  );
+  return 1;
+};
+
+// --- Self-test --------------------------------------------------------------
+// Materialize synthetic app fixtures under temp apps-roots and assert each
+// detector fires (and that a fully valid set passes). Exercises the same
+// checkApp/checkAll used by --check, only with the apps-root parameterized.
+
+const writeFixtureFile = (root: string, rel: string, content: string): void => {
+  const full = path.join(root, rel);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, content);
+};
+
+const NOINDEX_HTML =
+  '<!doctype html><html><head><meta name="robots" content="noindex, nofollow" /></head><body></body></html>\n';
+const PLAIN_HTML = "<!doctype html><html><head></head><body></body></html>\n";
+const DENY_ALL_ROBOTS = "User-agent: *\nDisallow: /\n";
+const DENY_ALL_ROBOTS_WITH_SITEMAP =
+  "User-agent: *\nDisallow: /\n\nSitemap: https://example.com/sitemap.xml\n";
+const NOT_DENY_ALL_ROBOTS = "User-agent: *\nDisallow: /admin\n";
+const PUBLIC_ROBOTS =
+  "User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n";
+const PUBLIC_ROBOTS_NO_SITEMAP = "User-agent: *\nAllow: /\n";
+const LLMS_TXT = "# Example\nA public surface for LLM readers.\n";
+
+const pkg = (posture: string): string =>
+  `${JSON.stringify({ name: `@stll/${posture}`, crawlPosture: posture }, null, 2)}\n`;
+
+// --- Mixed fixtures ---------------------------------------------------------
+// The guard only reads these lexically, so the fixtures are minimal stand-ins,
+// not runnable modules. A valid robots lib: a crawl-prefix constant, literal
+// `Allow:` lines all drawn from it, and a quoted `"Disallow: /"` default-deny.
+const ROUTE_STUB = "export const Route = {};\n";
+const MIXED_LIB_VALID_LINES = [
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/sitemap.xml"] as const;',
+  'const lines = ["User-agent: *", "Allow: /law", "Allow: /sitemap.xml", "Disallow: /"];',
+] as const;
+const MIXED_LIB_VALID = `${MIXED_LIB_VALID_LINES.join("\n")}\n`;
+// No quoted "Disallow: /" anywhere.
+const MIXED_LIB_NO_DENY =
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/sitemap.xml"] as const;\n' +
+  'const lines = ["User-agent: *", "Allow: /law", "Allow: /sitemap.xml"];\n';
+// An `Allow: /secret` literal that is not in the constant.
+const MIXED_LIB_BAD_ALLOW =
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;\n' +
+  'const lines = ["User-agent: *", "Allow: /law", "Allow: /secret", "Disallow: /"];\n';
+// A constant prefix (`/ghost`) that maps to no route.
+const MIXED_LIB_GHOST_PREFIX =
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law", "/ghost"] as const;\n' +
+  'const lines = ["User-agent: *", "Allow: /law", "Disallow: /"];\n';
+// A law-only constant, used where /sitemap.xml must not be required as a route.
+const MIXED_LIB_LAW_ONLY =
+  'export const PUBLIC_CRAWL_PATH_PREFIXES = ["/law"] as const;\n' +
+  'const lines = ["User-agent: *", "Allow: /law", "Disallow: /"];\n';
+
+// Lay out a fully valid mixed app; broken fixtures start here and mutate one
+// thing. `/law` resolves to a directory route, `/sitemap.xml` to the escaped
+// sitemap route file.
+const layoutValidMixed = (root: string, app: string): void => {
+  writeFixtureFile(root, path.join(app, "package.json"), pkg("mixed"));
+  writeFixtureFile(root, path.join(app, MIXED_ROBOTS_ROUTE), ROUTE_STUB);
+  writeFixtureFile(root, path.join(app, MIXED_SITEMAP_ROUTE), ROUTE_STUB);
+  writeFixtureFile(
+    root,
+    path.join(app, MIXED_ROUTES_DIR, "law", "route.tsx"),
+    ROUTE_STUB,
+  );
+  writeFixtureFile(root, path.join(app, MIXED_ROBOTS_LIB), MIXED_LIB_VALID);
+  writeFixtureFile(root, path.join(app, MIXED_INDEX_HTML), PLAIN_HTML);
+};
+
+// One temp apps-root holding a single app fixture, run through checkApp.
+const reportForSingleApp = (
+  layout: (root: string, app: string) => void,
+): AppReport => {
+  const root = mkdtempSync(path.join(tmpdir(), "crawl-posture-selftest-"));
+  const app = "fixture";
+  try {
+    layout(root, app);
+    return checkApp(root, app);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+const codes = (report: AppReport): ViolationCode[] =>
+  report.violations.map((violation) => violation.code);
+
+const runSelfTest = (): number => {
+  const failures: string[] = [];
+
+  const expectCode = (
+    label: string,
+    report: AppReport,
+    code: ViolationCode,
+  ) => {
+    if (!codes(report).includes(code)) {
+      failures.push(
+        `${label}: expected detector "${code}" to fire, got [${codes(report).join(", ")}]`,
+      );
+    }
+  };
+
+  // 1. missing crawlPosture
+  expectCode(
+    "missing crawlPosture",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(
+        root,
+        path.join(app, "package.json"),
+        `${JSON.stringify({ name: "@stll/x" }, null, 2)}\n`,
+      );
+    }),
+    "missing-posture",
+  );
+
+  // 2. invalid value
+  expectCode(
+    "invalid crawlPosture",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(
+        root,
+        path.join(app, "package.json"),
+        `${JSON.stringify({ name: "@stll/x", crawlPosture: "sometimes" }, null, 2)}\n`,
+      );
+    }),
+    "invalid-posture",
+  );
+
+  // 3. private without robots.txt
+  expectCode(
+    "private without robots.txt",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
+    }),
+    "private-robots-missing",
+  );
+
+  // 4. private robots.txt without deny-all
+  expectCode(
+    "private robots.txt without deny-all",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        NOT_DENY_ALL_ROBOTS,
+      );
+      writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
+    }),
+    "private-robots-not-deny-all",
+  );
+
+  // 5. private robots.txt with a Sitemap line
+  expectCode(
+    "private robots.txt with Sitemap",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS_WITH_SITEMAP,
+      );
+      writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
+    }),
+    "private-robots-has-sitemap",
+  );
+
+  // 6. private index.html without noindex meta
+  expectCode(
+    "private index.html without noindex",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS,
+      );
+      writeFixtureFile(root, path.join(app, "index.html"), PLAIN_HTML);
+    }),
+    "private-html-no-noindex",
+  );
+
+  // 7. private with llms.txt
+  expectCode(
+    "private with llms.txt",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("private"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS,
+      );
+      writeFixtureFile(root, path.join(app, "index.html"), NOINDEX_HTML);
+      writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
+    }),
+    "private-has-llms",
+  );
+
+  // 8. public with deny-all robots.txt
+  expectCode(
+    "public with deny-all robots.txt",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("public"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS_WITH_SITEMAP,
+      );
+      writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
+    }),
+    "public-robots-deny-all",
+  );
+
+  // 9. public missing Sitemap line
+  expectCode(
+    "public missing Sitemap",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("public"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        PUBLIC_ROBOTS_NO_SITEMAP,
+      );
+      writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
+    }),
+    "public-robots-missing-sitemap",
+  );
+
+  // 10. public missing llms.txt
+  expectCode(
+    "public missing llms.txt",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("public"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        PUBLIC_ROBOTS,
+      );
+    }),
+    "public-llms-missing",
+  );
+
+  // 11. public src page containing a noindex robots meta
+  expectCode(
+    "public src with noindex",
+    reportForSingleApp((root, app) => {
+      writeFixtureFile(root, path.join(app, "package.json"), pkg("public"));
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        PUBLIC_ROBOTS,
+      );
+      writeFixtureFile(root, path.join(app, "public", "llms.txt"), LLMS_TXT);
+      writeFixtureFile(
+        root,
+        path.join(app, "src", "pages", "index.astro"),
+        '---\n---\n<meta name="robots" content="noindex" />\n',
+      );
+    }),
+    "public-src-noindex",
+  );
+
+  // 12. mixed missing the dynamic robots route.
+  expectCode(
+    "mixed missing robots route",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      rmSync(path.join(root, app, MIXED_ROBOTS_ROUTE));
+    }),
+    "mixed-robots-route-missing",
+  );
+
+  // 13. mixed with a static robots.txt shadowing the dynamic route.
+  expectCode(
+    "mixed with static robots.txt",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      writeFixtureFile(
+        root,
+        path.join(app, "public", "robots.txt"),
+        DENY_ALL_ROBOTS,
+      );
+    }),
+    "mixed-static-robots-present",
+  );
+
+  // 14. mixed missing the dynamic sitemap route. Drop /sitemap.xml from the
+  //     constant too so only the route-missing detector fires.
+  expectCode(
+    "mixed missing sitemap route",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      rmSync(path.join(root, app, MIXED_SITEMAP_ROUTE));
+      writeFixtureFile(
+        root,
+        path.join(app, MIXED_ROBOTS_LIB),
+        MIXED_LIB_LAW_ONLY,
+      );
+    }),
+    "mixed-sitemap-route-missing",
+  );
+
+  // 15. mixed with a robots <meta> tag in the app-root HTML.
+  expectCode(
+    "mixed index.html robots meta",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      writeFixtureFile(root, path.join(app, MIXED_INDEX_HTML), NOINDEX_HTML);
+    }),
+    "mixed-index-html-robots-meta",
+  );
+
+  // 16. mixed robots lib missing its default-deny.
+  expectCode(
+    "mixed lib without default-deny",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      writeFixtureFile(
+        root,
+        path.join(app, MIXED_ROBOTS_LIB),
+        MIXED_LIB_NO_DENY,
+      );
+    }),
+    "mixed-lib-no-default-deny",
+  );
+
+  // 17. mixed robots lib with an Allow line not in the crawl-prefix constant.
+  expectCode(
+    "mixed allow not in constant",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      writeFixtureFile(
+        root,
+        path.join(app, MIXED_ROBOTS_LIB),
+        MIXED_LIB_BAD_ALLOW,
+      );
+    }),
+    "mixed-allow-not-in-constant",
+  );
+
+  // 18. mixed crawl-prefix constant with a prefix that maps to no route.
+  expectCode(
+    "mixed prefix without a route",
+    reportForSingleApp((root, app) => {
+      layoutValidMixed(root, app);
+      writeFixtureFile(
+        root,
+        path.join(app, MIXED_ROBOTS_LIB),
+        MIXED_LIB_GHOST_PREFIX,
+      );
+    }),
+    "mixed-prefix-no-route",
+  );
+
+  // A valid mixed app must pass clean.
+  const validMixed = reportForSingleApp(layoutValidMixed);
+  if (validMixed.violations.length !== 0) {
+    failures.push(
+      `valid mixed fixture produced violations: [${codes(validMixed).join(", ")}]`,
+    );
+  }
+
+  // A fully valid set (one public, one private, one unserved) must pass clean.
+  const validRoot = mkdtempSync(
+    path.join(tmpdir(), "crawl-posture-selftest-valid-"),
+  );
+  try {
+    writeFixtureFile(validRoot, "site/package.json", pkg("public"));
+    writeFixtureFile(validRoot, "site/public/robots.txt", PUBLIC_ROBOTS);
+    writeFixtureFile(validRoot, "site/public/llms.txt", LLMS_TXT);
+    writeFixtureFile(
+      validRoot,
+      "site/src/pages/index.astro",
+      "---\n---\n<h1>Hello</h1>\n",
+    );
+    writeFixtureFile(validRoot, "app/package.json", pkg("private"));
+    writeFixtureFile(validRoot, "app/public/robots.txt", DENY_ALL_ROBOTS);
+    writeFixtureFile(validRoot, "app/index.html", NOINDEX_HTML);
+    writeFixtureFile(validRoot, "runtime/package.json", pkg("unserved"));
+
+    const { violations } = checkAll(validRoot);
+    if (violations.length !== 0) {
+      failures.push(
+        `valid fixture set produced violations: [${violations.map((v) => `${v.app}:${v.code}`).join(", ")}]`,
+      );
+    }
+  } finally {
+    rmSync(validRoot, { recursive: true, force: true });
+  }
+
+  if (failures.length > 0) {
+    console.error("crawl-posture --self-test: FAIL");
+    for (const failure of failures) {
+      console.error(`  ${failure}`);
+    }
+    return 1;
+  }
+  console.log("crawl-posture --self-test: PASS");
+  return 0;
+};
+
+// --- Entry ------------------------------------------------------------------
+
+const main = (): number => {
+  if (process.argv.includes("--self-test")) {
+    return runSelfTest();
+  }
+  return runCheck(APPS_ROOT);
+};
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -124,6 +124,19 @@ run_ratchet_guard() {
   bun scripts/ratchet.ts --check
 }
 
+run_crawl_posture_guard() {
+  # Every app under apps/ declares a `crawlPosture` in package.json (public /
+  # private / mixed / unserved), and this guard verifies its crawl artifacts
+  # match: public apps ship a crawler-inviting robots.txt plus llms.txt; private
+  # apps ship a deny-all robots.txt and per-page noindex; mixed SSR apps serve a
+  # dynamic default-deny robots.txt with an explicit public allowlist (checked in
+  # source) instead of static files. Keeps the public SEO/LLM surface and the
+  # private app from silently drifting. The --self-test run first proves each
+  # detector still fires, so a broken guard cannot pass silently.
+  bun scripts/crawl-posture.ts --self-test || return 1
+  bun scripts/crawl-posture.ts --check
+}
+
 run_exact_mirror_guard() {
   # Build the real app and force every route's Elysia exactMirror to compile;
   # fail if any route's schema cannot be mirrored (recursive schemas fall back
@@ -190,6 +203,7 @@ run_step "Rust format" run_rust_format
 run_step "Typecheck" run_typecheck
 run_step "React Compiler bailout guard" bun scripts/rc-bailouts.ts --check
 run_step "Ratchet guard" run_ratchet_guard
+run_step "Crawl posture guard" run_crawl_posture_guard
 run_step "exactMirror route guard" run_exact_mirror_guard
 run_step "MCP coverage guard" run_mcp_coverage_guard
 run_step "CLI registry snapshot" run_cli_registry_snapshot


### PR DESCRIPTION
## What

- Every app under `apps/` now declares `crawlPosture` in its `package.json` (`public` | `private` | `mixed` | `unserved`). A new self-testing guard (`scripts/crawl-posture.ts`, wired into `scripts/verify.sh` and the `ci-checks` job) verifies the on-disk crawl artifacts match the declared posture: robots.txt shape, robots meta, dynamic robots/sitemap routes, `llms.txt`.
- `createRobotsTxt` in `apps/web` now generates an allowlist + default-deny robots.txt from a single exported `PUBLIC_CRAWL_PATH_PREFIXES` constant instead of a hand-maintained per-route `Disallow` list. New routes need no robots entry; the guard cross-checks the allowlist in both directions (every `Allow:` line must be in the constant, every constant entry must resolve to a real route).

## Why

The crawlable surfaces (landing, the public `/law` pages) and the app's non-public routes were kept apart only by convention. Declaring the posture per app and checking the artifacts in CI turns that into an invariant: a new app cannot ship without choosing a posture, and an existing surface cannot drift from its declaration. Like the ratchet and MCP-coverage guards, the detectors self-test first so a broken guard cannot pass silently.

## Behavior change

On indexable deployments, `robots.txt` now default-denies everything outside the public allowlist instead of enumerating disallowed prefixes. Newly added routes are excluded from crawling by default until explicitly allow-listed; the non-indexable branch is unchanged.

## Testing

- `bun scripts/crawl-posture.ts --self-test` and `--check` (self-test proves each detector fires)
- `apps/web` robots/sitemap unit tests updated for the new output shape, plus an invariant test that every flag combination emits a `Disallow: /` line (36 pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear crawl-access settings for each application.
  - Public and mixed-content sites now use safer robots.txt rules, allowing only approved paths while blocking others.
  - Public sites include sitemap and LLM discovery information where applicable.

- **Bug Fixes**
  - Improved crawl controls to prevent unintended indexing and exposure of private content.

- **Tests**
  - Added automated checks to verify robots.txt, sitemap, metadata, and crawl-posture settings during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->