### PR TITLE
fix(cli): refresh expired access tokens instead of failing commands

### DIFF
--- a/packages/cli/src/auth/ensure-fresh-credential.test.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.test.ts
@@ -3,8 +3,12 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { readCredentialFile } from "./credential-store.js";
-import type { StoredCredential } from "./credential-store.js";
+import {
+  readCredentialFile,
+  upsertCredential,
+  writeCredentialFile,
+} from "./credential-store.js";
+import type { CredentialFile, StoredCredential } from "./credential-store.js";
 import { ensureFreshCredential } from "./ensure-fresh-credential.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
 
@@ -23,6 +27,23 @@ const buildCredential = (
   updatedAt: 0,
   ...overrides,
 });
+
+const EMPTY_FILE: CredentialFile = {
+  credentials: [],
+  defaultOrgByServer: {},
+  version: 1,
+};
+
+/** Seeds `configDir`'s `credentials.json` with `credential`, as a real caller would have loaded it from. */
+const seedCredential = async (
+  configDir: string,
+  credential: StoredCredential,
+): Promise<void> => {
+  await writeCredentialFile(
+    configDir,
+    upsertCredential(EMPTY_FILE, credential),
+  );
+};
 
 /** A mock `/oauth2/token` endpoint whose response depends on the test scenario, plus a request counter. */
 const startMockProvider = (
@@ -73,6 +94,7 @@ describe("ensureFreshCredential", () => {
     );
     try {
       const credential = buildCredential({ expiresAt: Date.now() + 60_000 });
+      await seedCredential(configDir, credential);
       const result = await ensureFreshCredential({
         configDir,
         credential,
@@ -111,6 +133,7 @@ describe("ensureFreshCredential", () => {
 
     try {
       const credential = buildCredential({ expiresAt: Date.now() - 1000 });
+      await seedCredential(configDir, credential);
       const now = Date.now();
       const result = await ensureFreshCredential({
         configDir,
@@ -145,6 +168,7 @@ describe("ensureFreshCredential", () => {
 
     try {
       const credential = buildCredential({ expiresAt: Date.now() - 1000 });
+      await seedCredential(configDir, credential);
       const result = await ensureFreshCredential({
         configDir,
         credential,
@@ -170,6 +194,7 @@ describe("ensureFreshCredential", () => {
         expiresAt: Date.now() - 1000,
         refreshToken: undefined,
       });
+      await seedCredential(configDir, credential);
       const result = await ensureFreshCredential({
         configDir,
         credential,

--- a/packages/cli/src/auth/ensure-fresh-credential.test.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.test.ts
@@ -3,8 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { readCredentialFile, upsertCredential } from "./credential-store.js";
-import type { CredentialFile, StoredCredential } from "./credential-store.js";
+import { readCredentialFile } from "./credential-store.js";
+import type { StoredCredential } from "./credential-store.js";
 import { ensureFreshCredential } from "./ensure-fresh-credential.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
 
@@ -56,13 +56,11 @@ const startMockProvider = (
 
 describe("ensureFreshCredential", () => {
   let configDir: string;
-  let credentialFile: CredentialFile;
 
   beforeEach(async () => {
     configDir = await mkdtemp(
       path.join(os.tmpdir(), "stella-cli-refresh-test-"),
     );
-    credentialFile = { credentials: [], defaultOrgByServer: {}, version: 1 };
   });
 
   afterEach(async () => {
@@ -78,7 +76,6 @@ describe("ensureFreshCredential", () => {
       const result = await ensureFreshCredential({
         configDir,
         credential,
-        credentialFile,
         metadata: provider.metadata,
       });
 
@@ -118,7 +115,6 @@ describe("ensureFreshCredential", () => {
       const result = await ensureFreshCredential({
         configDir,
         credential,
-        credentialFile: upsertCredential(credentialFile, credential),
         metadata: provider.metadata,
         now,
       });
@@ -152,7 +148,6 @@ describe("ensureFreshCredential", () => {
       const result = await ensureFreshCredential({
         configDir,
         credential,
-        credentialFile: upsertCredential(credentialFile, credential),
         metadata: provider.metadata,
       });
 
@@ -178,7 +173,6 @@ describe("ensureFreshCredential", () => {
       const result = await ensureFreshCredential({
         configDir,
         credential,
-        credentialFile: upsertCredential(credentialFile, credential),
         metadata: provider.metadata,
       });
 

--- a/packages/cli/src/auth/ensure-fresh-credential.test.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.test.ts
@@ -103,7 +103,8 @@ describe("ensureFreshCredential", () => {
 
       expect(result.status).toBe("ok");
       if (result.status === "ok") {
-        expect(result.value).toEqual(credential);
+        expect(result.value.credential).toEqual(credential);
+        expect(result.value.persistWarning).toBeUndefined();
       }
       expect(provider.getRequestCount()).toBe(0);
     } finally {
@@ -144,9 +145,10 @@ describe("ensureFreshCredential", () => {
 
       expect(result.status).toBe("ok");
       if (result.status === "ok") {
-        expect(result.value.accessToken).toBe("new-access-token");
-        expect(result.value.refreshToken).toBe("new-refresh-token");
-        expect(result.value.expiresAt).toBe(now + 900 * 1000);
+        expect(result.value.credential.accessToken).toBe("new-access-token");
+        expect(result.value.credential.refreshToken).toBe("new-refresh-token");
+        expect(result.value.credential.expiresAt).toBe(now + 900 * 1000);
+        expect(result.value.persistWarning).toBeUndefined();
       }
       expect(provider.getRequestCount()).toBe(1);
 

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -125,6 +125,36 @@ export const ensureFreshCredential = async (
     );
   }
 
+  // Existing, not just present: a concurrent process (another command's
+  // refresh racing this one, or a fresh `auth login` to the same org) may
+  // have already replaced this exact credential's token-bearing fields
+  // while our exchange was in flight. Writing `updated` — derived from
+  // `input.credential`, the generation this refresh started from — would
+  // then roll that newer generation back to an older one. Only write when
+  // nothing has moved since we read `input.credential`; otherwise the
+  // fresher entry already on disk wins and we hand that back instead of
+  // touching the file. (This is a compare-and-skip, not a true atomic
+  // compare-and-swap — a lock across the read-modify-write is out of scope
+  // here; see the atomic temp+rename write follow-up.)
+  const unchangedSinceRefreshStarted =
+    stillPresent.accessToken === input.credential.accessToken &&
+    stillPresent.refreshToken === input.credential.refreshToken &&
+    stillPresent.expiresAt === input.credential.expiresAt &&
+    stillPresent.scope === input.credential.scope &&
+    stillPresent.updatedAt === input.credential.updatedAt;
+
+  if (!unchangedSinceRefreshStarted) {
+    if (!credentialNeedsRefresh(stillPresent, now)) {
+      return Result.ok(stillPresent);
+    }
+    // The concurrent writer's own credential is itself already due a
+    // refresh (rare — e.g. it raced in with a short-lived token). Retry
+    // from this newer generation rather than either clobbering it or
+    // handing back a token that's already stale; `credentialNeedsRefresh`
+    // re-checks first, so this terminates once nothing further races in.
+    return ensureFreshCredential({ ...input, credential: stillPresent, now });
+  }
+
   await writeCredentialFile(
     input.configDir,
     upsertCredential(latestCredentialFile, updated),

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -12,8 +12,12 @@
 import { Result } from "better-result";
 
 import { getMcpResourceUrl } from "./constants.js";
-import { upsertCredential, writeCredentialFile } from "./credential-store.js";
-import type { CredentialFile, StoredCredential } from "./credential-store.js";
+import {
+  readCredentialFile,
+  upsertCredential,
+  writeCredentialFile,
+} from "./credential-store.js";
+import type { StoredCredential } from "./credential-store.js";
 import { NoRefreshTokenError } from "./errors.js";
 import type { CliAuthError } from "./errors.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
@@ -44,7 +48,6 @@ export const credentialNeedsRefresh = (
 export type EnsureFreshCredentialInput = {
   readonly configDir: string;
   readonly credential: StoredCredential;
-  readonly credentialFile: CredentialFile;
   readonly metadata: AuthorizationServerMetadata;
   readonly now?: number;
 };
@@ -90,9 +93,18 @@ export const ensureFreshCredential = async (
     updatedAt: now,
   };
 
+  // Re-read right before the write rather than trusting any snapshot the
+  // caller took earlier: `refreshAccessToken` above is a network round trip,
+  // during which another `stella` process (a concurrent command, or `auth
+  // login`/`logout` for a different server) may have written to
+  // `credentials.json`. Merging into the file as it stands right now — not
+  // as it stood before the exchange — keeps that window as small as this
+  // process can make it without a lock (full read-modify-write atomicity is
+  // a separate, tracked follow-up).
+  const latestCredentialFile = await readCredentialFile(input.configDir);
   await writeCredentialFile(
     input.configDir,
-    upsertCredential(input.credentialFile, updated),
+    upsertCredential(latestCredentialFile, updated),
   );
 
   return Result.ok(updated);

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -227,11 +227,12 @@ export const ensureFreshCredential = async (
   // refresh itself already succeeded, so treat a persistence failure as a
   // warning, not a failure: hand back the (unsaved) fresh credential and
   // let the caller decide how to surface the warning.
-  const persisted = await Result.tryPromise(() =>
-    writeCredentialFile(
-      input.configDir,
-      upsertCredential(check.latestCredentialFile, updated),
-    ),
+  const persisted = await Result.tryPromise(
+    async () =>
+      await writeCredentialFile(
+        input.configDir,
+        upsertCredential(check.latestCredentialFile, updated),
+      ),
   );
   if (Result.isError(persisted)) {
     return Result.ok({

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -22,6 +22,25 @@ import { refreshAccessToken } from "./token-exchange.js";
 /** How much of a credential's remaining lifetime triggers a proactive refresh. */
 const REFRESH_SKEW_MS = 30_000;
 
+/**
+ * Shared message for the "expired, and no way to refresh" terminal state, used
+ * both here and by the `resolveAccessToken` accessor so the two callers never
+ * drift.
+ */
+export const NO_REFRESH_TOKEN_MESSAGE =
+  "The stored access token has expired and no refresh token is available. Run `stella auth login` again.";
+
+/**
+ * Whether `credential` is expired or within `REFRESH_SKEW_MS` of expiring at
+ * `now` — i.e. a proactive refresh is worth attempting. Callers gate the
+ * network-bearing discovery + token exchange on this so a comfortably-valid
+ * credential stays offline-instant.
+ */
+export const credentialNeedsRefresh = (
+  credential: Pick<StoredCredential, "expiresAt">,
+  now: number,
+): boolean => credential.expiresAt - REFRESH_SKEW_MS <= now;
+
 export type EnsureFreshCredentialInput = {
   readonly configDir: string;
   readonly credential: StoredCredential;
@@ -41,16 +60,13 @@ export const ensureFreshCredential = async (
   input: EnsureFreshCredentialInput,
 ): Promise<Result<StoredCredential, CliAuthError>> => {
   const now = input.now ?? Date.now();
-  if (input.credential.expiresAt - REFRESH_SKEW_MS > now) {
+  if (!credentialNeedsRefresh(input.credential, now)) {
     return Result.ok(input.credential);
   }
 
   if (!input.credential.refreshToken) {
     return Result.err(
-      new NoRefreshTokenError({
-        message:
-          "The stored access token has expired and no refresh token is available. Run `stella auth login` again.",
-      }),
+      new NoRefreshTokenError({ message: NO_REFRESH_TOKEN_MESSAGE }),
     );
   }
 

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -18,7 +18,7 @@ import {
   upsertCredential,
   writeCredentialFile,
 } from "./credential-store.js";
-import type { StoredCredential } from "./credential-store.js";
+import type { CredentialFile, StoredCredential } from "./credential-store.js";
 import { CredentialNotFoundError, NoRefreshTokenError } from "./errors.js";
 import type { CliAuthError } from "./errors.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
@@ -54,11 +54,103 @@ export type EnsureFreshCredentialInput = {
 };
 
 /**
+ * The seam shared by every place this module needs to answer "did a
+ * concurrent `stella` process already move this exact (serverUrl, orgId)
+ * credential out from under this refresh attempt, and if so to what":
+ *
+ *  - `unchanged`: the stored entry still matches the generation this
+ *    attempt started from (`input.credential`) — nothing raced in, so the
+ *    caller proceeds with its own outcome (write the token it just
+ *    refreshed, or surface the token-endpoint error it just got).
+ *  - `resolved`: something did move. `CredentialNotFoundError` when the
+ *    entry is gone — a concurrent `auth logout` wins over anything this
+ *    attempt concluded, success or failure, so writing/using this
+ *    attempt's result would resurrect a credential the user signed out of.
+ *    Otherwise the fresher stored credential, refreshed further (from that
+ *    newer generation, reusing the already-discovered `metadata`) if it
+ *    turns out to itself already be due a refresh.
+ */
+type StoredGenerationCheck =
+  | {
+      readonly kind: "unchanged";
+      readonly latestCredentialFile: CredentialFile;
+    }
+  | {
+      readonly kind: "resolved";
+      readonly result: Result<StoredCredential, CliAuthError>;
+    };
+
+const checkForNewerStoredGeneration = async (
+  input: EnsureFreshCredentialInput,
+  now: number,
+): Promise<StoredGenerationCheck> => {
+  // Re-read right before deciding rather than trusting any snapshot the
+  // caller took earlier: both the token exchange and metadata discovery
+  // that precede this check are network round trips, during which another
+  // `stella` process (a concurrent command, or `auth login`/`logout`) may
+  // have written to `credentials.json`. This keeps that window as small as
+  // this process can make it without a lock (full read-modify-write
+  // atomicity — a store-level lock or true compare-and-swap across the
+  // whole critical section — is a separate, tracked follow-up: this is a
+  // compare-and-skip, not a swap).
+  const latestCredentialFile = await readCredentialFile(input.configDir);
+  const stillPresent = findCredentialByOrgId(
+    latestCredentialFile,
+    input.credential.serverUrl,
+    input.credential.orgId,
+  );
+  if (stillPresent === undefined) {
+    return {
+      kind: "resolved",
+      result: Result.err(
+        new CredentialNotFoundError({
+          message: `Not signed in to ${input.credential.serverUrl}. Run \`stella auth login\`.`,
+          org: input.credential.orgId,
+          serverUrl: input.credential.serverUrl,
+        }),
+      ),
+    };
+  }
+
+  const unchangedSinceAttemptStarted =
+    stillPresent.accessToken === input.credential.accessToken &&
+    stillPresent.refreshToken === input.credential.refreshToken &&
+    stillPresent.expiresAt === input.credential.expiresAt &&
+    stillPresent.scope === input.credential.scope &&
+    stillPresent.updatedAt === input.credential.updatedAt;
+  if (unchangedSinceAttemptStarted) {
+    return { kind: "unchanged", latestCredentialFile };
+  }
+
+  if (!credentialNeedsRefresh(stillPresent, now)) {
+    return { kind: "resolved", result: Result.ok(stillPresent) };
+  }
+  // The concurrent writer's own credential is itself already due a refresh
+  // (rare — e.g. it raced in with a short-lived token). Retry from this
+  // newer generation rather than clobbering it, using it as a failure
+  // excuse, or handing back a token that's already stale;
+  // `credentialNeedsRefresh` re-checks first on every call, so this
+  // terminates once nothing further races in.
+  return {
+    kind: "resolved",
+    result: await ensureFreshCredential({
+      ...input,
+      credential: stillPresent,
+      now,
+    }),
+  };
+};
+
+/**
  * Returns a credential guaranteed usable "now" (with `REFRESH_SKEW_MS` of
  * slack), refreshing and persisting it first if it is expired or about to
  * expire. Errors when the credential is expired and either has no refresh
  * token or the refresh call itself fails — both cases mean the caller must
- * fall back to `stella auth login`.
+ * fall back to `stella auth login`. A refresh-call failure is only trusted
+ * once a re-read confirms no concurrent process already landed newer
+ * tokens (see `checkForNewerStoredGeneration`): the OAuth server may have
+ * rotated the refresh token out from under this exact exchange because a
+ * racing `stella` invocation already won it.
  */
 export const ensureFreshCredential = async (
   input: EnsureFreshCredentialInput,
@@ -81,6 +173,10 @@ export const ensureFreshCredential = async (
     resource: getMcpResourceUrl(input.credential.serverUrl),
   });
   if (Result.isError(refreshed)) {
+    const check = await checkForNewerStoredGeneration(input, now);
+    if (check.kind === "resolved") {
+      return check.result;
+    }
     return Result.err(refreshed.error);
   }
 
@@ -94,70 +190,14 @@ export const ensureFreshCredential = async (
     updatedAt: now,
   };
 
-  // Re-read right before the write rather than trusting any snapshot the
-  // caller took earlier: `refreshAccessToken` above is a network round trip,
-  // during which another `stella` process (a concurrent command, or `auth
-  // login`/`logout` for a different server) may have written to
-  // `credentials.json`. Merging into the file as it stands right now — not
-  // as it stood before the exchange — keeps that window as small as this
-  // process can make it without a lock (full read-modify-write atomicity is
-  // a separate, tracked follow-up).
-  const latestCredentialFile = await readCredentialFile(input.configDir);
-
-  // The exchange itself doesn't prove this exact (serverUrl, orgId)
-  // credential is still meant to exist: a concurrent `stella auth logout`
-  // may have removed it while the refresh request was in flight. Writing
-  // the refreshed token back unconditionally would resurrect a credential
-  // the user explicitly signed out of — fail the same way as "never had a
-  // credential" instead of reviving it.
-  const stillPresent = findCredentialByOrgId(
-    latestCredentialFile,
-    input.credential.serverUrl,
-    input.credential.orgId,
-  );
-  if (stillPresent === undefined) {
-    return Result.err(
-      new CredentialNotFoundError({
-        message: `Not signed in to ${input.credential.serverUrl}. Run \`stella auth login\`.`,
-        org: input.credential.orgId,
-        serverUrl: input.credential.serverUrl,
-      }),
-    );
-  }
-
-  // Existing, not just present: a concurrent process (another command's
-  // refresh racing this one, or a fresh `auth login` to the same org) may
-  // have already replaced this exact credential's token-bearing fields
-  // while our exchange was in flight. Writing `updated` — derived from
-  // `input.credential`, the generation this refresh started from — would
-  // then roll that newer generation back to an older one. Only write when
-  // nothing has moved since we read `input.credential`; otherwise the
-  // fresher entry already on disk wins and we hand that back instead of
-  // touching the file. (This is a compare-and-skip, not a true atomic
-  // compare-and-swap — a lock across the read-modify-write is out of scope
-  // here; see the atomic temp+rename write follow-up.)
-  const unchangedSinceRefreshStarted =
-    stillPresent.accessToken === input.credential.accessToken &&
-    stillPresent.refreshToken === input.credential.refreshToken &&
-    stillPresent.expiresAt === input.credential.expiresAt &&
-    stillPresent.scope === input.credential.scope &&
-    stillPresent.updatedAt === input.credential.updatedAt;
-
-  if (!unchangedSinceRefreshStarted) {
-    if (!credentialNeedsRefresh(stillPresent, now)) {
-      return Result.ok(stillPresent);
-    }
-    // The concurrent writer's own credential is itself already due a
-    // refresh (rare — e.g. it raced in with a short-lived token). Retry
-    // from this newer generation rather than either clobbering it or
-    // handing back a token that's already stale; `credentialNeedsRefresh`
-    // re-checks first, so this terminates once nothing further races in.
-    return ensureFreshCredential({ ...input, credential: stillPresent, now });
+  const check = await checkForNewerStoredGeneration(input, now);
+  if (check.kind === "resolved") {
+    return check.result;
   }
 
   await writeCredentialFile(
     input.configDir,
-    upsertCredential(latestCredentialFile, updated),
+    upsertCredential(check.latestCredentialFile, updated),
   );
 
   return Result.ok(updated);

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -13,12 +13,13 @@ import { Result } from "better-result";
 
 import { getMcpResourceUrl } from "./constants.js";
 import {
+  findCredentialByOrgId,
   readCredentialFile,
   upsertCredential,
   writeCredentialFile,
 } from "./credential-store.js";
 import type { StoredCredential } from "./credential-store.js";
-import { NoRefreshTokenError } from "./errors.js";
+import { CredentialNotFoundError, NoRefreshTokenError } from "./errors.js";
 import type { CliAuthError } from "./errors.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
 import { refreshAccessToken } from "./token-exchange.js";
@@ -102,6 +103,28 @@ export const ensureFreshCredential = async (
   // process can make it without a lock (full read-modify-write atomicity is
   // a separate, tracked follow-up).
   const latestCredentialFile = await readCredentialFile(input.configDir);
+
+  // The exchange itself doesn't prove this exact (serverUrl, orgId)
+  // credential is still meant to exist: a concurrent `stella auth logout`
+  // may have removed it while the refresh request was in flight. Writing
+  // the refreshed token back unconditionally would resurrect a credential
+  // the user explicitly signed out of — fail the same way as "never had a
+  // credential" instead of reviving it.
+  const stillPresent = findCredentialByOrgId(
+    latestCredentialFile,
+    input.credential.serverUrl,
+    input.credential.orgId,
+  );
+  if (stillPresent === undefined) {
+    return Result.err(
+      new CredentialNotFoundError({
+        message: `Not signed in to ${input.credential.serverUrl}. Run \`stella auth login\`.`,
+        org: input.credential.orgId,
+        serverUrl: input.credential.serverUrl,
+      }),
+    );
+  }
+
   await writeCredentialFile(
     input.configDir,
     upsertCredential(latestCredentialFile, updated),

--- a/packages/cli/src/auth/ensure-fresh-credential.ts
+++ b/packages/cli/src/auth/ensure-fresh-credential.ts
@@ -13,6 +13,7 @@ import { Result } from "better-result";
 
 import { getMcpResourceUrl } from "./constants.js";
 import {
+  credentialsFilePath,
   findCredentialByOrgId,
   readCredentialFile,
   upsertCredential,
@@ -54,6 +55,19 @@ export type EnsureFreshCredentialInput = {
 };
 
 /**
+ * `ensureFreshCredential`'s success payload: the credential itself, plus an
+ * optional warning when a freshly-refreshed token could not be written to
+ * `credentials.json` (read-only config dir, full disk, etc.). The token in
+ * `credential` is still valid and safe to use for the command in flight
+ * either way — persistence failing doesn't invalidate it, it just means the
+ * next command will have to refresh again instead of finding it on disk.
+ */
+export type EnsureFreshCredentialOutcome = {
+  readonly credential: StoredCredential;
+  readonly persistWarning?: string;
+};
+
+/**
  * The seam shared by every place this module needs to answer "did a
  * concurrent `stella` process already move this exact (serverUrl, orgId)
  * credential out from under this refresh attempt, and if so to what":
@@ -77,7 +91,7 @@ type StoredGenerationCheck =
     }
   | {
       readonly kind: "resolved";
-      readonly result: Result<StoredCredential, CliAuthError>;
+      readonly result: Result<EnsureFreshCredentialOutcome, CliAuthError>;
     };
 
 const checkForNewerStoredGeneration = async (
@@ -123,7 +137,10 @@ const checkForNewerStoredGeneration = async (
   }
 
   if (!credentialNeedsRefresh(stillPresent, now)) {
-    return { kind: "resolved", result: Result.ok(stillPresent) };
+    return {
+      kind: "resolved",
+      result: Result.ok({ credential: stillPresent }),
+    };
   }
   // The concurrent writer's own credential is itself already due a refresh
   // (rare — e.g. it raced in with a short-lived token). Retry from this
@@ -151,13 +168,20 @@ const checkForNewerStoredGeneration = async (
  * tokens (see `checkForNewerStoredGeneration`): the OAuth server may have
  * rotated the refresh token out from under this exact exchange because a
  * racing `stella` invocation already won it.
+ *
+ * Note the `Result` only ever carries an error for states the caller must
+ * act on (no credential, expired-and-unrefreshable, a genuine refresh
+ * failure). A failure to *persist* an otherwise-successful refresh — the
+ * config dir is read-only, the disk is full — is not one of those: the
+ * refreshed token is valid in memory regardless, so it comes back as
+ * `Result.ok` with `persistWarning` set, not as an error.
  */
 export const ensureFreshCredential = async (
   input: EnsureFreshCredentialInput,
-): Promise<Result<StoredCredential, CliAuthError>> => {
+): Promise<Result<EnsureFreshCredentialOutcome, CliAuthError>> => {
   const now = input.now ?? Date.now();
   if (!credentialNeedsRefresh(input.credential, now)) {
-    return Result.ok(input.credential);
+    return Result.ok({ credential: input.credential });
   }
 
   if (!input.credential.refreshToken) {
@@ -195,10 +219,26 @@ export const ensureFreshCredential = async (
     return check.result;
   }
 
-  await writeCredentialFile(
-    input.configDir,
-    upsertCredential(check.latestCredentialFile, updated),
+  // The write itself (mkdir + writeFile + chmod) can throw — a read-only
+  // config dir, a full disk — outside anything the `Result` flow above
+  // accounts for. `resolvePreamble()` (cli.ts) calls this path before
+  // dispatching every command, so an unhandled rejection here would crash
+  // ordinary commands that have nothing to do with credential storage. The
+  // refresh itself already succeeded, so treat a persistence failure as a
+  // warning, not a failure: hand back the (unsaved) fresh credential and
+  // let the caller decide how to surface the warning.
+  const persisted = await Result.tryPromise(() =>
+    writeCredentialFile(
+      input.configDir,
+      upsertCredential(check.latestCredentialFile, updated),
+    ),
   );
+  if (Result.isError(persisted)) {
+    return Result.ok({
+      credential: updated,
+      persistWarning: `Warning: refreshed the stella credential but could not save it to ${credentialsFilePath(input.configDir)} (${persisted.error.message}). This command will use the fresh token; the next command will need to refresh again.`,
+    });
+  }
 
-  return Result.ok(updated);
+  return Result.ok({ credential: updated });
 };

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -15,20 +15,32 @@ import { resolveAccessToken } from "./resolve-access-token.js";
  * A mock stella server exposing both the RFC 8414 metadata document and the
  * `/oauth2/token` endpoint, plus a total request counter so a test can assert
  * the offline-instant fast path made no network call at all.
+ *
+ * `onDiscovery`, when given, runs while the `.well-known` request is being
+ * answered — a hook for simulating a concurrent `stella` process (e.g. a
+ * parallel `auth login`) that writes to `credentials.json` during the window
+ * `resolveAccessToken` spends awaiting metadata discovery.
  */
 const startMockProvider = (
   handleTokenRequest: (body: URLSearchParams) => Response,
+  onDiscovery?: () => Promise<void>,
 ) => {
   let requestCount = 0;
   const server = Bun.serve({
+    // Derives the endpoint URLs from the incoming request's own origin
+    // rather than `server.port` — referencing `server` from inside its own
+    // `fetch` handler is a circular initializer TypeScript can't type
+    // (`server`'s type depends on `fetch`'s type, which would depend on
+    // `server`). `request.url` already carries the correct host:port.
     fetch: async (request) => {
       requestCount += 1;
       const url = new URL(request.url);
       if (url.pathname === "/.well-known/oauth-authorization-server") {
+        await onDiscovery?.();
         return Response.json({
-          authorization_endpoint: `http://127.0.0.1:${server.port}/oauth2/authorize`,
-          issuer: `http://127.0.0.1:${server.port}`,
-          token_endpoint: `http://127.0.0.1:${server.port}/oauth2/token`,
+          authorization_endpoint: `${url.origin}/oauth2/authorize`,
+          issuer: url.origin,
+          token_endpoint: `${url.origin}/oauth2/token`,
         });
       }
       if (url.pathname === "/oauth2/token") {
@@ -224,6 +236,71 @@ describe("resolveAccessToken", () => {
 
       expect(result.status).toBe("unauthenticated");
       expect(provider.getRequestCount()).toBe(0);
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("does not clobber a credential a concurrent process writes while metadata discovery is in flight", async () => {
+    const otherServerUrl = "https://other.example";
+    let discoveryRequestCount = 0;
+    const provider = startMockProvider(
+      (body) =>
+        body.get("grant_type") === "refresh_token" &&
+        body.get("refresh_token") === "old-refresh-token"
+          ? Response.json({
+              access_token: "new-access-token",
+              expires_in: 900,
+              refresh_token: "new-refresh-token",
+              scope: "openid stella:read",
+              token_type: "Bearer",
+            })
+          : Response.json({ error: "invalid_grant" }, { status: 400 }),
+      async () => {
+        discoveryRequestCount += 1;
+        // Simulate a concurrent `stella` process (e.g. `auth login` to a
+        // different server) finishing a write to `credentials.json` while
+        // this command's metadata discovery request is still in flight.
+        const concurrent = await readCredentialFile(configDir);
+        await writeCredentialFile(
+          configDir,
+          upsertCredential(
+            concurrent,
+            buildCredential(otherServerUrl, {
+              accessToken: "other-server-token",
+            }),
+          ),
+        );
+      },
+    );
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("new-access-token");
+      }
+      expect(discoveryRequestCount).toBe(1);
+
+      // The concurrently-written credential for the other server must
+      // survive this command's refresh write-back rather than being
+      // silently dropped by a stale pre-discovery snapshot of
+      // `credentials.json`.
+      const persisted = await readCredentialFile(configDir);
+      expect(
+        persisted.credentials.find(
+          (stored) => stored.serverUrl === otherServerUrl,
+        )?.accessToken,
+      ).toBe("other-server-token");
     } finally {
       provider.close();
     }

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 import {
+  credentialsFilePath,
   readCredentialFile,
   removeCredential,
   upsertCredential,
@@ -581,6 +582,59 @@ describe("resolveAccessToken", () => {
       );
       expect(stored?.accessToken).toBe("winner-access-token");
       expect(stored?.refreshToken).toBe("winner-refresh-token");
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("returns the fresh token with a warning instead of failing when the credential store can't be written", async () => {
+    const provider = startMockProvider((body) =>
+      body.get("grant_type") === "refresh_token" &&
+      body.get("refresh_token") === "old-refresh-token"
+        ? Response.json({
+            access_token: "new-access-token",
+            expires_in: 900,
+            refresh_token: "new-refresh-token",
+            scope: "openid stella:read",
+            token_type: "Bearer",
+          })
+        : Response.json({ error: "invalid_grant" }, { status: 400 }),
+    );
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      // Force the persist step specifically — not the read — to fail: a
+      // read-only `credentials.json` still opens for reading (so
+      // `checkForNewerStoredGeneration`'s re-read still sees the real,
+      // unchanged credential) but rejects the write with EACCES. This is
+      // deterministic and root-safe-enough for this repo's CI runners
+      // (non-root); there's no fs-injection point on this branch to stub
+      // `writeFile` directly (that lands with the atomic temp+rename
+      // hygiene follow-up).
+      await chmod(credentialsFilePath(configDir), 0o400);
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      // The refresh itself succeeded — the in-memory token is valid and
+      // must not be discarded just because it couldn't be saved.
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("new-access-token");
+        expect(result.persistWarning).toBeDefined();
+        expect(result.persistWarning).toContain(credentialsFilePath(configDir));
+      }
+
+      // Disk genuinely wasn't updated — the write really did fail, this
+      // isn't a warning issued despite a silent successful write.
+      const persisted = await readCredentialFile(configDir);
+      expect(persisted.credentials.at(0)?.accessToken).toBe("old-access-token");
     } finally {
       provider.close();
     }

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -19,10 +19,12 @@ import { resolveAccessToken } from "./resolve-access-token.js";
  * `onDiscovery`, when given, runs while the `.well-known` request is being
  * answered — a hook for simulating a concurrent `stella` process (e.g. a
  * parallel `auth login`) that writes to `credentials.json` during the window
- * `resolveAccessToken` spends awaiting metadata discovery.
+ * `resolveAccessToken` spends awaiting metadata discovery. `handleTokenRequest`
+ * may itself be async for the equivalent simulation around the token-endpoint
+ * exchange.
  */
 const startMockProvider = (
-  handleTokenRequest: (body: URLSearchParams) => Response,
+  handleTokenRequest: (body: URLSearchParams) => Response | Promise<Response>,
   onDiscovery?: () => Promise<void>,
 ) => {
   let requestCount = 0;
@@ -44,7 +46,9 @@ const startMockProvider = (
         });
       }
       if (url.pathname === "/oauth2/token") {
-        return handleTokenRequest(new URLSearchParams(await request.text()));
+        return await handleTokenRequest(
+          new URLSearchParams(await request.text()),
+        );
       }
       return new Response("not found", { status: 404 });
     },
@@ -301,6 +305,71 @@ describe("resolveAccessToken", () => {
           (stored) => stored.serverUrl === otherServerUrl,
         )?.accessToken,
       ).toBe("other-server-token");
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("does not clobber a credential a concurrent process writes during the token-endpoint exchange", async () => {
+    const otherServerUrl = "https://other-exchange.example";
+    let tokenRequestCount = 0;
+    const provider = startMockProvider(async (body) => {
+      tokenRequestCount += 1;
+      if (
+        body.get("grant_type") !== "refresh_token" ||
+        body.get("refresh_token") !== "old-refresh-token"
+      ) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      // Simulate a concurrent `stella` process (e.g. `auth login` to a
+      // different server) finishing a write to `credentials.json` while the
+      // token-endpoint exchange itself — not just metadata discovery — is
+      // still in flight.
+      const concurrent = await readCredentialFile(configDir);
+      await writeCredentialFile(
+        configDir,
+        upsertCredential(
+          concurrent,
+          buildCredential(otherServerUrl, {
+            accessToken: "other-exchange-token",
+          }),
+        ),
+      );
+      return Response.json({
+        access_token: "new-access-token",
+        expires_in: 900,
+        refresh_token: "new-refresh-token",
+        scope: "openid stella:read",
+        token_type: "Bearer",
+      });
+    });
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("new-access-token");
+      }
+      expect(tokenRequestCount).toBe(1);
+
+      // The concurrently-written credential for the other server must
+      // survive `ensureFreshCredential`'s write-back rather than being
+      // silently dropped by a snapshot taken before the token exchange.
+      const persisted = await readCredentialFile(configDir);
+      expect(
+        persisted.credentials.find(
+          (stored) => stored.serverUrl === otherServerUrl,
+        )?.accessToken,
+      ).toBe("other-exchange-token");
     } finally {
       provider.close();
     }

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -440,4 +440,81 @@ describe("resolveAccessToken", () => {
       provider.close();
     }
   });
+
+  test("preserves a newer same-org credential a concurrent process writes mid-exchange", async () => {
+    let tokenRequestCount = 0;
+    const provider = startMockProvider(async (body) => {
+      tokenRequestCount += 1;
+      if (
+        body.get("grant_type") !== "refresh_token" ||
+        body.get("refresh_token") !== "old-refresh-token"
+      ) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      // Simulate a concurrent process (another command's own refresh
+      // racing this one, or a fresh `auth login` to the same org)
+      // finishing first and replacing this exact (serverUrl, orgId)
+      // credential's tokens while this exchange is still in flight. Reads
+      // the target back off disk rather than closing over `provider`.
+      const concurrent = await readCredentialFile(configDir);
+      const target = concurrent.credentials.at(0);
+      if (target === undefined) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      await writeCredentialFile(
+        configDir,
+        upsertCredential(concurrent, {
+          ...target,
+          accessToken: "concurrent-access-token",
+          expiresAt: Date.now() + 60_000,
+          refreshToken: "concurrent-refresh-token",
+          updatedAt: Date.now(),
+        }),
+      );
+      // The stale-generation exchange still "succeeds" at the network
+      // level — the token endpoint has no way to know a newer credential
+      // already landed locally.
+      return Response.json({
+        access_token: "stale-generation-token",
+        expires_in: 900,
+        refresh_token: "stale-generation-refresh-token",
+        scope: "openid stella:read",
+        token_type: "Bearer",
+      });
+    });
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      // The concurrent write already landed a newer, comfortably-valid
+      // credential; this command must use that one rather than the token
+      // from its own (now-stale) exchange.
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("concurrent-access-token");
+      }
+      expect(tokenRequestCount).toBe(1);
+
+      // The newer credential must survive on disk untouched — not rolled
+      // back to the stale-generation tokens this exchange produced.
+      const persisted = await readCredentialFile(configDir);
+      const stored = persisted.credentials.find(
+        (credential) =>
+          credential.serverUrl === provider.serverUrl &&
+          credential.orgId === "org-1",
+      );
+      expect(stored?.accessToken).toBe("concurrent-access-token");
+      expect(stored?.refreshToken).toBe("concurrent-refresh-token");
+    } finally {
+      provider.close();
+    }
+  });
 });

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import {
   readCredentialFile,
+  removeCredential,
   upsertCredential,
   writeCredentialFile,
 } from "./credential-store.js";
@@ -370,6 +371,71 @@ describe("resolveAccessToken", () => {
           (stored) => stored.serverUrl === otherServerUrl,
         )?.accessToken,
       ).toBe("other-exchange-token");
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("does not resurrect a credential a concurrent auth logout removes mid-exchange", async () => {
+    let tokenRequestCount = 0;
+    const provider = startMockProvider(async (body) => {
+      tokenRequestCount += 1;
+      if (
+        body.get("grant_type") !== "refresh_token" ||
+        body.get("refresh_token") !== "old-refresh-token"
+      ) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      // Simulate a concurrent `stella auth logout` removing this exact
+      // credential while the token-endpoint exchange (which still succeeds
+      // at the network level) is in flight. Reads the target's own
+      // serverUrl/orgId back off disk rather than closing over `provider`
+      // (not yet assigned while this callback is being constructed).
+      const concurrent = await readCredentialFile(configDir);
+      const target = concurrent.credentials.at(0);
+      if (target === undefined) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      await writeCredentialFile(
+        configDir,
+        removeCredential(concurrent, target.serverUrl, target.orgId),
+      );
+      return Response.json({
+        access_token: "resurrected-access-token",
+        expires_in: 900,
+        refresh_token: "resurrected-refresh-token",
+        scope: "openid stella:read",
+        token_type: "Bearer",
+      });
+    });
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      // Logout wins: the exchange happened, but the credential it would
+      // have refreshed is gone, so this resolves the same as "never signed
+      // in" rather than handing back the resurrected token.
+      expect(result.status).toBe("unauthenticated");
+      expect(tokenRequestCount).toBe(1);
+
+      // The logged-out credential must not reappear on disk, and
+      // specifically not carrying the token from the (already-in-flight)
+      // exchange that should never have been written back.
+      const persisted = await readCredentialFile(configDir);
+      expect(
+        persisted.credentials.find(
+          (stored) =>
+            stored.serverUrl === provider.serverUrl && stored.orgId === "org-1",
+        ),
+      ).toBeUndefined();
     } finally {
       provider.close();
     }

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -517,4 +517,72 @@ describe("resolveAccessToken", () => {
       provider.close();
     }
   });
+
+  test("uses the winner's tokens instead of failing when a racing refresh already rotated the shared refresh token", async () => {
+    let tokenRequestCount = 0;
+    const provider = startMockProvider(async (body) => {
+      tokenRequestCount += 1;
+      if (
+        body.get("grant_type") !== "refresh_token" ||
+        body.get("refresh_token") !== "old-refresh-token"
+      ) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      // Simulate a concurrent `stella` process that started from the same
+      // expired credential winning the race: its own refresh already
+      // landed rotated tokens on disk, which invalidates "old-refresh-token"
+      // server-side. Reads the target back off disk rather than closing
+      // over `provider`.
+      const concurrent = await readCredentialFile(configDir);
+      const target = concurrent.credentials.at(0);
+      if (target === undefined) {
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      await writeCredentialFile(
+        configDir,
+        upsertCredential(concurrent, {
+          ...target,
+          accessToken: "winner-access-token",
+          expiresAt: Date.now() + 60_000,
+          refreshToken: "winner-refresh-token",
+          updatedAt: Date.now(),
+        }),
+      );
+      // This (losing) exchange's refresh token is now invalid server-side —
+      // the OAuth server rotated it away when the winner refreshed first.
+      return Response.json({ error: "invalid_grant" }, { status: 400 });
+    });
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      // The token-endpoint rejection must not surface as refresh-failed:
+      // a valid, fresher credential is already sitting in the store because
+      // the concurrent process won the race, so this command uses that one.
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("winner-access-token");
+      }
+      expect(tokenRequestCount).toBe(1);
+
+      const persisted = await readCredentialFile(configDir);
+      const stored = persisted.credentials.find(
+        (credential) =>
+          credential.serverUrl === provider.serverUrl &&
+          credential.orgId === "org-1",
+      );
+      expect(stored?.accessToken).toBe("winner-access-token");
+      expect(stored?.refreshToken).toBe("winner-refresh-token");
+    } finally {
+      provider.close();
+    }
+  });
 });

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  readCredentialFile,
+  upsertCredential,
+  writeCredentialFile,
+} from "./credential-store.js";
+import type { StoredCredential } from "./credential-store.js";
+import { resolveAccessToken } from "./resolve-access-token.js";
+
+/**
+ * A mock stella server exposing both the RFC 8414 metadata document and the
+ * `/oauth2/token` endpoint, plus a total request counter so a test can assert
+ * the offline-instant fast path made no network call at all.
+ */
+const startMockProvider = (
+  handleTokenRequest: (body: URLSearchParams) => Response,
+) => {
+  let requestCount = 0;
+  const server = Bun.serve({
+    fetch: async (request) => {
+      requestCount += 1;
+      const url = new URL(request.url);
+      if (url.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          authorization_endpoint: `http://127.0.0.1:${server.port}/oauth2/authorize`,
+          issuer: `http://127.0.0.1:${server.port}`,
+          token_endpoint: `http://127.0.0.1:${server.port}/oauth2/token`,
+        });
+      }
+      if (url.pathname === "/oauth2/token") {
+        return handleTokenRequest(new URLSearchParams(await request.text()));
+      }
+      return new Response("not found", { status: 404 });
+    },
+    hostname: "127.0.0.1",
+    port: 0,
+  });
+
+  return {
+    close: () => {
+      void server.stop(true);
+    },
+    getRequestCount: () => requestCount,
+    serverUrl: `http://127.0.0.1:${server.port}`,
+  };
+};
+
+describe("resolveAccessToken", () => {
+  let configDir: string;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(
+      path.join(os.tmpdir(), "stella-cli-resolve-token-test-"),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(configDir, { force: true, recursive: true });
+  });
+
+  const buildCredential = (
+    serverUrl: string,
+    overrides: Partial<StoredCredential> = {},
+  ): StoredCredential => ({
+    accessToken: "old-access-token",
+    clientId: "client-id",
+    createdAt: 0,
+    expiresAt: 10_000,
+    orgId: "org-1",
+    refreshToken: "old-refresh-token",
+    scope: "openid stella:read",
+    serverUrl,
+    tokenType: "Bearer",
+    updatedAt: 0,
+    ...overrides,
+  });
+
+  const seedCredential = async (
+    credential: StoredCredential,
+  ): Promise<void> => {
+    await writeCredentialFile(
+      configDir,
+      upsertCredential(
+        { credentials: [], defaultOrgByServer: {}, version: 1 },
+        credential,
+      ),
+    );
+  };
+
+  test("returns the stored token with no network call when the credential is comfortably valid", async () => {
+    const provider = startMockProvider(
+      () => new Response("should not be called", { status: 500 }),
+    );
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now + 60_000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("old-access-token");
+      }
+      expect(provider.getRequestCount()).toBe(0);
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("refreshes, persists, and returns the rotated token when the stored token is expired", async () => {
+    const provider = startMockProvider((body) =>
+      body.get("grant_type") === "refresh_token" &&
+      body.get("refresh_token") === "old-refresh-token"
+        ? Response.json({
+            access_token: "new-access-token",
+            expires_in: 900,
+            refresh_token: "new-refresh-token",
+            scope: "openid stella:read",
+            token_type: "Bearer",
+          })
+        : Response.json({ error: "invalid_grant" }, { status: 400 }),
+    );
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.token).toBe("new-access-token");
+      }
+
+      const persisted = await readCredentialFile(configDir);
+      const stored = persisted.credentials.at(0);
+      expect(stored?.accessToken).toBe("new-access-token");
+      expect(stored?.refreshToken).toBe("new-refresh-token");
+      expect(stored?.expiresAt).toBe(now + 900 * 1000);
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("reports refresh-failed when the token endpoint rejects the refresh", async () => {
+    const provider = startMockProvider(() =>
+      Response.json({ error: "invalid_grant" }, { status: 400 }),
+    );
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      expect(result.status).toBe("refresh-failed");
+      if (result.status === "refresh-failed") {
+        expect(result.error._tag).toBe("TokenRefreshError");
+      }
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("reports refresh-failed without a network call when the expired credential has no refresh token", async () => {
+    const provider = startMockProvider(
+      () => new Response("should not be called", { status: 500 }),
+    );
+    try {
+      const now = Date.now();
+      await seedCredential(
+        buildCredential(provider.serverUrl, {
+          expiresAt: now - 1000,
+          refreshToken: undefined,
+        }),
+      );
+
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now,
+      });
+
+      expect(result.status).toBe("refresh-failed");
+      if (result.status === "refresh-failed") {
+        expect(result.error._tag).toBe("NoRefreshTokenError");
+      }
+      expect(provider.getRequestCount()).toBe(0);
+    } finally {
+      provider.close();
+    }
+  });
+
+  test("reports unauthenticated when no credential is stored for the server", async () => {
+    const provider = startMockProvider(
+      () => new Response("should not be called", { status: 500 }),
+    );
+    try {
+      const result = await resolveAccessToken({
+        configDir,
+        serverUrl: provider.serverUrl,
+        now: Date.now(),
+      });
+
+      expect(result.status).toBe("unauthenticated");
+      expect(provider.getRequestCount()).toBe(0);
+    } finally {
+      provider.close();
+    }
+  });
+});

--- a/packages/cli/src/auth/resolve-access-token.ts
+++ b/packages/cli/src/auth/resolve-access-token.ts
@@ -34,7 +34,11 @@ export type ResolveAccessTokenOptions = {
 
 /**
  * Outcome of resolving a live access token:
- *  - `ok`: a token usable now (fresh, or freshly refreshed and persisted);
+ *  - `ok`: a token usable now (fresh, or freshly refreshed). `persistWarning`
+ *    is set when a freshly-refreshed token could not be saved to disk (e.g.
+ *    a read-only config dir) — the token is still valid for this command,
+ *    but the caller should tell the user the next command will need to
+ *    refresh again rather than finding it on disk;
  *  - `unauthenticated`: no stored credential for `serverUrl` at all;
  *  - `refresh-failed`: a credential exists but is expired and could not be
  *    refreshed (no refresh token, metadata discovery failure, or the token
@@ -42,7 +46,11 @@ export type ResolveAccessTokenOptions = {
  *    `stella auth login`.
  */
 export type ResolveAccessTokenResult =
-  | { readonly status: "ok"; readonly token: string }
+  | {
+      readonly status: "ok";
+      readonly token: string;
+      readonly persistWarning?: string;
+    }
   | { readonly status: "unauthenticated" }
   | { readonly status: "refresh-failed"; readonly error: CliAuthError };
 
@@ -105,5 +113,12 @@ export const resolveAccessToken = async ({
     }
     return { status: "refresh-failed", error: fresh.error };
   }
-  return { status: "ok", token: fresh.value.accessToken };
+  if (fresh.value.persistWarning !== undefined) {
+    return {
+      status: "ok",
+      token: fresh.value.credential.accessToken,
+      persistWarning: fresh.value.persistWarning,
+    };
+  }
+  return { status: "ok", token: fresh.value.credential.accessToken };
 };

--- a/packages/cli/src/auth/resolve-access-token.ts
+++ b/packages/cli/src/auth/resolve-access-token.ts
@@ -75,10 +75,25 @@ export const resolveAccessToken = async ({
     return { status: "refresh-failed", error: metadata.error };
   }
 
+  // Re-read right before the refresh/write rather than reusing the snapshot
+  // from the top of this function: metadata discovery is a network round
+  // trip, and another `stella` process (a concurrent command, or `auth
+  // login`/`logout` for a different server) may have written to
+  // `credentials.json` while it was in flight. Refreshing off a stale
+  // in-memory copy would both retry with a possibly-already-rotated refresh
+  // token and, on write, silently clobber that concurrent update —
+  // `upsertCredential` merges into whatever `credentialFile` it's handed, so
+  // a stale handle here becomes data loss on disk, not just a stale read.
+  const freshCredentialFile = await readCredentialFile(configDir);
+  const freshCredential = findDefaultCredential(freshCredentialFile, serverUrl);
+  if (freshCredential === undefined) {
+    return { status: "unauthenticated" };
+  }
+
   const fresh = await ensureFreshCredential({
     configDir,
-    credential,
-    credentialFile,
+    credential: freshCredential,
+    credentialFile: freshCredentialFile,
     metadata: metadata.value,
     now,
   });

--- a/packages/cli/src/auth/resolve-access-token.ts
+++ b/packages/cli/src/auth/resolve-access-token.ts
@@ -96,6 +96,13 @@ export const resolveAccessToken = async ({
     now,
   });
   if (Result.isError(fresh)) {
+    // `ensureFreshCredential` reports this exact tag when a concurrent
+    // `auth logout` removed the credential while the exchange was in
+    // flight: not a failure to refresh, just "no longer signed in," so this
+    // command sees the same outcome as if it had never found a credential.
+    if (fresh.error._tag === "CredentialNotFoundError") {
+      return { status: "unauthenticated" };
+    }
     return { status: "refresh-failed", error: fresh.error };
   }
   return { status: "ok", token: fresh.value.accessToken };

--- a/packages/cli/src/auth/resolve-access-token.ts
+++ b/packages/cli/src/auth/resolve-access-token.ts
@@ -1,0 +1,89 @@
+// The single choke point that turns a stored credential into a live bearer
+// token for server requests. Everything that authenticates against `serverUrl`
+// (the startup registry refresh and every generated command via the shell
+// context) resolves its token here instead of reading
+// `StoredCredential.accessToken` raw, so the freshness/refresh check can never
+// be skipped and an expired-but-refreshable session heals itself in place.
+//
+// The offline-instant fast path is preserved: a credential still comfortably
+// within its lifetime is returned without any network call (no metadata
+// discovery, no token round-trip). Only an expired / near-expiry credential
+// discovers the token endpoint and refreshes, and the rotated credential is
+// persisted so the next command is fast again.
+
+import { Result } from "better-result";
+
+import {
+  findDefaultCredential,
+  readCredentialFile,
+} from "./credential-store.js";
+import {
+  credentialNeedsRefresh,
+  ensureFreshCredential,
+  NO_REFRESH_TOKEN_MESSAGE,
+} from "./ensure-fresh-credential.js";
+import { NoRefreshTokenError } from "./errors.js";
+import type { CliAuthError } from "./errors.js";
+import { discoverAuthorizationServerMetadata } from "./oauth-metadata.js";
+
+export type ResolveAccessTokenOptions = {
+  readonly configDir: string;
+  readonly serverUrl: string;
+  readonly now?: number;
+};
+
+/**
+ * Outcome of resolving a live access token:
+ *  - `ok`: a token usable now (fresh, or freshly refreshed and persisted);
+ *  - `unauthenticated`: no stored credential for `serverUrl` at all;
+ *  - `refresh-failed`: a credential exists but is expired and could not be
+ *    refreshed (no refresh token, metadata discovery failure, or the token
+ *    endpoint rejected the refresh) — the caller must fall back to
+ *    `stella auth login`.
+ */
+export type ResolveAccessTokenResult =
+  | { readonly status: "ok"; readonly token: string }
+  | { readonly status: "unauthenticated" }
+  | { readonly status: "refresh-failed"; readonly error: CliAuthError };
+
+export const resolveAccessToken = async ({
+  configDir,
+  serverUrl,
+  now = Date.now(),
+}: ResolveAccessTokenOptions): Promise<ResolveAccessTokenResult> => {
+  const credentialFile = await readCredentialFile(configDir);
+  const credential = findDefaultCredential(credentialFile, serverUrl);
+  if (credential === undefined) {
+    return { status: "unauthenticated" };
+  }
+
+  // Comfortably valid: hand back the stored token with no network round-trip.
+  if (!credentialNeedsRefresh(credential, now)) {
+    return { status: "ok", token: credential.accessToken };
+  }
+
+  // Expired and unrefreshable: fail closed before spending a discovery request.
+  if (credential.refreshToken === undefined) {
+    return {
+      status: "refresh-failed",
+      error: new NoRefreshTokenError({ message: NO_REFRESH_TOKEN_MESSAGE }),
+    };
+  }
+
+  const metadata = await discoverAuthorizationServerMetadata(serverUrl);
+  if (Result.isError(metadata)) {
+    return { status: "refresh-failed", error: metadata.error };
+  }
+
+  const fresh = await ensureFreshCredential({
+    configDir,
+    credential,
+    credentialFile,
+    metadata: metadata.value,
+    now,
+  });
+  if (Result.isError(fresh)) {
+    return { status: "refresh-failed", error: fresh.error };
+  }
+  return { status: "ok", token: fresh.value.accessToken };
+};

--- a/packages/cli/src/auth/resolve-access-token.ts
+++ b/packages/cli/src/auth/resolve-access-token.ts
@@ -75,15 +75,14 @@ export const resolveAccessToken = async ({
     return { status: "refresh-failed", error: metadata.error };
   }
 
-  // Re-read right before the refresh/write rather than reusing the snapshot
-  // from the top of this function: metadata discovery is a network round
-  // trip, and another `stella` process (a concurrent command, or `auth
-  // login`/`logout` for a different server) may have written to
-  // `credentials.json` while it was in flight. Refreshing off a stale
-  // in-memory copy would both retry with a possibly-already-rotated refresh
-  // token and, on write, silently clobber that concurrent update —
-  // `upsertCredential` merges into whatever `credentialFile` it's handed, so
-  // a stale handle here becomes data loss on disk, not just a stale read.
+  // Re-derive the credential right before the refresh rather than reusing
+  // the snapshot from the top of this function: metadata discovery is a
+  // network round trip, and another `stella` process (a concurrent command,
+  // or `auth login`/`logout` for a different server) may have rotated or
+  // removed it while that request was in flight. Retrying with an
+  // already-rotated-away refresh token would fail unnecessarily.
+  // `ensureFreshCredential` re-reads the file again itself, right before its
+  // own write, to close the equivalent window around the token exchange.
   const freshCredentialFile = await readCredentialFile(configDir);
   const freshCredential = findDefaultCredential(freshCredentialFile, serverUrl);
   if (freshCredential === undefined) {
@@ -93,7 +92,6 @@ export const resolveAccessToken = async ({
   const fresh = await ensureFreshCredential({
     configDir,
     credential: freshCredential,
-    credentialFile: freshCredentialFile,
     metadata: metadata.value,
     now,
   });

--- a/packages/cli/src/cli-commands.test.ts
+++ b/packages/cli/src/cli-commands.test.ts
@@ -92,10 +92,12 @@ const writeCredentials = async ({
   configHome,
   url,
   token,
+  expiresAt,
 }: {
   configHome: string;
   url: string;
   token: string;
+  expiresAt?: number | undefined;
 }): Promise<void> => {
   const dir = path.join(configHome, "stella");
   await mkdir(dir, { recursive: true });
@@ -111,7 +113,7 @@ const writeCredentials = async ({
         accessToken: token,
         scope: "stella:read",
         tokenType: "Bearer",
-        expiresAt: now + 3_600_000,
+        expiresAt: expiresAt ?? now + 3_600_000,
         createdAt: now,
         updatedAt: now,
       },
@@ -128,17 +130,19 @@ const runCli = async ({
   token,
   stdin,
   signedIn = true,
+  expiresAt,
 }: {
   args: readonly string[];
   url: string;
   token: string;
   stdin?: string;
   signedIn?: boolean;
+  expiresAt?: number | undefined;
 }): Promise<RunResult> => {
   const configHome = await mkdtemp(path.join(tmpdir(), "stella-cli-"));
   tempDirs.push(configHome);
   if (signedIn) {
-    await writeCredentials({ configHome, url, token });
+    await writeCredentials({ configHome, url, token, expiresAt });
   }
 
   const proc = Bun.spawn({
@@ -202,6 +206,29 @@ describe("auth and scope gating (S4)", () => {
     server.stop();
     expect(result.exitCode).toBe(3);
     expect(result.stderr).toContain("stella:matters_write");
+    expect(server.requests).toHaveLength(0);
+  });
+
+  test("an expired credential with no refresh token surfaces the specific refresh-failed reason, not just 'Not signed in'", async () => {
+    const server = startMockServer(() => ({ toolPayload: {} }));
+    const result = await runCli({
+      args: ["matter", "list"],
+      url: server.url,
+      token: READ,
+      // No refresh token is ever written by `writeCredentials`, so an
+      // already-expired token fails closed without any network call
+      // (see `resolveAccessToken`'s "Expired and unrefreshable" branch).
+      expiresAt: Date.now() - 1000,
+    });
+    server.stop();
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toContain("Not signed in");
+    // The specific reason (the stored token expired and has no refresh
+    // token) must reach the user instead of being silently discarded by
+    // `resolvePreamble`.
+    expect(result.stderr).toContain(
+      "no refresh token is available. Run `stella auth login` again.",
+    );
     expect(server.requests).toHaveLength(0);
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,10 +17,7 @@ import { Result } from "better-result";
 
 import packageJson from "../package.json" with { type: "json" };
 import { defaultConfigDir } from "./auth/cli-config.js";
-import {
-  findDefaultCredential,
-  readCredentialFile,
-} from "./auth/credential-store.js";
+import { resolveAccessToken } from "./auth/resolve-access-token.js";
 import { resolveServerUrl } from "./auth/server-resolution.js";
 import { buildGeneratedRoutes, buildResourceRoutes } from "./build-cli-tree.js";
 import { authRoute } from "./commands/auth.js";
@@ -107,10 +104,19 @@ const resolvePreamble = async (): Promise<{
   const serverUrl = Result.isOk(serverUrlResult)
     ? serverUrlResult.value
     : undefined;
-  const token = serverUrl
-    ? findDefaultCredential(await readCredentialFile(configDir), serverUrl)
-        ?.accessToken
-    : undefined;
+  if (serverUrl === undefined) {
+    return { configDir, serverUrl: undefined, token: undefined };
+  }
+
+  // The single choke point where a stored credential becomes a request token:
+  // an expired/near-expiry access token is refreshed (and the rotation
+  // persisted) before use, so a valid refresh token keeps commands working
+  // without a re-login. A refresh failure (or no credential) yields no token,
+  // so the command path's established "Not signed in" / exit-`auth` contract
+  // still applies, and the startup registry refresh below is skipped rather
+  // than firing a doomed request that 401-warns on a stale token.
+  const resolved = await resolveAccessToken({ configDir, serverUrl });
+  const token = resolved.status === "ok" ? resolved.token : undefined;
   return { configDir, serverUrl, token };
 };
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -122,6 +122,11 @@ const resolvePreamble = async (): Promise<{
     // signed in" message stand in for it.
     process.stderr.write(`${resolved.error.message}\n`);
   }
+  if (resolved.status === "ok" && resolved.persistWarning !== undefined) {
+    // The refresh succeeded but couldn't be saved to disk (read-only config
+    // dir, full disk); the token below is still valid for this command.
+    process.stderr.write(`${resolved.persistWarning}\n`);
+  }
   const token = resolved.status === "ok" ? resolved.token : undefined;
   return { configDir, serverUrl, token };
 };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -116,6 +116,12 @@ const resolvePreamble = async (): Promise<{
   // still applies, and the startup registry refresh below is skipped rather
   // than firing a doomed request that 401-warns on a stale token.
   const resolved = await resolveAccessToken({ configDir, serverUrl });
+  if (resolved.status === "refresh-failed") {
+    // Surface the specific reason (e.g. "no refresh token, run `stella auth
+    // login` again") instead of letting the command path's generic "Not
+    // signed in" message stand in for it.
+    process.stderr.write(`${resolved.error.message}\n`);
+  }
   const token = resolved.status === "ok" ? resolved.token : undefined;
   return { configDir, serverUrl, token };
 };

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -20,10 +20,13 @@ export type Context = CommandContext & {
   /** Resolved server origin (`--server`/env/config; see `auth/server-resolution.ts`), if any. */
   readonly serverUrl: string | undefined;
   /**
-   * The default org's stored access token for `serverUrl`, if signed in.
-   * Not proactively refreshed here — a Phase 3+ HTTP client wrapper should
-   * call `auth/ensure-fresh-credential.ts` reactively on a 401, matching
-   * `stella auth whoami`'s "no extra server calls unless needed" stance.
+   * The default org's live access token for `serverUrl`, if signed in.
+   * Resolved through `auth/resolve-access-token.ts`, which proactively
+   * refreshes (and persists) an expired/near-expiry credential before the
+   * command runs; `undefined` when there is no credential or a refresh failed,
+   * in which case the command falls back to the "Not signed in" / exit-`auth`
+   * path. A comfortably-valid credential is returned without any server call,
+   * keeping startup offline-instant.
    */
   readonly token: string | undefined;
 };


### PR DESCRIPTION
The CLI read the stored `accessToken` raw from the credential store, so once
the access token expired every command failed with the auth exit code (and the
startup registry refresh 401-warned on unrelated commands) even when a valid
refresh token was on hand, forcing a manual re-login. `ensureFreshCredential`
existed but had no production call site.

Route every request token through a single `resolveAccessToken` accessor that
proactively refreshes and persists an expired/near-expiry credential before
use. `cli.ts` resolves the shell-context token (and the token feeding the
startup registry refresh) through it, so a valid refresh token keeps commands
working; a refresh failure yields no token and falls back to the established
"Not signed in" / exit-`auth` path. The offline-instant fast path is preserved:
a comfortably-valid credential returns with no metadata discovery or token
round-trip. Extract `credentialNeedsRefresh` and the no-refresh-token message
so the accessor and `ensureFreshCredential` share one freshness source.

Add tests for the accessor: fresh token returns with no network call, expired
token triggers a refresh whose rotated token is persisted and returned, a
rejected refresh and a missing refresh token both report the auth-required
path, and an absent credential reports unauthenticated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access tokens are now resolved at startup, with automatic refresh when expired or nearing expiry.
  * Refreshed credentials are written back so future commands can use rotated tokens.
  * Clearer “refresh-failed” handling when credentials can’t be refreshed.

* **Bug Fixes**
  * Prevented concurrent credential updates from being clobbered during refresh.
  * Signing out while a refresh is in progress no longer restores deleted credentials.
  * Refresh token errors and missing-token scenarios are handled safely without unnecessary network calls.
  * If credential persistence fails, the refreshed token still works while reporting a warning.

* **Documentation**
  * Updated auth context messaging to reflect proactive token resolution and refresh behaviour.

* **Tests**
  * Expanded token resolution and concurrency coverage, including race conditions and persistence failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->