### PR TITLE
fix(api): close SSE races around aborted signals and subscriber attach failures

### DIFF
--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -8,13 +8,52 @@ import { logger } from "@/api/lib/observability/logger";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
 
 class ConfiguredRedisClient extends RedisClient implements BunRedisRawClient {
+  readonly #connectHandlers = new Set<() => void>();
+
   override onclose: (error?: Error) => void = () => undefined;
+  // Declared as a non-null field so the class satisfies `BunRedisRawClient`
+  // (Bun types the inherited `onconnect` as nullable). The field's own-property
+  // is removed in the constructor before the real callback is registered — see
+  // there for why the runtime path cannot be a plain field assignment.
   override onconnect: () => void = () => undefined;
   readonly url: string;
 
   constructor(url = env.REDIS_URL, overrides?: RedisOptions) {
     super(url, { ...redisConnectionOptions(url), ...overrides });
     this.url = url;
+    // Register one owned dispatcher on Bun's native `onconnect` setter so a
+    // pub/sub subscriber can observe reconnects. Two facts (both verified
+    // against a mock RESP3 server) shape this: (1) `onconnect` must be reached
+    // through `[[Set]]` so Bun registers the callback — the class field above
+    // defines an own data property that shadows the prototype setter, and a
+    // callback stored that way never fires; deleting the own property first
+    // makes the setter reachable. (2) Bun's RedisClient is not an EventTarget,
+    // so a direct `this.onconnect = …` is the only real option, but the
+    // prefer-add-event-listener lint rule bans that syntax — `Reflect.set`
+    // performs the same `[[Set]]` without the banned member-assignment form.
+    // The dispatcher fans every (re)connection out to the handlers registered
+    // via `onReconnect`.
+    Reflect.deleteProperty(this, "onconnect");
+    Reflect.set(this, "onconnect", () => {
+      for (const handler of this.#connectHandlers) {
+        handler();
+      }
+    });
+  }
+
+  /**
+   * Register `handler` to run on every (re)connection of this client,
+   * including reconnects after a transient drop. Bun's RedisClient auto-
+   * reconnects but does NOT re-issue SUBSCRIBE, so a pub/sub subscriber must
+   * observe reconnects to re-establish its subscription (see sse.ts). Register
+   * after the initial subscribe so the handler sees only genuine reconnects.
+   * Returns a disposer that removes the handler.
+   */
+  onReconnect(handler: () => void): () => void {
+    this.#connectHandlers.add(handler);
+    return () => {
+      this.#connectHandlers.delete(handler);
+    };
   }
 }
 

--- a/apps/api/src/lib/sse-broadcast.ts
+++ b/apps/api/src/lib/sse-broadcast.ts
@@ -18,6 +18,8 @@ type RedisPayload =
       scope: "organization";
       id: string;
       event: SSEEvent;
+      originInstanceId?: string | undefined;
+      deliveredInline?: boolean | undefined;
     }
   | {
       scope: "session";
@@ -29,7 +31,23 @@ type RedisPayload =
       scope: "workspace";
       id: string;
       event: SSEEvent;
+      originInstanceId?: string | undefined;
+      deliveredInline?: boolean | undefined;
     };
+
+/**
+ * Origin metadata for workspace/organization broadcasts. `originInstanceId`
+ * identifies the publishing instance and `deliveredInline` records whether that
+ * instance already delivered the event to its local clients inline (during a
+ * subscriber attach window). A receiver drops its own looped-back copy only
+ * when both hold, keeping own events exactly-once without dropping other
+ * instances' events. Both are optional so a message from an
+ * older-format publisher during a rolling deploy still delivers.
+ */
+type PublishOptions = {
+  originInstanceId?: string | undefined;
+  deliveredInline?: boolean | undefined;
+};
 
 export class SSEBroadcastError extends TaggedError("SSEBroadcastError")<{
   message: string;
@@ -81,6 +99,10 @@ export const parseRedisPayload = (raw: string): RedisPayload | null => {
       typeof parsed.originInstanceId === "string"
         ? parsed.originInstanceId
         : undefined,
+    deliveredInline:
+      "deliveredInline" in parsed && typeof parsed.deliveredInline === "boolean"
+        ? parsed.deliveredInline
+        : undefined,
   };
 };
 
@@ -106,22 +128,28 @@ const publishRedisPayload = async (payload: RedisPayload): Promise<void> => {
 export const publishWorkspaceEvent = async (
   workspaceId: SafeId<"workspace">,
   event: SSEEvent,
+  options: PublishOptions = {},
 ): Promise<void> => {
   await publishRedisPayload({
     scope: "workspace",
     id: workspaceId,
     event,
+    originInstanceId: options.originInstanceId,
+    deliveredInline: options.deliveredInline,
   });
 };
 
 export const publishOrganizationEvent = async (
   organizationId: SafeId<"organization">,
   event: SSEEvent,
+  options: PublishOptions = {},
 ): Promise<void> => {
   await publishRedisPayload({
     scope: "organization",
     id: organizationId,
     event,
+    originInstanceId: options.originInstanceId,
+    deliveredInline: options.deliveredInline,
   });
 };
 

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -10,10 +10,18 @@ type FakeRedisClient = {
 
 const createdClients: FakeRedisClient[] = [];
 let subscribeBehavior: "reject" | "resolve" = "resolve";
+// Number of subscribe() attempts to fail before succeeding, independent of
+// subscribeBehavior. Lets a test model a transient boot blip (fail once,
+// then the retry attaches) without permanently rejecting.
+let subscribeFailuresRemaining = 0;
 
 const makeFakeRedisClient = (): FakeRedisClient => {
   const client: FakeRedisClient = {
     subscribe: mock(async () => {
+      if (subscribeFailuresRemaining > 0) {
+        subscribeFailuresRemaining -= 1;
+        throw new Error("redis unavailable");
+      }
       if (subscribeBehavior === "reject") {
         throw new Error("redis unavailable");
       }
@@ -201,5 +209,83 @@ describe("startSse / stopSse lifecycle", () => {
     expect(newClient?.close).toHaveBeenCalledTimes(1);
 
     await flushMicrotasks();
+  });
+});
+
+describe("subscribe: already-aborted signal", () => {
+  test("an already-aborted signal registers no connection and closes the stream", async () => {
+    const controller = new AbortController();
+    // The signal aborts before subscribe runs, mirroring a client that
+    // disconnects during the async auth macro. With the leak, the stream
+    // would stay open and registered forever; the fix closes it up front.
+    controller.abort();
+
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    const first = await reader.read();
+    expect(first.done).toBe(true);
+
+    // A subsequent broadcast must not resurrect or feed the dead stream:
+    // nothing was registered, so there is nothing to enqueue into.
+    broadcast(workspaceId, { type: "after-abort", data: null });
+    await flushMicrotasks();
+
+    const second = await reader.read();
+    expect(second.done).toBe(true);
+  });
+});
+
+describe("broadcast: local delivery without an attached subscriber", () => {
+  test("broadcast delivers locally when no Redis subscriber is attached", async () => {
+    // No startSse: this instance has no attached subscriber, so a
+    // published event never loops back. Local clients must still get it.
+    stopSse();
+    await flushMicrotasks();
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    broadcast(workspaceId, { type: "local-only", data: { n: 1 } });
+
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("local-only");
+
+    controller.abort();
+    await flushMicrotasks();
+  });
+});
+
+describe("startSse: subscriber attach retry", () => {
+  test("a transient attach failure is retried and the subscriber attaches", async () => {
+    createdClients.length = 0;
+    // First attach attempt fails; the bounded backoff retry must attach.
+    subscribeFailuresRemaining = 1;
+
+    startSse();
+    await flushMicrotasks();
+
+    // The first attempt created a client, failed, and closed it.
+    expect(createdClients).toHaveLength(1);
+    expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
+
+    // Wait past the first backoff delay (200ms) so the retry can run.
+    await Bun.sleep(300);
+    await flushMicrotasks();
+
+    // A second client was created for the retry and stayed attached.
+    expect(createdClients).toHaveLength(2);
+    const attached = createdClients[1];
+    expect(attached?.subscribe).toHaveBeenCalledTimes(1);
+    expect(attached?.close).not.toHaveBeenCalled();
+
+    // Stopping now closes the attached retry client exactly once.
+    stopSse();
+    expect(attached?.close).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+    subscribeFailuresRemaining = 0;
   });
 });

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -536,36 +536,53 @@ describe("startSse: subscriber attach retry", () => {
     subscribeFailuresRemaining = 0;
   });
 
-  test("keeps retrying at the capped interval and recovers after a prolonged outage", async () => {
+  test("keeps retrying at the capped interval and recovers after a long outage", async () => {
     createdClients.length = 0;
     subscribeBehavior = "resolve";
-    // Fail the whole 5-step ramp plus one steady attempt (6 failures), then
-    // attach: proves retries continue past the ramp instead of giving up, so an
-    // outage longer than the ramp still self-heals when Redis recovers.
-    subscribeFailuresRemaining = 6;
-    const sleepSpy = spyOn(Bun, "sleep").mockImplementation(async () => {});
+    // Fail the 5-step ramp plus 35 steady attempts (40 failures), then attach.
+    // Proves retries continue indefinitely deep into the steady phase, so an
+    // outage far longer than the ramp still self-heals when Redis recovers —
+    // and, with the timer-scheduled driver, without any recursive/awaited
+    // attempt chain building up.
+    subscribeFailuresRemaining = 40;
+
+    // Zero out the retry backoff so 41 attempts run fast: each attempt's timer
+    // fires on the next macrotask instead of after the real ramp/steady delay.
+    // The drain below uses the real setTimeout captured here.
+    const realSetTimeout = globalThis.setTimeout;
+    // A timer stub that fires the callback promptly, ignoring the delay. Matching
+    // Bun's full overloaded setTimeout type adds no test value, so assert it.
+    // oxlint-disable-next-line no-unsafe-type-assertion -- test-only timer stub
+    const immediateSetTimeout = ((callback: (...args: unknown[]) => void) =>
+      realSetTimeout(callback, 0)) as typeof globalThis.setTimeout;
+    const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+      immediateSetTimeout,
+    );
 
     startSse();
-    // Bun.sleep is instant here, so the whole retry chain drains within
-    // microtasks; a macrotask tick lets every attempt run to the eventual
-    // success. A few ticks give margin.
-    const tick = async (): Promise<void> => {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
-    };
-    await tick();
-    await tick();
-    await tick();
 
-    // 7 clients: 6 failed attach attempts + the one that finally subscribed.
-    expect(createdClients).toHaveLength(7);
+    // Drain macrotasks until the subscriber attaches; bounded recursion (not a
+    // loop) so no await sits inside a loop and a stuck run cannot hang forever.
+    const drainUntilAttached = async (remaining: number): Promise<void> => {
+      if (createdClients.at(-1)?.subscribedLive === true || remaining <= 0) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        realSetTimeout(resolve, 0);
+      });
+      await drainUntilAttached(remaining - 1);
+    };
+    await drainUntilAttached(300);
+
+    // 41 clients: 40 failed attach attempts (well past the 5-step ramp) + the
+    // one that finally subscribed.
+    expect(createdClients).toHaveLength(41);
     const attached = createdClients.at(-1);
     expect(attached?.subscribedLive).toBe(true);
     expect(attached?.subscribe).toHaveBeenCalledTimes(1);
     expect(attached?.close).not.toHaveBeenCalled();
 
-    sleepSpy.mockRestore();
+    timeoutSpy.mockRestore();
     subscribeFailuresRemaining = 0;
     stopSse();
     await flushMicrotasks();

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -6,6 +6,10 @@ type FakeRedisClient = {
   subscribe: ReturnType<typeof mock>;
   publish: ReturnType<typeof mock>;
   close: ReturnType<typeof mock>;
+  // Bun's RedisClient exposes a live `connected` flag; sse.ts reads it to
+  // decide whether a published event will loop back. Defaults true once the
+  // fake "attaches"; tests flip it to model the socket dropping/reconnecting.
+  connected: boolean;
 };
 
 const createdClients: FakeRedisClient[] = [];
@@ -28,6 +32,9 @@ const makeFakeRedisClient = (): FakeRedisClient => {
     }),
     publish: mock(async () => undefined),
     close: mock(() => undefined),
+    // A freshly attached subscriber is connected; a real Bun client reports
+    // the same once subscribe() resolves.
+    connected: true,
   };
   createdClients.push(client);
   return client;
@@ -254,6 +261,87 @@ describe("broadcast: local delivery without an attached subscriber", () => {
     expect(text).toContain("local-only");
 
     controller.abort();
+    await flushMicrotasks();
+  });
+});
+
+describe("broadcast: delivery tracks the subscriber's live connection", () => {
+  test("a broadcast is not delivered inline while the subscriber is connected, and is once it drops", async () => {
+    createdClients.length = 0;
+    subscribeFailuresRemaining = 0;
+    subscribeBehavior = "resolve";
+
+    startSse();
+    await flushMicrotasks();
+    const client = createdClients.at(-1);
+    expect(client).toBeDefined();
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    // Subscriber attached and connected: this event rides the Redis loopback,
+    // so it must NOT be delivered inline (delivering both would double up).
+    broadcast(workspaceId, { type: "while-connected", data: null });
+
+    // The subscriber's Redis connection drops. Bun keeps the client object,
+    // so the old `Boolean(subscriber)` check would still report "attached"
+    // and keep skipping inline delivery, losing events for this instance.
+    if (client) {
+      client.connected = false;
+    }
+
+    // Disconnected: no loopback arrives, so this one MUST be delivered inline.
+    broadcast(workspaceId, { type: "after-disconnect", data: null });
+
+    // The first chunk the local stream sees is the post-disconnect event:
+    // proves the connected broadcast was not inline-delivered (no double
+    // delivery) and the disconnect restored inline delivery (no miss).
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("after-disconnect");
+    expect(text).not.toContain("while-connected");
+
+    controller.abort();
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("reconnecting restores loopback-only delivery, then a second drop restores inline", async () => {
+    createdClients.length = 0;
+    subscribeFailuresRemaining = 0;
+    subscribeBehavior = "resolve";
+
+    startSse();
+    await flushMicrotasks();
+    const client = createdClients.at(-1);
+    expect(client).toBeDefined();
+
+    if (client) {
+      client.connected = false; // down → inline
+      client.connected = true; // back up → loopback only
+    }
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    // Reconnected: back to loopback-only, so this is NOT delivered inline.
+    broadcast(workspaceId, { type: "after-reconnect", data: null });
+
+    if (client) {
+      client.connected = false; // down again → inline
+    }
+
+    broadcast(workspaceId, { type: "after-second-drop", data: null });
+
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("after-second-drop");
+    expect(text).not.toContain("after-reconnect");
+
+    controller.abort();
+    stopSse();
     await flushMicrotasks();
   });
 });

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -423,6 +423,86 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
     stopSse();
     await flushMicrotasks();
   });
+
+  test("an own event broadcast during the attach window is delivered exactly once (loopback copy dropped)", async () => {
+    createdClients.length = 0;
+    subscribeFailuresRemaining = 0;
+    subscribeBehavior = "resolve";
+
+    startSse();
+    await flushMicrotasks();
+    const original = createdClients.at(-1);
+    expect(original).toBeDefined();
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    // Enter the attach window: the replacement client's SUBSCRIBE is accepted
+    // (subscribedLive), so the server loops events back, but sse.ts has not yet
+    // set subscriptionLive, so hasAttachedSubscriber() is false. Do NOT flush.
+    if (original) {
+      simulateDeafReconnect(original);
+    }
+    const replacement = createdClients.at(-1);
+    expect(replacement).not.toBe(original);
+    expect(replacement?.subscribedLive).toBe(true);
+
+    // Broadcast our own event in the window: delivered inline AND published with
+    // our origin id + deliveredInline=true, so the copy that loops back through
+    // the already-live subscription must be suppressed.
+    broadcast(workspaceId, { type: "own-in-window", data: null });
+
+    // Exactly one copy (the inline one). Attaching the replacement and then
+    // broadcasting a steady event that rides loopback only; reading it second
+    // proves the windowed event was not delivered twice.
+    expect(decode((await reader.read()).value)).toContain("own-in-window");
+    await flushMicrotasks();
+    broadcast(workspaceId, { type: "after-window", data: null });
+    expect(decode((await reader.read()).value)).toContain("after-window");
+
+    controller.abort();
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("a remote event received during the attach window is delivered via loopback", async () => {
+    createdClients.length = 0;
+    subscribeFailuresRemaining = 0;
+    subscribeBehavior = "resolve";
+
+    startSse();
+    await flushMicrotasks();
+    const original = createdClients.at(-1);
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    if (original) {
+      simulateDeafReconnect(original);
+    }
+    const replacement = createdClients.at(-1);
+    expect(replacement?.messageHandler).toBeTruthy();
+
+    // Another instance's event arrives on our subscription during the window.
+    // Inline delivery never covers remote events, and origin suppression only
+    // drops OUR own inline-delivered events, so this must deliver via loopback.
+    const remotePayload = JSON.stringify({
+      scope: "workspace",
+      id: workspaceId,
+      event: { type: "remote-in-window", data: null },
+      originInstanceId: "some-other-instance",
+      deliveredInline: false,
+    });
+    replacement?.messageHandler?.(remotePayload);
+
+    expect(decode((await reader.read()).value)).toContain("remote-in-window");
+
+    controller.abort();
+    stopSse();
+    await flushMicrotasks();
+  });
 });
 
 describe("startSse: subscriber attach retry", () => {
@@ -454,5 +534,40 @@ describe("startSse: subscriber attach retry", () => {
 
     await flushMicrotasks();
     subscribeFailuresRemaining = 0;
+  });
+
+  test("keeps retrying at the capped interval and recovers after a prolonged outage", async () => {
+    createdClients.length = 0;
+    subscribeBehavior = "resolve";
+    // Fail the whole 5-step ramp plus one steady attempt (6 failures), then
+    // attach: proves retries continue past the ramp instead of giving up, so an
+    // outage longer than the ramp still self-heals when Redis recovers.
+    subscribeFailuresRemaining = 6;
+    const sleepSpy = spyOn(Bun, "sleep").mockImplementation(async () => {});
+
+    startSse();
+    // Bun.sleep is instant here, so the whole retry chain drains within
+    // microtasks; a macrotask tick lets every attempt run to the eventual
+    // success. A few ticks give margin.
+    const tick = async (): Promise<void> => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    };
+    await tick();
+    await tick();
+    await tick();
+
+    // 7 clients: 6 failed attach attempts + the one that finally subscribed.
+    expect(createdClients).toHaveLength(7);
+    const attached = createdClients.at(-1);
+    expect(attached?.subscribedLive).toBe(true);
+    expect(attached?.subscribe).toHaveBeenCalledTimes(1);
+    expect(attached?.close).not.toHaveBeenCalled();
+
+    sleepSpy.mockRestore();
+    subscribeFailuresRemaining = 0;
+    stopSse();
+    await flushMicrotasks();
   });
 });

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -2,14 +2,23 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 
 import { toSafeId } from "@/api/lib/branded-types";
 
+type MessageHandler = (message: string) => void;
+
+// Models a Bun RedisClient closely enough to exercise pub/sub loopback. Key
+// modelled facts (all verified against a mock RESP3 server): `connected`
+// reflects the socket; `subscribedLive` reflects whether the SERVER currently
+// delivers pub/sub to this connection; a reconnect restores `connected` but NOT
+// `subscribedLive` (Bun does not re-issue SUBSCRIBE); `publish` fans a message
+// out only to clients that are `subscribedLive`.
 type FakeRedisClient = {
   subscribe: ReturnType<typeof mock>;
   publish: ReturnType<typeof mock>;
   close: ReturnType<typeof mock>;
-  // Bun's RedisClient exposes a live `connected` flag; sse.ts reads it to
-  // decide whether a published event will loop back. Defaults true once the
-  // fake "attaches"; tests flip it to model the socket dropping/reconnecting.
+  onReconnect: ReturnType<typeof mock>;
   connected: boolean;
+  subscribedLive: boolean;
+  messageHandler: MessageHandler | null;
+  reconnectHandlers: (() => void)[];
 };
 
 const createdClients: FakeRedisClient[] = [];
@@ -21,7 +30,7 @@ let subscribeFailuresRemaining = 0;
 
 const makeFakeRedisClient = (): FakeRedisClient => {
   const client: FakeRedisClient = {
-    subscribe: mock(async () => {
+    subscribe: mock(async (_channel: string, handler: MessageHandler) => {
       if (subscribeFailuresRemaining > 0) {
         subscribeFailuresRemaining -= 1;
         throw new Error("redis unavailable");
@@ -29,15 +38,54 @@ const makeFakeRedisClient = (): FakeRedisClient => {
       if (subscribeBehavior === "reject") {
         throw new Error("redis unavailable");
       }
+      // A confirmed subscribe: the server now delivers to this connection.
+      client.messageHandler = handler;
+      client.subscribedLive = true;
+      client.connected = true;
     }),
-    publish: mock(async () => undefined),
-    close: mock(() => undefined),
-    // A freshly attached subscriber is connected; a real Bun client reports
-    // the same once subscribe() resolves.
-    connected: true,
+    // Redis fans a published message out to every connection with a live
+    // subscription. A reconnected-but-not-resubscribed client is absent here,
+    // so it receives nothing — modelling the real deaf-after-reconnect hazard.
+    publish: mock(async (_channel: string, message: string) => {
+      for (const peer of createdClients) {
+        if (peer.subscribedLive && peer.messageHandler) {
+          peer.messageHandler(message);
+        }
+      }
+    }),
+    close: mock(() => {
+      client.subscribedLive = false;
+      client.connected = false;
+    }),
+    onReconnect: mock((handler: () => void) => {
+      client.reconnectHandlers.push(handler);
+      return () => {
+        const index = client.reconnectHandlers.indexOf(handler);
+        if (index !== -1) {
+          client.reconnectHandlers.splice(index, 1);
+        }
+      };
+    }),
+    connected: false,
+    subscribedLive: false,
+    messageHandler: null,
+    reconnectHandlers: [],
   };
   createdClients.push(client);
   return client;
+};
+
+// Model a transient socket drop + Bun auto-reconnect: the socket comes back
+// (`connected` true) but the SERVER no longer has a subscription for it
+// (`subscribedLive` false, because Bun does not re-issue SUBSCRIBE), then Bun
+// fires the onconnect/reconnect handlers.
+const simulateDeafReconnect = (client: FakeRedisClient): void => {
+  client.connected = true;
+  client.subscribedLive = false;
+  client.messageHandler = null;
+  for (const handler of [...client.reconnectHandlers]) {
+    handler();
+  }
 };
 
 const createRedisClientMock = mock(() => makeFakeRedisClient());
@@ -265,81 +313,112 @@ describe("broadcast: local delivery without an attached subscriber", () => {
   });
 });
 
-describe("broadcast: delivery tracks the subscriber's live connection", () => {
-  test("a broadcast is not delivered inline while the subscriber is connected, and is once it drops", async () => {
+describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
+  const decode = (value: Uint8Array | undefined): string =>
+    new TextDecoder().decode(value);
+
+  test("delivers each event to local clients exactly once via loopback while subscribed", async () => {
     createdClients.length = 0;
     subscribeFailuresRemaining = 0;
     subscribeBehavior = "resolve";
 
     startSse();
     await flushMicrotasks();
-    const client = createdClients.at(-1);
-    expect(client).toBeDefined();
 
     const controller = new AbortController();
     const stream = subscribe(workspaceId, organizationId, controller.signal);
     const reader = stream.getReader();
 
-    // Subscriber attached and connected: this event rides the Redis loopback,
-    // so it must NOT be delivered inline (delivering both would double up).
-    broadcast(workspaceId, { type: "while-connected", data: null });
+    // Subscribed: each event must arrive exactly once through the Redis
+    // loopback (publish -> subscriber handler -> local delivery), never a
+    // second inline copy. Reading two events in order proves the first was
+    // delivered exactly once.
+    broadcast(workspaceId, { type: "event-a", data: null });
+    broadcast(workspaceId, { type: "event-b", data: null });
 
-    // The subscriber's Redis connection drops. Bun keeps the client object,
-    // so the old `Boolean(subscriber)` check would still report "attached"
-    // and keep skipping inline delivery, losing events for this instance.
-    if (client) {
-      client.connected = false;
-    }
-
-    // Disconnected: no loopback arrives, so this one MUST be delivered inline.
-    broadcast(workspaceId, { type: "after-disconnect", data: null });
-
-    // The first chunk the local stream sees is the post-disconnect event:
-    // proves the connected broadcast was not inline-delivered (no double
-    // delivery) and the disconnect restored inline delivery (no miss).
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
-    expect(text).toContain("after-disconnect");
-    expect(text).not.toContain("while-connected");
+    expect(decode((await reader.read()).value)).toContain("event-a");
+    expect(decode((await reader.read()).value)).toContain("event-b");
 
     controller.abort();
     stopSse();
     await flushMicrotasks();
   });
 
-  test("reconnecting restores loopback-only delivery, then a second drop restores inline", async () => {
+  test("a transient drop+reconnect re-subscribes via a fresh client and resumes exactly-once loopback delivery", async () => {
     createdClients.length = 0;
     subscribeFailuresRemaining = 0;
     subscribeBehavior = "resolve";
 
     startSse();
     await flushMicrotasks();
-    const client = createdClients.at(-1);
-    expect(client).toBeDefined();
-
-    if (client) {
-      client.connected = false; // down → inline
-      client.connected = true; // back up → loopback only
-    }
+    const original = createdClients.at(-1);
+    expect(original).toBeDefined();
 
     const controller = new AbortController();
     const stream = subscribe(workspaceId, organizationId, controller.signal);
     const reader = stream.getReader();
 
-    // Reconnected: back to loopback-only, so this is NOT delivered inline.
-    broadcast(workspaceId, { type: "after-reconnect", data: null });
+    // Baseline: loopback delivery works while subscribed.
+    broadcast(workspaceId, { type: "before-drop", data: null });
+    expect(decode((await reader.read()).value)).toContain("before-drop");
 
-    if (client) {
-      client.connected = false; // down again → inline
+    // Bun reconnects the socket but does NOT re-issue SUBSCRIBE: the client is
+    // connected yet deaf. sse.ts must tear it down and attach a FRESH client
+    // (re-subscribing on the same client would double-register the callback).
+    if (original) {
+      simulateDeafReconnect(original);
     }
+    await flushMicrotasks();
 
-    broadcast(workspaceId, { type: "after-second-drop", data: null });
+    // The deaf client was closed and a distinct replacement subscribed.
+    expect(original?.close).toHaveBeenCalledTimes(1);
+    const replacement = createdClients.at(-1);
+    expect(replacement).not.toBe(original);
+    expect(replacement?.subscribedLive).toBe(true);
+    expect(replacement?.subscribe).toHaveBeenCalledTimes(1);
 
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
-    expect(text).toContain("after-second-drop");
-    expect(text).not.toContain("after-reconnect");
+    // Loopback is restored through the replacement, still exactly once: if the
+    // old code kept treating the reconnected client as attached, no loopback
+    // would arrive and these reads would hang; if it re-subscribed on the same
+    // client, each event would be delivered twice.
+    broadcast(workspaceId, { type: "after-reconnect-1", data: null });
+    broadcast(workspaceId, { type: "after-reconnect-2", data: null });
+    expect(decode((await reader.read()).value)).toContain("after-reconnect-1");
+    expect(decode((await reader.read()).value)).toContain("after-reconnect-2");
 
+    controller.abort();
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("while the replacement subscriber has not yet attached, broadcasts fall back to inline delivery", async () => {
+    createdClients.length = 0;
+    subscribeFailuresRemaining = 0;
+    subscribeBehavior = "resolve";
+
+    startSse();
+    await flushMicrotasks();
+    const original = createdClients.at(-1);
+    expect(original).toBeDefined();
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    // The replacement attach will fail, so no subscriber is live: the instance
+    // is effectively deaf. Broadcasts MUST still reach local clients inline so
+    // nothing is missed during the reconnect/reattach window.
+    subscribeBehavior = "reject";
+    if (original) {
+      simulateDeafReconnect(original);
+    }
+    await flushMicrotasks();
+
+    broadcast(workspaceId, { type: "deaf-window", data: null });
+    expect(decode((await reader.read()).value)).toContain("deaf-window");
+
+    subscribeBehavior = "resolve";
+    subscribeFailuresRemaining = 0;
     controller.abort();
     stopSse();
     await flushMicrotasks();

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -58,12 +58,17 @@ const makeFakeRedisClient = (): FakeRedisClient => {
       }
     }),
     close: mock(() => {
-      client.subscribedLive = false;
-      client.connected = false;
       if (closeFailuresRemaining > 0) {
         closeFailuresRemaining -= 1;
+        // A failed close leaves the subscription state intact: the callback is
+        // still live and could deliver, mirroring a real client whose close()
+        // threw. Delivery must be prevented structurally (generation), not by
+        // relying on this teardown.
         throw new Error("close failed");
       }
+      client.subscribedLive = false;
+      client.connected = false;
+      client.messageHandler = null;
     }),
     onReconnect: mock((handler: () => void) => {
       client.reconnectHandlers.push(handler);
@@ -507,6 +512,58 @@ describe("broadcast: subscriber reconnect keeps delivery exactly-once", () => {
 
     expect(decode((await reader.read()).value)).toContain("remote-in-window");
 
+    controller.abort();
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("a stale subscriber whose close() threw cannot deliver after a replacement attaches", async () => {
+    createdClients.length = 0;
+    subscribeFailuresRemaining = 0;
+    subscribeBehavior = "resolve";
+    closeFailuresRemaining = 0;
+
+    startSse();
+    await flushMicrotasks();
+    const original = createdClients.at(-1);
+    expect(original?.subscribedLive).toBe(true);
+
+    const controller = new AbortController();
+    const stream = subscribe(workspaceId, organizationId, controller.signal);
+    const reader = stream.getReader();
+
+    // The reconnect teardown's close() throws, so the old client keeps its live
+    // pub/sub callback — exactly the "close() may not invalidate delivery" case.
+    closeFailuresRemaining = 1;
+    if (original) {
+      for (const handler of [...original.reconnectHandlers]) {
+        handler();
+      }
+    }
+    await flushMicrotasks();
+
+    const replacement = createdClients.at(-1);
+    expect(replacement).not.toBe(original);
+    expect(replacement?.subscribedLive).toBe(true);
+    // The old client's callback is still live (its close threw and left it).
+    expect(original?.messageHandler).toBeTruthy();
+
+    // A loopback arrives on the OLD generation's still-live callback: the
+    // generation gate must drop it. The replacement's loopback delivers once.
+    const workspacePayload = (type: string): string =>
+      JSON.stringify({
+        scope: "workspace",
+        id: workspaceId,
+        event: { type, data: null },
+      });
+    original?.messageHandler?.(workspacePayload("stale-old-generation"));
+    replacement?.messageHandler?.(workspacePayload("fresh-new-generation"));
+
+    const text = decode((await reader.read()).value);
+    expect(text).toContain("fresh-new-generation");
+    expect(text).not.toContain("stale-old-generation");
+
+    closeFailuresRemaining = 0;
     controller.abort();
     stopSse();
     await flushMicrotasks();

--- a/apps/api/src/lib/sse.test.ts
+++ b/apps/api/src/lib/sse.test.ts
@@ -27,6 +27,10 @@ let subscribeBehavior: "reject" | "resolve" = "resolve";
 // subscribeBehavior. Lets a test model a transient boot blip (fail once,
 // then the retry attaches) without permanently rejecting.
 let subscribeFailuresRemaining = 0;
+// Number of close() calls that throw before succeeding. Models a cleanup close
+// that fails (e.g. the socket is already gone), which must not abort the
+// attach-retry scheduling.
+let closeFailuresRemaining = 0;
 
 const makeFakeRedisClient = (): FakeRedisClient => {
   const client: FakeRedisClient = {
@@ -56,6 +60,10 @@ const makeFakeRedisClient = (): FakeRedisClient => {
     close: mock(() => {
       client.subscribedLive = false;
       client.connected = false;
+      if (closeFailuresRemaining > 0) {
+        closeFailuresRemaining -= 1;
+        throw new Error("close failed");
+      }
     }),
     onReconnect: mock((handler: () => void) => {
       client.reconnectHandlers.push(handler);
@@ -584,6 +592,50 @@ describe("startSse: subscriber attach retry", () => {
 
     timeoutSpy.mockRestore();
     subscribeFailuresRemaining = 0;
+    stopSse();
+    await flushMicrotasks();
+  });
+
+  test("a failed attach whose cleanup close() also throws still schedules the next attempt", async () => {
+    createdClients.length = 0;
+    subscribeBehavior = "resolve";
+    // The first 3 attach attempts fail AND their cleanup close() throws. The
+    // retry scheduling must survive the throwing close, so a 4th attempt runs
+    // and attaches — otherwise a single unlucky close would leave the instance
+    // permanently deaf.
+    subscribeFailuresRemaining = 3;
+    closeFailuresRemaining = 3;
+
+    const realSetTimeout = globalThis.setTimeout;
+    // oxlint-disable-next-line no-unsafe-type-assertion -- test-only timer stub
+    const immediateSetTimeout = ((callback: (...args: unknown[]) => void) =>
+      realSetTimeout(callback, 0)) as typeof globalThis.setTimeout;
+    const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+      immediateSetTimeout,
+    );
+
+    startSse();
+
+    const drainUntilAttached = async (remaining: number): Promise<void> => {
+      if (createdClients.at(-1)?.subscribedLive === true || remaining <= 0) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        realSetTimeout(resolve, 0);
+      });
+      await drainUntilAttached(remaining - 1);
+    };
+    await drainUntilAttached(100);
+
+    // 4 clients: 3 failed attempts (each whose close() threw) + the attach.
+    expect(createdClients).toHaveLength(4);
+    expect(createdClients.at(-1)?.subscribedLive).toBe(true);
+    // All three throwing closes were consumed, proving they actually ran.
+    expect(closeFailuresRemaining).toBe(0);
+
+    timeoutSpy.mockRestore();
+    subscribeFailuresRemaining = 0;
+    closeFailuresRemaining = 0;
     stopSse();
     await flushMicrotasks();
   });

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -152,6 +152,22 @@ const broadcastLocalToOrganization = (
 // local SSE connections. Publishing lives in sse-broadcast.ts so the
 // scheduler can publish without importing this connection registry.
 
+/**
+ * Whether a looped-back workspace/organization payload is one THIS instance
+ * already delivered inline during a subscriber attach/reattach window (when
+ * `subscriptionLive` was false at broadcast time but Redis had already accepted
+ * our SUBSCRIBE, so the event both delivered inline and comes back on the
+ * loopback). Dropping only that duplicate copy keeps own events exactly-once
+ * without affecting other instances' events, which never carry our origin id
+ * and must still deliver via loopback. Absent fields (older-format publisher on
+ * a rolling deploy) never match, so such messages always deliver.
+ */
+const isOwnInlineDelivery = (payload: {
+  originInstanceId?: string | undefined;
+  deliveredInline?: boolean | undefined;
+}): boolean =>
+  payload.deliveredInline === true && payload.originInstanceId === INSTANCE_ID;
+
 const handleMessage = (message: string) => {
   try {
     const parsed = parseRedisPayload(message);
@@ -159,8 +175,14 @@ const handleMessage = (message: string) => {
       return;
     }
     if (parsed.scope === "workspace") {
+      if (isOwnInlineDelivery(parsed)) {
+        return;
+      }
       broadcastLocal(brandPersistedWorkspaceId(parsed.id), parsed.event);
     } else if (parsed.scope === "organization") {
+      if (isOwnInlineDelivery(parsed)) {
+        return;
+      }
       broadcastLocalToOrganization(
         brandPersistedOrganizationId(parsed.id),
         parsed.event,
@@ -196,13 +218,19 @@ export const broadcast = (
   // otherwise reach no local client. When a subscriber IS attached, the
   // loopback (handleMessage → broadcastLocal) delivers locally, so
   // delivering inline as well would double-deliver — hence the guard on
-  // the attach state evaluated here, at broadcast time.
+  // the attach state evaluated here, at broadcast time. During an attach
+  // window the guard can read "not attached" while Redis has already accepted
+  // our SUBSCRIBE, so the event both delivers inline AND loops back; the
+  // origin metadata below lets handleMessage drop that duplicate loopback copy.
   const deliveredLocally = !hasAttachedSubscriber();
   if (deliveredLocally) {
     broadcastLocal(workspaceId, event);
   }
 
-  publishWorkspaceEvent(workspaceId, event).catch((error: unknown) => {
+  publishWorkspaceEvent(workspaceId, event, {
+    originInstanceId: INSTANCE_ID,
+    deliveredInline: deliveredLocally,
+  }).catch((error: unknown) => {
     logger.warn("sse.redis_publish_failed", {
       "error.type": errorTag(error),
     });
@@ -224,7 +252,10 @@ export const broadcastToOrganization = (
     broadcastLocalToOrganization(organizationId, event);
   }
 
-  publishOrganizationEvent(organizationId, event).catch((error: unknown) => {
+  publishOrganizationEvent(organizationId, event, {
+    originInstanceId: INSTANCE_ID,
+    deliveredInline: deliveredLocally,
+  }).catch((error: unknown) => {
     logger.warn("sse.redis_publish_failed", {
       "error.type": errorTag(error),
     });
@@ -353,12 +384,24 @@ const hasAttachedSubscriber = (): boolean =>
   );
 
 /**
- * Bounded backoff for retrying the subscriber attach. A transient Redis
- * blip at boot must not leave this instance permanently deaf (publisher
- * healthy, subscriber never attached); retry a handful of times with a
- * short capped backoff before logging a persistent failure.
+ * Backoff ramp for retrying the subscriber attach. A transient Redis blip at
+ * boot must not leave this instance permanently deaf (publisher healthy,
+ * subscriber never attached), and — since inline local delivery only covers
+ * this instance's own events — a longer outage must self-heal on recovery
+ * rather than miss every other replica's events until the process restarts.
+ * So after this ramp, retries continue forever at the steady capped interval.
  */
 const SUBSCRIBER_ATTACH_RETRY_DELAYS_MS = [200, 500, 1000, 2000, 5000];
+
+/** Capped interval every retry uses once the ramp above is exhausted. */
+const SUBSCRIBER_ATTACH_STEADY_DELAY_MS = 5000;
+
+/**
+ * When retrying at the steady interval, escalate to a single error log the
+ * moment the ramp is exhausted, then warn only every Nth steady attempt so a
+ * prolonged outage does not spam the logs (≈ once per minute at 5s).
+ */
+const SUBSCRIBER_ATTACH_STEADY_LOG_EVERY = 12;
 
 /**
  * Attach the cross-instance Redis subscriber for `lifecycle`, retrying with a
@@ -420,16 +463,31 @@ const attachSubscriber = async (
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
     subscriber?.close();
-    const delayMs = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
-    if (delayMs === undefined || activeLifecycle !== lifecycle) {
-      // Retries exhausted (or the lifecycle was torn down): surface a
-      // persistent failure. Local delivery still works because
-      // `broadcast`/`broadcastToOrganization` deliver inline while no
-      // subscriber is attached.
-      logger.error("sse.redis_connection_failed", connectionErrorFields(error));
+    if (activeLifecycle !== lifecycle) {
+      // The lifecycle was torn down (stop, or stop+restart) during the
+      // attempt; abandon this attach loop quietly.
       return;
     }
-    logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
+    const rampDelay = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
+    const delayMs = rampDelay ?? SUBSCRIBER_ATTACH_STEADY_DELAY_MS;
+    if (rampDelay !== undefined) {
+      // Still ramping up after a transient blip.
+      logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
+    } else {
+      const steadyAttempt = attempt - SUBSCRIBER_ATTACH_RETRY_DELAYS_MS.length;
+      if (steadyAttempt === 0) {
+        // Ramp exhausted: escalate once to surface a persistent outage. Retries
+        // continue at the steady interval so the instance self-heals whenever
+        // Redis recovers; inline local delivery covers this instance's own
+        // events meanwhile, but other replicas' events need the subscriber.
+        logger.error(
+          "sse.redis_connection_failed",
+          connectionErrorFields(error),
+        );
+      } else if (steadyAttempt % SUBSCRIBER_ATTACH_STEADY_LOG_EVERY === 0) {
+        logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
+      }
+    }
     await Bun.sleep(delayMs);
     await attachSubscriber(lifecycle, attempt + 1);
   }

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -359,6 +359,13 @@ type SseLifecycle = {
    * WITHOUT re-issuing SUBSCRIBE — so a `connected` client can be silently deaf.
    */
   subscriptionLive: boolean;
+  /**
+   * Pending retry timer for the next attach attempt, or null when an attempt is
+   * running or a subscriber is attached. Each failed attempt schedules the next
+   * via `setTimeout` and returns, so attempts never await one another (no
+   * unbounded promise/stack chain over a long outage). `stopSse` clears it.
+   */
+  attachTimer: ReturnType<typeof setTimeout> | null;
 };
 
 let activeLifecycle: SseLifecycle | null = null;
@@ -404,20 +411,18 @@ const SUBSCRIBER_ATTACH_STEADY_DELAY_MS = 5000;
 const SUBSCRIBER_ATTACH_STEADY_LOG_EVERY = 12;
 
 /**
- * Attach the cross-instance Redis subscriber for `lifecycle`, retrying with a
- * bounded backoff on failure. Written as recursion rather than a for-loop so
- * each attempt still observes success/failure sequentially without awaiting
- * inside a loop. Bails whenever `lifecycle` is no longer the active one, so a
- * stop (or stop+restart) during a connect or a backoff never attaches a stale
- * subscriber to a lifecycle that is no longer current.
+ * Run one attach attempt for `lifecycle`. On success it attaches the subscriber
+ * and wires reconnect handling; on failure it logs and schedules the NEXT
+ * attempt via a timer, then returns. Attempts therefore never await one another
+ * — no unbounded promise/stack chain builds up over a long outage. Bails
+ * whenever `lifecycle` is no longer the active one, so a stop (or stop+restart)
+ * during a connect or a backoff never attaches a stale subscriber.
  */
-const attachSubscriber = async (
+const runAttachAttempt = async (
   lifecycle: SseLifecycle,
   attempt: number,
 ): Promise<void> => {
   if (activeLifecycle !== lifecycle) {
-    // stopSse (and possibly a subsequent startSse) ran while we were waiting
-    // between retries; abandon this attach loop.
     return;
   }
 
@@ -458,14 +463,14 @@ const attachSubscriber = async (
       logger.warn("sse.redis_subscriber_reconnected", {
         channel: REDIS_CHANNEL,
       });
-      void attachSubscriber(lifecycle, 0);
+      launchAttachAttempt(lifecycle, 0);
     });
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
     subscriber?.close();
     if (activeLifecycle !== lifecycle) {
       // The lifecycle was torn down (stop, or stop+restart) during the
-      // attempt; abandon this attach loop quietly.
+      // attempt; abandon the retry chain quietly.
       return;
     }
     const rampDelay = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
@@ -488,9 +493,41 @@ const attachSubscriber = async (
         logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
       }
     }
-    await Bun.sleep(delayMs);
-    await attachSubscriber(lifecycle, attempt + 1);
+    scheduleAttachAttempt(lifecycle, attempt + 1, delayMs);
   }
+};
+
+/**
+ * Kick off an attach attempt as detached work, capturing any unexpected
+ * rejection (`runAttachAttempt` handles expected connection failures itself, so
+ * this guards only against a throw the attempt did not model, keeping it from
+ * becoming an unhandled rejection). Handling the promise with `.catch` here is
+ * why no caller needs a bare `void` on the attempt.
+ */
+const launchAttachAttempt = (
+  lifecycle: SseLifecycle,
+  attempt: number,
+): void => {
+  runAttachAttempt(lifecycle, attempt).catch((error: unknown) => {
+    logger.error("sse.redis_connection_failed", connectionErrorFields(error));
+  });
+};
+
+/**
+ * Schedule the next attach attempt after `delayMs`. The timer is unref'd (like
+ * the keep-alive timer) so a pending retry never keeps the process alive on its
+ * own, and tracked on the lifecycle so `stopSse` can clear it.
+ */
+const scheduleAttachAttempt = (
+  lifecycle: SseLifecycle,
+  attempt: number,
+  delayMs: number,
+): void => {
+  const timer = setTimeout(() => {
+    launchAttachAttempt(lifecycle, attempt);
+  }, delayMs);
+  timer.unref();
+  lifecycle.attachTimer = timer;
 };
 
 /**
@@ -521,11 +558,13 @@ export const startSse = (): void => {
     keepAliveTimer: setInterval(sendKeepAlive, KEEP_ALIVE_INTERVAL_MS),
     subscriber: null,
     subscriptionLive: false,
+    attachTimer: null,
   };
   lifecycle.keepAliveTimer.unref();
   activeLifecycle = lifecycle;
 
-  void attachSubscriber(lifecycle, 0);
+  // First attempt runs immediately; only retries are timer-scheduled.
+  launchAttachAttempt(lifecycle, 0);
 
   logger.info("sse.initialized", {
     keepAliveIntervalMs: KEEP_ALIVE_INTERVAL_MS,
@@ -544,6 +583,11 @@ export const stopSse = (): void => {
   activeLifecycle = null;
 
   clearInterval(lifecycle.keepAliveTimer);
+
+  if (lifecycle.attachTimer) {
+    clearTimeout(lifecycle.attachTimer);
+    lifecycle.attachTimer = null;
+  }
 
   if (lifecycle.subscriber) {
     try {

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -324,14 +324,21 @@ type SseLifecycle = {
 let activeLifecycle: SseLifecycle | null = null;
 
 /**
- * Whether this instance currently has a Redis subscriber attached. Used
+ * Whether this instance currently has a live Redis subscriber attached. Used
  * by `broadcast`/`broadcastToOrganization` to decide whether they must
- * deliver locally inline: without an attached subscriber, a published
- * event never loops back to this instance, so local clients would be
- * missed even when the (independent) publisher connection is healthy.
+ * deliver locally inline: without a connected subscriber, a published event
+ * never loops back to this instance, so local clients would be missed even
+ * when the (independent) publisher connection is healthy.
+ *
+ * Reads the client's own live `connected` flag rather than a mirrored bit, so
+ * a subscriber that Bun has auto-reconnected away from (transient drop) counts
+ * as not attached for as long as it is down — during which `broadcast` falls
+ * back to inline local delivery — and counts as attached again the instant its
+ * connection (and Bun's re-subscribe) is restored. A stale flag could drift
+ * out of step with the socket; the property cannot.
  */
 const hasAttachedSubscriber = (): boolean =>
-  Boolean(activeLifecycle?.subscriber);
+  Boolean(activeLifecycle?.subscriber?.connected);
 
 /**
  * Bounded backoff for retrying the subscriber attach. A transient Redis
@@ -340,6 +347,58 @@ const hasAttachedSubscriber = (): boolean =>
  * short capped backoff before logging a persistent failure.
  */
 const SUBSCRIBER_ATTACH_RETRY_DELAYS_MS = [200, 500, 1000, 2000, 5000];
+
+/**
+ * Attach the cross-instance Redis subscriber for `lifecycle`, retrying with a
+ * bounded backoff on failure. Written as recursion rather than a for-loop so
+ * each attempt still observes success/failure sequentially without awaiting
+ * inside a loop. Bails whenever `lifecycle` is no longer the active one, so a
+ * stop (or stop+restart) during a connect or a backoff never attaches a stale
+ * subscriber to a lifecycle that is no longer current.
+ */
+const attachSubscriber = async (
+  lifecycle: SseLifecycle,
+  attempt: number,
+): Promise<void> => {
+  if (activeLifecycle !== lifecycle) {
+    // stopSse (and possibly a subsequent startSse) ran while we were waiting
+    // between retries; abandon this attach loop.
+    return;
+  }
+
+  // The client is constructed inside the try so a throwing constructor hits
+  // the fail-soft catch below instead of escaping as an unhandled rejection.
+  let subscriber: ReturnType<typeof createRedisClient> | undefined;
+  try {
+    subscriber = createRedisClient();
+    await subscriber.subscribe(REDIS_CHANNEL, (message) => {
+      handleMessage(message);
+    });
+    if (activeLifecycle !== lifecycle) {
+      // stopSse (and possibly a subsequent startSse) ran while the connection
+      // was still being established; do not attach a stale subscriber to a
+      // lifecycle that is no longer the active one.
+      subscriber.close();
+      return;
+    }
+    lifecycle.subscriber = subscriber;
+    logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
+  } catch (error: unknown) {
+    subscriber?.close();
+    const delayMs = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
+    if (delayMs === undefined || activeLifecycle !== lifecycle) {
+      // Retries exhausted (or the lifecycle was torn down): surface a
+      // persistent failure. Local delivery still works because
+      // `broadcast`/`broadcastToOrganization` deliver inline while no
+      // subscriber is attached.
+      logger.error("sse.redis_connection_failed", connectionErrorFields(error));
+      return;
+    }
+    logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
+    await Bun.sleep(delayMs);
+    await attachSubscriber(lifecycle, attempt + 1);
+  }
+};
 
 /**
  * Start the SSE keep-alive heartbeat and the cross-instance Redis
@@ -372,54 +431,7 @@ export const startSse = (): void => {
   lifecycle.keepAliveTimer.unref();
   activeLifecycle = lifecycle;
 
-  void (async () => {
-    for (let attempt = 0; ; attempt += 1) {
-      if (activeLifecycle !== lifecycle) {
-        // stopSse (and possibly a subsequent startSse) ran while we were
-        // waiting between retries; abandon this attach loop.
-        return;
-      }
-
-      // The client is constructed inside the try so a throwing constructor
-      // hits the fail-soft catch below instead of escaping this detached
-      // IIFE as an unhandled rejection.
-      let subscriber: ReturnType<typeof createRedisClient> | undefined;
-      try {
-        subscriber = createRedisClient();
-        // oxlint-disable-next-line no-await-in-loop -- each attach attempt must observe success/failure before deciding to retry
-        await subscriber.subscribe(REDIS_CHANNEL, (message) => {
-          handleMessage(message);
-        });
-        if (activeLifecycle !== lifecycle) {
-          // stopSse (and possibly a subsequent startSse) ran while the
-          // connection was still being established; do not attach a stale
-          // subscriber to a lifecycle that is no longer the active one.
-          subscriber.close();
-          return;
-        }
-        lifecycle.subscriber = subscriber;
-        logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
-        return;
-      } catch (error: unknown) {
-        subscriber?.close();
-        const delayMs = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
-        if (delayMs === undefined || activeLifecycle !== lifecycle) {
-          // Retries exhausted (or the lifecycle was torn down): surface a
-          // persistent failure. Local delivery still works because
-          // `broadcast`/`broadcastToOrganization` deliver inline while no
-          // subscriber is attached.
-          logger.error(
-            "sse.redis_connection_failed",
-            connectionErrorFields(error),
-          );
-          return;
-        }
-        logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
-        // oxlint-disable-next-line no-await-in-loop -- sequential backoff between retries, not parallel work
-        await Bun.sleep(delayMs);
-      }
-    }
-  })();
+  void attachSubscriber(lifecycle, 0);
 
   logger.info("sse.initialized", {
     keepAliveIntervalMs: KEEP_ALIVE_INTERVAL_MS,

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -366,6 +366,16 @@ type SseLifecycle = {
    * unbounded promise/stack chain over a long outage). `stopSse` clears it.
    */
   attachTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Monotonic delivery generation. Each attach captures the current value in
+   * its subscribe callback; every invalidation (a candidate that failed, the
+   * deaf client on reconnect, the active subscriber at shutdown) bumps it. The
+   * callback delivers only while its captured generation still equals this, so
+   * a stale client whose `close()` threw — leaving its pub/sub callback live —
+   * can never deliver alongside its replacement, regardless of `close()`
+   * behaviour. This is structural: it does not depend on cleanup succeeding.
+   */
+  generation: number;
 };
 
 let activeLifecycle: SseLifecycle | null = null;
@@ -448,8 +458,18 @@ const runAttachAttempt = async (
   try {
     subscriber = createRedisClient();
     const attached = subscriber;
+    // Capture the generation this client is attaching under. The callback stays
+    // authorized to deliver only while the lifecycle's generation still matches;
+    // any later invalidation bumps it, structurally silencing a stale client
+    // even if its close() threw and left this callback live.
+    const attachGeneration = lifecycle.generation;
     await attached.subscribe(REDIS_CHANNEL, (message) => {
-      handleMessage(message);
+      if (
+        activeLifecycle === lifecycle &&
+        lifecycle.generation === attachGeneration
+      ) {
+        handleMessage(message);
+      }
     });
     if (activeLifecycle !== lifecycle) {
       // stopSse (and possibly a subsequent startSse) ran while the connection
@@ -475,8 +495,10 @@ const runAttachAttempt = async (
       }
       lifecycle.subscriptionLive = false;
       lifecycle.subscriber = null;
-      // Best-effort: a throwing close() must not skip the re-attach below, or a
-      // reconnect would leave this instance deaf.
+      // Invalidate the deaf client's generation BEFORE closing it, so it stops
+      // delivering even if close() throws and leaves its callback live. The
+      // close itself is then only best-effort resource cleanup.
+      lifecycle.generation += 1;
       closeSubscriberQuietly(attached);
       logger.warn("sse.redis_subscriber_reconnected", {
         channel: REDIS_CHANNEL,
@@ -485,10 +507,12 @@ const runAttachAttempt = async (
     });
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
-    // Best-effort close: a throwing close() here must not skip the retry
-    // scheduling below, or a single failed attempt whose cleanup also throws
-    // would stop the instance retrying and leave it deaf until restart.
+    // Invalidate the failed candidate's generation BEFORE closing it, then
+    // close best-effort: a throwing close() must neither leave the candidate's
+    // callback able to deliver nor skip the retry scheduling below (which would
+    // stop the instance retrying and leave it deaf until restart).
     if (subscriber) {
+      lifecycle.generation += 1;
       closeSubscriberQuietly(subscriber);
     }
     if (activeLifecycle !== lifecycle) {
@@ -582,6 +606,7 @@ export const startSse = (): void => {
     subscriber: null,
     subscriptionLive: false,
     attachTimer: null,
+    generation: 0,
   };
   lifecycle.keepAliveTimer.unref();
   activeLifecycle = lifecycle;
@@ -613,6 +638,9 @@ export const stopSse = (): void => {
   }
 
   if (lifecycle.subscriber) {
+    // Invalidate the active subscriber's generation before shutdown cleanup so
+    // it cannot deliver even if close() throws.
+    lifecycle.generation += 1;
     closeSubscriberQuietly(lifecycle.subscriber);
   }
 };

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -319,26 +319,38 @@ const sendKeepAlive = () => {
 type SseLifecycle = {
   keepAliveTimer: ReturnType<typeof setInterval>;
   subscriber: ReturnType<typeof createRedisClient> | null;
+  /**
+   * Whether `subscriber` currently holds a live SUBSCRIBE on its present
+   * connection. Set true only after a confirmed subscribe on the active
+   * client; set false the moment a reconnect is observed (the old connection's
+   * subscription is gone) and while a replacement client is attaching. Distinct
+   * from the socket's `connected` flag because Bun reconnects the socket
+   * WITHOUT re-issuing SUBSCRIBE — so a `connected` client can be silently deaf.
+   */
+  subscriptionLive: boolean;
 };
 
 let activeLifecycle: SseLifecycle | null = null;
 
 /**
- * Whether this instance currently has a live Redis subscriber attached. Used
- * by `broadcast`/`broadcastToOrganization` to decide whether they must
- * deliver locally inline: without a connected subscriber, a published event
- * never loops back to this instance, so local clients would be missed even
- * when the (independent) publisher connection is healthy.
+ * Whether this instance currently has a live, subscribed Redis subscriber. Used
+ * by `broadcast`/`broadcastToOrganization` to decide whether they must deliver
+ * locally inline: without a subscribed subscriber a published event never loops
+ * back to this instance, so local clients would be missed even when the
+ * (independent) publisher connection is healthy.
  *
- * Reads the client's own live `connected` flag rather than a mirrored bit, so
- * a subscriber that Bun has auto-reconnected away from (transient drop) counts
- * as not attached for as long as it is down — during which `broadcast` falls
- * back to inline local delivery — and counts as attached again the instant its
- * connection (and Bun's re-subscribe) is restored. A stale flag could drift
- * out of step with the socket; the property cannot.
+ * Requires BOTH the socket to be `connected` AND `subscriptionLive`. Bun's
+ * RedisClient auto-reconnects a dropped subscriber but does NOT re-issue
+ * SUBSCRIBE, so `connected` alone would report a reconnected-but-deaf client as
+ * attached and silently drop this instance's events. During the disconnected
+ * window (`connected` false) and the reconnect/reattach window
+ * (`subscriptionLive` false) this returns false, routing broadcasts to inline
+ * local delivery so nothing is missed.
  */
 const hasAttachedSubscriber = (): boolean =>
-  Boolean(activeLifecycle?.subscriber?.connected);
+  Boolean(
+    activeLifecycle?.subscriber?.connected && activeLifecycle.subscriptionLive,
+  );
 
 /**
  * Bounded backoff for retrying the subscriber attach. A transient Redis
@@ -371,17 +383,40 @@ const attachSubscriber = async (
   let subscriber: ReturnType<typeof createRedisClient> | undefined;
   try {
     subscriber = createRedisClient();
-    await subscriber.subscribe(REDIS_CHANNEL, (message) => {
+    const attached = subscriber;
+    await attached.subscribe(REDIS_CHANNEL, (message) => {
       handleMessage(message);
     });
     if (activeLifecycle !== lifecycle) {
       // stopSse (and possibly a subsequent startSse) ran while the connection
       // was still being established; do not attach a stale subscriber to a
       // lifecycle that is no longer the active one.
-      subscriber.close();
+      attached.close();
       return;
     }
-    lifecycle.subscriber = subscriber;
+    lifecycle.subscriber = attached;
+    lifecycle.subscriptionLive = true;
+    // Bun auto-reconnects a dropped subscriber but does NOT re-issue SUBSCRIBE,
+    // and re-subscribing on the SAME client double-registers the callback (both
+    // verified against a mock RESP3 server), which would double-deliver every
+    // event locally. So on any reconnect, drop this now-deaf client and attach
+    // a fresh one, which subscribes exactly once on the new connection. Exactly-
+    // once local delivery holds because `subscriptionLive` is false for the
+    // whole deaf/reattach window, routing broadcasts to inline delivery until
+    // the replacement is subscribed. The initial connect fired before this
+    // handler was registered, so it runs only for genuine reconnects.
+    attached.onReconnect(() => {
+      if (activeLifecycle !== lifecycle || lifecycle.subscriber !== attached) {
+        return;
+      }
+      lifecycle.subscriptionLive = false;
+      lifecycle.subscriber = null;
+      attached.close();
+      logger.warn("sse.redis_subscriber_reconnected", {
+        channel: REDIS_CHANNEL,
+      });
+      void attachSubscriber(lifecycle, 0);
+    });
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
     subscriber?.close();
@@ -427,6 +462,7 @@ export const startSse = (): void => {
   const lifecycle: SseLifecycle = {
     keepAliveTimer: setInterval(sendKeepAlive, KEEP_ALIVE_INTERVAL_MS),
     subscriber: null,
+    subscriptionLive: false,
   };
   lifecycle.keepAliveTimer.unref();
   activeLifecycle = lifecycle;

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -50,6 +50,23 @@ export const subscribe = (
 ): ReadableStream => {
   const stream = new ReadableStream({
     start(controller) {
+      // The request signal can already be aborted here: the async auth
+      // macro that runs before subscribe() awaits, and the client can
+      // disconnect in that window. An already-aborted signal never fires
+      // a fresh "abort" event, so registering the connection would leak
+      // it for the process lifetime (nothing reads the orphaned stream,
+      // so enqueue never throws and the self-heal delete paths never
+      // run). Treat it as an immediately-closed connection: close the
+      // controller and never register.
+      if (signal.aborted) {
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+        return;
+      }
+
       const conn: SSEConnection = { controller, organizationId };
 
       let set = connections.get(workspaceId);
@@ -171,13 +188,30 @@ export const broadcast = (
   workspaceId: SafeId<"workspace">,
   event: SSEEvent,
 ): void => {
+  // When this instance has no attached subscriber it never receives its
+  // own published message back through the Redis loopback, so deliver
+  // locally inline. This must not depend on the publisher's health: the
+  // publisher is a separate lazy connection that can be healthy while the
+  // subscriber never attached, in which case a successful publish would
+  // otherwise reach no local client. When a subscriber IS attached, the
+  // loopback (handleMessage → broadcastLocal) delivers locally, so
+  // delivering inline as well would double-deliver — hence the guard on
+  // the attach state evaluated here, at broadcast time.
+  const deliveredLocally = !hasAttachedSubscriber();
+  if (deliveredLocally) {
+    broadcastLocal(workspaceId, event);
+  }
+
   publishWorkspaceEvent(workspaceId, event).catch((error: unknown) => {
     logger.warn("sse.redis_publish_failed", {
       "error.type": errorTag(error),
     });
     // Fallback: deliver locally when Redis is unavailable so
-    // single-instance deployments still get SSE invalidation.
-    broadcastLocal(workspaceId, event);
+    // single-instance deployments still get SSE invalidation. Skip it
+    // when we already delivered inline above to avoid double delivery.
+    if (!deliveredLocally) {
+      broadcastLocal(workspaceId, event);
+    }
   });
 };
 
@@ -185,11 +219,18 @@ export const broadcastToOrganization = (
   organizationId: SafeId<"organization">,
   event: SSEEvent,
 ): void => {
+  const deliveredLocally = !hasAttachedSubscriber();
+  if (deliveredLocally) {
+    broadcastLocalToOrganization(organizationId, event);
+  }
+
   publishOrganizationEvent(organizationId, event).catch((error: unknown) => {
     logger.warn("sse.redis_publish_failed", {
       "error.type": errorTag(error),
     });
-    broadcastLocalToOrganization(organizationId, event);
+    if (!deliveredLocally) {
+      broadcastLocalToOrganization(organizationId, event);
+    }
   });
 };
 
@@ -283,6 +324,24 @@ type SseLifecycle = {
 let activeLifecycle: SseLifecycle | null = null;
 
 /**
+ * Whether this instance currently has a Redis subscriber attached. Used
+ * by `broadcast`/`broadcastToOrganization` to decide whether they must
+ * deliver locally inline: without an attached subscriber, a published
+ * event never loops back to this instance, so local clients would be
+ * missed even when the (independent) publisher connection is healthy.
+ */
+const hasAttachedSubscriber = (): boolean =>
+  Boolean(activeLifecycle?.subscriber);
+
+/**
+ * Bounded backoff for retrying the subscriber attach. A transient Redis
+ * blip at boot must not leave this instance permanently deaf (publisher
+ * healthy, subscriber never attached); retry a handful of times with a
+ * short capped backoff before logging a persistent failure.
+ */
+const SUBSCRIBER_ATTACH_RETRY_DELAYS_MS = [200, 500, 1000, 2000, 5000];
+
+/**
  * Start the SSE keep-alive heartbeat and the cross-instance Redis
  * subscriber. Idempotent: a second call while already started is a no-op.
  *
@@ -314,27 +373,51 @@ export const startSse = (): void => {
   activeLifecycle = lifecycle;
 
   void (async () => {
-    // The client is constructed inside the try so a throwing constructor
-    // hits the fail-soft catch below instead of escaping this detached
-    // IIFE as an unhandled rejection.
-    let subscriber: ReturnType<typeof createRedisClient> | undefined;
-    try {
-      subscriber = createRedisClient();
-      await subscriber.subscribe(REDIS_CHANNEL, (message) => {
-        handleMessage(message);
-      });
+    for (let attempt = 0; ; attempt += 1) {
       if (activeLifecycle !== lifecycle) {
-        // stopSse (and possibly a subsequent startSse) ran while the
-        // connection was still being established; do not attach a stale
-        // subscriber to a lifecycle that is no longer the active one.
-        subscriber.close();
+        // stopSse (and possibly a subsequent startSse) ran while we were
+        // waiting between retries; abandon this attach loop.
         return;
       }
-      lifecycle.subscriber = subscriber;
-      logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
-    } catch (error: unknown) {
-      logger.error("sse.redis_connection_failed", connectionErrorFields(error));
-      subscriber?.close();
+
+      // The client is constructed inside the try so a throwing constructor
+      // hits the fail-soft catch below instead of escaping this detached
+      // IIFE as an unhandled rejection.
+      let subscriber: ReturnType<typeof createRedisClient> | undefined;
+      try {
+        subscriber = createRedisClient();
+        // oxlint-disable-next-line no-await-in-loop -- each attach attempt must observe success/failure before deciding to retry
+        await subscriber.subscribe(REDIS_CHANNEL, (message) => {
+          handleMessage(message);
+        });
+        if (activeLifecycle !== lifecycle) {
+          // stopSse (and possibly a subsequent startSse) ran while the
+          // connection was still being established; do not attach a stale
+          // subscriber to a lifecycle that is no longer the active one.
+          subscriber.close();
+          return;
+        }
+        lifecycle.subscriber = subscriber;
+        logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
+        return;
+      } catch (error: unknown) {
+        subscriber?.close();
+        const delayMs = SUBSCRIBER_ATTACH_RETRY_DELAYS_MS[attempt];
+        if (delayMs === undefined || activeLifecycle !== lifecycle) {
+          // Retries exhausted (or the lifecycle was torn down): surface a
+          // persistent failure. Local delivery still works because
+          // `broadcast`/`broadcastToOrganization` deliver inline while no
+          // subscriber is attached.
+          logger.error(
+            "sse.redis_connection_failed",
+            connectionErrorFields(error),
+          );
+          return;
+        }
+        logger.warn("sse.redis_subscribe_retry", connectionErrorFields(error));
+        // oxlint-disable-next-line no-await-in-loop -- sequential backoff between retries, not parallel work
+        await Bun.sleep(delayMs);
+      }
     }
   })();
 

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -411,6 +411,22 @@ const SUBSCRIBER_ATTACH_STEADY_DELAY_MS = 5000;
 const SUBSCRIBER_ATTACH_STEADY_LOG_EVERY = 12;
 
 /**
+ * Close a subscriber client best-effort: a throwing `close()` (mirroring how
+ * `stopSse` already treats it) must never abort the caller. This matters most
+ * on the attach-failure and reconnect-teardown paths, where an exception here
+ * would skip the retry scheduling and leave the instance permanently deaf.
+ */
+const closeSubscriberQuietly = (
+  client: ReturnType<typeof createRedisClient>,
+): void => {
+  try {
+    client.close();
+  } catch (error: unknown) {
+    logger.warn("sse.redis_close_failed", { "error.type": errorTag(error) });
+  }
+};
+
+/**
  * Run one attach attempt for `lifecycle`. On success it attaches the subscriber
  * and wires reconnect handling; on failure it logs and schedules the NEXT
  * attempt via a timer, then returns. Attempts therefore never await one another
@@ -439,7 +455,7 @@ const runAttachAttempt = async (
       // stopSse (and possibly a subsequent startSse) ran while the connection
       // was still being established; do not attach a stale subscriber to a
       // lifecycle that is no longer the active one.
-      attached.close();
+      closeSubscriberQuietly(attached);
       return;
     }
     lifecycle.subscriber = attached;
@@ -459,7 +475,9 @@ const runAttachAttempt = async (
       }
       lifecycle.subscriptionLive = false;
       lifecycle.subscriber = null;
-      attached.close();
+      // Best-effort: a throwing close() must not skip the re-attach below, or a
+      // reconnect would leave this instance deaf.
+      closeSubscriberQuietly(attached);
       logger.warn("sse.redis_subscriber_reconnected", {
         channel: REDIS_CHANNEL,
       });
@@ -467,7 +485,12 @@ const runAttachAttempt = async (
     });
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
-    subscriber?.close();
+    // Best-effort close: a throwing close() here must not skip the retry
+    // scheduling below, or a single failed attempt whose cleanup also throws
+    // would stop the instance retrying and leave it deaf until restart.
+    if (subscriber) {
+      closeSubscriberQuietly(subscriber);
+    }
     if (activeLifecycle !== lifecycle) {
       // The lifecycle was torn down (stop, or stop+restart) during the
       // attempt; abandon the retry chain quietly.
@@ -590,10 +613,6 @@ export const stopSse = (): void => {
   }
 
   if (lifecycle.subscriber) {
-    try {
-      lifecycle.subscriber.close();
-    } catch (error: unknown) {
-      logger.warn("sse.redis_close_failed", { "error.type": errorTag(error) });
-    }
+    closeSubscriberQuietly(lifecycle.subscriber);
   }
 };


### PR DESCRIPTION
subscribe() registered its cleanup only via signal.addEventListener("abort"),
which never fires for a signal that already aborted before the call (e.g. a
client that disconnects during the async auth macro). The orphaned stream was
never read, so controller.enqueue never threw and the self-heal delete paths
never ran; every broadcast plus the 20s keep-alive buffered into the dead
stream for the process lifetime. Check signal.aborted up front and treat an
already-aborted request as an immediately-closed connection that is never
registered, keeping the listener path for later aborts.

The Redis subscriber attach failed soft on the first error and gave up
forever, leaving the instance permanently deaf while its independent publisher
stayed healthy: events published fine and reached no local client until
restart. Retry the attach with bounded backoff, and deliver locally inline
whenever no subscriber is attached so being deaf no longer depends on the
publisher's health. Local delivery is guarded on the attach state at broadcast
time, so once the subscriber attaches the Redis loopback is the sole local
path and events are not delivered twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Server-Sent Events reliability across reconnects and temporary connection failures.
  * Added automatic subscriber reattachment with retries after interruptions.
  * Preserved event delivery during subscriber attachment windows and Redis outages.

* **Bug Fixes**
  * Prevented duplicate event delivery during reconnects.
  * Fixed streams created with an already-aborted request not remaining open.
  * Ensured local broadcasts continue when the Redis subscriber is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->