### PR TITLE
fix(api): re-run pdf extraction on retry after the ready flip

### DIFF
--- a/apps/api/src/lib/file-derivative-decision.test.ts
+++ b/apps/api/src/lib/file-derivative-decision.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FieldContent } from "@/api/db/schema-validators";
+
+import { decidePdfDerivativeAction } from "./file-derivative-decision";
+
+type FileContent = Extract<FieldContent, { type: "file" }>;
+
+// A convertible, non-natively-rendered MIME type (.xlsx) drives PDF generation.
+const CONVERTIBLE_MIME =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+// A native PDF is not convertible, so no derivative is generated.
+const NON_CONVERTIBLE_MIME = "application/pdf";
+
+const fileContent = (overrides: Partial<FileContent> = {}): FileContent => ({
+  version: 1,
+  type: "file",
+  id: "11111111-1111-1111-1111-111111111111",
+  fileName: "report.xlsx",
+  mimeType: CONVERTIBLE_MIME,
+  sizeBytes: 1024,
+  encrypted: false,
+  sha256Hex: "a".repeat(64),
+  pdfFileId: null,
+  ...overrides,
+});
+
+describe("decidePdfDerivativeAction", () => {
+  it("skips when the field is missing", () => {
+    expect(decidePdfDerivativeAction(undefined)).toEqual({ type: "skip" });
+  });
+
+  it("skips non-file content", () => {
+    const content: FieldContent = { version: 1, type: "pending" };
+    expect(decidePdfDerivativeAction(content)).toEqual({ type: "skip" });
+  });
+
+  it("generates for a fresh convertible file with no pdf yet", () => {
+    const content = fileContent({ pdfFileId: null, pdfDerivative: undefined });
+    expect(decidePdfDerivativeAction(content)).toEqual({
+      type: "generate",
+      content,
+    });
+  });
+
+  it("generates when status is explicitly pending", () => {
+    const content = fileContent({ pdfDerivative: { status: "pending" } });
+    expect(decidePdfDerivativeAction(content).type).toBe("generate");
+  });
+
+  it("skips non-convertible files (native PDF)", () => {
+    const content = fileContent({
+      mimeType: NON_CONVERTIBLE_MIME,
+      fileName: "report.pdf",
+    });
+    expect(decidePdfDerivativeAction(content)).toEqual({ type: "skip" });
+  });
+
+  it("skips encrypted files", () => {
+    const content = fileContent({ encrypted: true });
+    expect(decidePdfDerivativeAction(content)).toEqual({ type: "skip" });
+  });
+
+  // The core bug: after the ready flip, `pdfFileId` is set. A retry that
+  // previously threw during extraction/indexing must re-run extraction rather
+  // than early-returning and silently dropping the document from search.
+  it("re-runs extraction when the derivative is already ready", () => {
+    const content = fileContent({
+      pdfFileId: "22222222-2222-2222-2222-222222222222",
+      pdfDerivative: { status: "ready" },
+    });
+    expect(decidePdfDerivativeAction(content)).toEqual({
+      type: "extract-only",
+    });
+  });
+
+  it("does not regenerate a failed derivative", () => {
+    const content = fileContent({ pdfDerivative: { status: "failed" } });
+    expect(decidePdfDerivativeAction(content)).toEqual({ type: "skip" });
+  });
+
+  it("does not regenerate a not-required derivative", () => {
+    const content = fileContent({ pdfDerivative: { status: "not-required" } });
+    expect(decidePdfDerivativeAction(content)).toEqual({ type: "skip" });
+  });
+
+  it("skips when a pdf already exists but status is not ready (foreign write)", () => {
+    const content = fileContent({
+      pdfFileId: "33333333-3333-3333-3333-333333333333",
+      pdfDerivative: { status: "pending" },
+    });
+    expect(decidePdfDerivativeAction(content)).toEqual({ type: "skip" });
+  });
+
+  // Transient failure then successful retry: the first invocation flips the
+  // derivative to `ready` (generate), and the retry re-runs extraction to
+  // completion (extract-only). Both invocations act, so indexing is not lost.
+  it("progresses generate -> extract-only across a transient-failure retry", () => {
+    const first = fileContent({ pdfFileId: null, pdfDerivative: undefined });
+    expect(decidePdfDerivativeAction(first).type).toBe("generate");
+
+    const afterReadyFlip = fileContent({
+      pdfFileId: "44444444-4444-4444-4444-444444444444",
+      pdfDerivative: { status: "ready" },
+    });
+    expect(decidePdfDerivativeAction(afterReadyFlip).type).toBe("extract-only");
+  });
+});

--- a/apps/api/src/lib/file-derivative-decision.test.ts
+++ b/apps/api/src/lib/file-derivative-decision.test.ts
@@ -36,7 +36,7 @@ describe("decidePdfDerivativeAction", () => {
   });
 
   it("generates for a fresh convertible file with no pdf yet", () => {
-    const content = fileContent({ pdfFileId: null, pdfDerivative: undefined });
+    const content = fileContent({ pdfFileId: null });
     expect(decidePdfDerivativeAction(content)).toEqual({
       type: "generate",
       content,
@@ -96,7 +96,7 @@ describe("decidePdfDerivativeAction", () => {
   // derivative to `ready` (generate), and the retry re-runs extraction to
   // completion (extract-only). Both invocations act, so indexing is not lost.
   it("progresses generate -> extract-only across a transient-failure retry", () => {
-    const first = fileContent({ pdfFileId: null, pdfDerivative: undefined });
+    const first = fileContent({ pdfFileId: null });
     expect(decidePdfDerivativeAction(first).type).toBe("generate");
 
     const afterReadyFlip = fileContent({

--- a/apps/api/src/lib/file-derivative-decision.ts
+++ b/apps/api/src/lib/file-derivative-decision.ts
@@ -1,0 +1,64 @@
+import type { FieldContent } from "@/api/db/schema-validators";
+import { shouldGeneratePdfDerivative } from "@/api/handlers/files/gotenberg";
+
+type FileContent = Extract<FieldContent, { type: "file" }>;
+
+/**
+ * A PDF-derivative field is still awaiting generation only when its
+ * `pdfDerivative` status has not reached a terminal value. Absent status is
+ * treated as `pending` (the default state written on upload).
+ */
+export const isPendingPdfDerivative = (content: FileContent): boolean =>
+  content.pdfDerivative?.status !== "not-required" &&
+  content.pdfDerivative?.status !== "ready" &&
+  content.pdfDerivative?.status !== "failed";
+
+/**
+ * What a PDF-derivative worker invocation should do given the current field
+ * content:
+ *
+ * - `generate`: no derivative yet; convert, flip to `ready`, then extract.
+ * - `extract-only`: the derivative is already `ready` (PDF preview is durable),
+ *   so this is a retry whose previous run threw during text extraction /
+ *   search indexing. Extraction is the terminal step of the job, so a retry
+ *   reaching a `ready` field means extraction never completed. Re-run it;
+ *   `processExtraction` is idempotent (upsert + index replace).
+ * - `skip`: nothing to do (missing/foreign field, wrong content type,
+ *   already `failed`/`not-required`, or the file is not convertible).
+ */
+export type PdfDerivativeAction =
+  | { type: "skip" }
+  | { type: "extract-only" }
+  | { type: "generate"; content: FileContent };
+
+export const decidePdfDerivativeAction = (
+  content: FieldContent | undefined,
+): PdfDerivativeAction => {
+  if (!content || content.type !== "file") {
+    return { type: "skip" };
+  }
+
+  // Derivative already produced: the ready flip set `pdfFileId` and made the
+  // PDF preview available. Reaching here again is a retry after extraction /
+  // indexing threw, so re-run extraction rather than silently succeeding.
+  if (content.pdfFileId !== null && content.pdfDerivative?.status === "ready") {
+    return { type: "extract-only" };
+  }
+
+  // A pdf already exists (foreign write) or the derivative reached a terminal
+  // state (`failed`/`not-required`): do not regenerate.
+  if (content.pdfFileId !== null || !isPendingPdfDerivative(content)) {
+    return { type: "skip" };
+  }
+
+  if (
+    !shouldGeneratePdfDerivative({
+      encrypted: content.encrypted,
+      mimeType: content.mimeType,
+    })
+  ) {
+    return { type: "skip" };
+  }
+
+  return { type: "generate", content };
+};

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -19,6 +19,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
+import { decidePdfDerivativeAction } from "@/api/lib/file-derivative-decision";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -285,25 +286,23 @@ const processPdfDerivativeJob = async ({
     }),
   );
 
-  if (
-    !row ||
-    row.content.type !== "file" ||
-    row.content.pdfFileId !== null ||
-    !isPendingPdfDerivative(row.content)
-  ) {
+  const action = decidePdfDerivativeAction(row?.content);
+  if (action.type === "skip") {
     return;
   }
 
-  const content = row.content;
-  if (
-    !shouldGeneratePdfDerivative({
-      encrypted: content.encrypted,
-      mimeType: content.mimeType,
-    })
-  ) {
+  if (action.type === "extract-only") {
+    // The derivative is already `ready`; only search extraction/indexing is
+    // outstanding (a retry after it threw). Re-run it so the document is not
+    // permanently missing from search. If it keeps failing, BullMQ exhausts
+    // the job and the `failed` handler captures the error; the derivative
+    // stays `ready` because the PDF preview itself genuinely succeeded.
+    // Broadcasts already fired on the ready flip, so they are not repeated.
+    await processExtraction(brandedEntityId);
     return;
   }
 
+  const content = action.content;
   const sourceKey = createFileKey({
     organizationId: branded.organizationId,
     workspaceId: branded.workspaceId,
@@ -386,13 +385,6 @@ const processPdfDerivativeJob = async ({
 
 const getS3File = async (key: string): Promise<ArrayBuffer> =>
   await getS3().file(key).arrayBuffer();
-
-const isPendingPdfDerivative = (
-  content: Extract<FieldContent, { type: "file" }>,
-): boolean =>
-  content.pdfDerivative?.status !== "not-required" &&
-  content.pdfDerivative?.status !== "ready" &&
-  content.pdfDerivative?.status !== "failed";
 
 const readyPdfDerivativeContent = (pdfFileId: string) =>
   sql<FieldContent>`jsonb_set(


### PR DESCRIPTION
processPdfDerivativeJob flipped pdfDerivative to "ready" (setting pdfFileId)
before running processExtraction (S3 read, text extraction, DB write, search
indexing). If extraction/indexing threw, the job retried, but the retry guard
early-returned because pdfFileId was now non-null, so the job "succeeded"
without ever indexing the document. markPdfDerivativeFailed was also a no-op in
that state (its WHERE requires pdfFileId is null and status pending). Net
effect: the document looked fine but was permanently missing from search, with
no failure recorded.

Extraction runs after the flip on purpose: it needs pdfFileId set to extract
from the higher-quality converted PDF, and the flip is what makes the PDF
preview available early. So rather than reorder, treat an already-ready
derivative on a later invocation as a retry whose extraction never completed
(extraction is the terminal job step) and re-run it. processExtraction is
idempotent (upsert + index replace), so re-running is safe and bounded to
retries. If extraction keeps failing, BullMQ exhausts the job and the failed
handler captures the error; the derivative correctly stays ready because the
PDF preview itself succeeded.

The invocation decision is extracted into a pure decidePdfDerivativeAction
(skip | generate | extract-only) and unit-tested.
