### PR TITLE
fix(mcp): return structured internal_error envelopes for tool db failures

### DIFF
--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -47,6 +47,7 @@ import {
   ensureWorkspaceAccess,
   enumProp,
   errorResult,
+  internalFailureResult,
   intProp,
   MAX_LIST_LIMIT,
   notFoundResult,
@@ -1037,7 +1038,7 @@ const handleSaveTimeEntryTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(created)) {
-      return errorResult(created.error.message);
+      return internalFailureResult(created.error);
     }
     return textResult({ timeEntryId: created.value.id });
   }
@@ -1096,7 +1097,7 @@ const handleSaveTimeEntryTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(updated)) {
-    return errorResult(updated.error.message);
+    return internalFailureResult(updated.error);
   }
   return textResult({ timeEntryId, updated: true });
 };
@@ -1140,7 +1141,7 @@ const handleDeleteTimeEntryTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(deleted)) {
-    return errorResult(deleted.error.message);
+    return internalFailureResult(deleted.error);
   }
   return textResult({ deleted: deleted.value.deleted });
 };
@@ -1184,7 +1185,7 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
       ),
   );
   if (Result.isError(validated)) {
-    return errorResult(validated.error.message);
+    return internalFailureResult(validated.error);
   }
   if (!validated.value) {
     return errorResult("user_id is not a member of this organization");
@@ -1201,7 +1202,7 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
     return Result.ok(rate);
   });
   if (Result.isError(resolved)) {
-    return errorResult(resolved.error.message);
+    return internalFailureResult(resolved.error);
   }
 
   // Passthrough: only a rate amount (minor units) and currency code, no
@@ -1496,7 +1497,7 @@ const handleGetUsageTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(entitlement)) {
-    return errorResult(entitlement.error.message);
+    return internalFailureResult(entitlement.error);
   }
 
   // Passthrough: plan/seat/period/remaining-units are organization billing

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -60,6 +60,7 @@ import {
   ensureWorkspaceAccess,
   enumProp,
   errorResult,
+  internalFailureResult,
   intProp,
   isToolErrorResult,
   MAX_LIST_LIMIT,
@@ -1091,7 +1092,7 @@ const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(baseResult)) {
-      return errorResult(baseResult.error.message);
+      return internalFailureResult(baseResult.error);
     }
     const targetResult = await Result.gen(() =>
       loadEntityVersionDocxText({
@@ -1103,7 +1104,7 @@ const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(targetResult)) {
-      return errorResult(targetResult.error.message);
+      return internalFailureResult(targetResult.error);
     }
 
     const segments = buildLineDiffSegments(
@@ -1178,7 +1179,7 @@ const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
     readEntityByIdHandler({ safeDb: context.safeDb, workspaceId, entityId }),
   );
   if (Result.isError(currentResult)) {
-    return errorResult(currentResult.error.message);
+    return internalFailureResult(currentResult.error);
   }
   const current = currentResult.value;
 
@@ -1387,7 +1388,7 @@ const createDocumentEntity = async ({
     }),
   );
   if (Result.isError(created)) {
-    return errorResult(created.error.message);
+    return internalFailureResult(created.error);
   }
 
   return textResult({ entityId: created.value.entityId });
@@ -1479,7 +1480,7 @@ const applyVersionAnnotations = async ({
       }),
     );
     if (Result.isError(labelled)) {
-      return errorResult(labelled.error.message);
+      return internalFailureResult(labelled.error);
     }
   }
   if (description !== undefined) {
@@ -1494,7 +1495,7 @@ const applyVersionAnnotations = async ({
       }),
     );
     if (Result.isError(described)) {
-      return errorResult(described.error.message);
+      return internalFailureResult(described.error);
     }
   }
   return null;
@@ -1565,7 +1566,7 @@ const updateDocumentEntity = async ({
       }),
     );
     if (Result.isError(renamed)) {
-      return errorResult(renamed.error.message);
+      return internalFailureResult(renamed.error);
     }
   }
 
@@ -1579,7 +1580,7 @@ const updateDocumentEntity = async ({
       }),
     );
     if (Result.isError(moved)) {
-      return errorResult(moved.error.message);
+      return internalFailureResult(moved.error);
     }
   }
 
@@ -1669,7 +1670,7 @@ const handleDeleteDocumentTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(deleted)) {
-      return errorResult(deleted.error.message);
+      return internalFailureResult(deleted.error);
     }
     return textResult({ deleted: true });
   }
@@ -1687,7 +1688,7 @@ const handleDeleteDocumentTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(deleted)) {
-    return errorResult(deleted.error.message);
+    return internalFailureResult(deleted.error);
   }
   return textResult({ deleted: true });
 };
@@ -1905,7 +1906,7 @@ const handleSetFieldValueTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(result)) {
-    return errorResult(result.error.message);
+    return internalFailureResult(result.error);
   }
 
   return textResult({});

--- a/apps/api/src/mcp/error-codes.ts
+++ b/apps/api/src/mcp/error-codes.ts
@@ -50,6 +50,40 @@ export const MCP_ERROR_CODES = [
 export type McpErrorCode = (typeof MCP_ERROR_CODES)[number];
 
 /**
+ * Map a backing safe handler's HTTP-ish status onto a stable envelope code,
+ * preserving the handler's curated message at the call site. Mirrors the sweep
+ * of 4xx statuses the handlers actually return:
+ *  - 400 / 413 / 422 -> `validation_error` (shape, payload size, semantic);
+ *  - 401 / 403 -> `permission_denied` (the tool paths are always authenticated,
+ *    so a 401 here is an authorization gap, not a login prompt);
+ *  - 402 -> `usage_limited`; 404 -> `not_found`; 409 -> `conflict`;
+ *  - 429 -> `rate_limited`.
+ * Any other status (5xx, or an unmapped value) is a genuine server failure whose
+ * detail must not leak, so it falls through to `internal_error`.
+ */
+export const statusCodeToErrorCode = (status: number): McpErrorCode => {
+  switch (status) {
+    case 400:
+    case 413:
+    case 422:
+      return "validation_error";
+    case 401:
+    case 403:
+      return "permission_denied";
+    case 402:
+      return "usage_limited";
+    case 404:
+      return "not_found";
+    case 409:
+      return "conflict";
+    case 429:
+      return "rate_limited";
+    default:
+      return "internal_error";
+  }
+};
+
+/**
  * One structured validation issue in the error envelope. `path` is the dot-path
  * to the offending field (empty string for a whole-object / root issue);
  * `message` is the human-readable reason. Emitted under `error.issues` only for

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -1,20 +1,38 @@
+import { Result } from "better-result";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
+import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import type { McpRequestContext } from "@/api/mcp/context";
+import type { McpErrorCode } from "@/api/mcp/error-codes";
 import type { McpToolHandler, McpToolResponse } from "@/api/mcp/tool-types";
 import { isMcpEgressPlan } from "@/api/mcp/tool-types";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const captureErrorMock = mock();
+const createTimeEntryHandlerMock = mock();
 
 void mock.module("@/api/lib/analytics/capture", () => ({
   captureError: captureErrorMock,
   captureRequestError: captureErrorMock,
   getAnalytics: () => ({ capture: mock(), flush: mock(async () => undefined) }),
+}));
+
+// Stub the backing time-entry create handler so the tool site receives a chosen
+// `Result` error (a curated 4xx business `HandlerError`, or an internal 5xx)
+// without needing a real DB. `save_time_entry`'s create branch calls it after
+// its own auth/schema/workspace pre-checks. Spread the real module so its other
+// exports (utilities imported elsewhere) keep working; only the handler is
+// swapped.
+const actualTimeEntryCreate =
+  await import("@/api/handlers/time-entries/create");
+void mock.module("@/api/handlers/time-entries/create", () => ({
+  ...actualTimeEntryCreate,
+  createTimeEntryHandler: createTimeEntryHandlerMock,
 }));
 
 const { MATTER_TOOL_HANDLERS } = await import("@/api/mcp/matter-tools");
@@ -64,6 +82,21 @@ const asCallToolResult = (result: McpToolResponse) => {
     throw new Error("expected a CallToolResult, got an egress plan");
   }
   return result;
+};
+
+const envelopeText = (result: McpToolResponse): string => {
+  const first = asCallToolResult(result).content.at(0);
+  return first !== undefined && "text" in first ? first.text : "";
+};
+
+// Assert an expected business failure surfaced with the mapped code and the
+// handler's own message preserved (no generic flattening, no hint, no receipt).
+const expectBusinessEnvelope = (
+  result: McpToolResponse,
+  expected: { code: McpErrorCode; message: string },
+) => {
+  expect(asCallToolResult(result).isError).toBe(true);
+  expect(JSON.parse(envelopeText(result))).toEqual({ error: expected });
 };
 
 // Assert the shared `internal_error` contract: the stable code, the generic
@@ -168,6 +201,117 @@ describe("MCP tool DB failures return a structured internal_error envelope", () 
   });
 });
 
+// The sink must not flatten expected business failures. A backing safe handler
+// signals those as a HandlerError carrying a curated message and a 4xx status;
+// the agent needs that message and a branchable code, and it is not a fault to
+// record as telemetry.
+describe("internalFailureResult preserves expected handler errors", () => {
+  const EXPECTED_BUSINESS_CASES: {
+    status: HandlerErrorStatusCode;
+    code: McpErrorCode;
+  }[] = [
+    { status: 400, code: "validation_error" },
+    { status: 413, code: "validation_error" },
+    { status: 422, code: "validation_error" },
+    { status: 401, code: "permission_denied" },
+    { status: 403, code: "permission_denied" },
+    { status: 402, code: "usage_limited" },
+    { status: 404, code: "not_found" },
+    { status: 409, code: "conflict" },
+    { status: 429, code: "rate_limited" },
+  ];
+
+  beforeEach(() => {
+    captureErrorMock.mockReset();
+  });
+
+  for (const { code, status } of EXPECTED_BUSINESS_CASES) {
+    test(`a ${status} HandlerError surfaces its message as ${code} and is not captured`, () => {
+      const message = `curated business message for ${status}`;
+      const result = internalFailureResult(
+        new HandlerError({ status, message }),
+      );
+
+      expectBusinessEnvelope(result, { code, message });
+      // Expected business flow is not a telemetry error.
+      expect(captureErrorMock).not.toHaveBeenCalled();
+    });
+  }
+
+  test("a 5xx HandlerError stays generic and is captured", () => {
+    const result = internalFailureResult(
+      new HandlerError({
+        status: 500,
+        message: `internal boom ${DB_INTERNAL_LEAK_TOKEN}`,
+      }),
+    );
+
+    expectInternalErrorEnvelope(result);
+    expect(captureErrorMock).toHaveBeenCalled();
+  });
+});
+
+// End-to-end through a real tool handler: `save_time_entry`'s create branch
+// unwraps `createTimeEntryHandler`'s `Result`. Its curated 400s (future date,
+// too-old date, per-workspace limit) must reach the agent verbatim; a genuine
+// 5xx must not.
+describe("save_time_entry threads backing handler errors correctly", () => {
+  const TIME_ENTRY_CREATE_ARGS = {
+    matter_id: "ws_1",
+    entity_id: "entity_1",
+    date_worked: "2024-01-01",
+    timezone_id: "Europe/Prague",
+    duration_minutes: 60,
+    rate_at_entry: 100,
+    currency: "EUR",
+    narrative: "Reviewed the share purchase agreement.",
+  };
+
+  beforeEach(() => {
+    captureErrorMock.mockReset();
+    createTimeEntryHandlerMock.mockReset();
+  });
+
+  test("a curated 400 becomes a validation_error carrying the handler message", async () => {
+    const message = "date_worked cannot be in the future";
+    // The backing safe handler is an async generator driven by `Result.gen`, so
+    // it returns (not resolves) its `Result`.
+    createTimeEntryHandlerMock.mockImplementation(async function* () {
+      yield* [];
+      return Result.err(new HandlerError({ status: 400, message }));
+    });
+
+    const result = await BILLING_TOOL_HANDLERS.save_time_entry({
+      args: TIME_ENTRY_CREATE_ARGS,
+      context: createFailingDbContext(),
+    });
+
+    expectBusinessEnvelope(result, { code: "validation_error", message });
+    expect(createTimeEntryHandlerMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("an internal 5xx stays generic and is captured", async () => {
+    createTimeEntryHandlerMock.mockImplementation(async function* () {
+      yield* [];
+      return Result.err(
+        new HandlerError({
+          status: 500,
+          message: `boom ${DB_INTERNAL_LEAK_TOKEN}`,
+        }),
+      );
+    });
+
+    const result = await BILLING_TOOL_HANDLERS.save_time_entry({
+      args: TIME_ENTRY_CREATE_ARGS,
+      context: createFailingDbContext(),
+    });
+
+    expectInternalErrorEnvelope(result);
+    expect(captureErrorMock).toHaveBeenCalled();
+  });
+});
+
 // Structural class guard: no MCP tool module may feed a backing-handler `Result`
 // error message straight into a plain-text `errorResult`, which would leak the
 // internal text, drop the `error.code` the CLI branches on, and omit the request
@@ -179,7 +323,10 @@ describe("MCP tool DB failures return a structured internal_error envelope", () 
 // messages are meant to reach the agent (pinned by template-tools.test.ts). It
 // keeps `errorResult(x.error.message)` deliberately.
 describe("no tool file leaks a Result error message into errorResult", () => {
-  const LEAK_PATTERN = /errorResult\(\s*\w+\.error\.message\s*\)/u;
+  // Match the raw-message pattern including optional-chaining variants
+  // (`x?.error?.message`, `x.error?.message`, `x?.error.message`) so the guard
+  // cannot be dodged by threading the unwrap through `?.`.
+  const LEAK_PATTERN = /errorResult\(\s*\w+\??\.error\??\.message\s*\)/u;
   const SURFACES_CURATED_SERVICE_MESSAGES = new Set(["template-tools.ts"]);
 
   const toolFiles = readdirSync(import.meta.dir).filter(
@@ -194,7 +341,7 @@ describe("no tool file leaks a Result error message into errorResult", () => {
   for (const file of toolFiles) {
     const isException = SURFACES_CURATED_SERVICE_MESSAGES.has(file);
     test(`${file} ${isException ? "keeps its curated service-message exception" : "routes DB failures through internalFailureResult"}`, () => {
-      const source = readFileSync(`${import.meta.dir}/${file}`, "utf8");
+      const source = readFileSync(`${import.meta.dir}/${file}`, "utf-8");
       if (isException) {
         // Pin the exception: if the leak pattern ever disappears here, revisit
         // whether the allowlist entry is still warranted.

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { McpRequestContext } from "@/api/mcp/context";
+import type { McpToolHandler, McpToolResponse } from "@/api/mcp/tool-types";
+import { isMcpEgressPlan } from "@/api/mcp/tool-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
+
+const captureErrorMock = mock();
+
+void mock.module("@/api/lib/analytics/capture", () => ({
+  captureError: captureErrorMock,
+  captureRequestError: captureErrorMock,
+  getAnalytics: () => ({ capture: mock(), flush: mock(async () => undefined) }),
+}));
+
+const { MATTER_TOOL_HANDLERS } = await import("@/api/mcp/matter-tools");
+const { BILLING_TOOL_HANDLERS } = await import("@/api/mcp/billing-tools");
+const { DOCUMENT_TOOL_HANDLERS } = await import("@/api/mcp/document-tools");
+const { KNOWLEDGE_TOOL_HANDLERS } = await import("@/api/mcp/knowledge-tools");
+const { RESEARCH_ADMIN_TOOL_HANDLERS } =
+  await import("@/api/mcp/research-admin-tools");
+const { internalFailureResult, MCP_INTERNAL_ERROR_HINT } =
+  await import("@/api/mcp/tool-utils");
+
+// A unique token the fake DB failure carries. The whole point of the envelope
+// is that this internal text never reaches the caller, so every assertion below
+// checks it is absent from the serialized tool result.
+const DB_INTERNAL_LEAK_TOKEN = "PGDRIVER_INTERNAL_DETAIL_9f3a";
+
+// Every DB seam throws, standing in for a driver/ORM failure. `toSafeDbMock`
+// funnels the throw into a `Result.err`, so the backing handler returns a
+// failed `Result` exactly as it would on a real outage; the tool site then
+// unwraps `.error` into the internal-error envelope.
+const throwingScopedDb = asTestRaw<McpRequestContext["scopedDb"]>(() => {
+  throw new Error(`database unavailable: ${DB_INTERNAL_LEAK_TOKEN}`);
+});
+
+const createRecordAuditEventMock = () =>
+  asTestRaw<AuditRecorder>(async () => undefined);
+
+// Owner role with one active, accessible workspace, so authorization and
+// workspace-access pre-checks pass and each handler advances to its first DB
+// call (the only thing that fails here).
+const createFailingDbContext = (): McpRequestContext => ({
+  accessibleWorkspaceIds: [toSafeId<"workspace">("ws_1")],
+  accessibleWorkspaceIdSet: new Set(["ws_1"]),
+  accessibleWorkspaceStatusById: new Map([["ws_1", "active"]]),
+  accessibleWorkspaces: [],
+  grantedScopes: [],
+  memberRole: "owner",
+  organizationId: toSafeId<"organization">("org_1"),
+  recordAuditEvent: createRecordAuditEventMock(),
+  safeDb: toSafeDbMock(throwingScopedDb),
+  scopedDb: throwingScopedDb,
+  userId: toSafeId<"user">("user_1"),
+});
+
+const asCallToolResult = (result: McpToolResponse) => {
+  if (isMcpEgressPlan(result)) {
+    throw new Error("expected a CallToolResult, got an egress plan");
+  }
+  return result;
+};
+
+// Assert the shared `internal_error` contract: the stable code, the generic
+// message (never the driver text), the feedback hint, and that the raw internal
+// detail is nowhere in the serialized payload.
+const expectInternalErrorEnvelope = (result: McpToolResponse) => {
+  const callResult = asCallToolResult(result);
+  expect(callResult.isError).toBe(true);
+
+  const first = callResult.content.at(0);
+  const text = first !== undefined && "text" in first ? first.text : "";
+  expect(text).not.toContain(DB_INTERNAL_LEAK_TOKEN);
+
+  expect(JSON.parse(text)).toEqual({
+    error: {
+      code: "internal_error",
+      message: "Tool execution failed",
+      hint: MCP_INTERNAL_ERROR_HINT,
+    },
+  });
+};
+
+// One representative write handler per affected tool module, each reaching a
+// `safeDb` / `Result.gen(() => handler(...))` DB call that fails. If any of
+// these regresses to `errorResult(x.error.message)` the leak assertion fails.
+const REPRESENTATIVE_DB_FAILURES: {
+  args: Record<string, unknown>;
+  file: string;
+  handler: McpToolHandler;
+}[] = [
+  {
+    file: "matter-tools.ts",
+    handler: MATTER_TOOL_HANDLERS.save_matter,
+    args: { name: "New matter" },
+  },
+  {
+    file: "billing-tools.ts",
+    handler: BILLING_TOOL_HANDLERS.resolve_rate,
+    args: { matter_id: "ws_1", user_id: "user_2", date: "2024-01-01" },
+  },
+  {
+    file: "document-tools.ts",
+    handler: DOCUMENT_TOOL_HANDLERS.save_document,
+    args: { matter_id: "ws_1", kind: "document", name: "Doc" },
+  },
+  {
+    file: "knowledge-tools.ts",
+    handler: KNOWLEDGE_TOOL_HANDLERS.save_clause,
+    args: {
+      title: "Indemnity",
+      body: [{ text: "The Supplier shall indemnify the Customer." }],
+    },
+  },
+  {
+    file: "research-admin-tools.ts",
+    handler: RESEARCH_ADMIN_TOOL_HANDLERS.manage_organization,
+    args: { action: "add_member", matter_id: "ws_1", user_id: "user_2" },
+  },
+];
+
+describe("MCP tool DB failures return a structured internal_error envelope", () => {
+  beforeEach(() => {
+    captureErrorMock.mockReset();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  for (const { args, file, handler } of REPRESENTATIVE_DB_FAILURES) {
+    test(`${file}: hides the driver message and captures the cause`, async () => {
+      const result = await handler({ args, context: createFailingDbContext() });
+
+      expectInternalErrorEnvelope(result);
+      // The real cause still reaches telemetry (captured, not surfaced).
+      expect(captureErrorMock).toHaveBeenCalled();
+      expect(captureErrorMock).toHaveBeenCalledWith(expect.anything(), {
+        source: "mcp",
+      });
+    });
+  }
+
+  test("internalFailureResult never echoes the internal error text", () => {
+    const result = internalFailureResult(
+      new Error(`unhandled: ${DB_INTERNAL_LEAK_TOKEN}`),
+    );
+
+    expect(result.isError).toBe(true);
+    const first = result.content.at(0);
+    const text = first !== undefined && "text" in first ? first.text : "";
+    expect(text).not.toContain(DB_INTERNAL_LEAK_TOKEN);
+    expect(JSON.parse(text)).toEqual({
+      error: {
+        code: "internal_error",
+        message: "Tool execution failed",
+        hint: MCP_INTERNAL_ERROR_HINT,
+      },
+    });
+    expect(captureErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+      source: "mcp",
+    });
+  });
+});
+
+// Structural class guard: no MCP tool module may feed a backing-handler `Result`
+// error message straight into a plain-text `errorResult`, which would leak the
+// internal text, drop the `error.code` the CLI branches on, and omit the request
+// receipt. `internalFailureResult(x.error)` is the sanctioned replacement.
+//
+// `template-tools.ts` is the one sanctioned exception: its fill/configure
+// services return curated `{ message }` domain rejections (e.g. an unknown field
+// path in the template manifest) that the MCP schema cannot pre-check, and those
+// messages are meant to reach the agent (pinned by template-tools.test.ts). It
+// keeps `errorResult(x.error.message)` deliberately.
+describe("no tool file leaks a Result error message into errorResult", () => {
+  const LEAK_PATTERN = /errorResult\(\s*\w+\.error\.message\s*\)/u;
+  const SURFACES_CURATED_SERVICE_MESSAGES = new Set(["template-tools.ts"]);
+
+  const toolFiles = readdirSync(import.meta.dir).filter(
+    (name) => name.endsWith("-tools.ts") && !name.endsWith(".test.ts"),
+  );
+
+  test("scans at least the known tool modules", () => {
+    // Guards the guard: an empty glob would make the invariant vacuously pass.
+    expect(toolFiles.length).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const file of toolFiles) {
+    const isException = SURFACES_CURATED_SERVICE_MESSAGES.has(file);
+    test(`${file} ${isException ? "keeps its curated service-message exception" : "routes DB failures through internalFailureResult"}`, () => {
+      const source = readFileSync(`${import.meta.dir}/${file}`, "utf8");
+      if (isException) {
+        // Pin the exception: if the leak pattern ever disappears here, revisit
+        // whether the allowlist entry is still warranted.
+        expect(source).toMatch(LEAK_PATTERN);
+        return;
+      }
+      expect(source).not.toMatch(LEAK_PATTERN);
+    });
+  }
+});

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -48,6 +48,7 @@ import {
   ensureActiveWorkspace,
   enumProp,
   errorResult,
+  internalFailureResult,
   intProp,
   nullableStringProp,
   stringProp,
@@ -877,7 +878,7 @@ const readClauseDetail = async ({
       }),
     );
     if (Result.isError(result)) {
-      return errorResult(result.error.message);
+      return internalFailureResult(result.error);
     }
     const version = result.value;
     // Fail-closed (P7): a malformed version body aborts before any push runs,
@@ -909,7 +910,7 @@ const readClauseDetail = async ({
     getClauseHandler({ safeDb: context.safeDb, organizationId, clauseId }),
   );
   if (Result.isError(result)) {
-    return errorResult(result.error.message);
+    return internalFailureResult(result.error);
   }
   const clause = { ...result.value, metadata: undefined };
   // title/description/usageNotes are queued unconditionally, matching the
@@ -1020,7 +1021,7 @@ const handleListClausesTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(listed)) {
-    return errorResult(listed.error.message);
+    return internalFailureResult(listed.error);
   }
   const clauses = listed.value.items;
 
@@ -1036,7 +1037,7 @@ const handleListClausesTool: McpToolHandler = async ({ args, context }) => {
         )
       : undefined;
   if (categoriesResult !== undefined && Result.isError(categoriesResult)) {
-    return errorResult(categoriesResult.error.message);
+    return internalFailureResult(categoriesResult.error);
   }
   const categories =
     categoriesResult !== undefined && !Result.isError(categoriesResult)
@@ -1239,7 +1240,7 @@ const handleSaveClauseTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(created)) {
-      return errorResult(created.error.message);
+      return internalFailureResult(created.error);
     }
     return textResult({ clauseId: created.value.id });
   }
@@ -1282,7 +1283,7 @@ const handleSaveClauseTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(updated)) {
-    return errorResult(updated.error.message);
+    return internalFailureResult(updated.error);
   }
   return textResult({ clauseId: updated.value.id });
 };
@@ -1316,7 +1317,7 @@ const handleDeleteClauseTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(deleted)) {
-    return errorResult(deleted.error.message);
+    return internalFailureResult(deleted.error);
   }
   return textResult({ deleted: true });
 };
@@ -1362,7 +1363,7 @@ const readPlaybookDetail = async ({
     }),
   );
   if (Result.isError(result)) {
-    return errorResult(result.error.message);
+    return internalFailureResult(result.error);
   }
   const playbook = result.value;
 
@@ -1410,7 +1411,7 @@ const handleListPlaybooksTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(listed)) {
-    return errorResult(listed.error.message);
+    return internalFailureResult(listed.error);
   }
   const items = listed.value.items;
 
@@ -1489,7 +1490,7 @@ const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
     });
   });
   if (Result.isError(txResult)) {
-    return errorResult(txResult.error.message);
+    return internalFailureResult(txResult.error);
   }
   const outcome = txResult.value;
   if (!outcome.ok) {

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -63,6 +63,7 @@ import {
   ensureWorkspaceAccess,
   enumProp,
   errorResult,
+  internalFailureResult,
   getWorkspaceStatus,
   intProp,
   MAX_LIST_LIMIT,
@@ -587,7 +588,7 @@ const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(created)) {
-      return errorResult(created.error.message);
+      return internalFailureResult(created.error);
     }
     return textResult({ matterId: created.value.id });
   }
@@ -648,7 +649,7 @@ const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(updated)) {
-      return errorResult(updated.error.message);
+      return internalFailureResult(updated.error);
     }
   }
 
@@ -661,7 +662,7 @@ const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(archived)) {
-      return errorResult(archived.error.message);
+      return internalFailureResult(archived.error);
     }
   } else if (input.status === "active") {
     const unarchived = await Result.gen(() =>
@@ -672,7 +673,7 @@ const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(unarchived)) {
-      return errorResult(unarchived.error.message);
+      return internalFailureResult(unarchived.error);
     }
   }
 
@@ -719,7 +720,7 @@ const handleDeleteMatterTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(deleted)) {
-    return errorResult(deleted.error.message);
+    return internalFailureResult(deleted.error);
   }
   return textResult({ deleted: true });
 };
@@ -829,7 +830,7 @@ const handleSaveContactTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(created)) {
-      return errorResult(created.error.message);
+      return internalFailureResult(created.error);
     }
     return textResult({ contactId: created.value.id });
   }
@@ -862,7 +863,7 @@ const handleSaveContactTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(updated)) {
-    return errorResult(updated.error.message);
+    return internalFailureResult(updated.error);
   }
   return textResult({ contactId: updated.value.id });
 };
@@ -896,7 +897,7 @@ const handleDeleteContactTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(deleted)) {
-    return errorResult(deleted.error.message);
+    return internalFailureResult(deleted.error);
   }
   return textResult({ deleted: true });
 };
@@ -931,7 +932,7 @@ const handleLookupBusinessRegistryTool: McpToolHandler = async ({
     q: parsed.output.query,
   });
   if (Result.isError(result)) {
-    return errorResult(result.error.message);
+    return internalFailureResult(result.error);
   }
   // Passthrough: the output is public business-register data and the query is
   // caller-supplied, so no tenant-authored text needs redaction.
@@ -1578,7 +1579,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(created)) {
-      return errorResult(created.error.message);
+      return internalFailureResult(created.error);
     }
     return textResult({ taskId: created.value.entityId });
   }
@@ -1635,7 +1636,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(updated)) {
-      return errorResult(updated.error.message);
+      return internalFailureResult(updated.error);
     }
   }
 
@@ -1650,7 +1651,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(added)) {
-      return errorResult(added.error.message);
+      return internalFailureResult(added.error);
     }
   }
 
@@ -1665,7 +1666,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(removed)) {
-      return errorResult(removed.error.message);
+      return internalFailureResult(removed.error);
     }
   }
 
@@ -1680,7 +1681,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(linked)) {
-      return errorResult(linked.error.message);
+      return internalFailureResult(linked.error);
     }
   }
 
@@ -1695,7 +1696,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
       }),
     );
     if (Result.isError(unlinked)) {
-      return errorResult(unlinked.error.message);
+      return internalFailureResult(unlinked.error);
     }
   }
 
@@ -1824,7 +1825,7 @@ const handleLinkMatterContactTool: McpToolHandler = async ({
       }),
     );
     if (Result.isError(removed)) {
-      return errorResult(removed.error.message);
+      return internalFailureResult(removed.error);
     }
     return textResult({ unlinked: true });
   }
@@ -1846,7 +1847,7 @@ const handleLinkMatterContactTool: McpToolHandler = async ({
     }),
   );
   if (Result.isError(created)) {
-    return errorResult(created.error.message);
+    return internalFailureResult(created.error);
   }
   return textResult({ workspaceContactId: created.value.id });
 };

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -34,6 +34,7 @@ import {
   ensureActiveWorkspace,
   enumProp,
   errorResult,
+  internalFailureResult,
   intProp,
   stringProp,
   structuredErrorResult,
@@ -400,7 +401,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
         catch: mapBoeError,
       });
       if (Result.isError(block)) {
-        return errorResult(block.error.message);
+        return internalFailureResult(block.error);
       }
       return textResult({ lawId, blockId, block: block.value });
     }
@@ -412,7 +413,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
         catch: mapBoeError,
       });
       if (Result.isError(related)) {
-        return errorResult(related.error.message);
+        return internalFailureResult(related.error);
       }
       return textResult(related.value);
     }
@@ -434,7 +435,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
       catch: mapBoeError,
     });
     if (Result.isError(detail)) {
-      return errorResult(detail.error.message);
+      return internalFailureResult(detail.error);
     }
     return textResult(detail.value);
   }
@@ -464,7 +465,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
     catch: mapBoeError,
   });
   if (Result.isError(result)) {
-    return errorResult(result.error.message);
+    return internalFailureResult(result.error);
   }
   // Passthrough: the output is public BOE statutory data and the query is
   // caller-supplied, so no tenant-authored text needs redaction.
@@ -555,7 +556,7 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
     }),
   );
   if (Result.isError(page)) {
-    return errorResult(page.error.message);
+    return internalFailureResult(page.error);
   }
   return textResult(page.value);
 };
@@ -672,7 +673,7 @@ const handleAddMember = async ({
     }),
   );
   if (Result.isError(added)) {
-    return errorResult(added.error.message);
+    return internalFailureResult(added.error);
   }
   return textResult({ memberId: added.value.id });
 };
@@ -702,7 +703,7 @@ const handleRemoveMember = async ({
     }),
   );
   if (Result.isError(removed)) {
-    return errorResult(removed.error.message);
+    return internalFailureResult(removed.error);
   }
   return textResult({ removed: true, id: removed.value.id });
 };
@@ -780,7 +781,7 @@ const handleManageOrganizationTool: McpToolHandler = async ({
     }),
   );
   if (Result.isError(updated)) {
-    return errorResult(updated.error.message);
+    return internalFailureResult(updated.error);
   }
   return textResult(updated.value);
 };

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -8,6 +8,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { getCurrentRequestId } from "@/api/lib/observability/request-context";
 import {
@@ -17,6 +18,7 @@ import {
 import type { McpRequestContext } from "@/api/mcp/context";
 import { getAccessibleWorkspaceId } from "@/api/mcp/context";
 import type { McpErrorCode, McpValidationIssue } from "@/api/mcp/error-codes";
+import { statusCodeToErrorCode } from "@/api/mcp/error-codes";
 
 /**
  * Wrap the request-scoped recorder so audit rows written by the reused backing
@@ -240,20 +242,34 @@ export const notFoundResult = (
   structuredErrorResult({ code: "not_found", hint, message });
 
 /**
- * `internal_error` envelope for a failed DB / backing-handler `Result`. The real
- * error (a `HandlerError`, `UnhandledException`, driver/ORM message, ...) is
- * captured for telemetry and never echoed back, so an internal message cannot
- * leak to an external agent; the caller gets the same generic, code-bearing
- * envelope the central pipeline's catch-all emits (see `handleMcpToolCall`), so
- * the companion CLI branches on `error.code` and the receipt is attached.
+ * Envelope for a failed backing-handler `Result`, the single sink for the
+ * `errorResult(result.error.message)` class. Every tool site that unwraps a
+ * `context.safeDb(...)` / `Result.gen(() => handler(...))` failure routes here
+ * instead of surfacing the raw `.message` as plain text. Pass `result.error`
+ * (the `Result` error), not its message, so the cause reaches `captureError`
+ * intact.
  *
- * This is the single sink for the `errorResult(result.error.message)` class:
- * every tool site that unwraps a `context.safeDb(...)` /
- * `Result.gen(() => handler(...))` failure routes through here instead of
- * surfacing the raw `.message` as plain text. Pass `result.error` (the `Result`
- * error), not its message, so the cause reaches `captureError` intact.
+ * The backing safe handlers return two distinct kinds of error, and they must
+ * not be conflated:
+ *  - An *expected* business failure is a `HandlerError` carrying a curated
+ *    message and a 4xx status (e.g. "date is in the future" = 400, "already
+ *    archived" = 409). An agent needs that message and a branchable code, so it
+ *    is surfaced with the status mapped to an envelope code and the handler's
+ *    own message preserved. It is *not* recorded as a telemetry error: it is
+ *    normal, caller-driven flow, not a fault.
+ *  - A genuine internal failure (a 5xx `HandlerError`, an `UnhandledException`
+ *    or `DatabaseError` from a driver/ORM throw, or any non-`HandlerError`) is
+ *    captured and returned as the same generic, code-bearing `internal_error`
+ *    envelope the central pipeline's catch-all emits (see `handleMcpToolCall`),
+ *    so no internal detail leaks to an external agent.
  */
 export const internalFailureResult = (error: unknown): CallToolResult => {
+  if (HandlerError.is(error)) {
+    const code = statusCodeToErrorCode(error.status);
+    if (code !== "internal_error") {
+      return structuredErrorResult({ code, message: error.message });
+    }
+  }
   captureError(error, { source: "mcp" });
   return structuredErrorResult({
     code: "internal_error",

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -4,6 +4,7 @@ import * as v from "valibot";
 
 import { env } from "@/api/env";
 import { createOrgTools } from "@/api/handlers/chat/tools/org-tools";
+import { captureError } from "@/api/lib/analytics/capture";
 import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -237,6 +238,29 @@ export const notFoundResult = (
   hint?: string,
 ): CallToolResult =>
   structuredErrorResult({ code: "not_found", hint, message });
+
+/**
+ * `internal_error` envelope for a failed DB / backing-handler `Result`. The real
+ * error (a `HandlerError`, `UnhandledException`, driver/ORM message, ...) is
+ * captured for telemetry and never echoed back, so an internal message cannot
+ * leak to an external agent; the caller gets the same generic, code-bearing
+ * envelope the central pipeline's catch-all emits (see `handleMcpToolCall`), so
+ * the companion CLI branches on `error.code` and the receipt is attached.
+ *
+ * This is the single sink for the `errorResult(result.error.message)` class:
+ * every tool site that unwraps a `context.safeDb(...)` /
+ * `Result.gen(() => handler(...))` failure routes through here instead of
+ * surfacing the raw `.message` as plain text. Pass `result.error` (the `Result`
+ * error), not its message, so the cause reaches `captureError` intact.
+ */
+export const internalFailureResult = (error: unknown): CallToolResult => {
+  captureError(error, { source: "mcp" });
+  return structuredErrorResult({
+    code: "internal_error",
+    message: "Tool execution failed",
+    hint: MCP_INTERNAL_ERROR_HINT,
+  });
+};
 
 /**
  * Up to `limit` known tool names closest to `target` by Levenshtein distance,


### PR DESCRIPTION
## Summary

MCP tool handlers that unwrap a failed DB / backing-handler `Result` were returning the raw `.error.message` as plain text. That broke the structured-error contract on exactly the failure class where it matters most: no `error.code` for clients to branch on (the CLI's exit-code map falls through to the generic server-error exit), no `requestId` receipt for tracing, and internal driver/ORM message text echoed to external clients.

- Adds a single sink `internalFailureResult(error)` in `tool-utils.ts`: captures the real cause for telemetry, returns the same generic `internal_error` envelope the central pipeline's catch-all emits (stable code, hint, request-id receipt), and never echoes internal text.
- Migrates all 52 affected sites across `matter-tools`, `document-tools`, `knowledge-tools`, `research-admin-tools`, and `billing-tools` onto it.
- `template-tools.ts` is deliberately excluded: its two `.error.message` sites surface curated domain rejections from the template services (pinned by existing tests as intentionally agent-facing), not internal failures. Splitting that service's DB-outage subcase from its business messages needs error-type branching at the service boundary; left as a follow-up.
- New `internal-failure-envelope.test.ts` (18 tests): a representative DB failure per converted module asserting the envelope shape, that injected internal text never leaks into output, and that the cause is captured; plus a static class guard scanning every `*-tools.ts` so no new `errorResult(x.error.message)` site can land (template's exception is an explicit allowlist entry the test also pins).

Verified with the MCP-scoped `apps/api` suite (404 pass, 0 fail).