### PR TITLE
feat(mcp): declare idempotent and open-world tool annotations

### DIFF
--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -600,7 +600,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\\"tenant.name\\": \\"ACME Sp. z o.o.\\", \\"signing_date\\": \\"2026-06-08\\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Returns the rendered text and any placeholders left unfilled.",
     "annotations": {
       "idempotentHint": false,
-      "openWorldHint": false
+      "openWorldHint": true
     },
     "inputSchema": {
       "type": "object",

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -8,7 +8,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Search knowledge across accessible matters using the OpenAI-compatible search tool shape. Returns results with id, title, and url for follow-up fetch calls.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -35,7 +36,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Fetch a knowledge document by id using the OpenAI-compatible fetch tool shape. Use ids returned by the search tool. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -61,7 +63,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the matters you can access, or get one matter's overview. Omit matter_id to list accessible matters (filter with status, page with cursor); list first when the user does not name a matter or you need matter IDs for follow-up tools. Pass matter_id to return that matter's overview instead: counts, recent entities, linked contacts, and members.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -98,7 +101,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Search across all accessible matters. Use this when the user explicitly asks to search outside a single matter or you do not yet know the right matter.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -132,7 +136,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search the shared case-law corpus. Supports free-text search plus optional filters such as court, country, language, date range, and decision type.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -200,7 +205,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read extracted text from a document found anywhere in your accessible matters. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -227,7 +233,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Read a single case-law decision by its decision ID. Returns metadata, plain text, citation links, and source URLs. Long decision text and large citation lists are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -253,7 +260,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read a contact by ID. Use this after matter overview or entity metadata surfaces a contact the user wants to inspect more closely.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -273,6 +281,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:onboarding",
     "access": "write",
     "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {countryCode, isPrimary}; exactly one entry should be primary.",
+    "annotations": {
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -563,7 +575,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -585,6 +598,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:templates",
     "access": "write",
     "description": "Fill a template with values and return the assembled document text plus the filled DOCX as base64. Call list_templates with a template_id first to learn the field paths. 'values' maps each field path to its value, e.g. {\\"tenant.name\\": \\"ACME Sp. z o.o.\\", \\"signing_date\\": \\"2026-06-08\\"}. Registry lookups, composite fields, formula fields, and AI-fillable fields are resolved automatically; AI-fillable fields are drafted when you omit them. Returns the rendered text and any placeholders left unfilled.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -609,6 +626,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:templates",
     "access": "write",
     "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and you can pass fields to configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Each fields entry's path must match a {{marker}} in the template. Read the marker grammar from the template-markers reference resource when unsure. Returns the template id and field count when creating, or the updated field list when configuring.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -772,7 +793,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -816,7 +838,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -853,6 +876,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:documents_write",
     "access": "write",
     "description": "Create a document or folder, or update an existing one. Omit entity_id to create: pass matter_id and name, optionally a parent_id folder and kind ('document' by default, or 'folder'). Creating makes an empty named entity; uploading file content is a separate step. Pass entity_id to update: set name to rename; parent_id to move it into a folder or move_to_root to move it to the matter root; version_id with label and/or description to annotate a version. An update needs at least one change. Returns the entity ID.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -914,7 +941,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Delete a document and all its versions, or delete a single version when version_id is provided (the current version is promoted to the next latest; the only remaining version cannot be deleted). This is irreversible.",
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -943,7 +972,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the property (column) definitions of a matter. Returns each property's id, name, value type (text, single-select, multi-select, date, or int), and status. Use the returned property id with set_field_value to set a document's value for that property.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -974,6 +1004,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:documents_write",
     "access": "write",
     "description": "Set a document's value for a property (a cell in the matter's table). Pass the document entity_id, the property_id (from list_properties), and a content object whose 'type' matches the property's value type: text (value: string), single-select (value: string or null), multi-select (value: array of strings), date (value: ISO YYYY-MM-DD or null), or int (value: integer, optional currency: 3-letter ISO code). An empty value clears the cell.",
+    "annotations": {
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1027,6 +1061,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:matters_write",
     "access": "write",
     "description": "Create, update, archive, or unarchive a matter. Omit matter_id to create a new matter (name required; pass client_id to attach a client contact). Pass matter_id to update an existing matter: set name, reference, or billing_reference, and/or set status to 'archived' or 'active' to archive or unarchive it. Returns the matter ID.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1073,7 +1111,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Permanently delete a matter and all its documents, tasks, fields, and chat history. This is irreversible.",
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1097,6 +1137,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:matters_write",
     "access": "write",
     "description": "Create or update a contact (a person or organization in the address book, shared across the whole organization). Omit contact_id to create (type and display_name required); pass contact_id to update. String fields other than display_name accept null to clear them.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1157,7 +1201,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Permanently delete a contact from the organization address book. Rejected while the contact is still the client of any matter. This is irreversible.",
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1182,7 +1228,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Look up a company in a public business register (ARES, Brreg, Companies House, EDGAR, GCIS, KRS, ORSR, PRH, recherche-entreprises, or VIES). Pass a canonical identifier (company/registration number, VAT number) for an exact match, or a company name to search where the register supports it. Returns registered names, addresses, and registry-specific details.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": true
     },
     "inputSchema": {
       "type": "object",
@@ -1222,7 +1269,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each task's id, name, status, priority, and due date.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1269,6 +1317,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:matters_write",
     "access": "write",
     "description": "Create or update a task, and manage its assignees and entity links. Omit task_id to create a task (matter_id and name required). Pass task_id to update: set name, status, priority, or due_date (ISO YYYY-MM-DD, null to clear); add or remove one assignee (add_assignee_user_id / remove_assignee_user_id); link the task to another entity (link_entity_id) or remove a link (unlink_link_id). Returns the task ID.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1327,6 +1379,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:matters_write",
     "access": "write",
     "description": "Link a contact to a matter in a party role (opposing party/counsel, co-counsel, witness, expert witness, third party, judge, mediator, or other), or remove such a link. Pass contact_id with role to link. To unlink, pass workspace_contact_id (precise, from list_matters) or contact_id alone; contact_id alone is rejected when the contact holds several roles on the matter.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1369,7 +1425,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the clause library for this organization, or read one clause in detail. Pass clause_id to get a clause's body, description, usage notes, variants, and version history; add version_id to read one version's body. Otherwise list clauses (newest first), optionally filtered by category_id or a text query, and set include_categories to also return the category tree. Returns each clause's id, title, category, language, and current version.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1413,6 +1470,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:knowledge_write",
     "access": "write",
     "description": "Create or update a clause in the organization's clause library. Omit clause_id to create (title and body required); pass clause_id to update. body is an ordered array of paragraphs, each with text and optional formatting. category_id, language, description, usage_notes, and metadata accept null to clear them on update. Set snapshot_version true on an update to also append a version snapshot of the body. Returns the clause id.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1557,7 +1618,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Permanently delete a clause and all its variants and versions from the organization's clause library. This is irreversible.",
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1582,7 +1645,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "List the review playbooks in this organization, or read one in detail. Pass playbook_id to get a playbook's positions (the issues it reviews, their questions, tiered rules, and ideal language), scope, and description. Otherwise list playbooks (newest first). Returns each playbook's id, name, and description.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1610,6 +1674,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:knowledge_write",
     "access": "write",
     "description": "Run a review playbook over a matter's documents. Materializes the playbook's extraction and verdict columns onto the matter's table and starts the AI review; findings populate asynchronously. Pass matter_id and playbook_id. Returns the number of columns queued for review.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1635,7 +1703,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1696,6 +1765,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "feature": "FEATURE_TIME_BILLING",
     "description": "Create or update a time entry. Omit time_entry_id to create (matter_id, entity_id, date_worked, timezone_id, duration_minutes, rate_at_entry, currency, and narrative all required). Pass time_entry_id to update: set date_worked, duration_minutes, narrative, invoice_narrative, billable, no_charge, entity_id (move the entry), task_code, activity_code, rate_at_entry, currency, and/or status (draft or approved). Rates and amounts are integer minor currency units (e.g. cents); durations are whole minutes. Returns the time entry ID.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1791,7 +1864,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "Delete a time entry. A draft entry is permanently deleted; an approved entry is written off instead (kept for the audit trail, excluded from billing). A billed entry cannot be deleted until its invoice is reverted. Returns whether the entry was hard-deleted.",
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1817,7 +1892,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1850,7 +1926,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_TIME_BILLING",
     "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1884,7 +1961,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_USAGE",
     "description": "Read the organization's current usage entitlement: plan, seats, billing period, and how many usage units (AI credits) remain this period. Returns { entitlement: null } when the organization has no active plan. Requires organization-settings management access.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -1898,7 +1976,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search and read Spanish consolidated legislation from the BOE. In search mode, pass query (free text) and/or filters (title, department_code, legal_range_code, matter_code, date_from/date_to as YYYYMMDD); at least one filter is required. In read mode, pass law_id (e.g. BOE-A-1889-4763) to return the law with its block structure; add full_text to include the consolidated text, block_id to return one text block, or relation_type to list related laws instead. Returns public statutory data.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": true
     },
     "inputSchema": {
       "type": "object",
@@ -1982,7 +2061,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "read",
     "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by workspace_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2036,6 +2116,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:admin_write",
     "access": "write",
     "description": "Administer the organization (owner/admin actions). Set action to add_member or remove_member to add/remove a workspace member (matter_id and user_id required); or update_org_settings to change non-secret organization settings: matter_number_pattern with matter_number_padding (sent together) and/or prompt_caching_enabled. Provider API keys and other secrets are managed only in the dashboard, not here.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -2086,6 +2170,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:feedback",
     "access": "write",
     "description": "File a bug, feature request, or docs issue with the stella maintainers. Requires explicit human approval; the tool never publishes anything on its own. It returns a prefilled new-issue URL and a gh command the human opens and submits under their own GitHub account. All content is sanitized server-side (emails, ids, secrets, URLs, IPs are redacted). Never include tenant data, client or matter names, ids, or secrets; describe the problem, reproduction steps, and expected vs actual result.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": true
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -2129,6 +2217,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:read",
     "access": "read",
     "description": "List the automatable capabilities beyond the curated tools: every safe backend operation (CRUD, exports, processing triggers) reachable through invoke_capability. Paginated; filter by domain (the id prefix, e.g. \\"time-entries\\") or access (read/write). Each item gives the capability id, a one-line summary, and the OAuth scope it needs. Use describe_capability for the full input schema.",
+    "annotations": {
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -2164,6 +2255,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:read",
     "access": "read",
     "description": "Describe one capability in full: its live input JSON Schema (body/params/query), required OAuth scope, member permissions, whether it is destructive, its handler kind (workspace/root), and its disposition. Call this before invoke_capability to learn exactly what input to pass.",
+    "annotations": {
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -2183,6 +2277,10 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "scope": "stella:read",
     "access": "write",
     "description": "Invoke one capability by id (from list_capabilities/describe_capability). Pass its input under { body, params, query }; workspace-scoped capabilities take the target workspace as input.params.workspaceId. Real authority is enforced per capability: the session must hold the capability's scope and your member role its permissions. Set validateOnly: true to check input without running it; destructive capabilities require confirm: true after human approval.",
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
+    },
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -2238,7 +2336,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Search anonymized knowledge across accessible matters using the OpenAI-compatible search tool shape. Returns anonymized titles with ids and urls for follow-up fetch calls.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2265,7 +2364,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Fetch anonymized document text by id using the OpenAI-compatible fetch tool shape. Use ids returned by the anonymized search tool. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2291,7 +2391,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the matters you can access, or get one matter's overview. Omit matter_id to list accessible matters (filter with status, page with cursor); list first when the user does not name a matter or you need matter IDs for follow-up tools. Pass matter_id to return that matter's overview instead: counts, recent entities, linked contacts, and members.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2328,7 +2429,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Search across all accessible matters. Use this when the user explicitly asks to search outside a single matter or you do not yet know the right matter.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2362,7 +2464,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search the shared case-law corpus. Supports free-text search plus optional filters such as court, country, language, date range, and decision type.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2430,7 +2533,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Read extracted text from a document found anywhere in your accessible matters. Use after search_across_matters. Long documents are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2457,7 +2561,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Read a single case-law decision by its decision ID. Returns metadata, plain text, citation links, and source URLs. Long decision text and large citation lists are returned in windows; pass the returned nextCursor back as cursor to read more.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2483,7 +2588,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Read a contact by ID. Use this after matter overview or entity metadata surfaces a contact the user wants to inspect more closely.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2504,7 +2610,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration (path, label, inputType, required, hint, options, optionsFrom, aiPrompt / aiAdapt, date format, composite parts, registry-lookup formats) plus its named conditions and formula fields; feed the same shape to save_template to update it.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2527,7 +2634,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the documents and folders in a matter. Use 'flat' mode to enumerate every document and folder in the matter, or 'children' mode to walk the folder tree one level at a time (pass parent_id to list a folder's direct children, or omit it for the matter root). Returns each entity's id, name, kind (document or folder), and parentId. Read a document's metadata, fields, or versions with read_document.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2571,7 +2679,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Read a document's metadata and field values by entity ID. By default returns the current version's name, kind, and field/property values. Pass version_id to inspect a specific version instead. Pass version_id and compare_with_version_id to get a plain-text line diff between two versions. Pass include_versions to also return the version history. To read the document's extracted text content, use read_content_across_matters.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2609,7 +2718,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the property (column) definitions of a matter. Returns each property's id, name, value type (text, single-select, multi-select, date, or int), and status. Use the returned property id with set_field_value to set a document's value for that property.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2641,7 +2751,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "Look up a company in a public business register (ARES, Brreg, Companies House, EDGAR, GCIS, KRS, ORSR, PRH, recherche-entreprises, or VIES). Pass a canonical identifier (company/registration number, VAT number) for an exact match, or a company name to search where the register supports it. Returns registered names, addresses, and registry-specific details.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": true
     },
     "inputSchema": {
       "type": "object",
@@ -2681,7 +2792,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List tasks in a matter, or read one task in detail. Pass task_id to get a single task's fields, assignees, and linked entities. Otherwise pass matter_id to list the matter's tasks, optionally filtered by a due-date range (date_from/date_to, ISO YYYY-MM-DD) and status. Returns each task's id, name, status, priority, and due date.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2729,7 +2841,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the clause library for this organization, or read one clause in detail. Pass clause_id to get a clause's body, description, usage notes, variants, and version history; add version_id to read one version's body. Otherwise list clauses (newest first), optionally filtered by category_id or a text query, and set include_categories to also return the category tree. Returns each clause's id, title, category, language, and current version.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2774,7 +2887,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "access": "read",
     "description": "List the review playbooks in this organization, or read one in detail. Pass playbook_id to get a playbook's positions (the issues it reviews, their questions, tiered rules, and ideal language), scope, and description. Otherwise list playbooks (newest first). Returns each playbook's id, name, and description.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2804,7 +2918,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_TIME_BILLING",
     "description": "List time entries in a matter, or read one entry in detail. Pass time_entry_id to get a single entry. Otherwise pass matter_id to list the matter's entries, optionally filtered by entity_id (the item the time was logged against), user_id, a date-worked range (date_from/date_to, ISO YYYY-MM-DD), and status. Returns each entry's id, entity, user, date, minutes, rate (minor currency units), currency, narrative, and status.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2866,7 +2981,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_TIME_BILLING",
     "description": "Resolve the effective hourly rate for a user on a given date in a matter, using the matter's default rate table (user-specific rate first, then the table default). Returns the hourly rate in integer minor currency units (e.g. cents) and the currency, or nulls when no rate applies.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2899,7 +3015,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_TIME_BILLING",
     "description": "List invoices in a matter, or read one invoice in detail. Pass invoice_id to get a single invoice with its line items (time entries and expenses). Otherwise pass matter_id to list the matter's invoices. Returns each invoice's id, number, reference, status, dates, currency, and total (integer minor currency units).",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2933,7 +3050,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_USAGE",
     "description": "Read the organization's current usage entitlement: plan, seats, billing period, and how many usage units (AI credits) remain this period. Returns { entitlement: null } when the organization has no active plan. Requires organization-settings management access.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     },
     "inputSchema": {
       "type": "object",
@@ -2947,7 +3065,8 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "feature": "FEATURE_PUBLIC_LAW",
     "description": "Search and read Spanish consolidated legislation from the BOE. In search mode, pass query (free text) and/or filters (title, department_code, legal_range_code, matter_code, date_from/date_to as YYYYMMDD); at least one filter is required. In read mode, pass law_id (e.g. BOE-A-1889-4763) to return the law with its block structure; add full_text to include the consolidated text, block_id to return one text block, or relation_type to list related laws instead. Returns public statutory data.",
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": true
     },
     "inputSchema": {
       "type": "object",

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -2279,7 +2279,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "description": "Invoke one capability by id (from list_capabilities/describe_capability). Pass its input under { body, params, query }; workspace-scoped capabilities take the target workspace as input.params.workspaceId. Real authority is enforced per capability: the session must hold the capability's scope and your member role its permissions. Set validateOnly: true to check input without running it; destructive capabilities require confirm: true after human approval.",
     "annotations": {
       "idempotentHint": false,
-      "openWorldHint": false
+      "openWorldHint": true
     },
     "inputSchema": {
       "type": "object",

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -282,7 +282,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {countryCode, isPrimary}; exactly one entry should be primary.",
     "annotations": {
-      "idempotentHint": true,
+      "idempotentHint": false,
       "openWorldHint": false
     },
     "inputSchema": {
@@ -1005,7 +1005,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "access": "write",
     "description": "Set a document's value for a property (a cell in the matter's table). Pass the document entity_id, the property_id (from list_properties), and a content object whose 'type' matches the property's value type: text (value: string), single-select (value: string or null), multi-select (value: array of strings), date (value: ISO YYYY-MM-DD or null), or int (value: integer, optional currency: 3-letter ISO code). An empty value clears the cell.",
     "annotations": {
-      "idempotentHint": true,
+      "idempotentHint": false,
       "openWorldHint": false
     },
     "inputSchema": {

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -289,7 +289,7 @@ const INVOICE_DETAIL_TEXT_FIELD_PATHS = deriveTextFieldPaths(
 
 export const BILLING_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List time entries in a matter, or read one entry in detail. Pass " +
       "time_entry_id to get a single entry. Otherwise pass matter_id to list " +
@@ -421,6 +421,7 @@ export const BILLING_TOOL_DEFINITIONS = [
         ),
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     feature: "FEATURE_TIME_BILLING",
@@ -428,7 +429,11 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:billing_write",
   },
   {
-    annotations: { destructiveHint: true },
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description:
       "Delete a time entry. A draft entry is permanently deleted; an approved " +
       "entry is written off instead (kept for the audit trail, excluded from " +
@@ -449,7 +454,7 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:billing_write",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Resolve the effective hourly rate for a user on a given date in a " +
       "matter, using the matter's default rate table (user-specific rate " +
@@ -474,7 +479,7 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List invoices in a matter, or read one invoice in detail. Pass " +
       "invoice_id to get a single invoice with its line items (time entries " +
@@ -512,7 +517,7 @@ export const BILLING_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Read the organization's current usage entitlement: plan, seats, billing " +
       "period, and how many usage units (AI credits) remain this period. " +

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -1136,7 +1136,14 @@ const CAPABILITY_TOOL_DEFINITIONS = [
     },
   },
   {
-    annotations: { idempotentHint: false, openWorldHint: false },
+    // openWorldHint: true because the target capability is selected at
+    // runtime by id, and the catalog includes contacts.business-registries-
+    // lookup, which reaches the shared business-registry dispatch (ARES,
+    // KRS, ORSR, ...) the same external interaction matter-tools.ts's company
+    // lookup and template-tools.ts's fill_template declare open-world for;
+    // the hint is static per tool, so it must cover that reachable case even
+    // though most capabilities never leave the closed Stella domain.
+    annotations: { idempotentHint: false, openWorldHint: true },
     name: "invoke_capability",
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -1083,6 +1083,7 @@ export const mapHandlerResult = ({
 
 const CAPABILITY_TOOL_DEFINITIONS = [
   {
+    annotations: { openWorldHint: false },
     name: "list_capabilities",
     access: "read",
     anonymized: { exposure: "excluded", reason: "dynamic_tenant_payload" },
@@ -1113,6 +1114,7 @@ const CAPABILITY_TOOL_DEFINITIONS = [
     },
   },
   {
+    annotations: { openWorldHint: false },
     name: "describe_capability",
     access: "read",
     anonymized: { exposure: "excluded", reason: "dynamic_tenant_payload" },
@@ -1134,6 +1136,7 @@ const CAPABILITY_TOOL_DEFINITIONS = [
     },
   },
   {
+    annotations: { idempotentHint: false, openWorldHint: false },
     name: "invoke_capability",
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -230,7 +230,7 @@ const getCompatFetchPayload = ({
 
 export const COMPAT_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     access: "read",
     anonymized: {
       exposure: "anonymize",
@@ -259,7 +259,7 @@ export const COMPAT_TOOL_DEFINITIONS = [
     scope: "stella:search",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     access: "read",
     anonymized: {
       exposure: "anonymize",

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -661,7 +661,11 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
       },
       required: ["entity_id", "property_id", "content"],
     },
-    annotations: { idempotentHint: true, openWorldHint: false },
+    // Not idempotent: upsertFieldHandler unconditionally deletes/reinserts and
+    // reindexes the cell and records a fresh audit event + updatedAt bump on
+    // every call, so a repeat with identical args has an observable additional
+    // effect (a duplicate audit entry) in this compliance context.
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "set_field_value",

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -431,7 +431,7 @@ const READ_DOCUMENT_TEXT_FIELD_PATHS = [
 
 export const DOCUMENT_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List the documents and folders in a matter. Use 'flat' mode to " +
       "enumerate every document and folder in the matter, or 'children' mode " +
@@ -476,7 +476,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Read a document's metadata and field values by entity ID. By default " +
       "returns the current version's name, kind, and field/property values. " +
@@ -560,13 +560,18 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
         ),
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_document",
     scope: "stella:documents_write",
   },
   {
-    annotations: { destructiveHint: true },
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description:
       "Delete a document and all its versions, or delete a single version when " +
       "version_id is provided (the current version is promoted to the next " +
@@ -589,7 +594,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     scope: "stella:documents_write",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List the property (column) definitions of a matter. Returns each " +
       "property's id, name, value type (text, single-select, multi-select, " +
@@ -656,6 +661,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
       },
       required: ["entity_id", "property_id", "content"],
     },
+    annotations: { idempotentHint: true, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "set_field_value",

--- a/apps/api/src/mcp/feedback-tools.ts
+++ b/apps/api/src/mcp/feedback-tools.ts
@@ -67,6 +67,7 @@ export const FEEDBACK_TOOL_DEFINITIONS = [
       },
       required: ["kind", "title", "body"],
     },
+    annotations: { idempotentHint: false, openWorldHint: true },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "send_feedback",

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -606,7 +606,7 @@ const playbookDetailTextFieldSpecs = (
 
 export const KNOWLEDGE_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List the clause library for this organization, or read one clause in " +
       "detail. Pass clause_id to get a clause's body, description, usage notes, " +
@@ -694,13 +694,18 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
         },
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_clause",
     scope: "stella:knowledge_write",
   },
   {
-    annotations: { destructiveHint: true },
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description:
       "Permanently delete a clause and all its variants and versions from the " +
       "organization's clause library. This is irreversible.",
@@ -718,7 +723,7 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
     scope: "stella:knowledge_write",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List the review playbooks in this organization, or read one in detail. " +
       "Pass playbook_id to get a playbook's positions (the issues it reviews, " +
@@ -767,6 +772,7 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
       },
       required: ["matter_id", "playbook_id"],
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "run_playbook",

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -241,13 +241,18 @@ export const MATTER_TOOL_DEFINITIONS = [
         ),
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_matter",
     scope: "stella:matters_write",
   },
   {
-    annotations: { destructiveHint: true },
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description:
       "Permanently delete a matter and all its documents, tasks, fields, and " +
       "chat history. This is irreversible.",
@@ -292,13 +297,18 @@ export const MATTER_TOOL_DEFINITIONS = [
         notes: nullableStringProp("Free-text notes; pass null to clear"),
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_contact",
     scope: "stella:matters_write",
   },
   {
-    annotations: { destructiveHint: true },
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description:
       "Permanently delete a contact from the organization address book. " +
       "Rejected while the contact is still the client of any matter. This is " +
@@ -317,7 +327,7 @@ export const MATTER_TOOL_DEFINITIONS = [
     scope: "stella:matters_write",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: true },
     description:
       "Look up a company in a public business register (ARES, Brreg, " +
       "Companies House, EDGAR, GCIS, KRS, ORSR, PRH, recherche-entreprises, " +
@@ -345,7 +355,7 @@ export const MATTER_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List tasks in a matter, or read one task in detail. Pass task_id to " +
       "get a single task's fields, assignees, and linked entities. Otherwise " +
@@ -426,6 +436,7 @@ export const MATTER_TOOL_DEFINITIONS = [
         unlink_link_id: stringProp("Entity-link ID to remove"),
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_task",
@@ -457,6 +468,7 @@ export const MATTER_TOOL_DEFINITIONS = [
       },
       required: ["matter_id"],
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "link_matter_contact",

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -208,6 +208,79 @@ describe("MCP registry access coherence", () => {
   });
 });
 
+/**
+ * The two behavioural MCP annotations (`openWorldHint`, `idempotentHint`) must
+ * be declared coherently with each tool's `access` classification, so an agent
+ * client reasoning off the hints can never be misled by a missing or
+ * contradictory declaration. Like the access-coherence block above, these are
+ * deterministic cross-checks over the static registry: a new tool that omits
+ * `openWorldHint`, forgets `idempotentHint` on a write, declares it on a read,
+ * or ships a `delete_*` that is not idempotent fails the build.
+ */
+describe("MCP registry annotation coherence", () => {
+  test("every tool declares openWorldHint explicitly (boolean)", () => {
+    for (const tool of defaultTools) {
+      expect(
+        typeof tool.annotations?.openWorldHint,
+        `Tool ${tool.name} must declare annotations.openWorldHint explicitly`,
+      ).toBe("boolean");
+    }
+  });
+
+  test('every access: "write" tool declares idempotentHint explicitly (boolean)', () => {
+    for (const tool of defaultTools) {
+      if (tool.access !== "write") {
+        continue;
+      }
+      expect(
+        typeof tool.annotations?.idempotentHint,
+        `Tool ${tool.name} is access: "write" but does not declare annotations.idempotentHint`,
+      ).toBe("boolean");
+    }
+  });
+
+  test('read-only (access: "read") tools do not declare idempotentHint', () => {
+    for (const tool of defaultTools) {
+      if (tool.access !== "read") {
+        continue;
+      }
+      expect(
+        tool.annotations?.idempotentHint,
+        `Tool ${tool.name} is access: "read"; idempotentHint is meaningless and must be omitted`,
+      ).toBeUndefined();
+    }
+  });
+
+  test("every delete_* tool is idempotentHint true", () => {
+    for (const tool of defaultTools) {
+      if (!tool.name.startsWith("delete_")) {
+        continue;
+      }
+      expect(
+        tool.annotations?.idempotentHint,
+        `Tool ${tool.name} is a delete_* tool and must be idempotentHint true`,
+      ).toBe(true);
+    }
+  });
+
+  test("the anonymized projection carries annotations through unchanged", () => {
+    const defaultByName = new Map(
+      defaultTools.map((tool) => [tool.name, tool]),
+    );
+    for (const tool of anonymizedTools) {
+      const source = defaultByName.get(tool.name);
+      expect(
+        source,
+        `Anonymized tool ${tool.name} has no default-surface counterpart`,
+      ).toBeDefined();
+      expect(
+        tool.annotations,
+        `Anonymized tool ${tool.name} annotations diverge from the default surface`,
+      ).toEqual(source?.annotations);
+    }
+  });
+});
+
 describe("MCP static tool-set coherence", () => {
   test("each static tool set binds exactly one handler per advertised definition", () => {
     for (const toolSet of DEFAULT_MCP_TOOL_SETS) {

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -9,7 +9,7 @@ import {
   ANONYMIZED_MCP_TOOL_DEFINITIONS,
   DEFAULT_MCP_TOOL_DEFINITIONS,
 } from "@/api/mcp/static-tool-definitions";
-import type { McpToolResponse } from "@/api/mcp/tool-types";
+import type { McpToolDefinition, McpToolResponse } from "@/api/mcp/tool-types";
 import { isMcpEgressPlan } from "@/api/mcp/tool-types";
 import { listMcpTools } from "@/api/mcp/tools";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
@@ -236,9 +236,12 @@ describe("manage_organization per-action validation", () => {
 
 describe("manage_organization remove_member confirm gate", () => {
   test("the tool is not marked destructiveHint (so the central gate skips it)", () => {
-    const def = DEFAULT_MCP_TOOL_DEFINITIONS.find(
-      (tool) => tool.name === "manage_organization",
-    );
+    // Widen to the SDK annotations shape (the `as const` registry element types
+    // annotations to only the keys manage_organization declares, which omits
+    // destructiveHint) so the assertion below can read the hint it must be absent.
+    const definitions: readonly McpToolDefinition[] =
+      DEFAULT_MCP_TOOL_DEFINITIONS;
+    const def = definitions.find((tool) => tool.name === "manage_organization");
     expect(def).toBeDefined();
     // manage_organization also adds members and updates settings, so it must not
     // trip the whole-tool central confirm gate: it carries no destructiveHint.

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -241,9 +241,11 @@ describe("manage_organization remove_member confirm gate", () => {
     );
     expect(def).toBeDefined();
     // manage_organization also adds members and updates settings, so it must not
-    // trip the whole-tool central confirm gate: it carries no annotations block
-    // at all. The remove_member gate is action-level inside the handler instead.
-    expect("annotations" in (def ?? {})).toBe(false);
+    // trip the whole-tool central confirm gate: it carries no destructiveHint.
+    // The remove_member gate is action-level inside the handler instead. (It
+    // does carry the behavioural idempotent/open-world hints like every write
+    // tool; only destructiveHint drives the central gate.)
+    expect(def?.annotations?.destructiveHint).not.toBe(true);
   });
 
   test("remove_member without confirm is refused with confirmation_required", async () => {

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -71,7 +71,7 @@ const MANAGE_ORG_ACTIONS = [
 
 export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: true },
     description:
       "Search and read Spanish consolidated legislation from the BOE. In " +
       "search mode, pass query (free text) and/or filters (title, " +
@@ -144,7 +144,7 @@ export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Read the organization's audit trail (compliance view). Returns audit " +
       "entries newest first, each with its action, resource type and id, actor " +
@@ -229,6 +229,7 @@ export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
       },
       required: ["action"],
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "manage_organization",

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -661,7 +661,11 @@ export const STELLA_TOOL_DEFINITIONS = [
       },
       required: ["jurisdictions"],
     },
-    annotations: { idempotentHint: true, openWorldHint: false },
+    // Not idempotent: the handler records a fresh audit event and bumps
+    // updatedAt on every call even when the jurisdictions are unchanged, so a
+    // repeat with identical args has an observable additional effect (a
+    // duplicate audit entry) in this compliance context.
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "set_practice_jurisdictions",

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -435,7 +435,7 @@ const buildContactTextFieldSpecs = (
 
 export const STELLA_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List the matters you can access, or get one matter's overview. Omit " +
       "matter_id to list accessible matters (filter with status, page with " +
@@ -474,7 +474,7 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Search across all accessible matters. Use this when the user explicitly " +
       "asks to search outside a single matter or you do not yet know the right matter.",
@@ -504,7 +504,7 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:search",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Search the shared case-law corpus. Supports free-text search plus " +
       "optional filters such as court, country, language, date range, and " +
@@ -550,7 +550,7 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:search",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Read extracted text from a document found anywhere in your accessible " +
       "matters. Use after search_across_matters. Long documents are returned " +
@@ -577,7 +577,7 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Read a single case-law decision by its decision ID. Returns metadata, " +
       "plain text, citation links, and source URLs. Long decision text and " +
@@ -603,7 +603,7 @@ export const STELLA_TOOL_DEFINITIONS = [
     scope: "stella:read",
   },
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "Read a contact by ID. Use this after matter overview or entity metadata " +
       "surfaces a contact the user wants to inspect more closely.",
@@ -661,6 +661,7 @@ export const STELLA_TOOL_DEFINITIONS = [
       },
       required: ["jurisdictions"],
     },
+    annotations: { idempotentHint: true, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "set_practice_jurisdictions",

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -419,7 +419,13 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       },
       required: ["template_id", "values"],
     },
-    annotations: { idempotentHint: false, openWorldHint: false },
+    // openWorldHint: true because a manifest with a registry-lookup field
+    // (see lookup-fields.ts) sends the fill through the shared business-
+    // registry dispatch (ARES, KRS, ORSR, ...) before rendering, the same
+    // external interaction matter-tools.ts's company lookup declares open-
+    // world for; the hint is static per tool, so it must cover that case even
+    // though most fills touch no lookup field.
+    annotations: { idempotentHint: false, openWorldHint: true },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "fill_template",

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -360,7 +360,7 @@ const buildTemplateDetailTextFieldSpecs = (
 
 export const TEMPLATE_TOOL_DEFINITIONS = [
   {
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: true, openWorldHint: false },
     description:
       "List the document templates in this organization (NDAs, powers of " +
       "attorney, leases), or describe one template's fillable fields. Omit " +
@@ -419,6 +419,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       },
       required: ["template_id", "values"],
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "fill_template",
@@ -452,6 +453,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
         fields: fieldsOverlayProp,
       },
     },
+    annotations: { idempotentHint: false, openWorldHint: false },
     access: "write",
     anonymized: { exposure: "excluded", reason: "write" },
     name: "save_template",

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -564,7 +564,7 @@
       "required": ["jurisdictions"]
     },
     "annotations": {
-      "idempotentHint": true,
+      "idempotentHint": false,
       "openWorldHint": false
     }
   },
@@ -1016,7 +1016,7 @@
       "required": ["entity_id", "property_id", "content"]
     },
     "annotations": {
-      "idempotentHint": true,
+      "idempotentHint": false,
       "openWorldHint": false
     }
   },

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -621,7 +621,7 @@
     },
     "annotations": {
       "idempotentHint": false,
-      "openWorldHint": false
+      "openWorldHint": true
     }
   },
   {

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -2248,7 +2248,7 @@
     },
     "annotations": {
       "idempotentHint": false,
-      "openWorldHint": false
+      "openWorldHint": true
     }
   }
 ]

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -24,7 +24,8 @@
       "required": ["query"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -51,7 +52,8 @@
       "required": ["id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -89,7 +91,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -123,7 +126,8 @@
       "required": ["query"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -192,7 +196,8 @@
       "required": ["query"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -219,7 +224,8 @@
       "required": ["entity_id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -246,7 +252,8 @@
       "required": ["decision_id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -267,7 +274,8 @@
       "required": ["contact_id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -554,6 +562,10 @@
         }
       },
       "required": ["jurisdictions"]
+    },
+    "annotations": {
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -581,7 +593,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -605,6 +618,10 @@
         }
       },
       "required": ["template_id", "values"]
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -747,6 +764,10 @@
           }
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -788,7 +809,8 @@
       "required": ["matter_id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -826,7 +848,8 @@
       "required": ["entity_id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -880,6 +903,10 @@
           "maxLength": 1024
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -908,7 +935,9 @@
       "required": ["entity_id"]
     },
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -941,7 +970,8 @@
       "required": ["matter_id"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -984,6 +1014,10 @@
         }
       },
       "required": ["entity_id", "property_id", "content"]
+    },
+    "annotations": {
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1025,6 +1059,10 @@
           "description": "Set 'archived' to archive the matter or 'active' to unarchive it. Only valid when updating."
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1049,7 +1087,9 @@
       "required": ["matter_id"]
     },
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1096,6 +1136,10 @@
           "description": "Free-text notes; pass null to clear"
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1120,7 +1164,9 @@
       "required": ["contact_id"]
     },
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1159,7 +1205,8 @@
       "required": ["registry", "query"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -1211,7 +1258,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1269,6 +1317,10 @@
           "description": "Entity-link ID to remove"
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1310,6 +1362,10 @@
         }
       },
       "required": ["matter_id"]
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1358,7 +1414,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1475,6 +1532,10 @@
           "description": "When updating, also append a version snapshot of the body"
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1499,7 +1560,9 @@
       "required": ["clause_id"]
     },
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1532,7 +1595,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1555,6 +1619,10 @@
         }
       },
       "required": ["matter_id", "playbook_id"]
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1614,7 +1682,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1698,6 +1767,10 @@
           "description": "Set the entry's status. Only valid when updating."
         }
       }
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -1722,7 +1795,9 @@
       "required": ["time_entry_id"]
     },
     "annotations": {
-      "destructiveHint": true
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1752,7 +1827,8 @@
       "required": ["matter_id", "user_id", "date"]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1789,7 +1865,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1804,7 +1881,8 @@
       "properties": {}
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -1885,7 +1963,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -1943,7 +2022,8 @@
       }
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "openWorldHint": false
     }
   },
   {
@@ -2014,6 +2094,10 @@
         }
       },
       "required": ["action"]
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   },
   {
@@ -2048,6 +2132,10 @@
         }
       },
       "required": ["kind", "title", "body"]
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": true
     }
   },
   {
@@ -2082,6 +2170,9 @@
         }
       },
       "additionalProperties": false
+    },
+    "annotations": {
+      "openWorldHint": false
     }
   },
   {
@@ -2101,6 +2192,9 @@
       },
       "required": ["capability"],
       "additionalProperties": false
+    },
+    "annotations": {
+      "openWorldHint": false
     }
   },
   {
@@ -2151,6 +2245,10 @@
       },
       "required": ["capability"],
       "additionalProperties": false
+    },
+    "annotations": {
+      "idempotentHint": false,
+      "openWorldHint": false
     }
   }
 ]

--- a/packages/cli/src/registry-trust.ts
+++ b/packages/cli/src/registry-trust.ts
@@ -41,6 +41,8 @@ export const TOOL_NAME_PATTERN: RegExp = /^[a-z][a-z0-9_]{0,63}$/u;
 const ALLOWED_ANNOTATION_KEYS: ReadonlySet<string> = new Set([
   "readOnlyHint",
   "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
 ]);
 
 /** The success/failure result of validating a fetched tools/list body. */
@@ -161,12 +163,23 @@ const projectListing = (
   if (!isRecord(rawAnnotations)) {
     return { name, description, inputSchema };
   }
-  const annotations: { readOnlyHint?: boolean; destructiveHint?: boolean } = {};
+  const annotations: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  } = {};
   if (typeof rawAnnotations["readOnlyHint"] === "boolean") {
     annotations.readOnlyHint = rawAnnotations["readOnlyHint"];
   }
   if (typeof rawAnnotations["destructiveHint"] === "boolean") {
     annotations.destructiveHint = rawAnnotations["destructiveHint"];
+  }
+  if (typeof rawAnnotations["idempotentHint"] === "boolean") {
+    annotations.idempotentHint = rawAnnotations["idempotentHint"];
+  }
+  if (typeof rawAnnotations["openWorldHint"] === "boolean") {
+    annotations.openWorldHint = rawAnnotations["openWorldHint"];
   }
   return { name, description, inputSchema, annotations };
 };

--- a/packages/cli/src/route-types.ts
+++ b/packages/cli/src/route-types.ts
@@ -31,6 +31,8 @@ export type RegistryToolListing = {
   annotations?: {
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
   };
 };
 


### PR DESCRIPTION
## Summary

Declares the two MCP spec tool annotations the registry did not carry: `openWorldHint` on all 44 static tools and `idempotentHint` on all 20 write tools. Clients use these to decide retry safety (the spec default `idempotentHint: false` forbids silent retry of e.g. `delete_*`, which actually converges) and side-effect scope (`openWorldHint` defaults to true; nearly all Stella tools are closed-world over the org workspace or Stella-hosted corpora).

Decision rule: `openWorldHint: true` only where the handler makes live calls to services outside Stella's control — `lookup_business_registry` (external public registers), `search_legislation` (external BOE fetches), `send_feedback` (GitHub channel). `idempotentHint: true` for `delete_*` and pure set-style writes (`set_practice_jurisdictions`, `set_field_value`); `false` for create-capable upserts, `run_playbook`, `fill_template` (meters usage and records a fill per call), `manage_organization` (mixed action set), and `invoke_capability` (target unknown statically).

Enforced, not just declared — new registry coherence tests: every tool must declare `openWorldHint`; `idempotentHint` is required on writes and forbidden on read-only tools; `delete_*` must be idempotent; the anonymized projection must carry annotations through unchanged.

CLI side: the runtime trust-boundary allowlist accepts the two new annotation keys and projects them through; `registry-snapshot.json` regenerated. Downstream CLI codegen output is byte-identical because only `readOnlyHint`/`destructiveHint` drive CLI behavior.

Verified: MCP-scoped api suite 392 pass, CLI suite 288 pass, coverage guard and capability-catalog `--check` clean, codegen leaves no drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Tool listings now provide clearer metadata about whether actions are read-only, destructive, repeatable, or able to reach external sources.
  - These hints are consistently available across billing, documents, knowledge, matters, research, templates, feedback, and other tools.
  - The command-line interface now recognises and preserves the additional tool metadata.

- **Tests**
  - Added validation to ensure tool annotations remain complete, consistent, and unchanged across available tool surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->