### PR TITLE
fix(api): bound scheduler job runtime and stop heartbeating hung tasks

### DIFF
--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -244,3 +244,17 @@ export class TimeoutError extends TaggedError("TimeoutError")<{
   timeoutMs?: number;
   cause?: unknown;
 }>() {}
+
+/**
+ * A scheduler job exceeded its per-job execution ceiling. The task promise
+ * cannot be cancelled, so the runner stops heartbeating, releases the lease,
+ * and marks the run as timed out; a later "zombie" completion is rejected by
+ * the guarded completion writes.
+ */
+export class SchedulerJobTimeoutError extends TaggedError(
+  "SchedulerJobTimeoutError",
+)<{
+  message: string;
+  jobId: string;
+  timeoutMs: number;
+}>() {}

--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -357,6 +357,49 @@ describe("per-job runtime ceiling", () => {
     expect(run.error).toBe("SchedulerJobTimeoutError");
   });
 
+  test("a task resolving from its own abort handler at the ceiling is still a timeout failure", async () => {
+    await seedJob({ id: "abort-resolve.job", task: "test.abort-resolve" });
+
+    // A cooperative task that returns cleanly the instant its signal aborts: it
+    // fulfills the Promise.race even though the ceiling already fired, so the
+    // fulfillment must be treated as a zombie result, not a success.
+    const registry = registryOf("test.abort-resolve", async ({ signal }) => {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => {
+          resolve();
+        });
+      });
+    });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      maxRuntimeMs: 25,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    // The race fulfilled, but the ceiling fired first: recorded as a timeout
+    // failure (rescheduled), never a success that clears the lease and advances
+    // nextRunAt on an over-ceiling job.
+    expect(result).toMatchObject({
+      acquired: 1,
+      failed: 1,
+      skipped: 0,
+      succeeded: 0,
+    });
+
+    const job = await readJob("abort-resolve.job");
+    expect(job.lastError).toBe("SchedulerJobTimeoutError");
+    expect(job.lastSuccessAt).toBeNull();
+    expect(job.lockedBy).toBeNull();
+    expect(job.nextRunAt.getTime()).toBeGreaterThan(PAST.getTime());
+
+    const run = await readLatestRun("abort-resolve.job");
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("SchedulerJobTimeoutError");
+  });
+
   test("a parent abort during run creation skips the job without starting the task", async () => {
     await seedJob({ id: "abort-on-create.job", task: "test.tracked" });
 

--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -16,6 +16,8 @@ import type { TestDatabase } from "@/api/tests/security/test-utils";
 
 import {
   acquireDueJobs,
+  finishRunFailure,
+  finishRunSkipped,
   finishRunSuccess,
   runSchedulerOnce,
   type SchedulerDb,
@@ -208,12 +210,15 @@ describe("per-job runtime ceiling", () => {
     const hangingTask = new Promise<void>((resolve) => {
       releaseHangingTask = resolve;
     });
-    const registry = registryOf("test.hangs", ({ job }) => {
-      if (job.id === "hanging.job") {
-        return hangingTask;
-      }
-      return undefined;
-    });
+    const registry = registryOf(
+      "test.hangs",
+      ({ job }): Promise<void> | undefined => {
+        if (job.id === "hanging.job") {
+          return hangingTask;
+        }
+        return undefined;
+      },
+    );
 
     const result = await runSchedulerOnce({
       db,
@@ -255,5 +260,130 @@ describe("per-job runtime ceiling", () => {
     const runAfterZombie = await readLatestRun("hanging.job");
     expect(runAfterZombie.status).toBe("failed");
     expect(runAfterZombie.error).toBe("SchedulerJobTimeoutError");
+  });
+
+  test("aborts the task's signal on timeout so a cooperative task can stop", async () => {
+    await seedJob({ id: "cooperative.job", task: "test.cooperative" });
+
+    let signalAborted = false;
+    // The task hangs past the ceiling; a cooperative task observes the abort on
+    // its signal instead of running blind past its lease release. The promise
+    // stays pending so the timeout (not a synchronous resolve) settles the race.
+    const registry = registryOf("test.cooperative", async ({ signal }) => {
+      signal.addEventListener("abort", () => {
+        signalAborted = true;
+      });
+      await new Promise<void>(() => {});
+    });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      maxRuntimeMs: 25,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    expect(result).toMatchObject({ acquired: 1, failed: 1 });
+    expect(signalAborted).toBe(true);
+
+    // A ceiling expiry is still accounted as a failure, not a cooperative skip,
+    // even though aborting the controller also flips `signal.aborted`.
+    const run = await readLatestRun("cooperative.job");
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("SchedulerJobTimeoutError");
+  });
+});
+
+// The two-layer zombie guard (run-status precondition + lease-token check) is
+// funnelled through one writer, so every completion path must reject a late
+// write once its run row has already reached a terminal state, even if the same
+// runner has re-acquired the job under a fresh lease.
+describe("zombie completion guard holds on every write path", () => {
+  // Keep the run duration inside the int32 `duration_ms` column; the job's
+  // nextRunAt still uses PAST (seedJob default) to prove it is left untouched.
+  const RUN_STARTED_AT = new Date(Date.now() - 1000);
+
+  const seedReacquiredJobWithTerminalRun = async () => {
+    const freshLease = new Date(Date.now() + LEASE_MS);
+    await seedJob({
+      id: "zombie.job",
+      lockedBy: "runner-a",
+      lockedUntil: freshLease,
+    });
+    const [terminalRun] = await testDb
+      .insert(schedulerJobRuns)
+      .values({
+        error: "SchedulerJobTimeoutError",
+        finishedAt: new Date(),
+        jobId: "zombie.job",
+        runnerId: "runner-a",
+        startedAt: RUN_STARTED_AT,
+        status: "failed",
+        task: "test.noop",
+      })
+      .returning();
+    if (!terminalRun) {
+      throw new Error("Expected terminal run row to be seeded");
+    }
+    return terminalRun;
+  };
+
+  const expectJobAndRunUntouched = async () => {
+    const job = await readJob("zombie.job");
+    // The re-acquired lease token survives: the zombie never cleared the lock.
+    expect(job.lockedBy).toBe("runner-a");
+    expect(job.nextRunAt.getTime()).toBe(PAST.getTime());
+    expect(job.lastSuccessAt).toBeNull();
+
+    const run = await readLatestRun("zombie.job");
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("SchedulerJobTimeoutError");
+  };
+
+  test("finishRunSuccess", async () => {
+    const terminalRun = await seedReacquiredJobWithTerminalRun();
+    const job = await readJob("zombie.job");
+
+    await finishRunSuccess({
+      db,
+      job,
+      runId: terminalRun.id,
+      runnerId: "runner-a",
+      startedAt: RUN_STARTED_AT,
+    });
+
+    await expectJobAndRunUntouched();
+  });
+
+  test("finishRunSkipped", async () => {
+    const terminalRun = await seedReacquiredJobWithTerminalRun();
+    const job = await readJob("zombie.job");
+
+    await finishRunSkipped({
+      db,
+      job,
+      runId: terminalRun.id,
+      runnerId: "runner-a",
+      startedAt: RUN_STARTED_AT,
+    });
+
+    await expectJobAndRunUntouched();
+  });
+
+  test("finishRunFailure", async () => {
+    const terminalRun = await seedReacquiredJobWithTerminalRun();
+    const job = await readJob("zombie.job");
+
+    await finishRunFailure({
+      db,
+      error: new Error("late zombie failure"),
+      job,
+      runId: terminalRun.id,
+      runnerId: "runner-a",
+      startedAt: RUN_STARTED_AT,
+    });
+
+    await expectJobAndRunUntouched();
   });
 });

--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -1,0 +1,259 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { desc, eq } from "drizzle-orm";
+
+import type { SchedulerSchedule } from "@/api/db/schema";
+import { schedulerJobRuns, schedulerJobs } from "@/api/db/schema";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import {
+  acquireDueJobs,
+  finishRunSuccess,
+  runSchedulerOnce,
+  type SchedulerDb,
+} from "./runner";
+import type { SchedulerTask, SchedulerTaskRegistry } from "./types";
+
+// leaseMs has a hard floor of three poll intervals (3 * 60_000). The runtime
+// ceiling is independent, so a tiny ceiling times a job out long before the
+// first heartbeat (min interval 60_000ms) could fire.
+const LEASE_MS = 3 * 60_000;
+const PAST = new Date("2020-01-01T00:00:00.000Z");
+const INTERVAL_SCHEDULE = {
+  type: "interval",
+  everyMs: 60_000,
+} as const satisfies SchedulerSchedule;
+
+let testDb: TestDatabase;
+// The runner is written against the postgres-role `rootDb`; the PGlite handle
+// is structurally identical for these queries (same pattern as the usage-ledger
+// and entity-cap-lock DB tests).
+let db: SchedulerDb;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  db = asTestRaw<SchedulerDb>(testDb);
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+beforeEach(async () => {
+  await testDb.delete(schedulerJobRuns);
+  await testDb.delete(schedulerJobs);
+});
+
+type SeedJobOptions = {
+  id?: string;
+  task?: string;
+  nextRunAt?: Date;
+  enabled?: boolean;
+  lockedBy?: string | null;
+  lockedUntil?: Date | null;
+};
+
+const seedJob = async ({
+  enabled = true,
+  id = "test.job",
+  lockedBy = null,
+  lockedUntil = null,
+  nextRunAt = PAST,
+  task = "test.noop",
+}: SeedJobOptions = {}): Promise<string> => {
+  await testDb.insert(schedulerJobs).values({
+    description: "test job",
+    enabled,
+    id,
+    lockedBy,
+    lockedUntil,
+    nextRunAt,
+    schedule: INTERVAL_SCHEDULE,
+    task,
+  });
+  return id;
+};
+
+const readJob = async (id: string) => {
+  const [job] = await testDb
+    .select()
+    .from(schedulerJobs)
+    .where(eq(schedulerJobs.id, id));
+  if (!job) {
+    throw new Error(`Expected scheduler job ${id} to exist`);
+  }
+  return job;
+};
+
+const readLatestRun = async (jobId: string) => {
+  const [run] = await testDb
+    .select()
+    .from(schedulerJobRuns)
+    .where(eq(schedulerJobRuns.jobId, jobId))
+    .orderBy(desc(schedulerJobRuns.startedAt))
+    .limit(1);
+  if (!run) {
+    throw new Error(`Expected a run row for scheduler job ${jobId}`);
+  }
+  return run;
+};
+
+const registryOf = (task: string, fn: SchedulerTask): SchedulerTaskRegistry =>
+  new Map([[task, fn]]);
+
+const noopRegistry = registryOf("test.noop", () => {});
+
+describe("acquireDueJobs claim exclusivity", () => {
+  test("two interleaved passes never claim the same job", async () => {
+    await seedJob();
+
+    const first = await acquireDueJobs({
+      db,
+      leaseMs: LEASE_MS,
+      limit: 10,
+      runnerId: "runner-a",
+    });
+    const second = await acquireDueJobs({
+      db,
+      leaseMs: LEASE_MS,
+      limit: 10,
+      runnerId: "runner-b",
+    });
+
+    expect(first.map((job) => job.id)).toEqual(["test.job"]);
+    expect(second).toEqual([]);
+
+    const job = await readJob("test.job");
+    expect(job.lockedBy).toBe("runner-a");
+  });
+});
+
+describe("lease expiry", () => {
+  test("a job whose lease has expired is reclaimable by another runner", async () => {
+    await seedJob({ lockedBy: "dead-runner", lockedUntil: PAST });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "fresh-runner",
+    });
+
+    expect(result).toMatchObject({ acquired: 1, succeeded: 1, failed: 0 });
+
+    const job = await readJob("test.job");
+    expect(job.lockedBy).toBeNull();
+    expect(job.lastSuccessAt).not.toBeNull();
+  });
+
+  test("a job with a live lease is not reclaimed", async () => {
+    const future = new Date(Date.now() + LEASE_MS);
+    await seedJob({ lockedBy: "live-runner", lockedUntil: future });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      registry: noopRegistry,
+      runnerId: "fresh-runner",
+    });
+
+    expect(result.acquired).toBe(0);
+  });
+});
+
+describe("failure accounting", () => {
+  test("a throwing task is recorded as failed and rescheduled, not wedged", async () => {
+    await seedJob({ task: "test.throws" });
+    const registry = registryOf("test.throws", () => {
+      throw new Error("boom");
+    });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    expect(result).toMatchObject({ acquired: 1, failed: 1, succeeded: 0 });
+
+    const job = await readJob("test.job");
+    expect(job.lockedBy).toBeNull();
+    expect(job.lastError).not.toBeNull();
+    expect(job.lastFailureAt).not.toBeNull();
+    // Rescheduled forward off the interval, so the runner is not wedged.
+    expect(job.nextRunAt.getTime()).toBeGreaterThan(PAST.getTime());
+
+    const run = await readLatestRun("test.job");
+    expect(run.status).toBe("failed");
+  });
+});
+
+describe("per-job runtime ceiling", () => {
+  test("a task exceeding the ceiling is timed out, the runner continues, and a late zombie completion does not overwrite the timeout", async () => {
+    await seedJob({ id: "hanging.job", task: "test.hangs" });
+    await seedJob({ id: "healthy.job", task: "test.hangs" });
+
+    // A task that never resolves within the ceiling; resolved manually later to
+    // simulate the zombie finally completing.
+    let releaseHangingTask = () => {};
+    const hangingTask = new Promise<void>((resolve) => {
+      releaseHangingTask = resolve;
+    });
+    const registry = registryOf("test.hangs", ({ job }) => {
+      if (job.id === "hanging.job") {
+        return hangingTask;
+      }
+      return undefined;
+    });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      maxRuntimeMs: 25,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    // One job timed out (counted as failed), the other still ran to success:
+    // the hung job did not starve the rest of the pass.
+    expect(result).toMatchObject({ acquired: 2, failed: 1, succeeded: 1 });
+
+    const timedOutJob = await readJob("hanging.job");
+    expect(timedOutJob.lockedBy).toBeNull();
+    expect(timedOutJob.lastError).toBe("SchedulerJobTimeoutError");
+    expect(timedOutJob.lastSuccessAt).toBeNull();
+    expect(timedOutJob.nextRunAt.getTime()).toBeGreaterThan(PAST.getTime());
+
+    const timedOutRun = await readLatestRun("hanging.job");
+    expect(timedOutRun.status).toBe("failed");
+    expect(timedOutRun.error).toBe("SchedulerJobTimeoutError");
+
+    // The zombie task finishes late and attempts to record success. The
+    // lease-token (lockedBy) and run-generation (status) guards must reject it.
+    releaseHangingTask();
+    await finishRunSuccess({
+      db,
+      job: timedOutJob,
+      runId: timedOutRun.id,
+      runnerId: "runner-a",
+      startedAt: timedOutRun.startedAt,
+    });
+
+    const jobAfterZombie = await readJob("hanging.job");
+    expect(jobAfterZombie.lastSuccessAt).toBeNull();
+    expect(jobAfterZombie.lastError).toBe("SchedulerJobTimeoutError");
+
+    const runAfterZombie = await readLatestRun("hanging.job");
+    expect(runAfterZombie.status).toBe("failed");
+    expect(runAfterZombie.error).toBe("SchedulerJobTimeoutError");
+  });
+});

--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -400,6 +400,59 @@ describe("per-job runtime ceiling", () => {
     expect(run.error).toBe("SchedulerJobTimeoutError");
   });
 
+  test("a signal-ignoring task that completes while the parent aborts records success", async () => {
+    await seedJob({ id: "ignores-abort.job", task: "test.ignores-abort" });
+
+    const parentController = new AbortController();
+    let startTask = () => {};
+    const started = new Promise<void>((resolve) => {
+      startTask = resolve;
+    });
+    let releaseTask = () => {};
+    // Ignores its signal entirely, mirroring an await that never threads the
+    // AbortSignal (e.g. a queue.add during graceful shutdown).
+    const registry = registryOf("test.ignores-abort", async () => {
+      startTask();
+      await new Promise<void>((resolve) => {
+        releaseTask = resolve;
+      });
+    });
+
+    const runPromise = runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      maxRuntimeMs: 60_000,
+      registry,
+      runnerId: "runner-a",
+      signal: parentController.signal,
+    });
+
+    await started;
+    // The parent aborts mid-run; the task ignores it and finishes its work.
+    parentController.abort();
+    releaseTask();
+
+    const result = await runPromise;
+
+    // The finished unit of work is recorded, not skipped-and-left-due (which
+    // would re-dispatch the completed occurrence after a restart or later poll).
+    expect(result).toMatchObject({
+      acquired: 1,
+      failed: 0,
+      skipped: 0,
+      succeeded: 1,
+    });
+
+    const job = await readJob("ignores-abort.job");
+    expect(job.lastSuccessAt).not.toBeNull();
+    expect(job.lastError).toBeNull();
+    expect(job.lockedBy).toBeNull();
+    expect(job.nextRunAt.getTime()).toBeGreaterThan(PAST.getTime());
+
+    const run = await readLatestRun("ignores-abort.job");
+    expect(run.status).toBe("success");
+  });
+
   test("a parent abort during run creation skips the job without starting the task", async () => {
     await seedJob({ id: "abort-on-create.job", task: "test.tracked" });
 

--- a/apps/api/src/lib/scheduler/runner.test.ts
+++ b/apps/api/src/lib/scheduler/runner.test.ts
@@ -113,6 +113,30 @@ const registryOf = (task: string, fn: SchedulerTask): SchedulerTaskRegistry =>
 
 const noopRegistry = registryOf("test.noop", () => {});
 
+// Wraps a db handle so inserting a scheduler run row fires a side effect. Used to
+// abort a parent signal exactly while runJob awaits createRun(), reproducing an
+// abort that a listener attached after that await would miss.
+const abortSignalWhenRunInserted = (
+  base: SchedulerDb,
+  onRunInsert: () => void,
+): SchedulerDb =>
+  new Proxy(base, {
+    get(target, prop) {
+      if (prop === "insert") {
+        return (table: Parameters<SchedulerDb["insert"]>[0]) => {
+          if (table === schedulerJobRuns) {
+            onRunInsert();
+          }
+          return target.insert(table);
+        };
+      }
+      // Bind delegated methods to the real handle so drizzle's query builders
+      // run with `this` pointing at the underlying db, not the proxy.
+      const value = Reflect.get(target, prop);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+
 describe("acquireDueJobs claim exclusivity", () => {
   test("two interleaved passes never claim the same job", async () => {
     await seedJob();
@@ -134,7 +158,10 @@ describe("acquireDueJobs claim exclusivity", () => {
     expect(second).toEqual([]);
 
     const job = await readJob("test.job");
-    expect(job.lockedBy).toBe("runner-a");
+    // lockedBy carries the per-acquisition lease token (runnerId prefix plus a
+    // unique suffix), not the bare runnerId.
+    expect(job.lockedBy).toMatch(/^runner-a#/u);
+    expect(first.at(0)?.lockedBy).toBe(job.lockedBy);
   });
 });
 
@@ -248,8 +275,8 @@ describe("per-job runtime ceiling", () => {
     await finishRunSuccess({
       db,
       job: timedOutJob,
+      leaseToken: "runner-a",
       runId: timedOutRun.id,
-      runnerId: "runner-a",
       startedAt: timedOutRun.startedAt,
     });
 
@@ -292,6 +319,81 @@ describe("per-job runtime ceiling", () => {
     const run = await readLatestRun("cooperative.job");
     expect(run.status).toBe("failed");
     expect(run.error).toBe("SchedulerJobTimeoutError");
+  });
+
+  test("a task rejecting from its own abort handler at the ceiling is still a timeout failure", async () => {
+    await seedJob({ id: "abort-reject.job", task: "test.abort-reject" });
+
+    // Emulates a resource bound to the signal (e.g. an aborted fetch): when the
+    // ceiling aborts the signal, the task rejects with an AbortError that can win
+    // the race ahead of our own timeout rejection.
+    const registry = registryOf("test.abort-reject", async ({ signal }) => {
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted", "AbortError"));
+        });
+      });
+    });
+
+    const result = await runSchedulerOnce({
+      db,
+      leaseMs: LEASE_MS,
+      maxRuntimeMs: 25,
+      registry,
+      runnerId: "runner-a",
+    });
+
+    // Classified as a timeout failure (rescheduled), not a cooperative skip that
+    // would leave the over-ceiling job due and retried every poll.
+    expect(result).toMatchObject({ acquired: 1, failed: 1, skipped: 0 });
+
+    const job = await readJob("abort-reject.job");
+    expect(job.lastError).toBe("SchedulerJobTimeoutError");
+    expect(job.lockedBy).toBeNull();
+    expect(job.nextRunAt.getTime()).toBeGreaterThan(PAST.getTime());
+
+    const run = await readLatestRun("abort-reject.job");
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("SchedulerJobTimeoutError");
+  });
+
+  test("a parent abort during run creation skips the job without starting the task", async () => {
+    await seedJob({ id: "abort-on-create.job", task: "test.tracked" });
+
+    let taskRan = false;
+    const registry = registryOf("test.tracked", () => {
+      taskRan = true;
+    });
+
+    // Abort the parent signal at the instant the run row is inserted, i.e. while
+    // runJob awaits createRun(); a listener attached after that await misses it.
+    const controller = new AbortController();
+    const abortingDb = abortSignalWhenRunInserted(db, () => {
+      controller.abort();
+    });
+
+    const result = await runSchedulerOnce({
+      db: abortingDb,
+      leaseMs: LEASE_MS,
+      registry,
+      runnerId: "runner-a",
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({
+      acquired: 1,
+      failed: 0,
+      skipped: 1,
+      succeeded: 0,
+    });
+    // The task never started, and the lease was released cleanly.
+    expect(taskRan).toBe(false);
+
+    const job = await readJob("abort-on-create.job");
+    expect(job.lockedBy).toBeNull();
+
+    const run = await readLatestRun("abort-on-create.job");
+    expect(run.status).toBe("skipped");
   });
 });
 
@@ -349,7 +451,7 @@ describe("zombie completion guard holds on every write path", () => {
       db,
       job,
       runId: terminalRun.id,
-      runnerId: "runner-a",
+      leaseToken: "runner-a",
       startedAt: RUN_STARTED_AT,
     });
 
@@ -364,7 +466,7 @@ describe("zombie completion guard holds on every write path", () => {
       db,
       job,
       runId: terminalRun.id,
-      runnerId: "runner-a",
+      leaseToken: "runner-a",
       startedAt: RUN_STARTED_AT,
     });
 
@@ -380,10 +482,100 @@ describe("zombie completion guard holds on every write path", () => {
       error: new Error("late zombie failure"),
       job,
       runId: terminalRun.id,
-      runnerId: "runner-a",
+      leaseToken: "runner-a",
       startedAt: RUN_STARTED_AT,
     });
 
     await expectJobAndRunUntouched();
+  });
+});
+
+// The lease token is unique per acquisition: when the same runner re-acquires a
+// job while a prior execution is still running, a stale completion arriving with
+// the OLD token must leave the fresh lease untouched, even though its run row is
+// still `running` (so the generation check alone would let it through).
+describe("stale-token completion preserves a same-runner re-acquired lease", () => {
+  const RUN_STARTED_AT = new Date(Date.now() - 1000);
+  const FRESH_TOKEN = "runner-a#fresh";
+  const STALE_TOKEN = "runner-a#stale";
+
+  const seedReacquiredJobWithStaleRunningRun = async () => {
+    const freshLease = new Date(Date.now() + LEASE_MS);
+    await seedJob({
+      id: "reacquired.job",
+      lockedBy: FRESH_TOKEN,
+      lockedUntil: freshLease,
+    });
+    const [staleRun] = await testDb
+      .insert(schedulerJobRuns)
+      .values({
+        jobId: "reacquired.job",
+        runnerId: "runner-a",
+        startedAt: RUN_STARTED_AT,
+        status: "running",
+        task: "test.noop",
+      })
+      .returning();
+    if (!staleRun) {
+      throw new Error("Expected stale running run row to be seeded");
+    }
+    return { freshLease, staleRun };
+  };
+
+  const expectFreshLeaseIntact = async (freshLease: Date) => {
+    const job = await readJob("reacquired.job");
+    expect(job.lockedBy).toBe(FRESH_TOKEN);
+    expect(job.lockedUntil?.getTime()).toBe(freshLease.getTime());
+    expect(job.nextRunAt.getTime()).toBe(PAST.getTime());
+    expect(job.lastSuccessAt).toBeNull();
+  };
+
+  test("finishRunSuccess", async () => {
+    const { freshLease, staleRun } =
+      await seedReacquiredJobWithStaleRunningRun();
+    const job = await readJob("reacquired.job");
+
+    await finishRunSuccess({
+      db,
+      job,
+      leaseToken: STALE_TOKEN,
+      runId: staleRun.id,
+      startedAt: RUN_STARTED_AT,
+    });
+
+    await expectFreshLeaseIntact(freshLease);
+  });
+
+  test("finishRunSkipped", async () => {
+    const { freshLease, staleRun } =
+      await seedReacquiredJobWithStaleRunningRun();
+    const job = await readJob("reacquired.job");
+
+    await finishRunSkipped({
+      db,
+      job,
+      leaseToken: STALE_TOKEN,
+      runId: staleRun.id,
+      startedAt: RUN_STARTED_AT,
+    });
+
+    await expectFreshLeaseIntact(freshLease);
+  });
+
+  test("finishRunFailure", async () => {
+    const { freshLease, staleRun } =
+      await seedReacquiredJobWithStaleRunningRun();
+    const job = await readJob("reacquired.job");
+
+    await finishRunFailure({
+      db,
+      error: new Error("late zombie failure"),
+      job,
+      leaseToken: STALE_TOKEN,
+      runId: staleRun.id,
+      startedAt: RUN_STARTED_AT,
+    });
+
+    await expectFreshLeaseIntact(freshLease);
   });
 });

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -596,11 +596,17 @@ type ResolveRunOutcomeOptions = {
   timeoutError: SchedulerJobTimeoutError | undefined;
 };
 
-// Single-homed post-race classification. Precedence matters: the ceiling flag
-// wins over the abort state (the ceiling aborts the controller itself), and both
-// win over the race outcome, because a fulfilled or rejected race is a zombie
-// result once the ceiling has fired or the parent has aborted. Only a race that
-// fulfilled with neither condition set is a genuine success.
+// Single-homed post-race classification, in strict precedence:
+//   1. the ceiling fired  -> timeout failure: the result is a zombie, the lease
+//      was already released, and the job must be rescheduled.
+//   2. the race fulfilled  -> success, even if the parent signal aborted
+//      mid-flight. A finished unit of work is recorded once; re-running it (by
+//      skipping and leaving nextRunAt due) would duplicate side effects, which
+//      is exactly the idempotency bug this ceiling exists to prevent. Recording
+//      a real completion is always safe during graceful shutdown.
+//   3. the race rejected while the controller was aborted -> skip: the task did
+//      not finish, it bailed on the abort, so leave it due to run again.
+//   4. the race rejected on its own -> failure.
 const resolveRunOutcome = async ({
   aborted,
   db,
@@ -638,37 +644,37 @@ const resolveRunOutcome = async ({
     return "failed";
   }
 
+  if (!raceRejected) {
+    await finishRunSuccess({ db, job, leaseToken, runId, startedAt });
+    return "success";
+  }
+
   if (aborted) {
     await finishRunSkipped({ db, job, leaseToken, runId, startedAt });
     return "skipped";
   }
 
-  if (raceRejected) {
-    captureError(raceError, {
-      schedulerJobId: job.id,
-      schedulerRunId: runId,
-      schedulerTask: job.task,
-    });
-    logger.error("scheduler.job_failed", {
-      "scheduler.job_id": job.id,
-      "scheduler.run_id": runId,
-      "scheduler.runner_id": runnerId,
-      "scheduler.task": job.task,
-      "error.type": errorTag(raceError),
-    });
-    await finishRunFailure({
-      db,
-      error: raceError,
-      job,
-      leaseToken,
-      runId,
-      startedAt,
-    });
-    return "failed";
-  }
-
-  await finishRunSuccess({ db, job, leaseToken, runId, startedAt });
-  return "success";
+  captureError(raceError, {
+    schedulerJobId: job.id,
+    schedulerRunId: runId,
+    schedulerTask: job.task,
+  });
+  logger.error("scheduler.job_failed", {
+    "scheduler.job_id": job.id,
+    "scheduler.run_id": runId,
+    "scheduler.runner_id": runnerId,
+    "scheduler.task": job.task,
+    "error.type": errorTag(raceError),
+  });
+  await finishRunFailure({
+    db,
+    error: raceError,
+    job,
+    leaseToken,
+    runId,
+    startedAt,
+  });
+  return "failed";
 };
 
 type CreateRunOptions = {

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -5,7 +5,10 @@ import { rootDb } from "@/api/db/root";
 import { schedulerJobRuns, schedulerJobs } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import { ConfigurationError } from "@/api/lib/errors/tagged-errors";
+import {
+  ConfigurationError,
+  SchedulerJobTimeoutError,
+} from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createSchedulerTaskRegistry } from "@/api/lib/scheduler/registry";
@@ -20,10 +23,26 @@ const DEFAULT_LEASE_MS = 30 * 60_000;
 const DEFAULT_JOB_LIMIT = 10;
 const MIN_LEASE_MS = 3 * DEFAULT_POLL_INTERVAL_MS;
 
+// Hard upper bound on how long a single task may run. The lease heartbeat
+// renews `lockedUntil` indefinitely, so without this ceiling a task that never
+// resolves would block the sequential runner AND keep the lease fresh forever,
+// defeating the self-heal the lease exists for. Set to one lease period: a job
+// that has not finished within a full lease is treated as hung. A JS promise
+// cannot be cancelled, so the ceiling stops the heartbeat and releases the job
+// rather than truly aborting the task.
+const DEFAULT_MAX_RUNTIME_MS = DEFAULT_LEASE_MS;
+
+// The scheduler owns the postgres-role `rootDb`; tests inject a structurally
+// equivalent database handle. Threaded explicitly so the claim, lease, and
+// completion paths are exercisable against a real (PGlite) database.
+export type SchedulerDb = typeof rootDb;
+
 type RunSchedulerOnceOptions = {
+  db?: SchedulerDb;
   runnerId?: string;
   limit?: number;
   leaseMs?: number;
+  maxRuntimeMs?: number;
   registry?: SchedulerTaskRegistry;
   signal?: AbortSignal;
 };
@@ -46,13 +65,19 @@ type SchedulerLoop = {
 };
 
 export const runSchedulerOnce = async ({
+  db = rootDb,
   leaseMs = DEFAULT_LEASE_MS,
   limit = DEFAULT_JOB_LIMIT,
+  maxRuntimeMs = DEFAULT_MAX_RUNTIME_MS,
   registry = createSchedulerTaskRegistry(),
   runnerId = defaultRunnerId(),
   signal,
 }: RunSchedulerOnceOptions = {}): Promise<RunSchedulerOnceResult> => {
-  const jobs = await acquireDueJobs({ leaseMs, limit, runnerId });
+  if (!Number.isInteger(maxRuntimeMs) || maxRuntimeMs < 1) {
+    return panic("Scheduler job runtime ceiling must be a positive integer");
+  }
+
+  const jobs = await acquireDueJobs({ db, leaseMs, limit, runnerId });
   const result: RunSchedulerOnceResult = {
     acquired: jobs.length,
     failed: 0,
@@ -65,6 +90,7 @@ export const runSchedulerOnce = async ({
 
   const unstartedJobIds = new Set(jobs.map((job) => job.id));
   const unstartedHeartbeat = startUnstartedJobsHeartbeat({
+    db,
     jobIds: unstartedJobIds,
     leaseMs,
     runnerId,
@@ -77,6 +103,7 @@ export const runSchedulerOnce = async ({
         const unstartedJobs = jobs.slice(index);
         // oxlint-disable-next-line no-await-in-loop -- runs once before the break on abort; jobs are drained sequentially
         await releaseUnstartedJobs({
+          db,
           jobs: unstartedJobs,
           runnerId,
         });
@@ -86,6 +113,7 @@ export const runSchedulerOnce = async ({
 
       // oxlint-disable-next-line no-await-in-loop -- jobs run sequentially; lease renewal must precede this job's run
       const leasedJob = await renewJobLeaseBeforeStart({
+        db,
         job,
         leaseMs,
         runnerId,
@@ -98,8 +126,10 @@ export const runSchedulerOnce = async ({
 
       // oxlint-disable-next-line no-await-in-loop -- scheduler runs leased jobs one at a time, in order, honouring the abort signal
       const status = await runJob({
+        db,
         job: leasedJob,
         leaseMs,
+        maxRuntimeMs,
         registry,
         runnerId,
         signal,
@@ -208,12 +238,14 @@ export const startSchedulerLoop = ({
 };
 
 type AcquireDueJobsOptions = {
+  db: SchedulerDb;
   runnerId: string;
   limit: number;
   leaseMs: number;
 };
 
-const acquireDueJobs = async ({
+export const acquireDueJobs = async ({
+  db,
   leaseMs,
   limit,
   runnerId,
@@ -228,7 +260,7 @@ const acquireDueJobs = async ({
 
   const now = new Date();
   const leaseExpiresAt = new Date(now.getTime() + leaseMs);
-  const candidates = await rootDb
+  const candidates = await db
     .select()
     .from(schedulerJobs)
     .where(dueJobPredicate(now))
@@ -237,8 +269,8 @@ const acquireDueJobs = async ({
   const acquired: SchedulerJob[] = [];
 
   for (const candidate of candidates) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential conditional locking preserves due-order acquisition
-    const [job] = await rootDb
+    // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential conditional locking preserves due-order acquisition
+    const [job] = await db
       .update(schedulerJobs)
       .set({
         lockedAt: now,
@@ -257,11 +289,13 @@ const acquireDueJobs = async ({
 };
 
 type ReleaseUnstartedJobsOptions = {
+  db: SchedulerDb;
   jobs: SchedulerJob[];
   runnerId: string;
 };
 
 const releaseUnstartedJobs = async ({
+  db,
   jobs,
   runnerId,
 }: ReleaseUnstartedJobsOptions): Promise<void> => {
@@ -269,7 +303,7 @@ const releaseUnstartedJobs = async ({
     return;
   }
 
-  await rootDb
+  await db
     .update(schedulerJobs)
     .set({
       lockedAt: null,
@@ -288,18 +322,20 @@ const releaseUnstartedJobs = async ({
 };
 
 type RenewJobLeaseBeforeStartOptions = {
+  db: SchedulerDb;
   job: SchedulerJob;
   leaseMs: number;
   runnerId: string;
 };
 
 const renewJobLeaseBeforeStart = async ({
+  db,
   job,
   leaseMs,
   runnerId,
 }: RenewJobLeaseBeforeStartOptions): Promise<SchedulerJob | null> => {
   const now = new Date();
-  const [leasedJob] = await rootDb
+  const [leasedJob] = await db
     .update(schedulerJobs)
     .set({
       lockedAt: now,
@@ -315,6 +351,7 @@ const renewJobLeaseBeforeStart = async ({
 };
 
 type StartUnstartedJobsHeartbeatOptions = {
+  db: SchedulerDb;
   jobIds: Set<string>;
   leaseMs: number;
   runnerId: string;
@@ -322,6 +359,7 @@ type StartUnstartedJobsHeartbeatOptions = {
 };
 
 const startUnstartedJobsHeartbeat = ({
+  db,
   jobIds,
   leaseMs,
   runnerId,
@@ -337,7 +375,7 @@ const startUnstartedJobsHeartbeat = ({
       return;
     }
 
-    await rootDb
+    await db
       .update(schedulerJobs)
       .set({
         lockedUntil: new Date(Date.now() + leaseMs),
@@ -378,6 +416,7 @@ type LeaseHeartbeat = {
 };
 
 type StartLeaseHeartbeatOptions = {
+  db: SchedulerDb;
   jobId: string;
   leaseMs: number;
   runnerId: string;
@@ -385,6 +424,7 @@ type StartLeaseHeartbeatOptions = {
 };
 
 const startLeaseHeartbeat = ({
+  db,
   jobId,
   leaseMs,
   runnerId,
@@ -400,7 +440,7 @@ const startLeaseHeartbeat = ({
       return;
     }
 
-    await rootDb
+    await db
       .update(schedulerJobs)
       .set({
         lockedUntil: new Date(Date.now() + leaseMs),
@@ -428,8 +468,10 @@ const startLeaseHeartbeat = ({
 };
 
 type RunJobOptions = {
+  db: SchedulerDb;
   job: SchedulerJob;
   leaseMs: number;
+  maxRuntimeMs: number;
   runnerId: string;
   registry: SchedulerTaskRegistry;
   signal: AbortSignal | undefined;
@@ -438,24 +480,28 @@ type RunJobOptions = {
 type RunJobStatus = "failed" | "skipped" | "success";
 
 const runJob = async ({
+  db,
   job,
   leaseMs,
+  maxRuntimeMs,
   registry,
   runnerId,
   signal,
 }: RunJobOptions): Promise<RunJobStatus> => {
   const startedAt = new Date();
-  const runId = await createRun({ job, runnerId, startedAt });
+  const runId = await createRun({ db, job, runnerId, startedAt });
   const controller = new AbortController();
   const abortListener = () => controller.abort();
   signal?.addEventListener("abort", abortListener, { once: true });
   const heartbeat = startLeaseHeartbeat({
+    db,
     jobId: job.id,
     leaseMs,
     runnerId,
     signal: controller.signal,
   });
   const task = registry.get(job.task);
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
   try {
     if (!task) {
@@ -464,19 +510,61 @@ const runJob = async ({
       });
     }
 
-    await task({
-      job,
-      logger,
-      payload: job.payload,
-      runId,
-      signal: controller.signal,
+    // Bound the task's runtime. A JS promise cannot be cancelled, so on timeout
+    // the losing task promise keeps running as a "zombie". We never chain a
+    // completion write onto it, and the guarded completion writes below reject
+    // a late write anyway, so a zombie can never overwrite the timed-out state.
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutTimer = setTimeout(() => {
+        reject(
+          new SchedulerJobTimeoutError({
+            jobId: job.id,
+            message: `Scheduler job ${job.id} exceeded its ${maxRuntimeMs}ms runtime ceiling`,
+            timeoutMs: maxRuntimeMs,
+          }),
+        );
+      }, maxRuntimeMs);
     });
-    await finishRunSuccess({ job, runId, runnerId, startedAt });
+
+    await Promise.race([
+      Promise.resolve(
+        task({
+          job,
+          logger,
+          payload: job.payload,
+          runId,
+          signal: controller.signal,
+        }),
+      ),
+      timeout,
+    ]);
+    await finishRunSuccess({ db, job, runId, runnerId, startedAt });
     return "success";
   } catch (error: unknown) {
     if (controller.signal.aborted) {
-      await finishRunSkipped({ job, runId, runnerId, startedAt });
+      await finishRunSkipped({ db, job, runId, runnerId, startedAt });
       return "skipped";
+    }
+
+    if (error instanceof SchedulerJobTimeoutError) {
+      // Stop heartbeating first so the released lease cannot be re-extended,
+      // then release the job and mark the run timed out. Another runner can
+      // now reclaim it once the (already-released) lease is past.
+      heartbeat.stop();
+      captureError(error, {
+        schedulerJobId: job.id,
+        schedulerRunId: runId,
+        schedulerTask: job.task,
+      });
+      logger.error("scheduler.job_timed_out", {
+        "scheduler.job_id": job.id,
+        "scheduler.run_id": runId,
+        "scheduler.runner_id": runnerId,
+        "scheduler.task": job.task,
+        "scheduler.timeout_ms": maxRuntimeMs,
+      });
+      await finishRunFailure({ db, error, job, runId, runnerId, startedAt });
+      return "failed";
     }
 
     captureError(error, {
@@ -491,26 +579,31 @@ const runJob = async ({
       "scheduler.task": job.task,
       "error.type": errorTag(error),
     });
-    await finishRunFailure({ error, job, runId, runnerId, startedAt });
+    await finishRunFailure({ db, error, job, runId, runnerId, startedAt });
     return "failed";
   } finally {
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer);
+    }
     signal?.removeEventListener("abort", abortListener);
     heartbeat.stop();
   }
 };
 
 type CreateRunOptions = {
+  db: SchedulerDb;
   job: SchedulerJob;
   runnerId: string;
   startedAt: Date;
 };
 
 const createRun = async ({
+  db,
   job,
   runnerId,
   startedAt,
 }: CreateRunOptions): Promise<SafeId<"schedulerJobRun">> => {
-  const [run] = await rootDb
+  const [run] = await db
     .insert(schedulerJobRuns)
     .values({
       jobId: job.id,
@@ -529,13 +622,19 @@ const createRun = async ({
 };
 
 type FinishRunOptions = {
+  db: SchedulerDb;
   job: SchedulerJob;
   runId: SafeId<"schedulerJobRun">;
   runnerId: string;
   startedAt: Date;
 };
 
-const finishRunSuccess = async ({
+// A run terminates exactly once. Guarding the run-row write on
+// `status = "running"` (a generation check) plus the job-row write on
+// `lockedBy = runnerId` (a lease-token check) means a late zombie completion
+// can never overwrite a timed-out or reclaimed job with a stale success.
+export const finishRunSuccess = async ({
+  db,
   job,
   runId,
   runnerId,
@@ -543,16 +642,21 @@ const finishRunSuccess = async ({
 }: FinishRunOptions): Promise<void> => {
   const finishedAt = new Date();
 
-  await rootDb
+  await db
     .update(schedulerJobRuns)
     .set({
       durationMs: durationMs(startedAt, finishedAt),
       finishedAt,
       status: "success",
     })
-    .where(eq(schedulerJobRuns.id, runId));
+    .where(
+      and(
+        eq(schedulerJobRuns.id, runId),
+        eq(schedulerJobRuns.status, "running"),
+      ),
+    );
 
-  await rootDb
+  await db
     .update(schedulerJobs)
     .set({
       lastError: null,
@@ -569,6 +673,7 @@ const finishRunSuccess = async ({
 };
 
 const finishRunSkipped = async ({
+  db,
   job,
   runId,
   runnerId,
@@ -576,7 +681,7 @@ const finishRunSkipped = async ({
 }: FinishRunOptions): Promise<void> => {
   const finishedAt = new Date();
 
-  await rootDb
+  await db
     .update(schedulerJobRuns)
     .set({
       durationMs: durationMs(startedAt, finishedAt),
@@ -584,9 +689,14 @@ const finishRunSkipped = async ({
       finishedAt,
       status: "skipped",
     })
-    .where(eq(schedulerJobRuns.id, runId));
+    .where(
+      and(
+        eq(schedulerJobRuns.id, runId),
+        eq(schedulerJobRuns.status, "running"),
+      ),
+    );
 
-  await rootDb
+  await db
     .update(schedulerJobs)
     .set({
       lockedAt: null,
@@ -603,6 +713,7 @@ type FinishRunFailureOptions = FinishRunOptions & {
 };
 
 const finishRunFailure = async ({
+  db,
   error,
   job,
   runId,
@@ -612,7 +723,7 @@ const finishRunFailure = async ({
   const finishedAt = new Date();
   const sanitizedError = errorTag(error);
 
-  await rootDb
+  await db
     .update(schedulerJobRuns)
     .set({
       durationMs: durationMs(startedAt, finishedAt),
@@ -620,9 +731,14 @@ const finishRunFailure = async ({
       finishedAt,
       status: "failed",
     })
-    .where(eq(schedulerJobRuns.id, runId));
+    .where(
+      and(
+        eq(schedulerJobRuns.id, runId),
+        eq(schedulerJobRuns.status, "running"),
+      ),
+    );
 
-  await rootDb
+  await db
     .update(schedulerJobs)
     .set({
       lastError: sanitizedError,

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -1,5 +1,6 @@
 import { panic } from "better-result";
 import { and, asc, eq, inArray, isNull, lte, or } from "drizzle-orm";
+import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 
 import { rootDb } from "@/api/db/root";
 import { schedulerJobRuns, schedulerJobs } from "@/api/db/schema";
@@ -28,8 +29,8 @@ const MIN_LEASE_MS = 3 * DEFAULT_POLL_INTERVAL_MS;
 // resolves would block the sequential runner AND keep the lease fresh forever,
 // defeating the self-heal the lease exists for. Set to one lease period: a job
 // that has not finished within a full lease is treated as hung. A JS promise
-// cannot be cancelled, so the ceiling stops the heartbeat and releases the job
-// rather than truly aborting the task.
+// cannot be force-cancelled, so on expiry the ceiling aborts the task's signal
+// (cooperative tasks unwind), stops the heartbeat, and releases the job.
 const DEFAULT_MAX_RUNTIME_MS = DEFAULT_LEASE_MS;
 
 // The scheduler owns the postgres-role `rootDb`; tests inject a structurally
@@ -510,12 +511,15 @@ const runJob = async ({
       });
     }
 
-    // Bound the task's runtime. A JS promise cannot be cancelled, so on timeout
-    // the losing task promise keeps running as a "zombie". We never chain a
-    // completion write onto it, and the guarded completion writes below reject
-    // a late write anyway, so a zombie can never overwrite the timed-out state.
+    // Bound the task's runtime. A JS promise cannot be force-cancelled, so on
+    // expiry we abort the task's signal FIRST, giving a cooperative task a
+    // chance to stop before its lease is released; a task that ignores the
+    // signal keeps running as a "zombie". We never chain a completion write onto
+    // it, and the guarded completion writes below reject a late write anyway, so
+    // a zombie can never overwrite the timed-out state.
     const timeout = new Promise<never>((_resolve, reject) => {
       timeoutTimer = setTimeout(() => {
+        controller.abort();
         reject(
           new SchedulerJobTimeoutError({
             jobId: job.id,
@@ -541,11 +545,9 @@ const runJob = async ({
     await finishRunSuccess({ db, job, runId, runnerId, startedAt });
     return "success";
   } catch (error: unknown) {
-    if (controller.signal.aborted) {
-      await finishRunSkipped({ db, job, runId, runnerId, startedAt });
-      return "skipped";
-    }
-
+    // The timeout branch aborts `controller` before rejecting, so it must be
+    // checked before the abort branch below: otherwise a ceiling expiry would
+    // be misclassified as a cooperatively-skipped run.
     if (error instanceof SchedulerJobTimeoutError) {
       // Stop heartbeating first so the released lease cannot be re-extended,
       // then release the job and mark the run timed out. Another runner can
@@ -565,6 +567,11 @@ const runJob = async ({
       });
       await finishRunFailure({ db, error, job, runId, runnerId, startedAt });
       return "failed";
+    }
+
+    if (controller.signal.aborted) {
+      await finishRunSkipped({ db, job, runId, runnerId, startedAt });
+      return "skipped";
     }
 
     captureError(error, {
@@ -629,10 +636,55 @@ type FinishRunOptions = {
   startedAt: Date;
 };
 
-// A run terminates exactly once. Guarding the run-row write on
-// `status = "running"` (a generation check) plus the job-row write on
-// `lockedBy = runnerId` (a lease-token check) means a late zombie completion
-// can never overwrite a timed-out or reclaimed job with a stale success.
+type CompleteRunOptions = {
+  db: SchedulerDb;
+  jobId: string;
+  runId: SafeId<"schedulerJobRun">;
+  runnerId: string;
+  runValues: PgUpdateSetSource<typeof schedulerJobRuns>;
+  jobValues: PgUpdateSetSource<typeof schedulerJobs>;
+};
+
+// A run terminates exactly once. Every completion path (success, skipped,
+// failure) funnels through this single guarded writer so a future path cannot
+// forget the guard. Two layers reject a late zombie completion:
+//   1. run-row write is conditioned on `status = "running"` (a generation
+//      check) and only counts if it actually updated a row;
+//   2. the job-row write runs only when (1) won AND `lockedBy = runnerId` (a
+//      lease-token check) still matches.
+// Together they mean a zombie cannot overwrite a timed-out or reclaimed job,
+// even if the same runner has since re-acquired the job under a fresh run.
+const completeRun = async ({
+  db,
+  jobId,
+  jobValues,
+  runId,
+  runnerId,
+  runValues,
+}: CompleteRunOptions): Promise<void> => {
+  const [updatedRun] = await db
+    .update(schedulerJobRuns)
+    .set(runValues)
+    .where(
+      and(
+        eq(schedulerJobRuns.id, runId),
+        eq(schedulerJobRuns.status, "running"),
+      ),
+    )
+    .returning({ id: schedulerJobRuns.id });
+
+  if (!updatedRun) {
+    return;
+  }
+
+  await db
+    .update(schedulerJobs)
+    .set(jobValues)
+    .where(
+      and(eq(schedulerJobs.id, jobId), eq(schedulerJobs.lockedBy, runnerId)),
+    );
+};
+
 export const finishRunSuccess = async ({
   db,
   job,
@@ -642,23 +694,10 @@ export const finishRunSuccess = async ({
 }: FinishRunOptions): Promise<void> => {
   const finishedAt = new Date();
 
-  await db
-    .update(schedulerJobRuns)
-    .set({
-      durationMs: durationMs(startedAt, finishedAt),
-      finishedAt,
-      status: "success",
-    })
-    .where(
-      and(
-        eq(schedulerJobRuns.id, runId),
-        eq(schedulerJobRuns.status, "running"),
-      ),
-    );
-
-  await db
-    .update(schedulerJobs)
-    .set({
+  await completeRun({
+    db,
+    jobId: job.id,
+    jobValues: {
       lastError: null,
       lastRunAt: startedAt,
       lastSuccessAt: finishedAt,
@@ -666,13 +705,18 @@ export const finishRunSuccess = async ({
       lockedBy: null,
       lockedUntil: null,
       nextRunAt: computeNextRunAt(job.schedule, finishedAt),
-    })
-    .where(
-      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, runnerId)),
-    );
+    },
+    runId,
+    runnerId,
+    runValues: {
+      durationMs: durationMs(startedAt, finishedAt),
+      finishedAt,
+      status: "success",
+    },
+  });
 };
 
-const finishRunSkipped = async ({
+export const finishRunSkipped = async ({
   db,
   job,
   runId,
@@ -681,38 +725,30 @@ const finishRunSkipped = async ({
 }: FinishRunOptions): Promise<void> => {
   const finishedAt = new Date();
 
-  await db
-    .update(schedulerJobRuns)
-    .set({
+  await completeRun({
+    db,
+    jobId: job.id,
+    jobValues: {
+      lockedAt: null,
+      lockedBy: null,
+      lockedUntil: null,
+    },
+    runId,
+    runnerId,
+    runValues: {
       durationMs: durationMs(startedAt, finishedAt),
       error: "SchedulerAborted",
       finishedAt,
       status: "skipped",
-    })
-    .where(
-      and(
-        eq(schedulerJobRuns.id, runId),
-        eq(schedulerJobRuns.status, "running"),
-      ),
-    );
-
-  await db
-    .update(schedulerJobs)
-    .set({
-      lockedAt: null,
-      lockedBy: null,
-      lockedUntil: null,
-    })
-    .where(
-      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, runnerId)),
-    );
+    },
+  });
 };
 
 type FinishRunFailureOptions = FinishRunOptions & {
   error: unknown;
 };
 
-const finishRunFailure = async ({
+export const finishRunFailure = async ({
   db,
   error,
   job,
@@ -723,24 +759,10 @@ const finishRunFailure = async ({
   const finishedAt = new Date();
   const sanitizedError = errorTag(error);
 
-  await db
-    .update(schedulerJobRuns)
-    .set({
-      durationMs: durationMs(startedAt, finishedAt),
-      error: sanitizedError,
-      finishedAt,
-      status: "failed",
-    })
-    .where(
-      and(
-        eq(schedulerJobRuns.id, runId),
-        eq(schedulerJobRuns.status, "running"),
-      ),
-    );
-
-  await db
-    .update(schedulerJobs)
-    .set({
+  await completeRun({
+    db,
+    jobId: job.id,
+    jobValues: {
       lastError: sanitizedError,
       lastFailureAt: finishedAt,
       lastRunAt: startedAt,
@@ -748,10 +770,16 @@ const finishRunFailure = async ({
       lockedBy: null,
       lockedUntil: null,
       nextRunAt: computeNextRunAt(job.schedule, finishedAt),
-    })
-    .where(
-      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, runnerId)),
-    );
+    },
+    runId,
+    runnerId,
+    runValues: {
+      durationMs: durationMs(startedAt, finishedAt),
+      error: sanitizedError,
+      finishedAt,
+      status: "failed",
+    },
+  });
 };
 
 const durationMs = (startedAt: Date, finishedAt: Date): number =>

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -89,11 +89,11 @@ export const runSchedulerOnce = async ({
     return result;
   }
 
-  const unstartedJobIds = new Set(jobs.map((job) => job.id));
+  const unstartedTokens = new Set(jobs.map(leaseTokenOf));
   const unstartedHeartbeat = startUnstartedJobsHeartbeat({
     db,
-    jobIds: unstartedJobIds,
     leaseMs,
+    leaseTokens: unstartedTokens,
     runnerId,
     signal,
   });
@@ -106,7 +106,6 @@ export const runSchedulerOnce = async ({
         await releaseUnstartedJobs({
           db,
           jobs: unstartedJobs,
-          runnerId,
         });
         result.skipped += unstartedJobs.length;
         break;
@@ -117,9 +116,8 @@ export const runSchedulerOnce = async ({
         db,
         job,
         leaseMs,
-        runnerId,
       });
-      unstartedJobIds.delete(job.id);
+      unstartedTokens.delete(leaseTokenOf(job));
       if (!leasedJob) {
         result.skipped += 1;
         continue;
@@ -270,12 +268,13 @@ export const acquireDueJobs = async ({
   const acquired: SchedulerJob[] = [];
 
   for (const candidate of candidates) {
+    const leaseToken = acquireLeaseToken(runnerId);
     // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential conditional locking preserves due-order acquisition
     const [job] = await db
       .update(schedulerJobs)
       .set({
         lockedAt: now,
-        lockedBy: runnerId,
+        lockedBy: leaseToken,
         lockedUntil: leaseExpiresAt,
       })
       .where(and(eq(schedulerJobs.id, candidate.id), dueJobPredicate(now)))
@@ -292,18 +291,18 @@ export const acquireDueJobs = async ({
 type ReleaseUnstartedJobsOptions = {
   db: SchedulerDb;
   jobs: SchedulerJob[];
-  runnerId: string;
 };
 
 const releaseUnstartedJobs = async ({
   db,
   jobs,
-  runnerId,
 }: ReleaseUnstartedJobsOptions): Promise<void> => {
   if (jobs.length === 0) {
     return;
   }
 
+  // Lease tokens are globally unique, so matching the acquired token set targets
+  // exactly the rows this pass still holds.
   await db
     .update(schedulerJobs)
     .set({
@@ -311,40 +310,30 @@ const releaseUnstartedJobs = async ({
       lockedBy: null,
       lockedUntil: null,
     })
-    .where(
-      and(
-        eq(schedulerJobs.lockedBy, runnerId),
-        inArray(
-          schedulerJobs.id,
-          jobs.map((job) => job.id),
-        ),
-      ),
-    );
+    .where(inArray(schedulerJobs.lockedBy, jobs.map(leaseTokenOf)));
 };
 
 type RenewJobLeaseBeforeStartOptions = {
   db: SchedulerDb;
   job: SchedulerJob;
   leaseMs: number;
-  runnerId: string;
 };
 
 const renewJobLeaseBeforeStart = async ({
   db,
   job,
   leaseMs,
-  runnerId,
 }: RenewJobLeaseBeforeStartOptions): Promise<SchedulerJob | null> => {
+  const leaseToken = leaseTokenOf(job);
   const now = new Date();
   const [leasedJob] = await db
     .update(schedulerJobs)
     .set({
       lockedAt: now,
-      lockedBy: runnerId,
       lockedUntil: new Date(now.getTime() + leaseMs),
     })
     .where(
-      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, runnerId)),
+      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, leaseToken)),
     )
     .returning();
 
@@ -353,16 +342,16 @@ const renewJobLeaseBeforeStart = async ({
 
 type StartUnstartedJobsHeartbeatOptions = {
   db: SchedulerDb;
-  jobIds: Set<string>;
   leaseMs: number;
+  leaseTokens: Set<string>;
   runnerId: string;
   signal: AbortSignal | undefined;
 };
 
 const startUnstartedJobsHeartbeat = ({
   db,
-  jobIds,
   leaseMs,
+  leaseTokens,
   runnerId,
   signal,
 }: StartUnstartedJobsHeartbeatOptions): LeaseHeartbeat => {
@@ -372,7 +361,7 @@ const startUnstartedJobsHeartbeat = ({
   );
 
   const renew = async () => {
-    if (signal?.aborted || jobIds.size === 0) {
+    if (signal?.aborted || leaseTokens.size === 0) {
       return;
     }
 
@@ -381,12 +370,7 @@ const startUnstartedJobsHeartbeat = ({
       .set({
         lockedUntil: new Date(Date.now() + leaseMs),
       })
-      .where(
-        and(
-          eq(schedulerJobs.lockedBy, runnerId),
-          inArray(schedulerJobs.id, [...jobIds]),
-        ),
-      );
+      .where(inArray(schedulerJobs.lockedBy, [...leaseTokens]));
   };
 
   const timer = setInterval(() => {
@@ -420,6 +404,7 @@ type StartLeaseHeartbeatOptions = {
   db: SchedulerDb;
   jobId: string;
   leaseMs: number;
+  leaseToken: string;
   runnerId: string;
   signal: AbortSignal;
 };
@@ -428,6 +413,7 @@ const startLeaseHeartbeat = ({
   db,
   jobId,
   leaseMs,
+  leaseToken,
   runnerId,
   signal,
 }: StartLeaseHeartbeatOptions): LeaseHeartbeat => {
@@ -447,7 +433,10 @@ const startLeaseHeartbeat = ({
         lockedUntil: new Date(Date.now() + leaseMs),
       })
       .where(
-        and(eq(schedulerJobs.id, jobId), eq(schedulerJobs.lockedBy, runnerId)),
+        and(
+          eq(schedulerJobs.id, jobId),
+          eq(schedulerJobs.lockedBy, leaseToken),
+        ),
       );
   };
 
@@ -489,20 +478,38 @@ const runJob = async ({
   runnerId,
   signal,
 }: RunJobOptions): Promise<RunJobStatus> => {
+  const leaseToken = leaseTokenOf(job);
   const startedAt = new Date();
   const runId = await createRun({ db, job, runnerId, startedAt });
   const controller = new AbortController();
   const abortListener = () => controller.abort();
   signal?.addEventListener("abort", abortListener, { once: true });
+
+  // A parent abort that fired while createRun() was awaited would not replay
+  // through the listener attached above. Re-check synchronously and bail before
+  // any task or heartbeat starts, releasing the lease cleanly.
+  if (signal?.aborted) {
+    controller.abort();
+    signal.removeEventListener("abort", abortListener);
+    await finishRunSkipped({ db, job, leaseToken, runId, startedAt });
+    return "skipped";
+  }
+
   const heartbeat = startLeaseHeartbeat({
     db,
     jobId: job.id,
     leaseMs,
+    leaseToken,
     runnerId,
     signal: controller.signal,
   });
   const task = registry.get(job.task);
   let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  // Set the instant the ceiling fires, before the abort is broadcast. The run is
+  // classified on this flag, not on which rejection wins the race: a task whose
+  // own abort handler rejects (e.g. an aborted fetch) must still be recorded as
+  // a timeout failure, never as a cooperative skip.
+  let timeoutError: SchedulerJobTimeoutError | undefined;
 
   try {
     if (!task) {
@@ -512,21 +519,21 @@ const runJob = async ({
     }
 
     // Bound the task's runtime. A JS promise cannot be force-cancelled, so on
-    // expiry we abort the task's signal FIRST, giving a cooperative task a
-    // chance to stop before its lease is released; a task that ignores the
-    // signal keeps running as a "zombie". We never chain a completion write onto
-    // it, and the guarded completion writes below reject a late write anyway, so
-    // a zombie can never overwrite the timed-out state.
+    // expiry we abort the task's signal, giving a cooperative task a chance to
+    // stop before its lease is released; a task that ignores the signal keeps
+    // running as a "zombie". We never chain a completion write onto it, and the
+    // guarded completion writes below reject a late write anyway, so a zombie
+    // can never overwrite the timed-out state.
     const timeout = new Promise<never>((_resolve, reject) => {
       timeoutTimer = setTimeout(() => {
+        const ceilingError = new SchedulerJobTimeoutError({
+          jobId: job.id,
+          message: `Scheduler job ${job.id} exceeded its ${maxRuntimeMs}ms runtime ceiling`,
+          timeoutMs: maxRuntimeMs,
+        });
+        timeoutError = ceilingError;
         controller.abort();
-        reject(
-          new SchedulerJobTimeoutError({
-            jobId: job.id,
-            message: `Scheduler job ${job.id} exceeded its ${maxRuntimeMs}ms runtime ceiling`,
-            timeoutMs: maxRuntimeMs,
-          }),
-        );
+        reject(ceilingError);
       }, maxRuntimeMs);
     });
 
@@ -542,18 +549,23 @@ const runJob = async ({
       ),
       timeout,
     ]);
-    await finishRunSuccess({ db, job, runId, runnerId, startedAt });
+    // Stop heartbeating before finalizing: the lease must not be renewed while
+    // we release it, and the completion transaction must not race a renewal on
+    // the same connection.
+    heartbeat.stop();
+    await finishRunSuccess({ db, job, leaseToken, runId, startedAt });
     return "success";
   } catch (error: unknown) {
-    // The timeout branch aborts `controller` before rejecting, so it must be
-    // checked before the abort branch below: otherwise a ceiling expiry would
-    // be misclassified as a cooperatively-skipped run.
-    if (error instanceof SchedulerJobTimeoutError) {
-      // Stop heartbeating first so the released lease cannot be re-extended,
-      // then release the job and mark the run timed out. Another runner can
-      // now reclaim it once the (already-released) lease is past.
-      heartbeat.stop();
-      captureError(error, {
+    // Stop heartbeating before any completion write: the lease must not be
+    // re-extended while we release it, and the write itself runs a transaction
+    // that must not race a renewal on the same connection.
+    heartbeat.stop();
+    // Classify on whether the ceiling fired, not on which rejection surfaced:
+    // aborting the task can make it reject with its own AbortError before our
+    // timeout rejection is observed. A ceiling expiry is always a timeout
+    // failure (rescheduled), never a cooperative skip (left due).
+    if (timeoutError) {
+      captureError(timeoutError, {
         schedulerJobId: job.id,
         schedulerRunId: runId,
         schedulerTask: job.task,
@@ -565,12 +577,19 @@ const runJob = async ({
         "scheduler.task": job.task,
         "scheduler.timeout_ms": maxRuntimeMs,
       });
-      await finishRunFailure({ db, error, job, runId, runnerId, startedAt });
+      await finishRunFailure({
+        db,
+        error: timeoutError,
+        job,
+        leaseToken,
+        runId,
+        startedAt,
+      });
       return "failed";
     }
 
     if (controller.signal.aborted) {
-      await finishRunSkipped({ db, job, runId, runnerId, startedAt });
+      await finishRunSkipped({ db, job, leaseToken, runId, startedAt });
       return "skipped";
     }
 
@@ -586,7 +605,7 @@ const runJob = async ({
       "scheduler.task": job.task,
       "error.type": errorTag(error),
     });
-    await finishRunFailure({ db, error, job, runId, runnerId, startedAt });
+    await finishRunFailure({ db, error, job, leaseToken, runId, startedAt });
     return "failed";
   } finally {
     if (timeoutTimer) {
@@ -631,65 +650,73 @@ const createRun = async ({
 type FinishRunOptions = {
   db: SchedulerDb;
   job: SchedulerJob;
+  leaseToken: string;
   runId: SafeId<"schedulerJobRun">;
-  runnerId: string;
   startedAt: Date;
 };
 
 type CompleteRunOptions = {
   db: SchedulerDb;
   jobId: string;
+  leaseToken: string;
   runId: SafeId<"schedulerJobRun">;
-  runnerId: string;
   runValues: PgUpdateSetSource<typeof schedulerJobRuns>;
   jobValues: PgUpdateSetSource<typeof schedulerJobs>;
 };
 
 // A run terminates exactly once. Every completion path (success, skipped,
-// failure) funnels through this single guarded writer so a future path cannot
-// forget the guard. Two layers reject a late zombie completion:
-//   1. run-row write is conditioned on `status = "running"` (a generation
+// failure) funnels through this single guarded, atomic writer so a future path
+// cannot forget the guard. Inside one transaction, two layers reject a late
+// completion:
+//   1. the run-row write is conditioned on `status = "running"` (a generation
 //      check) and only counts if it actually updated a row;
-//   2. the job-row write runs only when (1) won AND `lockedBy = runnerId` (a
-//      lease-token check) still matches.
-// Together they mean a zombie cannot overwrite a timed-out or reclaimed job,
-// even if the same runner has since re-acquired the job under a fresh run.
+//   2. the job-row write runs only when (1) won AND `lockedBy` still equals the
+//      exact lease token this execution acquired (a unique-lease check).
+// Because the lease token is unique per acquisition, a stale still-running
+// execution cannot complete the job after it has been re-acquired -- even by the
+// same runner process -- and the transaction stops the run write from committing
+// without the lease check.
 const completeRun = async ({
   db,
   jobId,
   jobValues,
+  leaseToken,
   runId,
-  runnerId,
   runValues,
 }: CompleteRunOptions): Promise<void> => {
-  const [updatedRun] = await db
-    .update(schedulerJobRuns)
-    .set(runValues)
-    .where(
-      and(
-        eq(schedulerJobRuns.id, runId),
-        eq(schedulerJobRuns.status, "running"),
-      ),
-    )
-    .returning({ id: schedulerJobRuns.id });
+  await db.transaction(async (tx) => {
+    const [updatedRun] = await tx
+      .update(schedulerJobRuns)
+      .set(runValues)
+      .where(
+        and(
+          eq(schedulerJobRuns.id, runId),
+          eq(schedulerJobRuns.status, "running"),
+        ),
+      )
+      .returning({ id: schedulerJobRuns.id });
 
-  if (!updatedRun) {
-    return;
-  }
+    if (!updatedRun) {
+      return;
+    }
 
-  await db
-    .update(schedulerJobs)
-    .set(jobValues)
-    .where(
-      and(eq(schedulerJobs.id, jobId), eq(schedulerJobs.lockedBy, runnerId)),
-    );
+    await tx
+      .update(schedulerJobs)
+      .set(jobValues)
+      .where(
+        and(
+          eq(schedulerJobs.id, jobId),
+          eq(schedulerJobs.lockedBy, leaseToken),
+        ),
+      );
+  });
 };
 
 export const finishRunSuccess = async ({
   db,
   job,
+  leaseToken,
   runId,
-  runnerId,
   startedAt,
 }: FinishRunOptions): Promise<void> => {
   const finishedAt = new Date();
@@ -706,8 +733,8 @@ export const finishRunSuccess = async ({
       lockedUntil: null,
       nextRunAt: computeNextRunAt(job.schedule, finishedAt),
     },
+    leaseToken,
     runId,
-    runnerId,
     runValues: {
       durationMs: durationMs(startedAt, finishedAt),
       finishedAt,
@@ -719,8 +746,8 @@ export const finishRunSuccess = async ({
 export const finishRunSkipped = async ({
   db,
   job,
+  leaseToken,
   runId,
-  runnerId,
   startedAt,
 }: FinishRunOptions): Promise<void> => {
   const finishedAt = new Date();
@@ -733,8 +760,8 @@ export const finishRunSkipped = async ({
       lockedBy: null,
       lockedUntil: null,
     },
+    leaseToken,
     runId,
-    runnerId,
     runValues: {
       durationMs: durationMs(startedAt, finishedAt),
       error: "SchedulerAborted",
@@ -752,8 +779,8 @@ export const finishRunFailure = async ({
   db,
   error,
   job,
+  leaseToken,
   runId,
-  runnerId,
   startedAt,
 }: FinishRunFailureOptions): Promise<void> => {
   const finishedAt = new Date();
@@ -771,8 +798,8 @@ export const finishRunFailure = async ({
       lockedUntil: null,
       nextRunAt: computeNextRunAt(job.schedule, finishedAt),
     },
+    leaseToken,
     runId,
-    runnerId,
     runValues: {
       durationMs: durationMs(startedAt, finishedAt),
       error: sanitizedError,
@@ -789,3 +816,23 @@ const defaultRunnerId = (): string => {
   const host = process.env["HOSTNAME"] ?? "local";
   return `${host}:${process.pid}:${Bun.randomUUIDv7()}`;
 };
+
+// scheduler_jobs.locked_by is varchar(128). The lease token binds a completion
+// to one specific acquisition: a globally-unique suffix means re-acquiring the
+// same job (even within the same runner process) yields a different token, so a
+// stale still-running execution can no longer satisfy the completion guard. The
+// runnerId prefix is kept for observability but truncated so the token always
+// fits the column.
+const LEASE_TOKEN_COLUMN_LENGTH = 128;
+
+const acquireLeaseToken = (runnerId: string): string => {
+  const suffix = `#${Bun.randomUUIDv7()}`;
+  const prefix = runnerId.slice(0, LEASE_TOKEN_COLUMN_LENGTH - suffix.length);
+  return `${prefix}${suffix}`;
+};
+
+// After a successful claim the acquired row carries its lease token in
+// `lockedBy`; every downstream lease operation matches against exactly that
+// token rather than the reusable runnerId.
+const leaseTokenOf = (job: SchedulerJob): string =>
+  job.lockedBy ?? panic("Leased scheduler job is missing its lease token");

--- a/apps/api/src/lib/scheduler/runner.ts
+++ b/apps/api/src/lib/scheduler/runner.ts
@@ -505,11 +505,14 @@ const runJob = async ({
   });
   const task = registry.get(job.task);
   let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-  // Set the instant the ceiling fires, before the abort is broadcast. The run is
-  // classified on this flag, not on which rejection wins the race: a task whose
-  // own abort handler rejects (e.g. an aborted fetch) must still be recorded as
-  // a timeout failure, never as a cooperative skip.
+  // Set the instant the ceiling fires, before the abort is broadcast, and
+  // consulted after the race regardless of how it settled. The race outcome
+  // alone is not authoritative: a cooperative task that resolves (or rejects)
+  // from its abort listener can fulfill the race even though the ceiling already
+  // fired, so that fulfillment is a zombie result, not a success.
   let timeoutError: SchedulerJobTimeoutError | undefined;
+  let raceError: unknown;
+  let raceRejected = false;
 
   try {
     if (!task) {
@@ -549,51 +552,99 @@ const runJob = async ({
       ),
       timeout,
     ]);
-    // Stop heartbeating before finalizing: the lease must not be renewed while
-    // we release it, and the completion transaction must not race a renewal on
-    // the same connection.
-    heartbeat.stop();
-    await finishRunSuccess({ db, job, leaseToken, runId, startedAt });
-    return "success";
   } catch (error: unknown) {
-    // Stop heartbeating before any completion write: the lease must not be
-    // re-extended while we release it, and the write itself runs a transaction
-    // that must not race a renewal on the same connection.
-    heartbeat.stop();
-    // Classify on whether the ceiling fired, not on which rejection surfaced:
-    // aborting the task can make it reject with its own AbortError before our
-    // timeout rejection is observed. A ceiling expiry is always a timeout
-    // failure (rescheduled), never a cooperative skip (left due).
-    if (timeoutError) {
-      captureError(timeoutError, {
-        schedulerJobId: job.id,
-        schedulerRunId: runId,
-        schedulerTask: job.task,
-      });
-      logger.error("scheduler.job_timed_out", {
-        "scheduler.job_id": job.id,
-        "scheduler.run_id": runId,
-        "scheduler.runner_id": runnerId,
-        "scheduler.task": job.task,
-        "scheduler.timeout_ms": maxRuntimeMs,
-      });
-      await finishRunFailure({
-        db,
-        error: timeoutError,
-        job,
-        leaseToken,
-        runId,
-        startedAt,
-      });
-      return "failed";
+    raceError = error;
+    raceRejected = true;
+  } finally {
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer);
     }
+    signal?.removeEventListener("abort", abortListener);
+  }
 
-    if (controller.signal.aborted) {
-      await finishRunSkipped({ db, job, leaseToken, runId, startedAt });
-      return "skipped";
-    }
+  // Stop heartbeating before any completion write: the lease must not be renewed
+  // while we release it, and the completion transaction must not race a renewal
+  // on the same connection.
+  heartbeat.stop();
 
-    captureError(error, {
+  return await resolveRunOutcome({
+    aborted: controller.signal.aborted,
+    db,
+    job,
+    leaseToken,
+    maxRuntimeMs,
+    raceError,
+    raceRejected,
+    runId,
+    runnerId,
+    startedAt,
+    timeoutError,
+  });
+};
+
+type ResolveRunOutcomeOptions = {
+  aborted: boolean;
+  db: SchedulerDb;
+  job: SchedulerJob;
+  leaseToken: string;
+  maxRuntimeMs: number;
+  raceError: unknown;
+  raceRejected: boolean;
+  runId: SafeId<"schedulerJobRun">;
+  runnerId: string;
+  startedAt: Date;
+  timeoutError: SchedulerJobTimeoutError | undefined;
+};
+
+// Single-homed post-race classification. Precedence matters: the ceiling flag
+// wins over the abort state (the ceiling aborts the controller itself), and both
+// win over the race outcome, because a fulfilled or rejected race is a zombie
+// result once the ceiling has fired or the parent has aborted. Only a race that
+// fulfilled with neither condition set is a genuine success.
+const resolveRunOutcome = async ({
+  aborted,
+  db,
+  job,
+  leaseToken,
+  maxRuntimeMs,
+  raceError,
+  raceRejected,
+  runId,
+  runnerId,
+  startedAt,
+  timeoutError,
+}: ResolveRunOutcomeOptions): Promise<RunJobStatus> => {
+  if (timeoutError) {
+    captureError(timeoutError, {
+      schedulerJobId: job.id,
+      schedulerRunId: runId,
+      schedulerTask: job.task,
+    });
+    logger.error("scheduler.job_timed_out", {
+      "scheduler.job_id": job.id,
+      "scheduler.run_id": runId,
+      "scheduler.runner_id": runnerId,
+      "scheduler.task": job.task,
+      "scheduler.timeout_ms": maxRuntimeMs,
+    });
+    await finishRunFailure({
+      db,
+      error: timeoutError,
+      job,
+      leaseToken,
+      runId,
+      startedAt,
+    });
+    return "failed";
+  }
+
+  if (aborted) {
+    await finishRunSkipped({ db, job, leaseToken, runId, startedAt });
+    return "skipped";
+  }
+
+  if (raceRejected) {
+    captureError(raceError, {
       schedulerJobId: job.id,
       schedulerRunId: runId,
       schedulerTask: job.task,
@@ -603,17 +654,21 @@ const runJob = async ({
       "scheduler.run_id": runId,
       "scheduler.runner_id": runnerId,
       "scheduler.task": job.task,
-      "error.type": errorTag(error),
+      "error.type": errorTag(raceError),
     });
-    await finishRunFailure({ db, error, job, leaseToken, runId, startedAt });
+    await finishRunFailure({
+      db,
+      error: raceError,
+      job,
+      leaseToken,
+      runId,
+      startedAt,
+    });
     return "failed";
-  } finally {
-    if (timeoutTimer) {
-      clearTimeout(timeoutTimer);
-    }
-    signal?.removeEventListener("abort", abortListener);
-    heartbeat.stop();
   }
+
+  await finishRunSuccess({ db, job, leaseToken, runId, startedAt });
+  return "success";
 };
 
 type CreateRunOptions = {


### PR DESCRIPTION
runJob awaited a task with no timeout while startLeaseHeartbeat renewed
lockedUntil every leaseMs/3 forever. A task that never resolved blocked
the sequential runSchedulerOnce loop (starving every other job on the
runner) and kept the lease fresh, so no other runner could reclaim it,
defeating the self-heal the lease exists for.

Add a per-job execution ceiling (DEFAULT_MAX_RUNTIME_MS, one lease
period; overridable via maxRuntimeMs). The task is raced against a
timeout; on expiry the runner stops heartbeating, releases the lease,
and records the run as failed with a SchedulerJobTimeoutError tag so
another runner can proceed.

A JS promise cannot be cancelled, so guard against a late "zombie"
completion writing success over the timeout: completion writes are now
conditioned on the run still being in `running` state (generation check)
in addition to the existing `lockedBy = runnerId` lease-token check on
the job row.

Thread the database handle through the runner so the claim, lease, and
completion paths are testable, and add coverage for claim exclusivity,
lease reclaim, failure accounting, and the runtime ceiling plus its
zombie-completion guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-job runtime limits (`maxRuntimeMs`) for scheduler tasks; timed-out jobs are aborted and recorded as timeout failures.
* **Bug Fixes**
  * Prevented timed-out, reclaimed, or late “zombie” completions from overwriting final run results.
  * Improved failure recording and rescheduling after task errors, including correct handling of aborts during timeout and run creation.
  * Ensured concurrent scheduler runs can’t claim the same job.
* **Tests**
  * Added a comprehensive scheduler runner test suite covering locking, lease expiry, timeouts, rescheduling, and zombie-completion guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->