### PR TITLE
fix(mcp): map infrastructure failures to retryable errors instead of 401/unknown_tool

### DIFF
--- a/apps/api/src/mcp/auth.test.ts
+++ b/apps/api/src/mcp/auth.test.ts
@@ -90,6 +90,16 @@ describe("classifyMcpTokenVerificationError", () => {
     expect(classifyMcpTokenVerificationError(claimError)).toBe(claimError);
   });
 
+  test("returns an existing verification error as-is (idempotent)", () => {
+    const verificationError = new McpTokenVerificationError({
+      message: "Token verification is temporarily unavailable",
+    });
+
+    expect(classifyMcpTokenVerificationError(verificationError)).toBe(
+      verificationError,
+    );
+  });
+
   test("maps a JWKS fetch outage to a retryable verification error", () => {
     // `verifyAccessToken` re-throws a JWKS fetch/network failure as a plain
     // Error (no UNAUTHORIZED status), so it must not present as a bad token.

--- a/apps/api/src/mcp/auth.test.ts
+++ b/apps/api/src/mcp/auth.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, test } from "bun:test";
 
 import { getAuthIssuerUrl } from "@/api/lib/auth-paths";
 import {
+  classifyMcpTokenVerificationError,
   extractMcpSession,
   getMcpAccessTokenVerificationOptions,
 } from "@/api/mcp/auth";
 import { getMcpResourceUrl } from "@/api/mcp/constants";
+import {
+  McpAuthenticationError,
+  McpTokenVerificationError,
+} from "@/api/mcp/errors";
 
 describe("extractMcpSession", () => {
   test("uses explicit auth endpoints for MCP access token verification", () => {
@@ -58,5 +63,54 @@ describe("extractMcpSession", () => {
         sub: "user_123",
       }),
     ).toThrow("Token missing org_id claim");
+  });
+});
+
+describe("classifyMcpTokenVerificationError", () => {
+  test("maps an UNAUTHORIZED verifier error to a token rejection", () => {
+    // Shape of a better-call APIError as re-thrown by the resource client for a
+    // genuinely invalid/expired token.
+    const apiError = Object.assign(new Error("token expired"), {
+      name: "APIError",
+      status: "UNAUTHORIZED",
+      statusCode: 401,
+    });
+
+    const classified = classifyMcpTokenVerificationError(apiError);
+
+    expect(classified).toBeInstanceOf(McpAuthenticationError);
+    expect(classified.cause).toBe(apiError);
+  });
+
+  test("keeps a claim-extraction rejection as an authentication error", () => {
+    const claimError = new McpAuthenticationError({
+      message: "Token missing org_id claim",
+    });
+
+    expect(classifyMcpTokenVerificationError(claimError)).toBe(claimError);
+  });
+
+  test("maps a JWKS fetch outage to a retryable verification error", () => {
+    // `verifyAccessToken` re-throws a JWKS fetch/network failure as a plain
+    // Error (no UNAUTHORIZED status), so it must not present as a bad token.
+    const jwksError = new Error("Jwks failed: fetch failed");
+
+    const classified = classifyMcpTokenVerificationError(jwksError);
+
+    expect(classified).toBeInstanceOf(McpTokenVerificationError);
+    expect(classified).not.toBeInstanceOf(McpAuthenticationError);
+    expect(classified.cause).toBe(jwksError);
+  });
+
+  test("maps a non-UNAUTHORIZED APIError to a retryable verification error", () => {
+    const internalError = Object.assign(new Error("introspection failed"), {
+      name: "APIError",
+      status: "INTERNAL_SERVER_ERROR",
+      statusCode: 500,
+    });
+
+    expect(classifyMcpTokenVerificationError(internalError)).toBeInstanceOf(
+      McpTokenVerificationError,
+    );
   });
 });

--- a/apps/api/src/mcp/auth.ts
+++ b/apps/api/src/mcp/auth.ts
@@ -90,6 +90,11 @@ export const classifyMcpTokenVerificationError = (
   if (error instanceof McpAuthenticationError) {
     return error;
   }
+  // Already-classified faults are returned as-is so re-classification is
+  // idempotent and never nests a verification error inside another one.
+  if (error instanceof McpTokenVerificationError) {
+    return error;
+  }
   if (isTokenRejectionError(error)) {
     return new McpAuthenticationError({
       message: "Invalid or expired token",

--- a/apps/api/src/mcp/auth.ts
+++ b/apps/api/src/mcp/auth.ts
@@ -4,7 +4,10 @@ import type { JWTPayload } from "jose";
 import { getAuthEndpointUrl, getAuthIssuerUrl } from "@/api/lib/auth-paths";
 import type { McpMode } from "@/api/mcp/constants";
 import { getMcpResourceUrl } from "@/api/mcp/constants";
-import { McpAuthenticationError } from "@/api/mcp/errors";
+import {
+  McpAuthenticationError,
+  McpTokenVerificationError,
+} from "@/api/mcp/errors";
 
 export type McpSession = {
   userId: string;
@@ -58,6 +61,47 @@ export const extractMcpSession = (payload: JWTPayload): McpSession => {
   };
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/**
+ * A genuine token rejection surfaces as a better-call `APIError` with an
+ * `UNAUTHORIZED` (401) status: `verifyAccessToken` maps expired tokens, invalid
+ * signatures, wrong audience/issuer, no-matching-key, and a missing payload to
+ * that shape. Everything else the verifier can throw is an infrastructure fault
+ * (a JWKS fetch/network error re-thrown as a plain `Error`, or a jose JWKS
+ * timeout/invalid error) and must not be reported to the caller as a bad token.
+ */
+const isTokenRejectionError = (error: unknown): boolean =>
+  isRecord(error) &&
+  error["name"] === "APIError" &&
+  (error["status"] === "UNAUTHORIZED" || error["statusCode"] === 401);
+
+/**
+ * Classify a failure thrown while resolving the bearer token. A genuine token
+ * rejection (bad claims from `extractMcpSession`, or an `UNAUTHORIZED` verifier
+ * error) becomes an `McpAuthenticationError` (surfaces as 401). An
+ * infrastructure fault becomes an `McpTokenVerificationError` (captured,
+ * retryable 5xx) so a JWKS outage does not masquerade as an invalid token.
+ */
+export const classifyMcpTokenVerificationError = (
+  error: unknown,
+): McpAuthenticationError | McpTokenVerificationError => {
+  if (error instanceof McpAuthenticationError) {
+    return error;
+  }
+  if (isTokenRejectionError(error)) {
+    return new McpAuthenticationError({
+      message: "Invalid or expired token",
+      cause: error,
+    });
+  }
+  return new McpTokenVerificationError({
+    message: "Token verification is temporarily unavailable",
+    cause: error,
+  });
+};
+
 export const authenticateMcpRequest = async (
   bearerToken: string,
   mode: McpMode = "default",
@@ -70,9 +114,6 @@ export const authenticateMcpRequest = async (
 
     return extractMcpSession(payload);
   } catch (error) {
-    throw new McpAuthenticationError({
-      message: "Invalid or expired token",
-      cause: error,
-    });
+    throw classifyMcpTokenVerificationError(error);
   }
 };

--- a/apps/api/src/mcp/errors.ts
+++ b/apps/api/src/mcp/errors.ts
@@ -12,3 +12,31 @@ export class McpOrganizationAccessError extends TaggedError(
 )<{
   message: string;
 }>() {}
+
+/**
+ * An infrastructure failure while verifying the bearer token (JWKS fetch/network
+ * outage, JWKS timeout, or any non-rejection fault) rather than a genuine bad or
+ * expired token. Distinct from `McpAuthenticationError` so the transport can
+ * surface it as a captured, retryable 5xx instead of a 401: a JWKS outage must
+ * not present to clients as "invalid token" (which triggers pointless re-consent
+ * and hides the outage from telemetry).
+ */
+export class McpTokenVerificationError extends TaggedError(
+  "McpTokenVerificationError",
+)<{
+  message: string;
+  cause?: unknown;
+}>() {}
+
+/**
+ * A backing store read failed while loading the dynamic gateway surface
+ * (external connector tools or agent skills). Distinct from an empty result so
+ * dispatch answers a transient DB outage with a retryable `internal_error`
+ * instead of a non-retryable `unknown_tool`, and `tools/list` fails loudly
+ * instead of silently shrinking. The underlying failure is captured at the load
+ * site; this error only carries the fact that the load failed.
+ */
+export class McpGatewayLoadError extends TaggedError("McpGatewayLoadError")<{
+  message: string;
+  cause?: unknown;
+}>() {}

--- a/apps/api/src/mcp/gateway/dispatch-call.ts
+++ b/apps/api/src/mcp/gateway/dispatch-call.ts
@@ -8,8 +8,10 @@ import type { McpMode } from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   callGatewayExternalMcpTool,
+  gatewayLoadErrorResult,
   recordSkillGatewayToolAudit,
 } from "@/api/mcp/gateway/external-tools";
+import type { ResolvedSkillTool } from "@/api/mcp/gateway/skills";
 import { resolveSkillTool } from "@/api/mcp/gateway/skills";
 import { structuredErrorResult, textResult } from "@/api/mcp/tool-utils";
 
@@ -37,7 +39,18 @@ export const dispatchGatewayToolCall = async ({
   }
 
   const startedAt = Date.now();
-  const skill = await resolveSkillTool({ context, toolName });
+  let skill: ResolvedSkillTool | null;
+  try {
+    skill = await resolveSkillTool({ context, toolName });
+  } catch (error) {
+    // A load fault means we cannot tell whether the skill exists: answer with a
+    // retryable error, never a definitive `unknown_tool`.
+    const loadError = gatewayLoadErrorResult(error);
+    if (loadError) {
+      return loadError;
+    }
+    throw error;
+  }
   if (!skill) {
     return structuredErrorResult({
       code: "unknown_tool",

--- a/apps/api/src/mcp/gateway/external-tools.test.ts
+++ b/apps/api/src/mcp/gateway/external-tools.test.ts
@@ -7,8 +7,10 @@ import type { CachedMcpToolDefinition } from "@/api/db/schema";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
+import { DatabaseError } from "@/api/lib/errors/tagged-errors";
 import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
 import type { McpRequestContext } from "@/api/mcp/context";
+import { McpGatewayLoadError } from "@/api/mcp/errors";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const loadActiveMcpConnectionsForUserMock = mock();
@@ -21,7 +23,7 @@ void mock.module("@/api/lib/mcp-upstream/connections", () => ({
   refreshCachedMcpToolsForConnection: refreshCachedMcpToolsForConnectionMock,
 }));
 
-const { listGatewayExternalMcpTools } =
+const { callGatewayExternalMcpTool, listGatewayExternalMcpTools } =
   await import("@/api/mcp/gateway/external-tools");
 
 type GatewayConnectionToolRow = {
@@ -105,6 +107,14 @@ const createContext = (
   };
 };
 
+/** Context whose backing-store read always fails (transient DB outage). */
+const createFailingContext = (): McpRequestContext => {
+  const base = createContext([]);
+  const safeDb: McpRequestContext["safeDb"] = async () =>
+    Result.err(new DatabaseError({ message: "connection refused" }));
+  return { ...base, safeDb };
+};
+
 describe("external MCP gateway tools", () => {
   beforeEach(() => {
     loadActiveMcpConnectionsForUserMock.mockReset();
@@ -131,5 +141,33 @@ describe("external MCP gateway tools", () => {
     expect(tools).toHaveLength(1);
     expect(tools.at(0)?.cachedTool.rawName).toBe("lookup");
     expect(tools.at(0)?.connection).toEqual(activeConnection);
+  });
+
+  test("propagates a backing-store load fault instead of shrinking to an empty list", async () => {
+    const context = createFailingContext();
+
+    // A DB outage must not be mistaken for "no connectors": the loader throws a
+    // distinct fault so tools/list fails loudly rather than silently dropping
+    // every external tool.
+    await expect(listGatewayExternalMcpTools({ context })).rejects.toThrow(
+      McpGatewayLoadError,
+    );
+  });
+
+  test("answers a call with a retryable internal_error, not unknown_tool, when the load fails", async () => {
+    const context = createFailingContext();
+
+    const result = await callGatewayExternalMcpTool({
+      args: {},
+      context,
+      toolName: "mcp__registry__lookup",
+    });
+
+    const item = result.content.at(0);
+    const parsed = item?.type === "text" ? JSON.parse(item.text) : undefined;
+    expect(parsed.error.code).toBe("internal_error");
+    expect(parsed.error.retryable).toBe(true);
+    expect(parsed.error.code).not.toBe("unknown_tool");
+    expect(result.isError).toBe(true);
   });
 });

--- a/apps/api/src/mcp/gateway/external-tools.test.ts
+++ b/apps/api/src/mcp/gateway/external-tools.test.ts
@@ -149,9 +149,16 @@ describe("external MCP gateway tools", () => {
     // A DB outage must not be mistaken for "no connectors": the loader throws a
     // distinct fault so tools/list fails loudly rather than silently dropping
     // every external tool.
-    await expect(listGatewayExternalMcpTools({ context })).rejects.toThrow(
-      McpGatewayLoadError,
+    // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+    // type-aware lint; capture the rejection explicitly instead.
+    const rejection: unknown = await listGatewayExternalMcpTools({
+      context,
+    }).then(
+      () => null,
+      (error: unknown) => error,
     );
+
+    expect(rejection).toBeInstanceOf(McpGatewayLoadError);
   });
 
   test("answers a call with a retryable internal_error, not unknown_tool, when the load fails", async () => {

--- a/apps/api/src/mcp/gateway/external-tools.ts
+++ b/apps/api/src/mcp/gateway/external-tools.ts
@@ -1,3 +1,4 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
 
@@ -14,6 +15,7 @@ import {
 } from "@/api/lib/mcp-upstream/connections";
 import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
 import type { McpRequestContext } from "@/api/mcp/context";
+import { McpGatewayLoadError } from "@/api/mcp/errors";
 import { consumeMcpGatewayRateLimit } from "@/api/mcp/gateway/rate-limit";
 import {
   MCP_INTERNAL_ERROR_HINT,
@@ -35,6 +37,23 @@ export type ResolvedExternalMcpTool = {
   connectorSlug: string;
   connection: LoadedMcpConnection;
 };
+
+/**
+ * Map a dynamic-gateway load fault to a retryable `internal_error` envelope, or
+ * `null` when the error is not a load fault (the caller rethrows). Shared by the
+ * external and skill dispatch paths so a transient backing-store outage answers
+ * a `tools/call` with a retryable error instead of a non-retryable
+ * `unknown_tool`. The underlying failure was captured at the load site.
+ */
+export const gatewayLoadErrorResult = (error: unknown): CallToolResult | null =>
+  error instanceof McpGatewayLoadError
+    ? structuredErrorResult({
+        code: "internal_error",
+        message: "MCP gateway tools are temporarily unavailable",
+        retryable: true,
+        hint: MCP_INTERNAL_ERROR_HINT,
+      })
+    : null;
 
 export const listGatewayExternalMcpTools = async ({
   context,
@@ -103,7 +122,18 @@ export const callGatewayExternalMcpTool = async ({
   context: McpRequestContext;
   toolName: string;
 }) => {
-  const resolved = await resolveGatewayExternalMcpTool({ context, toolName });
+  let resolved: ResolvedExternalMcpTool | null;
+  try {
+    resolved = await resolveGatewayExternalMcpTool({ context, toolName });
+  } catch (error) {
+    // A load fault means we cannot tell whether the tool exists: answer with a
+    // retryable error, never a definitive `unknown_tool`.
+    const loadError = gatewayLoadErrorResult(error);
+    if (loadError) {
+      return loadError;
+    }
+    throw error;
+  }
   if (!resolved) {
     return structuredErrorResult({
       code: "unknown_tool",
@@ -304,7 +334,14 @@ const loadCachedGatewayToolRows = async ({
 
   if (Result.isError(rows)) {
     captureError(rows.error, { source: "mcp-gateway-external-list" });
-    return [];
+    // Propagate the load fault as a distinct state: returning `[]` here would
+    // make a transient DB outage indistinguishable from "no connectors", so a
+    // `tools/call` would answer `unknown_tool` and `tools/list` would silently
+    // shrink. Callers map this to a retryable error / a loud list failure.
+    throw new McpGatewayLoadError({
+      message: "Failed to load MCP gateway connectors",
+      cause: rows.error,
+    });
   }
 
   return rows.value;

--- a/apps/api/src/mcp/gateway/skills.ts
+++ b/apps/api/src/mcp/gateway/skills.ts
@@ -9,6 +9,7 @@ import {
   namespaceSkillToolName,
 } from "@/api/lib/mcp-upstream/namespace";
 import type { McpRequestContext } from "@/api/mcp/context";
+import { McpGatewayLoadError } from "@/api/mcp/errors";
 
 type SkillToolRow = {
   body: string;
@@ -67,7 +68,13 @@ export const loadVisibleSkillTools = async ({
 
   if (Result.isError(rows)) {
     captureError(rows.error, { source: "mcp-gateway-skills" });
-    return [];
+    // Propagate the load fault instead of `[]`, so a transient DB outage is not
+    // mistaken for "no skills": dispatch maps this to a retryable error and
+    // `tools/list` fails loudly rather than silently dropping skill tools.
+    throw new McpGatewayLoadError({
+      message: "Failed to load agent skills",
+      cause: rows.error,
+    });
   }
 
   return resolveSkillToolPrecedence(rows.value);

--- a/apps/api/src/mcp/onboarding.test.ts
+++ b/apps/api/src/mcp/onboarding.test.ts
@@ -64,6 +64,7 @@ type MattersRow = {
 type SelectChain = {
   select: () => SelectChain;
   from: () => SelectChain;
+  innerJoin: () => SelectChain;
   where: () => SelectChain;
   orderBy: () => SelectChain;
   limit: () => Promise<MattersRow[]>;
@@ -108,6 +109,9 @@ const createScopedDb = ({
       const builder: SelectChain = {
         select: () => builder,
         from: () => builder,
+        // The gateway connector load joins two tables; model the step so its
+        // read resolves to the (empty by default) seed instead of erroring.
+        innerJoin: () => builder,
         where: () => builder,
         orderBy: () => builder,
         limit: async () => matters,

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -18,6 +18,7 @@ import type { McpMode } from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
 import {
   McpAuthenticationError,
+  McpGatewayLoadError,
   McpOrganizationAccessError,
 } from "@/api/mcp/errors";
 import { getMcpInstructions } from "@/api/mcp/instructions";
@@ -26,7 +27,11 @@ import {
   getMcpWwwAuthenticateHeader,
 } from "@/api/mcp/metadata";
 import type { McpToolDefinition, ToolScope } from "@/api/mcp/tool-types";
-import { closestToolNames, structuredErrorResult } from "@/api/mcp/tool-utils";
+import {
+  closestToolNames,
+  MCP_INTERNAL_ERROR_HINT,
+  structuredErrorResult,
+} from "@/api/mcp/tool-utils";
 
 const MAX_TOOL_NAME_SUGGESTION_CHARS = 128;
 
@@ -125,6 +130,40 @@ const accessDeniedResponse = ({
   });
 };
 
+/** Hint (seconds) for a client to back off before retrying a transient fault. */
+const MCP_RETRY_AFTER_SECONDS = 2;
+
+/**
+ * A server-side fault (token-verification infrastructure outage, a bug in
+ * session resolution, or a transport failure) is not a bad token: it must not
+ * carry `WWW-Authenticate` (which would trigger a re-consent loop) and must not
+ * leak internals. A generic, retryable 5xx tells the client to back off and
+ * retry; the real cause is captured for observability by the caller.
+ */
+const retryableServerErrorResponse = () => {
+  const headers = createMcpCorsHeaders();
+  headers.set("Retry-After", String(MCP_RETRY_AFTER_SECONDS));
+
+  return new Response("Service temporarily unavailable", {
+    headers,
+    status: 503,
+  });
+};
+
+/**
+ * Generic, retryable tool-error envelope for an unexpected failure while
+ * handling a `tools/call` (e.g. a gateway load fault surfaced before dispatch).
+ * Details never reach the caller; they are captured at the failure site.
+ */
+const retryableToolErrorResult = (): CallToolResult =>
+  structuredErrorResult({
+    code: "internal_error",
+    message:
+      "The request could not be completed due to a temporary server error",
+    retryable: true,
+    hint: MCP_INTERNAL_ERROR_HINT,
+  });
+
 export const createMcpHttpRequestHandler = ({
   authenticateMcpRequest,
   captureError,
@@ -182,7 +221,21 @@ export const createMcpHttpRequestHandler = ({
         return missingScopeResult(hintedScope);
       }
 
-      const definition = await getMcpToolDefinition(toolName, context, mode);
+      // Resolving a dynamic-gateway tool reads the backing store. A load fault
+      // (`McpGatewayLoadError`) must not collapse into `unknown_tool`: answer a
+      // transient outage with a retryable `internal_error` so the caller retries
+      // instead of treating the tool as gone. The underlying failure is captured
+      // at the load site, so it is not re-captured here.
+      let definition: McpToolDefinition | undefined;
+      try {
+        definition = await getMcpToolDefinition(toolName, context, mode);
+      } catch (error) {
+        if (error instanceof McpGatewayLoadError) {
+          return retryableToolErrorResult();
+        }
+        captureError(error, { phase: "tools/call", mode, source: "mcp" });
+        return retryableToolErrorResult();
+      }
       if (!definition) {
         // Suggest the closest names the caller can actually see (scope-filtered
         // list), so a typo resolves without leaking tools they lack access to.
@@ -270,19 +323,27 @@ export const createMcpHttpRequestHandler = ({
         });
       }
 
-      if (!(error instanceof McpAuthenticationError)) {
-        captureError(error, {
-          phase: "transport",
+      // Only a genuine token rejection gets a 401 + `WWW-Authenticate`. Anything
+      // else (a token-verification infrastructure outage surfaced as
+      // `McpTokenVerificationError`, a bug in session resolution, or a transport
+      // fault) is a server-side problem, not a bad token: capture it and return
+      // a retryable 5xx so the client backs off instead of dropping into a
+      // re-consent loop.
+      if (error instanceof McpAuthenticationError) {
+        return accessDeniedResponse({
+          message: "Invalid or expired token",
           mode,
-          source: "mcp",
+          status: 401,
         });
       }
 
-      return accessDeniedResponse({
-        message: "Invalid or expired token",
+      captureError(error, {
+        phase: "transport",
         mode,
-        status: 401,
+        source: "mcp",
       });
+
+      return retryableServerErrorResponse();
     } finally {
       if (transport) {
         await transport.close().catch(() => null);

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -230,10 +230,12 @@ export const createMcpHttpRequestHandler = ({
       try {
         definition = await getMcpToolDefinition(toolName, context, mode);
       } catch (error) {
-        if (error instanceof McpGatewayLoadError) {
-          return retryableToolErrorResult();
+        // A gateway load fault is already captured at the load site; anything
+        // else is unexpected here and must be captured before it degrades to a
+        // generic retryable result.
+        if (!(error instanceof McpGatewayLoadError)) {
+          captureError(error, { phase: "tools/call", mode, source: "mcp" });
         }
-        captureError(error, { phase: "tools/call", mode, source: "mcp" });
         return retryableToolErrorResult();
       }
       if (!definition) {

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -13,7 +13,9 @@ import {
 } from "@/api/mcp/constants";
 import {
   McpAuthenticationError,
+  McpGatewayLoadError,
   McpOrganizationAccessError,
+  McpTokenVerificationError,
 } from "@/api/mcp/errors";
 import { createMcpHttpRequestHandler } from "@/api/mcp/server-core";
 import type { ToolScope } from "@/api/mcp/tool-types";
@@ -164,7 +166,7 @@ describe("handleMcpHttpRequest", () => {
     expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
-  test("captures unexpected transport errors while returning a generic 401", async () => {
+  test("captures unexpected transport errors as a retryable 5xx, not a 401", async () => {
     const error = new Error("database connection refused");
     authenticateMcpRequestMock.mockResolvedValue({
       organizationId: "org_1",
@@ -182,13 +184,79 @@ describe("handleMcpHttpRequest", () => {
       }),
     );
 
-    expect(response.status).toBe(401);
-    expect(await response.text()).toBe("Invalid or expired token");
+    // A server-side bug must not present to the client as a bad token (which
+    // would trigger a pointless re-consent loop): no 401, no WWW-Authenticate.
+    expect(response.status).toBe(503);
+    expect(response.headers.get("WWW-Authenticate")).toBeNull();
+    expect(response.headers.get("Retry-After")).toBe("2");
     expect(captureErrorMock).toHaveBeenCalledWith(error, {
       mode: "default",
       phase: "transport",
       source: "mcp",
     });
+  });
+
+  test("captures a token-verification infrastructure outage as a retryable 5xx, not a 401", async () => {
+    const error = new McpTokenVerificationError({
+      message: "Token verification is temporarily unavailable",
+      cause: new Error("Jwks failed: fetch failed"),
+    });
+    authenticateMcpRequestMock.mockRejectedValue(error);
+
+    const response = await handleMcpHttpRequest(
+      new Request("http://localhost/mcp", {
+        headers: {
+          authorization: "Bearer token",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("WWW-Authenticate")).toBeNull();
+    expect(captureErrorMock).toHaveBeenCalledWith(error, {
+      mode: "default",
+      phase: "transport",
+      source: "mcp",
+    });
+  });
+
+  test("answers a gateway load fault during tools/call with a retryable internal_error, not unknown_tool", async () => {
+    const context = { type: "mcp-context" };
+    authenticateMcpRequestMock.mockResolvedValue({
+      organizationId: "org_1",
+      scopes: ["stella:read", "stella:skills"],
+      userId: "user_1",
+    });
+    resolveMcpSessionContextMock.mockResolvedValue(context);
+    getMcpToolScopeHintMock.mockReturnValue(undefined);
+    // The dynamic-gateway definition load fails (backing store outage). This
+    // must not collapse into a definitive unknown_tool.
+    getMcpToolDefinitionMock.mockRejectedValue(
+      new McpGatewayLoadError({ message: "Failed to load agent skills" }),
+    );
+
+    const response = await handleMcpHttpRequest(
+      createMcpRequest({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { arguments: {}, name: "skill__research" },
+      }),
+    );
+    const body = await readTestJson<McpJsonResponse<CallToolResult>>(response);
+
+    expect(response.status).toBe(200);
+    expect(handleMcpToolCallMock).not.toHaveBeenCalled();
+    const item = body.result.content.at(0);
+    const parsed = item?.type === "text" ? JSON.parse(item.text) : undefined;
+    expect(parsed.error.code).toBe("internal_error");
+    expect(parsed.error.retryable).toBe(true);
+    expect(parsed.error.code).not.toBe("unknown_tool");
+    expect(body.result.isError).toBe(true);
+    // The load site already captured the DB failure; the transport must not
+    // re-capture the mapped gateway error.
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
   test("passes granted scopes to tool listing", async () => {

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -112,6 +112,9 @@ const createScopedDb = (templates: unknown[] = []) =>
       const builder = {
         select: () => builder,
         from: () => builder,
+        // The gateway connector load joins two tables; model the step so its
+        // read resolves to the (empty by default) seed instead of erroring.
+        innerJoin: () => builder,
         where: () => builder,
         orderBy: () => builder,
         limit: async () => templates,

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -302,11 +302,20 @@ const createReadDecisionResult = () => ({
 });
 
 const createSelectBuilder = (rows: unknown[]) => {
+  // `.where()` is terminal for most callers (awaited directly as the row array),
+  // but the gateway connector query chains `.orderBy().limit()` after it. Return
+  // an array that also answers those builder steps with the same rows so every
+  // shape resolves identically; a bare array would make `.orderBy` undefined and
+  // turn the connector load into a spurious McpGatewayLoadError.
+  const terminal = Object.assign([...rows], {
+    orderBy: () => terminal,
+    limit: () => terminal,
+  });
   const builder = {
     from: () => builder,
     innerJoin: () => builder,
     leftJoin: () => builder,
-    where: () => rows,
+    where: () => terminal,
   };
 
   return builder;


### PR DESCRIPTION
Three related error-mapping bugs in the MCP server let server-side faults
masquerade as client faults:

- Token verification wrapped every throw (including JWKS fetch/network
  outages) into McpAuthenticationError, so a JWKS outage 401'd all traffic
  as "invalid token" with no telemetry. Classify the caught error: an
  UNAUTHORIZED APIError is a genuine token rejection (401); anything else is
  an infrastructure fault surfaced as McpTokenVerificationError, captured and
  returned as a retryable 503 (no WWW-Authenticate, so no re-consent loop).

- The transport catch-all returned 401 + WWW-Authenticate for any non-auth
  error (session-resolution or transport bugs), presenting server bugs as bad
  tokens. Only McpAuthenticationError now yields 401; everything else is
  captured and returned as a retryable 503.

- Gateway tool loaders answered a safeDb read failure with an empty list, so
  dispatch returned a non-retryable unknown_tool and tools/list silently
  shrank. Loaders now throw McpGatewayLoadError; dispatch and the pre-dispatch
  definition load map it to a retryable internal_error, and tools/list fails
  loudly instead of dropping tools.

Generic messages out; details only to telemetry. Adds coverage for
error classification, transport mapping, and gateway load faults.
