### PR TITLE
fix(api): make workflow entity completion retry-idempotent

### DIFF
--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -56,10 +56,7 @@ import {
   readFullWorkflowSnapshotCursor,
 } from "@/api/lib/workflow-target-queries";
 import { resolveWorkflowTargetEntityIds } from "@/api/lib/workflow-targets";
-import {
-  COMPLETE_ENTITY_SCRIPT,
-  parseEntityCompletionReply,
-} from "@/api/lib/workflow/completion-tracking";
+import { recordEntityCompletion } from "@/api/lib/workflow/completion-tracking";
 import { getBatchGenerator } from "@/api/lib/workflow/generate-batch-provider";
 import type {
   AIJustification,
@@ -114,7 +111,7 @@ const workflowKey = (workspaceId: SafeId<"workspace">, field: string) =>
 const WORKFLOW_RUN_STATE_FIELDS = [
   "running",
   "total",
-  "completed",
+  "completed-entities",
   "plan-properties",
   "request-id",
   "scoped",
@@ -548,9 +545,17 @@ export const startWorkflow = async ({
       return { status: "skipped" };
     }
 
-    // Store entity count for completion tracking
-    await redis.set(workflowKey(workspaceId, "total"), String(targetCount));
-    await redis.set(workflowKey(workspaceId, "completed"), "0");
+    // Store entity count for completion tracking. Carries the run-lock TTL
+    // (refreshed on each entity completion) so it self-heals with the rest
+    // of the run-state instead of leaking after the run lapses. The
+    // completed-entities set is created lazily by the completion script's
+    // first SADD and given its TTL there, so it needs no seed here.
+    await redis.set(
+      workflowKey(workspaceId, "total"),
+      String(targetCount),
+      "EX",
+      runLockTtlSec,
+    );
 
     // Snapshot the property IDs in this workflow's plan so finishWorkflow
     // can freshen only the ones it actually processed. Without this,
@@ -1128,13 +1133,14 @@ const handleWorkflowJobFailed = (
           });
         },
       );
-      await onEntityCompleted(
-        branded.workspaceId,
-        branded.organizationId,
-        brandPersistedUserId(data.userId),
-        data.requestId,
-        data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
-      );
+      await onEntityCompleted({
+        workspaceId: branded.workspaceId,
+        organizationId: branded.organizationId,
+        userId: brandPersistedUserId(data.userId),
+        entityId: brandPersistedEntityId(data.entityId),
+        requestId: data.requestId,
+        runLockTtlSec: data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
+      });
     })().catch((completionError: unknown) => {
       captureError(completionError, {
         workspaceId: data.workspaceId,
@@ -1374,13 +1380,14 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
   // Broadcast entity invalidation so frontend refetches
   broadcastInvalidation(branded.workspaceId, ["entities", branded.workspaceId]);
 
-  await onEntityCompleted(
-    branded.workspaceId,
-    branded.organizationId,
+  await onEntityCompleted({
+    workspaceId: branded.workspaceId,
+    organizationId: branded.organizationId,
     userId,
+    entityId: brandedEntityId,
     requestId,
-    data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
-  );
+    runLockTtlSec: data.runLockTtlSec ?? RUNNING_LOCK_TTL_SEC,
+  });
 };
 
 type ProcessOneBatchArgs = {
@@ -1853,34 +1860,46 @@ const processOneBatch = async ({
 
 // ── Completion tracking ────────────────────────────────
 
-const onEntityCompleted = async (
-  workspaceId: SafeId<"workspace">,
-  organizationId: SafeId<"organization">,
-  userId: SafeId<"user">,
-  requestId: string,
-  runLockTtlSec: number,
-) => {
+type OnEntityCompletedArgs = {
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  entityId: SafeId<"entity">;
+  requestId: string;
+  runLockTtlSec: number;
+};
+
+const onEntityCompleted = async ({
+  workspaceId,
+  organizationId,
+  userId,
+  entityId,
+  requestId,
+  runLockTtlSec,
+}: OnEntityCompletedArgs) => {
   const redis = getRedis();
 
-  // Atomically re-check that this job still belongs to the active
-  // workflow request AND increment the completed counter in the same
-  // Redis command (see `COMPLETE_ENTITY_SCRIPT`). A plain check-then-INCR
-  // (two round trips) leaves a window where a stale job's check can pass
-  // just before the run it belongs to finishes and a new run resets the
-  // counters — the stale job's INCR would then land on the new run's
-  // counter instead of being a no-op. Same idiom as
-  // `RESERVE_RECOVERY_LOCK_SCRIPT` above.
-  const reply: unknown = await redis.send("EVAL", [
-    COMPLETE_ENTITY_SCRIPT,
-    "4",
-    workflowKey(workspaceId, "request-id"),
-    workflowKey(workspaceId, "running"),
-    workflowKey(workspaceId, "completed"),
-    workflowKey(workspaceId, "total"),
-    requestId,
-    LEGACY_RUNNING_LOCK_VALUE,
-  ]);
-  const result = parseEntityCompletionReply(reply);
+  // Atomically re-check that this job still belongs to the active workflow
+  // request AND record this entity's completion in the same Redis command
+  // (see `COMPLETE_ENTITY_SCRIPT`). The check-and-write bundling closes the
+  // stale-run window (a check could otherwise pass just before the run it
+  // belongs to finishes); the SADD/SCARD set makes the write idempotent per
+  // entity, so a re-driven entity (timeout after completion, stalled-job
+  // reclaim, exhausted-retry failure handler) cannot double-count and push
+  // the run to finalize while an entity is still mid-flight.
+  const result = await recordEntityCompletion({
+    redis,
+    keys: {
+      requestId: workflowKey(workspaceId, "request-id"),
+      running: workflowKey(workspaceId, "running"),
+      completedEntities: workflowKey(workspaceId, "completed-entities"),
+      total: workflowKey(workspaceId, "total"),
+    },
+    activeRequestId: requestId,
+    legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
+    entityId,
+    runStateTtlSec: runLockTtlSec,
+  });
   if (!result.matched) {
     return;
   }
@@ -1890,16 +1909,17 @@ const onEntityCompleted = async (
     return;
   }
 
-  // Long workflows can outlast the initial TTL on the running lock and
-  // the plan-properties snapshot. Each completed entity refreshes both
-  // back to the full window so progress keeps the lock alive instead
-  // of letting a slow batch fall back to the "freshen everything"
-  // path or admit a parallel run.
+  // Long workflows can outlast the initial TTL on the run-state keys. Each
+  // completed entity refreshes them back to the full window so progress
+  // keeps the lock alive instead of letting a slow batch fall back to the
+  // "freshen everything" path, admit a parallel run, or leak `total`. The
+  // completed-entities set is refreshed inside the completion script above.
   await Promise.all([
     redis.expire(workflowKey(workspaceId, "running"), runLockTtlSec),
     redis.expire(workflowKey(workspaceId, "plan-properties"), runLockTtlSec),
     redis.expire(workflowKey(workspaceId, "request-id"), runLockTtlSec),
     redis.expire(workflowKey(workspaceId, "service-tier"), runLockTtlSec),
+    redis.expire(workflowKey(workspaceId, "total"), runLockTtlSec),
     // Refresh the scoped flag's TTL for the same reason: if it
     // expires mid-run, `finishWorkflow` would mistake a long-running
     // scoped retry for a full sweep and freshen the property globally.

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -56,7 +56,10 @@ import {
   readFullWorkflowSnapshotCursor,
 } from "@/api/lib/workflow-target-queries";
 import { resolveWorkflowTargetEntityIds } from "@/api/lib/workflow-targets";
-import { recordEntityCompletion } from "@/api/lib/workflow/completion-tracking";
+import {
+  recordEntityCompletion,
+  resetCompletionState,
+} from "@/api/lib/workflow/completion-tracking";
 import { getBatchGenerator } from "@/api/lib/workflow/generate-batch-provider";
 import type {
   AIJustification,
@@ -545,11 +548,22 @@ export const startWorkflow = async ({
       return { status: "skipped" };
     }
 
+    // Start from an empty completion set. It grows lazily via SADD, so a
+    // prior run whose run-state outlived it (worker death between the
+    // completion script's EXPIRE and the sibling-key refresh, a manual lock
+    // deletion, a TTL discrepancy) could leave stale members that inflate
+    // this run's SCARD and finalize it early. We hold the run lock (NX)
+    // here, so no live run shares the key.
+    await resetCompletionState({
+      redis,
+      completedEntitiesKey: workflowKey(workspaceId, "completed-entities"),
+    });
+
     // Store entity count for completion tracking. Carries the run-lock TTL
     // (refreshed on each entity completion) so it self-heals with the rest
     // of the run-state instead of leaking after the run lapses. The
-    // completed-entities set is created lazily by the completion script's
-    // first SADD and given its TTL there, so it needs no seed here.
+    // completed-entities set is (re)given its TTL by the completion script's
+    // first SADD, so it needs no seed here.
     await redis.set(
       workflowKey(workspaceId, "total"),
       String(targetCount),

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -120,6 +120,12 @@ const WORKFLOW_RUN_STATE_FIELDS = [
   // its counter deleted on finish/skip/orphan, and so the compat path dies
   // with the transition.
   "completed",
+  // Marker written by `resetCompletionState` for every run started under
+  // this code. Gates the completion script's legacy-counter read so a
+  // straggler old-code replica cannot contaminate a run that provably
+  // started under set-mode tracking (see completion-tracking.ts guarantee
+  // 3). Cleaned up here like every sibling run-state key.
+  "set-mode",
   "plan-properties",
   "request-id",
   "scoped",
@@ -553,16 +559,22 @@ export const startWorkflow = async ({
       return { status: "skipped" };
     }
 
-    // Start from an empty completion set. It grows lazily via SADD, so a
-    // prior run whose run-state outlived it (worker death between the
-    // completion script's EXPIRE and the sibling-key refresh, a manual lock
-    // deletion, a TTL discrepancy) could leave stale members that inflate
-    // this run's SCARD and finalize it early. We hold the run lock (NX)
-    // here, so no live run shares the key.
+    // Start from an empty completion set and mark this run as set-mode. The
+    // set grows lazily via SADD, so a prior run whose run-state outlived it
+    // (worker death between the completion script's EXPIRE and the
+    // sibling-key refresh, a manual lock deletion, a TTL discrepancy) could
+    // leave stale members that inflate this run's SCARD and finalize it
+    // early. The set-mode marker gates the completion script's legacy
+    // counter out of this run's count entirely, even if a straggler
+    // old-code replica recreates the legacy counter for one of this run's
+    // entities mid-rollout (see completion-tracking.ts guarantee 3). We
+    // hold the run lock (NX) here, so no live run shares these keys.
     await resetCompletionState({
       redis,
       completedEntitiesKey: workflowKey(workspaceId, "completed-entities"),
       legacyCompletedKey: workflowKey(workspaceId, "completed"),
+      setModeKey: workflowKey(workspaceId, "set-mode"),
+      runStateTtlSec: runLockTtlSec,
     });
 
     // Store entity count for completion tracking. Carries the run-lock TTL
@@ -1915,6 +1927,7 @@ const onEntityCompleted = async ({
       completedEntities: workflowKey(workspaceId, "completed-entities"),
       total: workflowKey(workspaceId, "total"),
       legacyCompleted: workflowKey(workspaceId, "completed"),
+      setMode: workflowKey(workspaceId, "set-mode"),
     },
     activeRequestId: requestId,
     legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,
@@ -1934,7 +1947,8 @@ const onEntityCompleted = async ({
   // completed entity refreshes them back to the full window so progress
   // keeps the lock alive instead of letting a slow batch fall back to the
   // "freshen everything" path, admit a parallel run, or leak `total`. The
-  // completed-entities set is refreshed inside the completion script above.
+  // completed-entities set and the set-mode marker are both refreshed
+  // inside the completion script above.
   await Promise.all([
     redis.expire(workflowKey(workspaceId, "running"), runLockTtlSec),
     redis.expire(workflowKey(workspaceId, "plan-properties"), runLockTtlSec),

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -115,6 +115,11 @@ const WORKFLOW_RUN_STATE_FIELDS = [
   "running",
   "total",
   "completed-entities",
+  // Legacy pre-set INCR counter. Kept in the cleanup surface so a run that
+  // straddled the deploy (read via the completion script's compat path) has
+  // its counter deleted on finish/skip/orphan, and so the compat path dies
+  // with the transition.
+  "completed",
   "plan-properties",
   "request-id",
   "scoped",
@@ -557,6 +562,7 @@ export const startWorkflow = async ({
     await resetCompletionState({
       redis,
       completedEntitiesKey: workflowKey(workspaceId, "completed-entities"),
+      legacyCompletedKey: workflowKey(workspaceId, "completed"),
     });
 
     // Store entity count for completion tracking. Carries the run-lock TTL
@@ -1908,6 +1914,7 @@ const onEntityCompleted = async ({
       running: workflowKey(workspaceId, "running"),
       completedEntities: workflowKey(workspaceId, "completed-entities"),
       total: workflowKey(workspaceId, "total"),
+      legacyCompleted: workflowKey(workspaceId, "completed"),
     },
     activeRequestId: requestId,
     legacyRunningLockValue: LEGACY_RUNNING_LOCK_VALUE,

--- a/apps/api/src/lib/workflow/completion-tracking.test.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseEntityCompletionReply } from "@/api/lib/workflow/completion-tracking";
+import {
+  COMPLETE_ENTITY_SCRIPT,
+  parseEntityCompletionReply,
+  recordEntityCompletion,
+} from "@/api/lib/workflow/completion-tracking";
 
 describe("parseEntityCompletionReply", () => {
   test("reads a matched increment", () => {
@@ -44,5 +48,152 @@ describe("parseEntityCompletionReply", () => {
     expect(parseEntityCompletionReply([2, 3, 10])).toEqual({
       matched: false,
     });
+  });
+});
+
+// In-memory fake modelling the exact Redis commands COMPLETE_ENTITY_SCRIPT
+// issues. Mirrors the FakeRedisClient pattern used by the rate-limit tests:
+// the real Lua cannot run in-process, so `send("EVAL", …)` dispatches on the
+// production script constant and reproduces its GET / SADD / EXPIRE / SCARD
+// semantics against a Map. This exercises the real `recordEntityCompletion`
+// wiring (arg layout, reply parsing) and the script's documented behaviour.
+type FakeRedisState = {
+  strings: Map<string, string>;
+  sets: Map<string, Set<string>>;
+  ttlSec: Map<string, number>;
+};
+
+const arg = (args: string[], index: number): string => {
+  const value = args.at(index);
+  if (value === undefined) {
+    throw new TypeError(`Missing Redis argument at index ${index}`);
+  }
+  return value;
+};
+
+const createFakeRedis = (state: FakeRedisState) => ({
+  send: async (command: string, args: string[]): Promise<unknown> => {
+    if (command !== "EVAL" || arg(args, 0) !== COMPLETE_ENTITY_SCRIPT) {
+      throw new TypeError(`Unexpected Redis command: ${command}`);
+    }
+    // KEYS[1..4] then ARGV[1..4]; KEYS start at index 2 (after script + numkeys).
+    const requestIdKey = arg(args, 2);
+    const runningKey = arg(args, 3);
+    const completedEntitiesKey = arg(args, 4);
+    const totalKey = arg(args, 5);
+    const activeRequestId = arg(args, 6);
+    const legacyRunningLockValue = arg(args, 7);
+    const entityId = arg(args, 8);
+    const runStateTtlSec = Number(arg(args, 9));
+
+    const currentRequestId = state.strings.get(requestIdKey) ?? null;
+    const runningValue = state.strings.get(runningKey) ?? null;
+    if (currentRequestId !== activeRequestId) {
+      return [0, 0, 0];
+    }
+    if (
+      runningValue !== activeRequestId &&
+      runningValue !== legacyRunningLockValue
+    ) {
+      return [0, 0, 0];
+    }
+
+    const completedSet =
+      state.sets.get(completedEntitiesKey) ?? new Set<string>();
+    completedSet.add(entityId);
+    state.sets.set(completedEntitiesKey, completedSet);
+    state.ttlSec.set(completedEntitiesKey, runStateTtlSec);
+
+    const total = Number(state.strings.get(totalKey) ?? "0") || 0;
+    return [1, completedSet.size, total];
+  },
+});
+
+describe("recordEntityCompletion", () => {
+  const keys = {
+    requestId: "workflow:ws_1:request-id",
+    running: "workflow:ws_1:running",
+    completedEntities: "workflow:ws_1:completed-entities",
+    total: "workflow:ws_1:total",
+  };
+  const activeRequestId = "req_1";
+  const legacyRunningLockValue = "1";
+
+  const seedActiveRun = (total: number): FakeRedisState => ({
+    strings: new Map([
+      [keys.requestId, activeRequestId],
+      [keys.running, activeRequestId],
+      [keys.total, String(total)],
+    ]),
+    sets: new Map(),
+    ttlSec: new Map(),
+  });
+
+  const complete = (state: FakeRedisState, entityId: string) =>
+    recordEntityCompletion({
+      redis: createFakeRedis(state),
+      keys,
+      activeRequestId,
+      legacyRunningLockValue,
+      entityId,
+      runStateTtlSec: 3600,
+    });
+
+  test("counts distinct entities, not repeated completions of the same one", async () => {
+    // The class of bug: an entity job can run its completion path more than
+    // once for the same run (timeout after completion, stalled-job reclaim,
+    // exhausted-retry failure handler). A blind counter would over-count and
+    // let `completed` reach `total` while another entity is still mid-flight.
+    const state = seedActiveRun(2);
+
+    const first = await complete(state, "entity_a");
+    expect(first).toEqual({ matched: true, completed: 1, total: 2 });
+
+    // Same entity again: idempotent, count does not advance and the run must
+    // NOT be treated as finished (completed stays below total).
+    const retry = await complete(state, "entity_a");
+    expect(retry).toEqual({ matched: true, completed: 1, total: 2 });
+
+    // A genuinely distinct entity finally reaches the total.
+    const second = await complete(state, "entity_b");
+    expect(second).toEqual({ matched: true, completed: 2, total: 2 });
+  });
+
+  test("does not finalize early when one entity double-completes", async () => {
+    const state = seedActiveRun(3);
+    // Two completions from entity_a (retry) plus one from entity_b: a counter
+    // would read 3 and finalize; the set reads 2 distinct, so the run stays
+    // open for the still-pending third entity.
+    await complete(state, "entity_a");
+    await complete(state, "entity_a");
+    const latest = await complete(state, "entity_b");
+
+    expect(latest.matched).toBe(true);
+    if (!latest.matched) {
+      throw new Error("expected a matched completion");
+    }
+    expect(latest.completed).toBe(2);
+    expect(latest.completed < latest.total).toBe(true);
+  });
+
+  test("gives the completed-entities set the run-state TTL", async () => {
+    const state = seedActiveRun(1);
+    await complete(state, "entity_a");
+    // Guards the no-TTL-leak fix: the set is created by the script and must
+    // carry the run-state TTL so it self-heals rather than lingering forever.
+    expect(state.ttlSec.get(keys.completedEntities)).toBe(3600);
+  });
+
+  test("does not record a completion for a superseded request", async () => {
+    const state = seedActiveRun(2);
+    // A new run reset the request-id/running lock; the stale job's completion
+    // must be a no-op, leaving the new run's set untouched.
+    state.strings.set(keys.requestId, "req_2");
+    state.strings.set(keys.running, "req_2");
+
+    const result = await complete(state, "entity_a");
+
+    expect(result).toEqual({ matched: false });
+    expect(state.sets.get(keys.completedEntities)).toBeUndefined();
   });
 });

--- a/apps/api/src/lib/workflow/completion-tracking.test.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.test.ts
@@ -4,6 +4,7 @@ import {
   COMPLETE_ENTITY_SCRIPT,
   parseEntityCompletionReply,
   recordEntityCompletion,
+  resetCompletionState,
 } from "@/api/lib/workflow/completion-tracking";
 
 describe("parseEntityCompletionReply", () => {
@@ -73,6 +74,20 @@ const arg = (args: string[], index: number): string => {
 
 const createFakeRedis = (state: FakeRedisState) => ({
   send: async (command: string, args: string[]): Promise<unknown> => {
+    if (command === "DEL") {
+      let removed = 0;
+      for (const key of args) {
+        const existed =
+          state.strings.has(key) ||
+          state.sets.has(key) ||
+          state.ttlSec.has(key);
+        state.strings.delete(key);
+        state.sets.delete(key);
+        state.ttlSec.delete(key);
+        removed += Number(existed);
+      }
+      return removed;
+    }
     if (command !== "EVAL" || arg(args, 0) !== COMPLETE_ENTITY_SCRIPT) {
       throw new TypeError(`Unexpected Redis command: ${command}`);
     }
@@ -129,8 +144,8 @@ describe("recordEntityCompletion", () => {
     ttlSec: new Map(),
   });
 
-  const complete = (state: FakeRedisState, entityId: string) =>
-    recordEntityCompletion({
+  const complete = async (state: FakeRedisState, entityId: string) =>
+    await recordEntityCompletion({
       redis: createFakeRedis(state),
       keys,
       activeRequestId,
@@ -182,6 +197,30 @@ describe("recordEntityCompletion", () => {
     // Guards the no-TTL-leak fix: the set is created by the script and must
     // carry the run-state TTL so it self-heals rather than lingering forever.
     expect(state.ttlSec.get(keys.completedEntities)).toBe(3600);
+  });
+
+  test("clears a prior run's leftover completion set before counting", async () => {
+    // The class of bug: the completion set is grown lazily via SADD, so it
+    // can outlive the run-state that named it (worker death between the
+    // script's EXPIRE and the sibling-key refresh, a manual lock deletion, a
+    // TTL discrepancy). A new run reuses the same key, and its first SADD
+    // would land in the stale set — SCARD could then reach `total` while
+    // this run's entities are still mid-flight and finalize it early.
+    const state = seedActiveRun(2);
+    state.sets.set(
+      keys.completedEntities,
+      new Set(["entity_stale_1", "entity_stale_2"]),
+    );
+
+    await resetCompletionState({
+      redis: createFakeRedis(state),
+      completedEntitiesKey: keys.completedEntities,
+    });
+    expect(state.sets.get(keys.completedEntities)).toBeUndefined();
+
+    // The new run now counts only its own entities from a clean slate.
+    const first = await complete(state, "entity_a");
+    expect(first).toEqual({ matched: true, completed: 1, total: 2 });
   });
 
   test("does not record a completion for a superseded request", async () => {

--- a/apps/api/src/lib/workflow/completion-tracking.test.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.test.ts
@@ -91,15 +91,16 @@ const createFakeRedis = (state: FakeRedisState) => ({
     if (command !== "EVAL" || arg(args, 0) !== COMPLETE_ENTITY_SCRIPT) {
       throw new TypeError(`Unexpected Redis command: ${command}`);
     }
-    // KEYS[1..4] then ARGV[1..4]; KEYS start at index 2 (after script + numkeys).
+    // KEYS[1..5] then ARGV[1..4]; KEYS start at index 2 (after script + numkeys).
     const requestIdKey = arg(args, 2);
     const runningKey = arg(args, 3);
     const completedEntitiesKey = arg(args, 4);
     const totalKey = arg(args, 5);
-    const activeRequestId = arg(args, 6);
-    const legacyRunningLockValue = arg(args, 7);
-    const entityId = arg(args, 8);
-    const runStateTtlSec = Number(arg(args, 9));
+    const legacyCompletedKey = arg(args, 6);
+    const activeRequestId = arg(args, 7);
+    const legacyRunningLockValue = arg(args, 8);
+    const entityId = arg(args, 9);
+    const runStateTtlSec = Number(arg(args, 10));
 
     const currentRequestId = state.strings.get(requestIdKey) ?? null;
     const runningValue = state.strings.get(runningKey) ?? null;
@@ -119,8 +120,12 @@ const createFakeRedis = (state: FakeRedisState) => ({
     state.sets.set(completedEntitiesKey, completedSet);
     state.ttlSec.set(completedEntitiesKey, runStateTtlSec);
 
+    // Deploy-transition compat: a pre-set run's finished entities live in the
+    // legacy INCR counter, absent from the set. Add them so the run reaches total.
+    const legacyCompleted =
+      Number(state.strings.get(legacyCompletedKey) ?? "0") || 0;
     const total = Number(state.strings.get(totalKey) ?? "0") || 0;
-    return [1, completedSet.size, total];
+    return [1, completedSet.size + legacyCompleted, total];
   },
 });
 
@@ -130,6 +135,7 @@ describe("recordEntityCompletion", () => {
     running: "workflow:ws_1:running",
     completedEntities: "workflow:ws_1:completed-entities",
     total: "workflow:ws_1:total",
+    legacyCompleted: "workflow:ws_1:completed",
   };
   const activeRequestId = "req_1";
   const legacyRunningLockValue = "1";
@@ -215,6 +221,7 @@ describe("recordEntityCompletion", () => {
     await resetCompletionState({
       redis: createFakeRedis(state),
       completedEntitiesKey: keys.completedEntities,
+      legacyCompletedKey: keys.legacyCompleted,
     });
     expect(state.sets.get(keys.completedEntities)).toBeUndefined();
 
@@ -234,5 +241,52 @@ describe("recordEntityCompletion", () => {
 
     expect(result).toEqual({ matched: false });
     expect(state.sets.get(keys.completedEntities)).toBeUndefined();
+  });
+
+  test("finalizes an in-flight run that straddled a deploy", async () => {
+    // The class of bug: a deploy lands mid-run. The pre-set code recorded
+    // finished entities in the legacy `completed` INCR counter; those entities
+    // never enter the new set. Counting the set alone would leave `completed`
+    // permanently below `total`, so the run would never finalize.
+    const state = seedActiveRun(3);
+    state.strings.set(keys.legacyCompleted, "2"); // 2 entities finished pre-deploy
+
+    // The remaining entity finishes post-deploy under the new set path.
+    const result = await complete(state, "entity_c");
+
+    // Effective completed = SCARD(1) + legacy(2) = 3 == total, so the run
+    // reaches total and finalizes instead of stranding below it.
+    expect(result).toEqual({ matched: true, completed: 3, total: 3 });
+  });
+
+  test("accepts the narrow overshoot when a pre-deploy entity retries post-deploy", async () => {
+    // Documented, accepted window: an entity counted in the legacy counter is
+    // retried post-deploy and also lands in the set, so it is counted twice
+    // (legacy 2 + set 1 = 3 == total). Finalizing one completion early beats a
+    // run that never finalizes; still no blind counting of post-deploy work.
+    const state = seedActiveRun(3);
+    state.strings.set(keys.legacyCompleted, "2");
+
+    const result = await complete(state, "entity_a");
+
+    expect(result).toEqual({ matched: true, completed: 3, total: 3 });
+  });
+
+  test("reset clears the legacy counter so fresh runs count the set alone", async () => {
+    // Guards that the compat path dies with the transition: a stale legacy
+    // counter left by a prior run must not inflate a fresh run's count and
+    // finalize it early. resetCompletionState deletes it under the run lock.
+    const state = seedActiveRun(2);
+    state.strings.set(keys.legacyCompleted, "5");
+
+    await resetCompletionState({
+      redis: createFakeRedis(state),
+      completedEntitiesKey: keys.completedEntities,
+      legacyCompletedKey: keys.legacyCompleted,
+    });
+    expect(state.strings.get(keys.legacyCompleted)).toBeUndefined();
+
+    const first = await complete(state, "entity_a");
+    expect(first).toEqual({ matched: true, completed: 1, total: 2 });
   });
 });

--- a/apps/api/src/lib/workflow/completion-tracking.test.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.test.ts
@@ -88,19 +88,31 @@ const createFakeRedis = (state: FakeRedisState) => ({
       }
       return removed;
     }
+    if (command === "SET") {
+      // Only the ["key", "1", "EX", "<sec>"] shape `resetCompletionState`
+      // issues for the set-mode marker is exercised here.
+      const key = arg(args, 0);
+      const value = arg(args, 1);
+      state.strings.set(key, value);
+      if (arg(args, 2) === "EX") {
+        state.ttlSec.set(key, Number(arg(args, 3)));
+      }
+      return "OK";
+    }
     if (command !== "EVAL" || arg(args, 0) !== COMPLETE_ENTITY_SCRIPT) {
       throw new TypeError(`Unexpected Redis command: ${command}`);
     }
-    // KEYS[1..5] then ARGV[1..4]; KEYS start at index 2 (after script + numkeys).
+    // KEYS[1..6] then ARGV[1..4]; KEYS start at index 2 (after script + numkeys).
     const requestIdKey = arg(args, 2);
     const runningKey = arg(args, 3);
     const completedEntitiesKey = arg(args, 4);
     const totalKey = arg(args, 5);
     const legacyCompletedKey = arg(args, 6);
-    const activeRequestId = arg(args, 7);
-    const legacyRunningLockValue = arg(args, 8);
-    const entityId = arg(args, 9);
-    const runStateTtlSec = Number(arg(args, 10));
+    const setModeKey = arg(args, 7);
+    const activeRequestId = arg(args, 8);
+    const legacyRunningLockValue = arg(args, 9);
+    const entityId = arg(args, 10);
+    const runStateTtlSec = Number(arg(args, 11));
 
     const currentRequestId = state.strings.get(requestIdKey) ?? null;
     const runningValue = state.strings.get(runningKey) ?? null;
@@ -120,10 +132,19 @@ const createFakeRedis = (state: FakeRedisState) => ({
     state.sets.set(completedEntitiesKey, completedSet);
     state.ttlSec.set(completedEntitiesKey, runStateTtlSec);
 
-    // Deploy-transition compat: a pre-set run's finished entities live in the
-    // legacy INCR counter, absent from the set. Add them so the run reaches total.
-    const legacyCompleted =
-      Number(state.strings.get(legacyCompletedKey) ?? "0") || 0;
+    // Deploy-transition compat, gated to runs that never set the set-mode
+    // marker: a pre-set run's finished entities live in the legacy INCR
+    // counter, absent from the set. Add them so the run reaches total. A
+    // run with the marker present (started under this code) never adds the
+    // legacy counter, even if a straggler old-code replica repopulated it.
+    const setMode = state.strings.has(setModeKey);
+    let legacyCompleted = 0;
+    if (setMode) {
+      state.ttlSec.set(setModeKey, runStateTtlSec);
+    } else {
+      legacyCompleted =
+        Number(state.strings.get(legacyCompletedKey) ?? "0") || 0;
+    }
     const total = Number(state.strings.get(totalKey) ?? "0") || 0;
     return [1, completedSet.size + legacyCompleted, total];
   },
@@ -136,6 +157,7 @@ describe("recordEntityCompletion", () => {
     completedEntities: "workflow:ws_1:completed-entities",
     total: "workflow:ws_1:total",
     legacyCompleted: "workflow:ws_1:completed",
+    setMode: "workflow:ws_1:set-mode",
   };
   const activeRequestId = "req_1";
   const legacyRunningLockValue = "1";
@@ -222,6 +244,8 @@ describe("recordEntityCompletion", () => {
       redis: createFakeRedis(state),
       completedEntitiesKey: keys.completedEntities,
       legacyCompletedKey: keys.legacyCompleted,
+      setModeKey: keys.setMode,
+      runStateTtlSec: 3600,
     });
     expect(state.sets.get(keys.completedEntities)).toBeUndefined();
 
@@ -243,13 +267,17 @@ describe("recordEntityCompletion", () => {
     expect(state.sets.get(keys.completedEntities)).toBeUndefined();
   });
 
-  test("finalizes an in-flight run that straddled a deploy", async () => {
+  test("finalizes an in-flight run that straddled a deploy (no set-mode marker)", async () => {
     // The class of bug: a deploy lands mid-run. The pre-set code recorded
     // finished entities in the legacy `completed` INCR counter; those entities
     // never enter the new set. Counting the set alone would leave `completed`
-    // permanently below `total`, so the run would never finalize.
+    // permanently below `total`, so the run would never finalize. This run
+    // predates the code that writes the set-mode marker (it never called
+    // `resetCompletionState` under this code), so the marker key is absent
+    // and the legacy counter still applies.
     const state = seedActiveRun(3);
     state.strings.set(keys.legacyCompleted, "2"); // 2 entities finished pre-deploy
+    expect(state.strings.has(keys.setMode)).toBe(false);
 
     // The remaining entity finishes post-deploy under the new set path.
     const result = await complete(state, "entity_c");
@@ -260,10 +288,11 @@ describe("recordEntityCompletion", () => {
   });
 
   test("accepts the narrow overshoot when a pre-deploy entity retries post-deploy", async () => {
-    // Documented, accepted window: an entity counted in the legacy counter is
-    // retried post-deploy and also lands in the set, so it is counted twice
-    // (legacy 2 + set 1 = 3 == total). Finalizing one completion early beats a
-    // run that never finalizes; still no blind counting of post-deploy work.
+    // Documented, accepted window for runs without a set-mode marker: an
+    // entity counted in the legacy counter is retried post-deploy and also
+    // lands in the set, so it is counted twice (legacy 2 + set 1 = 3 ==
+    // total). Finalizing one completion early beats a run that never
+    // finalizes; still no blind counting of post-deploy work.
     const state = seedActiveRun(3);
     state.strings.set(keys.legacyCompleted, "2");
 
@@ -272,10 +301,13 @@ describe("recordEntityCompletion", () => {
     expect(result).toEqual({ matched: true, completed: 3, total: 3 });
   });
 
-  test("reset clears the legacy counter so fresh runs count the set alone", async () => {
+  test("reset clears the legacy counter and writes the set-mode marker", async () => {
     // Guards that the compat path dies with the transition: a stale legacy
     // counter left by a prior run must not inflate a fresh run's count and
-    // finalize it early. resetCompletionState deletes it under the run lock.
+    // finalize it early. resetCompletionState deletes it under the run lock
+    // and marks this run as set-mode so the legacy path can never apply to
+    // it again, even if the key reappears later (see the straggler test
+    // below).
     const state = seedActiveRun(2);
     state.strings.set(keys.legacyCompleted, "5");
 
@@ -283,10 +315,53 @@ describe("recordEntityCompletion", () => {
       redis: createFakeRedis(state),
       completedEntitiesKey: keys.completedEntities,
       legacyCompletedKey: keys.legacyCompleted,
+      setModeKey: keys.setMode,
+      runStateTtlSec: 3600,
     });
     expect(state.strings.get(keys.legacyCompleted)).toBeUndefined();
+    expect(state.strings.get(keys.setMode)).toBe("1");
+    expect(state.ttlSec.get(keys.setMode)).toBe(3600);
 
     const first = await complete(state, "entity_a");
     expect(first).toEqual({ matched: true, completed: 1, total: 2 });
+  });
+
+  test("CLASS GUARD: ignores a legacy counter a straggler old-code replica repopulates mid fresh-run", async () => {
+    // The bug this round's fix closes: during a rolling deploy, queue
+    // topology lets an old-code replica keep draining jobs from the shared
+    // queue even for runs that started after the deploy. If that replica
+    // dequeues one of THIS run's entity jobs, its old `onEntityCompleted`
+    // logic blindly INCRs the legacy `completed` key — recreating it for a
+    // run that already started fresh under set-mode tracking. Without the
+    // marker gate, a subsequent new-code completion would add that
+    // straggler value into the count and could finalize the run early
+    // while other entities are still pending — reintroducing the exact bug
+    // this PR exists to fix, on every rolling deploy.
+    const state = seedActiveRun(3);
+    await resetCompletionState({
+      redis: createFakeRedis(state),
+      completedEntitiesKey: keys.completedEntities,
+      legacyCompletedKey: keys.legacyCompleted,
+      setModeKey: keys.setMode,
+      runStateTtlSec: 3600,
+    });
+
+    // entity_a finishes normally under new code.
+    const first = await complete(state, "entity_a");
+    expect(first).toEqual({ matched: true, completed: 1, total: 3 });
+
+    // A straggler old-code replica processes entity_b and blindly INCRs the
+    // legacy counter, recreating a key resetCompletionState had deleted.
+    state.strings.set(keys.legacyCompleted, "1");
+
+    // entity_c finishes under new code. If the legacy value leaked in, the
+    // effective count would misread as SCARD(2) + legacy(1) = 3 == total
+    // and finalize early — but entity_b never actually completed under new
+    // code, so that would be wrong. The marker gate must keep the legacy
+    // value out entirely.
+    const third = await complete(state, "entity_c");
+
+    // completed(2) < total(3): the run correctly stays open.
+    expect(third).toEqual({ matched: true, completed: 2, total: 3 });
   });
 });

--- a/apps/api/src/lib/workflow/completion-tracking.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.ts
@@ -30,14 +30,31 @@
 // The set is (re)given the run-state TTL on every completion so it never
 // lingers TTL-less after the run lapses, matching every sibling key.
 //
+//  3. Deploy-transition compatibility. A run that began under the previous
+//     code recorded finished entities in a legacy INCR counter
+//     (`completed`, KEYS[5]) instead of this set. After a mid-run deploy
+//     those entities are absent from the set, so counting the set alone
+//     would leave `completed` permanently below `total` and the run would
+//     never finalize (stranded until TTL or the boot reconciler). We add
+//     the legacy counter to the set's cardinality so an in-flight old run
+//     can still reach `total`. New runs never have this key
+//     (`resetCompletionState` / `clearWorkflowRunState` delete it), so once
+//     the transition passes, effective completed equals `SCARD` alone.
+//     Narrow accepted window: an entity that finished pre-deploy and is
+//     retried post-deploy is counted in both the legacy counter and the
+//     set, overshooting by one and finalizing one completion early —
+//     preferred over a run that never finalizes.
+//
 // KEYS[1] = request-id key, KEYS[2] = running key,
-// KEYS[3] = completed-entities set key, KEYS[4] = total key.
+// KEYS[3] = completed-entities set key, KEYS[4] = total key,
+// KEYS[5] = legacy `completed` counter key (deploy-transition only).
 // ARGV[1] = requestId, ARGV[2] = legacy running-lock value,
 // ARGV[3] = entityId, ARGV[4] = run-state TTL seconds.
 //
 // Returns `[matched, completed, total]`, where `matched` is `1` only when
 // the completion was recorded against the currently active request and
-// `completed` is the count of distinct entities finished so far.
+// `completed` is the count of distinct entities finished so far (the set's
+// cardinality plus any legacy pre-deploy counter, per guarantee 3).
 export const COMPLETE_ENTITY_SCRIPT = `
 local currentRequestId = redis.call("GET", KEYS[1])
 local runningValue = redis.call("GET", KEYS[2])
@@ -56,9 +73,10 @@ end
 redis.call("SADD", KEYS[3], entityId)
 redis.call("EXPIRE", KEYS[3], tonumber(runStateTtlSec))
 local completed = redis.call("SCARD", KEYS[3])
+local legacyCompleted = tonumber(redis.call("GET", KEYS[5])) or 0
 local totalRaw = redis.call("GET", KEYS[4])
 local total = tonumber(totalRaw) or 0
-return {1, completed, total}
+return {1, completed + legacyCompleted, total}
 `;
 
 export type EntityCompletionReply =
@@ -107,6 +125,9 @@ export type WorkflowCompletionKeys = {
   running: string;
   completedEntities: string;
   total: string;
+  // Legacy pre-set INCR counter, read only for deploy-transition
+  // compatibility (guarantee 3). Absent for runs started under this code.
+  legacyCompleted: string;
 };
 
 type RecordEntityCompletionArgs = {
@@ -133,11 +154,12 @@ export const recordEntityCompletion = async ({
 }: RecordEntityCompletionArgs): Promise<EntityCompletionReply> => {
   const reply = await redis.send("EVAL", [
     COMPLETE_ENTITY_SCRIPT,
-    "4",
+    "5",
     keys.requestId,
     keys.running,
     keys.completedEntities,
     keys.total,
+    keys.legacyCompleted,
     activeRequestId,
     legacyRunningLockValue,
     entityId,
@@ -149,27 +171,34 @@ export const recordEntityCompletion = async ({
 type ResetCompletionStateArgs = {
   redis: EntityCompletionRedis;
   completedEntitiesKey: string;
+  legacyCompletedKey: string;
 };
 
 /**
- * Clear the distinct-entity completion set before a new run enqueues its
- * jobs. The set is a Redis Set that completions grow lazily via `SADD`, so
- * it can outlive the run-state that named it: a worker death between the
- * completion script's `EXPIRE` and the sibling-key TTL refresh, a manual
- * lock deletion, or a TTL discrepancy can leave a populated set behind. A
- * later run reuses the same key, and its first `SADD`/`SCARD` would then
- * read the stale members and could reach `total` while entities are still
- * mid-flight — finalizing the run early and stranding cells at `pending`.
+ * Clear the completion accounting before a new run enqueues its jobs. The
+ * distinct-entity set grows lazily via `SADD`, so it can outlive the
+ * run-state that named it: a worker death between the completion script's
+ * `EXPIRE` and the sibling-key TTL refresh, a manual lock deletion, or a
+ * TTL discrepancy can leave a populated set behind. A later run reuses the
+ * same key, and its first `SADD`/`SCARD` would then read the stale members
+ * and could reach `total` while entities are still mid-flight — finalizing
+ * the run early and stranding cells at `pending`.
  *
- * Deleting the key here gives every run an empty set, so `SCARD` counts
- * only this run's entities. The caller must already hold the run lock so no
- * live run shares the key. Routed through `send` (not a typed `del`) to
- * keep this module free of a live-connection dependency and unit-testable
- * against the same in-memory fake as `recordEntityCompletion`.
+ * Also deletes the legacy `completed` counter so the deploy-transition
+ * compat path (guarantee 3 in `COMPLETE_ENTITY_SCRIPT`) dies with the
+ * transition: once a fresh run starts, effective completed is the set's
+ * `SCARD` alone, never inheriting a prior run's counter.
+ *
+ * Deleting both keys here gives every run empty accounting. The caller must
+ * already hold the run lock so no live run shares the keys. Routed through
+ * `send` (not a typed `del`) to keep this module free of a live-connection
+ * dependency and unit-testable against the same in-memory fake as
+ * `recordEntityCompletion`.
  */
 export const resetCompletionState = async ({
   redis,
   completedEntitiesKey,
+  legacyCompletedKey,
 }: ResetCompletionStateArgs): Promise<void> => {
-  await redis.send("DEL", [completedEntitiesKey]);
+  await redis.send("DEL", [completedEntitiesKey, legacyCompletedKey]);
 };

--- a/apps/api/src/lib/workflow/completion-tracking.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.ts
@@ -4,26 +4,47 @@
 
 // Atomically re-checks that `requestId` is still the workspace's active
 // workflow request (matching both the `request-id` key and the `running`
-// lock, including the legacy running-lock value) and, only if so,
-// increments the completed counter and reads the total in the same Redis
-// command. A plain check-then-INCR (two separate round trips) leaves a
-// window where a stale job's check can pass just before the run it
-// belongs to finishes and a new run resets the counters: the stale job's
-// INCR would then land on the new run instead of a no-op. Bundling the
-// check and the increment into one script closes that window, since Redis
-// executes Lua scripts atomically with no other command interleaved.
+// lock, including the legacy running-lock value) and, only if so, records
+// this entity as completed and reads the total in the same Redis command.
 //
-// KEYS[1] = request-id key, KEYS[2] = running key, KEYS[3] = completed
-// key, KEYS[4] = total key.
-// ARGV[1] = requestId, ARGV[2] = legacy running-lock value.
+// Two atomicity guarantees, both closed by bundling the work into one
+// script (Redis executes Lua with no other command interleaved):
+//
+//  1. Stale-run isolation. A plain check-then-write (two round trips)
+//     leaves a window where a stale job's check can pass just before the
+//     run it belongs to finishes and a new run resets the counters — the
+//     stale write would then land on the new run instead of a no-op.
+//
+//  2. Per-entity idempotency. Completion is tracked as a SET of entity
+//     ids (`SADD` + `SCARD`), not a blind counter. An entity job can run
+//     its completion path more than once for the same run: a job timeout
+//     or a BullMQ stalled-job reclaim can mark a job failed *after* it
+//     recorded completion, and the retry (or the exhausted-retry failure
+//     handler) records the same entity again. A counter would over-count
+//     and let `completed` reach `total` while an entity is still
+//     mid-flight, so `finishWorkflow` would clear the run lock early and
+//     strand that entity's cells at `pending`. `SADD` of an
+//     already-present member is a no-op, so `SCARD` reflects distinct
+//     entities only and a re-driven entity cannot advance the count.
+//
+// The set is (re)given the run-state TTL on every completion so it never
+// lingers TTL-less after the run lapses, matching every sibling key.
+//
+// KEYS[1] = request-id key, KEYS[2] = running key,
+// KEYS[3] = completed-entities set key, KEYS[4] = total key.
+// ARGV[1] = requestId, ARGV[2] = legacy running-lock value,
+// ARGV[3] = entityId, ARGV[4] = run-state TTL seconds.
 //
 // Returns `[matched, completed, total]`, where `matched` is `1` only when
-// the increment happened against the currently active request.
+// the completion was recorded against the currently active request and
+// `completed` is the count of distinct entities finished so far.
 export const COMPLETE_ENTITY_SCRIPT = `
 local currentRequestId = redis.call("GET", KEYS[1])
 local runningValue = redis.call("GET", KEYS[2])
 local requestId = ARGV[1]
 local legacyRunningLockValue = ARGV[2]
+local entityId = ARGV[3]
+local runStateTtlSec = ARGV[4]
 
 if currentRequestId ~= requestId then
   return {0, 0, 0}
@@ -32,7 +53,9 @@ if runningValue ~= requestId and runningValue ~= legacyRunningLockValue then
   return {0, 0, 0}
 end
 
-local completed = redis.call("INCR", KEYS[3])
+redis.call("SADD", KEYS[3], entityId)
+redis.call("EXPIRE", KEYS[3], runStateTtlSec)
+local completed = redis.call("SCARD", KEYS[3])
 local totalRaw = redis.call("GET", KEYS[4])
 local total = tonumber(totalRaw) or 0
 return {1, completed, total}
@@ -67,4 +90,58 @@ export const parseEntityCompletionReply = (
     return { matched: false };
   }
   return { matched: true, completed, total };
+};
+
+// Minimal structural view of the Redis client needed to run the
+// completion script. Kept structural (not Bun's `RedisClient`) so this
+// module stays free of a live-connection dependency and the completion
+// path is exercisable against an in-memory fake in tests.
+type EntityCompletionRedis = {
+  send: (command: string, args: string[]) => Promise<unknown>;
+};
+
+// Resolved Redis key names for a workspace's run-state. The caller owns
+// key naming (`workflowKey`); this helper only wires them into the script.
+export type WorkflowCompletionKeys = {
+  requestId: string;
+  running: string;
+  completedEntities: string;
+  total: string;
+};
+
+type RecordEntityCompletionArgs = {
+  redis: EntityCompletionRedis;
+  keys: WorkflowCompletionKeys;
+  activeRequestId: string;
+  legacyRunningLockValue: string;
+  entityId: string;
+  runStateTtlSec: number;
+};
+
+/**
+ * Run `COMPLETE_ENTITY_SCRIPT` for one entity and parse its reply. The
+ * script is atomic and idempotent per entity (see its comment), so
+ * calling this twice for the same `entityId` records the entity once.
+ */
+export const recordEntityCompletion = async ({
+  redis,
+  keys,
+  activeRequestId,
+  legacyRunningLockValue,
+  entityId,
+  runStateTtlSec,
+}: RecordEntityCompletionArgs): Promise<EntityCompletionReply> => {
+  const reply = await redis.send("EVAL", [
+    COMPLETE_ENTITY_SCRIPT,
+    "4",
+    keys.requestId,
+    keys.running,
+    keys.completedEntities,
+    keys.total,
+    activeRequestId,
+    legacyRunningLockValue,
+    entityId,
+    String(runStateTtlSec),
+  ]);
+  return parseEntityCompletionReply(reply);
 };

--- a/apps/api/src/lib/workflow/completion-tracking.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.ts
@@ -30,31 +30,47 @@
 // The set is (re)given the run-state TTL on every completion so it never
 // lingers TTL-less after the run lapses, matching every sibling key.
 //
-//  3. Deploy-transition compatibility. A run that began under the previous
-//     code recorded finished entities in a legacy INCR counter
-//     (`completed`, KEYS[5]) instead of this set. After a mid-run deploy
-//     those entities are absent from the set, so counting the set alone
-//     would leave `completed` permanently below `total` and the run would
-//     never finalize (stranded until TTL or the boot reconciler). We add
-//     the legacy counter to the set's cardinality so an in-flight old run
-//     can still reach `total`. New runs never have this key
-//     (`resetCompletionState` / `clearWorkflowRunState` delete it), so once
-//     the transition passes, effective completed equals `SCARD` alone.
-//     Narrow accepted window: an entity that finished pre-deploy and is
-//     retried post-deploy is counted in both the legacy counter and the
-//     set, overshooting by one and finalizing one completion early —
-//     preferred over a run that never finalizes.
+//  3. Deploy-transition compatibility, gated to runs that provably predate
+//     this code. A run that began under the previous code recorded finished
+//     entities in a legacy INCR counter (`completed`, KEYS[5]) instead of
+//     this set. After a mid-run deploy those entities are absent from the
+//     set, so counting the set alone would leave `completed` permanently
+//     below `total` and the run would never finalize (stranded until TTL or
+//     the boot reconciler). We add the legacy counter to the set's
+//     cardinality so an in-flight old run can still reach `total` — but
+//     only when KEYS[6], the set-mode marker written by
+//     `resetCompletionState`, is absent. A fresh run (marker present)
+//     never trusts the legacy key, even if one of its entity jobs is
+//     dequeued by a straggler old-code replica that recreates `completed`
+//     via its own INCR path mid-rollout (queue topology lets old replicas
+//     keep draining the shared queue during a deploy). Without this gate
+//     that straggler write would add into `completed + legacyCompleted`
+//     for a run whose own entities are tracked purely by the set,
+//     reintroducing this PR's target bug — early finalization — on every
+//     rolling deploy instead of only for runs that genuinely started
+//     before it. New runs never have the legacy key deleted from under
+//     them mid-run (`clearWorkflowRunState` only runs after finish), so
+//     once a run's marker is set, `completed` is `SCARD` alone for its
+//     entire lifetime, straggler writes included.
+//     Narrow accepted window, unchanged for genuinely pre-deploy runs: an
+//     entity that finished pre-deploy (no marker was ever written for that
+//     run) and is retried post-deploy is counted in both the legacy
+//     counter and the set, overshooting by one and finalizing one
+//     completion early — preferred over a run that never finalizes.
 //
 // KEYS[1] = request-id key, KEYS[2] = running key,
 // KEYS[3] = completed-entities set key, KEYS[4] = total key,
-// KEYS[5] = legacy `completed` counter key (deploy-transition only).
+// KEYS[5] = legacy `completed` counter key (deploy-transition only),
+// KEYS[6] = set-mode marker key (present only for runs started under this
+// code; gates KEYS[5] out of the count once present).
 // ARGV[1] = requestId, ARGV[2] = legacy running-lock value,
 // ARGV[3] = entityId, ARGV[4] = run-state TTL seconds.
 //
 // Returns `[matched, completed, total]`, where `matched` is `1` only when
 // the completion was recorded against the currently active request and
 // `completed` is the count of distinct entities finished so far (the set's
-// cardinality plus any legacy pre-deploy counter, per guarantee 3).
+// cardinality plus the legacy pre-deploy counter, but only for runs that
+// never set the set-mode marker, per guarantee 3).
 export const COMPLETE_ENTITY_SCRIPT = `
 local currentRequestId = redis.call("GET", KEYS[1])
 local runningValue = redis.call("GET", KEYS[2])
@@ -73,7 +89,15 @@ end
 redis.call("SADD", KEYS[3], entityId)
 redis.call("EXPIRE", KEYS[3], tonumber(runStateTtlSec))
 local completed = redis.call("SCARD", KEYS[3])
-local legacyCompleted = tonumber(redis.call("GET", KEYS[5])) or 0
+
+local setMode = redis.call("EXISTS", KEYS[6])
+local legacyCompleted = 0
+if setMode == 0 then
+  legacyCompleted = tonumber(redis.call("GET", KEYS[5])) or 0
+else
+  redis.call("EXPIRE", KEYS[6], tonumber(runStateTtlSec))
+end
+
 local totalRaw = redis.call("GET", KEYS[4])
 local total = tonumber(totalRaw) or 0
 return {1, completed + legacyCompleted, total}
@@ -126,8 +150,14 @@ export type WorkflowCompletionKeys = {
   completedEntities: string;
   total: string;
   // Legacy pre-set INCR counter, read only for deploy-transition
-  // compatibility (guarantee 3). Absent for runs started under this code.
+  // compatibility (guarantee 3), and only when `setMode` is absent.
   legacyCompleted: string;
+  // Marker written by `resetCompletionState` for every run started under
+  // this code. Once present, `legacyCompleted` is never added to the
+  // count for this run's lifetime — including if a straggler old-code
+  // replica recreates it mid-run — so the run's completion is tracked by
+  // the set alone (guarantee 3).
+  setMode: string;
 };
 
 type RecordEntityCompletionArgs = {
@@ -154,12 +184,13 @@ export const recordEntityCompletion = async ({
 }: RecordEntityCompletionArgs): Promise<EntityCompletionReply> => {
   const reply = await redis.send("EVAL", [
     COMPLETE_ENTITY_SCRIPT,
-    "5",
+    "6",
     keys.requestId,
     keys.running,
     keys.completedEntities,
     keys.total,
     keys.legacyCompleted,
+    keys.setMode,
     activeRequestId,
     legacyRunningLockValue,
     entityId,
@@ -172,6 +203,8 @@ type ResetCompletionStateArgs = {
   redis: EntityCompletionRedis;
   completedEntitiesKey: string;
   legacyCompletedKey: string;
+  setModeKey: string;
+  runStateTtlSec: number;
 };
 
 /**
@@ -184,21 +217,33 @@ type ResetCompletionStateArgs = {
  * and could reach `total` while entities are still mid-flight — finalizing
  * the run early and stranding cells at `pending`.
  *
- * Also deletes the legacy `completed` counter so the deploy-transition
- * compat path (guarantee 3 in `COMPLETE_ENTITY_SCRIPT`) dies with the
- * transition: once a fresh run starts, effective completed is the set's
- * `SCARD` alone, never inheriting a prior run's counter.
+ * Also deletes the legacy `completed` counter, then writes the set-mode
+ * marker (with the same TTL/refresh discipline as every other run-state
+ * key — refreshed by the completion script itself on each entity, deleted
+ * by `clearWorkflowRunState` on finish). The marker, not merely the
+ * counter's absence, is what gates `COMPLETE_ENTITY_SCRIPT`'s legacy read
+ * (guarantee 3): a run started under this code sets the marker once, up
+ * front, before any entity completes, so a straggler old-code replica
+ * that later recreates the legacy counter for one of this run's entities
+ * (rolling deploys let old replicas keep draining the shared queue) can
+ * never make that write count — the marker's presence alone decides,
+ * independent of whatever the legacy key currently holds. A genuinely
+ * pre-deploy run never has this marker (it never called
+ * `resetCompletionState` under this code), so its legacy counter still
+ * applies, unchanged from before.
  *
- * Deleting both keys here gives every run empty accounting. The caller must
- * already hold the run lock so no live run shares the keys. Routed through
- * `send` (not a typed `del`) to keep this module free of a live-connection
- * dependency and unit-testable against the same in-memory fake as
- * `recordEntityCompletion`.
+ * The caller must already hold the run lock so no live run shares the
+ * keys. Routed through `send` (not a typed `del`/`set`) to keep this
+ * module free of a live-connection dependency and unit-testable against
+ * the same in-memory fake as `recordEntityCompletion`.
  */
 export const resetCompletionState = async ({
   redis,
   completedEntitiesKey,
   legacyCompletedKey,
+  setModeKey,
+  runStateTtlSec,
 }: ResetCompletionStateArgs): Promise<void> => {
   await redis.send("DEL", [completedEntitiesKey, legacyCompletedKey]);
+  await redis.send("SET", [setModeKey, "1", "EX", String(runStateTtlSec)]);
 };

--- a/apps/api/src/lib/workflow/completion-tracking.ts
+++ b/apps/api/src/lib/workflow/completion-tracking.ts
@@ -54,7 +54,7 @@ if runningValue ~= requestId and runningValue ~= legacyRunningLockValue then
 end
 
 redis.call("SADD", KEYS[3], entityId)
-redis.call("EXPIRE", KEYS[3], runStateTtlSec)
+redis.call("EXPIRE", KEYS[3], tonumber(runStateTtlSec))
 local completed = redis.call("SCARD", KEYS[3])
 local totalRaw = redis.call("GET", KEYS[4])
 local total = tonumber(totalRaw) or 0
@@ -144,4 +144,32 @@ export const recordEntityCompletion = async ({
     String(runStateTtlSec),
   ]);
   return parseEntityCompletionReply(reply);
+};
+
+type ResetCompletionStateArgs = {
+  redis: EntityCompletionRedis;
+  completedEntitiesKey: string;
+};
+
+/**
+ * Clear the distinct-entity completion set before a new run enqueues its
+ * jobs. The set is a Redis Set that completions grow lazily via `SADD`, so
+ * it can outlive the run-state that named it: a worker death between the
+ * completion script's `EXPIRE` and the sibling-key TTL refresh, a manual
+ * lock deletion, or a TTL discrepancy can leave a populated set behind. A
+ * later run reuses the same key, and its first `SADD`/`SCARD` would then
+ * read the stale members and could reach `total` while entities are still
+ * mid-flight — finalizing the run early and stranding cells at `pending`.
+ *
+ * Deleting the key here gives every run an empty set, so `SCARD` counts
+ * only this run's entities. The caller must already hold the run lock so no
+ * live run shares the key. Routed through `send` (not a typed `del`) to
+ * keep this module free of a live-connection dependency and unit-testable
+ * against the same in-memory fake as `recordEntityCompletion`.
+ */
+export const resetCompletionState = async ({
+  redis,
+  completedEntitiesKey,
+}: ResetCompletionStateArgs): Promise<void> => {
+  await redis.send("DEL", [completedEntitiesKey]);
 };


### PR DESCRIPTION
The entity-completion path incremented a blind Redis `completed` counter
as the last step of processing an entity, then re-checked the job's abort
signal afterwards. A job timeout landing in that gap, a BullMQ stalled-job
reclaim, or the exhausted-retry failure handler could mark the job failed
after the increment already ran; the retry (or failure handler) then
counted the same entity again. `completed` reached `total` one entity
early, so `finishWorkflow` cleared the run lock while another entity was
still mid-flight, and that entity's remaining batches bailed at the
`isCurrentWorkflowRequest` check, stranding its cells at `pending` until
the boot-time reconciler.

Track completion as a Redis SET of entity ids (`SADD` + `SCARD` against
`total`) inside the existing atomic Lua script instead of a counter.
`SADD` of an already-present member is a no-op, so the distinct-entity
count cannot advance when the same entity completes twice, making the
finalize decision structurally immune to re-driven jobs.

Also give the `total` key and the new completed-entities set the run-lock
TTL (refreshed on each completion), matching every sibling run-state key,
so they cannot leak after a run lapses.
