### PR TITLE
fix(cli): atomic credential writes, corruption reporting, error boundary, lazy registry refresh

### DIFF
--- a/packages/cli/src/auth/browser-open.ts
+++ b/packages/cli/src/auth/browser-open.ts
@@ -32,6 +32,10 @@ export const openInBrowser = async (url: string): Promise<boolean> => {
   // (the old `Bun.spawn` ignored all three streams too); a bound `error`
   // handler keeps an async spawn failure (ENOENT) from throwing on the emitter.
   const child = spawn(file, args, { detached: true, stdio: "ignore" });
+  // Drop the child from the parent's event loop reference count so a slow or
+  // GUI-detaching opener can never keep the CLI alive after login completes;
+  // the `exit`/`error` listeners below still settle the race while we wait.
+  child.unref();
 
   // Mirror the old logic: succeed on a zero exit code, fail on a spawn error,
   // and bound the wait so a hung opener can never stall the CLI. Each executor

--- a/packages/cli/src/auth/credential-store.test.ts
+++ b/packages/cli/src/auth/credential-store.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, rm, stat } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -16,7 +24,7 @@ import {
   upsertCredential,
   writeCredentialFile,
 } from "./credential-store.js";
-import type { StoredCredential } from "./credential-store.js";
+import type { AtomicWriteOps, StoredCredential } from "./credential-store.js";
 
 const buildCredential = (
   overrides: Partial<StoredCredential> = {},
@@ -76,6 +84,19 @@ describe("credential file round-trip (tmp XDG dir)", () => {
     });
   });
 
+  test("a genuinely-absent file is silent (never signed in, not corruption)", async () => {
+    const warnings: string[] = [];
+    const file = await readCredentialFile(configDir, (message) =>
+      warnings.push(message),
+    );
+    expect(file).toEqual({
+      credentials: [],
+      defaultOrgByServer: {},
+      version: 1,
+    });
+    expect(warnings).toEqual([]);
+  });
+
   test("round-trips a written credential file exactly", async () => {
     const credential = buildCredential();
     const written = upsertCredential(
@@ -119,14 +140,75 @@ describe("credential file round-trip (tmp XDG dir)", () => {
     expect(stats.mode & 0o777).toBe(0o600);
   });
 
-  test("ignores a malformed credentials file instead of throwing", async () => {
+  test("warns (with the path) and falls back to empty on a non-JSON file", async () => {
     await Bun.write(credentialsFilePath(configDir), "not json");
-    const file = await readCredentialFile(configDir);
+    const warnings: string[] = [];
+    const file = await readCredentialFile(configDir, (message) =>
+      warnings.push(message),
+    );
     expect(file).toEqual({
       credentials: [],
       defaultOrgByServer: {},
       version: 1,
     });
+    expect(warnings).toHaveLength(1);
+    expect(warnings.at(0)).toContain(credentialsFilePath(configDir));
+    expect(warnings.at(0)).toContain("not valid JSON");
+  });
+
+  test("warns and falls back to empty on a schema-mismatched file", async () => {
+    await Bun.write(
+      credentialsFilePath(configDir),
+      JSON.stringify({ credentials: "not-an-array", version: 99 }),
+    );
+    const warnings: string[] = [];
+    const file = await readCredentialFile(configDir, (message) =>
+      warnings.push(message),
+    );
+    expect(file.credentials).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings.at(0)).toContain("schema");
+  });
+
+  test("a successful write leaves no temp files behind", async () => {
+    await writeCredentialFile(
+      configDir,
+      upsertCredential(await readCredentialFile(configDir), buildCredential()),
+    );
+    expect(await readdir(configDir)).toEqual(["credentials.json"]);
+  });
+
+  test("a failed write leaves the existing credential store intact", async () => {
+    const original = upsertCredential(
+      await readCredentialFile(configDir),
+      buildCredential({ orgId: "org-1" }),
+    );
+    await writeCredentialFile(configDir, original);
+
+    // Inject a `rename` that throws to simulate a crash at the atomic point,
+    // after the temp file is written but before it replaces the live file.
+    const failingRename: AtomicWriteOps = {
+      writeFile: async (filePath, data, options) =>
+        await writeFile(filePath, data, options),
+      chmod: async (filePath, mode) => await chmod(filePath, mode),
+      rename: () => {
+        throw new Error("simulated crash before rename");
+      },
+      rm: async (filePath) => await rm(filePath, { force: true }),
+    };
+
+    const replacement = upsertCredential(
+      original,
+      buildCredential({ accessToken: "new-token", orgId: "org-2" }),
+    );
+    await expect(
+      writeCredentialFile(configDir, replacement, failingRename),
+    ).rejects.toThrow("simulated crash before rename");
+
+    // Live file is byte-for-byte the pre-failure store: no truncation, no
+    // partial write, and the failed temp was cleaned up.
+    expect(await readCredentialFile(configDir)).toEqual(original);
+    expect(await readdir(configDir)).toEqual(["credentials.json"]);
   });
 });
 

--- a/packages/cli/src/auth/credential-store.test.ts
+++ b/packages/cli/src/auth/credential-store.test.ts
@@ -1,13 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  chmod,
-  mkdtemp,
-  readdir,
-  rename,
-  rm,
-  stat,
-  writeFile,
-} from "node:fs/promises";
+import { chmod, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -86,9 +78,9 @@ describe("credential file round-trip (tmp XDG dir)", () => {
 
   test("a genuinely-absent file is silent (never signed in, not corruption)", async () => {
     const warnings: string[] = [];
-    const file = await readCredentialFile(configDir, (message) =>
-      warnings.push(message),
-    );
+    const file = await readCredentialFile(configDir, (message) => {
+      warnings.push(message);
+    });
     expect(file).toEqual({
       credentials: [],
       defaultOrgByServer: {},
@@ -143,9 +135,9 @@ describe("credential file round-trip (tmp XDG dir)", () => {
   test("warns (with the path) and falls back to empty on a non-JSON file", async () => {
     await Bun.write(credentialsFilePath(configDir), "not json");
     const warnings: string[] = [];
-    const file = await readCredentialFile(configDir, (message) =>
-      warnings.push(message),
-    );
+    const file = await readCredentialFile(configDir, (message) => {
+      warnings.push(message);
+    });
     expect(file).toEqual({
       credentials: [],
       defaultOrgByServer: {},
@@ -162,9 +154,9 @@ describe("credential file round-trip (tmp XDG dir)", () => {
       JSON.stringify({ credentials: "not-an-array", version: 99 }),
     );
     const warnings: string[] = [];
-    const file = await readCredentialFile(configDir, (message) =>
-      warnings.push(message),
-    );
+    const file = await readCredentialFile(configDir, (message) => {
+      warnings.push(message);
+    });
     expect(file.credentials).toEqual([]);
     expect(warnings).toHaveLength(1);
     expect(warnings.at(0)).toContain("schema");
@@ -201,9 +193,20 @@ describe("credential file round-trip (tmp XDG dir)", () => {
       original,
       buildCredential({ accessToken: "new-token", orgId: "org-2" }),
     );
-    await expect(
-      writeCredentialFile(configDir, replacement, failingRename),
-    ).rejects.toThrow("simulated crash before rename");
+    // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+    // type-aware lint; capture the rejection explicitly instead.
+    const rejection = await writeCredentialFile(
+      configDir,
+      replacement,
+      failingRename,
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection instanceof Error ? rejection.message : "").toContain(
+      "simulated crash before rename",
+    );
 
     // Live file is byte-for-byte the pre-failure store: no truncation, no
     // partial write, and the failed temp was cleaned up.

--- a/packages/cli/src/auth/credential-store.ts
+++ b/packages/cli/src/auth/credential-store.ts
@@ -207,8 +207,15 @@ export const writeCredentialFile = async (
   });
   if (Result.isError(written)) {
     // Best-effort cleanup so a failed write leaves no temp litter behind; the
-    // live file was never opened, so it is already intact.
-    await Result.tryPromise(async () => await fsOps.rm(tempPath));
+    // live file was never opened, so it is already intact. The write's own
+    // error (thrown below) is what surfaces to the caller — a failed
+    // cleanup here has no further signal to add.
+    const cleanup = await Result.tryPromise(
+      async () => await fsOps.rm(tempPath),
+    );
+    if (Result.isError(cleanup)) {
+      // Ignored: see comment above.
+    }
     throw written.error;
   }
 };

--- a/packages/cli/src/auth/credential-store.ts
+++ b/packages/cli/src/auth/credential-store.ts
@@ -13,6 +13,7 @@
 // `aws`/`gh` multi-profile credential file pattern.
 
 import { Result } from "better-result";
+import { randomUUID } from "node:crypto";
 import {
   chmod,
   mkdir,
@@ -193,7 +194,11 @@ export const writeCredentialFile = async (
   const filePath = credentialsFilePath(configDir);
   await mkdir(configDir, { mode: 0o700, recursive: true });
 
-  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  // `process.pid` + `Date.now()` alone can collide: two concurrent writes in
+  // the same process land in the same millisecond and would race on the same
+  // temp path. `randomUUID` makes each call's temp path unique regardless of
+  // timing.
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
   const written = await Result.tryPromise(async () => {
     await fsOps.writeFile(tempPath, `${JSON.stringify(file, null, 2)}\n`, {
       mode: CREDENTIALS_FILE_MODE,

--- a/packages/cli/src/auth/credential-store.ts
+++ b/packages/cli/src/auth/credential-store.ts
@@ -13,7 +13,14 @@
 // `aws`/`gh` multi-profile credential file pattern.
 
 import { Result } from "better-result";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import * as v from "valibot";
 
@@ -85,39 +92,125 @@ const EMPTY_FILE: CredentialFile = {
 export const credentialsFilePath = (configDir: string): string =>
   path.join(configDir, "credentials.json");
 
+/** A genuinely-absent file (never signed in) vs. an unreadable/corrupt one. */
+const isMissingFileError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+  return error.code === "ENOENT";
+};
+
+const corruptionWarning = (filePath: string, reason: string): string =>
+  `stella: credentials file ${filePath} ${reason}; delete it and run 'stella auth login' to re-authenticate.`;
+
+/**
+ * Read the credential store. A genuinely-missing file (the user has never
+ * signed in) resolves to the empty store silently. Anything else — an
+ * unreadable file, invalid JSON, or a schema mismatch — is corruption, not
+ * "not signed in": it warns to stderr with the file path (so the user can
+ * delete it and re-login) and still falls back to the empty store so the
+ * command degrades onto the unauthenticated path instead of crashing.
+ *
+ * `warn` is injectable so callers (and tests) can capture the corruption
+ * notice; it defaults to the process's stderr, matching the rest of the CLI.
+ */
 export const readCredentialFile = async (
   configDir: string,
+  warn: (message: string) => void = (message) =>
+    void process.stderr.write(`${message}\n`),
 ): Promise<CredentialFile> => {
   const filePath = credentialsFilePath(configDir);
 
-  const raw = await Result.tryPromise(
-    async () => await readFile(filePath, "utf-8"),
-  );
+  const raw = await Result.tryPromise({
+    // Preserve the raw Node error (the single-arg form wraps it) so the ENOENT
+    // "genuinely absent" case can be told apart from an unreadable file.
+    try: async (): Promise<string> => await readFile(filePath, "utf-8"),
+    catch: (cause) => cause,
+  });
   if (Result.isError(raw)) {
+    if (!isMissingFileError(raw.error)) {
+      warn(corruptionWarning(filePath, "could not be read"));
+    }
     return EMPTY_FILE;
   }
 
   const parsedJson = Result.try((): unknown => JSON.parse(raw.value));
   if (Result.isError(parsedJson)) {
+    warn(corruptionWarning(filePath, "is not valid JSON"));
     return EMPTY_FILE;
   }
 
   const parsed = v.safeParse(credentialFileSchema, parsedJson.value);
-  return parsed.success ? parsed.output : EMPTY_FILE;
+  if (!parsed.success) {
+    warn(corruptionWarning(filePath, "does not match the expected schema"));
+    return EMPTY_FILE;
+  }
+  return parsed.output;
 };
 
+/**
+ * The filesystem primitives the atomic write uses, injectable so a test can
+ * simulate a mid-write failure (e.g. a throwing `rename`) and assert the live
+ * file is never left partially written. Defaults to `node:fs/promises`.
+ */
+export type AtomicWriteOps = {
+  writeFile: (
+    path: string,
+    data: string,
+    options: { mode: number },
+  ) => Promise<void>;
+  chmod: (path: string, mode: number) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+  rm: (path: string) => Promise<void>;
+};
+
+const defaultAtomicWriteOps: AtomicWriteOps = {
+  writeFile: async (filePath, data, options) =>
+    await writeFile(filePath, data, options),
+  chmod: async (filePath, mode) => await chmod(filePath, mode),
+  rename: async (oldPath, newPath) => await rename(oldPath, newPath),
+  rm: async (filePath) => await rm(filePath, { force: true }),
+};
+
+/**
+ * Persist the whole credential store. The write is atomic: the serialized file
+ * lands in a sibling temp file (0600) and is then `rename`d over the live file,
+ * so a crash mid-write can never truncate an existing store and lose every
+ * org's credentials — a reader sees either the old file or the new one, never a
+ * partial. The temp shares the target directory so the rename stays on one
+ * filesystem (a cross-device rename is not atomic). A failed write drops the
+ * temp and never touches the live file.
+ *
+ * Concurrent writers are out of scope (a last-writer-wins read-modify-write
+ * race remains); this fix targets only the truncation/corruption mode, which
+ * atomic replace eliminates.
+ */
 export const writeCredentialFile = async (
   configDir: string,
   file: CredentialFile,
+  fsOps: AtomicWriteOps = defaultAtomicWriteOps,
 ): Promise<void> => {
   const filePath = credentialsFilePath(configDir);
   await mkdir(configDir, { mode: 0o700, recursive: true });
-  await writeFile(filePath, `${JSON.stringify(file, null, 2)}\n`, {
-    mode: CREDENTIALS_FILE_MODE,
+
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  const written = await Result.tryPromise(async () => {
+    await fsOps.writeFile(tempPath, `${JSON.stringify(file, null, 2)}\n`, {
+      mode: CREDENTIALS_FILE_MODE,
+    });
+    // `writeFile`'s `mode` only applies on creation; force it so the temp (and
+    // thus the renamed-in live file) is always 0600 regardless of umask. The
+    // rename replaces the target inode, so this also tightens a pre-existing
+    // looser-permission credentials file.
+    await fsOps.chmod(tempPath, CREDENTIALS_FILE_MODE);
+    await fsOps.rename(tempPath, filePath);
   });
-  // `writeFile`'s `mode` option only applies when the file is created; force
-  // it on every write so a pre-existing looser-permission file gets fixed.
-  await chmod(filePath, CREDENTIALS_FILE_MODE);
+  if (Result.isError(written)) {
+    // Best-effort cleanup so a failed write leaves no temp litter behind; the
+    // live file was never opened, so it is already intact.
+    await Result.tryPromise(async () => await fsOps.rm(tempPath));
+    throw written.error;
+  }
 };
 
 const credentialKey = (serverUrl: string, orgId: string): string =>

--- a/packages/cli/src/auth/resolve-access-token.test.ts
+++ b/packages/cli/src/auth/resolve-access-token.test.ts
@@ -606,21 +606,32 @@ describe("resolveAccessToken", () => {
         buildCredential(provider.serverUrl, { expiresAt: now - 1000 }),
       );
 
-      // Force the persist step specifically — not the read — to fail: a
-      // read-only `credentials.json` still opens for reading (so
+      // Force the persist step specifically — not the read — to fail. The
+      // store write is atomic (temp file + rename, see credential-store.ts),
+      // so a read-only `credentials.json` no longer blocks it: `rename`
+      // replaces the target inode, which only requires the *directory* to be
+      // writable. Drop the directory's write bit instead — that blocks the
+      // temp file from ever being created — while keeping read+execute so
       // `checkForNewerStoredGeneration`'s re-read still sees the real,
-      // unchanged credential) but rejects the write with EACCES. This is
-      // deterministic and root-safe-enough for this repo's CI runners
-      // (non-root); there's no fs-injection point on this branch to stub
-      // `writeFile` directly (that lands with the atomic temp+rename
-      // hygiene follow-up).
-      await chmod(credentialsFilePath(configDir), 0o400);
+      // unchanged credential on disk. `resolveAccessToken` has no
+      // `AtomicWriteOps` injection point of its own (that seam is exercised
+      // directly against `writeCredentialFile` in credential-store.test.ts),
+      // so this stays a filesystem-level simulation. Deterministic and
+      // root-safe-enough for this repo's CI runners (non-root); permissions
+      // are restored in `finally` so `afterEach`'s recursive cleanup of
+      // `configDir` can still remove it.
+      await chmod(configDir, 0o500);
 
-      const result = await resolveAccessToken({
-        configDir,
-        serverUrl: provider.serverUrl,
-        now,
-      });
+      let result: Awaited<ReturnType<typeof resolveAccessToken>>;
+      try {
+        result = await resolveAccessToken({
+          configDir,
+          serverUrl: provider.serverUrl,
+          now,
+        });
+      } finally {
+        await chmod(configDir, 0o700);
+      }
 
       // The refresh itself succeeded — the in-memory token is valid and
       // must not be discarded just because it couldn't be saved.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,11 +20,13 @@ import { defaultConfigDir } from "./auth/cli-config.js";
 import { resolveAccessToken } from "./auth/resolve-access-token.js";
 import { resolveServerUrl } from "./auth/server-resolution.js";
 import { buildGeneratedRoutes, buildResourceRoutes } from "./build-cli-tree.js";
+import { commandNeedsRegistry } from "./command-locality.js";
 import { authRoute } from "./commands/auth.js";
 import { compatibilityRoute } from "./commands/compatibility.js";
 import type { Context } from "./context.js";
 import { HOME, XDG_CACHE_HOME } from "./env.js";
 import { generatedResourceTree } from "./generated/resource-tree.js";
+import { reportFatalError } from "./main-error-boundary.js";
 import {
   refreshRegistryCache,
   resolveCommandTree,
@@ -146,6 +148,10 @@ const stricliProcess = process as unknown as StricliProcess & typeof process;
 const main = async (): Promise<void> => {
   const argv = process.argv.slice(2);
   const isAuthLogin = argv.at(0) === "auth" && argv.at(1) === "login";
+  // Purely local commands (`--help`, `auth whoami`, `tools list`, ...) read no
+  // server registry, so they must not pay the `tools/list` round-trip; only a
+  // command that consumes the command tree triggers the pre-dispatch refresh.
+  const needsRegistry = commandNeedsRegistry(argv);
   // A named slice of the env (read through `env.ts`) so the cache module never
   // touches the full `ProcessEnv` (whose index signature would not narrow to
   // `CacheEnv`).
@@ -155,7 +161,7 @@ const main = async (): Promise<void> => {
   // Keep an EXISTING per-origin cache current before building the tree; a
   // missing cache stays offline-instant (seeded at `auth login` below). Any
   // transport/trust failure warns and falls back to the baked-in tree (S5.5).
-  if (serverUrl !== undefined && token !== undefined && !isAuthLogin) {
+  if (serverUrl !== undefined && token !== undefined && needsRegistry) {
     const outcome = await refreshRegistryCache({
       serverOrigin: serverUrl,
       token,
@@ -207,4 +213,6 @@ const main = async (): Promise<void> => {
   }
 };
 
-void main();
+// Top-level boundary: map anything that escapes startup I/O to the CLI's
+// exit-code contract instead of letting it surface as an unhandled rejection.
+main().catch((error: unknown) => reportFatalError(error, process));

--- a/packages/cli/src/command-locality.test.ts
+++ b/packages/cli/src/command-locality.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { commandNeedsRegistry } from "./command-locality.js";
+
+describe("commandNeedsRegistry", () => {
+  test("local hand-wired routes never need the registry", () => {
+    expect(commandNeedsRegistry(["auth", "login"])).toBe(false);
+    expect(commandNeedsRegistry(["auth", "whoami"])).toBe(false);
+    expect(commandNeedsRegistry(["tools", "list"])).toBe(false);
+    expect(commandNeedsRegistry(["compatibility", "check"])).toBe(false);
+  });
+
+  test("the root invocation and global flags stay local", () => {
+    expect(commandNeedsRegistry([])).toBe(false);
+    expect(commandNeedsRegistry(["--help"])).toBe(false);
+    expect(commandNeedsRegistry(["--version"])).toBe(false);
+    expect(commandNeedsRegistry(["-h"])).toBe(false);
+  });
+
+  test("generated domain commands and reference commands need the registry", () => {
+    expect(commandNeedsRegistry(["matter", "list"])).toBe(true);
+    expect(commandNeedsRegistry(["usage", "get"])).toBe(true);
+    expect(commandNeedsRegistry(["reference", "get"])).toBe(true);
+  });
+});

--- a/packages/cli/src/command-locality.ts
+++ b/packages/cli/src/command-locality.ts
@@ -1,0 +1,32 @@
+// Startup decides whether to keep the per-origin registry cache current before
+// dispatching (spec 051 S5.3). The `tools/list` round-trip only earns its cost
+// when the invoked command actually consumes the server-derived command tree.
+// The hand-wired top-level routes (`auth`, `compatibility`, `tools`) and the
+// global `--help`/`--version` flags run entirely from local state, so they must
+// never pay a network call; only the generated domain commands and the
+// `reference` resource commands read the registry and warrant a refresh.
+
+/**
+ * Top-level routes that run without any server-derived registry data. Every
+ * other top-level command (the generated domain routes plus `reference`)
+ * consumes the command tree and therefore benefits from a fresh cache.
+ */
+export const LOCAL_COMMAND_ROUTES: ReadonlySet<string> = new Set([
+  "auth",
+  "compatibility",
+  "tools",
+]);
+
+/**
+ * Whether the invoked command needs the server registry (and so warrants a
+ * startup cache refresh). A root invocation (help), a leading global flag
+ * (`--help`, `--version`), and the local routes above all resolve to `false`
+ * so purely local commands never round-trip to the server.
+ */
+export const commandNeedsRegistry = (argv: readonly string[]): boolean => {
+  const first = argv.at(0);
+  if (first === undefined || first.startsWith("-")) {
+    return false;
+  }
+  return !LOCAL_COMMAND_ROUTES.has(first);
+};

--- a/packages/cli/src/main-error-boundary.test.ts
+++ b/packages/cli/src/main-error-boundary.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { reportFatalError } from "./main-error-boundary.js";
+import { EXIT_CODES } from "./mcp-constants.js";
+
+const makeReporter = () => {
+  const stderr: string[] = [];
+  return {
+    stderr: { write: (text: string) => void stderr.push(text) },
+    exitCode: undefined as number | string | null | undefined,
+    lines: stderr,
+  };
+};
+
+describe("reportFatalError", () => {
+  test("maps a thrown Error to the unexpected exit code and a stderr line", () => {
+    const reporter = makeReporter();
+    reportFatalError(new Error("boom"), reporter);
+    expect(reporter.exitCode).toBe(EXIT_CODES.unexpected);
+    expect(reporter.lines).toEqual(["stella: boom\n"]);
+  });
+
+  test("stringifies a non-Error rejection value", () => {
+    const reporter = makeReporter();
+    reportFatalError("plain string failure", reporter);
+    expect(reporter.exitCode).toBe(EXIT_CODES.unexpected);
+    expect(reporter.lines).toEqual(["stella: plain string failure\n"]);
+  });
+});

--- a/packages/cli/src/main-error-boundary.ts
+++ b/packages/cli/src/main-error-boundary.ts
@@ -1,0 +1,24 @@
+// The top-level error boundary for the CLI shell. `main()` performs unguarded
+// startup I/O (config/credential reads, cache refresh); without a boundary an
+// unexpected throw escapes as an unhandled promise rejection with a raw stack
+// and a default exit code, bypassing the CLI's exit-code contract (spec 051
+// S4). This maps any such error to a one-line stderr message and the generic
+// `unexpected` (1) exit class. Command-level failures already set their own
+// exit codes upstream; this catches only what escapes that path.
+
+import { EXIT_CODES } from "./mcp-constants.js";
+
+/** The minimal process surface the boundary writes to. */
+export type FatalErrorReporter = {
+  stderr: { write: (text: string) => void };
+  exitCode?: number | string | null | undefined;
+};
+
+export const reportFatalError = (
+  error: unknown,
+  reporter: FatalErrorReporter,
+): void => {
+  const message = error instanceof Error ? error.message : String(error);
+  reporter.stderr.write(`stella: ${message}\n`);
+  reporter.exitCode = EXIT_CODES.unexpected;
+};


### PR DESCRIPTION
Four hardening fixes in packages/cli:

- writeCredentialFile now writes a sibling temp file (0600) and renames it
  over the live credentials.json, so a crash mid-write can no longer truncate
  the store and lose every org's credentials. A failed write drops the temp
  and never touches the live file. The filesystem primitives are injectable so
  the atomic guarantee is testable. Concurrent-writer races stay out of scope.

- readCredentialFile distinguishes a genuinely-absent file (silent empty
  store, never signed in) from an unreadable/corrupt one (read error other
  than ENOENT, invalid JSON, or schema mismatch). Corruption now warns to
  stderr with the file path instead of masquerading as "not signed in", while
  still degrading onto the unauthenticated path.

- The CLI entrypoint wraps main() in a top-level catch that maps an escaped
  error to a one-line stderr message and the generic "unexpected" (1) exit
  class, instead of surfacing an unhandled rejection with a raw stack that
  bypasses the exit-code contract.

- The startup registry refresh is gated on whether the invoked command
  actually consumes the server-derived command tree (commandNeedsRegistry).
  Purely local commands (--help, --version, auth *, tools list,
  compatibility) no longer pay a tools/list round-trip. browser-open also
  unref()s the detached opener so login cannot hang on a slow opener.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI startup reliability by preventing unnecessary registry checks for local commands.
  - Ensured unexpected startup errors produce a clear message and appropriate exit status.
  - Prevented browser launchers from keeping the CLI running after login.
  - Made credential storage safer, preserving existing credentials if a write fails.
  - Added clearer warnings for invalid or unreadable credential files.

- **Tests**
  - Expanded coverage for command routing, fatal errors, credential validation and atomic credential updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->