### PR TITLE
fix(api): three-state chat title source so AI titling cannot clobber renames

### DIFF
--- a/apps/api/drizzle/20260718120000_chat_thread_title_source_default/migration.sql
+++ b/apps/api/drizzle/20260718120000_chat_thread_title_source_default/migration.sql
@@ -1,0 +1,10 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - widening varchar(4) -> varchar(7) is a metadata-only catalog change (no table rewrite, no data loss); it only enlarges the length limit so the new "default" title-source value fits. Rollback is to shrink back to varchar(4) once no row exceeds it.
+ALTER TABLE "chat_threads" ALTER COLUMN "title_source" SET DATA TYPE varchar(7);--> statement-breakpoint
+-- New threads now start "default" (AI-replaceable placeholder) instead of
+-- "user". Existing rows are intentionally left as-is: AI titling only fires for
+-- threads created in the same send-message request, so it never runs against
+-- pre-existing rows. Backfilling "user" -> "default" would risk re-opening
+-- genuine renames to AI overwrite, so those rows keep "user" and stay protected.
+ALTER TABLE "chat_threads" ALTER COLUMN "title_source" SET DEFAULT 'default';

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -21,6 +21,8 @@ export * from "./schema/relations";
 export {
   ACCOUNT_DELETION_REQUEST_STATUSES,
   BILLING_STATUS,
+  CHAT_TITLE_SOURCE,
+  CHAT_TITLE_SOURCES,
   ENTITY_KINDS,
   EXPENSE_CATEGORIES,
   PROPERTY_ROLES,
@@ -48,6 +50,7 @@ export type {
   CellMetadata,
   ChatCompactionSummary,
   ChatMessageRole,
+  ChatTitleSource,
   ClauseBody,
   ClauseMetadata,
   ConditionNode,

--- a/apps/api/src/db/schema/chat.ts
+++ b/apps/api/src/db/schema/chat.ts
@@ -20,6 +20,7 @@ import {
 import type {
   ChatCompactionSummary,
   ChatMessageRole,
+  ChatTitleSource,
   PersistedChatMessageContent,
 } from "./common";
 import { workspaces } from "./contacts";
@@ -44,11 +45,15 @@ export const chatThreads = p.pgTable(
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
     title: p.varchar({ length: 255 }).notNull(),
+    // Provenance of `title`; gates whether background AI titling may replace it.
+    // See ChatTitleSource in ./common. New threads start "default"; a rename
+    // stamps "user"; the generator only replaces "default" and stamps "ai".
+    // Length fits the longest value ("default").
     titleSource: p
-      .varchar("title_source", { length: 4 })
-      .$type<"ai" | "user">()
+      .varchar("title_source", { length: 7 })
+      .$type<ChatTitleSource>()
       .notNull()
-      .default("user"),
+      .default("default"),
     /**
      * A successful mutation adopts a newly created thread, preventing the
      * creating request's disconnect compensation from deleting changed state.

--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -332,6 +332,25 @@ export const TIME_ENTRY_SOURCE = {
   TIMER: "timer",
 } as const satisfies Record<string, TimeEntrySource>;
 
+/**
+ * Provenance of a chat thread's title. A three-state discriminator (not a
+ * boolean) so background AI title generation can never clobber a title the
+ * user chose:
+ *   - "default": the placeholder title a freshly created thread starts with;
+ *     the only source the background generator is allowed to replace.
+ *   - "user": the user renamed the thread; a rename stamps this, and it is
+ *     never overwritten by AI titling.
+ *   - "ai": the background generator wrote the title; it stamps this after
+ *     replacing a "default" title and never regenerates over its own result.
+ */
+export const CHAT_TITLE_SOURCES = ["default", "user", "ai"] as const;
+export type ChatTitleSource = (typeof CHAT_TITLE_SOURCES)[number];
+export const CHAT_TITLE_SOURCE = {
+  DEFAULT: "default",
+  USER: "user",
+  AI: "ai",
+} as const satisfies Record<string, ChatTitleSource>;
+
 // -- Contacts --
 
 export {

--- a/apps/api/src/handlers/chat/generate-thread-title.integration.test.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.integration.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { CHAT_TITLE_SOURCE, chatThreads } from "@/api/db/schema";
+import type { ChatTitleSource } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+// Exercises the title_source column against PGlite: the schema default a new
+// thread receives, and the conditional UPDATE the background title generator
+// runs. The column is varchar(7); if it were left at the old varchar(4) the
+// "default" value would truncate to "defa" and every guard below would break,
+// so these round-trips also pin the migration's length change.
+
+let testDb: TestDatabase;
+let ids: TestIds;
+const seededThreadIds: SafeId<"chatThread">[] = [];
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+});
+
+afterAll(async () => {
+  if (seededThreadIds.length > 0) {
+    await testDb
+      .delete(chatThreads)
+      .where(inArray(chatThreads.id, seededThreadIds));
+  }
+  await releaseRlsFixture();
+});
+
+const seedThread = async (
+  titleSource?: ChatTitleSource,
+): Promise<SafeId<"chatThread">> => {
+  const threadId = toSafeId<"chatThread">(Bun.randomUUIDv7());
+  await testDb.insert(chatThreads).values({
+    id: threadId,
+    organizationId: ids.orgA,
+    userId: ids.userA1,
+    title: "New chat",
+    workspaceId: ids.wsA1,
+    // Omit titleSource to observe the schema default.
+    ...(titleSource ? { titleSource } : {}),
+  });
+  seededThreadIds.push(threadId);
+  return threadId;
+};
+
+const readTitleState = async (threadId: SafeId<"chatThread">) => {
+  const [row] = await testDb
+    .select({ title: chatThreads.title, titleSource: chatThreads.titleSource })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  if (!row) {
+    throw new TypeError(`thread ${threadId} not found`);
+  }
+  return row;
+};
+
+// Mirrors the guarded write in generate-thread-title.ts: replace the title only
+// while the source is still "default", then stamp "ai".
+const runGeneratorWrite = async (
+  threadId: SafeId<"chatThread">,
+  title: string,
+) =>
+  await testDb
+    .update(chatThreads)
+    .set({ title, titleSource: CHAT_TITLE_SOURCE.AI })
+    .where(
+      and(
+        eq(chatThreads.id, threadId),
+        eq(chatThreads.titleSource, CHAT_TITLE_SOURCE.DEFAULT),
+      ),
+    )
+    .returning({ id: chatThreads.id });
+
+describe("chat thread title source", () => {
+  test("a new thread defaults to the AI-replaceable 'default' source", async () => {
+    const threadId = await seedThread();
+    const { titleSource } = await readTitleState(threadId);
+    expect(titleSource).toBe(CHAT_TITLE_SOURCE.DEFAULT);
+  });
+
+  test("generator write replaces a default-source title and stamps 'ai'", async () => {
+    const threadId = await seedThread();
+    const updated = await runGeneratorWrite(threadId, "Contract review");
+    expect(updated).toHaveLength(1);
+
+    const { title, titleSource } = await readTitleState(threadId);
+    expect(title).toBe("Contract review");
+    expect(titleSource).toBe(CHAT_TITLE_SOURCE.AI);
+  });
+
+  test("generator write does not clobber a user rename", async () => {
+    const threadId = await seedThread(CHAT_TITLE_SOURCE.USER);
+    const updated = await runGeneratorWrite(threadId, "AI generated title");
+    expect(updated).toHaveLength(0);
+
+    const { title, titleSource } = await readTitleState(threadId);
+    expect(title).toBe("New chat");
+    expect(titleSource).toBe(CHAT_TITLE_SOURCE.USER);
+  });
+
+  test("generator write does not regenerate over a prior ai title", async () => {
+    const threadId = await seedThread(CHAT_TITLE_SOURCE.AI);
+    const updated = await runGeneratorWrite(threadId, "Second title");
+    expect(updated).toHaveLength(0);
+
+    const { titleSource } = await readTitleState(threadId);
+    expect(titleSource).toBe(CHAT_TITLE_SOURCE.AI);
+  });
+});

--- a/apps/api/src/handlers/chat/generate-thread-title.integration.test.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.integration.test.ts
@@ -67,10 +67,12 @@ const readTitleState = async (threadId: SafeId<"chatThread">) => {
 };
 
 // Mirrors the guarded write in generate-thread-title.ts: replace the title only
-// while the source is still "default", then stamp "ai".
+// while the source is still "default" and the text still matches what the
+// generator observed at dispatch time, then stamp "ai".
 const runGeneratorWrite = async (
   threadId: SafeId<"chatThread">,
   title: string,
+  initialTitle: string,
 ) =>
   await testDb
     .update(chatThreads)
@@ -79,6 +81,7 @@ const runGeneratorWrite = async (
       and(
         eq(chatThreads.id, threadId),
         eq(chatThreads.titleSource, CHAT_TITLE_SOURCE.DEFAULT),
+        eq(chatThreads.title, initialTitle),
       ),
     )
     .returning({ id: chatThreads.id });
@@ -92,7 +95,11 @@ describe("chat thread title source", () => {
 
   test("generator write replaces a default-source title and stamps 'ai'", async () => {
     const threadId = await seedThread();
-    const updated = await runGeneratorWrite(threadId, "Contract review");
+    const updated = await runGeneratorWrite(
+      threadId,
+      "Contract review",
+      "New chat",
+    );
     expect(updated).toHaveLength(1);
 
     const { title, titleSource } = await readTitleState(threadId);
@@ -102,7 +109,11 @@ describe("chat thread title source", () => {
 
   test("generator write does not clobber a user rename", async () => {
     const threadId = await seedThread(CHAT_TITLE_SOURCE.USER);
-    const updated = await runGeneratorWrite(threadId, "AI generated title");
+    const updated = await runGeneratorWrite(
+      threadId,
+      "AI generated title",
+      "New chat",
+    );
     expect(updated).toHaveLength(0);
 
     const { title, titleSource } = await readTitleState(threadId);
@@ -112,10 +123,41 @@ describe("chat thread title source", () => {
 
   test("generator write does not regenerate over a prior ai title", async () => {
     const threadId = await seedThread(CHAT_TITLE_SOURCE.AI);
-    const updated = await runGeneratorWrite(threadId, "Second title");
+    const updated = await runGeneratorWrite(
+      threadId,
+      "Second title",
+      "New chat",
+    );
     expect(updated).toHaveLength(0);
 
     const { titleSource } = await readTitleState(threadId);
     expect(titleSource).toBe(CHAT_TITLE_SOURCE.AI);
+  });
+
+  // Rolling-deploy window: an old API task's rename-thread implementation
+  // predates titleSource and writes only `title`, leaving titleSource
+  // "default" behind. The generator must not treat that stale column as
+  // license to overwrite the rename — it also has to notice the title text
+  // no longer matches what it observed when the background job started.
+  test("generator write does not clobber a rename left by a pre-migration rename-thread", async () => {
+    const threadId = await seedThread();
+
+    // Simulate the old rename-thread handler: it only ever touched `title`,
+    // so titleSource stays "default" even though the user did rename.
+    await testDb
+      .update(chatThreads)
+      .set({ title: "Renamed by old task" })
+      .where(eq(chatThreads.id, threadId));
+
+    const updated = await runGeneratorWrite(
+      threadId,
+      "AI generated title",
+      "New chat",
+    );
+    expect(updated).toHaveLength(0);
+
+    const { title, titleSource } = await readTitleState(threadId);
+    expect(title).toBe("Renamed by old task");
+    expect(titleSource).toBe(CHAT_TITLE_SOURCE.DEFAULT);
   });
 });

--- a/apps/api/src/handlers/chat/generate-thread-title.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.ts
@@ -20,6 +20,7 @@ const TITLE_MAX_OUTPUT_TOKENS = 32;
 const TITLE_GENERATION_TIMEOUT_MS = 10_000;
 
 type GenerateThreadTitleProps = {
+  initialTitle: string;
   messages: [ChatMessage, ChatMessage]; // [userMessage, AIMessage]
   organizationId: SafeId<"organization">;
   orgAIConfig: OrgAIConfig | null;
@@ -32,6 +33,7 @@ type GenerateThreadTitleProps = {
 };
 
 export const generateThreadTitle = async ({
+  initialTitle,
   messages,
   organizationId,
   orgAIConfig,
@@ -98,10 +100,22 @@ Assistant: ${assistantText}`,
         },
       });
 
-      // Only replace a still-default placeholder title. A "user" rename or a
+      // Only replace a still-default placeholder title whose text still
+      // matches what this request set at creation. A "user" rename or a
       // prior "ai" title is left untouched: the generator writes once, and a
       // rename that raced this fire-and-forget path must win.
-      if (!currentThread || !aiTitlingMayReplace(currentThread.titleSource)) {
+      //
+      // The title-text comparison (not just titleSource) also covers a
+      // rolling-deploy window: an old API task's rename-thread implementation
+      // predates titleSource and only writes `title`, so a rename it serves
+      // leaves titleSource="default" behind. Requiring the title to still
+      // equal initialTitle catches that stale-column case too, since any
+      // rename necessarily changes the text.
+      if (
+        !currentThread ||
+        !aiTitlingMayReplace(currentThread.titleSource) ||
+        currentThread.title !== initialTitle
+      ) {
         return false;
       }
 
@@ -114,6 +128,7 @@ Assistant: ${assistantText}`,
             // Re-check inside the UPDATE so a rename committing between the
             // read above and this write cannot be clobbered.
             eq(chatThreads.titleSource, CHAT_TITLE_SOURCE.DEFAULT),
+            eq(chatThreads.title, initialTitle),
           ),
         )
         .returning({ id: chatThreads.id });

--- a/apps/api/src/handlers/chat/generate-thread-title.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.ts
@@ -2,7 +2,8 @@ import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 
 import type { SafeDb } from "@/api/db/safe-db";
-import { chatThreads } from "@/api/db/schema";
+import { CHAT_TITLE_SOURCE, chatThreads } from "@/api/db/schema";
+import { aiTitlingMayReplace } from "@/api/handlers/chat/thread-title";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import { resolveCaching, type OrgAIConfig } from "@/api/lib/ai-config";
 import { captureError } from "@/api/lib/analytics/capture";
@@ -97,17 +98,22 @@ Assistant: ${assistantText}`,
         },
       });
 
-      if (!currentThread || currentThread.titleSource !== "user") {
+      // Only replace a still-default placeholder title. A "user" rename or a
+      // prior "ai" title is left untouched: the generator writes once, and a
+      // rename that raced this fire-and-forget path must win.
+      if (!currentThread || !aiTitlingMayReplace(currentThread.titleSource)) {
         return false;
       }
 
       const updatedRows = await tx
         .update(chatThreads)
-        .set({ title, titleSource: "ai" })
+        .set({ title, titleSource: CHAT_TITLE_SOURCE.AI })
         .where(
           and(
             eq(chatThreads.id, threadId),
-            eq(chatThreads.titleSource, "user"),
+            // Re-check inside the UPDATE so a rename committing between the
+            // read above and this write cannot be clobbered.
+            eq(chatThreads.titleSource, CHAT_TITLE_SOURCE.DEFAULT),
           ),
         )
         .returning({ id: chatThreads.id });
@@ -123,7 +129,10 @@ Assistant: ${assistantText}`,
         workspaceId: threadWorkspaceId,
         changes: {
           title: { old: currentThread.title, new: title },
-          titleSource: { old: currentThread.titleSource, new: "ai" },
+          titleSource: {
+            old: currentThread.titleSource,
+            new: CHAT_TITLE_SOURCE.AI,
+          },
         },
       });
 

--- a/apps/api/src/handlers/chat/rename-thread.ts
+++ b/apps/api/src/handlers/chat/rename-thread.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { t } from "elysia";
 
 import { defaultDatabaseRetry } from "@/api/db/safe-db";
-import { chatThreads } from "@/api/db/schema";
+import { CHAT_TITLE_SOURCE, chatThreads } from "@/api/db/schema";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -79,7 +79,13 @@ const renameThread = createSafeRootHandler(
           return [];
         }
 
-        await tx.update(chatThreads).set({ title }).where(threadPredicate());
+        // Stamp titleSource="user" so the fire-and-forget AI title generator
+        // (which only replaces "default") can never overwrite this rename,
+        // even when it lands after a just-created thread's rename.
+        await tx
+          .update(chatThreads)
+          .set({ title, titleSource: CHAT_TITLE_SOURCE.USER })
+          .where(threadPredicate());
 
         await recordAuditEvent(tx, {
           action: AUDIT_ACTION.UPDATE,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -464,6 +464,12 @@ const sendMessage = createSafeRootHandler(
       }
       const validatedMessage = validatedMessageResult.value;
 
+      // Captured once and threaded through to generateThreadTitle below: the
+      // generator's guard compares the thread's live title against this
+      // value to detect any rename (even one whose titleSource column went
+      // stale) rather than trusting titleSource alone.
+      const initialThreadTitle = extractTitle(validatedMessage.message.parts);
+
       const thread = yield* Result.await(
         loadThread({
           initialContextMatterIds: requestedContextMatterIds,
@@ -472,7 +478,7 @@ const sendMessage = createSafeRootHandler(
           recordAuditEvent,
           safeDb,
           threadId: body.threadId,
-          title: extractTitle(validatedMessage.message.parts),
+          title: initialThreadTitle,
           userId: user.id,
           workspaceId,
         }),
@@ -1125,6 +1131,7 @@ const sendMessage = createSafeRootHandler(
                       body.sendMode !== CHAT_SEND_MODE.anonymized
                     ) {
                       void generateThreadTitle({
+                        initialTitle: initialThreadTitle,
                         messages: [
                           parsedMessage.message,
                           resolvedResponseMessage,

--- a/apps/api/src/handlers/chat/thread-title.test.ts
+++ b/apps/api/src/handlers/chat/thread-title.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import { CHAT_TITLE_SOURCES } from "@/api/db/schema";
+import type { ChatTitleSource } from "@/api/db/schema";
+
 import {
+  aiTitlingMayReplace,
   CHAT_THREAD_PLACEHOLDER_TITLE,
   shouldRefreshEmptyThreadTitle,
 } from "./thread-title";
@@ -32,4 +36,22 @@ describe("shouldRefreshEmptyThreadTitle", () => {
       }),
     ).toBe(false);
   });
+});
+
+describe("aiTitlingMayReplace", () => {
+  // The whole point of the three-state title source: AI titling replaces only
+  // an untouched placeholder. A user rename and a prior AI title are off limits.
+  const expected: Record<ChatTitleSource, boolean> = {
+    default: true,
+    user: false,
+    ai: false,
+  };
+
+  // Exhaustive over the union so adding a fourth source forces a decision here
+  // (the table above stops type-checking) rather than defaulting to replaceable.
+  for (const source of CHAT_TITLE_SOURCES) {
+    test(`${source} -> ${expected[source] ? "replaceable" : "protected"}`, () => {
+      expect(aiTitlingMayReplace(source)).toBe(expected[source]);
+    });
+  }
 });

--- a/apps/api/src/handlers/chat/thread-title.ts
+++ b/apps/api/src/handlers/chat/thread-title.ts
@@ -1,4 +1,16 @@
+import { CHAT_TITLE_SOURCE } from "@/api/db/schema";
+import type { ChatTitleSource } from "@/api/db/schema";
+
 export const CHAT_THREAD_PLACEHOLDER_TITLE = "New chat";
+
+/**
+ * Whether background AI title generation may replace a thread's current title.
+ * Only a still-default placeholder ("default") is replaceable: a user rename
+ * ("user") and a title the generator already wrote ("ai") are left untouched,
+ * so a rename that races the fire-and-forget generator always wins.
+ */
+export const aiTitlingMayReplace = (source: ChatTitleSource): boolean =>
+  source === CHAT_TITLE_SOURCE.DEFAULT;
 
 export const isPlaceholderThreadTitle = (title: string) =>
   title === CHAT_THREAD_PLACEHOLDER_TITLE;


### PR DESCRIPTION
Background AI title generation runs fire-and-forget after the first
assistant response for a newly created thread. Previously every new
thread's title_source defaulted to "user", and rename-thread updated the
title without touching title_source. The generator replaced any title
whose source was "user", so a user who renamed a just-created thread
while the first response streamed had their rename overwritten.

Model title provenance as a three-state discriminator
("default" | "user" | "ai") instead of the previous "ai" | "user":

- New threads start "default" (the AI-replaceable placeholder).
- rename-thread stamps "user"; a user rename is never overwritten.
- The generator replaces only "default" and stamps "ai"; it never
  regenerates over its own "ai" title, and the guard is re-checked
  inside the UPDATE so a rename that commits mid-flight still wins.

The replaceability rule lives in a single predicate (aiTitlingMayReplace)
covered by an exhaustive test, so a future fourth source must decide
explicitly rather than defaulting to replaceable.

Migration widens title_source varchar(4) -> varchar(7) to fit "default"
and changes the column default. Existing rows keep their current value:
AI titling only fires for threads created in the same request, so it
never runs against pre-existing rows, and backfilling "user" -> "default"
would re-expose genuine renames to overwrite.
