### PR TITLE
refactor(api): shared cursor codec factory; fix millisecond cursor truncation

### DIFF
--- a/apps/api/src/handlers/audit-logs/query.ts
+++ b/apps/api/src/handlers/audit-logs/query.ts
@@ -15,43 +15,15 @@ import {
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, tUserId } from "@/api/lib/custom-schema";
-import {
-  parsePgTimestampCursorValue,
-  pgTimestampCursorBoundary,
-  pgTimestampCursorValue,
-} from "@/api/lib/db-pagination";
-import type { ParsedPgTimestampCursor } from "@/api/lib/db-pagination";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
 import { brandPersistedAuditLogId } from "@/api/lib/safe-id-boundaries";
 
-const CURSOR_SEPARATOR = "|";
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
-
-const auditLogCreatedAtCursor = pgTimestampCursorValue(auditLogs.createdAt);
-
-const encodeCursor = (createdAt: string, id: string): string =>
-  `${createdAt}${CURSOR_SEPARATOR}${id}`;
-
-const decodeCursor = (
-  cursor: string,
-): { createdAt: ParsedPgTimestampCursor; id: SafeId<"auditLog"> } | null => {
-  const separatorIndex = cursor.indexOf(CURSOR_SEPARATOR);
-  if (separatorIndex === -1) {
-    return null;
-  }
-
-  const createdAt = parsePgTimestampCursorValue(
-    cursor.slice(0, separatorIndex),
-  );
-  const id = cursor.slice(separatorIndex + 1);
-  if (createdAt === null || !UUID_RE.test(id)) {
-    return null;
-  }
-
-  return { createdAt, id: brandPersistedAuditLogId(id) };
-};
+const auditLogCursor = createTimestampIdCursorCodec({
+  column: auditLogs.createdAt,
+  brandId: brandPersistedAuditLogId,
+});
 
 export const readAuditLogsQuerySchema = t.Object({
   workspaceId: t.Optional(tSafeId("workspace")),
@@ -105,17 +77,15 @@ export const toAuditLogConditions = (query: ReadAuditLogsQuery): SQL[] => {
     conditions.push(lt(auditLogs.createdAt, new Date(query.toExclusive)));
   }
   if (query.cursor) {
-    const cursor = decodeCursor(query.cursor);
+    const cursor = auditLogCursor.decode(query.cursor);
     if (!cursor) {
       return conditions;
     }
 
+    const boundary = auditLogCursor.boundary(cursor);
     const cursorCondition = or(
-      lt(auditLogs.createdAt, pgTimestampCursorBoundary(cursor.createdAt)),
-      and(
-        eq(auditLogs.createdAt, pgTimestampCursorBoundary(cursor.createdAt)),
-        lt(auditLogs.id, cursor.id),
-      ),
+      lt(auditLogs.createdAt, boundary),
+      and(eq(auditLogs.createdAt, boundary), lt(auditLogs.id, cursor.id)),
     );
     if (cursorCondition) {
       conditions.push(cursorCondition);
@@ -158,7 +128,7 @@ export const validateAuditLogFilter = (
   if (query.resourceId && !query.resourceType) {
     return "resourceType is required when resourceId is provided";
   }
-  if (query.cursor && !decodeCursor(query.cursor)) {
+  if (query.cursor && !auditLogCursor.decode(query.cursor)) {
     return "Invalid cursor";
   }
   return null;
@@ -197,7 +167,7 @@ export const queryAuditLogPage = async function* ({
           resourceType: auditLogs.resourceType,
           resourceId: auditLogs.resourceId,
           changes: auditLogs.changes,
-          createdAtCursor: auditLogCreatedAtCursor.as("created_at_cursor"),
+          createdAtCursor: auditLogCursor.cursorValue.as("created_at_cursor"),
         })
         .from(auditLogs)
         .where(and(...conditions))
@@ -252,7 +222,8 @@ export const queryAuditLogPage = async function* ({
   const page = createCursorPage({
     rows,
     limit,
-    cursorForItem: (item) => encodeCursor(item.createdAtCursor, item.id),
+    cursorForItem: (item) =>
+      auditLogCursor.encode(item.createdAtCursor, item.id),
   });
 
   return Result.ok({

--- a/apps/api/src/handlers/audit-logs/query.ts
+++ b/apps/api/src/handlers/audit-logs/query.ts
@@ -1,6 +1,6 @@
 import { Result } from "better-result";
 import type { SQL } from "drizzle-orm";
-import { and, desc, eq, inArray, gte, lt, lte, or } from "drizzle-orm";
+import { and, desc, eq, inArray, gte, lt, lte } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
@@ -82,11 +82,11 @@ export const toAuditLogConditions = (query: ReadAuditLogsQuery): SQL[] => {
       return conditions;
     }
 
-    const boundary = auditLogCursor.boundary(cursor);
-    const cursorCondition = or(
-      lt(auditLogs.createdAt, boundary),
-      and(eq(auditLogs.createdAt, boundary), lt(auditLogs.id, cursor.id)),
-    );
+    const cursorCondition = auditLogCursor.keysetAfter({
+      cursor,
+      idColumn: auditLogs.id,
+      direction: "descending",
+    });
     if (cursorCondition) {
       conditions.push(cursorCondition);
     }

--- a/apps/api/src/handlers/clauses/read.ts
+++ b/apps/api/src/handlers/clauses/read.ts
@@ -5,41 +5,20 @@ import { t } from "elysia";
 import type { SafeDb } from "@/api/db/safe-db";
 import { clauses } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
-import { isUuid, tSafeId } from "@/api/lib/custom-schema";
-import {
-  parsePgTimestampCursorValue,
-  pgTimestampCursorBoundary,
-  pgTimestampCursorValue,
-} from "@/api/lib/db-pagination";
-import type { ParsedPgTimestampCursor } from "@/api/lib/db-pagination";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
+import { brandPersistedClauseId } from "@/api/lib/safe-id-boundaries";
 
 // ── Cursor helpers ───────────────────────────────────
 
-const CURSOR_SEP = "|";
-
-const clauseCreatedAtCursor = pgTimestampCursorValue(clauses.createdAt);
-
-const encodeCursor = (date: string, id: string): string =>
-  `${date}${CURSOR_SEP}${id}`;
-
-const decodeCursor = (
-  cursor: string,
-): { date: ParsedPgTimestampCursor; id: string } | null => {
-  const idx = cursor.indexOf(CURSOR_SEP);
-  if (idx === -1) {
-    return null;
-  }
-  const date = parsePgTimestampCursorValue(cursor.slice(0, idx));
-  const id = cursor.slice(idx + 1);
-  if (date === null || !isUuid(id)) {
-    return null;
-  }
-  return { date, id };
-};
+const clauseCursor = createTimestampIdCursorCodec({
+  column: clauses.createdAt,
+  brandId: brandPersistedClauseId,
+});
 
 // ── List ────────────────────────────────────────────
 
@@ -112,7 +91,7 @@ export const listClausesHandler = async function* ({
   // Cursor pagination only applies to date-ordered
   // browsing; search results ignore the cursor.
   if (query.cursor && !isSearching) {
-    const parsed = decodeCursor(query.cursor);
+    const parsed = clauseCursor.decode(query.cursor);
     if (parsed === null) {
       return Result.err(
         new HandlerError({ status: 400, message: "Invalid cursor" }),
@@ -120,12 +99,10 @@ export const listClausesHandler = async function* ({
     }
     // Compound cursor: (createdAt < cursorDate) OR
     // (createdAt = cursorDate AND id < cursorId)
+    const boundary = clauseCursor.boundary(parsed);
     const cursorCondition = or(
-      lt(clauses.createdAt, pgTimestampCursorBoundary(parsed.date)),
-      and(
-        eq(clauses.createdAt, pgTimestampCursorBoundary(parsed.date)),
-        sql`${clauses.id} < ${parsed.id}`,
-      ),
+      lt(clauses.createdAt, boundary),
+      and(eq(clauses.createdAt, boundary), lt(clauses.id, parsed.id)),
     );
     if (cursorCondition) {
       conditions.push(cursorCondition);
@@ -140,7 +117,7 @@ export const listClausesHandler = async function* ({
     description: clauses.description,
     currentVersion: clauses.currentVersion,
     createdAt: clauses.createdAt,
-    createdAtCursor: clauseCreatedAtCursor.as("created_at_cursor"),
+    createdAtCursor: clauseCursor.cursorValue.as("created_at_cursor"),
     updatedAt: clauses.updatedAt,
   };
 
@@ -164,7 +141,7 @@ export const listClausesHandler = async function* ({
   const page = createCursorPage({
     rows,
     limit,
-    cursorForItem: (item) => encodeCursor(item.createdAtCursor, item.id),
+    cursorForItem: (item) => clauseCursor.encode(item.createdAtCursor, item.id),
   });
 
   return Result.ok({

--- a/apps/api/src/handlers/clauses/read.ts
+++ b/apps/api/src/handlers/clauses/read.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db/safe-db";
@@ -99,11 +99,11 @@ export const listClausesHandler = async function* ({
     }
     // Compound cursor: (createdAt < cursorDate) OR
     // (createdAt = cursorDate AND id < cursorId)
-    const boundary = clauseCursor.boundary(parsed);
-    const cursorCondition = or(
-      lt(clauses.createdAt, boundary),
-      and(eq(clauses.createdAt, boundary), lt(clauses.id, parsed.id)),
-    );
+    const cursorCondition = clauseCursor.keysetAfter({
+      cursor: parsed,
+      idColumn: clauses.id,
+      direction: "descending",
+    });
     if (cursorCondition) {
       conditions.push(cursorCondition);
     }

--- a/apps/api/src/handlers/contacts/read.ts
+++ b/apps/api/src/handlers/contacts/read.ts
@@ -28,10 +28,34 @@ type DecodedCursor = {
   id: SafeId<"contact">;
 };
 
+// Legacy cursors were base64 of `displayName\0uuid`; the current form is the
+// base64url JSON tuple `encodePaginationCursor` emits. `decodePaginationCursor`
+// returns null for the legacy shape (its NUL-delimited payload is not JSON), so
+// fall back to it there and an in-flight cursor survives the format change
+// instead of silently restarting pagination at page 1 (duplicate contacts).
+const LEGACY_CONTACT_CURSOR_SEPARATOR = "\0";
+
+const decodeLegacyContactCursor = (cursor: string): DecodedCursor | null => {
+  const decoded = Buffer.from(cursor, "base64").toString("utf-8");
+  const separatorIndex = decoded.indexOf(LEGACY_CONTACT_CURSOR_SEPARATOR);
+  if (separatorIndex === -1) {
+    return null;
+  }
+  const displayName = decoded.slice(0, separatorIndex);
+  const id = decoded.slice(separatorIndex + 1);
+  if (!isUuidPaginationCursorPart(id)) {
+    return null;
+  }
+  return { displayName, id: brandPersistedContactId(id) };
+};
+
 const decodeCursor = (cursor: string): DecodedCursor | null => {
   const parts = decodePaginationCursor(cursor);
-  const displayName = parts?.at(0);
-  const id = parts?.at(1);
+  if (parts === null) {
+    return decodeLegacyContactCursor(cursor);
+  }
+  const displayName = parts.at(0);
+  const id = parts.at(1);
   if (typeof displayName !== "string" || !isUuidPaginationCursorPart(id)) {
     return null;
   }

--- a/apps/api/src/handlers/contacts/read.ts
+++ b/apps/api/src/handlers/contacts/read.ts
@@ -8,7 +8,12 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tPaginationLimit } from "@/api/lib/custom-schema";
 import { escapeLike } from "@/api/lib/escape-like";
 import { LIMITS } from "@/api/lib/limits";
-import { createCursorPage } from "@/api/lib/pagination";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
 import { brandPersistedContactId } from "@/api/lib/safe-id-boundaries";
 
 const readContactsQuerySchema = t.Object({
@@ -24,22 +29,17 @@ type DecodedCursor = {
 };
 
 const decodeCursor = (cursor: string): DecodedCursor | null => {
-  const decodeResult = Result.try(() =>
-    Buffer.from(cursor, "base64").toString("utf-8"),
-  );
-  if (Result.isError(decodeResult)) {
-    return null;
-  }
-
-  const [displayName, id] = decodeResult.value.split("\0");
-  if (!displayName || !id) {
+  const parts = decodePaginationCursor(cursor);
+  const displayName = parts?.at(0);
+  const id = parts?.at(1);
+  if (typeof displayName !== "string" || !isUuidPaginationCursorPart(id)) {
     return null;
   }
   return { displayName, id: brandPersistedContactId(id) };
 };
 
 const encodeCursor = (displayName: string, id: string): string =>
-  Buffer.from(`${displayName}\0${id}`, "utf-8").toString("base64");
+  encodePaginationCursor([displayName, id]);
 
 const readContacts = createSafeRootHandler(
   {

--- a/apps/api/src/handlers/invoices/read.ts
+++ b/apps/api/src/handlers/invoices/read.ts
@@ -1,19 +1,13 @@
 import { Result } from "better-result";
-import { and, asc, eq, gt, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, or } from "drizzle-orm";
 import { t } from "elysia";
 
 import { invoices } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
-import type { SafeId } from "@/api/lib/branded-types";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
-import {
-  createCursorPage,
-  decodePaginationCursor,
-  encodePaginationCursor,
-  isUuidPaginationCursorPart,
-  parseDateTimePaginationCursorPart,
-} from "@/api/lib/pagination";
+import { createCursorPage } from "@/api/lib/pagination";
 import { brandPersistedInvoiceId } from "@/api/lib/safe-id-boundaries";
 
 const readInvoicesQuerySchema = t.Object({
@@ -23,26 +17,10 @@ const readInvoicesQuerySchema = t.Object({
   cursor: t.Optional(t.String({ maxLength: 512 })),
 });
 
-type InvoiceCursor = {
-  createdAt: Date;
-  id: SafeId<"invoice">;
-};
-
-const invoiceCreatedAtCursor = sql<Date>`date_trunc('milliseconds', ${invoices.createdAt})`;
-
-const decodeInvoiceCursor = (cursor: string): InvoiceCursor | null => {
-  const parts = decodePaginationCursor(cursor);
-  const createdAt = parts?.at(0);
-  const id = parts?.at(1);
-
-  const createdAtDate = parseDateTimePaginationCursorPart(createdAt);
-
-  if (!createdAtDate || !isUuidPaginationCursorPart(id)) {
-    return null;
-  }
-
-  return { createdAt: createdAtDate, id: brandPersistedInvoiceId(id) };
-};
+const invoiceCursor = createTimestampIdCursorCodec({
+  column: invoices.createdAt,
+  brandId: brandPersistedInvoiceId,
+});
 
 const readInvoices = createSafeHandler(
   {
@@ -55,7 +33,7 @@ const readInvoices = createSafeHandler(
     const conditions = [eq(invoices.workspaceId, workspaceId)];
 
     if (query.cursor) {
-      const cursor = decodeInvoiceCursor(query.cursor);
+      const cursor = invoiceCursor.decode(query.cursor);
 
       if (!cursor) {
         return Result.err(
@@ -63,12 +41,10 @@ const readInvoices = createSafeHandler(
         );
       }
 
+      const boundary = invoiceCursor.boundary(cursor);
       const cursorCondition = or(
-        gt(invoiceCreatedAtCursor, cursor.createdAt),
-        and(
-          eq(invoiceCreatedAtCursor, cursor.createdAt),
-          gt(invoices.id, cursor.id),
-        ),
+        gt(invoices.createdAt, boundary),
+        and(eq(invoices.createdAt, boundary), gt(invoices.id, cursor.id)),
       );
 
       if (cursorCondition) {
@@ -89,12 +65,12 @@ const readInvoices = createSafeHandler(
             currency: invoices.currency,
             totalAmount: invoices.totalAmount,
             createdAt: invoices.createdAt,
-            createdAtCursor: invoiceCreatedAtCursor.as("created_at_cursor"),
+            createdAtCursor: invoiceCursor.cursorValue.as("created_at_cursor"),
             updatedAt: invoices.updatedAt,
           })
           .from(invoices)
           .where(and(...conditions))
-          .orderBy(asc(invoiceCreatedAtCursor), asc(invoices.id))
+          .orderBy(asc(invoices.createdAt), asc(invoices.id))
           .limit(limit + 1),
       ),
     );
@@ -103,7 +79,7 @@ const readInvoices = createSafeHandler(
       rows,
       limit,
       cursorForItem: (item) =>
-        encodePaginationCursor([item.createdAtCursor.toISOString(), item.id]),
+        invoiceCursor.encode(item.createdAtCursor, item.id),
     });
 
     return Result.ok({

--- a/apps/api/src/handlers/invoices/read.ts
+++ b/apps/api/src/handlers/invoices/read.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq, gt, or } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { invoices } from "@/api/db/schema";
@@ -41,11 +41,11 @@ const readInvoices = createSafeHandler(
         );
       }
 
-      const boundary = invoiceCursor.boundary(cursor);
-      const cursorCondition = or(
-        gt(invoices.createdAt, boundary),
-        and(eq(invoices.createdAt, boundary), gt(invoices.id, cursor.id)),
-      );
+      const cursorCondition = invoiceCursor.keysetAfter({
+        cursor,
+        idColumn: invoices.id,
+        direction: "ascending",
+      });
 
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/handlers/rates/read.ts
+++ b/apps/api/src/handlers/rates/read.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { rateEntries, rateTables } from "@/api/db/schema";
@@ -41,11 +41,11 @@ const readRateTables = createSafeHandler(
         );
       }
 
-      const boundary = rateTableCursor.boundary(cursor);
-      const cursorCondition = or(
-        gt(rateTables.createdAt, boundary),
-        and(eq(rateTables.createdAt, boundary), gt(rateTables.id, cursor.id)),
-      );
+      const cursorCondition = rateTableCursor.keysetAfter({
+        cursor,
+        idColumn: rateTables.id,
+        direction: "ascending",
+      });
 
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/handlers/rates/read.ts
+++ b/apps/api/src/handlers/rates/read.ts
@@ -4,16 +4,10 @@ import { t } from "elysia";
 
 import { rateEntries, rateTables } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
-import type { SafeId } from "@/api/lib/branded-types";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
-import {
-  createCursorPage,
-  decodePaginationCursor,
-  encodePaginationCursor,
-  isUuidPaginationCursorPart,
-  parseDateTimePaginationCursorPart,
-} from "@/api/lib/pagination";
+import { createCursorPage } from "@/api/lib/pagination";
 import { brandPersistedRateTableId } from "@/api/lib/safe-id-boundaries";
 
 const readRateTablesQuerySchema = t.Object({
@@ -23,26 +17,10 @@ const readRateTablesQuerySchema = t.Object({
   cursor: t.Optional(t.String({ maxLength: 512 })),
 });
 
-type RateTableCursor = {
-  createdAt: Date;
-  id: SafeId<"rateTable">;
-};
-
-const rateTableCreatedAtCursor = sql<Date>`date_trunc('milliseconds', ${rateTables.createdAt})`;
-
-const decodeRateTableCursor = (cursor: string): RateTableCursor | null => {
-  const parts = decodePaginationCursor(cursor);
-  const createdAt = parts?.at(0);
-  const id = parts?.at(1);
-
-  const createdAtDate = parseDateTimePaginationCursorPart(createdAt);
-
-  if (!createdAtDate || !isUuidPaginationCursorPart(id)) {
-    return null;
-  }
-
-  return { createdAt: createdAtDate, id: brandPersistedRateTableId(id) };
-};
+const rateTableCursor = createTimestampIdCursorCodec({
+  column: rateTables.createdAt,
+  brandId: brandPersistedRateTableId,
+});
 
 const readRateTables = createSafeHandler(
   {
@@ -55,7 +33,7 @@ const readRateTables = createSafeHandler(
     const conditions = [eq(rateTables.workspaceId, workspaceId)];
 
     if (query.cursor) {
-      const cursor = decodeRateTableCursor(query.cursor);
+      const cursor = rateTableCursor.decode(query.cursor);
 
       if (!cursor) {
         return Result.err(
@@ -63,12 +41,10 @@ const readRateTables = createSafeHandler(
         );
       }
 
+      const boundary = rateTableCursor.boundary(cursor);
       const cursorCondition = or(
-        gt(rateTableCreatedAtCursor, cursor.createdAt),
-        and(
-          eq(rateTableCreatedAtCursor, cursor.createdAt),
-          gt(rateTables.id, cursor.id),
-        ),
+        gt(rateTables.createdAt, boundary),
+        and(eq(rateTables.createdAt, boundary), gt(rateTables.id, cursor.id)),
       );
 
       if (cursorCondition) {
@@ -85,12 +61,13 @@ const readRateTables = createSafeHandler(
             currency: rateTables.currency,
             isDefault: rateTables.isDefault,
             createdAt: rateTables.createdAt,
-            createdAtCursor: rateTableCreatedAtCursor.as("created_at_cursor"),
+            createdAtCursor:
+              rateTableCursor.cursorValue.as("created_at_cursor"),
             updatedAt: rateTables.updatedAt,
           })
           .from(rateTables)
           .where(and(...conditions))
-          .orderBy(asc(rateTableCreatedAtCursor), asc(rateTables.id))
+          .orderBy(asc(rateTables.createdAt), asc(rateTables.id))
           .limit(limit + 1),
       ),
     );
@@ -99,7 +76,7 @@ const readRateTables = createSafeHandler(
       rows: tables,
       limit,
       cursorForItem: (item) =>
-        encodePaginationCursor([item.createdAtCursor.toISOString(), item.id]),
+        rateTableCursor.encode(item.createdAtCursor, item.id),
     });
 
     // Batch count entries per table

--- a/apps/api/src/handlers/style-sets/list.ts
+++ b/apps/api/src/handlers/style-sets/list.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { t } from "elysia";
 
 import { styleSets } from "@/api/db/schema";
@@ -46,11 +46,11 @@ export default createSafeRootHandler(
           new HandlerError({ status: 400, message: "Invalid cursor" }),
         );
       }
-      const boundary = styleSetCursor.boundary(cursor);
-      const cursorCondition = or(
-        lt(styleSets.updatedAt, boundary),
-        and(eq(styleSets.updatedAt, boundary), lt(styleSets.id, cursor.id)),
-      );
+      const cursorCondition = styleSetCursor.keysetAfter({
+        cursor,
+        idColumn: styleSets.id,
+        direction: "descending",
+      });
       if (cursorCondition) {
         conditions.push(cursorCondition);
       }

--- a/apps/api/src/handlers/style-sets/list.ts
+++ b/apps/api/src/handlers/style-sets/list.ts
@@ -5,21 +5,10 @@ import { t } from "elysia";
 import { styleSets } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import type { SafeId } from "@/api/lib/branded-types";
-import type { ParsedPgTimestampCursor } from "@/api/lib/db-pagination";
-import {
-  parsePgTimestampCursorValue,
-  pgTimestampCursorBoundary,
-  pgTimestampCursorValue,
-} from "@/api/lib/db-pagination";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
-import {
-  createCursorPage,
-  decodePaginationCursor,
-  encodePaginationCursor,
-  isUuidPaginationCursorPart,
-} from "@/api/lib/pagination";
+import { createCursorPage } from "@/api/lib/pagination";
 import { brandPersistedStyleSetId } from "@/api/lib/safe-id-boundaries";
 import { styleSetColumns } from "@/api/lib/style-sets";
 
@@ -36,21 +25,10 @@ const config = {
   query: querySchema,
 } satisfies HandlerConfig;
 
-type StyleSetCursor = {
-  updatedAt: ParsedPgTimestampCursor;
-  id: SafeId<"styleSet">;
-};
-
-const decodeStyleSetCursor = (cursor: string): StyleSetCursor | null => {
-  const parts = decodePaginationCursor(cursor);
-  const updatedAt = parsePgTimestampCursorValue(parts?.at(0));
-  const id = parts?.at(1);
-  if (!updatedAt || !isUuidPaginationCursorPart(id)) {
-    return null;
-  }
-
-  return { updatedAt, id: brandPersistedStyleSetId(id) };
-};
+const styleSetCursor = createTimestampIdCursorCodec({
+  column: styleSets.updatedAt,
+  brandId: brandPersistedStyleSetId,
+});
 
 export default createSafeRootHandler(
   config,
@@ -62,18 +40,16 @@ export default createSafeRootHandler(
     ];
 
     if (query.cursor) {
-      const cursor = decodeStyleSetCursor(query.cursor);
+      const cursor = styleSetCursor.decode(query.cursor);
       if (!cursor) {
         return Result.err(
           new HandlerError({ status: 400, message: "Invalid cursor" }),
         );
       }
+      const boundary = styleSetCursor.boundary(cursor);
       const cursorCondition = or(
-        lt(styleSets.updatedAt, pgTimestampCursorBoundary(cursor.updatedAt)),
-        and(
-          eq(styleSets.updatedAt, pgTimestampCursorBoundary(cursor.updatedAt)),
-          lt(styleSets.id, cursor.id),
-        ),
+        lt(styleSets.updatedAt, boundary),
+        and(eq(styleSets.updatedAt, boundary), lt(styleSets.id, cursor.id)),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);
@@ -85,9 +61,7 @@ export default createSafeRootHandler(
         tx
           .select({
             ...styleSetColumns,
-            updatedAtCursor: pgTimestampCursorValue(styleSets.updatedAt).as(
-              "updated_at_cursor",
-            ),
+            updatedAtCursor: styleSetCursor.cursorValue.as("updated_at_cursor"),
           })
           .from(styleSets)
           .where(and(...conditions))
@@ -99,7 +73,7 @@ export default createSafeRootHandler(
       rows,
       limit,
       cursorForItem: (item) =>
-        encodePaginationCursor([item.updatedAtCursor, item.id]),
+        styleSetCursor.encode(item.updatedAtCursor, item.id),
     });
 
     return Result.ok({

--- a/apps/api/src/lib/db-pagination.test.ts
+++ b/apps/api/src/lib/db-pagination.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import { parsePgTimestampCursorValue } from "@/api/lib/db-pagination";
+import {
+  createTimestampIdCursorCodec,
+  parsePgTimestampCursorValue,
+} from "@/api/lib/db-pagination";
+import { brandPersistedInvoiceId } from "@/api/lib/safe-id-boundaries";
 
 const cursorTimestamp = (date: Date, microseconds: number): string =>
   `${date.toISOString().slice(0, 19)}.${microseconds.toString().padStart(6, "0")}`;
@@ -51,5 +56,75 @@ describe("PostgreSQL timestamp cursor values", () => {
     ]) {
       expect(parsePgTimestampCursorValue(value)).toBeNull();
     }
+  });
+});
+
+describe("createTimestampIdCursorCodec", () => {
+  // `cursorValue`/`boundary` build SQL; encode/decode never touch the column,
+  // so a placeholder column is enough to exercise the wire codec.
+  const codec = createTimestampIdCursorCodec({
+    column: sql`created_at`,
+    brandId: brandPersistedInvoiceId,
+  });
+
+  test("INVARIANT: decode ∘ encode round-trips any (timestamp, id)", () => {
+    fc.assert(
+      fc.property(
+        fc.date({
+          min: new Date("2000-01-01T00:00:00.000Z"),
+          max: new Date("2099-12-31T23:59:59.999Z"),
+          noInvalidDate: true,
+        }),
+        fc.integer({ min: 0, max: 999_999 }),
+        fc.uuid(),
+        (date, microseconds, id) => {
+          const timestamp = cursorTimestamp(date, microseconds);
+          const decoded = codec.decode(codec.encode(timestamp, id));
+          expect(decoded).toEqual({
+            timestamp: { type: "pgTimestampCursor", value: timestamp },
+            id: brandPersistedInvoiceId(id),
+          });
+        },
+      ),
+      propertyConfig({ numRuns: 500 }),
+    );
+  });
+
+  test("garbage or malformed cursors decode to null (→ first page)", () => {
+    fc.assert(
+      fc.property(fc.string(), (raw) => {
+        const decoded = codec.decode(raw);
+        expect(decoded === null || typeof decoded.id === "string").toBe(true);
+      }),
+      propertyConfig({ numRuns: 500 }),
+    );
+    // A well-formed cursor whose id is not a UUID is rejected.
+    expect(
+      codec.decode(codec.encode("2026-07-10T08:15:30.123456", "nope")),
+    ).toBeNull();
+    // Wrong arity (single-part payload) is rejected.
+    expect(
+      codec.decode(
+        Buffer.from(JSON.stringify(["only-one"])).toString("base64url"),
+      ),
+    ).toBeNull();
+  });
+
+  test("accepts the legacy pipe-delimited `timestamp|uuid` form", () => {
+    const timestamp = "2026-07-10T08:15:30.123456";
+    const id = "6f5b2c1a-1111-4222-8333-444455556666";
+    expect(codec.decode(`${timestamp}${"|"}${id}`)).toEqual({
+      timestamp: { type: "pgTimestampCursor", value: timestamp },
+      id: brandPersistedInvoiceId(id),
+    });
+  });
+
+  test("accepts already-issued millisecond ISO timestamps in the tuple", () => {
+    const timestamp = "2026-07-10T08:15:30.123Z";
+    const id = "6f5b2c1a-1111-4222-8333-444455556666";
+    expect(codec.decode(codec.encode(timestamp, id))).toEqual({
+      timestamp: { type: "pgTimestampCursor", value: timestamp },
+      id: brandPersistedInvoiceId(id),
+    });
   });
 });

--- a/apps/api/src/lib/db-pagination.test.ts
+++ b/apps/api/src/lib/db-pagination.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
+import { invoices } from "@/api/db/schema";
 import {
   createTimestampIdCursorCodec,
   parsePgTimestampCursorValue,
@@ -28,6 +30,7 @@ describe("PostgreSQL timestamp cursor values", () => {
           expect(parsePgTimestampCursorValue(value)).toEqual({
             type: "pgTimestampCursor",
             value,
+            precision: "microseconds",
           });
         },
       ),
@@ -35,11 +38,12 @@ describe("PostgreSQL timestamp cursor values", () => {
     );
   });
 
-  test("keeps already-issued ISO cursor values readable", () => {
+  test("keeps already-issued ISO cursor values readable, tagged millisecond", () => {
     const value = "2026-07-10T08:15:30.123Z";
     expect(parsePgTimestampCursorValue(value)).toEqual({
       type: "pgTimestampCursor",
       value,
+      precision: "milliseconds",
     });
   });
 
@@ -81,7 +85,11 @@ describe("createTimestampIdCursorCodec", () => {
           const timestamp = cursorTimestamp(date, microseconds);
           const decoded = codec.decode(codec.encode(timestamp, id));
           expect(decoded).toEqual({
-            timestamp: { type: "pgTimestampCursor", value: timestamp },
+            timestamp: {
+              type: "pgTimestampCursor",
+              value: timestamp,
+              precision: "microseconds",
+            },
             id: brandPersistedInvoiceId(id),
           });
         },
@@ -113,8 +121,12 @@ describe("createTimestampIdCursorCodec", () => {
   test("accepts the legacy pipe-delimited `timestamp|uuid` form", () => {
     const timestamp = "2026-07-10T08:15:30.123456";
     const id = "6f5b2c1a-1111-4222-8333-444455556666";
-    expect(codec.decode(`${timestamp}${"|"}${id}`)).toEqual({
-      timestamp: { type: "pgTimestampCursor", value: timestamp },
+    expect(codec.decode(`${timestamp}|${id}`)).toEqual({
+      timestamp: {
+        type: "pgTimestampCursor",
+        value: timestamp,
+        precision: "microseconds",
+      },
       id: brandPersistedInvoiceId(id),
     });
   });
@@ -123,8 +135,78 @@ describe("createTimestampIdCursorCodec", () => {
     const timestamp = "2026-07-10T08:15:30.123Z";
     const id = "6f5b2c1a-1111-4222-8333-444455556666";
     expect(codec.decode(codec.encode(timestamp, id))).toEqual({
-      timestamp: { type: "pgTimestampCursor", value: timestamp },
+      timestamp: {
+        type: "pgTimestampCursor",
+        value: timestamp,
+        precision: "milliseconds",
+      },
       id: brandPersistedInvoiceId(id),
     });
+  });
+});
+
+describe("createTimestampIdCursorCodec keysetAfter", () => {
+  // `keysetAfter` builds the SQL keyset predicate; render it with the Postgres
+  // dialect so the class guard asserts on the emitted comparison, not internals.
+  const dialect = new PgDialect();
+  const codec = createTimestampIdCursorCodec({
+    column: invoices.createdAt,
+    brandId: brandPersistedInvoiceId,
+  });
+  const id = "6f5b2c1a-1111-4222-8333-444455556666";
+
+  const renderAfter = (
+    rawTimestamp: string,
+    direction: "ascending" | "descending",
+  ): string => {
+    const cursor = codec.decode(codec.encode(rawTimestamp, id));
+    if (cursor === null) {
+      throw new Error("cursor failed to decode");
+    }
+    const predicate = codec.keysetAfter({
+      cursor,
+      idColumn: invoices.id,
+      direction,
+    });
+    if (predicate === undefined) {
+      throw new Error("keysetAfter produced no predicate");
+    }
+    return dialect.sqlToQuery(predicate).sql;
+  };
+
+  test("canonical microsecond cursor compares the raw column", () => {
+    const ascending = renderAfter("2026-07-10T08:15:30.123456", "ascending");
+    expect(ascending).not.toContain("date_trunc");
+    // Forward page: timestamp `>` boundary, id `>` on the tie-break.
+    expect(ascending).toContain('"created_at" >');
+    expect(ascending).toContain('"id" >');
+
+    const descending = renderAfter("2026-07-10T08:15:30.123456", "descending");
+    expect(descending).not.toContain("date_trunc");
+    expect(descending).toContain('"created_at" <');
+    expect(descending).toContain('"id" <');
+  });
+
+  test("INVARIANT: legacy millisecond cursor truncates the column on both sides", () => {
+    // A page issued before the microsecond migration truncated created_at to the
+    // millisecond and ordered on that; resuming it must compare the truncated
+    // column so a row at `…​.123456` is not re-emitted (asc) or skipped (desc)
+    // against a `…​.123` boundary. Both the range and tie-break clauses must
+    // truncate, so require two date_trunc occurrences.
+    const cases = [
+      { direction: "ascending", op: ">" },
+      { direction: "descending", op: "<" },
+    ] as const;
+    for (const { direction, op } of cases) {
+      const rendered = renderAfter("2026-07-10T08:15:30.123Z", direction);
+      const truncation = `date_trunc('milliseconds', "invoices"."created_at")`;
+      // Both the range clause and the tie-break clause truncate the column.
+      const truncations = rendered.match(
+        /date_trunc\('milliseconds', "invoices"\."created_at"\)/gu,
+      );
+      expect(truncations?.length).toBe(2);
+      expect(rendered).toContain(`${truncation} ${op}`);
+      expect(rendered).toContain(`${truncation} =`);
+    }
   });
 });

--- a/apps/api/src/lib/db-pagination.ts
+++ b/apps/api/src/lib/db-pagination.ts
@@ -1,5 +1,5 @@
-import { sql } from "drizzle-orm";
-import type { SQL, SQLWrapper } from "drizzle-orm";
+import { and, eq, gt, lt, or, sql } from "drizzle-orm";
+import type { Column, SQL, SQLWrapper } from "drizzle-orm";
 
 import {
   decodePaginationCursor,
@@ -13,9 +13,20 @@ const LEGACY_ISO_CURSOR_PATTERN =
   /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})\.(?<milliseconds>\d{3})Z$/u;
 const THIRTY_DAY_MONTHS = new Set([4, 6, 9, 11]);
 
+/**
+ * `microseconds` is the canonical `to_char(..., '...US')` projection this codec
+ * emits today; `milliseconds` marks a legacy `date_trunc('milliseconds', ...)`
+ * cursor (ISO `…​.123Z`) issued before the microsecond migration. Keyset
+ * comparisons truncate the column to match a `milliseconds` boundary so a page
+ * cut before the migration resumes without duplicating or skipping the rows
+ * that shared its truncated millisecond.
+ */
+export type PgTimestampCursorPrecision = "microseconds" | "milliseconds";
+
 export type ParsedPgTimestampCursor = {
   type: "pgTimestampCursor";
   value: string;
+  precision: PgTimestampCursorPrecision;
 };
 
 /**
@@ -78,14 +89,17 @@ export const parsePgTimestampCursorValue = (
     return null;
   }
 
-  const match =
-    PG_TIMESTAMP_CURSOR_PATTERN.exec(value) ??
-    LEGACY_ISO_CURSOR_PATTERN.exec(value);
-  if (!match || !hasValidTimestampParts(match.groups)) {
-    return null;
+  const canonical = PG_TIMESTAMP_CURSOR_PATTERN.exec(value);
+  if (canonical && hasValidTimestampParts(canonical.groups)) {
+    return { type: "pgTimestampCursor", value, precision: "microseconds" };
   }
 
-  return { type: "pgTimestampCursor", value };
+  const legacy = LEGACY_ISO_CURSOR_PATTERN.exec(value);
+  if (legacy && hasValidTimestampParts(legacy.groups)) {
+    return { type: "pgTimestampCursor", value, precision: "milliseconds" };
+  }
+
+  return null;
 };
 
 // ── (timestamp, id) keyset cursor codec ──────────────
@@ -103,6 +117,21 @@ export type TimestampIdCursor<Id> = {
   id: Id;
 };
 
+/**
+ * `ascending` pages forward (`ORDER BY column, id`, keyset `>`); `descending`
+ * pages backward (`ORDER BY column DESC, id DESC`, keyset `<`). The codec owns
+ * the whole keyset predicate so no handler can mismatch the boundary column,
+ * the tie-break, or the legacy-millisecond truncation across the two clauses.
+ */
+export type KeysetCursorDirection = "ascending" | "descending";
+
+type KeysetAfterOptions<Id> = {
+  cursor: TimestampIdCursor<Id>;
+  /** Tie-break id column, ordered after the timestamp column. */
+  idColumn: Column;
+  direction: KeysetCursorDirection;
+};
+
 export type TimestampIdCursorCodec<Id> = {
   /**
    * Microsecond-precision timestamp projected into the row for serialization.
@@ -110,8 +139,14 @@ export type TimestampIdCursorCodec<Id> = {
    * value to `encode`. Ordering stays on the underlying column.
    */
   cursorValue: SQL<string>;
-  /** Parameterized keyset boundary for the `<`/`>` comparison on the column. */
-  boundary: (cursor: TimestampIdCursor<Id>) => SQL<Date>;
+  /**
+   * Full keyset predicate selecting the rows strictly after `cursor` in
+   * `direction`, on the codec's timestamp column plus `idColumn`. Canonical
+   * microsecond cursors compare the raw column; a legacy millisecond cursor
+   * compares `date_trunc('milliseconds', column)` on both sides of the
+   * comparison so the page it was cut from resumes exactly.
+   */
+  keysetAfter: (options: KeysetAfterOptions<Id>) => SQL | undefined;
   encode: (timestampValue: string, id: string) => string;
   decode: (cursor: string) => TimestampIdCursor<Id> | null;
 };
@@ -144,7 +179,21 @@ export const createTimestampIdCursorCodec = <Id>({
   brandId,
 }: TimestampIdCursorCodecOptions<Id>): TimestampIdCursorCodec<Id> => ({
   cursorValue: pgTimestampCursorValue(column),
-  boundary: (cursor) => pgTimestampCursorBoundary(cursor.timestamp),
+  keysetAfter: ({ cursor, idColumn, direction }) => {
+    const boundary = pgTimestampCursorBoundary(cursor.timestamp);
+    const compare = direction === "ascending" ? gt : lt;
+    // A legacy millisecond cursor was cut from a page ordered on the
+    // millisecond-truncated timestamp, so compare the truncated column against
+    // it; a canonical microsecond cursor compares the raw column directly.
+    const timestampExpr =
+      cursor.timestamp.precision === "milliseconds"
+        ? sql`date_trunc('milliseconds', ${column})`
+        : column;
+    return or(
+      compare(timestampExpr, boundary),
+      and(eq(timestampExpr, boundary), compare(idColumn, cursor.id)),
+    );
+  },
   encode: (timestampValue, id) => encodePaginationCursor([timestampValue, id]),
   decode: (cursor) => {
     const tuple = timestampIdCursorTuple(cursor);

--- a/apps/api/src/lib/db-pagination.ts
+++ b/apps/api/src/lib/db-pagination.ts
@@ -1,6 +1,12 @@
 import { sql } from "drizzle-orm";
 import type { SQL, SQLWrapper } from "drizzle-orm";
 
+import {
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
+
 const PG_TIMESTAMP_CURSOR_PATTERN =
   /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})\.(?<microseconds>\d{6})$/u;
 const LEGACY_ISO_CURSOR_PATTERN =
@@ -81,3 +87,75 @@ export const parsePgTimestampCursorValue = (
 
   return { type: "pgTimestampCursor", value };
 };
+
+// ── (timestamp, id) keyset cursor codec ──────────────
+//
+// The `(created_at, id)` (or `(updated_at, id)`) keyset cursor is the same
+// shape everywhere: project a microsecond-precision timestamp for
+// serialization, keep ordering on the indexed column, and compare against a
+// `value::timestamp` boundary. This factory owns that codec so each list
+// handler only supplies the timestamp column and the branded-id constructor.
+
+const LEGACY_PIPE_SEPARATOR = "|";
+
+export type TimestampIdCursor<Id> = {
+  timestamp: ParsedPgTimestampCursor;
+  id: Id;
+};
+
+export type TimestampIdCursorCodec<Id> = {
+  /**
+   * Microsecond-precision timestamp projected into the row for serialization.
+   * Alias it in the `select` (`.as("created_at_cursor")`) and hand the aliased
+   * value to `encode`. Ordering stays on the underlying column.
+   */
+  cursorValue: SQL<string>;
+  /** Parameterized keyset boundary for the `<`/`>` comparison on the column. */
+  boundary: (cursor: TimestampIdCursor<Id>) => SQL<Date>;
+  encode: (timestampValue: string, id: string) => string;
+  decode: (cursor: string) => TimestampIdCursor<Id> | null;
+};
+
+type TimestampIdCursorCodecOptions<Id> = {
+  column: SQLWrapper;
+  brandId: (id: string) => Id;
+};
+
+// Accepts the canonical base64url JSON tuple and, as a fallback, the legacy
+// plain `"timestamp|uuid"` form so cursors issued before the codec was unified
+// keep decoding. base64url never contains `|`, and the timestamp half always
+// contains `:`/`-` (outside the base64url alphabet), so the two forms cannot be
+// confused.
+const timestampIdCursorTuple = (cursor: string): [unknown, unknown] | null => {
+  const parts = decodePaginationCursor(cursor);
+  if (parts !== null) {
+    return parts.length === 2 ? [parts[0], parts[1]] : null;
+  }
+
+  const separatorIndex = cursor.indexOf(LEGACY_PIPE_SEPARATOR);
+  if (separatorIndex === -1) {
+    return null;
+  }
+  return [cursor.slice(0, separatorIndex), cursor.slice(separatorIndex + 1)];
+};
+
+export const createTimestampIdCursorCodec = <Id>({
+  column,
+  brandId,
+}: TimestampIdCursorCodecOptions<Id>): TimestampIdCursorCodec<Id> => ({
+  cursorValue: pgTimestampCursorValue(column),
+  boundary: (cursor) => pgTimestampCursorBoundary(cursor.timestamp),
+  encode: (timestampValue, id) => encodePaginationCursor([timestampValue, id]),
+  decode: (cursor) => {
+    const tuple = timestampIdCursorTuple(cursor);
+    if (tuple === null) {
+      return null;
+    }
+    const [rawTimestamp, rawId] = tuple;
+    const timestamp = parsePgTimestampCursorValue(rawTimestamp);
+    if (timestamp === null || !isUuidPaginationCursorPart(rawId)) {
+      return null;
+    }
+    return { timestamp, id: brandId(rawId) };
+  },
+});

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -1,5 +1,5 @@
 import { panic, Result } from "better-result";
-import { and, asc, eq, gt, gte, inArray, lte, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, gte, inArray, lte, or } from "drizzle-orm";
 import * as v from "valibot";
 
 import { roles } from "@stll/permissions";
@@ -13,13 +13,13 @@ import { updateTimeEntryHandler } from "@/api/handlers/time-entries/update-by-id
 import { readOrgEntitlementHandler } from "@/api/handlers/usage/get-entitlement";
 import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
+import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
 import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
   isDateOnlyPaginationCursorPart,
   isUuidPaginationCursorPart,
-  parseDateTimePaginationCursorPart,
 } from "@/api/lib/pagination";
 import {
   brandPersistedEntityId,
@@ -1236,19 +1236,10 @@ const listInvoicesArgsSchema = v.pipe(
   ),
 );
 
-const invoiceCreatedAtCursor = sql<Date>`date_trunc('milliseconds', ${invoices.createdAt})`;
-
-const decodeInvoicePageCursor = (
-  cursor: string,
-): { createdAt: Date; id: SafeId<"invoice"> } | null => {
-  const parts = decodePaginationCursor(cursor);
-  const createdAt = parseDateTimePaginationCursorPart(parts?.at(0));
-  const id = parts?.at(1);
-  if (!createdAt || !isUuidPaginationCursorPart(id)) {
-    return null;
-  }
-  return { createdAt, id: brandPersistedInvoiceId(id) };
-};
+const invoicePageCursor = createTimestampIdCursorCodec({
+  column: invoices.createdAt,
+  brandId: brandPersistedInvoiceId,
+});
 
 const readInvoiceDetail = async ({
   context,
@@ -1401,17 +1392,15 @@ const handleListInvoicesTool: McpToolHandler = async ({ args, context }) => {
     return notFoundResult("Matter not found or not accessible");
   }
 
-  let boundary: { createdAt: Date; id: SafeId<"invoice"> } | null = null;
-  if (input.cursor !== undefined) {
-    boundary = decodeInvoicePageCursor(input.cursor);
-    if (boundary === null) {
-      return structuredErrorResult({
-        code: "validation_error",
-        message: "Invalid cursor",
-        issues: [{ path: "cursor", message: "Invalid cursor" }],
-        hint: "Pass the 'cursor' verbatim as returned by a previous call, or omit it for the first page.",
-      });
-    }
+  const cursor =
+    input.cursor === undefined ? null : invoicePageCursor.decode(input.cursor);
+  if (input.cursor !== undefined && cursor === null) {
+    return structuredErrorResult({
+      code: "validation_error",
+      message: "Invalid cursor",
+      issues: [{ path: "cursor", message: "Invalid cursor" }],
+      hint: "Pass the 'cursor' verbatim as returned by a previous call, or omit it for the first page.",
+    });
   }
   const limit = input.limit ?? DEFAULT_LIST_LIMIT;
 
@@ -1426,24 +1415,24 @@ const handleListInvoicesTool: McpToolHandler = async ({ args, context }) => {
         dueDate: invoices.dueDate,
         currency: invoices.currency,
         totalAmount: invoices.totalAmount,
-        createdAtCursor: invoiceCreatedAtCursor.as("created_at_cursor"),
+        createdAtCursor: invoicePageCursor.cursorValue.as("created_at_cursor"),
       })
       .from(invoices)
       .where(
         and(
           eq(invoices.workspaceId, workspaceId),
-          boundary === null
+          cursor === null
             ? undefined
             : or(
-                gt(invoiceCreatedAtCursor, boundary.createdAt),
+                gt(invoices.createdAt, invoicePageCursor.boundary(cursor)),
                 and(
-                  eq(invoiceCreatedAtCursor, boundary.createdAt),
-                  gt(invoices.id, boundary.id),
+                  eq(invoices.createdAt, invoicePageCursor.boundary(cursor)),
+                  gt(invoices.id, cursor.id),
                 ),
               ),
         ),
       )
-      .orderBy(asc(invoiceCreatedAtCursor), asc(invoices.id))
+      .orderBy(asc(invoices.createdAt), asc(invoices.id))
       .limit(limit + 1),
   );
 
@@ -1451,7 +1440,7 @@ const handleListInvoicesTool: McpToolHandler = async ({ args, context }) => {
     rows,
     limit,
     cursorForItem: (item) =>
-      encodePaginationCursor([item.createdAtCursor.toISOString(), item.id]),
+      invoicePageCursor.encode(item.createdAtCursor, item.id),
   });
 
   const invoiceList = page.items.map(

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -1423,13 +1423,11 @@ const handleListInvoicesTool: McpToolHandler = async ({ args, context }) => {
           eq(invoices.workspaceId, workspaceId),
           cursor === null
             ? undefined
-            : or(
-                gt(invoices.createdAt, invoicePageCursor.boundary(cursor)),
-                and(
-                  eq(invoices.createdAt, invoicePageCursor.boundary(cursor)),
-                  gt(invoices.id, cursor.id),
-                ),
-              ),
+            : invoicePageCursor.keysetAfter({
+                cursor,
+                idColumn: invoices.id,
+                direction: "ascending",
+              }),
         ),
       )
       .orderBy(asc(invoices.createdAt), asc(invoices.id))


### PR DESCRIPTION
Add `createTimestampIdCursorCodec` to `lib/db-pagination.ts`, parameterized
over the branded id constructor. It owns the `(timestamp, id)` keyset codec:
the microsecond `to_char` value projected for serialization, the
`value::timestamp` boundary for the keyset comparison, and base64url-JSON
encode/decode. This replaces ~15 lines of near-identical encode/decode wrappers
copy-pasted across the list handlers.

Migrate invoices, rates, style-sets, audit-logs, clauses, and the billing MCP
`list_invoices` tool to the factory. Route contacts through the shared
`encodePaginationCursor`/`decodePaginationCursor` primitives (name-based
ordering, not a timestamp cursor, so no factory).

Fix a page-boundary row-skip class in the invoice and rate-table cursors and in
the billing MCP invoice list: they truncated the cursor timestamp to
milliseconds (`date_trunc('milliseconds', ...)`), which can equate two distinct
rows that share a millisecond at a page boundary and drop rows from the next
page. The factory compares at the column's native microsecond precision, so
rows within the same millisecond are ordered and paged deterministically.

Cursor decode accepts both the canonical base64url-JSON tuple and the legacy
plain `timestamp|uuid` form, so cursors issued before this change keep working
across the audit-logs and clauses format change. The invoice and rate-table
timestamp representation moves from millisecond ISO to microsecond, but the
tuple envelope is unchanged and the timestamp parser still accepts the old
millisecond form.

Extend `db-pagination.test.ts` with property coverage for the factory:
decode∘encode identity over arbitrary microsecond timestamps and ids, garbage
cursors decoding to null, and legacy pipe / millisecond-ISO acceptance.
