### PR TITLE
refactor(api): dedupe chat scope check, recap window fetch, redis timeout helper, template storage keys

### DIFF
--- a/apps/api/src/handlers/chat/chat-scope.test.ts
+++ b/apps/api/src/handlers/chat/chat-scope.test.ts
@@ -1,11 +1,17 @@
 import { Result } from "better-result";
 import { describe, expect, mock, test } from "bun:test";
 
-import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import {
+  assertChatThreadScopeMatches,
+  resolveChatScope,
+} from "@/api/handlers/chat/chat-scope";
 import { toSafeId } from "@/api/lib/branded-types";
 
 const workspaceId = toSafeId<"workspace">(
   "019d0000-0000-7000-8000-000000000001",
+);
+const otherWorkspaceId = toSafeId<"workspace">(
+  "019d0000-0000-7000-8000-000000000002",
 );
 
 describe("resolveChatScope", () => {
@@ -61,5 +67,55 @@ describe("resolveChatScope", () => {
 
     expect(Result.isError(deleting)).toBe(true);
     expect(Result.isError(inaccessible)).toBe(true);
+  });
+});
+
+describe("assertChatThreadScopeMatches", () => {
+  test("passes when a workspace thread is requested under its own scope", () => {
+    const result = assertChatThreadScopeMatches({
+      persistedWorkspaceId: workspaceId,
+      scope: { scope: "workspace", workspaceId },
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("passes when a global thread is requested under global scope", () => {
+    const result = assertChatThreadScopeMatches({
+      persistedWorkspaceId: null,
+      scope: { scope: "global" },
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("rejects a workspace thread requested under global scope", () => {
+    const result = assertChatThreadScopeMatches({
+      persistedWorkspaceId: workspaceId,
+      scope: { scope: "global" },
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error.status).toBe(400);
+    }
+  });
+
+  test("rejects a global thread requested under a workspace scope", () => {
+    const result = assertChatThreadScopeMatches({
+      persistedWorkspaceId: null,
+      scope: { scope: "workspace", workspaceId },
+    });
+
+    expect(Result.isError(result)).toBe(true);
+  });
+
+  test("rejects a workspace thread requested under a different workspace", () => {
+    const result = assertChatThreadScopeMatches({
+      persistedWorkspaceId: workspaceId,
+      scope: { scope: "workspace", workspaceId: otherWorkspaceId },
+    });
+
+    expect(Result.isError(result)).toBe(true);
   });
 });

--- a/apps/api/src/handlers/chat/chat-scope.ts
+++ b/apps/api/src/handlers/chat/chat-scope.ts
@@ -37,3 +37,34 @@ export const resolveChatScope = async function* ({
     workspaceId: workspace.id,
   } as const;
 };
+
+export type ChatScope =
+  | { scope: "global" }
+  | { scope: "workspace"; workspaceId: SafeId<"workspace"> };
+
+type AssertChatThreadScopeMatchesProps = {
+  persistedWorkspaceId: SafeId<"workspace"> | null;
+  scope: ChatScope;
+};
+
+/**
+ * Reject a request whose chat scope contradicts the persisted thread: a
+ * workspace-scoped thread asked for as global (or vice versa) is a client bug.
+ * Fail loud with a 400 instead of silently 404'ing or creating a duplicate.
+ */
+export const assertChatThreadScopeMatches = ({
+  persistedWorkspaceId,
+  scope,
+}: AssertChatThreadScopeMatchesProps): Result<void, HandlerError<400>> => {
+  const requestedWorkspaceId =
+    scope.scope === "workspace" ? scope.workspaceId : null;
+  if (persistedWorkspaceId !== requestedWorkspaceId) {
+    return Result.err(
+      new HandlerError({
+        status: 400,
+        message: "Chat thread scope does not match request",
+      }),
+    );
+  }
+  return Result.ok();
+};

--- a/apps/api/src/handlers/chat/get-messages.ts
+++ b/apps/api/src/handlers/chat/get-messages.ts
@@ -3,7 +3,10 @@ import { t } from "elysia";
 
 import type { SafeDbError } from "@/api/db/safe-db";
 import { estimateChatContextPromptTokens } from "@/api/handlers/chat/chat-prompt";
-import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import {
+  assertChatThreadScopeMatches,
+  resolveChatScope,
+} from "@/api/handlers/chat/chat-scope";
 import { computeThreadContextUsage } from "@/api/handlers/chat/compaction";
 import type { ThreadContextUsage } from "@/api/handlers/chat/compaction";
 import { resolveChatCompactionBudget } from "@/api/handlers/chat/compaction-budget";
@@ -173,11 +176,17 @@ const getMessages = createSafeRootHandler(
         // Reject requests whose scope contradicts the persisted thread.
         // A workspace-scoped thread asked for as global (or vice versa)
         // is a client bug — fail loud instead of silently 404'ing or
-        // creating a duplicate.
-        const persistedWorkspaceId = thread.workspaceId ?? null;
-        const requestedWorkspaceId =
-          scope.scope === "workspace" ? scope.workspaceId : null;
-        if (persistedWorkspaceId !== requestedWorkspaceId) {
+        // creating a duplicate. The shared assertion owns the check; this
+        // read short-circuits with a discriminated kind so the mismatch
+        // 400 is emitted after the transaction closes.
+        if (
+          Result.isError(
+            assertChatThreadScopeMatches({
+              persistedWorkspaceId: thread.workspaceId ?? null,
+              scope,
+            }),
+          )
+        ) {
           return { kind: "scope-mismatch" as const };
         }
 

--- a/apps/api/src/handlers/chat/get-older-messages.ts
+++ b/apps/api/src/handlers/chat/get-older-messages.ts
@@ -1,7 +1,10 @@
 import { Result } from "better-result";
 import { t } from "elysia";
 
-import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import {
+  assertChatThreadScopeMatches,
+  resolveChatScope,
+} from "@/api/handlers/chat/chat-scope";
 import {
   decodeMessagePageCursor,
   loadChatMessagePage,
@@ -60,17 +63,10 @@ const getOlderMessages = createSafeRootHandler(
       );
     }
 
-    const persistedWorkspaceId = thread.workspaceId ?? null;
-    const requestedWorkspaceId =
-      scope.scope === "workspace" ? scope.workspaceId : null;
-    if (persistedWorkspaceId !== requestedWorkspaceId) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Chat thread scope does not match request",
-        }),
-      );
-    }
+    yield* assertChatThreadScopeMatches({
+      persistedWorkspaceId: thread.workspaceId ?? null,
+      scope,
+    });
 
     const cursor = decodeMessagePageCursor(before);
     if (!cursor) {

--- a/apps/api/src/handlers/chat/get-suggested-prompts.ts
+++ b/apps/api/src/handlers/chat/get-suggested-prompts.ts
@@ -2,12 +2,12 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import { normalizePersistedChatMessageContent } from "@/api/handlers/chat/chat-message-parts";
-import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
-import { buildRecapTranscript } from "@/api/handlers/chat/thread-recap-transcript";
 import {
-  buildRecapMessageWindow,
-  RECAP_RECENT_MESSAGE_LIMIT,
-} from "@/api/handlers/chat/thread-recap-window";
+  assertChatThreadScopeMatches,
+  resolveChatScope,
+} from "@/api/handlers/chat/chat-scope";
+import { buildRecapTranscript } from "@/api/handlers/chat/thread-recap-transcript";
+import { loadRecapMessageWindow } from "@/api/handlers/chat/thread-recap-window";
 import { resolveCaching } from "@/api/lib/ai-config";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
@@ -127,61 +127,14 @@ const getSuggestedPrompts = createSafeRootHandler(
     }
 
     const persistedWorkspaceId = thread.workspaceId ?? null;
-    const requestedWorkspaceId =
-      scope.scope === "workspace" ? scope.workspaceId : null;
-    if (persistedWorkspaceId !== requestedWorkspaceId) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Chat thread scope does not match request",
-        }),
-      );
-    }
+    yield* assertChatThreadScopeMatches({ persistedWorkspaceId, scope });
 
     if (thread.usedAnonymization) {
       return Result.ok<SuggestedPromptsResult>({ prompts: [] });
     }
 
     const messageWindow = yield* Result.await(
-      safeDb(async (tx) => {
-        const firstUserMessages = await tx.query.chatMessages.findMany({
-          where: {
-            threadId: { eq: threadId },
-            userId: { eq: user.id },
-            role: { eq: "user" },
-          },
-          columns: {
-            id: true,
-            role: true,
-            content: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: "asc" },
-          limit: 1,
-        });
-
-        const recentMessagesDesc = await tx.query.chatMessages.findMany({
-          where: {
-            threadId: { eq: threadId },
-            userId: { eq: user.id },
-          },
-          columns: {
-            id: true,
-            role: true,
-            content: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: "desc" },
-          limit: RECAP_RECENT_MESSAGE_LIMIT,
-        });
-
-        return {
-          messages: buildRecapMessageWindow({
-            firstUserMessage: firstUserMessages.at(0) ?? null,
-            recentMessagesDesc,
-          }),
-        };
-      }),
+      loadRecapMessageWindow({ safeDb, threadId, userId: user.id }),
     );
 
     if (messageWindow.messages.length === 0) {

--- a/apps/api/src/handlers/chat/get-thread-recap.ts
+++ b/apps/api/src/handlers/chat/get-thread-recap.ts
@@ -4,17 +4,17 @@ import { t } from "elysia";
 
 import { chatThreads } from "@/api/db/schema";
 import { chatMessageFromPersisted } from "@/api/handlers/chat/chat-message-parts";
-import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import {
+  assertChatThreadScopeMatches,
+  resolveChatScope,
+} from "@/api/handlers/chat/chat-scope";
 import {
   generateThreadRecapText,
   isThreadStaleForRecap,
   RECAP_MIN_MESSAGE_COUNT,
   RECAP_PROMPT_VERSION,
 } from "@/api/handlers/chat/thread-recap";
-import {
-  buildRecapMessageWindow,
-  RECAP_RECENT_MESSAGE_LIMIT,
-} from "@/api/handlers/chat/thread-recap-window";
+import { loadRecapMessageWindow } from "@/api/handlers/chat/thread-recap-window";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -88,66 +88,15 @@ const getThreadRecap = createSafeRootHandler(
       );
     }
 
-    // Reject a scope that contradicts the persisted thread, mirroring
-    // get-messages: a workspace thread asked for as global (or vice
-    // versa) is a client bug.
     const persistedWorkspaceId = thread.workspaceId ?? null;
-    const requestedWorkspaceId =
-      scope.scope === "workspace" ? scope.workspaceId : null;
-    if (persistedWorkspaceId !== requestedWorkspaceId) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Chat thread scope does not match request",
-        }),
-      );
-    }
+    yield* assertChatThreadScopeMatches({ persistedWorkspaceId, scope });
 
     if (thread.usedAnonymization) {
       return Result.ok<ThreadRecapResult>({ recap: null });
     }
 
     const messageWindow = yield* Result.await(
-      safeDb(async (tx) => {
-        const firstUserMessages = await tx.query.chatMessages.findMany({
-          where: {
-            threadId: { eq: threadId },
-            userId: { eq: user.id },
-            role: { eq: "user" },
-          },
-          columns: {
-            id: true,
-            role: true,
-            content: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: "asc" },
-          limit: 1,
-        });
-
-        const recentMessagesDesc = await tx.query.chatMessages.findMany({
-          where: {
-            threadId: { eq: threadId },
-            userId: { eq: user.id },
-          },
-          columns: {
-            id: true,
-            role: true,
-            content: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: "desc" },
-          limit: RECAP_RECENT_MESSAGE_LIMIT,
-        });
-
-        return {
-          recentCount: recentMessagesDesc.length,
-          messages: buildRecapMessageWindow({
-            firstUserMessage: firstUserMessages.at(0) ?? null,
-            recentMessagesDesc,
-          }),
-        };
-      }),
+      loadRecapMessageWindow({ safeDb, threadId, userId: user.id }),
     );
 
     // Only recap a completed exchange the user is returning to after a

--- a/apps/api/src/handlers/chat/thread-recap-window.ts
+++ b/apps/api/src/handlers/chat/thread-recap-window.ts
@@ -39,42 +39,43 @@ type LoadRecapMessageWindowProps = {
  * into chronological order. `recentCount` is the pre-merge recent-message
  * count the recap uses for its staleness gate; suggested prompts ignore it.
  */
-export const loadRecapMessageWindow = ({
+export const loadRecapMessageWindow = async ({
   safeDb,
   threadId,
   userId,
 }: LoadRecapMessageWindowProps) =>
-  safeDb(async (tx) => {
-    const firstUserMessages = await tx.query.chatMessages.findMany({
-      where: {
-        threadId: { eq: threadId },
-        userId: { eq: userId },
-        role: { eq: "user" },
-      },
-      columns: {
-        id: true,
-        role: true,
-        content: true,
-        createdAt: true,
-      },
-      orderBy: { createdAt: "asc" },
-      limit: 1,
-    });
-
-    const recentMessagesDesc = await tx.query.chatMessages.findMany({
-      where: {
-        threadId: { eq: threadId },
-        userId: { eq: userId },
-      },
-      columns: {
-        id: true,
-        role: true,
-        content: true,
-        createdAt: true,
-      },
-      orderBy: { createdAt: "desc" },
-      limit: RECAP_RECENT_MESSAGE_LIMIT,
-    });
+  await safeDb(async (tx) => {
+    const [firstUserMessages, recentMessagesDesc] = await Promise.all([
+      tx.query.chatMessages.findMany({
+        where: {
+          threadId: { eq: threadId },
+          userId: { eq: userId },
+          role: { eq: "user" },
+        },
+        columns: {
+          id: true,
+          role: true,
+          content: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "asc" },
+        limit: 1,
+      }),
+      tx.query.chatMessages.findMany({
+        where: {
+          threadId: { eq: threadId },
+          userId: { eq: userId },
+        },
+        columns: {
+          id: true,
+          role: true,
+          content: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "desc" },
+        limit: RECAP_RECENT_MESSAGE_LIMIT,
+      }),
+    ]);
 
     return {
       recentCount: recentMessagesDesc.length,

--- a/apps/api/src/handlers/chat/thread-recap-window.ts
+++ b/apps/api/src/handlers/chat/thread-recap-window.ts
@@ -1,3 +1,6 @@
+import type { SafeDb } from "@/api/db/safe-db";
+import type { SafeId } from "@/api/lib/branded-types";
+
 export const RECAP_RECENT_MESSAGE_LIMIT = 24;
 
 type RecapWindowMessage = {
@@ -23,3 +26,61 @@ export const buildRecapMessageWindow = <TMessage extends RecapWindowMessage>({
 
   return [firstUserMessage, ...recentMessages];
 };
+
+type LoadRecapMessageWindowProps = {
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  userId: SafeId<"user">;
+};
+
+/**
+ * Load the message window both the recap and suggested-prompt generators run
+ * on: the thread's first user message plus its most recent messages, merged
+ * into chronological order. `recentCount` is the pre-merge recent-message
+ * count the recap uses for its staleness gate; suggested prompts ignore it.
+ */
+export const loadRecapMessageWindow = ({
+  safeDb,
+  threadId,
+  userId,
+}: LoadRecapMessageWindowProps) =>
+  safeDb(async (tx) => {
+    const firstUserMessages = await tx.query.chatMessages.findMany({
+      where: {
+        threadId: { eq: threadId },
+        userId: { eq: userId },
+        role: { eq: "user" },
+      },
+      columns: {
+        id: true,
+        role: true,
+        content: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+      limit: 1,
+    });
+
+    const recentMessagesDesc = await tx.query.chatMessages.findMany({
+      where: {
+        threadId: { eq: threadId },
+        userId: { eq: userId },
+      },
+      columns: {
+        id: true,
+        role: true,
+        content: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+      limit: RECAP_RECENT_MESSAGE_LIMIT,
+    });
+
+    return {
+      recentCount: recentMessagesDesc.length,
+      messages: buildRecapMessageWindow({
+        firstUserMessage: firstUserMessages.at(0) ?? null,
+        recentMessagesDesc,
+      }),
+    };
+  });

--- a/apps/api/src/handlers/feedback/intake-guards.ts
+++ b/apps/api/src/handlers/feedback/intake-guards.ts
@@ -20,6 +20,7 @@
 
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
+import { withCommandTimeout } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
 
 type RedisLike = {
@@ -137,8 +138,8 @@ export const createFeedbackIntakeGuards = ({
     ttlMs,
   }) => {
     try {
-      const reply = await withCommandTimeout(
-        getRedis().send("SET", [
+      const reply = await withCommandTimeout({
+        command: getRedis().send("SET", [
           `${REDIS_KEY_PREFIX}dedup:${key}`,
           "1",
           "NX",
@@ -146,7 +147,8 @@ export const createFeedbackIntakeGuards = ({
           String(ttlMs),
         ]),
         commandTimeoutMs,
-      );
+        label: "feedback-intake-redis-command",
+      });
       // Redis SET ... NX returns "OK" when it set the key, nil otherwise.
       return reply === "OK";
     } catch (error) {
@@ -165,10 +167,11 @@ export const createFeedbackIntakeGuards = ({
     key,
   }) => {
     try {
-      await withCommandTimeout(
-        getRedis().send("DEL", [`${REDIS_KEY_PREFIX}dedup:${key}`]),
+      await withCommandTimeout({
+        command: getRedis().send("DEL", [`${REDIS_KEY_PREFIX}dedup:${key}`]),
         commandTimeoutMs,
-      );
+        label: "feedback-intake-redis-command",
+      });
     } catch (error) {
       onRedisError(error);
       dedupFallback.delete(key);
@@ -181,14 +184,15 @@ export const createFeedbackIntakeGuards = ({
   }) => {
     const scoped = `${bucket}:${key}`;
     try {
-      await withCommandTimeout(
-        getRedis().send("EVAL", [
+      await withCommandTimeout({
+        command: getRedis().send("EVAL", [
           RELEASE_COUNTER_SCRIPT,
           "1",
           `${REDIS_KEY_PREFIX}${scoped}`,
         ]),
         commandTimeoutMs,
-      );
+        label: "feedback-intake-redis-command",
+      });
     } catch (error) {
       onRedisError(error);
       releaseCounterFallback({
@@ -213,10 +217,11 @@ const evalCounter = async ({
   redis: RedisLike;
   windowMs: number;
 }): Promise<number> => {
-  const rawCount = await withCommandTimeout(
-    redis.send("EVAL", [CONSUME_SCRIPT, "1", key, String(windowMs)]),
+  const rawCount = await withCommandTimeout({
+    command: redis.send("EVAL", [CONSUME_SCRIPT, "1", key, String(windowMs)]),
     commandTimeoutMs,
-  );
+    label: "feedback-intake-redis-command",
+  });
   const count = Number(rawCount);
   if (!Number.isFinite(count)) {
     throw new TypeError("Redis returned a non-numeric counter value");
@@ -325,24 +330,6 @@ const cleanupDedupFallback = (
       fallback.delete(key);
     }
   }
-};
-
-const withCommandTimeout = async <T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-): Promise<T> => {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(
-      () => reject(new Error("redis command timeout")),
-      timeoutMs,
-    );
-  });
-  return await Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  });
 };
 
 export const feedbackIntakeGuards = createFeedbackIntakeGuards();

--- a/apps/api/src/handlers/templates/create-template-service.ts
+++ b/apps/api/src/handlers/templates/create-template-service.ts
@@ -24,6 +24,7 @@ import {
   writeManifest,
 } from "@/api/handlers/docx/template-manifest";
 import type { FieldMeta, TemplateManifest } from "@/api/handlers/docx/types";
+import { buildTemplateS3Key } from "@/api/handlers/templates/storage-keys";
 import { detectTemplateLanguagesFromDocx } from "@/api/handlers/templates/template-languages";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeHandlerGenerator } from "@/api/lib/api-handlers";
@@ -73,11 +74,6 @@ export type CreateStoredTemplateOptions = {
   kind?: TemplateKind | undefined;
   recordAuditEvent: AuditRecorder;
 };
-
-const buildS3Key = (
-  organizationId: SafeId<"organization">,
-  templateId: SafeId<"template">,
-) => `${organizationId}/templates/${templateId}.docx`;
 
 export const createStoredTemplate = async function* ({
   safeDb,
@@ -192,7 +188,7 @@ export const createStoredTemplate = async function* ({
 
   // Pre-generate the ID so the S3 key and DB row stay in sync.
   const templateId = createSafeId<"template">();
-  const s3Key = buildS3Key(organizationId, templateId);
+  const s3Key = buildTemplateS3Key(organizationId, templateId);
 
   await getS3().write(s3Key, new Uint8Array(docxWithManifest));
 

--- a/apps/api/src/handlers/templates/save-document.ts
+++ b/apps/api/src/handlers/templates/save-document.ts
@@ -16,23 +16,17 @@ import type {
   TemplateManifest,
 } from "@/api/handlers/docx/types";
 import { isTemplateManifest } from "@/api/handlers/docx/types";
+import { buildTemplateVersionS3Key } from "@/api/handlers/templates/storage-keys";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { arrayOrEmpty } from "@/api/lib/array";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
-import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FILE_SIZE_LIMITS, LIMITS } from "@/api/lib/limits";
 import { getS3 } from "@/api/lib/s3";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
-
-const buildVersionS3Key = (
-  organizationId: SafeId<"organization">,
-  templateId: SafeId<"template">,
-  version: number,
-) => `${organizationId}/templates/${templateId}/v${version}.docx`;
 
 /** Every path discovery still found in the saved body, including nested
  *  loop-item paths (prefixed by their array root). A path absent from this set
@@ -270,7 +264,7 @@ const saveTemplateDocument = createSafeRootHandler(
         }
 
         const newVersion = locked.currentVersion + 1;
-        const versionS3Key = buildVersionS3Key(
+        const versionS3Key = buildTemplateVersionS3Key(
           organizationId,
           templateId,
           newVersion,

--- a/apps/api/src/handlers/templates/storage-keys.ts
+++ b/apps/api/src/handlers/templates/storage-keys.ts
@@ -1,0 +1,25 @@
+import type { SafeId } from "@/api/lib/branded-types";
+
+/**
+ * Single home for template DOCX object keys so the current file and its
+ * immutable per-version snapshots stay on the same addressing scheme. Both
+ * keys share the `${organizationId}/templates/${templateId}` prefix: the base
+ * key is the live document, and each version appends `/v${version}.docx`.
+ */
+const templateKeyPrefix = (
+  organizationId: SafeId<"organization">,
+  templateId: SafeId<"template">,
+) => `${organizationId}/templates/${templateId}`;
+
+/** Object key for a template's current (live) DOCX. */
+export const buildTemplateS3Key = (
+  organizationId: SafeId<"organization">,
+  templateId: SafeId<"template">,
+) => `${templateKeyPrefix(organizationId, templateId)}.docx`;
+
+/** Immutable per-version object key so historical snapshots stay downloadable. */
+export const buildTemplateVersionS3Key = (
+  organizationId: SafeId<"organization">,
+  templateId: SafeId<"template">,
+  version: number,
+) => `${templateKeyPrefix(organizationId, templateId)}/v${version}.docx`;

--- a/apps/api/src/handlers/templates/update.ts
+++ b/apps/api/src/handlers/templates/update.ts
@@ -8,6 +8,7 @@ import { templates, templateVersions } from "@/api/db/schema";
 import { writeManifest } from "@/api/handlers/docx/template-manifest";
 import type { TemplateManifest } from "@/api/handlers/docx/types";
 import { isTemplateManifest } from "@/api/handlers/docx/types";
+import { buildTemplateVersionS3Key } from "@/api/handlers/templates/storage-keys";
 import {
   MAX_TEMPLATE_LANGUAGES,
   normalizeTemplateLanguages,
@@ -23,12 +24,6 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { pickDefined } from "@/api/lib/pick-defined";
 import { getS3 } from "@/api/lib/s3";
-
-const buildVersionS3Key = (
-  organizationId: SafeId<"organization">,
-  templateId: SafeId<"template">,
-  version: number,
-) => `${organizationId}/templates/${templateId}/v${version}.docx`;
 
 const updateTemplateBodySchema = t.Object({
   name: t.Optional(tDefaultVarchar),
@@ -240,7 +235,7 @@ const updateTemplateHandler = async function* ({
 
         // Each version gets its own immutable S3 key so
         // historical snapshots remain downloadable.
-        const versionS3Key = buildVersionS3Key(
+        const versionS3Key = buildTemplateVersionS3Key(
           organizationId,
           templateId,
           newVersion,

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -1,4 +1,3 @@
-import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 /**
  * Redis-backed storage for better-auth's rate limiter.
  *
@@ -13,6 +12,10 @@ import { TimeoutError } from "@/api/lib/errors/tagged-errors";
  */
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
+import {
+  type ScheduleTimeout,
+  withCommandTimeout,
+} from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
 
 type RateLimitValue = {
@@ -78,31 +81,6 @@ const isStricterRateLimitValue = (
   (candidate.count === current.count &&
     candidate.lastRequest > current.lastRequest);
 
-const withCommandTimeout = async <T>(
-  promise: Promise<T>,
-  commandTimer: CommandTimer,
-): Promise<T> => {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = commandTimer.set(
-      () =>
-        reject(
-          new TimeoutError({
-            label: "auth-rate-limit-redis-command",
-            message: "Redis command timed out",
-            timeoutMs: COMMAND_TIMEOUT_MS,
-          }),
-        ),
-      COMMAND_TIMEOUT_MS,
-    );
-  });
-  return await Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) {
-      commandTimer.clear(timeoutId);
-    }
-  });
-};
-
 /**
  * Build the better-auth rate-limit storage. `ttlMs` is the longest
  * rate-limit window; it expires both Redis keys and fallback entries.
@@ -118,6 +96,10 @@ export const createAuthRateLimitStorage = (
       enableOfflineQueue: false,
     });
   const commandTimer = options.commandTimer ?? DEFAULT_COMMAND_TIMER;
+  const scheduleTimeout: ScheduleTimeout = (callback, delayMs) => {
+    const timeoutId = commandTimer.set(callback, delayMs);
+    return () => commandTimer.clear(timeoutId);
+  };
   // Bun's RedisClient surfaces connection loss via the onclose callback
   // and exposes errors through rejected commands. Leaving onclose unset
   // is safe; per-command rejections drive the fail-open path below.
@@ -143,25 +125,29 @@ export const createAuthRateLimitStorage = (
   };
 
   const writeRedis = async (key: string, value: RateLimitValue) => {
-    await withCommandTimeout(
-      redis.set(
+    await withCommandTimeout({
+      command: redis.set(
         `${REDIS_KEY_PREFIX}${key}`,
         JSON.stringify(value),
         "PX",
         ttlMs,
       ),
-      commandTimer,
-    );
+      commandTimeoutMs: COMMAND_TIMEOUT_MS,
+      label: "auth-rate-limit-redis-command",
+      scheduleTimeout,
+    });
   };
 
   return {
     get: async (key) => {
       try {
         const fallbackValue = readFallback(key);
-        const raw = await withCommandTimeout(
-          redis.get(`${REDIS_KEY_PREFIX}${key}`),
-          commandTimer,
-        );
+        const raw = await withCommandTimeout({
+          command: redis.get(`${REDIS_KEY_PREFIX}${key}`),
+          commandTimeoutMs: COMMAND_TIMEOUT_MS,
+          label: "auth-rate-limit-redis-command",
+          scheduleTimeout,
+        });
         if (raw === null) {
           return fallbackValue;
         }

--- a/apps/api/src/lib/rate-limit/redis-command-timeout.ts
+++ b/apps/api/src/lib/rate-limit/redis-command-timeout.ts
@@ -1,0 +1,52 @@
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+
+/**
+ * Bound every Redis command so a slow or unreachable Redis cannot stall the
+ * caller. Bun's RedisClient has no built-in command timeout, so we race the
+ * command against a timer and reject with a `TimeoutError` if it does not
+ * resolve in time. Callers race this against their fallback path.
+ *
+ * The timer is injectable (`scheduleTimeout` returns a cancel function) so
+ * tests can drive the timeout deterministically; the default uses
+ * `setTimeout`.
+ */
+export type ScheduleTimeout = (
+  callback: () => void,
+  delayMs: number,
+) => () => void;
+
+export const defaultScheduleTimeout: ScheduleTimeout = (callback, delayMs) => {
+  const timeoutId = setTimeout(callback, delayMs);
+  return () => clearTimeout(timeoutId);
+};
+
+type WithCommandTimeoutOptions<T> = {
+  command: Promise<T>;
+  commandTimeoutMs: number;
+  /** `label` on the emitted `TimeoutError`, identifying the calling context. */
+  label: string;
+  scheduleTimeout?: ScheduleTimeout;
+};
+
+export const withCommandTimeout = async <T>({
+  command,
+  commandTimeoutMs,
+  label,
+  scheduleTimeout = defaultScheduleTimeout,
+}: WithCommandTimeoutOptions<T>): Promise<T> => {
+  let cancelTimeout: () => void = () => undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    cancelTimeout = scheduleTimeout(
+      () =>
+        reject(
+          new TimeoutError({
+            label,
+            message: "Redis command timed out",
+            timeoutMs: commandTimeoutMs,
+          }),
+        ),
+      commandTimeoutMs,
+    );
+  });
+  return await Promise.race([command, timeout]).finally(cancelTimeout);
+};

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -8,6 +8,11 @@ import {
   InMemoryRateLimitContext,
   scopedGenerator,
 } from "@/api/lib/rate-limit/rate-limit";
+import {
+  defaultScheduleTimeout,
+  type ScheduleTimeout,
+  withCommandTimeout,
+} from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
 
 const REDIS_KEY_PREFIX = "api:ratelimit:v2:";
@@ -64,7 +69,6 @@ type RedisRateLimitClient = {
   send: (command: string, args: string[]) => Promise<unknown>;
 };
 
-type ScheduleTimeout = (callback: () => void, delayMs: number) => () => void;
 type RedisRateLimitOperation = "decrement" | "increment" | "reset";
 
 type RedisRateLimitContextOptions = {
@@ -313,6 +317,7 @@ export class RedisRateLimitContext implements Context {
         await withCommandTimeout({
           command: redis.send(command, args),
           commandTimeoutMs: this.commandTimeoutMs,
+          label: "api-rate-limit-redis-command",
           scheduleTimeout: this.scheduleTimeout,
         }),
       catch: (error: unknown) => error,
@@ -415,37 +420,4 @@ const parseIncrementReply = (
     nextReset,
     start: nextReset.getTime() - durationMs,
   };
-};
-
-const defaultScheduleTimeout: ScheduleTimeout = (callback, delayMs) => {
-  const timeoutId = setTimeout(callback, delayMs);
-  return () => clearTimeout(timeoutId);
-};
-
-type WithCommandTimeoutOptions<T> = {
-  command: Promise<T>;
-  commandTimeoutMs: number;
-  scheduleTimeout: ScheduleTimeout;
-};
-
-const withCommandTimeout = async <T>({
-  command,
-  commandTimeoutMs,
-  scheduleTimeout,
-}: WithCommandTimeoutOptions<T>): Promise<T> => {
-  let cancelTimeout: () => void = () => undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    cancelTimeout = scheduleTimeout(
-      () =>
-        reject(
-          new TimeoutError({
-            label: "api-rate-limit-redis-command",
-            message: "Redis rate-limit command timed out",
-            timeoutMs: commandTimeoutMs,
-          }),
-        ),
-      commandTimeoutMs,
-    );
-  });
-  return await Promise.race([command, timeout]).finally(cancelTimeout);
 };

--- a/apps/api/src/mcp/gateway/rate-limit.ts
+++ b/apps/api/src/mcp/gateway/rate-limit.ts
@@ -1,6 +1,7 @@
 import { errorTag } from "@/api/lib/errors/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
+import { withCommandTimeout } from "@/api/lib/rate-limit/redis-command-timeout";
 import { createRedisClient } from "@/api/lib/redis-client";
 
 type RedisLike = {
@@ -10,6 +11,10 @@ type RedisLike = {
 type FallbackEntry = {
   count: number;
   expiresAt: number;
+};
+
+type FallbackCleanupState = {
+  nextCleanupAt: number;
 };
 
 type McpGatewayRateLimiterOptions = {
@@ -22,6 +27,7 @@ type McpGatewayRateLimiterOptions = {
 const REDIS_KEY_PREFIX = "mcp:gateway:ratelimit:";
 const REDIS_COMMAND_TIMEOUT_MS = 500;
 const FALLBACK_CLEANUP_THRESHOLD = 10_000;
+const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
 const CONSUME_SCRIPT = `
 local current = redis.call("INCR", KEYS[1])
 if current == 1 then
@@ -46,6 +52,7 @@ export const createMcpGatewayRateLimiter = ({
 }: McpGatewayRateLimiterOptions = {}) => {
   let redis: RedisLike | null = null;
   const fallback = new Map<string, FallbackEntry>();
+  const cleanupState: FallbackCleanupState = { nextCleanupAt: 0 };
 
   const getRedis = () => {
     redis ??= createRedis();
@@ -71,6 +78,7 @@ export const createMcpGatewayRateLimiter = ({
     } catch (error) {
       onRedisError(error);
       return consumeFallback({
+        cleanupState,
         fallback,
         key,
         now: now(),
@@ -90,15 +98,16 @@ const consumeRedis = async ({
   key: string;
   redis: RedisLike;
 }): Promise<number> => {
-  const rawCount = await withCommandTimeout(
-    redis.send("EVAL", [
+  const rawCount = await withCommandTimeout({
+    command: redis.send("EVAL", [
       CONSUME_SCRIPT,
       "1",
       key,
       String(LIMITS.mcpGatewayRateLimitWindowMs),
     ]),
     commandTimeoutMs,
-  );
+    label: "mcp-gateway-redis-command",
+  });
   const count = Number(rawCount);
   if (!Number.isFinite(count)) {
     throw new TypeError("Redis returned a non-numeric rate-limit count");
@@ -107,10 +116,12 @@ const consumeRedis = async ({
 };
 
 const consumeFallback = ({
+  cleanupState,
   fallback,
   key,
   now,
 }: {
+  cleanupState: FallbackCleanupState;
   fallback: Map<string, FallbackEntry>;
   key: string;
   now: number;
@@ -121,7 +132,7 @@ const consumeFallback = ({
       count: 1,
       expiresAt: now + LIMITS.mcpGatewayRateLimitWindowMs,
     });
-    cleanupFallbackIfNeeded(fallback, now);
+    cleanupFallbackIfNeeded(fallback, now, cleanupState);
     return true;
   }
 
@@ -133,38 +144,24 @@ const consumeFallback = ({
   return true;
 };
 
+// Throttled O(n) sweep: even once the map is past its threshold, only sweep
+// expired entries at most once per interval so a Redis outage that inserts
+// past 10k entries does not run a full scan on every single insert.
 const cleanupFallbackIfNeeded = (
   fallback: Map<string, FallbackEntry>,
   now: number,
+  state: FallbackCleanupState,
 ) => {
-  if (fallback.size < FALLBACK_CLEANUP_THRESHOLD) {
+  if (fallback.size < FALLBACK_CLEANUP_THRESHOLD || now < state.nextCleanupAt) {
     return;
   }
 
+  state.nextCleanupAt = now + FALLBACK_CLEANUP_INTERVAL_MS;
   for (const [key, entry] of fallback) {
     if (entry.expiresAt <= now) {
       fallback.delete(key);
     }
   }
-};
-
-const withCommandTimeout = async <T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-): Promise<T> => {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(
-      () => reject(new Error("redis command timeout")),
-      timeoutMs,
-    );
-  });
-
-  return await Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  });
 };
 
 const gatewayRateLimiter = createMcpGatewayRateLimiter();


### PR DESCRIPTION
- Extract the chat-thread scope-match check into assertChatThreadScopeMatches
  (handlers/chat/chat-scope.ts) and use it in get-messages, get-older-messages,
  get-suggested-prompts, and get-thread-recap.
- Move the shared recap message-window fetch into thread-recap-window.ts as
  loadRecapMessageWindow; get-suggested-prompts and get-thread-recap call it.
- Add a single withCommandTimeout in lib/rate-limit/redis-command-timeout.ts
  that rejects with a TimeoutError, replacing four drifted copies (mcp gateway,
  auth-storage, redis-context, feedback intake-guards). Bring the mcp gateway
  fallback sweep up to the throttled (nextCleanupAt) pattern so a Redis outage
  past the cleanup threshold no longer runs an O(n) sweep on every insert.
- Single-home the template DOCX object keys in templates/storage-keys.ts
  (buildTemplateS3Key + buildTemplateVersionS3Key); update.ts, save-document.ts,
  and create-template-service.ts import from it.
