### PR TITLE
refactor(api): extract shared corpus-index core from case-law and legislation twins

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.test.ts
@@ -63,7 +63,7 @@ describe("loadDocsForBatch read-failure isolation", () => {
     const failure = readFailures.at(0);
     expect(failure?.indexId).toBe(corpusIndexId(generation, "CZ"));
     expect(failure?.job).toMatchObject({
-      decisionId: badRow.id,
+      entityId: badRow.id,
       contentHash: "hash_bad",
       operation: "index",
       status: "failed",

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -5,6 +5,7 @@ import {
   caseLawIndexJobs,
   caseLawSources,
 } from "@/api/db/schema";
+import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
@@ -103,8 +104,9 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
   family: "case_law",
   captureStep: "backfillCorpusIndex.loadText",
   buildDoc,
-  selectMissing: (scopedDb, { generation, limit }) =>
-    scopedDb((tx) =>
+  readCorpusText,
+  selectMissing: async (scopedDb, { generation, limit }) =>
+    await scopedDb((tx) =>
       tx
         .select(SELECT_COLUMNS)
         .from(caseLawDecisions)
@@ -125,8 +127,8 @@ const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
         .orderBy(asc(caseLawDecisions.createdAt))
         .limit(limit),
     ),
-  selectStale: (scopedDb, { generation, limit }) =>
-    scopedDb((tx) =>
+  selectStale: async (scopedDb, { generation, limit }) =>
+    await scopedDb((tx) =>
       tx
         .select(SELECT_COLUMNS)
         .from(caseLawDecisions)

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1,33 +1,23 @@
-import { Result } from "better-result";
 import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
 
-import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawDecisions,
   caseLawIndexJobs,
   caseLawSources,
 } from "@/api/db/schema";
-import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { redistributableCaseLawSource } from "@/api/handlers/case-law/redistribution";
-import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import {
-  getCorpusIndexClient,
-  type CorpusIndexError,
-} from "@/api/lib/legal-search/corpus-index-client";
-import { caseLawIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
-import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
 
 /**
- * corpus index search-projection maintenance. Mirrors search-index.ts (the
- * pg-fts projection): a backfill loop indexes corpus-backed decisions
- * whose content changed or that are missing from the active generation.
- * The license gate lives in the SQL filter so non-redistributable
- * sources never enter the scan (and cannot stall it). Every mutation is
- * recorded in the case_law_index_jobs audit trail.
+ * corpus index search-projection maintenance for the `case_law` family.
+ * Domain adapter over the shared core (lib/corpus-index/core.ts): supplies the
+ * case-law tables, batch queries, and per-decision document shape; the core
+ * owns the S3-chunked load, per-group ingest, compare-and-set commit, and audit
+ * trail (case_law_index_jobs). Per-jurisdiction indexes (`case_law_v1_<country>`)
+ * with the license gate in SQL so non-redistributable sources never enter the
+ * scan.
  */
-
-const INDEX_CONCURRENCY = 4;
 
 type IndexableRow = {
   id: SafeId<"caseLawDecision">;
@@ -52,7 +42,7 @@ type IndexableRow = {
 // Deliberately excludes `fulltext`: it is only the fallback for rows without
 // a canonical S3 object, and selecting it for every row would drag megabytes
 // of text through one batch transaction. Rows that need it fetch it lazily,
-// one small bounded read per document (see loadText / fetchFulltext).
+// one small bounded read per document (see the core's loadText / fetchFulltext).
 const SELECT_COLUMNS = {
   id: caseLawDecisions.id,
   sourceId: caseLawDecisions.sourceId,
@@ -75,31 +65,6 @@ const SELECT_COLUMNS = {
 
 // A row is indexable once its canonical payload is in object storage.
 const hasContent = sql`${caseLawDecisions.contentHash} IS NOT NULL`;
-
-// Per-jurisdiction indexes are created on first write. Cache the ids we
-// have confirmed this process so we don't probe corpus index every batch.
-const ensuredIndexes = new Set<string>();
-
-const ensureIndex = async (
-  indexId: string,
-): Promise<Result<void, CorpusIndexError>> => {
-  if (ensuredIndexes.has(indexId)) {
-    return Result.ok(undefined);
-  }
-  const client = getCorpusIndexClient();
-  const exists = await client.indexExists(indexId);
-  if (exists.isErr()) {
-    return Result.err(exists.error);
-  }
-  if (!exists.value) {
-    const created = await client.createIndex(caseLawIndexConfig(indexId));
-    if (created.isErr()) {
-      return Result.err(created.error);
-    }
-  }
-  ensuredIndexes.add(indexId);
-  return Result.ok(undefined);
-};
 
 /** Build the corpus index search document, omitting empty optional fields. */
 const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
@@ -134,201 +99,53 @@ const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
   return doc;
 };
 
-/** Lazy Postgres fulltext fallback for rows without a canonical S3 object. */
-type FetchFulltext = (id: SafeId<"caseLawDecision">) => Promise<string | null>;
-
-const loadText = async (
-  row: IndexableRow,
-  fetchFulltext: FetchFulltext,
-): Promise<string> => {
-  // No catch-and-fallback here: a read failure propagates so the caller
-  // can isolate this document (record it failed, drop it from the batch) and
-  // retry it next cycle. Swallowing it and indexing empty text would then
-  // record indexedHash = contentHash, permanently pinning a broken entry.
-  if (row.textS3Key !== null) {
-    return await readCorpusText(row.textS3Key);
-  }
-  // Only rows without a corpus object read their Postgres fulltext, one
-  // small bounded query per such row; the batch SELECT never carries text.
-  return (await fetchFulltext(row.id)) ?? "";
-};
-
-type LoadedBatch = {
-  docs: { row: IndexableRow; doc: Record<string, unknown> }[];
-  readFailures: { indexId: string; job: JobInput; cause: unknown }[];
-};
-
-type LoadDocsForBatchOptions = {
-  generation: string;
-  fetchFulltext: FetchFulltext;
-  /** Override the per-row text load (test seam). */
-  readText?: (row: IndexableRow) => Promise<string>;
-};
-
-/**
- * Build each row's index document from its canonical text, isolating per-row
- * read failures. A bounded corpus read that times out or errors fails only its
- * own document: that row is collected as a failed index job and dropped from
- * the batch (never marked indexed, so a later cycle retries it), while its
- * batch-mates still commit. Reads run in bounded-concurrency chunks so S3
- * pressure stays capped. `readText` is injectable so the isolation can be
- * exercised without a live object store.
- */
-export const loadDocsForBatch = async (
-  rows: readonly IndexableRow[],
-  { generation, fetchFulltext, readText }: LoadDocsForBatchOptions,
-): Promise<LoadedBatch> => {
-  const loadRowText =
-    readText ??
-    (async (row: IndexableRow) => await loadText(row, fetchFulltext));
-  const docs: LoadedBatch["docs"] = [];
-  const readFailures: LoadedBatch["readFailures"] = [];
-  for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
-    const chunk = rows.slice(i, i + INDEX_CONCURRENCY);
-    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
-    const built = await Promise.all(
-      chunk.map(async (row) => {
-        try {
-          return {
-            ok: true as const,
-            row,
-            doc: buildDoc(row, await loadRowText(row)),
-          };
-        } catch (error) {
-          return { ok: false as const, row, error };
-        }
-      }),
-    );
-    for (const entry of built) {
-      if (entry.ok) {
-        docs.push({ row: entry.row, doc: entry.doc });
-        continue;
-      }
-      readFailures.push({
-        indexId: corpusIndexId(generation, entry.row.country),
-        cause: entry.error,
-        job: {
-          decisionId: entry.row.id,
-          contentHash: entry.row.contentHash,
-          operation: "index",
-          status: "failed",
-          errorMessage: (entry.error instanceof Error
-            ? entry.error.message
-            : String(entry.error)
-          ).slice(0, 2048),
-        },
-      });
-    }
-  }
-  return { docs, readFailures };
-};
-
-/**
- * Fail loud, continue: record isolated per-document read failures. Captures
- * the underlying (tagged) error with jurisdiction/generation context — never
- * decision text — and writes a failed index job (the established audit
- * convention) under each affected jurisdiction index. The rows stay unindexed,
- * so a later cycle retries them while the batch's healthy documents proceed.
- */
-const recordReadFailures = async (
-  scopedDb: ScopedDb,
-  readFailures: LoadedBatch["readFailures"],
-  generation: string,
-): Promise<void> => {
-  const firstFailure = readFailures.at(0);
-  if (!firstFailure) {
-    return;
-  }
-  captureError(firstFailure.cause, {
-    step: "backfillCorpusIndex.loadText",
-    generation,
-    failed: String(readFailures.length),
-  });
-  const failuresByIndex = new Map<string, JobInput[]>();
-  for (const { indexId, job } of readFailures) {
-    const existing = failuresByIndex.get(indexId);
-    if (existing) {
-      existing.push(job);
-    } else {
-      failuresByIndex.set(indexId, [job]);
-    }
-  }
-  for (const [indexId, jobs] of failuresByIndex) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential per-index audit writes preserve job ordering
-    await recordJobs(scopedDb, jobs, indexId);
-  }
-};
-
-/**
- * Index a batch of corpus-backed decisions into the given generation.
- * Two-query missing/stale split mirrors backfillSearchIndex: `missing`
- * = not yet in this generation; `stale` = content changed since last
- * push. Reserves a quarter of the batch for stale so re-indexes are not
- * starved by a missing-doc backlog. Returns the number indexed.
- */
-export const backfillCorpusIndex = async (
-  scopedDb: ScopedDb,
-  batchSize: number,
-  generation: string,
-): Promise<number> => {
-  const staleReserved = Math.max(1, Math.floor(batchSize / 4));
-  const missingLimit = Math.max(1, batchSize - staleReserved);
-
-  const missing = await scopedDb((tx) =>
-    tx
-      .select(SELECT_COLUMNS)
-      .from(caseLawDecisions)
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(
-        and(
-          hasContent,
-          redistributableCaseLawSource,
-          or(
-            isNull(caseLawDecisions.indexedGeneration),
-            sql`${caseLawDecisions.indexedGeneration} <> (${generation} || '_' || lower(${caseLawDecisions.country}))`,
+const indexer = createCorpusIndexer<"caseLawDecision", IndexableRow>({
+  family: "case_law",
+  captureStep: "backfillCorpusIndex.loadText",
+  buildDoc,
+  selectMissing: (scopedDb, { generation, limit }) =>
+    scopedDb((tx) =>
+      tx
+        .select(SELECT_COLUMNS)
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(
+          and(
+            hasContent,
+            redistributableCaseLawSource,
+            or(
+              isNull(caseLawDecisions.indexedGeneration),
+              sql`${caseLawDecisions.indexedGeneration} <> (${generation} || '_' || lower(${caseLawDecisions.country}))`,
+            ),
           ),
-        ),
-      )
-      .orderBy(asc(caseLawDecisions.createdAt))
-      .limit(missingLimit),
-  );
-
-  const staleLimit = batchSize - missing.length;
-  const stale =
-    staleLimit <= 0
-      ? []
-      : await scopedDb((tx) =>
-          tx
-            .select(SELECT_COLUMNS)
-            .from(caseLawDecisions)
-            .innerJoin(
-              caseLawSources,
-              eq(caseLawSources.id, caseLawDecisions.sourceId),
-            )
-            .where(
-              and(
-                hasContent,
-                redistributableCaseLawSource,
-                sql`${caseLawDecisions.indexedGeneration} = (${generation} || '_' || lower(${caseLawDecisions.country}))`,
-                sql`${caseLawDecisions.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}`,
-              ),
-            )
-            .orderBy(asc(caseLawDecisions.createdAt))
-            .limit(staleLimit),
-        );
-
-  const rows: IndexableRow[] = [...missing, ...stale];
-  if (rows.length === 0) {
-    return 0;
-  }
-
-  // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
-  // A per-document read failure fails only that document; record it and let
-  // the rest still commit.
-  const fetchFulltext: FetchFulltext = async (id) => {
+        )
+        .orderBy(asc(caseLawDecisions.createdAt))
+        .limit(limit),
+    ),
+  selectStale: (scopedDb, { generation, limit }) =>
+    scopedDb((tx) =>
+      tx
+        .select(SELECT_COLUMNS)
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(
+          and(
+            hasContent,
+            redistributableCaseLawSource,
+            sql`${caseLawDecisions.indexedGeneration} = (${generation} || '_' || lower(${caseLawDecisions.country}))`,
+            sql`${caseLawDecisions.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}`,
+          ),
+        )
+        .orderBy(asc(caseLawDecisions.createdAt))
+        .limit(limit),
+    ),
+  fetchFulltext: async (scopedDb, id) => {
     const fallback = await scopedDb((tx) =>
       tx
         .select({ fulltext: caseLawDecisions.fulltext })
@@ -337,221 +154,59 @@ export const backfillCorpusIndex = async (
         .limit(1),
     );
     return fallback.at(0)?.fulltext ?? null;
-  };
-  const { docs, readFailures } = await loadDocsForBatch(rows, {
-    generation,
-    fetchFulltext,
-  });
-  await recordReadFailures(scopedDb, readFailures, generation);
-
-  // Route each doc to its jurisdiction's index (case_law_v1_<country>),
-  // grouping so each index gets one NDJSON ingest. A group that fails to
-  // ensure/ingest is recorded and retried next cycle; other groups still
-  // commit.
-  const groups = new Map<string, typeof docs>();
-  for (const entry of docs) {
-    const indexId = corpusIndexId(generation, entry.row.country);
-    const group = groups.get(indexId);
-    if (group) {
-      group.push(entry);
-    } else {
-      groups.set(indexId, [entry]);
-    }
-  }
-
-  const now = new Date();
-  let indexed = 0;
-  let firstError: CorpusIndexError | null = null;
-
-  for (const [indexId, group] of groups) {
-    // Ingest appends; it never replaces. Before re-ingesting, delete the
-    // previously indexed copy from wherever it lives (the same index for
-    // a content refresh, another jurisdiction index for a corrected
-    // country), or stale copies keep matching old text. Same generation
-    // only: generation rebuilds replace whole indexes. Engine delete
-    // tasks only affect splits that already exist, so the copy ingested
-    // below is not at risk.
-    const moved = group.flatMap(({ row }) =>
-      row.indexedGeneration !== null &&
-      row.indexedGeneration.startsWith(`${generation}_`)
-        ? [{ id: row.id, oldIndexId: row.indexedGeneration }]
-        : [],
-    );
-    let staleError: CorpusIndexError | null = null;
-    for (const entry of moved) {
-      // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
-      const removed = await removeDecisionFromCorpusIndex(
-        entry.id,
-        scopedDb,
-        entry.oldIndexId,
-      );
-      if (removed.isErr()) {
-        staleError = removed.error;
-        break;
-      }
-    }
-    if (staleError) {
-      firstError ??= staleError;
-      continue;
-    }
-
-    // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
-    const ensured = await ensureIndex(indexId);
-    const ingest = ensured.isErr()
-      ? ensured
-      : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
-        await getCorpusIndexClient().ingestBatch(
-          indexId,
-          group.map(({ doc }) => JSON.stringify(doc)).join("\n"),
-        );
-
-    if (ingest.isErr()) {
-      firstError ??= ingest.error;
-      // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
-      await recordJobs(
-        scopedDb,
-        group.map(({ row }) => ({
-          decisionId: row.id,
-          contentHash: row.contentHash,
-          operation: "index" as const,
-          status: "failed" as const,
-          errorMessage: ingest.error.message.slice(0, 2048),
-        })),
-        indexId,
-      );
-      continue;
-    }
-
-    const casMissed = new Set<SafeId<"caseLawDecision">>();
-    // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per group; sequential to keep index writes and audit rows consistent
-    await scopedDb(async (tx) => {
-      // audit: skip — search index maintenance; rebuilds derived state
-      for (const { row } of group) {
-        // Compare-and-set on the selected row state: a concurrent
-        // re-ingest clears indexedHash (possibly leaving it null-to-null
-        // when the row was already pending) and bumps updatedAt, and an
-        // unconditional write would mask that refresh so the stale index
-        // document would never be retried.
-        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
-        const marked = await tx
-          .update(caseLawDecisions)
-          .set({
-            indexedHash: row.contentHash,
-            indexedGeneration: indexId,
-            indexedAt: now,
-          })
-          .where(
-            and(
-              eq(caseLawDecisions.id, row.id),
-              sql`${caseLawDecisions.indexedHash} IS NOT DISTINCT FROM ${row.indexedHash}`,
-              sql`${caseLawDecisions.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
-            ),
-          )
-          .returning({ id: caseLawDecisions.id });
-        if (marked.length === 0) {
-          casMissed.add(row.id);
-        }
-      }
-      const markedRows = group.filter(({ row }) => !casMissed.has(row.id));
-      if (markedRows.length > 0) {
-        await tx.insert(caseLawIndexJobs).values(
-          markedRows.map(({ row }) => ({
-            decisionId: row.id,
-            generation: indexId,
-            operation: "index" as const,
-            status: "succeeded" as const,
-            contentHash: row.contentHash,
-          })),
-        );
-      }
-    });
-    // A missed CAS means a refresh outpaced this batch after the ingest
-    // appended its document: the row carries no generation pointer to it,
-    // so delete the unrecorded copy now; the refreshed row is re-indexed
-    // by a later cycle.
-    for (const missedId of casMissed) {
-      // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
-      const removed = await removeDecisionFromCorpusIndex(
-        missedId,
-        scopedDb,
-        indexId,
-      );
-      if (removed.isErr()) {
-        firstError ??= removed.error;
-      }
-    }
-    indexed += group.length - casMissed.size;
-  }
-
-  // Surface a failure so the daemon retries the un-indexed groups.
-  if (firstError) {
-    // eslint-disable-next-line no-throw-literal -- CorpusIndexError (TaggedError); rethrow to abort the batch for retry
-    throw firstError;
-  }
-
-  return indexed;
-};
-
-type JobInput = {
-  decisionId: SafeId<"caseLawDecision">;
-  contentHash: string | null;
-  operation: "index" | "delete" | "redact" | "rebuild";
-  status: "succeeded" | "failed";
-  errorMessage?: string;
-};
-
-const recordJobs = async (
-  scopedDb: ScopedDb,
-  jobs: readonly JobInput[],
-  generation: string,
-): Promise<void> => {
-  if (jobs.length === 0) {
-    return;
-  }
-  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-  await scopedDb((tx) => {
+  },
+  markIndexed: async (tx, { row, indexId, now }) => {
+    // audit: skip — search index maintenance; rebuilds derived state
+    const marked = await tx
+      .update(caseLawDecisions)
+      .set({
+        indexedHash: row.contentHash,
+        indexedGeneration: indexId,
+        indexedAt: now,
+      })
+      .where(
+        and(
+          eq(caseLawDecisions.id, row.id),
+          sql`${caseLawDecisions.indexedHash} IS NOT DISTINCT FROM ${row.indexedHash}`,
+          sql`${caseLawDecisions.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
+        ),
+      )
+      .returning({ id: caseLawDecisions.id });
+    return marked.length > 0;
+  },
+  insertSucceededJobs: async (tx, { rows, indexId }) => {
     // audit: skip — append-only index-job rows ARE the indexing audit trail
-    return tx.insert(caseLawIndexJobs).values(
-      jobs.map((job) => ({
-        decisionId: job.decisionId,
-        generation,
-        operation: job.operation,
-        status: job.status,
-        contentHash: job.contentHash,
-        errorMessage: job.errorMessage ?? null,
+    await tx.insert(caseLawIndexJobs).values(
+      rows.map((row) => ({
+        decisionId: row.id,
+        generation: indexId,
+        operation: "index" as const,
+        status: "succeeded" as const,
+        contentHash: row.contentHash,
       })),
     );
-  });
-};
+  },
+  recordJobs: async (scopedDb, jobs, generation) => {
+    if (jobs.length === 0) {
+      return;
+    }
+    // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+    await scopedDb((tx) => {
+      // audit: skip — append-only index-job rows ARE the indexing audit trail
+      return tx.insert(caseLawIndexJobs).values(
+        jobs.map((job) => ({
+          decisionId: job.entityId,
+          generation,
+          operation: job.operation,
+          status: job.status,
+          contentHash: job.contentHash,
+          errorMessage: job.errorMessage ?? null,
+        })),
+      );
+    });
+  },
+});
 
-/**
- * Remove a decision from a corpus index generation (GDPR/takedown). Uses a
- * delete-task (corpus index's async delete path) and records the operation.
- */
-export const removeDecisionFromCorpusIndex = async (
-  decisionId: SafeId<"caseLawDecision">,
-  scopedDb: ScopedDb,
-  indexId: string,
-  operation: "delete" | "redact" = "delete",
-): Promise<Result<void, CorpusIndexError>> => {
-  const result = await getCorpusIndexClient().deleteByQuery(
-    indexId,
-    `document_id:"${decisionId}"`,
-  );
-  await recordJobs(
-    scopedDb,
-    [
-      {
-        decisionId,
-        contentHash: null,
-        operation,
-        status: result.isErr() ? "failed" : "succeeded",
-        ...(result.isErr()
-          ? { errorMessage: result.error.message.slice(0, 2048) }
-          : {}),
-      },
-    ],
-    indexId,
-  );
-  return result;
-};
+export const loadDocsForBatch = indexer.loadDocsForBatch;
+export const backfillCorpusIndex = indexer.backfill;
+export const removeDecisionFromCorpusIndex = indexer.remove;

--- a/apps/api/src/handlers/legislation/corpus-index.test.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.test.ts
@@ -64,7 +64,7 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
     const failure = readFailures.at(0);
     expect(failure?.indexId).toBe(corpusIndexId(generation, "CZ"));
     expect(failure?.job).toMatchObject({
-      documentId: badRow.id,
+      entityId: badRow.id,
       contentHash: "hash_bad",
       operation: "index",
       status: "failed",

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -5,6 +5,7 @@ import {
   legislationIndexJobs,
   legislationSources,
 } from "@/api/db/schema";
+import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
@@ -101,8 +102,9 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
   family: "legislation",
   captureStep: "backfillLegislationCorpusIndex.loadText",
   buildDoc,
-  selectMissing: (scopedDb, { generation, limit }) =>
-    scopedDb((tx) =>
+  readCorpusText,
+  selectMissing: async (scopedDb, { generation, limit }) =>
+    await scopedDb((tx) =>
       tx
         .select(SELECT_COLUMNS)
         .from(legislationDocuments)
@@ -123,8 +125,8 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
         .orderBy(asc(legislationDocuments.createdAt))
         .limit(limit),
     ),
-  selectStale: (scopedDb, { generation, limit }) =>
-    scopedDb((tx) =>
+  selectStale: async (scopedDb, { generation, limit }) =>
+    await scopedDb((tx) =>
       tx
         .select(SELECT_COLUMNS)
         .from(legislationDocuments)

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -1,31 +1,21 @@
-import { Result } from "better-result";
 import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
 
-import type { ScopedDb } from "@/api/db/safe-db";
 import {
   legislationDocuments,
   legislationIndexJobs,
   legislationSources,
 } from "@/api/db/schema";
-import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
-import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import {
-  getCorpusIndexClient,
-  type CorpusIndexError,
-} from "@/api/lib/legal-search/corpus-index-client";
-import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
-import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { createCorpusIndexer } from "@/api/lib/corpus-index/core";
 
 /**
- * corpus index projection for the `legislation` family. Mirrors
- * case-law/corpus-index.ts: per-jurisdiction indexes
+ * corpus index projection for the `legislation` family. Domain adapter over the
+ * shared core (lib/corpus-index/core.ts): supplies the legislation tables, batch
+ * queries, and per-document shape. Per-jurisdiction indexes
  * (`legislation_v1_<country>`), license gate in SQL, batch ingest with a
  * per-group commit, audit trail in legislation_index_jobs.
  */
-
-const INDEX_CONCURRENCY = 4;
 
 type IndexableRow = {
   id: SafeId<"legislationDocument">;
@@ -74,31 +64,6 @@ const SELECT_COLUMNS = {
 
 const hasContent = sql`${legislationDocuments.contentHash} IS NOT NULL`;
 
-const ensuredIndexes = new Set<string>();
-
-const ensureIndex = async (
-  indexId: string,
-): Promise<Result<void, CorpusIndexError>> => {
-  if (ensuredIndexes.has(indexId)) {
-    return Result.ok(undefined);
-  }
-  const client = getCorpusIndexClient();
-  const exists = await client.indexExists(indexId);
-  if (exists.isErr()) {
-    return Result.err(exists.error);
-  }
-  if (!exists.value) {
-    const created = await client.createIndex(
-      corpusIndexConfig("legislation", indexId),
-    );
-    if (created.isErr()) {
-      return Result.err(created.error);
-    }
-  }
-  ensuredIndexes.add(indexId);
-  return Result.ok(undefined);
-};
-
 const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
   // eslint-disable-next-line no-untyped-updates/no-untyped-updates -- corpus index ingest document, not a DB update
   const doc: Record<string, unknown> = {
@@ -132,191 +97,53 @@ const buildDoc = (row: IndexableRow, text: string): Record<string, unknown> => {
   return doc;
 };
 
-/** Lazy Postgres fulltext fallback for rows without a canonical S3 object. */
-type FetchFulltext = (
-  id: SafeId<"legislationDocument">,
-) => Promise<string | null>;
-
-const loadText = async (
-  row: IndexableRow,
-  fetchFulltext: FetchFulltext,
-): Promise<string> => {
-  // Match the case-law indexer: a read failure propagates so the caller
-  // can isolate this document (record it failed, drop it from the batch) and
-  // retry it next cycle, rather than committing indexedHash = contentHash for
-  // fallback or empty text.
-  if (row.textS3Key !== null) {
-    return await readCorpusText(row.textS3Key);
-  }
-  // Only rows without a corpus object read their Postgres fulltext, one
-  // small bounded query per such row; the batch SELECT never carries text.
-  return (await fetchFulltext(row.id)) ?? "";
-};
-
-type LoadedBatch = {
-  docs: { row: IndexableRow; doc: Record<string, unknown> }[];
-  readFailures: { indexId: string; job: JobInput; cause: unknown }[];
-};
-
-type LoadDocsForBatchOptions = {
-  generation: string;
-  fetchFulltext: FetchFulltext;
-  /** Override the per-row text load (test seam). */
-  readText?: (row: IndexableRow) => Promise<string>;
-};
-
-/**
- * Build each row's index document from its canonical text, isolating per-row
- * read failures. Mirrors the case-law indexer: a bounded corpus read that
- * times out or errors fails only its own document (recorded failed, dropped
- * from the batch, retried next cycle) while its batch-mates still commit.
- */
-export const loadDocsForBatch = async (
-  rows: readonly IndexableRow[],
-  { generation, fetchFulltext, readText }: LoadDocsForBatchOptions,
-): Promise<LoadedBatch> => {
-  const loadRowText =
-    readText ??
-    (async (row: IndexableRow) => await loadText(row, fetchFulltext));
-  const docs: LoadedBatch["docs"] = [];
-  const readFailures: LoadedBatch["readFailures"] = [];
-  for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
-    const chunk = rows.slice(i, i + INDEX_CONCURRENCY);
-    // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
-    const built = await Promise.all(
-      chunk.map(async (row) => {
-        try {
-          return {
-            ok: true as const,
-            row,
-            doc: buildDoc(row, await loadRowText(row)),
-          };
-        } catch (error) {
-          return { ok: false as const, row, error };
-        }
-      }),
-    );
-    for (const entry of built) {
-      if (entry.ok) {
-        docs.push({ row: entry.row, doc: entry.doc });
-        continue;
-      }
-      readFailures.push({
-        indexId: corpusIndexId(generation, entry.row.country),
-        cause: entry.error,
-        job: {
-          documentId: entry.row.id,
-          contentHash: entry.row.contentHash,
-          operation: "index",
-          status: "failed",
-          errorMessage: (entry.error instanceof Error
-            ? entry.error.message
-            : String(entry.error)
-          ).slice(0, 2048),
-        },
-      });
-    }
-  }
-  return { docs, readFailures };
-};
-
-/**
- * Fail loud, continue: record isolated per-document read failures. Mirrors the
- * case-law indexer — captures the underlying (tagged) error with jurisdiction/
- * generation context (never document text) and writes a failed index job under
- * each affected jurisdiction index so a later cycle retries the rows.
- */
-const recordReadFailures = async (
-  scopedDb: ScopedDb,
-  readFailures: LoadedBatch["readFailures"],
-  generation: string,
-): Promise<void> => {
-  const firstFailure = readFailures.at(0);
-  if (!firstFailure) {
-    return;
-  }
-  captureError(firstFailure.cause, {
-    step: "backfillLegislationCorpusIndex.loadText",
-    generation,
-    failed: String(readFailures.length),
-  });
-  const failuresByIndex = new Map<string, JobInput[]>();
-  for (const { indexId, job } of readFailures) {
-    const existing = failuresByIndex.get(indexId);
-    if (existing) {
-      existing.push(job);
-    } else {
-      failuresByIndex.set(indexId, [job]);
-    }
-  }
-  for (const [indexId, jobs] of failuresByIndex) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential per-index audit writes preserve job ordering
-    await recordJobs(scopedDb, jobs, indexId);
-  }
-};
-
-export const backfillLegislationCorpusIndex = async (
-  scopedDb: ScopedDb,
-  batchSize: number,
-  generation: string,
-): Promise<number> => {
-  const staleReserved = Math.max(1, Math.floor(batchSize / 4));
-  const missingLimit = Math.max(1, batchSize - staleReserved);
-
-  const missing = await scopedDb((tx) =>
-    tx
-      .select(SELECT_COLUMNS)
-      .from(legislationDocuments)
-      .innerJoin(
-        legislationSources,
-        eq(legislationSources.id, legislationDocuments.sourceId),
-      )
-      .where(
-        and(
-          hasContent,
-          redistributableLegislationSource,
-          or(
-            isNull(legislationDocuments.indexedGeneration),
-            sql`${legislationDocuments.indexedGeneration} <> (${generation} || '_' || lower(${legislationDocuments.country}))`,
+const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
+  family: "legislation",
+  captureStep: "backfillLegislationCorpusIndex.loadText",
+  buildDoc,
+  selectMissing: (scopedDb, { generation, limit }) =>
+    scopedDb((tx) =>
+      tx
+        .select(SELECT_COLUMNS)
+        .from(legislationDocuments)
+        .innerJoin(
+          legislationSources,
+          eq(legislationSources.id, legislationDocuments.sourceId),
+        )
+        .where(
+          and(
+            hasContent,
+            redistributableLegislationSource,
+            or(
+              isNull(legislationDocuments.indexedGeneration),
+              sql`${legislationDocuments.indexedGeneration} <> (${generation} || '_' || lower(${legislationDocuments.country}))`,
+            ),
           ),
-        ),
-      )
-      .orderBy(asc(legislationDocuments.createdAt))
-      .limit(missingLimit),
-  );
-
-  const staleLimit = batchSize - missing.length;
-  const stale =
-    staleLimit <= 0
-      ? []
-      : await scopedDb((tx) =>
-          tx
-            .select(SELECT_COLUMNS)
-            .from(legislationDocuments)
-            .innerJoin(
-              legislationSources,
-              eq(legislationSources.id, legislationDocuments.sourceId),
-            )
-            .where(
-              and(
-                hasContent,
-                redistributableLegislationSource,
-                sql`${legislationDocuments.indexedGeneration} = (${generation} || '_' || lower(${legislationDocuments.country}))`,
-                sql`${legislationDocuments.indexedHash} IS DISTINCT FROM ${legislationDocuments.contentHash}`,
-              ),
-            )
-            .orderBy(asc(legislationDocuments.createdAt))
-            .limit(staleLimit),
-        );
-
-  const rows: IndexableRow[] = [...missing, ...stale];
-  if (rows.length === 0) {
-    return 0;
-  }
-
-  // A per-document read failure fails only that document; record it and let
-  // the rest still commit.
-  const fetchFulltext: FetchFulltext = async (id) => {
+        )
+        .orderBy(asc(legislationDocuments.createdAt))
+        .limit(limit),
+    ),
+  selectStale: (scopedDb, { generation, limit }) =>
+    scopedDb((tx) =>
+      tx
+        .select(SELECT_COLUMNS)
+        .from(legislationDocuments)
+        .innerJoin(
+          legislationSources,
+          eq(legislationSources.id, legislationDocuments.sourceId),
+        )
+        .where(
+          and(
+            hasContent,
+            redistributableLegislationSource,
+            sql`${legislationDocuments.indexedGeneration} = (${generation} || '_' || lower(${legislationDocuments.country}))`,
+            sql`${legislationDocuments.indexedHash} IS DISTINCT FROM ${legislationDocuments.contentHash}`,
+          ),
+        )
+        .orderBy(asc(legislationDocuments.createdAt))
+        .limit(limit),
+    ),
+  fetchFulltext: async (scopedDb, id) => {
     const fallback = await scopedDb((tx) =>
       tx
         .select({ fulltext: legislationDocuments.fulltext })
@@ -325,212 +152,59 @@ export const backfillLegislationCorpusIndex = async (
         .limit(1),
     );
     return fallback.at(0)?.fulltext ?? null;
-  };
-  const { docs, readFailures } = await loadDocsForBatch(rows, {
-    generation,
-    fetchFulltext,
-  });
-  await recordReadFailures(scopedDb, readFailures, generation);
-
-  const groups = new Map<string, typeof docs>();
-  for (const entry of docs) {
-    const indexId = corpusIndexId(generation, entry.row.country);
-    const group = groups.get(indexId);
-    if (group) {
-      group.push(entry);
-    } else {
-      groups.set(indexId, [entry]);
-    }
-  }
-
-  const now = new Date();
-  let indexed = 0;
-  let firstError: CorpusIndexError | null = null;
-
-  for (const [indexId, group] of groups) {
-    // Ingest appends; it never replaces. Before re-ingesting, delete the
-    // previously indexed copy from wherever it lives (the same index for
-    // a content refresh, another jurisdiction index for a corrected
-    // country), or stale copies keep matching old text. Same generation
-    // only: generation rebuilds replace whole indexes. Engine delete
-    // tasks only affect splits that already exist, so the copy ingested
-    // below is not at risk.
-    const moved = group.flatMap(({ row }) =>
-      row.indexedGeneration !== null &&
-      row.indexedGeneration.startsWith(`${generation}_`)
-        ? [{ id: row.id, oldIndexId: row.indexedGeneration }]
-        : [],
-    );
-    let staleError: CorpusIndexError | null = null;
-    for (const entry of moved) {
-      // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
-      const removed = await removeLegislationFromCorpusIndex(
-        entry.id,
-        scopedDb,
-        entry.oldIndexId,
-      );
-      if (removed.isErr()) {
-        staleError = removed.error;
-        break;
-      }
-    }
-    if (staleError) {
-      firstError ??= staleError;
-      continue;
-    }
-
-    // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
-    const ensured = await ensureIndex(indexId);
-    const ingest = ensured.isErr()
-      ? ensured
-      : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
-        await getCorpusIndexClient().ingestBatch(
-          indexId,
-          group.map(({ doc }) => JSON.stringify(doc)).join("\n"),
-        );
-
-    if (ingest.isErr()) {
-      firstError ??= ingest.error;
-      // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
-      await recordJobs(
-        scopedDb,
-        group.map(({ row }) => ({
-          documentId: row.id,
-          contentHash: row.contentHash,
-          operation: "index" as const,
-          status: "failed" as const,
-          errorMessage: ingest.error.message.slice(0, 2048),
-        })),
-        indexId,
-      );
-      continue;
-    }
-
-    const casMissed = new Set<SafeId<"legislationDocument">>();
-    // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per group; sequential to keep index writes and audit rows consistent
-    await scopedDb(async (tx) => {
-      // audit: skip — search index maintenance; rebuilds derived state
-      for (const { row } of group) {
-        // Compare-and-set on the selected row state: a concurrent
-        // re-ingest clears indexedHash (possibly leaving it null-to-null
-        // when the row was already pending) and bumps updatedAt, and an
-        // unconditional write would mask that refresh so the stale index
-        // document would never be retried.
-        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
-        const marked = await tx
-          .update(legislationDocuments)
-          .set({
-            indexedHash: row.contentHash,
-            indexedGeneration: indexId,
-            indexedAt: now,
-          })
-          .where(
-            and(
-              eq(legislationDocuments.id, row.id),
-              sql`${legislationDocuments.indexedHash} IS NOT DISTINCT FROM ${row.indexedHash}`,
-              sql`${legislationDocuments.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
-            ),
-          )
-          .returning({ id: legislationDocuments.id });
-        if (marked.length === 0) {
-          casMissed.add(row.id);
-        }
-      }
-      const markedRows = group.filter(({ row }) => !casMissed.has(row.id));
-      if (markedRows.length > 0) {
-        await tx.insert(legislationIndexJobs).values(
-          markedRows.map(({ row }) => ({
-            documentId: row.id,
-            generation: indexId,
-            operation: "index" as const,
-            status: "succeeded" as const,
-            contentHash: row.contentHash,
-          })),
-        );
-      }
-    });
-    // A missed CAS means a refresh outpaced this batch after the ingest
-    // appended its document: the row carries no generation pointer to it,
-    // so delete the unrecorded copy now; the refreshed row is re-indexed
-    // by a later cycle.
-    for (const missedId of casMissed) {
-      // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
-      const removed = await removeLegislationFromCorpusIndex(
-        missedId,
-        scopedDb,
-        indexId,
-      );
-      if (removed.isErr()) {
-        firstError ??= removed.error;
-      }
-    }
-    indexed += group.length - casMissed.size;
-  }
-
-  if (firstError) {
-    // eslint-disable-next-line no-throw-literal -- CorpusIndexError (TaggedError); rethrow to abort the batch for retry
-    throw firstError;
-  }
-
-  return indexed;
-};
-
-type JobInput = {
-  documentId: SafeId<"legislationDocument">;
-  contentHash: string | null;
-  operation: "index" | "delete" | "redact" | "rebuild";
-  status: "succeeded" | "failed";
-  errorMessage?: string;
-};
-
-const recordJobs = async (
-  scopedDb: ScopedDb,
-  jobs: readonly JobInput[],
-  generation: string,
-): Promise<void> => {
-  if (jobs.length === 0) {
-    return;
-  }
-  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-  await scopedDb((tx) => {
+  },
+  markIndexed: async (tx, { row, indexId, now }) => {
+    // audit: skip — search index maintenance; rebuilds derived state
+    const marked = await tx
+      .update(legislationDocuments)
+      .set({
+        indexedHash: row.contentHash,
+        indexedGeneration: indexId,
+        indexedAt: now,
+      })
+      .where(
+        and(
+          eq(legislationDocuments.id, row.id),
+          sql`${legislationDocuments.indexedHash} IS NOT DISTINCT FROM ${row.indexedHash}`,
+          sql`${legislationDocuments.updatedAt} IS NOT DISTINCT FROM ${row.updatedAt}`,
+        ),
+      )
+      .returning({ id: legislationDocuments.id });
+    return marked.length > 0;
+  },
+  insertSucceededJobs: async (tx, { rows, indexId }) => {
     // audit: skip — append-only index-job rows ARE the indexing audit trail
-    return tx.insert(legislationIndexJobs).values(
-      jobs.map((job) => ({
-        documentId: job.documentId,
-        generation,
-        operation: job.operation,
-        status: job.status,
-        contentHash: job.contentHash,
-        errorMessage: job.errorMessage ?? null,
+    await tx.insert(legislationIndexJobs).values(
+      rows.map((row) => ({
+        documentId: row.id,
+        generation: indexId,
+        operation: "index" as const,
+        status: "succeeded" as const,
+        contentHash: row.contentHash,
       })),
     );
-  });
-};
+  },
+  recordJobs: async (scopedDb, jobs, generation) => {
+    if (jobs.length === 0) {
+      return;
+    }
+    // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+    await scopedDb((tx) => {
+      // audit: skip — append-only index-job rows ARE the indexing audit trail
+      return tx.insert(legislationIndexJobs).values(
+        jobs.map((job) => ({
+          documentId: job.entityId,
+          generation,
+          operation: job.operation,
+          status: job.status,
+          contentHash: job.contentHash,
+          errorMessage: job.errorMessage ?? null,
+        })),
+      );
+    });
+  },
+});
 
-export const removeLegislationFromCorpusIndex = async (
-  documentId: SafeId<"legislationDocument">,
-  scopedDb: ScopedDb,
-  indexId: string,
-  operation: "delete" | "redact" = "delete",
-): Promise<Result<void, CorpusIndexError>> => {
-  const result = await getCorpusIndexClient().deleteByQuery(
-    indexId,
-    `document_id:"${documentId}"`,
-  );
-  await recordJobs(
-    scopedDb,
-    [
-      {
-        documentId,
-        contentHash: null,
-        operation,
-        status: result.isErr() ? "failed" : "succeeded",
-        ...(result.isErr()
-          ? { errorMessage: result.error.message.slice(0, 2048) }
-          : {}),
-      },
-    ],
-    indexId,
-  );
-  return result;
-};
+export const loadDocsForBatch = indexer.loadDocsForBatch;
+export const backfillLegislationCorpusIndex = indexer.backfill;
+export const removeLegislationFromCorpusIndex = indexer.remove;

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -1,0 +1,485 @@
+import { Result } from "better-result";
+
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
+import { captureError } from "@/api/lib/analytics/capture";
+import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
+import {
+  getCorpusIndexClient,
+  type CorpusIndexError,
+} from "@/api/lib/legal-search/corpus-index-client";
+import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+
+/**
+ * Shared corpus-index search-projection core for the corpus document families
+ * (case_law, legislation). A backfill loop indexes corpus-backed rows whose
+ * content changed or that are missing from the active generation; the license
+ * gate lives in each family's SQL filter so non-redistributable sources never
+ * enter the scan. Every mutation is recorded in the family's index-jobs audit
+ * trail. Each family plugs in a thin {@link CorpusIndexAdapter} that supplies
+ * the domain surface (tables, batch queries, per-row document shape); this
+ * module owns the orchestration, bounded-concurrency S3 loads, per-group commit
+ * with compare-and-set, and the read-failure isolation that are identical
+ * across families.
+ */
+
+const INDEX_CONCURRENCY = 4;
+
+/**
+ * The row fields the shared core reads directly. Each family's own row type
+ * extends this with its document-shaped columns, which only its
+ * {@link CorpusIndexAdapter.buildDoc} touches.
+ */
+export type CorpusIndexRow<TBrand extends SafeIdType> = {
+  id: SafeId<TBrand>;
+  country: string;
+  textS3Key: string | null;
+  contentHash: string | null;
+  indexedHash: string | null;
+  indexedGeneration: string | null;
+  updatedAt: Date;
+};
+
+/** One audit-trail entry for a corpus index-jobs row. */
+export type CorpusJobInput<TBrand extends SafeIdType> = {
+  entityId: SafeId<TBrand>;
+  contentHash: string | null;
+  operation: "index" | "delete" | "redact" | "rebuild";
+  status: "succeeded" | "failed";
+  errorMessage?: string;
+};
+
+/** Lazy Postgres fulltext fallback for rows without a canonical S3 object. */
+export type FetchFulltext<TBrand extends SafeIdType> = (
+  id: SafeId<TBrand>,
+) => Promise<string | null>;
+
+type SelectBatchArgs = { generation: string; limit: number };
+
+/**
+ * Family-specific surface consumed by the shared core. Everything that touches
+ * a family's Drizzle tables or its per-document shape lives here; the core
+ * never references a concrete table. Implementations are the thin adapters in
+ * each `handlers/<family>/corpus-index.ts`.
+ */
+export type CorpusIndexAdapter<
+  TBrand extends SafeIdType,
+  TRow extends CorpusIndexRow<TBrand>,
+> = {
+  /** Selects the index field mapping / config version for this family. */
+  family: CorpusFamily;
+  /** Telemetry step label for isolated read failures. */
+  captureStep: string;
+  /** Build the corpus index search document, omitting empty optional fields. */
+  buildDoc: (row: TRow, text: string) => Record<string, unknown>;
+  /**
+   * Rows not yet in this generation (missing). Ordered oldest-first, bounded by
+   * `limit`; the license gate is applied in the query.
+   */
+  selectMissing: (scopedDb: ScopedDb, args: SelectBatchArgs) => Promise<TRow[]>;
+  /**
+   * Rows in this generation whose content changed since last push (stale).
+   * Ordered oldest-first, bounded by `limit`; license gate applied in-query.
+   */
+  selectStale: (scopedDb: ScopedDb, args: SelectBatchArgs) => Promise<TRow[]>;
+  /** Lazy per-row Postgres fulltext fallback (rows without a corpus object). */
+  fetchFulltext: (
+    scopedDb: ScopedDb,
+    id: SafeId<TBrand>,
+  ) => Promise<string | null>;
+  /**
+   * Compare-and-set the selected row state to indexed, within the caller's
+   * transaction. Returns whether the row was marked (false = a concurrent
+   * refresh moved it on, so the caller treats it as a CAS miss).
+   */
+  markIndexed: (
+    tx: Transaction,
+    args: { row: TRow; indexId: string; now: Date },
+  ) => Promise<boolean>;
+  /** Insert succeeded index-job audit rows within the caller's transaction. */
+  insertSucceededJobs: (
+    tx: Transaction,
+    args: { rows: readonly TRow[]; indexId: string },
+  ) => Promise<void>;
+  /** Append index-job audit rows (failed reads/ingests, deletes) via scopedDb. */
+  recordJobs: (
+    scopedDb: ScopedDb,
+    jobs: readonly CorpusJobInput<TBrand>[],
+    generation: string,
+  ) => Promise<void>;
+};
+
+export type LoadedBatch<TBrand extends SafeIdType, TRow> = {
+  docs: { row: TRow; doc: Record<string, unknown> }[];
+  readFailures: {
+    indexId: string;
+    job: CorpusJobInput<TBrand>;
+    cause: unknown;
+  }[];
+};
+
+export type LoadDocsForBatchOptions<TBrand extends SafeIdType, TRow> = {
+  generation: string;
+  fetchFulltext: FetchFulltext<TBrand>;
+  /** Override the per-row text load (test seam). */
+  readText?: (row: TRow) => Promise<string>;
+};
+
+const loadText = async <
+  TBrand extends SafeIdType,
+  TRow extends CorpusIndexRow<TBrand>,
+>(
+  row: TRow,
+  fetchFulltext: FetchFulltext<TBrand>,
+): Promise<string> => {
+  // No catch-and-fallback here: a read failure propagates so the caller
+  // can isolate this document (record it failed, drop it from the batch) and
+  // retry it next cycle. Swallowing it and indexing empty text would then
+  // record indexedHash = contentHash, permanently pinning a broken entry.
+  if (row.textS3Key !== null) {
+    return await readCorpusText(row.textS3Key);
+  }
+  // Only rows without a corpus object read their Postgres fulltext, one
+  // small bounded query per such row; the batch SELECT never carries text.
+  return (await fetchFulltext(row.id)) ?? "";
+};
+
+/**
+ * Bound corpus indexer for one document family. Instantiate once per family at
+ * module scope so the per-process `ensuredIndexes` cache is shared across
+ * batches. Exposes the family's route-facing operations, which each handler
+ * re-exports under its established names.
+ */
+export const createCorpusIndexer = <
+  TBrand extends SafeIdType,
+  TRow extends CorpusIndexRow<TBrand>,
+>(
+  adapter: CorpusIndexAdapter<TBrand, TRow>,
+) => {
+  // Per-jurisdiction indexes are created on first write. Cache the ids we
+  // have confirmed this process so we don't probe corpus index every batch.
+  const ensuredIndexes = new Set<string>();
+
+  const ensureIndex = async (
+    indexId: string,
+  ): Promise<Result<void, CorpusIndexError>> => {
+    if (ensuredIndexes.has(indexId)) {
+      return Result.ok(undefined);
+    }
+    const client = getCorpusIndexClient();
+    const exists = await client.indexExists(indexId);
+    if (exists.isErr()) {
+      return Result.err(exists.error);
+    }
+    if (!exists.value) {
+      const created = await client.createIndex(
+        corpusIndexConfig(adapter.family, indexId),
+      );
+      if (created.isErr()) {
+        return Result.err(created.error);
+      }
+    }
+    ensuredIndexes.add(indexId);
+    return Result.ok(undefined);
+  };
+
+  /**
+   * Build each row's index document from its canonical text, isolating per-row
+   * read failures. A bounded corpus read that times out or errors fails only
+   * its own document: that row is collected as a failed index job and dropped
+   * from the batch (never marked indexed, so a later cycle retries it), while
+   * its batch-mates still commit. Reads run in bounded-concurrency chunks so S3
+   * pressure stays capped. `readText` is injectable so the isolation can be
+   * exercised without a live object store.
+   */
+  const loadDocsForBatch = async (
+    rows: readonly TRow[],
+    {
+      generation,
+      fetchFulltext,
+      readText,
+    }: LoadDocsForBatchOptions<TBrand, TRow>,
+  ): Promise<LoadedBatch<TBrand, TRow>> => {
+    const loadRowText =
+      readText ?? (async (row: TRow) => await loadText(row, fetchFulltext));
+    const docs: LoadedBatch<TBrand, TRow>["docs"] = [];
+    const readFailures: LoadedBatch<TBrand, TRow>["readFailures"] = [];
+    for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
+      const chunk = rows.slice(i, i + INDEX_CONCURRENCY);
+      // oxlint-disable-next-line no-await-in-loop -- bounded concurrency: drain one INDEX_CONCURRENCY chunk before loading the next so S3 reads stay capped
+      const built = await Promise.all(
+        chunk.map(async (row) => {
+          try {
+            return {
+              ok: true as const,
+              row,
+              doc: adapter.buildDoc(row, await loadRowText(row)),
+            };
+          } catch (error) {
+            return { ok: false as const, row, error };
+          }
+        }),
+      );
+      for (const entry of built) {
+        if (entry.ok) {
+          docs.push({ row: entry.row, doc: entry.doc });
+          continue;
+        }
+        readFailures.push({
+          indexId: corpusIndexId(generation, entry.row.country),
+          cause: entry.error,
+          job: {
+            entityId: entry.row.id,
+            contentHash: entry.row.contentHash,
+            operation: "index",
+            status: "failed",
+            errorMessage: (entry.error instanceof Error
+              ? entry.error.message
+              : String(entry.error)
+            ).slice(0, 2048),
+          },
+        });
+      }
+    }
+    return { docs, readFailures };
+  };
+
+  /**
+   * Fail loud, continue: record isolated per-document read failures. Captures
+   * the underlying (tagged) error with jurisdiction/generation context — never
+   * document text — and writes a failed index job (the established audit
+   * convention) under each affected jurisdiction index. The rows stay
+   * unindexed, so a later cycle retries them while the batch's healthy
+   * documents proceed.
+   */
+  const recordReadFailures = async (
+    scopedDb: ScopedDb,
+    readFailures: LoadedBatch<TBrand, TRow>["readFailures"],
+    generation: string,
+  ): Promise<void> => {
+    const firstFailure = readFailures.at(0);
+    if (!firstFailure) {
+      return;
+    }
+    captureError(firstFailure.cause, {
+      step: adapter.captureStep,
+      generation,
+      failed: String(readFailures.length),
+    });
+    const failuresByIndex = new Map<string, CorpusJobInput<TBrand>[]>();
+    for (const { indexId, job } of readFailures) {
+      const existing = failuresByIndex.get(indexId);
+      if (existing) {
+        existing.push(job);
+      } else {
+        failuresByIndex.set(indexId, [job]);
+      }
+    }
+    for (const [indexId, jobs] of failuresByIndex) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential per-index audit writes preserve job ordering
+      await adapter.recordJobs(scopedDb, jobs, indexId);
+    }
+  };
+
+  /**
+   * Remove a document from a corpus index generation (GDPR/takedown). Uses a
+   * delete-task (corpus index's async delete path) and records the operation.
+   */
+  const remove = async (
+    entityId: SafeId<TBrand>,
+    scopedDb: ScopedDb,
+    indexId: string,
+    operation: "delete" | "redact" = "delete",
+  ): Promise<Result<void, CorpusIndexError>> => {
+    const result = await getCorpusIndexClient().deleteByQuery(
+      indexId,
+      `document_id:"${entityId}"`,
+    );
+    await adapter.recordJobs(
+      scopedDb,
+      [
+        {
+          entityId,
+          contentHash: null,
+          operation,
+          status: result.isErr() ? "failed" : "succeeded",
+          ...(result.isErr()
+            ? { errorMessage: result.error.message.slice(0, 2048) }
+            : {}),
+        },
+      ],
+      indexId,
+    );
+    return result;
+  };
+
+  /**
+   * Index a batch of corpus-backed rows into the given generation. Two-query
+   * missing/stale split mirrors backfillSearchIndex: `missing` = not yet in
+   * this generation; `stale` = content changed since last push. Reserves a
+   * quarter of the batch for stale so re-indexes are not starved by a
+   * missing-doc backlog. Returns the number indexed.
+   */
+  const backfill = async (
+    scopedDb: ScopedDb,
+    batchSize: number,
+    generation: string,
+  ): Promise<number> => {
+    const staleReserved = Math.max(1, Math.floor(batchSize / 4));
+    const missingLimit = Math.max(1, batchSize - staleReserved);
+
+    const missing = await adapter.selectMissing(scopedDb, {
+      generation,
+      limit: missingLimit,
+    });
+
+    const staleLimit = batchSize - missing.length;
+    const stale =
+      staleLimit <= 0
+        ? []
+        : await adapter.selectStale(scopedDb, {
+            generation,
+            limit: staleLimit,
+          });
+
+    const rows: TRow[] = [...missing, ...stale];
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
+    // A per-document read failure fails only that document; record it and let
+    // the rest still commit.
+    const fetchFulltext: FetchFulltext<TBrand> = (id) =>
+      adapter.fetchFulltext(scopedDb, id);
+    const { docs, readFailures } = await loadDocsForBatch(rows, {
+      generation,
+      fetchFulltext,
+    });
+    await recordReadFailures(scopedDb, readFailures, generation);
+
+    // Route each doc to its jurisdiction's index (<family>_v1_<country>),
+    // grouping so each index gets one NDJSON ingest. A group that fails to
+    // ensure/ingest is recorded and retried next cycle; other groups still
+    // commit.
+    const groups = new Map<string, typeof docs>();
+    for (const entry of docs) {
+      const indexId = corpusIndexId(generation, entry.row.country);
+      const group = groups.get(indexId);
+      if (group) {
+        group.push(entry);
+      } else {
+        groups.set(indexId, [entry]);
+      }
+    }
+
+    const now = new Date();
+    let indexed = 0;
+    let firstError: CorpusIndexError | null = null;
+
+    for (const [indexId, group] of groups) {
+      // Ingest appends; it never replaces. Before re-ingesting, delete the
+      // previously indexed copy from wherever it lives (the same index for
+      // a content refresh, another jurisdiction index for a corrected
+      // country), or stale copies keep matching old text. Same generation
+      // only: generation rebuilds replace whole indexes. Engine delete
+      // tasks only affect splits that already exist, so the copy ingested
+      // below is not at risk.
+      const moved = group.flatMap(({ row }) =>
+        row.indexedGeneration !== null &&
+        row.indexedGeneration.startsWith(`${generation}_`)
+          ? [{ id: row.id, oldIndexId: row.indexedGeneration }]
+          : [],
+      );
+      let staleError: CorpusIndexError | null = null;
+      for (const entry of moved) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential deletes that early-break on the first error
+        const removed = await remove(entry.id, scopedDb, entry.oldIndexId);
+        if (removed.isErr()) {
+          staleError = removed.error;
+          break;
+        }
+      }
+      if (staleError) {
+        firstError ??= staleError;
+        continue;
+      }
+
+      // oxlint-disable-next-line no-await-in-loop -- per-jurisdiction indexes are ensured/ingested sequentially to avoid overwhelming the search backend
+      const ensured = await ensureIndex(indexId);
+      const ingest = ensured.isErr()
+        ? ensured
+        : // oxlint-disable-next-line no-await-in-loop -- sequential per-group ingest paces NDJSON pushes to the search backend
+          await getCorpusIndexClient().ingestBatch(
+            indexId,
+            group.map(({ doc }) => JSON.stringify(doc)).join("\n"),
+          );
+
+      if (ingest.isErr()) {
+        firstError ??= ingest.error;
+        // oxlint-disable-next-line no-await-in-loop -- sequential per-group audit write preserves job ordering
+        await adapter.recordJobs(
+          scopedDb,
+          group.map(({ row }) => ({
+            entityId: row.id,
+            contentHash: row.contentHash,
+            operation: "index" as const,
+            status: "failed" as const,
+            errorMessage: ingest.error.message.slice(0, 2048),
+          })),
+          indexId,
+        );
+        continue;
+      }
+
+      const casMissed = new Set<SafeId<TBrand>>();
+      // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per group; sequential to keep index writes and audit rows consistent
+      await scopedDb(async (tx) => {
+        // audit: skip — search index maintenance; rebuilds derived state
+        for (const { row } of group) {
+          // Compare-and-set on the selected row state: a concurrent
+          // re-ingest clears indexedHash (possibly leaving it null-to-null
+          // when the row was already pending) and bumps updatedAt, and an
+          // unconditional write would mask that refresh so the stale index
+          // document would never be retried.
+          // oxlint-disable-next-line no-await-in-loop -- sequential CAS updates within the transaction; ordering preserved
+          const marked = await adapter.markIndexed(tx, { row, indexId, now });
+          if (!marked) {
+            casMissed.add(row.id);
+          }
+        }
+        const markedRows = group
+          .filter(({ row }) => !casMissed.has(row.id))
+          .map(({ row }) => row);
+        if (markedRows.length > 0) {
+          await adapter.insertSucceededJobs(tx, { rows: markedRows, indexId });
+        }
+      });
+      // A missed CAS means a refresh outpaced this batch after the ingest
+      // appended its document: the row carries no generation pointer to it,
+      // so delete the unrecorded copy now; the refreshed row is re-indexed
+      // by a later cycle.
+      for (const missedId of casMissed) {
+        // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
+        const removed = await remove(missedId, scopedDb, indexId);
+        if (removed.isErr()) {
+          firstError ??= removed.error;
+        }
+      }
+      indexed += group.length - casMissed.size;
+    }
+
+    // Surface a failure so the daemon retries the un-indexed groups.
+    if (firstError) {
+      // eslint-disable-next-line no-throw-literal -- CorpusIndexError (TaggedError); rethrow to abort the batch for retry
+      throw firstError;
+    }
+
+    return indexed;
+  };
+
+  return { loadDocsForBatch, backfill, remove };
+};

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -2,7 +2,6 @@ import { Result } from "better-result";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
-import { readCorpusText } from "@/api/handlers/case-law/corpus-storage";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
@@ -76,6 +75,12 @@ export type CorpusIndexAdapter<
   /** Build the corpus index search document, omitting empty optional fields. */
   buildDoc: (row: TRow, text: string) => Record<string, unknown>;
   /**
+   * Read the canonical corpus text object for a row's `textS3Key`. Supplied
+   * by the family adapter (not imported directly) so the shared core stays
+   * free of a hard dependency on any one family's object-storage module.
+   */
+  readCorpusText: (key: string) => Promise<string>;
+  /**
    * Rows not yet in this generation (missing). Ordered oldest-first, bounded by
    * `limit`; the license gate is applied in the query.
    */
@@ -128,12 +133,10 @@ export type LoadDocsForBatchOptions<TBrand extends SafeIdType, TRow> = {
   readText?: (row: TRow) => Promise<string>;
 };
 
-const loadText = async <
-  TBrand extends SafeIdType,
-  TRow extends CorpusIndexRow<TBrand>,
->(
-  row: TRow,
+const loadText = async <TBrand extends SafeIdType>(
+  row: CorpusIndexRow<TBrand>,
   fetchFulltext: FetchFulltext<TBrand>,
+  readCorpusText: (key: string) => Promise<string>,
 ): Promise<string> => {
   // No catch-and-fallback here: a read failure propagates so the caller
   // can isolate this document (record it failed, drop it from the batch) and
@@ -204,7 +207,9 @@ export const createCorpusIndexer = <
     }: LoadDocsForBatchOptions<TBrand, TRow>,
   ): Promise<LoadedBatch<TBrand, TRow>> => {
     const loadRowText =
-      readText ?? (async (row: TRow) => await loadText(row, fetchFulltext));
+      readText ??
+      (async (row: TRow) =>
+        await loadText(row, fetchFulltext, adapter.readCorpusText));
     const docs: LoadedBatch<TBrand, TRow>["docs"] = [];
     const readFailures: LoadedBatch<TBrand, TRow>["readFailures"] = [];
     for (let i = 0; i < rows.length; i += INDEX_CONCURRENCY) {
@@ -353,8 +358,8 @@ export const createCorpusIndexer = <
     // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
     // A per-document read failure fails only that document; record it and let
     // the rest still commit.
-    const fetchFulltext: FetchFulltext<TBrand> = (id) =>
-      adapter.fetchFulltext(scopedDb, id);
+    const fetchFulltext: FetchFulltext<TBrand> = async (id) =>
+      await adapter.fetchFulltext(scopedDb, id);
     const { docs, readFailures } = await loadDocsForBatch(rows, {
       generation,
       fetchFulltext,


### PR DESCRIPTION
The case-law and legislation corpus-index handlers were near-identical
copies of one S3-chunked-load / sequential-ingest / compare-and-set audit
algorithm; every change had to land twice. Extract that orchestration into
lib/corpus-index/core.ts, parameterized over a per-family adapter that
supplies the domain surface (tables, batch queries, per-document shape,
audit-job writes).

Each handler keeps its route-facing exports (backfillCorpusIndex /
backfillLegislationCorpusIndex, removeDecisionFromCorpusIndex /
removeLegislationFromCorpusIndex, loadDocsForBatch) as thin re-exports of
the bound indexer, so callers need no changes. The per-process
ensuredIndexes cache stays one-per-family. The no-await-in-loop rationale
comments on the sequential ingest/CAS/delete paths move into the core,
once. Behavior is unchanged; the neutral entityId field on the shared
job-input type maps to each family's decisionId/documentId column in its
adapter.

Moving readCorpusText into the core also removes the legislation handler's
cross-domain import of case-law/corpus-storage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved corpus indexing reliability for case law and legislation.
  - Documents can now be indexed using available full text when a canonical stored copy is unavailable.
  - Individual document read failures are isolated, allowing healthy documents in the same batch to continue processing.
  - Index updates and removals now provide more consistent status and failure records.
  - Improved handling of outdated or missing indexed content to support more accurate search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->