### PR TITLE
chore(api): cover docx-suggestions and guard cross-tenant matrix completeness

### DIFF
--- a/apps/api/src/handlers/docx-suggestions/cursor.property.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/cursor.property.test.ts
@@ -3,7 +3,11 @@ import fc from "fast-check";
 
 import { propertyConfig } from "@stll/property-testing";
 
-import { encodePaginationCursor } from "@/api/lib/pagination";
+import {
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+  parseDateTimePaginationCursorPart,
+} from "@/api/lib/pagination";
 import { brandPersistedDocxSuggestionId } from "@/api/lib/safe-id-boundaries";
 
 import {
@@ -16,15 +20,12 @@ import {
 // cannot is the Invalid Date, which the encoder never produces.
 const validDate = fc.date({ noInvalidDate: true });
 
-// Local copies of the shapes the codec accepts, used only to filter generators
-// away from the (astronomically unlikely) case where a random string is itself
-// a valid part.
-const uuidCursorPartPattern =
-  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
-const isDateTimeCursorPart = (value: string): boolean => {
-  const parsed = new Date(value);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
-};
+// Filter predicate to steer generators away from the (astronomically
+// unlikely) case where a random string is itself a valid part. Reuses the
+// production decoder's own predicates so the test preconditions can never
+// drift from what `decodeDocxSuggestionCursor` actually accepts.
+const isDateTimeCursorPart = (value: string): boolean =>
+  parseDateTimePaginationCursorPart(value) !== null;
 
 describe("docx suggestion cursor codec (properties)", () => {
   test("decode ∘ encode recovers the (createdAt, id) pair", () => {
@@ -92,7 +93,7 @@ describe("docx suggestion cursor codec (properties)", () => {
   test("a non-UUID id part decodes to null", () => {
     fc.assert(
       fc.property(validDate, fc.string(), (createdAt, rawId) => {
-        fc.pre(!uuidCursorPartPattern.test(rawId));
+        fc.pre(!isUuidPaginationCursorPart(rawId));
         expect(
           decodeDocxSuggestionCursor(
             encodePaginationCursor([createdAt.toISOString(), rawId]),

--- a/apps/api/src/handlers/docx-suggestions/cursor.property.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/cursor.property.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import { encodePaginationCursor } from "@/api/lib/pagination";
+import { brandPersistedDocxSuggestionId } from "@/api/lib/safe-id-boundaries";
+
+import {
+  decodeDocxSuggestionCursor,
+  encodeDocxSuggestionCursor,
+} from "./cursor";
+
+// The cursor is exactly `(created_at ISO string, suggestion uuid)`. Any value
+// in the `Date` range round-trips through `toISOString()`; the only value that
+// cannot is the Invalid Date, which the encoder never produces.
+const validDate = fc.date({ noInvalidDate: true });
+
+// Local copies of the shapes the codec accepts, used only to filter generators
+// away from the (astronomically unlikely) case where a random string is itself
+// a valid part.
+const uuidCursorPartPattern =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
+const isDateTimeCursorPart = (value: string): boolean => {
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+};
+
+describe("docx suggestion cursor codec (properties)", () => {
+  test("decode ∘ encode recovers the (createdAt, id) pair", () => {
+    fc.assert(
+      fc.property(validDate, fc.uuid(), (createdAt, rawId) => {
+        const id = brandPersistedDocxSuggestionId(rawId);
+        const decoded = decodeDocxSuggestionCursor(
+          encodeDocxSuggestionCursor({ createdAt, id }),
+        );
+        expect(decoded).not.toBeNull();
+        expect(decoded?.createdAt).toEqual(createdAt);
+        expect(decoded?.id).toBe(id);
+      }),
+      propertyConfig({ numRuns: 500 }),
+    );
+  });
+
+  test("decode never throws and yields a valid cursor or null for any string", () => {
+    fc.assert(
+      fc.property(fc.string(), (raw) => {
+        const decoded = decodeDocxSuggestionCursor(raw);
+        expect(
+          decoded === null ||
+            (decoded.createdAt instanceof Date &&
+              typeof decoded.id === "string"),
+        ).toBe(true);
+      }),
+      propertyConfig({ numRuns: 500 }),
+    );
+  });
+
+  test("a well-formed but non-array payload decodes to null", () => {
+    const nonArray = fc.oneof(
+      fc.string(),
+      fc.integer(),
+      fc.boolean(),
+      fc.constant(null),
+      fc.dictionary(fc.string(), fc.string()),
+    );
+    fc.assert(
+      fc.property(nonArray, (value) => {
+        const encoded = Buffer.from(JSON.stringify(value)).toString(
+          "base64url",
+        );
+        expect(decodeDocxSuggestionCursor(encoded)).toBeNull();
+      }),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+
+  test("a payload that is not a 2-tuple decodes to null", () => {
+    const wrongArity = fc
+      .array(fc.oneof(fc.string(), fc.integer()))
+      .filter((parts) => parts.length !== 2);
+    fc.assert(
+      fc.property(wrongArity, (parts) => {
+        expect(
+          decodeDocxSuggestionCursor(encodePaginationCursor(parts)),
+        ).toBeNull();
+      }),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+
+  test("a non-UUID id part decodes to null", () => {
+    fc.assert(
+      fc.property(validDate, fc.string(), (createdAt, rawId) => {
+        fc.pre(!uuidCursorPartPattern.test(rawId));
+        expect(
+          decodeDocxSuggestionCursor(
+            encodePaginationCursor([createdAt.toISOString(), rawId]),
+          ),
+        ).toBeNull();
+      }),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+
+  test("a non-datetime created-at part decodes to null", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.uuid(), (rawCreatedAt, rawId) => {
+        fc.pre(!isDateTimeCursorPart(rawCreatedAt));
+        expect(
+          decodeDocxSuggestionCursor(
+            encodePaginationCursor([rawCreatedAt, rawId]),
+          ),
+        ).toBeNull();
+      }),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+});

--- a/apps/api/src/handlers/docx-suggestions/resolve-revert.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/resolve-revert.test.ts
@@ -243,7 +243,7 @@ const createWorkspaceContext = ({
 const runHandler = async <TContext>(
   endpoint: { handler: (context: TContext) => Promise<unknown> },
   context: WorkspaceTestContext,
-  requestShape: Record<string, unknown>,
+  requestShape: Partial<TContext> & Record<string, unknown>,
 ): Promise<unknown> => {
   try {
     return await endpoint.handler(

--- a/apps/api/src/handlers/docx-suggestions/resolve-revert.test.ts
+++ b/apps/api/src/handlers/docx-suggestions/resolve-revert.test.ts
@@ -1,0 +1,255 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import { docxSuggestions } from "@/api/db/schema";
+import { createSafeDb, createScopedDb } from "@/api/db/scoped";
+import resolveDocxSuggestion from "@/api/handlers/docx-suggestions/resolve";
+import revertDocxSuggestion from "@/api/handlers/docx-suggestions/revert";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type {
+  TestDatabase,
+  TestDatabaseTransaction,
+} from "@/api/tests/security/test-utils";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+
+setDefaultTimeout(120_000);
+
+type WorkspaceTestContext = {
+  memberRole: { role: "owner" };
+  request: Request;
+  route: string;
+  safeDb: ReturnType<typeof createSafeDb<TestDatabaseTransaction>>;
+  scopedDb: ReturnType<typeof createScopedDb<TestDatabaseTransaction>>;
+  session: { activeOrganizationId: SafeId<"organization"> };
+  user: { id: SafeId<"user"> };
+  workspaceId: SafeId<"workspace">;
+};
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+describe("docx suggestion resolve/revert state transitions", () => {
+  test("resolving a pending suggestion records the resolution and rejects a second resolve", async () => {
+    const suggestionId = await insertSuggestion();
+    const context = workspaceAContext();
+    const params = {
+      workspaceId: ids.wsA1,
+      entityId: ids.entityA1,
+      suggestionId,
+    };
+
+    const first = await runHandler(resolveDocxSuggestion, context, {
+      params,
+      body: { status: "accepted", appliedMode: "direct" },
+    });
+    expect(first).toEqual({ updated: true });
+
+    const afterFirst = await readSuggestion(suggestionId);
+    expect(afterFirst?.status).toBe("accepted");
+    expect(afterFirst?.appliedMode).toBe("direct");
+    expect(afterFirst?.resolvedByUserId).toBe(ids.userA1);
+
+    // A second resolve finds no pending row (WHERE status = 'pending'): the
+    // affected-row count is authoritative, so this is a `{ updated: false }`
+    // no-op rather than a silent double-write that would overwrite the mode.
+    const second = await runHandler(resolveDocxSuggestion, context, {
+      params,
+      body: { status: "rejected" },
+    });
+    expect(second).toEqual({ updated: false });
+
+    const afterSecond = await readSuggestion(suggestionId);
+    expect(afterSecond?.status).toBe("accepted");
+    expect(afterSecond?.appliedMode).toBe("direct");
+  });
+
+  test("rejecting a pending suggestion stores no applied mode", async () => {
+    const suggestionId = await insertSuggestion();
+
+    const result = await runHandler(
+      resolveDocxSuggestion,
+      workspaceAContext(),
+      {
+        params: { workspaceId: ids.wsA1, entityId: ids.entityA1, suggestionId },
+        body: { status: "rejected" },
+      },
+    );
+    expect(result).toEqual({ updated: true });
+
+    const row = await readSuggestion(suggestionId);
+    expect(row?.status).toBe("rejected");
+    expect(row?.appliedMode).toBeNull();
+    expect(row?.resolvedByUserId).toBe(ids.userA1);
+  });
+
+  test("reverting a resolved suggestion clears the trail and rejects a second revert", async () => {
+    const suggestionId = await insertSuggestion({
+      status: "accepted",
+      appliedMode: "direct",
+      resolvedByUserId: ids.userA1,
+      resolvedAt: new Date(),
+    });
+    const context = workspaceAContext();
+    const params = {
+      workspaceId: ids.wsA1,
+      entityId: ids.entityA1,
+      suggestionId,
+    };
+
+    const first = await runHandler(revertDocxSuggestion, context, { params });
+    expect(first).toEqual({ updated: true });
+
+    const afterFirst = await readSuggestion(suggestionId);
+    expect(afterFirst?.status).toBe("pending");
+    expect(afterFirst?.appliedMode).toBeNull();
+    expect(afterFirst?.resolvedByUserId).toBeNull();
+
+    const second = await runHandler(revertDocxSuggestion, context, { params });
+    expect(second).toEqual({ updated: false });
+  });
+
+  test("reverting an already-pending suggestion is a no-op", async () => {
+    const suggestionId = await insertSuggestion();
+
+    const result = await runHandler(revertDocxSuggestion, workspaceAContext(), {
+      params: { workspaceId: ids.wsA1, entityId: ids.entityA1, suggestionId },
+    });
+    expect(result).toEqual({ updated: false });
+
+    const row = await readSuggestion(suggestionId);
+    expect(row?.status).toBe("pending");
+  });
+
+  test("a workspace cannot resolve another workspace's suggestion", async () => {
+    // The row lives in workspace A; workspace B's scoped connection cannot see
+    // it, so the RLS-guarded UPDATE affects zero rows even though the params
+    // name A's ids. The row must remain untouched.
+    const suggestionId = await insertSuggestion();
+
+    const result = await runHandler(
+      resolveDocxSuggestion,
+      workspaceBContext(),
+      {
+        params: { workspaceId: ids.wsA1, entityId: ids.entityA1, suggestionId },
+        body: { status: "accepted", appliedMode: "direct" },
+      },
+    );
+    expect(result).toEqual({ updated: false });
+
+    const row = await readSuggestion(suggestionId);
+    expect(row?.status).toBe("pending");
+    expect(row?.resolvedByUserId).toBeNull();
+  });
+});
+
+type SuggestionOverrides = Partial<typeof docxSuggestions.$inferInsert>;
+
+const insertSuggestion = async (
+  overrides: SuggestionOverrides = {},
+): Promise<SafeId<"docxSuggestion">> => {
+  const suggestionId = createSafeId<"docxSuggestion">();
+  await testDb.insert(docxSuggestions).values({
+    id: suggestionId,
+    workspaceId: ids.wsA1,
+    entityId: ids.entityA1,
+    opPayload: {},
+    severity: "medium",
+    area: "body",
+    status: "pending",
+    ...overrides,
+  });
+  return suggestionId;
+};
+
+const readSuggestion = async (suggestionId: SafeId<"docxSuggestion">) => {
+  const rows = await testDb
+    .select({
+      status: docxSuggestions.status,
+      appliedMode: docxSuggestions.appliedMode,
+      resolvedByUserId: docxSuggestions.resolvedByUserId,
+    })
+    .from(docxSuggestions)
+    .where(eq(docxSuggestions.id, suggestionId));
+  return rows.at(0);
+};
+
+const workspaceAContext = (): WorkspaceTestContext =>
+  createWorkspaceContext({
+    workspaceId: ids.wsA1,
+    organizationId: ids.orgA,
+    userId: ids.userA1,
+  });
+
+const workspaceBContext = (): WorkspaceTestContext =>
+  createWorkspaceContext({
+    workspaceId: ids.wsB1,
+    organizationId: ids.orgB,
+    userId: ids.userB1,
+  });
+
+const createWorkspaceContext = ({
+  workspaceId,
+  organizationId,
+  userId,
+}: {
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+}): WorkspaceTestContext => {
+  const activeWorkspaceIds = [workspaceId];
+  return {
+    memberRole: { role: "owner" },
+    request: new Request(
+      `https://example.test/docx-suggestions/${workspaceId}`,
+    ),
+    route: "/security/docx-suggestions-transition",
+    safeDb: createSafeDb(testDb, activeWorkspaceIds, organizationId, userId),
+    scopedDb: createScopedDb(
+      testDb,
+      activeWorkspaceIds,
+      organizationId,
+      userId,
+    ),
+    session: { activeOrganizationId: organizationId },
+    user: { id: userId },
+    workspaceId,
+  };
+};
+
+const runHandler = async <TContext>(
+  endpoint: { handler: (context: TContext) => Promise<unknown> },
+  context: WorkspaceTestContext,
+  requestShape: Record<string, unknown>,
+): Promise<unknown> => {
+  try {
+    return await endpoint.handler(
+      asTestRaw<TContext>({ ...context, ...requestShape }),
+    );
+  } catch (error) {
+    return error;
+  }
+};

--- a/apps/api/src/tests/security/cross-tenant-coverage.test.ts
+++ b/apps/api/src/tests/security/cross-tenant-coverage.test.ts
@@ -57,6 +57,7 @@ const CROSS_TENANT_WAIVERS: Record<string, WaiverReason> = {
   "document-types": WAIVER_REASON.preExistingGap,
   docx: WAIVER_REASON.preExistingGap,
   fields: WAIVER_REASON.preExistingGap,
+  flows: WAIVER_REASON.preExistingGap,
   legislation: WAIVER_REASON.preExistingGap,
   me: WAIVER_REASON.preExistingGap,
   "organization-settings": WAIVER_REASON.preExistingGap,
@@ -73,6 +74,7 @@ const CROSS_TENANT_WAIVERS: Record<string, WaiverReason> = {
   "view-templates": WAIVER_REASON.preExistingGap,
   views: WAIVER_REASON.preExistingGap,
   workspaces: WAIVER_REASON.preExistingGap,
+  "agent-auth": WAIVER_REASON.noTenantReadSurface,
   auth: WAIVER_REASON.noTenantReadSurface,
   dev: WAIVER_REASON.noTenantReadSurface,
   "external-preview": WAIVER_REASON.noTenantReadSurface,
@@ -98,10 +100,12 @@ const handlerDomains = readdirSync(handlersDir, { withFileTypes: true })
 // with no second list to maintain.
 const coveredDomains = new Set(
   [
-    ...readFileSync(crossTenantMatrixPath, "utf8").matchAll(
-      /@\/api\/handlers\/([^/"]+)\//g,
+    ...readFileSync(crossTenantMatrixPath, "utf-8").matchAll(
+      /@\/api\/handlers\/([^/"]+)\//gu,
     ),
-  ].map((match) => match[1]),
+  ]
+    .map((match) => match[1])
+    .filter((domain): domain is string => domain !== undefined),
 );
 
 describe("cross-tenant matrix coverage guard", () => {

--- a/apps/api/src/tests/security/cross-tenant-coverage.test.ts
+++ b/apps/api/src/tests/security/cross-tenant-coverage.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+// Meta-test: the cross-tenant isolation matrix
+// (`cross-tenant-handlers.test.ts`) hand-enumerates read/list handlers and
+// proves workspace A cannot reach workspace/org B's resources. Nothing stopped
+// a *new* handler domain from landing without ever being added to that matrix.
+// This guard fails when a `handlers/<domain>/` directory is neither exercised
+// by the matrix nor carries an explicit, reasoned waiver, so a new domain is a
+// deliberate decision rather than a silent gap.
+
+const handlersDir = path.resolve(import.meta.dir, "../../handlers");
+const crossTenantMatrixPath = path.resolve(
+  import.meta.dir,
+  "cross-tenant-handlers.test.ts",
+);
+
+/**
+ * Reason a handler domain is intentionally absent from the cross-tenant
+ * isolation matrix. A closed set so a waiver is a reviewed choice, not free
+ * text.
+ */
+const WAIVER_REASON = {
+  /**
+   * The domain owns a tenant-scoped read/list handler that the matrix should
+   * eventually exercise but does not yet. Close the gap by adding a matrix
+   * case and deleting the waiver.
+   */
+  preExistingGap: "pre-existing gap, tracked",
+  /**
+   * The domain has no workspace/organization-scoped read surface to isolate:
+   * auth/session/transport/upload mechanics, webhooks, health, dev-only, or
+   * intentionally public reads. No cross-tenant matrix case is meaningful.
+   */
+  noTenantReadSurface: "no cross-tenant read surface",
+} as const;
+
+type WaiverReason = (typeof WAIVER_REASON)[keyof typeof WAIVER_REASON];
+
+/**
+ * Handler domains deliberately not in the cross-tenant matrix. Deleting an
+ * entry here is the natural act once a domain gains a matrix case: the
+ * "no covered domain stays waived" test below fails on a stale waiver, forcing
+ * it out. Most `preExistingGap` rows are genuine read handlers awaiting a
+ * matrix case (e.g. `usage`, `properties`, `fields`, `user-files`
+ * read-content/read-thumbnail); adding those is incremental follow-up work.
+ */
+const CROSS_TENANT_WAIVERS: Record<string, WaiverReason> = {
+  "ai-autocomplete": WAIVER_REASON.preExistingGap,
+  "ai-config": WAIVER_REASON.preExistingGap,
+  "audit-logs": WAIVER_REASON.preExistingGap,
+  "case-law": WAIVER_REASON.preExistingGap,
+  catalogue: WAIVER_REASON.preExistingGap,
+  chat: WAIVER_REASON.preExistingGap,
+  clauses: WAIVER_REASON.preExistingGap,
+  "document-types": WAIVER_REASON.preExistingGap,
+  docx: WAIVER_REASON.preExistingGap,
+  fields: WAIVER_REASON.preExistingGap,
+  legislation: WAIVER_REASON.preExistingGap,
+  me: WAIVER_REASON.preExistingGap,
+  "organization-settings": WAIVER_REASON.preExistingGap,
+  playbooks: WAIVER_REASON.preExistingGap,
+  properties: WAIVER_REASON.preExistingGap,
+  reports: WAIVER_REASON.preExistingGap,
+  search: WAIVER_REASON.preExistingGap,
+  skills: WAIVER_REASON.preExistingGap,
+  "style-sets": WAIVER_REASON.preExistingGap,
+  tasks: WAIVER_REASON.preExistingGap,
+  "template-recipes": WAIVER_REASON.preExistingGap,
+  usage: WAIVER_REASON.preExistingGap,
+  "user-files": WAIVER_REASON.preExistingGap,
+  "view-templates": WAIVER_REASON.preExistingGap,
+  views: WAIVER_REASON.preExistingGap,
+  workspaces: WAIVER_REASON.preExistingGap,
+  auth: WAIVER_REASON.noTenantReadSurface,
+  dev: WAIVER_REASON.noTenantReadSurface,
+  "external-preview": WAIVER_REASON.noTenantReadSurface,
+  feedback: WAIVER_REASON.noTenantReadSurface,
+  "folio-collab": WAIVER_REASON.noTenantReadSurface,
+  health: WAIVER_REASON.noTenantReadSurface,
+  "hosted-usage-webhook": WAIVER_REASON.noTenantReadSurface,
+  mcp: WAIVER_REASON.noTenantReadSurface,
+  "mcp-connectors": WAIVER_REASON.noTenantReadSurface,
+  smoke: WAIVER_REASON.noTenantReadSurface,
+  uploads: WAIVER_REASON.noTenantReadSurface,
+  verify: WAIVER_REASON.noTenantReadSurface,
+};
+
+const handlerDomains = readdirSync(handlersDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+// A domain is "covered" iff the matrix imports a handler from it. Parsing the
+// import specifiers keeps this in lockstep with the real matrix: a new case
+// drags its `@/api/handlers/<domain>/...` import along, and this set updates
+// with no second list to maintain.
+const coveredDomains = new Set(
+  [
+    ...readFileSync(crossTenantMatrixPath, "utf8").matchAll(
+      /@\/api\/handlers\/([^/"]+)\//g,
+    ),
+  ].map((match) => match[1]),
+);
+
+describe("cross-tenant matrix coverage guard", () => {
+  test("every handler domain is in the cross-tenant matrix or explicitly waived", () => {
+    const uncovered = handlerDomains.filter(
+      (domain) =>
+        !coveredDomains.has(domain) && !(domain in CROSS_TENANT_WAIVERS),
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  test("no covered domain is still waived (adding a matrix case removes the waiver)", () => {
+    const shadowed = Object.keys(CROSS_TENANT_WAIVERS).filter((domain) =>
+      coveredDomains.has(domain),
+    );
+    expect(shadowed).toEqual([]);
+  });
+
+  test("every waiver names a real handler domain", () => {
+    const staleWaivers = Object.keys(CROSS_TENANT_WAIVERS).filter(
+      (domain) => !handlerDomains.includes(domain),
+    );
+    expect(staleWaivers).toEqual([]);
+  });
+
+  test("every cross-tenant matrix import names a real handler domain", () => {
+    const unknownCovered = [...coveredDomains].filter(
+      (domain) => !handlerDomains.includes(domain),
+    );
+    expect(unknownCovered).toEqual([]);
+  });
+});

--- a/apps/api/src/tests/security/cross-tenant-handlers.test.ts
+++ b/apps/api/src/tests/security/cross-tenant-handlers.test.ts
@@ -11,6 +11,7 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import { createSafeDb, createScopedDb } from "@/api/db/scoped";
 import readBillingCodes from "@/api/handlers/billing-codes/read";
 import readContactById from "@/api/handlers/contacts/read-by-id";
+import listDocxSuggestions from "@/api/handlers/docx-suggestions/read";
 import readEntityById from "@/api/handlers/entities/read-by-id";
 import readVersionById from "@/api/handlers/entities/read-version-by-id";
 import readVersions from "@/api/handlers/entities/read-versions";
@@ -166,6 +167,22 @@ const isolationCases: IsolationCase[] = [
       }),
     expectDenied: expectStatus(404),
     expectPositive: expectStatus(400),
+  },
+  {
+    name: "docx suggestions list",
+    runAAgainstB: async ({ ids: testIds, workspaceA }) =>
+      await runHandler(listDocxSuggestions, workspaceA, {
+        params: { workspaceId: testIds.wsA1, entityId: testIds.entityB1 },
+        query: { limit: 100 },
+      }),
+    runBPositive: async ({ ids: testIds, workspaceB }) =>
+      await runHandler(listDocxSuggestions, workspaceB, {
+        params: { workspaceId: testIds.wsB1, entityId: testIds.entityB1 },
+        query: { limit: 100 },
+      }),
+    expectDenied: expectEmptyPage,
+    expectPositive: (result, { ids: testIds }) =>
+      expectPageContainsId(result, testIds.docxSuggestionB1),
   },
   {
     name: "invoice read by id",

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -18,6 +18,7 @@ import {
   contactRelationships,
   contacts,
   documentCounters,
+  docxSuggestions,
   entities,
   entityVersions,
   expenses,
@@ -93,6 +94,8 @@ export const createTestIds = () => ({
   fieldB1: id<"field">(),
   docCounterA1: id<"documentCounter">(),
   docCounterB1: id<"documentCounter">(),
+  docxSuggestionA1: id<"docxSuggestion">(),
+  docxSuggestionB1: id<"docxSuggestion">(),
   wsContactA1: id<"workspaceContact">(),
   wsContactB1: id<"workspaceContact">(),
   propDepA1: id<"propertyDependency">(),
@@ -416,6 +419,29 @@ export const setupRlsTestData = async (db: TestDatabase, ids: TestIds) => {
     .update(entities)
     .set({ currentVersionId: ids.entityVersionB1 })
     .where(eq(entities.id, ids.entityB1));
+
+  // Persisted DOCX review suggestions (opPayload stored opaquely). One per
+  // tenant so the cross-tenant read matrix can assert workspace isolation.
+  await db.insert(docxSuggestions).values([
+    {
+      id: ids.docxSuggestionA1,
+      workspaceId: ids.wsA1,
+      entityId: ids.entityA1,
+      opPayload: {},
+      severity: "medium" as const,
+      area: "body",
+      status: "pending" as const,
+    },
+    {
+      id: ids.docxSuggestionB1,
+      workspaceId: ids.wsB1,
+      entityId: ids.entityB1,
+      opPayload: {},
+      severity: "medium" as const,
+      area: "body",
+      status: "pending" as const,
+    },
+  ]);
 
   const propContent = {
     version: 1 as const,


### PR DESCRIPTION
Add tests for the docx-suggestions domain (previously untested) and a
meta-test that stops new handler domains from silently skipping the
cross-tenant isolation matrix.

- Cursor codec property tests: decode ∘ encode identity over
  (createdAt, id); arbitrary strings decode to a valid cursor or null
  and never throw; malformed payloads (non-array, wrong arity, non-UUID
  id, non-datetime created-at) decode to null.
- Resolve/revert state-transition tests over the PGlite handler harness:
  resolve records the resolution and a second resolve is a
  {updated:false} no-op (pending precondition in the WHERE); reject
  stores no applied mode; revert returns a resolved row to pending and
  clears the trail, a second revert is a no-op; a revert of an
  already-pending row is a no-op; a foreign workspace's resolve affects
  zero rows and leaves the row untouched.
- cross-tenant-coverage guard: enumerate handlers/<domain>/ directories
  and fail when a domain is neither exercised by the cross-tenant matrix
  (detected from the matrix's handler imports) nor carries an explicit,
  reasoned waiver. Seed the waiver list with the currently-uncovered
  domains; a covered domain that stays waived also fails, so closing a
  gap naturally removes its waiver.
- Add a real matrix case + fixture rows for docx-suggestions list, so
  that domain is covered rather than waived.