### PR TITLE
chore(api): rate-resolution and entitlement invariants; shared handler-context factory

### DIFF
--- a/apps/api/src/handlers/rates/resolve.test.ts
+++ b/apps/api/src/handlers/rates/resolve.test.ts
@@ -1,0 +1,317 @@
+import { Result } from "better-result";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+import fc from "fast-check";
+
+import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
+
+import { rateEntries, rateTables } from "@/api/db/schema";
+import { createSafeDb, createScopedDb } from "@/api/db/scoped";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { validateOrgUserId } from "@/api/lib/validated-org-user-id";
+import type { ValidatedOrgUserId } from "@/api/lib/validated-org-user-id";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import resolveRateHandler, { resolveRate } from "./resolve";
+
+setDefaultTimeout(120_000);
+
+// ── Effective-dated rate resolution contract (pinned after reading resolve.ts)
+//
+// Resolution is scoped to the workspace's single `isDefault` rate table:
+//   1. If the workspace has no default rate table -> null.
+//   2. Among entries in that table whose effective range covers the query date
+//      (effectiveFrom <= date AND (effectiveTo IS NULL OR effectiveTo >= date)):
+//        a. USER-SPECIFIC entries (userId = query user) take precedence; the
+//           one with the greatest effectiveFrom wins — even over a newer
+//           table-default entry.
+//        b. Otherwise TABLE-DEFAULT entries (userId IS NULL); the one with the
+//           greatest effectiveFrom wins.
+//        c. Otherwise -> null.
+//   Entries belonging to a different user never participate.
+//   The resolved currency is always the default table's currency.
+
+const BASE_EPOCH_MS = Date.UTC(2020, 0, 1);
+const DAY_MS = 86_400_000;
+const DEFAULT_CURRENCY = "USD";
+
+const isoDate = (dayOffset: number): string =>
+  new Date(BASE_EPOCH_MS + dayOffset * DAY_MS).toISOString().slice(0, 10);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let defaultTableId: SafeId<"rateTable">;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+
+  // A dedicated default rate table for wsA1. The fixture's rateTableA1 is not
+  // a default table, so this is the only isDefault table for the workspace and
+  // resolution is deterministic.
+  defaultTableId = toSafeId<"rateTable">(Bun.randomUUIDv7());
+  await testDb.insert(rateTables).values({
+    id: defaultTableId,
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    name: "Default table",
+    currency: DEFAULT_CURRENCY,
+    isDefault: true,
+  });
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+// safeDb authorized for wsA1 (owns the default table) and wsA2 (has no rate
+// table at all, exercising the "no default table -> null" branch).
+const scopedSafeDb = () =>
+  createSafeDb(testDb, [ids.wsA1, ids.wsA2], ids.orgA, ids.userA1);
+
+const runResolve = async (input: {
+  workspaceId: SafeId<"workspace">;
+  userId: ValidatedOrgUserId;
+  dateWorked: string;
+}) => {
+  // resolveRate delegates its DB failures via `yield*` and returns a plain
+  // value, so drive it through a generator that wraps the value back into a
+  // Result for `Result.gen`.
+  const result = await Result.gen(async function* () {
+    const value = yield* resolveRate({ safeDb: scopedSafeDb(), ...input });
+    return Result.ok(value);
+  });
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+type GeneratedEntry = {
+  fromOffset: number;
+  kind: "user" | "other" | "default";
+  rate: number;
+  toDelta: number | null;
+};
+
+const entryArb = fc.record<GeneratedEntry>({
+  fromOffset: fc.integer({ min: 0, max: 3650 }),
+  kind: fc.constantFrom("user", "other", "default"),
+  rate: fc.integer({ min: 1, max: 1_000_000 }),
+  toDelta: fc.option(fc.integer({ min: 0, max: 365 }), { nil: null }),
+});
+
+// Unique effectiveFrom offsets keep "greatest effectiveFrom" unambiguous, so
+// the property has a single well-defined expected winner (no ORDER BY tie).
+const entriesArb = fc.uniqueArray(entryArb, {
+  maxLength: 10,
+  selector: (entry) => entry.fromOffset,
+});
+
+type ResolvedRow = {
+  userId: SafeId<"user"> | null;
+  rate: number;
+  fromOffset: number;
+  fromIso: string;
+  toIso: string | null;
+};
+
+const rowUserId = (kind: GeneratedEntry["kind"]): SafeId<"user"> | null => {
+  if (kind === "user") {
+    return ids.userA1;
+  }
+  if (kind === "other") {
+    return ids.userA2;
+  }
+  return null;
+};
+
+const toRow = (entry: GeneratedEntry): ResolvedRow => ({
+  userId: rowUserId(entry.kind),
+  rate: entry.rate,
+  fromOffset: entry.fromOffset,
+  fromIso: isoDate(entry.fromOffset),
+  toIso:
+    entry.toDelta === null ? null : isoDate(entry.fromOffset + entry.toDelta),
+});
+
+const covers = (row: ResolvedRow, date: string): boolean =>
+  row.fromIso <= date && (row.toIso === null || row.toIso >= date);
+
+const pickLatest = (rows: ResolvedRow[]): ResolvedRow | null => {
+  let best: ResolvedRow | null = null;
+  for (const row of rows) {
+    if (best === null || row.fromOffset > best.fromOffset) {
+      best = row;
+    }
+  }
+  return best;
+};
+
+const expectedResolution = (
+  rows: ResolvedRow[],
+  date: string,
+): { hourlyRate: number; currency: string } | null => {
+  const inRange = rows.filter((row) => covers(row, date));
+  const userWinner = pickLatest(
+    inRange.filter((row) => row.userId === ids.userA1),
+  );
+  const winner =
+    userWinner ?? pickLatest(inRange.filter((row) => row.userId === null));
+  return winner === null
+    ? null
+    : { hourlyRate: winner.rate, currency: DEFAULT_CURRENCY };
+};
+
+describe("effective-dated rate resolution", () => {
+  let validatedUserA1: ValidatedOrgUserId;
+
+  beforeAll(async () => {
+    const scoped = createScopedDb(testDb, [ids.wsA1], ids.orgA, ids.userA1);
+    const validated = await scoped((tx) =>
+      validateOrgUserId(tx, ids.userA1, ids.orgA),
+    );
+    if (!validated) {
+      throw new Error("Expected userA1 to be a member of orgA");
+    }
+    validatedUserA1 = validated;
+  });
+
+  test(
+    "resolves the greatest-effectiveFrom in-range entry, user rate over default",
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          entriesArb,
+          fc.integer({ min: 0, max: 3650 }),
+          async (entries, queryOffset) => {
+            const rows = entries.map(toRow);
+            const queryDate = isoDate(queryOffset);
+
+            await testDb
+              .delete(rateEntries)
+              .where(eq(rateEntries.rateTableId, defaultTableId));
+            if (rows.length > 0) {
+              await testDb.insert(rateEntries).values(
+                rows.map((row) => ({
+                  id: toSafeId<"rateEntry">(Bun.randomUUIDv7()),
+                  workspaceId: ids.wsA1,
+                  rateTableId: defaultTableId,
+                  userId: row.userId,
+                  hourlyRate: row.rate,
+                  effectiveFrom: row.fromIso,
+                  effectiveTo: row.toIso,
+                })),
+              );
+            }
+
+            const actual = await runResolve({
+              workspaceId: ids.wsA1,
+              userId: validatedUserA1,
+              dateWorked: queryDate,
+            });
+
+            expect(actual).toEqual(expectedResolution(rows, queryDate));
+          },
+        ),
+        propertyConfig({ numRuns: 60 }),
+      );
+    },
+    propertyTestTimeout(120_000),
+  );
+
+  test("returns null when the workspace has no default rate table", async () => {
+    const actual = await runResolve({
+      workspaceId: ids.wsA2,
+      userId: validatedUserA1,
+      dateWorked: isoDate(1000),
+    });
+    expect(actual).toBeNull();
+  });
+});
+
+describe("resolveRate HTTP handler", () => {
+  const USER_RATE = 25_000;
+  const DEFAULT_RATE = 15_000;
+
+  beforeAll(async () => {
+    await testDb
+      .delete(rateEntries)
+      .where(eq(rateEntries.rateTableId, defaultTableId));
+    await testDb.insert(rateEntries).values([
+      {
+        id: toSafeId<"rateEntry">(Bun.randomUUIDv7()),
+        workspaceId: ids.wsA1,
+        rateTableId: defaultTableId,
+        userId: ids.userA1,
+        hourlyRate: USER_RATE,
+        effectiveFrom: "2025-01-01",
+      },
+      {
+        id: toSafeId<"rateEntry">(Bun.randomUUIDv7()),
+        workspaceId: ids.wsA1,
+        rateTableId: defaultTableId,
+        userId: null,
+        hourlyRate: DEFAULT_RATE,
+        effectiveFrom: "2024-01-01",
+      },
+    ]);
+  });
+
+  type ResolveCtx = Parameters<typeof resolveRateHandler.handler>[0];
+
+  const contextFor = (query: { userId: string; date: string }): ResolveCtx =>
+    createTestHandlerContext<ResolveCtx>({
+      workspaceId: ids.wsA1,
+      session: { activeOrganizationId: ids.orgA },
+      user: { id: ids.userA1 },
+      safeDb: scopedSafeDb(),
+      query,
+    });
+
+  test("returns the user-specific rate when one is effective", async () => {
+    const result = await resolveRateHandler.handler(
+      contextFor({ userId: ids.userA1, date: "2025-06-01" }),
+    );
+    expect(result).toEqual({
+      hourlyRate: USER_RATE,
+      currency: DEFAULT_CURRENCY,
+    });
+  });
+
+  test("falls back to the table default for a member without a user rate", async () => {
+    const result = await resolveRateHandler.handler(
+      contextFor({ userId: ids.userAdmin, date: "2025-06-01" }),
+    );
+    expect(result).toEqual({
+      hourlyRate: DEFAULT_RATE,
+      currency: DEFAULT_CURRENCY,
+    });
+  });
+
+  test("404s when the queried user is not a member of the organization", async () => {
+    const result = await resolveRateHandler.handler(
+      contextFor({
+        userId: toSafeId<"user">(Bun.randomUUIDv7()),
+        date: "2025-06-01",
+      }),
+    );
+    expect(result).toMatchObject({ code: 404 });
+  });
+});

--- a/apps/api/src/handlers/rates/resolve.test.ts
+++ b/apps/api/src/handlers/rates/resolve.test.ts
@@ -12,13 +12,17 @@ import fc from "fast-check";
 
 import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
 
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
 import { rateEntries, rateTables } from "@/api/db/schema";
 import { createSafeDb, createScopedDb } from "@/api/db/scoped";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { cents } from "@/api/lib/money";
 import { validateOrgUserId } from "@/api/lib/validated-org-user-id";
 import type { ValidatedOrgUserId } from "@/api/lib/validated-org-user-id";
 import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import {
   createTestIds,
   setupRlsTestData,
@@ -81,9 +85,14 @@ afterAll(async () => {
 });
 
 // safeDb authorized for wsA1 (owns the default table) and wsA2 (has no rate
-// table at all, exercising the "no default table -> null" branch).
-const scopedSafeDb = () =>
-  createSafeDb(testDb, [ids.wsA1, ids.wsA2], ids.orgA, ids.userA1);
+// table at all, exercising the "no default table -> null" branch). PGlite's
+// transaction type is structurally distinct from the production `Transaction`
+// (different QueryResultHKT); asTestRaw is the established cast for bridging
+// a PGlite-backed safeDb into a prod-typed handler context.
+const scopedSafeDb = (): SafeDb =>
+  asTestRaw<SafeDb>(
+    createSafeDb(testDb, [ids.wsA1, ids.wsA2], ids.orgA, ids.userA1),
+  );
 
 const runResolve = async (input: {
   workspaceId: SafeId<"workspace">;
@@ -184,8 +193,8 @@ describe("effective-dated rate resolution", () => {
 
   beforeAll(async () => {
     const scoped = createScopedDb(testDb, [ids.wsA1], ids.orgA, ids.userA1);
-    const validated = await scoped((tx) =>
-      validateOrgUserId(tx, ids.userA1, ids.orgA),
+    const validated = await scoped(async (tx) =>
+      validateOrgUserId(asTestRaw<Transaction>(tx), ids.userA1, ids.orgA),
     );
     if (!validated) {
       throw new Error("Expected userA1 to be a member of orgA");
@@ -214,7 +223,7 @@ describe("effective-dated rate resolution", () => {
                   workspaceId: ids.wsA1,
                   rateTableId: defaultTableId,
                   userId: row.userId,
-                  hourlyRate: row.rate,
+                  hourlyRate: cents(row.rate),
                   effectiveFrom: row.fromIso,
                   effectiveTo: row.toIso,
                 })),
@@ -260,7 +269,7 @@ describe("resolveRate HTTP handler", () => {
         workspaceId: ids.wsA1,
         rateTableId: defaultTableId,
         userId: ids.userA1,
-        hourlyRate: USER_RATE,
+        hourlyRate: cents(USER_RATE),
         effectiveFrom: "2025-01-01",
       },
       {
@@ -268,7 +277,7 @@ describe("resolveRate HTTP handler", () => {
         workspaceId: ids.wsA1,
         rateTableId: defaultTableId,
         userId: null,
-        hourlyRate: DEFAULT_RATE,
+        hourlyRate: cents(DEFAULT_RATE),
         effectiveFrom: "2024-01-01",
       },
     ]);

--- a/apps/api/src/handlers/usage/get-entitlement.test.ts
+++ b/apps/api/src/handlers/usage/get-entitlement.test.ts
@@ -8,6 +8,8 @@ import {
 } from "bun:test";
 import { eq } from "drizzle-orm";
 
+import type { Transaction } from "@/api/db/root";
+import type { SafeDb } from "@/api/db/safe-db";
 import {
   USAGE_ENTITLEMENT_STATUSES,
   usageAllocations,
@@ -20,6 +22,7 @@ import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { assertUsageAvailable } from "@/api/lib/usage/usage-ledger";
 import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import {
   createTestIds,
   setupRlsTestData,
@@ -102,10 +105,18 @@ const setEntitlementStatus = async (status: UsageEntitlementStatus) => {
     .where(eq(usageEntitlements.organizationId, ids.orgA));
 };
 
+// PGlite's transaction type is structurally distinct from the production
+// `Transaction` (different QueryResultHKT); asTestRaw is the established cast
+// for bridging a PGlite-backed tx into prod-typed lib functions.
 const assertForOrgA = async (required: number, asOf = AS_OF) => {
   const scoped = createScopedDb(testDb, [], ids.orgA, ids.userAdmin);
-  return await scoped((tx) =>
-    assertUsageAvailable({ tx, organizationId: ids.orgA, required, asOf }),
+  return await scoped(async (tx) =>
+    assertUsageAvailable({
+      tx: asTestRaw<Transaction>(tx),
+      organizationId: ids.orgA,
+      required,
+      asOf,
+    }),
   );
 };
 
@@ -148,8 +159,12 @@ describe("usage entitlement gating boundary", () => {
 
   test("rejects an organization with no entitlement", async () => {
     const scoped = createScopedDb(testDb, [], ids.orgB, ids.userB1);
-    const result = await scoped((tx) =>
-      assertUsageAvailable({ tx, organizationId: ids.orgB, required: 1 }),
+    const result = await scoped(async (tx) =>
+      assertUsageAvailable({
+        tx: asTestRaw<Transaction>(tx),
+        organizationId: ids.orgB,
+        required: 1,
+      }),
     );
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -190,7 +205,9 @@ describe("get-entitlement handler", () => {
       memberRole: { role },
       session: { activeOrganizationId: ids.orgA },
       user: { id: ids.userAdmin },
-      safeDb: createSafeDb(testDb, [], ids.orgA, ids.userAdmin),
+      safeDb: asTestRaw<SafeDb>(
+        createSafeDb(testDb, [], ids.orgA, ids.userAdmin),
+      ),
     });
 
   test("returns entitlement, policy, and remaining units for a manager", async () => {

--- a/apps/api/src/handlers/usage/get-entitlement.test.ts
+++ b/apps/api/src/handlers/usage/get-entitlement.test.ts
@@ -1,0 +1,210 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import {
+  USAGE_ENTITLEMENT_STATUSES,
+  usageAllocations,
+  usageEntitlements,
+  usagePolicies,
+} from "@/api/db/schema";
+import type { UsageEntitlementStatus } from "@/api/db/schema";
+import { createSafeDb, createScopedDb } from "@/api/db/scoped";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { assertUsageAvailable } from "@/api/lib/usage/usage-ledger";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import getEntitlement from "./get-entitlement";
+
+setDefaultTimeout(120_000);
+
+// Statuses under which the org may consume units; every other status blocks
+// consumption even with a positive balance. Mirrors CONSUMABLE_STATUSES in
+// usage-ledger.ts.
+const CONSUMABLE: ReadonlySet<UsageEntitlementStatus> = new Set([
+  "active",
+  "trialing",
+]);
+
+const ALLOCATED_UNITS = 10;
+const DAY_MS = 86_400_000;
+// The handler reads remaining units `asOf` now, so the allocation period must
+// cover the present instant; the boundary tests pin `asOf` explicitly.
+const PERIOD_START = new Date(Date.now() - 10 * DAY_MS);
+const PERIOD_END = new Date(Date.now() + 20 * DAY_MS);
+// An instant inside the allocation period, used as the balance `asOf`.
+const AS_OF = new Date();
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let policyId: SafeId<"usagePolicy">;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+
+  policyId = toSafeId<"usagePolicy">(Bun.randomUUIDv7());
+  await testDb.insert(usagePolicies).values({
+    id: policyId,
+    policyKey: `test_policy_${Bun.randomUUIDv7().replaceAll("-", "").slice(0, 16)}`,
+    displayName: "Test policy",
+    monthlyUsageUnits: 1000,
+  });
+
+  // One entitlement for orgA (unique per org). orgB is deliberately left
+  // without an entitlement to exercise the no-entitlement path.
+  await testDb.insert(usageEntitlements).values({
+    id: toSafeId<"usageEntitlement">(Bun.randomUUIDv7()),
+    organizationId: ids.orgA,
+    usagePolicyId: policyId,
+    status: "active",
+    seats: 5,
+    currentPeriodStart: PERIOD_START,
+    currentPeriodEnd: PERIOD_END,
+    source: "manual",
+  });
+
+  await testDb.insert(usageAllocations).values({
+    id: toSafeId<"usageAllocation">(Bun.randomUUIDv7()),
+    organizationId: ids.orgA,
+    periodStart: PERIOD_START,
+    periodEnd: PERIOD_END,
+    units: ALLOCATED_UNITS,
+    reason: "manual",
+    sourceType: "admin",
+    sourceRef: null,
+  });
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+const setEntitlementStatus = async (status: UsageEntitlementStatus) => {
+  await testDb
+    .update(usageEntitlements)
+    .set({ status })
+    .where(eq(usageEntitlements.organizationId, ids.orgA));
+};
+
+const assertForOrgA = async (required: number, asOf = AS_OF) => {
+  const scoped = createScopedDb(testDb, [], ids.orgA, ids.userAdmin);
+  return await scoped((tx) =>
+    assertUsageAvailable({ tx, organizationId: ids.orgA, required, asOf }),
+  );
+};
+
+describe("usage entitlement gating boundary", () => {
+  test("passes when available exactly equals the required units", async () => {
+    await setEntitlementStatus("active");
+    const result = await assertForOrgA(ALLOCATED_UNITS);
+    expect(result).toEqual({ ok: true, available: ALLOCATED_UNITS });
+  });
+
+  test("rejects when required is one unit over the available balance", async () => {
+    await setEntitlementStatus("active");
+    const result = await assertForOrgA(ALLOCATED_UNITS + 1);
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected rejection");
+    }
+    expect(result.error.reason).toBe("usage_limit_exceeded");
+    expect(result.error.available).toBe(ALLOCATED_UNITS);
+    expect(result.error.required).toBe(ALLOCATED_UNITS + 1);
+  });
+
+  test("passes a zero-cost request even against an exhausted balance", async () => {
+    await setEntitlementStatus("active");
+    // asOf outside the allocation period => available 0, but required 0.
+    const result = await assertForOrgA(0, PERIOD_END);
+    expect(result).toEqual({ ok: true, available: 0 });
+  });
+
+  test("counts no balance once asOf reaches the period end (exclusive)", async () => {
+    await setEntitlementStatus("active");
+    const result = await assertForOrgA(1, PERIOD_END);
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected rejection");
+    }
+    expect(result.error.reason).toBe("usage_limit_exceeded");
+    expect(result.error.available).toBe(0);
+  });
+
+  test("rejects an organization with no entitlement", async () => {
+    const scoped = createScopedDb(testDb, [], ids.orgB, ids.userB1);
+    const result = await scoped((tx) =>
+      assertUsageAvailable({ tx, organizationId: ids.orgB, required: 1 }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected rejection");
+    }
+    expect(result.error.reason).toBe("no_entitlement");
+  });
+
+  // Every entitlement status the schema distinguishes gets the boundary case:
+  // consumable statuses reach the balance check, the rest block regardless of
+  // balance.
+  for (const status of USAGE_ENTITLEMENT_STATUSES) {
+    test(`status "${status}": ${CONSUMABLE.has(status) ? "consumes" : "blocks"} against a full balance`, async () => {
+      await setEntitlementStatus(status);
+      try {
+        const result = await assertForOrgA(1);
+        if (CONSUMABLE.has(status)) {
+          expect(result).toEqual({ ok: true, available: ALLOCATED_UNITS });
+        } else {
+          expect(result.ok).toBe(false);
+          if (result.ok) {
+            throw new Error("expected rejection");
+          }
+          expect(result.error.reason).toBe("entitlement_inactive");
+        }
+      } finally {
+        await setEntitlementStatus("active");
+      }
+    });
+  }
+});
+
+describe("get-entitlement handler", () => {
+  type EntitlementCtx = Parameters<typeof getEntitlement.handler>[0];
+
+  const contextFor = (role: "owner" | "member"): EntitlementCtx =>
+    createTestHandlerContext<EntitlementCtx>({
+      memberRole: { role },
+      session: { activeOrganizationId: ids.orgA },
+      user: { id: ids.userAdmin },
+      safeDb: createSafeDb(testDb, [], ids.orgA, ids.userAdmin),
+    });
+
+  test("returns entitlement, policy, and remaining units for a manager", async () => {
+    await setEntitlementStatus("active");
+    const result = await getEntitlement.handler(contextFor("owner"));
+    expect(result).toMatchObject({
+      entitlement: { status: "active", seats: 5, source: "manual" },
+      policy: { id: policyId, monthlyUsageUnitsPerSeat: 1000 },
+      remainingUsageUnits: ALLOCATED_UNITS,
+    });
+  });
+
+  test("forbids a non-manager role", async () => {
+    const result = await getEntitlement.handler(contextFor("member"));
+    expect(result).toMatchObject({ code: 403 });
+  });
+});

--- a/apps/api/src/tests/helpers/handler-context.ts
+++ b/apps/api/src/tests/helpers/handler-context.ts
@@ -68,7 +68,7 @@ const DEFAULT_WORKSPACE_ID = toSafeId<"workspace">("workspace_test");
 const DEFAULT_ORGANIZATION_ID = toSafeId<"organization">("org_test");
 const DEFAULT_USER_ID = toSafeId<"user">("user_test");
 
-const noopAuditRecorder: AuditRecorder = () => Promise.resolve();
+const noopAuditRecorder: AuditRecorder = async () => await Promise.resolve();
 
 // A handler that reaches for the database without the test providing one is a
 // test bug, not an empty result: fail loudly instead of silently returning
@@ -87,16 +87,23 @@ const createBaseContext = (): BaseTestHandlerContext => ({
   scopedDb: unconfiguredDb,
   recordAuditEvent: noopAuditRecorder,
   createAuditRecorder: () => noopAuditRecorder,
-  getActiveWorkspaceIds: () => Promise.resolve([DEFAULT_WORKSPACE_ID]),
-  getAccessibleWorkspaces: () =>
-    Promise.resolve([{ id: DEFAULT_WORKSPACE_ID, status: "active" }]),
-  getWorkspaceAccess: (workspaceId) =>
-    Promise.resolve(
+  getActiveWorkspaceIds: async () =>
+    await Promise.resolve([DEFAULT_WORKSPACE_ID]),
+  getAccessibleWorkspaces: async () =>
+    await Promise.resolve([{ id: DEFAULT_WORKSPACE_ID, status: "active" }]),
+  getWorkspaceAccess: async (workspaceId) =>
+    await Promise.resolve(
       workspaceId === DEFAULT_WORKSPACE_ID
         ? { id: workspaceId, status: "active" }
         : null,
     ),
-  pinServerValidatedWorkspaceId: () => true,
+  // Mirrors the accessible set encoded above (getWorkspaceAccess /
+  // getActiveWorkspaceIds): only the default workspace is pinnable out of
+  // the box, matching production's rejection of IDs outside the validated
+  // set. Callers exercising cross-workspace/pinning rejection paths must
+  // override this alongside the accessible-workspace fields.
+  pinServerValidatedWorkspaceId: (workspaceId) =>
+    workspaceId === DEFAULT_WORKSPACE_ID,
   orgAIConfig: null,
   promptCachingEnabled: false,
   request: new Request("https://example.test/handler-context"),
@@ -108,6 +115,7 @@ const createBaseContext = (): BaseTestHandlerContext => ({
  * type (`Parameters<typeof handler.handler>[0]`); pass it so the result slots
  * into the handler call without a further cast.
  */
+// eslint-disable-next-line typescript/no-unnecessary-type-parameters -- the type parameter IS the API: callers pin the handler's own context type per call
 export const createTestHandlerContext = <TContext = BaseTestHandlerContext>(
   overrides: TestHandlerContextOverrides = {},
 ): TContext => {

--- a/apps/api/src/tests/helpers/handler-context.ts
+++ b/apps/api/src/tests/helpers/handler-context.ts
@@ -1,0 +1,124 @@
+import { panic } from "better-result";
+
+import type { roles } from "@stll/permissions";
+
+import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
+import type { OrgAIConfig } from "@/api/lib/ai-config";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { AccessibleWorkspace } from "@/api/lib/auth";
+import type { SafeId } from "@/api/lib/branded-types";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+/**
+ * Shared safe-handler context factory for API handler tests.
+ *
+ * Roughly forty handler test files hand-roll the object a `createSafeHandler`
+ * / `createSafeRootHandler` handler receives, repeating the same
+ * `workspaceId` / `memberRole` / `session` / `user` / `recordAuditEvent`
+ * boilerplate around whatever `body`, `query`, `params`, `safeDb`, and
+ * `scopedDb` the handler under test actually reads. This factory centralises
+ * that boilerplate so those files can migrate mechanically: replace the
+ * `asTestRaw<Ctx>({ ...identity boilerplate..., body })` literal with
+ * `createTestHandlerContext<Ctx>({ body, safeDb, scopedDb })`.
+ *
+ * The defaults mirror the most common hand-rolled shape (an owner acting in a
+ * single workspace) and additionally supply the richer accessor fields
+ * (`getActiveWorkspaceIds`, `getWorkspaceAccess`, `createAuditRecorder`, ...)
+ * that the DB-backed integration contexts need, so one factory covers both the
+ * pure-mock and the PGlite-backed styles. Every field is overridable, and the
+ * three nested identity objects deep-merge so a caller can change just
+ * `session.activeOrganizationId` or just `memberRole.role` without restating
+ * the rest.
+ */
+
+/** The identity/capability fields the factory owns defaults for. */
+export type BaseTestHandlerContext = {
+  workspaceId: SafeId<"workspace">;
+  memberRole: { role: keyof typeof roles };
+  session: { activeOrganizationId: SafeId<"organization"> };
+  user: { id: SafeId<"user"> };
+  safeDb: SafeDb;
+  scopedDb: ScopedDb;
+  recordAuditEvent: AuditRecorder;
+  createAuditRecorder: (opts?: {
+    workspaceId?: SafeId<"workspace"> | null;
+  }) => AuditRecorder;
+  getActiveWorkspaceIds: () => Promise<SafeId<"workspace">[]>;
+  getAccessibleWorkspaces: () => Promise<AccessibleWorkspace[]>;
+  getWorkspaceAccess: (
+    workspaceId: SafeId<"workspace">,
+  ) => Promise<AccessibleWorkspace | null>;
+  pinServerValidatedWorkspaceId: (workspaceId: SafeId<"workspace">) => boolean;
+  orgAIConfig: OrgAIConfig | null;
+  promptCachingEnabled: boolean;
+  request: Request;
+  route: string;
+};
+
+/**
+ * Overrides accepted by {@link createTestHandlerContext}. The base identity
+ * fields are partially overridable and any extra per-handler fields (`body`,
+ * `query`, `params`, ...) pass straight through onto the returned context.
+ */
+export type TestHandlerContextOverrides = Partial<BaseTestHandlerContext> &
+  Record<string, unknown>;
+
+const DEFAULT_WORKSPACE_ID = toSafeId<"workspace">("workspace_test");
+const DEFAULT_ORGANIZATION_ID = toSafeId<"organization">("org_test");
+const DEFAULT_USER_ID = toSafeId<"user">("user_test");
+
+const noopAuditRecorder: AuditRecorder = () => Promise.resolve();
+
+// A handler that reaches for the database without the test providing one is a
+// test bug, not an empty result: fail loudly instead of silently returning
+// nothing.
+const unconfiguredDb = (): never =>
+  panic(
+    "createTestHandlerContext: no safeDb/scopedDb provided; pass one in overrides",
+  );
+
+const createBaseContext = (): BaseTestHandlerContext => ({
+  workspaceId: DEFAULT_WORKSPACE_ID,
+  memberRole: { role: "owner" },
+  session: { activeOrganizationId: DEFAULT_ORGANIZATION_ID },
+  user: { id: DEFAULT_USER_ID },
+  safeDb: unconfiguredDb,
+  scopedDb: unconfiguredDb,
+  recordAuditEvent: noopAuditRecorder,
+  createAuditRecorder: () => noopAuditRecorder,
+  getActiveWorkspaceIds: () => Promise.resolve([DEFAULT_WORKSPACE_ID]),
+  getAccessibleWorkspaces: () =>
+    Promise.resolve([{ id: DEFAULT_WORKSPACE_ID, status: "active" }]),
+  getWorkspaceAccess: (workspaceId) =>
+    Promise.resolve(
+      workspaceId === DEFAULT_WORKSPACE_ID
+        ? { id: workspaceId, status: "active" }
+        : null,
+    ),
+  pinServerValidatedWorkspaceId: () => true,
+  orgAIConfig: null,
+  promptCachingEnabled: false,
+  request: new Request("https://example.test/handler-context"),
+  route: "/tests/handler-context",
+});
+
+/**
+ * Build a safe-handler test context. `TContext` is the handler's own context
+ * type (`Parameters<typeof handler.handler>[0]`); pass it so the result slots
+ * into the handler call without a further cast.
+ */
+export const createTestHandlerContext = <TContext = BaseTestHandlerContext>(
+  overrides: TestHandlerContextOverrides = {},
+): TContext => {
+  const base = createBaseContext();
+  return asTestRaw<TContext>({
+    ...base,
+    ...overrides,
+    // Deep-merge the nested identity objects so a caller can override a single
+    // field (just the org id, just the role) without restating the siblings.
+    memberRole: { ...base.memberRole, ...overrides.memberRole },
+    session: { ...base.session, ...overrides.session },
+    user: { ...base.user, ...overrides.user },
+  });
+};


### PR DESCRIPTION
Add a shared createTestHandlerContext factory in apps/api/src/tests/helpers
that mirrors the safe-handler context object ~40 handler test files hand-roll,
with sensible defaults and deep-override support so those files can migrate to
it mechanically later. This change only adds the helper and its consumers; no
existing test is migrated.

Cover the previously untested billing-adjacent resolution paths:

- rates/resolve.ts: a property test over generated effective-dated rate entry
  sets asserts the resolution contract against a PGlite-backed default rate
  table -- user-specific rate takes precedence over the table default, and
  within each the greatest in-range effectiveFrom wins; falls back to null when
  no default table or no covering entry exists. Handler-level cases cover the
  user/default precedence and the non-member 404.

- usage/get-entitlement.ts and the assertUsageAvailable gate: boundary tests
  for available-at-limit vs limit+1, the zero-cost path, the exclusive
  period-end balance edge, the no-entitlement path, and every entitlement
  status the schema distinguishes (consumable vs blocking). Handler cases cover
  the manager read and the non-manager 403.