### PR TITLE
chore(ci): run env-gated Postgres and smoke suites in nightly

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -46,3 +46,104 @@ jobs:
         run: bun run test -- --concurrency=2
         env:
           TURBO_FORCE: "true"
+
+  # Postgres-backed API suites that gate on STELLA_RUN_POSTGRES_TESTS=true and a
+  # real DATABASE_URL. The plain `bun run test` above skips them (they no-op in
+  # the skip branch), so they only ever execute here against a service Postgres
+  # with migrations applied. Failures are real regressions (pool isolation,
+  # JSONB persistence), so this job is kept separate from the network smoke
+  # canary below whose failures mean "upstream changed", not "we broke something".
+  postgres-suites:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:18.3
+        env:
+          POSTGRES_USER: stella
+          POSTGRES_PASSWORD: stella
+          POSTGRES_DB: stella
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U stella -d stella"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Apply migrations to service Postgres
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
+        # Exercises the shipped migrate entrypoint (Bun SQL + drizzle migrator),
+        # so the JSONB persistence suite runs against the real schema, including
+        # the case-law ingestion role/policy migrations.
+        run: bun run src/db/migrate.ts
+
+      - name: Run Postgres-gated API suites
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgres://stella:stella@127.0.0.1:5432/stella
+          STELLA_RUN_POSTGRES_TESTS: "true"
+        # setup-env.ts supplies the remaining test env via `??=`; the explicit
+        # DATABASE_URL above wins. These files never call `mock.module`, so a
+        # shared process is fine.
+        run: >-
+          bun test --preload ./src/tests/setup-env.ts
+          src/db/root.test.ts
+          src/handlers/case-law/ingestion/pipeline.db.test.ts
+
+  # Upstream-API drift canary for the CJEU adapter. Hits live Cellar SPARQL +
+  # EUR-Lex endpoints, so a failure most often means an upstream schema/endpoint
+  # changed, not a regression in our code. Isolated from the Postgres suites so
+  # a flaky external endpoint cannot mask a real DB regression, and vice versa.
+  smoke-suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Run live CJEU smoke suite
+        working-directory: apps/api
+        env:
+          SMOKE_TEST: "1"
+        run: >-
+          bun test --preload ./src/tests/setup-env.ts
+          src/handlers/case-law/ingestion/adapters/eu-ecj.smoke.test.ts

--- a/packages/property-testing/src/ci-gate-coverage.test.ts
+++ b/packages/property-testing/src/ci-gate-coverage.test.ts
@@ -6,85 +6,167 @@ const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 
 /**
  * Guard: every environment variable a test suite reads to decide whether to
- * run (a "CI gate") must be set by at least one GitHub Actions workflow.
+ * run (a "CI gate") must be turned on by a workflow that also runs that
+ * suite's test file.
  *
  * Env-gated suites (`describe.skipIf(process.env["X"] !== "1")`, or an
  * `if (...) describe.skip else describe`) look like coverage but execute
- * nowhere unless a workflow exports the gate variable. When no workflow does,
- * the suite is permanently skipped while still counting as a passing test: an
- * upstream-API drift canary or a Postgres integration suite that never runs.
- * This guard fails the moment a gate has no workflow that turns it on.
+ * nowhere unless a workflow sets the gate variable and invokes the file.
+ * When neither happens, the suite is permanently skipped while still
+ * counting as a passing test: an upstream-API drift canary or a Postgres
+ * integration suite that never runs. This guard fails the moment a gated
+ * file has no workflow that both sets its gate and runs it.
+ *
+ * Coverage is tracked per (gate, file), not per gate name alone: unrelated
+ * suites elsewhere in the repo can reuse the same gate name (SMOKE_TEST also
+ * gates the business-registries live-API suites) while never being invoked
+ * by any job. Matching only the gate name would treat those as covered
+ * because a workflow happens to mention the same string for a different
+ * file.
  *
  * Gates are discovered by pattern, not a hardcoded list: any test file that
- * compares an UPPER_SNAKE_CASE `process.env[...]` entry against a string
- * literal (`=== "true"`, `!== "1"`) declares a gate. New gates of the same
- * shape are picked up automatically. Always-present config such as
- * `DATABASE_URL` is not matched, because tests read it without a literal
- * comparison.
+ * compares an UPPER_SNAKE_CASE `process.env` entry (dot or bracket access)
+ * against a string literal (`=== "true"`, `!== "1"`, or their loose-equality
+ * forms) declares a gate. New gates of the same shape are picked up
+ * automatically. Always-present config such as `DATABASE_URL` is not
+ * matched, because tests read it without a literal comparison.
  *
- * Extension point: a gate intentionally exercised only in local runs (never
- * in CI) belongs in LOCAL_ONLY_GATES with a comment explaining why. That
- * documents the exemption instead of silently weakening the pattern.
+ * Extension points:
+ * - LOCAL_ONLY_GATES: a gate intentionally exercised only in local runs
+ *   (never in CI). Documents the exemption instead of silently weakening
+ *   the pattern.
+ * - UNWIRED_TEST_FILES: a gated file that is not yet wired into any
+ *   workflow by design (e.g. a live third-party API smoke suite that is a
+ *   separate follow-up decision from the suite this change wires up).
  */
 const LOCAL_ONLY_GATES = new Set<string>();
+
+// Live-API SMOKE_TEST suites not wired into a workflow by this change. Each
+// hits a real upstream endpoint (court register, company registry); wiring
+// them into nightly CI is a separate decision from the CJEU drift canary
+// this change adds. Remove an entry here once its workflow job exists.
+const UNWIRED_TEST_FILES = new Set<string>([
+  "apps/api/src/handlers/case-law/ingestion/adapters/at-courts.test.ts",
+  "packages/business-registries/src/ares/client.test.ts",
+  "packages/business-registries/src/brreg/client.test.ts",
+  "packages/business-registries/src/brreg/roles.test.ts",
+  "packages/business-registries/src/companies-house/client.test.ts",
+  "packages/business-registries/src/denue/client.test.ts",
+  "packages/business-registries/src/edgar/client.test.ts",
+  "packages/business-registries/src/gcis/client.test.ts",
+  "packages/business-registries/src/krs/client.test.ts",
+  "packages/business-registries/src/orsr/client.test.ts",
+  "packages/business-registries/src/prh/client.test.ts",
+  "packages/business-registries/src/recherche-entreprises/client.test.ts",
+  "packages/business-registries/src/vies/client.test.ts",
+]);
 
 const TEST_FILE_GLOB = "{apps,packages}/**/*.test.{ts,tsx}";
 const WORKFLOW_GLOB = ".github/workflows/*.{yml,yaml}";
 
-// process.env["NAME"] === "literal"  |  process.env["NAME"] !== "literal"
+// process.env.NAME or process.env["NAME"], compared with ===, !==, ==, or !=
+// against a string literal.
 const GATE_PATTERN =
-  /process\.env\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]\s*(?:===|!==)\s*["'][^"']*["']/gu;
+  /process\.env(?:\s*\.\s*([A-Z][A-Z0-9_]*)|\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\])\s*(?:===|!==|==|!=)\s*["'][^"']*["']/gu;
 
 // This guard's own source names the gate variables in prose; skip it so it
 // does not report itself as a gate declaration.
 const SELF_PATH = "packages/property-testing/src/ci-gate-coverage.test.ts";
 
-const collectGates = async (): Promise<Map<string, string>> => {
+type GateDeclaration = { gate: string; file: string };
+
+const collectGates = async (): Promise<GateDeclaration[]> => {
   const glob = new Bun.Glob(TEST_FILE_GLOB);
-  // Gate name -> first test file that declared it (for a readable failure).
-  const gates = new Map<string, string>();
+  const declarations: GateDeclaration[] = [];
+  const seen = new Set<string>();
   for await (const relativePath of glob.scan({ cwd: REPO_ROOT })) {
     if (relativePath.includes("node_modules") || relativePath === SELF_PATH) {
       continue;
     }
     const source = await Bun.file(path.resolve(REPO_ROOT, relativePath)).text();
     for (const match of source.matchAll(GATE_PATTERN)) {
-      const gate = match[1];
-      if (gate && !LOCAL_ONLY_GATES.has(gate) && !gates.has(gate)) {
-        gates.set(gate, relativePath);
+      const gate = match[1] || match[2];
+      const key = `${gate} ${relativePath}`;
+      if (!gate || LOCAL_ONLY_GATES.has(gate) || seen.has(key)) {
+        continue;
       }
+      seen.add(key);
+      declarations.push({ gate, file: relativePath });
     }
   }
-  return gates;
+  return declarations;
 };
 
-const readWorkflowText = async (): Promise<string> => {
+type Workflow = { path: string; text: string };
+
+const readWorkflows = async (): Promise<Workflow[]> => {
   const glob = new Bun.Glob(WORKFLOW_GLOB);
-  const chunks: string[] = [];
+  const workflows: Workflow[] = [];
   // `dot: true` so the scan descends into the hidden `.github` directory.
   for await (const relativePath of glob.scan({ cwd: REPO_ROOT, dot: true })) {
-    chunks.push(await Bun.file(path.resolve(REPO_ROOT, relativePath)).text());
+    workflows.push({
+      path: relativePath,
+      text: await Bun.file(path.resolve(REPO_ROOT, relativePath)).text(),
+    });
   }
-  return chunks.join("\n");
+  return workflows;
+};
+
+// Suffixes of a repo-relative path, longest first, dropping at least one
+// leading segment each step and stopping before the bare filename. Workflow
+// steps run tests from a `working-directory` (e.g. `apps/api`), so the
+// command text only ever contains a path relative to that directory, never
+// the full repo-relative path. Requiring >= 2 segments avoids treating a
+// coincidental filename mention (e.g. in a comment) as evidence the file
+// actually runs.
+const pathSuffixes = (file: string): string[] => {
+  const segments = file.split("/");
+  const suffixes: string[] = [];
+  for (let dropped = 0; dropped < segments.length - 1; dropped++) {
+    suffixes.push(segments.slice(dropped).join("/"));
+  }
+  return suffixes;
+};
+
+// A declaration is wired when some single workflow both sets the gate and
+// runs the declaring file. Checking the gate name against the whole
+// workflow corpus alone is not enough: see the UNWIRED_TEST_FILES doc above
+// for why that produces false coverage.
+const isWired = (
+  declaration: GateDeclaration,
+  workflows: Workflow[],
+): boolean => {
+  const suffixes = pathSuffixes(declaration.file);
+  return workflows.some(
+    (workflow) =>
+      workflow.text.includes(declaration.gate) &&
+      suffixes.some((suffix) => workflow.text.includes(suffix)),
+  );
 };
 
 describe("ci-gate coverage convention", () => {
-  test("every env-gated test suite has a workflow that sets its gate", async () => {
-    const [gates, workflowText] = await Promise.all([
+  test("every env-gated test suite has a workflow that runs it with its gate set", async () => {
+    const [declarations, workflows] = await Promise.all([
       collectGates(),
-      readWorkflowText(),
+      readWorkflows(),
     ]);
 
     // Sanity: the known gates must still be discovered by the pattern.
     // A miss here means the detection rotted, not that coverage is fine.
-    const discovered = [...gates.keys()].sort();
-    expect(discovered).toEqual(
+    const discoveredGates = [
+      ...new Set(declarations.map((d) => d.gate)),
+    ].sort();
+    expect(discoveredGates).toEqual(
       expect.arrayContaining(["SMOKE_TEST", "STELLA_RUN_POSTGRES_TESTS"]),
     );
 
-    const uncovered = [...gates.entries()]
-      .filter(([gate]) => !workflowText.includes(gate))
-      .map(([gate, file]) => `${gate} (declared in ${file})`)
+    const uncovered = declarations
+      .filter(
+        (declaration) =>
+          !UNWIRED_TEST_FILES.has(declaration.file) &&
+          !isWired(declaration, workflows),
+      )
+      .map(({ gate, file }) => `${gate} (declared in ${file})`)
       .sort();
     expect(uncovered).toEqual([]);
   });

--- a/packages/property-testing/src/ci-gate-coverage.test.ts
+++ b/packages/property-testing/src/ci-gate-coverage.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+// Repo root, four levels up from this file (packages/property-testing/src).
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+
+/**
+ * Guard: every environment variable a test suite reads to decide whether to
+ * run (a "CI gate") must be set by at least one GitHub Actions workflow.
+ *
+ * Env-gated suites (`describe.skipIf(process.env["X"] !== "1")`, or an
+ * `if (...) describe.skip else describe`) look like coverage but execute
+ * nowhere unless a workflow exports the gate variable. When no workflow does,
+ * the suite is permanently skipped while still counting as a passing test: an
+ * upstream-API drift canary or a Postgres integration suite that never runs.
+ * This guard fails the moment a gate has no workflow that turns it on.
+ *
+ * Gates are discovered by pattern, not a hardcoded list: any test file that
+ * compares an UPPER_SNAKE_CASE `process.env[...]` entry against a string
+ * literal (`=== "true"`, `!== "1"`) declares a gate. New gates of the same
+ * shape are picked up automatically. Always-present config such as
+ * `DATABASE_URL` is not matched, because tests read it without a literal
+ * comparison.
+ *
+ * Extension point: a gate intentionally exercised only in local runs (never
+ * in CI) belongs in LOCAL_ONLY_GATES with a comment explaining why. That
+ * documents the exemption instead of silently weakening the pattern.
+ */
+const LOCAL_ONLY_GATES = new Set<string>();
+
+const TEST_FILE_GLOB = "{apps,packages}/**/*.test.{ts,tsx}";
+const WORKFLOW_GLOB = ".github/workflows/*.{yml,yaml}";
+
+// process.env["NAME"] === "literal"  |  process.env["NAME"] !== "literal"
+const GATE_PATTERN =
+  /process\.env\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]\s*(?:===|!==)\s*["'][^"']*["']/gu;
+
+// This guard's own source names the gate variables in prose; skip it so it
+// does not report itself as a gate declaration.
+const SELF_PATH = "packages/property-testing/src/ci-gate-coverage.test.ts";
+
+const collectGates = async (): Promise<Map<string, string>> => {
+  const glob = new Bun.Glob(TEST_FILE_GLOB);
+  // Gate name -> first test file that declared it (for a readable failure).
+  const gates = new Map<string, string>();
+  for await (const relativePath of glob.scan({ cwd: REPO_ROOT })) {
+    if (relativePath.includes("node_modules") || relativePath === SELF_PATH) {
+      continue;
+    }
+    const source = await Bun.file(path.resolve(REPO_ROOT, relativePath)).text();
+    for (const match of source.matchAll(GATE_PATTERN)) {
+      const gate = match[1];
+      if (gate && !LOCAL_ONLY_GATES.has(gate) && !gates.has(gate)) {
+        gates.set(gate, relativePath);
+      }
+    }
+  }
+  return gates;
+};
+
+const readWorkflowText = async (): Promise<string> => {
+  const glob = new Bun.Glob(WORKFLOW_GLOB);
+  const chunks: string[] = [];
+  // `dot: true` so the scan descends into the hidden `.github` directory.
+  for await (const relativePath of glob.scan({ cwd: REPO_ROOT, dot: true })) {
+    chunks.push(await Bun.file(path.resolve(REPO_ROOT, relativePath)).text());
+  }
+  return chunks.join("\n");
+};
+
+describe("ci-gate coverage convention", () => {
+  test("every env-gated test suite has a workflow that sets its gate", async () => {
+    const [gates, workflowText] = await Promise.all([
+      collectGates(),
+      readWorkflowText(),
+    ]);
+
+    // Sanity: the known gates must still be discovered by the pattern.
+    // A miss here means the detection rotted, not that coverage is fine.
+    const discovered = [...gates.keys()].sort();
+    expect(discovered).toEqual(
+      expect.arrayContaining(["SMOKE_TEST", "STELLA_RUN_POSTGRES_TESTS"]),
+    );
+
+    const uncovered = [...gates.entries()]
+      .filter(([gate]) => !workflowText.includes(gate))
+      .map(([gate, file]) => `${gate} (declared in ${file})`)
+      .sort();
+    expect(uncovered).toEqual([]);
+  });
+});


### PR DESCRIPTION
Three env-gated API suites never executed in any workflow, so they
counted as passing coverage while running nowhere:

- src/db/root.test.ts (pool isolation)
- src/handlers/case-law/ingestion/pipeline.db.test.ts (JSONB persistence)
  both gate on STELLA_RUN_POSTGRES_TESTS=true + DATABASE_URL
- src/handlers/case-law/ingestion/adapters/eu-ecj.smoke.test.ts
  (live CJEU drift canary) gates on SMOKE_TEST=1

Add two nightly jobs:

- postgres-suites: a service Postgres (mirrors db-migrations.yml),
  applies migrations via the shipped migrate entrypoint, then runs the
  two Postgres suites with STELLA_RUN_POSTGRES_TESTS=true and an explicit
  DATABASE_URL.
- smoke-suite: runs the CJEU smoke suite with SMOKE_TEST=1 against live
  upstream endpoints. Kept separate from postgres-suites so a flaky
  external endpoint (upstream changed) cannot mask a real DB regression.

Add a convention guard (ci-gate-coverage.test.ts) that discovers env
gates by pattern (an UPPER_SNAKE_CASE process.env entry compared to a
string literal in a test file) and fails when a gate does not appear in
any workflow file, so a newly added gated suite cannot silently run
nowhere. LOCAL_ONLY_GATES is the documented exemption point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated testing with nightly checks against a real PostgreSQL database.
  - Added a live upstream API smoke test to help detect issues with external data integrations.
  - Added safeguards ensuring environment-specific test suites are correctly connected to continuous integration workflows.
- **Reliability**
  - Improved confidence that database-backed and live API functionality continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->