### PR TITLE
fix(web): correct query cache identity for clause preview and fill discover; guard version-diff race

### DIFF
--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -1441,14 +1441,20 @@ const HistoryTab = ({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [diffResult, setDiffResult] = useState<ParagraphDiff[] | null>(null);
   const [loading, setLoading] = useState(false);
+  // Bumped on every click so a slow response for an earlier version cannot
+  // clobber the diff of a version selected later (or after a toggle-off).
+  const requestGenerationRef = useRef(0);
 
   const handleVersionClick = async (versionId: string) => {
     if (selectedId === versionId) {
+      requestGenerationRef.current += 1;
       setSelectedId(null);
       setDiffResult(null);
+      setLoading(false);
       return;
     }
 
+    const generation = (requestGenerationRef.current += 1);
     setSelectedId(versionId);
     setLoading(true);
     setDiffResult(null);
@@ -1457,6 +1463,12 @@ const HistoryTab = ({
       .clauses({ clauseId })
       .versions({ versionId })
       .get();
+
+    if (generation !== requestGenerationRef.current) {
+      // A newer click superseded this request; the winning request owns the
+      // loading flag and diff state, so drop this stale response entirely.
+      return;
+    }
 
     setLoading(false);
 

--- a/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
@@ -37,6 +37,7 @@ import type {
   AsyncContent,
   VersionDiffSegment,
 } from "@/components/versions/version-list";
+import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors/api";
 import { userErrorMessage } from "@/lib/errors/user-safe";
@@ -108,8 +109,10 @@ export const TemplateClausesTab = ({ templateId }: TemplateClausesTabProps) => {
           templateId,
         ),
       })
-      .catch(() => {
-        /* fire-and-forget */
+      .catch((error: unknown) => {
+        // Invalidation failure leaves the clause list (and its nested preview)
+        // stale without a user-facing symptom: capture it for telemetry.
+        getAnalytics().captureError(error);
       });
   }, [queryClient, activeOrganizationId, templateId]);
 

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-inspector.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { panic, TaggedError } from "better-result";
 import {
   AlertTriangleIcon,
   BookmarkIcon,
@@ -66,14 +65,8 @@ import { useI18nStore } from "@/i18n/i18n-store";
 import { api } from "@/lib/api";
 import { optionalArray, optionalReadonlyArray } from "@/lib/arrays";
 import { BoundedMap } from "@/lib/bounded-set";
-import {
-  DOCX_MIME,
-  SIDE_RAIL_TAB_ICON_SIZE_PX,
-  TOOLBAR_ROW_HEIGHT,
-} from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
+import { SIDE_RAIL_TAB_ICON_SIZE_PX, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { userErrorMessage } from "@/lib/errors/user-safe";
-import { fetchWithTimeout } from "@/lib/fetch";
 import { toSafeId } from "@/lib/safe-id";
 import { LinkClauseDialog } from "@/routes/_protected.knowledge/-components/link-clause-dialog";
 import { parseArrayItemKey } from "@/routes/_protected.knowledge/-components/template-array-item-key";
@@ -114,18 +107,12 @@ import {
   templateClausePreviewOptions,
   templateClausesOptions,
   templateDetailOptions,
+  templateFillDiscoverOptions,
   templateRecipesOptions,
 } from "@/routes/_protected.knowledge/-queries";
 
 type StudioFacet = "fields" | "guidance" | "history" | "fill";
 type TemplateStudioPayload = { templateId: string };
-
-class TemplateDocumentFetchError extends TaggedError(
-  "TemplateDocumentFetchError",
-)<{
-  message: string;
-  status: number;
-}>() {}
 
 const STUDIO_FACETS: readonly StudioFacet[] = [
   "fields",
@@ -449,43 +436,12 @@ export const TemplateFillFacet = ({
     data: discovered,
     isLoading: discovering,
     isError,
-  } = useQuery({
-    queryKey: [
-      ...knowledgeKeys.templates.detail(activeOrganizationId, templateId),
-      "fill-discover",
-      presignedUrl,
-      fileName,
-    ],
-    queryFn: async ({ signal }) => {
-      if (presignedUrl === undefined || fileName === undefined) {
-        panic("fill tab: saved template document is unavailable");
-      }
-      const res = await fetchWithTimeout(presignedUrl, {
-        signal,
-        timeoutMs: 15_000,
-      });
-      if (!res.ok) {
-        throw new TemplateDocumentFetchError({
-          message: `Template document fetch failed (${res.status})`,
-          status: res.status,
-        });
-      }
-      const blob = await res.blob();
-      const file = new File([blob], fileName, { type: DOCX_MIME });
-      const response = await api.templates.discover.post(
-        { file },
-        { fetch: { signal } },
-      );
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      if (response.data instanceof Response) {
-        panic("fill tab: discover returned a raw response");
-      }
-      return response.data;
-    },
-    enabled: presignedUrl !== undefined && fileName !== undefined,
-  });
+  } = useQuery(
+    templateFillDiscoverOptions({
+      key: { organizationId: activeOrganizationId, templateId },
+      context: { presignedUrl, fileName },
+    }),
+  );
 
   if (!detail || discovering) {
     return (

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio.tsx
@@ -1068,9 +1068,29 @@ export const TemplateStudioPage = ({
       // where the stored DOCX already carries the renamed {{@clause:...}}
       // markers but template_clauses.slotName does not, showing a false
       // check-badge mismatch.
-      void queryClient.invalidateQueries({
-        queryKey: knowledgeKeys.templates.all(activeOrganizationId),
-      });
+      //
+      // `fillDiscover` is nested under `detail` but deliberately keyed on the
+      // stable template id only, not the rotating presigned URL (see the key
+      // comment in -queries.ts): its refetch must run against the *new*
+      // detail's URL. Invalidating it in the same pass as `detail` refetches
+      // both concurrently, so a still-mounted Fill facet can re-run discovery
+      // with the pre-save URL still in its context, discovering the old
+      // document's fields. Exclude it here and invalidate it separately once
+      // `detail` (and everything else) has settled.
+      void queryClient
+        .invalidateQueries({
+          queryKey: knowledgeKeys.templates.all(activeOrganizationId),
+          predicate: (query) => query.queryKey.at(-1) !== "fill-discover",
+        })
+        .then(
+          async () =>
+            await queryClient.invalidateQueries({
+              queryKey: knowledgeKeys.templates.fillDiscover(
+                activeOrganizationId,
+                templateId,
+              ),
+            }),
+        );
       // Report overall failure when a slot PATCH hard-failed: the document
       // itself saved, but "Save and leave" must stay in the Studio so the
       // still-pending steps (and their retry) are not discarded by the

--- a/apps/web/src/routes/_protected.knowledge/-components/use-template-fill-schema.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/use-template-fill-schema.ts
@@ -1,14 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
-import { panic, TaggedError } from "better-result";
 
-import { api } from "@/lib/api";
-import { DOCX_MIME } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors/api";
-import { fetchWithTimeout } from "@/lib/fetch";
+import type { api } from "@/lib/api";
 import {
-  knowledgeKeys,
   templateDetailOptions,
+  templateFillDiscoverOptions,
 } from "@/routes/_protected.knowledge/-queries";
 
 /**
@@ -16,15 +12,9 @@ import {
  * form outside the Studio: load the template detail (presigned source URL),
  * fetch the bytes, and re-discover fields server-side — the same merge the
  * fill endpoint applies, so `{{#each}}` array fields and manifest metadata
- * are both present.
+ * are both present. Shares the `templateFillDiscoverOptions` cache entry with
+ * the Studio fill tab.
  */
-
-class TemplateDocumentFetchError extends TaggedError(
-  "TemplateDocumentFetchError",
-)<{
-  message: string;
-  status: number;
-}>() {}
 
 type DiscoverResponse = Awaited<ReturnType<typeof api.templates.discover.post>>;
 
@@ -54,49 +44,19 @@ export const useTemplateFillSchema = (
       ? detailData
       : null;
 
-  const presignedUrl = detail?.presignedUrl;
-  const fileName = detail?.fileName;
   const {
     data: discovered,
     isError: discoverError,
     isLoading: discovering,
-  } = useQuery({
-    queryKey: [
-      ...knowledgeKeys.templates.detail(activeOrganizationId, templateId),
-      "fill-discover",
-      presignedUrl,
-      fileName,
-    ],
-    queryFn: async ({ signal }) => {
-      if (presignedUrl === undefined || fileName === undefined) {
-        panic("template fill: saved template document is unavailable");
-      }
-      const res = await fetchWithTimeout(presignedUrl, {
-        signal,
-        timeoutMs: 15_000,
-      });
-      if (!res.ok) {
-        throw new TemplateDocumentFetchError({
-          message: `Template document fetch failed (${res.status})`,
-          status: res.status,
-        });
-      }
-      const blob = await res.blob();
-      const file = new File([blob], fileName, { type: DOCX_MIME });
-      const response = await api.templates.discover.post(
-        { file },
-        { fetch: { signal } },
-      );
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
-      if (response.data instanceof Response) {
-        panic("template fill: discover returned a raw response");
-      }
-      return response.data;
-    },
-    enabled: presignedUrl !== undefined && fileName !== undefined,
-  });
+  } = useQuery(
+    templateFillDiscoverOptions({
+      key: { organizationId: activeOrganizationId, templateId },
+      context: {
+        presignedUrl: detail?.presignedUrl,
+        fileName: detail?.fileName,
+      },
+    }),
+  );
 
   if (detailError || discoverError) {
     return { state: "error" };

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -1,9 +1,11 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+import { panic, TaggedError } from "better-result";
 
 import { api } from "@/lib/api";
-import { STALE_TIME } from "@/lib/consts";
+import { DOCX_MIME, STALE_TIME } from "@/lib/consts";
 import { APIError, toAPIError } from "@/lib/errors/api";
 import { fetchWithTimeout } from "@/lib/fetch";
+import type { QueryOptionsInput } from "@/lib/react-query";
 import type { SafeId } from "@/lib/safe-id";
 import { toSafeId } from "@/lib/safe-id";
 
@@ -78,12 +80,12 @@ export const knowledgeKeys = {
       "clauses",
     ],
     // Resolved plain text of each linked clause slot, for the Fill subtab's
-    // live in-document preview. Lives in the templates subtree so editing a
-    // clause link (which invalidates templates) refreshes the preview text.
+    // live in-document preview. Nested under the `clauses` key so invalidating
+    // the clause links (both edit sites do) prefix-matches and refreshes the
+    // preview text; keeping it a sibling would leave the preview stale.
     clausePreview: (organizationId: string, templateId: string) => [
-      ...knowledgeKeys.templates.all(organizationId),
-      templateId,
-      "clause-preview",
+      ...knowledgeKeys.templates.clauses(organizationId, templateId),
+      "preview",
     ],
     check: (organizationId: string, templateId: string) => [
       ...knowledgeKeys.templates.all(organizationId),
@@ -94,6 +96,14 @@ export const knowledgeKeys = {
       ...knowledgeKeys.templates.all(organizationId),
       templateId,
       "docx-buffer",
+    ],
+    // Server re-discovered fill schema for the saved document. Nested under
+    // `detail` (the document reference it depends on), keyed on the stable
+    // template id only: the presigned URL rotates on every detail refetch and
+    // must not be part of the cache identity.
+    fillDiscover: (organizationId: string, templateId: string) => [
+      ...knowledgeKeys.templates.detail(organizationId, templateId),
+      "fill-discover",
     ],
   },
   templateCategories: {
@@ -277,6 +287,80 @@ export const templateDocxBufferOptions = (
       return response.arrayBuffer();
     },
     staleTime: STALE_TIME.FIVE.MINUTES,
+  });
+
+// Re-parses a *saved* template's stored .docx server-side to recover the
+// fillable field schema (the same merge the fill endpoint applies, so
+// `{{#each}}` array fields and manifest metadata are both present). Shared by
+// the Studio fill tab and any host that renders the fill form standalone, so
+// both dedupe on one cache entry. Keyed on the stable template id (see the
+// `fillDiscover` key comment): the presigned URL and file name are runtime-only
+// context, never cache identity.
+export class TemplateDocumentFetchError extends TaggedError(
+  "TemplateDocumentFetchError",
+)<{
+  message: string;
+  status: number;
+}>() {}
+
+type TemplateFillDiscoverKey = {
+  organizationId: string;
+  templateId: string;
+};
+
+type TemplateFillDiscoverContext = {
+  presignedUrl: string | undefined;
+  fileName: string | undefined;
+};
+
+type TemplateFillDiscoverOptionsInput = QueryOptionsInput<
+  TemplateFillDiscoverKey,
+  TemplateFillDiscoverContext
+>;
+
+export const templateFillDiscoverOptions = ({
+  key,
+  context,
+}: TemplateFillDiscoverOptionsInput) =>
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- presignedUrl/fileName are runtime-only context; keyed on the stable template id so a URL rotation does not evict this cache and force a re-download + re-discover.
+  queryOptions({
+    queryKey: knowledgeKeys.templates.fillDiscover(
+      key.organizationId,
+      key.templateId,
+    ),
+    queryFn: async ({ signal }) => {
+      if (
+        context.presignedUrl === undefined ||
+        context.fileName === undefined
+      ) {
+        panic("template fill: saved template document is unavailable");
+      }
+      const res = await fetchWithTimeout(context.presignedUrl, {
+        signal,
+        timeoutMs: 15_000,
+      });
+      if (!res.ok) {
+        throw new TemplateDocumentFetchError({
+          message: `Template document fetch failed (${res.status})`,
+          status: res.status,
+        });
+      }
+      const blob = await res.blob();
+      const file = new File([blob], context.fileName, { type: DOCX_MIME });
+      const response = await api.templates.discover.post(
+        { file },
+        { fetch: { signal } },
+      );
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      if (response.data instanceof Response) {
+        panic("template fill: discover returned a raw response");
+      }
+      return response.data;
+    },
+    enabled:
+      context.presignedUrl !== undefined && context.fileName !== undefined,
   });
 
 const TEMPLATE_VERSIONS_PAGE_SIZE = 20;


### PR DESCRIPTION
Three fixes in the knowledge/template-studio area:

- Clause-preview cache never refreshed after editing a linked clause. The
  Fill tab's resolved-text preview keyed as a sibling of the clause-links
  key ("clause-preview" vs "clauses"), so the invalidations both edit sites
  fire never covered it. Nest clausePreview under the clauses key (compose by
  spreading the parent) so a clause-link invalidation prefix-matches and
  refreshes the preview. Also capture the tab's invalidation failure via
  analytics instead of swallowing it.

- Fill-discover query embedded the server-rotated presigned URL in its key,
  so every template save rotated the key and forced a full DOCX re-download
  and re-discover. Key on the stable template id and pass the URL and file
  name as runtime-only context, mirroring templateDocxBufferOptions. Extract
  the duplicated inline query (inspector + useTemplateFillSchema) into one
  shared templateFillDiscoverOptions factory so both dedupe on one cache
  entry and cannot drift.

- Version-history diff had no ordering guard: a slow response for an earlier
  version could clobber the diff of a version selected later. Add a
  generation counter so a superseded request drops its result.
