### PR TITLE
fix(web): template fill and registry lookup correctness

### DIFF
--- a/apps/web/src/routes/_protected.knowledge/-components/registry-autofill.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/registry-autofill.ts
@@ -85,7 +85,12 @@ export const extractRegistryFields = (
     out.legalForm = hit.legalForm;
   }
   // The canonical id is the registration number for the chosen registry
-  // (KRS number, IČO, company number, …).
+  // (KRS number, IČO, company number, …). VIES is the one registry where
+  // `hit.id` is a VAT number rather than a registration number, so a
+  // field-group that only has a `vat`/`tax_id`-suffixed field (mapped to
+  // `taxId`, not `registrationId`) still gets zero updates from a
+  // successful VIES lookup. Mapping VIES's id into `taxId` too is
+  // deliberately deferred: known limitation, tracked for a follow-up pass.
   if (hit.id) {
     out.registrationId = hit.id;
   }

--- a/apps/web/src/routes/_protected.knowledge/-components/registry-options.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/registry-options.ts
@@ -1,0 +1,44 @@
+/**
+ * Registries offered for one-click company autofill, shared by the template
+ * fill form (the party-block "look up by company id" control) and the wizard's
+ * "Company ID" field configurator. One list so the two surfaces can never
+ * drift: a registry offered for configuration is always offered for autofill.
+ *
+ * Slugs mirror `LOOKUP_REGISTRIES` (the full `BUSINESS_REGISTRY_SLUGS`); labels
+ * are registry proper names (not translatable UI copy); `country` is the ISO
+ * 3166-1 alpha-2 region (or a pseudo-region like "EU"), used to order options
+ * jurisdiction-first.
+ *
+ * Autofill coverage per registry: the fill mapping (`extractRegistryFields` in
+ * `registry-autofill.ts`) always fills the cross-registry baseline (name,
+ * registration id, legal form, address) from the top-level hit, so every
+ * registry here supports baseline autofill. Registry-specific identifiers
+ * (tax/stat id, share capital) are only mapped for krs/ares/orsr today; the
+ * others degrade to the baseline until their `details` branch is mapped.
+ */
+
+import type { LookupRegistry } from "./template-field-manifest";
+
+export type LookupRegistryOption = {
+  slug: LookupRegistry;
+  label: string;
+  country: string;
+};
+
+export const LOOKUP_REGISTRY_OPTIONS: readonly LookupRegistryOption[] = [
+  { slug: "ares", label: "Czechia — ARES", country: "CZ" },
+  { slug: "orsr", label: "Slovakia — ORSR", country: "SK" },
+  { slug: "krs", label: "Poland — KRS", country: "PL" },
+  {
+    slug: "companies-house",
+    label: "United Kingdom — Companies House",
+    country: "GB",
+  },
+  { slug: "denue", label: "Mexico — INEGI DENUE", country: "MX" },
+  { slug: "brreg", label: "Norway — Brønnøysund (BRREG)", country: "NO" },
+  { slug: "prh", label: "Finland — PRH", country: "FI" },
+  { slug: "recherche-entreprises", label: "France — RNE", country: "FR" },
+  { slug: "edgar", label: "United States — SEC EDGAR", country: "US" },
+  { slug: "gcis", label: "Taiwan — GCIS", country: "TW" },
+  { slug: "vies", label: "European Union — VIES (VAT)", country: "EU" },
+];

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -58,13 +58,17 @@ import {
 } from "@/routes/_protected.knowledge/-queries";
 import { catalogueKeys } from "@/routes/_protected.knowledge/-queries/catalogue";
 
+import {
+  FILENAME_PATTERN,
+  reserveKnowledgePath,
+} from "./skill-resource-path.logic";
+
 const SKILL_BODY_FILE_NAME = "SKILL.md";
 
 // Mirrors apps/api/src/handlers/skills/resources/resource-path.ts.
 // Keep the two in sync.
 const RESOURCE_PATH_PATTERN =
   /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/u;
-const FILENAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
 
 // Default name for a freshly created (still empty) folder. A path segment,
 // not user-facing copy: resource paths only allow lowercase ASCII, so a
@@ -552,7 +556,10 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
     patchMetadata.mutate({ command: next });
   };
 
-  const handleUpload = async (file: File) => {
+  // Upload one file, reserving its `knowledge/<name>` path against the shared
+  // `takenPaths` set. The set carries reservations between files in the same
+  // drop, so identically named files get distinct paths instead of colliding.
+  const handleUpload = async (file: File, takenPaths: Set<string>) => {
     const binary = isBinaryUpload(file);
     const maxBytes = binary ? UPLOAD_MAX_BYTES_BINARY : UPLOAD_MAX_BYTES_TEXT;
     if (file.size > maxBytes) {
@@ -563,38 +570,34 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
       });
       return;
     }
-    // For binary uploads we replace the extension with `.md` because the
-    // stored resource holds the extracted text, not the original bytes.
-    const baseName = binary
-      ? `${file.name.replace(/\.(?:docx|pdf)$/iu, "")}.md`
-      : file.name;
-    const sanitizedName = baseName
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9._-]/gu, "-");
-    if (!FILENAME_PATTERN.test(sanitizedName)) {
+    // Drop new uploads into knowledge/ by default. The user can rename
+    // afterward if they want a different folder.
+    const reserved = reserveKnowledgePath(file.name, binary, takenPaths);
+    if (reserved.type === "invalid") {
       stellaToast.add({
         title: tSkills("invalidPath"),
         type: "error",
       });
       return;
     }
-    // Drop new uploads into knowledge/ by default. The user can rename
-    // afterward if they want a different folder.
-    const extMatch = /(?<ext>\.[^.]+)?$/u.exec(sanitizedName);
-    const ext = extMatch?.groups?.["ext"] ?? "";
-    const stem = ext ? sanitizedName.slice(0, -ext.length) : sanitizedName;
-    let path = `knowledge/${sanitizedName}`;
-    let suffix = 1;
-    while (existingPaths.has(path)) {
-      suffix += 1;
-      path = `knowledge/${stem}-${suffix}${ext}`;
-    }
+    const { path } = reserved;
     if (binary) {
       uploadResource.mutate({ path, file });
       return;
     }
     const content = await file.text();
     createResource.mutate({ path, content });
+  };
+
+  // Reserve every dropped/selected file's path up front against one set seeded
+  // from the current resources. `reserveKnowledgePath` runs synchronously
+  // before each upload's first await, so path assignment stays ordered and two
+  // same-named files in one batch never resolve to the same path.
+  const handleUploadFiles = (files: readonly File[]) => {
+    const takenPaths = new Set(existingPaths);
+    for (const file of files) {
+      void handleUpload(file, takenPaths);
+    }
   };
 
   const onCreateFile = (path: string, content: string) => {
@@ -767,9 +770,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
         className="p-3"
         label={t("workspaces.dropToUploadFiles")}
         onDrop={(files) => {
-          for (const file of files) {
-            void handleUpload(file);
-          }
+          handleUploadFiles(files);
         }}
       >
         <div className="mb-2 flex items-center gap-1 px-1">
@@ -847,9 +848,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
               onCreateFile={onCreateFile}
               onCreateFolder={() => createPendingFolder(null)}
               onUploadFiles={(files) => {
-                for (const file of files) {
-                  void handleUpload(file);
-                }
+                handleUploadFiles(files);
               }}
             />
           </div>

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-resource-path.logic.test.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-resource-path.logic.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { reserveKnowledgePath } from "@/routes/_protected.knowledge/-components/skill-resource-path.logic";
+
+describe("reserveKnowledgePath", () => {
+  test("places a new file under knowledge/", () => {
+    const result = reserveKnowledgePath("notes.md", false, new Set());
+    expect(result).toEqual({ type: "ok", path: "knowledge/notes.md" });
+  });
+
+  test("suffixes against paths already present", () => {
+    const taken = new Set(["knowledge/notes.md"]);
+    const result = reserveKnowledgePath("notes.md", false, taken);
+    expect(result).toEqual({ type: "ok", path: "knowledge/notes-2.md" });
+  });
+
+  test("two identical names in one drop resolve to distinct paths", () => {
+    const taken = new Set<string>();
+    const first = reserveKnowledgePath("report.md", false, taken);
+    const second = reserveKnowledgePath("report.md", false, taken);
+    const third = reserveKnowledgePath("report.md", false, taken);
+    expect(first).toEqual({ type: "ok", path: "knowledge/report.md" });
+    expect(second).toEqual({ type: "ok", path: "knowledge/report-2.md" });
+    expect(third).toEqual({ type: "ok", path: "knowledge/report-3.md" });
+  });
+
+  test("reserves each assigned path into the shared set", () => {
+    const taken = new Set<string>();
+    reserveKnowledgePath("a.md", false, taken);
+    reserveKnowledgePath("a.md", false, taken);
+    expect(taken).toEqual(new Set(["knowledge/a.md", "knowledge/a-2.md"]));
+  });
+
+  test("binary uploads store extracted text as .md", () => {
+    expect(reserveKnowledgePath("Brief.DOCX", true, new Set())).toEqual({
+      type: "ok",
+      path: "knowledge/brief.md",
+    });
+    expect(reserveKnowledgePath("scan.pdf", true, new Set())).toEqual({
+      type: "ok",
+      path: "knowledge/scan.md",
+    });
+  });
+
+  test("collision resolution preserves the extension on the suffix", () => {
+    const taken = new Set(["knowledge/data.json"]);
+    expect(reserveKnowledgePath("data.json", false, taken)).toEqual({
+      type: "ok",
+      path: "knowledge/data-2.json",
+    });
+  });
+
+  test("sanitizes disallowed characters", () => {
+    expect(
+      reserveKnowledgePath("My Notes (draft).md", false, new Set()),
+    ).toEqual({ type: "ok", path: "knowledge/my-notes--draft-.md" });
+  });
+
+  test("rejects a name that cannot start with an allowed character", () => {
+    expect(reserveKnowledgePath("---", false, new Set())).toEqual({
+      type: "invalid",
+    });
+  });
+});

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-resource-path.logic.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-resource-path.logic.ts
@@ -1,0 +1,53 @@
+/**
+ * Path reservation for uploaded skill resources.
+ *
+ * Pure and synchronous so a multi-file drop can reserve every path up front
+ * against one shared set: each reservation mutates `takenPaths`, so two
+ * identically named files in the same drop land on distinct paths
+ * (`knowledge/foo.md`, `knowledge/foo-2.md`) instead of both deriving the same
+ * path from a set that has not seen the first upload yet.
+ */
+
+/** Sanitized skill-resource filenames: lowercase alphanumeric plus dot,
+ *  underscore, and hyphen, never leading with a separator. */
+export const FILENAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
+
+const BINARY_EXTENSION_RE = /\.(?:docx|pdf)$/iu;
+
+export type ReservePathResult =
+  | { type: "ok"; path: string }
+  | { type: "invalid" };
+
+/**
+ * Reserve a collision-free `knowledge/<name>` path for one uploaded file,
+ * mutating `takenPaths` so the next reservation from the same set skips it.
+ *
+ * Binary uploads store extracted text rather than the original bytes, so their
+ * stored name swaps the original extension for `.md`.
+ */
+export const reserveKnowledgePath = (
+  fileName: string,
+  isBinary: boolean,
+  takenPaths: Set<string>,
+): ReservePathResult => {
+  const baseName = isBinary
+    ? `${fileName.replace(BINARY_EXTENSION_RE, "")}.md`
+    : fileName;
+  const sanitizedName = baseName
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9._-]/gu, "-");
+  if (!FILENAME_PATTERN.test(sanitizedName)) {
+    return { type: "invalid" };
+  }
+  const extMatch = /(?<ext>\.[^.]+)?$/u.exec(sanitizedName);
+  const ext = extMatch?.groups?.["ext"] ?? "";
+  const stem = ext ? sanitizedName.slice(0, -ext.length) : sanitizedName;
+  let path = `knowledge/${sanitizedName}`;
+  let suffix = 1;
+  while (takenPaths.has(path)) {
+    suffix += 1;
+    path = `knowledge/${stem}-${suffix}${ext}`;
+  }
+  takenPaths.add(path);
+  return { type: "ok", path };
+};

--- a/apps/web/src/routes/_protected.knowledge/-components/template-discover-types.ts
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-discover-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Types derived from the `/templates/discover` endpoint response, shared by the
+ * template fill form and the template wizard. Deriving them once keeps a
+ * discover-schema change from half-applying: both surfaces move together
+ * instead of one keeping a stale copy of the shape.
+ */
+
+import type { api } from "@/lib/api";
+
+type DiscoverResponse = Awaited<ReturnType<typeof api.templates.discover.post>>;
+
+type DiscoverData = Exclude<
+  NonNullable<Extract<DiscoverResponse, { data: unknown }>["data"]>,
+  Response
+>;
+
+export type ResolvedField = DiscoverData["fields"][number];
+export type NamedCondition = DiscoverData["conditions"][number];
+export type StructureError = DiscoverData["structureErrors"][number];

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -1412,9 +1412,29 @@ const RegistryAutofillControl = ({
     }
     const seq = (lookupSeq.current += 1);
     setLoading(true);
-    const response = await api.contacts["business-registries"].get({
-      query: { registry, q },
-    });
+    // A timeout, dropped connection, or DNS failure throws instead of
+    // resolving to an Eden `.error` response, which would otherwise leave
+    // `loading` stuck forever (see runDownload's own catch below for the
+    // same class of bug on the fill/download path).
+    let response: Awaited<
+      ReturnType<(typeof api.contacts)["business-registries"]["get"]>
+    >;
+    try {
+      response = await api.contacts["business-registries"].get({
+        query: { registry, q },
+      });
+    } catch (error) {
+      if (seq === lookupSeq.current) {
+        setLoading(false);
+        stellaToast.add({
+          type: "error",
+          title: t("templates.registryNotFound"),
+          description: userErrorFromThrown(error, t("common.unexpectedError")),
+        });
+      }
+      getAnalytics().captureError(error);
+      return;
+    }
     if (seq !== lookupSeq.current) {
       // A newer lookup started while this one was in flight; drop its result.
       return;

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -51,10 +51,11 @@ import type { MatterTarget } from "@/components/matter-target-picker";
 import Tooltip from "@/components/tooltip";
 import { useMountEffect } from "@/hooks/use-effect";
 import { useLocale } from "@/i18n/formatting-context";
+import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { optionalArray } from "@/lib/arrays";
 import { DOCX_MIME, PDF_MIME, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { userErrorMessage } from "@/lib/errors/user-safe";
+import { userErrorFromThrown, userErrorMessage } from "@/lib/errors/user-safe";
 import { toSafeId } from "@/lib/safe-id";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 
@@ -64,29 +65,25 @@ import {
   buildAutofillUpdates,
   groupSupportsRegistryAutofill,
 } from "./registry-autofill";
+import { LOOKUP_REGISTRY_OPTIONS } from "./registry-options";
 import {
   firstOfNextMonthIso,
   formatDateValue,
   inDaysIso,
   todayIso,
 } from "./template-date-format";
+import type {
+  NamedCondition,
+  ResolvedField,
+  StructureError,
+} from "./template-discover-types";
+import type { LookupRegistry } from "./template-field-manifest";
 import { TemplatePrefillPanel } from "./template-prefill-panel";
 import type { PrefillSuggestionDto } from "./template-prefill-panel";
 
 type FillFormat = "docx" | "pdf";
 
 const DOCX_EXT_RE = /\.docx$/iu;
-
-type DiscoverResponse = Awaited<ReturnType<typeof api.templates.discover.post>>;
-
-type DiscoverData = Exclude<
-  NonNullable<Extract<DiscoverResponse, { data: unknown }>["data"]>,
-  Response
->;
-
-type ResolvedField = DiscoverData["fields"][number];
-type NamedCondition = DiscoverData["conditions"][number];
-type StructureError = DiscoverData["structureErrors"][number];
 
 const REQUIRED_MARKER = "*";
 
@@ -1389,21 +1386,6 @@ const collectEmptyOptionalFields = (
   return labels;
 };
 
-// Registries offered for one-click party-block autofill. Slugs are a
-// subset of the unified lookup endpoint's supported registries; labels
-// are registry proper names (not translatable UI copy).
-const REGISTRY_OPTIONS = [
-  { slug: "krs", label: "Poland — KRS" },
-  { slug: "ares", label: "Czechia — ARES" },
-  { slug: "orsr", label: "Slovakia — ORSR" },
-  { slug: "companies-house", label: "United Kingdom — Companies House" },
-  { slug: "prh", label: "Finland — PRH" },
-  { slug: "brreg", label: "Norway — Brønnøysund" },
-  { slug: "recherche-entreprises", label: "France — recherche-entreprises" },
-] as const;
-
-type RegistrySlug = (typeof REGISTRY_OPTIONS)[number]["slug"];
-
 /** One-click party-block autofill from a business register. Looks up a
  *  company by its canonical id (KRS number, IČO, …) and fills the
  *  matching fields in this group; the user reviews before submitting. */
@@ -1415,19 +1397,28 @@ const RegistryAutofillControl = ({
   onApply: (updates: { path: string; value: string }[]) => void;
 }) => {
   const t = useTranslations();
-  const [registry, setRegistry] = useState<RegistrySlug>("krs");
+  const [registry, setRegistry] = useState<LookupRegistry>("krs");
   const [companyId, setCompanyId] = useState("");
   const [loading, setLoading] = useState(false);
+  // Monotonic id for the in-flight lookup: a newer lookup supersedes older
+  // ones so the last id the user issued wins, not whichever request happens
+  // to settle last.
+  const lookupSeq = useRef(0);
 
   const handleLookup = async () => {
     const q = companyId.trim();
     if (q === "") {
       return;
     }
+    const seq = (lookupSeq.current += 1);
     setLoading(true);
     const response = await api.contacts["business-registries"].get({
       query: { registry, q },
     });
+    if (seq !== lookupSeq.current) {
+      // A newer lookup started while this one was in flight; drop its result.
+      return;
+    }
     setLoading(false);
 
     if (response.error) {
@@ -1470,7 +1461,7 @@ const RegistryAutofillControl = ({
     <div className="flex flex-wrap items-center gap-2 border-b pb-3">
       <Select
         onValueChange={(val) => {
-          const option = REGISTRY_OPTIONS.find((o) => o.slug === val);
+          const option = LOOKUP_REGISTRY_OPTIONS.find((o) => o.slug === val);
           if (option) {
             setRegistry(option.slug);
           }
@@ -1481,7 +1472,7 @@ const RegistryAutofillControl = ({
           <SelectValue />
         </SelectTrigger>
         <SelectPopup>
-          {REGISTRY_OPTIONS.map((option) => (
+          {LOOKUP_REGISTRY_OPTIONS.map((option) => (
             <SelectItem key={option.slug} value={option.slug}>
               {option.label}
             </SelectItem>
@@ -1494,7 +1485,11 @@ const RegistryAutofillControl = ({
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
-            void handleLookup();
+            // Guard the Enter path on the same loading state as the button so
+            // two quick Enters cannot fire overlapping lookups.
+            if (!loading) {
+              void handleLookup();
+            }
           }
         }}
         placeholder={t("templates.registryIdPlaceholder")}
@@ -2069,6 +2064,30 @@ export const TemplateForm = ({
     ],
   );
 
+  // Run a download and surface a thrown fill/convert failure as a toast.
+  // handleDownload's own error-toast only covers Eden `.error` responses; a
+  // timeout, dropped connection, or blob-read failure throws instead, which
+  // would otherwise be swallowed into a silent no-op that also leaves the
+  // button stuck on its "generating" label.
+  const runDownload = (
+    format: FillFormat,
+    options?: { skipEmptyGate?: boolean },
+  ) => {
+    handleDownload(format, options).catch((error: unknown) => {
+      setLoading(false);
+      stellaToast.add({
+        type: "error",
+        title: t(
+          format === "pdf"
+            ? "templates.pdfConversionFailed"
+            : "templates.fillFailed",
+        ),
+        description: userErrorFromThrown(error, t("common.unexpectedError")),
+      });
+      getAnalytics().captureError(error);
+    });
+  };
+
   // ── Save to matter ────────────────────────────────
   const [matterDialogOpen, setMatterDialogOpen] = useState(false);
   const [matterTarget, setMatterTarget] = useState<MatterTarget | null>(null);
@@ -2169,8 +2188,7 @@ export const TemplateForm = ({
       void fillToMatter(saveTarget.workspaceId, saveTarget.parentId ?? null);
       return;
     }
-    // Errors are surfaced as toasts inside handleDownload
-    handleDownload("docx").catch(() => undefined);
+    runDownload("docx");
   };
 
   /** The empty-fields warning's explicit confirm: run the armed action while
@@ -2183,11 +2201,11 @@ export const TemplateForm = ({
     const { action } = emptyWarning;
     setEmptyWarning(null);
     if (action === "downloadDocx") {
-      handleDownload("docx", { skipEmptyGate: true }).catch(() => undefined);
+      runDownload("docx", { skipEmptyGate: true });
       return;
     }
     if (action === "downloadPdf") {
-      handleDownload("pdf", { skipEmptyGate: true }).catch(() => undefined);
+      runDownload("pdf", { skipEmptyGate: true });
       return;
     }
     if (action === "moveToMatter") {
@@ -2423,7 +2441,7 @@ export const TemplateForm = ({
             <DropdownMenuItem
               disabled={loading || hasErrors}
               onClick={() => {
-                void handleDownload("docx").catch(() => undefined);
+                runDownload("docx");
               }}
             >
               {t("templates.downloadDocx")}
@@ -2431,7 +2449,7 @@ export const TemplateForm = ({
             <DropdownMenuItem
               disabled={loading || hasErrors}
               onClick={() => {
-                void handleDownload("pdf").catch(() => undefined);
+                runDownload("pdf");
               }}
             >
               {t("templates.downloadPdf")}

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
@@ -272,6 +272,7 @@ const TemplateStudioChatInner = ({
   const t = useTranslations();
   const user = useAuthenticatedUser();
   const author = user.preferredName ?? user.name ?? user.email;
+  const queryClient = useQueryClient();
   const activeOrganizationId = protectedRouteApi.useRouteContext({
     select: (ctx) => ctx.user.activeOrganizationId,
   });
@@ -1344,9 +1345,21 @@ const TemplateStudioChatInner = ({
             stop();
           }}
           onSubmit={({ prompt, files }) => {
+            // ensureAIAvailable is a real round-trip; a concurrent "new chat"
+            // rotation can swap the active thread while it is in flight. This
+            // instance (keyed by chatThreadId) still targets its own thread,
+            // so bail if the active thread moved rather than deliver the send
+            // to a thread the user has already left.
+            const submittingThreadId = chatThreadId;
             ensureAIAvailable()
               .then(async (available) => {
                 if (!available) {
+                  return;
+                }
+                const currentThreadId = queryClient.getQueryData(
+                  chatKeys.templateThread(activeOrganizationId, { templateId }),
+                );
+                if (currentThreadId !== submittingThreadId) {
                   return;
                 }
                 // Always pop the thread open on send, even if the user

--- a/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
@@ -45,27 +45,25 @@ import { userErrorMessage } from "@/lib/errors/user-safe";
 import { inputTypeValueKind, VALUE_TYPE_META } from "@/lib/value-types";
 
 import {
+  LOOKUP_REGISTRY_OPTIONS,
+  type LookupRegistryOption,
+} from "./registry-options";
+import {
   DATE_FORMAT_STYLES,
   formatDateExample,
   type TemplateDateFormat,
 } from "./template-date-format";
+import type {
+  NamedCondition,
+  ResolvedField,
+  StructureError,
+} from "./template-discover-types";
 import {
   defaultCompositeFormat,
   isInputType,
   type InputType,
   type LookupRegistry,
 } from "./template-field-manifest";
-
-type DiscoverResponse = Awaited<ReturnType<typeof api.templates.discover.post>>;
-
-type DiscoverData = Exclude<
-  NonNullable<Extract<DiscoverResponse, { data: unknown }>["data"]>,
-  Response
->;
-
-export type ResolvedField = DiscoverData["fields"][number];
-export type NamedCondition = DiscoverData["conditions"][number];
-export type StructureError = DiscoverData["structureErrors"][number];
 
 const DOCX_EXTENSION_RE = /\.docx$/iu;
 const REQUIRED_MARKER = "*";
@@ -959,37 +957,6 @@ const OptionsFromFieldControl = ({
     </Field>
   );
 };
-
-/** One registry option for the "Company ID" field type. `country` is the
- *  registry's jurisdiction (ISO 3166-1 alpha-2, or "EU" for the EU-wide VIES
- *  pseudo-jurisdiction), used to order options jurisdiction-first. Labels are
- *  registry proper names, not translatable UI copy. */
-type LookupRegistryOption = {
-  slug: LookupRegistry;
-  label: string;
-  country: string;
-};
-
-/** Registries offered for the "Company ID" field type, one entry each. Mirrors
- *  `LOOKUP_REGISTRIES` (the full `BUSINESS_REGISTRY_SLUGS`); Eden exposes types
- *  only, so the slugs are mirrored here — extend together with the API. */
-const LOOKUP_REGISTRY_OPTIONS: readonly LookupRegistryOption[] = [
-  { slug: "ares", label: "Czechia — ARES", country: "CZ" },
-  { slug: "orsr", label: "Slovakia — ORSR", country: "SK" },
-  { slug: "krs", label: "Poland — KRS", country: "PL" },
-  {
-    slug: "companies-house",
-    label: "United Kingdom — Companies House",
-    country: "GB",
-  },
-  { slug: "denue", label: "Mexico — INEGI DENUE", country: "MX" },
-  { slug: "brreg", label: "Norway — Brønnøysund (BRREG)", country: "NO" },
-  { slug: "prh", label: "Finland — PRH", country: "FI" },
-  { slug: "recherche-entreprises", label: "France — RNE", country: "FR" },
-  { slug: "edgar", label: "United States — SEC EDGAR", country: "US" },
-  { slug: "gcis", label: "Taiwan — GCIS", country: "TW" },
-  { slug: "vies", label: "European Union — VIES (VAT)", country: "EU" },
-];
 
 /** The app locale's region (ISO 3166-1 alpha-2), or null when the locale has
  *  no resolvable region. `maximize()` adds the likely region for


### PR DESCRIPTION
Fixes five correctness bugs in the template form/wizard/studio area and
removes two sources of copy-paste drift.

- Skill multi-file drop: reserve each upload's knowledge/<name> path up
  front against one shared set so two identically named files in the same
  drop no longer collide on the same path. Path reservation is extracted to
  a pure, unit-tested helper.
- Template fill/download entry points: replace `.catch(() => undefined)`
  with a shared runner that surfaces a toast, captures the error, and
  resets the loading state; a thrown timeout/network failure is no longer a
  silent no-op.
- Registry autofill lookup: guard the Enter key on the same loading state
  as the button and drop results from superseded lookups so the last id the
  user issued wins.
- Registry option lists: replace the two hand-maintained lists with one
  shared constant so the fill form and the wizard offer the same
  registries. Baseline autofill (name, registration id, legal form,
  address) works for every listed registry; registry-specific identifiers
  remain mapped for krs/ares/orsr only.
- Studio composer submit: capture the thread id before the AI-availability
  round-trip and bail if a concurrent "new chat" rotation swapped the
  active thread, so a send can't land in a thread the user has left.
- Hoist the shared /templates/discover response type derivation into one
  module imported by both the form and the wizard.
