### PR TITLE
fix(web): prevent overlapping docx checkpoint saves

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -66,6 +66,8 @@ import { StatusMessage } from "@/components/route-components";
 import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
+import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { getAnalytics } from "@/lib/analytics/provider";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
 import { folioUIComponents } from "@/lib/folio-ui-components";
 import { composeRefs } from "@/lib/utils";
@@ -93,6 +95,7 @@ import {
   aggregateAnonymizationMatches,
   buildAnonymizationDetectionKey,
   buildExcludedCanonicalsSet,
+  createTrailingSingleFlight,
   decideAnonymizationDetectionRun,
   dedupeDetectedAnonymizationTerms,
   mergeAnonymizationTerms,
@@ -364,8 +367,12 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
           markRan();
           return;
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           inFlightUntil = 0;
+          // Surface worker failures to telemetry: a silent reset
+          // hides systemic detection-worker breakage behind a facet
+          // that merely stops showing "Detecting…".
+          getAnalytics().captureError(error);
           // Mark on failure too — without this, a worker
           // error would leave the facet stuck on
           // "Detecting…" forever.
@@ -967,37 +974,21 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     }
   }, []);
 
-  const saveChangeCheckpoint = useCallback(() => {
+  // The debounced autosave, the awaitable flush, and the Cmd/Ctrl+S
+  // handler all serialize the live editor and persist the buffer.
+  // Firing two concurrently raced two `ref.save()` round-trips whose
+  // `setAutosaveStatus` writes landed in nondeterministic order (and
+  // `flushPendingChanges` cancelled only the queued timer, not an
+  // in-flight save). Route every path through one single-flight
+  // coordinator: concurrent triggers coalesce into one in-flight
+  // save plus one trailing save. `ref.save()` re-snapshots the live
+  // document when it runs, so the trailing save captures edits made
+  // during the in-flight save (latest wins).
+  const runCheckpointSave = useLatestCallback(async () => {
     const ref = editorRef.current;
     if (!ref) {
       return;
     }
-
-    setAutosaveStatus("syncing");
-    void (async () => {
-      const buffer = await ref.save({ selective: true });
-      const checkpointSaved = buffer
-        ? await saveActiveCheckpoint(buffer)
-        : false;
-      setAutosaveStatus(
-        resolveCheckpointAutosaveStatus({
-          buffer: buffer ?? null,
-          checkpointSaved,
-        }),
-      );
-    })();
-  }, [saveActiveCheckpoint, setAutosaveStatus]);
-
-  // Awaitable variant of `saveChangeCheckpoint` for callers that
-  // need to wait for the round-trip before navigating (e.g. the
-  // sidepeek → full view handoff). Cancels the queued debounced
-  // checkpoint so we don't fire it twice.
-  const flushPendingChanges = useCallback(async () => {
-    const ref = editorRef.current;
-    if (!ref) {
-      return;
-    }
-    clearQueuedChangeCheckpoint();
     setAutosaveStatus("syncing");
     const buffer = await ref.save({ selective: true });
     const checkpointSaved = buffer ? await saveActiveCheckpoint(buffer) : false;
@@ -1007,7 +998,42 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
         checkpointSaved,
       }),
     );
-  }, [clearQueuedChangeCheckpoint, saveActiveCheckpoint, setAutosaveStatus]);
+  });
+
+  const reportCheckpointSaveError = useLatestCallback((error: unknown) => {
+    getAnalytics().captureError(error);
+    setAutosaveStatus("pending");
+  });
+
+  // Lazy-init once (React's sanctioned ref pattern): the coordinator
+  // owns the in-flight/trailing state, which must survive rerenders.
+  // Its `run`/`onError` are stable and read the latest committed
+  // closures, so recreating it would only lose that state.
+  const triggerCheckpointSaveRef = useRef<(() => Promise<void>) | null>(null);
+  if (triggerCheckpointSaveRef.current === null) {
+    triggerCheckpointSaveRef.current = createTrailingSingleFlight({
+      run: runCheckpointSave,
+      onError: reportCheckpointSaveError,
+    });
+  }
+  const triggerCheckpointSave = useCallback(
+    () => triggerCheckpointSaveRef.current?.() ?? Promise.resolve(),
+    [],
+  );
+
+  const saveChangeCheckpoint = useCallback(() => {
+    void triggerCheckpointSave();
+  }, [triggerCheckpointSave]);
+
+  // Awaitable variant of `saveChangeCheckpoint` for callers that
+  // need to wait for the round-trip before navigating (e.g. the
+  // sidepeek → full view handoff). Cancels the queued debounced
+  // checkpoint so we don't fire it twice; the coordinator coalesces
+  // an already in-flight save into the trailing run this awaits.
+  const flushPendingChanges = useCallback(async () => {
+    clearQueuedChangeCheckpoint();
+    await triggerCheckpointSave();
+  }, [clearQueuedChangeCheckpoint, triggerCheckpointSave]);
 
   // Cmd+S / Ctrl+S checkpoints only while the document is actively editable.
   useExternalSyncEffect(() => {
@@ -1022,28 +1048,11 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
 
       e.preventDefault();
       clearQueuedChangeCheckpoint();
-      const ref = editorRef.current;
-      if (!ref) {
-        return;
-      }
-
-      setAutosaveStatus("syncing");
-      void (async () => {
-        const buffer = await ref.save({ selective: true });
-        const checkpointSaved = buffer
-          ? await saveActiveCheckpoint(buffer)
-          : false;
-        setAutosaveStatus(
-          resolveCheckpointAutosaveStatus({
-            buffer: buffer ?? null,
-            checkpointSaved,
-          }),
-        );
-      })();
+      void triggerCheckpointSave();
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [clearQueuedChangeCheckpoint, isUnlocked, saveActiveCheckpoint]);
+  }, [clearQueuedChangeCheckpoint, isUnlocked, triggerCheckpointSave]);
 
   useMountEffect(() => () => {
     clearQueuedChangeCheckpoint();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -1010,14 +1010,13 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   // Its `run`/`onError` are stable and read the latest committed
   // closures, so recreating it would only lose that state.
   const triggerCheckpointSaveRef = useRef<(() => Promise<void>) | null>(null);
-  if (triggerCheckpointSaveRef.current === null) {
-    triggerCheckpointSaveRef.current = createTrailingSingleFlight({
-      run: runCheckpointSave,
-      onError: reportCheckpointSaveError,
-    });
-  }
+  triggerCheckpointSaveRef.current ??= createTrailingSingleFlight({
+    run: runCheckpointSave,
+    onError: reportCheckpointSaveError,
+  });
   const triggerCheckpointSave = useCallback(
-    () => triggerCheckpointSaveRef.current?.() ?? Promise.resolve(),
+    async () =>
+      await (triggerCheckpointSaveRef.current?.() ?? Promise.resolve()),
     [],
   );
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.test.ts
@@ -4,11 +4,34 @@ import {
   aggregateAnonymizationMatches,
   buildAnonymizationDetectionKey,
   buildExcludedCanonicalsSet,
+  createTrailingSingleFlight,
   decideAnonymizationDetectionRun,
   dedupeDetectedAnonymizationTerms,
   mergeAnonymizationTerms,
   resolveCheckpointAutosaveStatus,
 } from "./docx-edit-mode.logic";
+
+/** Resolve every queued microtask (and the current macrotask). */
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+type Gate = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+const gate = (): Gate => {
+  let settle!: () => void;
+  let fail!: (error: unknown) => void;
+  const promise = new Promise<void>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+  return { promise, resolve: settle, reject: fail };
+};
 
 const buffer = (values: number[]) => new Uint8Array(values).buffer;
 
@@ -263,5 +286,165 @@ describe("aggregated anonymization matches", () => {
     expect(result.totalMatches).toBe(0);
     expect(result.countByCanonical.size).toBe(0);
     expect(result.labelByCanonical.size).toBe(0);
+  });
+});
+
+describe("trailing single-flight coordinator", () => {
+  test("coalesces overlapping triggers into one in-flight plus one trailing run", async () => {
+    const gates: Gate[] = [];
+    let runCalls = 0;
+    const trigger = createTrailingSingleFlight({
+      run: () => {
+        runCalls += 1;
+        const g = gate();
+        gates.push(g);
+        return g.promise;
+      },
+    });
+
+    trigger();
+    expect(runCalls).toBe(1);
+
+    // Three more while the first is still in flight: they must all
+    // collapse into a single trailing run, not three.
+    trigger();
+    trigger();
+    trigger();
+    await tick();
+    expect(runCalls).toBe(1);
+
+    gates[0]?.resolve();
+    await tick();
+    expect(runCalls).toBe(2);
+
+    gates[1]?.resolve();
+    await tick();
+    expect(runCalls).toBe(2);
+  });
+
+  test("the trailing run re-snapshots, so the latest state wins", async () => {
+    const gates: Gate[] = [];
+    let live = "a";
+    const snapshots: string[] = [];
+    const trigger = createTrailingSingleFlight({
+      run: () => {
+        snapshots.push(live);
+        const g = gate();
+        gates.push(g);
+        return g.promise;
+      },
+    });
+
+    trigger();
+    // Edit lands while the first save is mid-flight.
+    live = "b";
+    trigger();
+
+    gates[0]?.resolve();
+    await tick();
+    gates[1]?.resolve();
+    await tick();
+
+    expect(snapshots).toEqual(["a", "b"]);
+  });
+
+  test("sequential non-overlapping triggers each run", async () => {
+    const gates: Gate[] = [];
+    let runCalls = 0;
+    const trigger = createTrailingSingleFlight({
+      run: () => {
+        runCalls += 1;
+        const g = gate();
+        gates.push(g);
+        return g.promise;
+      },
+    });
+
+    trigger();
+    gates[0]?.resolve();
+    await tick();
+    expect(runCalls).toBe(1);
+
+    trigger();
+    gates[1]?.resolve();
+    await tick();
+    expect(runCalls).toBe(2);
+  });
+
+  test("an awaiting trigger resolves only after the trailing run it belongs to", async () => {
+    const gates: Gate[] = [];
+    const trigger = createTrailingSingleFlight({
+      run: () => {
+        const g = gate();
+        gates.push(g);
+        return g.promise;
+      },
+    });
+
+    trigger();
+    let flushed = false;
+    // Issued while the first run is in flight: it belongs to the
+    // trailing run, not the already-snapshotted in-flight run.
+    const flush = (async () => {
+      await trigger();
+      flushed = true;
+    })();
+
+    await tick();
+    expect(flushed).toBe(false);
+
+    gates[0]?.resolve();
+    await tick();
+    // In-flight run settled, but the trailing run is only now
+    // starting, so the awaiting caller is still pending.
+    expect(flushed).toBe(false);
+
+    gates[1]?.resolve();
+    await flush;
+    expect(flushed).toBe(true);
+  });
+
+  test("a failed run reports to onError exactly once and still settles the caller", async () => {
+    let errorCount = 0;
+    const trigger = createTrailingSingleFlight({
+      run: () => Promise.reject(new Error("save failed")),
+      onError: () => {
+        errorCount += 1;
+      },
+    });
+
+    // Resolves (does not reject) despite the rejection.
+    await trigger();
+    expect(errorCount).toBe(1);
+  });
+
+  test("a rejection does not abort a queued trailing run", async () => {
+    const gates: Gate[] = [];
+    let runCalls = 0;
+    let errorCount = 0;
+    const trigger = createTrailingSingleFlight({
+      run: () => {
+        runCalls += 1;
+        const g = gate();
+        gates.push(g);
+        return g.promise;
+      },
+      onError: () => {
+        errorCount += 1;
+      },
+    });
+
+    trigger();
+    trigger();
+
+    gates[0]?.reject(new Error("first save failed"));
+    await tick();
+    expect(errorCount).toBe(1);
+    // The trailing run still fires after the in-flight failure.
+    expect(runCalls).toBe(2);
+
+    gates[1]?.resolve();
+    await tick();
+    expect(errorCount).toBe(1);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./docx-edit-mode.logic";
 
 /** Resolve every queued microtask (and the current macrotask). */
-const tick = () =>
+const tick = async () =>
   new Promise<void>((resolve) => {
     setTimeout(resolve, 0);
   });
@@ -294,7 +294,7 @@ describe("trailing single-flight coordinator", () => {
     const gates: Gate[] = [];
     let runCalls = 0;
     const trigger = createTrailingSingleFlight({
-      run: () => {
+      run: async () => {
         runCalls += 1;
         const g = gate();
         gates.push(g);
@@ -302,14 +302,14 @@ describe("trailing single-flight coordinator", () => {
       },
     });
 
-    trigger();
+    void trigger();
     expect(runCalls).toBe(1);
 
     // Three more while the first is still in flight: they must all
     // collapse into a single trailing run, not three.
-    trigger();
-    trigger();
-    trigger();
+    void trigger();
+    void trigger();
+    void trigger();
     await tick();
     expect(runCalls).toBe(1);
 
@@ -327,7 +327,7 @@ describe("trailing single-flight coordinator", () => {
     let live = "a";
     const snapshots: string[] = [];
     const trigger = createTrailingSingleFlight({
-      run: () => {
+      run: async () => {
         snapshots.push(live);
         const g = gate();
         gates.push(g);
@@ -335,10 +335,10 @@ describe("trailing single-flight coordinator", () => {
       },
     });
 
-    trigger();
+    void trigger();
     // Edit lands while the first save is mid-flight.
     live = "b";
-    trigger();
+    void trigger();
 
     gates[0]?.resolve();
     await tick();
@@ -352,7 +352,7 @@ describe("trailing single-flight coordinator", () => {
     const gates: Gate[] = [];
     let runCalls = 0;
     const trigger = createTrailingSingleFlight({
-      run: () => {
+      run: async () => {
         runCalls += 1;
         const g = gate();
         gates.push(g);
@@ -360,12 +360,12 @@ describe("trailing single-flight coordinator", () => {
       },
     });
 
-    trigger();
+    void trigger();
     gates[0]?.resolve();
     await tick();
     expect(runCalls).toBe(1);
 
-    trigger();
+    void trigger();
     gates[1]?.resolve();
     await tick();
     expect(runCalls).toBe(2);
@@ -374,14 +374,14 @@ describe("trailing single-flight coordinator", () => {
   test("an awaiting trigger resolves only after the trailing run it belongs to", async () => {
     const gates: Gate[] = [];
     const trigger = createTrailingSingleFlight({
-      run: () => {
+      run: async () => {
         const g = gate();
         gates.push(g);
         return g.promise;
       },
     });
 
-    trigger();
+    void trigger();
     let flushed = false;
     // Issued while the first run is in flight: it belongs to the
     // trailing run, not the already-snapshotted in-flight run.
@@ -407,7 +407,9 @@ describe("trailing single-flight coordinator", () => {
   test("a failed run reports to onError exactly once and still settles the caller", async () => {
     let errorCount = 0;
     const trigger = createTrailingSingleFlight({
-      run: () => Promise.reject(new Error("save failed")),
+      run: () => {
+        throw new Error("save failed");
+      },
       onError: () => {
         errorCount += 1;
       },
@@ -423,7 +425,7 @@ describe("trailing single-flight coordinator", () => {
     let runCalls = 0;
     let errorCount = 0;
     const trigger = createTrailingSingleFlight({
-      run: () => {
+      run: async () => {
         runCalls += 1;
         const g = gate();
         gates.push(g);
@@ -434,8 +436,8 @@ describe("trailing single-flight coordinator", () => {
       },
     });
 
-    trigger();
-    trigger();
+    void trigger();
+    void trigger();
 
     gates[0]?.reject(new Error("first save failed"));
     await tick();
@@ -446,5 +448,32 @@ describe("trailing single-flight coordinator", () => {
     gates[1]?.resolve();
     await tick();
     expect(errorCount).toBe(1);
+  });
+
+  test("a throwing onError still settles the caller and runs a queued trailing run", async () => {
+    const gates: Gate[] = [];
+    let runCalls = 0;
+    const trigger = createTrailingSingleFlight({
+      run: async () => {
+        runCalls += 1;
+        const g = gate();
+        gates.push(g);
+        return g.promise;
+      },
+      onError: () => {
+        throw new Error("reporter failed");
+      },
+    });
+
+    const first = trigger();
+    const second = trigger();
+
+    gates[0]?.reject(new Error("first save failed"));
+    // Resolves (does not reject and does not hang) despite onError throwing.
+    await first;
+    expect(runCalls).toBe(2);
+
+    gates[1]?.resolve();
+    await second;
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
@@ -29,6 +29,87 @@ export const resolveCheckpointAutosaveStatus = ({
   return checkpointSaved ? "synced" : "pending";
 };
 
+type TrailingSingleFlightOptions = {
+  run: () => Promise<void>;
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Single-flight coordinator with a coalesced trailing run.
+ *
+ * The three checkpoint paths (debounced autosave, awaitable flush,
+ * and the Cmd/Ctrl+S handler) each snapshot the live editor and
+ * persist the result. Firing two concurrently races two `save()`
+ * round-trips whose `setAutosaveStatus` writes land in
+ * nondeterministic order, so a stale "pending"/"synced" can win.
+ *
+ * The returned `trigger` runs `run` immediately when idle. Triggers
+ * that arrive while a run is in flight coalesce into exactly one
+ * trailing run that fires after the in-flight run settles, no matter
+ * how many arrived. Because `run` re-snapshots the editor when it
+ * executes, the trailing run captures state produced during the
+ * in-flight save (latest wins) and nothing is dropped.
+ *
+ * `trigger` resolves once a run that started at or after the call
+ * has settled, so awaitable callers (flush before navigation) block
+ * on a save that reflects their snapshot. A trigger during an
+ * in-flight run is satisfied by the trailing run, never by the
+ * already-snapshotted in-flight run.
+ *
+ * Rejections are routed to `onError` and never abort the trailing
+ * run, leave a caller's promise unsettled, or surface as an
+ * unhandled rejection; `onError` fires exactly once per failed run.
+ */
+export const createTrailingSingleFlight = ({
+  run,
+  onError,
+}: TrailingSingleFlightOptions): (() => Promise<void>) => {
+  let active = false;
+  let queued = false;
+  // Resolvers waiting for the *next* run to settle. A trigger is
+  // satisfied only by a run that starts at or after it, since an
+  // in-flight run may have snapshotted before the trigger fired.
+  let nextRunSettlers: (() => void)[] = [];
+
+  const drain = async () => {
+    active = true;
+    try {
+      do {
+        queued = false;
+        const settlers = nextRunSettlers;
+        nextRunSettlers = [];
+        try {
+          // Sequential by design: the trailing run must not start
+          // until the in-flight run settles (single-flight).
+          // eslint-disable-next-line no-await-in-loop
+          await run();
+        } catch (error) {
+          onError?.(error);
+        }
+        for (const settle of settlers) {
+          settle();
+        }
+      } while (queued);
+    } finally {
+      active = false;
+    }
+  };
+
+  return () => {
+    const settled = new Promise<void>((resolve) => {
+      // Runs synchronously: the resolver is registered before the
+      // active/idle branch below reads or mutates coordinator state.
+      nextRunSettlers.push(resolve);
+    });
+    if (active) {
+      queued = true;
+      return settled;
+    }
+    void drain();
+    return settled;
+  };
+};
+
 type BuildAnonymizationDetectionKeyOptions = {
   text: string;
   excludedCanonicals: Iterable<string>;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-edit-mode.logic.ts
@@ -84,17 +84,33 @@ export const createTrailingSingleFlight = ({
           // eslint-disable-next-line no-await-in-loop
           await run();
         } catch (error) {
-          onError?.(error);
+          try {
+            onError?.(error);
+          } catch {
+            // A reporter failure must not prevent settler resolution or
+            // abort a queued trailing run below: onError is telemetry,
+            // not part of the save contract.
+          }
         }
         for (const settle of settlers) {
           settle();
         }
+        // The returned trigger below can set `queued = true` while `run()`
+        // above is in flight; the checker only sees the straight-line reset
+        // on the line above and misses that concurrent path.
+        // eslint-disable-next-line typescript/no-unnecessary-condition
       } while (queued);
     } finally {
       active = false;
     }
   };
 
+  // Returns the already-created `settled` promise synchronously (either
+  // immediately, or after firing `drain` without awaiting it); wrapping in
+  // `async` would add a redundant microtask and could let a trigger observe
+  // a settled promise before `drain` has synchronously registered it as
+  // active.
+  // eslint-disable-next-line typescript/promise-function-async
   return () => {
     const settled = new Promise<void>((resolve) => {
       // Runs synchronously: the resolver is registered before the


### PR DESCRIPTION
The debounced autosave, the awaitable flush, and the Cmd/Ctrl+S handler
each serialized the live editor and persisted the buffer with no in-flight
guard. Firing two concurrently raced two ref.save() -> saveActiveCheckpoint
round-trips whose setAutosaveStatus writes landed in nondeterministic order,
and flushPendingChanges cancelled only the queued debounce timer, not an
in-flight save.

Route all three paths through a single-flight coordinator
(createTrailingSingleFlight): a trigger runs immediately when idle, and
triggers arriving during an in-flight run coalesce into exactly one trailing
run. ref.save() re-snapshots the document when it runs, so the trailing run
captures edits made during the in-flight save (latest wins) and nothing is
dropped. The trigger resolves once a run covering the call has settled, so
flush still blocks on a save reflecting its snapshot; Cmd/Ctrl+S during an
in-flight autosave coalesces instead of double-saving or erroring. Failed
saves route to captureError and set "pending" exactly once.

Also capture worker failures in the anonymization detection catch, which
previously reset facet state without any telemetry, hiding systemic
detection-worker breakage.

Add unit tests for the coordinator: overlapping triggers -> one in-flight
plus one trailing run, trailing run re-snapshots, awaiting caller resolves
on the trailing run, and failures propagate to onError exactly once.
