### PR TITLE
fix(web): surface mutation and auth failures that were analytics-only

### DIFF
--- a/apps/web/src/components/auth/otp-panel.tsx
+++ b/apps/web/src/components/auth/otp-panel.tsx
@@ -30,7 +30,8 @@ import {
   HTTP_TOO_MANY_REQUESTS,
   isTwoFactorRedirect,
 } from "@/lib/auth";
-import { toAuthClientError } from "@/lib/errors/auth";
+import { APIError } from "@/lib/errors/api";
+import { AuthClientError, toAuthClientError } from "@/lib/errors/auth";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { COMMON_TIMEZONES } from "@/lib/timezones";
 
@@ -52,6 +53,24 @@ type OTPPanelProps = {
 
 const OTP_LENGTH = 6;
 const OTP_EXPIRED_MESSAGE = "OTP expired";
+
+type VerifyOtpError = {
+  status?: number | undefined;
+  message?: string | undefined;
+};
+
+const verifyErrorTitle = (
+  error: VerifyOtpError,
+  t: ReturnType<typeof useTranslations>,
+): string => {
+  if (error.status === HTTP_TOO_MANY_REQUESTS) {
+    return t("auth.rateLimitExceeded");
+  }
+  if (error.message === OTP_EXPIRED_MESSAGE) {
+    return t("auth.oneTimeCodeExpired");
+  }
+  return error.message ?? t("errors.actionFailed");
+};
 
 export function OTPPanel({
   className,
@@ -132,15 +151,10 @@ export function OTPPanel({
 
       if (signInError) {
         setOtp("");
-        if (signInError.status !== HTTP_TOO_MANY_REQUESTS) {
-          stellaToast.add({
-            title:
-              signInError.message === OTP_EXPIRED_MESSAGE
-                ? t("auth.oneTimeCodeExpired")
-                : (signInError.message ?? t("errors.actionFailed")),
-            type: "error",
-          });
-        }
+        stellaToast.add({
+          title: verifyErrorTitle(signInError, t),
+          type: "error",
+        });
         throw toAuthClientError(signInError);
       }
 
@@ -174,6 +188,16 @@ export function OTPPanel({
     },
     onError: (error) => {
       analytics.captureError(error);
+      // Structured sign-in errors already surfaced a toast in the
+      // mutationFn; only unexpected throws (network failures, session
+      // invalidation) reach here without one, so toast those too.
+      if (AuthClientError.is(error) || APIError.is(error)) {
+        return;
+      }
+      stellaToast.add({
+        title: userErrorFromThrown(error, t("errors.actionFailed")),
+        type: "error",
+      });
     },
   });
 

--- a/apps/web/src/components/auth/otp-panel.tsx
+++ b/apps/web/src/components/auth/otp-panel.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { TaggedError } from "better-result";
 import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/components/bidi-text";
@@ -30,8 +31,7 @@ import {
   HTTP_TOO_MANY_REQUESTS,
   isTwoFactorRedirect,
 } from "@/lib/auth";
-import { APIError } from "@/lib/errors/api";
-import { AuthClientError, toAuthClientError } from "@/lib/errors/auth";
+import { toAuthClientError } from "@/lib/errors/auth";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { COMMON_TIMEZONES } from "@/lib/timezones";
 
@@ -59,18 +59,14 @@ type VerifyOtpError = {
   message?: string | undefined;
 };
 
-const verifyErrorTitle = (
-  error: VerifyOtpError,
-  t: ReturnType<typeof useTranslations>,
-): string => {
-  if (error.status === HTTP_TOO_MANY_REQUESTS) {
-    return t("auth.rateLimitExceeded");
-  }
-  if (error.message === OTP_EXPIRED_MESSAGE) {
-    return t("auth.oneTimeCodeExpired");
-  }
-  return error.message ?? t("errors.actionFailed");
-};
+// Thrown instead of the raw signIn error once its toast has already been
+// shown, so `onError` below can tell "already surfaced" apart from an
+// unreported failure (network drop, session-refresh error, …) without
+// blanket-skipping every AuthClientError/APIError that reaches it.
+class AlreadyToastedError extends TaggedError("AlreadyToastedError")<{
+  message: string;
+  cause: unknown;
+}>() {}
 
 export function OTPPanel({
   className,
@@ -88,6 +84,25 @@ export function OTPPanel({
   const invalidateSession = useInvalidateSession();
   const isOtpComplete = otp.length === OTP_LENGTH;
   const { isPulsing: isOtpPulsing, pulse: pulseOtp } = usePulse(600);
+
+  // A closure over `t` (not a parameter) so its type is never written out:
+  // annotating a parameter as `ReturnType<typeof useTranslations>` blows up
+  // overload resolution against the full namespaced-key union badly enough
+  // to hit TS's type-complexity ceiling (TS2590) at the call site below.
+  //
+  // Takes the already-converted `cause` (not the raw signIn error) for the
+  // fallback branch: `userErrorFromThrown` only ever surfaces a vetted,
+  // localized message, never the untrusted raw `error.message` from the
+  // server response.
+  const verifyErrorTitle = (error: VerifyOtpError, cause: unknown): string => {
+    if (error.status === HTTP_TOO_MANY_REQUESTS) {
+      return t("auth.rateLimitExceeded");
+    }
+    if (error.message === OTP_EXPIRED_MESSAGE) {
+      return t("auth.oneTimeCodeExpired");
+    }
+    return userErrorFromThrown(cause, t("errors.actionFailed"));
+  };
 
   const handleUseDifferentEmail = () => {
     if (onUseDifferentEmail) {
@@ -151,11 +166,10 @@ export function OTPPanel({
 
       if (signInError) {
         setOtp("");
-        stellaToast.add({
-          title: verifyErrorTitle(signInError, t),
-          type: "error",
-        });
-        throw toAuthClientError(signInError);
+        const cause = toAuthClientError(signInError);
+        const title = verifyErrorTitle(signInError, cause);
+        stellaToast.add({ title, type: "error" });
+        throw new AlreadyToastedError({ message: title, cause });
       }
 
       if (isTwoFactorRedirect(signInData)) {
@@ -187,11 +201,15 @@ export function OTPPanel({
       await onVerified?.();
     },
     onError: (error) => {
-      analytics.captureError(error);
-      // Structured sign-in errors already surfaced a toast in the
-      // mutationFn; only unexpected throws (network failures, session
-      // invalidation) reach here without one, so toast those too.
-      if (AuthClientError.is(error) || APIError.is(error)) {
+      analytics.captureError(
+        AlreadyToastedError.is(error) ? error.cause : error,
+      );
+      // Only the structured sign-in error already toasted a message in the
+      // mutationFn (marked by AlreadyToastedError); every other throw
+      // reaching here — network failures, a session-refresh error from
+      // invalidateSession, an onVerified failure — has never been surfaced,
+      // so it always gets a toast.
+      if (AlreadyToastedError.is(error)) {
         return;
       }
       stellaToast.add({

--- a/apps/web/src/components/inspector/use-file-tab-rename.ts
+++ b/apps/web/src/components/inspector/use-file-tab-rename.ts
@@ -1,9 +1,5 @@
 import { useCallback, useLayoutEffect, useState } from "react";
 
-import { useTranslations } from "use-intl";
-
-import { stellaToast } from "@stll/ui/components/toast";
-
 import { useInspectorStore } from "@/components/inspector/inspector-store";
 import type {
   FileTab,
@@ -16,7 +12,6 @@ type UseFileTabRenameOptions = {
 };
 
 export const useFileTabRename = ({ tabs }: UseFileTabRenameOptions) => {
-  const t = useTranslations();
   const [editingTabId, setEditingTabId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
   const renameEntity = useRenameEntity();
@@ -68,12 +63,10 @@ export const useFileTabRename = ({ tabs }: UseFileTabRenameOptions) => {
     renameEntity.mutate(
       { workspaceId: tab.workspaceId, entityId: tab.entityId, name: newName },
       {
+        // Roll back the optimistic label; the shared rename hook
+        // surfaces the failure toast.
         onError: () => {
           useInspectorStore.getState().updateLabel(tab.id, previousLabel);
-          stellaToast.add({
-            title: t("errors.actionFailed"),
-            type: "error",
-          });
         },
       },
     );

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "إيقاف",
     "stopped": "متوقف",
+    "suggestedFollowupsLabel": "أسئلة متابعة مقترحة",
     "suggestionSeverity": {
       "style": "أسلوب",
       "substantive": "جوهري",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Zastavit",
     "stopped": "Zastaveno",
+    "suggestedFollowupsLabel": "Navrhované navazující dotazy",
     "suggestionSeverity": {
       "style": "Styl",
       "substantive": "Věcné",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Stoppen",
     "stopped": "Gestoppt",
+    "suggestedFollowupsLabel": "Vorgeschlagene Folgefragen",
     "suggestionSeverity": {
       "style": "Stil",
       "substantive": "Inhaltlich",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Stop",
     "stopped": "Stopped",
+    "suggestedFollowupsLabel": "Suggested follow-up prompts",
     "suggestionSeverity": {
       "style": "Style",
       "substantive": "Substantive",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Detener",
     "stopped": "Detenido",
+    "suggestedFollowupsLabel": "Sugerencias de preguntas de seguimiento",
     "suggestionSeverity": {
       "style": "Estilo",
       "substantive": "Sustantivo",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Peata",
     "stopped": "Peatatud",
+    "suggestedFollowupsLabel": "Soovitatud jätkuküsimused",
     "suggestionSeverity": {
       "style": "Stiil",
       "substantive": "Sisuline",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Arrêter",
     "stopped": "Arrêté",
+    "suggestedFollowupsLabel": "Suggestions de questions de suivi",
     "suggestionSeverity": {
       "style": "Style",
       "substantive": "Substantiel",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Leállítás",
     "stopped": "Leállítva",
+    "suggestedFollowupsLabel": "Javasolt követő kérdések",
     "suggestionSeverity": {
       "style": "Stílus",
       "substantive": "Érdemi",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Stabdyti",
     "stopped": "Sustabdyta",
+    "suggestedFollowupsLabel": "Siūlomi tęstiniai klausimai",
     "suggestionSeverity": {
       "style": "Stilius",
       "substantive": "Esminis",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Apturēt",
     "stopped": "Apturēts",
+    "suggestedFollowupsLabel": "Ieteiktie papildjautājumi",
     "suggestionSeverity": {
       "style": "Stils",
       "substantive": "Pēc būtības",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -545,6 +545,7 @@ type Messages = {
     };
     "stopResponse": "Stop";
     "stopped": "Stopped";
+    "suggestedFollowupsLabel": "Suggested follow-up prompts";
     "suggestionSeverity": {
       "style": "Style";
       "substantive": "Substantive";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Zatrzymaj",
     "stopped": "Zatrzymano",
+    "suggestedFollowupsLabel": "Sugerowane pytania uzupełniające",
     "suggestionSeverity": {
       "style": "Styl",
       "substantive": "Merytoryczna",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Parar",
     "stopped": "Interrompido",
+    "suggestedFollowupsLabel": "Sugestões de perguntas de acompanhamento",
     "suggestionSeverity": {
       "style": "Estilo",
       "substantive": "Substancial",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -542,6 +542,7 @@
     },
     "stopResponse": "Zastaviť",
     "stopped": "Zastavené",
+    "suggestedFollowupsLabel": "Navrhované nadväzujúce otázky",
     "suggestionSeverity": {
       "style": "Štýl",
       "substantive": "Vecné",

--- a/apps/web/src/routes/_protected.chat/-components/suggested-followup-chips.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/suggested-followup-chips.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "use-intl";
+
 import { SuggestedActions } from "@/components/suggested-actions";
 
 // A user + assistant exchange is the minimum to have something to suggest from.
@@ -33,6 +35,7 @@ export const SuggestedFollowupChips = ({
   prompts,
   onSelect,
 }: SuggestedFollowupChipsProps) => {
+  const t = useTranslations();
   const eligible =
     isEmpty &&
     !isGenerating &&
@@ -48,7 +51,7 @@ export const SuggestedFollowupChips = ({
     <SuggestedActions
       actions={prompts.map((prompt) => ({ id: prompt, label: prompt }))}
       className="pb-2"
-      label="Suggested follow-up prompts"
+      label={t("chat.suggestedFollowupsLabel")}
       onSelect={onSelect}
       orientation="horizontal"
       surface="overlay"

--- a/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-global-chat-mention-registration.ts
@@ -6,6 +6,7 @@ import type {
 import { useMentionProviders } from "@/components/chat-mention-providers";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePublicLawPreviewEnabled } from "@/hooks/use-public-law-preview";
+import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { assertPublicLawApiData } from "@/lib/public-law-api";
 
@@ -32,6 +33,7 @@ const searchCaseLawMentions = async (
   });
 
   if (response.error) {
+    getAnalytics().captureError(response.error);
     return [];
   }
   const data = response.data;

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-selection-gesture.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-selection-gesture.tsx
@@ -402,7 +402,12 @@ export const useTemplateStudioSelectionGesture = ({
     if (sequence !== enrichSeqRef.current) {
       return;
     }
-    const match = response.error ? null : response.data.suggestions.at(0);
+    if (response.error) {
+      getAnalytics().captureError(response.error);
+      setEnrichment({ status: "idle" });
+      return;
+    }
+    const match = response.data.suggestions.at(0);
     if (!match) {
       setEnrichment({ status: "idle" });
       return;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -18,7 +18,6 @@ import {
 import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
 import { Form } from "@stll/ui/components/form";
 import { Input } from "@stll/ui/components/input";
-import { stellaToast } from "@stll/ui/components/toast";
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import { toFormErrors } from "@/lib/schema";
@@ -188,12 +187,6 @@ export const EditFieldDialog = ({
           },
           onSettled: () => {
             setIsOpen(false);
-          },
-          onError: () => {
-            stellaToast.add({
-              title: t("errors.actionFailed"),
-              type: "error",
-            });
           },
         },
       );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -336,6 +336,32 @@ export const RowActions = ({
     });
   };
 
+  // Force-release the lock and surface the same auth-aware feedback
+  // whether the caller is the synchronous fallback or the delayed
+  // takeover timer, so neither path can fail silently.
+  const forceTakeoverWithFeedback = async () => {
+    try {
+      await doForceTakeover();
+    } catch (forceError) {
+      if (forceError instanceof Error && isUnauthorizedError(forceError)) {
+        stellaToast.add({
+          description: t(
+            "workspaces.files.desktopEdit.authRequiredDescription",
+          ),
+          title: t("workspaces.files.desktopEdit.authRequiredTitle"),
+          type: "error",
+        });
+        return;
+      }
+
+      stellaToast.add({
+        description: t("workspaces.files.desktopEdit.unavailableDescription"),
+        title: t("workspaces.files.desktopEdit.unavailableTitle"),
+        type: "error",
+      });
+    }
+  };
+
   const handleReleaseLock = async () => {
     if (!file || file.mimeType !== DOCX_MIME) {
       return;
@@ -403,29 +429,10 @@ export const RowActions = ({
       // released lock is a no-op on the API side).
       setTimeout(() => {
         stellaToast.close(toastId);
-        void doForceTakeover();
+        void forceTakeoverWithFeedback();
       }, 30_000);
     } catch {
-      try {
-        await doForceTakeover();
-      } catch (forceError) {
-        if (forceError instanceof Error && isUnauthorizedError(forceError)) {
-          stellaToast.add({
-            description: t(
-              "workspaces.files.desktopEdit.authRequiredDescription",
-            ),
-            title: t("workspaces.files.desktopEdit.authRequiredTitle"),
-            type: "error",
-          });
-          return;
-        }
-
-        stellaToast.add({
-          description: t("workspaces.files.desktopEdit.unavailableDescription"),
-          title: t("workspaces.files.desktopEdit.unavailableTitle"),
-          type: "error",
-        });
-      }
+      await forceTakeoverWithFeedback();
     }
   };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/entities.ts
@@ -1,4 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -121,6 +124,7 @@ type RenameEntityVars = {
 
 export const useRenameEntity = () => {
   const analytics = useAnalytics();
+  const t = useTranslations();
 
   return useMutation({
     mutationFn: async ({ workspaceId, entityId, name }: RenameEntityVars) => {
@@ -140,6 +144,10 @@ export const useRenameEntity = () => {
     },
     onError: (error) => {
       analytics.captureError(error);
+      stellaToast.add({
+        title: t("errors.actionFailed"),
+        type: "error",
+      });
     },
   });
 };
@@ -153,6 +161,7 @@ type UpsertFieldVars = {
 
 export const useUpsertField = () => {
   const analytics = useAnalytics();
+  const t = useTranslations();
 
   return useMutation({
     mutationFn: async ({
@@ -179,6 +188,10 @@ export const useUpsertField = () => {
 
     onError: (error) => {
       analytics.captureError(error);
+      stellaToast.add({
+        title: t("errors.actionFailed"),
+        type: "error",
+      });
     },
   });
 };


### PR DESCRIPTION
Several web mutations and background calls captured errors to analytics
but never surfaced them, so failures were invisible to the user:

- useRenameEntity / useUpsertField now toast on failure at the hook
  level, so every call site (filesystem tree, workspace table, calendar,
  kanban, inline editors) surfaces a failure instead of silently closing
  the optimistic editor. Redundant per-call toasts that duplicated the
  generic message were removed; call sites keep only behaviour beyond the
  toast (optimistic rollback).
- Desktop-edit force-takeover: the 30s timer path shared the same
  auth-aware error feedback as the synchronous fallback via an extracted
  helper, instead of a fire-and-forget call that swallowed failures.
- OTP verify: HTTP 429 now toasts the rate-limit message, and thrown
  network errors toast instead of only being captured; the field-clear
  behaviour is preserved and structured errors are not double-toasted.
- Global chat mention registration and the template-studio suggestion
  gesture now capture HTTP-error responses to analytics, matching their
  thrown-exception paths (telemetry-only; these are background calls).
- Suggested follow-up chips: replaced a hardcoded English aria-label with
  a translated key, added to all supported languages.

The fix normalizes error surfacing at the shared hook level so individual
call sites can't silently drop failures.
