### PR TITLE
refactor: single-home spaced-letter, search-text, and diacritics normalization in @stll/text-normalize

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/slug.ts
+++ b/apps/api/src/handlers/case-law/decisions/slug.ts
@@ -1,6 +1,8 @@
 import { panic } from "better-result";
 import { type SQL, and, eq, like, or, sql } from "drizzle-orm";
 
+import { stripDiacriticsForSlug } from "@stll/text-normalize";
+
 import { caseLawDecisions } from "@/api/db/schema";
 import { escapeLike } from "@/api/lib/escape-like";
 
@@ -34,11 +36,12 @@ const fitSlug = (baseSlug: string, suffix?: number): string => {
 };
 
 export const createCaseLawDecisionSlug = (caseNumber: string): string => {
+  // NFKD strip is single-homed in stripDiacriticsForSlug; case folding and
+  // the [a-z0-9] filter stay here and run in the same order as before, so
+  // existing persisted slugs are reproduced byte-for-byte.
   const slug = trimSlugHyphens(
-    caseNumber
-      .normalize("NFKD")
+    stripDiacriticsForSlug(caseNumber)
       .toLowerCase()
-      .replace(/\p{Diacritic}/gu, "")
       .replace(/[^a-z0-9]+/gu, "-"),
   );
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/sk-courts.ts
@@ -38,6 +38,8 @@
 
 import { PDF } from "@libpdf/core";
 
+import { collapseSpacedLetters } from "@stll/text-normalize";
+
 import type {
   Block,
   DocumentAst,
@@ -365,7 +367,7 @@ function isStructuralStart(line: PdfLine): boolean {
   if (STARTS_NEW_PARAGRAPH_RE.test(line.text)) {
     return true;
   }
-  const norm = normalizeSpaced(line.text.toLowerCase().trim());
+  const norm = collapseSpacedLetters(line.text.toLowerCase().trim());
   if (
     HOLDING_MARKERS.some((m) => norm.endsWith(m)) ||
     REASONING_MARKERS.some((m) => norm === m) ||
@@ -480,20 +482,6 @@ const DECISION_TITLES = new Set([
   "uznesenie bez odôvodnenia",
 ]);
 
-/**
- * Collapse spaced-out letters for marker detection.
- * Same logic as pipeline.ts collapseSpacedLetters;
- * duplicated here to avoid circular imports.
- * Canonical location: pipeline.ts SPACED_WORD regex.
- */
-const SPACED_WORD_RE =
-  /(?<=\s|^)(?:\p{L} (?:\p{L} )*\p{L})(?: ?[,:;.!?])?(?=\s|$)/gu;
-
-const normalizeSpaced = (text: string): string =>
-  text
-    .replace(SPACED_WORD_RE, (match) => match.replace(/ /gu, ""))
-    .replace(/ {2,}/gu, " ");
-
 const HOLDING_MARKERS = ["rozhodol:", "rozhodol :", "rozhodla:", "rozhodlo:"];
 
 const REASONING_MARKERS = ["odôvodnenie:", "odôvodnenie :"];
@@ -501,17 +489,17 @@ const REASONING_MARKERS = ["odôvodnenie:", "odôvodnenie :"];
 const INSTRUCTION_MARKERS = ["poučenie:", "poučenie :"];
 
 const isHoldingMarker = (text: string): boolean => {
-  const norm = normalizeSpaced(text.toLowerCase().trim());
+  const norm = collapseSpacedLetters(text.toLowerCase().trim());
   return HOLDING_MARKERS.some((m) => norm.endsWith(m));
 };
 
 const isReasoningMarker = (text: string): boolean => {
-  const norm = normalizeSpaced(text.toLowerCase().trim());
+  const norm = collapseSpacedLetters(text.toLowerCase().trim());
   return REASONING_MARKERS.some((m) => norm === m);
 };
 
 const isInstructionMarker = (text: string): boolean => {
-  const norm = normalizeSpaced(text.toLowerCase().trim());
+  const norm = collapseSpacedLetters(text.toLowerCase().trim());
   // startsWith: SK ÚS PDFs put "Poučenie:" inline with
   // text on the same line, not as a standalone heading.
   return INSTRUCTION_MARKERS.some((m) => norm === m || norm.startsWith(m));
@@ -638,7 +626,7 @@ const classifyLines = (lines: readonly PdfLine[]): Block[] => {
 
     if (bold && isInstructionMarker(text)) {
       section = "instruction";
-      const norm = normalizeSpaced(text.toLowerCase().trim());
+      const norm = collapseSpacedLetters(text.toLowerCase().trim());
       const isStandalone = INSTRUCTION_MARKERS.some((m) => norm === m);
       if (isStandalone) {
         blocks.push({

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -1,6 +1,8 @@
 import { Result, panic } from "better-result";
 import { and, eq, sql } from "drizzle-orm";
 
+import { collapseSpacedLetters } from "@stll/text-normalize";
+
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawCitations,
@@ -118,45 +120,10 @@ type ProcessResult = {
  *
  * Applied once in the pipeline so adapters don't repeat this.
  */
-/**
- * Collapse spaced-out letters used for emphasis in court PDFs.
- *
- * Slovak and Czech courts format words with letter-spacing:
- *   `r o z h o d o l :` → `rozhodol:`
- *   `o d ô v o d n e n i e :` → `odôvodnenie:`
- *   `z a m i e t a` → `zamieta`
- *
- * These break full-text search ("rozhodol" won't match
- * "r o z h o d o l"). We collapse sequences of single Unicode
- * letters separated by single spaces, optionally followed by
- * punctuation. Multi-spaces between collapsed words are then
- * normalized to single space.
- *
- * Safe: won't touch normal text, digits, IČO numbers, or
- * case references (anchored by whitespace/string boundaries).
- *
- * Requires at least FOUR letters in the run. Czech/Slovak have many
- * single-letter words (prepositions a, i, k, o, s, u, v, z), so a 2–3
- * letter run like `u a v` ("u", "a", "v") is far more likely to be real
- * words than letter-spaced emphasis; collapsing it to `uav` would corrupt
- * the search text. Genuine spaced words ("z a m i e t a", "r o z h o d o l")
- * are always longer, so the floor loses nothing in practice.
- */
-const SPACED_WORD =
-  /(?<=\s|^)(?:\p{L} (?:\p{L} ){2,}\p{L})(?: ?[,:;.!?])?(?=\s|$)/gu;
-
-/**
- * Collapse multiple spaces to single. Applied to all
- * ingested text to normalize PDF justified spacing where
- * words are padded with extra spaces for alignment.
- */
-const collapseMultiSpaces = (text: string): string =>
-  text.replace(/ {2,}/gu, " ");
-
-const collapseSpacedLetters = (text: string): string =>
-  collapseMultiSpaces(
-    text.replace(SPACED_WORD, (match) => match.replace(/ /gu, "")),
-  );
+// Spaced-letter collapse (letter-spaced court headings such as
+// "r o z h o d o l :" -> "rozhodol:") is single-homed in
+// @stll/text-normalize's collapseSpacedLetters, so index-time collapse
+// here and the case-viewer's query-time collapse share one threshold.
 
 export const sanitizeResult = (r: IngestionResult): IngestionResult => {
   // Strip dangerous chars and normalize non-breaking spaces.

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -1,7 +1,11 @@
 import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
-import { applyArabicFolds, normalizeSearchText } from "@stll/text-normalize";
+import {
+  applyArabicFolds,
+  normalizeSearchText,
+  stripDiacritics,
+} from "@stll/text-normalize";
 
 const PREFIX_QUERY_TOKEN_LIMIT = 8;
 const ADVANCED_QUERY_OPERATOR_RE =
@@ -76,8 +80,7 @@ export const normalizeFileNameVariantForSearch = (
 const normalizeTextForLexemes = (text: string): string =>
   text.replace(/[._-]+/gu, " ");
 
-export const removeSearchDiacritics = (text: string): string =>
-  text.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+export const removeSearchDiacritics = stripDiacritics;
 
 export const fileNameSearchText = (name: string): string =>
   compact([

--- a/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-search.ts
@@ -1,4 +1,8 @@
-import { applyArabicFolds } from "@stll/text-normalize";
+import {
+  applyArabicFolds,
+  spacedLetterRunRegex,
+  stripDiacritics,
+} from "@stll/text-normalize";
 
 export type SearchPiece = {
   id: string;
@@ -16,16 +20,7 @@ export type SearchResults = {
   rangesByPieceId: Record<string, SearchMatchRange[]>;
 };
 
-const DIACRITIC_RE = /\p{Diacritic}+/gu;
 const LETTER_OR_NUMBER_RE = /[\p{L}\p{N}]/u;
-
-// Matches runs of single-letter words separated by spaces,
-// optionally followed by punctuation (e.g. "r o z h o d o l :"
-// or "z a m i e t a"). Collapsed to the concatenated letters
-// so users can search "rozhodol" and find the spaced heading.
-// Mirrors `collapseSpacedLetters` in the API pipeline.
-const SPACED_LETTER_RUN_RE =
-  /(?<=\s|^)(?:\p{L} (?:\p{L} )*\p{L})(?: ?[,:;.!?])?(?=\s|$)/gu;
 
 type NormalizedText = {
   endMap: number[];
@@ -46,7 +41,7 @@ const normalizeSearchText = (text: string): NormalizedText => {
   // so the letters collapse into one searchable word while each
   // letter's startMap/endMap still points at its original char.
   const dropSpaceAt = new Set<number>();
-  for (const match of text.matchAll(SPACED_LETTER_RUN_RE)) {
+  for (const match of text.matchAll(spacedLetterRunRegex())) {
     const matchStart = match.index;
     const matched = match[0];
     for (let i = 0; i < matched.length; i++) {
@@ -79,11 +74,11 @@ const normalizeSearchText = (text: string): NormalizedText => {
   for (const rawChar of text) {
     // NFKC folds presentation forms to canonical letters; applyArabicFolds
     // then folds Arabic variants (before NFD, so a composed alef-hamza is
-    // not split first); NFD + mark removal strips remaining Latin/Arabic
-    // combining diacritics.
-    const normalizedChar = applyArabicFolds(rawChar.normalize("NFKC"))
-      .normalize("NFD")
-      .replace(DIACRITIC_RE, "");
+    // not split first); stripDiacritics (NFD + mark removal) strips the
+    // remaining Latin/Arabic combining diacritics.
+    const normalizedChar = stripDiacritics(
+      applyArabicFolds(rawChar.normalize("NFKC")),
+    );
     const origStart = originalIndex;
     const origEnd = originalIndex + rawChar.length;
 

--- a/apps/web/src/lib/case-law-route.ts
+++ b/apps/web/src/lib/case-law-route.ts
@@ -1,3 +1,5 @@
+import { stripDiacriticsForSlug } from "@stll/text-normalize";
+
 const UUID_REGEX =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
 const COMPACT_UUID_REGEX = /^[A-Za-z0-9_-]{22}$/u;
@@ -144,11 +146,11 @@ const trimSlugHyphens = (value: string): string => {
 };
 
 const slugifyCaseLawPathSegment = (value: string): string => {
+  // Must reproduce the API's persisted case-law slugs byte-for-byte
+  // (apps/api/.../decisions/slug.ts): same NFKD strip, same op order.
   const slug = trimSlugHyphens(
-    value
-      .normalize("NFKD")
+    stripDiacriticsForSlug(value)
       .toLowerCase()
-      .replace(/\p{Diacritic}/gu, "")
       .replace(/[^a-z0-9]+/gu, "-"),
   );
 

--- a/apps/web/src/lib/public-law-material-route.ts
+++ b/apps/web/src/lib/public-law-material-route.ts
@@ -1,3 +1,5 @@
+import { stripDiacriticsForSlug } from "@stll/text-normalize";
+
 const PUBLIC_LEGAL_MATERIAL_TYPES = {
   guidelines: "guidelines",
   regulations: "regulations",
@@ -169,11 +171,11 @@ const isLanguageAlternate = (
 const normalizePublicLegalMaterialPathSegment = (
   value: string,
 ): string | null => {
+  // Byte-identical to the API-side slug normalization: same NFKD strip,
+  // same op order, so persisted public law-material slugs still resolve.
   const normalized = trimHyphens(
-    value
-      .normalize("NFKD")
+    stripDiacriticsForSlug(value)
       .toLowerCase()
-      .replace(/\p{Diacritic}/gu, "")
       .replace(/[^a-z0-9]+/gu, "-"),
   );
 

--- a/packages/text-normalize/README.md
+++ b/packages/text-normalize/README.md
@@ -36,3 +36,25 @@ normalizeSearchText("أحمد") === normalizeSearchText("احمد"); // true
 The same fold must be reproduced by the PostgreSQL `arabic_normalize()`
 function used in contacts trigram expression indexes and search predicates;
 the golden vectors in `src/normalize.test.ts` pin the shared contract.
+
+## Diacritics
+
+`stripDiacritics` decomposes with NFD and removes every combining mark
+(`\p{Diacritic}`, so marks beyond the U+0300–U+036F block are covered
+too). Use it for accent-insensitive search keys.
+
+`stripDiacriticsForSlug` is the same strip but decomposes with NFKD, so
+compatibility characters (ligatures, full-width forms, superscripts) fold
+to their base before a `[a-z0-9]` slug filter runs. Slugs are persisted,
+public URL segments; this variant pins the exact form existing slugs were
+generated with.
+
+## Spaced letters
+
+`collapseSpacedLetters` joins letter-spaced court headings
+(`r o z h o d o l :` to `rozhodol:`) back into searchable words. It
+requires at least four spaced letters, so Czech/Slovak single-letter word
+lists (`a b c`) are left intact. `spacedLetterRunRegex()` returns the
+underlying matcher for callers that need per-match offsets (find-in-page
+highlighting). Index-time and query-time collapse share this one
+threshold so a heading collapses identically on both sides.

--- a/packages/text-normalize/src/diacritics.test.ts
+++ b/packages/text-normalize/src/diacritics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { stripDiacritics, stripDiacriticsForSlug } from "./diacritics.js";
+
+// Czech, Slovak, and Polish legal text: the base letter must survive, the
+// diacritic must go, so accent-insensitive search matches either spelling.
+const LATIN_GOLDEN: readonly (readonly [string, string])[] = [
+  ["černý žaloba", "cerny zaloba"],
+  ["odôvodnenie", "odovodnenie"],
+  ["příliš žluťoučký kůň", "prilis zlutoucky kun"],
+  // ż/ó/ć/ę/ś/ź lose their marks; ł (U+0142) is an atomic stroke letter
+  // with no combining mark, so it is not a diacritic and survives.
+  ["zażółć gęślą jaźń", "zazołc gesla jazn"],
+  ["Ñandú", "Nandu"],
+];
+
+describe("stripDiacritics (NFD)", () => {
+  test.each(LATIN_GOLDEN)("strip(%p) === %p", (input, expected) => {
+    expect(stripDiacritics(input)).toBe(expected);
+  });
+
+  test("strips combining marks outside U+0300–U+036F", () => {
+    // U+1AB0 (Combining Diacritical Marks Extended) and U+1DC4
+    // (Supplement) are Diacritic=Yes marks a [̀-ͯ] range would miss.
+    expect(stripDiacritics("a᪰b᷄c")).toBe("abc");
+  });
+
+  test("leaves precomposed compatibility characters intact (NFD)", () => {
+    // NFD does not decompose the ﬁ ligature or the superscript ².
+    expect(stripDiacritics("ﬁ²")).toBe("ﬁ²");
+  });
+
+  test("is idempotent", () => {
+    for (const [input] of LATIN_GOLDEN) {
+      const once = stripDiacritics(input);
+      expect(stripDiacritics(once)).toBe(once);
+    }
+  });
+});
+
+describe("stripDiacriticsForSlug (NFKD)", () => {
+  test.each(LATIN_GOLDEN)("slug-strip(%p) === %p", (input, expected) => {
+    expect(stripDiacriticsForSlug(input)).toBe(expected);
+  });
+
+  test("decomposes compatibility characters so slugs fold to ASCII", () => {
+    // The NFKD form is what the persisted case-law/law-material slugs were
+    // generated with; these must keep folding to their ASCII base.
+    expect(stripDiacriticsForSlug("ﬁ")).toBe("fi");
+    expect(stripDiacriticsForSlug("²")).toBe("2");
+    expect(stripDiacriticsForSlug("Ⅳ")).toBe("Ⅳ".normalize("NFKD"));
+  });
+
+  test("diverges from NFD only on compatibility characters", () => {
+    // Plain accented Latin folds identically in both forms; the variants
+    // exist purely for the compatibility-decomposition cases above.
+    for (const [input, expected] of LATIN_GOLDEN) {
+      expect(stripDiacriticsForSlug(input)).toBe(expected);
+      expect(stripDiacriticsForSlug(input)).toBe(stripDiacritics(input));
+    }
+  });
+});

--- a/packages/text-normalize/src/diacritics.ts
+++ b/packages/text-normalize/src/diacritics.ts
@@ -1,0 +1,38 @@
+/**
+ * Latin/combining-mark diacritic stripping for search keys and slugs.
+ *
+ * Both variants decompose the input and then remove every character
+ * Unicode classifies as a diacritic (`\p{Diacritic}`). `\p{Diacritic}`
+ * is deliberate: it covers combining marks in every block, not only the
+ * Combining Diacritical Marks block (U+0300–U+036F). A range like
+ * `[̀-ͯ]` misses marks in the Extended (U+1AB0–U+1AFF) and
+ * Supplement (U+1DC0–U+1DFF) blocks, so two callers using different
+ * classes would disagree on the same text.
+ *
+ * The variants differ only in the decomposition form:
+ *
+ * - `stripDiacritics` uses NFD (canonical decomposition). Use it for
+ *   search keys, where compatibility characters must survive unchanged.
+ * - `stripDiacriticsForSlug` uses NFKD (compatibility decomposition), so
+ *   ligatures, full-width forms, superscripts, and similar fold to their
+ *   ASCII base before the `[a-z0-9]` slug filter runs. Slugs are
+ *   persisted, public URL segments, so this variant pins the exact form
+ *   the existing slugs were generated with; do not switch it to NFD.
+ */
+
+const DIACRITIC_RE = /\p{Diacritic}/gu;
+
+/**
+ * Strip combining diacritics from search text (NFD). Non-diacritic
+ * characters, including compatibility characters, pass through unchanged.
+ */
+export const stripDiacritics = (text: string): string =>
+  text.normalize("NFD").replace(DIACRITIC_RE, "");
+
+/**
+ * Strip combining diacritics for slug generation (NFKD). Callers apply
+ * their own case folding and `[a-z0-9]` filtering around this; the NFKD
+ * form is load-bearing for byte-stable slugs and must not change.
+ */
+export const stripDiacriticsForSlug = (text: string): string =>
+  text.normalize("NFKD").replace(DIACRITIC_RE, "");

--- a/packages/text-normalize/src/index.ts
+++ b/packages/text-normalize/src/index.ts
@@ -6,4 +6,9 @@ export {
   ARABIC_REMOVED,
 } from "./arabic.js";
 export type { FoldedText } from "./arabic.js";
+export { stripDiacritics, stripDiacriticsForSlug } from "./diacritics.js";
 export { normalizeSearchText } from "./normalize.js";
+export {
+  collapseSpacedLetters,
+  spacedLetterRunRegex,
+} from "./spaced-letters.js";

--- a/packages/text-normalize/src/spaced-letters.test.ts
+++ b/packages/text-normalize/src/spaced-letters.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collapseSpacedLetters,
+  spacedLetterRunRegex,
+} from "./spaced-letters.js";
+
+// Real letter-spaced court headings collapse; short single-letter word
+// lists (Czech/Slovak prepositions) must stay untouched.
+const GOLDEN: readonly (readonly [string, string])[] = [
+  ["r o z h o d o l :", "rozhodol:"],
+  ["z a m i e t a", "zamieta"],
+  ["o d ô v o d n e n i e :", "odôvodnenie:"],
+  ["súd r o z h o d o l : takto", "súd rozhodol: takto"],
+  // Threshold floor: fewer than four spaced letters is left verbatim.
+  ["a b", "a b"],
+  ["a b c", "a b c"],
+  ["u a v", "u a v"],
+  // Four is the first run that collapses.
+  ["a b c d", "abcd"],
+  // Normal prose is never touched.
+  ["hello world", "hello world"],
+];
+
+describe("collapseSpacedLetters", () => {
+  test.each(GOLDEN)("collapse(%p) === %p", (input, expected) => {
+    expect(collapseSpacedLetters(input)).toBe(expected);
+  });
+
+  test("collapses only runs of four or more spaced letters", () => {
+    // Exhaustive check of the threshold: build an n-letter spaced run and
+    // confirm it collapses iff n >= 4.
+    const letters = "abcdefgh";
+    for (let n = 1; n <= letters.length; n++) {
+      const run = letters.slice(0, n).split("").join(" ");
+      const collapsed = collapseSpacedLetters(run);
+      if (n >= 4) {
+        expect(collapsed).toBe(letters.slice(0, n));
+      } else {
+        expect(collapsed).toBe(run);
+      }
+    }
+  });
+
+  test("is idempotent", () => {
+    for (const [input] of GOLDEN) {
+      const once = collapseSpacedLetters(input);
+      expect(collapseSpacedLetters(once)).toBe(once);
+    }
+  });
+});
+
+describe("spacedLetterRunRegex", () => {
+  test("returns a fresh global regex each call", () => {
+    const a = spacedLetterRunRegex();
+    const b = spacedLetterRunRegex();
+    expect(a).not.toBe(b);
+    expect(a.global).toBe(true);
+  });
+
+  test("matches the same runs collapseSpacedLetters removes", () => {
+    const text = "súd r o z h o d o l : a b c dnes";
+    const matches = [...text.matchAll(spacedLetterRunRegex())].map((m) => m[0]);
+    // Only the four-plus run matches; the "a b c" list does not.
+    expect(matches).toEqual(["r o z h o d o l :"]);
+  });
+});

--- a/packages/text-normalize/src/spaced-letters.ts
+++ b/packages/text-normalize/src/spaced-letters.ts
@@ -1,0 +1,52 @@
+/**
+ * Collapse spaced-out letters used for emphasis in court PDFs.
+ *
+ * Slovak and Czech courts format words with letter-spacing:
+ *   `r o z h o d o l :` -> `rozhodol:`
+ *   `o d ô v o d n e n i e :` -> `odôvodnenie:`
+ *   `z a m i e t a` -> `zamieta`
+ *
+ * These break full-text search ("rozhodol" won't match
+ * "r o z h o d o l"). We collapse runs of single Unicode letters
+ * separated by single spaces, optionally followed by punctuation.
+ *
+ * Requires at least FOUR letters in the run. Czech/Slovak have many
+ * single-letter words (prepositions a, i, k, o, s, u, v, z), so a 2–3
+ * letter run like `u a v` ("u", "a", "v") is far more likely to be real
+ * words than letter-spaced emphasis; collapsing it to `uav` would corrupt
+ * the text. Genuine spaced words ("z a m i e t a", "r o z h o d o l") are
+ * always longer, so the floor loses nothing in practice.
+ *
+ * This is the single source of the threshold: the ingestion pipeline
+ * (index-time) and the case-viewer find-in-page normalizer (query-time)
+ * both consume it, so a spaced heading collapses identically on both
+ * sides and highlight offsets stay aligned.
+ */
+
+// `\p{L} (?:\p{L} ){2,}\p{L}` is four or more spaced letters: one leading
+// letter, at least two interior letters, one trailing letter. Anchored by
+// whitespace/string boundaries so it never touches normal words, digits,
+// or case references.
+const buildSpacedLetterRunSource = () =>
+  "(?<=\\s|^)(?:\\p{L} (?:\\p{L} ){2,}\\p{L})(?: ?[,:;.!?])?(?=\\s|$)";
+
+/**
+ * A fresh global RegExp matching one spaced-letter run. Returned from a
+ * factory (not a shared constant) because callers use it with both
+ * `String.replace` and `String.matchAll`; a fresh instance avoids any
+ * shared `lastIndex` surprises.
+ */
+export const spacedLetterRunRegex = (): RegExp =>
+  new RegExp(buildSpacedLetterRunSource(), "gu");
+
+const MULTI_SPACE_RE = / {2,}/gu;
+const SPACE_RE = / /gu;
+
+/**
+ * Collapse every spaced-letter run in `text` to its concatenated letters,
+ * then normalize any resulting multi-spaces to a single space.
+ */
+export const collapseSpacedLetters = (text: string): string =>
+  text
+    .replace(spacedLetterRunRegex(), (match) => match.replace(SPACE_RE, ""))
+    .replace(MULTI_SPACE_RE, " ");

--- a/packages/text-normalize/src/spaced-letters.ts
+++ b/packages/text-normalize/src/spaced-letters.ts
@@ -42,11 +42,27 @@ export const spacedLetterRunRegex = (): RegExp =>
 const MULTI_SPACE_RE = / {2,}/gu;
 const SPACE_RE = / /gu;
 
+// Single-entry cache: sk-courts.ts's classifiers (isHoldingMarker,
+// isReasoningMarker, isInstructionMarker) each re-normalize the same line
+// text in sequence while classifying a heading, so consecutive calls on an
+// identical string are common during ingestion. Deterministic pure
+// function, so caching only the most recent call is always correct — a
+// cache miss just falls through to the normal computation.
+let lastInput: string | undefined;
+let lastResult: string | undefined;
+
 /**
  * Collapse every spaced-letter run in `text` to its concatenated letters,
  * then normalize any resulting multi-spaces to a single space.
  */
-export const collapseSpacedLetters = (text: string): string =>
-  text
+export const collapseSpacedLetters = (text: string): string => {
+  if (text === lastInput && lastResult !== undefined) {
+    return lastResult;
+  }
+  const result = text
     .replace(spacedLetterRunRegex(), (match) => match.replace(SPACE_RE, ""))
     .replace(MULTI_SPACE_RE, " ");
+  lastInput = text;
+  lastResult = result;
+  return result;
+};


### PR DESCRIPTION
Three text-normalization primitives were copied across the case-law slice
and had drifted behaviorally. Consolidate them in @stll/text-normalize so
index-time and query-time paths cannot disagree.

Spaced-letter collapse (letter-spaced court headings like
"r o z h o d o l :"): the ingestion pipeline required four or more spaced
letters, while the SK-courts parser and the case-viewer find-in-page
normalizer had both drifted to a two-letter floor, collapsing legitimate
Czech/Slovak single-letter word lists ("a b c", "u a v"). Move the
four-letter threshold into collapseSpacedLetters (plus spacedLetterRunRegex
for the offset-mapping caller). All three call sites now share it, so the
drift is structurally impossible.

Search-text diacritic stripping: add stripDiacritics (NFD +
\p{Diacritic}). \p{Diacritic} is deliberate; it strips combining marks in
every block, not only U+0300-U+036F. The API search helper and the web
find-in-page normalizer now import it instead of re-implementing the strip.

Slug diacritic stripping: add stripDiacriticsForSlug (NFKD + \p{Diacritic}).
Slugs are persisted, public URL segments, so the NFKD form and operation
order are preserved exactly; the API slug builder and both web slugifiers
reproduce existing slugs byte-for-byte.

Tests pin the four-letter threshold, the out-of-range combining marks, and
the NFD/NFKD split.
