### PR TITLE
chore: cover transactional emails, tsquery robustness, and bidi segmentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,18 @@ jobs:
       needs.trust-check.outputs.trusted == 'true'
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 25m, matching lint/typecheck-baseline: this job's own "Test" step
+    # duration scales with however many packages `turbo --affected` marks
+    # (any PR touching multiple large packages' test suites at once runs
+    # them with --concurrency=2 on a standard runner, not in isolation).
+    # Bumped from 20m after a PR whose diff was affected-flagged across
+    # apps/api, apps/web, packages/transactional and packages/ui
+    # simultaneously hit the old 20m ceiling with the Test step still in
+    # progress; a same-day comparable run (apps/api affected alone) needed
+    # only ~8m for the whole job, and re-running each affected package's
+    # suite locally finished in well under 5m with zero failures — so this
+    # is legitimate multi-package work outgrowing the budget, not a hang.
+    timeout-minutes: 25
     permissions:
       contents: read
 

--- a/apps/api/src/lib/search/pg-fts-provider.property.test.ts
+++ b/apps/api/src/lib/search/pg-fts-provider.property.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import fc from "fast-check";
+
+import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
+
+import {
+  buildPlainSearchTsQuery,
+  buildSearchTsQuery,
+} from "@/api/lib/search/query";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+/**
+ * User-query robustness for the Postgres FTS providers.
+ *
+ * `pgFtsProvider.search` (and the legal `pgFtsLegalProvider`) feed the
+ * caller's raw query string into Postgres text-search functions via
+ * `buildSearchTsQuery` / `buildPlainSearchTsQuery`. `to_tsquery` raises a
+ * hard SQL error on unbalanced operators (`&`, `|`, `!`, `:`, `*`, `(`,
+ * `)`), so any user query that reaches those functions unsanitized turns a
+ * search box into a 500. The builders defend against this by reducing every
+ * query to `[\p{L}\p{N}]+` lexemes before composing tsquery operators; this
+ * suite pins that invariant against the *real* Postgres parser (a regex-only
+ * check would miss how `to_tsquery` actually tokenizes).
+ *
+ * The builders wrap their arguments in `unaccent(...)`. PGlite ships no
+ * `unaccent` extension, so we install an identity stub: `unaccent` only folds
+ * accented characters to their base letters and can never introduce a tsquery
+ * operator, so an identity function is sound for a *syntax-validity* property
+ * (it exercises the exact same `to_tsquery`/`plainto_tsquery` parse path). The
+ * repo's `arabic_normalize` SQL function is installed by `getTestDb`.
+ */
+
+let db: TestDatabase;
+
+beforeAll(async () => {
+  db = await getTestDb();
+  await db.execute(
+    sql.raw(
+      "CREATE OR REPLACE FUNCTION unaccent(text) RETURNS text LANGUAGE sql IMMUTABLE AS $$ SELECT $1 $$",
+    ),
+  );
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+// A sampled `sample text نص قانون` document so a matching tsquery returns
+// `true` and a non-matching one returns `false`; either way the parse must
+// succeed. The boolean itself is irrelevant, only that no error is raised.
+const runQuery = async (query: string): Promise<void> => {
+  const built = buildSearchTsQuery(query);
+  const plain = buildPlainSearchTsQuery(query, {});
+  const plainAccented = buildPlainSearchTsQuery(query, { useUnaccent: true });
+  await db.execute(
+    sql`SELECT
+      (to_tsvector('simple', 'sample text نص قانون') @@ ${built}) AS a,
+      (to_tsvector('simple', 'sample') @@ ${plain}) AS b,
+      (to_tsvector('simple', 'sample') @@ ${plainAccented}) AS c`,
+  );
+};
+
+// Inputs that have historically broken naive tsquery construction: bare and
+// unbalanced tsquery operators, quotes, prefix stars, boolean keywords,
+// leading `-`, RTL/Arabic text mixed with operators, emoji, and
+// empty/whitespace-only strings.
+const ADVERSARIAL_QUERIES: readonly string[] = [
+  "",
+  "   ",
+  "\t\n",
+  "&",
+  "|",
+  "!",
+  ":",
+  "*",
+  "(",
+  ")",
+  "()",
+  "(((",
+  ":::",
+  "a & b",
+  "a | b",
+  "a:*)|(b",
+  "foo:*",
+  '"',
+  '"unclosed',
+  '"phrase"',
+  "'",
+  "'; DROP TABLE search_documents; --",
+  "!!!",
+  "a<->b",
+  "AND OR NOT",
+  "-foo",
+  "- ",
+  "foo AND (bar OR)",
+  "قانون & (شركة",
+  "شركة | !عقد",
+  "مُحَمَّد:*",
+  "😀🔥",
+  "日本語 & 中文",
+  "\\",
+  "\\\\",
+  "a\\:b",
+];
+
+describe("pg-fts tsquery robustness", () => {
+  test("adversarial queries never raise a tsquery syntax error", async () => {
+    for (const query of ADVERSARIAL_QUERIES) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential queries on one PGlite connection
+      await runQuery(query);
+    }
+  });
+
+  test(
+    "arbitrary Unicode queries never raise a tsquery syntax error",
+    async () => {
+      // Bias toward tsquery metacharacters, Arabic script, boolean keywords,
+      // and structural noise while still covering arbitrary Unicode (including
+      // lone surrogates from `fc.string()`).
+      const metaChar = fc.constantFrom(
+        "&",
+        "|",
+        "!",
+        ":",
+        "*",
+        "(",
+        ")",
+        '"',
+        "'",
+        "\\",
+        "-",
+        "<",
+        ">",
+        " ",
+        "\t",
+        "AND",
+        "OR",
+        "NOT",
+        "قانون",
+        "شركة",
+        "عقد",
+        "مُحَمَّد",
+        "日本語",
+        "😀",
+        "a",
+        "9",
+      );
+      const queryArb = fc.oneof(
+        fc.string(),
+        fc.array(metaChar, { maxLength: 12 }).map((parts) => parts.join("")),
+        fc.array(metaChar, { maxLength: 12 }).map((parts) => parts.join(" ")),
+      );
+
+      await fc.assert(
+        fc.asyncProperty(queryArb, async (query) => {
+          await runQuery(query);
+        }),
+        propertyConfig({ numRuns: 300 }),
+      );
+    },
+    propertyTestTimeout(30_000),
+  );
+
+  test("a normal query still matches its document", async () => {
+    const built = buildSearchTsQuery("sample text");
+    const rows = await db.execute<{ m: boolean }>(
+      sql`SELECT (to_tsvector('simple', 'sample text نص') @@ ${built}) AS m`,
+    );
+    expect(rows.rows.at(0)?.m).toBe(true);
+  });
+});

--- a/apps/api/src/lib/search/pg-fts-provider.property.test.ts
+++ b/apps/api/src/lib/search/pg-fts-provider.property.test.ts
@@ -153,11 +153,21 @@ describe("pg-fts tsquery robustness", () => {
         fc.array(metaChar, { maxLength: 12 }).map((parts) => parts.join(" ")),
       );
 
+      // numRuns is capped at 60 (not the 200-1000 typical of pure in-memory
+      // property tests, see src/handlers/rates/resolve.test.ts for the same
+      // convention): every run does 3 real round-trips against the process-
+      // wide shared PGlite singleton (test-utils.ts `getTestDb`), and PGlite's
+      // WASM linear memory only ever grows for the life of an instance, never
+      // shrinks. That singleton is reused by ~20 other test files across the
+      // suite's single shared-process `bun test` run, so numRuns here adds
+      // directly to the permanent memory floor for the rest of that run, not
+      // just this file's own footprint. PR CI stays at this budget; the
+      // nightly sweep still gets full depth via PROPERTY_TEST_NUM_RUNS_FACTOR.
       await fc.assert(
         fc.asyncProperty(queryArb, async (query) => {
           await runQuery(query);
         }),
-        propertyConfig({ numRuns: 300 }),
+        propertyConfig({ numRuns: 60 }),
       );
     },
     propertyTestTimeout(30_000),

--- a/packages/transactional/emails/transactional-emails.test.tsx
+++ b/packages/transactional/emails/transactional-emails.test.tsx
@@ -1,0 +1,254 @@
+import { render } from "@react-email/components";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import nodePath from "node:path";
+
+import { isUiLocale, UI_LOCALES } from "@stll/locales";
+
+import type { SupportedLang } from "../i18n/translate";
+import * as BetterAuthOTP from "./better-auth-otp";
+import { subject as otpSubject } from "./better-auth-otp-subject";
+import * as NewDeviceLogin from "./new-device-login";
+import { subject as newDeviceLoginSubject } from "./new-device-login-subject";
+import * as OrganizationInvitation from "./organization-invitation";
+import { subject as invitationSubject } from "./organization-invitation-subject";
+import * as ProductFeedback from "./product-feedback";
+
+/**
+ * Render tests for the transactional emails. A broken OTP or invite render is
+ * a silent sign-in / onboarding lockout: SMTP is not exercised in e2e, so
+ * these are the only automated guard that every locale of every critical
+ * template produces valid, correctly-interpolated, injection-safe HTML.
+ */
+
+// Enumerate locales from where the email translations actually live, so a new
+// locale is covered automatically (and a locale file with no translator entry
+// fails loudly rather than being skipped).
+const LOCALES: readonly SupportedLang[] = readdirSync(
+  nodePath.resolve(import.meta.dir, "../i18n/langs"),
+)
+  .filter((name) => name.endsWith(".json"))
+  .map((name) => name.slice(0, -".json".length))
+  .filter(isUiLocale)
+  .sort();
+
+const OTP_TYPES = [
+  "sign-in",
+  "email-verification",
+  "forget-password",
+  "change-email",
+  "delete-account",
+] as const;
+
+// use-intl reports missing messages and malformed interpolation through
+// `onError`, whose default is `console.error(intlError)`. Capturing those
+// calls turns "renders but silently falls back to the message key" into a
+// test failure.
+const INTL_ERROR_CODES = [
+  "MISSING_MESSAGE",
+  "MISSING_FORMAT",
+  "FORMATTING_ERROR",
+  "INVALID_MESSAGE",
+  "INVALID_KEY",
+  "INSUFFICIENT_PATH",
+  "ENVIRONMENT_FALLBACK",
+];
+
+let intlErrors: string[];
+let originalConsoleError: typeof console.error;
+
+beforeEach(() => {
+  intlErrors = [];
+  originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    const text = args.map(String).join(" ");
+    if (INTL_ERROR_CODES.some((code) => text.includes(code))) {
+      intlErrors.push(text);
+    }
+  };
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+const expectNoIntlErrors = () => {
+  expect(intlErrors).toEqual([]);
+};
+
+describe("OTP email", () => {
+  test("renders the one-time code for every OTP type", async () => {
+    for (const type of OTP_TYPES) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential renders keep console.error capture attributable per type
+      const html = await render(
+        <BetterAuthOTP.Email lang="en" otp="951753" type={type} />,
+      );
+      expect(html).toContain("951753");
+      expectNoIntlErrors();
+    }
+  });
+
+  test("subject is present for every locale", () => {
+    for (const lang of LOCALES) {
+      expect(otpSubject(lang).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+test("the email translation directory covers every supported UI locale", () => {
+  // A locale JSON that is not a real UI locale (or a UI locale missing its
+  // JSON) would silently shrink coverage; pin the two sets to the same size.
+  expect(LOCALES.length).toBe(UI_LOCALES.length);
+});
+
+describe("link/CTA emails carry the correct href", () => {
+  test("organization invitation embeds the invite link", async () => {
+    const inviteLink =
+      "https://app.stella.test/auth/accept-invitation/tok_abc123";
+    const html = await render(
+      <OrganizationInvitation.Email
+        invitedByUsername="Jane Doe"
+        inviteLink={inviteLink}
+        lang="en"
+        organizationName="Acme Inc"
+      />,
+    );
+    expect(html).toContain(`href="${inviteLink}"`);
+    expect(html).toContain("Acme Inc");
+    expectNoIntlErrors();
+  });
+
+  test("new-device-login embeds the sessions URL", async () => {
+    const sessionsUrl = "https://app.stella.test/account/sessions";
+    const html = await render(
+      <NewDeviceLogin.Email
+        device="Chrome on macOS"
+        ipAddress="203.0.113.42"
+        lang="en"
+        sessionsUrl={sessionsUrl}
+        time="Mar 6, 2026, 2:30 PM UTC"
+      />,
+    );
+    expect(html).toContain(`href="${sessionsUrl}"`);
+    expectNoIntlErrors();
+  });
+
+  test("ampersands in an invite link are HTML-escaped, not left raw", async () => {
+    const html = await render(
+      <OrganizationInvitation.Email
+        invitedByUsername="Jane Doe"
+        inviteLink="https://app.stella.test/accept?token=a&next=/x"
+        lang="en"
+        organizationName="Acme Inc"
+      />,
+    );
+    expect(html).toContain(
+      'href="https://app.stella.test/accept?token=a&amp;next=/x"',
+    );
+  });
+});
+
+describe("every supported locale renders without missing-interpolation errors", () => {
+  test("OTP, invitation, and new-device-login render cleanly in all locales", async () => {
+    // Sequential renders so a captured console.error stays attributable to a
+    // single locale rather than interleaving across parallel renders.
+    for (const lang of LOCALES) {
+      // oxlint-disable-next-line no-await-in-loop -- see note above
+      const otpHtml = await render(
+        <BetterAuthOTP.Email lang={lang} otp="123456" type="sign-in" />,
+      );
+      expect(otpHtml).toContain("123456");
+
+      // oxlint-disable-next-line no-await-in-loop -- see note above
+      const inviteHtml = await render(
+        <OrganizationInvitation.Email
+          invitedByUsername="Jane Doe"
+          inviteLink="https://app.stella.test/accept/tok"
+          lang={lang}
+          organizationName="Acme Inc"
+        />,
+      );
+      // A missing `invitation.body` message would drop the interpolated org
+      // name; its presence proves the ICU string resolved and interpolated.
+      expect(inviteHtml).toContain("Acme Inc");
+      expect(inviteHtml).toContain("Jane Doe");
+
+      // oxlint-disable-next-line no-await-in-loop -- see note above
+      const deviceHtml = await render(
+        <NewDeviceLogin.Email
+          device="Chrome on macOS"
+          ipAddress="203.0.113.42"
+          lang={lang}
+          sessionsUrl="https://app.stella.test/account/sessions"
+          time="Mar 6, 2026, 2:30 PM UTC"
+        />,
+      );
+      expect(deviceHtml).toContain("Chrome on macOS");
+
+      // The subject helpers hit a second, separately-namespaced key path.
+      expect(otpSubject(lang).length).toBeGreaterThan(0);
+      expect(newDeviceLoginSubject(lang).length).toBeGreaterThan(0);
+      expect(
+        invitationSubject(lang, { organizationName: "Acme Inc" }).length,
+      ).toBeGreaterThan(0);
+
+      expectNoIntlErrors();
+    }
+  });
+
+  test("Arabic renders right-to-left and Latin locales left-to-right", async () => {
+    const arabic = await render(
+      <BetterAuthOTP.Email lang="ar" otp="123456" type="sign-in" />,
+    );
+    expect(arabic).toContain('dir="rtl"');
+
+    const english = await render(
+      <BetterAuthOTP.Email lang="en" otp="123456" type="sign-in" />,
+    );
+    expect(english).toContain('dir="ltr"');
+  });
+});
+
+describe("user-supplied strings are HTML-escaped in the rendered output", () => {
+  const INJECTION = "<script>alert('xss')</script>";
+
+  test("invitation escapes the organization name and inviter name", async () => {
+    const html = await render(
+      <OrganizationInvitation.Email
+        invitedByUsername={INJECTION}
+        inviteLink="https://app.stella.test/accept/tok"
+        lang="en"
+        organizationName={INJECTION}
+      />,
+    );
+    expect(html).not.toContain(INJECTION);
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  test("new-device-login escapes the device string", async () => {
+    const html = await render(
+      <NewDeviceLogin.Email
+        device={INJECTION}
+        ipAddress="203.0.113.42"
+        lang="en"
+        sessionsUrl="https://app.stella.test/account/sessions"
+        time="Mar 6, 2026, 2:30 PM UTC"
+      />,
+    );
+    expect(html).not.toContain(INJECTION);
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  test("product-feedback escapes the reporter-supplied title and body", async () => {
+    const html = await render(
+      <ProductFeedback.Email
+        body={INJECTION}
+        kind="bug"
+        reporter={{ via: "mcp", userId: "user_1", organizationId: "org_1" }}
+        title={INJECTION}
+      />,
+    );
+    expect(html).not.toContain(INJECTION);
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/packages/transactional/emails/transactional-emails.test.tsx
+++ b/packages/transactional/emails/transactional-emails.test.tsx
@@ -64,6 +64,8 @@ beforeEach(() => {
     const text = args.map(String).join(" ");
     if (INTL_ERROR_CODES.some((code) => text.includes(code))) {
       intlErrors.push(text);
+    } else {
+      originalConsoleError(...args);
     }
   };
 });

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -13,6 +13,7 @@
     "dev": "email dev -p 3002",
     "export": "email export",
     "start": "email start -p 3002",
+    "test": "bun test emails",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
     "typegen": "bun ../scripts/src/i18n-typegen.ts i18n/langs",
     "i18n:check": "bun ../scripts/src/i18n-typegen.ts i18n/langs --check && bun ../scripts/src/i18n-check.ts i18n/langs",

--- a/packages/transactional/tsconfig.json
+++ b/packages/transactional/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@stll/typescript-config/react-library.json",
   "compilerOptions": {
+    "types": ["bun"],
     "paths": {
       "@stll/transactional/*": ["./*"]
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
+    "test": "bun test src",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/ui",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/ui",

--- a/packages/ui/src/hooks/use-content-dir.test.ts
+++ b/packages/ui/src/hooks/use-content-dir.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import { contentDir, isStructuredInputType } from "./use-content-dir";
+
+/**
+ * Bidi direction resolution for free-text fields.
+ *
+ * The direction of a user-text field is *not* segmented in JS: `BidiText`
+ * (`../components/bidi-text.tsx`) and the shared inputs delegate per-character
+ * bidi to the browser via `dir="auto"` + `unicode-bidi: isolate`. The only
+ * decision made in JS is `contentDir`: whether to emit `dir="auto"` (let the
+ * content pick its own direction) or omit `dir` entirely (inherit the ambient
+ * UI direction so an empty field keeps its caret on the RTL side under Arabic).
+ *
+ * These tests pin that script-agnostic contract: any non-empty value resolves
+ * to `"auto"` regardless of script or mix (Latin, Arabic, mixed runs, digits),
+ * and only an empty value inherits. A regression that started computing a
+ * concrete `"ltr"`/`"rtl"` from the text in JS — instead of deferring to the
+ * browser — would break this and mis-place carets in mixed content.
+ */
+
+const ARABIC = "السلام عليكم";
+const LATIN = "Hello world";
+// A Latin sentence carrying an Arabic quotation.
+const LTR_WITH_ARABIC = 'He said "السلام" today';
+// An Arabic sentence carrying a Latin case citation.
+const RTL_WITH_LATIN = "حكم رقم Smith v Jones لعام";
+// Digits embedded in an Arabic run.
+const RTL_WITH_NUMBERS = "المادة 42 من القانون";
+
+describe("contentDir", () => {
+  test("empty string inherits the ambient direction (no dir attribute)", () => {
+    expect(contentDir("")).toBeUndefined();
+  });
+
+  test("undefined value inherits the ambient direction", () => {
+    expect(contentDir(undefined)).toBeUndefined();
+  });
+
+  test("pure LTR text resolves to auto", () => {
+    expect(contentDir(LATIN)).toBe("auto");
+  });
+
+  test("pure RTL (Arabic) text resolves to auto", () => {
+    expect(contentDir(ARABIC)).toBe("auto");
+  });
+
+  test("LTR text with an Arabic quote resolves to auto", () => {
+    expect(contentDir(LTR_WITH_ARABIC)).toBe("auto");
+  });
+
+  test("RTL text with a Latin citation resolves to auto", () => {
+    expect(contentDir(RTL_WITH_LATIN)).toBe("auto");
+  });
+
+  test("digits inside an RTL run resolve to auto", () => {
+    expect(contentDir(RTL_WITH_NUMBERS)).toBe("auto");
+  });
+
+  test("script never changes the outcome: all non-empty text is auto", () => {
+    // The decision is content-presence, not script; the browser segments.
+    for (const value of [LATIN, ARABIC, LTR_WITH_ARABIC, RTL_WITH_LATIN]) {
+      expect(contentDir(value)).toBe("auto");
+    }
+  });
+
+  test("whitespace-only text counts as content (auto, not inherit)", () => {
+    expect(contentDir(" ")).toBe("auto");
+  });
+
+  test("a numeric value counts as content", () => {
+    expect(contentDir(0)).toBe("auto");
+    expect(contentDir(42)).toBe("auto");
+  });
+
+  test("a multi-value field is content only when non-empty", () => {
+    expect(contentDir([])).toBeUndefined();
+    expect(contentDir(["a"])).toBe("auto");
+  });
+});
+
+describe("isStructuredInputType", () => {
+  test("structured input types are treated as always-LTR", () => {
+    for (const type of [
+      "email",
+      "url",
+      "tel",
+      "number",
+      "password",
+      "date",
+      "datetime-local",
+      "time",
+      "month",
+      "week",
+    ]) {
+      expect(isStructuredInputType(type)).toBe(true);
+    }
+  });
+
+  test("free-text and unspecified types are not structured", () => {
+    expect(isStructuredInputType("text")).toBe(false);
+    expect(isStructuredInputType("search")).toBe(false);
+    expect(isStructuredInputType(undefined)).toBe(false);
+  });
+});

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@stll/typescript-config/react-library.json",
   "compilerOptions": {
+    "types": ["bun"],
     "paths": {
       "@stll/ui/*": ["./src/*"]
     }


### PR DESCRIPTION
Add three independent test suites:

- packages/transactional: render tests for the OTP, invitation, and
  new-device-login emails plus product-feedback. Assert the OTP code and
  CTA hrefs render, every supported locale interpolates without falling
  back to the message key (captured via use-intl's onError), Arabic
  renders RTL, and user-supplied names/titles are HTML-escaped. Adds a
  test script to the package.

- apps/api search: property test feeding arbitrary Unicode (tsquery
  metacharacters, Arabic, emoji, empty/whitespace) through
  buildSearchTsQuery / buildPlainSearchTsQuery and executing the result
  against a real Postgres parser via the PGlite harness, asserting no
  tsquery syntax error is ever raised.

- packages/ui: pin the content-direction contract in use-content-dir
  (contentDir, isStructuredInputType): non-empty text of any script
  resolves to dir=auto, empty inherits, structured input types stay LTR.
  Adds a test script to the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Bun coverage to ensure Postgres FTS search safely handles adversarial and arbitrary Unicode input without query syntax errors, while preserving normal matching.
  * Added transactional email rendering tests for all supported locales, verifying OTP content, links, escaping, and RTL/LTR directionality.
  * Added tests for automatic content direction and structured input detection in the UI hooks.
* **Chores**
  * Added Bun test scripts for transactional email and UI test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->