### PR TITLE
chore: mcp upstream connection lifecycle and desktop rpc golden fixtures

### DIFF
--- a/apps/api/src/lib/mcp-upstream/connections.test.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.test.ts
@@ -1,0 +1,356 @@
+import { Result } from "better-result";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import type { CachedMcpToolDefinition } from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
+
+// This suite pins the OAuth/token-refresh connection lifecycle in
+// `connections.ts` against faked crypto, OAuth, transport, and DB
+// collaborators. All external collaborators are injected either as
+// arguments (`safeDb`) or replaced with `mock.module`, so no network,
+// KMS, or Postgres access happens. The point is to lock in the exact
+// failure-normalization contract the MCP gateway depends on.
+
+type RefreshResult = Result<
+  { access_token: string; refresh_token?: string },
+  Error
+>;
+
+type CapturedTransport = {
+  headers?: Record<string, string>;
+  url: string;
+};
+
+// Mutable controls the mocked collaborators close over. Reset per test.
+const state = {
+  captured: [] as unknown[],
+  closes: 0,
+  dbSets: [] as Record<string, unknown>[],
+  encryptCalls: 0,
+  refresh: (() =>
+    Result.ok({
+      access_token: "fresh-access",
+      refresh_token: "fresh-refresh",
+    })) as () => RefreshResult,
+  refreshCalls: 0,
+  toolsImpl: (async () => [
+    { execute: async () => ({ content: [{ text: "ok", type: "text" }] }) },
+  ]) as (defs?: unknown) => Promise<unknown[]>,
+  transports: [] as CapturedTransport[],
+};
+
+void mock.module("@tanstack/ai-mcp", () => ({
+  createMCPClient: async ({ transport }: { transport: CapturedTransport }) => {
+    state.transports.push(transport);
+    return {
+      close: async () => {
+        state.closes += 1;
+      },
+      tools: async (defs?: unknown) => await state.toolsImpl(defs),
+    };
+  },
+}));
+
+void mock.module("@/api/handlers/mcp-connectors/oauth", () => ({
+  refreshOAuthToken: async () => {
+    state.refreshCalls += 1;
+    return state.refresh();
+  },
+  // Deterministic future expiry; the value is only forwarded to the DB set.
+  tokenExpiresAt: () => new Date(Date.now() + 3_600_000),
+}));
+
+void mock.module("@/api/handlers/mcp-connectors/crypto", () => ({
+  decryptMcpSecret: async ({ purpose }: { purpose: string }) =>
+    `decrypted-${purpose}`,
+  encryptMcpSecret: async () => {
+    state.encryptCalls += 1;
+    return { ciphertext: Buffer.from("cipher"), iv: Buffer.from("iv") };
+  },
+}));
+
+void mock.module("@/api/lib/safe-outbound-fetch", () => ({
+  safeOutboundFetchStream: async () =>
+    Result.err(new Error("unused: transport is mocked at the client layer")),
+  validateOutboundFetchTarget: async (url: string) =>
+    Result.ok({ url: new URL(url) }),
+}));
+
+void mock.module("@/api/lib/analytics/capture", () => ({
+  captureError: (error: unknown) => {
+    state.captured.push(error);
+  },
+}));
+
+const { createMcpClientForConnection, proxyMcpToolCall } =
+  await import("@/api/lib/mcp-upstream/connections");
+
+const organizationId = toSafeId<"organization">("org_1");
+const userId = toSafeId<"user">("user_1");
+
+const cachedTool = {
+  exposedName: "mcp__registry__lookup",
+  inputSchema: { properties: {}, type: "object" },
+  rawName: "lookup",
+} satisfies CachedMcpToolDefinition;
+
+// Records every `.set(...)` payload written through the fake so tests can
+// assert on the status transitions the module persists.
+const makeSafeDb = (): SafeDb => {
+  const chain: Record<string, (arg?: unknown) => unknown> = {
+    set: (value?: unknown) => {
+      state.dbSets.push(value as Record<string, unknown>);
+      return chain;
+    },
+    update: () => chain,
+    where: () => chain,
+  };
+  // SAFETY: test double; the module only ever calls update().set().where()
+  // and awaits the returned Result, none of which touches a real Transaction.
+  return (async (fn: (tx: unknown) => unknown) => {
+    await fn(chain);
+    return Result.ok(undefined);
+  }) as unknown as SafeDb;
+};
+
+const oauthRow = (
+  overrides: Partial<Extract<LoadedMcpConnection, { type: "oauth2" }>> = {},
+): LoadedMcpConnection => ({
+  accessTokenEncrypted: Buffer.from("access"),
+  accessTokenIv: Buffer.from("iv"),
+  allowedTools: null,
+  connectorId: toSafeId<"mcpConnector">("connector_1"),
+  description: "Registry connector",
+  displayName: "Registry",
+  // Expired by default so the refresh path is exercised.
+  expiresAt: new Date(Date.now() - 60_000),
+  oauthAuthorizationServerUrl: "https://auth.example.com",
+  oauthClientId: "client-1",
+  oauthClientSecretEncrypted: Buffer.from("secret"),
+  oauthClientSecretIv: Buffer.from("iv"),
+  oauthResourceUrl: "https://mcp.example.com",
+  refreshTokenEncrypted: Buffer.from("refresh"),
+  refreshTokenIv: Buffer.from("iv"),
+  slug: "registry",
+  type: "oauth2",
+  url: "https://mcp.example.com/rpc",
+  userConnectionId: toSafeId<"mcpUserConnection">("conn_1"),
+  ...overrides,
+});
+
+const lastAuthHeader = () =>
+  state.transports.at(-1)?.headers?.["Authorization"];
+
+const hasStatusSet = (status: string) =>
+  state.dbSets.some((set) => set["status"] === status);
+
+beforeEach(() => {
+  state.captured = [];
+  state.closes = 0;
+  state.dbSets = [];
+  state.encryptCalls = 0;
+  state.refreshCalls = 0;
+  state.refresh = () =>
+    Result.ok({ access_token: "fresh-access", refresh_token: "fresh-refresh" });
+  state.toolsImpl = async () => [
+    { execute: async () => ({ content: [{ text: "ok", type: "text" }] }) },
+  ];
+  state.transports = [];
+});
+
+describe("MCP upstream connection lifecycle", () => {
+  test("valid, unexpired OAuth token is used directly without a refresh", async () => {
+    const client = await createMcpClientForConnection({
+      organizationId,
+      row: oauthRow({ expiresAt: new Date(Date.now() + 3_600_000) }),
+      safeDb: makeSafeDb(),
+      userId,
+    });
+
+    expect(client).not.toBeNull();
+    expect(state.refreshCalls).toBe(0);
+    // Header carries the decrypted access token, not a refreshed one.
+    expect(lastAuthHeader()).toBe("Bearer decrypted-mcp_access_token");
+  });
+
+  test("expired token triggers a refresh and the call proceeds with the new token", async () => {
+    state.refresh = () =>
+      Result.ok({ access_token: "rotated-token", refresh_token: "r2" });
+
+    const client = await createMcpClientForConnection({
+      organizationId,
+      row: oauthRow(),
+      safeDb: makeSafeDb(),
+      userId,
+    });
+
+    expect(client).not.toBeNull();
+    // Refresh is proactive (driven by `expiresAt`), not a 401-retry: the
+    // token is resolved once, up front, before the client is opened.
+    expect(state.refreshCalls).toBe(1);
+    expect(lastAuthHeader()).toBe("Bearer rotated-token");
+    // The rotated token is re-encrypted and persisted with status "connected".
+    expect(state.encryptCalls).toBeGreaterThan(0);
+    expect(hasStatusSet("connected")).toBe(true);
+  });
+
+  test("refresh failure normalizes to needs_reauth and a skipped (null) client", async () => {
+    state.refresh = () => Result.err(new Error("token endpoint 400"));
+
+    const client = await createMcpClientForConnection({
+      organizationId,
+      row: oauthRow(),
+      safeDb: makeSafeDb(),
+      userId,
+    });
+
+    expect(client).toBeNull();
+    expect(hasStatusSet("needs_reauth")).toBe(true);
+  });
+
+  test("refresh failure surfaces as an error tool-result, never a raw throw", async () => {
+    state.refresh = () => Result.err(new Error("token endpoint 400"));
+
+    const result = await proxyMcpToolCall({
+      args: {},
+      cachedTool,
+      organizationId,
+      row: oauthRow(),
+      safeDb: makeSafeDb(),
+      userId,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain("unavailable");
+  });
+
+  test("a missing refresh token short-circuits to needs_reauth without calling refresh", async () => {
+    const client = await createMcpClientForConnection({
+      organizationId,
+      row: oauthRow({ refreshTokenEncrypted: null, refreshTokenIv: null }),
+      safeDb: makeSafeDb(),
+      userId,
+    });
+
+    expect(client).toBeNull();
+    expect(state.refreshCalls).toBe(0);
+    expect(hasStatusSet("needs_reauth")).toBe(true);
+  });
+
+  // FINDING (pinned, not fixed): a transport failure thrown from
+  // `client.tools()` is NOT normalized inside `connections.ts`. There is no
+  // catch around the tool call, so it rejects. Normalization to a structured
+  // error happens one layer up, in the gateway caller
+  // (`mcp/gateway/external-tools.ts` wraps `proxyMcpToolCall` in try/catch).
+  test("an upstream failure during tools() propagates as a rejection (not normalized here)", async () => {
+    state.toolsImpl = async () => {
+      throw new Error("upstream timeout: the operation was aborted");
+    };
+
+    await expect(
+      proxyMcpToolCall({
+        args: {},
+        cachedTool,
+        organizationId,
+        row: oauthRow(),
+        safeDb: makeSafeDb(),
+        userId,
+      }),
+    ).rejects.toThrow("upstream timeout");
+    // The `finally` still closes the client, so the connection does not leak.
+    expect(state.closes).toBeGreaterThan(0);
+  });
+
+  test("an upstream failure during execute() propagates as a rejection (not normalized here)", async () => {
+    state.toolsImpl = async () => [
+      {
+        execute: async () => {
+          throw new Error("ECONNRESET from upstream");
+        },
+      },
+    ];
+
+    await expect(
+      proxyMcpToolCall({
+        args: {},
+        cachedTool,
+        organizationId,
+        row: oauthRow(),
+        safeDb: makeSafeDb(),
+        userId,
+      }),
+    ).rejects.toThrow("ECONNRESET");
+    expect(state.closes).toBeGreaterThan(0);
+  });
+
+  // FINDING (pinned, not fixed): there is no single-flight guard. Each call
+  // resolves its token independently, so N concurrent calls on an expired
+  // OAuth connection stampede N refreshes and N DB writes.
+  test("concurrent calls during an expired-token window each refresh independently", async () => {
+    const safeDb = makeSafeDb();
+    const row = oauthRow();
+
+    await Promise.all([
+      createMcpClientForConnection({ organizationId, row, safeDb, userId }),
+      createMcpClientForConnection({ organizationId, row, safeDb, userId }),
+      createMcpClientForConnection({ organizationId, row, safeDb, userId }),
+    ]);
+
+    expect(state.refreshCalls).toBe(3);
+  });
+
+  // FINDING (pinned, not fixed): the module keeps no in-memory circuit-breaker
+  // or cooldown. Each failure writes needs_reauth again; there is no backoff
+  // counter. The only "circuit break" is at the persistence layer
+  // (`loadActiveMcpConnectionsForUser` filters status = "connected"), so a
+  // downed connection is excluded on the *next load*, not by any in-module
+  // state on a row that is already in hand.
+  test("repeated refresh failures re-attempt every time (no in-module cooldown)", async () => {
+    state.refresh = () => Result.err(new Error("token endpoint 400"));
+    const safeDb = makeSafeDb();
+    const row = oauthRow();
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential: pin per-attempt behavior
+      await createMcpClientForConnection({
+        organizationId,
+        row,
+        safeDb,
+        userId,
+      });
+    }
+
+    expect(state.refreshCalls).toBe(3);
+    expect(
+      state.dbSets.filter((set) => set["status"] === "needs_reauth"),
+    ).toHaveLength(3);
+  });
+
+  test("bearer connections send the decrypted static token, no OAuth path", async () => {
+    const bearerRow: LoadedMcpConnection = {
+      allowedTools: null,
+      connectorId: toSafeId<"mcpConnector">("connector_1"),
+      description: "Static-token connector",
+      displayName: "Registry",
+      slug: "registry",
+      staticTokenEncrypted: Buffer.from("static"),
+      staticTokenIv: Buffer.from("iv"),
+      type: "bearer",
+      url: "https://mcp.example.com/rpc",
+      userConnectionId: toSafeId<"mcpUserConnection">("conn_1"),
+    };
+
+    const client = await createMcpClientForConnection({
+      organizationId,
+      row: bearerRow,
+      safeDb: makeSafeDb(),
+      userId,
+    });
+
+    expect(client).not.toBeNull();
+    expect(state.refreshCalls).toBe(0);
+    expect(lastAuthHeader()).toBe("Bearer decrypted-mcp_static_token");
+  });
+});

--- a/apps/api/src/lib/mcp-upstream/connections.test.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.test.ts
@@ -5,6 +5,7 @@ import type { SafeDb } from "@/api/db/safe-db";
 import type { CachedMcpToolDefinition } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 // This suite pins the OAuth/token-refresh connection lifecycle in
 // `connections.ts` against faked crypto, OAuth, transport, and DB
@@ -101,7 +102,7 @@ const cachedTool = {
 const makeSafeDb = (): SafeDb => {
   const chain: Record<string, (arg?: unknown) => unknown> = {
     set: (value?: unknown) => {
-      state.dbSets.push(value as Record<string, unknown>);
+      state.dbSets.push(asTestRaw<Record<string, unknown>>(value));
       return chain;
     },
     update: () => chain,
@@ -109,10 +110,10 @@ const makeSafeDb = (): SafeDb => {
   };
   // SAFETY: test double; the module only ever calls update().set().where()
   // and awaits the returned Result, none of which touches a real Transaction.
-  return (async (fn: (tx: unknown) => unknown) => {
+  return asTestRaw<SafeDb>(async (fn: (tx: unknown) => unknown) => {
     await fn(chain);
     return Result.ok(undefined);
-  }) as unknown as SafeDb;
+  });
 };
 
 const oauthRow = (
@@ -249,16 +250,23 @@ describe("MCP upstream connection lifecycle", () => {
       throw new Error("upstream timeout: the operation was aborted");
     };
 
-    await expect(
-      proxyMcpToolCall({
-        args: {},
-        cachedTool,
-        organizationId,
-        row: oauthRow(),
-        safeDb: makeSafeDb(),
-        userId,
-      }),
-    ).rejects.toThrow("upstream timeout");
+    // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+    // type-aware lint; capture the rejection explicitly instead.
+    const rejection = await proxyMcpToolCall({
+      args: {},
+      cachedTool,
+      organizationId,
+      row: oauthRow(),
+      safeDb: makeSafeDb(),
+      userId,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection instanceof Error ? rejection.message : "").toContain(
+      "upstream timeout",
+    );
     // The `finally` still closes the client, so the connection does not leak.
     expect(state.closes).toBeGreaterThan(0);
   });
@@ -272,16 +280,23 @@ describe("MCP upstream connection lifecycle", () => {
       },
     ];
 
-    await expect(
-      proxyMcpToolCall({
-        args: {},
-        cachedTool,
-        organizationId,
-        row: oauthRow(),
-        safeDb: makeSafeDb(),
-        userId,
-      }),
-    ).rejects.toThrow("ECONNRESET");
+    // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+    // type-aware lint; capture the rejection explicitly instead.
+    const rejection = await proxyMcpToolCall({
+      args: {},
+      cachedTool,
+      organizationId,
+      row: oauthRow(),
+      safeDb: makeSafeDb(),
+      userId,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection instanceof Error ? rejection.message : "").toContain(
+      "ECONNRESET",
+    );
     expect(state.closes).toBeGreaterThan(0);
   });
 

--- a/apps/desktop/fixtures/rpc/app-snapshot.json
+++ b/apps/desktop/fixtures/rpc/app-snapshot.json
@@ -1,0 +1,52 @@
+{
+  "bridgePort": 45901,
+  "bridgeVersion": 7,
+  "capabilities": ["self-host.connect"],
+  "linkedAccount": {
+    "email": "counsel@example.com",
+    "name": "Jane Counsel",
+    "verifiedAt": "2026-07-01T09:30:00Z"
+  },
+  "notificationPreferences": {
+    "documentReady": true,
+    "revisionCreated": true,
+    "syncIssues": false
+  },
+  "runningSince": "2026-07-18T08:00:00Z",
+  "sessions": [
+    {
+      "baseVersionNumber": 3,
+      "entityId": "8f3b2c1a-9d4e-4f6a-8b2c-1a9d4e4f6a8b",
+      "fileName": "merger-agreement.docx",
+      "filePath": "/Users/jane/Stella/merger-agreement.docx",
+      "id": "b2d4f6a8-1c3e-4a5b-9c7d-2e4f6a8b0c1d",
+      "lastError": null,
+      "lastCheckpointAt": "2026-07-18T10:15:00Z",
+      "pendingFinalize": false,
+      "propertyId": "22222222-2222-4222-8222-222222222222",
+      "status": "ready",
+      "takeoverDetected": false,
+      "workspaceId": "33333333-3333-4333-8333-333333333333"
+    }
+  ],
+  "trustedSelfHostConnections": [
+    {
+      "apiBaseUrl": "https://api.selfhost.example",
+      "trustedAt": "2026-07-10T12:00:00Z",
+      "webOrigin": "https://app.selfhost.example"
+    }
+  ],
+  "update": {
+    "baseUrl": "https://downloads.example.com/desktop",
+    "channel": "stable",
+    "currentHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "currentVersion": "1.4.2",
+    "lastCheckedAt": "2026-07-18T09:00:00Z",
+    "latestHash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "latestVersion": "1.4.3",
+    "status": "available",
+    "statusMessage": "An update is available.",
+    "updateAvailable": true,
+    "updateReady": false
+  }
+}

--- a/apps/desktop/fixtures/rpc/desktop-update.json
+++ b/apps/desktop/fixtures/rpc/desktop-update.json
@@ -1,0 +1,13 @@
+{
+  "baseUrl": null,
+  "channel": null,
+  "currentHash": null,
+  "currentVersion": "1.4.2",
+  "lastCheckedAt": null,
+  "latestHash": null,
+  "latestVersion": null,
+  "status": "disabled",
+  "statusMessage": "Updates will appear here once configured.",
+  "updateAvailable": false,
+  "updateReady": false
+}

--- a/apps/desktop/fixtures/rpc/linked-account.json
+++ b/apps/desktop/fixtures/rpc/linked-account.json
@@ -1,0 +1,5 @@
+{
+  "email": "solo@example.com",
+  "name": null,
+  "verifiedAt": "2026-06-15T14:20:00Z"
+}

--- a/apps/desktop/fixtures/rpc/notification-preferences.json
+++ b/apps/desktop/fixtures/rpc/notification-preferences.json
@@ -1,0 +1,5 @@
+{
+  "documentReady": true,
+  "revisionCreated": false,
+  "syncIssues": true
+}

--- a/apps/desktop/fixtures/rpc/open-docx-request.json
+++ b/apps/desktop/fixtures/rpc/open-docx-request.json
@@ -1,0 +1,21 @@
+{
+  "apiBaseUrl": "https://api.example.com",
+  "entityId": "11111111-1111-4111-8111-111111111111",
+  "linkedAccount": {
+    "email": "counsel@example.com",
+    "name": "Jane Counsel",
+    "verifiedAt": "2026-07-01T09:30:00Z"
+  },
+  "propertyId": "22222222-2222-4222-8222-222222222222",
+  "remoteSession": {
+    "baseVersionNumber": 2,
+    "downloadUrl": "https://s3.example.com/doc.docx?sig=abc123",
+    "fileName": "motion.docx",
+    "lastCheckpointAt": null,
+    "resumedFromCheckpoint": false,
+    "sessionId": "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6",
+    "sessionToken": "sess-tok-abc123",
+    "tookOverExistingSession": false
+  },
+  "workspaceId": "33333333-3333-4333-8333-333333333333"
+}

--- a/apps/desktop/fixtures/rpc/open-docx-response.json
+++ b/apps/desktop/fixtures/rpc/open-docx-response.json
@@ -1,0 +1,5 @@
+{
+  "alreadyOpen": false,
+  "filePath": "/Users/jane/Stella/motion.docx",
+  "sessionId": "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6"
+}

--- a/apps/desktop/fixtures/rpc/session-snapshot-error.json
+++ b/apps/desktop/fixtures/rpc/session-snapshot-error.json
@@ -1,0 +1,14 @@
+{
+  "baseVersionNumber": 12,
+  "entityId": "88888888-8888-4888-8888-888888888888",
+  "fileName": "nda.docx",
+  "filePath": "/Users/jane/Stella/nda.docx",
+  "id": "99999999-9999-4999-8999-999999999999",
+  "lastError": "Checkpoint upload failed: connection reset",
+  "lastCheckpointAt": "2026-07-18T11:02:00Z",
+  "pendingFinalize": false,
+  "propertyId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  "status": "error",
+  "takeoverDetected": false,
+  "workspaceId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+}

--- a/apps/desktop/fixtures/rpc/session-snapshot-syncing.json
+++ b/apps/desktop/fixtures/rpc/session-snapshot-syncing.json
@@ -1,0 +1,14 @@
+{
+  "baseVersionNumber": 0,
+  "entityId": "44444444-4444-4444-8444-444444444444",
+  "fileName": "settlement-draft.docx",
+  "filePath": "/Users/jane/Stella/settlement-draft.docx",
+  "id": "55555555-5555-4555-8555-555555555555",
+  "lastError": null,
+  "lastCheckpointAt": null,
+  "pendingFinalize": true,
+  "propertyId": "66666666-6666-4666-8666-666666666666",
+  "status": "syncing",
+  "takeoverDetected": true,
+  "workspaceId": "77777777-7777-4777-8777-777777777777"
+}

--- a/apps/desktop/fixtures/rpc/trusted-self-host-connection.json
+++ b/apps/desktop/fixtures/rpc/trusted-self-host-connection.json
@@ -1,0 +1,5 @@
+{
+  "apiBaseUrl": "https://api.selfhost.example",
+  "trustedAt": "2026-07-10T12:00:00Z",
+  "webOrigin": "https://app.selfhost.example"
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,7 @@
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware apps/desktop",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/desktop",
     "test": "bun test --pass-with-no-tests",
-    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit"
+    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
     "@stll/ui": "workspace:*",

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -425,3 +425,129 @@ mod tests {
     assert!(!json.contains("session_id"));
   }
 }
+
+/// Golden-fixture contract shared with the TypeScript bridge types.
+///
+/// The JSON files under `apps/desktop/fixtures/rpc/` are the single
+/// source of truth for every message that crosses the web <-> desktop
+/// bridge. `src/shared/rpc.golden.test.ts` validates the same files
+/// against the TypeScript `rpc.ts` types; this module validates the Rust
+/// serde types. A field renamed, retyped, or dropped on either side
+/// without updating the fixtures fails one of the two suites, so
+/// TS/Rust message-shape drift cannot land silently.
+///
+/// The fixtures are embedded with `include_str!` (path relative to this
+/// source file), the same mechanism `i18n.rs` uses for bundled language
+/// packs, so `cargo test` needs no runtime file access.
+#[cfg(test)]
+mod fixture_tests {
+  use super::*;
+
+  const APP_SNAPSHOT: &str = include_str!("../../fixtures/rpc/app-snapshot.json");
+  const SESSION_SYNCING: &str =
+    include_str!("../../fixtures/rpc/session-snapshot-syncing.json");
+  const SESSION_ERROR: &str =
+    include_str!("../../fixtures/rpc/session-snapshot-error.json");
+  const OPEN_DOCX_REQUEST: &str =
+    include_str!("../../fixtures/rpc/open-docx-request.json");
+  const OPEN_DOCX_RESPONSE: &str =
+    include_str!("../../fixtures/rpc/open-docx-response.json");
+  const LINKED_ACCOUNT: &str = include_str!("../../fixtures/rpc/linked-account.json");
+  const DESKTOP_UPDATE: &str = include_str!("../../fixtures/rpc/desktop-update.json");
+  const TRUSTED_SELF_HOST: &str =
+    include_str!("../../fixtures/rpc/trusted-self-host-connection.json");
+  const NOTIFICATION_PREFERENCES: &str =
+    include_str!("../../fixtures/rpc/notification-preferences.json");
+
+  /// Deserialize a fixture into `T`, re-serialize it, and assert the
+  /// value round-trips unchanged. Because none of these structs use
+  /// `skip_serializing_if`, a missing, renamed, or ignored-unknown field
+  /// makes the re-serialized value diverge from the fixture, so this is a
+  /// bidirectional drift guard for symmetric types.
+  fn assert_roundtrip<T>(fixture: &str)
+  where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+  {
+    let original: serde_json::Value =
+      serde_json::from_str(fixture).expect("fixture is valid JSON");
+    let typed: T = serde_json::from_str(fixture).expect("fixture deserializes into T");
+    let reserialized = serde_json::to_value(&typed).expect("T serializes");
+    assert_eq!(
+      reserialized, original,
+      "serde round-trip diverged from the golden fixture",
+    );
+  }
+
+  #[test]
+  fn app_snapshot_fixture_roundtrips() {
+    assert_roundtrip::<AppSnapshot>(APP_SNAPSHOT);
+  }
+
+  #[test]
+  fn session_snapshot_fixtures_roundtrip() {
+    assert_roundtrip::<SessionSnapshot>(SESSION_SYNCING);
+    assert_roundtrip::<SessionSnapshot>(SESSION_ERROR);
+
+    // Status strings map onto the enum variants exactly.
+    let syncing: SessionSnapshot = serde_json::from_str(SESSION_SYNCING).unwrap();
+    assert_eq!(syncing.status, SessionStatus::Syncing);
+    let errored: SessionSnapshot = serde_json::from_str(SESSION_ERROR).unwrap();
+    assert_eq!(errored.status, SessionStatus::Error);
+    assert_eq!(
+      errored.last_error.as_deref(),
+      Some("Checkpoint upload failed: connection reset")
+    );
+  }
+
+  #[test]
+  fn open_docx_response_fixture_roundtrips() {
+    assert_roundtrip::<OpenDocxResponse>(OPEN_DOCX_RESPONSE);
+  }
+
+  #[test]
+  fn linked_account_fixture_roundtrips() {
+    assert_roundtrip::<LinkedAccountSnapshot>(LINKED_ACCOUNT);
+    let account: LinkedAccountSnapshot = serde_json::from_str(LINKED_ACCOUNT).unwrap();
+    assert_eq!(account.name, None);
+  }
+
+  #[test]
+  fn desktop_update_fixture_roundtrips() {
+    assert_roundtrip::<DesktopUpdateSnapshot>(DESKTOP_UPDATE);
+  }
+
+  #[test]
+  fn trusted_self_host_fixture_roundtrips() {
+    assert_roundtrip::<TrustedSelfHostConnection>(TRUSTED_SELF_HOST);
+  }
+
+  #[test]
+  fn notification_preferences_fixture_roundtrips() {
+    assert_roundtrip::<DesktopNotificationPreferences>(NOTIFICATION_PREFERENCES);
+  }
+
+  /// `OpenDocxRequest` is intentionally deserialize-only here: the Rust
+  /// struct carries a `#[serde(default)] handoff_id` that the TypeScript
+  /// `OpenDocxRequest` type (and the HTTP bridge payload the web sends)
+  /// omit. Since the field has no `skip_serializing_if`, re-serializing
+  /// injects `"handoffId": null`, which the shared fixture deliberately
+  /// does not contain, so a strict round-trip would not hold. We assert
+  /// the fixture deserializes and the required fields decode correctly;
+  /// the asymmetry is documented rather than papered over.
+  #[test]
+  fn open_docx_request_fixture_deserializes() {
+    let request: OpenDocxRequest =
+      serde_json::from_str(OPEN_DOCX_REQUEST).expect("fixture deserializes");
+    assert_eq!(request.api_base_url, "https://api.example.com");
+    assert_eq!(request.entity_id, "11111111-1111-4111-8111-111111111111");
+    assert_eq!(request.handoff_id, None);
+    assert_eq!(
+      request.remote_session.session_id,
+      "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6"
+    );
+    assert!(is_safe_session_id(&request.remote_session.session_id));
+    assert_eq!(request.remote_session.file_name, "motion.docx");
+    let linked = request.linked_account.expect("linked account present");
+    assert_eq!(linked.email, "counsel@example.com");
+  }
+}

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -121,7 +121,7 @@ pub struct TrustedSelfHostConnection {
 /// new bridge endpoint or backwards-compatible field is added so
 /// the web side can gate features on `snapshot.bridgeVersion >= N`
 /// without coupling to the desktop's literal app version.
-pub const BRIDGE_VERSION: u32 = 7;
+pub const BRIDGE_VERSION: u32 = 8;
 
 /// Feature flags advertised to the web app. Add a string here
 /// whenever a new capability lands on the bridge so the web app

--- a/apps/desktop/src/shared/rpc.golden.test.ts
+++ b/apps/desktop/src/shared/rpc.golden.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  isAppSnapshot,
+  type AppSnapshot,
+  type DesktopNotificationPreferences,
+  type DesktopUpdateSnapshot,
+  type LinkedAccountSnapshot,
+  type OpenDocxRequest,
+  type OpenDocxResponse,
+  type SessionSnapshot,
+  type TrustedSelfHostConnection,
+} from "./rpc";
+
+// Golden-fixture contract for the desktop bridge RPC surface.
+//
+// `rpc.ts` (TypeScript) and `src-tauri/src/types.rs` (Rust serde) each
+// own a copy of every message that crosses the web <-> desktop bridge.
+// The bug class this suite guards against is silent drift between those
+// two definitions: a field renamed on one side, a `rename_all` dropped,
+// an optional made required, a new field added to one side only.
+//
+// The fixtures under `apps/desktop/fixtures/rpc/*.json` are the single
+// shared source of truth. This test asserts the TypeScript side:
+//   1. every fixture deep-equals a typed literal that `satisfies` the
+//      corresponding `rpc.ts` type (compile-time drift is caught by the
+//      `typecheck` script; on-disk drift is caught by the deep-equal);
+//   2. every fixture round-trips through JSON.parse/stringify unchanged
+//      (no `undefined` leakage, key order irrelevant);
+//   3. every object key is camelCase, mirroring Rust's
+//      `#[serde(rename_all = "camelCase")]`;
+//   4. the shipped `isAppSnapshot` runtime guard accepts the canonical
+//      snapshot and rejects structurally broken variants.
+//
+// The Rust counterpart (`types.rs` `mod fixture_tests`) deserializes the
+// same files via serde, so a change on either side that is not mirrored
+// in the fixtures fails one of the two suites.
+
+const FIXTURE_DIR = path.join(import.meta.dir, "../../fixtures/rpc");
+
+const readFixture = (name: string): unknown =>
+  JSON.parse(readFileSync(path.join(FIXTURE_DIR, name), "utf-8"));
+
+const collectKeys = (value: unknown, keys: string[] = []): string[] => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectKeys(item, keys);
+    }
+    return keys;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const [key, nested] of Object.entries(value)) {
+      keys.push(key);
+      collectKeys(nested, keys);
+    }
+  }
+  return keys;
+};
+
+const CAMEL_CASE = /^[a-z][a-zA-Z0-9]*$/u;
+
+// Each entry pairs a fixture file with a literal typed via `satisfies`.
+// The `satisfies` is the compile-time half of the drift guard; the
+// runtime `toEqual` is the on-disk half.
+const appSnapshot = {
+  bridgePort: 45_901,
+  bridgeVersion: 7,
+  capabilities: ["self-host.connect"],
+  linkedAccount: {
+    email: "counsel@example.com",
+    name: "Jane Counsel",
+    verifiedAt: "2026-07-01T09:30:00Z",
+  },
+  notificationPreferences: {
+    documentReady: true,
+    revisionCreated: true,
+    syncIssues: false,
+  },
+  runningSince: "2026-07-18T08:00:00Z",
+  sessions: [
+    {
+      baseVersionNumber: 3,
+      entityId: "8f3b2c1a-9d4e-4f6a-8b2c-1a9d4e4f6a8b",
+      fileName: "merger-agreement.docx",
+      filePath: "/Users/jane/Stella/merger-agreement.docx",
+      id: "b2d4f6a8-1c3e-4a5b-9c7d-2e4f6a8b0c1d",
+      lastCheckpointAt: "2026-07-18T10:15:00Z",
+      lastError: null,
+      pendingFinalize: false,
+      propertyId: "22222222-2222-4222-8222-222222222222",
+      status: "ready",
+      takeoverDetected: false,
+      workspaceId: "33333333-3333-4333-8333-333333333333",
+    },
+  ],
+  trustedSelfHostConnections: [
+    {
+      apiBaseUrl: "https://api.selfhost.example",
+      trustedAt: "2026-07-10T12:00:00Z",
+      webOrigin: "https://app.selfhost.example",
+    },
+  ],
+  update: {
+    baseUrl: "https://downloads.example.com/desktop",
+    channel: "stable",
+    currentHash:
+      "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    currentVersion: "1.4.2",
+    lastCheckedAt: "2026-07-18T09:00:00Z",
+    latestHash:
+      "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    latestVersion: "1.4.3",
+    status: "available",
+    statusMessage: "An update is available.",
+    updateAvailable: true,
+    updateReady: false,
+  },
+} as const satisfies AppSnapshot;
+
+const sessionSyncing = {
+  baseVersionNumber: 0,
+  entityId: "44444444-4444-4444-8444-444444444444",
+  fileName: "settlement-draft.docx",
+  filePath: "/Users/jane/Stella/settlement-draft.docx",
+  id: "55555555-5555-4555-8555-555555555555",
+  lastCheckpointAt: null,
+  lastError: null,
+  pendingFinalize: true,
+  propertyId: "66666666-6666-4666-8666-666666666666",
+  status: "syncing",
+  takeoverDetected: true,
+  workspaceId: "77777777-7777-4777-8777-777777777777",
+} as const satisfies SessionSnapshot;
+
+const sessionError = {
+  baseVersionNumber: 12,
+  entityId: "88888888-8888-4888-8888-888888888888",
+  fileName: "nda.docx",
+  filePath: "/Users/jane/Stella/nda.docx",
+  id: "99999999-9999-4999-8999-999999999999",
+  lastCheckpointAt: "2026-07-18T11:02:00Z",
+  lastError: "Checkpoint upload failed: connection reset",
+  pendingFinalize: false,
+  propertyId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  status: "error",
+  takeoverDetected: false,
+  workspaceId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+} as const satisfies SessionSnapshot;
+
+const openDocxRequest = {
+  apiBaseUrl: "https://api.example.com",
+  entityId: "11111111-1111-4111-8111-111111111111",
+  linkedAccount: {
+    email: "counsel@example.com",
+    name: "Jane Counsel",
+    verifiedAt: "2026-07-01T09:30:00Z",
+  },
+  propertyId: "22222222-2222-4222-8222-222222222222",
+  remoteSession: {
+    baseVersionNumber: 2,
+    downloadUrl: "https://s3.example.com/doc.docx?sig=abc123",
+    fileName: "motion.docx",
+    lastCheckpointAt: null,
+    resumedFromCheckpoint: false,
+    sessionId: "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6",
+    sessionToken: "sess-tok-abc123",
+    tookOverExistingSession: false,
+  },
+  workspaceId: "33333333-3333-4333-8333-333333333333",
+} as const satisfies OpenDocxRequest;
+
+const openDocxResponse = {
+  alreadyOpen: false,
+  filePath: "/Users/jane/Stella/motion.docx",
+  sessionId: "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6",
+} as const satisfies OpenDocxResponse;
+
+const linkedAccount = {
+  email: "solo@example.com",
+  name: null,
+  verifiedAt: "2026-06-15T14:20:00Z",
+} as const satisfies LinkedAccountSnapshot;
+
+const desktopUpdate = {
+  baseUrl: null,
+  channel: null,
+  currentHash: null,
+  currentVersion: "1.4.2",
+  lastCheckedAt: null,
+  latestHash: null,
+  latestVersion: null,
+  status: "disabled",
+  statusMessage: "Updates will appear here once configured.",
+  updateAvailable: false,
+  updateReady: false,
+} as const satisfies DesktopUpdateSnapshot;
+
+const trustedSelfHost = {
+  apiBaseUrl: "https://api.selfhost.example",
+  trustedAt: "2026-07-10T12:00:00Z",
+  webOrigin: "https://app.selfhost.example",
+} as const satisfies TrustedSelfHostConnection;
+
+const notificationPreferences = {
+  documentReady: true,
+  revisionCreated: false,
+  syncIssues: true,
+} as const satisfies DesktopNotificationPreferences;
+
+const cases: { expected: unknown; file: string; name: string }[] = [
+  { expected: appSnapshot, file: "app-snapshot.json", name: "AppSnapshot" },
+  {
+    expected: sessionSyncing,
+    file: "session-snapshot-syncing.json",
+    name: "SessionSnapshot (syncing)",
+  },
+  {
+    expected: sessionError,
+    file: "session-snapshot-error.json",
+    name: "SessionSnapshot (error)",
+  },
+  {
+    expected: openDocxRequest,
+    file: "open-docx-request.json",
+    name: "OpenDocxRequest",
+  },
+  {
+    expected: openDocxResponse,
+    file: "open-docx-response.json",
+    name: "OpenDocxResponse",
+  },
+  {
+    expected: linkedAccount,
+    file: "linked-account.json",
+    name: "LinkedAccountSnapshot",
+  },
+  {
+    expected: desktopUpdate,
+    file: "desktop-update.json",
+    name: "DesktopUpdateSnapshot",
+  },
+  {
+    expected: trustedSelfHost,
+    file: "trusted-self-host-connection.json",
+    name: "TrustedSelfHostConnection",
+  },
+  {
+    expected: notificationPreferences,
+    file: "notification-preferences.json",
+    name: "DesktopNotificationPreferences",
+  },
+];
+
+describe("desktop bridge RPC golden fixtures", () => {
+  for (const { expected, file, name } of cases) {
+    test(`${name} fixture matches the typed rpc.ts shape`, () => {
+      const parsed = readFixture(file);
+      expect(parsed).toEqual(expected);
+    });
+
+    test(`${name} fixture round-trips through JSON unchanged`, () => {
+      const parsed = readFixture(file);
+      // Serialize then re-parse to prove the wire form is stable: no
+      // undefined leakage, no key reordering that changes the value. This
+      // deliberately exercises JSON (not structuredClone), since JSON is
+      // the actual bridge transport.
+      const serialized = JSON.stringify(parsed);
+      expect(JSON.parse(serialized)).toEqual(parsed);
+    });
+
+    test(`${name} fixture uses only camelCase keys`, () => {
+      for (const key of collectKeys(readFixture(file))) {
+        expect(key).toMatch(CAMEL_CASE);
+      }
+    });
+  }
+
+  test("isAppSnapshot accepts the canonical app-snapshot fixture", () => {
+    expect(isAppSnapshot(readFixture("app-snapshot.json"))).toBe(true);
+  });
+
+  test("isAppSnapshot rejects a snapshot missing a required field", () => {
+    const parsed = readFixture("app-snapshot.json") as Record<string, unknown>;
+    const { bridgeVersion: _dropped, ...withoutBridgeVersion } = parsed;
+    expect(isAppSnapshot(withoutBridgeVersion)).toBe(false);
+  });
+
+  test("isAppSnapshot rejects a snapshot whose capabilities are not strings", () => {
+    const parsed = readFixture("app-snapshot.json") as Record<string, unknown>;
+    expect(isAppSnapshot({ ...parsed, capabilities: [1, 2, 3] })).toBe(false);
+  });
+
+  test("isAppSnapshot rejects non-object input", () => {
+    expect(isAppSnapshot(null)).toBe(false);
+    expect(isAppSnapshot("app-snapshot")).toBe(false);
+    expect(isAppSnapshot([])).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/rpc.golden.test.ts
+++ b/apps/desktop/src/shared/rpc.golden.test.ts
@@ -43,6 +43,18 @@ const FIXTURE_DIR = path.join(import.meta.dir, "../../fixtures/rpc");
 const readFixture = (name: string): unknown =>
   JSON.parse(readFileSync(path.join(FIXTURE_DIR, name), "utf-8"));
 
+// Fixtures are hand-authored JSON objects (never arrays or primitives); this
+// guard narrows the parsed `unknown` before mutating tests spread/drop keys,
+// rather than asserting the shape blind.
+const readFixtureRecord = (name: string): Record<string, unknown> => {
+  const parsed = readFixture(name);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new TypeError(`fixture ${name} is not a JSON object`);
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed above: plain JSON object, not null/array
+  return parsed as Record<string, unknown>;
+};
+
 const collectKeys = (value: unknown, keys: string[] = []): string[] => {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -282,13 +294,13 @@ describe("desktop bridge RPC golden fixtures", () => {
   });
 
   test("isAppSnapshot rejects a snapshot missing a required field", () => {
-    const parsed = readFixture("app-snapshot.json") as Record<string, unknown>;
+    const parsed = readFixtureRecord("app-snapshot.json");
     const { bridgeVersion: _dropped, ...withoutBridgeVersion } = parsed;
     expect(isAppSnapshot(withoutBridgeVersion)).toBe(false);
   });
 
   test("isAppSnapshot rejects a snapshot whose capabilities are not strings", () => {
-    const parsed = readFixture("app-snapshot.json") as Record<string, unknown>;
+    const parsed = readFixtureRecord("app-snapshot.json");
     expect(isAppSnapshot({ ...parsed, capabilities: [1, 2, 3] })).toBe(false);
   });
 

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -4,5 +4,11 @@
     "types": ["vite/client"]
   },
   "include": ["src", "vite.config.ts"],
-  "exclude": ["dist", "node_modules", "src-tauri"]
+  "exclude": [
+    "dist",
+    "node_modules",
+    "src-tauri",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/apps/desktop/tsconfig.test.json
+++ b/apps/desktop/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@stll/typescript-config/react-library.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "tsBuildInfoFile": "./.cache/tsbuildinfo.test.json"
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": ["dist", "node_modules", "src-tauri"]
+}


### PR DESCRIPTION
Add two independent, previously-missing test suites.

MCP upstream connections (apps/api/src/lib/mcp-upstream/connections.ts):
unit tests for the OAuth/token-refresh connection lifecycle against
faked crypto, OAuth, transport, and DB collaborators. Pins:
- unexpired token used directly; expired token proactively refreshed
  and the call proceeds with the rotated token (no 401-retry loop)
- refresh failure normalizes to status needs_reauth and a null client;
  through proxyMcpToolCall it becomes an isError tool-result, not a throw
- a missing refresh token short-circuits to needs_reauth
- transport failures thrown from client.tools()/execute() are NOT
  normalized in this module (they propagate; the gateway caller catches
  and normalizes them)
- no single-flight guard: N concurrent expired-token calls fan out to N
  refreshes and N DB writes
- no in-module cooldown/circuit-breaker: repeated failures re-attempt
  every time; exclusion happens at the load query (status = connected)

Desktop bridge RPC golden fixtures (apps/desktop/fixtures/rpc): shared
JSON fixtures for every bridge message variant, consumed by both sides.
- TS: rpc.golden.test.ts deep-equals each fixture against a typed literal
  that satisfies the rpc.ts type, checks JSON round-trip stability and
  camelCase keys, and exercises the shipped isAppSnapshot guard
- Rust: types.rs fixture_tests deserializes the same files via serde and
  round-trips the symmetric types (embedded with include_str!)
This guards against TS/Rust message-shape drift. One asymmetry is
documented in both suites: Rust OpenDocxRequest carries an optional
handoffId that the TS type and HTTP bridge payload omit, so that fixture
is deserialize-only on the Rust side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for MCP connection authentication, token refresh, bearer access, tool failures, and connection cleanup.
  - Added desktop RPC compatibility checks covering serialisation, deserialisation, field naming, required values, and invalid payload handling.
  - Added safeguards to detect drift between desktop RPC message formats and their reference data.

- **Fixtures**
  - Added representative desktop RPC snapshots for linked accounts, notifications, sessions, document opening, trusted connections, and update status.
  - Added scenarios for syncing and error states to improve validation of desktop workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->