### PR TITLE
fix(web): respect upload concurrency cap when re-admitting retries

### DIFF
--- a/apps/web/src/lib/upload-queue.test.ts
+++ b/apps/web/src/lib/upload-queue.test.ts
@@ -674,3 +674,106 @@ describe("retry re-injection respects the concurrency cap", () => {
     }
   });
 });
+
+describe("a stale retry does not leak across runs", () => {
+  // retryFailed() is documented and tested to work from the "cancelled"
+  // state (see the state map above). If a file is sleeping through its
+  // retry backoff when cancel() fires, and retryFailed() starts a fresh
+  // run before the backoff elapses, the sleeping retry must not resume
+  // into the new run: it belongs to a run that no longer exists.
+  test("a retry that wakes after cancel+retryFailed is dropped, not re-admitted", async () => {
+    jest.useFakeTimers();
+    try {
+      const uploader = new ScriptedUploader();
+      const cap = 2;
+      const { queue, doneEvents } = harness(uploader, cap);
+
+      queue.enqueue(makeFiles("flaky", "badfile"));
+      await flush();
+      expect(uploader.active).toBe(2);
+
+      // Permanent failure: lands in `failed`, eligible for retryFailed().
+      uploader.rejectFile("badfile", httpError(400));
+      await flush();
+
+      // Retryable failure: frees its inflight slot and starts sleeping
+      // through backoff. It is neither pending, inflight, nor failed
+      // while asleep.
+      uploader.rejectFile("flaky", httpError(500));
+      await flush();
+      expect(uploader.active).toBe(0);
+
+      queue.cancel();
+      await flush();
+      expect(queue.getState()).toBe("cancelled");
+      expect(doneEvents).toHaveLength(1);
+      expect(doneEvents[0]!.cancelled).toBe(true);
+
+      // Starts a new run scoped to the previously-failed file only.
+      queue.retryFailed();
+      await flush();
+      expect(queue.getState()).toBe("running");
+      expect(uploader.liveNamesList()).toEqual(["badfile"]);
+
+      // "flaky"'s backoff from the cancelled run elapses mid-way through
+      // the new run.
+      jest.advanceTimersByTime(1000);
+      await flush();
+
+      // Dropped: never re-admitted into the new run's pending queue or
+      // re-uploaded.
+      expect(uploader.callCount("flaky")).toBe(1);
+      expect(uploader.liveNamesList()).toEqual(["badfile"]);
+      expect(queue.getState()).toBe("running");
+
+      uploader.resolveFile("badfile");
+      await flush();
+
+      expect(queue.getState()).toBe("done");
+      expect(doneEvents).toHaveLength(2);
+      expect(doneEvents[1]!.cancelled).toBe(false);
+      expect(doneEvents[1]!.completed).toHaveLength(1);
+      expect(doneEvents[1]!.failed).toHaveLength(0);
+      expect(uploader.sawConcurrentDoubleUpload).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("a stale retry waking with nothing else pending still lets the new run reach done", async () => {
+    jest.useFakeTimers();
+    try {
+      const uploader = new ScriptedUploader();
+      const { queue, doneEvents } = harness(uploader, 1);
+
+      queue.enqueue(makeFiles("flaky"));
+      await flush();
+
+      uploader.rejectFile("flaky", httpError(500));
+      await flush();
+
+      queue.cancel();
+      await flush();
+      expect(doneEvents).toHaveLength(1);
+
+      // No failed files to retry: the new run starts empty, with only
+      // the stale sleeping retry outstanding.
+      queue.retryFailed();
+      await flush();
+      expect(queue.getState()).toBe("running");
+
+      jest.advanceTimersByTime(1000);
+      await flush();
+
+      // The new (empty) run must still reach "done" once the stale
+      // retry is dropped, rather than hanging forever.
+      expect(queue.getState()).toBe("done");
+      expect(doneEvents).toHaveLength(2);
+      expect(doneEvents[1]!.completed).toHaveLength(0);
+      expect(doneEvents[1]!.failed).toHaveLength(0);
+      expect(uploader.callCount("flaky")).toBe(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/lib/upload-queue.test.ts
+++ b/apps/web/src/lib/upload-queue.test.ts
@@ -624,17 +624,14 @@ describe("interleaving table (deterministic scheduling coverage)", () => {
   }
 });
 
-describe("KNOWN BUG: retry re-injection oversubscribes the concurrency cap", () => {
+describe("retry re-injection respects the concurrency cap", () => {
   // The retry path frees the file's slot (deletes it from `inflight`) and
-  // then calls pump() to fill that slot with the next pending file *before*
-  // awaiting the backoff. When the backoff elapses, processFile() re-inserts
-  // the retried file directly into `inflight` without re-checking the cap, so
-  // the in-flight count transiently exceeds `concurrency`.
-  //
-  // This test documents the CURRENT (buggy) behaviour so a future fix has a
-  // regression anchor; the assertion below flips once the cap is respected.
-  // See report: no product-code fix is made in this tests-only change.
-  test("in-flight count reaches cap + 1 when a retry resumes into a full pipe", async () => {
+  // then calls pump() to fill that slot with the next pending file while the
+  // backoff runs. When the backoff elapses, the retry re-enters through the
+  // pending queue, so pump() is the single gate that admits it against the
+  // cap: a retry resuming into a full pipe waits its turn rather than
+  // pushing the in-flight count over `concurrency`.
+  test("a retry resuming into a full pipe does not exceed the cap", async () => {
     jest.useFakeTimers();
     try {
       const uploader = new ScriptedUploader();
@@ -651,21 +648,27 @@ describe("KNOWN BUG: retry re-injection oversubscribes the concurrency cap", () 
       expect(uploader.liveNamesList()).toEqual(["filler"]);
       expect(uploader.active).toBe(1);
 
-      // "filler" is still hanging when the backoff elapses and "retry" resumes.
+      // "filler" is still hanging when the backoff elapses. The retry cannot
+      // barge into the occupied slot; it stays parked until a slot frees.
       jest.advanceTimersByTime(1000);
       await flush();
 
-      // BUG: two uploads are now concurrent under a cap of 1.
-      expect(uploader.active).toBe(2);
-      expect(uploader.maxActive).toBe(cap + 1);
-      // The two live uploads are different files, so this is a cap breach,
-      // not the same file uploaded twice at once.
+      expect(uploader.active).toBe(1);
+      expect(uploader.maxActive).toBe(cap);
+      expect(uploader.liveNamesList()).toEqual(["filler"]);
       expect(uploader.sawConcurrentDoubleUpload).toBe(false);
 
+      // Once "filler" completes, the parked retry is admitted (exactly once).
       uploader.resolveFile("filler");
+      await flush();
+      expect(uploader.liveNamesList()).toEqual(["retry"]);
+      expect(uploader.active).toBe(1);
+      expect(uploader.callCount("retry")).toBe(2);
+
       uploader.resolveFile("retry");
       await flush();
       expect(queue.getState()).toBe("done");
+      expect(uploader.maxActive).toBe(cap);
     } finally {
       jest.useRealTimers();
     }

--- a/apps/web/src/lib/upload-queue.test.ts
+++ b/apps/web/src/lib/upload-queue.test.ts
@@ -71,6 +71,14 @@ class ScriptedUploader {
   totalCalls = 0;
   readonly callsByFile = new Map<string, number>();
   sawConcurrentDoubleUpload = false;
+  /**
+   * File names that should survive `controller.abort()` instead of
+   * auto-rejecting. Models the race where cancel() aborts a request that
+   * has already gone far enough (or whose transport ignores the signal)
+   * that it settles on its own later, well after the abort call: the
+   * queue's controller is aborted, but the underlying promise is not.
+   */
+  readonly ignoreAbortFor = new Set<string>();
 
   private readonly live: PendingUpload[] = [];
   private readonly settled = new WeakSet<PendingUpload>();
@@ -98,7 +106,7 @@ class ScriptedUploader {
         },
       };
       signal.addEventListener("abort", () => {
-        if (this.settled.has(entry)) {
+        if (this.settled.has(entry) || this.ignoreAbortFor.has(file.name)) {
           return;
         }
         // Mirror fetch(): an aborted request rejects. The queue checks
@@ -775,5 +783,119 @@ describe("a stale retry does not leak across runs", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+});
+
+describe("a stale in-flight settlement does not leak across runs", () => {
+  // cancel() aborts every in-flight controller, but aborting a controller
+  // does not stop the underlying promise from settling: the request may
+  // already be far enough along (or the transport may not honour the
+  // signal promptly) that it resolves or rejects on its own after
+  // retryFailed() has already started a fresh run. The stale settlement
+  // must not be counted into the new run's completed/failed/total
+  // bookkeeping or its `done` event.
+  test("an in-flight file that resolves after cancel+retryFailed is dropped from the new run", async () => {
+    const uploader = new ScriptedUploader();
+    const cap = 2;
+    const { queue, doneEvents } = harness(uploader, cap);
+
+    // "stale" is never allowed to auto-reject on abort, so it stays live
+    // through cancel() to model the resolve-after-abort race.
+    uploader.ignoreAbortFor.add("stale");
+
+    queue.enqueue(makeFiles("stale", "badfile"));
+    await flush();
+    expect(uploader.active).toBe(2);
+
+    // Permanent failure: lands in `failed`, eligible for retryFailed().
+    uploader.rejectFile("badfile", httpError(400));
+    await flush();
+
+    queue.cancel();
+    await flush();
+    expect(queue.getState()).toBe("cancelled");
+    expect(doneEvents).toHaveLength(1);
+    // Aborted, but ignoreAbortFor kept the promise alive.
+    expect(uploader.liveNamesList()).toEqual(["stale"]);
+
+    // Starts a new run scoped to the previously-failed file only.
+    queue.retryFailed();
+    await flush();
+    expect(queue.getState()).toBe("running");
+    expect(queue.getProgress().total).toBe(1);
+    expect(uploader.liveNamesList()).toEqual(["stale", "badfile"]);
+
+    // The cancelled run's request finally resolves, well after the new
+    // run started.
+    uploader.resolveFile("stale", "ok:stale");
+    await flush();
+
+    // Dropped: not counted as completed, total unaffected, new run still
+    // running (only "badfile" outstanding).
+    expect(queue.getProgress().completed).toBe(0);
+    expect(queue.getProgress().total).toBe(1);
+    expect(queue.getState()).toBe("running");
+    expect(doneEvents).toHaveLength(1);
+
+    uploader.resolveFile("badfile", "ok:badfile");
+    await flush();
+
+    expect(queue.getState()).toBe("done");
+    expect(doneEvents).toHaveLength(2);
+    expect(doneEvents[1]!.cancelled).toBe(false);
+    expect(doneEvents[1]!.completed).toEqual(["ok:badfile"]);
+    expect(doneEvents[1]!.failed).toHaveLength(0);
+    expect(uploader.callCount("stale")).toBe(1);
+    expect(uploader.sawConcurrentDoubleUpload).toBe(false);
+  });
+
+  test("an in-flight file that rejects after cancel+retryFailed is dropped from the new run", async () => {
+    const uploader = new ScriptedUploader();
+    const cap = 2;
+    const { queue, doneEvents } = harness(uploader, cap);
+
+    // "stale" is never allowed to auto-reject on abort, so the test
+    // controls exactly when (and how) it settles, after the new run has
+    // already started.
+    uploader.ignoreAbortFor.add("stale");
+
+    queue.enqueue(makeFiles("stale", "badfile"));
+    await flush();
+    expect(uploader.active).toBe(2);
+
+    uploader.rejectFile("badfile", httpError(400));
+    await flush();
+
+    queue.cancel();
+    await flush();
+    expect(doneEvents).toHaveLength(1);
+    expect(uploader.liveNamesList()).toEqual(["stale"]);
+
+    queue.retryFailed();
+    await flush();
+    expect(queue.getState()).toBe("running");
+    expect(uploader.liveNamesList()).toEqual(["stale", "badfile"]);
+
+    // The cancelled run's request finally rejects (server error, i.e. one
+    // that would normally be retryable) well after the new run started.
+    uploader.rejectFile("stale", httpError(500));
+    await flush();
+
+    // Dropped: not counted as failed, not scheduled for a retry, total
+    // unaffected, new run still running.
+    expect(queue.getProgress().failed).toBe(0);
+    expect(queue.getProgress().total).toBe(1);
+    expect(queue.getState()).toBe("running");
+    expect(doneEvents).toHaveLength(1);
+
+    uploader.resolveFile("badfile", "ok:badfile");
+    await flush();
+
+    expect(queue.getState()).toBe("done");
+    expect(doneEvents).toHaveLength(2);
+    expect(doneEvents[1]!.completed).toEqual(["ok:badfile"]);
+    expect(doneEvents[1]!.failed).toHaveLength(0);
+    expect(uploader.callCount("stale")).toBe(1);
+    expect(uploader.sawConcurrentDoubleUpload).toBe(false);
   });
 });

--- a/apps/web/src/lib/upload-queue.test.ts
+++ b/apps/web/src/lib/upload-queue.test.ts
@@ -748,7 +748,7 @@ describe("a stale retry does not leak across runs", () => {
     }
   });
 
-  test("a stale retry waking with nothing else pending still lets the new run reach done", async () => {
+  test("a stale retry waking with nothing else pending does not block or re-block the new run", async () => {
     jest.useFakeTimers();
     try {
       const uploader = new ScriptedUploader();
@@ -764,22 +764,95 @@ describe("a stale retry does not leak across runs", () => {
       await flush();
       expect(doneEvents).toHaveLength(1);
 
-      // No failed files to retry: the new run starts empty, with only
-      // the stale sleeping retry outstanding.
+      // No failed files to retry: the new run starts empty, with only the
+      // stale sleeping retry outstanding. cancel()/retryFailed() reset the
+      // retry counter on their own run transition, so the empty run has
+      // nothing left to wait on and reaches "done" immediately, without
+      // sitting "running" until the stale sleeper's backoff elapses.
       queue.retryFailed();
       await flush();
-      expect(queue.getState()).toBe("running");
-
-      jest.advanceTimersByTime(1000);
-      await flush();
-
-      // The new (empty) run must still reach "done" once the stale
-      // retry is dropped, rather than hanging forever.
       expect(queue.getState()).toBe("done");
       expect(doneEvents).toHaveLength(2);
       expect(doneEvents[1]!.completed).toHaveLength(0);
       expect(doneEvents[1]!.failed).toHaveLength(0);
+
+      // The stale retry then wakes, well after the run that admitted it is
+      // gone. It must be dropped silently: no re-upload, no extra `done`,
+      // and no corruption of the counter a later run would depend on.
+      jest.advanceTimersByTime(1000);
+      await flush();
+
+      expect(queue.getState()).toBe("done");
+      expect(doneEvents).toHaveLength(2);
       expect(uploader.callCount("flaky")).toBe(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("the new run reaches done as soon as its own work drains, without waiting for a stale sleeper", async () => {
+    jest.useFakeTimers();
+    try {
+      const uploader = new ScriptedUploader();
+      const cap = 2;
+      const { queue, doneEvents } = harness(uploader, cap);
+
+      queue.enqueue(makeFiles("flaky", "badfile"));
+      await flush();
+      expect(uploader.active).toBe(2);
+
+      // Permanent failure: lands in `failed`, eligible for retryFailed().
+      uploader.rejectFile("badfile", httpError(400));
+      await flush();
+
+      // Retryable failure: frees its inflight slot and starts sleeping
+      // through backoff, bumping the (then-)global `retrying` counter.
+      uploader.rejectFile("flaky", httpError(500));
+      await flush();
+
+      queue.cancel();
+      await flush();
+      expect(doneEvents).toHaveLength(1);
+
+      // New run scoped to "badfile" only. "flaky"'s retry is still asleep,
+      // with a full 1000ms left on its backoff.
+      queue.retryFailed();
+      await flush();
+      expect(uploader.liveNamesList()).toEqual(["badfile"]);
+
+      // The new run's only file finishes well before the stale sleeper
+      // wakes. The run has no other pending or in-flight work, so it must
+      // reach "done" right away instead of waiting on a counter left over
+      // from a run that no longer exists.
+      uploader.resolveFile("badfile", "ok:badfile");
+      await flush();
+
+      expect(queue.getState()).toBe("done");
+      expect(doneEvents).toHaveLength(2);
+      expect(doneEvents[1]!.cancelled).toBe(false);
+      expect(doneEvents[1]!.completed).toEqual(["ok:badfile"]);
+      expect(doneEvents[1]!.failed).toHaveLength(0);
+
+      // "flaky"'s stale backoff now elapses. It must be dropped silently:
+      // no re-upload, no extra `done`, and no corruption of the (already
+      // reset) counter that a THIRD run would depend on.
+      jest.advanceTimersByTime(1000);
+      await flush();
+
+      expect(uploader.callCount("flaky")).toBe(1);
+      expect(doneEvents).toHaveLength(2);
+      expect(queue.getState()).toBe("done");
+
+      // A third run must not be blocked or corrupted by the long-dead
+      // sleeper either.
+      queue.enqueue(makeFiles("third"));
+      await flush();
+      uploader.resolveFile("third", "ok:third");
+      await flush();
+
+      expect(queue.getState()).toBe("done");
+      expect(doneEvents).toHaveLength(3);
+      expect(doneEvents[2]!.completed).toEqual(["ok:third"]);
     } finally {
       jest.useRealTimers();
     }

--- a/apps/web/src/lib/upload-queue.ts
+++ b/apps/web/src/lib/upload-queue.ts
@@ -77,10 +77,15 @@ export class UploadQueue<T> {
   private total = 0;
   private retrying = 0;
   // Bumped on every enqueue()/retryFailed() to give each run a distinct
-  // identity. A retry sleeping through backoff captures the run it was
-  // admitted under; if the run has moved on (cancel() followed by a new
-  // retryFailed() run) by the time it wakes, it is dropped instead of
-  // leaking into a batch it does not belong to.
+  // identity. Every processFile() call (in flight or sleeping through
+  // retry backoff) captures the run it was admitted under; if the run has
+  // moved on (cancel() followed by a new enqueue()/retryFailed() run) by
+  // the time that call settles, the settlement is dropped instead of
+  // leaking into a batch it does not belong to. This also covers the
+  // case where cancel() aborts a controller but the underlying promise
+  // still settles (successfully or not) after a new run has started:
+  // `this.state` alone can no longer distinguish "still that cancelled
+  // run" from "a fresh run happens to be running now".
   private runId = 0;
   private readonly fileRunIds = new Map<File, number>();
   private readonly concurrency: number;
@@ -268,11 +273,27 @@ export class UploadQueue<T> {
     const controller = new AbortController();
     this.inflight.set(file, controller);
 
+    // Captured once, at admission, so every settlement path below can be
+    // gated on the same run identity. cancel() aborts the controller but
+    // does not stop the underlying promise from settling; if retryFailed()
+    // starts a fresh run before that stale settlement lands, `this.state`
+    // is back to "running" and can no longer tell the two runs apart, so
+    // the comparison must be against the run this call was admitted under,
+    // not against transient state alone.
+    const admittedRunId = this.fileRunIds.get(file);
+    const isStaleSettlement = () =>
+      this.state === "cancelled" || this.runId !== admittedRunId;
+
     try {
       const result = await this.uploadFn(file, controller.signal);
       this.inflight.delete(file);
 
-      if (this.state === "cancelled") {
+      if (isStaleSettlement()) {
+        // Belongs to a superseded run: drop it from accounting, but still
+        // pump() so the freed slot (and, for the current run, a possible
+        // "done") is picked up immediately rather than waiting for the
+        // next unrelated event.
+        this.pump();
         return;
       }
 
@@ -282,11 +303,8 @@ export class UploadQueue<T> {
     } catch (error) {
       this.inflight.delete(file);
 
-      if (this.state === "cancelled") {
-        return;
-      }
-
-      if (controller.signal.aborted) {
+      if (isStaleSettlement()) {
+        this.pump();
         return;
       }
 
@@ -304,7 +322,6 @@ export class UploadQueue<T> {
       const isRetryable = status >= HTTP_SERVER_ERROR_MIN || status === 0;
       if (isRetryable && attempt < MAX_RETRIES) {
         const delay = RETRY_BACKOFF_MS[attempt] ?? 4000;
-        const expectedRunId = this.fileRunIds.get(file);
         this.retrying++;
 
         // Fill the freed concurrency slot while this file
@@ -325,7 +342,7 @@ export class UploadQueue<T> {
         // way, still call pump() so the current run (if any) can
         // notice `retrying` dropped and reach "done"; pump() is a
         // no-op while cancelled.
-        if (this.getState() === "cancelled" || this.runId !== expectedRunId) {
+        if (isStaleSettlement()) {
           this.pump();
           return;
         }

--- a/apps/web/src/lib/upload-queue.ts
+++ b/apps/web/src/lib/upload-queue.ts
@@ -159,6 +159,7 @@ export class UploadQueue<T> {
     this.completed = [];
     this.failed = [];
     this.total = files.length;
+    this.retrying = 0;
 
     this.setState("running");
     this.emitProgress();
@@ -206,6 +207,7 @@ export class UploadQueue<T> {
     }
     this.inflight.clear();
     this.pending = [];
+    this.retrying = 0;
 
     this.setState("cancelled");
     this.emit("done", {
@@ -228,6 +230,7 @@ export class UploadQueue<T> {
     this.total = this.pending.length;
     this.failed = [];
     this.completed = [];
+    this.retrying = 0;
 
     this.setState("running");
     this.emitProgress();
@@ -331,7 +334,16 @@ export class UploadQueue<T> {
         this.pump();
 
         await sleep(delay);
-        this.retrying--;
+
+        // Only decrement if this sleeper's run is still the current one.
+        // cancel()/enqueue()/retryFailed() all reset `retrying` to 0 as
+        // part of starting or tearing down a run; a sleeper admitted
+        // under an earlier, superseded run must not touch a fresh run's
+        // counter (or drive an already-reset counter negative) just
+        // because it happens to wake up after the reset.
+        if (this.runId === admittedRunId) {
+          this.retrying--;
+        }
 
         // Cancelled during backoff: cancel() already cleared
         // the pending queue and emitted done; drop the retry.

--- a/apps/web/src/lib/upload-queue.ts
+++ b/apps/web/src/lib/upload-queue.ts
@@ -76,6 +76,13 @@ export class UploadQueue<T> {
   private failed: FailedUpload[] = [];
   private total = 0;
   private retrying = 0;
+  // Bumped on every enqueue()/retryFailed() to give each run a distinct
+  // identity. A retry sleeping through backoff captures the run it was
+  // admitted under; if the run has moved on (cancel() followed by a new
+  // retryFailed() run) by the time it wakes, it is dropped instead of
+  // leaking into a batch it does not belong to.
+  private runId = 0;
+  private readonly fileRunIds = new Map<File, number>();
   private readonly concurrency: number;
   private readonly uploadFn: UploadFn<T>;
   private rateLimitTimer: ReturnType<typeof setTimeout> | null = null;
@@ -140,6 +147,8 @@ export class UploadQueue<T> {
       return;
     }
 
+    this.runId++;
+    this.fileRunIds.clear();
     this.pending = files.map((file) => ({ file, attempt: 0 }));
     this.inflight.clear();
     this.completed = [];
@@ -208,6 +217,8 @@ export class UploadQueue<T> {
     if (this.state !== "done" && this.state !== "cancelled") {
       return;
     }
+    this.runId++;
+    this.fileRunIds.clear();
     this.pending = this.failed.map(({ file }) => ({ file, attempt: 0 }));
     this.total = this.pending.length;
     this.failed = [];
@@ -245,6 +256,7 @@ export class UploadQueue<T> {
     while (this.inflight.size < this.concurrency && this.pending.length > 0) {
       const next = this.pending.shift();
       if (next) {
+        this.fileRunIds.set(next.file, this.runId);
         this.processFile(next.file, next.attempt).catch(() => {
           // Errors are handled inside processFile
         });
@@ -292,6 +304,7 @@ export class UploadQueue<T> {
       const isRetryable = status >= HTTP_SERVER_ERROR_MIN || status === 0;
       if (isRetryable && attempt < MAX_RETRIES) {
         const delay = RETRY_BACKOFF_MS[attempt] ?? 4000;
+        const expectedRunId = this.fileRunIds.get(file);
         this.retrying++;
 
         // Fill the freed concurrency slot while this file
@@ -305,7 +318,15 @@ export class UploadQueue<T> {
 
         // Cancelled during backoff: cancel() already cleared
         // the pending queue and emitted done; drop the retry.
-        if (this.getState() === "cancelled") {
+        // Same if a new run (retryFailed() from "cancelled")
+        // started while this retry was asleep: the run that
+        // admitted it is gone, so re-admitting now would leak
+        // this file into a batch it does not belong to. Either
+        // way, still call pump() so the current run (if any) can
+        // notice `retrying` dropped and reach "done"; pump() is a
+        // no-op while cancelled.
+        if (this.getState() === "cancelled" || this.runId !== expectedRunId) {
+          this.pump();
           return;
         }
 

--- a/apps/web/src/lib/upload-queue.ts
+++ b/apps/web/src/lib/upload-queue.ts
@@ -21,6 +21,18 @@ type FailedUpload = {
   error: Error;
 };
 
+/**
+ * A file waiting in the pending queue, tagged with the retry
+ * attempt it should run as. Carrying the attempt on the queue
+ * entry lets `pump()` stay the single place that admits work
+ * against the concurrency cap: retries re-enter through the
+ * pending queue rather than calling `processFile` directly.
+ */
+type QueuedUpload = {
+  file: File;
+  attempt: number;
+};
+
 type ProgressEvent = {
   completed: number;
   failed: number;
@@ -58,7 +70,7 @@ const sleep = async (ms: number) =>
  */
 export class UploadQueue<T> {
   private state: UploadState = "idle";
-  private pending: File[] = [];
+  private pending: QueuedUpload[] = [];
   private readonly inflight = new Map<File, AbortController>();
   private completed: T[] = [];
   private failed: FailedUpload[] = [];
@@ -128,7 +140,7 @@ export class UploadQueue<T> {
       return;
     }
 
-    this.pending = [...files];
+    this.pending = files.map((file) => ({ file, attempt: 0 }));
     this.inflight.clear();
     this.completed = [];
     this.failed = [];
@@ -196,10 +208,9 @@ export class UploadQueue<T> {
     if (this.state !== "done" && this.state !== "cancelled") {
       return;
     }
-    const filesToRetry = this.failed.map((f) => f.file);
+    this.pending = this.failed.map(({ file }) => ({ file, attempt: 0 }));
+    this.total = this.pending.length;
     this.failed = [];
-    this.pending = filesToRetry;
-    this.total = filesToRetry.length;
     this.completed = [];
 
     this.setState("running");
@@ -232,9 +243,9 @@ export class UploadQueue<T> {
     }
 
     while (this.inflight.size < this.concurrency && this.pending.length > 0) {
-      const file = this.pending.shift();
-      if (file) {
-        this.processFile(file).catch(() => {
+      const next = this.pending.shift();
+      if (next) {
+        this.processFile(next.file, next.attempt).catch(() => {
           // Errors are handled inside processFile
         });
       }
@@ -271,7 +282,7 @@ export class UploadQueue<T> {
 
       if (status === HTTP_TOO_MANY_REQUESTS) {
         // Put the file back at the front of the queue
-        this.pending.unshift(file);
+        this.pending.unshift({ file, attempt: 0 });
         this.handleRateLimit(error);
         return;
       }
@@ -292,20 +303,19 @@ export class UploadQueue<T> {
         await sleep(delay);
         this.retrying--;
 
-        // State may have changed during sleep (cancel,
-        // pause). Only continue if still running.
-        if (this.getState() !== "running") {
-          // If cancelled, don't push back to pending
-          // (already cleared by cancel()).
-          if (this.getState() !== "cancelled") {
-            this.pending.unshift(file);
-          }
+        // Cancelled during backoff: cancel() already cleared
+        // the pending queue and emitted done; drop the retry.
+        if (this.getState() === "cancelled") {
           return;
         }
 
-        this.processFile(file, attempt + 1).catch(() => {
-          // Errors are handled inside processFile
-        });
+        // Re-admit the retry through the pending queue so pump()
+        // remains the single gate that checks it against the
+        // concurrency cap. If the queue is paused or rate-limited,
+        // the entry waits in pending until the next pump() (on
+        // resume) admits it; its attempt count is preserved.
+        this.pending.unshift({ file, attempt: attempt + 1 });
+        this.pump();
         return;
       }
 


### PR DESCRIPTION
The retry path freed a file's in-flight slot, let pump() fill it with the
next pending file during the backoff, then re-entered processFile() directly
once the backoff elapsed. That re-entry inserted the file straight into
`inflight` without re-checking `concurrency`, so the in-flight count could
transiently reach cap + 1.

Route retries back through the pending queue so pump() is the single place
that admits work against the cap. Pending entries now carry their retry
attempt (`{ file, attempt }`), so a retry re-enters like any other queued
file: after the backoff it is unshifted to the front of pending and pump()
decides admission. A retry resuming into a full pipe waits for a free slot
instead of oversubscribing. Pause and rate-limit hold the parked retry until
the next pump(); cancel drops it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry handling so uploads do not exceed the configured concurrency limit.
  * Prevented cancelled or superseded retries from reappearing in later upload runs.
  * Ensured queues complete cleanly when stale retries are discarded.
  * Preserved retry attempts correctly across server and network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->