### PR TITLE
fix(api): stop discarding ingestion cursor progress on empty-page DB-slot abort

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -302,3 +302,76 @@ describe("runIngestionPipeline — database timeouts", () => {
     expect(persistedCursor).toBe("cursor-1");
   });
 });
+
+describe("runIngestionPipeline — empty-page cursor progress", () => {
+  test("persists the fetched cursor when the cycle aborts on an empty page", async () => {
+    const source = {
+      id: createSafeId<"caseLawSource">(),
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      name: "Empty-page source",
+      enabled: true,
+      syncCursor: "cursor-1",
+      lastSyncAt: null,
+      config: {},
+      descriptor: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    } satisfies typeof caseLawSources.$inferSelect;
+
+    // The cycle deadline fires while the fetch is in flight; the page it
+    // returns carries no decisions but real cursor progress. Acquiring the
+    // DB slot here used to throw AbortError before the cursor advance ran,
+    // pinning the adapter to the same cursor on every later cycle.
+    const controller = new AbortController();
+    czNsAdapter.fetchPage = async () => {
+      controller.abort();
+      return Result.ok({ decisions: [], nextCursor: "cursor-2" });
+    };
+
+    let acquires = 0;
+    const dbSlot = {
+      acquire: async (signal?: AbortSignal) => {
+        acquires++;
+        if (signal?.aborted) {
+          throw new DOMException("aborted", "AbortError");
+        }
+      },
+      release: () => undefined,
+    };
+
+    let persistedCursor: string | null | undefined;
+    const scopedDb: ScopedDb = async (callback) => {
+      const tx = {
+        update: (table: unknown) => ({
+          set: (values: { syncCursor?: string | null }) => {
+            if (table === caseLawSources) {
+              persistedCursor = values.syncCursor;
+            }
+
+            return { where: async () => undefined };
+          },
+        }),
+      };
+
+      // SAFETY: this test exercises only the final case_law_sources cursor
+      // update (the empty page performs no decision writes); the fake
+      // implements that chain.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return await callback(tx as unknown as Transaction);
+    };
+
+    const result = await runIngestionPipeline({
+      source,
+      scopedDb,
+      signal: controller.signal,
+      maxPages: 1,
+      dbSlot,
+    });
+
+    // An empty page has no DB work, so the slot must never be contended.
+    expect(acquires).toBe(0);
+    expect(result.pagesProcessed).toBe(1);
+    expect(result.nextCursor).toBe("cursor-2");
+    expect(persistedCursor).toBe("cursor-2");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -623,10 +623,19 @@ export const runIngestionPipeline = async ({
     // before the next page fetch so external API calls don't
     // hold the slot. try-finally ensures no slot leak on
     // unexpected exceptions.
-    if (dbSlot) {
+    //
+    // A page with no decisions never touches the slot: it has no DB
+    // work, and acquiring anyway let a cycle-timeout abort land in
+    // the gap between the fetch returning and the acquire — breaking
+    // out before the cursor advance below ever ran, silently
+    // discarding the forward progress the fetch had already made and
+    // pinning the adapter to the same cursor on every later cycle.
+    let pageHoldsDbSlot = false;
+    if (dbSlot && page.decisions.length > 0) {
       try {
         // oxlint-disable-next-line no-await-in-loop -- sequential per-page DB-slot acquisition bounds concurrent DB pressure
         await dbSlot.acquire(signal);
+        pageHoldsDbSlot = true;
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
           haltReason = "Cycle timeout exceeded";
@@ -761,7 +770,7 @@ export const runIngestionPipeline = async ({
       cursor = page.nextCursor;
       pagesProcessed++;
     } finally {
-      if (dbSlot) {
+      if (dbSlot && pageHoldsDbSlot) {
         dbSlot.release();
       }
     }


### PR DESCRIPTION
A fetched page with zero decisions still acquired the DB slot before being skipped. When the cycle's abort signal fired in the gap between the fetch returning and the acquire, `dbSlot.acquire()` threw AbortError before the `cursor = page.nextCursor` advance ever ran, so the pipeline persisted the pre-fetch cursor — silently discarding the forward progress the fetch had already made and pinning the adapter to the same cursor on every subsequent cycle.

Fix: a page with no decisions never contends for the DB slot (it has no DB work), so the returned cursor is recorded regardless of abort timing; the `finally` release is guarded by an acquisition flag to keep the semaphore balanced.

Includes a regression test (empty page + aborted signal) verified to fail on the previous behavior and pass with the fix; the full case-law ingestion suite (278 tests) is green.