### PR TITLE
docs: showcase-scene re-record runbook + release checklist step

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -302,3 +302,76 @@ describe("runIngestionPipeline — database timeouts", () => {
     expect(persistedCursor).toBe("cursor-1");
   });
 });
+
+describe("runIngestionPipeline — empty-page cursor progress", () => {
+  test("persists the fetched cursor when the cycle aborts on an empty page", async () => {
+    const source = {
+      id: createSafeId<"caseLawSource">(),
+      adapterKey: ADAPTER_KEYS.CZ_NS,
+      name: "Empty-page source",
+      enabled: true,
+      syncCursor: "cursor-1",
+      lastSyncAt: null,
+      config: {},
+      descriptor: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    } satisfies typeof caseLawSources.$inferSelect;
+
+    // The cycle deadline fires while the fetch is in flight; the page it
+    // returns carries no decisions but real cursor progress. Acquiring the
+    // DB slot here used to throw AbortError before the cursor advance ran,
+    // pinning the adapter to the same cursor on every later cycle.
+    const controller = new AbortController();
+    czNsAdapter.fetchPage = async () => {
+      controller.abort();
+      return Result.ok({ decisions: [], nextCursor: "cursor-2" });
+    };
+
+    let acquires = 0;
+    const dbSlot = {
+      acquire: async (signal?: AbortSignal) => {
+        acquires++;
+        if (signal?.aborted) {
+          throw new DOMException("aborted", "AbortError");
+        }
+      },
+      release: () => undefined,
+    };
+
+    let persistedCursor: string | null | undefined;
+    const scopedDb: ScopedDb = async (callback) => {
+      const tx = {
+        update: (table: unknown) => ({
+          set: (values: { syncCursor?: string | null }) => {
+            if (table === caseLawSources) {
+              persistedCursor = values.syncCursor;
+            }
+
+            return { where: async () => undefined };
+          },
+        }),
+      };
+
+      // SAFETY: this test exercises only the final case_law_sources cursor
+      // update (the empty page performs no decision writes); the fake
+      // implements that chain.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return await callback(tx as unknown as Transaction);
+    };
+
+    const result = await runIngestionPipeline({
+      source,
+      scopedDb,
+      signal: controller.signal,
+      maxPages: 1,
+      dbSlot,
+    });
+
+    // An empty page has no DB work, so the slot must never be contended.
+    expect(acquires).toBe(0);
+    expect(result.pagesProcessed).toBe(1);
+    expect(result.nextCursor).toBe("cursor-2");
+    expect(persistedCursor).toBe("cursor-2");
+  });
+});

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -623,10 +623,19 @@ export const runIngestionPipeline = async ({
     // before the next page fetch so external API calls don't
     // hold the slot. try-finally ensures no slot leak on
     // unexpected exceptions.
-    if (dbSlot) {
+    //
+    // A page with no decisions never touches the slot: it has no DB
+    // work, and acquiring anyway let a cycle-timeout abort land in
+    // the gap between the fetch returning and the acquire — breaking
+    // out before the cursor advance below ever ran, silently
+    // discarding the forward progress the fetch had already made and
+    // pinning the adapter to the same cursor on every later cycle.
+    let pageHoldsDbSlot = false;
+    if (dbSlot && page.decisions.length > 0) {
       try {
         // oxlint-disable-next-line no-await-in-loop -- sequential per-page DB-slot acquisition bounds concurrent DB pressure
         await dbSlot.acquire(signal);
+        pageHoldsDbSlot = true;
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
           haltReason = "Cycle timeout exceeded";
@@ -761,7 +770,7 @@ export const runIngestionPipeline = async ({
       cursor = page.nextCursor;
       pagesProcessed++;
     } finally {
-      if (dbSlot) {
+      if (dbSlot && pageHoldsDbSlot) {
         dbSlot.release();
       }
     }

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,8 +40,10 @@ should lag the release that stopped using the old data.
 ## Creating A Release
 
 1. Ensure CI is green on `main`.
-2. Generate and review any required migration files.
-3. In one commit, bump `VERSION` and optionally add the matching manual
+2. Review the landing showcase scenes for staleness and re-record any that
+   the release made inaccurate (see `docs/showcase-scenes.md`).
+3. Generate and review any required migration files.
+4. In one commit, bump `VERSION` and optionally add the matching manual
    changelog note:
 
    ```bash
@@ -54,14 +56,14 @@ should lag the release that stopped using the old data.
    For RCs, use matching values such as `VERSION=1.2.3-rc.1` and
    `docs/changelog/v1.2.3-rc.1.md`.
 
-4. Merge the commit to `main`. The `tag-on-version-bump.yml` workflow pushes
+5. Merge the commit to `main`. The `tag-on-version-bump.yml` workflow pushes
    the matching `vX.Y.Z` tag automatically. The tag then triggers
    `release.yml`.
-5. Wait for the release workflow to publish the image, manifest, and GitHub
+6. Wait for the release workflow to publish the image, manifest, and GitHub
    release notes. Stable releases are promoted automatically; the workflow does
    not succeed until `https://api.stll.app/health` reports the exact release
    commit. RCs continue to target staging.
-6. After a stable release succeeds, `publish-npm.yml` checks out the same
+7. After a stable release succeeds, `publish-npm.yml` checks out the same
    release commit, packs the CLI, installs that exact tarball under plain Node,
    and runs its unauthenticated compatibility canary against production. Only
    then can the hardened npm publishing job publish `@stll/cli`.

--- a/docs/showcase-scenes.md
+++ b/docs/showcase-scenes.md
@@ -1,0 +1,71 @@
+# Showcase Scenes
+
+The landing page presents the product through a small set of "scenes":
+draft, review, and research. This runbook records what those scenes are,
+how to re-record them, and how to decide at release time whether any of
+them has gone stale.
+
+## Inventory
+
+| Scene    | Asset today                                            | Depicts                                             |
+| -------- | ------------------------------------------------------ | --------------------------------------------------- |
+| draft    | animated geometric tile (inline SVG in `index.astro`)  | drafting a document with AI assistance              |
+| review   | animated geometric tile (inline SVG in `index.astro`)  | reviewing tracked changes on a contract             |
+| research | animated geometric tile (inline SVG in `index.astro`)  | legal research across the corpus                    |
+
+Legacy assets: `apps/landing/public/showcase/{draft,review,research}.png`
+are the static poster screenshots that preceded the geometric tiles. They
+are currently referenced nowhere in the source but are still published at
+`/showcase/*.png`, so external links may point at them. History: the
+scenes were originally Remotion-rendered videos; #807 replaced them with
+poster images and then with the current geometric tiles, deleting the
+Remotion pipeline.
+
+## Re-recording a scene (product screenshots)
+
+Use this whenever a scene shows real product UI (the legacy posters, or
+any future reintroduction of screenshots/video).
+
+1. Start the stack: `bun run dev --no-browser`, and seed demo content
+   (`bun --filter @stll/api db:seed-dev`). Never screenshot real tenant
+   data; scenes must only ever contain seeded demo content.
+2. Browser setup: 1440×900 viewport at 2x device pixel ratio, light
+   theme, `en` locale, no devtools or extensions visible.
+3. Stage each scene:
+   - **draft** — a document open in the editor with a partially drafted
+     contract and the composer visible.
+   - **review** — a DOCX with visible tracked changes and the suggestion
+     review bar engaged.
+   - **research** — legal research view with a query and result list
+     (case law + legislation hits).
+4. Capture, then optimize (`oxipng -o 4` or equivalent; keep each file
+   under ~400 KB) and overwrite the asset in
+   `apps/landing/public/showcase/`.
+5. Commit with `docs(landing): re-record <scene> showcase scene`.
+
+The geometric tiles are code, not recordings: they only need work when
+the product story changes (e.g., a scene's headline feature is renamed
+or replaced). Edit them in `apps/landing/src/pages/index.astro` and keep
+the surrounding copy in sync.
+
+## Catching stale scenes at release time
+
+A scene is **stale** when a user comparing it to the shipping product
+would notice a mismatch. Check, per scene, whether the release changed:
+
+- the visual chrome of the depicted screen (navigation, editor frame,
+  theme tokens, typography);
+- the depicted feature itself (renamed, redesigned, or removed);
+- the copy next to the scene (claims a capability the release changed).
+
+Release procedure (referenced from `docs/releases.md`): before the
+version-bump PR, open each scene beside the current app screen and mark
+it fresh or stale; re-record stale ones as above in the same release.
+Most releases will conclude "nothing stale" in a couple of minutes; the
+point is that the check happens every time.
+
+Future automation (not built): a Playwright job that stages each scene
+from fixtures at the pinned viewport, screenshots it, and pixel-diffs
+against the committed asset, failing the release checklist when the
+difference exceeds a threshold. If the posters return to the landing
+page, build this before relying on manual eyeballing.


### PR DESCRIPTION
Documents the landing showcase scenes (current geometric tiles, legacy poster screenshots, their Remotion history), the exact re-record procedure (seeded demo data only, pinned viewport, optimization budget), and a per-release staleness check now referenced as step 2 of the release checklist in docs/releases.md. Notes the future Playwright pixel-diff automation as an explicit non-built follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-law ingestion so empty pages advance and persist their cursors correctly when processing is interrupted.

* **Documentation**
  * Added guidance for reviewing and re-recording landing-page showcase scenes.
  * Clarified release steps, including scene checks, deployment verification, tagging, and release publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->